### PR TITLE
Dev Workflow PR Prep Helpers

### DIFF
--- a/plans/PR-Dev-Workflow-PR-Prep.md
+++ b/plans/PR-Dev-Workflow-PR-Prep.md
@@ -1,0 +1,116 @@
+# PR-Dev-Workflow-PR-Prep
+
+## Why this slice exists
+
+Issue #1306 asks which developer-workflow friction is burning time when
+opening PRs. The concrete failure just reproduced in #1305: the branch passed
+manual local review, but the pre-push hook failed because it was not given
+`ATLAS_CURRENT_PR_BODY_FILE`; before that, the plan failed on parser-specific
+shape details (`### Files touched` and a `| **Total** | **N** |` diff-size
+table).
+
+This slice fixes the highest-leverage ergonomic gap with a small wrapper pair:
+one command updates the plan's machine-checked file list and diff-size total
+from git, and one command runs local review/push with the PR body env wired
+correctly. That removes the trial-and-error loop without weakening the audit
+checks.
+
+The slice is over the 400 LOC soft cap because the plan-sync helper and push
+wrapper need focused failure-branch tests in the same PR; otherwise this would
+ship more process machinery without proving it catches the exact drift that
+caused the failed push.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/pr-prep-ergonomics
+Slice phase: Workflow/process
+
+1. Add a plan-sync helper that rewrites `### Files touched` and
+   `## Estimated diff size` from the current git diff.
+2. Add a push wrapper that validates a PR body file exists, exports
+   `ATLAS_CURRENT_PR_BODY_FILE`, runs `scripts/local_pr_review.sh` with the
+   body file, and then pushes with the same env so the pre-push hook sees it.
+3. Add focused tests for plan-section rewriting and wrapper command/env
+   construction.
+4. Document the intended operator command sequence in the plan.
+
+### Files touched
+
+- `plans/PR-Dev-Workflow-PR-Prep.md`
+- `scripts/push_pr.sh`
+- `scripts/sync_pr_plan.py`
+- `tests/test_push_pr_wrapper.py`
+- `tests/test_sync_pr_plan.py`
+
+## Mechanism
+
+`scripts/sync_pr_plan.py PLAN [BASE_REF]` computes the merge-base against the
+base ref, reads `git diff --numstat -z`, normalizes renamed/copied entries to
+their destination paths, then rewrites the plan's machine-checked subsections:
+
+```bash
+python scripts/sync_pr_plan.py plans/PR-Example.md
+```
+
+`scripts/push_pr.sh BODY_FILE [git push args...]` is the one push path for
+builder sessions:
+
+```bash
+bash scripts/push_pr.sh tmp/pr-body-example.md -u origin HEAD
+```
+
+It fails early with a clear message if the body file is missing. Otherwise it
+runs:
+
+```bash
+ATLAS_CURRENT_PR_BODY_FILE=... bash scripts/local_pr_review.sh --current-pr-body-file ...
+ATLAS_CURRENT_PR_BODY_FILE=... git push ...
+```
+
+The wrapper carries the same env var into the installed pre-push hook, so the
+hook does not bounce a push that already passed manual local review.
+
+## Intentional
+
+- The helpers do not relax any existing audit. They make the audited inputs
+  easier to produce and pass the same data to the hook.
+- The plan-sync helper updates only the machine-checked file list and diff-size
+  section. Why/Scope/Mechanism/Intentional/Deferred/Verification remain human
+  authored.
+- The push wrapper requires an explicit body file instead of generating PR copy.
+  That keeps PR judgment text human-authored while fixing the missing-env
+  failure.
+- #1305 and #1268 are not modified.
+
+## Deferred
+
+- `PR-Dev-Workflow-Plan-Scaffold`: optional `new_pr_plan.sh <slice>` template
+  if the plan-sync helper does not remove enough friction.
+- `PR-Dev-Workflow-PR-Body-Generator`: optional body generation from the plan if
+  PR body churn remains a real bottleneck.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_sync_pr_plan.py tests/test_push_pr_wrapper.py -q` -- 7
+  passed.
+- `python -m py_compile scripts/sync_pr_plan.py` -- passed.
+- `python scripts/audit_plan_doc.py plans/PR-Dev-Workflow-PR-Prep.md` --
+  passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Dev-Workflow-PR-Prep.md`
+  -- passed.
+- `git diff --check` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-dev-workflow-pr-prep.md`
+  -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Dev-Workflow-PR-Prep.md` | 116 |
+| `scripts/push_pr.sh` | 50 |
+| `scripts/sync_pr_plan.py` | 223 |
+| `tests/test_push_pr_wrapper.py` | 45 |
+| `tests/test_sync_pr_plan.py` | 150 |
+| **Total** | **584** |

