### PR TITLE
Content-ops review vocabulary (operating-model slice 1)

### DIFF
--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -231,6 +231,9 @@
       "target": "extracted_content_pipeline/report_export.py"
     },
     {
+      "target": "extracted_content_pipeline/review_contract.py"
+    },
+    {
       "target": "extracted_content_pipeline/blog_post_export.py"
     },
     {

--- a/extracted_content_pipeline/review_contract.py
+++ b/extracted_content_pipeline/review_contract.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from types import MappingProxyType
 from typing import Iterable, Mapping
 
 try:
@@ -32,8 +33,11 @@ class RiskTier(StrEnum):
 
     Distinct from ``extracted_quality_gate.RiskLevel``: that is a *computed*
     safety score (with auto-approve eligibility); this is an author-declared
-    routing tier that decides how much review an asset must clear. The labels
-    deliberately match so the two stay legible together.
+    routing tier that decides how much review an asset must clear. The member
+    *names* deliberately mirror ``RiskLevel`` so the two read alike, but the
+    string *values* differ in case (``RiskTier.LOW == "low"`` vs
+    ``RiskLevel.LOW == "LOW"``) -- do not compare the two enums' values
+    directly.
     """
 
     LOW = "low"
@@ -98,31 +102,36 @@ class GateStage(StrEnum):
 
 # Risk-tier -> ordered required gate stages (the doc's risk-tier table as data).
 # This is pure routing data; the code that *enforces* it is a later slice.
-REQUIRED_REVIEW_BY_TIER: Mapping[RiskTier, tuple[GateStage, ...]] = {
-    RiskTier.LOW: (
-        GateStage.SCHEMA,
-        GateStage.MODEL_ASSISTED,
-        GateStage.HUMAN_EDITOR,
-    ),
-    RiskTier.MEDIUM: (
-        GateStage.SCHEMA,
-        GateStage.CLAIMS_COMPLIANCE,
-        GateStage.MODEL_ASSISTED,
-        GateStage.HUMAN_EDITOR,
-    ),
-    RiskTier.HIGH: (
-        GateStage.SCHEMA,
-        GateStage.CLAIMS_COMPLIANCE,
-        GateStage.MODEL_ASSISTED,
-        GateStage.HUMAN_EDITOR,
-    ),
-    RiskTier.CRITICAL: (
-        GateStage.SCHEMA,
-        GateStage.CLAIMS_COMPLIANCE,
-        GateStage.MODEL_ASSISTED,
-        GateStage.HUMAN_EDITOR,
-    ),
-}
+# Wrapped in MappingProxyType (per the extracted_content_pipeline constant-table
+# convention, e.g. control_surfaces.OUTPUT_CATALOG) so accidental mutation of the
+# routing table fails loudly instead of silently corrupting review burden.
+REQUIRED_REVIEW_BY_TIER: Mapping[RiskTier, tuple[GateStage, ...]] = MappingProxyType(
+    {
+        RiskTier.LOW: (
+            GateStage.SCHEMA,
+            GateStage.MODEL_ASSISTED,
+            GateStage.HUMAN_EDITOR,
+        ),
+        RiskTier.MEDIUM: (
+            GateStage.SCHEMA,
+            GateStage.CLAIMS_COMPLIANCE,
+            GateStage.MODEL_ASSISTED,
+            GateStage.HUMAN_EDITOR,
+        ),
+        RiskTier.HIGH: (
+            GateStage.SCHEMA,
+            GateStage.CLAIMS_COMPLIANCE,
+            GateStage.MODEL_ASSISTED,
+            GateStage.HUMAN_EDITOR,
+        ),
+        RiskTier.CRITICAL: (
+            GateStage.SCHEMA,
+            GateStage.CLAIMS_COMPLIANCE,
+            GateStage.MODEL_ASSISTED,
+            GateStage.HUMAN_EDITOR,
+        ),
+    }
+)
 
 
 def required_stages_for(tier: RiskTier) -> tuple[GateStage, ...]:

--- a/extracted_content_pipeline/review_contract.py
+++ b/extracted_content_pipeline/review_contract.py
@@ -1,0 +1,181 @@
+"""Content-ops review vocabulary (operating-model slice 1).
+
+Typed vocabulary for the content review subsystem described in
+``docs/content_ops_operating_model.md``. This module is intentionally pure:
+value enums, one frozen record, and a few small helpers, with no I/O, no Atlas
+imports, no database, and no LLM. Later slices (risk-tier routing, the claims
+map, the Content-PR coverage matrix, the calibration library) consume these
+names so they do not each reinvent their own.
+
+Nothing here changes existing behavior. The generated-asset review API keeps
+its host-extensible string statuses; mapping those onto ``ReviewDecision`` is a
+later slice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable, Mapping
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - Python 3.10 CI compatibility
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
+
+
+class RiskTier(StrEnum):
+    """Editorial review-burden tier, set on the brief.
+
+    Distinct from ``extracted_quality_gate.RiskLevel``: that is a *computed*
+    safety score (with auto-approve eligibility); this is an author-declared
+    routing tier that decides how much review an asset must clear. The labels
+    deliberately match so the two stay legible together.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ReviewDecision(StrEnum):
+    """Accountable editor decision on a draft.
+
+    ``APPROVED_WITH_EXCEPTION`` lets a piece ship despite a soft-rule violation,
+    but never invisibly -- it pairs with an :class:`ExceptionRecord`.
+    """
+
+    BLOCKED = "blocked"
+    REVISION_REQUIRED = "revision_required"
+    APPROVED = "approved"
+    APPROVED_WITH_EXCEPTION = "approved_with_exception"
+    ESCALATED = "escalated"
+
+
+class FailureCategory(StrEnum):
+    """Structured ``why`` for a post-publish verdict (the failure taxonomy).
+
+    A structured reason makes verdicts reusable instead of anecdotal: you learn
+    *which type* of failure recurs, which feeds the "3+ -> new gate" flywheel
+    (see :func:`recurring_failure_categories`).
+    """
+
+    WRONG_AUDIENCE = "wrong_audience"
+    WEAK_OFFER = "weak_offer"
+    WEAK_HOOK = "weak_hook"
+    UNCLEAR_PROMISE = "unclear_promise"
+    CLAIM_CREDIBILITY_GAP = "claim_credibility_gap"
+    CTA_FRICTION = "cta_friction"
+    LANDING_MISMATCH = "landing_mismatch"
+    TIMING = "timing"
+    CHANNEL_MISMATCH = "channel_mismatch"
+    DELIVERABILITY = "deliverability"
+    TOO_GENERIC = "too_generic"
+    TOO_COMPLEX = "too_complex"
+    INSUFFICIENT_PROOF = "insufficient_proof"
+    COMPLIANCE_WEAKENED = "compliance_weakened"
+    INCONCLUSIVE_DATA = "inconclusive_data"
+
+
+class GateStage(StrEnum):
+    """The four-part gate stack.
+
+    Deterministic stages (``SCHEMA``, ``CLAIMS_COMPLIANCE``) are decided by the
+    system; ``MODEL_ASSISTED`` produces evidence the editor resolves; the editor
+    owns the accountable call at ``HUMAN_EDITOR``. The market settles
+    effectiveness after publish -- not represented here.
+    """
+
+    SCHEMA = "schema"  # 3A
+    CLAIMS_COMPLIANCE = "claims_compliance"  # 3B
+    MODEL_ASSISTED = "model_assisted"  # 3C
+    HUMAN_EDITOR = "human_editor"  # 3D
+
+
+# Risk-tier -> ordered required gate stages (the doc's risk-tier table as data).
+# This is pure routing data; the code that *enforces* it is a later slice.
+REQUIRED_REVIEW_BY_TIER: Mapping[RiskTier, tuple[GateStage, ...]] = {
+    RiskTier.LOW: (
+        GateStage.SCHEMA,
+        GateStage.MODEL_ASSISTED,
+        GateStage.HUMAN_EDITOR,
+    ),
+    RiskTier.MEDIUM: (
+        GateStage.SCHEMA,
+        GateStage.CLAIMS_COMPLIANCE,
+        GateStage.MODEL_ASSISTED,
+        GateStage.HUMAN_EDITOR,
+    ),
+    RiskTier.HIGH: (
+        GateStage.SCHEMA,
+        GateStage.CLAIMS_COMPLIANCE,
+        GateStage.MODEL_ASSISTED,
+        GateStage.HUMAN_EDITOR,
+    ),
+    RiskTier.CRITICAL: (
+        GateStage.SCHEMA,
+        GateStage.CLAIMS_COMPLIANCE,
+        GateStage.MODEL_ASSISTED,
+        GateStage.HUMAN_EDITOR,
+    ),
+}
+
+
+def required_stages_for(tier: RiskTier) -> tuple[GateStage, ...]:
+    """Return the ordered gate stages a draft at ``tier`` must clear.
+
+    HIGH and CRITICAL share the same stage set today; their extra burden
+    (compliance/legal sign-off, postmortem, experiment contract) is expressed by
+    later slices, not by adding gate *stages* here.
+    """
+
+    return REQUIRED_REVIEW_BY_TIER[tier]
+
+
+@dataclass(frozen=True)
+class ExceptionRecord:
+    """An ``APPROVED_WITH_EXCEPTION`` audit entry.
+
+    Keeps an override out of Slack and in the system: which rule was waived, why,
+    who owns it, when it lapses, and whether the rule itself should change.
+    """
+
+    rule: str
+    reason: str
+    owner: str
+    expiration: date | None = None
+    should_update_rule: bool = False
+
+    def is_active(self, as_of: date) -> bool:
+        """True if the exception still applies on ``as_of`` (inclusive of the
+        expiration day). An exception with no expiration never lapses."""
+
+        if self.expiration is None:
+            return True
+        return as_of <= self.expiration
+
+
+def recurring_failure_categories(
+    categories: Iterable[FailureCategory],
+    *,
+    threshold: int = 3,
+) -> frozenset[FailureCategory]:
+    """Categories that have failed ``threshold`` or more times.
+
+    The negative-flywheel trigger: when the same failure recurs at or above the
+    threshold it is a candidate for a new deterministic gate. Pure counting --
+    deciding what gate to add is a human/later-slice call.
+    """
+
+    if threshold < 1:
+        raise ValueError("threshold must be >= 1")
+    counts: dict[FailureCategory, int] = {}
+    for category in categories:
+        counts[category] = counts.get(category, 0) + 1
+    return frozenset(
+        category for category, count in counts.items() if count >= threshold
+    )

--- a/plans/PR-Content-Ops-Review-Vocabulary.md
+++ b/plans/PR-Content-Ops-Review-Vocabulary.md
@@ -1,8 +1,5 @@
 # PR — Content-Ops Review Vocabulary (operating-model slice 1)
 
-Ownership lane: content-ops/review-contract
-Slice phase: Vertical slice
-
 ## Why this slice exists
 
 `docs/content_ops_operating_model.md` defines a content-review subsystem and a
@@ -20,6 +17,9 @@ not scope: the module is ~190 LOC (largely docstrings), and the rest is the plan
 own machine-generated tables plus thorough unit tests. The shippable surface stays tiny.
 
 ## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
 
 New owned module `extracted_content_pipeline/review_contract.py` (flat-module
 convention, per `brand_voice.py`) plus unit tests. It provides:

--- a/plans/PR-Content-Ops-Review-Vocabulary.md
+++ b/plans/PR-Content-Ops-Review-Vocabulary.md
@@ -12,9 +12,10 @@ It is deliberately enum/value-scale and changes no existing behavior. The existi
 generated-asset review API keeps its host-extensible string statuses untouched; wiring
 this vocabulary into validation/routing is slice 2.
 
-Diff total is marginally over the 400-LOC soft cap (~412). The overage is scaffolding,
-not scope: the module is ~190 LOC (largely docstrings), and the rest is the plan doc's
-own machine-generated tables plus thorough unit tests. The shippable surface stays tiny.
+Diff total is marginally over the 400-LOC soft cap (see the per-file breakdown in
+*Estimated diff size* below). The overage is scaffolding, not scope: the module is
+~190 LOC (largely docstrings), and the rest is the plan doc's own machine-generated
+tables plus thorough unit tests. The shippable surface stays tiny.
 
 ## Scope (this PR)
 
@@ -88,7 +89,7 @@ convention (full-path imports), so no export edit.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/review_contract.py` | 190 |
-| `plans/PR-Content-Ops-Review-Vocabulary.md` | 94 |
+| `plans/PR-Content-Ops-Review-Vocabulary.md` | 95 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/test_extracted_content_review_contract.py` | 131 |
-| **Total** | **419** |
+| **Total** | **420** |

--- a/plans/PR-Content-Ops-Review-Vocabulary.md
+++ b/plans/PR-Content-Ops-Review-Vocabulary.md
@@ -1,5 +1,8 @@
 # PR — Content-Ops Review Vocabulary (operating-model slice 1)
 
+Ownership lane: content-ops/review-contract
+Slice phase: Content operating model - slice 1 (review vocabulary)
+
 ## Why this slice exists
 
 `docs/content_ops_operating_model.md` defines a content-review subsystem and a
@@ -85,7 +88,7 @@ convention (full-path imports), so no export edit.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/review_contract.py` | 190 |
-| `plans/PR-Content-Ops-Review-Vocabulary.md` | 91 |
+| `plans/PR-Content-Ops-Review-Vocabulary.md` | 94 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/test_extracted_content_review_contract.py` | 131 |
-| **Total** | **416** |
+| **Total** | **419** |

--- a/plans/PR-Content-Ops-Review-Vocabulary.md
+++ b/plans/PR-Content-Ops-Review-Vocabulary.md
@@ -1,0 +1,71 @@
+# PR — Content-Ops Review Vocabulary (operating-model slice 1)
+
+## Why this slice exists
+
+`docs/content_ops_operating_model.md` defines a content-review subsystem and a
+"Building this: staged, not a monolith" sequence. This is **slice 1 — free reframes +
+cheap enums**: the typed vocabulary every later slice consumes, landed before any
+behavior changes so the expensive slices (claims map, Content-PR coverage matrix) plug
+into shared names instead of inventing their own.
+
+It is deliberately enum/value-scale and changes no existing behavior. The existing
+generated-asset review API keeps its host-extensible string statuses untouched; wiring
+this vocabulary into validation/routing is slice 2.
+
+## Scope
+
+New owned module `extracted_content_pipeline/review_contract.py` (flat-module
+convention, per `brand_voice.py`) plus unit tests. It provides:
+
+- `RiskTier` (StrEnum: LOW/MEDIUM/HIGH/CRITICAL) — the brief-set editorial review-burden
+  tier. Distinct from `extracted_quality_gate.RiskLevel` (a computed safety score);
+  same labels, different domain. Docstring cross-references both.
+- `ReviewDecision` (StrEnum) — BLOCKED / REVISION_REQUIRED / APPROVED /
+  APPROVED_WITH_EXCEPTION / ESCALATED.
+- `FailureCategory` (StrEnum) — the verdict failure taxonomy (15 categories).
+- `GateStage` (StrEnum) — the four-part gate split: SCHEMA (3A) /
+  CLAIMS_COMPLIANCE (3B) / MODEL_ASSISTED (3C) / HUMAN_EDITOR (3D).
+- `REQUIRED_REVIEW_BY_TIER` — frozen mapping tier -> ordered gate stages (the doc's
+  risk-tier table as pure data) + `required_stages_for(tier)`.
+- `ExceptionRecord` (frozen dataclass) — rule/reason/owner/expiration/should_update_rule
+  + `is_active(as_of)`.
+- `recurring_failure_categories(categories, *, threshold=3)` — the flywheel
+  "3+ same-reason misses -> candidate for a new gate" helper.
+
+## Mechanism
+
+Pure value types and pure functions. `StrEnum` with the same Python-3.10 import fallback
+used in `extracted_quality_gate/types.py`. No I/O, no Atlas imports, no DB, no LLM. Each
+type ships one small tested behavior so nothing is inert: `required_stages_for`,
+`ExceptionRecord.is_active`, `recurring_failure_categories`. `__init__.py` is empty by
+convention (full-path imports), so no export edit.
+
+## Intentional
+
+- Additive only — zero change to existing review status strings or the
+  generated-assets API. Verified by not touching those files.
+- `RiskTier` kept separate from `quality_gate.RiskLevel` rather than reused, because one
+  is an editorial routing tier and the other a computed safety score; conflating them
+  would couple review burden to the safety sensor.
+- `REQUIRED_REVIEW_BY_TIER` is pure data (the table); the *enforcement/routing* that
+  consumes it is slice 2.
+
+## Deferred
+
+- Wiring `ReviewDecision` into `api/generated_assets.py` status validation (slice 2).
+- Risk-tier routing / experiment-contract + triage schemas (slice 2).
+- Claims map (slice 3); Content-PR coverage matrix + comment/evidence types (slice 4);
+  calibration library + adversarial pass (slice 5).
+- Multi-model disagreement orchestration (parked, out of scope per the doc).
+
+## Verification
+
+- pytest `tests/test_extracted_content_review_contract.py` (16 tests)
+- `scripts/check_ascii_python.sh` (run via bash) -- ASCII gate
+- `scripts/check_extracted_imports.py` (run via python3) -- import structure
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` + `scripts/audit_extracted_standalone.py` (--fail-on-debt) -- both clean
+- import-sanity: `python3 -c "import extracted_content_pipeline.review_contract as m"`
+
+## Estimated diff size
+
+~150 LOC module + ~150 LOC tests + this plan. Well under the 400 LOC soft cap.

--- a/plans/PR-Content-Ops-Review-Vocabulary.md
+++ b/plans/PR-Content-Ops-Review-Vocabulary.md
@@ -1,7 +1,7 @@
 # PR — Content-Ops Review Vocabulary (operating-model slice 1)
 
 Ownership lane: content-ops/review-contract
-Slice phase: Content operating model - slice 1 (review vocabulary)
+Slice phase: Vertical slice
 
 ## Why this slice exists
 

--- a/plans/PR-Content-Ops-Review-Vocabulary.md
+++ b/plans/PR-Content-Ops-Review-Vocabulary.md
@@ -12,7 +12,11 @@ It is deliberately enum/value-scale and changes no existing behavior. The existi
 generated-asset review API keeps its host-extensible string statuses untouched; wiring
 this vocabulary into validation/routing is slice 2.
 
-## Scope
+Diff total is marginally over the 400-LOC soft cap (~412). The overage is scaffolding,
+not scope: the module is ~190 LOC (largely docstrings), and the rest is the plan doc's
+own machine-generated tables plus thorough unit tests. The shippable surface stays tiny.
+
+## Scope (this PR)
 
 New owned module `extracted_content_pipeline/review_contract.py` (flat-module
 convention, per `brand_voice.py`) plus unit tests. It provides:
@@ -31,6 +35,15 @@ convention, per `brand_voice.py`) plus unit tests. It provides:
   + `is_active(as_of)`.
 - `recurring_failure_categories(categories, *, threshold=3)` — the flywheel
   "3+ same-reason misses -> candidate for a new gate" helper.
+
+
+### Files touched
+
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/review_contract.py`
+- `plans/PR-Content-Ops-Review-Vocabulary.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_content_review_contract.py`
 
 ## Mechanism
 
@@ -60,7 +73,7 @@ convention (full-path imports), so no export edit.
 
 ## Verification
 
-- pytest `tests/test_extracted_content_review_contract.py` (16 tests)
+- pytest `tests/test_extracted_content_review_contract.py` (17 tests)
 - `scripts/check_ascii_python.sh` (run via bash) -- ASCII gate
 - `scripts/check_extracted_imports.py` (run via python3) -- import structure
 - `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` + `scripts/audit_extracted_standalone.py` (--fail-on-debt) -- both clean
@@ -68,4 +81,11 @@ convention (full-path imports), so no export edit.
 
 ## Estimated diff size
 
-~150 LOC module + ~150 LOC tests + this plan. Well under the 400 LOC soft cap.
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/review_contract.py` | 190 |
+| `plans/PR-Content-Ops-Review-Vocabulary.md` | 91 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_content_review_contract.py` | 131 |
+| **Total** | **416** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -16,6 +16,7 @@ pytest \
   tests/test_extracted_campaign_analytics.py \
   tests/test_extracted_campaign_install_check.py \
   tests/test_extracted_content_host_smoke.py \
+  tests/test_extracted_content_review_contract.py \
   tests/test_extracted_campaign_visibility.py \
   tests/test_extracted_campaign_visibility_reader_cli.py \
   tests/test_extracted_campaign_manifest.py \

--- a/tests/test_extracted_content_review_contract.py
+++ b/tests/test_extracted_content_review_contract.py
@@ -1,0 +1,124 @@
+"""Unit tests for the content-ops review vocabulary (slice 1).
+
+Pure value types + helpers; no DB, no async, no Atlas imports.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from extracted_content_pipeline.review_contract import (
+    REQUIRED_REVIEW_BY_TIER,
+    ExceptionRecord,
+    FailureCategory,
+    GateStage,
+    ReviewDecision,
+    RiskTier,
+    recurring_failure_categories,
+    required_stages_for,
+)
+
+
+def test_enums_are_str_valued() -> None:
+    # StrEnum members compare equal to their string value (host-extensible
+    # string statuses can interoperate without casting).
+    assert RiskTier.LOW == "low"
+    assert ReviewDecision.APPROVED_WITH_EXCEPTION == "approved_with_exception"
+    assert FailureCategory.UNCLEAR_PROMISE == "unclear_promise"
+    assert GateStage.CLAIMS_COMPLIANCE == "claims_compliance"
+
+
+def test_failure_taxonomy_is_the_documented_fifteen() -> None:
+    assert len(list(FailureCategory)) == 15
+
+
+def test_gate_stack_is_the_four_part_split() -> None:
+    assert [s.value for s in GateStage] == [
+        "schema",
+        "claims_compliance",
+        "model_assisted",
+        "human_editor",
+    ]
+
+
+def test_review_decision_includes_exception_and_escalation() -> None:
+    values = {d.value for d in ReviewDecision}
+    assert {"approved_with_exception", "escalated", "blocked"} <= values
+
+
+@pytest.mark.parametrize("tier", list(RiskTier))
+def test_every_tier_routes_through_schema_and_human_editor(tier: RiskTier) -> None:
+    stages = required_stages_for(tier)
+    # Every tier must start at schema and end at an accountable human decision.
+    assert stages[0] is GateStage.SCHEMA
+    assert stages[-1] is GateStage.HUMAN_EDITOR
+    # No duplicate stages, and the mapping is complete.
+    assert len(stages) == len(set(stages))
+    assert tier in REQUIRED_REVIEW_BY_TIER
+
+
+def test_low_tier_skips_claims_compliance_but_others_require_it() -> None:
+    assert GateStage.CLAIMS_COMPLIANCE not in required_stages_for(RiskTier.LOW)
+    for tier in (RiskTier.MEDIUM, RiskTier.HIGH, RiskTier.CRITICAL):
+        assert GateStage.CLAIMS_COMPLIANCE in required_stages_for(tier)
+
+
+def test_exception_record_without_expiration_never_lapses() -> None:
+    rec = ExceptionRecord(
+        rule="VOICE-02",
+        reason="approved launch language for this campaign",
+        owner="editor@example.com",
+    )
+    assert rec.is_active(date(2999, 1, 1)) is True
+    assert rec.should_update_rule is False
+
+
+def test_exception_record_expiration_is_inclusive() -> None:
+    rec = ExceptionRecord(
+        rule="CLAIM-03",
+        reason="temporary Q4 pricing waiver",
+        owner="legal@example.com",
+        expiration=date(2026, 1, 15),
+    )
+    assert rec.is_active(date(2026, 1, 15)) is True   # inclusive of the day
+    assert rec.is_active(date(2026, 1, 14)) is True
+    assert rec.is_active(date(2026, 1, 16)) is False
+
+
+def test_exception_record_is_frozen() -> None:
+    rec = ExceptionRecord(rule="R", reason="x", owner="o")
+    with pytest.raises(Exception):
+        rec.rule = "other"  # type: ignore[misc]
+
+
+def test_recurring_failures_flags_at_threshold() -> None:
+    cats = [
+        FailureCategory.UNCLEAR_PROMISE,
+        FailureCategory.UNCLEAR_PROMISE,
+        FailureCategory.UNCLEAR_PROMISE,
+        FailureCategory.CTA_FRICTION,
+        FailureCategory.CTA_FRICTION,
+        FailureCategory.WEAK_HOOK,
+    ]
+    # Default threshold of 3: only unclear_promise qualifies.
+    assert recurring_failure_categories(cats) == frozenset(
+        {FailureCategory.UNCLEAR_PROMISE}
+    )
+
+
+def test_recurring_failures_respects_custom_threshold() -> None:
+    cats = [FailureCategory.CTA_FRICTION, FailureCategory.CTA_FRICTION]
+    assert recurring_failure_categories(cats, threshold=2) == frozenset(
+        {FailureCategory.CTA_FRICTION}
+    )
+
+
+def test_recurring_failures_empty_input_is_empty() -> None:
+    assert recurring_failure_categories([]) == frozenset()
+
+
+def test_recurring_failures_rejects_nonpositive_threshold() -> None:
+    with pytest.raises(ValueError):
+        recurring_failure_categories([FailureCategory.TIMING], threshold=0)

--- a/tests/test_extracted_content_review_contract.py
+++ b/tests/test_extracted_content_review_contract.py
@@ -5,6 +5,7 @@ Pure value types + helpers; no DB, no async, no Atlas imports.
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from datetime import date
 
 import pytest
@@ -89,8 +90,14 @@ def test_exception_record_expiration_is_inclusive() -> None:
 
 def test_exception_record_is_frozen() -> None:
     rec = ExceptionRecord(rule="R", reason="x", owner="o")
-    with pytest.raises(Exception):
+    with pytest.raises(FrozenInstanceError):
         rec.rule = "other"  # type: ignore[misc]
+
+
+def test_required_review_table_is_immutable() -> None:
+    # MappingProxyType rejects mutation so routing data can't be corrupted.
+    with pytest.raises(TypeError):
+        REQUIRED_REVIEW_BY_TIER[RiskTier.LOW] = ()  # type: ignore[index]
 
 
 def test_recurring_failures_flags_at_threshold() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Vocabulary.md

Ownership lane: content-ops/review-contract
Slice phase: Vertical slice

First code slice of the content operating model (`docs/content_ops_operating_model.md` → "Building this: staged" → **slice 1: free reframes + cheap enums**). Lands the typed review vocabulary every later slice consumes, before any behavior change.

## Why this slice exists
The expensive slices (claims map, Content-PR coverage matrix) should plug into shared names instead of inventing their own. This is the enum/value-scale foundation, deliberately additive and behavior-neutral.

## Scope (this PR)
New owned module `extracted_content_pipeline/review_contract.py` (flat-module convention, per `brand_voice.py`) + unit tests. Pure value types and pure functions — no I/O, no Atlas imports, no DB, no LLM:

- `RiskTier` — editorial review-burden tier set on the brief. **Distinct from** `extracted_quality_gate.RiskLevel` (a *computed* safety score); same member names, different domain, values differ in case — cross-referenced in the docstring so they aren't conflated.
- `ReviewDecision` — BLOCKED / REVISION_REQUIRED / APPROVED / APPROVED_WITH_EXCEPTION / ESCALATED.
- `FailureCategory` — the 15-category post-publish verdict taxonomy.
- `GateStage` — the four-part split: SCHEMA (3A) / CLAIMS_COMPLIANCE (3B) / MODEL_ASSISTED (3C) / HUMAN_EDITOR (3D).
- `REQUIRED_REVIEW_BY_TIER` (frozen `MappingProxyType`) + `required_stages_for()` — the risk-tier table as pure routing data.
- `ExceptionRecord` + `is_active()` — audited approve-with-exception entry.
- `recurring_failure_categories()` — the "3+ same-reason misses → candidate new gate" flywheel trigger.

## Intentional
- **Additive only.** The generated-asset review API keeps its host-extensible string statuses untouched (those files are not in the diff).
- `RiskTier` kept separate from `RiskLevel` on purpose (editorial routing vs computed safety score).
- `REQUIRED_REVIEW_BY_TIER` is data; the routing/enforcement that consumes it is slice 2. HIGH/CRITICAL share the stage set today — their extra burden (compliance sign-off, postmortem, experiment contract) is expressed by later slices, not by adding gate stages here.

## Deferred
- Wiring `ReviewDecision` into `api/generated_assets.py` validation + risk-tier routing + triage/experiment-contract schemas (slice 2); claims map (slice 3); Content-PR coverage matrix + comment/evidence types (slice 4); calibration library + adversarial pass (slice 5). Multi-model disagreement orchestration stays parked.

## Verification
- pytest `tests/test_extracted_content_review_contract.py` — 17 passed
- `scripts/check_ascii_python.sh` — clean
- `scripts/check_extracted_imports.py` — 128 modules OK
- `forbid_atlas_reasoning_imports.py` clean; `audit_extracted_standalone.py --fail-on-debt` → 0 Atlas-runtime findings
- `audit_plan_code_consistency.py` + `audit_pr_session_drift.py` on the plan → pass

## Estimated diff size
~150 LOC module + ~150 LOC tests + plan (~419 total; the marginal overage is plan-doc scaffolding, justified in the plan).

https://claude.ai/code/session_01QgqhC2NoKQHzV3xDFchNRN