### PR TITLE
Content Ops Brand Voice Profile Storage

### DIFF
--- a/.github/workflows/atlas_content_ops_generated_assets_checks.yml
+++ b/.github/workflows/atlas_content_ops_generated_assets_checks.yml
@@ -4,17 +4,29 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_generated_assets_checks.yml"
+      - "atlas_brain/_content_ops_brand_voice_profiles.py"
       - "atlas_brain/api/__init__.py"
+      - "atlas_brain/api/content_ops_brand_voice_profiles.py"
+      - "atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql"
+      - "extracted_content_pipeline/api/control_surfaces.py"
       - "extracted_content_pipeline/api/generated_assets.py"
       - "tests/test_atlas_content_ops_generated_assets_api.py"
+      - "tests/test_content_ops_brand_voice_profiles.py"
+      - "tests/test_content_ops_brand_voice_profiles_api.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_generated_assets_checks.yml"
+      - "atlas_brain/_content_ops_brand_voice_profiles.py"
       - "atlas_brain/api/__init__.py"
+      - "atlas_brain/api/content_ops_brand_voice_profiles.py"
+      - "atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql"
+      - "extracted_content_pipeline/api/control_surfaces.py"
       - "extracted_content_pipeline/api/generated_assets.py"
       - "tests/test_atlas_content_ops_generated_assets_api.py"
+      - "tests/test_content_ops_brand_voice_profiles.py"
+      - "tests/test_content_ops_brand_voice_profiles_api.py"
 
 jobs:
   atlas-content-ops-generated-assets-checks:
@@ -39,4 +51,6 @@ jobs:
         run: |
           python -m pytest \
             tests/test_atlas_content_ops_generated_assets_api.py \
+            tests/test_content_ops_brand_voice_profiles.py \
+            tests/test_content_ops_brand_voice_profiles_api.py \
             -q

--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Test Content Ops upload source run handoff
         run: npm run test:content-ops-upload-source-run-handoff
 
+      - name: Test Content Ops brand voice profile selector
+        run: npm run test:content-ops-brand-voice-profile-selector
+
       - name: Test Content Ops blog review public link
         run: npm run test:content-ops-blog-review-public-link
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -14,6 +14,7 @@
     "test:content-ops-cache-policy-ui": "node --test scripts/content-ops-cache-policy-ui.test.mjs",
     "test:content-ops-usage-budget-ui": "node --test scripts/content-ops-usage-budget-ui.test.mjs",
     "test:content-ops-usage-summary": "node --test scripts/content-ops-usage-summary.test.mjs",
+    "test:content-ops-brand-voice-profile-selector": "node --test scripts/content-ops-brand-voice-profile-selector.test.mjs",
     "test:content-ops-zendesk-credentials": "node --test scripts/content-ops-zendesk-credentials-ui.test.mjs",
     "test:content-ops-faq-macro-publish": "node --test scripts/content-ops-faq-macro-publish-ui.test.mjs",
     "test:content-ops-faq-source-selection": "node --test scripts/content-ops-faq-source-selection.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const API_ORIGIN = 'https://api.example.test'