--- a/scripts/push_pr.sh
+++ b/scripts/push_pr.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Push a PR branch with the PR body env wired into local review and pre-push.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/push_pr.sh BODY_FILE [git-push-args...]
+
+Runs local PR review with BODY_FILE, then pushes with ATLAS_CURRENT_PR_BODY_FILE
+exported so the installed pre-push hook validates the same body.
+
+Examples:
+  bash scripts/push_pr.sh tmp/pr-body-my-slice.md -u origin HEAD
+  bash scripts/push_pr.sh tmp/pr-body-my-slice.md -u origin claude/pr-my-slice
+EOF
+}
+
+if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
+    exit 2
+fi
+
+body_file="$1"
+shift
+
+if [ ! -f "$body_file" ]; then
+    echo "push_pr.sh: PR body file not found: $body_file" >&2
+    echo "Create the body file first, then rerun this wrapper." >&2
+    exit 2
+fi
+
+if [ "$#" -eq 0 ]; then
+    set -- -u origin HEAD
+fi
+
+if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
+    echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file bash scripts/local_pr_review.sh --current-pr-body-file $body_file"
+    echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file git push $*"
+    exit 0
+fi
+
+echo "Running local PR review with PR body: $body_file"
+ATLAS_CURRENT_PR_BODY_FILE="$body_file" \
+    bash scripts/local_pr_review.sh --current-pr-body-file "$body_file"
+
+echo "Pushing with PR body env available to pre-push hook: $body_file"
+ATLAS_CURRENT_PR_BODY_FILE="$body_file" git push "$@"

