### PR TITLE
Content Ops Brand Voice Presets

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
@@ -45,8 +45,10 @@ const {
 } = await loadTsModule('../src/domain/contentOps/fromWire.ts')
 
 const {
+  BRAND_VOICE_PROFILE_PRESETS,
   applyBrandVoiceProfileEditorPatch,
   blankBrandVoiceProfileEditorState,
+  brandVoicePresetEditorPatch,
   brandVoiceProfileEditorRequest,
   canSaveBrandVoiceProfileEditor,
   deriveBrandVoiceProfileEditorPatch,
@@ -318,8 +320,42 @@ test('brand voice sample patch preserves manually entered fields', () => {
   assert.equal(merged.preferredPov, 'second_person')
 })
 
+test('brand voice preset patch fills only empty guidance fields', () => {
+  assert.ok(BRAND_VOICE_PROFILE_PRESETS.length >= 4)
+  const patch = brandVoicePresetEditorPatch('technical_trust')
+
+  assert.ok(patch)
+  assert.equal(patch.name, undefined)
+  assert.equal(patch.exemplarsText, undefined)
+  assert.ok(patch.descriptorsText.includes('technical'))
+  assert.ok(patch.descriptorsText.includes('credible'))
+  assert.ok(patch.bannedTermsText.includes('magic'))
+  assert.equal(patch.preferredPov, 'second_person')
+  assert.equal(patch.readingLevel, 'detailed')
+  assert.deepEqual(patch.metadata, {
+    source: 'content_ops_ui_preset',
+    preset_id: 'technical_trust',
+  })
+
+  const editor = {
+    ...blankBrandVoiceProfileEditorState(),
+    name: 'Manual profile',
+    descriptorsText: 'already set',
+    bannedTermsText: '',
+  }
+  const merged = applyBrandVoiceProfileEditorPatch(editor, patch)
+
+  assert.equal(merged.name, 'Manual profile')
+  assert.equal(merged.descriptorsText, 'already set')
+  assert.ok(merged.bannedTermsText.includes('magic'))
+  assert.equal(merged.preferredPov, 'second_person')
+  assert.equal(brandVoicePresetEditorPatch('missing'), null)
+})
+
 test('new run page renders brand voice profile selector wiring', () => {
   assert.ok(newRunSource.includes('function BrandVoiceProfileSelector'))
+  assert.ok(newRunSource.includes('BRAND_VOICE_PROFILE_PRESETS'))
+  assert.ok(newRunSource.includes('brandVoicePresetEditorPatch'))
   assert.ok(newRunSource.includes('fetchContentOpsBrandVoiceProfiles'))
   assert.ok(newRunSource.includes('fetchContentOpsBrandVoiceSampleUrl'))
   assert.ok(newRunSource.includes('createContentOpsBrandVoiceProfile'))
@@ -331,6 +367,7 @@ test('new run page renders brand voice profile selector wiring', () => {
   assert.ok(newRunSource.includes('New brand voice'))
   assert.ok(newRunSource.includes('Edit brand voice'))
   assert.ok(newRunSource.includes('Archive'))
+  assert.ok(newRunSource.includes('Apply preset'))
   assert.ok(newRunSource.includes('Sample import'))
   assert.ok(newRunSource.includes('type="file"'))
   assert.ok(newRunSource.includes('Fetch URL'))

--- a/atlas-intel-ui/src/domain/contentOps/brandVoiceProfileEditor.ts
+++ b/atlas-intel-ui/src/domain/contentOps/brandVoiceProfileEditor.ts
@@ -19,6 +19,50 @@ export type BrandVoiceProfileEditorPatch = Partial<
   Omit<BrandVoiceProfileEditorState, 'mode' | 'profileId'>
 >
 
+export type BrandVoiceProfilePreset = {
+  id: string
+  label: string
+  descriptors: readonly string[]
+  bannedTerms?: readonly string[]
+  preferredPov?: string
+  readingLevel?: string
+}
+
+export const BRAND_VOICE_PROFILE_PRESETS: readonly BrandVoiceProfilePreset[] = [
+  {
+    id: 'operator_plainspoken',
+    label: 'Plainspoken operator',
+    descriptors: ['plainspoken', 'concise', 'practical', 'customer-focused'],
+    bannedTerms: ['synergy', 'leverage'],
+    preferredPov: 'second_person',
+    readingLevel: 'plain',
+  },
+  {
+    id: 'technical_trust',
+    label: 'Technical trust',
+    descriptors: ['technical', 'credible', 'precise', 'calm'],
+    bannedTerms: ['magic', 'seamless'],
+    preferredPov: 'second_person',
+    readingLevel: 'detailed',
+  },
+  {
+    id: 'executive_brief',
+    label: 'Executive brief',
+    descriptors: ['strategic', 'direct', 'measured', 'outcome-focused'],
+    bannedTerms: ['game-changing', 'revolutionary'],
+    preferredPov: 'third_person',
+    readingLevel: 'plain',
+  },
+  {
+    id: 'founder_direct',
+    label: 'Founder direct',
+    descriptors: ['direct', 'conversational', 'confident', 'specific'],
+    bannedTerms: ['best-in-class', 'world-class'],
+    preferredPov: 'first_person',
+    readingLevel: 'plain',
+  },
+]
+
 export function blankBrandVoiceProfileEditorState(): BrandVoiceProfileEditorState {
   return {
     mode: 'create',
@@ -122,6 +166,23 @@ export function applyBrandVoiceProfileEditorPatch(
       ? editor.readingLevel
       : patch.readingLevel ?? editor.readingLevel,
     metadata: { ...editor.metadata, ...patch.metadata },
+  }
+}
+
+export function brandVoicePresetEditorPatch(
+  presetId: string,
+): BrandVoiceProfileEditorPatch | null {
+  const preset = BRAND_VOICE_PROFILE_PRESETS.find((item) => item.id === presetId)
+  if (!preset) return null
+  return {
+    descriptorsText: brandVoiceProfileListText([...preset.descriptors]),
+    bannedTermsText: brandVoiceProfileListText([...(preset.bannedTerms ?? [])]),
+    preferredPov: preset.preferredPov ?? '',
+    readingLevel: preset.readingLevel ?? '',
+    metadata: {
+      source: 'content_ops_ui_preset',
+      preset_id: preset.id,
+    },
   }
 }
 

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -71,14 +71,19 @@ export { inputContractDisplay } from './inputDisplay'
 export type { ContentOpsInputDisplayFallback } from './inputDisplay'
 
 export {
+  BRAND_VOICE_PROFILE_PRESETS,
   applyBrandVoiceProfileEditorPatch,
   blankBrandVoiceProfileEditorState,
+  brandVoicePresetEditorPatch,
   brandVoiceProfileEditorRequest,
   brandVoiceProfileEditorStateFromProfile,
   canSaveBrandVoiceProfileEditor,
   deriveBrandVoiceProfileEditorPatch,
 } from './brandVoiceProfileEditor'
-export type { BrandVoiceProfileEditorState } from './brandVoiceProfileEditor'
+export type {
+  BrandVoiceProfileEditorState,
+  BrandVoiceProfilePreset,
+} from './brandVoiceProfileEditor'
 
 export {
   FAQ_CONFIGURATION_OUTPUTS,

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -72,8 +72,10 @@ import {
   FAQ_INTENT_RULES_INPUT,
   FAQ_RESOLUTION_EVIDENCE_STATUS,
   FAQ_VOCABULARY_GAP_RULES_INPUT,
+  BRAND_VOICE_PROFILE_PRESETS,
   applyBrandVoiceProfileEditorPatch,
   blankBrandVoiceProfileEditorState,
+  brandVoicePresetEditorPatch,
   brandVoiceProfileEditorRequest,
   brandVoiceProfileEditorStateFromProfile,
   canSaveBrandVoiceProfileEditor,
@@ -183,6 +185,11 @@ type BrandVoiceSampleImportState =
   | { kind: 'idle' }
   | { kind: 'loading'; message: string }
   | { kind: 'loaded'; message: string }
+  | { kind: 'applied'; message: string }
+  | { kind: 'error'; message: string }
+
+type BrandVoicePresetApplyState =
+  | { kind: 'idle' }
   | { kind: 'applied'; message: string }
   | { kind: 'error'; message: string }
 
@@ -1936,6 +1943,11 @@ function BrandVoiceProfileSelector({
   const [sampleText, setSampleText] = useState('')
   const [sampleName, setSampleName] = useState('')
   const [sampleUrl, setSampleUrl] = useState('')
+  const [selectedPresetId, setSelectedPresetId] = useState(
+    BRAND_VOICE_PROFILE_PRESETS[0]?.id ?? '',
+  )
+  const [presetApplyState, setPresetApplyState] =
+    useState<BrandVoicePresetApplyState>({ kind: 'idle' })
   const [sampleImportState, setSampleImportState] =
     useState<BrandVoiceSampleImportState>({ kind: 'idle' })
   const mutating =
@@ -1962,6 +1974,7 @@ function BrandVoiceProfileSelector({
 
   const startCreate = () => {
     resetSampleImport()
+    setPresetApplyState({ kind: 'idle' })
     setEditor(blankBrandVoiceProfileEditorState())
     setMutationState({ kind: 'idle' })
   }
@@ -1969,6 +1982,7 @@ function BrandVoiceProfileSelector({
   const startEdit = () => {
     if (!selectedProfile) return
     resetSampleImport()
+    setPresetApplyState({ kind: 'idle' })
     setEditor(brandVoiceProfileEditorStateFromProfile(selectedProfile))
     setMutationState({ kind: 'idle' })
   }
@@ -2101,6 +2115,24 @@ function BrandVoiceProfileSelector({
         message: err instanceof Error ? err.message : String(err),
       })
     }
+  }
+
+  const handleApplyPreset = () => {
+    const patch = brandVoicePresetEditorPatch(selectedPresetId)
+    if (!patch) {
+      setPresetApplyState({
+        kind: 'error',
+        message: 'Select a preset before applying.',
+      })
+      return
+    }
+    setEditor((current) =>
+      current ? applyBrandVoiceProfileEditorPatch(current, patch) : current,
+    )
+    setPresetApplyState({
+      kind: 'applied',
+      message: 'Preset applied to empty profile fields.',
+    })
   }
 
   const handleApplySample = () => {
@@ -2244,6 +2276,50 @@ function BrandVoiceProfileSelector({
               <X className="h-3.5 w-3.5" />
               Cancel
             </button>
+          </div>
+
+          <div className="rounded-md border border-slate-800 bg-slate-950/40 p-3">
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+              <label className="block text-sm">
+                <span className="text-slate-300">Preset</span>
+                <select
+                  value={selectedPresetId}
+                  onChange={(event) => {
+                    setSelectedPresetId(event.target.value)
+                    setPresetApplyState({ kind: 'idle' })
+                  }}
+                  disabled={mutating}
+                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+                >
+                  {BRAND_VOICE_PROFILE_PRESETS.map((preset) => (
+                    <option key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                onClick={handleApplyPreset}
+                disabled={!selectedPresetId || mutating}
+                className="flex h-9 items-center justify-center gap-2 self-end rounded-md border border-cyan-500/60 px-2.5 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
+              >
+                <Palette className="h-3.5 w-3.5" />
+                Apply preset
+              </button>
+            </div>
+            {presetApplyState.kind !== 'idle' && (
+              <div
+                className={clsx(
+                  'mt-2 text-xs',
+                  presetApplyState.kind === 'error'
+                    ? 'text-rose-200'
+                    : 'text-slate-400',
+                )}
+              >
+                {presetApplyState.message}
+              </div>
+            )}
           </div>
 
           <div className="rounded-md border border-slate-800 bg-slate-950/40 p-3">

--- a/plans/PR-Content-Ops-Brand-Voice-Presets.md
+++ b/plans/PR-Content-Ops-Brand-Voice-Presets.md
@@ -1,0 +1,90 @@
+# PR-Content-Ops-Brand-Voice-Presets
+
+## Why this slice exists
+
+PR-Content-Ops-Brand-Voice-Scrape-Onboarding completed the paste/file/URL
+sample path and deferred `PR-Content-Ops-Brand-Voice-Presets` as the next
+brand voice convenience slice. Operators can now derive a profile from real
+copy, but when a customer has no useful public copy yet, profile authoring still
+starts from a blank form.
+
+This slice adds a descriptor-only preset library to the existing inline editor.
+It gives operators a deterministic starting point without creating stored
+profiles automatically and without introducing an LLM prompt or backend preset
+API.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/presets
+Slice phase: Product polish
+
+1. Add a small typed client-side preset catalog for common brand voice starting
+   points.
+2. Add a domain helper that converts a selected preset into the same
+   editor-patch shape used by sample import.
+3. Add an inline preset selector/button in the existing brand voice editor.
+4. Preserve manually entered fields by applying presets only through the
+   existing non-overwrite patch merge.
+5. Extend the existing enrolled brand voice frontend test script.
+
+### Files touched
+
+- `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs`
+- `atlas-intel-ui/src/domain/contentOps/brandVoiceProfileEditor.ts`
+- `atlas-intel-ui/src/domain/contentOps/index.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `plans/PR-Content-Ops-Brand-Voice-Presets.md`
+
+## Mechanism
+
+The domain layer exports `BRAND_VOICE_PROFILE_PRESETS` and
+`brandVoicePresetEditorPatch(presetId)`. Each preset supplies only deterministic
+authoring fields: descriptors, preferred POV, reading level, and optional
+banned terms. It intentionally does not generate exemplars.
+
+The UI renders a preset select while an editor is open. Clicking "Apply preset"
+looks up the selected preset, builds a `BrandVoiceProfileEditorPatch`, and calls
+`applyBrandVoiceProfileEditorPatch(...)`, which already fills only empty fields.
+The operator still reviews and saves the resulting profile through the existing
+create/update route.
+
+## Intentional
+
+- Presets are client-side and descriptor-only. They are authoring shortcuts, not
+  persisted tenant records.
+- Presets do not include exemplars; real exemplars should still come from
+  customer copy via paste/file/URL.
+- Applying a preset does not overwrite manually entered fields. Operators can
+  clear a field first if they want the preset value.
+- No new frontend test script is added; this extends the already enrolled brand
+  voice profile selector script.
+
+## Deferred
+
+- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management
+  page if inline authoring becomes too dense.
+- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can
+  consume brand voice.
+
+Parked hardening: none.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci` (installed dependencies; npm reported
+  pre-existing audit findings: 2 moderate, 6 high)
+- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector`
+  (11 passed)
+- `cd atlas-intel-ui && npm run lint`
+- `cd atlas-intel-ui && npm run build`
+- `git diff --check`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs` | 37 |
+| `atlas-intel-ui/src/domain/contentOps/brandVoiceProfileEditor.ts` | 61 |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | 7 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 76 |
+| `plans/PR-Content-Ops-Brand-Voice-Presets.md` | 90 |
+| **Total** | **271** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Brand-Voice-Presets.md
Slice phase: Product polish

Adds a client-side descriptor-only brand voice preset library to the existing inline profile editor, giving operators deterministic starting points when customer copy is not available while preserving the existing save/review flow.

## Intentional
- Presets are client-side and descriptor-only; they are authoring shortcuts, not persisted tenant records.
- Presets do not include exemplars; real exemplars should still come from customer copy via paste/file/URL.
- Applying a preset does not overwrite manually entered fields.
- No new frontend test script is added; this extends the already enrolled brand voice profile selector script.

## Deferred
- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management page if inline authoring becomes too dense.
- `PR-Content-Ops-Social-Post-LLM-Voice`: LLM social-post variant that can consume brand voice.

## Parked hardening
- None.

## Verification
- `cd atlas-intel-ui && npm ci` (installed dependencies; npm reported pre-existing audit findings: 2 moderate, 6 high)
- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector` (11 passed)
- `cd atlas-intel-ui && npm run lint`
- `cd atlas-intel-ui && npm run build`
- `git diff --check`

## Diff size
5 files, +270 / -1