### PR TITLE
Content Ops Social Post Channel Selector UI

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Test Content Ops social post review assets
         run: npm run test:content-ops-social-post-review-assets
 
+      - name: Test Content Ops social post channel selector
+        run: npm run test:content-ops-social-post-channel-selector
+
       - name: Test Content Ops ad copy review assets
         run: npm run test:content-ops-ad-copy-review-assets
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -24,6 +24,7 @@
     "test:content-ops-upload-source-run-handoff": "node --test scripts/content-ops-upload-source-run-handoff.test.mjs",
     "test:content-ops-blog-review-public-link": "node --test scripts/content-ops-blog-review-public-link.test.mjs",
     "test:content-ops-social-post-review-assets": "node --test scripts/content-ops-social-post-review-assets.test.mjs",
+    "test:content-ops-social-post-channel-selector": "node --test scripts/content-ops-social-post-channel-selector.test.mjs",
     "test:content-ops-ad-copy-review-assets": "node --test scripts/content-ops-ad-copy-review-assets.test.mjs",
     "test:content-ops-quote-card-review-assets": "node --test scripts/content-ops-quote-card-review-assets.test.mjs",
     "test:content-ops-stat-card-review-assets": "node --test scripts/content-ops-stat-card-review-assets.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-social-post-channel-selector.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-social-post-channel-selector.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+async function loadTsModule(path) {
