### PR TITLE
Content-ops claims map (operating-model slice 3)

### DIFF
--- a/extracted_content_pipeline/claims_map.py
+++ b/extracted_content_pipeline/claims_map.py
@@ -73,7 +73,7 @@ class ExtractedClaim:
     registry entry). Producing these from prose is the deferred LLM step.
     """
 
-    text: str
+    text: str | None
     location: str = ""
     registry_id: str | None = None
 
@@ -82,7 +82,7 @@ class ExtractedClaim:
 class MappedClaim:
     """A claims-map row: an extracted claim resolved against the registry."""
 
-    text: str
+    text: str | None
     location: str
     registry_id: str | None
     approved_wording: str | None
@@ -100,10 +100,13 @@ def map_claim(
 
     entry = registry.get(claim.registry_id) if claim.registry_id else None
     if entry is None:
+        # Preserve the extractor's candidate id (None if it had none, or the
+        # stale/typo'd id if it pointed at a missing registry entry) so a
+        # reviewer can tell "no candidate" apart from "bad candidate".
         return MappedClaim(
             text=claim.text,
             location=claim.location,
-            registry_id=None,
+            registry_id=claim.registry_id,
             approved_wording=None,
             status=ClaimStatus.UNREGISTERED,
         )

--- a/extracted_content_pipeline/claims_map.py
+++ b/extracted_content_pipeline/claims_map.py
@@ -1,0 +1,152 @@
+"""Content-ops claims map (operating-model slice 3).
+
+The deterministic core of the stage-3B claims/compliance gate from
+``docs/content_ops_operating_model.md``: map each claim a draft makes onto the
+messaging registry and status-check it, so a draft can't ship wording that
+conflicts with (or outlives) the approved claim. Pure value types + pure
+functions -- no I/O, no Atlas imports, no DB, no LLM.
+
+The part that *requires* an LLM -- extracting claims from prose into
+``ExtractedClaim`` rows -- is a later slice; this module takes already-extracted
+claims and decides their status against a registry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable, Mapping
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - Python 3.10 CI compatibility
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
+
+from .review_contract import RiskTier
+
+
+class ClaimStatus(StrEnum):
+    """Status of one mapped claim against the messaging registry."""
+
+    MATCH = "match"  # wording matches the approved registry wording
+    MISMATCH = "mismatch"  # references a registry entry but the wording differs
+    UNREGISTERED = "unregistered"  # no known registry entry -- needs human review
+    EXPIRED = "expired"  # matched an entry whose approved wording has lapsed
+
+
+def _normalize(value: object) -> str:
+    """Casefold + collapse whitespace for wording comparison.
+
+    Non-``str`` (e.g. ``None`` from JSON null) normalizes to ``""`` rather than
+    raising, so callers can build these from decoded/untrusted input.
+    """
+
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split()).casefold()
+
+
+@dataclass(frozen=True)
+class RegistryClaim:
+    """An entry in the messaging/claim registry (the source of truth)."""
+
+    id: str
+    approved_wording: str
+    risk_tier: RiskTier | None = None
+    expiration: date | None = None
+
+    def is_expired(self, as_of: date) -> bool:
+        """True if the approved wording has lapsed on ``as_of`` (exclusive of the
+        expiration day -- the day itself is still valid)."""
+
+        return self.expiration is not None and as_of > self.expiration
+
+
+@dataclass(frozen=True)
+class ExtractedClaim:
+    """One claim as an extractor would emit it.
+
+    ``registry_id`` is the extractor's candidate match (``None`` if it found no
+    registry entry). Producing these from prose is the deferred LLM step.
+    """
+
+    text: str
+    location: str = ""
+    registry_id: str | None = None
+
+
+@dataclass(frozen=True)
+class MappedClaim:
+    """A claims-map row: an extracted claim resolved against the registry."""
+
+    text: str
+    location: str
+    registry_id: str | None
+    approved_wording: str | None
+    status: ClaimStatus
+    risk_tier: RiskTier | None = None
+
+
+def map_claim(
+    claim: ExtractedClaim,
+    registry: Mapping[str, RegistryClaim],
+    *,
+    as_of: date,
+) -> MappedClaim:
+    """Resolve one ``ExtractedClaim`` against ``registry`` as of ``as_of``."""
+
+    entry = registry.get(claim.registry_id) if claim.registry_id else None
+    if entry is None:
+        return MappedClaim(
+            text=claim.text,
+            location=claim.location,
+            registry_id=None,
+            approved_wording=None,
+            status=ClaimStatus.UNREGISTERED,
+        )
+    if entry.is_expired(as_of):
+        status = ClaimStatus.EXPIRED
+    elif _normalize(claim.text) == _normalize(entry.approved_wording):
+        status = ClaimStatus.MATCH
+    else:
+        status = ClaimStatus.MISMATCH
+    return MappedClaim(
+        text=claim.text,
+        location=claim.location,
+        registry_id=entry.id,
+        approved_wording=entry.approved_wording,
+        status=status,
+        risk_tier=entry.risk_tier,
+    )
+
+
+def build_claims_map(
+    claims: Iterable[ExtractedClaim],
+    registry: Mapping[str, RegistryClaim],
+    *,
+    as_of: date,
+) -> tuple[MappedClaim, ...]:
+    """Map every extracted claim, preserving input order."""
+
+    return tuple(map_claim(claim, registry, as_of=as_of) for claim in claims)
+
+
+# Statuses that should stop a draft at the claims gate. UNREGISTERED is
+# deliberately excluded -- an unknown claim is a human-review signal, not an
+# automatic block (per the doc's routing).
+_BLOCKING_STATUSES = frozenset({ClaimStatus.MISMATCH, ClaimStatus.EXPIRED})
+
+
+def blocking_claims(mapped: Iterable[MappedClaim]) -> tuple[MappedClaim, ...]:
+    """The mapped claims whose status blocks publish (MISMATCH or EXPIRED)."""
+
+    return tuple(m for m in mapped if m.status in _BLOCKING_STATUSES)
+
+
+def is_clear(mapped: Iterable[MappedClaim]) -> bool:
+    """True if no mapped claim blocks (no MISMATCH/EXPIRED)."""
+
+    return not blocking_claims(mapped)

