### PR TITLE
Docs: content marketing operating model (writeup + diagram)

### DIFF
--- a/docs/content_ops_operating_model.md
+++ b/docs/content_ops_operating_model.md
@@ -1,6 +1,7 @@
 # How Atlas Ships Marketing Content — The Same Operating Model, Adapted
 
-> A sister to `docs/ai_dev_operating_model.md`. Same spine — plan a thin artifact,
+> A sister to the AI-dev operating model (`docs/ai_dev_operating_model.md`, landing in
+> PR #1317 — not yet on `main`). Same spine — plan a thin artifact,
 > let mechanical gates catch every repeatable failure, keep the builder and reviewer
 > separate, turn every miss into a gate — adapted to content marketing, where the
 > artifact is structured copy, the "test" is the market, and the value compounds in a
@@ -169,7 +170,7 @@ lawsuit — and it makes every claim trivially re-checkable when the registry ch
     { "issue_type": "unsupported_claim", "severity": "blocker", "rule_id": "CLAIM-03",
       "draft_span": "...", "why_it_matters": "...", "recommended_action": "revise|remove|escalate" }
   ],
-  "approval_recommendation": "DO_NOT_APPROVE"
+  "review_signal": "blockers_present"
 }
 ```
 

--- a/docs/content_ops_operating_model.md
+++ b/docs/content_ops_operating_model.md
@@ -5,6 +5,11 @@
 > separate, turn every miss into a gate — adapted to content marketing, where the
 > artifact is structured copy, the "test" is the market, and the value compounds in a
 > living record of what worked.
+>
+> **Diagram note.** `content_ops_operating_model.svg` shows the *simplified* 7-stage
+> flow. This writeup is canonical and goes further (a 0→11 lifecycle, a four-part gate
+> stack, the review contract). A v2 diagram — a clean top-level flow plus a separate
+> "review contract" canvas — is **deferred** rather than crammed onto one page.
 
 The dev model and this one share a thesis: **make the machine catch every failure
 mode a script can decide, so human judgment is only ever spent where a script can't.**
@@ -16,180 +21,358 @@ Two things change in content, and they change the shape of the whole loop:
    doesn't end at publish, and the source of truth is a *living record of outcomes*,
    not a write-only archive.
 
+And one thing the dev model gets wrong if you copy it naively, corrected here: **the
+LLM is not a judge.** Code has hard surfaces (types, tests, imports) where a model can
+sometimes adjudicate. Content is squishier — tone, persuasion, promise clarity — and a
+model will happily be convinced by its own polished draft. So the model never *decides*
+in this pipeline. It produces **structured review evidence** a human must resolve.
+
 ---
 
 ## 1. The crew model: writer + editor, per channel lane
 
-Work splits into **channel/campaign lanes** (e.g. "lifecycle email", "SEO blog",
-"paid social"). Each lane is a pair:
+Work splits into **channel/campaign lanes** (e.g. "lifecycle email", "SEO blog"). Each
+lane is a pair:
 
 - **Writer session** — fills the brief + asset schema, drafts the copy, runs the gates.
-- **Editor session** — reviews *independently* against the brief and posts one verdict:
-  **BLOCKER / MAJOR / NIT / LGTM**.
+- **Editor session** — reviews *independently* against a frozen contract and posts an
+  accountable decision (§5). Most of the editor's judgment goes to **taste and
+  persuasion**, because the mechanical gates have already settled consistency and
+  compliance.
 
-Same reason as code: a model editing its own copy inherits its own blind spots. The
-editor re-judges against the brief and the brand-voice contract from scratch, never
-rubber-stamps. The difference from code review: the editor spends most of its judgment
-on **taste and persuasion** (is this on-brand, does it earn the click), because the
-mechanical gates have already settled consistency and compliance.
+Same reason as code: a model (or human) editing its own work inherits its own blind
+spots. The editor re-judges from scratch and never rubber-stamps.
 
 ---
 
 ## 2. The unit of work: a brief + an asset schema (the contract *is* the interface)
 
-Nothing ships without a **contract first** — but the contract is a filled schema, not
-a prose plan. It has two layers, kept distinct on purpose:
+Nothing ships without a **contract first** — but the contract is a filled schema, not a
+prose plan. Two layers, kept distinct on purpose:
 
-- **The brief (intent).** `objective`, `audience`, `funnel_stage`, `one_message`,
-  `proof`, `offer`/`CTA`. This is the strategy the editor judges *good* against.
+- **The brief (intent).** `objective`, `audience`, `funnel_stage`, `reader_problem`,
+  `primary_promise`, `proof`, `offer`/`CTA`, `channel`, `risk_tier`, `success_metric`.
+  This is the strategy the editor judges *good* against.
 - **The asset schema (structure).** Typed fields per output type — an email is
   `subject / preheader / body_blocks[] / cta / utm`; a blog is
-  `title / meta / outline_h2[] / claims[] / internal_links[]`; an ad is different
-  again. This is what the gates validate.
+  `title / meta / outline_h2[] / claims[] / internal_links[]`. This is what the gates
+  validate.
 
-Folding strategy into structure is the failure mode: you get copy that is
-schema-valid and soulless. Keep both layers; gates run mostly against the asset
-schema, the editor judges against the brief.
+Folding strategy into structure is the failure mode: you get copy that is schema-valid
+and soulless. Keep both layers; gates run mostly against the asset schema, the human
+judges against the brief.
 
 **The schema is the UI.** You don't need a webpage — you need a typed document the
-session fills and the gates validate. Driving the workflow is: fill (or approve) the
-schema → gates run → editor → publish. Once the contract exists, most operator turns
-are "approve / next"; you only step in at the two things that can't be mechanized:
-**taste** and the eventual **verdict**.
+session fills and the gates validate. Once the contract exists, most operator turns are
+"approve / next"; you only step in at the things that can't be mechanized: **taste**,
+the **brief's own quality**, and the eventual **verdict**.
 
 ---
 
-## 3. Pre-publish gates: what you *can* know before shipping
+## 3. The lifecycle: 0 → 11 (publish is the midpoint, not the finish)
 
-The gates enforce only what is knowable in advance. Two tiers:
+Code's terminal state is real — merge plus green CI means done. Content has no such
+moment, because the test runs *after* you ship and answers days later, probabilistically.
+So the lifecycle has a tail code lacks, and a triage gate code rarely needs:
 
-**Deterministic (a regex/registry can decide):**
+```
+ 0 · Triage            Should this asset even exist?
+ 1 · Brief + schema    Audience, promise, offer, CTA, channel, metric, risk tier
+ 2 · Evidence packet   Registry claims, proof points, prior winners, examples
+ 3 · Writer drafts     Fields first, prose second
+ 4 · Contract gates    Schema · claims · compliance · structure · tracking   (3A/3B)
+ 5 · Model-assisted    Adversarial pass: drift, ambiguity, weak proof, genericness (3C)
+     review
+ 6 · Editor review     Forced rule coverage, cited evidence, exception logging   (3D)
+ 7 · Experiment +      Hypothesis, metric, attribution window, links, UTM,
+     publish QA        launch readiness
+ 8 · Publish           Ship to channel
+ 9 · Measure           Wait the window. No premature victory dances.
+10 · Verdict           Worked / didn't / inconclusive — structured reason
+11 · Compound          Miss → gate · win → prior · override → calibration ·
+                       claim change → registry
+```
 
-| Gate | Fails when… | Source of truth it checks against |
-|---|---|---|
-| **Claim / cross-channel consistency** | a stat, price, product name, or CTA disagrees with canon | the **claim/messaging registry** |
-| **Compliance** | a required disclaimer is missing or a banned/regulated claim appears | compliance ruleset (**fails closed**) |
-| **Structure / SEO** | title/meta length, heading shape, keyword, link, or word-budget out of spec | the asset schema |
-| **Grounding** | a factual claim cites no source | the registry / provided evidence |
+### Stage 0 — "Should this exist?"
 
-**LLM-judge (needs a rubric, not a regex):**
+Most content requests are organizational anxiety wearing a hat. Before any brief, a
+cheap triage decides **create / clone-an-existing-winner / defer / reject** from:
+audience segment, lifecycle stage, business goal, expected behavior change, channel,
+opportunity size, reuse potential, risk level, *why now*. This is the gate that keeps
+the pipeline from becoming an efficient machine for producing polished landfill.
 
-| Gate | Scores |
+### Stage 7 — the experiment contract (defined *before* ship)
+
+The measurement plan is frozen *before* the asset publishes, or the verdict ledger rots
+into "the graph went up and nobody wants to argue." Required fields: `hypothesis`,
+`primary_metric`, `secondary_metric`, `attribution_window`, `audience/segment`,
+`control_or_comparison`, `min_sample_size` (rough is fine), `what_counts_as_worked`,
+`what_counts_as_inconclusive`, `decision_if_it_works` / `decision_if_it_doesn't`.
+
+---
+
+## 4. The gate stack — four sub-gates, deterministic where it can be
+
+The old single "Content gates" box splits into four, so the deterministic parts stay
+deterministic and the squishy parts are *assisted* but never automated into fake
+certainty:
+
+| Sub-gate | What it checks | Type | **Who decides** |
+|---|---|---|---|
+| **3A · Schema** | required fields, asset format, channel constraints, word count, CTA present | deterministic | system |
+| **3B · Claims / compliance** | claims match registry, disclaimers, pricing/product names, banned phrases, required legal language, source freshness | deterministic (+ source mapping) | system |
+| **3C · Model-assisted review** | voice drift, promise clarity, specificity, persuasion weakness, reader objections, genericness | LLM-assisted | **editor** |
+| **3D · Human editor decision** | the accountable call | judgment | **editor** (effectiveness → market) |
+
+Deterministic gates settle what a regex/registry can decide. **3C does not adjudicate** —
+it lints and argues; the editor resolves. Effectiveness is settled only post-publish, by
+the market. Atlas already has substrate here: `extracted_quality_gate` (deterministic
+packs: blog / campaign / witness-specificity / evidence-coverage / source-quality) and
+brand-voice profiles (`content_ops_brand_voice_profiles`).
+
+### The claims map (highest-value 3B addition)
+
+The draft auto-produces a **claims map** — every meaningful claim extracted and
+classified against the registry:
+
+```
+Claim:            "Save 30% on all plans"
+Registry ID:      pricing.discount.q4
+Approved wording: "Save up to 30% on eligible annual plans"
+Risk level:       high
+Expiration:       2026-01-15
+Appears at:       hero, line 1
+Status:           FAIL (mismatch: "all plans" vs "eligible annual plans")
+```
+
+Not subjective. This is the system quietly preventing marketing from inventing a
+lawsuit — and it makes every claim trivially re-checkable when the registry changes.
+
+### The LLM does not say "LGTM" — it fills a coverage matrix
+
+3C's model is given a narrow job and forced into JSON, never prose approval:
+
+> You are not approving this draft. You produce review evidence. Cite exact draft
+> spans. Cite exact rule IDs. Mark every required rule `PASS` / `FAIL` / `NOT_APPLICABLE`.
+> Missing evidence = `FAIL`. Do not invent rules. Do not rewrite unless asked.
+
+```json
+{
+  "review_id": "...",
+  "ruleset_versions": { "brief": "...", "brand_voice": "...", "claim_registry": "...",
+                        "compliance": "...", "channel_schema": "..." },
+  "rule_coverage": [
+    { "rule_id": "VOICE-01", "status": "PASS", "draft_span": "...", "reason": "...", "confidence": 0.82 },
+    { "rule_id": "CLAIM-03", "status": "FAIL", "draft_span": "...", "registry_conflict": "registry says X, draft says Y", "severity": "blocker", "confidence": 0.94 }
+  ],
+  "issues": [
+    { "issue_type": "unsupported_claim", "severity": "blocker", "rule_id": "CLAIM-03",
+      "draft_span": "...", "why_it_matters": "...", "recommended_action": "revise|remove|escalate" }
+  ],
+  "approval_recommendation": "DO_NOT_APPROVE"
+}
+```
+
+**Adversarial pass.** A second model-assisted prompt (different prompt, maybe different
+model, same inputs) does *only* one thing: find the strongest reason this should not
+ship — overclaims, ambiguity, reader objections, promise/CTA mismatch, generic stretches,
+missing proof, voice slips. It is the annoying reviewer who catches what everyone missed.
+Still not a judge.
+
+> **Deferred / advanced (my call, not the reviewer's):** treating *model disagreement*
+> as an orchestrated signal (LLM-A pass vs LLM-B fail → route to human, log override as
+> calibration data) is elegant but the highest-complexity, lowest-marginal-value piece.
+> Deterministic blockers always block and model-found blockers always go to a human
+> regardless — so we get most of the benefit without the orchestration. Park it.
+
+---
+
+## 5. The review contract — the anti-drift mechanism
+
+The guarantee against drift **cannot come from the reviewer** (humans drift, models
+drift, rules drift). It comes from the *interface*. A reviewer is never handed a draft
+and asked "thoughts?" — that is how you get vibes. They are handed a **Content PR**:
+
+1. **Brief snapshot** — immutable at review time (id, asset type, audience, lifecycle
+   stage, reader problem, primary promise, offer, CTA, channel, risk tier, success metric).
+2. **Rule packet** — versioned and frozen: brand-voice contract version, claim-registry
+   version, compliance pack version, schema version, channel-rules version.
+3. **Draft.**
+4. **Claims map** (§4).
+5. **Gate results** — pass / fail / needs-human-judgment.
+6. **Required reviewer coverage matrix** — the reviewer cannot approve until every
+   required row is resolved with cited evidence:
+
+   | Rule ID | Rule | Reviewer must provide | Status |
+   |---|---|---|---|
+   | VOICE-02 | Avoids hype language | quote or issue | pass/fail |
+   | CLAIM-04 | Pricing claims match registry | system evidence | pass/fail |
+   | PROMISE-02 | Primary promise appears early / above fold | quote location | pass/fail |
+   | RISK-01 | No unsupported competitive claim | claims-map evidence | pass/fail |
+
+**The rule: no required rule passes silently.** Missing coverage = fail.
+
+### Comment discipline
+
+Every reviewer comment must attach to one of: a brief requirement, a brand rule, a claim
+registry item, a compliance rule, a channel constraint, a performance hypothesis, or a
+named editorial-judgment category. So instead of "can we make this punchier?" you get:
+
+```
+Category: Promise clarity   Severity: medium
+Issue:    Opening delays the reader benefit until paragraph 3.
+Evidence: "<span>"          Suggested fix: move the outcome into the first sentence.
+```
+
+> **My one softening of the reviewer here:** drive-by polish notes shouldn't be *illegal*,
+> they should be a **NIT** category (the dev model already has BLOCKER/MAJOR/NIT/LGTM).
+> A NIT is still categorized and still non-blocking — that preserves cheap taste input
+> without letting "feels off-brand" masquerade as a blocker.
+
+### Decision states (incl. "approve with exception")
+
+`BLOCKED` · `REVISION REQUIRED` · `APPROVED` · `APPROVED WITH EXCEPTION` · `ESCALATED`.
+
+Sometimes a piece should ship despite a soft-rule violation — but never *invisibly*. An
+exception logs: `exception_rule`, `reason`, `owner`, `expiration`, `should_this_update_the_rule?`.
+This keeps tribal knowledge out of Slack, where knowledge goes to die.
+
+### Four review targets (in order)
+
+| Target | Question |
 |---|---|
-| **Voice / tone drift** | the draft against the **brand-voice contract** (lexicon, banned words, reading level, POV, formality) |
-
-The split mirrors the dev model's honesty: deterministic gates settle
-consistency/compliance/structure; the LLM-judge plus the editor handle voice and
-persuasion. **What neither can settle pre-publish is whether it will work** — that is
-the market's job (§4). Atlas already has scaffolding here: `extracted_quality_gate`
-(deterministic packs: blog / campaign / witness-specificity / evidence-coverage /
-source-quality) and brand-voice profiles (`content_ops_brand_voice_profiles`).
+| Draft vs brief | Did the writer satisfy the contract? |
+| Brief quality | Was *this* the right promise, audience, offer, CTA? (sometimes the brief was garbage in a blazer) |
+| Market result | Did the asset actually work? |
+| System learning | Should we update a gate, registry, prior, or calibration set? |
 
 ---
 
-## 4. The part code doesn't have: publish is the midpoint, not the finish
+## 6. Risk tiering — so the process isn't bureaucratic sludge
 
-Code's terminal state is real — merge plus green CI means done, move on. Content has
-no such moment, because **the test runs after you ship and answers days later,
-probabilistically.** So the lifecycle has a tail code lacks:
+Not every asset earns the same review burden. The risk tier (set in the brief, §2) routes
+the work — this is the primary lever against over-engineering harmless copy:
 
-```
-brief+schema → draft → gates → editor → PUBLISH → measure → verdict → record
-```
-
-- **Publish** ships to the channel (UTM-tagged so the measurement is attributable).
-- **Measure** waits for the delayed signal (open/click/conversion/engagement).
-- **Verdict** is a human call the data informs: *worked / didn't / why* — it can't be
-  automated, because it depends on signal that didn't exist at ship time.
-- **Record** writes that one-line verdict to the living ledger (§5).
-
-This tail is where the value compounds. A model that stops at "publish" has shipped a
-piece; a model that closes the loop has learned something reusable.
+| Tier | Example | Required review |
+|---|---|---|
+| **Low** | internal nurture email, low-claim social | automated gates + editor |
+| **Medium** | lifecycle email with pricing/product claims | gates + editor + claims check |
+| **High** | regulated/legal/medical/financial, aggressive competitor comparison | gates + editor + compliance/legal |
+| **Critical** | public launch, major paid campaign, exec byline | full review + experiment contract + postmortem |
 
 ---
 
-## 5. The source of truth: a *living* record, not a write-only archive
+## 7. Measure → verdict → compound (where the value lives)
 
-This is the sharpest divergence from the dev model. In code, the merged artifact is
-the truth and the plan is disposable — we literally archive-and-forget plans on merge.
-In content, the published piece is *not* the valuable retained thing; **the outcomes
-and the patterns that won are**, and you read them *before every new brief*. So the
-content source of truth is the inverse of `plans/archive/`: it is consulted constantly,
-never retired. It is the analogue of `CANONICAL.md`, not of the plan archive.
+- **Measure** waits for the (delayed, noisy) signal defined by the experiment contract.
+- **Verdict** is a human call the data informs — *worked / didn't / inconclusive* — but
+  the **"why" is structured**, drawn from a **failure taxonomy**: wrong audience · weak
+  offer · weak hook · unclear promise · claim-credibility gap · CTA friction · landing
+  mismatch · timing · channel mismatch · deliverability · too generic · too complex ·
+  insufficient proof · compliance weakened the message · inconclusive data.
+- **Compound** routes the verdict into the flywheels (§9).
 
-Three living docs:
-
-- **Campaign ledger (lightweight verdict log).** One record per campaign/piece:
-  `hypothesis · assets · headline metric · worked-didn't-why`. Deliberately cheap, so
-  it actually gets kept — and queried at the start of every brief ("what subject line
-  won for this segment?").
-- **Claim / messaging registry.** Canonical stats, prices, positioning, product names.
-  The consistency gate checks copy against this; it is content's `CANONICAL.md`.
-- **Brand-voice contract.** The voice rules the voice-drift gate scores against —
-  content's `AGENTS.md`.
-
-The raw drafts and process *are* archivable-and-forgettable like plans; only the
-outcomes and patterns live on. Conflating the two is the trap — you don't need draft
-#6 from three campaigns ago, but you very much need to know that campaign's angle
-converted.
+Structured "why" is what makes verdicts *reusable* instead of anecdotal: you don't just
+learn "this failed," you learn *which type* of failure keeps recurring.
 
 ---
 
-## 6. Two flywheels: kill the repeat, clone the winner
+## 8. The source of truth: a *living* record (now a quartet)
 
-Code's flywheel is purely negative: a mistake that cost a cycle becomes a gate, so it
-never recurs. Content keeps that one **and adds a positive twin**, which is arguably
-its engine:
+The sharpest divergence from the dev model. In code, the merged artifact is truth and
+the plan is disposable — we archive-and-forget plans on merge. In content, the published
+piece is *not* the retained value; **the outcomes and winning patterns are**, read
+*before every new brief*. This is the inverse of `plans/archive/`: consulted constantly,
+never retired. It is content's `CANONICAL.md`, not its plan archive.
 
-- **Negative (same as code).** A miss that slips — off-brand line, inconsistent stat,
-  missing disclaimer — becomes a new gate: a banned phrase, a registry entry, a rubric
-  criterion. It can't recur.
-- **Positive (new).** A *winner* — an angle, format, or subject that converted —
-  becomes a **reusable prior**: a template, a schema default, a line in the brief's
-  "what's worked here" preamble. It gets deliberately repeated.
+- **Campaign ledger (lightweight verdict log).** One record per piece:
+  `hypothesis · assets · headline metric · worked-didn't-why (taxonomy)`. Deliberately
+  cheap, so it actually gets kept and queried.
+- **Claim / messaging registry.** Canonical stats, prices, positioning, product names —
+  the source the 3B gate and claims map check against.
+- **Brand-voice contract.** The voice rules the 3C drift review scores against.
+- **Review calibration library** *(new — the missing anti-drift piece)*. Worked examples
+  with verdicts + reasoning: approved / rejected / borderline / known-defect / good-voice
+  / voice-drift / overclaim / weak-vs-strong persuasion. Without examples, "brand voice"
+  is a séance. This reference set anchors *both* human and model reviewers, and overrides
+  (§5) feed new examples into it.
 
-Every published piece earns a verdict (§4); the verdict feeds whichever loop applies;
-both front-load into the next brief. Quality compounds in both directions at once:
-fewer bad pieces, more pieces built on what already won.
+The raw drafts *are* archivable-and-forgettable like plans; only outcomes, patterns, and
+calibration examples live on.
 
 ---
 
-## 7. Honest limits — where this model can't be mechanical
+## 9. Two flywheels — kill the repeat, clone the winner
 
-Same discipline as the dev doc's "Known gaps": name the residual, don't pretend it's
-covered.
+Code's flywheel is purely negative: a mistake becomes a gate. Content keeps that and adds
+a positive twin:
 
-- **The effectiveness test is delayed and probabilistic.** Pre-publish gates can
-  guarantee consistency, compliance, structure, and on-brand voice — never "this will
-  convert." The flywheel still works, just on a slower, noisier loop than CI's
-  two-minute verdict. Attribution noise (seasonality, audience mix, sample size) means
-  a single piece's "verdict" is a weak signal; patterns emerge over many.
-- **Taste isn't fully mechanizable.** More of the gate budget here is LLM-judge than
-  regex, so the model leans harder on the judgment layer — which makes the dev doc's
-  rule **"external-bot/LLM findings are advisory, never auto-applied"** matter *more*,
-  not less. A naive "auto-apply every gate suggestion" loop degrades copy.
-- **The ledger rots if the verdict step is skipped.** The whole positive flywheel
-  depends on someone actually recording *worked/didn't/why*. Keeping the ledger
-  lightweight is the defense (a heavy ledger is the one that silently stops being
-  filled) — but it still rests on the same human-discipline floor the dev model admits.
+- **Negative.** A miss → a new gate (banned phrase, registry entry, rubric criterion).
+  Sharpened by the failure taxonomy: **if 3+ assets fail for the same reason, that
+  becomes a gate** — 3+ "unclear promise" → a Promise-Clarity gate; 3+ "insufficient
+  proof" → a Proof-Density gate; 3+ "CTA friction" → a CTA-Specificity gate.
+- **Positive.** A *winner* → a reusable prior (template, schema default, brief preamble),
+  deliberately repeated.
+- **Overrides** (approve-with-exception) → calibration examples, so the *judgment layer*
+  itself compounds.
+
+Every published piece earns a verdict; the verdict feeds whichever loop applies; all
+front-load into the next brief. Quality compounds in three directions at once: fewer bad
+pieces, more pieces built on what won, and sharper review.
+
+---
+
+## 10. Honest limits — where this can't be mechanical
+
+- **The effectiveness test is delayed and probabilistic.** Pre-publish gates can't
+  promise "this will work." They promise something narrower and honest: *"this is
+  coherent, compliant, on-contract, measurable, and not obviously doomed."* Note the
+  precise wording — effectiveness is **not *provable* pre-publish, but some failure modes
+  *are* knowable** (weak, confusing, unsupported, misaligned, generic). Attribution noise
+  means a single verdict is a weak signal; patterns emerge over many.
+- **Taste isn't fully mechanizable**, which is exactly why the model is **evidence, not
+  judge**, and why the dev doc's rule — **external-bot/LLM findings are advisory, never
+  auto-applied** — matters *more* here, not less. A naive auto-apply loop degrades copy.
+- **The ledger and calibration library rot if the discipline lapses.** The positive
+  flywheel and the calibration set both depend on someone recording the verdict and
+  curating examples. Keeping the ledger lightweight is the defense (a heavy ledger is the
+  one that silently stops being filled) — but it still rests on a human-discipline floor.
 
 ---
 
 ## Why it works — the principles worth stealing
 
-1. **The contract is the interface.** A brief + asset schema, filled and gated — not a
-   UI. Press enter to advance; step in only for taste and the verdict.
-2. **Gate what you can know before shipping; let the market test the rest.** Consistency,
-   compliance, structure, voice are pre-publish; effectiveness is post-publish.
-3. **Separate the writer from the editor.** Independent judgment against the brief beats
-   self-review.
-4. **Publish is the midpoint, not the finish.** Measure, give a verdict, write it down —
-   the loop the value lives in.
-5. **Two flywheels.** Kill the repeat (miss → gate) *and* clone the winner (win → prior).
-6. **Keep one living source of truth, queried before every brief.** Outcomes and
-   patterns live on; drafts are disposable. The opposite of a write-only archive.
+1. **The contract is the interface.** A brief + asset schema, filled and gated — not a UI.
+2. **Triage before you build.** "Should this exist?" beats efficiently producing landfill.
+3. **The LLM produces evidence, not verdicts.** Deterministic gates block hard failures;
+   models surface structured risks and cite spans; humans make accountable decisions;
+   the market settles effectiveness.
+4. **Force complete review coverage.** No required rule passes silently; every comment is
+   categorized and evidenced; overrides are logged.
+5. **Risk-tier the burden.** Heavy review for what can hurt you, light for what can't.
+6. **Publish is the midpoint.** Define the experiment first, measure, give a structured
+   verdict, record it.
+7. **Two flywheels.** Kill the repeat (miss → gate, on a 3+ threshold) and clone the
+   winner (win → prior); overrides → calibration.
+8. **One living source of truth, queried before every brief** — ledger, registry,
+   voice contract, calibration library. The opposite of a write-only archive.
 
-The net effect mirrors the dev model: the operator runs writer/editor pairs across
-channels and moves fast, because the system mechanically refuses to let any of them ship
-off-brand, inconsistent, or non-compliant copy — and every new way one *could* miss, or
-every angle that *won*, becomes one more thing the next brief starts with.
+The system's job is not to make humans or models reliable — they aren't. It is to make
+unreliability **visible, logged, and harder to repeat.**
+
+---
+
+## Building this: staged, not a monolith
+
+The model above is a spec for a subsystem, not a weekend. It sequences into ~5 slices,
+cheapest-and-highest-value first (most of it *extends* existing substrate — the claim
+registry, `extracted_quality_gate` packs, brand-voice profiles — so little is greenfield):
+
+1. **Free reframes + cheap enums** — LLM-as-evidence wording, failure taxonomy, risk
+   tier field, exception state + log, the four-part gate split. (config/enum-scale)
+2. **Triage gate + experiment contract** — two schemas + human decisions. (small)
+3. **Claims map** — claim extraction + registry mapping + status. (its own slice)
+4. **Content-PR + coverage matrix** — the review interface; the anti-drift core. (epic)
+5. **Calibration library + adversarial pass** — curated set + second prompt. (ongoing)
+
+Model-disagreement orchestration (§4) is explicitly **out of scope** until 1–5 prove out.

--- a/docs/content_ops_operating_model.md
+++ b/docs/content_ops_operating_model.md
@@ -1,0 +1,195 @@
+# How Atlas Ships Marketing Content — The Same Operating Model, Adapted
+
+> A sister to `docs/ai_dev_operating_model.md`. Same spine — plan a thin artifact,
+> let mechanical gates catch every repeatable failure, keep the builder and reviewer
+> separate, turn every miss into a gate — adapted to content marketing, where the
+> artifact is structured copy, the "test" is the market, and the value compounds in a
+> living record of what worked.
+
+The dev model and this one share a thesis: **make the machine catch every failure
+mode a script can decide, so human judgment is only ever spent where a script can't.**
+Two things change in content, and they change the shape of the whole loop:
+
+1. **The artifact is structured data, not freeform code** — so the contract is a
+   *schema*, and the schema is the interface (no UI required).
+2. **The real test runs after you ship, and it's probabilistic** — so the lifecycle
+   doesn't end at publish, and the source of truth is a *living record of outcomes*,
+   not a write-only archive.
+
+---
+
+## 1. The crew model: writer + editor, per channel lane
+
+Work splits into **channel/campaign lanes** (e.g. "lifecycle email", "SEO blog",
+"paid social"). Each lane is a pair:
+
+- **Writer session** — fills the brief + asset schema, drafts the copy, runs the gates.
+- **Editor session** — reviews *independently* against the brief and posts one verdict:
+  **BLOCKER / MAJOR / NIT / LGTM**.
+
+Same reason as code: a model editing its own copy inherits its own blind spots. The
+editor re-judges against the brief and the brand-voice contract from scratch, never
+rubber-stamps. The difference from code review: the editor spends most of its judgment
+on **taste and persuasion** (is this on-brand, does it earn the click), because the
+mechanical gates have already settled consistency and compliance.
+
+---
+
+## 2. The unit of work: a brief + an asset schema (the contract *is* the interface)
+
+Nothing ships without a **contract first** — but the contract is a filled schema, not
+a prose plan. It has two layers, kept distinct on purpose:
+
+- **The brief (intent).** `objective`, `audience`, `funnel_stage`, `one_message`,
+  `proof`, `offer`/`CTA`. This is the strategy the editor judges *good* against.
+- **The asset schema (structure).** Typed fields per output type — an email is
+  `subject / preheader / body_blocks[] / cta / utm`; a blog is
+  `title / meta / outline_h2[] / claims[] / internal_links[]`; an ad is different
+  again. This is what the gates validate.
+
+Folding strategy into structure is the failure mode: you get copy that is
+schema-valid and soulless. Keep both layers; gates run mostly against the asset
+schema, the editor judges against the brief.
+
+**The schema is the UI.** You don't need a webpage — you need a typed document the
+session fills and the gates validate. Driving the workflow is: fill (or approve) the
+schema → gates run → editor → publish. Once the contract exists, most operator turns
+are "approve / next"; you only step in at the two things that can't be mechanized:
+**taste** and the eventual **verdict**.
+
+---
+
+## 3. Pre-publish gates: what you *can* know before shipping
+
+The gates enforce only what is knowable in advance. Two tiers:
+
+**Deterministic (a regex/registry can decide):**
+
+| Gate | Fails when… | Source of truth it checks against |
+|---|---|---|
+| **Claim / cross-channel consistency** | a stat, price, product name, or CTA disagrees with canon | the **claim/messaging registry** |
+| **Compliance** | a required disclaimer is missing or a banned/regulated claim appears | compliance ruleset (**fails closed**) |
+| **Structure / SEO** | title/meta length, heading shape, keyword, link, or word-budget out of spec | the asset schema |
+| **Grounding** | a factual claim cites no source | the registry / provided evidence |
+
+**LLM-judge (needs a rubric, not a regex):**
+
+| Gate | Scores |
+|---|---|
+| **Voice / tone drift** | the draft against the **brand-voice contract** (lexicon, banned words, reading level, POV, formality) |
+
+The split mirrors the dev model's honesty: deterministic gates settle
+consistency/compliance/structure; the LLM-judge plus the editor handle voice and
+persuasion. **What neither can settle pre-publish is whether it will work** — that is
+the market's job (§4). Atlas already has scaffolding here: `extracted_quality_gate`
+(deterministic packs: blog / campaign / witness-specificity / evidence-coverage /
+source-quality) and brand-voice profiles (`content_ops_brand_voice_profiles`).
+
+---
+
+## 4. The part code doesn't have: publish is the midpoint, not the finish
+
+Code's terminal state is real — merge plus green CI means done, move on. Content has
+no such moment, because **the test runs after you ship and answers days later,
+probabilistically.** So the lifecycle has a tail code lacks:
+
+```
+brief+schema → draft → gates → editor → PUBLISH → measure → verdict → record
+```
+
+- **Publish** ships to the channel (UTM-tagged so the measurement is attributable).
+- **Measure** waits for the delayed signal (open/click/conversion/engagement).
+- **Verdict** is a human call the data informs: *worked / didn't / why* — it can't be
+  automated, because it depends on signal that didn't exist at ship time.
+- **Record** writes that one-line verdict to the living ledger (§5).
+
+This tail is where the value compounds. A model that stops at "publish" has shipped a
+piece; a model that closes the loop has learned something reusable.
+
+---
+
+## 5. The source of truth: a *living* record, not a write-only archive
+
+This is the sharpest divergence from the dev model. In code, the merged artifact is
+the truth and the plan is disposable — we literally archive-and-forget plans on merge.
+In content, the published piece is *not* the valuable retained thing; **the outcomes
+and the patterns that won are**, and you read them *before every new brief*. So the
+content source of truth is the inverse of `plans/archive/`: it is consulted constantly,
+never retired. It is the analogue of `CANONICAL.md`, not of the plan archive.
+
+Three living docs:
+
+- **Campaign ledger (lightweight verdict log).** One record per campaign/piece:
+  `hypothesis · assets · headline metric · worked-didn't-why`. Deliberately cheap, so
+  it actually gets kept — and queried at the start of every brief ("what subject line
+  won for this segment?").
+- **Claim / messaging registry.** Canonical stats, prices, positioning, product names.
+  The consistency gate checks copy against this; it is content's `CANONICAL.md`.
+- **Brand-voice contract.** The voice rules the voice-drift gate scores against —
+  content's `AGENTS.md`.
+
+The raw drafts and process *are* archivable-and-forgettable like plans; only the
+outcomes and patterns live on. Conflating the two is the trap — you don't need draft
+#6 from three campaigns ago, but you very much need to know that campaign's angle
+converted.
+
+---
+
+## 6. Two flywheels: kill the repeat, clone the winner
+
+Code's flywheel is purely negative: a mistake that cost a cycle becomes a gate, so it
+never recurs. Content keeps that one **and adds a positive twin**, which is arguably
+its engine:
+
+- **Negative (same as code).** A miss that slips — off-brand line, inconsistent stat,
+  missing disclaimer — becomes a new gate: a banned phrase, a registry entry, a rubric
+  criterion. It can't recur.
+- **Positive (new).** A *winner* — an angle, format, or subject that converted —
+  becomes a **reusable prior**: a template, a schema default, a line in the brief's
+  "what's worked here" preamble. It gets deliberately repeated.
+
+Every published piece earns a verdict (§4); the verdict feeds whichever loop applies;
+both front-load into the next brief. Quality compounds in both directions at once:
+fewer bad pieces, more pieces built on what already won.
+
+---
+
+## 7. Honest limits — where this model can't be mechanical
+
+Same discipline as the dev doc's "Known gaps": name the residual, don't pretend it's
+covered.
+
+- **The effectiveness test is delayed and probabilistic.** Pre-publish gates can
+  guarantee consistency, compliance, structure, and on-brand voice — never "this will
+  convert." The flywheel still works, just on a slower, noisier loop than CI's
+  two-minute verdict. Attribution noise (seasonality, audience mix, sample size) means
+  a single piece's "verdict" is a weak signal; patterns emerge over many.
+- **Taste isn't fully mechanizable.** More of the gate budget here is LLM-judge than
+  regex, so the model leans harder on the judgment layer — which makes the dev doc's
+  rule **"external-bot/LLM findings are advisory, never auto-applied"** matter *more*,
+  not less. A naive "auto-apply every gate suggestion" loop degrades copy.
+- **The ledger rots if the verdict step is skipped.** The whole positive flywheel
+  depends on someone actually recording *worked/didn't/why*. Keeping the ledger
+  lightweight is the defense (a heavy ledger is the one that silently stops being
+  filled) — but it still rests on the same human-discipline floor the dev model admits.
+
+---
+
+## Why it works — the principles worth stealing
+
+1. **The contract is the interface.** A brief + asset schema, filled and gated — not a
+   UI. Press enter to advance; step in only for taste and the verdict.
+2. **Gate what you can know before shipping; let the market test the rest.** Consistency,
+   compliance, structure, voice are pre-publish; effectiveness is post-publish.
+3. **Separate the writer from the editor.** Independent judgment against the brief beats
+   self-review.
+4. **Publish is the midpoint, not the finish.** Measure, give a verdict, write it down —
+   the loop the value lives in.
+5. **Two flywheels.** Kill the repeat (miss → gate) *and* clone the winner (win → prior).
+6. **Keep one living source of truth, queried before every brief.** Outcomes and
+   patterns live on; drafts are disposable. The opposite of a write-only archive.
+
+The net effect mirrors the dev model: the operator runs writer/editor pairs across
+channels and moves fast, because the system mechanically refuses to let any of them ship
+off-brand, inconsistent, or non-compliant copy — and every new way one *could* miss, or
+every angle that *won*, becomes one more thing the next brief starts with.

--- a/docs/content_ops_operating_model.svg
+++ b/docs/content_ops_operating_model.svg
@@ -1,0 +1,194 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1080" viewBox="0 0 1400 1080" font-family="'Segoe UI',Helvetica,Arial,sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#475569"/>
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#0d9488"/>
+    </marker>
+    <marker id="arrowRed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#b91c1c"/>
+    </marker>
+    <style>
+      .title{font-size:30px;font-weight:700;fill:#0f172a}
+      .sub{font-size:15px;fill:#475569}
+      .lane{font-size:15px;font-weight:700;fill:#1e3a8a}
+      .box-t{font-size:15px;font-weight:700;fill:#0f172a}
+      .box-s{font-size:12px;fill:#334155}
+      .gate-t{font-size:14px;font-weight:700;fill:#7c2d12}
+      .gate-s{font-size:11.5px;fill:#7c2d12}
+      .hdr{font-size:17px;font-weight:700;fill:#fff}
+      .lbl{font-size:11.5px;fill:#475569;font-style:italic}
+      .foot{font-size:12.5px;fill:#64748b}
+      .k{font-size:13px;fill:#334155}
+    </style>
+  </defs>
+
+  <rect width="1400" height="1080" fill="#f8fafc"/>
+  <text x="40" y="50" class="title">The Atlas Content Marketing Operating Model</text>
+  <text x="40" y="75" class="sub">Brief + schema contract -&gt; gated drafting -&gt; independent editor -&gt; publish -&gt; measure &amp; learn. Same gate discipline as code; a living source of truth and a winner-flywheel instead of a terminal merge.</text>
+
+  <!-- ================= LANES ================= -->
+  <rect x="40" y="100" width="1320" height="250" rx="12" fill="#eff6ff" stroke="#bfdbfe"/>
+  <text x="60" y="125" class="lane">LANE A — e.g. "lifecycle email"  (writer + editor pair)</text>
+  <text x="60" y="332" class="lane">LANE B — e.g. "SEO blog"  (independent writer + editor pair, separate channel lane)</text>
+  <line x1="40" y1="300" x2="1360" y2="300" stroke="#cbd5e1" stroke-dasharray="4 4"/>
+
+  <!-- ===== pipeline (Lane A) ===== -->
+  <!-- 1 Brief + schema -->
+  <rect x="60" y="150" width="158" height="120" rx="9" fill="#fff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="73" y="172" class="box-t">1 · Brief + schema</text>
+  <text x="73" y="194" class="box-s">intent + asset schema</text>
+  <text x="73" y="212" class="box-s">the contract = the UI</text>
+  <text x="73" y="230" class="box-s">(no webpage needed)</text>
+  <text x="73" y="262" class="lbl">press enter to advance</text>
+
+  <!-- 2 Writer drafts -->
+  <rect x="238" y="150" width="158" height="120" rx="9" fill="#fff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="251" y="172" class="box-t">2 · Writer drafts</text>
+  <text x="251" y="194" class="box-s">fills the schema</text>
+  <text x="251" y="212" class="box-s">one asset, thin</text>
+  <text x="251" y="230" class="box-s">grounded in registry</text>
+  <text x="251" y="262" class="lbl">fields, not prose</text>
+
+  <!-- 3 Content gates -->
+  <rect x="416" y="150" width="158" height="120" rx="9" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
+  <text x="429" y="172" class="gate-t">3 · Content gates</text>
+  <text x="429" y="193" class="gate-s">voice-drift · claims</text>
+  <text x="429" y="210" class="gate-s">compliance · structure</text>
+  <text x="429" y="227" class="gate-s">determ. + LLM-judge</text>
+  <text x="429" y="244" class="gate-s">compliance fails closed</text>
+
+  <!-- 4 Editor -->
+  <rect x="594" y="150" width="158" height="120" rx="9" fill="#fff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="607" y="172" class="box-t">4 · Editor session</text>
+  <text x="607" y="194" class="box-s">INDEPENDENT</text>
+  <text x="607" y="212" class="box-s">judges vs the brief</text>
+  <text x="607" y="230" class="box-s">taste + persuasion</text>
+  <text x="607" y="248" class="box-s">BLOCKER/.../LGTM</text>
+
+  <!-- 5 Publish -->
+  <rect x="772" y="150" width="158" height="120" rx="9" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+  <text x="785" y="172" class="box-t">5 · Publish</text>
+  <text x="785" y="194" class="box-s">ship to channel</text>
+  <text x="785" y="212" class="box-s">UTM-tagged</text>
+  <text x="785" y="244" class="lbl">attributable</text>
+
+  <!-- 6 Measure -->
+  <rect x="950" y="150" width="158" height="120" rx="9" fill="#f0fdfa" stroke="#0d9488" stroke-width="1.5"/>
+  <text x="963" y="172" class="box-t">6 · Measure</text>
+  <text x="963" y="194" class="box-s">signal lands (delayed)</text>
+  <text x="963" y="212" class="box-s">open/click/convert</text>
+  <text x="963" y="244" class="lbl">the market is the test</text>
+
+  <!-- 7 Verdict -->
+  <rect x="1128" y="150" width="158" height="120" rx="9" fill="#f0fdfa" stroke="#0d9488" stroke-width="1.5"/>
+  <text x="1141" y="172" class="box-t">7 · Verdict</text>
+  <text x="1141" y="194" class="box-s">worked / didn't / why</text>
+  <text x="1141" y="212" class="box-s">1 line -&gt; ledger</text>
+  <text x="1141" y="244" class="lbl">human call</text>
+
+  <!-- arrows -->
+  <line x1="218" y1="210" x2="236" y2="210" stroke="#475569" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="396" y1="210" x2="414" y2="210" stroke="#475569" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="574" y1="210" x2="592" y2="210" stroke="#475569" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="752" y1="210" x2="770" y2="210" stroke="#0d9488" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <line x1="930" y1="210" x2="948" y2="210" stroke="#0d9488" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <line x1="1108" y1="210" x2="1126" y2="210" stroke="#0d9488" stroke-width="2" marker-end="url(#arrowGreen)"/>
+
+  <!-- reject loop -->
+  <path d="M673,270 q0,34 -178,34 q-178,0 -178,-30" fill="none" stroke="#b91c1c" stroke-width="1.8" stroke-dasharray="6 4" marker-end="url(#arrowRed)"/>
+  <text x="420" y="296" fill="#b91c1c" font-size="11.5" font-weight="700">BLOCKER -&gt; revise &amp; re-gate</text>
+
+  <!-- post-publish bracket -->
+  <text x="950" y="288" fill="#0f766e" font-size="11.5" font-weight="700">post-publish — the loop code doesn't have</text>
+
+  <!-- Lane B mini pipeline -->
+  <rect x="60" y="316" width="1226" height="26" rx="6" fill="#dbeafe" stroke="#bfdbfe"/>
+  <text x="75" y="334" class="k">Brief -&gt; Draft -&gt; Gates -&gt; Editor -&gt; Publish -&gt; Measure -&gt; Verdict   ·   same contract, different channel (lanes can't collide)</text>
+
+  <!-- ================= PRE-PUBLISH GATES ================= -->
+  <rect x="40" y="370" width="650" height="250" rx="12" fill="#fff7ed" stroke="#fed7aa"/>
+  <text x="60" y="397" class="lane" fill="#9a3412">PRE-PUBLISH GATES — what you can know before shipping</text>
+
+  <rect x="60" y="410" width="610" height="44" rx="8" fill="#fff" stroke="#ea580c"/>
+  <text x="73" y="430" class="box-t">Voice / tone drift  [LLM-judge]</text>
+  <text x="73" y="447" class="box-s">vs brand-voice contract: lexicon, reading level, POV, formality</text>
+
+  <rect x="60" y="460" width="610" height="44" rx="8" fill="#fff" stroke="#ea580c"/>
+  <text x="73" y="480" class="box-t">Claim consistency  [deterministic]</text>
+  <text x="73" y="497" class="box-s">vs claim/messaging registry: stats · price · product names · CTA</text>
+
+  <rect x="60" y="510" width="610" height="44" rx="8" fill="#fff" stroke="#ea580c"/>
+  <text x="73" y="530" class="box-t">Compliance + structure  [deterministic]</text>
+  <text x="73" y="547" class="box-s">required disclaimers (fail closed) · SEO · format · word budget</text>
+
+  <text x="60" y="578" class="k">Deterministic gates settle consistency / compliance / structure; the LLM-judge +</text>
+  <text x="60" y="596" class="k">editor handle voice &amp; persuasion. Effectiveness is <tspan font-weight="700">not</tspan> knowable pre-publish.</text>
+
+  <!-- ================= LIVING SOURCE OF TRUTH ================= -->
+  <rect x="710" y="370" width="650" height="250" rx="12" fill="#eef2ff" stroke="#c7d2fe"/>
+  <text x="730" y="397" class="lane" fill="#3730a3">LIVING SOURCE OF TRUTH — read before every brief</text>
+
+  <rect x="730" y="410" width="610" height="44" rx="8" fill="#fff" stroke="#6366f1"/>
+  <text x="743" y="430" class="box-t">Campaign ledger  (lightweight verdict log)</text>
+  <text x="743" y="447" class="box-s">hypothesis · assets · headline metric · worked / didn't / why</text>
+
+  <rect x="730" y="460" width="610" height="44" rx="8" fill="#fff" stroke="#6366f1"/>
+  <text x="743" y="480" class="box-t">Claim / messaging registry</text>
+  <text x="743" y="497" class="box-s">canonical stats · price · positioning   (content's CANONICAL.md)</text>
+
+  <rect x="730" y="510" width="610" height="44" rx="8" fill="#fff" stroke="#6366f1"/>
+  <text x="743" y="530" class="box-t">Brand-voice contract</text>
+  <text x="743" y="547" class="box-s">the voice rules the drift gate scores against   (content's AGENTS.md)</text>
+
+  <text x="730" y="578" class="k">Unlike plans/archive (write-only, forgotten), this is consulted constantly.</text>
+  <text x="730" y="596" class="k">Outcomes &amp; winning patterns live on; drafts are disposable.</text>
+
+  <!-- ================= TWO FLYWHEELS ================= -->
+  <rect x="40" y="640" width="1320" height="180" rx="12" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="60" y="667" class="lane" fill="#166534">TWO FLYWHEELS — kill the repeat, clone the winner</text>
+
+  <rect x="60" y="685" width="250" height="110" rx="9" fill="#fff" stroke="#16a34a"/>
+  <text x="75" y="708" class="box-t">Every piece earns a verdict</text>
+  <text x="75" y="730" class="box-s">worked / didn't / why,</text>
+  <text x="75" y="746" class="box-s">recorded to the ledger</text>
+
+  <rect x="430" y="685" width="270" height="110" rx="9" fill="#fff" stroke="#16a34a"/>
+  <text x="445" y="708" class="box-t">Convert it — two ways</text>
+  <text x="445" y="730" class="box-s">miss -&gt; a new gate (kill repeat)</text>
+  <text x="445" y="748" class="box-s">winner -&gt; a reusable prior (clone)</text>
+
+  <rect x="820" y="685" width="270" height="110" rx="9" fill="#fff" stroke="#16a34a"/>
+  <text x="835" y="708" class="box-t">Front-load the next brief</text>
+  <text x="835" y="730" class="box-s">gates auto-apply;</text>
+  <text x="835" y="748" class="box-s">winning patterns -&gt; schema defaults</text>
+
+  <rect x="1200" y="685" width="140" height="110" rx="9" fill="#dcfce7" stroke="#16a34a"/>
+  <text x="1215" y="712" class="box-t">Quality</text>
+  <text x="1215" y="732" class="box-t">compounds</text>
+  <text x="1215" y="758" class="box-s">fewer misses,</text>
+  <text x="1215" y="774" class="box-s">more winners</text>
+
+  <line x1="310" y1="740" x2="428" y2="740" stroke="#15803d" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <line x1="700" y1="740" x2="818" y2="740" stroke="#15803d" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <line x1="1090" y1="740" x2="1198" y2="740" stroke="#15803d" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <path d="M1270,795 q0,40 -640,40 q-630,0 -630,-36" fill="none" stroke="#15803d" stroke-width="1.6" stroke-dasharray="6 4" marker-end="url(#arrowGreen)"/>
+  <text x="590" y="852" fill="#166534" font-size="12" font-weight="700">...and every verdict sharpens the next brief — the loop tightens with each cycle</text>
+
+  <!-- ================= FOOTER PRINCIPLES ================= -->
+  <rect x="40" y="872" width="1320" height="180" rx="12" fill="#0f172a"/>
+  <text x="60" y="900" class="hdr">Principles worth stealing</text>
+  <text x="60" y="930" fill="#e2e8f0" font-size="13.5">1 · The contract is the interface — brief + asset schema, filled &amp; gated. Not a UI; press enter to advance.</text>
+  <text x="60" y="956" fill="#e2e8f0" font-size="13.5">2 · Gate what you can know pre-publish — voice, consistency, compliance, structure. The market tests the rest.</text>
+  <text x="60" y="982" fill="#e2e8f0" font-size="13.5">3 · Separate the writer from the editor — independent judgment against the brief beats self-review.</text>
+  <text x="60" y="1008" fill="#e2e8f0" font-size="13.5">4 · Publish is the midpoint — measure, give a verdict, record it. The loop the value lives in.</text>
+  <text x="60" y="1034" fill="#e2e8f0" font-size="13.5">5 · Two flywheels — kill the repeat (miss -&gt; gate) and clone the winner (win -&gt; prior).</text>
+
+  <text x="1010" y="930" fill="#94a3b8" font-size="12">Living source of truth:</text>
+  <text x="1010" y="952" fill="#cbd5e1" font-size="12">· brand-voice contract  (voice gate)</text>
+  <text x="1010" y="972" fill="#cbd5e1" font-size="12">· claim/messaging registry  (consistency)</text>
+  <text x="1010" y="992" fill="#cbd5e1" font-size="12">· campaign ledger  (verdict log)</text>
+  <text x="1010" y="1012" fill="#cbd5e1" font-size="12">Builds on: extracted_content_pipeline</text>
+  <text x="1010" y="1032" fill="#cbd5e1" font-size="12">+ extracted_quality_gate  (gate packs)</text>
+</svg>


### PR DESCRIPTION
Slice phase: Workflow/process

Docs-only. The content-marketing analogue of `docs/ai_dev_operating_model.*` (#1317), adapting the same operating model to content — now folding in a full long-form review of the model.

## Files
- `docs/content_ops_operating_model.md` — the writeup (canonical; carries the full model)
- `docs/content_ops_operating_model.svg` — one-page diagram showing the **simplified** 7-stage flow

## The model (post-review)
- **LLM is evidence, not judge** — deterministic gates block hard failures; models surface structured risks with cited spans (forced JSON coverage matrix, no prose "LGTM"); humans make accountable decisions; the market settles effectiveness.
- **0->11 lifecycle** — adds stage 0 triage ("should this exist?") and stage 7 experiment contract (measurement plan frozen before publish), then publish -> measure -> verdict -> compound.
- **Four-part gate stack** — 3A schema / 3B claims+compliance / 3C model-assisted review / 3D human editor.
- **Claims map** — every claim auto-extracted, mapped to the registry, status-checked (the "Save 30%" vs "Save up to 30% on eligible plans" liability catch).
- **Review contract** — Content-PR with frozen rule-pack versions + a required coverage matrix (no silent pass) + categorized/evidenced comments + approve-with-exception logging + four review targets.
- **Risk tiering** (low/medium/high/critical) routes review burden — the anti-bureaucracy lever.
- **Failure taxonomy** on the verdict; flywheel "3+ same-reason misses -> new gate"; overrides -> calibration.
- **Living source of truth = quartet** — campaign ledger + claim/messaging registry + brand-voice contract + review calibration library.

## Intentional
- Draft, for iteration — the model on paper before we build the schemas/gates underneath it.
- Two judgment calls preserved as dissent from the review: keep a **NIT** escape hatch for drive-by polish; park **multi-model disagreement orchestration** as advanced/out-of-scope.
- Derived PNG not committed; SVG is the editable source (same convention as #1317).

## Deferred
- v2 diagram (clean top-level flow + a separate "review contract" canvas) — not crammed onto the existing one page.
- The build itself, staged into ~5 slices (see the doc's "Building this" section): free reframes + enums -> triage/experiment contract -> claims map -> Content-PR + coverage matrix -> calibration library + adversarial pass. Mostly extends existing substrate (`extracted_quality_gate`, brand-voice profiles, claim registry).

## Parked hardening
- None.

## Verification
- `python3 -c "import xml.dom.minidom; xml.dom.minidom.parse('docs/content_ops_operating_model.svg')"` — SVG well-formed.
- Docs-only; no code paths touched.

https://claude.ai/code/session_01QgqhC2NoKQHzV3xDFchNRN