### PR TITLE
Wire archive-on-merge into the AGENTS teardown ritual (#1319 item 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,8 @@ is already used by worktree at ...`):
   unmerged by content, so `-d` refuses — `-D` is expected here).
 - Archive the merged plan doc so `plans/` only ever holds **in-flight**
   slices (the plan's content is already preserved in the squash commit).
-  On an up-to-date `main`, move **your own** plan by name and refresh the
-  index:
+  On a local `main` synced to `origin/main` (`git checkout main && git
+  pull`), move **your own** plan by name and refresh the index:
 
   ```bash
   git mv plans/PR-<Slice>.md plans/archive/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,23 @@ is already used by worktree at ...`):
   (`--force` if it still holds throwaway state). This frees the branch.
 - `git branch -D <branch>` (squash-merge leaves the local branch
   unmerged by content, so `-d` refuses — `-D` is expected here).
+- Archive the merged plan doc so `plans/` only ever holds **in-flight**
+  slices (the plan's content is already preserved in the squash commit).
+  On an up-to-date `main`, move **your own** plan by name and refresh the
+  index:
+
+  ```bash
+  git mv plans/PR-<Slice>.md plans/archive/
+  python scripts/archive_plans.py index   # rebuild plans/INDEX.md
+  ```
+
+  Land that move on `origin/main` as a trivial housekeeping commit (or
+  fold the `git mv` into your next branch off `main` if direct main
+  commits are gated). Move **only** your own merged plan by name — do
+  **not** run `archive_plans.py archive` (bulk) during teardown: it would
+  sweep concurrent sessions' still-in-flight plans out of the root. The
+  non-blocking "Plans archive backlog" advisory in `local_pr_review.sh` is
+  the backstop that nudges you if this step is ever missed.
 
 Do **not** let merged branches or finished worktrees linger. They drift
 behind `origin/main`, accumulate stale staged state, and become the

--- a/plans/PR-Archive-On-Merge-Ritual.md
+++ b/plans/PR-Archive-On-Merge-Ritual.md
@@ -1,0 +1,75 @@
+# PR-Archive-On-Merge-Ritual
+
+## Why this slice exists
+
+#1319 item 1 asked for archive-on-merge to be a **mechanical** step in the
+teardown ritual, not a one-time sweep. Slices 1-3 shipped the tooling
+(`scripts/archive_plans.py`), swept the 878-plan backlog, and added a
+non-blocking advisory -- but the actual ritual wiring was never added, so newly
+merged plans still land in the `plans/` root and accumulate until someone runs the
+tool. This slice closes that gap: it adds the archive step to `AGENTS.md` §1g so the
+retirement of a plan is tied to the same merge event that retires its branch and
+worktree.
+
+## Scope (this PR)
+
+Ownership lane: governance/plans-archive
+Slice phase: Workflow/process
+
+1. Add a plan-archival step to the "Teardown on merge" ritual in `AGENTS.md` §1g.
+
+### Files touched
+
+- `AGENTS.md`
+- `plans/PR-Archive-On-Merge-Ritual.md`
+
+## Mechanism
+
+The step is a targeted `git mv plans/PR-<Slice>.md plans/archive/` followed by
+`python scripts/archive_plans.py index` to rebuild `plans/INDEX.md`, landed on
+`origin/main` as a housekeeping commit (or folded into the next branch off `main`).
+No tool change is needed: `git mv` is inherently scoped to the named plan, and the
+existing `index` mode regenerates the navigation aid.
+
+## Intentional
+
+- **Targeted move, never bulk during teardown.** The ritual moves only the merged
+  plan by name and explicitly forbids `archive_plans.py archive` (bulk) here, because
+  bulk would sweep concurrent sessions' still-in-flight plans out of the root. Bulk
+  `archive` stays a deliberate solo catch-up tool, not a per-merge step.
+- **Nothing deprecated.** The bulk `archive` mode (catch-up/cleanup) and the
+  non-blocking `check` advisory (backstop that nudges when the ritual is missed) both
+  remain useful and complementary to the now-mechanical ritual step; neither is
+  superseded.
+- **Docs-only.** The capability already exists; this slice only ties it to the merge
+  event, so the change is contained to the `AGENTS.md` contract.
+
+## Deferred
+
+- **Item 2 refinement:** a per-plan *merged-PR-status* detector (the spec's original
+  item 2) rather than the current count-threshold advisory -- now lower priority since
+  the ritual prevents accumulation at the source.
+- **Item 4 refinement:** `drain_hardening.py` currently archives to a markdown file
+  (`docs/technical-debt/hardening-archive.md`); the issue named the CSV debt register
+  (`docs/technical-debt/debt-register-latest.csv`) as the correct archive tier. A
+  retarget is a separate follow-up.
+- **#1319 item 5:** segregating one-shot scripts into `scripts/oneshot/`.
+- Parked hardening: none.
+
+## Verification
+
+```bash
+python scripts/archive_plans.py index   # regenerates plans/INDEX.md (existing mode)
+bash scripts/local_pr_review.sh          # gates pass; docs-only change
+```
+
+Verified locally: the referenced commands exist and run; the change is confined to the
+`AGENTS.md` teardown section.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 17 |
+| `plans/PR-Archive-On-Merge-Ritual.md` | 74 |
+| **Total** | **91** |


### PR DESCRIPTION
Plan: plans/PR-Archive-On-Merge-Ritual.md
Slice phase: Workflow/process

#1319 item 1, the piece that was missing. Slices 1-3 shipped the tooling, swept the 878-plan backlog, and added a non-blocking advisory — but the **mechanical archive-on-merge ritual** was never wired in, so newly merged plans still accumulate in the `plans/` root until someone runs the tool. This ties plan retirement to the same teardown event that retires the branch/worktree.

## What this does
Adds a plan-archival step to `AGENTS.md` §1g ("Teardown on merge"):
```bash
git mv plans/PR-<Slice>.md plans/archive/
python scripts/archive_plans.py index   # rebuild plans/INDEX.md
```
landed on `origin/main` (or folded into the next branch off main if direct main commits are gated).

## Intentional
- **Targeted move, never bulk during teardown.** Moves only your own merged plan by name; explicitly forbids `archive_plans.py archive` (bulk) here because it would sweep concurrent sessions' still-in-flight plans. `git mv` needs no tool change.
- **Nothing deprecated.** Bulk `archive` stays a deliberate solo catch-up tool; the `check` advisory stays the backstop that nudges when the ritual is missed. Both complement the now-mechanical step.
- **Docs-only** — the capability already exists; this just ties it to the merge event.

## Deviation cleanup (answering "what else did we deviate that we didn't need to")
Two deviations from the issue spec are noted in the plan's Deferred section as separate follow-ups rather than silently left:
- **Item 2** shipped as a count-threshold advisory, not the spec's per-plan *merged-PR-status* detector (now lower priority since this ritual prevents accumulation at the source).
- **Item 4** (`drain_hardening.py`) archives to a markdown file; the issue named the CSV debt register (`docs/technical-debt/debt-register-latest.csv`) as the correct tier. Retarget is a separate follow-up.

## Verification
- `python scripts/archive_plans.py index` — regenerates `plans/INDEX.md` (existing mode).
- `bash scripts/local_pr_review.sh` — all gates pass (docs-only change).

## Diff size
2 files, 91 LOC.

Part of #1319.

https://claude.ai/code/session_01QgqhC2NoKQHzV3xDFchNRN

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgqhC2NoKQHzV3xDFchNRN)_