### PR TITLE
Content Ops Social Post Channel Review Fixes

### DIFF
--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -632,6 +632,13 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
             blocked.append(output_id)
             warnings.append(f"Output not implemented yet: {output_id}")
 
+    if "social_post" in outputs and "social_post" not in blocked:
+        try:
+            _item_multiplier_for_output("social_post", inputs=request.inputs)
+        except ValueError as exc:
+            blocked.append("social_post")
+            warnings.append(f"Unsupported social channel: {exc}")
+
     selected_outputs = tuple(output for output in outputs if output not in blocked)
     missing = missing_required_inputs(selected_outputs, request.inputs)
     estimated_cost = estimate_cost_usd(

--- a/extracted_content_pipeline/social_post_generation.py
+++ b/extracted_content_pipeline/social_post_generation.py
@@ -598,7 +598,8 @@ def _post_body_for_channel(
             f'{hook} "{evidence}" Keep the takeaway conversational and grounded '
             "in the customer proof."
         )
-    return f'{hook} Source note: "{evidence}"'
+    # Channels are normalized before this helper; reaching this branch is drift.
+    raise ValueError(f"unsupported social_post channel: {channel}")
 
 
 def _drafts_from_posts(

--- a/plans/PR-Content-Ops-Social-Post-Channel-Review-Fixes.md
+++ b/plans/PR-Content-Ops-Social-Post-Channel-Review-Fixes.md
@@ -1,0 +1,127 @@
+# PR-Content-Ops-Social-Post-Channel-Review-Fixes
+
+## Why this slice exists
+
+PR #1340 merged the social-post channel-variant path, then the review posted
+two actionable MAJOR findings:
+
+1. Unsupported `social_channels` values now flow through the preview cost path,
+   where `normalize_social_post_channels(...)` can raise `ValueError`. The API
+   `/plan` and `/execute` routes already turn request-shape `ValueError`s into
+   400s, but `/preview` is intended to be a non-throwing preflight surface and
+   currently lets this new invalid input become an unhandled preview failure.
+2. The core channel behavior was correct, but several load-bearing behaviors
+   were not mutation-pinned: source-row limit semantics, partial brand-voice
+   rewrite failure isolation, and channel-specific caps/coverage.
+
+This slice closes only those review findings before moving to the next product
+feature.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/social-post-channel-variants
+Slice phase: Robust testing
+
+1. Keep `/preview` non-throwing for unsupported social-post channels by turning
+   the normalization error into a warning and `can_run=False`.
+2. Add focused tests proving invalid preview channels do not raise or allow a
+   run.
+3. Add mutation-pinning tests for multi-channel limit semantics, partial LLM
+   rewrite failure isolation, and channel-specific caps/coverage.
+4. Remove the unreachable defensive fallback in `_post_body_for_channel(...)`
+   that the review marked as a NIT.
+
+### Review Contract
+
+- Acceptance criteria: unsupported preview channels return a blocked preview
+  with a warning; generator `limit` caps source rows under multi-channel fanout;
+  one failed brand-voice channel rewrite does not abort sibling channels; X
+  brand-voice output is capped at 280 chars; Threads deterministic generation
+  has direct coverage; the unreachable channel body fallback is gone.
+- Affected surfaces: extracted control-surface preview, extracted social-post
+  generator tests, plan doc.
+- Risk areas: preview API compatibility, invalid input handling, regression
+  test strength.
+- Reviewer rules triggered: R1 (review findings map to tests and behavior),
+  R10 (validator/normalizer failure branch is proven).
+
+### Files touched
+
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/social_post_generation.py`
+- `plans/PR-Content-Ops-Social-Post-Channel-Review-Fixes.md`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_social_post_generation.py`
+
+## Mechanism
+
+`preview_control_surface(...)` already owns the warning/blocking decision for
+unknown presets, outputs, ingestion profiles, missing inputs, and cost-budget
+warnings. This slice keeps unsupported social-post channels in that same
+preflight model: validate the social-post channel multiplier before estimating
+cost, catch the channel normalization `ValueError`, append a warning, block the
+`social_post` output, and keep `can_run=False`. The execution path still fails
+closed through the existing `/plan` and `/execute` `ValueError -> 400`
+handling.
+
+Tests then pin the behaviors that #1340 introduced:
+
+- multi-channel generation with `limit=2` and three usable rows proves limit is
+  a source-row cap, not a total-post cap;
+- a first-channel LLM exception followed by a valid second-channel response
+  proves per-channel failure isolation and no deterministic fallback;
+- an overlong X rewrite proves the 280-char cap is active;
+- a Threads deterministic request proves that channel's body path is exercised.
+
+The unreachable `_post_body_for_channel(...)` fallback becomes an explicit
+invariant failure with a comment naming the upstream normalization guarantee.
+
+## Intentional
+
+- This does not reopen the product contract from #1340 or add frontend selector
+  wiring.
+- Preview warnings keep invalid social-channel input in the same UX category as
+  other preflight-only blockers instead of throwing an API error from preview.
+- `/plan` and `/execute` are left unchanged; they already return 400 for the
+  same invalid request shape.
+
+## Deferred
+
+- `PR-Content-Ops-Social-Post-Channel-Selector-UI`: expose `social_channels`
+  in the New Run UI after these review findings are fixed.
+- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management
+  page if the inline New Run panel becomes too dense.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m py_compile extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/social_post_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_social_post_generation.py
+  - Pass.
+- pytest tests/test_extracted_social_post_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py -q
+  - `199 passed, 1 skipped in 3.77s`.
+- bash scripts/validate_extracted_content_pipeline.sh
+  - Pass.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Pass.
+- python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Pass.
+- bash scripts/check_ascii_python.sh
+  - Pass.
+- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline
+  - Pass; refreshed 46 synced files with no additional working-tree changes.
+- bash scripts/run_extracted_pipeline_checks.sh
+  - `3222 passed, 10 skipped, 1 warning in 56.07s`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/control_surfaces.py` | 7 |
+| `extracted_content_pipeline/social_post_generation.py` | 3 |
+| `plans/PR-Content-Ops-Social-Post-Channel-Review-Fixes.md` | 127 |
+| `tests/test_extracted_content_control_surface_api.py` | 27 |
+| `tests/test_extracted_content_control_surfaces.py` | 22 |
+| `tests/test_extracted_social_post_generation.py` | 142 |
+| **Total** | **328** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -906,6 +906,33 @@ async def test_preview_generation_route_returns_preflight_plan():
 
 
 @pytest.mark.asyncio
+async def test_preview_generation_route_blocks_unsupported_social_channel():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["social_post"],
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+                "social_channels": ["discord"],
+            },
+        }
+    )
+
+    assert payload["can_run"] is False
+    assert payload["blocked_outputs"] == ["social_post"]
+    assert payload["estimated_cost_usd"] == 0.0
+    assert any(
+        "Unsupported social channel: unsupported social_post channel: discord"
+        in warning
+        for warning in payload["warnings"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_preview_generation_route_normalizes_cache_policy_field():
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -232,6 +232,28 @@ def test_preview_keeps_deterministic_multi_channel_social_post_at_zero_cost():
     assert preview["estimated_cost_usd"] == 0.0
 
 
+def test_preview_blocks_unsupported_social_post_channel_without_raising():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+                "social_channels": ["discord"],
+            },
+        }
+    )
+
+    assert preview["can_run"] is False
+    assert preview["outputs"] == []
+    assert preview["blocked_outputs"] == ["social_post"]
+    assert preview["estimated_cost_usd"] == 0.0
+    assert any(
+        "Unsupported social channel: unsupported social_post channel: discord"
+        in warning
+        for warning in preview["warnings"]
+    )
+
+
 def test_preview_charges_stored_brand_voice_social_post_rewrite():
     preview = preview_from_mapping(
         {

--- a/tests/test_extracted_social_post_generation.py
+++ b/tests/test_extracted_social_post_generation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
@@ -13,7 +15,7 @@ from extracted_content_pipeline.social_post_ports import SocialPostDraft
 
 
 class _LLM:
-    def __init__(self, *responses: str) -> None:
+    def __init__(self, *responses: str | Exception) -> None:
         self.responses = list(responses)
         self.calls: list[dict[str, object]] = []
 
@@ -25,6 +27,8 @@ class _LLM:
             "metadata": dict(metadata or {}),
         })
         content = self.responses.pop(0) if self.responses else "{}"
+        if isinstance(content, Exception):
+            raise content
         return LLMResponse(
             content=content,
             model="test-model",
@@ -270,6 +274,73 @@ async def test_social_post_service_generates_requested_channel_variants() -> Non
 
 
 @pytest.mark.asyncio
+async def test_social_post_service_applies_limit_to_source_rows_for_channel_variants() -> None:
+    service = SocialPostGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=2,
+        channels=("linkedin", "x"),
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+            },
+            {
+                "review_id": "review-2",
+                "vendor": "Zendesk",
+                "review_text": "Support queues took too long to triage.",
+            },
+            {
+                "review_id": "review-3",
+                "vendor": "Intercom",
+                "review_text": "Reporting did not explain where leads came from.",
+            },
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 4
+    assert [post["source_id"] for post in payload["posts"]] == [
+        "review-1",
+        "review-1",
+        "review-2",
+        "review-2",
+    ]
+    assert [post["channel"] for post in payload["posts"]] == [
+        "linkedin",
+        "x",
+        "linkedin",
+        "x",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_generates_threads_variant_body() -> None:
+    service = SocialPostGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        channels=("threads",),
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["posts"][0]["channel"] == "threads"
+    assert "Keep the takeaway conversational" in payload["posts"][0]["text"]
+
+
+@pytest.mark.asyncio
 async def test_social_post_service_rejects_unknown_channel() -> None:
     service = SocialPostGenerationService()
 
@@ -399,6 +470,75 @@ async def test_social_post_service_rewrites_brand_voice_per_requested_channel() 
     assert "channel=linkedin" in llm.calls[0]["messages"][1].content
     assert "channel=x" in llm.calls[1]["messages"][1].content
     assert 'Return channel exactly "x".' in llm.calls[1]["messages"][1].content
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_keeps_sibling_channel_when_one_rewrite_fails() -> None:
+    llm = _LLM(
+        RuntimeError("provider down"),
+        '{"channel":"linkedin","text":"LinkedIn rewrite survived the sibling failure."}',
+    )
+    service = SocialPostGenerationService(llm=llm, skills=_Skills())
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        channels=("x", "linkedin"),
+        brand_voice={
+            "id": "voice-1",
+            "account_id": "acct-1",
+            "descriptors": ["direct"],
+        },
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["posts"][0]["channel"] == "linkedin"
+    assert payload["posts"][0]["text"] == (
+        "LinkedIn rewrite survived the sibling failure."
+    )
+    assert "Source note" not in payload["posts"][0]["text"]
+    assert [warning["code"] for warning in payload["warnings"]] == [
+        "social_post_llm_error"
+    ]
+    assert len(llm.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_caps_x_brand_voice_rewrite_at_280_chars() -> None:
+    llm = _LLM(json.dumps({"channel": "x", "text": "x" * 350}))
+    service = SocialPostGenerationService(llm=llm, skills=_Skills())
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        channels=("x",),
+        brand_voice={
+            "id": "voice-1",
+            "account_id": "acct-1",
+            "descriptors": ["direct"],
+        },
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["posts"][0]["channel"] == "x"
+    assert len(payload["posts"][0]["text"]) == 280
+    assert payload["posts"][0]["text"].endswith("...")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Social-Post-Channel-Review-Fixes.md
Slice phase: Robust testing

Closes the actionable #1340 review findings: unsupported `social_channels` now block preview with a warning instead of escaping as an unhandled preview error, and the channel-variant behaviors are pinned with mutation-targeted tests for source-row limits, partial rewrite failure isolation, X caps, and Threads coverage.

## Intentional
- This does not reopen the #1340 product contract or add frontend selector wiring.
- Preview warnings keep invalid social-channel input in the same UX category as other preflight blockers.
- `/plan` and `/execute` are left unchanged because they already return 400 for the same invalid request shape.

## Deferred
- `PR-Content-Ops-Social-Post-Channel-Selector-UI`: expose `social_channels` in the New Run UI after these review fixes land.
- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management page if the inline New Run panel becomes too dense.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/social_post_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_social_post_generation.py` — pass.
- `pytest tests/test_extracted_social_post_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py -q` — `199 passed, 1 skipped in 3.77s`.
- `bash scripts/validate_extracted_content_pipeline.sh` — pass.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — pass.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — pass.
- `bash scripts/check_ascii_python.sh` — pass.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` — pass; refreshed 46 synced files with no additional working-tree changes.
- `bash scripts/run_extracted_pipeline_checks.sh` — `3222 passed, 10 skipped, 1 warning in 56.07s`.

## Diff size
6 files, +249 / -2.
