### PR TITLE
Content Ops Brand Voice Profile

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -512,6 +512,7 @@ if BaseModel is not None:
         account_usage_budget_usd: float | None = Field(default=None, gt=0)
         account_usage_budget_days: int = Field(7, ge=1, le=90)
         content_ops_cache_policy: str | None = Field(default=None, max_length=40)
+        brand_voice_profile_id: str | None = Field(default=None, max_length=120)
         inputs: dict[str, Any] = Field(default_factory=dict, max_length=_MAX_INPUT_KEYS)
         ingestion_profile: str = Field("domain_specific", min_length=1, max_length=80)
         require_quality_gates: bool = True

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -604,6 +604,7 @@ def create_generated_asset_router(
     async def repair_landing_page_draft(
         asset: str,
         draft_id: str,
+        payload: dict[str, Any] | None = Body(default=None),
     ) -> dict[str, Any]:
         asset_name = _asset_arg(asset)
         if asset_name != "landing_page":
@@ -653,7 +654,12 @@ def create_generated_asset_router(
                 landing_pages=claimed_repository,
                 llm=llm,
                 skills=skills,
-            ).repair_draft(scope=tenant, draft=claimed)
+            ).repair_draft(
+                scope=tenant,
+                draft=claimed,
+                brand_voice=(payload or {}).get("brand_voice"),
+                brand_voice_profile_id=(payload or {}).get("brand_voice_profile_id"),
+            )
             result_payload = result.as_dict()
             if result.generated == 0 and result.skipped > 0:
                 raise HTTPException(
@@ -677,6 +683,8 @@ def create_generated_asset_router(
             row = landing_page_draft_export_row(refreshed)
             row["repair_result"] = result_payload
             return row
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         finally:
             if release_claim:
                 await _release_landing_page_repair_claim(

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -16,6 +16,12 @@ from .campaign_ports import (
     SkillStore,
     TenantScope,
 )
+from .brand_voice import (
+    BrandVoiceProfile,
+    apply_brand_voice_to_system_prompt,
+    brand_voice_profile_from_mapping,
+    brand_voice_result_metadata,
+)
 from .content_image_provider import (
     ContentImageAsset,
     ContentImageProvider,
@@ -478,6 +484,7 @@ class BlogPostGenerationService:
         quality_repair_attempts: int | None = None,
         topic: str | None = None,
         data_context: Mapping[str, Any] | None = None,
+        brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
     ) -> BlogPostGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -519,6 +526,10 @@ class BlogPostGenerationService:
         # Empty string when None so prompt substitution is a clean no-op.
         resolved_topic = (topic or "").strip()
         trusted_data_context = _mapping_dict(data_context)
+        resolved_brand_voice = brand_voice_profile_from_mapping(
+            brand_voice,
+            scope=scope,
+        )
 
         requested = int(limit or self._config.limit)
         rows = await self._blueprints.read_blog_blueprints(
@@ -551,6 +562,7 @@ class BlogPostGenerationService:
                     parse_retry_attempts=resolved_parse_retry_attempts,
                     parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                     topic=resolved_topic,
+                    brand_voice=resolved_brand_voice,
                 )
             except Exception as exc:
                 skipped += 1
@@ -583,6 +595,7 @@ class BlogPostGenerationService:
                             max_tokens=resolved_max_tokens,
                             quality_repair_attempt_no=repair_attempt_no,
                             topic=resolved_topic,
+                            brand_voice=resolved_brand_voice,
                         )
                     except Exception as exc:
                         skipped += 1
@@ -691,11 +704,13 @@ class BlogPostGenerationService:
         parse_retry_attempts: int,
         parse_retry_response_excerpt_chars: int,
         topic: str = "",
+        brand_voice: BrandVoiceProfile | None = None,
     ) -> dict[str, Any] | None:
         system_prompt, base_user_prompt = _blog_generation_prompts(
             prompt_template,
             blueprint=blueprint,
             topic=topic,
+            brand_voice=brand_voice,
         )
         attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
@@ -725,13 +740,13 @@ class BlogPostGenerationService:
             total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_blog_post_response(response.content)
             if parsed:
-                return {
+                return brand_voice_result_metadata({
                     **parsed,
                     "_model": response.model,
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
                     "_quality_repair_attempts": 0,
-                }
+                }, brand_voice)
             last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
@@ -750,6 +765,7 @@ class BlogPostGenerationService:
         max_tokens: int,
         quality_repair_attempt_no: int,
         topic: str = "",
+        brand_voice: BrandVoiceProfile | None = None,
     ) -> dict[str, Any] | None:
         blockers = tuple(str(item) for item in quality.get("blockers") or () if item)
         if not blockers:
@@ -759,6 +775,7 @@ class BlogPostGenerationService:
             prompt_template,
             blueprint=blueprint,
             topic=topic,