+  const source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  fromWireRequest,
+  toWireRequest,
+} = await loadTsModule('../src/domain/contentOps/fromWire.ts')
+
+const {
+  DEFAULT_SOCIAL_POST_CHANNELS,
+  SOCIAL_POST_CHANNEL_OPTIONS,
+  SOCIAL_POST_OUTPUT,
+  normalizeSocialPostChannels,
+  requestWithSocialPostChannels,
+} = await loadTsModule('../src/domain/contentOps/socialPostChannels.ts')
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+const helperSource = readFileSync(
+  new URL('../src/domain/contentOps/socialPostChannels.ts', import.meta.url),
+  'utf8',
+)
+
+test('social post channel ids match the backend contract order', () => {
+  assert.equal(SOCIAL_POST_OUTPUT, 'social_post')
+  assert.deepEqual(
+    SOCIAL_POST_CHANNEL_OPTIONS.map((option) => option.id),
+    ['linkedin', 'x', 'facebook', 'instagram', 'threads'],
+  )
+  assert.deepEqual(DEFAULT_SOCIAL_POST_CHANNELS, ['linkedin'])
+})
+
+test('normalizes selected social post channels with LinkedIn default fallback', () => {
+  assert.deepEqual(normalizeSocialPostChannels([]), ['linkedin'])
+  assert.deepEqual(normalizeSocialPostChannels(null), ['linkedin'])
+  assert.deepEqual(
+    normalizeSocialPostChannels(['linkedin', 'x', 'linkedin', 'invalid']),
+    ['linkedin', 'x'],
+  )
+})
+
+test('social post output submits selected channels through inputs.social_channels', () => {
+  const request = fromWireRequest({
+    outputs: ['social_post'],
+    inputs: {
+      topic: 'retention',
+      channels: ['email'],
+      social_post_channels: ['instagram'],
+    },
+  })
+
+  const wire = toWireRequest(
+    requestWithSocialPostChannels(request, ['linkedin', 'x', 'facebook']),
+  )
+
+  assert.deepEqual(wire.inputs.social_channels, [
+    'linkedin',
+    'x',
+    'facebook',
+  ])
+  assert.deepEqual(wire.inputs.channels, ['email'])
+  assert.equal(wire.inputs.social_post_channels, undefined)
+})
+
+test('non-social outputs omit social channel inputs', () => {
+  const request = fromWireRequest({
+    outputs: ['blog_post'],
+    inputs: {
+      social_channels: ['x'],
+      social_post_channels: ['threads'],
+    },
+  })
+
+  const wire = toWireRequest(requestWithSocialPostChannels(request, ['x']))
+
+  assert.equal(wire.inputs.social_channels, undefined)
+  assert.equal(wire.inputs.social_post_channels, undefined)
+})
+
+test('New Run UI gates the selector and uses the same submit request mapper', () => {
+  assert.match(newRunSource, /socialPostOutputSelected &&/)
+  assert.match(newRunSource, /SOCIAL_POST_CHANNEL_OPTIONS\.map/)
+  assert.match(newRunSource, /handleSocialPostChannelChange/)
+  assert.match(newRunSource, /requestWithSocialPostChannels\(/)
+  assert.match(newRunSource, /toWireRequest\(parsed\.domainRequest\)/)
+  assert.match(helperSource, /social_channels/)
+  assert.doesNotMatch(helperSource, /inputs\.channels/)
+})

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -86,6 +86,15 @@ export type {
 } from './brandVoiceProfileEditor'
 
 export {
+  DEFAULT_SOCIAL_POST_CHANNELS,
+  SOCIAL_POST_CHANNEL_OPTIONS,
+  SOCIAL_POST_OUTPUT,
+  normalizeSocialPostChannels,
+  requestWithSocialPostChannels,
+} from './socialPostChannels'
+export type { SocialPostChannelId } from './socialPostChannels'
+
+export {
   FAQ_CONFIGURATION_OUTPUTS,
   FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
   FAQ_DOCUMENTATION_TERMS_INPUT,

--- a/atlas-intel-ui/src/domain/contentOps/socialPostChannels.ts
+++ b/atlas-intel-ui/src/domain/contentOps/socialPostChannels.ts
@@ -1,0 +1,61 @@
+import type { ContentOpsRequest } from './types'
+
+export const SOCIAL_POST_OUTPUT = 'social_post' as const
+
+// Mirror extracted_content_pipeline/social_post_generation.py.
+export const SOCIAL_POST_CHANNEL_OPTIONS = [
+  { id: 'linkedin', label: 'LinkedIn' },
+  { id: 'x', label: 'X' },
+  { id: 'facebook', label: 'Facebook' },
+  { id: 'instagram', label: 'Instagram' },
+  { id: 'threads', label: 'Threads' },
+] as const
+
+export type SocialPostChannelId =
+  (typeof SOCIAL_POST_CHANNEL_OPTIONS)[number]['id']
+
+export const DEFAULT_SOCIAL_POST_CHANNELS: SocialPostChannelId[] = [
+  'linkedin',
+]
+
+const SOCIAL_POST_CHANNEL_IDS = new Set<string>(
+  SOCIAL_POST_CHANNEL_OPTIONS.map((option) => option.id),
+)
+
+export function normalizeSocialPostChannels(
+  channels: readonly string[] | null | undefined,
+): SocialPostChannelId[] {
+  const normalized: SocialPostChannelId[] = []
+  for (const channel of channels ?? []) {
+    if (
+      SOCIAL_POST_CHANNEL_IDS.has(channel) &&
+      !normalized.includes(channel as SocialPostChannelId)
+    ) {
+      normalized.push(channel as SocialPostChannelId)
+    }
+  }
+  return normalized.length > 0
+    ? normalized
+    : [...DEFAULT_SOCIAL_POST_CHANNELS]
+}
+
+export function requestWithSocialPostChannels(
+  request: ContentOpsRequest,
+  channels: readonly string[],
+): ContentOpsRequest {
+  const inputs = { ...request.inputs }
+  delete inputs.social_post_channels
+
+  if (!request.outputs.includes(SOCIAL_POST_OUTPUT)) {
+    delete inputs.social_channels
+    return { ...request, inputs }
+  }
+
+  return {
+    ...request,
+    inputs: {
+      ...inputs,
+      social_channels: normalizeSocialPostChannels(channels),
+    },
+  }
+}

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -73,6 +73,9 @@ import {
   FAQ_RESOLUTION_EVIDENCE_STATUS,
   FAQ_VOCABULARY_GAP_RULES_INPUT,
   BRAND_VOICE_PROFILE_PRESETS,
+  DEFAULT_SOCIAL_POST_CHANNELS,
+  SOCIAL_POST_CHANNEL_OPTIONS,
+  SOCIAL_POST_OUTPUT,
   applyBrandVoiceProfileEditorPatch,
   blankBrandVoiceProfileEditorState,
   brandVoicePresetEditorPatch,
@@ -80,6 +83,8 @@ import {
   brandVoiceProfileEditorStateFromProfile,
   canSaveBrandVoiceProfileEditor,
   deriveBrandVoiceProfileEditorPatch,
+  normalizeSocialPostChannels,
+  requestWithSocialPostChannels,
   type ContentOpsCatalog,
   type ContentOpsCachePolicy,
   type ContentOpsIngestionDiagnostics,
@@ -100,6 +105,7 @@ import {
   type GenerationPlanStep,
   type ContentOpsUsageBudgetEvaluation,
   type BrandVoiceProfileEditorState,
+  type SocialPostChannelId,
 } from '../domain/contentOps'
 import type {
   ContentOpsBrandVoiceProfile,
@@ -316,6 +322,9 @@ export default function ContentOpsNewRun() {
   const [request, setRequest] = useState<ContentOpsRequest>(() =>
     fromWireRequest({}),
   )
+  const [selectedSocialPostChannels, setSelectedSocialPostChannels] = useState<
+    SocialPostChannelId[]
+  >(() => [...DEFAULT_SOCIAL_POST_CHANNELS])
   // Codex P2 fix v3: keep the max-cost input as a string draft so the
   // user can type `0.` mid-entry without React re-rendering as `0` and
   // swallowing the decimal point. Parsed to a number at submit time.
@@ -383,6 +392,7 @@ export default function ContentOpsNewRun() {
   const sourceMode = sourceModeDraftValue(parsedInputsForControls)
   const landingPageOutputSelected = request.outputs.includes('landing_page')
   const blogPostOutputSelected = request.outputs.includes(BLOG_POST_OUTPUT)
+  const socialPostOutputSelected = request.outputs.includes(SOCIAL_POST_OUTPUT)
   const faqSourceSelectionVisible =
     (landingPageOutputSelected || blogPostOutputSelected) &&
     sourceMode === 'support_ticket'
@@ -555,6 +565,20 @@ export default function ContentOpsNewRun() {
     markStale()
   }
 
+  const handleSocialPostChannelChange = (
+    channelId: SocialPostChannelId,
+    checked: boolean,
+  ) => {
+    setSelectedSocialPostChannels((prev) =>
+      normalizeSocialPostChannels(
+        checked
+          ? [...prev, channelId]
+          : prev.filter((selected) => selected !== channelId),
+      ),
+    )
+    markStale()
+  }
+
   const togglePreset = (presetId: string) => {
     const preset = catalog.presets.find((p) => p.id === presetId)
     if (!preset) return
@@ -673,15 +697,20 @@ export default function ContentOpsNewRun() {
       }
     }
 
-    return {
-      ok: true,
-      domainRequest: {
+    const domainRequest = requestWithSocialPostChannels(
+      {
         ...request,
         inputs: parsedInputs,
         maxCostUsd: normalizedMaxCost,
         accountUsageBudgetUsd: normalizedAccountBudget,
         accountUsageBudgetDays: parsedAccountBudgetDays,
       },
+      selectedSocialPostChannels,
+    )
+
+    return {
+      ok: true,
+      domainRequest,
     }
   }
 
@@ -1174,6 +1203,49 @@ export default function ContentOpsNewRun() {
             })}
           </div>
         </section>
+
+        {socialPostOutputSelected && (
+          <section>
+            <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-slate-400">
+              Social channels
+            </h2>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+              {SOCIAL_POST_CHANNEL_OPTIONS.map((channel) => {
+                const checked = selectedSocialPostChannels.includes(channel.id)
+                const lastChecked =
+                  checked && selectedSocialPostChannels.length === 1
+                return (
+                  <label
+                    key={channel.id}
+                    className={clsx(
+                      'flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm transition',
+                      checked
+                        ? 'border-cyan-500 bg-cyan-500/10 text-cyan-100'
+                        : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-500',
+                      lastChecked
+                        ? 'cursor-default'
+                        : 'cursor-pointer',
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={lastChecked}
+                      onChange={(event) =>
+                        handleSocialPostChannelChange(
+                          channel.id,
+                          event.currentTarget.checked,
+                        )
+                      }
+                      className="h-4 w-4 rounded border-slate-600 bg-slate-800 accent-cyan-500 disabled:opacity-80"
+                    />
+                    <span className="min-w-0 truncate">{channel.label}</span>
+                  </label>
+                )
+              })}
+            </div>
+          </section>
+        )}
 
         {/* Inputs (v0: raw JSON) */}
         <section>

--- a/plans/PR-Content-Ops-Social-Post-Channel-Selector-UI.md
+++ b/plans/PR-Content-Ops-Social-Post-Channel-Selector-UI.md
@@ -1,0 +1,104 @@
+# PR-Content-Ops-Social-Post-Channel-Selector-UI
+
+## Why this slice exists
+
+PR #1340 added the backend/package contract for social-post channel variants:
+`inputs.social_channels` / `inputs.social_post_channels` fan out one source row
+into platform-specific drafts and preview cost scales for brand-voice rewrites.
+PR #1341 hardened the invalid-channel preview path and mutation-pinned the core
+behavior.
+
+The remaining product gap is that a user still cannot select those channels in
+the New Run UI. This slice exposes the contract at the run-configuration
+surface so selecting `social_post` can send the desired platform list instead
+of always using the backend default LinkedIn-only behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/social-post-channel-selector-ui
+Slice phase: Vertical slice
+
+1. Add a social-post channel selector to the New Run configuration UI when the
+   `social_post` output is selected.
+2. Default the selector to LinkedIn only, matching the backend default and
+   preserving existing runs unless the user opts into more channels.
+3. Submit selected channels as `inputs.social_channels` on preview/plan/execute
+   payloads without reusing campaign-owned `inputs.channels`.
+4. Keep the selector state stable when outputs are toggled, but omit
+   `social_channels` when `social_post` is not selected.
+5. Add UI/domain tests proving default payload compatibility, multi-channel
+   payload threading, and non-social output omission.
+
+### Review Contract
+
+- Acceptance criteria: selecting `social_post` reveals a channel selector;
+  LinkedIn is selected by default; additional checked channels are included in
+  `inputs.social_channels`; non-social runs do not send social channels; tests
+  exercise the real request mapper/submit path used by the UI.
+- Affected surfaces: atlas-intel-ui Content Ops New Run UI, request mapping,
+  frontend tests, plan doc.
+- Risk areas: payload contract drift, accidental collision with campaign
+  `channels`, UI test enrollment, mobile/compact layout text fit.
+- Reviewer rules triggered: R1 (UI behavior matches backend contract), R2
+  (tests prove payload threading), R9 (frontend behavior), R12 (frontend CI
+  enrollment if a new test is added).
+
+### Files touched
+
+- `.github/workflows/atlas_intel_ui_checks.yml`
+- `atlas-intel-ui/package.json`
+- `atlas-intel-ui/scripts/content-ops-social-post-channel-selector.test.mjs`
+- `atlas-intel-ui/src/domain/contentOps/index.ts`
+- `atlas-intel-ui/src/domain/contentOps/socialPostChannels.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `plans/PR-Content-Ops-Social-Post-Channel-Selector-UI.md`
+
+## Mechanism
+
+The UI will keep a small, typed list of supported social channels matching the
+backend normalized ids (`linkedin`, `x`, `facebook`, `instagram`, `threads`).
+The New Run state stores selected social-post channels separately from any
+campaign channel state. The request builder adds `inputs.social_channels` only
+when `social_post` is selected and at least one social channel is checked.
+
+The control is intentionally a compact checkbox/segmented list near the output
+selection area rather than a separate settings page. The backend still enforces
+valid ids and default LinkedIn behavior, so the UI does not need to duplicate
+validation beyond keeping the selector non-empty.
+
+## Intentional
+
+- This does not add a new backend enum endpoint; the supported ids are a tiny
+  product list already fixed in the backend contract.
+- This does not use `inputs.channels`, which remains the email/campaign channel
+  field.
+- This does not add a standalone brand-voice settings page; it only exposes the
+  social-post channel selector needed for the current run.
+
+## Deferred
+
+- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management
+  page if the inline New Run panel becomes too dense.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm run test:content-ops-social-post-channel-selector` - 5/5 tests passed.
+- `npm run lint` - passed.
+- `npm run build` - passed.
+- Manual enrollment grep for `test:content-ops-social-post-channel-selector` - package script and workflow run step both present.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-content-ops-social-post-channel-selector-ui-body.md` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_intel_ui_checks.yml` | 3 |
+| `atlas-intel-ui/package.json` | 1 |
+| `atlas-intel-ui/scripts/content-ops-social-post-channel-selector.test.mjs` | 106 |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | 9 |
+| `atlas-intel-ui/src/domain/contentOps/socialPostChannels.ts` | 61 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 78 |
+| `plans/PR-Content-Ops-Social-Post-Channel-Selector-UI.md` | 104 |
+| **Total** | **362** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Social-Post-Channel-Selector-UI.md
Slice phase: Vertical slice

This slice exposes the merged social-post channel contract in the Content Ops New Run UI so a `social_post` run can submit selected platform variants through `inputs.social_channels` instead of silently using the backend's LinkedIn-only default.

## Intentional
- This does not add a new backend enum endpoint; the supported ids are a tiny product list already fixed in the backend contract.
- This does not use `inputs.channels`, which remains the email/campaign channel field.
- This does not add a standalone brand-voice settings page; it only exposes the social-post channel selector needed for the current run.

## Deferred
- `PR-Content-Ops-Brand-Voice-Settings-Page`: optional standalone management page if the inline New Run panel becomes too dense.

## Parked hardening
- None.

## Verification
- `npm run test:content-ops-social-post-channel-selector` - 5/5 tests passed.
- `npm run lint` - passed.
- `npm run build` - passed.
- Manual enrollment grep for `test:content-ops-social-post-channel-selector` - package script and workflow run step both present.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-content-ops-social-post-channel-selector-ui-body.md` - passed.

## Diff size
7 files, +359 / -3