--- a/extracted_content_pipeline/claims_map.py
+++ b/extracted_content_pipeline/claims_map.py
@@ -150,6 +150,10 @@ def blocking_claims(mapped: Iterable[MappedClaim]) -> tuple[MappedClaim, ...]:
 
 
 def is_clear(mapped: Iterable[MappedClaim]) -> bool:
-    """True if no mapped claim blocks (no MISMATCH/EXPIRED)."""
+    """True if no mapped claim blocks (no MISMATCH/EXPIRED).
 
-    return not blocking_claims(mapped)
+    Uses ``any`` so it short-circuits on the first blocking claim instead of
+    materializing the full ``blocking_claims`` tuple.
+    """
+
+    return not any(m.status in _BLOCKING_STATUSES for m in mapped)

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -234,6 +234,9 @@
       "target": "extracted_content_pipeline/review_contract.py"
     },
     {
+      "target": "extracted_content_pipeline/claims_map.py"
+    },
+    {
       "target": "extracted_content_pipeline/blog_post_export.py"
     },
     {

--- a/plans/PR-Content-Ops-Claims-Map.md
+++ b/plans/PR-Content-Ops-Claims-Map.md
@@ -82,9 +82,9 @@ dataclasses, `None`/non-`str` tolerated, not raised).
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/claims_map.py` | 155 |
+| `extracted_content_pipeline/claims_map.py` | 159 |
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `plans/PR-Content-Ops-Claims-Map.md` | 90 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/test_extracted_content_claims_map.py` | 169 |
-| **Total** | **418** |
+| **Total** | **422** |

