### PR TITLE
Content Ops Brand Voice Onboarding

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
@@ -43,6 +43,14 @@ const {
   toWireRequest,
 } = await loadTsModule('../src/domain/contentOps/fromWire.ts')
 
+const {
+  applyBrandVoiceProfileEditorPatch,
+  blankBrandVoiceProfileEditorState,
+  brandVoiceProfileEditorRequest,
+  canSaveBrandVoiceProfileEditor,
+  deriveBrandVoiceProfileEditorPatch,
+} = await loadTsModule('../src/domain/contentOps/brandVoiceProfileEditor.ts')
+
 const newRunSource = readFileSync(
   new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
   'utf8',
@@ -197,6 +205,88 @@ test('brand voice profile id round-trips through domain request mapping', () => 
   assert.deepEqual(wire.inputs, { target_keyword: 'support tickets' })
 })
 
+test('brand voice editor request trims and bounds textarea fields', () => {
+  const editor = {
+    ...blankBrandVoiceProfileEditorState(),
+    name: '  Acme editorial  ',
+    descriptorsText: Array.from({ length: 10 }, (_, index) => ` descriptor ${index} `).join('\n'),
+    exemplarsText: ' First example. \n\n Second example. \n Third example. \n Fourth example. ',
+    bannedTermsText: ' synergy \n\n leverage ',
+    preferredPov: ' second_person ',
+    readingLevel: ' plain ',
+  }
+
+  assert.equal(canSaveBrandVoiceProfileEditor(editor), true)
+  const body = brandVoiceProfileEditorRequest(editor)
+
+  assert.equal(body.name, 'Acme editorial')
+  assert.deepEqual(body.descriptors, [
+    'descriptor 0',
+    'descriptor 1',
+    'descriptor 2',
+    'descriptor 3',
+    'descriptor 4',
+    'descriptor 5',
+    'descriptor 6',
+    'descriptor 7',
+  ])
+  assert.deepEqual(body.exemplars, [
+    'First example.',
+    'Second example.',
+    'Third example.',
+  ])
+  assert.deepEqual(body.banned_terms, ['synergy', 'leverage'])
+  assert.equal(body.preferred_pov, 'second_person')
+  assert.equal(body.reading_level, 'plain')
+  assert.equal(
+    canSaveBrandVoiceProfileEditor({
+      ...blankBrandVoiceProfileEditorState(),
+      name: 'Acme editorial',
+    }),
+    false,
+  )
+})
+
+test('brand voice sample import derives editable profile fields', () => {
+  const patch = deriveBrandVoiceProfileEditorPatch(
+    "You can launch secure workflows faster. Your team gets clean automation without waiting on a long integration project. We're here when your operators need help!",
+    { fallbackName: 'acme-homepage.txt' },
+  )
+
+  assert.equal(patch.name, 'acme homepage')
+  assert.equal(patch.preferredPov, 'second_person')
+  assert.equal(patch.readingLevel, 'plain')
+  assert.ok(patch.descriptorsText.includes('concise'))
+  assert.ok(patch.descriptorsText.includes('customer-focused'))
+  assert.ok(patch.descriptorsText.includes('conversational'))
+  assert.ok(patch.descriptorsText.includes('technical'))
+  assert.ok(patch.exemplarsText.includes('secure workflows'))
+  assert.deepEqual(patch.metadata, {
+    source: 'content_ops_ui_sample',
+    sample_character_count: 160,
+  })
+})
+
+test('brand voice sample patch preserves manually entered fields', () => {
+  const editor = {
+    ...blankBrandVoiceProfileEditorState(),
+    name: 'Manual profile',
+    descriptorsText: '',
+    exemplarsText: 'Existing example.',
+  }
+  const patch = deriveBrandVoiceProfileEditorPatch(
+    'Your support team can resolve data questions quickly.',
+    { fallbackName: 'sample.txt' },
+  )
+
+  const merged = applyBrandVoiceProfileEditorPatch(editor, patch)
+
+  assert.equal(merged.name, 'Manual profile')
+  assert.ok(merged.descriptorsText.includes('customer-focused'))
+  assert.equal(merged.exemplarsText, 'Existing example.')
+  assert.equal(merged.preferredPov, 'second_person')
+})
+
 test('new run page renders brand voice profile selector wiring', () => {
   assert.ok(newRunSource.includes('function BrandVoiceProfileSelector'))
   assert.ok(newRunSource.includes('fetchContentOpsBrandVoiceProfiles'))
@@ -209,8 +299,9 @@ test('new run page renders brand voice profile selector wiring', () => {
   assert.ok(newRunSource.includes('New brand voice'))
   assert.ok(newRunSource.includes('Edit brand voice'))
   assert.ok(newRunSource.includes('Archive'))
+  assert.ok(newRunSource.includes('Sample import'))
+  assert.ok(newRunSource.includes('type="file"'))
+  assert.ok(newRunSource.includes('deriveBrandVoiceProfileEditorPatch'))
   assert.ok(newRunSource.includes('disabled={loading || mutating}'))
   assert.ok(newRunSource.includes('selectedProfileIdRef.current === archiveProfileId'))
-  assert.ok(newRunSource.includes('function brandVoiceProfileEditorRequest'))
-  assert.ok(newRunSource.includes('function canSaveBrandVoiceProfileEditor'))
 })

--- a/atlas-intel-ui/src/domain/contentOps/brandVoiceProfileEditor.ts
+++ b/atlas-intel-ui/src/domain/contentOps/brandVoiceProfileEditor.ts
@@ -1,0 +1,219 @@
+import type {
+  ContentOpsBrandVoiceProfile,
+  UpsertContentOpsBrandVoiceProfileRequest,
+} from '../../api/contentOps'
+
+export type BrandVoiceProfileEditorState = {
+  mode: 'create' | 'edit'
+  profileId: string | null
+  name: string
+  descriptorsText: string
+  exemplarsText: string
+  bannedTermsText: string
+  preferredPov: string
+  readingLevel: string
+  metadata: Record<string, unknown>
+}
+
+export type BrandVoiceProfileEditorPatch = Partial<
+  Omit<BrandVoiceProfileEditorState, 'mode' | 'profileId'>
+>
+
+export function blankBrandVoiceProfileEditorState(): BrandVoiceProfileEditorState {
+  return {
+    mode: 'create',
+    profileId: null,
+    name: '',
+    descriptorsText: '',
+    exemplarsText: '',
+    bannedTermsText: '',
+    preferredPov: '',
+    readingLevel: '',
+    metadata: { source: 'content_ops_ui' },
+  }
+}
+
+export function brandVoiceProfileEditorStateFromProfile(
+  profile: ContentOpsBrandVoiceProfile,
+): BrandVoiceProfileEditorState {
+  return {
+    mode: 'edit',
+    profileId: profile.id,
+    name: profile.name,
+    descriptorsText: brandVoiceProfileListText(profile.descriptors),
+    exemplarsText: brandVoiceProfileListText(profile.exemplars),
+    bannedTermsText: brandVoiceProfileListText(profile.banned_terms),
+    preferredPov: profile.preferred_pov ?? '',
+    readingLevel: profile.reading_level ?? '',
+    metadata: { ...profile.metadata },
+  }
+}
+
+export function brandVoiceProfileEditorRequest(
+  editor: BrandVoiceProfileEditorState,
+): UpsertContentOpsBrandVoiceProfileRequest {
+  const preferredPov = cleanOptionalText(editor.preferredPov)
+  const readingLevel = cleanOptionalText(editor.readingLevel)
+  return {
+    name: editor.name.trim(),
+    descriptors: brandVoiceProfileListItems(editor.descriptorsText, 8),
+    exemplars: brandVoiceProfileListItems(editor.exemplarsText, 3),
+    banned_terms: brandVoiceProfileListItems(editor.bannedTermsText, 20),
+    preferred_pov: preferredPov,
+    reading_level: readingLevel,
+    metadata: { ...editor.metadata },
+  }
+}
+
+export function canSaveBrandVoiceProfileEditor(
+  editor: BrandVoiceProfileEditorState,
+): boolean {
+  if (!editor.name.trim()) return false
+  const body = brandVoiceProfileEditorRequest(editor)
+  return Boolean(
+    (body.descriptors?.length ?? 0) > 0 ||
+      (body.exemplars?.length ?? 0) > 0 ||
+      (body.banned_terms?.length ?? 0) > 0 ||
+      body.preferred_pov ||
+      body.reading_level,
+  )
+}
+
+export function deriveBrandVoiceProfileEditorPatch(
+  sampleText: string,
+  options: { fallbackName?: string } = {},
+): BrandVoiceProfileEditorPatch {
+  const normalized = normalizeSampleText(sampleText)
+  const sentences = sampleSentences(normalized)
+  return {
+    name: brandVoiceSampleName(options.fallbackName ?? ''),
+    descriptorsText: sampleDescriptors(normalized, sentences).join('\n'),
+    exemplarsText: sampleExemplars(sentences, normalized).join('\n'),
+    bannedTermsText: '',
+    preferredPov: samplePreferredPov(normalized),
+    readingLevel: sampleReadingLevel(sentences),
+    metadata: {
+      source: 'content_ops_ui_sample',
+      sample_character_count: normalized.length,
+    },
+  }
+}
+
+export function applyBrandVoiceProfileEditorPatch(
+  editor: BrandVoiceProfileEditorState,
+  patch: BrandVoiceProfileEditorPatch,
+): BrandVoiceProfileEditorState {
+  return {
+    ...editor,
+    name: editor.name.trim() ? editor.name : patch.name ?? editor.name,
+    descriptorsText: editor.descriptorsText.trim()
+      ? editor.descriptorsText
+      : patch.descriptorsText ?? editor.descriptorsText,
+    exemplarsText: editor.exemplarsText.trim()
+      ? editor.exemplarsText
+      : patch.exemplarsText ?? editor.exemplarsText,
+    bannedTermsText: editor.bannedTermsText.trim()
+      ? editor.bannedTermsText
+      : patch.bannedTermsText ?? editor.bannedTermsText,
+    preferredPov: editor.preferredPov.trim()
+      ? editor.preferredPov
+      : patch.preferredPov ?? editor.preferredPov,
+    readingLevel: editor.readingLevel.trim()
+      ? editor.readingLevel
+      : patch.readingLevel ?? editor.readingLevel,
+    metadata: { ...editor.metadata, ...patch.metadata },
+  }
+}
+
+export function brandVoiceProfileListItems(text: string, limit: number): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, limit)
+}
+
+function brandVoiceProfileListText(values: string[]): string {
+  return values.join('\n')
+}
+
+function cleanOptionalText(value: string): string | null {
+  const cleaned = value.trim()
+  return cleaned ? cleaned : null
+}
+
+function normalizeSampleText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+function sampleSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length >= 24)
+}
+
+function sampleExemplars(sentences: string[], normalized: string): string[] {
+  const candidates = sentences.length > 0 ? sentences : [normalized]
+  return candidates
+    .map((sentence) => sentence.slice(0, 280).trim())
+    .filter(Boolean)
+    .slice(0, 3)
+}
+
+function sampleDescriptors(text: string, sentences: string[]): string[] {
+  const lower = text.toLowerCase()
+  const descriptors: string[] = []
+  const avgWords = averageSentenceWords(sentences)
+  if (avgWords > 0 && avgWords <= 16) descriptors.push('concise')
+  if (/\b(you|your|customers?|teams?)\b/.test(lower)) {
+    descriptors.push('customer-focused')
+  }
+  if (/\b(can't|don't|won't|we're|you're|it's|they're)\b/.test(lower)) {
+    descriptors.push('conversational')
+  }
+  if (/\b(api|data|security|workflow|integration|automation)\b/.test(lower)) {
+    descriptors.push('technical')
+  }
+  if (/[!?]/.test(text)) descriptors.push('energetic')
+  if (descriptors.length === 0) descriptors.push('plainspoken')
+  return [...new Set(descriptors)].slice(0, 8)
+}
+
+function samplePreferredPov(text: string): string {
+  const lower = text.toLowerCase()
+  const second = countMatches(lower, /\b(you|your|yours)\b/g)
+  const first = countMatches(lower, /\b(we|our|ours|us)\b/g)
+  const third = countMatches(lower, /\b(they|their|customer|customers|team|teams)\b/g)
+  if (second >= first && second >= third && second > 0) return 'second_person'
+  if (first >= third && first > 0) return 'first_person'
+  if (third > 0) return 'third_person'
+  return ''
+}
+
+function sampleReadingLevel(sentences: string[]): string {
+  const avgWords = averageSentenceWords(sentences)
+  if (avgWords === 0) return ''
+  return avgWords <= 18 ? 'plain' : 'detailed'
+}
+
+function averageSentenceWords(sentences: string[]): number {
+  if (sentences.length === 0) return 0
+  const totalWords = sentences.reduce((total, sentence) => {
+    return total + sentence.split(/\s+/).filter(Boolean).length
+  }, 0)
+  return totalWords / sentences.length
+}
+
+function countMatches(text: string, pattern: RegExp): number {
+  return text.match(pattern)?.length ?? 0
+}
+
+function brandVoiceSampleName(name: string): string {
+  const cleaned = name
+    .replace(/\.[^.]+$/, '')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return cleaned
+}

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -71,6 +71,16 @@ export { inputContractDisplay } from './inputDisplay'
 export type { ContentOpsInputDisplayFallback } from './inputDisplay'
 
 export {
+  applyBrandVoiceProfileEditorPatch,
+  blankBrandVoiceProfileEditorState,
+  brandVoiceProfileEditorRequest,
+  brandVoiceProfileEditorStateFromProfile,
+  canSaveBrandVoiceProfileEditor,
+  deriveBrandVoiceProfileEditorPatch,
+} from './brandVoiceProfileEditor'
+export type { BrandVoiceProfileEditorState } from './brandVoiceProfileEditor'
+
+export {
   FAQ_CONFIGURATION_OUTPUTS,
   FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
   FAQ_DOCUMENTATION_TERMS_INPUT,

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -71,6 +71,12 @@ import {
   FAQ_INTENT_RULES_INPUT,
   FAQ_RESOLUTION_EVIDENCE_STATUS,
   FAQ_VOCABULARY_GAP_RULES_INPUT,
+  applyBrandVoiceProfileEditorPatch,
+  blankBrandVoiceProfileEditorState,
+  brandVoiceProfileEditorRequest,
+  brandVoiceProfileEditorStateFromProfile,
+  canSaveBrandVoiceProfileEditor,
+  deriveBrandVoiceProfileEditorPatch,
   type ContentOpsCatalog,
   type ContentOpsCachePolicy,
   type ContentOpsIngestionDiagnostics,
@@ -90,13 +96,13 @@ import {
   type GenerationPlan,
   type GenerationPlanStep,
   type ContentOpsUsageBudgetEvaluation,
+  type BrandVoiceProfileEditorState,
 } from '../domain/contentOps'
 import type {
   ContentOpsBrandVoiceProfile,
   ContentOpsZendeskCredential,
   GeneratedAssetDraft,
   GeneratedAssetType,
-  UpsertContentOpsBrandVoiceProfileRequest,
 } from '../api/contentOps'
 import useApiData from '../hooks/useApiData'
 import { PageError } from '../components/ErrorBoundary'
@@ -165,23 +171,17 @@ type ZendeskCredentialMutationState =
   | { kind: 'success'; message: string }
   | { kind: 'error'; message: string }
 
-type BrandVoiceProfileEditorState = {
-  mode: 'create' | 'edit'
-  profileId: string | null
-  name: string
-  descriptorsText: string
-  exemplarsText: string
-  bannedTermsText: string
-  preferredPov: string
-  readingLevel: string
-  metadata: Record<string, unknown>
-}
-
 type BrandVoiceProfileMutationState =
   | { kind: 'idle' }
   | { kind: 'saving' }
   | { kind: 'archiving'; id: string }
   | { kind: 'success'; message: string }
+  | { kind: 'error'; message: string }
+
+type BrandVoiceSampleImportState =
+  | { kind: 'idle' }
+  | { kind: 'loaded'; message: string }
+  | { kind: 'applied'; message: string }
   | { kind: 'error'; message: string }
 
 const DEFAULT_INPUTS_JSON = '{\n  \n}'
@@ -1931,6 +1931,10 @@ function BrandVoiceProfileSelector({
   const [editor, setEditor] = useState<BrandVoiceProfileEditorState | null>(null)
   const [mutationState, setMutationState] =
     useState<BrandVoiceProfileMutationState>({ kind: 'idle' })
+  const [sampleText, setSampleText] = useState('')
+  const [sampleName, setSampleName] = useState('')
+  const [sampleImportState, setSampleImportState] =
+    useState<BrandVoiceSampleImportState>({ kind: 'idle' })
   const mutating =
     mutationState.kind === 'saving' || mutationState.kind === 'archiving'
   const canSave = editor ? canSaveBrandVoiceProfileEditor(editor) : false
@@ -1939,13 +1943,21 @@ function BrandVoiceProfileSelector({
     selectedProfileIdRef.current = selectedProfileId
   }, [selectedProfileId])
 
+  const resetSampleImport = () => {
+    setSampleText('')
+    setSampleName('')
+    setSampleImportState({ kind: 'idle' })
+  }
+
   const startCreate = () => {
+    resetSampleImport()
     setEditor(blankBrandVoiceProfileEditorState())
     setMutationState({ kind: 'idle' })
   }
 
   const startEdit = () => {
     if (!selectedProfile) return
+    resetSampleImport()
     setEditor(brandVoiceProfileEditorStateFromProfile(selectedProfile))
     setMutationState({ kind: 'idle' })
   }
@@ -2018,6 +2030,45 @@ function BrandVoiceProfileSelector({
         message: err instanceof Error ? err.message : String(err),
       })
     }
+  }
+
+  const handleSampleFileChange = async (
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    try {
+      const text = await file.text()
+      setSampleText(text)
+      setSampleName(file.name)
+      setSampleImportState({ kind: 'loaded', message: `Loaded ${file.name}.` })
+    } catch (err) {
+      setSampleImportState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handleApplySample = () => {
+    if (!sampleText.trim()) {
+      setSampleImportState({
+        kind: 'error',
+        message: 'Add sample copy before applying.',
+      })
+      return
+    }
+    const patch = deriveBrandVoiceProfileEditorPatch(sampleText, {
+      fallbackName: sampleName,
+    })
+    setEditor((current) =>
+      current ? applyBrandVoiceProfileEditorPatch(current, patch) : current,
+    )
+    setSampleImportState({
+      kind: 'applied',
+      message: 'Sample applied to empty profile fields.',
+    })
   }
 
   return (
@@ -2138,6 +2189,64 @@ function BrandVoiceProfileSelector({
               <X className="h-3.5 w-3.5" />
               Cancel
             </button>
+          </div>
+
+          <div className="rounded-md border border-slate-800 bg-slate-950/40 p-3">
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                Sample import
+              </h4>
+              <label className="flex cursor-pointer items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800">
+                <FileUp className="h-3.5 w-3.5" />
+                Load file
+                <input
+                  type="file"
+                  accept=".txt,.md,text/plain,text/markdown"
+                  disabled={mutating}
+                  onChange={handleSampleFileChange}
+                  className="sr-only"
+                />
+              </label>
+            </div>
+            <textarea
+              value={sampleText}
+              onChange={(event) => {
+                setSampleText(event.target.value)
+                setSampleName('')
+                setSampleImportState({ kind: 'idle' })
+              }}
+              disabled={mutating}
+              rows={4}
+              placeholder="Paste customer copy samples here."
+              className="w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+            />
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+              {sampleImportState.kind !== 'idle' ? (
+                <span
+                  className={clsx(
+                    'text-xs',
+                    sampleImportState.kind === 'error'
+                      ? 'text-rose-200'
+                      : 'text-slate-400',
+                  )}
+                >
+                  {sampleImportState.message}
+                </span>
+              ) : (
+                <span className="text-xs text-slate-500">
+                  Fields already filled stay unchanged.
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={handleApplySample}
+                disabled={!sampleText.trim() || mutating}
+                className="flex items-center justify-center gap-2 rounded-md border border-cyan-500/60 px-2.5 py-1 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
+              >
+                <Palette className="h-3.5 w-3.5" />
+                Apply sample
+              </button>
+            </div>
           </div>
 
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
@@ -3154,83 +3263,6 @@ function formatBrandVoiceProfileSummary(
     parts.push(profile.reading_level)
   }
   return parts.length > 0 ? parts.join(' - ') : 'Saved profile selected'
-}
-
-function blankBrandVoiceProfileEditorState(): BrandVoiceProfileEditorState {
-  return {
-    mode: 'create',
-    profileId: null,
-    name: '',
-    descriptorsText: '',
-    exemplarsText: '',
-    bannedTermsText: '',
-    preferredPov: '',
-    readingLevel: '',
-    metadata: { source: 'content_ops_ui' },
-  }
-}
-
-function brandVoiceProfileEditorStateFromProfile(
-  profile: ContentOpsBrandVoiceProfile,
-): BrandVoiceProfileEditorState {
-  return {
-    mode: 'edit',
-    profileId: profile.id,
-    name: profile.name,
-    descriptorsText: brandVoiceProfileListText(profile.descriptors),
-    exemplarsText: brandVoiceProfileListText(profile.exemplars),
-    bannedTermsText: brandVoiceProfileListText(profile.banned_terms),
-    preferredPov: profile.preferred_pov ?? '',
-    readingLevel: profile.reading_level ?? '',
-    metadata: { ...profile.metadata },
-  }
-}
-
-function brandVoiceProfileEditorRequest(
-  editor: BrandVoiceProfileEditorState,
-): UpsertContentOpsBrandVoiceProfileRequest {
-  const preferredPov = cleanOptionalText(editor.preferredPov)
-  const readingLevel = cleanOptionalText(editor.readingLevel)
-  return {
-    name: editor.name.trim(),
-    descriptors: brandVoiceProfileListItems(editor.descriptorsText, 8),
-    exemplars: brandVoiceProfileListItems(editor.exemplarsText, 3),
-    banned_terms: brandVoiceProfileListItems(editor.bannedTermsText, 20),
-    preferred_pov: preferredPov,
-    reading_level: readingLevel,
-    metadata: { ...editor.metadata },
-  }
-}
-
-function canSaveBrandVoiceProfileEditor(
-  editor: BrandVoiceProfileEditorState,
-): boolean {
-  if (!editor.name.trim()) return false
-  const body = brandVoiceProfileEditorRequest(editor)
-  return Boolean(
-    (body.descriptors?.length ?? 0) > 0 ||
-      (body.exemplars?.length ?? 0) > 0 ||
-      (body.banned_terms?.length ?? 0) > 0 ||
-      body.preferred_pov ||
-      body.reading_level,
-  )
-}
-
-function brandVoiceProfileListText(values: string[]): string {
-  return values.join('\n')
-}
-
-function brandVoiceProfileListItems(text: string, limit: number): string[] {
-  return text
-    .split(/\r?\n/)
-    .map((item) => item.trim())
-    .filter(Boolean)
-    .slice(0, limit)
-}
-
-function cleanOptionalText(value: string): string | null {
-  const cleaned = value.trim()
-  return cleaned ? cleaned : null
 }
 
 function formatZendeskCredentialEndpoint(

--- a/plans/PR-Content-Ops-Brand-Voice-Onboarding.md
+++ b/plans/PR-Content-Ops-Brand-Voice-Onboarding.md
@@ -1,0 +1,114 @@
+# PR-Content-Ops-Brand-Voice-Onboarding
+
+## Why this slice exists
+
+PR-Content-Ops-Brand-Voice-Profile-Editor made saved brand voice profiles
+editable in the New Run page, but operators still have to hand-transcribe a
+customer's voice into descriptors, exemplars, POV, and reading level. The
+brand-voice plan chain explicitly deferred onboarding from samples; this slice
+adds the thinnest usable version: load sample copy, derive an editable draft,
+and keep the human in control before save.
+
+This keeps the product moving without adding a live scraper, LLM classifier, or
+new backend contract. The current proof point is upload/paste to prefill the
+existing editor; authenticated URL scrape can follow once the backend scrape
+adapter and rate-limit/error contract are scoped.
+
+This slice is expected to exceed the 400 LOC soft cap because the prior editor
+helpers must be extracted into a behavioral-testable module at the same time as
+the sample import UI. Splitting the helper extraction from the onboarding
+controls would either keep the #1311 request-builder NIT untested or introduce
+sample controls without the pure fixtures that prove their derivation behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/onboarding
+Slice phase: Vertical slice
+
+1. Add a pure frontend brand-voice editor helper module that owns the editor
+   request transform, save validation, and deterministic sample-to-draft
+   derivation.
+2. Extend the existing `ContentOpsNewRun` brand voice editor with sample copy
+   onboarding: paste text, load a local text/copy sample file, and apply the
+   derived fields into the editable profile form.
+3. Preserve the existing create/update/archive API behavior and continue to
+   save only through the tenant-scoped brand voice profile CRUD routes.
+4. Add behavioral tests in the existing CI-enrolled selector script so the
+   request-builder NIT from #1311 is covered and sample import heuristics are
+   locked.
+
+### Files touched
+
+- `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs`
+- `atlas-intel-ui/src/domain/contentOps/brandVoiceProfileEditor.ts`
+- `atlas-intel-ui/src/domain/contentOps/index.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `plans/PR-Content-Ops-Brand-Voice-Onboarding.md`
+
+## Mechanism
+
+The new domain helper exports the page-local editor state and pure helpers:
+
+```ts
+deriveBrandVoiceProfileEditorPatch(sampleText, { fallbackName })
+brandVoiceProfileEditorRequest(editor)
+canSaveBrandVoiceProfileEditor(editor)
+```
+
+The derivation is intentionally deterministic and conservative. It normalizes
+sample text, extracts up to three short exemplars, infers POV from pronoun
+balance, marks plain reading level for short average sentences, and derives a
+small descriptor set from observable markers such as concise sentences,
+contractions, customer-directed language, and technical terms. It never calls a
+network service, never invents claims about the business, and never saves until
+the operator reviews and submits the normal profile form.
+
+`ContentOpsNewRun` keeps local sample text/file-load state while the editor is
+open. Applying a sample merges the derived patch into the current editor,
+preserving manually entered name/guidance unless the field was blank.
+
+## Intentional
+
+- No live URL scraping in this slice. Browser-side cross-origin fetch would be
+  unreliable, and a backend scrape path needs its own auth, timeout, and error
+  contract.
+- No LLM voice classifier. The first onboarding step should be transparent and
+  predictable; human review remains the quality gate.
+- No new frontend test script. The existing
+  `test:content-ops-brand-voice-profile-selector` script is already enrolled
+  in the intel-ui workflow, so extending it avoids another CI-enrollment risk.
+- No settings page. The profile workflow stays in the New Run brand voice panel
+  until the inline surface becomes too dense.
+
+## Deferred
+
+- `PR-Content-Ops-Brand-Voice-Scrape-Onboarding`: authenticated URL scrape or
+  backend text extraction into the same sample-to-draft helper.
+- `PR-Content-Ops-Brand-Voice-Presets`: descriptor-only preset library.
+- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management
+  page if inline authoring becomes too dense.
+- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can
+  consume brand voice.
+
+Parked hardening: none.
+
+## Verification
+
+- `cd atlas-intel-ui && npm run lint` -- passed.
+- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector`
+  -- 9 passed.
+- `cd atlas-intel-ui && npm run build` -- passed.
+- `git diff --check` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-brand-voice-onboarding.md`
+  -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs` | 95 |
+| `atlas-intel-ui/src/domain/contentOps/brandVoiceProfileEditor.ts` | 219 |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | 10 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 212 |
+| `plans/PR-Content-Ops-Brand-Voice-Onboarding.md` | 114 |
+| **Total** | **650** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Brand-Voice-Onboarding.md
Slice phase: Vertical slice

This adds deterministic sample-copy onboarding to the existing brand voice editor: operators can paste or upload local sample text, apply a derived patch into empty profile fields, review the editable profile, and save through the already-shipped tenant CRUD API.

## Intentional
- No live URL scraping in this slice; backend scrape onboarding is deferred.
- No LLM voice classifier; derivation stays deterministic and human-reviewed.
- No new frontend test script; this extends the existing CI-enrolled selector test.
- No settings page; the workflow stays in the New Run brand voice panel.

## Deferred
- `PR-Content-Ops-Brand-Voice-Scrape-Onboarding`: authenticated URL scrape or backend text extraction into the same helper.
- `PR-Content-Ops-Brand-Voice-Presets`: descriptor-only preset library.
- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management page.
- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can consume brand voice.

## Parked hardening
- None.

## Verification
- `cd atlas-intel-ui && npm run lint` -- passed.
- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector` -- 9 passed.
- `cd atlas-intel-ui && npm run build` -- passed.
- `git diff --check` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-brand-voice-onboarding.md` -- passed.

## Diff size
5 files, +558 / -92. Over the 400 LOC soft cap because helper extraction, sample import UI, and behavioral fixtures need to ship together for one usable onboarding slice.
