### PR TITLE
Dev Workflow Plan Scaffold

### DIFF
--- a/plans/PR-Dev-Workflow-Plan-Scaffold.md
+++ b/plans/PR-Dev-Workflow-Plan-Scaffold.md
@@ -1,0 +1,102 @@
+# PR-Dev-Workflow-Plan-Scaffold
+
+## Why this slice exists
+
+PR #1307 removed two PR-prep friction points: it syncs the plan's
+machine-checked file/diff-size sections from git and pushes with
+`ATLAS_CURRENT_PR_BODY_FILE` wired through the local review and pre-push hook.
+The remaining item from that review is the initial plan-shape scaffold. Today a
+builder still has to hand-type the seven-section `AGENTS.md` structure before
+`scripts/sync_pr_plan.py` can help; missing or misspelled headings then waste a
+review cycle.
+
+This slice adds a narrow skeleton emitter for new plans. It should create a
+valid starting shape, refuse risky or ambiguous writes, and hand off cleanly to
+the existing sync/push helpers without weakening any audit.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/pr-prep-ergonomics
+Slice phase: Workflow/process
+
+1. Add `scripts/new_pr_plan.sh` to create a PR-prefixed plan file with the seven
+   required plan sections, ownership-lane and slice-phase lines, a `### Files
+   touched` placeholder, and a zero-row diff-size table.
+2. Refuse missing/unsafe slice names and existing plan files unless `--force`
+   is explicit.
+3. Add focused tests that exercise creation, default `PR-` prefixing,
+   overwrite refusal, invalid-name rejection, and audit compatibility.
+4. Keep PR body generation deferred; this helper emits only the plan skeleton.
+
+### Files touched
+
+- `plans/PR-Dev-Workflow-Plan-Scaffold.md`
+- `scripts/new_pr_plan.sh`
+- `tests/test_new_pr_plan.py`
+
+## Mechanism
+
+The helper runs from any directory inside a Git worktree:
+
+```bash
+bash scripts/new_pr_plan.sh Dev-Workflow-Plan-Scaffold \
+  --lane dev-workflow/pr-prep-ergonomics \
+  --phase Workflow/process
+```
+
+It resolves the repository root with `git rev-parse --show-toplevel`,
+normalizes `Dev-Workflow-Plan-Scaffold` to
+`plans/PR-Dev-Workflow-Plan-Scaffold.md`, creates `plans/` when needed, and
+writes the fixed AGENTS seven-section scaffold. The output includes an empty
+files-touched list and an initial `| **Total** | **0** |` diff-size table, so
+the next command can be `python scripts/sync_pr_plan.py <plan>`.
+
+Safety checks fail before writing when the slice name is missing, includes path
+separators/traversal, or the target plan already exists without `--force`.
+
+## Intentional
+
+- The script is Bash to match `scripts/push_pr.sh` and keep the operator
+  command lightweight.
+- The helper does not infer lane, phase, deferred work, or verification from
+  git state. It creates the contract shape; the builder still supplies
+  judgment content.
+- The generated plan is an editable scaffold, not a guarantee that local review
+  will pass before the builder fills in the human-authored sections and runs
+  `sync_pr_plan.py`.
+- #1268 remains read-only and is not modified.
+
+## Deferred
+
+- `PR-Dev-Workflow-PR-Body-Generator`: optional body generation from the plan if
+  PR body churn remains a real bottleneck after this scaffold lands.
+- Brand voice storage/API/UI resumes after this workflow slice is opened and
+  handed back.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_new_pr_plan.py tests/test_sync_pr_plan.py tests/test_push_pr_wrapper.py -q` --
+  13 passed.
+- `bash -n scripts/new_pr_plan.sh` -- passed.
+- Temp-repo E2E smoke:
+  `bash scripts/new_pr_plan.sh Sample-Workflow --lane workflow/test --phase Workflow/process`,
+  then `python scripts/audit_plan_doc.py <temp>/plans/PR-Sample-Workflow.md`
+  -- passed.
+- `python scripts/audit_plan_doc.py plans/PR-Dev-Workflow-Plan-Scaffold.md`
+  -- passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Dev-Workflow-Plan-Scaffold.md`
+  -- passed.
+- `git diff --check` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-dev-workflow-plan-scaffold.md`
+  -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Dev-Workflow-Plan-Scaffold.md` | 102 |
+| `scripts/new_pr_plan.sh` | 145 |
+| `tests/test_new_pr_plan.py` | 120 |
+| **Total** | **367** |