--- a/plans/PR-Content-Ops-Claims-Map.md
+++ b/plans/PR-Content-Ops-Claims-Map.md
@@ -1,0 +1,90 @@
+# PR — Content-Ops Claims Map (operating-model slice 3)
+
+## Why this slice exists
+
+`docs/content_ops_operating_model.md` makes the **claims map** the highest-value piece of
+the stage-3B (claims/compliance) gate: every claim a draft makes is mapped to the
+messaging registry and status-checked, so marketing can't quietly invent a lawsuit
+("Save 30% on all plans" vs the approved "Save up to 30% on eligible annual plans"). This
+slice lands the deterministic core of that map; the part that *requires* an LLM (extracting
+the claims from prose) is deferred so this stays additive and testable, matching slices 1-2.
+
+Diff total sits just over the 400-LOC soft cap (see *Estimated diff size*); the excess is
+test surface, not product — the module itself is ~150 LOC. The shippable surface stays
+small.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+New owned module `extracted_content_pipeline/claims_map.py` + tests. Pure value types +
+pure functions; no I/O, no Atlas imports, no DB, no LLM:
+
+- `ClaimStatus` (StrEnum) — MATCH / MISMATCH / UNREGISTERED / EXPIRED.
+- `RegistryClaim` (frozen dataclass) — a messaging-registry entry: `id`, `approved_wording`,
+  `risk_tier` (slice 1 `RiskTier`), `expiration` (date or None).
+- `ExtractedClaim` (frozen dataclass) — one claim as an extractor would emit it: `text`,
+  `location`, candidate `registry_id` (the extractor that produces these from prose is the
+  deferred LLM step).
+- `MappedClaim` (frozen dataclass) — a claims-map row: text, location, registry_id,
+  approved_wording, status, risk_tier.
+- `map_claim(...)` / `build_claims_map(...)` — assign status against a registry as of a
+  date; `blocking_claims(...)` / `is_clear(...)` — the gate signal (MISMATCH or EXPIRED
+  blocks).
+
+
+### Files touched
+
+- `extracted_content_pipeline/claims_map.py`
+- `extracted_content_pipeline/manifest.json`
+- `plans/PR-Content-Ops-Claims-Map.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_content_claims_map.py`
+
+## Mechanism
+
+Status is decided by normalized comparison (casefold + collapsed whitespace): an unknown /
+missing `registry_id` is `UNREGISTERED`; a matched entry past its `expiration` (relative to
+a caller-supplied `as_of`) is `EXPIRED`; otherwise wording equal to the approved wording is
+`MATCH`, else `MISMATCH`. `blocking_claims` returns the rows whose status is MISMATCH or
+EXPIRED. Same conventions as slices 1-2 (`StrEnum` with the 3.10 fallback, frozen
+dataclasses, `None`/non-`str` tolerated, not raised).
+
+## Intentional
+
+- Additive only — no existing code path changes; the stage-3B gate that *calls* this is a
+  later slice.
+- Matching is normalized-exact, not fuzzy/semantic. A real "close paraphrase" still reads
+  as MISMATCH, which is the safe default for a compliance gate; fuzzy/semantic similarity
+  is deferred.
+- `UNREGISTERED` is reported but not itself blocking — surfacing an unknown claim is a
+  human-review signal, not an automatic block (the doc routes that to the editor).
+
+## Deferred
+
+- The LLM extractor (prose -> `ExtractedClaim` list with candidate registry ids) — needs
+  the host LLM factory; later slice.
+- Wiring the claims map into a stage-3B gate / the Content-PR coverage matrix (slice 4).
+- Fuzzy/semantic wording match; registry persistence schema. Calibration library +
+  adversarial pass (slice 5). Multi-model disagreement orchestration stays parked.
+
+## Verification
+
+- pytest `tests/test_extracted_content_claims_map.py`
+- `scripts/check_ascii_python.sh` (run via bash) -- ASCII gate
+- `scripts/check_extracted_imports.py` (run via python3) -- import structure
+- `scripts/audit_extracted_pipeline_ci_enrollment.py` -- new test enrolled
+- `scripts/audit_extracted_standalone.py` (--fail-on-debt) -- no Atlas runtime imports
+- `scripts/audit_pr_session_drift.py` + `scripts/sync_pr_plan.py` -- plan shape/drift
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/claims_map.py` | 152 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `plans/PR-Content-Ops-Claims-Map.md` | 90 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_content_claims_map.py` | 166 |
+| **Total** | **412** |

