### PR TITLE
Wire archive_plans check into local review as a non-blocking advisory (#1319 slice 3)

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -32,3 +32,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash scripts/local_pr_review.sh
+
+      # Unit-cover the PR-review tooling itself (including the plans-archive
+      # advisory). This workflow runs the bundle above, so its fixtures belong
+      # in CI rather than only in local dev.
+      - name: PR-review tooling unit tests
+        run: |
+          python -m pip install --quiet pytest pytest-asyncio
+          python -m pytest tests/test_local_pr_review.py -q

--- a/plans/PR-Plans-Check-Wiring.md
+++ b/plans/PR-Plans-Check-Wiring.md
@@ -1,0 +1,83 @@
+# PR-Plans-Check-Wiring
+
+## Why this slice exists
+
+Slice 3 of #1319. Slices 1-2 shipped the `archive_plans.py` tool and swept the
+878-plan backlog into `plans/archive/`, leaving the `plans/` root empty. The tool's
+`check` mode (a non-blocking threshold warning) was deliberately *not* wired into any
+runner until the sweep landed, because pre-sweep it would have warned on every PR
+against the full 878-plan backlog. The backlog is now cleared, so the threshold is
+finally meaningful: this slice activates the forcing function by surfacing `check` as
+an advisory in `local_pr_review.sh`.
+
+## Scope (this PR)
+
+Ownership lane: governance/plans-archive
+Slice phase: Workflow/process
+
+1. Add a non-blocking "Plans archive backlog" advisory step to
+   `scripts/local_pr_review.sh` that runs `archive_plans.py check` and prints its
+   output without affecting the pass/fail count.
+2. Cover it with two fixtures in `tests/test_local_pr_review.py` (advisory runs when
+   the script is present and stays non-blocking; SKIPs cleanly when absent).
+3. Enroll `tests/test_local_pr_review.py` in `.github/workflows/pre_push_audit.yml` so
+   the fixtures run in CI (the workflow already runs `local_pr_review.sh`, so its tests
+   belong there).
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `plans/PR-Plans-Check-Wiring.md`
+- `scripts/local_pr_review.sh`
+- `tests/test_local_pr_review.py`
+
+## Mechanism
+
+The advisory runs after the last real check (`git diff --check`) and before the
+summary. It is intentionally *not* a `run_check` step, so it never touches the
+`failures` tally: it prints `==> Plans archive backlog (advisory, non-blocking)`,
+runs `python scripts/archive_plans.py check || true`, and echoes a one-line nudge to
+run `archive_plans.py archive`. The `|| true` keeps `set -e` happy, and the
+`[ -f scripts/archive_plans.py ]` guard makes it SKIP cleanly where the tool is
+absent (e.g. the test fixture repos). The default threshold (50) is unchanged.
+
+## Intentional
+
+- **Advisory, not a gate.** Wiring `check` as a `run_check` would either always PASS
+  (it exits 0) or, if hardened to fail, add per-PR friction every time the root
+  creeps past the threshold. A pure advisory surfaces the nudge without ever
+  blocking a PR -- the "script + threshold warn" forcing function chosen in slice 1.
+- **`local_pr_review.sh`, not `pre_push_audit.sh`.** The local review bundle is the
+  right altitude for a human-facing nudge; the CI pre-push audit is for hard gates.
+- **Guarded + `|| true`.** Keeps the existing `set -euo pipefail` contract intact and
+  the script portable to checkouts (or fixtures) that lack the tool.
+
+## Deferred
+
+- **Enrolling the sibling PR-tooling meta-tests** (`test_pre_push_audit.py`,
+  `test_new_pr_plan.py`, `test_sync_pr_plan.py`, `test_install_local_pr_hook.py`,
+  `test_push_pr_wrapper.py`) in CI -- a pre-existing gap; this slice only enrolls the
+  file it touches rather than batch-enrolling tests it has not validated here.
+- **#1319 items 4-5:** mechanical `HARDENING.md` drain (size/age threshold) and
+  segregating one-shot scripts into `scripts/oneshot/` -- independent follow-ups.
+- Parked hardening: none.
+
+## Verification
+
+```bash
+python -m pytest tests/test_local_pr_review.py -q     # 9 passed (7 existing + 2 new)
+bash scripts/local_pr_review.sh --current-pr-body-file <body>   # advisory prints, review passes
+```
+
+Verified locally: 9/9 fixtures pass; the advisory prints `OK: 0 plan doc(s) in root`
+on the cleared backlog and never changes the review's exit status.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pre_push_audit.yml` | 8 |
+| `plans/PR-Plans-Check-Wiring.md` | 83 |
+| `scripts/local_pr_review.sh` | 12 |
+| `tests/test_local_pr_review.py` | 30 |
+| **Total** | **133** |

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -146,6 +146,18 @@ fi
 
 run_check "git diff --check" git diff --check
 
+# Advisory only: nudge to archive merged plan docs once the plans/ root grows
+# past the threshold. Never affects the failure count -- archive_plans.py check
+# always exits 0, and the guard keeps set -e happy if it is ever absent.
+echo
+echo "==> Plans archive backlog (advisory, non-blocking)"
+if [ -f scripts/archive_plans.py ]; then
+    python scripts/archive_plans.py check || true
+    echo "    advisory only -- run 'python scripts/archive_plans.py archive' to archive merged plans"
+else
+    echo "    SKIP (scripts/archive_plans.py not found)"
+fi
+
 echo
 if [ "$failures" -eq 0 ]; then
     echo "local PR review passed"

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -97,6 +97,37 @@ def test_local_pr_review_runs_cross_session_drift_audit_when_present(tmp_path: P
     assert "drift guard ran" in result.stdout
 
 
+def test_local_pr_review_runs_plans_archive_advisory_when_present(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    # A stub that deliberately exits non-zero. The real archive_plans.py check
+    # always exits 0; this simulates an *unexpected* failure to prove the advisory
+    # stays non-blocking regardless, because it is wrapped in `|| true`.
+    _write_executable(
+        repo / "scripts" / "archive_plans.py",
+        "#!/usr/bin/env python3\nimport sys\nprint('WARNING: plans backlog advisory ran')\nsys.exit(1)\n",
+    )
+    _git(repo, "add", "scripts/archive_plans.py")
+    _git(repo, "commit", "-m", "add archive_plans stub")
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Plans archive backlog (advisory, non-blocking)" in result.stdout
+    assert "plans backlog advisory ran" in result.stdout
+    assert "local PR review passed" in result.stdout
+
+
+def test_local_pr_review_skips_plans_advisory_when_absent(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "SKIP (scripts/archive_plans.py not found)" in result.stdout
+
+
 def _write_fixture_repo(repo: Path) -> None:
     (repo / "scripts").mkdir(parents=True)
     _write_executable(


### PR DESCRIPTION
Plan: plans/PR-Plans-Check-Wiring.md
Slice phase: Workflow/process

Slice 3 of #1319. Slices 1-2 shipped the `archive_plans.py` tool and swept the 878-plan backlog into `plans/archive/`. The tool's `check` mode (non-blocking threshold warning) was deliberately left unwired until the sweep landed — pre-sweep it would have warned on every PR against the full backlog. The backlog is now cleared, so this slice activates the forcing function.

## What this does
1. Adds a non-blocking "Plans archive backlog" advisory to `scripts/local_pr_review.sh`: it runs `archive_plans.py check` and prints the warn/ok line **without affecting the pass/fail count**.
2. Two fixtures in `tests/test_local_pr_review.py` (advisory runs + stays non-blocking; SKIPs when the tool is absent).
3. Enrolls `tests/test_local_pr_review.py` in `.github/workflows/pre_push_audit.yml` so those fixtures actually run in CI — that workflow already runs `local_pr_review.sh`, so its tests belong there (the #1318 "enroll what you ship" lesson).

## Intentional
- **Advisory, not a gate.** Not a `run_check` step — it never touches the `failures` tally. A pure nudge, never blocks a PR (the "script + threshold warn" forcing function from slice 1).
- **`local_pr_review.sh`, not `pre_push_audit.sh`.** The local review bundle is the right altitude for a human-facing nudge; CI pre-push is for hard gates.
- **Guarded + `|| true`.** Preserves the `set -euo pipefail` contract and SKIPs cleanly where the tool is absent (e.g. fixture repos).
- Default threshold (50) unchanged.

## Deferred
- Enrolling the sibling PR-tooling meta-tests (`test_pre_push_audit.py`, `test_new_pr_plan.py`, `test_sync_pr_plan.py`, `test_install_local_pr_hook.py`, `test_push_pr_wrapper.py`) — a pre-existing gap; this slice only enrolls the file it touches rather than batch-enrolling tests it hasn't validated here.
- #1319 items 4-5: mechanical `HARDENING.md` drain + `scripts/oneshot/` segregation.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_local_pr_review.py -q` — 9 passed (7 existing + 2 new).
- `bash scripts/local_pr_review.sh --current-pr-body-file ...` — advisory prints `OK: 1 plan doc(s) in root`; review passes.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/pre_push_audit.yml'))"` — valid.

## Diff size
4 files, 133 LOC.

Part of #1319.

https://claude.ai/code/session_01QgqhC2NoKQHzV3xDFchNRN