### PR TITLE
Content Ops Social Post Channel Variants

### DIFF
--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -711,6 +711,7 @@ async def _dispatch_social_post(
         "target_mode": request.target_mode,
         "source_material": request.inputs.get("source_material"),
         "limit": request.limit,
+        "channels": _step_config_sequence(step.config, "channels"),
         "max_text_chars": _step_config_int(step.config, "max_text_chars"),
         "temperature": _step_config_float(step.config, "temperature"),
         "max_tokens": _step_config_int(step.config, "max_tokens"),

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -17,6 +17,7 @@ from .landing_page_repair_contract import (
     LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS_DEFAULT,
     landing_page_quality_repair_attempts_from_inputs,
 )
+from .social_post_generation import normalize_social_post_channels
 
 SOCIAL_POST_BRAND_VOICE_UNIT_COST_USD = 0.08
 SOCIAL_POST_BRAND_VOICE_PARSE_RETRY_ATTEMPTS = 1
@@ -499,6 +500,19 @@ def _cost_definition_for_output(
     return definition
 
 
+def _item_multiplier_for_output(
+    output_id: str,
+    *,
+    inputs: Mapping[str, Any],
+) -> int:
+    if output_id != "social_post":
+        return 1
+    channels = inputs.get("social_channels")
+    if channels is None:
+        channels = inputs.get("social_post_channels")
+    return max(1, len(normalize_social_post_channels(channels)))
+
+
 def estimate_cost_usd(
     outputs: Sequence[str],
     *,
@@ -539,6 +553,7 @@ def estimate_cost_usd(
                 quality_repair_attempts=repair_attempts,
             )
             * max(1, limit)
+            * _item_multiplier_for_output(output_id, inputs=provided_inputs)
         )
     return total
 

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -35,7 +35,10 @@ from .reasoning_policy import (
 from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
-from .social_post_generation import SocialPostGenerationConfig
+from .social_post_generation import (
+    SocialPostGenerationConfig,
+    normalize_social_post_channels,
+)
 from .stat_card_generation import StatCardGenerationConfig
 from .ticket_faq_markdown import (
     DEFAULT_INTENT_RULES,
@@ -222,12 +225,19 @@ def _signal_extraction_config_for_request(
 
 
 def _social_post_config_for_request(request: ContentOpsRequest) -> SocialPostGenerationConfig:
-    config = SocialPostGenerationConfig(limit=request.limit)
+    channels = request.inputs.get("social_channels")
+    if channels is None:
+        channels = request.inputs.get("social_post_channels")
+    config = SocialPostGenerationConfig(
+        limit=request.limit,
+        channels=normalize_social_post_channels(channels),
+    )
     max_text_chars = _positive_int_input(request.inputs, "source_max_text_chars")
     if max_text_chars is None:
         return config
     return SocialPostGenerationConfig(
         limit=config.limit,
+        channels=config.channels,
         max_text_chars=max_text_chars,
     )
 
@@ -478,6 +488,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
             status="runnable",
             config={
                 "skill_name": config.skill_name,
+                "channels": list(config.channels),
                 "limit": config.limit,
                 "max_text_chars": config.max_text_chars,
                 "max_tokens": config.max_tokens,

--- a/extracted_content_pipeline/social_post_generation.py
+++ b/extracted_content_pipeline/social_post_generation.py
@@ -26,6 +26,67 @@ from .services._parse_retry_helpers import (
 from .social_post_ports import SocialPostDraft, SocialPostRepository
 
 _ROW_LIST_KEYS = ("sources", "opportunities", "reviews", "documents", "rows", "data")
+DEFAULT_SOCIAL_POST_CHANNELS = ("linkedin",)
+_SOCIAL_POST_CHANNEL_ALIASES = {
+    "linked_in": "linkedin",
+    "linkedin": "linkedin",
+    "li": "linkedin",
+    "twitter": "x",
+    "x_twitter": "x",
+    "x": "x",
+    "facebook": "facebook",
+    "fb": "facebook",
+    "instagram": "instagram",
+    "ig": "instagram",
+    "threads": "threads",
+}
+_SOCIAL_POST_CHANNEL_LABELS = {
+    "linkedin": "LinkedIn",
+    "x": "X",
+    "facebook": "Facebook",
+    "instagram": "Instagram",
+    "threads": "Threads",
+}
+_SOCIAL_POST_CHANNEL_MAX_CHARS = {
+    "x": 280,
+    "threads": 500,
+}
+
+
+def normalize_social_post_channels(value: Any | None) -> tuple[str, ...]:
+    """Return canonical social-post channel ids, preserving first-seen order."""
+
+    if value is None:
+        return DEFAULT_SOCIAL_POST_CHANNELS
+    if isinstance(value, str):
+        raw_items: Sequence[Any] = value.split(",")
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        raw_items = value
+    else:
+        raise ValueError("social_post channels must be a string or sequence")
+
+    channels: list[str] = []
+    for item in raw_items:
+        channel = _normalize_social_post_channel(item)
+        if channel and channel not in channels:
+            channels.append(channel)
+    return tuple(channels) or DEFAULT_SOCIAL_POST_CHANNELS
+
+
+def _normalize_social_post_channel(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    if not text:
+        return ""
+    key = re.sub(r"[\s\-/]+", "_", text)
+    channel = _SOCIAL_POST_CHANNEL_ALIASES.get(key)
+    if channel is None:
+        allowed = ", ".join(sorted(set(_SOCIAL_POST_CHANNEL_ALIASES.values())))
+        raise ValueError(
+            f"unsupported social_post channel: {text}; expected one of {allowed}"
+        )
+    return channel
 
 
 @dataclass(frozen=True)
@@ -33,6 +94,7 @@ class SocialPostGenerationConfig:
     """Config for deterministic source-material social posts."""
 
     skill_name: str = "digest/social_post_generation"
+    channels: tuple[str, ...] = DEFAULT_SOCIAL_POST_CHANNELS
     limit: int = 3
     max_text_chars: int = 600
     max_post_chars: int = 420
@@ -40,6 +102,13 @@ class SocialPostGenerationConfig:
     temperature: float = 0.4
     parse_retry_attempts: int = 1
     parse_retry_response_excerpt_chars: int = 800
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "channels",
+            normalize_social_post_channels(self.channels),
+        )
 
 
 @dataclass(frozen=True)
@@ -93,6 +162,7 @@ class SocialPostGenerationService:
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
+        channels: Sequence[str] | str | None = None,
         brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
         **kwargs: Any,
     ) -> SocialPostGenerationResult:
@@ -111,12 +181,18 @@ class SocialPostGenerationService:
         )
         if resolved_max_text_chars < 1:
             raise ValueError("max_text_chars must be at least 1")
+        resolved_channels = (
+            normalize_social_post_channels(channels)
+            if channels is not None
+            else self.config.channels
+        )
         result = _generate_social_posts(
             _rows_from_source_material(source_material),
             target_mode=target_mode,
             limit=resolved_limit,
             max_text_chars=resolved_max_text_chars,
             max_post_chars=self.config.max_post_chars,
+            channels=resolved_channels,
         )
         if resolved_brand_voice is not None and result.posts:
             prompt_template = self._social_post_prompt()
@@ -231,6 +307,13 @@ class SocialPostGenerationService:
             raise ValueError("brand voice social_post generation requires configured LLM")
         prior_invalid_response = ""
         usage: dict[str, Any] = {}
+        requested_channel = _normalize_social_post_channel(
+            post.get("channel") or DEFAULT_SOCIAL_POST_CHANNELS[0]
+        )
+        channel_max_post_chars = _max_post_chars_for_channel(
+            requested_channel,
+            self.config.max_post_chars,
+        )
         for _attempt in range(parse_attempt_limit(parse_retry_attempts)):
             response = await self._llm.complete(
                 [
@@ -240,7 +323,8 @@ class SocialPostGenerationService:
                         content=_social_post_user_prompt(
                             target_mode=target_mode,
                             source_post=post,
-                            max_post_chars=self.config.max_post_chars,
+                            channel=requested_channel,
+                            max_post_chars=channel_max_post_chars,
                             prior_invalid_response=prior_invalid_response,
                         ),
                     ),
@@ -249,6 +333,7 @@ class SocialPostGenerationService:
                 temperature=temperature,
                 metadata={
                     "asset_type": "social_post",
+                    "channel": requested_channel,
                     "target_mode": target_mode,
                     "source_id": _clean(post.get("source_id") or post.get("id")),
                 },
@@ -261,25 +346,20 @@ class SocialPostGenerationService:
                     limit=parse_retry_response_excerpt_chars,
                 )
                 continue
-            text = _truncate(parsed["text"], self.config.max_post_chars)
+            text = _truncate(parsed["text"], channel_max_post_chars)
             if not text:
                 prior_invalid_response = clip_invalid_response(
                     response.content,
                     limit=parse_retry_response_excerpt_chars,
                 )
                 continue
-            channel = (
-                _clean(parsed.get("channel"))
-                or _clean(post.get("channel"))
-                or "linkedin"
-            )
             rewritten = {
                 **dict(post),
-                "channel": channel,
+                "channel": requested_channel,
                 "text": text,
             }
             voice_metadata = brand_voice_result_metadata(
-                {"channel": channel, "text": text},
+                {"channel": requested_channel, "text": text},
                 brand_voice,
             )
             if voice_metadata.get("_brand_voice_profile"):
@@ -365,13 +445,18 @@ def _social_post_user_prompt(
     *,
     target_mode: str,
     source_post: Mapping[str, Any],
+    channel: str,
     max_post_chars: int,
     prior_invalid_response: str = "",
 ) -> str:
+    label = _SOCIAL_POST_CHANNEL_LABELS.get(channel, channel)
     prompt = (
         "Rewrite this source-backed social post.\n"
         f"target_mode={target_mode}\n"
+        f"channel={channel}\n"
+        f"platform={label}\n"
         f"max_post_chars={max_post_chars}\n"
+        f'Return channel exactly "{channel}".\n'
         "source_post="
         + json.dumps(dict(source_post), sort_keys=True, separators=(",", ":"))
     )
@@ -392,11 +477,14 @@ def _generate_social_posts(
     limit: int,
     max_text_chars: int,
     max_post_chars: int,
+    channels: Sequence[str],
 ) -> SocialPostGenerationResult:
     posts: list[dict[str, Any]] = []
     warnings: list[CampaignOpportunityWarning] = []
+    source_count = 0
+    resolved_channels = normalize_social_post_channels(channels)
     for index, row in enumerate(rows, start=1):
-        if len(posts) >= limit:
+        if source_count >= limit:
             break
         if not isinstance(row, Mapping):
             warnings.append(CampaignOpportunityWarning(
@@ -411,19 +499,29 @@ def _generate_social_posts(
             max_text_chars=max_text_chars,
         )
         warnings.extend(row_warnings)
-        post = _post_from_opportunity(
-            opportunity,
-            index=len(posts) + 1,
-            max_post_chars=max_post_chars,
+        channel_posts = tuple(
+            item
+            for item in (
+                _post_from_opportunity(
+                    opportunity,
+                    index=source_count + 1,
+                    max_post_chars=max_post_chars,
+                    channel=channel,
+                    include_channel_in_id=len(resolved_channels) > 1,
+                )
+                for channel in resolved_channels
+            )
+            if item is not None
         )
-        if post is None:
+        if not channel_posts:
             warnings.append(CampaignOpportunityWarning(
                 code="missing_social_post_evidence",
                 row_index=index,
                 message="Skipped source row because it did not contain usable evidence.",
             ))
             continue
-        posts.append(post)
+        posts.extend(channel_posts)
+        source_count += 1
     return SocialPostGenerationResult(
         posts=tuple(posts),
         warnings=tuple(warnings),
@@ -436,6 +534,8 @@ def _post_from_opportunity(
     *,
     index: int,
     max_post_chars: int,
+    channel: str,
+    include_channel_in_id: bool = False,
 ) -> dict[str, Any] | None:
     if not opportunity:
         return None
@@ -450,15 +550,17 @@ def _post_from_opportunity(
     if pain:
         hook_parts.append(f"flags {pain}")
     hook = " ".join(hook_parts) + "."
-    body = (
-        f'{hook} Source note: "{evidence}" Use this proof point to sharpen '
-        "the next landing page, blog post, or sales brief."
+    body = _post_body_for_channel(
+        channel=channel,
+        hook=hook,
+        evidence=evidence,
     )
     source_id = _clean(opportunity.get("source_id") or opportunity.get("target_id"))
+    base_id = source_id or f"social-post-{index}"
     return {
-        "id": source_id or f"social-post-{index}",
-        "channel": "linkedin",
-        "text": _truncate(body, max_post_chars),
+        "id": f"{base_id}:{channel}" if include_channel_in_id else base_id,
+        "channel": channel,
+        "text": _truncate(body, _max_post_chars_for_channel(channel, max_post_chars)),
         "source_id": source_id,
         "source_type": _clean(opportunity.get("source_type")),
         "target_id": _clean(opportunity.get("target_id")),
@@ -466,6 +568,37 @@ def _post_from_opportunity(
         "vendor_name": vendor,
         "pain_points": list(opportunity.get("pain_points") or ()),
     }
+
+
+def _post_body_for_channel(
+    *,
+    channel: str,
+    hook: str,
+    evidence: str,
+) -> str:
+    if channel == "linkedin":
+        return (
+            f'{hook} Source note: "{evidence}" Use this proof point to sharpen '
+            "the next landing page, blog post, or sales brief."
+        )
+    if channel == "x":
+        return f'{hook} "{evidence}" Proof point for the next sales motion.'
+    if channel == "facebook":
+        return (
+            f'{hook} Customer note: "{evidence}" Turn this into a helpful, '
+            "plain-language post for buyers comparing their options."
+        )
+    if channel == "instagram":
+        return (
+            f'{hook} Source note: "{evidence}" Shape this into a concise caption '
+            "with one concrete takeaway and a useful next step."
+        )
+    if channel == "threads":
+        return (
+            f'{hook} "{evidence}" Keep the takeaway conversational and grounded '
+            "in the customer proof."
+        )
+    return f'{hook} Source note: "{evidence}"'
 
 
 def _drafts_from_posts(
@@ -564,6 +697,13 @@ def _truncate(value: str, max_chars: int) -> str:
     return text[: max(0, max_chars - 3)].rstrip() + "..."
 
 
+def _max_post_chars_for_channel(channel: str, max_post_chars: int) -> int:
+    channel_max = _SOCIAL_POST_CHANNEL_MAX_CHARS.get(channel)
+    if channel_max is None:
+        return max_post_chars
+    return min(max_post_chars, channel_max)
+
+
 def _clean(value: Any) -> str:
     return str(value or "").strip()
 
@@ -574,5 +714,7 @@ __all__ = [
     "SocialPostGenerationService",
     "SocialPostDraft",
     "SocialPostRepository",
+    "DEFAULT_SOCIAL_POST_CHANNELS",
+    "normalize_social_post_channels",
     "parse_social_post_response",
 ]

--- a/plans/PR-Content-Ops-Social-Post-Channel-Variants.md
+++ b/plans/PR-Content-Ops-Social-Post-Channel-Variants.md
@@ -1,0 +1,144 @@
+# PR-Content-Ops-Social-Post-Channel-Variants
+
+## Why this slice exists
+
+PR-Content-Ops-Social-Post-LLM-Voice made `social_post` consume stored brand
+voice, but deliberately kept the output to one LinkedIn draft per source row.
+Its Deferred section named `PR-Content-Ops-Social-Post-Channel-Variants` as
+the next product step: social posts need platform-specific variants, not one
+generic card with a hardcoded `channel="linkedin"`.
+
+This slice keeps the default behavior unchanged while adding the thinnest
+request-level channel control: when the request supplies social channels, the
+social-post service emits one source-backed draft per selected platform and the
+preview budget scales the brand-voice LLM estimate by the selected channel
+count.
+
+The estimated diff is over the 400 LOC soft cap because the slice crosses the
+minimum contract surfaces together: generator behavior, plan metadata,
+execution dispatch, cost preview, and focused tests for each boundary. Splitting
+these would leave a channel selector path without either cost gating or a real
+execution proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/social-post-channel-variants
+Slice phase: Vertical slice
+
+1. Add normalized `social_channels` / `social_post_channels` input handling for
+   `social_post`; the default remains `("linkedin",)`.
+2. Expand deterministic social-post generation to one draft per selected
+   channel for each usable source row, with stable channel-specific ids and
+   copy constraints.
+3. Keep the brand-voice LLM rewrite path fail-closed, but call it once per
+   selected channel and preserve the requested channel on the rewritten draft.
+4. Thread selected channels through generation-plan metadata and the execution
+   dispatcher into `SocialPostGenerationService.generate(...)`.
+5. Scale the brand-voice social-post preview cost by selected channel count so
+   `max_cost_usd` still protects multi-channel LLM rewrites.
+6. Add focused tests for default compatibility, channel expansion, invalid
+   channel rejection, dispatcher threading, and cost scaling.
+
+### Review Contract
+
+- Acceptance criteria: default `social_post` still emits the existing LinkedIn
+  draft; requested social channels emit one draft per channel; invalid channel
+  ids fail closed; brand-voice rewrites preserve requested channels; preview
+  cost scales by channel count only for brand-voice social posts.
+- Affected surfaces: extracted social-post generator, generation-plan config,
+  execution dispatcher, control-surface preview cost, package tests.
+- Risk areas: backcompat, cost gating, LLM prompt/metadata shape, invalid input
+  validation.
+- Reviewer rules triggered: R1 (requirements match the plan/test contract),
+  R10 (channel normalization and dispatch stay centralized and maintainable).
+
+### Files touched
+
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/social_post_generation.py`
+- `plans/PR-Content-Ops-Social-Post-Channel-Variants.md`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_social_post_generation.py`
+
+## Mechanism
+
+`SocialPostGenerationConfig` gains a normalized `channels` tuple. The service's
+`generate(...)` accepts an optional `channels` override, normalizes it through a
+single helper, and passes the result into `_generate_social_posts(...)`. The
+default is still `("linkedin",)`, so existing callers and tests keep the same
+single-post behavior and current text.
+
+For multi-channel requests, `_generate_social_posts(...)` treats `limit` as the
+source-row limit and emits a draft per selected channel. Non-default multi-
+channel ids include the channel suffix to avoid duplicate UI ids for the same
+source row. Each channel receives a bounded deterministic text variant; the
+`x` variant is capped tighter than the configured post bound.
+
+Brand-voice rewriting already operates over the deterministic posts. This slice
+keeps that shape: after deterministic expansion, the LLM rewrite path is called
+once per generated channel draft. The rewrite prompt and metadata include the
+requested channel, and the rewritten result preserves the source draft's
+normalized channel rather than letting a model silently drift a LinkedIn draft
+into another platform.
+
+The generation plan records `channels` in the `social_post` step config, the
+executor passes that config into the social-post service, and the control-
+surface estimator multiplies the brand-voice social-post unit estimate by the
+same normalized channel count. Deterministic social posts remain zero-estimate.
+
+## Intentional
+
+- This does not add a new output id. `social_post` remains the product output;
+  `inputs.social_channels` only selects platform variants.
+- `inputs.channels` remains campaign-owned. This slice uses
+  `social_channels` / `social_post_channels` so email campaign channel
+  selection and social platform selection do not collide in mixed-output runs.
+- No frontend selector in this slice; this is the API/package path that the UI
+  can wire in a follow-up.
+
+## Deferred
+
+- `PR-Content-Ops-Social-Post-Channel-Selector-UI`: expose `social_channels`
+  in the New Run UI.
+- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management
+  page if the inline New Run panel becomes too dense.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/control_surfaces.py tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surfaces.py
+  - Pass.
+- pytest tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surfaces.py -q
+  - `180 passed in 0.28s`.
+- bash scripts/validate_extracted_content_pipeline.sh
+  - Pass.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Pass.
+- python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Pass.
+- bash scripts/check_ascii_python.sh
+  - Pass.
+- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline
+  - Pass; refreshed 46 synced files with no additional working-tree changes.
+- bash scripts/run_extracted_pipeline_checks.sh
+  - `3220 passed, 10 skipped, 1 warning in 55.92s`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/content_ops_execution.py` | 1 |
+| `extracted_content_pipeline/control_surfaces.py` | 15 |
+| `extracted_content_pipeline/generation_plan.py` | 15 |
+| `extracted_content_pipeline/social_post_generation.py` | 186 |
+| `plans/PR-Content-Ops-Social-Post-Channel-Variants.md` | 144 |
+| `tests/test_extracted_content_control_surfaces.py` | 34 |
+| `tests/test_extracted_content_generation_plan.py` | 24 |
+| `tests/test_extracted_content_ops_execution.py` | 31 |
+| `tests/test_extracted_social_post_generation.py` | 105 |
+| **Total** | **555** |

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -198,6 +198,40 @@ def test_preview_charges_brand_voice_social_post_rewrite():
     assert "Estimated cost exceeds max_cost_usd: 0.32 > 0.01" in preview["warnings"]
 
 
+def test_preview_scales_brand_voice_social_post_rewrite_by_channels():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 2,
+            "max_cost_usd": 0.7,
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+                "social_channels": ["linkedin", "twitter"],
+                "brand_voice": {"id": "voice-1", "descriptors": ["direct"]},
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 0.64
+
+
+def test_preview_keeps_deterministic_multi_channel_social_post_at_zero_cost():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 2,
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+                "social_channels": ["linkedin", "twitter", "facebook"],
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 0.0
+
+
 def test_preview_charges_stored_brand_voice_social_post_rewrite():
     preview = preview_from_mapping(
         {

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -524,6 +524,7 @@ def test_plan_maps_social_post_to_social_post_service():
     assert plan["steps"][0]["status"] == "runnable"
     assert plan["steps"][0]["config"] == {
         "skill_name": "digest/social_post_generation",
+        "channels": ["linkedin"],
         "limit": 3,
         "max_text_chars": 300,
         "max_tokens": 700,
@@ -531,6 +532,29 @@ def test_plan_maps_social_post_to_social_post_service():
         "parse_retry_attempts": 1,
         "parse_retry_response_excerpt_chars": 800,
     }
+
+
+def test_plan_threads_social_post_channels_to_social_post_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 2,
+            "inputs": {
+                "social_channels": ["linkedin", "twitter"],
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing pressure came up at renewal.",
+                    }
+                ],
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["runner"] == "SocialPostGenerationService.generate"
+    assert plan["steps"][0]["config"]["channels"] == ["linkedin", "x"]
 
 
 def test_plan_maps_ad_copy_to_ad_copy_service():

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -752,6 +752,7 @@ async def test_execute_runs_social_post_service_from_source_material() -> None:
     assert "Pricing is a problem" in post["text"]
     assert result["plan"]["steps"][0]["config"] == {
         "skill_name": "digest/social_post_generation",
+        "channels": ["linkedin"],
         "limit": 1,
         "max_text_chars": 20,
         "max_tokens": 700,
@@ -759,6 +760,36 @@ async def test_execute_runs_social_post_service_from_source_material() -> None:
         "parse_retry_attempts": 1,
         "parse_retry_response_excerpt_chars": 800,
     }
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_social_post_channels_from_request() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 1,
+            "inputs": {
+                "social_channels": ["linkedin", "twitter"],
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "company": "Acme",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing is a problem after renewal.",
+                    }
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(
+            social_post=SocialPostGenerationService()
+        ),
+    )
+
+    assert result["status"] == "completed"
+    step = result["steps"][0]
+    assert step["result"]["generated"] == 2
+    assert [post["channel"] for post in step["result"]["posts"]] == ["linkedin", "x"]
+    assert result["plan"]["steps"][0]["config"]["channels"] == ["linkedin", "x"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_social_post_generation.py
+++ b/tests/test_extracted_social_post_generation.py
@@ -6,6 +6,7 @@ from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
 from extracted_content_pipeline.social_post_generation import (
     SocialPostGenerationConfig,
     SocialPostGenerationService,
+    normalize_social_post_channels,
     parse_social_post_response,
 )
 from extracted_content_pipeline.social_post_ports import SocialPostDraft
@@ -228,6 +229,73 @@ async def test_social_post_service_applies_limit_to_usable_rows() -> None:
     assert [post["source_id"] for post in payload["posts"]] == ["review-1", "review-2"]
 
 
+@pytest.mark.asyncio
+async def test_social_post_service_generates_requested_channel_variants() -> None:
+    service = SocialPostGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=1,
+        channels=("linkedin", "twitter", "facebook"),
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+                "pain_category": "pricing pressure",
+            },
+            {
+                "review_id": "review-2",
+                "vendor": "Zendesk",
+                "review_text": "Support queues took too long to triage.",
+            },
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 3
+    assert [post["channel"] for post in payload["posts"]] == [
+        "linkedin",
+        "x",
+        "facebook",
+    ]
+    assert [post["id"] for post in payload["posts"]] == [
+        "review-1:linkedin",
+        "review-1:x",
+        "review-1:facebook",
+    ]
+    assert {post["source_id"] for post in payload["posts"]} == {"review-1"}
+    assert len(payload["posts"][1]["text"]) <= 280
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_rejects_unknown_channel() -> None:
+    service = SocialPostGenerationService()
+
+    with pytest.raises(ValueError, match="unsupported social_post channel: discord"):
+        await service.generate(
+            scope=TenantScope(account_id="acct-1"),
+            target_mode="vendor_retention",
+            channels=["discord"],
+            source_material=[
+                {
+                    "review_id": "review-1",
+                    "vendor": "HubSpot",
+                    "review_text": "Pricing became hard to justify after renewal.",
+                }
+            ],
+        )
+
+
+def test_normalize_social_post_channels_dedupes_aliases_in_order() -> None:
+    assert normalize_social_post_channels("linkedin, twitter, X, ig") == (
+        "linkedin",
+        "x",
+        "instagram",
+    )
+
+
 def test_parse_social_post_response_accepts_fenced_json() -> None:
     assert parse_social_post_response(
         '```json\n{"channel":"linkedin","text":"Use the proof point."}\n```'
@@ -281,6 +349,7 @@ async def test_social_post_service_rewrites_with_brand_voice_and_persists_metada
     llm_call = llm.calls[0]
     assert llm_call["metadata"] == {
         "asset_type": "social_post",
+        "channel": "linkedin",
         "target_mode": "vendor_retention",
         "source_id": "review-1",
     }
@@ -294,6 +363,42 @@ async def test_social_post_service_rewrites_with_brand_voice_and_persists_metada
     assert draft.metadata["brand_voice_profile"]["id"] == "voice-1"
     assert draft.metadata["brand_voice_audit"]["passed"] is True
     assert draft.metadata["generation_usage"]["input_tokens"] == 11
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_rewrites_brand_voice_per_requested_channel() -> None:
+    llm = _LLM(
+        '{"channel":"linkedin","text":"LinkedIn rewrite that keeps the proof."}',
+        '{"channel":"linkedin","text":"X rewrite that should keep requested channel."}',
+    )
+    service = SocialPostGenerationService(llm=llm, skills=_Skills())
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        channels=("linkedin", "x"),
+        brand_voice={
+            "id": "voice-1",
+            "account_id": "acct-1",
+            "descriptors": ["direct"],
+        },
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 2
+    assert [post["channel"] for post in payload["posts"]] == ["linkedin", "x"]
+    assert len(llm.calls) == 2
+    assert [call["metadata"]["channel"] for call in llm.calls] == ["linkedin", "x"]
+    assert "channel=linkedin" in llm.calls[0]["messages"][1].content
+    assert "channel=x" in llm.calls[1]["messages"][1].content
+    assert 'Return channel exactly "x".' in llm.calls[1]["messages"][1].content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Social-Post-Channel-Variants.md
Slice phase: Vertical slice

Adds request-level `social_channels` / `social_post_channels` handling for the `social_post` output so one source row can produce platform-specific LinkedIn/X/Facebook/Instagram/Threads drafts. The default remains the existing single LinkedIn draft, brand-voice rewrites preserve the requested channel, and preview cost scales for brand-voice social-post rewrites by selected channel count.

## Intentional
- This does not add a new output id; `social_post` remains the product output.
- `inputs.channels` remains campaign-owned, so this uses `social_channels` / `social_post_channels` to avoid collisions.
- No frontend selector in this slice; the API/package path lands first so the UI can wire it next.

## Deferred
- `PR-Content-Ops-Social-Post-Channel-Selector-UI`: expose `social_channels` in the New Run UI.
- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management page if the inline New Run panel becomes too dense.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/control_surfaces.py tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surfaces.py` — pass.
- `pytest tests/test_extracted_social_post_generation.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surfaces.py -q` — `180 passed in 0.28s`.
- `bash scripts/validate_extracted_content_pipeline.sh` — pass.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — pass.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — pass.
- `bash scripts/check_ascii_python.sh` — pass.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` — pass; refreshed 46 synced files with no additional working-tree changes.
- `bash scripts/run_extracted_pipeline_checks.sh` — `3220 passed, 10 skipped, 1 warning in 55.92s`.

## Diff size
9 files, +531 / -24.

Over the 400 LOC soft cap because the slice crosses the minimum contract surfaces together: generator behavior, plan metadata, execution dispatch, cost preview, and focused tests for each boundary. Splitting these would leave a channel selector path without either cost gating or a real execution proof.