+            brand_voice=brand_voice,
         )
         response = await self._llm.complete(
             [
@@ -786,7 +803,7 @@ class BlogPostGenerationService:
         repaired = parse_blog_post_response(response.content)
         if not repaired:
             return None
-        return {
+        return brand_voice_result_metadata({
             **repaired,
             "_model": response.model,
             "_usage": accumulate_usage(
@@ -795,7 +812,7 @@ class BlogPostGenerationService:
             ),
             "_parse_attempts": parse_attempts_used,
             "_quality_repair_attempts": int(parsed.get("_quality_repair_attempts") or 0) + 1,
-        }
+        }, brand_voice)
 
     def _quality_check(
         self,
@@ -854,6 +871,8 @@ class BlogPostGenerationService:
             "generation_usage": parsed.get("_usage") or {},
             "generation_parse_attempts": parsed.get("_parse_attempts"),
             "generation_quality_repair_attempts": parsed.get("_quality_repair_attempts") or 0,
+            "brand_voice_profile": parsed.get("_brand_voice_profile"),
+            "brand_voice_audit": parsed.get("_brand_voice_audit"),
         }
         # PR-Blog-Reasoning-Parity: surface reasoning audit fields on
         # the draft metadata when the blueprint carried merged context.
@@ -1259,6 +1278,7 @@ def _blog_generation_prompts(
     *,
     blueprint: Mapping[str, Any],
     topic: str = "",
+    brand_voice: BrandVoiceProfile | None = None,
 ) -> tuple[str, str]:
     blueprint_json = json.dumps(dict(blueprint), separators=(",", ":"), default=str)
     system_prompt = (
@@ -1266,6 +1286,7 @@ def _blog_generation_prompts(
         .replace("{blueprint_json}", "the blueprint JSON supplied in the user message")
         .replace("{topic}", "the operator-supplied topic provided in the user message")
     )
+    system_prompt = apply_brand_voice_to_system_prompt(system_prompt, brand_voice)
     base_user_prompt_parts = [
         "Generate one blog post from this blueprint JSON:",
         blueprint_json,

--- a/extracted_content_pipeline/brand_voice.py
+++ b/extracted_content_pipeline/brand_voice.py
@@ -1,0 +1,305 @@
+"""Brand-voice profile helpers for content-ops LLM generation."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+_MAX_DESCRIPTOR_COUNT = 8
+_MAX_DESCRIPTOR_CHARS = 120
+_MAX_EXEMPLAR_COUNT = 3
+_MAX_EXEMPLAR_CHARS = 1200
+_MAX_BANNED_TERM_CHARS = 120
+_SUPPORTED_POV = {
+    "first_person": "first_person",
+    "first": "first_person",
+    "we": "first_person",
+    "second_person": "second_person",
+    "second": "second_person",
+    "you": "second_person",
+    "third_person": "third_person",
+    "third": "third_person",
+}
+_PLAIN_READING_LEVELS = frozenset({"plain", "simple", "accessible"})
+_CONCISE_READING_LEVELS = frozenset({"concise", "short"})
+
+
+@dataclass(frozen=True)
+class BrandVoiceProfile:
+    """Request-time brand voice profile for one tenant/account."""
+
+    id: str = ""
+    account_id: str = ""
+    name: str = ""
+    descriptors: tuple[str, ...] = ()
+    exemplars: tuple[str, ...] = ()
+    banned_terms: tuple[str, ...] = ()
+    preferred_pov: str | None = None
+    reading_level: str | None = None
+    metadata: JsonDict = field(default_factory=dict)
+
+    def has_guidance(self) -> bool:
+        return bool(
+            self.descriptors
+            or self.exemplars
+            or self.banned_terms
+            or self.preferred_pov
+            or self.reading_level
+        )
+
+
+def brand_voice_profile_from_mapping(
+    value: Mapping[str, Any] | BrandVoiceProfile | None,
+    *,
+    scope: TenantScope | None = None,
+    profile_id: str | None = None,
+) -> BrandVoiceProfile | None:
+    """Normalize an inline profile and fail closed on cross-account drift."""
+
+    if value is None:
+        if _clean(profile_id):
+            raise ValueError("brand_voice_profile_id requires inputs.brand_voice")
+        return None
+    if isinstance(value, BrandVoiceProfile):
+        _validate_profile_id(value.id, profile_id)
+        _validate_scope(value, scope)
+        return value
+    if not isinstance(value, Mapping):
+        raise ValueError("brand_voice must be an object")
+
+    inline_profile_id = _clean(value.get("id") or value.get("profile_id"))
+    _validate_profile_id(inline_profile_id, profile_id)
+    profile = BrandVoiceProfile(
+        id=inline_profile_id or _clean(profile_id),
+        account_id=_clean(value.get("account_id") or getattr(scope, "account_id", "")),
+        name=_clean(value.get("name") or value.get("label")),
+        descriptors=_clean_sequence(
+            value.get("descriptors")
+            or value.get("descriptor")
+            or value.get("tone")
+            or value.get("voice"),
+            limit=_MAX_DESCRIPTOR_COUNT,
+            char_limit=_MAX_DESCRIPTOR_CHARS,
+        ),
+        exemplars=_exemplars(value.get("exemplars") or value.get("samples")),
+        banned_terms=_clean_sequence(
+            value.get("banned_terms") or value.get("forbidden_terms"),
+            limit=20,
+            char_limit=_MAX_BANNED_TERM_CHARS,
+        ),
+        preferred_pov=_preferred_pov(value.get("preferred_pov") or value.get("pov")),
+        reading_level=_clean(value.get("reading_level")),
+        metadata=dict(value.get("metadata") or {}),
+    )
+    _validate_scope(profile, scope)
+    return profile if profile.has_guidance() or profile.id else None
+
+
+def apply_brand_voice_to_system_prompt(
+    prompt: str,
+    profile: BrandVoiceProfile | None,
+) -> str:
+    """Inject brand-voice guidance into the grounded system prompt."""
+
+    block = brand_voice_prompt_block(profile)
+    if "{brand_voice}" in prompt:
+        return prompt.replace("{brand_voice}", block)
+    if not block:
+        return prompt
+    return f"{prompt.rstrip()}\n\n{block}"
+
+
+def brand_voice_prompt_block(profile: BrandVoiceProfile | None) -> str:
+    if profile is None or not profile.has_guidance():
+        return ""
+    lines = [
+        "## Brand voice",
+        "Use this profile as style guidance only. It changes wording, rhythm, "
+        "and tone; it must not add facts, claims, evidence, or source details. "
+        "Do not omit or alter grounded claims to satisfy the voice profile.",
+    ]
+    if profile.name:
+        lines.append(f"Profile: {profile.name}")
+    if profile.descriptors:
+        lines.append("Descriptors: " + ", ".join(profile.descriptors))
+    if profile.preferred_pov:
+        lines.append(f"Preferred POV: {profile.preferred_pov}")
+    if profile.reading_level:
+        lines.append(f"Reading level: {profile.reading_level}")
+    if profile.banned_terms:
+        lines.append("Avoid these terms: " + ", ".join(profile.banned_terms))
+    if profile.exemplars:
+        lines.append("Style exemplars:")
+        for index, exemplar in enumerate(profile.exemplars, start=1):
+            lines.append(f"{index}. {exemplar}")
+    return "\n".join(lines)
+
+
+def brand_voice_result_metadata(
+    parsed: Mapping[str, Any],
+    profile: BrandVoiceProfile | None,
+) -> dict[str, Any]:
+    if profile is None:
+        return dict(parsed)
+    return {
+        **dict(parsed),
+        "_brand_voice_profile": brand_voice_profile_metadata(profile),
+        "_brand_voice_audit": brand_voice_audit(parsed, profile),
+    }
+
+
+def brand_voice_profile_metadata(profile: BrandVoiceProfile) -> JsonDict:
+    return {
+        key: value
+        for key, value in {
+            "id": profile.id,
+            "account_id": profile.account_id,
+            "name": profile.name,
+            "descriptors": list(profile.descriptors),
+            "preferred_pov": profile.preferred_pov,
+            "reading_level": profile.reading_level,
+        }.items()
+        if value not in ("", None, [], {})
+    }
+
+
+def brand_voice_audit(parsed: Mapping[str, Any], profile: BrandVoiceProfile) -> JsonDict:
+    text = _flatten_text(parsed)
+    lower_text = text.lower()
+    banned_terms = [
+        term for term in profile.banned_terms if term and term.lower() in lower_text
+    ]
+    warnings: list[str] = []
+    pov_warning = _pov_warning(lower_text, profile.preferred_pov)
+    if pov_warning:
+        warnings.append(pov_warning)
+    reading_warning = _reading_level_warning(text, profile.reading_level)
+    if reading_warning:
+        warnings.append(reading_warning)
+    return {
+        "passed": not banned_terms and not warnings,
+        "banned_terms": banned_terms,
+        "warnings": warnings,
+    }
+
+
+def _validate_scope(profile: BrandVoiceProfile, scope: TenantScope | None) -> None:
+    expected = _clean(getattr(scope, "account_id", ""))
+    if expected and profile.account_id and expected != profile.account_id:
+        raise ValueError("brand_voice.account_id does not match tenant scope")
+
+
+def _validate_profile_id(inline_id: str, profile_id: str | None) -> None:
+    expected = _clean(profile_id)
+    if expected and inline_id and expected != inline_id:
+        raise ValueError("brand_voice.id does not match brand_voice_profile_id")
+
+
+def _preferred_pov(value: Any) -> str | None:
+    text = _clean(value).lower().replace("-", "_").replace(" ", "_")
+    return _SUPPORTED_POV.get(text)
+
+
+def _exemplars(value: Any) -> tuple[str, ...]:
+    items: list[str] = []
+    raw_items: Sequence[Any]
+    if value is None:
+        raw_items = ()
+    elif isinstance(value, str):
+        raw_items = (value,)
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        raw_items = value
+    else:
+        raw_items = ()
+    for item in raw_items:
+        if isinstance(item, Mapping):
+            text = _clean(item.get("text") or item.get("content") or item.get("body"))
+        else:
+            text = _clean(item)
+        if text and text not in items:
+            items.append(text[:_MAX_EXEMPLAR_CHARS])
+        if len(items) >= _MAX_EXEMPLAR_COUNT:
+            break
+    return tuple(items)
+
+
+def _clean_sequence(
+    value: Any,
+    *,
+    limit: int,
+    char_limit: int | None = None,
+) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    raw_items = (value,) if isinstance(value, str) else value
+    if not isinstance(raw_items, Sequence) or isinstance(raw_items, (bytes, bytearray)):
+        return ()
+    items: list[str] = []
+    for item in raw_items:
+        text = _clean(item)
+        if char_limit is not None:
+            text = text[:char_limit]
+        if text and text not in items:
+            items.append(text)
+        if len(items) >= limit:
+            break
+    return tuple(items)
+
+
+def _flatten_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        return " ".join(_flatten_text(item) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return " ".join(_flatten_text(item) for item in value)
+    return ""
+
+
+def _pov_warning(lower_text: str, preferred_pov: str | None) -> str:
+    if not preferred_pov:
+        return ""
+    has_you = bool(re.search(r"\b(you|your|yours)\b", lower_text))
+    has_we = bool(re.search(r"\b(we|our|ours|us)\b", lower_text))
+    if preferred_pov == "second_person" and not has_you:
+        return "preferred_pov_second_person_not_detected"
+    if preferred_pov == "first_person" and not has_we:
+        return "preferred_pov_first_person_not_detected"
+    if preferred_pov == "third_person" and (has_you or has_we):
+        return "preferred_pov_third_person_mixed"
+    return ""
+
+
+def _reading_level_warning(text: str, reading_level: str | None) -> str:
+    level = _clean(reading_level).lower()
+    if level not in _PLAIN_READING_LEVELS and level not in _CONCISE_READING_LEVELS:
+        return ""
+    sentences = [
+        sentence for sentence in re.split(r"[.!?]+", text) if sentence.strip()
+    ] or [text]
+    word_count = sum(len(re.findall(r"\b\w+\b", sentence)) for sentence in sentences)
+    average_words = word_count / max(1, len(sentences))
+    if level in _CONCISE_READING_LEVELS and average_words > 18:
+        return "reading_level_concise_exceeded"
+    if level in _PLAIN_READING_LEVELS and average_words > 24:
+        return "reading_level_plain_exceeded"
+    return ""
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+__all__ = [
+    "BrandVoiceProfile",
+    "apply_brand_voice_to_system_prompt",
+    "brand_voice_audit",
+    "brand_voice_profile_from_mapping",
+    "brand_voice_profile_metadata",
+    "brand_voice_prompt_block",
+    "brand_voice_result_metadata",
+]

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -22,6 +22,12 @@ from .campaign_ports import (
     SkillStore,
     TenantScope,
 )
+from .brand_voice import (
+    BrandVoiceProfile,
+    apply_brand_voice_to_system_prompt,
+    brand_voice_profile_from_mapping,
+    brand_voice_result_metadata,
+)
 from .services.campaign_reasoning_context import (
     campaign_reasoning_context_metadata,
     campaign_reasoning_context_payload,
@@ -317,6 +323,7 @@ class CampaignGenerationService:
         quality_prompt_proof_term_limit: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
         opportunity_defaults: Mapping[str, Any] | None = None,
+        brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
     ) -> CampaignGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -352,6 +359,10 @@ class CampaignGenerationService:
             self._config.parse_retry_response_excerpt_chars
             if parse_retry_response_excerpt_chars is None
             else int(parse_retry_response_excerpt_chars)
+        )
+        resolved_brand_voice = brand_voice_profile_from_mapping(
+            brand_voice,
+            scope=scope,
         )
 
         requested = int(limit or self._config.limit)
@@ -410,6 +421,7 @@ class CampaignGenerationService:
                         max_tokens=resolved_max_tokens,
                         parse_retry_attempts=resolved_parse_retry_attempts,
                         parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
+                        brand_voice=resolved_brand_voice,
                     )
                 except Exception as exc:
                     skipped += 1
@@ -625,6 +637,7 @@ class CampaignGenerationService:
         max_tokens: int,
         parse_retry_attempts: int,
         parse_retry_response_excerpt_chars: int,
+        brand_voice: BrandVoiceProfile | None = None,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
         system_prompt = (
@@ -634,6 +647,7 @@ class CampaignGenerationService:
             .replace("{opportunity}", opportunity_json)
             .replace("{opportunity_json}", opportunity_json)
         )
+        system_prompt = apply_brand_voice_to_system_prompt(system_prompt, brand_voice)
         attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
@@ -664,12 +678,12 @@ class CampaignGenerationService:
             total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_campaign_draft_response(response.content)
             if parsed:
-                return {
+                return brand_voice_result_metadata({
                     **parsed,
                     "_model": response.model,
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
-                }
+                }, brand_voice)
             last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
@@ -731,6 +745,8 @@ class CampaignGenerationService:
             "generation_usage": parsed.get("_usage") or {},
             "generation_parse_attempts": parsed.get("_parse_attempts"),
             "campaign_revalidation": parsed.get("_quality_revalidation"),
+            "brand_voice_profile": parsed.get("_brand_voice_profile"),
+            "brand_voice_audit": parsed.get("_brand_voice_audit"),
         }
         context = normalize_campaign_reasoning_context(opportunity)
         metadata.update(campaign_reasoning_context_metadata(context))

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -14,6 +14,7 @@ from .campaign_llm_client import (
     reset_content_ops_llm_trace_context,
     set_content_ops_llm_trace_context,
 )
+from .brand_voice import BrandVoiceProfile, brand_voice_profile_from_mapping
 from .control_surfaces import OUTPUT_CATALOG, ContentOpsRequest, request_from_mapping
 from .generation_plan import GenerationPlan, GenerationPlanStep, build_generation_plan
 from .landing_page_input_contract import LANDING_PAGE_CONTEXT_INPUT_KEYS
@@ -307,6 +308,14 @@ async def execute_content_ops_request(
         )
 
     resolved_scope = scope or TenantScope()
+    try:
+        brand_voice = _brand_voice_for_request(request, scope=resolved_scope)
+    except ValueError as exc:
+        return ContentOpsExecutionResult(
+            status="blocked",
+            plan=plan,
+            errors=({"reason": str(exc)},),
+        )
     filters = _filters_from_inputs(request.inputs)
     step_results = await asyncio.gather(*(
         _execute_step(
@@ -314,6 +323,7 @@ async def execute_content_ops_request(
             request=request,
             service=services.for_output(step.output),
             scope=resolved_scope,
+            brand_voice=brand_voice,
             trace_metadata=trace_metadata,
             filters=filters,
             reasoning_provider_configured=services.reasoning_provider_active_for(
@@ -348,6 +358,7 @@ async def _execute_step(
     request: ContentOpsRequest,
     service: Any | None,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     trace_metadata: Mapping[str, Any] | None,
     filters: Mapping[str, Any] | None,
     reasoning_provider_configured: bool,
@@ -376,6 +387,7 @@ async def _execute_step(
             request=request,
             service=service,
             scope=scope,
+            brand_voice=brand_voice,
             filters=filters,
         )
     except Exception as exc:
@@ -442,6 +454,18 @@ def _request_trace_metadata(
     return metadata
 
 
+def _brand_voice_for_request(
+    request: ContentOpsRequest,
+    *,
+    scope: TenantScope,
+) -> BrandVoiceProfile | None:
+    return brand_voice_profile_from_mapping(
+        request.inputs.get("brand_voice"),
+        scope=scope,
+        profile_id=request.brand_voice_profile_id,
+    )
+
+
 async def execute_content_ops_from_mapping(
     payload: Mapping[str, Any],
     *,
@@ -466,6 +490,7 @@ async def _run_step(
     request: ContentOpsRequest,
     service: Any,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
     """Dispatch a step to its per-output handler.
@@ -482,6 +507,7 @@ async def _run_step(
         service=service,
         request=request,
         scope=scope,
+        brand_voice=brand_voice,
         filters=filters,
     )
 
@@ -492,6 +518,7 @@ async def _dispatch_email_campaign(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
     kwargs: dict[str, Any] = {
@@ -513,6 +540,8 @@ async def _dispatch_email_campaign(
             step.config, "parse_retry_response_excerpt_chars"
         ),
     }
+    if brand_voice is not None:
+        kwargs["brand_voice"] = brand_voice
     opportunity_defaults = _opportunity_defaults_from_inputs(request.inputs)
     if opportunity_defaults is not None:
         kwargs["opportunity_defaults"] = opportunity_defaults
@@ -525,8 +554,10 @@ async def _dispatch_report(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
+    del brand_voice
     return await service.generate(
         scope=scope,
         target_mode=request.target_mode,
@@ -549,6 +580,7 @@ async def _dispatch_sales_brief(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
     kwargs: dict[str, Any] = {
@@ -565,6 +597,8 @@ async def _dispatch_sales_brief(
         ),
         "quality_gates_enabled": _step_config_bool(step.config, "quality_gates_enabled"),
     }
+    if brand_voice is not None:
+        kwargs["brand_voice"] = brand_voice
     if "source_material" in request.inputs:
         kwargs["source_material"] = request.inputs.get("source_material")
     return await service.generate(**kwargs)
@@ -576,21 +610,25 @@ async def _dispatch_landing_page(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
     del filters  # unused: landing pages take a campaign, not a target_mode
-    return await service.generate(
-        scope=scope,
-        campaign=_marketing_campaign_from_inputs(request.inputs),
-        temperature=_step_config_float(step.config, "temperature"),
-        max_tokens=_step_config_int(step.config, "max_tokens"),
-        parse_retry_attempts=_step_config_int(step.config, "parse_retry_attempts"),
-        parse_retry_response_excerpt_chars=_step_config_int(
+    kwargs: dict[str, Any] = {
+        "scope": scope,
+        "campaign": _marketing_campaign_from_inputs(request.inputs),
+        "temperature": _step_config_float(step.config, "temperature"),
+        "max_tokens": _step_config_int(step.config, "max_tokens"),
+        "parse_retry_attempts": _step_config_int(step.config, "parse_retry_attempts"),
+        "parse_retry_response_excerpt_chars": _step_config_int(
             step.config, "parse_retry_response_excerpt_chars"
         ),
-        quality_gates_enabled=_step_config_bool(step.config, "quality_gates_enabled"),
-        quality_repair_attempts=_step_config_int(step.config, "quality_repair_attempts"),
-    )
+        "quality_gates_enabled": _step_config_bool(step.config, "quality_gates_enabled"),
+        "quality_repair_attempts": _step_config_int(step.config, "quality_repair_attempts"),
+    }
+    if brand_voice is not None:
+        kwargs["brand_voice"] = brand_voice
+    return await service.generate(**kwargs)
 
 
 async def _dispatch_blog_post(
@@ -599,6 +637,7 @@ async def _dispatch_blog_post(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
     # PR-OptionA-2: blog_post graduates from _dispatch_default into its own
@@ -619,6 +658,8 @@ async def _dispatch_blog_post(
         "quality_repair_attempts": _step_config_int(step.config, "quality_repair_attempts"),
         "topic": _step_config_text(step.config, "topic"),
     }
+    if brand_voice is not None:
+        kwargs["brand_voice"] = brand_voice
     data_context = (
         _competitive_blog_data_context_from_inputs(request.inputs)
         or _review_blog_data_context_from_inputs(request.inputs)
@@ -641,8 +682,10 @@ async def _dispatch_signal_extraction(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
+    del brand_voice
     del filters
     return await service.generate(
         scope=scope,
@@ -659,8 +702,10 @@ async def _dispatch_social_post(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
+    del brand_voice
     del filters
     return await service.generate(
         scope=scope,
@@ -677,8 +722,10 @@ async def _dispatch_ad_copy(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
+    del brand_voice
     del filters
     return await service.generate(
         scope=scope,
@@ -695,8 +742,10 @@ async def _dispatch_quote_card(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
+    del brand_voice
     del filters
     return await service.generate(
         scope=scope,
@@ -713,8 +762,10 @@ async def _dispatch_stat_card(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
+    del brand_voice
     del filters
     return await service.generate(
         scope=scope,
@@ -731,8 +782,10 @@ async def _dispatch_faq_markdown(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
+    del brand_voice
     del filters
     return await service.generate(
         scope=scope,
@@ -761,8 +814,10 @@ async def _dispatch_faq_deflection_report(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
+    del brand_voice
     del filters
     return await service.generate(
         scope=scope,
@@ -792,13 +847,15 @@ async def _dispatch_default(
     service: Any,
     request: ContentOpsRequest,
     scope: TenantScope,
+    brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
     """Fallback for outputs that don't yet thread step.config kwargs.
 
-    Currently used by `blog_post`. Future outputs that need per-call
-    config kwargs should register their own handler in `_DISPATCH`.
+    Future outputs that need per-call config kwargs should register their
+    own handler in `_DISPATCH`.
     """
+    del brand_voice
     del step  # config is informational for outputs without per-call overrides
     return await service.generate(
         scope=scope,

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -61,6 +61,7 @@ class ContentOpsRequest:
     account_usage_budget_usd: float | None = None
     account_usage_budget_days: int = 7
     content_ops_cache_policy: str | None = None
+    brand_voice_profile_id: str | None = None
     inputs: Mapping[str, Any] = field(default_factory=dict)
     ingestion_profile: str = "domain_specific"
     require_quality_gates: bool = True
@@ -104,6 +105,9 @@ class ControlSurfacePreview:
                 ),
                 "content_ops_cache_policy": (
                     self.normalized_request.content_ops_cache_policy
+                ),
+                "brand_voice_profile_id": (
+                    self.normalized_request.brand_voice_profile_id
                 ),
                 "ingestion_profile": self.normalized_request.ingestion_profile,
                 "require_quality_gates": self.normalized_request.require_quality_gates,
@@ -390,6 +394,11 @@ def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
         content_ops_cache_policy=normalize_content_ops_cache_policy(
             payload.get("content_ops_cache_policy")
         ),
+        brand_voice_profile_id=(
+            str(payload.get("brand_voice_profile_id")).strip() or None
+        )
+        if payload.get("brand_voice_profile_id") is not None
+        else None,
         inputs=raw_inputs if isinstance(raw_inputs, Mapping) else {},
         ingestion_profile=str(payload.get("ingestion_profile") or "domain_specific").strip()
         or "domain_specific",
@@ -603,6 +612,7 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
         account_usage_budget_usd=request.account_usage_budget_usd,
         account_usage_budget_days=request.account_usage_budget_days,
         content_ops_cache_policy=request.content_ops_cache_policy,
+        brand_voice_profile_id=request.brand_voice_profile_id,
         inputs=request.inputs,
         ingestion_profile=request.ingestion_profile,
         require_quality_gates=request.require_quality_gates,

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -200,6 +200,14 @@ def _blog_post_config_for_request(request: ContentOpsRequest) -> BlogPostGenerat
     return BlogPostGenerationConfig(limit=request.limit)
 
 
+def _brand_voice_config_for_request(request: ContentOpsRequest) -> dict[str, Any]:
+    profile_id = str(request.brand_voice_profile_id or "").strip()
+    inline = request.inputs.get("brand_voice")
+    if not profile_id and isinstance(inline, Mapping):
+        profile_id = str(inline.get("id") or inline.get("profile_id") or "").strip()
+    return {"brand_voice_profile_id": profile_id} if profile_id else {}
+
+
 def _signal_extraction_config_for_request(
     request: ContentOpsRequest,
 ) -> SignalExtractionConfig:
@@ -372,6 +380,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_prompt_proof_term_limit": config.quality_prompt_proof_term_limit,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_brand_voice_config_for_request(request),
                 **_reasoning_config_for_output(output, request),
             },
         )
@@ -407,6 +416,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_repair_attempts": config.quality_repair_attempts,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_brand_voice_config_for_request(request),
                 **_reasoning_config_for_output(output, request),
             },
         )
@@ -425,6 +435,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_gates_enabled": request.require_quality_gates,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_brand_voice_config_for_request(request),
                 **_reasoning_config_for_output(output, request),
             },
         )
@@ -444,6 +455,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
                 "topic": request.inputs.get("topic"),
+                **_brand_voice_config_for_request(request),
                 **_reasoning_config_for_output(output, request),
             },
         )

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -35,6 +35,12 @@ from .campaign_ports import (
     SkillStore,
     TenantScope,
 )
+from .brand_voice import (
+    BrandVoiceProfile,
+    apply_brand_voice_to_system_prompt,
+    brand_voice_profile_from_mapping,
+    brand_voice_result_metadata,
+)
 from .content_image_provider import (
     ContentImageAsset,
     ContentImageProvider,
@@ -282,6 +288,7 @@ class LandingPageGenerationService:
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
         quality_repair_attempts: int | None = None,
+        brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
     ) -> LandingPageGenerationResult:
         # PR-OptionA-2: per-call LLM-tuning overrides; None falls through.
         resolved_temperature = (
@@ -314,6 +321,10 @@ class LandingPageGenerationService:
         )
         resolved_quality_repair_attempts = normalize_landing_page_quality_repair_attempts(
             resolved_quality_repair_attempts
+        )
+        resolved_brand_voice = brand_voice_profile_from_mapping(
+            brand_voice,
+            scope=scope,
         )
 
         prompt_template = self._skills.get_prompt(self._config.skill_name)
@@ -366,6 +377,7 @@ class LandingPageGenerationService:
                     parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                     quality_blockers=quality_blockers,
                     quality_repair_attempt_no=repair_attempt_no,
+                    brand_voice=resolved_brand_voice,
                 )
             except Exception as exc:
                 return LandingPageGenerationResult(
@@ -473,6 +485,8 @@ class LandingPageGenerationService:
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
         quality_repair_attempts: int | None = None,
+        brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
+        brand_voice_profile_id: str | None = None,
     ) -> LandingPageGenerationResult:
         """Repair an existing saved landing-page draft and update the same row."""
 
@@ -493,6 +507,11 @@ class LandingPageGenerationService:
                     "reason": "approved_draft_not_repairable",
                 },),
             )
+        resolved_brand_voice = brand_voice_profile_from_mapping(
+            brand_voice,
+            scope=scope,
+            profile_id=brand_voice_profile_id,
+        )
 
         campaign = MarketingCampaign(
             name=draft.campaign_name,
@@ -593,6 +612,7 @@ class LandingPageGenerationService:
                     parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                     quality_blockers=quality_blockers,
                     quality_repair_attempt_no=repair_attempt_no,
+                    brand_voice=resolved_brand_voice,
                 )
             except Exception as exc:
                 return LandingPageGenerationResult(
@@ -745,12 +765,14 @@ class LandingPageGenerationService:
         parse_retry_response_excerpt_chars: int,
         quality_blockers: Sequence[str] = (),
         quality_repair_attempt_no: int = 0,
+        brand_voice: BrandVoiceProfile | None = None,
     ) -> dict[str, Any] | None:
         campaign_json = json.dumps(dict(campaign_payload), separators=(",", ":"), default=str)
         # Single source for the campaign payload: in the system prompt
         # via {campaign_json}. User message is structural-only so the
         # campaign isn't sent twice (matches the report-generator fix).
         system_prompt = prompt_template.replace("{campaign_json}", campaign_json)
+        system_prompt = apply_brand_voice_to_system_prompt(system_prompt, brand_voice)
         attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
@@ -780,12 +802,12 @@ class LandingPageGenerationService:
             total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_landing_page_response(response.content)
             if parsed:
-                return {
+                return brand_voice_result_metadata({
                     **parsed,
                     "_model": response.model,
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
-                }
+                }, brand_voice)
             last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
@@ -878,6 +900,8 @@ class LandingPageGenerationService:
             "generation_quality_repair_attempts": parsed.get("_quality_repair_attempts"),
             "generation_quality_repair_history": parsed.get("_quality_repair_history")
             or (),
+            "brand_voice_profile": parsed.get("_brand_voice_profile"),
+            "brand_voice_audit": parsed.get("_brand_voice_audit"),
         }
         if campaign_payload is not None:
             context = normalize_campaign_reasoning_context(campaign_payload)

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -192,6 +192,9 @@
       "target": "extracted_content_pipeline/content_image_provider.py"
     },
     {
+      "target": "extracted_content_pipeline/brand_voice.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_ports.py"
     },
     {

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -47,6 +47,12 @@ from .campaign_ports import (
     SkillStore,
     TenantScope,
 )
+from .brand_voice import (
+    BrandVoiceProfile,
+    apply_brand_voice_to_system_prompt,
+    brand_voice_profile_from_mapping,
+    brand_voice_result_metadata,
+)
 from .campaign_source_adapters import (
     source_material_to_source_rows,
     source_rows_to_campaign_opportunities,
@@ -254,6 +260,7 @@ class SalesBriefGenerationService:
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
         source_material: Any = None,
+        brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
     ) -> SalesBriefGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -283,6 +290,10 @@ class SalesBriefGenerationService:
             self._config.quality_gates_enabled
             if quality_gates_enabled is None
             else bool(quality_gates_enabled)
+        )
+        resolved_brand_voice = brand_voice_profile_from_mapping(
+            brand_voice,
+            scope=scope,
         )
 
         requested = int(limit or self._config.limit)
@@ -336,6 +347,7 @@ class SalesBriefGenerationService:
                     max_tokens=resolved_max_tokens,
                     parse_retry_attempts=resolved_parse_retry_attempts,
                     parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
+                    brand_voice=resolved_brand_voice,
                 )
             except Exception as exc:
                 skipped += 1
@@ -439,6 +451,7 @@ class SalesBriefGenerationService:
         max_tokens: int,
         parse_retry_attempts: int,
         parse_retry_response_excerpt_chars: int,
+        brand_voice: BrandVoiceProfile | None = None,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
         # Single source for the opportunity payload: in the system prompt
@@ -449,6 +462,7 @@ class SalesBriefGenerationService:
             .replace("{target_mode}", target_mode)
             .replace("{opportunity_json}", opportunity_json)
         )
+        system_prompt = apply_brand_voice_to_system_prompt(system_prompt, brand_voice)
         attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
@@ -474,12 +488,12 @@ class SalesBriefGenerationService:
             total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_sales_brief_response(response.content)
             if parsed:
-                return {
+                return brand_voice_result_metadata({
                     **parsed,
                     "_model": response.model,
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
-                }
+                }, brand_voice)
             last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
@@ -556,6 +570,8 @@ class SalesBriefGenerationService:
             "generation_model": parsed.get("_model"),
             "generation_usage": parsed.get("_usage") or {},
             "generation_parse_attempts": parsed.get("_parse_attempts"),
+            "brand_voice_profile": parsed.get("_brand_voice_profile"),
+            "brand_voice_audit": parsed.get("_brand_voice_audit"),
         }
         if opportunity is not None:
             context = normalize_campaign_reasoning_context(opportunity)

--- a/plans/PR-Content-Ops-Brand-Voice-Profile.md
+++ b/plans/PR-Content-Ops-Brand-Voice-Profile.md
@@ -1,0 +1,179 @@
+# PR-Content-Ops-Brand-Voice-Profile
+
+## Why this slice exists
+
+Issue #1276 captured a missing content-ops control: LLM-backed copy can be
+generated from evidence, but the run has no brand voice/tone profile and no
+safe way to preserve a customer's established voice with exemplars. The
+social-post lifecycle dependency named in the issue is now merged, and the
+card visual-export lane is complete, so this slice can add the first executable
+brand-voice primitive without colliding with the open output-variations plan
+#1268.
+
+This PR intentionally keeps brand voice as a request-time profile contract:
+normalize and scope-check the profile, inject its descriptors/exemplars into
+the original grounded system prompt, and surface deterministic adherence
+metadata. That gives operators a usable path while leaving profile-management
+CRUD/UI for a follow-up.
+
+The slice is over the 400 LOC soft cap because the first executable contract is
+cross-layer by nature: request/API parsing, plan metadata, dispatcher routing,
+four generator prompt hooks, and the failure-branch tests must land together.
+Splitting before generator coverage would create an inert request field; splitting
+before the fail-closed tests would leave the tenant-scope safety claim unproven.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice-profile
+Slice phase: Vertical slice
+
+1. Add a pure extracted-package `BrandVoiceProfile` primitive with bounded
+   descriptor, exemplar, banned-term, reading-level, and POV fields.
+2. Thread optional `brand_voice_profile_id` plus inline `brand_voice` profile
+   payload through `ContentOpsRequest`, the API model, plan metadata, and the
+   execution dispatcher.
+3. Inject the normalized brand voice block into the system prompt for the LLM
+   copy generators named by #1276: `email_campaign`, `blog_post`,
+   `landing_page`, and `sales_brief`.
+4. Validate tenant scope fail-closed when an inline profile carries an
+   `account_id` that does not match `TenantScope.account_id`.
+5. Add deterministic adherence metadata for explicit rules only: banned terms,
+   first/second/third-person POV hints, and rough reading-level band.
+6. Preserve brand voice on the reachable landing-page draft repair path by
+   accepting a re-supplied full profile and applying it to repair generation.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Brand-Voice-Profile.md`
+- `extracted_content_pipeline/brand_voice.py`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/campaign_generation.py`
+- `extracted_content_pipeline/blog_generation.py`
+- `extracted_content_pipeline/landing_page_generation.py`
+- `extracted_content_pipeline/sales_brief_generation.py`
+- `extracted_content_pipeline/manifest.json`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_brand_voice.py`
+- `tests/test_extracted_campaign_generation.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_extracted_landing_page_generation.py`
+
+## Mechanism
+
+`brand_voice.py` owns the profile contract and prompt/audit helpers. The
+request accepts:
+
+```json
+{
+  "brand_voice_profile_id": "acme-main",
+  "inputs": {
+    "brand_voice": {
+      "id": "acme-main",
+      "account_id": "acct-1",
+      "name": "Acme editorial",
+      "descriptors": ["plainspoken", "operator-led"],
+      "exemplars": ["Real customer copy sample..."],
+      "banned_terms": ["synergy"],
+      "preferred_pov": "second_person",
+      "reading_level": "plain"
+    }
+  }
+}
+```
+
+The executor resolves the inline profile once per request and passes it only to
+LLM copy outputs. Each generator applies the profile to the existing system
+prompt before the user prompt is created; there is no generate-then-restyle
+post-pass, so evidence grounding stays in the original generation discipline.
+Parsed artifacts get `_brand_voice_profile` and `_brand_voice_audit` metadata
+when a profile is active.
+
+Landing-page draft repair accepts an optional repair payload with
+`brand_voice_profile_id` and inline `brand_voice`. The full profile must be
+re-supplied for repair because the saved draft metadata is intentionally lossy
+and omits exemplars/banned terms until stored profile lookup lands.
+
+## Intentional
+
+- No profile CRUD/API/UI in this PR. The vertical slice proves the generation
+  contract first; stored profile management can mirror the existing generated
+  asset table pattern in the next slice.
+- No social-post voice support. #1276 correctly notes current social posts are
+  deterministic template assembly, not LLM generation.
+- No automated "voice match" score. This PR checks only explicit rule-shaped
+  constraints and leaves actual voice fidelity to the human review queue.
+- No attempt to reconstruct a full repair profile from saved draft metadata.
+  The repair caller must re-supply the full profile until stored profile lookup
+  lands.
+- No output-variations work. #1268 remains open and owned elsewhere.
+
+## Deferred
+
+- `PR-Content-Ops-Brand-Voice-Profile-Storage`: account-scoped stored
+  `brand_voice_profiles` repository, API CRUD/list endpoints, and UI selector.
+- `PR-Content-Ops-Brand-Voice-Presets`: shipped descriptor-only preset library.
+- `PR-Content-Ops-Brand-Voice-Onboarding`: scrape/upload samples and pre-fill a
+  custom profile for human edit.
+- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can
+  consume brand voice.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_support_ticket_provider_landing_blog_execute.py -q` --
+  13 passed.
+- `pytest tests/test_extracted_brand_voice.py tests/test_extracted_landing_page_generation.py tests/test_extracted_content_asset_api.py -q`
+  -- 140 passed.
+- `pytest tests/test_extracted_brand_voice.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_generation_plan.py tests/test_extracted_campaign_generation.py -q`
+  -- 165 passed.
+- `python -m py_compile extracted_content_pipeline/brand_voice.py extracted_content_pipeline/landing_page_generation.py extracted_content_pipeline/api/generated_assets.py extracted_content_pipeline/content_ops_execution.py`
+  -- passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main`
+  -- 146 matching tests enrolled.
+- `bash scripts/run_extracted_pipeline_checks.sh` -- 295 reasoning-core tests
+  passed, then 3081 extracted-content tests passed / 10 skipped.
+- `git diff --check` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-brand-voice-profile.md`
+  -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 1 |
+| `extracted_content_pipeline/api/generated_assets.py` | 10 |
+| `extracted_content_pipeline/blog_generation.py` | 29 |
+| `extracted_content_pipeline/brand_voice.py` | 305 |
+| `extracted_content_pipeline/campaign_generation.py` | 20 |
+| `extracted_content_pipeline/content_ops_execution.py` | 81 |
+| `extracted_content_pipeline/control_surfaces.py` | 10 |
+| `extracted_content_pipeline/generation_plan.py` | 12 |
+| `extracted_content_pipeline/landing_page_generation.py` | 28 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/sales_brief_generation.py` | 20 |
+| `plans/PR-Content-Ops-Brand-Voice-Profile.md` | 179 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_brand_voice.py` | 123 |
+| `tests/test_extracted_campaign_generation.py` | 38 |
+| `tests/test_extracted_content_asset_api.py` | 46 |
+| `tests/test_extracted_content_generation_plan.py` | 29 |
+| `tests/test_extracted_content_ops_execution.py` | 115 |
+| `tests/test_extracted_landing_page_generation.py` | 38 |
+| **Total** | **1088** |
+
+Expected final: 19 files, +1065 / -23. This is over the 400 LOC soft cap
+because the request contract, four prompt-injection hooks, dispatcher routing,
+reviewed repair-path wiring, new helper, and failure-branch tests are the
+minimum executable vertical slice.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -94,6 +94,7 @@ pytest \
   tests/test_smoke_content_ops_support_ticket_package.py \
   tests/test_extracted_content_control_surface_api.py \
   tests/test_extracted_content_ops_usage_summary.py \
+  tests/test_extracted_brand_voice.py \
   tests/test_extracted_content_ops_execution.py \
   tests/test_extracted_content_ops_execution_smoke.py \
   tests/test_atlas_content_ops_infrastructure.py \

--- a/tests/test_extracted_brand_voice.py
+++ b/tests/test_extracted_brand_voice.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.brand_voice import (
+    apply_brand_voice_to_system_prompt,
+    brand_voice_profile_from_mapping,
+    brand_voice_prompt_block,
+    brand_voice_result_metadata,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+def test_brand_voice_profile_normalizes_prompt_block_and_audit_metadata() -> None:
+    profile = brand_voice_profile_from_mapping(
+        {
+            "id": "acme-main",
+            "account_id": "acct-1",
+            "name": "Acme main voice",
+            "descriptors": ["plainspoken", "operator-led", "plainspoken"],
+            "exemplars": [
+                {"text": "We explain tradeoffs in plain English."},
+                "Use concrete proof before claims.",
+                "Avoid theatrical language.",
+                "Ignored fourth sample.",
+            ],
+            "banned_terms": ["synergy"],
+            "preferred_pov": "you",
+            "reading_level": "plain",
+        },
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert profile is not None
+    assert profile.descriptors == ("plainspoken", "operator-led")
+    assert profile.exemplars == (
+        "We explain tradeoffs in plain English.",
+        "Use concrete proof before claims.",
+        "Avoid theatrical language.",
+    )
+    block = brand_voice_prompt_block(profile)
+    assert "Use this profile as style guidance only" in block
+    assert "Do not omit or alter grounded claims" in block
+    assert "operator-led" in block
+    assert "Ignored fourth sample" not in block
+    assert apply_brand_voice_to_system_prompt("Base\n{brand_voice}", profile) == (
+        "Base\n" + block
+    )
+
+    parsed = brand_voice_result_metadata(
+        {"subject": "No synergy pitch", "body": "We explain the tradeoff."},
+        profile,
+    )
+
+    assert parsed["_brand_voice_profile"]["id"] == "acme-main"
+    audit = parsed["_brand_voice_audit"]
+    assert audit["passed"] is False
+    assert audit["banned_terms"] == ["synergy"]
+    assert "preferred_pov_second_person_not_detected" in audit["warnings"]
+
+
+def test_brand_voice_profile_scope_mismatch_fails_closed() -> None:
+    with pytest.raises(ValueError, match="account_id does not match"):
+        brand_voice_profile_from_mapping(
+            {"account_id": "acct-2", "name": "Wrong tenant", "descriptors": ["warm"]},
+            scope=TenantScope(account_id="acct-1"),
+        )
+
+
+def test_brand_voice_profile_id_without_inline_profile_fails_closed() -> None:
+    with pytest.raises(ValueError, match="requires inputs.brand_voice"):
+        brand_voice_profile_from_mapping(
+            None,
+            scope=TenantScope(account_id="acct-1"),
+            profile_id="acme-main",
+        )
+
+
+def test_brand_voice_profile_id_mismatch_fails_closed() -> None:
+    with pytest.raises(ValueError, match="id does not match"):
+        brand_voice_profile_from_mapping(
+            {"id": "stale-profile", "descriptors": ["warm"]},
+            scope=TenantScope(account_id="acct-1"),
+            profile_id="acme-main",
+        )
+
+
+def test_brand_voice_profile_caps_descriptor_and_banned_term_lengths() -> None:
+    long_descriptor = "d" * 500
+    long_term = "b" * 500
+
+    profile = brand_voice_profile_from_mapping(
+        {
+            "id": "acme-main",
+            "descriptors": [long_descriptor],
+            "banned_terms": [long_term],
+        },
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert profile is not None
+    assert profile.descriptors == ("d" * 120,)
+    assert profile.banned_terms == ("b" * 120,)
+
+
+def test_brand_voice_audit_flags_reading_level_band() -> None:
+    profile = brand_voice_profile_from_mapping(
+        {"id": "acme-main", "reading_level": "concise"},
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    parsed = brand_voice_result_metadata(
+        {
+            "body": (
+                "This sentence intentionally keeps going with many extra words "
+                "so the concise reading level detector has a clear breach."
+            )
+        },
+        profile,
+    )
+
+    assert parsed["_brand_voice_audit"]["passed"] is False
+    assert "reading_level_concise_exceeded" in parsed["_brand_voice_audit"]["warnings"]

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -290,6 +290,44 @@ async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
 
 
 @pytest.mark.asyncio
+async def test_generate_injects_brand_voice_and_persists_audit_metadata():
+    service, _intelligence, campaigns, llm, _skills = _service(
+        [{"id": "opp-1", "company_name": "Acme", "pain": "pricing pressure"}],
+        [json.dumps({
+            "subject": "Acme pricing signal",
+            "body": "<p>You get the tradeoff without synergy.</p>",
+            "cta": "Reply",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="churning_company",
+        channels=("email_cold",),
+        brand_voice={
+            "id": "acme-main",
+            "account_id": "acct-1",
+            "name": "Acme main voice",
+            "descriptors": ["plainspoken", "operator-led"],
+            "exemplars": ["You get the tradeoff in one paragraph."],
+            "banned_terms": ["synergy"],
+            "preferred_pov": "second_person",
+        },
+    )
+
+    assert result.generated == 1
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "## Brand voice" in system_prompt
+    assert "operator-led" in system_prompt
+    assert "You get the tradeoff in one paragraph." in system_prompt
+    draft = campaigns.saved[0]["drafts"][0]
+    assert draft.metadata["brand_voice_profile"]["id"] == "acme-main"
+    assert draft.metadata["brand_voice_profile"]["account_id"] == "acct-1"
+    assert draft.metadata["brand_voice_audit"]["passed"] is False
+    assert draft.metadata["brand_voice_audit"]["banned_terms"] == ["synergy"]
+
+
+@pytest.mark.asyncio
 async def test_generate_merges_opportunity_defaults_into_prompt_and_metadata():
     service, _intelligence, campaigns, llm, _skills = _service(
         [{"id": "opp-1", "company_name": "Acme", "vendor": "Slack"}],

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -996,6 +996,52 @@ def test_generated_asset_router_repairs_landing_page_draft_and_returns_review_ro
     assert asset_api.LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY not in body["metadata"]
 
 
+def test_generated_asset_router_threads_brand_voice_to_landing_page_repair() -> None:
+    repaired_row = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    needs_repair = {
+        **repaired_row,
+        "meta": {
+            key: value
+            for key, value in repaired_row["meta"].items()
+            if key != "description"
+        },
+    }
+    pool = _LockingEditableLandingPagePool(needs_repair)
+    llm = _LLM([_landing_page_generation_response(repaired_row)])
+    skills = _Skills()
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+        llm=llm,
+        skills=skills,
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair",
+        json={
+            "brand_voice_profile_id": "acme-main",
+            "brand_voice": {
+                "id": "acme-main",
+                "account_id": "acct_1",
+                "name": "Acme main voice",
+                "descriptors": ["plainspoken"],
+                "exemplars": ["You explain the tradeoff before the CTA."],
+                "banned_terms": ["synergy"],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "## Brand voice" in system_prompt
+    assert "plainspoken" in system_prompt
+    assert "You explain the tradeoff before the CTA." in system_prompt
+    update_args = pool.fetch_calls[2][1]
+    persisted_metadata = json.loads(update_args[9])
+    assert persisted_metadata["brand_voice_profile"]["id"] == "acme-main"
+    assert persisted_metadata["brand_voice_audit"]["passed"] is True
+
+
 def test_generated_asset_router_repairs_without_advisory_lock_connection(caplog) -> None:
     repaired_row = {**_ready_landing_page_row(), "status": "quality_blocked"}
     needs_repair = {

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -71,6 +71,35 @@ def test_plan_maps_report_to_report_generation_service():
     }
 
 
+def test_plan_threads_brand_voice_profile_id_to_llm_copy_outputs_only():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": [
+                "email_campaign",
+                "blog_post",
+                "landing_page",
+                "sales_brief",
+                "social_post",
+            ],
+            "brand_voice_profile_id": "acme-main",
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "topic": "Churn pressure",
+                "audience": "B2B SaaS founders",
+                "source_material": [{"review_text": "Pricing pressure."}],
+            },
+        }
+    )
+
+    configs = {step["output"]: step["config"] for step in plan["steps"]}
+    assert configs["email_campaign"]["brand_voice_profile_id"] == "acme-main"
+    assert configs["blog_post"]["brand_voice_profile_id"] == "acme-main"
+    assert configs["landing_page"]["brand_voice_profile_id"] == "acme-main"
+    assert configs["sales_brief"]["brand_voice_profile_id"] == "acme-main"
+    assert "brand_voice_profile_id" not in configs["social_post"]
+
+
 def test_plan_threads_structured_reasoning_preset_to_report_and_sales_brief():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -76,6 +76,7 @@ class _OpportunityService:
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
         topic: str | None = None,
+        brand_voice: Any | None = None,
         opportunity_defaults: Mapping[str, Any] | None = None,
         source_material: Any | None = None,
         **extras: Any,
@@ -97,6 +98,7 @@ class _OpportunityService:
             "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
             "quality_gates_enabled": quality_gates_enabled,
             "topic": topic,
+            "brand_voice": brand_voice,
             "opportunity_defaults": dict(opportunity_defaults or {}),
             "source_material": source_material,
             "extras": dict(extras),
@@ -134,6 +136,7 @@ class _StrictCampaignService:
         quality_revalidation_enabled: bool | None = None,
         quality_prompt_proof_term_limit: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
+        brand_voice: Any | None = None,
     ) -> _Result:
         del scope
         del target_mode
@@ -146,6 +149,7 @@ class _StrictCampaignService:
         del quality_revalidation_enabled
         del quality_prompt_proof_term_limit
         del parse_retry_response_excerpt_chars
+        del brand_voice
         self.calls += 1
         return _Result()
 
@@ -305,6 +309,7 @@ class _LandingPageService:
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
         quality_repair_attempts: int | None = None,
+        brand_voice: Any | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -316,6 +321,7 @@ class _LandingPageService:
             "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
             "quality_gates_enabled": quality_gates_enabled,
             "quality_repair_attempts": quality_repair_attempts,
+            "brand_voice": brand_voice,
             "extras": dict(extras),
         })
         return _Result()
@@ -533,6 +539,115 @@ async def test_execute_runs_landing_page_with_marketing_campaign_input() -> None
     assert campaign.persona == "B2B SaaS founders"
     assert campaign.vendors == ("HubSpot", "Salesforce")
     assert campaign.tags == ("retention", "pipeline")
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_brand_voice_to_llm_copy_outputs_only() -> None:
+    campaign = _OpportunityService()
+    blog = _OpportunityService()
+    sales_brief = _OpportunityService()
+    landing_page = _LandingPageService()
+    social_post = _OpportunityService()
+    scope = TenantScope(account_id="acct-1")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": [
+                "email_campaign",
+                "blog_post",
+                "landing_page",
+                "sales_brief",
+                "social_post",
+            ],
+            "target_mode": "vendor_retention",
+            "brand_voice_profile_id": "acme-main",
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "topic": "Churn pressure",
+                "audience": "B2B SaaS founders",
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "review_text": "Pricing is a problem after renewal.",
+                    }
+                ],
+                "brand_voice": {
+                    "id": "acme-main",
+                    "account_id": "acct-1",
+                    "name": "Acme main voice",
+                    "descriptors": ["plainspoken"],
+                    "exemplars": ["You get the tradeoff in one paragraph."],
+                },
+            },
+        },
+        services=ContentOpsExecutionServices(
+            campaign=campaign,
+            blog_post=blog,
+            landing_page=landing_page,
+            sales_brief=sales_brief,
+            social_post=social_post,
+        ),
+        scope=scope,
+    )
+
+    assert result["status"] == "completed"
+    for call in (
+        campaign.calls[0],
+        blog.calls[0],
+        sales_brief.calls[0],
+        landing_page.calls[0],
+    ):
+        assert call["brand_voice"].id == "acme-main"
+        assert call["brand_voice"].account_id == "acct-1"
+    assert social_post.calls[0]["brand_voice"] is None
+
+
+@pytest.mark.asyncio
+async def test_execute_blocks_brand_voice_profile_id_without_inline_profile() -> None:
+    campaign = _OpportunityService()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "brand_voice_profile_id": "acme-main",
+            "inputs": {"target_account": "Acme", "offer": "Churn audit"},
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert result["status"] == "blocked"
+    assert result["errors"] == [{"reason": "brand_voice_profile_id requires inputs.brand_voice"}]
+    assert campaign.calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_blocks_cross_tenant_inline_brand_voice() -> None:
+    campaign = _OpportunityService()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "brand_voice": {
+                    "account_id": "acct-2",
+                    "name": "Wrong tenant voice",
+                    "descriptors": ["warm"],
+                },
+            },
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert result["status"] == "blocked"
+    assert result["errors"] == [
+        {"reason": "brand_voice.account_id does not match tenant scope"}
+    ]
+    assert campaign.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -952,6 +952,44 @@ async def test_repair_draft_sends_current_draft_and_repair_issues_and_updates_sa
 
 
 @pytest.mark.asyncio
+async def test_repair_draft_applies_brand_voice_to_repaired_landing_page() -> None:
+    needs_repair = json.loads(_valid_response())
+    needs_repair["meta"].pop("description")
+    draft = _draft_from_response(needs_repair)
+    service, landing_pages, llm, _skills, _rp = _service(
+        responses=[_valid_response()],
+    )
+
+    result = await service.repair_draft(
+        scope=TenantScope(account_id="acct-1"),
+        draft=draft,
+        brand_voice_profile_id="acme-main",
+        brand_voice={
+            "id": "acme-main",
+            "account_id": "acct-1",
+            "name": "Acme main voice",
+            "descriptors": ["plainspoken"],
+            "exemplars": ["You explain the tradeoff before the CTA."],
+            "banned_terms": ["synergy"],
+        },
+    )
+
+    assert result.generated == 1
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "## Brand voice" in system_prompt
+    assert "plainspoken" in system_prompt
+    assert "You explain the tradeoff before the CTA." in system_prompt
+    repaired = landing_pages.updated[0]["draft"]
+    assert repaired.metadata["brand_voice_profile"] == {
+        "id": "acme-main",
+        "account_id": "acct-1",
+        "name": "Acme main voice",
+        "descriptors": ["plainspoken"],
+    }
+    assert repaired.metadata["brand_voice_audit"]["passed"] is True
+
+
+@pytest.mark.asyncio
 async def test_repair_draft_rejects_approved_draft_without_llm_call() -> None:
     draft = _draft_from_response(_valid_response(), status="approved")
     service, landing_pages, llm, _skills, _rp = _service()


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Brand-Voice-Profile.md
Slice phase: Vertical slice

Issue #1276 needs a real brand voice path for content-ops copy generation. This PR adds the first executable request-time `BrandVoiceProfile` contract, fail-closed tenant scoping, prompt injection for the four LLM copy outputs named in the issue, landing-page repair preservation, and deterministic audit metadata for explicit voice rules.

## Intentional
- No profile CRUD/API/UI in this PR. The vertical slice proves the generation contract first; stored profile management is deferred to the next profile-storage slice.
- No social-post voice support. Current social posts are deterministic template assembly, not LLM generation.
- No automated "voice match" score. This PR checks only explicit rule-shaped constraints and leaves actual voice fidelity to human review.
- No attempt to reconstruct a full repair profile from saved draft metadata. Repair callers must re-supply the full profile until stored profile lookup lands.
- No output-variations work. #1268 remains open and owned elsewhere.

## Deferred
- `PR-Content-Ops-Brand-Voice-Profile-Storage`: account-scoped stored `brand_voice_profiles` repository, API CRUD/list endpoints, and UI selector.
- `PR-Content-Ops-Brand-Voice-Presets`: shipped descriptor-only preset library.
- `PR-Content-Ops-Brand-Voice-Onboarding`: scrape/upload samples and pre-fill a custom profile for human edit.
- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can consume brand voice.

## Parked hardening
- None.

## Verification
- `pytest tests/test_support_ticket_provider_landing_blog_execute.py -q` -- 13 passed.
- `pytest tests/test_extracted_brand_voice.py tests/test_extracted_landing_page_generation.py tests/test_extracted_content_asset_api.py -q` -- 140 passed.
- `pytest tests/test_extracted_brand_voice.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_generation_plan.py tests/test_extracted_campaign_generation.py -q` -- 165 passed.
- `python -m py_compile extracted_content_pipeline/brand_voice.py extracted_content_pipeline/landing_page_generation.py extracted_content_pipeline/api/generated_assets.py extracted_content_pipeline/content_ops_execution.py` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` -- 146 matching tests enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 295 reasoning-core tests passed, then 3081 extracted-content tests passed / 10 skipped.
- `git diff --check` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-brand-voice-profile.md` -- passed.

## Diff size
19 files, +1065 / -23. Over the 400 LOC soft cap because the minimum executable slice spans request/API parsing, plan metadata, dispatcher routing, four generator prompt hooks, repair-path wiring, the helper module, and failure-branch tests.
