### PR TITLE
Content Ops Brand Voice Scrape Onboarding

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
@@ -25,6 +25,7 @@ async function loadTsModule(path, replacements = []) {
 const {
   createContentOpsBrandVoiceProfile,
   deleteContentOpsBrandVoiceProfile,
+  fetchContentOpsBrandVoiceSampleUrl,
   fetchContentOpsBrandVoiceProfiles,
   updateContentOpsBrandVoiceProfile,
 } = await loadTsModule('../src/api/contentOps.ts', [
@@ -190,6 +191,36 @@ test('brand voice profile delete archives encoded profile id', async () => {
   assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
 })
 
+test('brand voice sample URL fetch posts authenticated URL payload', async () => {
+  const payload = {
+    url: 'https://example.test/about',
+    title: 'Acme About',
+    text: 'Launch secure workflows faster.',
+    source_character_count: 31,
+  }
+  const calls = installFetchResponder(payload)
+
+  const result = await fetchContentOpsBrandVoiceSampleUrl({
+    url: 'https://example.test/about',
+  })
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/brand-voice-profiles/sample-url`,
+  )
+  assert.equal(init.method, 'POST')
+  assert.deepEqual(init.headers, {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer test-token',
+  })
+  assert.deepEqual(JSON.parse(init.body), {
+    url: 'https://example.test/about',
+  })
+})
+
 test('brand voice profile id round-trips through domain request mapping', () => {
   const domain = fromWireRequest({
     target_mode: 'vendor_retention',
@@ -290,6 +321,7 @@ test('brand voice sample patch preserves manually entered fields', () => {
 test('new run page renders brand voice profile selector wiring', () => {
   assert.ok(newRunSource.includes('function BrandVoiceProfileSelector'))
   assert.ok(newRunSource.includes('fetchContentOpsBrandVoiceProfiles'))
+  assert.ok(newRunSource.includes('fetchContentOpsBrandVoiceSampleUrl'))
   assert.ok(newRunSource.includes('createContentOpsBrandVoiceProfile'))
   assert.ok(newRunSource.includes('updateContentOpsBrandVoiceProfile'))
   assert.ok(newRunSource.includes('deleteContentOpsBrandVoiceProfile'))
@@ -301,6 +333,8 @@ test('new run page renders brand voice profile selector wiring', () => {
   assert.ok(newRunSource.includes('Archive'))
   assert.ok(newRunSource.includes('Sample import'))
   assert.ok(newRunSource.includes('type="file"'))
+  assert.ok(newRunSource.includes('Fetch URL'))
+  assert.ok(newRunSource.includes('brandVoiceSampleFallbackName'))
   assert.ok(newRunSource.includes('deriveBrandVoiceProfileEditorPatch'))
   assert.ok(newRunSource.includes('disabled={loading || mutating}'))
   assert.ok(newRunSource.includes('selectedProfileIdRef.current === archiveProfileId'))

--- a/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
@@ -335,6 +335,8 @@ test('new run page renders brand voice profile selector wiring', () => {
   assert.ok(newRunSource.includes('type="file"'))
   assert.ok(newRunSource.includes('Fetch URL'))
   assert.ok(newRunSource.includes('brandVoiceSampleFallbackName'))
+  assert.ok(newRunSource.includes('sampleFetchTokenRef'))
+  assert.ok(newRunSource.includes('invalidateSampleFetch'))
   assert.ok(newRunSource.includes('deriveBrandVoiceProfileEditorPatch'))
   assert.ok(newRunSource.includes('disabled={loading || mutating}'))
   assert.ok(newRunSource.includes('selectedProfileIdRef.current === archiveProfileId'))

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -7,6 +7,7 @@
  *   GET  /content-ops/control-surfaces
  *   GET  /content-ops/brand-voice-profiles
  *   POST /content-ops/brand-voice-profiles
+ *   POST /content-ops/brand-voice-profiles/sample-url
  *   PUT  /content-ops/brand-voice-profiles/{profile_id}
  *   DELETE /content-ops/brand-voice-profiles/{profile_id}
  *   GET  /content-ops/zendesk-credentials
@@ -232,6 +233,17 @@ export interface UpsertContentOpsBrandVoiceProfileRequest {
   preferred_pov?: string | null
   reading_level?: string | null
   metadata?: Record<string, unknown>
+}
+
+export interface ContentOpsBrandVoiceSampleUrlRequest {
+  url: string
+}
+
+export interface ContentOpsBrandVoiceSampleUrlResponse {
+  url: string
+  title?: string | null
+  text: string
+  source_character_count: number
 }
 
 // POST /content-ops/preview, /plan, /execute share this body shape.
@@ -1013,6 +1025,16 @@ export function createContentOpsBrandVoiceProfile(
   body: UpsertContentOpsBrandVoiceProfileRequest,
 ): Promise<ContentOpsBrandVoiceProfile> {
   return postJson<ContentOpsBrandVoiceProfile>('/brand-voice-profiles', body)
+}
+
+/** POST /content-ops/brand-voice-profiles/sample-url -- extract public page copy. */
+export function fetchContentOpsBrandVoiceSampleUrl(
+  body: ContentOpsBrandVoiceSampleUrlRequest,
+): Promise<ContentOpsBrandVoiceSampleUrlResponse> {
+  return postJson<ContentOpsBrandVoiceSampleUrlResponse>(
+    '/brand-voice-profiles/sample-url',
+    body,
+  )
 }
 
 /** PUT /content-ops/brand-voice-profiles/{id} -- update a tenant saved profile. */

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -28,6 +28,7 @@ import {
   createContentOpsBrandVoiceProfile,
   deleteContentOpsBrandVoiceProfile,
   executeContentOpsRun,
+  fetchContentOpsBrandVoiceSampleUrl,
   fetchContentOpsBrandVoiceProfiles,
   fetchContentOpsZendeskCredentials,
   fetchGeneratedAssetDrafts,
@@ -180,6 +181,7 @@ type BrandVoiceProfileMutationState =
 
 type BrandVoiceSampleImportState =
   | { kind: 'idle' }
+  | { kind: 'loading'; message: string }
   | { kind: 'loaded'; message: string }
   | { kind: 'applied'; message: string }
   | { kind: 'error'; message: string }
@@ -1933,10 +1935,12 @@ function BrandVoiceProfileSelector({
     useState<BrandVoiceProfileMutationState>({ kind: 'idle' })
   const [sampleText, setSampleText] = useState('')
   const [sampleName, setSampleName] = useState('')
+  const [sampleUrl, setSampleUrl] = useState('')
   const [sampleImportState, setSampleImportState] =
     useState<BrandVoiceSampleImportState>({ kind: 'idle' })
   const mutating =
     mutationState.kind === 'saving' || mutationState.kind === 'archiving'
+  const sampleFetching = sampleImportState.kind === 'loading'
   const canSave = editor ? canSaveBrandVoiceProfileEditor(editor) : false
   const selectedProfileIdRef = useRef(selectedProfileId)
   useEffect(() => {
@@ -1946,6 +1950,7 @@ function BrandVoiceProfileSelector({
   const resetSampleImport = () => {
     setSampleText('')
     setSampleName('')
+    setSampleUrl('')
     setSampleImportState({ kind: 'idle' })
   }
 
@@ -2043,6 +2048,35 @@ function BrandVoiceProfileSelector({
       setSampleText(text)
       setSampleName(file.name)
       setSampleImportState({ kind: 'loaded', message: `Loaded ${file.name}.` })
+    } catch (err) {
+      setSampleImportState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handleFetchSampleUrl = async () => {
+    const url = sampleUrl.trim()
+    if (!url) {
+      setSampleImportState({
+        kind: 'error',
+        message: 'Add a URL before fetching.',
+      })
+      return
+    }
+    setSampleImportState({ kind: 'loading', message: 'Fetching URL.' })
+    try {
+      const sample = await fetchContentOpsBrandVoiceSampleUrl({ url })
+      const fallbackName =
+        sample.title?.trim() || brandVoiceSampleFallbackName(sample.url)
+      setSampleText(sample.text)
+      setSampleName(fallbackName)
+      setSampleUrl(sample.url)
+      setSampleImportState({
+        kind: 'loaded',
+        message: `Loaded ${fallbackName}.`,
+      })
     } catch (err) {
       setSampleImportState({
         kind: 'error',
@@ -2202,11 +2236,40 @@ function BrandVoiceProfileSelector({
                 <input
                   type="file"
                   accept=".txt,.md,text/plain,text/markdown"
-                  disabled={mutating}
+                  disabled={mutating || sampleFetching}
                   onChange={handleSampleFileChange}
                   className="sr-only"
                 />
               </label>
+            </div>
+            <div className="mb-2 grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+              <label className="block text-sm">
+                <span className="text-slate-300">URL</span>
+                <input
+                  type="url"
+                  value={sampleUrl}
+                  onChange={(event) => {
+                    setSampleUrl(event.target.value)
+                    setSampleImportState({ kind: 'idle' })
+                  }}
+                  disabled={mutating || sampleFetching}
+                  placeholder="https://example.com/about"
+                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={handleFetchSampleUrl}
+                disabled={!sampleUrl.trim() || mutating || sampleFetching}
+                className="flex h-9 items-center justify-center gap-2 self-end rounded-md border border-slate-700 px-2.5 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+              >
+                {sampleFetching ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Search className="h-3.5 w-3.5" />
+                )}
+                Fetch URL
+              </button>
             </div>
             <textarea
               value={sampleText}
@@ -2215,7 +2278,7 @@ function BrandVoiceProfileSelector({
                 setSampleName('')
                 setSampleImportState({ kind: 'idle' })
               }}
-              disabled={mutating}
+              disabled={mutating || sampleFetching}
               rows={4}
               placeholder="Paste customer copy samples here."
               className="w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
@@ -2240,7 +2303,7 @@ function BrandVoiceProfileSelector({
               <button
                 type="button"
                 onClick={handleApplySample}
-                disabled={!sampleText.trim() || mutating}
+                disabled={!sampleText.trim() || mutating || sampleFetching}
                 className="flex items-center justify-center gap-2 rounded-md border border-cyan-500/60 px-2.5 py-1 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
               >
                 <Palette className="h-3.5 w-3.5" />
@@ -3263,6 +3326,15 @@ function formatBrandVoiceProfileSummary(
     parts.push(profile.reading_level)
   }
   return parts.length > 0 ? parts.join(' - ') : 'Saved profile selected'
+}
+
+function brandVoiceSampleFallbackName(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname.replace(/^www\./, '') || 'sample URL'
+  } catch {
+    return 'sample URL'
+  }
 }
 
 function formatZendeskCredentialEndpoint(

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1943,11 +1943,17 @@ function BrandVoiceProfileSelector({
   const sampleFetching = sampleImportState.kind === 'loading'
   const canSave = editor ? canSaveBrandVoiceProfileEditor(editor) : false
   const selectedProfileIdRef = useRef(selectedProfileId)
+  const sampleFetchTokenRef = useRef(0)
   useEffect(() => {
     selectedProfileIdRef.current = selectedProfileId
   }, [selectedProfileId])
 
+  const invalidateSampleFetch = () => {
+    sampleFetchTokenRef.current += 1
+  }
+
   const resetSampleImport = () => {
+    invalidateSampleFetch()
     setSampleText('')
     setSampleName('')
     setSampleUrl('')
@@ -1979,7 +1985,9 @@ function BrandVoiceProfileSelector({
 
   const handleSave = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    if (!editor || !canSave || mutationState.kind === 'saving') return
+    if (!editor || !canSave || mutationState.kind === 'saving' || sampleFetching) {
+      return
+    }
     const mode = editor.mode
     setMutationState({ kind: 'saving' })
     try {
@@ -1988,6 +1996,7 @@ function BrandVoiceProfileSelector({
         mode === 'edit' && editor.profileId
           ? await updateContentOpsBrandVoiceProfile(editor.profileId, body)
           : await createContentOpsBrandVoiceProfile(body)
+      resetSampleImport()
       onChange(profile.id)
       setEditor(null)
       setMutationState({
@@ -2022,6 +2031,7 @@ function BrandVoiceProfileSelector({
         onChange(null)
       }
       if (editor?.profileId === archiveProfileId) {
+        resetSampleImport()
         setEditor(null)
       }
       setMutationState({
@@ -2065,9 +2075,14 @@ function BrandVoiceProfileSelector({
       })
       return
     }
+    const requestToken = sampleFetchTokenRef.current + 1
+    sampleFetchTokenRef.current = requestToken
     setSampleImportState({ kind: 'loading', message: 'Fetching URL.' })
     try {
       const sample = await fetchContentOpsBrandVoiceSampleUrl({ url })
+      if (sampleFetchTokenRef.current !== requestToken) {
+        return
+      }
       const fallbackName =
         sample.title?.trim() || brandVoiceSampleFallbackName(sample.url)
       setSampleText(sample.text)
@@ -2078,6 +2093,9 @@ function BrandVoiceProfileSelector({
         message: `Loaded ${fallbackName}.`,
       })
     } catch (err) {
+      if (sampleFetchTokenRef.current !== requestToken) {
+        return
+      }
       setSampleImportState({
         kind: 'error',
         message: err instanceof Error ? err.message : String(err),
@@ -2216,7 +2234,10 @@ function BrandVoiceProfileSelector({
             </h3>
             <button
               type="button"
-              onClick={() => setEditor(null)}
+              onClick={() => {
+                resetSampleImport()
+                setEditor(null)
+              }}
               disabled={mutating}
               className="flex items-center justify-center gap-1.5 rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
             >
@@ -2381,7 +2402,7 @@ function BrandVoiceProfileSelector({
           <div className="flex justify-end">
             <button
               type="submit"
-              disabled={!canSave || mutating}
+              disabled={!canSave || mutating || sampleFetching}
               className="flex items-center justify-center gap-2 rounded-md bg-cyan-500 px-3 py-1.5 text-sm font-medium text-slate-950 hover:bg-cyan-400 disabled:opacity-50"
             >
               <Save className="h-4 w-4" />

--- a/atlas_brain/api/content_ops_brand_voice_profiles.py
+++ b/atlas_brain/api/content_ops_brand_voice_profiles.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from html.parser import HTMLParser
+import http.client
+import ipaddress
+import re
+import socket
+import ssl
+import urllib.error
+import urllib.parse
 import uuid as _uuid
 from typing import Any
 
@@ -21,6 +31,11 @@ from ..auth.dependencies import AuthUser
 
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 AuthDependency = Callable[..., AuthUser | Awaitable[AuthUser]]
+_SAMPLE_URL_FETCH_TIMEOUT_SECONDS = 10
+_SAMPLE_URL_MAX_BYTES = 512_000
+_SAMPLE_TEXT_MAX_CHARS = 24_000
+_SAMPLE_URL_USER_AGENT = "Atlas-Content-Ops/1.0"
+_HTML_CONTENT_TYPES = ("text/html", "application/xhtml+xml")
 
 
 class UpsertBrandVoiceProfileRequest(BaseModel):
@@ -46,6 +61,17 @@ class BrandVoiceProfileView(BaseModel):
     created_at: str
     updated_at: str
     archived_at: str | None = None
+
+
+class BrandVoiceSampleUrlRequest(BaseModel):
+    url: str = Field(..., min_length=1, max_length=2048)
+
+
+class BrandVoiceSampleUrlView(BaseModel):
+    url: str
+    title: str | None = None
+    text: str
+    source_character_count: int
 
 
 def _default_pool_provider() -> Any:
@@ -99,6 +125,20 @@ def create_content_ops_brand_voice_profiles_router(
                 )
             raise
         return _record_to_view(record)
+
+    @router.post("/sample-url", response_model=BrandVoiceSampleUrlView)
+    async def sample_url(
+        body: BrandVoiceSampleUrlRequest,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> BrandVoiceSampleUrlView:
+        _require_profile_admin(user)
+        sample = await asyncio.to_thread(_extract_brand_voice_sample_from_url, body.url)
+        return BrandVoiceSampleUrlView(
+            url=sample.url,
+            title=sample.title,
+            text=sample.text,
+            source_character_count=sample.source_character_count,
+        )
 
     @router.put("/{profile_id}", response_model=BrandVoiceProfileView)
     async def update_profile(
@@ -205,7 +245,379 @@ def _fmt_time(value: Any) -> str | None:
     return str(value)
 
 
+@dataclass(frozen=True)
+class _SampleUrlFetchTarget:
+    url: str
+    host: str
+    port: int
+    path: str
+    host_header: str
+    connect_host: str
+
+
+@dataclass(frozen=True)
+class _ExtractedBrandVoiceSample:
+    url: str
+    title: str | None
+    text: str
+    source_character_count: int
+
+
+class _ReadableHtmlTextParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._skip_depth = 0
+        self._head_depth = 0
+        self._title_depth = 0
+        self._title_parts: list[str] = []
+        self._text_parts: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        del attrs
+        lowered = tag.lower()
+        if lowered in {"script", "style", "noscript", "svg"}:
+            self._skip_depth += 1
+        elif lowered == "head":
+            self._head_depth += 1
+        elif lowered == "title":
+            self._title_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        lowered = tag.lower()
+        if lowered in {"script", "style", "noscript", "svg"}:
+            self._skip_depth = max(0, self._skip_depth - 1)
+        elif lowered == "head":
+            self._head_depth = max(0, self._head_depth - 1)
+        elif lowered == "title":
+            self._title_depth = max(0, self._title_depth - 1)
+
+    def handle_data(self, data: str) -> None:
+        text = _normalize_readable_text(data)
+        if not text:
+            return
+        if self._title_depth > 0:
+            self._title_parts.append(text)
+            return
+        if self._skip_depth == 0 and self._head_depth == 0:
+            self._text_parts.append(text)
+
+    @property
+    def title(self) -> str | None:
+        return _normalize_readable_text(" ".join(self._title_parts)) or None
+
+    @property
+    def text(self) -> str:
+        return _normalize_readable_text(" ".join(self._text_parts))
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(
+        self,
+        host: str,
+        *,
+        port: int,
+        connect_host: str,
+        timeout: int,
+    ) -> None:
+        super().__init__(
+            host,
+            port=port,
+            timeout=timeout,
+            context=ssl.create_default_context(),
+        )
+        self._connect_host = connect_host
+
+    def connect(self) -> None:
+        self.sock = self._create_connection(
+            (self._connect_host, self.port),
+            self.timeout,
+            self.source_address,
+        )
+        if self._tunnel_host:
+            self._tunnel()
+        self.sock = self._context.wrap_socket(self.sock, server_hostname=self.host)
+
+
+_PINNED_HTTPS_CONNECTION_CLASS = _PinnedHTTPSConnection
+
+
+class _PinnedSampleUrlResponse:
+    def __init__(
+        self,
+        response: http.client.HTTPResponse,
+        connection: http.client.HTTPSConnection,
+    ) -> None:
+        self._response = response
+        self._connection = connection
+        self.status = response.status
+
+    def read(self, size: int) -> bytes:
+        return self._response.read(size)
+
+    def getheader(self, name: str, default: str = "") -> str:
+        return self._response.getheader(name, default)
+
+    def close(self) -> None:
+        self._response.close()
+        self._connection.close()
+
+
+def _extract_brand_voice_sample_from_url(url: str) -> _ExtractedBrandVoiceSample:
+    body, content_type, resolved_url = _read_bounded_https_sample_url(
+        url,
+        max_bytes=_SAMPLE_URL_MAX_BYTES,
+    )
+    title, text = _extract_readable_text(body, content_type=content_type)
+    if not text:
+        raise HTTPException(
+            status_code=400,
+            detail="Sample URL did not include readable text.",
+        )
+    source_character_count = len(text)
+    return _ExtractedBrandVoiceSample(
+        url=resolved_url,
+        title=title,
+        text=text[:_SAMPLE_TEXT_MAX_CHARS],
+        source_character_count=source_character_count,
+    )
+
+
+def _read_bounded_https_sample_url(
+    value: str,
+    *,
+    max_bytes: int,
+) -> tuple[bytes, str, str]:
+    target = _validate_https_sample_url_fetch_target(value)
+    response: Any | None = None
+    try:
+        response = _open_https_sample_url_request(
+            target,
+            timeout=_SAMPLE_URL_FETCH_TIMEOUT_SECONDS,
+        )
+        status = int(getattr(response, "status", 0) or 0)
+        if 300 <= status < 400:
+            raise HTTPException(
+                status_code=400,
+                detail="Sample URL redirects are not allowed.",
+            )
+        if status < 200 or status >= 300:
+            raise HTTPException(
+                status_code=400,
+                detail="Sample URL could not be fetched.",
+            )
+        data = response.read(max_bytes + 1)
+        content_type = _sample_url_response_header(response, "Content-Type")
+    except urllib.error.HTTPError as exc:
+        if 300 <= int(getattr(exc, "code", 0) or 0) < 400:
+            raise HTTPException(
+                status_code=400,
+                detail="Sample URL redirects are not allowed.",
+            ) from exc
+        raise HTTPException(
+            status_code=400,
+            detail="Sample URL could not be fetched.",
+        ) from exc
+    except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Sample URL could not be fetched.",
+        ) from exc
+    finally:
+        if response is not None:
+            _close_https_sample_url_response(response)
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "reason": "brand_voice_sample_url_too_large",
+                "max_bytes": max_bytes,
+            },
+        )
+    return data, content_type, target.url
+
+
+def _open_https_sample_url_request(
+    target: _SampleUrlFetchTarget,
+    *,
+    timeout: int,
+) -> Any:
+    connection = _PINNED_HTTPS_CONNECTION_CLASS(
+        target.host,
+        port=target.port,
+        connect_host=target.connect_host,
+        timeout=timeout,
+    )
+    try:
+        connection.request(
+            "GET",
+            target.path,
+            headers={
+                "Host": target.host_header,
+                "User-Agent": _SAMPLE_URL_USER_AGENT,
+                "Accept": "text/html,text/plain;q=0.9,*/*;q=0.5",
+            },
+        )
+        response = connection.getresponse()
+        return _PinnedSampleUrlResponse(response, connection)
+    except Exception:
+        connection.close()
+        raise
+
+
+def _close_https_sample_url_response(response: Any) -> None:
+    close = getattr(response, "close", None)
+    if callable(close):
+        close()
+
+
+def _sample_url_response_header(response: Any, name: str) -> str:
+    getheader = getattr(response, "getheader", None)
+    if callable(getheader):
+        return str(getheader(name, "") or "")
+    headers = getattr(response, "headers", None)
+    if isinstance(headers, dict):
+        return str(headers.get(name) or headers.get(name.lower()) or "")
+    get = getattr(headers, "get", None)
+    if callable(get):
+        return str(get(name, "") or "")
+    return ""
+
+
+def _validate_https_sample_url_fetch_target(value: Any) -> _SampleUrlFetchTarget:
+    url = _validate_https_sample_url(value)
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    port = parsed.port or 443
+    try:
+        connect_host = _validate_sample_url_host_resolution(host, port)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    path = urllib.parse.urlunparse((
+        "",
+        "",
+        parsed.path or "/",
+        parsed.params,
+        parsed.query,
+        "",
+    ))
+    return _SampleUrlFetchTarget(
+        url=url,
+        host=host,
+        port=port,
+        path=path,
+        host_header=parsed.netloc,
+        connect_host=connect_host,
+    )
+
+
+def _validate_https_sample_url(value: Any) -> str:
+    text = str(value or "").strip()
+    parsed = urllib.parse.urlparse(text)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="Sample URL must be an https URL")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Sample URL must be an https URL",
+        ) from exc
+    host = parsed.hostname or ""
+    if not host or _is_blocked_sample_url_host(host):
+        raise HTTPException(status_code=400, detail="Sample URL host is not allowed")
+    if parsed.username or parsed.password:
+        raise HTTPException(
+            status_code=400,
+            detail="Sample URL must not include credentials",
+        )
+    return text
+
+
+def _validate_sample_url_host_resolution(host: str, port: int) -> str:
+    try:
+        resolved = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise ValueError("Sample URL host could not be resolved") from exc
+    if not resolved:
+        raise ValueError("Sample URL host could not be resolved")
+    connect_host: str | None = None
+    for item in resolved:
+        sockaddr = item[4]
+        if not sockaddr:
+            raise ValueError("Sample URL host could not be resolved")
+        address = str(sockaddr[0])
+        if _is_blocked_sample_url_host(address):
+            raise ValueError("Sample URL host is not allowed")
+        if connect_host is None:
+            connect_host = address
+    if connect_host is None:
+        raise ValueError("Sample URL host could not be resolved")
+    return connect_host
+
+
+def _is_blocked_sample_url_host(host: str) -> bool:
+    lowered = host.strip().lower().rstrip(".")
+    if lowered in {"localhost", "0.0.0.0"} or lowered.endswith(".local"):
+        return True
+    try:
+        address = ipaddress.ip_address(lowered)
+    except ValueError:
+        return False
+    return bool(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )
+
+
+def _extract_readable_text(
+    data: bytes,
+    *,
+    content_type: str,
+) -> tuple[str | None, str]:
+    text = data.decode(_sample_url_charset(content_type), errors="replace")
+    if _looks_like_html(text, content_type):
+        parser = _ReadableHtmlTextParser()
+        parser.feed(text)
+        parser.close()
+        return parser.title, parser.text
+    return None, _normalize_readable_text(text)
+
+
+def _sample_url_charset(content_type: str) -> str:
+    match = re.search(r"charset=([^;\s]+)", content_type, flags=re.IGNORECASE)
+    if not match:
+        return "utf-8"
+    charset = match.group(1).strip('"').lower()
+    try:
+        "".encode(charset)
+    except LookupError:
+        return "utf-8"
+    return charset
+
+
+def _looks_like_html(text: str, content_type: str) -> bool:
+    lowered_type = content_type.lower()
+    if any(marker in lowered_type for marker in _HTML_CONTENT_TYPES):
+        return True
+    prefix = text.lstrip()[:200].lower()
+    return prefix.startswith("<!doctype html") or prefix.startswith("<html")
+
+
+def _normalize_readable_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
 __all__ = [
+    "BrandVoiceSampleUrlRequest",
+    "BrandVoiceSampleUrlView",
     "BrandVoiceProfileView",
     "UpsertBrandVoiceProfileRequest",
     "create_content_ops_brand_voice_profiles_router",

--- a/atlas_brain/api/content_ops_brand_voice_profiles.py
+++ b/atlas_brain/api/content_ops_brand_voice_profiles.py
@@ -574,6 +574,7 @@ def _is_blocked_sample_url_host(host: str) -> bool:
         or address.is_multicast
         or address.is_reserved
         or address.is_unspecified
+        or not address.is_global
     )
 
 

--- a/plans/PR-Content-Ops-Brand-Voice-Scrape-Onboarding.md
+++ b/plans/PR-Content-Ops-Brand-Voice-Scrape-Onboarding.md
@@ -98,7 +98,7 @@ Parked hardening: none.
 
 ## Verification
 
-- `pytest tests/test_content_ops_brand_voice_profiles_api.py -q` (14 passed)
+- `pytest tests/test_content_ops_brand_voice_profiles_api.py -q` (16 passed)
 - `cd atlas-intel-ui && npm ci` (installed dependencies; npm reported
   pre-existing audit findings: 2 moderate, 6 high)
 - `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector`
@@ -112,10 +112,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs` | 34 |
+| `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs` | 36 |
 | `atlas-intel-ui/src/api/contentOps.ts` | 22 |
-| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 78 |
-| `atlas_brain/api/content_ops_brand_voice_profiles.py` | 412 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 105 |
+| `atlas_brain/api/content_ops_brand_voice_profiles.py` | 413 |
 | `plans/PR-Content-Ops-Brand-Voice-Scrape-Onboarding.md` | 121 |
-| `tests/test_content_ops_brand_voice_profiles_api.py` | 200 |
-| **Total** | **867** |
+| `tests/test_content_ops_brand_voice_profiles_api.py` | 257 |
+| **Total** | **954** |

--- a/plans/PR-Content-Ops-Brand-Voice-Scrape-Onboarding.md
+++ b/plans/PR-Content-Ops-Brand-Voice-Scrape-Onboarding.md
@@ -1,0 +1,121 @@
+# PR-Content-Ops-Brand-Voice-Scrape-Onboarding
+
+## Why this slice exists
+
+PR-Content-Ops-Brand-Voice-Onboarding added paste/local-file sample import, but
+operators still need to manually copy text from a customer's public site before
+they can prefill a profile. That PR explicitly deferred authenticated URL
+scrape/backend text extraction. This slice adds the thinnest safe backend URL
+path and feeds the returned text into the existing human-reviewed sample
+derivation flow.
+
+The risk in this slice is not the profile derivation; it is safe URL fetching.
+The host route therefore reuses the deflection submit hardening shape:
+HTTPS-only, DNS private-IP rejection before fetch, no redirects, bounded bytes,
+and transport-mocked tests that prove each failure branch fires.
+
+This PR is expected to exceed the 400 LOC soft cap because the safe URL fetch
+guard, host route, UI call site, and negative SSRF/redirect tests must land
+together. Splitting the UI from the guard would create an unreachable product
+path; splitting the guard tests would leave the safety claim unenforced.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/scrape-onboarding
+Slice phase: Vertical slice
+
+1. Add an authenticated admin-only host route at
+   `/api/v1/content-ops/brand-voice-profiles/sample-url`.
+2. Fetch only public HTTPS URLs with bounded reads, no redirect following, and
+   DNS resolution checks that reject private, loopback, link-local, multicast,
+   and reserved targets before any request is opened.
+3. Extract readable text from HTML by ignoring script/style/head content and
+   falling back to plain text for non-HTML bodies.
+4. Extend the Content Ops UI sample import panel with a URL field and "Fetch
+   URL" button that loads returned text into the existing sample textarea.
+5. Add API/UI tests with mocked transport/DNS; no live network calls in CI.
+
+### Files touched
+
+- `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas_brain/api/content_ops_brand_voice_profiles.py`
+- `plans/PR-Content-Ops-Brand-Voice-Scrape-Onboarding.md`
+- `tests/test_content_ops_brand_voice_profiles_api.py`
+
+## Mechanism
+
+The route accepts:
+
+```json
+{ "url": "https://example.com/about" }
+```
+
+and returns:
+
+```json
+{
+  "url": "https://example.com/about",
+  "title": "Example",
+  "text": "Readable sample copy...",
+  "source_character_count": 1234
+}
+```
+
+Validation is fail-closed:
+
+- URL must parse as absolute HTTPS with a hostname and valid port.
+- Host resolution happens before fetch and every resolved IP must be public.
+- The opener disables redirect following; redirect status and `HTTPError`
+  redirect responses are rejected.
+- Reads are capped to a fixed byte limit and oversized bodies return 413.
+
+The UI does not derive or save on fetch. It puts returned text in the existing
+sample textarea and stores the title/host as the sample name, so the already
+tested `deriveBrandVoiceProfileEditorPatch(...)` path remains the single
+sample-to-profile implementation.
+
+## Intentional
+
+- No unauthenticated public scrape endpoint. This is an account profile
+  authoring helper, so it follows the existing owner/admin write guard.
+- No JavaScript rendering, crawling, sitemap expansion, or form-authenticated
+  fetch. The first URL path extracts one public page only.
+- No LLM summarization. The same deterministic sample derivation from #1312
+  remains the only prefill path.
+- No external network in tests; DNS and opener boundaries are mocked.
+
+## Deferred
+
+- `PR-Content-Ops-Brand-Voice-Presets`: descriptor-only preset library.
+- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management
+  page if inline authoring becomes too dense.
+- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can
+  consume brand voice.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_content_ops_brand_voice_profiles_api.py -q` (14 passed)
+- `cd atlas-intel-ui && npm ci` (installed dependencies; npm reported
+  pre-existing audit findings: 2 moderate, 6 high)
+- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector`
+  (10 passed)
+- `python -m py_compile atlas_brain/api/content_ops_brand_voice_profiles.py tests/test_content_ops_brand_voice_profiles_api.py`
+- `cd atlas-intel-ui && npm run lint`
+- `cd atlas-intel-ui && npm run build`
+- `git diff --check`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs` | 34 |
+| `atlas-intel-ui/src/api/contentOps.ts` | 22 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 78 |
+| `atlas_brain/api/content_ops_brand_voice_profiles.py` | 412 |
+| `plans/PR-Content-Ops-Brand-Voice-Scrape-Onboarding.md` | 121 |
+| `tests/test_content_ops_brand_voice_profiles_api.py` | 200 |
+| **Total** | **867** |

--- a/tests/test_content_ops_brand_voice_profiles_api.py
+++ b/tests/test_content_ops_brand_voice_profiles_api.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import subprocess
 import sys
 import textwrap
-import urllib.error
 import uuid
 
 import pytest
@@ -281,19 +280,39 @@ def test_sample_url_rejects_private_dns_before_fetch(
     assert response.json()["detail"] == "Sample URL host is not allowed"
 
 
+def test_sample_url_rejects_shared_address_space_dns_before_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (api.socket.AF_INET, api.socket.SOCK_STREAM, 6, "", ("100.64.0.1", 443)),
+        ],
+    )
+
+    def open_request(target, *, timeout):
+        raise AssertionError("shared-address-space target must be rejected first")
+
+    monkeypatch.setattr(api, "_open_https_sample_url_request", open_request)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://example.test/about"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Sample URL host is not allowed"
+
+
 def test_sample_url_rejects_redirect_responses(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _allow_public_sample_url_dns(monkeypatch)
 
     def open_request(target, *, timeout):
-        raise urllib.error.HTTPError(
-            target.url,
-            302,
-            "Found",
-            hdrs=None,
-            fp=None,
-        )
+        return _FakeSampleUrlResponse(b"", status=302)
 
     monkeypatch.setattr(api, "_open_https_sample_url_request", open_request)
     client = _client()
@@ -307,22 +326,60 @@ def test_sample_url_rejects_redirect_responses(
     assert response.json()["detail"] == "Sample URL redirects are not allowed."
 
 
-def test_sample_url_rejects_non_https_and_credentials() -> None:
+def test_sample_url_rejects_non_success_response_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_public_sample_url_dns(monkeypatch)
+
+    def open_request(target, *, timeout):
+        return _FakeSampleUrlResponse(b"", status=500)
+
+    monkeypatch.setattr(api, "_open_https_sample_url_request", open_request)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://example.test/about"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Sample URL could not be fetched."
+
+
+def test_sample_url_rejects_non_https_credentials_and_literal_private_hosts() -> None:
     client = _client()
 
     non_https = client.post(
         "/content-ops/brand-voice-profiles/sample-url",
         json={"url": "http://example.test/about"},
     )
+    file_scheme = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "file:///etc/passwd"},
+    )
     credentials = client.post(
         "/content-ops/brand-voice-profiles/sample-url",
         json={"url": "https://user:secret@example.test/about"},
     )
+    metadata_ip = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://169.254.169.254/latest/meta-data"},
+    )
+    shared_space = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://100.64.0.1/about"},
+    )
 
     assert non_https.status_code == 400
     assert non_https.json()["detail"] == "Sample URL must be an https URL"
+    assert file_scheme.status_code == 400
+    assert file_scheme.json()["detail"] == "Sample URL must be an https URL"
     assert credentials.status_code == 400
     assert credentials.json()["detail"] == "Sample URL must not include credentials"
+    assert metadata_ip.status_code == 400
+    assert metadata_ip.json()["detail"] == "Sample URL host is not allowed"
+    assert shared_space.status_code == 400
+    assert shared_space.json()["detail"] == "Sample URL host is not allowed"
 
 
 def test_sample_url_rejects_oversized_body(

--- a/tests/test_content_ops_brand_voice_profiles_api.py
+++ b/tests/test_content_ops_brand_voice_profiles_api.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import subprocess
 import sys
 import textwrap
+import urllib.error
 import uuid
 
 import pytest
@@ -42,6 +43,7 @@ def _load_api_module():
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -94,6 +96,45 @@ def _client(*, pool=None, user: AuthUser | None = None) -> TestClient:
         auth_dependency=auth_dependency,
     ))
     return TestClient(app)
+
+
+class _FakeSampleUrlResponse:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        status: int = 200,
+        content_type: str = "text/html; charset=utf-8",
+    ) -> None:
+        self._body = body
+        self.status = status
+        self.content_type = content_type
+        self.closed = False
+
+    def read(self, size: int) -> bytes:
+        return self._body[:size]
+
+    def getheader(self, name: str, default: str = "") -> str:
+        if name.lower() == "content-type":
+            return self.content_type
+        return default
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _allow_public_sample_url_dns(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    address: str = "93.184.216.34",
+) -> None:
+    monkeypatch.setattr(
+        api.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (api.socket.AF_INET, api.socket.SOCK_STREAM, 6, "", (address, 443)),
+        ],
+    )
 
 
 def test_list_brand_voice_profiles_returns_tenant_rows(
@@ -158,6 +199,164 @@ def test_add_brand_voice_profile_requires_admin_role(
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Admin access required"
+
+
+def test_sample_url_fetch_returns_readable_text_and_requires_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_public_sample_url_dns(monkeypatch)
+    responses: list[_FakeSampleUrlResponse] = []
+    calls: list[dict] = []
+
+    def open_request(target, *, timeout):
+        calls.append({"target": target, "timeout": timeout})
+        response = _FakeSampleUrlResponse(
+            b"""
+            <html>
+              <head><title>Acme About</title><style>.x{}</style></head>
+              <body>
+                <h1>Launch secure workflows faster.</h1>
+                <script>doNotInclude()</script>
+                <p>Your team gets clean automation without waiting.</p>
+              </body>
+            </html>
+            """,
+        )
+        responses.append(response)
+        return response
+
+    monkeypatch.setattr(api, "_open_https_sample_url_request", open_request)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://example.test/about?ref=atlas"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["url"] == "https://example.test/about?ref=atlas"
+    assert body["title"] == "Acme About"
+    assert body["text"] == (
+        "Launch secure workflows faster. "
+        "Your team gets clean automation without waiting."
+    )
+    assert body["source_character_count"] == len(body["text"])
+    assert calls[0]["target"].host == "example.test"
+    assert calls[0]["target"].connect_host == "93.184.216.34"
+    assert calls[0]["target"].path == "/about?ref=atlas"
+    assert responses[0].closed is True
+
+    member_response = _client(user=_user(role="member")).post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://example.test/about"},
+    )
+    assert member_response.status_code == 403
+    assert member_response.json()["detail"] == "Admin access required"
+
+
+def test_sample_url_rejects_private_dns_before_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (api.socket.AF_INET, api.socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443)),
+        ],
+    )
+
+    def open_request(target, *, timeout):
+        raise AssertionError("private DNS target must be rejected before fetch")
+
+    monkeypatch.setattr(api, "_open_https_sample_url_request", open_request)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://example.test/about"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Sample URL host is not allowed"
+
+
+def test_sample_url_rejects_redirect_responses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_public_sample_url_dns(monkeypatch)
+
+    def open_request(target, *, timeout):
+        raise urllib.error.HTTPError(
+            target.url,
+            302,
+            "Found",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(api, "_open_https_sample_url_request", open_request)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://example.test/about"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Sample URL redirects are not allowed."
+
+
+def test_sample_url_rejects_non_https_and_credentials() -> None:
+    client = _client()
+
+    non_https = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "http://example.test/about"},
+    )
+    credentials = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://user:secret@example.test/about"},
+    )
+
+    assert non_https.status_code == 400
+    assert non_https.json()["detail"] == "Sample URL must be an https URL"
+    assert credentials.status_code == 400
+    assert credentials.json()["detail"] == "Sample URL must not include credentials"
+
+
+def test_sample_url_rejects_oversized_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_public_sample_url_dns(monkeypatch)
+    body = b"a" * (api._SAMPLE_URL_MAX_BYTES + 1)
+
+    def open_request(target, *, timeout):
+        return _FakeSampleUrlResponse(body, content_type="text/plain")
+
+    monkeypatch.setattr(api, "_open_https_sample_url_request", open_request)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/brand-voice-profiles/sample-url",
+        json={"url": "https://example.test/about"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == {
+        "reason": "brand_voice_sample_url_too_large",
+        "max_bytes": api._SAMPLE_URL_MAX_BYTES,
+    }
+
+
+def test_sample_url_plain_text_extraction_falls_back_without_html() -> None:
+    title, text = api._extract_readable_text(
+        b"  First line.\n\nSecond\tline.  ",
+        content_type="text/plain",
+    )
+
+    assert title is None
+    assert text == "First line. Second line."
 
 
 def test_update_brand_voice_profile_is_account_scoped(
@@ -264,6 +463,7 @@ spec = importlib.util.spec_from_file_location(
 )
 module = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
+sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 print(module.BrandVoiceProfileView.__name__)
 """)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Brand-Voice-Scrape-Onboarding.md
Slice phase: Vertical slice

Adds an authenticated brand-voice sample URL extraction path so operators can fetch readable copy from one public HTTPS page into the existing editable sample textarea before applying the already-shipped deterministic brand voice prefill.

## Intentional
- No unauthenticated public scrape endpoint; this follows the existing owner/admin profile authoring guard.
- No JavaScript rendering, crawling, sitemap expansion, or form-authenticated fetch; the first URL path extracts one public page only.
- No LLM summarization; the same deterministic sample derivation from #1312 remains the only prefill path.
- No external network in tests; DNS and opener boundaries are mocked.

## Deferred
- `PR-Content-Ops-Brand-Voice-Presets`: descriptor-only preset library.
- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management page if inline authoring becomes too dense.
- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can consume brand voice.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_brand_voice_profiles_api.py -q` (16 passed)
- `cd atlas-intel-ui && npm ci` (installed dependencies; npm reported pre-existing audit findings: 2 moderate, 6 high)
- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector` (10 passed)
- `python -m py_compile atlas_brain/api/content_ops_brand_voice_profiles.py tests/test_content_ops_brand_voice_profiles_api.py`
- `cd atlas-intel-ui && npm run lint`
- `cd atlas-intel-ui && npm run build`
- `git diff --check`

## Diff size
6 files, +948 / -6