### PR TITLE
Content Ops Social Post LLM Voice

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -10,7 +10,8 @@ Currently wired:
 - `signal_extraction` (E1, PR #452): deterministic generator
   with no external dependencies.
 - `social_post`: deterministic source-evidence social post drafts
-  with no external dependencies.
+  with no external dependencies, plus optional brand-voice LLM rewrite when
+  DB services have the configured Content Ops LLM and skill store.
 - `ad_copy`: deterministic source-evidence ad-copy drafts
   with no external dependencies; persists when DB services are enabled.
 - `quote_card`: deterministic source-evidence quote-card drafts
@@ -284,13 +285,20 @@ def _build_ticket_faq_service(*, pool: Any) -> TicketFAQMarkdownService | None:
     return TicketFAQMarkdownService(ticket_faqs=PostgresTicketFAQRepository(pool=pool))
 
 
-def _build_social_post_service(*, pool: Any) -> SocialPostGenerationService:
+def _build_social_post_service(
+    *,
+    pool: Any,
+    llm: LLMClient | None = None,
+    skills: SkillStore | None = None,
+) -> SocialPostGenerationService:
     """Build social-post generation with optional draft persistence."""
 
     if pool is None:
         return _SOCIAL_POST_SERVICE
     return SocialPostGenerationService(
-        social_posts=PostgresSocialPostRepository(pool=pool)
+        social_posts=PostgresSocialPostRepository(pool=pool),
+        llm=llm,
+        skills=skills,
     )
 
 
@@ -429,7 +437,11 @@ def build_content_ops_execution_services(
             pool=pool,
             image_provider=image_provider,
         )
-        social_post = _build_social_post_service(pool=pool)
+        social_post = _build_social_post_service(
+            pool=pool,
+            llm=llm,
+            skills=skills,
+        )
         ad_copy = _build_ad_copy_service(pool=pool)
         quote_card = _build_quote_card_service(pool=pool)
         stat_card = _build_stat_card_service(pool=pool)

--- a/atlas_brain/skills/digest/social_post_generation.md
+++ b/atlas_brain/skills/digest/social_post_generation.md
@@ -1,0 +1,59 @@
+---
+name: digest/social_post_generation
+domain: digest
+description: Rewrite evidence-backed social-post drafts with optional brand voice guidance
+tags: [digest, content-ops, social, brand-voice]
+version: 1
+---
+
+# Evidence-Backed Social Post Generator
+
+You rewrite one deterministic social-post draft into customer-facing social copy.
+Use the supplied source evidence and original draft as the only factual basis.
+
+{brand_voice}
+
+## Input
+
+The user message contains JSON with this shape:
+
+```json
+{
+  "target_mode": "vendor_retention",
+  "source_post": {
+    "channel": "linkedin",
+    "text": "Existing deterministic draft",
+    "source_id": "review-1",
+    "source_type": "review",
+    "company_name": "Acme Logistics",
+    "vendor_name": "HubSpot",
+    "pain_points": ["pricing pressure"]
+  }
+}
+```
+
+## Output
+
+Return only one JSON object:
+
+```json
+{
+  "channel": "linkedin",
+  "text": "Short social copy grounded only in the source post."
+}
+```
+
+## Rules
+
+1. Keep the same channel unless the input channel is blank.
+2. The `text` field must be non-empty and fit within the requested character
+   limit supplied in the user message.
+3. Use the brand voice for wording, rhythm, point of view, and banned terms
+   only. It must not add facts, claims, metrics, names, timelines, or product
+   details that are absent from the source post.
+4. Preserve source meaning. If the source post says a pain point was observed,
+   write an observed-evidence social post, not a promise of outcomes.
+5. Do not invent hashtags, URLs, markdown, statistics, or calls to buy unless
+   they appear in the source post.
+6. Do not mention that a brand voice profile, system prompt, or rewrite process
+   was used.

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -705,15 +705,24 @@ async def _dispatch_social_post(
     brand_voice: BrandVoiceProfile | None,
     filters: Mapping[str, Any] | None,
 ) -> Any:
-    del brand_voice
     del filters
-    return await service.generate(
-        scope=scope,
-        target_mode=request.target_mode,
-        source_material=request.inputs.get("source_material"),
-        limit=request.limit,
-        max_text_chars=_step_config_int(step.config, "max_text_chars"),
-    )
+    kwargs: dict[str, Any] = {
+        "scope": scope,
+        "target_mode": request.target_mode,
+        "source_material": request.inputs.get("source_material"),
+        "limit": request.limit,
+        "max_text_chars": _step_config_int(step.config, "max_text_chars"),
+        "temperature": _step_config_float(step.config, "temperature"),
+        "max_tokens": _step_config_int(step.config, "max_tokens"),
+        "parse_retry_attempts": _step_config_int(step.config, "parse_retry_attempts"),
+        "parse_retry_response_excerpt_chars": _step_config_int(
+            step.config,
+            "parse_retry_response_excerpt_chars",
+        ),
+    }
+    if brand_voice is not None:
+        kwargs["brand_voice"] = brand_voice
+    return await service.generate(**kwargs)
 
 
 async def _dispatch_ad_copy(

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -8,7 +8,7 @@ runs.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -17,6 +17,9 @@ from .landing_page_repair_contract import (
     LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS_DEFAULT,
     landing_page_quality_repair_attempts_from_inputs,
 )
+
+SOCIAL_POST_BRAND_VOICE_UNIT_COST_USD = 0.08
+SOCIAL_POST_BRAND_VOICE_PARSE_RETRY_ATTEMPTS = 1
 
 
 @dataclass(frozen=True)
@@ -460,12 +463,49 @@ def retry_adjusted_unit_cost_usd(
     return definition.estimated_unit_cost_usd * parse_attempts * (repair_attempts + 1)
 
 
+def _brand_voice_requested(
+    inputs: Mapping[str, Any],
+    *,
+    brand_voice_profile_id: str | None,
+) -> bool:
+    if str(brand_voice_profile_id or "").strip():
+        return True
+    value = inputs.get("brand_voice")
+    if value is None:
+        return False
+    if isinstance(value, Mapping):
+        return bool(value)
+    return True
+
+
+def _cost_definition_for_output(
+    output_id: str,
+    definition: OutputDefinition,
+    *,
+    inputs: Mapping[str, Any],
+    brand_voice_profile_id: str | None,
+) -> OutputDefinition:
+    """Return the dynamic preview-cost definition for one output."""
+
+    if output_id == "social_post" and _brand_voice_requested(
+        inputs,
+        brand_voice_profile_id=brand_voice_profile_id,
+    ):
+        return replace(
+            definition,
+            estimated_unit_cost_usd=SOCIAL_POST_BRAND_VOICE_UNIT_COST_USD,
+            default_parse_retry_attempts=SOCIAL_POST_BRAND_VOICE_PARSE_RETRY_ATTEMPTS,
+        )
+    return definition
+
+
 def estimate_cost_usd(
     outputs: Sequence[str],
     *,
     limit: int,
     inputs: Mapping[str, Any] | None = None,
     require_quality_gates: bool = True,
+    brand_voice_profile_id: str | None = None,
 ) -> float:
     """Estimate cost from selected outputs and opportunity limit.
 
@@ -481,15 +521,21 @@ def estimate_cost_usd(
         definition = OUTPUT_CATALOG.get(output_id)
         if not definition:
             continue
-        repair_attempts = _quality_repair_attempts_for_output(
+        cost_definition = _cost_definition_for_output(
             output_id,
             definition,
+            inputs=provided_inputs,
+            brand_voice_profile_id=brand_voice_profile_id,
+        )
+        repair_attempts = _quality_repair_attempts_for_output(
+            output_id,
+            cost_definition,
             inputs=provided_inputs,
             require_quality_gates=require_quality_gates,
         )
         total += (
             retry_adjusted_unit_cost_usd(
-                definition,
+                cost_definition,
                 quality_repair_attempts=repair_attempts,
             )
             * max(1, limit)
@@ -578,6 +624,7 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
         limit=request.limit,
         inputs=request.inputs,
         require_quality_gates=request.require_quality_gates,
+        brand_voice_profile_id=request.brand_voice_profile_id,
     )
 
     if request.max_cost_usd is not None and estimated_cost > request.max_cost_usd:

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -477,8 +477,14 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
             runner="SocialPostGenerationService.generate",
             status="runnable",
             config={
+                "skill_name": config.skill_name,
                 "limit": config.limit,
                 "max_text_chars": config.max_text_chars,
+                "max_tokens": config.max_tokens,
+                "temperature": config.temperature,
+                "parse_retry_attempts": config.parse_retry_attempts,
+                "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_brand_voice_config_for_request(request),
             },
         )
     if output == "ad_copy":

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -37,6 +37,10 @@
       "target": "extracted_content_pipeline/skills/digest/b2b_campaign_generation.md"
     },
     {
+      "source": "atlas_brain/skills/digest/social_post_generation.md",
+      "target": "extracted_content_pipeline/skills/digest/social_post_generation.md"
+    },
+    {
       "source": "atlas_brain/skills/digest/b2b_vendor_outreach.md",
       "target": "extracted_content_pipeline/skills/digest/b2b_vendor_outreach.md"
     },

--- a/extracted_content_pipeline/skills/digest/social_post_generation.md
+++ b/extracted_content_pipeline/skills/digest/social_post_generation.md
@@ -1,0 +1,59 @@
+---
+name: digest/social_post_generation
+domain: digest
+description: Rewrite evidence-backed social-post drafts with optional brand voice guidance
+tags: [digest, content-ops, social, brand-voice]
+version: 1
+---
+
+# Evidence-Backed Social Post Generator
+
+You rewrite one deterministic social-post draft into customer-facing social copy.
+Use the supplied source evidence and original draft as the only factual basis.
+
+{brand_voice}
+
+## Input
+
+The user message contains JSON with this shape:
+
+```json
+{
+  "target_mode": "vendor_retention",
+  "source_post": {
+    "channel": "linkedin",
+    "text": "Existing deterministic draft",
+    "source_id": "review-1",
+    "source_type": "review",
+    "company_name": "Acme Logistics",
+    "vendor_name": "HubSpot",
+    "pain_points": ["pricing pressure"]
+  }
+}
+```
+
+## Output
+
+Return only one JSON object:
+
+```json
+{
+  "channel": "linkedin",
+  "text": "Short social copy grounded only in the source post."
+}
+```
+
+## Rules
+
+1. Keep the same channel unless the input channel is blank.
+2. The `text` field must be non-empty and fit within the requested character
+   limit supplied in the user message.
+3. Use the brand voice for wording, rhythm, point of view, and banned terms
+   only. It must not add facts, claims, metrics, names, timelines, or product
+   details that are absent from the source post.
+4. Preserve source meaning. If the source post says a pain point was observed,
+   write an observed-evidence social post, not a promise of outcomes.
+5. Do not invent hashtags, URLs, markdown, statistics, or calls to buy unless
+   they appear in the source post.
+6. Do not mention that a brand voice profile, system prompt, or rewrite process
+   was used.

--- a/extracted_content_pipeline/social_post_generation.py
+++ b/extracted_content_pipeline/social_post_generation.py
@@ -2,13 +2,27 @@
 
 from __future__ import annotations
 
+import json
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import Any
 
+from .brand_voice import (
+    BrandVoiceProfile,
+    apply_brand_voice_to_system_prompt,
+    brand_voice_profile_from_mapping,
+    brand_voice_result_metadata,
+)
 from .campaign_customer_data import CampaignOpportunityWarning
-from .campaign_ports import TenantScope
+from .campaign_ports import LLMClient, LLMMessage, SkillStore, TenantScope
 from .campaign_source_adapters import source_row_to_campaign_opportunity
+from .services._parse_retry_helpers import (
+    accumulate_usage,
+    clip_invalid_response,
+    parse_attempt_limit,
+    retry_prompt_with_invalid_response,
+)
 from .social_post_ports import SocialPostDraft, SocialPostRepository
 
 _ROW_LIST_KEYS = ("sources", "opportunities", "reviews", "documents", "rows", "data")
@@ -18,9 +32,14 @@ _ROW_LIST_KEYS = ("sources", "opportunities", "reviews", "documents", "rows", "d
 class SocialPostGenerationConfig:
     """Config for deterministic source-material social posts."""
 
+    skill_name: str = "digest/social_post_generation"
     limit: int = 3
     max_text_chars: int = 600
     max_post_chars: int = 420
+    max_tokens: int = 700
+    temperature: float = 0.4
+    parse_retry_attempts: int = 1
+    parse_retry_response_excerpt_chars: int = 800
 
 
 @dataclass(frozen=True)
@@ -54,9 +73,13 @@ class SocialPostGenerationService:
         config: SocialPostGenerationConfig | None = None,
         *,
         social_posts: SocialPostRepository | None = None,
+        llm: LLMClient | None = None,
+        skills: SkillStore | None = None,
     ) -> None:
         self.config = config or SocialPostGenerationConfig()
         self._social_posts = social_posts
+        self._llm = llm
+        self._skills = skills
 
     async def generate(
         self,
@@ -66,9 +89,18 @@ class SocialPostGenerationService:
         source_material: Any,
         limit: int | None = None,
         max_text_chars: int | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        parse_retry_attempts: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
+        brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
         **kwargs: Any,
     ) -> SocialPostGenerationResult:
         del kwargs
+        resolved_brand_voice = brand_voice_profile_from_mapping(
+            brand_voice,
+            scope=scope,
+        )
         resolved_limit = int(limit) if limit is not None else self.config.limit
         if resolved_limit < 1:
             raise ValueError("limit must be at least 1")
@@ -86,6 +118,188 @@ class SocialPostGenerationService:
             max_text_chars=resolved_max_text_chars,
             max_post_chars=self.config.max_post_chars,
         )
+        if resolved_brand_voice is not None and result.posts:
+            prompt_template = self._social_post_prompt()
+            posts, warnings = await self._rewrite_posts_with_brand_voice(
+                result.posts,
+                target_mode=target_mode,
+                prompt_template=prompt_template,
+                brand_voice=resolved_brand_voice,
+                temperature=(
+                    self.config.temperature
+                    if temperature is None
+                    else float(temperature)
+                ),
+                max_tokens=(
+                    self.config.max_tokens
+                    if max_tokens is None
+                    else int(max_tokens)
+                ),
+                parse_retry_attempts=(
+                    self.config.parse_retry_attempts
+                    if parse_retry_attempts is None
+                    else int(parse_retry_attempts)
+                ),
+                parse_retry_response_excerpt_chars=(
+                    self.config.parse_retry_response_excerpt_chars
+                    if parse_retry_response_excerpt_chars is None
+                    else int(parse_retry_response_excerpt_chars)
+                ),
+            )
+            result = replace(
+                result,
+                posts=tuple(posts),
+                warnings=tuple(result.warnings) + tuple(warnings),
+            )
+        return await self._persist_result(result, scope=scope, target_mode=target_mode)
+
+    def _social_post_prompt(self) -> str:
+        if self._llm is None or self._skills is None:
+            raise ValueError(
+                "brand voice social_post generation requires configured LLM and skill store"
+            )
+        prompt_template = self._skills.get_prompt(self.config.skill_name)
+        if not prompt_template:
+            raise ValueError(
+                f"Social post generation skill not found: {self.config.skill_name}"
+            )
+        return prompt_template
+
+    async def _rewrite_posts_with_brand_voice(
+        self,
+        posts: Sequence[Mapping[str, Any]],
+        *,
+        target_mode: str,
+        prompt_template: str,
+        brand_voice: BrandVoiceProfile,
+        temperature: float,
+        max_tokens: int,
+        parse_retry_attempts: int,
+        parse_retry_response_excerpt_chars: int,
+    ) -> tuple[list[dict[str, Any]], list[CampaignOpportunityWarning]]:
+        rewritten: list[dict[str, Any]] = []
+        warnings: list[CampaignOpportunityWarning] = []
+        system_prompt = apply_brand_voice_to_system_prompt(prompt_template, brand_voice)
+        for index, post in enumerate(posts, start=1):
+            try:
+                parsed = await self._rewrite_one_post(
+                    post,
+                    target_mode=target_mode,
+                    system_prompt=system_prompt,
+                    brand_voice=brand_voice,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    parse_retry_attempts=parse_retry_attempts,
+                    parse_retry_response_excerpt_chars=parse_retry_response_excerpt_chars,
+                )
+            except Exception as exc:
+                warnings.append(CampaignOpportunityWarning(
+                    code="social_post_llm_error",
+                    row_index=index,
+                    message=(
+                        "Skipped social post rewrite because LLM generation failed: "
+                        f"{exc}"
+                    ),
+                ))
+                continue
+            if parsed is None:
+                warnings.append(CampaignOpportunityWarning(
+                    code="social_post_llm_unparseable_response",
+                    row_index=index,
+                    message=(
+                        "Skipped social post rewrite because the LLM did not return "
+                        "valid social-post JSON."
+                    ),
+                ))
+                continue
+            rewritten.append(parsed)
+        return rewritten, warnings
+
+    async def _rewrite_one_post(
+        self,
+        post: Mapping[str, Any],
+        *,
+        target_mode: str,
+        system_prompt: str,
+        brand_voice: BrandVoiceProfile,
+        temperature: float,
+        max_tokens: int,
+        parse_retry_attempts: int,
+        parse_retry_response_excerpt_chars: int,
+    ) -> dict[str, Any] | None:
+        if self._llm is None:
+            raise ValueError("brand voice social_post generation requires configured LLM")
+        prior_invalid_response = ""
+        usage: dict[str, Any] = {}
+        for _attempt in range(parse_attempt_limit(parse_retry_attempts)):
+            response = await self._llm.complete(
+                [
+                    LLMMessage(role="system", content=system_prompt),
+                    LLMMessage(
+                        role="user",
+                        content=_social_post_user_prompt(
+                            target_mode=target_mode,
+                            source_post=post,
+                            max_post_chars=self.config.max_post_chars,
+                            prior_invalid_response=prior_invalid_response,
+                        ),
+                    ),
+                ],
+                max_tokens=max_tokens,
+                temperature=temperature,
+                metadata={
+                    "asset_type": "social_post",
+                    "target_mode": target_mode,
+                    "source_id": _clean(post.get("source_id") or post.get("id")),
+                },
+            )
+            usage = accumulate_usage(usage, response.usage)
+            parsed = parse_social_post_response(response.content)
+            if parsed is None:
+                prior_invalid_response = clip_invalid_response(
+                    response.content,
+                    limit=parse_retry_response_excerpt_chars,
+                )
+                continue
+            text = _truncate(parsed["text"], self.config.max_post_chars)
+            if not text:
+                prior_invalid_response = clip_invalid_response(
+                    response.content,
+                    limit=parse_retry_response_excerpt_chars,
+                )
+                continue
+            channel = (
+                _clean(parsed.get("channel"))
+                or _clean(post.get("channel"))
+                or "linkedin"
+            )
+            rewritten = {
+                **dict(post),
+                "channel": channel,
+                "text": text,
+            }
+            voice_metadata = brand_voice_result_metadata(
+                {"channel": channel, "text": text},
+                brand_voice,
+            )
+            if voice_metadata.get("_brand_voice_profile"):
+                rewritten["_brand_voice_profile"] = voice_metadata[
+                    "_brand_voice_profile"
+                ]
+            if voice_metadata.get("_brand_voice_audit"):
+                rewritten["_brand_voice_audit"] = voice_metadata["_brand_voice_audit"]
+            if usage:
+                rewritten["_generation_usage"] = dict(usage)
+            return rewritten
+        return None
+
+    async def _persist_result(
+        self,
+        result: SocialPostGenerationResult,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+    ) -> SocialPostGenerationResult:
         if self._social_posts is None or not result.posts:
             return result
         saved_ids = tuple(
@@ -96,6 +310,79 @@ class SocialPostGenerationService:
             )
         )
         return replace(result, saved_ids=saved_ids)
+
+
+def parse_social_post_response(text: str) -> dict[str, str] | None:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return None
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
+
+    candidates: list[Any] = []
+    try:
+        candidates.append(json.loads(cleaned))
+    except json.JSONDecodeError:
+        pass
+
+    depth = 0
+    start = -1
+    for index, char in enumerate(cleaned):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    candidates.append(json.loads(cleaned[start : index + 1]))
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            candidate = candidate[0] if candidate else None
+        if not isinstance(candidate, Mapping):
+            continue
+        post_text = _clean(
+            candidate.get("text")
+            or candidate.get("body")
+            or candidate.get("content")
+        )
+        if not post_text:
+            continue
+        return {
+            "channel": _clean(candidate.get("channel")),
+            "text": post_text,
+        }
+    return None
+
+
+def _social_post_user_prompt(
+    *,
+    target_mode: str,
+    source_post: Mapping[str, Any],
+    max_post_chars: int,
+    prior_invalid_response: str = "",
+) -> str:
+    prompt = (
+        "Rewrite this source-backed social post.\n"
+        f"target_mode={target_mode}\n"
+        f"max_post_chars={max_post_chars}\n"
+        "source_post="
+        + json.dumps(dict(source_post), sort_keys=True, separators=(",", ":"))
+    )
+    return retry_prompt_with_invalid_response(
+        prompt,
+        prior_invalid_response=prior_invalid_response,
+        instruction=(
+            "The previous response was not valid social-post JSON. "
+            "Return one JSON object with non-empty text."
+        ),
+    )
 
 
 def _generate_social_posts(
@@ -201,10 +488,21 @@ def _drafts_from_posts(
                 company_name=_clean(post.get("company_name")),
                 vendor_name=_clean(post.get("vendor_name")),
                 pain_points=_pain_points_from_post(post.get("pain_points")),
-                metadata={"source_post": dict(post)},
+                metadata=_post_metadata(post),
             )
         )
     return tuple(drafts)
+
+
+def _post_metadata(post: Mapping[str, Any]) -> dict[str, Any]:
+    metadata = {"source_post": dict(post)}
+    if isinstance(post.get("_brand_voice_profile"), Mapping):
+        metadata["brand_voice_profile"] = dict(post["_brand_voice_profile"])
+    if isinstance(post.get("_brand_voice_audit"), Mapping):
+        metadata["brand_voice_audit"] = dict(post["_brand_voice_audit"])
+    if isinstance(post.get("_generation_usage"), Mapping):
+        metadata["generation_usage"] = dict(post["_generation_usage"])
+    return metadata
 
 
 def _pain_points_from_post(value: Any) -> tuple[str, ...]:
@@ -276,4 +574,5 @@ __all__ = [
     "SocialPostGenerationService",
     "SocialPostDraft",
     "SocialPostRepository",
+    "parse_social_post_response",
 ]

--- a/plans/PR-Content-Ops-Social-Post-LLM-Voice.md
+++ b/plans/PR-Content-Ops-Social-Post-LLM-Voice.md
@@ -136,7 +136,7 @@ Parked hardening: none.
 - `python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py atlas_brain/_content_ops_services.py tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_execution_services.py`
   -- passed.
 - `pytest tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py -q`
-  -- 126 passed.
+  -- 128 passed.
 - `pytest tests/test_atlas_content_ops_execution_services.py -q` -- 28 passed.
 - `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
@@ -156,6 +156,7 @@ Parked hardening: none.
   - `pytest tests/test_extracted_content_control_surfaces.py -q` -- 44 passed.
   - `pytest tests/test_extracted_content_control_surface_api.py -q` -- 131
     passed / 1 skipped.
+  - `pytest tests/test_extracted_social_post_generation.py -q` -- 12 passed.
 
 ## Estimated diff size
 
@@ -169,10 +170,10 @@ Parked hardening: none.
 | `extracted_content_pipeline/manifest.json` | 4 |
 | `extracted_content_pipeline/skills/digest/social_post_generation.md` | 59 |
 | `extracted_content_pipeline/social_post_generation.py` | 303 |
-| `plans/PR-Content-Ops-Social-Post-LLM-Voice.md` | 178 |
+| `plans/PR-Content-Ops-Social-Post-LLM-Voice.md` | 179 |
 | `tests/test_atlas_content_ops_execution_services.py` | 132 |
 | `tests/test_extracted_content_control_surfaces.py` | 34 |
 | `tests/test_extracted_content_generation_plan.py` | 9 |
 | `tests/test_extracted_content_ops_execution.py` | 43 |
-| `tests/test_extracted_social_post_generation.py` | 178 |
-| **Total** | **1103** |
+| `tests/test_extracted_social_post_generation.py` | 264 |
+| **Total** | **1190** |

--- a/plans/PR-Content-Ops-Social-Post-LLM-Voice.md
+++ b/plans/PR-Content-Ops-Social-Post-LLM-Voice.md
@@ -1,0 +1,145 @@
+# PR-Content-Ops-Social-Post-LLM-Voice
+
+## Why this slice exists
+
+PR-Content-Ops-Brand-Voice-Profile deliberately skipped social-post voice
+support because `social_post` was still a deterministic template output. The
+subsequent storage, editor, onboarding, scrape, and preset slices made saved
+brand voice usable from the Content Ops UI, and each deferred
+`PR-Content-Ops-Social-Post-LLM-Voice` as the remaining product path.
+
+Today social posts are persisted and reviewable, but selecting a brand voice
+profile still does not affect them. This slice adds the thinnest LLM-backed
+social-post variant over the existing source-evidence drafts so the selected
+brand voice is actually consumed instead of silently ignored.
+
+This is over the 400 LOC soft cap because the first executable social-post
+voice path needs the prompt, synced manifest entry, generator behavior,
+dispatcher/plan wiring, host service wiring, and fail-closed tests together.
+Splitting before the host wiring would leave the new LLM path unreachable;
+splitting before the negative tests would make the "selected brand voice is not
+silently ignored" claim unenforced.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/social-post-llm
+Slice phase: Vertical slice
+
+1. Keep the existing deterministic social-post generator as the fallback path.
+2. Add optional LLM social-post rewriting when a request supplies brand voice;
+   no brand voice means the existing deterministic behavior remains unchanged.
+3. Fail the social-post step when brand voice is supplied but the service has no
+   LLM client or prompt, so a selected profile is not silently ignored.
+4. Thread `brand_voice` through the social-post dispatcher and include
+   `brand_voice_profile_id` in social-post plan metadata.
+5. Wire the host DB-backed social-post service with the existing configured
+   Content Ops LLM and skill store while preserving the no-LLM deterministic
+   singleton.
+6. Add a host-owned social-post prompt synced into the extracted package by the
+   manifest.
+7. Add focused package and host wiring tests for LLM rewrite, fail-closed
+   missing LLM/prompt behavior, plan metadata, dispatcher threading, and
+   deterministic fallback.
+
+### Files touched
+
+- `atlas_brain/_content_ops_services.py`
+- `atlas_brain/skills/digest/social_post_generation.md`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/skills/digest/social_post_generation.md`
+- `extracted_content_pipeline/social_post_generation.py`
+- `plans/PR-Content-Ops-Social-Post-LLM-Voice.md`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_social_post_generation.py`
+
+## Mechanism
+
+`SocialPostGenerationService` gains optional `llm` and `skills` ports using the
+same `LLMClient` / `SkillStore` contracts as campaign, blog, landing page, and
+sales brief. It first builds the existing evidence-backed deterministic posts.
+When no brand voice is supplied, it returns those posts exactly as before.
+
+When brand voice is supplied, the service resolves it through
+`brand_voice_profile_from_mapping(...)`, loads `digest/social_post_generation`,
+injects the standard brand-voice block with
+`apply_brand_voice_to_system_prompt(...)`, and asks the configured Content Ops
+LLM to rewrite each deterministic post into JSON:
+
+```json
+{"channel": "linkedin", "text": "bounded social copy"}
+```
+
+The rewrite prompt carries the original post and source evidence; the model is
+allowed to change wording and rhythm only. Parsed LLM posts keep the existing
+fields (`source_id`, `vendor_name`, `pain_points`, etc.) and add
+`_brand_voice_profile` / `_brand_voice_audit` metadata before persistence. If a
+brand voice request reaches a service without `llm` or `skills`, or without the
+prompt, the step fails rather than returning unvoiced deterministic copy.
+
+Host wiring changes only the DB-enabled social-post builder: when an LLM and
+pool are available it passes the existing OpenRouter-configured Content Ops LLM
+client and skill store into `SocialPostGenerationService`. The no-DB/no-LLM
+singleton remains deterministic and wired.
+
+## Intentional
+
+- This does not add a new output id. `social_post` remains the product output;
+  brand voice switches it to the LLM rewrite path only when the request has a
+  resolved profile.
+- Deterministic social posts still run without LLM or DB services. The fail
+  closed behavior applies only when brand voice is selected.
+- No local-model route is introduced. Host LLM wiring reuses the existing
+  Content Ops OpenRouter path with `auto_activate_ollama=False`.
+- No social-post edit/repair UI in this slice. The existing generated-asset
+  review table remains the approval surface.
+
+## Deferred
+
+- `PR-Content-Ops-Social-Post-Channel-Variants`: platform-specific variants
+  beyond the current single LinkedIn draft.
+- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management
+  page if the inline New Run panel becomes too dense.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py atlas_brain/_content_ops_services.py tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_execution_services.py`
+  -- passed.
+- `pytest tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py -q`
+  -- 126 passed.
+- `pytest tests/test_atlas_content_ops_execution_services.py -q` -- 28 passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- 0 findings.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` --
+  refreshed 46 mapped files.
+- `bash scripts/run_extracted_pipeline_checks.sh` -- 295 reasoning-core tests
+  passed; 3115 extracted-content tests passed / 10 skipped / 1 warning.
+- `git diff --check` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-social-post-llm-voice.md`
+  -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/_content_ops_services.py` | 20 |
+| `atlas_brain/skills/digest/social_post_generation.md` | 59 |
+| `extracted_content_pipeline/content_ops_execution.py` | 25 |
+| `extracted_content_pipeline/generation_plan.py` | 6 |
+| `extracted_content_pipeline/manifest.json` | 4 |
+| `extracted_content_pipeline/skills/digest/social_post_generation.md` | 59 |
+| `extracted_content_pipeline/social_post_generation.py` | 303 |
+| `plans/PR-Content-Ops-Social-Post-LLM-Voice.md` | 145 |
+| `tests/test_atlas_content_ops_execution_services.py` | 132 |
+| `tests/test_extracted_content_generation_plan.py` | 9 |
+| `tests/test_extracted_content_ops_execution.py` | 43 |
+| `tests/test_extracted_social_post_generation.py` | 178 |
+| **Total** | **983** |

--- a/plans/PR-Content-Ops-Social-Post-LLM-Voice.md
+++ b/plans/PR-Content-Ops-Social-Post-LLM-Voice.md
@@ -40,18 +40,36 @@ Slice phase: Vertical slice
 7. Add focused package and host wiring tests for LLM rewrite, fail-closed
    missing LLM/prompt behavior, plan metadata, dispatcher threading, and
    deterministic fallback.
+8. Review follow-up: make the preview/budget estimator charge for
+   brand-voice social-post LLM rewrites, while preserving the zero-cost
+   deterministic social-post path when no brand voice is selected.
+
+### Review Contract
+
+- Acceptance criteria: brand-voice social posts route through the configured
+  LLM path; missing LLM or prompt wiring fails closed; no-brand-voice social
+  posts keep the deterministic fallback; preview/budget estimation charges
+  only brand-voice social-post rewrites.
+- Affected surfaces: extracted content execution, host social-post service
+  wiring, control-surface preview, synced prompt and manifest.
+- Risk areas: backcompat, cost gating, LLM failure handling, extracted package
+  sync.
+- Reviewer rules triggered: R1 (requirements match the plan/test contract),
+  R10 (LLM path and estimator changes stay centralized and maintainable).
 
 ### Files touched
 
 - `atlas_brain/_content_ops_services.py`
 - `atlas_brain/skills/digest/social_post_generation.md`
 - `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/control_surfaces.py`
 - `extracted_content_pipeline/generation_plan.py`
 - `extracted_content_pipeline/manifest.json`
 - `extracted_content_pipeline/skills/digest/social_post_generation.md`
 - `extracted_content_pipeline/social_post_generation.py`
 - `plans/PR-Content-Ops-Social-Post-LLM-Voice.md`
 - `tests/test_atlas_content_ops_execution_services.py`
+- `tests/test_extracted_content_control_surfaces.py`
 - `tests/test_extracted_content_generation_plan.py`
 - `tests/test_extracted_content_ops_execution.py`
 - `tests/test_extracted_social_post_generation.py`
@@ -84,6 +102,13 @@ Host wiring changes only the DB-enabled social-post builder: when an LLM and
 pool are available it passes the existing OpenRouter-configured Content Ops LLM
 client and skill store into `SocialPostGenerationService`. The no-DB/no-LLM
 singleton remains deterministic and wired.
+
+The control-surface estimator keeps deterministic social posts at zero cost,
+but applies a dynamic brand-voice premium when `social_post` is selected with
+either inline `inputs.brand_voice` or a stored `brand_voice_profile_id`. That
+dynamic cost mirrors the social-post LLM rewrite retry default so a low
+`max_cost_usd` blocks paid rewrites during preview instead of allowing budget
+gate bypass.
 
 ## Intentional
 
@@ -121,10 +146,16 @@ Parked hardening: none.
 - `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` --
   refreshed 46 mapped files.
 - `bash scripts/run_extracted_pipeline_checks.sh` -- 295 reasoning-core tests
-  passed; 3115 extracted-content tests passed / 10 skipped / 1 warning.
+  passed; 3216 extracted-content tests passed / 10 skipped / 1 warning.
 - `git diff --check` -- passed.
 - `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-social-post-llm-voice.md`
   -- passed.
+- Review follow-up:
+  - `python -m py_compile extracted_content_pipeline/control_surfaces.py tests/test_extracted_content_control_surfaces.py`
+    -- passed.
+  - `pytest tests/test_extracted_content_control_surfaces.py -q` -- 44 passed.
+  - `pytest tests/test_extracted_content_control_surface_api.py -q` -- 131
+    passed / 1 skipped.
 
 ## Estimated diff size
 
@@ -133,13 +164,15 @@ Parked hardening: none.
 | `atlas_brain/_content_ops_services.py` | 20 |
 | `atlas_brain/skills/digest/social_post_generation.md` | 59 |
 | `extracted_content_pipeline/content_ops_execution.py` | 25 |
+| `extracted_content_pipeline/control_surfaces.py` | 53 |
 | `extracted_content_pipeline/generation_plan.py` | 6 |
 | `extracted_content_pipeline/manifest.json` | 4 |
 | `extracted_content_pipeline/skills/digest/social_post_generation.md` | 59 |
 | `extracted_content_pipeline/social_post_generation.py` | 303 |
-| `plans/PR-Content-Ops-Social-Post-LLM-Voice.md` | 145 |
+| `plans/PR-Content-Ops-Social-Post-LLM-Voice.md` | 178 |
 | `tests/test_atlas_content_ops_execution_services.py` | 132 |
+| `tests/test_extracted_content_control_surfaces.py` | 34 |
 | `tests/test_extracted_content_generation_plan.py` | 9 |
 | `tests/test_extracted_content_ops_execution.py` | 43 |
 | `tests/test_extracted_social_post_generation.py` | 178 |
-| **Total** | **983** |
+| **Total** | **1103** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -18,7 +18,8 @@ the host has wired. Currently:
 - `faq_markdown`: wired by default, but host callers can hide it from
   customer-executable output lists while keeping it as the internal
   deflection-report source.
-- `social_post`: deterministic; persists when DB services are enabled.
+- `social_post`: deterministic without brand voice; persists when DB services
+  are enabled and uses the configured LLM when brand voice is supplied.
 - `quote_card`: deterministic; persists when DB services are enabled.
 - `stat_card`: deterministic; persists when DB services are enabled.
 - `faq_deflection_report` (this slice): always wired (stateless wrapper over
@@ -30,47 +31,14 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (25 tests):
-
-1. `signal_extraction` runs through the full executor.
-2. `landing_page` populated when LLM + db enabled (E2 canary).
-3. `landing_page` skips when no LLM (E2 fallback).
-4. `landing_page` skips when pool is None.
-5. `landing_page` skips in production default
-   (Codex P1 safety pin).
-6. `campaign` populated when LLM + db enabled (E3 canary).
-7. `report` populated when LLM + db enabled (E3 canary).
-8. `sales_brief` populated when LLM + db enabled (E3 canary).
-9. campaign / report / sales_brief skip together when no LLM.
-10. campaign / report / sales_brief skip together when pool
-    is None.
-11. `blog_post` populated when LLM + db enabled (E4 canary)
-    and `for_output("blog_post")` returns the service.
-12. `blog_post` skips when no LLM (E4 fallback).
-13. `faq_markdown` runs through the full executor.
-14. `faq_markdown` persists when DB services are enabled.
-15. `social_post` persists when DB services are enabled.
-16. `ad_copy` persists when DB services are enabled.
-17. `quote_card` runs through the full executor.
-18. `stat_card` persists when DB services are enabled.
-19. `faq_deflection_report` runs through the full executor.
-20. `social_post` is always wired.
-21. `ad_copy` is always wired.
-22. `quote_card` is always wired.
-23. `stat_card` is always wired.
-24. `configured_outputs()` with LLM + db enabled advertises
-    every wired output: `(email_campaign, blog_post, report,
-    landing_page, sales_brief, social_post, ad_copy,
-    quote_card, stat_card, signal_extraction, faq_markdown,
-    faq_deflection_report)` -- order
-    follows the upstream
-    `ContentOpsExecutionServices.configured_outputs`
-    iteration (not alphabetical).
-25. `configured_outputs()` without an active LLM (even with
-    `enable_db_services=True`) advertises only
-    deterministic outputs.
-26. The hosted paywall mode can hide `faq_markdown` while
-    retaining a runnable `faq_deflection_report`.
+Test inventory covers:
+- deterministic outputs running and persisting when DB services are enabled;
+- LLM-backed outputs wiring only when the configured LLM and pool are present;
+- social-post brand voice using the configured Content Ops LLM path;
+- always-wired deterministic outputs remaining available without an LLM;
+- configured output advertisement with and without active LLM services;
+- hosted paywall mode hiding `faq_markdown` while retaining
+  `faq_deflection_report`.
 """
 
 from __future__ import annotations
@@ -83,7 +51,7 @@ import pytest
 from atlas_brain._content_ops_services import (
     build_content_ops_execution_services,
 )
-from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
 from extracted_content_pipeline.content_ops_execution import (
     execute_content_ops_from_mapping,
 )
@@ -104,6 +72,37 @@ def _make_llm_stub() -> Any:
 
 def _make_skill_store_stub() -> Any:
     return SimpleNamespace(get_prompt=lambda _name: None)
+
+
+class _SocialPostLLMStub:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": tuple(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        return LLMResponse(
+            content=(
+                '{"channel":"linkedin","text":"You can use this renewal proof '
+                'without guessing."}'
+            ),
+            model="test-model",
+            usage={"input_tokens": 3, "output_tokens": 5},
+        )
+
+
+def _make_social_skill_store_stub() -> Any:
+    return SimpleNamespace(
+        get_prompt=lambda name: (
+            "Social prompt\n{brand_voice}"
+            if name == "digest/social_post_generation"
+            else None
+        )
+    )
 
 
 def _make_pool_stub() -> Any:
@@ -265,6 +264,53 @@ async def test_social_post_persists_when_db_services_enabled() -> None:
         "linkedin",
         step["result"]["posts"][0]["text"],
     )
+
+
+@pytest.mark.asyncio
+async def test_social_post_uses_configured_llm_for_brand_voice_when_db_enabled() -> None:
+    pool = _FAQPoolStub(return_id="social-post-uuid-1")
+    llm = _SocialPostLLMStub()
+    services = build_content_ops_execution_services(
+        llm_factory=lambda: llm,
+        skills_factory=_make_social_skill_store_stub,
+        pool_factory=lambda: pool,
+        enable_db_services=True,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "brand_voice_profile_id": "voice-1",
+            "inputs": {
+                "brand_voice": {
+                    "id": "voice-1",
+                    "account_id": "acct-1",
+                    "descriptors": ["plainspoken"],
+                    "preferred_pov": "second_person",
+                },
+                "source_material": [{
+                    "review_id": "review-1",
+                    "source_type": "review",
+                    "vendor": "HubSpot",
+                    "review_text": "Pricing became hard to justify after renewal.",
+                }],
+            },
+        },
+        services=services,
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    step = result["steps"][0]
+    assert step["output"] == "social_post"
+    assert step["status"] == "completed"
+    assert step["result"]["posts"][0]["text"] == (
+        "You can use this renewal proof without guessing."
+    )
+    assert step["result"]["posts"][0]["_brand_voice_profile"]["id"] == "voice-1"
+    assert llm.calls[0]["metadata"]["asset_type"] == "social_post"
+    assert "## Brand voice" in llm.calls[0]["messages"][0].content
+    persisted_metadata = pool.fetchval_calls[0]["args"][10]
+    assert "brand_voice_profile" in persisted_metadata
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -180,6 +180,40 @@ def test_preview_allows_social_post_when_source_material_present():
     assert preview["estimated_cost_usd"] == 0.0
 
 
+def test_preview_charges_brand_voice_social_post_rewrite():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 2,
+            "max_cost_usd": 0.01,
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+                "brand_voice": {"id": "voice-1", "descriptors": ["direct"]},
+            },
+        }
+    )
+
+    assert preview["can_run"] is False
+    assert preview["estimated_cost_usd"] == 0.32
+    assert "Estimated cost exceeds max_cost_usd: 0.32 > 0.01" in preview["warnings"]
+
+
+def test_preview_charges_stored_brand_voice_social_post_rewrite():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 1,
+            "brand_voice_profile_id": "voice-1",
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 0.16
+
+
 def test_preview_allows_ad_copy_when_source_material_present():
     preview = preview_from_mapping(
         {

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -71,7 +71,7 @@ def test_plan_maps_report_to_report_generation_service():
     }
 
 
-def test_plan_threads_brand_voice_profile_id_to_llm_copy_outputs_only():
+def test_plan_threads_brand_voice_profile_id_to_supported_copy_outputs():
     plan = build_generation_plan_from_mapping(
         {
             "outputs": [
@@ -97,7 +97,7 @@ def test_plan_threads_brand_voice_profile_id_to_llm_copy_outputs_only():
     assert configs["blog_post"]["brand_voice_profile_id"] == "acme-main"
     assert configs["landing_page"]["brand_voice_profile_id"] == "acme-main"
     assert configs["sales_brief"]["brand_voice_profile_id"] == "acme-main"
-    assert "brand_voice_profile_id" not in configs["social_post"]
+    assert configs["social_post"]["brand_voice_profile_id"] == "acme-main"
 
 
 def test_plan_threads_structured_reasoning_preset_to_report_and_sales_brief():
@@ -523,8 +523,13 @@ def test_plan_maps_social_post_to_social_post_service():
     assert plan["steps"][0]["runner"] == "SocialPostGenerationService.generate"
     assert plan["steps"][0]["status"] == "runnable"
     assert plan["steps"][0]["config"] == {
+        "skill_name": "digest/social_post_generation",
         "limit": 3,
         "max_text_chars": 300,
+        "max_tokens": 700,
+        "temperature": 0.4,
+        "parse_retry_attempts": 1,
+        "parse_retry_response_excerpt_chars": 800,
     }
 
 

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -542,7 +542,7 @@ async def test_execute_runs_landing_page_with_marketing_campaign_input() -> None
 
 
 @pytest.mark.asyncio
-async def test_execute_threads_brand_voice_to_llm_copy_outputs_only() -> None:
+async def test_execute_threads_brand_voice_to_supported_copy_outputs() -> None:
     campaign = _OpportunityService()
     blog = _OpportunityService()
     sales_brief = _OpportunityService()
@@ -597,10 +597,10 @@ async def test_execute_threads_brand_voice_to_llm_copy_outputs_only() -> None:
         blog.calls[0],
         sales_brief.calls[0],
         landing_page.calls[0],
+        social_post.calls[0],
     ):
         assert call["brand_voice"].id == "acme-main"
         assert call["brand_voice"].account_id == "acct-1"
-    assert social_post.calls[0]["brand_voice"] is None
 
 
 @pytest.mark.asyncio
@@ -751,9 +751,48 @@ async def test_execute_runs_social_post_service_from_source_material() -> None:
     assert post["vendor_name"] == "HubSpot"
     assert "Pricing is a problem" in post["text"]
     assert result["plan"]["steps"][0]["config"] == {
+        "skill_name": "digest/social_post_generation",
         "limit": 1,
         "max_text_chars": 20,
+        "max_tokens": 700,
+        "temperature": 0.4,
+        "parse_retry_attempts": 1,
+        "parse_retry_response_excerpt_chars": 800,
     }
+
+
+@pytest.mark.asyncio
+async def test_execute_social_post_brand_voice_fails_when_service_lacks_llm() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "brand_voice_profile_id": "voice-1",
+            "inputs": {
+                "brand_voice": {
+                    "id": "voice-1",
+                    "account_id": "acct-1",
+                    "descriptors": ["plainspoken"],
+                },
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing is a problem after renewal.",
+                    }
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(
+            social_post=SocialPostGenerationService()
+        ),
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert result["status"] == "failed"
+    step = result["steps"][0]
+    assert step["output"] == "social_post"
+    assert step["status"] == "failed"
+    assert "requires configured LLM and skill store" in step["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_social_post_generation.py
+++ b/tests/test_extracted_social_post_generation.py
@@ -2,12 +2,43 @@ from __future__ import annotations
 
 import pytest
 
-from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
 from extracted_content_pipeline.social_post_generation import (
     SocialPostGenerationConfig,
     SocialPostGenerationService,
+    parse_social_post_response,
 )
 from extracted_content_pipeline.social_post_ports import SocialPostDraft
+
+
+class _LLM:
+    def __init__(self, *responses: str) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": tuple(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        content = self.responses.pop(0) if self.responses else "{}"
+        return LLMResponse(
+            content=content,
+            model="test-model",
+            usage={"input_tokens": 11, "output_tokens": 7},
+        )
+
+
+class _Skills:
+    def __init__(self, prompt: str | None = "Social prompt\n{brand_voice}") -> None:
+        self.prompt = prompt
+        self.calls: list[str] = []
+
+    def get_prompt(self, name: str) -> str | None:
+        self.calls.append(name)
+        return self.prompt
 
 
 class _SocialPostRepository:
@@ -181,3 +212,148 @@ async def test_social_post_service_applies_limit_to_usable_rows() -> None:
     payload = result.as_dict()
     assert payload["generated"] == 2
     assert [post["source_id"] for post in payload["posts"]] == ["review-1", "review-2"]
+
+
+def test_parse_social_post_response_accepts_fenced_json() -> None:
+    assert parse_social_post_response(
+        '```json\n{"channel":"linkedin","text":"Use the proof point."}\n```'
+    ) == {"channel": "linkedin", "text": "Use the proof point."}
+    assert parse_social_post_response('{"channel":"linkedin"}') is None
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_rewrites_with_brand_voice_and_persists_metadata() -> None:
+    repository = _SocialPostRepository()
+    llm = _LLM(
+        '{"channel":"linkedin","text":"You can use this renewal proof without guessing."}'
+    )
+    skills = _Skills()
+    service = SocialPostGenerationService(
+        social_posts=repository,
+        llm=llm,
+        skills=skills,
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+        target_mode="vendor_retention",
+        brand_voice={
+            "id": "voice-1",
+            "account_id": "acct-1",
+            "name": "Plain voice",
+            "descriptors": ["plainspoken"],
+            "preferred_pov": "second_person",
+        },
+        source_material=[
+            {
+                "review_id": "review-1",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["posts"][0]["text"] == (
+        "You can use this renewal proof without guessing."
+    )
+    assert payload["posts"][0]["_brand_voice_profile"]["id"] == "voice-1"
+    assert payload["posts"][0]["_brand_voice_audit"]["passed"] is True
+    assert payload["saved_ids"] == ["social-post-db-id-1"]
+    assert skills.calls == ["digest/social_post_generation"]
+    llm_call = llm.calls[0]
+    assert llm_call["metadata"] == {
+        "asset_type": "social_post",
+        "target_mode": "vendor_retention",
+        "source_id": "review-1",
+    }
+    system_prompt = llm_call["messages"][0].content
+    assert "## Brand voice" in system_prompt
+    assert "plainspoken" in system_prompt
+    user_prompt = llm_call["messages"][1].content
+    assert '"source_id":"review-1"' in user_prompt
+    draft = repository.calls[0]["drafts"][0]
+    assert draft.text == "You can use this renewal proof without guessing."
+    assert draft.metadata["brand_voice_profile"]["id"] == "voice-1"
+    assert draft.metadata["brand_voice_audit"]["passed"] is True
+    assert draft.metadata["generation_usage"]["input_tokens"] == 11
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_retries_unparseable_llm_response() -> None:
+    llm = _LLM(
+        "not json",
+        '{"channel":"linkedin","text":"You can turn the review into a grounded post."}',
+    )
+    service = SocialPostGenerationService(llm=llm, skills=_Skills())
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        brand_voice={
+            "id": "voice-1",
+            "account_id": "acct-1",
+            "descriptors": ["direct"],
+        },
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+            }
+        ],
+    )
+
+    assert result.generated == 1
+    assert len(llm.calls) == 2
+    retry_prompt = llm.calls[1]["messages"][1].content
+    assert "Previous response excerpt:\nnot json" in retry_prompt
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_fails_closed_when_brand_voice_has_no_llm() -> None:
+    service = SocialPostGenerationService()
+
+    with pytest.raises(ValueError, match="requires configured LLM and skill store"):
+        await service.generate(
+            scope=TenantScope(account_id="acct-1"),
+            target_mode="vendor_retention",
+            brand_voice={
+                "id": "voice-1",
+                "account_id": "acct-1",
+                "descriptors": ["direct"],
+            },
+            source_material=[
+                {
+                    "review_id": "review-1",
+                    "vendor": "HubSpot",
+                    "review_text": "Pricing became hard to justify after renewal.",
+                }
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_fails_closed_when_prompt_is_missing() -> None:
+    service = SocialPostGenerationService(llm=_LLM("{}"), skills=_Skills(prompt=None))
+
+    with pytest.raises(ValueError, match="Social post generation skill not found"):
+        await service.generate(
+            scope=TenantScope(account_id="acct-1"),
+            target_mode="vendor_retention",
+            brand_voice={
+                "id": "voice-1",
+                "account_id": "acct-1",
+                "descriptors": ["direct"],
+            },
+            source_material=[
+                {
+                    "review_id": "review-1",
+                    "vendor": "HubSpot",
+                    "review_text": "Pricing became hard to justify after renewal.",
+                }
+            ],
+        )

--- a/tests/test_extracted_social_post_generation.py
+++ b/tests/test_extracted_social_post_generation.py
@@ -31,6 +31,20 @@ class _LLM:
         )
 
 
+class _RaisingLLM:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": tuple(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        raise RuntimeError("provider down")
+
+
 class _Skills:
     def __init__(self, prompt: str | None = "Social prompt\n{brand_voice}") -> None:
         self.prompt = prompt
@@ -311,6 +325,78 @@ async def test_social_post_service_retries_unparseable_llm_response() -> None:
     assert len(llm.calls) == 2
     retry_prompt = llm.calls[1]["messages"][1].content
     assert "Previous response excerpt:\nnot json" in retry_prompt
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_drops_post_when_llm_raises() -> None:
+    repository = _SocialPostRepository()
+    llm = _RaisingLLM()
+    service = SocialPostGenerationService(
+        social_posts=repository,
+        llm=llm,
+        skills=_Skills(),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        brand_voice={
+            "id": "voice-1",
+            "account_id": "acct-1",
+            "descriptors": ["direct"],
+        },
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+            }
+        ],
+    )
+
+    assert result.generated == 0
+    assert result.saved_ids == ()
+    assert repository.calls == []
+    assert [warning.code for warning in result.warnings] == [
+        "social_post_llm_error"
+    ]
+    assert len(llm.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_drops_post_when_llm_never_returns_parseable_json() -> None:
+    repository = _SocialPostRepository()
+    llm = _LLM("not json", "still not json")
+    service = SocialPostGenerationService(
+        social_posts=repository,
+        llm=llm,
+        skills=_Skills(),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        brand_voice={
+            "id": "voice-1",
+            "account_id": "acct-1",
+            "descriptors": ["direct"],
+        },
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+            }
+        ],
+    )
+
+    assert result.generated == 0
+    assert result.saved_ids == ()
+    assert repository.calls == []
+    assert [warning.code for warning in result.warnings] == [
+        "social_post_llm_unparseable_response"
+    ]
+    assert len(llm.calls) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Social-Post-LLM-Voice.md
Slice phase: Vertical slice

Adds the deferred LLM social-post brand-voice path: social posts keep the existing deterministic fallback when no brand voice is selected, but a resolved brand voice profile now routes through the configured Content Ops LLM and prompt, adds brand-voice audit metadata, and fails the step if LLM/prompt wiring is absent instead of silently returning unvoiced copy. Review follow-up also charges brand-voice social-post rewrites in preview/budget estimation so the new LLM path cannot bypass `max_cost_usd`.

## Intentional
- `social_post` remains the same output id; brand voice switches it to the LLM rewrite path only when a profile is resolved.
- Deterministic social posts still run without LLM or DB services.
- No local-model route is introduced; host wiring reuses the existing Content Ops OpenRouter path with `auto_activate_ollama=False`.
- No social-post edit/repair UI in this slice.
- Deterministic social posts remain zero-estimate; only social posts with inline `inputs.brand_voice` or a stored `brand_voice_profile_id` get the dynamic brand-voice LLM estimate.

## Deferred
- `PR-Content-Ops-Social-Post-Channel-Variants`: platform-specific variants beyond the current LinkedIn draft.
- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management page if the inline panel becomes too dense.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py atlas_brain/_content_ops_services.py tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_execution_services.py` -- passed.
- `pytest tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py -q` -- 128 passed.
- `pytest tests/test_atlas_content_ops_execution_services.py -q` -- 28 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- 0 findings.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` -- refreshed 46 mapped files.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 295 reasoning-core tests passed; 3216 extracted-content tests passed / 10 skipped / 1 warning.
- `git diff --check` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-social-post-llm-voice.md` -- passed.
- Review follow-up:
  - `python -m py_compile extracted_content_pipeline/control_surfaces.py tests/test_extracted_content_control_surfaces.py` -- passed.
  - `pytest tests/test_extracted_content_control_surfaces.py -q` -- 44 passed.
  - `pytest tests/test_extracted_content_control_surface_api.py -q` -- 131 passed / 1 skipped.
  - `pytest tests/test_extracted_social_post_generation.py -q` -- 12 passed.

## Diff size
14 files, +1125 / -65.