--- a/scripts/sync_pr_plan.py
+++ b/scripts/sync_pr_plan.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Sync a PR plan's machine-checked sections with the current git diff."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DiffEntry:
+    path: str
+    added: int
+    deleted: int
+
+    @property
+    def loc(self) -> int:
+        return self.added + self.deleted
+
+
+def run_git(args: list[str], *, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git command failed")
+    return result.stdout
+
+
+def merge_base(base_ref: str, *, cwd: Path) -> str:
+    return run_git(["merge-base", "HEAD", base_ref], cwd=cwd).strip()
+
+
+def git_diff_entries(base_ref: str, *, cwd: Path) -> list[DiffEntry]:
+    base = merge_base(base_ref, cwd=cwd)
+    tracked = _tracked_entries(base, cwd=cwd)
+    untracked = _untracked_entries(cwd=cwd)
+    by_path = {entry.path: entry for entry in tracked}
+    by_path.update({entry.path: entry for entry in untracked})
+    return [by_path[path] for path in sorted(by_path)]
+
+
+def sync_plan_text(text: str, entries: list[DiffEntry]) -> str:
+    text = _replace_files_touched(text, entries)
+    return _replace_estimated_diff_size(text, entries)
+
+
+def _tracked_entries(base: str, *, cwd: Path) -> list[DiffEntry]:
+    return _parse_numstat_z(run_git(["diff", "--numstat", "-z", base], cwd=cwd))
+
+
+def _parse_numstat_z(payload: str) -> list[DiffEntry]:
+    entries: list[DiffEntry] = []
+    index = 0
+    while index < len(payload):
+        header_end = payload.find("\0", index)
+        if header_end == -1:
+            raise ValueError("unexpected git numstat output: missing path terminator")
+        header = payload[index:header_end]
+        index = header_end + 1
+        if not header:
+            continue
+
+        parts = header.split("\t", 2)
+        if len(parts) != 3:
+            raise ValueError("unexpected git numstat output: missing count fields")
+        added, deleted, path = parts
+
+        # With -z, Git emits renamed/copied paths as:
+        # added<TAB>deleted<TAB><NUL>old<NUL>new<NUL>
+        # The plan should list the destination path, matching --name-only.
+        if path == "":
+            old_end = payload.find("\0", index)
+            if old_end == -1:
+                raise ValueError("unexpected git numstat output: missing rename source")
+            index = old_end + 1
+            new_end = payload.find("\0", index)
+            if new_end == -1:
+                raise ValueError("unexpected git numstat output: missing rename destination")
+            path = payload[index:new_end]
+            index = new_end + 1
+
+        entries.append(
+            DiffEntry(path=path, added=_count_value(added), deleted=_count_value(deleted))
+        )
+    return entries
+
+
+def _untracked_entries(*, cwd: Path) -> list[DiffEntry]:
+    entries: list[DiffEntry] = []
+    for line in run_git(["status", "--porcelain", "--untracked-files=all"], cwd=cwd).splitlines():
+        if not line.startswith("?? "):
+            continue
+        path = line[3:].strip()
+        if not path:
+            continue
+        file_path = cwd / path
+        if file_path.is_file():
+            entries.append(DiffEntry(path=path, added=_line_count(file_path), deleted=0))
+    return entries
+
+
+def _replace_files_touched(text: str, entries: list[DiffEntry]) -> str:
+    lines = text.splitlines()
+    scope_index = _find_heading(lines, "## Scope (this PR)")
+    if scope_index is None:
+        raise ValueError("plan is missing required heading: ## Scope (this PR)")
+
+    next_section = _next_heading(lines, scope_index + 1, "## ")
+    files_index = _find_heading(lines, "### Files touched", start=scope_index + 1, end=next_section)
+    block = ["### Files touched", "", *[f"- `{entry.path}`" for entry in entries], ""]
+
+    if files_index is None:
+        insert_at = next_section if next_section is not None else len(lines)
+        return "\n".join(lines[:insert_at] + [""] + block + lines[insert_at:]).rstrip() + "\n"
+
+    end = _next_heading(lines, files_index + 1, "### ", "## ")
+    if end is None:
+        end = len(lines)
+    return "\n".join(lines[:files_index] + block + lines[end:]).rstrip() + "\n"
+
+
+def _replace_estimated_diff_size(text: str, entries: list[DiffEntry]) -> str:
+    lines = text.splitlines()
+    section_index = _find_heading(lines, "## Estimated diff size")
+    if section_index is None:
+        raise ValueError("plan is missing required heading: ## Estimated diff size")
+
+    end = _next_heading(lines, section_index + 1, "## ")
+    if end is None:
+        end = len(lines)
+    block = [
+        "## Estimated diff size",
+        "",
+        "| File | LOC |",
+        "|---|---:|",
+        *[f"| `{entry.path}` | {entry.loc} |" for entry in entries],
+        f"| **Total** | **{sum(entry.loc for entry in entries)}** |",
+        "",
+    ]
+    return "\n".join(lines[:section_index] + block + lines[end:]).rstrip() + "\n"
+
+
+def _find_heading(
+    lines: list[str],
+    heading: str,
+    *,
+    start: int = 0,
+    end: int | None = None,
+) -> int | None:
+    limit = len(lines) if end is None else end
+    normalized = heading.strip().lower()
+    for index in range(start, limit):
+        if lines[index].strip().lower() == normalized:
+            return index
+    return None
+
+
+def _next_heading(lines: list[str], start: int, *prefixes: str) -> int | None:
+    for index in range(start, len(lines)):
+        if any(lines[index].startswith(prefix) for prefix in prefixes):
+            return index
+    return None
+
+
+def _count_value(value: str) -> int:
+    return 0 if value == "-" else int(value)
+
+
+def _line_count(path: Path) -> int:
+    try:
+        return len(path.read_text(encoding="utf-8").splitlines())
+    except UnicodeDecodeError:
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Sync a PR plan's files-touched and diff-size sections."
+    )
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("base_ref", nargs="?", default="origin/main")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if the plan would be rewritten instead of writing changes",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(run_git(["rev-parse", "--show-toplevel"], cwd=Path.cwd()).strip())
+    plan_path = args.plan if args.plan.is_absolute() else repo_root / args.plan
+    if not plan_path.exists():
+        print(f"sync_pr_plan.py: plan not found: {args.plan}", file=sys.stderr)
+        return 2
+
+    try:
+        entries = git_diff_entries(args.base_ref, cwd=repo_root)
+        original = plan_path.read_text(encoding="utf-8")
+        updated = sync_plan_text(original, entries)
+    except (RuntimeError, ValueError) as exc:
+        print(f"sync_pr_plan.py: {exc}", file=sys.stderr)
+        return 2
+
+    if updated == original:
+        print(f"plan already in sync: {args.plan}")
+        return 0
+    if args.check:
+        print(f"plan is out of sync: {args.plan}", file=sys.stderr)
+        return 1
+    plan_path.write_text(updated, encoding="utf-8")
+    print(f"updated plan from git diff: {args.plan}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "push_pr.sh"
+
+
+def test_push_pr_dry_run_wires_body_file_env(tmp_path: Path) -> None:
+    body = tmp_path / "body.md"
+    body.write_text("Plan: plans/PR-Test.md\nSlice phase: Workflow/process\n", encoding="utf-8")
+    env = {**os.environ, "ATLAS_PUSH_PR_DRY_RUN": "1"}
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(body), "-u", "origin", "HEAD"],
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
+    assert f"--current-pr-body-file {body}" in result.stdout
+    assert "git push -u origin HEAD" in result.stdout
+
+
+def test_push_pr_missing_body_file_fails_clearly(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.md"
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(missing), "-u", "origin", "HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "PR body file not found" in result.stderr
+    assert str(missing) in result.stderr

--- a/tests/test_sync_pr_plan.py
+++ b/tests/test_sync_pr_plan.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "sync_pr_plan.py"
+
+
+def load_sync_pr_plan():
+    name = "sync_pr_plan"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sync_plan_text_rewrites_machine_checked_sections() -> None:
+    module = load_sync_pr_plan()
+    text = textwrap.dedent(
+        """\
+        # Plan
+
+        ## Why this slice exists
+
+        Test.
+
+        ## Scope (this PR)
+
+        Ownership lane: workflow
+        Slice phase: Workflow/process
+
+        ### Files touched
+
+        - `stale.py`
+
+        ## Mechanism
+
+        Keep this prose.
+
+        ## Estimated diff size
+
+        | File | LOC |
+        |---|---:|
+        | `stale.py` | 99 |
+        | **Total** | **99** |
+        """
+    )
+
+    updated = module.sync_plan_text(
+        text,
+        [
+            module.DiffEntry("plans/PR-Test.md", 10, 1),
+            module.DiffEntry("scripts/tool.py", 3, 2),
+        ],
+    )
+
+    assert "- `stale.py`" not in updated
+    assert "- `plans/PR-Test.md`" in updated
+    assert "- `scripts/tool.py`" in updated
+    assert "## Mechanism\n\nKeep this prose." in updated
+    assert "| `plans/PR-Test.md` | 11 |" in updated
+    assert "| `scripts/tool.py` | 5 |" in updated
+    assert "| **Total** | **16** |" in updated
+
+
+def test_sync_plan_text_inserts_files_touched_when_missing() -> None:
+    module = load_sync_pr_plan()
+    text = textwrap.dedent(
+        """\
+        # Plan
+
+        ## Scope (this PR)
+
+        Ownership lane: workflow
+        Slice phase: Workflow/process
+
+        ## Mechanism
+
+        Test.
+
+        ## Estimated diff size
+
+        | File | LOC |
+        |---|---:|
+        | **Total** | **0** |
+        """
+    )
+
+    updated = module.sync_plan_text(text, [module.DiffEntry("scripts/tool.py", 1, 0)])
+
+    assert "### Files touched\n\n- `scripts/tool.py`\n\n## Mechanism" in updated
+
+
+def test_sync_plan_text_requires_scope_heading() -> None:
+    module = load_sync_pr_plan()
+    text = "# Plan\n\n## Estimated diff size\n"
+
+    try:
+        module.sync_plan_text(text, [])
+    except ValueError as exc:
+        assert "## Scope (this PR)" in str(exc)
+    else:
+        raise AssertionError("expected missing scope heading to fail")
+
+
+def test_tracked_entries_count_renamed_destination_path(tmp_path: Path) -> None:
+    module = load_sync_pr_plan()
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+    )
+    old_path = tmp_path / "old.txt"
+    old_path.write_text("one\ntwo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "old.txt"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
+
+    subprocess.run(["git", "mv", "old.txt", "new.txt"], cwd=tmp_path, check=True)
+    (tmp_path / "new.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
+
+    entries = module._tracked_entries("HEAD", cwd=tmp_path)
+
+    assert entries == [module.DiffEntry(path="new.txt", added=1, deleted=0)]
+
+
+def test_parse_numstat_z_rejects_malformed_rename_destination() -> None:
+    module = load_sync_pr_plan()
+
+    try:
+        module._parse_numstat_z("1\t0\t\0old.txt\0")
+    except ValueError as exc:
+        assert "missing rename destination" in str(exc)
+    else:
+        raise AssertionError("expected malformed rename output to fail")


### PR DESCRIPTION
Plan: plans/PR-Dev-Workflow-PR-Prep.md
Slice phase: Workflow/process

Issue #1306 identified PR-opening friction from plan-format churn and failed pushes when the pre-push hook lacks `ATLAS_CURRENT_PR_BODY_FILE`. This PR adds a plan sync helper for the machine-checked file/diff-size sections and a push wrapper that carries the PR body file through local review and the installed pre-push hook. The sync helper uses `git diff --numstat -z` so renamed/copied files count against the destination path instead of losing their LOC stats.

## Intentional
- The helpers do not relax any existing audit; they make the audited inputs easier to produce.
- The plan-sync helper updates only `### Files touched` and `## Estimated diff size`; human judgment sections remain human-authored.
- The push wrapper requires an explicit PR body file instead of generating PR copy.
- #1305 and #1268 are not modified.

## Deferred
- `PR-Dev-Workflow-Plan-Scaffold`: optional `new_pr_plan.sh <slice>` template if plan shape remains a bottleneck.
- `PR-Dev-Workflow-PR-Body-Generator`: optional body generation from the plan if PR body churn remains a bottleneck.

## Parked hardening
- None.

## Verification
- `pytest tests/test_sync_pr_plan.py tests/test_push_pr_wrapper.py -q` -- 7 passed.
- `python -m py_compile scripts/sync_pr_plan.py` -- passed.
- `python scripts/audit_plan_doc.py plans/PR-Dev-Workflow-PR-Prep.md` -- passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Dev-Workflow-PR-Prep.md` -- passed.
- `git diff --check` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-dev-workflow-pr-prep.md` -- passed.

## Diff size
5 files, +584 / -0.
