### PR TITLE
Content-ops triage + experiment contract (operating-model slice 2)

### DIFF
--- a/extracted_content_pipeline/review_contract.py
+++ b/extracted_content_pipeline/review_contract.py
@@ -188,3 +188,119 @@ def recurring_failure_categories(
     return frozenset(
         category for category, count in counts.items() if count >= threshold
     )
+
+
+# --------------------------------------------------------------------------
+# Slice 2: stage-0 triage + stage-7 experiment contract.
+# Additive schemas; the routing that *requires* them is a later slice.
+# --------------------------------------------------------------------------
+
+
+class TriageDecision(StrEnum):
+    """Stage-0 verdict: should this asset exist at all?
+
+    The gate that keeps the pipeline from becoming an efficient machine for
+    producing polished landfill. ``CLONE_WINNER`` reuses an existing proven
+    asset instead of creating net-new.
+    """
+
+    CREATE = "create"
+    CLONE_WINNER = "clone_winner"
+    DEFER = "defer"
+    REJECT = "reject"
+
+
+# Required stage-0 text inputs, in declaration order. opportunity_size and
+# reuse_potential are optional context, not completeness-gating.
+_TRIAGE_REQUIRED_TEXT = (
+    "audience_segment",
+    "lifecycle_stage",
+    "business_goal",
+    "expected_behavior_change",
+    "channel",
+    "why_now",
+)
+
+
+@dataclass(frozen=True)
+class TriageRequest:
+    """Stage-0 triage inputs (what a triage decision is made from).
+
+    Completeness only: ``missing_fields`` reports blank required inputs so a
+    triage can't be waved through empty. It does not judge whether the asset is
+    *worth* making -- that is the human ``TriageDecision``.
+    """
+
+    audience_segment: str = ""
+    lifecycle_stage: str = ""
+    business_goal: str = ""
+    expected_behavior_change: str = ""
+    channel: str = ""
+    why_now: str = ""
+    opportunity_size: str = ""  # optional context
+    reuse_potential: str = ""  # optional context
+    risk_tier: RiskTier | None = None
+
+    def missing_fields(self) -> tuple[str, ...]:
+        missing = [
+            name
+            for name in _TRIAGE_REQUIRED_TEXT
+            if not getattr(self, name).strip()
+        ]
+        if self.risk_tier is None:
+            missing.append("risk_tier")
+        return tuple(missing)
+
+    def is_complete(self) -> bool:
+        return not self.missing_fields()
+
+
+# Required stage-7 text fields, in declaration order. secondary_metric is
+# optional; the two numeric fields are checked separately (must be > 0).
+_EXPERIMENT_REQUIRED_TEXT = (
+    "hypothesis",
+    "primary_metric",
+    "audience",
+    "comparison",
+    "success_definition",
+    "inconclusive_definition",
+    "decision_if_works",
+    "decision_if_not",
+)
+
+
+@dataclass(frozen=True)
+class ExperimentContract:
+    """Stage-7 measurement plan, frozen *before* publish.
+
+    Defining this up front is what keeps the verdict ledger from rotting into
+    "the graph went up and nobody wants to argue." Completeness only: it checks
+    the plan is filled, not that the hypothesis is sound.
+    """
+
+    hypothesis: str = ""
+    primary_metric: str = ""
+    audience: str = ""
+    comparison: str = ""  # control or baseline being compared against
+    success_definition: str = ""  # what counts as "worked"
+    inconclusive_definition: str = ""  # what counts as "inconclusive"
+    decision_if_works: str = ""
+    decision_if_not: str = ""
+    attribution_window_days: int = 0
+    min_sample_size: int = 0
+    secondary_metric: str = ""  # optional
+
+    def missing_fields(self) -> tuple[str, ...]:
+        missing = [
+            name
+            for name in _EXPERIMENT_REQUIRED_TEXT
+            if not getattr(self, name).strip()
+        ]
+        if self.attribution_window_days <= 0:
+            missing.append("attribution_window_days")
+        if self.min_sample_size <= 0:
+            missing.append("min_sample_size")
+        return tuple(missing)
+
+    def is_complete(self) -> bool:
+        return not self.missing_fields()

--- a/extracted_content_pipeline/review_contract.py
+++ b/extracted_content_pipeline/review_contract.py
@@ -196,6 +196,18 @@ def recurring_failure_categories(
 # --------------------------------------------------------------------------
 
 
+def _missing_text(value: object) -> bool:
+    """True if a required text value should count as missing.
+
+    A value is present only if it is a non-empty, non-whitespace ``str``.
+    ``None`` or any non-``str`` (e.g. JSON ``null`` deserialized into the field)
+    counts as missing rather than raising ``AttributeError`` on ``.strip()`` --
+    these schemas are typed by convention, not enforced at runtime.
+    """
+
+    return not (isinstance(value, str) and value.strip())
+
+
 class TriageDecision(StrEnum):
     """Stage-0 verdict: should this asset exist at all?
 
@@ -245,9 +257,9 @@ class TriageRequest:
         missing = [
             name
             for name in _TRIAGE_REQUIRED_TEXT
-            if not getattr(self, name).strip()
+            if _missing_text(getattr(self, name))
         ]
-        if self.risk_tier is None:
+        if not isinstance(self.risk_tier, RiskTier):
             missing.append("risk_tier")
         return tuple(missing)
 
@@ -256,10 +268,12 @@ class TriageRequest:
 
 
 # Required stage-7 text fields, in declaration order. secondary_metric is
-# optional; the two numeric fields are checked separately (must be > 0).
+# required per docs/content_ops_operating_model.md (stage 7 "Required fields");
+# the two numeric fields are checked separately (must be > 0).
 _EXPERIMENT_REQUIRED_TEXT = (
     "hypothesis",
     "primary_metric",
+    "secondary_metric",
     "audience",
     "comparison",
     "success_definition",
@@ -275,11 +289,13 @@ class ExperimentContract:
 
     Defining this up front is what keeps the verdict ledger from rotting into
     "the graph went up and nobody wants to argue." Completeness only: it checks
-    the plan is filled, not that the hypothesis is sound.
+    the plan is filled, not that the hypothesis is sound. The required field set
+    mirrors stage 7 in ``docs/content_ops_operating_model.md``.
     """
 
     hypothesis: str = ""
     primary_metric: str = ""
+    secondary_metric: str = ""  # required (a guardrail metric, per the doc)
     audience: str = ""
     comparison: str = ""  # control or baseline being compared against
     success_definition: str = ""  # what counts as "worked"
@@ -288,13 +304,12 @@ class ExperimentContract:
     decision_if_not: str = ""
     attribution_window_days: int = 0
     min_sample_size: int = 0
-    secondary_metric: str = ""  # optional
 
     def missing_fields(self) -> tuple[str, ...]:
         missing = [
             name
             for name in _EXPERIMENT_REQUIRED_TEXT
-            if not getattr(self, name).strip()
+            if _missing_text(getattr(self, name))
         ]
         if self.attribution_window_days <= 0:
             missing.append("attribution_window_days")

--- a/extracted_content_pipeline/review_contract.py
+++ b/extracted_content_pipeline/review_contract.py
@@ -208,6 +208,17 @@ def _missing_text(value: object) -> bool:
     return not (isinstance(value, str) and value.strip())
 
 
+def _missing_positive_int(value: object) -> bool:
+    """True if a required positive-int value should count as missing.
+
+    Present only if it is a real ``int`` (not ``bool``) greater than zero.
+    ``None`` or any non-int counts as missing rather than raising ``TypeError``
+    on the ``> 0`` comparison -- same robustness contract as ``_missing_text``.
+    """
+
+    return not (isinstance(value, int) and not isinstance(value, bool) and value > 0)
+
+
 class TriageDecision(StrEnum):
     """Stage-0 verdict: should this asset exist at all?
 
@@ -311,9 +322,9 @@ class ExperimentContract:
             for name in _EXPERIMENT_REQUIRED_TEXT
             if _missing_text(getattr(self, name))
         ]
-        if self.attribution_window_days <= 0:
+        if _missing_positive_int(self.attribution_window_days):
             missing.append("attribution_window_days")
-        if self.min_sample_size <= 0:
+        if _missing_positive_int(self.min_sample_size):
             missing.append("min_sample_size")
         return tuple(missing)
 

--- a/plans/PR-Content-Ops-Triage-Experiment.md
+++ b/plans/PR-Content-Ops-Triage-Experiment.md
@@ -27,13 +27,13 @@ imports, no DB, no LLM:
   that keeps the pipeline from efficiently producing landfill).
 - `TriageRequest` (frozen dataclass) — the stage-0 inputs: audience_segment,
   lifecycle_stage, business_goal, expected_behavior_change, channel, opportunity_size,
-  reuse_potential, `risk_tier` (slice 1 `RiskTier`), why_now. `missing_fields()` /
-  `is_complete()` so triage can't be waved through blank.
+  reuse_potential, `risk_tier` (slice 1 `RiskTier`), why_now. `missing_fields` /
+  `is_complete` so triage can't be waved through blank.
 - `ExperimentContract` (frozen dataclass) — the stage-7 measurement plan: hypothesis,
   primary_metric, secondary_metric, attribution_window_days, audience, comparison,
   min_sample_size, success_definition, inconclusive_definition, decision_if_works,
-  decision_if_not (required set mirrors the doc's stage-7 list). `missing_fields()` /
-  `is_complete()` so a piece can't publish against an empty plan; completeness treats
+  decision_if_not (required set mirrors the doc's stage-7 list). `missing_fields` /
+  `is_complete` so a piece can't publish against an empty plan; completeness treats
   `None`/non-`str` as missing rather than raising.
 
 
@@ -47,8 +47,8 @@ imports, no DB, no LLM:
 ## Mechanism
 
 Frozen dataclasses + pure validation helpers, same conventions as slice 1 (`StrEnum` with
-the Python-3.10 fallback already imported in the module). `missing_fields()` returns the
-empty required-field names in declaration order; `is_complete()` is `not missing_fields()`.
+the Python-3.10 fallback already imported in the module). `missing_fields` returns the
+empty required-field names in declaration order; `is_complete` is `not missing_fields()`.
 `TriageRequest.risk_tier` reuses `RiskTier` so triage and the later risk-tier routing
 table speak the same vocabulary. No existing code path changes.
 
@@ -81,8 +81,8 @@ table speak the same vocabulary. No existing code path changes.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/review_contract.py` | 131 |
+| `extracted_content_pipeline/review_contract.py` | 142 |
 | `plans/PR-Content-Ops-Triage-Experiment.md` | 88 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_extracted_content_triage_experiment.py` | 236 |
-| **Total** | **456** |
+| `tests/test_extracted_content_triage_experiment.py` | 276 |
+| **Total** | **507** |

--- a/plans/PR-Content-Ops-Triage-Experiment.md
+++ b/plans/PR-Content-Ops-Triage-Experiment.md
@@ -9,6 +9,11 @@ experiment contract** (the measurement plan frozen *before* publish). Like slice
 are additive, behavior-neutral schemas that consume slice 1's vocabulary; the routing /
 enforcement that *requires* them is a later slice.
 
+Diff total runs slightly over the 400-LOC soft cap (see *Estimated diff size*). The excess
+is test surface, not product: the module itself is ~130 LOC, and the tests grew with review
+hardening (None/non-`str` completeness, the required-field set). The shippable surface
+stays small.
+
 ## Scope (this PR)
 
 Ownership lane: content-ops/review-contract
@@ -25,10 +30,11 @@ imports, no DB, no LLM:
   reuse_potential, `risk_tier` (slice 1 `RiskTier`), why_now. `missing_fields()` /
   `is_complete()` so triage can't be waved through blank.
 - `ExperimentContract` (frozen dataclass) — the stage-7 measurement plan: hypothesis,
-  primary_metric, optional secondary_metric, attribution_window_days, audience,
-  comparison, min_sample_size, success_definition, inconclusive_definition,
-  decision_if_works, decision_if_not. `missing_fields()` / `is_complete()` so a piece
-  can't publish against an empty plan.
+  primary_metric, secondary_metric, attribution_window_days, audience, comparison,
+  min_sample_size, success_definition, inconclusive_definition, decision_if_works,
+  decision_if_not (required set mirrors the doc's stage-7 list). `missing_fields()` /
+  `is_complete()` so a piece can't publish against an empty plan; completeness treats
+  `None`/non-`str` as missing rather than raising.
 
 
 ### Files touched
@@ -75,8 +81,8 @@ table speak the same vocabulary. No existing code path changes.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/review_contract.py` | 116 |
-| `plans/PR-Content-Ops-Triage-Experiment.md` | 82 |
+| `extracted_content_pipeline/review_contract.py` | 131 |
+| `plans/PR-Content-Ops-Triage-Experiment.md` | 88 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_extracted_content_triage_experiment.py` | 186 |
-| **Total** | **385** |
+| `tests/test_extracted_content_triage_experiment.py` | 236 |
+| **Total** | **456** |

--- a/plans/PR-Content-Ops-Triage-Experiment.md
+++ b/plans/PR-Content-Ops-Triage-Experiment.md
@@ -1,0 +1,82 @@
+# PR — Content-Ops Triage + Experiment Contract (operating-model slice 2)
+
+## Why this slice exists
+
+`docs/content_ops_operating_model.md` stages the build; this is **slice 2 — triage gate +
+experiment contract**. It adds the two lifecycle bookends the model hinges on but slice 1
+(vocabulary) did not provide: **stage 0 "should this exist?"** triage, and the **stage 7
+experiment contract** (the measurement plan frozen *before* publish). Like slice 1 these
+are additive, behavior-neutral schemas that consume slice 1's vocabulary; the routing /
+enforcement that *requires* them is a later slice.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+Extends the owned module `extracted_content_pipeline/review_contract.py` (no new file, no
+manifest change) plus unit tests. Pure value types + pure helpers; no I/O, no Atlas
+imports, no DB, no LLM:
+
+- `TriageDecision` (StrEnum) — CREATE / CLONE_WINNER / DEFER / REJECT (the stage-0 verdict
+  that keeps the pipeline from efficiently producing landfill).
+- `TriageRequest` (frozen dataclass) — the stage-0 inputs: audience_segment,
+  lifecycle_stage, business_goal, expected_behavior_change, channel, opportunity_size,
+  reuse_potential, `risk_tier` (slice 1 `RiskTier`), why_now. `missing_fields()` /
+  `is_complete()` so triage can't be waved through blank.
+- `ExperimentContract` (frozen dataclass) — the stage-7 measurement plan: hypothesis,
+  primary_metric, optional secondary_metric, attribution_window_days, audience,
+  comparison, min_sample_size, success_definition, inconclusive_definition,
+  decision_if_works, decision_if_not. `missing_fields()` / `is_complete()` so a piece
+  can't publish against an empty plan.
+
+
+### Files touched
+
+- `extracted_content_pipeline/review_contract.py`
+- `plans/PR-Content-Ops-Triage-Experiment.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_content_triage_experiment.py`
+
+## Mechanism
+
+Frozen dataclasses + pure validation helpers, same conventions as slice 1 (`StrEnum` with
+the Python-3.10 fallback already imported in the module). `missing_fields()` returns the
+empty required-field names in declaration order; `is_complete()` is `not missing_fields()`.
+`TriageRequest.risk_tier` reuses `RiskTier` so triage and the later risk-tier routing
+table speak the same vocabulary. No existing code path changes.
+
+## Intentional
+
+- Additive only — the generated-asset review API and existing flows are untouched.
+- Validation is *completeness*, not *quality*: these helpers check that required fields are
+  filled, not whether the hypothesis is good. Quality stays a human/market call per the doc.
+- `attribution_window_days` and `min_sample_size` are typed numbers with light bounds
+  (`> 0`); richer statistical validation is out of scope.
+
+## Deferred
+
+- Routing that *requires* a passing triage before drafting, and a frozen experiment
+  contract before publish (consumes these schemas) — later slice.
+- Wiring `ReviewDecision` into `api/generated_assets.py` + risk-tier routing table
+  enforcement — later slice.
+- Claims map (slice 3); Content-PR coverage matrix (slice 4); calibration library +
+  adversarial pass (slice 5). Multi-model disagreement orchestration stays parked.
+
+## Verification
+
+- pytest `tests/test_extracted_content_triage_experiment.py`
+- `scripts/check_ascii_python.sh` (run via bash) -- ASCII gate
+- `scripts/check_extracted_imports.py` (run via python3) -- import structure
+- `scripts/audit_extracted_pipeline_ci_enrollment.py` -- new test enrolled
+- `scripts/audit_pr_session_drift.py` + `scripts/sync_pr_plan.py` -- plan shape/drift
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/review_contract.py` | 116 |
+| `plans/PR-Content-Ops-Triage-Experiment.md` | 82 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_content_triage_experiment.py` | 186 |
+| **Total** | **385** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -17,6 +17,7 @@ pytest \
   tests/test_extracted_campaign_install_check.py \
   tests/test_extracted_content_host_smoke.py \
   tests/test_extracted_content_review_contract.py \
+  tests/test_extracted_content_triage_experiment.py \
   tests/test_extracted_campaign_visibility.py \
   tests/test_extracted_campaign_visibility_reader_cli.py \
   tests/test_extracted_campaign_manifest.py \

--- a/tests/test_extracted_content_triage_experiment.py
+++ b/tests/test_extracted_content_triage_experiment.py
@@ -33,6 +33,7 @@ def _complete_experiment() -> ExperimentContract:
     return ExperimentContract(
         hypothesis="a shorter subject lifts opens",
         primary_metric="open_rate",
+        secondary_metric="unsubscribe_rate",
         audience="trial users day 3",
         comparison="current subject line",
         success_definition="+3pp open rate",
@@ -115,6 +116,20 @@ def test_triage_request_is_frozen() -> None:
         req.channel = "other"  # type: ignore[misc]
 
 
+def test_triage_none_text_is_missing_not_error() -> None:
+    # A None field (e.g. from JSON null) must report missing, not raise.
+    req = TriageRequest(
+        audience_segment=None,  # type: ignore[arg-type]
+        lifecycle_stage="b",
+        business_goal="c",
+        expected_behavior_change="d",
+        channel="e",
+        why_now="f",
+        risk_tier=RiskTier.LOW,
+    )
+    assert req.missing_fields() == ("audience_segment",)
+
+
 def test_experiment_complete_contract_has_no_missing_fields() -> None:
     contract = _complete_experiment()
     assert contract.missing_fields() == ()
@@ -127,6 +142,7 @@ def test_experiment_empty_contract_lists_all_required() -> None:
     assert missing == (
         "hypothesis",
         "primary_metric",
+        "secondary_metric",
         "audience",
         "comparison",
         "success_definition",
@@ -139,10 +155,24 @@ def test_experiment_empty_contract_lists_all_required() -> None:
     assert contract.is_complete() is False
 
 
-def test_experiment_secondary_metric_is_optional() -> None:
+def test_experiment_secondary_metric_is_required() -> None:
+    # The canonical doc lists secondary_metric among the required stage-7 fields.
     contract = _complete_experiment()
-    assert contract.secondary_metric == ""
-    assert contract.is_complete() is True
+    without = ExperimentContract(
+        hypothesis=contract.hypothesis,
+        primary_metric=contract.primary_metric,
+        secondary_metric="",
+        audience=contract.audience,
+        comparison=contract.comparison,
+        success_definition=contract.success_definition,
+        inconclusive_definition=contract.inconclusive_definition,
+        decision_if_works=contract.decision_if_works,
+        decision_if_not=contract.decision_if_not,
+        attribution_window_days=contract.attribution_window_days,
+        min_sample_size=contract.min_sample_size,
+    )
+    assert without.missing_fields() == ("secondary_metric",)
+    assert without.is_complete() is False
 
 
 @pytest.mark.parametrize("window", [0, -1])
@@ -150,6 +180,7 @@ def test_experiment_nonpositive_window_is_missing(window: int) -> None:
     contract = ExperimentContract(
         hypothesis="h",
         primary_metric="m",
+        secondary_metric="m2",
         audience="a",
         comparison="c",
         success_definition="s",
@@ -168,6 +199,7 @@ def test_experiment_nonpositive_sample_size_is_missing() -> None:
     bad = ExperimentContract(
         hypothesis=contract.hypothesis,
         primary_metric=contract.primary_metric,
+        secondary_metric=contract.secondary_metric,
         audience=contract.audience,
         comparison=contract.comparison,
         success_definition=contract.success_definition,
@@ -178,6 +210,24 @@ def test_experiment_nonpositive_sample_size_is_missing() -> None:
         min_sample_size=0,
     )
     assert bad.missing_fields() == ("min_sample_size",)
+
+
+def test_experiment_none_text_is_missing_not_error() -> None:
+    contract = _complete_experiment()
+    holey = ExperimentContract(
+        hypothesis=None,  # type: ignore[arg-type]
+        primary_metric=contract.primary_metric,
+        secondary_metric=contract.secondary_metric,
+        audience=contract.audience,
+        comparison=contract.comparison,
+        success_definition=contract.success_definition,
+        inconclusive_definition=contract.inconclusive_definition,
+        decision_if_works=contract.decision_if_works,
+        decision_if_not=contract.decision_if_not,
+        attribution_window_days=contract.attribution_window_days,
+        min_sample_size=contract.min_sample_size,
+    )
+    assert holey.missing_fields() == ("hypothesis",)
 
 
 def test_experiment_contract_is_frozen() -> None:

--- a/tests/test_extracted_content_triage_experiment.py
+++ b/tests/test_extracted_content_triage_experiment.py
@@ -230,6 +230,46 @@ def test_experiment_none_text_is_missing_not_error() -> None:
     assert holey.missing_fields() == ("hypothesis",)
 
 
+def test_experiment_none_numeric_is_missing_not_error() -> None:
+    # None / non-int numeric fields report missing, not raise TypeError.
+    contract = _complete_experiment()
+    holey = ExperimentContract(
+        hypothesis=contract.hypothesis,
+        primary_metric=contract.primary_metric,
+        secondary_metric=contract.secondary_metric,
+        audience=contract.audience,
+        comparison=contract.comparison,
+        success_definition=contract.success_definition,
+        inconclusive_definition=contract.inconclusive_definition,
+        decision_if_works=contract.decision_if_works,
+        decision_if_not=contract.decision_if_not,
+        attribution_window_days=None,  # type: ignore[arg-type]
+        min_sample_size=None,  # type: ignore[arg-type]
+    )
+    missing = holey.missing_fields()
+    assert "attribution_window_days" in missing
+    assert "min_sample_size" in missing
+
+
+def test_experiment_bool_sample_size_is_missing() -> None:
+    # bool is an int subclass but is non-conforming for a count.
+    contract = _complete_experiment()
+    holey = ExperimentContract(
+        hypothesis=contract.hypothesis,
+        primary_metric=contract.primary_metric,
+        secondary_metric=contract.secondary_metric,
+        audience=contract.audience,
+        comparison=contract.comparison,
+        success_definition=contract.success_definition,
+        inconclusive_definition=contract.inconclusive_definition,
+        decision_if_works=contract.decision_if_works,
+        decision_if_not=contract.decision_if_not,
+        attribution_window_days=contract.attribution_window_days,
+        min_sample_size=True,  # type: ignore[arg-type]
+    )
+    assert "min_sample_size" in holey.missing_fields()
+
+
 def test_experiment_contract_is_frozen() -> None:
     contract = _complete_experiment()
     with pytest.raises(FrozenInstanceError):

--- a/tests/test_extracted_content_triage_experiment.py
+++ b/tests/test_extracted_content_triage_experiment.py
@@ -1,0 +1,186 @@
+"""Unit tests for slice 2: stage-0 triage + stage-7 experiment contract.
+
+Pure value types + completeness helpers; no DB, no async, no Atlas imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from extracted_content_pipeline.review_contract import (
+    ExperimentContract,
+    RiskTier,
+    TriageDecision,
+    TriageRequest,
+)
+
+
+def _complete_triage() -> TriageRequest:
+    return TriageRequest(
+        audience_segment="enterprise admins",
+        lifecycle_stage="onboarding",
+        business_goal="activation",
+        expected_behavior_change="complete first integration",
+        channel="lifecycle email",
+        why_now="new onboarding flow shipped",
+        risk_tier=RiskTier.MEDIUM,
+    )
+
+
+def _complete_experiment() -> ExperimentContract:
+    return ExperimentContract(
+        hypothesis="a shorter subject lifts opens",
+        primary_metric="open_rate",
+        audience="trial users day 3",
+        comparison="current subject line",
+        success_definition="+3pp open rate",
+        inconclusive_definition="<1pp difference",
+        decision_if_works="roll out to all trials",
+        decision_if_not="revert",
+        attribution_window_days=7,
+        min_sample_size=500,
+    )
+
+
+def test_triage_decision_values() -> None:
+    assert {d.value for d in TriageDecision} == {
+        "create",
+        "clone_winner",
+        "defer",
+        "reject",
+    }
+    assert TriageDecision.CLONE_WINNER == "clone_winner"
+
+
+def test_triage_complete_request_has_no_missing_fields() -> None:
+    req = _complete_triage()
+    assert req.missing_fields() == ()
+    assert req.is_complete() is True
+
+
+def test_triage_empty_request_lists_required_fields_in_order() -> None:
+    req = TriageRequest()
+    assert req.missing_fields() == (
+        "audience_segment",
+        "lifecycle_stage",
+        "business_goal",
+        "expected_behavior_change",
+        "channel",
+        "why_now",
+        "risk_tier",
+    )
+    assert req.is_complete() is False
+
+
+def test_triage_optional_context_does_not_gate_completeness() -> None:
+    # opportunity_size / reuse_potential blank but everything required present.
+    req = _complete_triage()
+    assert req.opportunity_size == ""
+    assert req.reuse_potential == ""
+    assert req.is_complete() is True
+
+
+def test_triage_whitespace_counts_as_missing() -> None:
+    req = _complete_triage()
+    holey = TriageRequest(
+        audience_segment="   ",
+        lifecycle_stage=req.lifecycle_stage,
+        business_goal=req.business_goal,
+        expected_behavior_change=req.expected_behavior_change,
+        channel=req.channel,
+        why_now=req.why_now,
+        risk_tier=req.risk_tier,
+    )
+    assert "audience_segment" in holey.missing_fields()
+
+
+def test_triage_missing_risk_tier_is_flagged() -> None:
+    req = TriageRequest(
+        audience_segment="a",
+        lifecycle_stage="b",
+        business_goal="c",
+        expected_behavior_change="d",
+        channel="e",
+        why_now="f",
+        risk_tier=None,
+    )
+    assert req.missing_fields() == ("risk_tier",)
+
+
+def test_triage_request_is_frozen() -> None:
+    req = _complete_triage()
+    with pytest.raises(FrozenInstanceError):
+        req.channel = "other"  # type: ignore[misc]
+
+
+def test_experiment_complete_contract_has_no_missing_fields() -> None:
+    contract = _complete_experiment()
+    assert contract.missing_fields() == ()
+    assert contract.is_complete() is True
+
+
+def test_experiment_empty_contract_lists_all_required() -> None:
+    contract = ExperimentContract()
+    missing = contract.missing_fields()
+    assert missing == (
+        "hypothesis",
+        "primary_metric",
+        "audience",
+        "comparison",
+        "success_definition",
+        "inconclusive_definition",
+        "decision_if_works",
+        "decision_if_not",
+        "attribution_window_days",
+        "min_sample_size",
+    )
+    assert contract.is_complete() is False
+
+
+def test_experiment_secondary_metric_is_optional() -> None:
+    contract = _complete_experiment()
+    assert contract.secondary_metric == ""
+    assert contract.is_complete() is True
+
+
+@pytest.mark.parametrize("window", [0, -1])
+def test_experiment_nonpositive_window_is_missing(window: int) -> None:
+    contract = ExperimentContract(
+        hypothesis="h",
+        primary_metric="m",
+        audience="a",
+        comparison="c",
+        success_definition="s",
+        inconclusive_definition="i",
+        decision_if_works="w",
+        decision_if_not="n",
+        attribution_window_days=window,
+        min_sample_size=100,
+    )
+    assert "attribution_window_days" in contract.missing_fields()
+    assert "min_sample_size" not in contract.missing_fields()
+
+
+def test_experiment_nonpositive_sample_size_is_missing() -> None:
+    contract = _complete_experiment()
+    bad = ExperimentContract(
+        hypothesis=contract.hypothesis,
+        primary_metric=contract.primary_metric,
+        audience=contract.audience,
+        comparison=contract.comparison,
+        success_definition=contract.success_definition,
+        inconclusive_definition=contract.inconclusive_definition,
+        decision_if_works=contract.decision_if_works,
+        decision_if_not=contract.decision_if_not,
+        attribution_window_days=contract.attribution_window_days,
+        min_sample_size=0,
+    )
+    assert bad.missing_fields() == ("min_sample_size",)
+
+
+def test_experiment_contract_is_frozen() -> None:
+    contract = _complete_experiment()
+    with pytest.raises(FrozenInstanceError):
+        contract.primary_metric = "other"  # type: ignore[misc]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Triage-Experiment.md

Ownership lane: content-ops/review-contract
Slice phase: Vertical slice

Slice 2 of the content operating model (`docs/content_ops_operating_model.md` → "Building this: staged" → **triage gate + experiment contract**). Adds the two lifecycle bookends slice 1 (vocabulary, #1329) did not provide.

## Why this slice exists
Stage 0 ("should this exist?") and stage 7 (the measurement plan frozen *before* publish) are where the model earns its keep — but they're schemas, not behavior. Landing them additively (same pattern as slice 1) lets later slices wire routing against stable names.

## Scope (this PR)
Extends the owned module `extracted_content_pipeline/review_contract.py` (no new file, no manifest change) + tests. Pure value types + pure helpers; no I/O, no Atlas imports, no DB, no LLM:

- `TriageDecision` — CREATE / CLONE_WINNER / DEFER / REJECT.
- `TriageRequest` — stage-0 inputs (audience, lifecycle stage, goal, expected behavior change, channel, why-now, + optional opportunity/reuse context, + slice-1 `RiskTier`) with a completeness check.
- `ExperimentContract` — stage-7 plan (hypothesis, primary metric, **secondary metric**, attribution window, audience, comparison, min sample size, success/inconclusive definitions, decision-if-works/not) with a completeness check. Required set mirrors the doc's stage-7 list.

## Intentional
- **Additive only** — the generated-asset review API and existing flows are untouched.
- Validation is **completeness, not quality** — checks required fields are filled, not whether the hypothesis is good (that stays a human/market call per the doc).
- Completeness is **robust to bad input**: `None` / non-`str` text and `None` / non-int (or `bool`) numerics report as *missing* rather than raising, so callers can build these from decoded/untrusted input safely.
- `TriageRequest.risk_tier` reuses `RiskTier` so triage and the later routing table share one vocabulary.

## Deferred
- Routing that *requires* a passing triage before drafting / a frozen experiment contract before publish (consumes these) — later slice.
- Wiring `ReviewDecision` into `api/generated_assets.py` + risk-tier routing enforcement — later slice.
- Claims map (slice 3); Content-PR coverage matrix (slice 4); calibration library + adversarial pass (slice 5). Multi-model disagreement orchestration stays parked.

## Verification
- pytest `tests/test_extracted_content_triage_experiment.py` (35 total in the review-contract suite, slice-1 regression included)
- `scripts/check_ascii_python.sh` — clean
- `scripts/check_extracted_imports.py` — 128 modules OK
- `scripts/audit_extracted_pipeline_ci_enrollment.py` — new test enrolled
- `scripts/audit_extracted_standalone.py --fail-on-debt` — 0 Atlas-runtime findings
- `scripts/audit_pr_session_drift.py` + `sync_pr_plan.py` + `audit_plan_code_consistency.py` — pass

## Estimated diff size
Over the 400-LOC soft cap — see the plan's **Estimated diff size** table for the per-file breakdown. The overage is test surface (review hardening: None/non-str/non-int completeness + the required-field set), not added product surface; the module itself is ~145 LOC. Justified in the plan's *Why this slice exists*.

https://claude.ai/code/session_01QgqhC2NoKQHzV3xDFchNRN