--- a/scripts/new_pr_plan.sh
+++ b/scripts/new_pr_plan.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Create the initial AGENTS.md seven-section PR plan scaffold.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/new_pr_plan.sh SLICE [--lane LANE] [--phase PHASE] [--force]
+
+Creates plans/PR-<SLICE>.md with the required AGENTS.md plan sections.
+SLICE may be passed with or without the PR- prefix.
+
+Examples:
+  bash scripts/new_pr_plan.sh Content-Ops-Thing --lane content-ops/example --phase "Vertical slice"
+  bash scripts/new_pr_plan.sh PR-Dev-Workflow-Plan-Scaffold --lane dev-workflow/pr-prep-ergonomics --phase Workflow/process
+EOF
+}
+
+die() {
+    echo "new_pr_plan.sh: $*" >&2
+    exit 2
+}
+
+slice=""
+lane="TODO-ownership-lane"
+phase="TODO-slice-phase"
+force=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --force)
+            force=1
+            ;;
+        --lane)
+            shift
+            [ "$#" -gt 0 ] || die "--lane requires a value"
+            lane="$1"
+            ;;
+        --phase)
+            shift
+            [ "$#" -gt 0 ] || die "--phase requires a value"
+            phase="$1"
+            ;;
+        --*)
+            die "unknown option: $1"
+            ;;
+        *)
+            if [ -n "$slice" ]; then
+                die "expected one slice name, got extra argument: $1"
+            fi
+            slice="$1"
+            ;;
+    esac
+    shift
+done
+
+[ -n "$slice" ] || {
+    usage >&2
+    die "missing slice name"
+}
+
+case "$slice" in
+    */*|*\\*|.*|*..*)
+        die "unsafe slice name: $slice"
+        ;;
+esac
+
+case "$slice" in
+    PR-*) plan_name="$slice" ;;
+    *) plan_name="PR-$slice" ;;
+esac
+
+[ "$plan_name" != "PR-" ] || die "slice name must include text after PR-"
+
+case "$plan_name" in
+    *[!A-Za-z0-9._-]*)
+        die "slice name may contain only letters, numbers, dot, underscore, and dash: $slice"
+        ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git worktree"
+plan_rel="plans/$plan_name.md"
+plan_path="$repo_root/$plan_rel"
+
+if [ -e "$plan_path" ] && [ "$force" -ne 1 ]; then
+    die "plan already exists: $plan_rel (pass --force to overwrite)"
+fi
+
+mkdir -p "$repo_root/plans"
+tmp="$(mktemp "$repo_root/plans/.new-pr-plan.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+
+cat > "$tmp" <<EOF
+# $plan_name
+
+## Why this slice exists
+
+TODO: Tie this slice to a concrete user request, prior plan, audit finding, or
+review comment.
+
+## Scope (this PR)
+
+Ownership lane: $lane
+Slice phase: $phase
+
+1. TODO: Name the narrow behavior this PR changes.
+2. TODO: Name the proof this PR adds.
+
+### Files touched
+
+- TODO: run \`python scripts/sync_pr_plan.py $plan_rel\` after implementation.
+
+## Mechanism
+
+TODO: Explain how the change works so the reviewer does not have to
+reverse-engineer the diff.
+
+## Intentional
+
+- TODO: Name explicit trade-offs or rejected alternatives.
+
+## Deferred
+
+- TODO: Name follow-up work, or replace this with "None."
+
+Parked hardening: none.
+
+## Verification
+
+- Pending before push: TODO.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| **Total** | **0** |
+EOF
+
+mv "$tmp" "$plan_path"
+trap - EXIT
+echo "created plan scaffold: $plan_rel"

--- a/tests/test_new_pr_plan.py
+++ b/tests/test_new_pr_plan.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "new_pr_plan.sh"
+AUDIT_PLAN_DOC = REPO_ROOT / "scripts" / "audit_plan_doc.py"
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+
+
+def _run_new_plan(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_new_pr_plan_creates_agents_plan_skeleton(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+
+    result = _run_new_plan(
+        tmp_path,
+        "Dev-Workflow-Example",
+        "--lane",
+        "dev-workflow/test",
+        "--phase",
+        "Workflow/process",
+    )
+
+    assert result.returncode == 0
+    assert "created plan scaffold: plans/PR-Dev-Workflow-Example.md" in result.stdout
+    plan_path = tmp_path / "plans" / "PR-Dev-Workflow-Example.md"
+    text = plan_path.read_text(encoding="utf-8")
+    assert text.startswith("# PR-Dev-Workflow-Example\n")
+    assert "Ownership lane: dev-workflow/test" in text
+    assert "Slice phase: Workflow/process" in text
+    assert "### Files touched" in text
+    assert "| **Total** | **0** |" in text
+
+    audit = subprocess.run(
+        ["python", str(AUDIT_PLAN_DOC), str(plan_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert audit.returncode == 0
+
+
+def test_new_pr_plan_does_not_double_prefix_existing_pr_name(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+
+    result = _run_new_plan(tmp_path, "PR-Already-Prefixed")
+
+    assert result.returncode == 0
+    assert (tmp_path / "plans" / "PR-Already-Prefixed.md").exists()
+    assert not (tmp_path / "plans" / "PR-PR-Already-Prefixed.md").exists()
+
+
+def test_new_pr_plan_refuses_existing_plan_without_force(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    first = _run_new_plan(tmp_path, "Overwrite-Check", "--phase", "Workflow/process")
+    assert first.returncode == 0
+    plan_path = tmp_path / "plans" / "PR-Overwrite-Check.md"
+    original = plan_path.read_text(encoding="utf-8")
+
+    second = _run_new_plan(tmp_path, "Overwrite-Check", "--phase", "Vertical slice")
+
+    assert second.returncode == 2
+    assert "plan already exists" in second.stderr
+    assert plan_path.read_text(encoding="utf-8") == original
+
+
+def test_new_pr_plan_force_overwrites_existing_plan(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    first = _run_new_plan(tmp_path, "Force-Check", "--phase", "Workflow/process")
+    assert first.returncode == 0
+
+    second = _run_new_plan(tmp_path, "Force-Check", "--phase", "Vertical slice", "--force")
+
+    assert second.returncode == 0
+    text = (tmp_path / "plans" / "PR-Force-Check.md").read_text(encoding="utf-8")
+    assert "Slice phase: Vertical slice" in text
+
+
+def test_new_pr_plan_rejects_missing_and_unsafe_slice_names(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+
+    missing = _run_new_plan(tmp_path)
+    traversal = _run_new_plan(tmp_path, "../Bad")
+    separator = _run_new_plan(tmp_path, "bad/name")
+    empty_prefix = _run_new_plan(tmp_path, "PR-")
+
+    assert missing.returncode == 2
+    assert "missing slice name" in missing.stderr
+    assert traversal.returncode == 2
+    assert "unsafe slice name" in traversal.stderr
+    assert separator.returncode == 2
+    assert "unsafe slice name" in separator.stderr
+    assert empty_prefix.returncode == 2
+    assert "slice name must include text after PR-" in empty_prefix.stderr
+
+
+def test_new_pr_plan_requires_option_values(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+
+    lane = _run_new_plan(tmp_path, "Option-Check", "--lane")
+    phase = _run_new_plan(tmp_path, "Option-Check", "--phase")
+
+    assert lane.returncode == 2
+    assert "--lane requires a value" in lane.stderr
+    assert phase.returncode == 2
+    assert "--phase requires a value" in phase.stderr


### PR DESCRIPTION
Plan: plans/PR-Dev-Workflow-Plan-Scaffold.md
Slice phase: Workflow/process

PR #1307 handled plan syncing and push-body wiring, but left one PR-prep gap: builders still hand-type the initial seven-section plan shape before `sync_pr_plan.py` can help. This PR adds `scripts/new_pr_plan.sh`, a narrow scaffold emitter that creates `plans/PR-<Slice>.md` with the required AGENTS sections, lane/phase fields, files-touched placeholder, and zero diff-size table while failing before risky writes.

## Intentional
- The helper creates only the plan skeleton; human judgment sections remain human-authored.
- The script is Bash to match `scripts/push_pr.sh` and keep the operator command lightweight.
- The generated scaffold is editable starting shape, not an audit bypass.
- #1268 is not modified.

## Deferred
- `PR-Dev-Workflow-PR-Body-Generator`: optional body generation from the plan if PR body churn remains a real bottleneck.
- Brand voice storage/API/UI resumes after this workflow slice is opened and handed back.

## Parked hardening
- None.

## Verification
- `pytest tests/test_new_pr_plan.py tests/test_sync_pr_plan.py tests/test_push_pr_wrapper.py -q` -- 13 passed.
- `bash -n scripts/new_pr_plan.sh` -- passed.
- Temp-repo scaffold plus `audit_plan_doc.py` smoke -- passed.
- `python scripts/audit_plan_doc.py plans/PR-Dev-Workflow-Plan-Scaffold.md` -- passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Dev-Workflow-Plan-Scaffold.md` -- passed.
- `git diff --check` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-dev-workflow-plan-scaffold.md` -- passed.

## Diff size
3 files, +367 / -0.