--- a/plans/PR-Content-Ops-Claims-Map.md
+++ b/plans/PR-Content-Ops-Claims-Map.md
@@ -82,9 +82,9 @@ dataclasses, `None`/non-`str` tolerated, not raised).
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/claims_map.py` | 152 |
+| `extracted_content_pipeline/claims_map.py` | 155 |
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `plans/PR-Content-Ops-Claims-Map.md` | 90 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_extracted_content_claims_map.py` | 166 |
-| **Total** | **412** |
+| `tests/test_extracted_content_claims_map.py` | 169 |
+| **Total** | **418** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -18,6 +18,7 @@ pytest \
   tests/test_extracted_content_host_smoke.py \
   tests/test_extracted_content_review_contract.py \
   tests/test_extracted_content_triage_experiment.py \
+  tests/test_extracted_content_claims_map.py \
   tests/test_extracted_campaign_visibility.py \
   tests/test_extracted_campaign_visibility_reader_cli.py \
   tests/test_extracted_campaign_manifest.py \

--- a/tests/test_extracted_content_claims_map.py
+++ b/tests/test_extracted_content_claims_map.py
@@ -1,0 +1,166 @@
+"""Unit tests for slice 3: the deterministic claims map.
+
+Pure value types + matching logic; no DB, no async, no Atlas imports, no LLM.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from extracted_content_pipeline.claims_map import (
+    ClaimStatus,
+    ExtractedClaim,
+    RegistryClaim,
+    blocking_claims,
+    build_claims_map,
+    is_clear,
+    map_claim,
+)
+from extracted_content_pipeline.review_contract import RiskTier
+
+_AS_OF = date(2026, 6, 6)
+
+_REGISTRY = {
+    "pricing.discount.q4": RegistryClaim(
+        id="pricing.discount.q4",
+        approved_wording="Save up to 30% on eligible annual plans",
+        risk_tier=RiskTier.HIGH,
+        expiration=date(2026, 1, 15),  # lapsed before _AS_OF
+    ),
+    "feature.sso": RegistryClaim(
+        id="feature.sso",
+        approved_wording="SSO is included on every plan",
+        risk_tier=RiskTier.MEDIUM,
+        expiration=None,  # never lapses
+    ),
+}
+
+
+def test_claim_status_values() -> None:
+    assert {s.value for s in ClaimStatus} == {
+        "match",
+        "mismatch",
+        "unregistered",
+        "expired",
+    }
+
+
+def test_match_when_wording_equals_approved_modulo_normalization() -> None:
+    claim = ExtractedClaim(
+        text="  SSO is   included on EVERY plan ",  # case + spacing differ
+        location="hero",
+        registry_id="feature.sso",
+    )
+    mapped = map_claim(claim, _REGISTRY, as_of=_AS_OF)
+    assert mapped.status is ClaimStatus.MATCH
+    assert mapped.approved_wording == "SSO is included on every plan"
+    assert mapped.risk_tier is RiskTier.MEDIUM
+
+
+def test_mismatch_when_wording_differs() -> None:
+    # The doc's liability example: "all plans" vs "eligible annual plans".
+    claim = ExtractedClaim(
+        text="Save 30% on all plans",
+        location="subject",
+        registry_id="pricing.discount.q4",
+    )
+    # Use a date before expiration so the status is MISMATCH, not EXPIRED.
+    mapped = map_claim(claim, _REGISTRY, as_of=date(2026, 1, 1))
+    assert mapped.status is ClaimStatus.MISMATCH
+    assert mapped.registry_id == "pricing.discount.q4"
+    assert mapped.risk_tier is RiskTier.HIGH
+
+
+def test_unregistered_when_no_or_unknown_registry_id() -> None:
+    no_id = map_claim(ExtractedClaim(text="we are the best"), _REGISTRY, as_of=_AS_OF)
+    assert no_id.status is ClaimStatus.UNREGISTERED
+    assert no_id.registry_id is None
+    assert no_id.approved_wording is None
+
+    unknown = map_claim(
+        ExtractedClaim(text="x", registry_id="does.not.exist"),
+        _REGISTRY,
+        as_of=_AS_OF,
+    )
+    assert unknown.status is ClaimStatus.UNREGISTERED
+
+
+def test_expired_takes_precedence_even_if_wording_matches() -> None:
+    claim = ExtractedClaim(
+        text="Save up to 30% on eligible annual plans",  # exact approved wording
+        location="hero",
+        registry_id="pricing.discount.q4",
+    )
+    mapped = map_claim(claim, _REGISTRY, as_of=_AS_OF)  # _AS_OF is past expiration
+    assert mapped.status is ClaimStatus.EXPIRED
+
+
+def test_expiration_day_itself_is_still_valid() -> None:
+    claim = ExtractedClaim(
+        text="Save up to 30% on eligible annual plans",
+        registry_id="pricing.discount.q4",
+    )
+    on_day = map_claim(claim, _REGISTRY, as_of=date(2026, 1, 15))
+    assert on_day.status is ClaimStatus.MATCH
+
+
+def test_build_claims_map_preserves_order() -> None:
+    claims = [
+        ExtractedClaim(text="SSO is included on every plan", registry_id="feature.sso"),
+        ExtractedClaim(text="unbeatable prices", registry_id=None),
+    ]
+    mapped = build_claims_map(claims, _REGISTRY, as_of=_AS_OF)
+    assert [m.status for m in mapped] == [
+        ClaimStatus.MATCH,
+        ClaimStatus.UNREGISTERED,
+    ]
+
+
+def test_blocking_claims_flags_mismatch_and_expired_only() -> None:
+    claims = [
+        ExtractedClaim(text="SSO is included on every plan", registry_id="feature.sso"),
+        ExtractedClaim(text="Save 30% on all plans", registry_id="pricing.discount.q4"),
+        ExtractedClaim(text="brand new", registry_id=None),
+    ]
+    mapped = build_claims_map(claims, _REGISTRY, as_of=_AS_OF)
+    blocking = blocking_claims(mapped)
+    statuses = {m.status for m in blocking}
+    # pricing claim is EXPIRED at _AS_OF; SSO matches; unregistered does not block.
+    assert statuses == {ClaimStatus.EXPIRED}
+    assert is_clear(mapped) is False
+
+
+def test_is_clear_true_when_only_match_and_unregistered() -> None:
+    claims = [
+        ExtractedClaim(text="SSO is included on every plan", registry_id="feature.sso"),
+        ExtractedClaim(text="brand new", registry_id=None),
+    ]
+    mapped = build_claims_map(claims, _REGISTRY, as_of=_AS_OF)
+    assert is_clear(mapped) is True
+
+
+def test_none_text_normalizes_to_unmatched_not_error() -> None:
+    # None text (e.g. JSON null) must not raise; with a real registry id it
+    # simply won't match the approved wording.
+    claim = ExtractedClaim(text=None, registry_id="feature.sso")  # type: ignore[arg-type]
+    mapped = map_claim(claim, _REGISTRY, as_of=_AS_OF)
+    assert mapped.status is ClaimStatus.MISMATCH
+
+
+def test_registry_claim_is_expired_helper() -> None:
+    entry = _REGISTRY["pricing.discount.q4"]
+    assert entry.is_expired(date(2026, 6, 6)) is True
+    assert entry.is_expired(date(2026, 1, 15)) is False  # day-of still valid
+    assert _REGISTRY["feature.sso"].is_expired(date(2999, 1, 1)) is False
+
+
+def test_mapped_claim_is_frozen() -> None:
+    mapped = map_claim(
+        ExtractedClaim(text="x", registry_id="feature.sso"),
+        _REGISTRY,
+        as_of=_AS_OF,
+    )
+    with pytest.raises(Exception):
+        mapped.status = ClaimStatus.MATCH  # type: ignore[misc]

--- a/tests/test_extracted_content_claims_map.py
+++ b/tests/test_extracted_content_claims_map.py
@@ -5,6 +5,7 @@ Pure value types + matching logic; no DB, no async, no Atlas imports, no LLM.
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from datetime import date
 
 import pytest
@@ -85,6 +86,8 @@ def test_unregistered_when_no_or_unknown_registry_id() -> None:
         as_of=_AS_OF,
     )
     assert unknown.status is ClaimStatus.UNREGISTERED
+    # The stale/typo'd candidate id is preserved for diagnosis (not dropped to None).
+    assert unknown.registry_id == "does.not.exist"
 
 
 def test_expired_takes_precedence_even_if_wording_matches() -> None:
@@ -144,7 +147,7 @@ def test_is_clear_true_when_only_match_and_unregistered() -> None:
 def test_none_text_normalizes_to_unmatched_not_error() -> None:
     # None text (e.g. JSON null) must not raise; with a real registry id it
     # simply won't match the approved wording.
-    claim = ExtractedClaim(text=None, registry_id="feature.sso")  # type: ignore[arg-type]
+    claim = ExtractedClaim(text=None, registry_id="feature.sso")
     mapped = map_claim(claim, _REGISTRY, as_of=_AS_OF)
     assert mapped.status is ClaimStatus.MISMATCH
 
@@ -162,5 +165,5 @@ def test_mapped_claim_is_frozen() -> None:
         _REGISTRY,
         as_of=_AS_OF,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(FrozenInstanceError):
         mapped.status = ClaimStatus.MATCH  # type: ignore[misc]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claims-Map.md

Ownership lane: content-ops/review-contract
Slice phase: Vertical slice

Slice 3 of the content operating model (`docs/content_ops_operating_model.md` → "Building this: staged" → **claims map**). The deterministic core of the stage-3B claims/compliance gate.

## Why this slice exists
The claims map is the doc's highest-value gate piece: map every claim a draft makes onto the messaging registry and status-check it, so marketing can't quietly invent a lawsuit ("Save 30% on all plans" vs the approved "Save up to 30% on eligible annual plans"). The deterministic matcher is needed regardless of how extraction lands, so it's the never-wrong first step.

## Scope (this PR)
New owned module `extracted_content_pipeline/claims_map.py` + tests. Pure value types + pure functions; no I/O, no Atlas imports, no DB, no LLM:

- `ClaimStatus` — MATCH / MISMATCH / UNREGISTERED / EXPIRED.
- `RegistryClaim` — a messaging-registry entry (`id`, `approved_wording`, `risk_tier` [slice-1 `RiskTier`], `expiration`).
- `ExtractedClaim` — one claim as an extractor emits it (`text`, `location`, candidate `registry_id`).
- `MappedClaim` — a claims-map row.
- `map_claim` / `build_claims_map` (normalized comparison, `as_of` expiry) + `blocking_claims` / `is_clear` (gate signal).

## Intentional
- **Additive only** — no existing code path changes; the stage-3B gate that *calls* this is a later slice.
- **LLM extraction deferred** — turning prose into `ExtractedClaim` rows needs the host LLM factory; this slice takes already-extracted claims and decides status. Keeps the additive/no-LLM pattern of slices 1–2.
- Matching is **normalized-exact, not fuzzy** — a close paraphrase reads as `MISMATCH`, the safe default for a compliance gate (fuzzy/semantic deferred).
- `UNREGISTERED` is reported but **not blocking** — an unknown claim is a human-review signal, not an auto-block (per the doc's routing). Only `MISMATCH`/`EXPIRED` block.
- `None`/non-`str` text normalizes safely (no raise), consistent with slice 2's hardening.

## Deferred
- The LLM extractor (prose → `ExtractedClaim`) — later slice.
- Wiring the map into a stage-3B gate / Content-PR coverage matrix (slice 4).
- Fuzzy/semantic match; registry persistence schema. Calibration library + adversarial pass (slice 5). Multi-model disagreement orchestration parked.

## Verification
- pytest `tests/test_extracted_content_claims_map.py` — 12 passed
- `scripts/check_ascii_python.sh` — clean
- `scripts/check_extracted_imports.py` — 129 modules OK
- `scripts/audit_extracted_pipeline_ci_enrollment.py` — enrolled (151)
- `scripts/audit_extracted_standalone.py --fail-on-debt` — 0 Atlas-runtime findings
- `scripts/audit_pr_session_drift.py` + `sync_pr_plan.py` + `audit_plan_code_consistency.py` — pass

## Estimated diff size
Just over the 400-LOC soft cap — see the plan's **Estimated diff size** table; the excess is test surface (module itself ~150 LOC), justified in the plan's *Why this slice exists*.

https://claude.ai/code/session_01QgqhC2NoKQHzV3xDFchNRN

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgqhC2NoKQHzV3xDFchNRN)_