+
+async function loadTsModule(path, replacements = []) {
+  let source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  for (const [needle, replacement] of replacements) {
+    source = source.replace(needle, replacement)
+  }
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  createContentOpsBrandVoiceProfile,
+  deleteContentOpsBrandVoiceProfile,
+  fetchContentOpsBrandVoiceProfiles,
+  updateContentOpsBrandVoiceProfile,
+} = await loadTsModule('../src/api/contentOps.ts', [
+  [
+    "import { tryRefreshToken } from '../auth/AuthContext'\n",
+    'const tryRefreshToken = async () => null\n',
+  ],
+  [
+    "import { API_BASE } from './config'\n",
+    `const API_BASE = '${API_ORIGIN}'\n`,
+  ],
+])
+
+const {
+  fromWireRequest,
+  toWireRequest,
+} = await loadTsModule('../src/domain/contentOps/fromWire.ts')
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+function installBrowserStubs() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem(key) {
+        return key === 'atlas_token' ? 'test-token' : null
+      },
+      removeItem() {},
+    },
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { href: '' } },
+  })
+}
+
+function installFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    const body = status === 204 ? null : JSON.stringify(payload)
+    return new Response(body, {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+function profilePayload(overrides = {}) {
+  return {
+    id: 'profile-1',
+    account_id: 'account-1',
+    name: 'Acme editorial',
+    descriptors: ['plainspoken'],
+    exemplars: ['Write like this.'],
+    banned_terms: ['synergy'],
+    preferred_pov: 'second_person',
+    reading_level: 'plain',
+    metadata: { source: 'operator' },
+    created_at: '2026-06-04T00:00:00+00:00',
+    updated_at: '2026-06-04T00:00:00+00:00',
+    archived_at: null,
+    ...overrides,
+  }
+}
+
+test.beforeEach(() => {
+  installBrowserStubs()
+})
+
+test('brand voice profile list calls tenant route', async () => {
+  const payload = [profilePayload()]
+  const calls = installFetchResponder(payload)
+
+  const result = await fetchContentOpsBrandVoiceProfiles()
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/brand-voice-profiles`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+test('brand voice profile create posts bounded profile payload', async () => {
+  const calls = installFetchResponder(profilePayload(), 201)
+  const body = {
+    name: 'Acme editorial',
+    descriptors: ['plainspoken'],
+    exemplars: ['Write like this.'],
+    banned_terms: ['synergy'],
+    preferred_pov: 'second_person',
+    reading_level: 'plain',
+    metadata: { source: 'operator' },
+  }
+
+  await createContentOpsBrandVoiceProfile(body)
+
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/brand-voice-profiles`,
+  )
+  assert.equal(init.method, 'POST')
+  assert.deepEqual(init.headers, {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer test-token',
+  })
+  assert.deepEqual(JSON.parse(init.body), body)
+})
+
+test('brand voice profile update request shape is encoded and authenticated', async () => {
+  const calls = installFetchResponder(profilePayload())
+  const body = {
+    name: 'Acme editorial',
+    descriptors: ['plainspoken'],
+  }
+
+  await updateContentOpsBrandVoiceProfile('profile/id', body)
+
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/brand-voice-profiles/profile%2Fid`,
+  )
+  assert.equal(init.method, 'PUT')
+  assert.deepEqual(init.headers, {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer test-token',
+  })
+  assert.deepEqual(JSON.parse(init.body), body)
+})
+
+test('brand voice profile delete archives encoded profile id', async () => {
+  const calls = installFetchResponder('', 204)
+
+  await deleteContentOpsBrandVoiceProfile('profile/id')
+
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/brand-voice-profiles/profile%2Fid`,
+  )
+  assert.equal(init.method, 'DELETE')
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+test('brand voice profile id round-trips through domain request mapping', () => {
+  const domain = fromWireRequest({
+    target_mode: 'vendor_retention',
+    outputs: ['landing_page'],
+    brand_voice_profile_id: 'profile-1',
+    inputs: { target_keyword: 'support tickets' },
+  })
+
+  assert.equal(domain.brandVoiceProfileId, 'profile-1')
+
+  const wire = toWireRequest(domain)
+  assert.equal(wire.brand_voice_profile_id, 'profile-1')
+  assert.deepEqual(wire.inputs, { target_keyword: 'support tickets' })
+})
+
+test('new run page renders brand voice profile selector wiring', () => {
+  assert.ok(newRunSource.includes('function BrandVoiceProfileSelector'))
+  assert.ok(newRunSource.includes('fetchContentOpsBrandVoiceProfiles'))
+  assert.ok(newRunSource.includes('brandVoiceProfileId'))
+  assert.ok(newRunSource.includes('Saved profile'))
+  assert.ok(newRunSource.includes('No saved brand voice'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -5,6 +5,10 @@
  * `/content-ops/*` and `/content-assets/*` routes the backend exposes:
  *
  *   GET  /content-ops/control-surfaces
+ *   GET  /content-ops/brand-voice-profiles
+ *   POST /content-ops/brand-voice-profiles
+ *   PUT  /content-ops/brand-voice-profiles/{profile_id}
+ *   DELETE /content-ops/brand-voice-profiles/{profile_id}
  *   GET  /content-ops/zendesk-credentials
  *   POST /content-ops/zendesk-credentials
  *   DELETE /content-ops/zendesk-credentials/{credential_id}
@@ -203,6 +207,33 @@ export interface UpsertContentOpsZendeskCredentialRequest {
   label?: string
 }
 
+// GET/POST/PUT/DELETE /content-ops/brand-voice-profiles
+
+export interface ContentOpsBrandVoiceProfile {
+  id: string
+  account_id: string
+  name: string
+  descriptors: string[]
+  exemplars: string[]
+  banned_terms: string[]
+  preferred_pov?: string | null
+  reading_level?: string | null
+  metadata: Record<string, unknown>
+  created_at: string
+  updated_at: string
+  archived_at?: string | null
+}
+
+export interface UpsertContentOpsBrandVoiceProfileRequest {
+  name: string
+  descriptors?: string[]
+  exemplars?: string[]
+  banned_terms?: string[]
+  preferred_pov?: string | null
+  reading_level?: string | null
+  metadata?: Record<string, unknown>
+}
+
 // POST /content-ops/preview, /plan, /execute share this body shape.
 
 export interface ContentOpsRequestBody {
@@ -214,6 +245,7 @@ export interface ContentOpsRequestBody {
   account_usage_budget_usd?: number | null
   account_usage_budget_days?: number
   content_ops_cache_policy?: string | null
+  brand_voice_profile_id?: string | null
   inputs?: Record<string, unknown>
   ingestion_profile?: string                       // default "domain_specific"
   require_quality_gates?: boolean                  // default true
@@ -721,6 +753,22 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
   return rawJson<T>(res)
 }
 
+async function putJson<T>(path: string, body: unknown): Promise<T> {
+  const url = `${BASE}${path}`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(body),
+    })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const text = await rawText(res)
+    throw new Error(`API ${res.status}: ${text || res.statusText}`)
+  }
+  return rawJson<T>(res)
+}
+
 async function deleteJson(path: string): Promise<void> {
   const url = `${BASE}${path}`
   const doFetch = () =>
@@ -951,6 +999,36 @@ export function saveContentOpsZendeskCredential(
 /** DELETE /content-ops/zendesk-credentials/{id} -- revoke tenant Zendesk credential. */
 export function revokeContentOpsZendeskCredential(id: string): Promise<void> {
   return deleteJson(`/zendesk-credentials/${encodeURIComponent(id)}`)
+}
+
+/** GET /content-ops/brand-voice-profiles -- tenant saved profile list. */
+export function fetchContentOpsBrandVoiceProfiles(): Promise<
+  ContentOpsBrandVoiceProfile[]
+> {
+  return getJson<ContentOpsBrandVoiceProfile[]>('/brand-voice-profiles')
+}
+
+/** POST /content-ops/brand-voice-profiles -- create a tenant saved profile. */
+export function createContentOpsBrandVoiceProfile(
+  body: UpsertContentOpsBrandVoiceProfileRequest,
+): Promise<ContentOpsBrandVoiceProfile> {
+  return postJson<ContentOpsBrandVoiceProfile>('/brand-voice-profiles', body)
+}
+
+/** PUT /content-ops/brand-voice-profiles/{id} -- update a tenant saved profile. */
+export function updateContentOpsBrandVoiceProfile(
+  id: string,
+  body: UpsertContentOpsBrandVoiceProfileRequest,
+): Promise<ContentOpsBrandVoiceProfile> {
+  return putJson<ContentOpsBrandVoiceProfile>(
+    `/brand-voice-profiles/${encodeURIComponent(id)}`,
+    body,
+  )
+}
+
+/** DELETE /content-ops/brand-voice-profiles/{id} -- archive a tenant saved profile. */
+export function deleteContentOpsBrandVoiceProfile(id: string): Promise<void> {
+  return deleteJson(`/brand-voice-profiles/${encodeURIComponent(id)}`)
 }
 
 /** GET /content-assets/{asset}/drafts -- persisted generated assets. */

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -257,6 +257,7 @@ export function fromWireRequest(
     accountUsageBudgetUsd: wire.account_usage_budget_usd ?? null,
     accountUsageBudgetDays: wire.account_usage_budget_days ?? 7,
     contentOpsCachePolicy: normalizedCachePolicy(wire.content_ops_cache_policy),
+    brandVoiceProfileId: wire.brand_voice_profile_id ?? null,
     inputs: { ...(wire.inputs ?? {}) },
     ingestionProfile: wire.ingestion_profile ?? 'domain_specific',
     requireQualityGates: wire.require_quality_gates ?? true,
@@ -280,6 +281,7 @@ export function toWireRequest(
     account_usage_budget_usd: domain.accountUsageBudgetUsd,
     account_usage_budget_days: domain.accountUsageBudgetDays,
     content_ops_cache_policy: domain.contentOpsCachePolicy,
+    brand_voice_profile_id: domain.brandVoiceProfileId,
     inputs: { ...domain.inputs },
     ingestion_profile: domain.ingestionProfile,
     require_quality_gates: domain.requireQualityGates,
@@ -395,6 +397,8 @@ export function fromWirePreview(
           contentOpsCachePolicy: normalizedCachePolicy(
             wire.normalized_request.content_ops_cache_policy,
           ),
+          brandVoiceProfileId:
+            wire.normalized_request.brand_voice_profile_id ?? null,
           ingestionProfile:
             wire.normalized_request.ingestion_profile ?? 'domain_specific',
           requireQualityGates:

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -163,6 +163,7 @@ export interface ContentOpsRequest {
   accountUsageBudgetUsd: number | null
   accountUsageBudgetDays: number
   contentOpsCachePolicy: ContentOpsCachePolicy | null
+  brandVoiceProfileId: string | null
   inputs: Record<string, unknown>
   ingestionProfile: string
   requireQualityGates: boolean

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -5,6 +5,7 @@ import {
   FileUp,
   KeyRound,
   Loader2,
+  Palette,
   Play,
   RefreshCw,
   Search,
@@ -14,6 +15,7 @@ import {
 import { clsx } from 'clsx'
 import {
   executeContentOpsRun,
+  fetchContentOpsBrandVoiceProfiles,
   fetchContentOpsZendeskCredentials,
   fetchGeneratedAssetDrafts,
   fetchContentOpsControlSurfaces,
@@ -76,6 +78,7 @@ import {
   type ContentOpsUsageBudgetEvaluation,
 } from '../domain/contentOps'
 import type {
+  ContentOpsBrandVoiceProfile,
   ContentOpsZendeskCredential,
   GeneratedAssetDraft,
   GeneratedAssetType,
@@ -233,6 +236,13 @@ export default function ContentOpsNewRun() {
     refresh: refreshZendeskCredentials,
     refreshing: zendeskCredentialsRefreshing,
   } = useApiData(() => fetchContentOpsZendeskCredentials(), [])
+  const {
+    data: brandVoiceProfiles,
+    loading: brandVoiceProfilesLoading,
+    error: brandVoiceProfilesError,
+    refresh: refreshBrandVoiceProfiles,
+    refreshing: brandVoiceProfilesRefreshing,
+  } = useApiData(() => fetchContentOpsBrandVoiceProfiles(), [])
   const {
     data: faqDrafts,
     loading: faqDraftsLoading,
@@ -494,6 +504,11 @@ export default function ContentOpsNewRun() {
     const updated = updateSourceModeInputJson(inputsJson, mode)
     if (!updated.ok) return
     setInputsJson(updated.value)
+    markStale()
+  }
+
+  const handleBrandVoiceProfileChange = (profileId: string | null) => {
+    setRequest((prev) => ({ ...prev, brandVoiceProfileId: profileId }))
     markStale()
   }
 
@@ -1006,6 +1021,15 @@ export default function ContentOpsNewRun() {
         refreshing={zendeskCredentialsRefreshing}
         error={zendeskCredentialsError}
         onRefresh={refreshZendeskCredentials}
+      />
+      <BrandVoiceProfileSelector
+        profiles={brandVoiceProfiles ?? []}
+        selectedProfileId={request.brandVoiceProfileId}
+        loading={brandVoiceProfilesLoading}
+        refreshing={brandVoiceProfilesRefreshing}
+        error={brandVoiceProfilesError}
+        onRefresh={refreshBrandVoiceProfiles}
+        onChange={handleBrandVoiceProfileChange}
       />
 
       <form onSubmit={handleSubmit} className="space-y-8">
@@ -1844,6 +1868,91 @@ function UsageSummaryCard({
           )}
         </>
       )}
+    </section>
+  )
+}
+
+function BrandVoiceProfileSelector({
+  profiles,
+  selectedProfileId,
+  loading,
+  refreshing,
+  error,
+  onRefresh,
+  onChange,
+}: {
+  profiles: ContentOpsBrandVoiceProfile[]
+  selectedProfileId: string | null
+  loading: boolean
+  refreshing: boolean
+  error: Error | null
+  onRefresh: () => void
+  onChange: (profileId: string | null) => void
+}) {
+  const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId)
+  const missingSelectedProfile = Boolean(
+    selectedProfileId && !loading && !selectedProfile,
+  )
+
+  return (
+    <section className="mb-8 rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-medium text-slate-100">
+            <Palette className="h-4 w-4 text-cyan-300" />
+            Brand voice
+          </h2>
+          {selectedProfile && (
+            <p className="mt-1 text-xs text-slate-500">
+              {formatBrandVoiceProfileSummary(selectedProfile)}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={loading || refreshing}
+          className="flex items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+        >
+          <RefreshCw className={clsx('h-3.5 w-3.5', refreshing && 'animate-spin')} />
+          Refresh
+        </button>
+      </div>
+
+      {error && !loading && (
+        <div className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          Brand voice profiles unavailable: {error.message}
+        </div>
+      )}
+      {missingSelectedProfile && (
+        <div className="mb-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
+          Selected brand voice profile was not found for this tenant.
+        </div>
+      )}
+
+      <label className="block text-sm">
+        <span className="text-slate-300">Saved profile</span>
+        <select
+          value={selectedProfileId ?? ''}
+          disabled={loading}
+          onChange={(event) => onChange(event.target.value || null)}
+          className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+        >
+          <option value="">
+            {loading ? 'Loading profiles...' : 'No saved brand voice'}
+          </option>
+          {missingSelectedProfile && (
+            <option value={selectedProfileId ?? ''}>
+              Selected profile unavailable
+            </option>
+          )}
+          {profiles.map((profile) => (
+            <option key={profile.id} value={profile.id}>
+              {profile.name}
+            </option>
+          ))}
+        </select>
+      </label>
     </section>
   )
 }
@@ -2764,6 +2873,22 @@ function formatCredentialDate(value: string | null | undefined): string {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return date.toLocaleDateString()
+}
+
+function formatBrandVoiceProfileSummary(
+  profile: ContentOpsBrandVoiceProfile,
+): string {
+  const parts: string[] = []
+  if (profile.descriptors.length > 0) {
+    parts.push(profile.descriptors.slice(0, 3).join(', '))
+  }
+  if (profile.preferred_pov) {
+    parts.push(profile.preferred_pov.replaceAll('_', ' '))
+  }
+  if (profile.reading_level) {
+    parts.push(profile.reading_level)
+  }
+  return parts.length > 0 ? parts.join(' - ') : 'Saved profile selected'
 }
 
 function formatZendeskCredentialEndpoint(

--- a/atlas_brain/_content_ops_brand_voice_profiles.py
+++ b/atlas_brain/_content_ops_brand_voice_profiles.py
@@ -1,0 +1,328 @@
+"""Tenant brand voice profiles for Content Ops generation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid as _uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping, Optional
+
+from extracted_content_pipeline.brand_voice import (
+    BrandVoiceProfile,
+    brand_voice_profile_from_mapping,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+logger = logging.getLogger("atlas.content_ops_brand_voice_profiles")
+
+
+@dataclass(frozen=True)
+class ContentOpsBrandVoiceProfileRecord:
+    """Display-safe saved brand voice profile row."""
+
+    id: _uuid.UUID
+    account_id: _uuid.UUID
+    name: str
+    descriptors: tuple[str, ...]
+    exemplars: tuple[str, ...]
+    banned_terms: tuple[str, ...]
+    preferred_pov: Optional[str]
+    reading_level: Optional[str]
+    metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    archived_at: Optional[datetime]
+
+    def as_profile(self) -> BrandVoiceProfile:
+        return BrandVoiceProfile(
+            id=str(self.id),
+            account_id=str(self.account_id),
+            name=self.name,
+            descriptors=self.descriptors,
+            exemplars=self.exemplars,
+            banned_terms=self.banned_terms,
+            preferred_pov=self.preferred_pov,
+            reading_level=self.reading_level,
+            metadata=dict(self.metadata),
+        )
+
+
+async def create_brand_voice_profile(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    payload: Mapping[str, Any],
+) -> ContentOpsBrandVoiceProfileRecord:
+    """Create one active brand voice profile for an account."""
+
+    profile = _validated_profile(account_id=account_id, payload=payload)
+    row = await pool.fetchrow(
+        """
+        INSERT INTO content_ops_brand_voice_profiles (
+            account_id, name, descriptors, exemplars, banned_terms,
+            preferred_pov, reading_level, metadata
+        )
+        VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6, $7, $8::jsonb)
+        RETURNING id, account_id, name, descriptors, exemplars, banned_terms,
+                  preferred_pov, reading_level, metadata,
+                  created_at, updated_at, archived_at
+        """,
+        account_id,
+        profile.name,
+        _json_dump(profile.descriptors),
+        _json_dump(profile.exemplars),
+        _json_dump(profile.banned_terms),
+        profile.preferred_pov,
+        profile.reading_level,
+        _json_dump(profile.metadata),
+    )
+    return _display_record(row)
+
+
+async def update_brand_voice_profile(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    profile_id: _uuid.UUID,
+    payload: Mapping[str, Any],
+) -> ContentOpsBrandVoiceProfileRecord | None:
+    """Update one active tenant profile. Missing/cross-tenant rows return None."""
+
+    profile = _validated_profile(
+        account_id=account_id,
+        profile_id=profile_id,
+        payload=payload,
+    )
+    row = await pool.fetchrow(
+        """
+        UPDATE content_ops_brand_voice_profiles
+           SET name = $3,
+               descriptors = $4::jsonb,
+               exemplars = $5::jsonb,
+               banned_terms = $6::jsonb,
+               preferred_pov = $7,
+               reading_level = $8,
+               metadata = $9::jsonb,
+               updated_at = NOW()
+         WHERE id = $1
+           AND account_id = $2
+           AND archived_at IS NULL
+        RETURNING id, account_id, name, descriptors, exemplars, banned_terms,
+                  preferred_pov, reading_level, metadata,
+                  created_at, updated_at, archived_at
+        """,
+        profile_id,
+        account_id,
+        profile.name,
+        _json_dump(profile.descriptors),
+        _json_dump(profile.exemplars),
+        _json_dump(profile.banned_terms),
+        profile.preferred_pov,
+        profile.reading_level,
+        _json_dump(profile.metadata),
+    )
+    return _display_record(row) if row is not None else None
+
+
+async def list_brand_voice_profiles(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+) -> list[ContentOpsBrandVoiceProfileRecord]:
+    """Return active brand voice profiles for one tenant."""
+
+    rows = await pool.fetch(
+        """
+        SELECT id, account_id, name, descriptors, exemplars, banned_terms,
+               preferred_pov, reading_level, metadata,
+               created_at, updated_at, archived_at
+          FROM content_ops_brand_voice_profiles
+         WHERE account_id = $1
+           AND archived_at IS NULL
+         ORDER BY updated_at DESC
+        """,
+        account_id,
+    )
+    return [_display_record(row) for row in rows]
+
+
+async def get_brand_voice_profile_record(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    profile_id: _uuid.UUID,
+) -> ContentOpsBrandVoiceProfileRecord | None:
+    """Return one active tenant profile row."""
+
+    row = await pool.fetchrow(
+        """
+        SELECT id, account_id, name, descriptors, exemplars, banned_terms,
+               preferred_pov, reading_level, metadata,
+               created_at, updated_at, archived_at
+          FROM content_ops_brand_voice_profiles
+         WHERE id = $1
+           AND account_id = $2
+           AND archived_at IS NULL
+        """,
+        profile_id,
+        account_id,
+    )
+    return _display_record(row) if row is not None else None
+
+
+async def lookup_brand_voice_profile(
+    pool: Any,
+    *,
+    account_id: str | _uuid.UUID,
+    profile_id: str | _uuid.UUID,
+) -> BrandVoiceProfile | None:
+    """Resolve a full stored brand voice profile for one tenant."""
+
+    try:
+        account_uuid = _uuid.UUID(str(account_id))
+        profile_uuid = _uuid.UUID(str(profile_id))
+    except (TypeError, ValueError):
+        logger.warning(
+            "brand voice profile lookup: invalid account_id/profile_id",
+        )
+        return None
+    record = await get_brand_voice_profile_record(
+        pool,
+        account_id=account_uuid,
+        profile_id=profile_uuid,
+    )
+    return record.as_profile() if record is not None else None
+
+
+async def archive_brand_voice_profile(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    profile_id: _uuid.UUID,
+) -> bool:
+    """Soft-delete one tenant brand voice profile."""
+
+    row = await pool.fetchrow(
+        """
+        UPDATE content_ops_brand_voice_profiles
+           SET archived_at = NOW(),
+               updated_at = NOW()
+         WHERE id = $1
+           AND account_id = $2
+           AND archived_at IS NULL
+        RETURNING id
+        """,
+        profile_id,
+        account_id,
+    )
+    return row is not None
+
+
+def _validated_profile(
+    *,
+    account_id: _uuid.UUID,
+    payload: Mapping[str, Any],
+    profile_id: _uuid.UUID | None = None,
+) -> BrandVoiceProfile:
+    if not isinstance(payload, Mapping):
+        raise ValueError("Brand voice profile payload must be an object")
+    name = _clean(payload.get("name") or payload.get("label"))
+    if not name:
+        raise ValueError("Brand voice profile name is required")
+
+    expected_id = str(profile_id) if profile_id is not None else None
+    normalized = brand_voice_profile_from_mapping(
+        {
+            **dict(payload),
+            "id": expected_id or payload.get("id") or payload.get("profile_id"),
+            "account_id": str(account_id),
+            "name": name,
+        },
+        scope=TenantScope(account_id=str(account_id)),
+        profile_id=expected_id,
+    )
+    if normalized is None or not normalized.has_guidance():
+        raise ValueError(
+            "Brand voice profile requires at least one descriptor, exemplar, "
+            "banned term, preferred POV, or reading level"
+        )
+    return BrandVoiceProfile(
+        id=expected_id or normalized.id,
+        account_id=str(account_id),
+        name=name,
+        descriptors=normalized.descriptors,
+        exemplars=normalized.exemplars,
+        banned_terms=normalized.banned_terms,
+        preferred_pov=normalized.preferred_pov,
+        reading_level=normalized.reading_level,
+        metadata=dict(normalized.metadata or {}),
+    )
+
+
+def _display_record(row: Any) -> ContentOpsBrandVoiceProfileRecord:
+    return ContentOpsBrandVoiceProfileRecord(
+        id=row["id"],
+        account_id=row["account_id"],
+        name=str(row["name"] or ""),
+        descriptors=_json_string_sequence(row["descriptors"]),
+        exemplars=_json_string_sequence(row["exemplars"]),
+        banned_terms=_json_string_sequence(row["banned_terms"]),
+        preferred_pov=_optional_text(row["preferred_pov"]),
+        reading_level=_optional_text(row["reading_level"]),
+        metadata=_json_mapping(row["metadata"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        archived_at=row["archived_at"],
+    )
+
+
+def _json_dump(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    decoded = _decode_json(value, default={})
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _json_string_sequence(value: Any) -> tuple[str, ...]:
+    decoded = _decode_json(value, default=[])
+    if isinstance(decoded, (str, bytes, bytearray)) or not isinstance(decoded, list):
+        return ()
+    return tuple(str(item) for item in decoded if str(item).strip())
+
+
+def _decode_json(value: Any, *, default: Any) -> Any:
+    if value is None:
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return default
+    return value
+
+
+def _optional_text(value: Any) -> str | None:
+    return _clean(value) or None
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+__all__ = [
+    "ContentOpsBrandVoiceProfileRecord",
+    "archive_brand_voice_profile",
+    "create_brand_voice_profile",
+    "get_brand_voice_profile_record",
+    "list_brand_voice_profiles",
+    "lookup_brand_voice_profile",
+    "update_brand_voice_profile",
+]

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -177,6 +177,7 @@ try:
     from .._content_ops_macro_writeback import (
         build_content_ops_macro_publish_provider,
     )
+    from .._content_ops_brand_voice_profiles import lookup_brand_voice_profile
     from .._content_ops_services import build_content_ops_execution_services
     from .._content_ops_scope import (
         build_content_ops_scope,
@@ -188,6 +189,9 @@ try:
     )
     from .content_ops_zendesk_credentials import (
         create_content_ops_zendesk_credentials_router,
+    )
+    from .content_ops_brand_voice_profiles import (
+        create_content_ops_brand_voice_profiles_router,
     )
     from ..auth.dependencies import AuthUser
     from ..config import settings
@@ -249,6 +253,13 @@ try:
         cache_policy_default_provider=_content_ops_cache_policy_default,
         opportunity_import_pool_provider=get_db_pool,
         usage_pool_provider=get_db_pool,
+        brand_voice_profile_provider=lambda scope, profile_id: (
+            lookup_brand_voice_profile(
+                get_db_pool(),
+                account_id=scope.account_id,
+                profile_id=profile_id,
+            )
+        ),
         usage_dependencies=[Depends(_require_content_ops_usage_operator)],
         deflection_report_paid_dependencies=[
             Depends(_require_content_ops_usage_operator)
@@ -282,6 +293,11 @@ try:
         auth_dependency=_capture_content_ops_auth_user,
     )
     router.include_router(zendesk_credentials_router)
+    brand_voice_profiles_router = create_content_ops_brand_voice_profiles_router(
+        pool_provider=get_db_pool,
+        auth_dependency=_capture_content_ops_auth_user,
+    )
+    router.include_router(brand_voice_profiles_router)
     public_landing_page_router = create_public_landing_page_router(
         pool_provider=get_db_pool,
     )

--- a/atlas_brain/api/content_ops_brand_voice_profiles.py
+++ b/atlas_brain/api/content_ops_brand_voice_profiles.py
@@ -1,0 +1,212 @@
+"""Content Ops brand voice profile management routes."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import uuid as _uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .._content_ops_brand_voice_profiles import (
+    ContentOpsBrandVoiceProfileRecord,
+    archive_brand_voice_profile,
+    create_brand_voice_profile,
+    list_brand_voice_profiles,
+    update_brand_voice_profile,
+)
+from ..auth.dependencies import AuthUser
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+AuthDependency = Callable[..., AuthUser | Awaitable[AuthUser]]
+
+
+class UpsertBrandVoiceProfileRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=160)
+    descriptors: tuple[str, ...] = Field(default_factory=tuple, max_length=8)
+    exemplars: tuple[str, ...] = Field(default_factory=tuple, max_length=3)
+    banned_terms: tuple[str, ...] = Field(default_factory=tuple, max_length=20)
+    preferred_pov: str | None = Field(default=None, max_length=40)
+    reading_level: str | None = Field(default=None, max_length=80)
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class BrandVoiceProfileView(BaseModel):
+    id: str
+    account_id: str
+    name: str
+    descriptors: list[str]
+    exemplars: list[str]
+    banned_terms: list[str]
+    preferred_pov: str | None = None
+    reading_level: str | None = None
+    metadata: dict[str, object]
+    created_at: str
+    updated_at: str
+    archived_at: str | None = None
+
+
+def _default_pool_provider() -> Any:
+    from ..storage.database import get_db_pool
+
+    return get_db_pool()
+
+
+def create_content_ops_brand_voice_profiles_router(
+    *,
+    pool_provider: PoolProvider = _default_pool_provider,
+    auth_dependency: AuthDependency,
+) -> APIRouter:
+    """Create tenant-scoped Content Ops brand voice profile routes."""
+
+    router = APIRouter(
+        prefix="/content-ops/brand-voice-profiles",
+        tags=["content-ops"],
+    )
+
+    @router.get("", response_model=list[BrandVoiceProfileView])
+    async def list_profiles(
+        user: AuthUser = Depends(auth_dependency),
+    ) -> list[BrandVoiceProfileView]:
+        pool = await _resolve_ready_pool(pool_provider)
+        account_id = _account_uuid(user)
+        records = await list_brand_voice_profiles(pool, account_id=account_id)
+        return [_record_to_view(record) for record in records]
+
+    @router.post("", response_model=BrandVoiceProfileView, status_code=201)
+    async def add_profile(
+        body: UpsertBrandVoiceProfileRequest,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> BrandVoiceProfileView:
+        _require_profile_admin(user)
+        pool = await _resolve_ready_pool(pool_provider)
+        account_id = _account_uuid(user)
+        try:
+            record = await create_brand_voice_profile(
+                pool,
+                account_id=account_id,
+                payload=body.model_dump(),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:
+            if exc.__class__.__name__ in ("UniqueViolationError", "IntegrityError"):
+                raise HTTPException(
+                    status_code=409,
+                    detail="A brand voice profile with that name already exists.",
+                )
+            raise
+        return _record_to_view(record)
+
+    @router.put("/{profile_id}", response_model=BrandVoiceProfileView)
+    async def update_profile(
+        profile_id: str,
+        body: UpsertBrandVoiceProfileRequest,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> BrandVoiceProfileView:
+        _require_profile_admin(user)
+        pool = await _resolve_ready_pool(pool_provider)
+        account_id = _account_uuid(user)
+        parsed_profile_id = _profile_uuid(profile_id)
+        try:
+            record = await update_brand_voice_profile(
+                pool,
+                account_id=account_id,
+                profile_id=parsed_profile_id,
+                payload=body.model_dump(),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:
+            if exc.__class__.__name__ in ("UniqueViolationError", "IntegrityError"):
+                raise HTTPException(
+                    status_code=409,
+                    detail="A brand voice profile with that name already exists.",
+                )
+            raise
+        if record is None:
+            raise HTTPException(status_code=404, detail="Brand voice profile not found")
+        return _record_to_view(record)
+
+    @router.delete("/{profile_id}", status_code=204)
+    async def delete_profile(
+        profile_id: str,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> None:
+        _require_profile_admin(user)
+        pool = await _resolve_ready_pool(pool_provider)
+        account_id = _account_uuid(user)
+        archived = await archive_brand_voice_profile(
+            pool,
+            account_id=account_id,
+            profile_id=_profile_uuid(profile_id),
+        )
+        if not archived:
+            raise HTTPException(status_code=404, detail="Brand voice profile not found")
+        return None
+
+    return router
+
+
+async def _resolve_ready_pool(pool_provider: PoolProvider) -> Any:
+    pool = pool_provider()
+    if hasattr(pool, "__await__"):
+        pool = await pool
+    if pool is None or getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(status_code=503, detail="Database not ready")
+    return pool
+
+
+def _account_uuid(user: AuthUser) -> _uuid.UUID:
+    try:
+        return _uuid.UUID(str(user.account_id))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid tenant scope")
+
+
+def _profile_uuid(profile_id: str) -> _uuid.UUID:
+    try:
+        return _uuid.UUID(str(profile_id))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=404, detail="Brand voice profile not found")
+
+
+def _require_profile_admin(user: AuthUser) -> None:
+    role = str(getattr(user, "role", "") or "").strip().lower()
+    if bool(getattr(user, "is_admin", False)) or role in {"owner", "admin"}:
+        return
+    raise HTTPException(status_code=403, detail="Admin access required")
+
+
+def _record_to_view(record: ContentOpsBrandVoiceProfileRecord) -> BrandVoiceProfileView:
+    return BrandVoiceProfileView(
+        id=str(record.id),
+        account_id=str(record.account_id),
+        name=record.name,
+        descriptors=list(record.descriptors),
+        exemplars=list(record.exemplars),
+        banned_terms=list(record.banned_terms),
+        preferred_pov=record.preferred_pov,
+        reading_level=record.reading_level,
+        metadata=dict(record.metadata),
+        created_at=_fmt_time(record.created_at) or "",
+        updated_at=_fmt_time(record.updated_at) or "",
+        archived_at=_fmt_time(record.archived_at),
+    )
+
+
+def _fmt_time(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+__all__ = [
+    "BrandVoiceProfileView",
+    "UpsertBrandVoiceProfileRequest",
+    "create_content_ops_brand_voice_profiles_router",
+]

--- a/atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql
+++ b/atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql
@@ -1,0 +1,39 @@
+-- Tenant-scoped saved brand voice profiles for Content Ops generation.
+--
+-- The executable request-time brand voice contract lives in the extracted
+-- package. This host table stores account-owned profiles so the UI can select
+-- a profile id and the API can resolve the full bounded prompt guidance before
+-- preview, plan, or execute.
+
+CREATE TABLE IF NOT EXISTS content_ops_brand_voice_profiles (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id     UUID NOT NULL REFERENCES saas_accounts(id) ON DELETE CASCADE,
+    name           TEXT NOT NULL,
+    descriptors    JSONB NOT NULL DEFAULT '[]'::jsonb,
+    exemplars      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    banned_terms   JSONB NOT NULL DEFAULT '[]'::jsonb,
+    preferred_pov  TEXT,
+    reading_level  TEXT,
+    metadata       JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    archived_at    TIMESTAMPTZ,
+    CONSTRAINT chk_content_ops_brand_voice_profiles_name
+        CHECK (btrim(name) <> ''),
+    CONSTRAINT chk_content_ops_brand_voice_profiles_guidance
+        CHECK (
+            jsonb_array_length(descriptors) > 0
+            OR jsonb_array_length(exemplars) > 0
+            OR jsonb_array_length(banned_terms) > 0
+            OR preferred_pov IS NOT NULL
+            OR reading_level IS NOT NULL
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_ops_brand_voice_profiles_account_active
+    ON content_ops_brand_voice_profiles (account_id, updated_at DESC)
+    WHERE archived_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_content_ops_brand_voice_profiles_account_name_active
+    ON content_ops_brand_voice_profiles (account_id, lower(name))
+    WHERE archived_at IS NULL;

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -42,6 +42,7 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..campaign_ports import TenantScope
+from ..brand_voice import BrandVoiceProfile, brand_voice_profile_from_mapping
 from ..campaign_postgres_import import import_campaign_opportunities
 from ..campaign_source_adapters import source_material_to_source_rows
 from ..campaign_source_adapters import load_source_rows_from_file
@@ -117,6 +118,15 @@ ImportAdmissionProvider = Callable[[], Any | Awaitable[Any]]
 CachePolicyDefaultProvider = Callable[
     [TenantScope],
     str | None | Awaitable[str | None],
+]
+BrandVoiceProfileProvider = Callable[
+    [TenantScope, str],
+    (
+        BrandVoiceProfile
+        | Mapping[str, Any]
+        | None
+        | Awaitable[BrandVoiceProfile | Mapping[str, Any] | None]
+    ),
 ]
 InputProvider = ContentOpsInputProvider
 
@@ -675,6 +685,7 @@ def create_content_ops_control_surface_router(
     deflection_report_paid_dependencies: Sequence[Any] | None = None,
     ingestion_import_admission_provider: ImportAdmissionProvider | None = None,
     cache_policy_default_provider: CachePolicyDefaultProvider | None = None,
+    brand_voice_profile_provider: BrandVoiceProfileProvider | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
     """Create host-mounted AI Content Ops control-surface routes.
@@ -823,6 +834,11 @@ def create_content_ops_control_surface_router(
             cache_policy_default_provider=cache_policy_default_provider,
             scope_provider=scope_provider,
         )
+        payload_mapping = await _payload_with_brand_voice_profile(
+            payload_mapping,
+            brand_voice_profile_provider=brand_voice_profile_provider,
+            scope_provider=scope_provider,
+        )
         budget_evaluation = await _evaluate_account_usage_budget(
             payload_mapping,
             usage_pool_provider=usage_pool_provider,
@@ -849,6 +865,11 @@ def create_content_ops_control_surface_router(
             payload_mapping = await _payload_with_cache_policy_default(
                 payload_mapping,
                 cache_policy_default_provider=cache_policy_default_provider,
+                scope_provider=scope_provider,
+            )
+            payload_mapping = await _payload_with_brand_voice_profile(
+                payload_mapping,
+                brand_voice_profile_provider=brand_voice_profile_provider,
                 scope_provider=scope_provider,
             )
             budget_evaluation = await _evaluate_account_usage_budget(
@@ -1042,6 +1063,11 @@ def create_content_ops_control_surface_router(
             payload_mapping = await _payload_with_cache_policy_default(
                 payload_mapping,
                 cache_policy_default_provider=cache_policy_default_provider,
+                scope=scope,
+            )
+            payload_mapping = await _payload_with_brand_voice_profile(
+                payload_mapping,
+                brand_voice_profile_provider=brand_voice_profile_provider,
                 scope=scope,
             )
             _enforce_faq_execute_source_material_limit(
@@ -1991,6 +2017,81 @@ async def _payload_with_cache_policy_default(
     if normalized:
         out["content_ops_cache_policy"] = normalized
     return out
+
+
+async def _payload_with_brand_voice_profile(
+    payload: Mapping[str, Any],
+    *,
+    brand_voice_profile_provider: BrandVoiceProfileProvider | None,
+    scope_provider: ScopeProvider | None = None,
+    scope: TenantScope | None = None,
+) -> dict[str, Any]:
+    out = dict(payload)
+    profile_id = _clean(out.get("brand_voice_profile_id"))
+    if not profile_id:
+        return out
+    inputs = out.get("inputs")
+    if isinstance(inputs, Mapping) and inputs.get("brand_voice") is not None:
+        return out
+    if brand_voice_profile_provider is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops brand voice profile lookup is not configured.",
+        )
+    resolved_scope = scope
+    if resolved_scope is None:
+        resolved_scope = await _resolve_scope(scope_provider)
+    _required_scope_account_id(resolved_scope)
+    try:
+        value = brand_voice_profile_provider(resolved_scope or TenantScope(), profile_id)
+        if hasattr(value, "__await__"):
+            value = await value
+        if value is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Brand voice profile not found.",
+            )
+        profile = brand_voice_profile_from_mapping(
+            value,
+            scope=resolved_scope,
+            profile_id=profile_id,
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.warning(
+            "Content Ops brand voice profile provider failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops brand voice profile lookup is unavailable.",
+        ) from exc
+    if profile is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Brand voice profile not found.",
+        )
+    out_inputs = dict(inputs) if isinstance(inputs, Mapping) else {}
+    out_inputs["brand_voice"] = _brand_voice_profile_payload(profile)
+    out["inputs"] = out_inputs
+    return out
+
+
+def _brand_voice_profile_payload(profile: BrandVoiceProfile) -> dict[str, Any]:
+    return {
+        "id": profile.id,
+        "account_id": profile.account_id,
+        "name": profile.name,
+        "descriptors": list(profile.descriptors),
+        "exemplars": list(profile.exemplars),
+        "banned_terms": list(profile.banned_terms),
+        "preferred_pov": profile.preferred_pov,
+        "reading_level": profile.reading_level,
+        "metadata": dict(profile.metadata or {}),
+    }
 
 
 def _with_input_provider_diagnostics(

--- a/plans/PR-Content-Ops-Brand-Voice-Profile-Storage.md
+++ b/plans/PR-Content-Ops-Brand-Voice-Profile-Storage.md
@@ -1,0 +1,186 @@
+# PR-Content-Ops-Brand-Voice-Profile-Storage
+
+## Why this slice exists
+
+PR-Content-Ops-Brand-Voice-Profile shipped the executable request-time brand
+voice contract, but it intentionally requires callers to include the full
+inline `inputs.brand_voice` payload whenever `brand_voice_profile_id` is set.
+That proves prompt injection and tenant scope checks, but it leaves operators
+without the product path they need: save a tenant profile once, select it in
+the Content Ops UI, and have preview/plan/execute resolve it safely.
+
+This slice closes the explicitly deferred
+`PR-Content-Ops-Brand-Voice-Profile-Storage` item from that plan. It keeps the
+storage and CRUD surface in the Atlas host because profiles are authenticated
+tenant data, while adding only a dependency-injected lookup hook to the
+extracted control-surface router so standalone extraction remains lightweight.
+
+The PR is expected to exceed the 400 LOC soft cap because the usable path is
+cross-layer: host migration/repository, host CRUD routes, extracted
+preview/plan/execute lookup, frontend API/domain mapping, selector UI, and the
+CI-enrolled frontend test have to land together. Splitting before the selector
+would create unreachable storage; splitting before the lookup would create a
+selector that sends an ID the backend still fails closed on.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice-profile-storage
+Slice phase: Vertical slice
+
+1. Add tenant-scoped host storage for saved brand voice profiles with soft
+   delete, list, get, create/update, and display-safe DTO conversion.
+2. Mount authenticated CRUD/list routes at
+   `/api/v1/content-ops/brand-voice-profiles`, mirroring the existing
+   Zendesk-credential route shape and admin write guard.
+3. Add an extracted control-surface lookup provider that resolves
+   `brand_voice_profile_id` into `inputs.brand_voice` for preview, plan, and
+   execute before the existing executor gate runs.
+4. Fail closed when a selected stored profile is missing, cross-tenant, or the
+   host did not wire the lookup provider. Do not fall back to any shared/global
+   profile.
+5. Add frontend wire/domain types, API functions, and a selector on
+   `ContentOpsNewRun` that sends only `brand_voice_profile_id`.
+6. Add focused backend and frontend tests, including the exact intel-ui workflow
+   enrollment step for the new frontend script.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Brand-Voice-Profile-Storage.md`
+- `atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql`
+- `atlas_brain/_content_ops_brand_voice_profiles.py`
+- `atlas_brain/api/content_ops_brand_voice_profiles.py`
+- `atlas_brain/api/__init__.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/domain/contentOps/types.ts`
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+- `.github/workflows/atlas_content_ops_generated_assets_checks.yml`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_content_ops_brand_voice_profiles.py`
+- `tests/test_content_ops_brand_voice_profiles_api.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+- `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs`
+
+## Mechanism
+
+Host storage owns rows keyed by `(account_id, id)`:
+
+```sql
+CREATE TABLE content_ops_brand_voice_profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id UUID NOT NULL REFERENCES saas_accounts(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  descriptors JSONB NOT NULL DEFAULT '[]'::jsonb,
+  exemplars JSONB NOT NULL DEFAULT '[]'::jsonb,
+  banned_terms JSONB NOT NULL DEFAULT '[]'::jsonb,
+  preferred_pov TEXT,
+  reading_level TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  archived_at TIMESTAMPTZ
+);
+```
+
+The host repository normalizes profile payloads through the existing
+`BrandVoiceProfile` helper, stores only bounded arrays, and returns display-safe
+records. API writes require the same owner/admin role pattern used by Zendesk
+credentials; reads use the authenticated account. Deletes are soft archives.
+
+The extracted router gets a new optional provider:
+
+```python
+BrandVoiceProfileProvider = Callable[
+    [TenantScope, str],
+    BrandVoiceProfile | Mapping[str, Any] | None
+    | Awaitable[BrandVoiceProfile | Mapping[str, Any] | None],
+]
+```
+
+Before preview, plan, or execute, the router checks for
+`brand_voice_profile_id` without inline `inputs.brand_voice`. If present, it
+requires a tenant scope and provider, resolves exactly that profile for that
+scope, injects the full normalized profile into `inputs.brand_voice`, and then
+continues through the already-merged executor/generator path. A miss returns a
+404/400-class failure rather than guessing or using defaults.
+
+The UI loads profiles with `fetchContentOpsBrandVoiceProfiles()`, renders a
+compact selector in the options area, and stores the selected ID on
+`request.brandVoiceProfileId`. `toWireRequest()` maps it to
+`brand_voice_profile_id`; the UI does not copy exemplars or banned terms into
+the editable inputs JSON.
+
+## Intentional
+
+- No profile authoring UI in this slice. The API supports create/update/delete;
+  the first UI surface is selection so the existing generation form can consume
+  stored profiles without building a second editor workflow.
+- Stored profiles are host-owned, not an extracted Postgres adapter. They are
+  authenticated SaaS account data and reuse host `AuthUser`, `saas_accounts`,
+  and admin write guards; the extracted router only gets a small lookup port.
+- The executor still fails closed on bare `brand_voice_profile_id` when called
+  directly without API lookup. That preserves the request-time contract for
+  standalone callers and keeps stored lookup explicitly host-wired.
+- No global preset/profile fallback. Missing tenant profiles are hard failures
+  when selected.
+- #1268 remains open and owned elsewhere; this PR does not touch output
+  variations.
+
+## Deferred
+
+- `PR-Content-Ops-Brand-Voice-Profile-Editor`: full in-app create/edit form
+  for descriptors, exemplars, banned terms, POV, and reading level.
+- `PR-Content-Ops-Brand-Voice-Presets`: shipped descriptor-only preset library.
+- `PR-Content-Ops-Brand-Voice-Onboarding`: scrape/upload samples and pre-fill a
+  custom profile for human edit.
+- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can
+  consume brand voice.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_content_ops_brand_voice_profiles.py tests/test_content_ops_brand_voice_profiles_api.py -q` -- 17 passed.
+- `pytest tests/test_extracted_content_control_surface_api.py -q` -- 131 passed, 1 skipped.
+- `pytest tests/test_atlas_content_ops_generated_assets_api.py -q` -- 16 passed, 1 warning.
+- `python -m pytest tests/test_atlas_content_ops_generated_assets_api.py tests/test_content_ops_brand_voice_profiles.py tests/test_content_ops_brand_voice_profiles_api.py -q` -- 33 passed, 1 warning.
+- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector` -- 6 assertions passed.
+- `cd atlas-intel-ui && npm run build` -- passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` -- 3105 passed, 10 skipped, 1 warning.
+- `git diff --check` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-brand-voice-profile-storage.md` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-Brand-Voice-Profile-Storage.md` | 186 |
+| `atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql` | 45 |
+| `atlas_brain/_content_ops_brand_voice_profiles.py` | 328 |
+| `atlas_brain/api/content_ops_brand_voice_profiles.py` | 212 |
+| `atlas_brain/api/__init__.py` | 16 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 101 |
+| `atlas-intel-ui/src/api/contentOps.ts` | 78 |
+| `atlas-intel-ui/src/domain/contentOps/types.ts` | 1 |
+| `atlas-intel-ui/src/domain/contentOps/fromWire.ts` | 4 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 125 |
+| `atlas-intel-ui/package.json` | 1 |
+| `.github/workflows/atlas_intel_ui_checks.yml` | 3 |
+| `.github/workflows/atlas_content_ops_generated_assets_checks.yml` | 14 |
+| `scripts/run_extracted_pipeline_checks.sh` | 2 |
+| `tests/test_content_ops_brand_voice_profiles.py` | 215 |
+| `tests/test_content_ops_brand_voice_profiles_api.py` | 278 |
+| `tests/test_extracted_content_control_surface_api.py` | 148 |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | 31 |
+| `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs` | 206 |
+| **Total** | **1988** |
+
+Expected final: 19 files, +1988 / -0. The overage is the
+minimum useful vertical slice for stored profiles to be selectable and
+generation-ready end to end.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -104,6 +104,8 @@ pytest \
   tests/test_atlas_content_ops_review_input_provider.py \
   tests/test_atlas_content_ops_macro_writeback.py \
   tests/test_content_ops_faq_macro_writeback_flow.py \
+  tests/test_content_ops_brand_voice_profiles.py \
+  tests/test_content_ops_brand_voice_profiles_api.py \
   tests/test_content_ops_zendesk_credentials.py \
   tests/test_content_ops_zendesk_credentials_api.py \
   tests/test_atlas_content_ops_reasoning.py \

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -268,6 +268,37 @@ def test_content_ops_zendesk_credentials_route_uses_shared_auth_and_pool() -> No
     assert "_capture_content_ops_auth_user" in dependency_names
 
 
+def test_content_ops_brand_voice_profiles_route_uses_shared_auth_and_pool() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/brand-voice-profiles")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert closure["pool_provider"].__name__ == "get_db_pool"
+    assert "_capture_content_ops_auth_user" in dependency_names
+
+
+def test_content_ops_preview_route_uses_host_brand_voice_profile_provider() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/preview")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+
+    assert closure["brand_voice_profile_provider"].__name__ == "<lambda>"
+
+
 def test_content_ops_usage_summary_route_uses_shared_auth_and_pool() -> None:
     api_pkg = _fresh_api_package()
     route = _route(api_pkg, "/content-ops/usage/summary")

--- a/tests/test_content_ops_brand_voice_profiles.py
+++ b/tests/test_content_ops_brand_voice_profiles.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import json
+import uuid
+
+import pytest
+
+from atlas_brain import _content_ops_brand_voice_profiles as service
+
+
+MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain"
+    / "storage"
+    / "migrations"
+    / "333_content_ops_brand_voice_profiles.sql"
+)
+
+
+class _Pool:
+    def __init__(self, *, fetchrow_result=None, fetch_rows=None) -> None:
+        self.fetchrow_result = fetchrow_result
+        self.fetch_rows = list(fetch_rows or [])
+        self.fetchrow_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append({"query": str(query), "args": args})
+        return self.fetchrow_result
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        return self.fetch_rows
+
+
+class _FailingFetchrowPool(_Pool):
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append({"query": str(query), "args": args})
+        raise RuntimeError("database unavailable")
+
+
+def _row(**overrides):
+    row = {
+        "id": uuid.uuid4(),
+        "account_id": uuid.uuid4(),
+        "name": "Acme editorial",
+        "descriptors": json.dumps(["plainspoken", "operator-led"]),
+        "exemplars": json.dumps(["This is how Acme writes."]),
+        "banned_terms": json.dumps(["synergy"]),
+        "preferred_pov": "second_person",
+        "reading_level": "plain",
+        "metadata": json.dumps({"source": "operator"}),
+        "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "updated_at": datetime(2026, 1, 2, tzinfo=timezone.utc),
+        "archived_at": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_content_ops_brand_voice_profiles_migration_is_tenant_scoped() -> None:
+    sql = MIGRATION.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS content_ops_brand_voice_profiles" in sql
+    assert "account_id     UUID NOT NULL REFERENCES saas_accounts(id)" in sql
+    assert "descriptors    JSONB NOT NULL DEFAULT '[]'::jsonb" in sql
+    assert "archived_at    TIMESTAMPTZ" in sql
+    assert "uq_content_ops_brand_voice_profiles_account_name_active" in sql
+    assert "WHERE archived_at IS NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_create_brand_voice_profile_normalizes_and_inserts_profile() -> None:
+    account_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result=_row(account_id=account_id))
+
+    record = await service.create_brand_voice_profile(
+        pool,
+        account_id=account_id,
+        payload={
+            "name": " Acme editorial ",
+            "descriptors": ["plainspoken", "operator-led"],
+            "exemplars": [{"text": "Write like this."}],
+            "banned_terms": ["synergy"],
+            "preferred_pov": "you",
+            "reading_level": "plain",
+            "metadata": {"source": "operator"},
+        },
+    )
+
+    call = pool.fetchrow_calls[0]
+    assert "INSERT INTO content_ops_brand_voice_profiles" in call["query"]
+    args = call["args"]
+    assert args[0] == account_id
+    assert args[1] == "Acme editorial"
+    assert json.loads(args[2]) == ["plainspoken", "operator-led"]
+    assert json.loads(args[3]) == ["Write like this."]
+    assert json.loads(args[4]) == ["synergy"]
+    assert args[5] == "second_person"
+    assert args[6] == "plain"
+    assert json.loads(args[7]) == {"source": "operator"}
+    assert record.account_id == account_id
+    assert record.descriptors == ("plainspoken", "operator-led")
+    assert record.as_profile().banned_terms == ("synergy",)
+
+
+@pytest.mark.asyncio
+async def test_update_brand_voice_profile_is_tenant_scoped() -> None:
+    account_id = uuid.uuid4()
+    profile_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result=_row(id=profile_id, account_id=account_id))
+
+    record = await service.update_brand_voice_profile(
+        pool,
+        account_id=account_id,
+        profile_id=profile_id,
+        payload={"name": "Acme v2", "descriptors": ["direct"]},
+    )
+
+    assert record is not None
+    call = pool.fetchrow_calls[0]
+    compact_sql = " ".join(call["query"].split())
+    assert "UPDATE content_ops_brand_voice_profiles" in compact_sql
+    assert "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL" in compact_sql
+    assert call["args"][:3] == (profile_id, account_id, "Acme v2")
+
+
+@pytest.mark.asyncio
+async def test_list_brand_voice_profiles_returns_display_records() -> None:
+    account_id = uuid.uuid4()
+    pool = _Pool(fetch_rows=[_row(account_id=account_id)])
+
+    records = await service.list_brand_voice_profiles(pool, account_id=account_id)
+
+    assert records[0].account_id == account_id
+    assert records[0].metadata == {"source": "operator"}
+    assert records[0].exemplars == ("This is how Acme writes.",)
+    call = pool.fetch_calls[0]
+    assert "WHERE account_id = $1" in call["query"]
+    assert "archived_at IS NULL" in call["query"]
+    assert call["args"] == (account_id,)
+
+
+@pytest.mark.asyncio
+async def test_lookup_brand_voice_profile_returns_full_profile() -> None:
+    account_id = uuid.uuid4()
+    profile_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result=_row(id=profile_id, account_id=account_id))
+
+    profile = await service.lookup_brand_voice_profile(
+        pool,
+        account_id=str(account_id),
+        profile_id=str(profile_id),
+    )
+
+    assert profile is not None
+    assert profile.id == str(profile_id)
+    assert profile.account_id == str(account_id)
+    assert profile.exemplars == ("This is how Acme writes.",)
+    assert pool.fetchrow_calls[0]["args"] == (profile_id, account_id)
+
+
+@pytest.mark.asyncio
+async def test_lookup_brand_voice_profile_fails_closed_on_bad_ids() -> None:
+    pool = _Pool(fetchrow_result=_row())
+
+    profile = await service.lookup_brand_voice_profile(
+        pool,
+        account_id="not-a-uuid",
+        profile_id=str(uuid.uuid4()),
+    )
+
+    assert profile is None
+    assert pool.fetchrow_calls == []
+
+
+@pytest.mark.asyncio
+async def test_lookup_brand_voice_profile_propagates_database_unavailable() -> None:
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await service.lookup_brand_voice_profile(
+            _FailingFetchrowPool(),
+            account_id=str(uuid.uuid4()),
+            profile_id=str(uuid.uuid4()),
+        )
+
+
+@pytest.mark.asyncio
+async def test_archive_brand_voice_profile_is_tenant_scoped() -> None:
+    account_id = uuid.uuid4()
+    profile_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result={"id": profile_id})
+
+    archived = await service.archive_brand_voice_profile(
+        pool,
+        account_id=account_id,
+        profile_id=profile_id,
+    )
+
+    assert archived is True
+    call = pool.fetchrow_calls[0]
+    compact_sql = " ".join(call["query"].split())
+    assert "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL" in compact_sql
+    assert call["args"] == (profile_id, account_id)
+
+
+@pytest.mark.asyncio
+async def test_brand_voice_profile_requires_guidance() -> None:
+    with pytest.raises(ValueError, match="requires at least one"):
+        await service.create_brand_voice_profile(
+            _Pool(fetchrow_result=_row()),
+            account_id=uuid.uuid4(),
+            payload={"name": "Empty profile"},
+        )

--- a/tests/test_content_ops_brand_voice_profiles_api.py
+++ b/tests/test_content_ops_brand_voice_profiles_api.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import uuid
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from atlas_brain._content_ops_brand_voice_profiles import (
+    ContentOpsBrandVoiceProfileRecord,
+)
+from atlas_brain.auth.dependencies import AuthUser
+
+
+API_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain"
+    / "api"
+    / "content_ops_brand_voice_profiles.py"
+)
+ACCOUNT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+PROFILE_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+api = None
+
+
+def setup_module() -> None:
+    global api
+    api = _load_api_module()
+
+
+def _load_api_module():
+    spec = importlib.util.spec_from_file_location(
+        "atlas_brain.api.content_ops_brand_voice_profiles_for_test",
+        API_MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Pool:
+    is_initialized = True
+
+
+def _user(account_id: uuid.UUID = ACCOUNT_ID, *, role: str = "owner") -> AuthUser:
+    return AuthUser(
+        user_id="33333333-3333-3333-3333-333333333333",
+        account_id=str(account_id),
+        plan="b2b_growth",
+        plan_status="active",
+        role=role,
+        product="b2b_challenger",
+    )
+
+
+def _record(**overrides) -> ContentOpsBrandVoiceProfileRecord:
+    row = {
+        "id": PROFILE_ID,
+        "account_id": ACCOUNT_ID,
+        "name": "Acme editorial",
+        "descriptors": ("plainspoken",),
+        "exemplars": ("Write like this.",),
+        "banned_terms": ("synergy",),
+        "preferred_pov": "second_person",
+        "reading_level": "plain",
+        "metadata": {"source": "operator"},
+        "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "updated_at": datetime(2026, 1, 2, tzinfo=timezone.utc),
+        "archived_at": None,
+    }
+    row.update(overrides)
+    return ContentOpsBrandVoiceProfileRecord(**row)
+
+
+def _client(*, pool=None, user: AuthUser | None = None) -> TestClient:
+    app = fastapi.FastAPI()
+
+    def pool_provider():
+        return pool if pool is not None else _Pool()
+
+    def auth_dependency():
+        return user or _user()
+
+    app.include_router(api.create_content_ops_brand_voice_profiles_router(
+        pool_provider=pool_provider,
+        auth_dependency=auth_dependency,
+    ))
+    return TestClient(app)
+
+
+def test_list_brand_voice_profiles_returns_tenant_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def list_profiles(pool, *, account_id):
+        calls.append({"pool": pool, "account_id": account_id})
+        return [_record()]
+
+    monkeypatch.setattr(api, "list_brand_voice_profiles", list_profiles)
+    client = _client()
+
+    response = client.get("/content-ops/brand-voice-profiles")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body[0]["id"] == str(PROFILE_ID)
+    assert body[0]["account_id"] == str(ACCOUNT_ID)
+    assert body[0]["descriptors"] == ["plainspoken"]
+    assert body[0]["banned_terms"] == ["synergy"]
+    assert calls[0]["account_id"] == ACCOUNT_ID
+
+
+def test_add_brand_voice_profile_uses_authenticated_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def create_profile(pool, *, account_id, payload):
+        calls.append({"pool": pool, "account_id": account_id, "payload": payload})
+        return _record(name=payload["name"])
+
+    monkeypatch.setattr(api, "create_brand_voice_profile", create_profile)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/brand-voice-profiles",
+        json={"name": "Acme editorial", "descriptors": ["plainspoken"]},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["name"] == "Acme editorial"
+    assert calls[0]["account_id"] == ACCOUNT_ID
+    assert calls[0]["payload"]["descriptors"] == ("plainspoken",)
+
+
+def test_add_brand_voice_profile_requires_admin_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def create_profile(pool, *, account_id, payload):
+        raise AssertionError("member should not create profiles")
+
+    monkeypatch.setattr(api, "create_brand_voice_profile", create_profile)
+    client = _client(user=_user(role="member"))
+
+    response = client.post(
+        "/content-ops/brand-voice-profiles",
+        json={"name": "Acme editorial", "descriptors": ["plainspoken"]},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin access required"
+
+
+def test_update_brand_voice_profile_is_account_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def update_profile(pool, *, account_id, profile_id, payload):
+        calls.append({
+            "account_id": account_id,
+            "profile_id": profile_id,
+            "payload": payload,
+        })
+        return _record(id=profile_id, account_id=account_id, name=payload["name"])
+
+    monkeypatch.setattr(api, "update_brand_voice_profile", update_profile)
+    client = _client()
+
+    response = client.put(
+        f"/content-ops/brand-voice-profiles/{PROFILE_ID}",
+        json={"name": "Acme v2", "descriptors": ["direct"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Acme v2"
+    assert calls == [{
+        "account_id": ACCOUNT_ID,
+        "profile_id": PROFILE_ID,
+        "payload": calls[0]["payload"],
+    }]
+    assert calls[0]["payload"]["descriptors"] == ("direct",)
+
+
+def test_update_brand_voice_profile_returns_404_for_missing_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def update_profile(pool, *, account_id, profile_id, payload):
+        return None
+
+    monkeypatch.setattr(api, "update_brand_voice_profile", update_profile)
+    client = _client()
+
+    invalid = client.put(
+        "/content-ops/brand-voice-profiles/not-a-uuid",
+        json={"name": "Acme v2", "descriptors": ["direct"]},
+    )
+    missing = client.put(
+        f"/content-ops/brand-voice-profiles/{PROFILE_ID}",
+        json={"name": "Acme v2", "descriptors": ["direct"]},
+    )
+
+    assert invalid.status_code == 404
+    assert missing.status_code == 404
+
+
+def test_delete_brand_voice_profile_is_account_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def archive(pool, *, account_id, profile_id):
+        calls.append({"account_id": account_id, "profile_id": profile_id})
+        return True
+
+    monkeypatch.setattr(api, "archive_brand_voice_profile", archive)
+    client = _client()
+
+    response = client.delete(f"/content-ops/brand-voice-profiles/{PROFILE_ID}")
+
+    assert response.status_code == 204
+    assert calls == [{"account_id": ACCOUNT_ID, "profile_id": PROFILE_ID}]
+
+
+def test_brand_voice_profile_routes_fail_when_database_unavailable() -> None:
+    class _UninitializedPool:
+        is_initialized = False
+
+    client = _client(pool=_UninitializedPool())
+
+    response = client.get("/content-ops/brand-voice-profiles")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database not ready"
+
+
+def test_brand_voice_profile_api_import_does_not_require_asyncpg() -> None:
+    script = textwrap.dedent("""
+import sys
+
+class BlockAsyncpg:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == 'asyncpg' or fullname.startswith('asyncpg.'):
+            raise ModuleNotFoundError("No module named 'asyncpg'")
+        return None
+
+sys.meta_path.insert(0, BlockAsyncpg())
+import importlib.util
+from pathlib import Path
+
+path = Path('atlas_brain/api/content_ops_brand_voice_profiles.py').resolve()
+spec = importlib.util.spec_from_file_location(
+    'atlas_brain.api.content_ops_brand_voice_profiles_block_asyncpg_test',
+    path,
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+print(module.BrandVoiceProfileView.__name__)
+""")
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "BrandVoiceProfileView" in result.stdout

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -1137,6 +1137,115 @@ async def test_plan_generation_route_marks_steps_blocked_when_account_budget_exc
 
 
 @pytest.mark.asyncio
+async def test_preview_generation_route_resolves_stored_brand_voice_profile():
+    calls: list[dict[str, str]] = []
+
+    def profile_provider(scope, profile_id):
+        calls.append({"account_id": scope.account_id, "profile_id": profile_id})
+        return {
+            "id": "acme-main",
+            "account_id": "acct-1",
+            "name": "Acme editorial",
+            "descriptors": ["plainspoken"],
+            "exemplars": ["Write like this."],
+            "banned_terms": ["synergy"],
+        }
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-1"},
+        brand_voice_profile_provider=profile_provider,
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint({
+        "brand_voice_profile_id": "acme-main",
+        "outputs": ["email_campaign"],
+        "inputs": {
+            "target_account": "Acme",
+            "offer": "Churn audit",
+        },
+    })
+
+    assert payload["can_run"] is True
+    assert payload["normalized_request"]["brand_voice_profile_id"] == "acme-main"
+    assert calls == [{"account_id": "acct-1", "profile_id": "acme-main"}]
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_fails_closed_without_brand_voice_provider():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "brand_voice_profile_id": "acme-main",
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+        })
+
+    assert exc.value.status_code == 503
+    assert "brand voice profile lookup is not configured" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_fails_closed_on_missing_brand_voice_profile():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-1"},
+        brand_voice_profile_provider=lambda scope, profile_id: None,
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "brand_voice_profile_id": "missing-profile",
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+        })
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Brand voice profile not found."
+
+
+@pytest.mark.asyncio
+async def test_plan_generation_route_fails_closed_on_brand_voice_scope_mismatch():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-1"},
+        brand_voice_profile_provider=lambda scope, profile_id: {
+            "id": profile_id,
+            "account_id": "acct-2",
+            "name": "Other tenant",
+            "descriptors": ["formal"],
+        },
+    )
+
+    route = _route(router, "/ops/plan", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "brand_voice_profile_id": "acme-main",
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+        })
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "brand_voice.account_id does not match tenant scope"
+
+
+@pytest.mark.asyncio
 async def test_preview_generation_route_hides_noop_input_provider_diagnostics():
     provider = _SyncInputProvider(
         ContentOpsInputPackage(
@@ -2181,6 +2290,45 @@ async def test_execute_generation_route_runs_configured_services():
     assert service.calls[0]["limit"] == 2
     assert service.calls[0]["filters"] == {"status": "ready"}
     assert "input_provider" not in payload
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_threads_stored_brand_voice_to_service():
+    service = _CampaignService()
+
+    async def profile_provider(scope, profile_id):
+        return {
+            "id": profile_id,
+            "account_id": scope.account_id,
+            "name": "Acme editorial",
+            "descriptors": ["plainspoken"],
+            "exemplars": ["Write like this."],
+            "banned_terms": ["synergy"],
+        }
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(campaign=service),
+        scope_provider=lambda: {"account_id": "acct-1"},
+        brand_voice_profile_provider=profile_provider,
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    payload = await route.endpoint({
+        "brand_voice_profile_id": "acme-main",
+        "outputs": ["email_campaign"],
+        "inputs": {
+            "target_account": "Acme",
+            "offer": "Churn audit",
+        },
+    })
+
+    assert payload["status"] == "completed"
+    brand_voice = service.calls[0]["kwargs"]["brand_voice"]
+    assert brand_voice.id == "acme-main"
+    assert brand_voice.account_id == "acct-1"
+    assert brand_voice.exemplars == ("Write like this.",)
+    assert brand_voice.banned_terms == ("synergy",)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Brand-Voice-Profile-Storage.md
Slice phase: Vertical slice

This finishes the stored brand-voice path that PR-Content-Ops-Brand-Voice-Profile deferred: authenticated tenants can store brand voice profiles in the host, the Content Ops UI can select a saved profile, and preview/plan/execute resolve the selected ID into the existing `inputs.brand_voice` contract without copying profile material into the editable inputs JSON.

## Intentional
- Stored profiles are host-owned tenant data, not an extracted Postgres adapter; the extracted router only gets a dependency-injected lookup provider.
- The UI adds selection only. Full create/edit/onboarding UX is deferred to keep this vertical slice focused.
- Direct extracted callers still fail closed on a bare `brand_voice_profile_id` unless a host lookup provider is wired.
- No global or shared profile fallback; a missing selected profile is a hard failure.
- #1268 remains open and owned elsewhere; this PR does not touch output variations.

## Deferred
- `PR-Content-Ops-Brand-Voice-Profile-Editor`: full in-app create/edit form.
- `PR-Content-Ops-Brand-Voice-Presets`: descriptor-only preset library.
- `PR-Content-Ops-Brand-Voice-Onboarding`: scrape/upload samples and pre-fill a custom profile for human edit.
- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can consume brand voice.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_brand_voice_profiles.py tests/test_content_ops_brand_voice_profiles_api.py -q` -- 17 passed.
- `pytest tests/test_extracted_content_control_surface_api.py -q` -- 131 passed, 1 skipped.
- `pytest tests/test_atlas_content_ops_generated_assets_api.py -q` -- 16 passed, 1 warning.
- `python -m pytest tests/test_atlas_content_ops_generated_assets_api.py tests/test_content_ops_brand_voice_profiles.py tests/test_content_ops_brand_voice_profiles_api.py -q` -- 33 passed, 1 warning.
- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector` -- 6 assertions passed.
- `cd atlas-intel-ui && npm run build` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 3105 passed, 10 skipped, 1 warning.
- `git diff --check` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-brand-voice-profile-storage.md` -- passed.

## Diff size
19 files, +1988 / -0. This is over the 400 LOC soft cap because the usable path spans host storage/API, extracted lookup, UI selection, and CI-enrolled tests.
