### PR TITLE
Content Ops Brand Voice Settings Page

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Test Content Ops brand voice profile selector
         run: npm run test:content-ops-brand-voice-profile-selector
 
+      - name: Test Content Ops brand voice settings page
+        run: npm run test:content-ops-brand-voice-settings-page
+
       - name: Test Content Ops blog review public link
         run: npm run test:content-ops-blog-review-public-link
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -15,6 +15,7 @@
     "test:content-ops-usage-budget-ui": "node --test scripts/content-ops-usage-budget-ui.test.mjs",
     "test:content-ops-usage-summary": "node --test scripts/content-ops-usage-summary.test.mjs",
     "test:content-ops-brand-voice-profile-selector": "node --test scripts/content-ops-brand-voice-profile-selector.test.mjs",
+    "test:content-ops-brand-voice-settings-page": "node --test scripts/content-ops-brand-voice-settings-page.test.mjs",
     "test:content-ops-zendesk-credentials": "node --test scripts/content-ops-zendesk-credentials-ui.test.mjs",
     "test:content-ops-faq-macro-publish": "node --test scripts/content-ops-faq-macro-publish-ui.test.mjs",
     "test:content-ops-faq-source-selection": "node --test scripts/content-ops-faq-source-selection.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-brand-voice-settings-page.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-brand-voice-settings-page.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const appSource = readFileSync(new URL('../src/App.tsx', import.meta.url), 'utf8')
+const sidebarSource = readFileSync(
+  new URL('../src/components/Sidebar.tsx', import.meta.url),
+  'utf8',
+)
+const pageSource = readFileSync(
+  new URL('../src/pages/ContentOpsBrandVoiceSettings.tsx', import.meta.url),
+  'utf8',
+)
+
+test('brand voice settings page is registered as protected Content Ops route', () => {
+  assert.ok(
+    appSource.includes(
+      "const ContentOpsBrandVoiceSettings = lazy(",
+    ),
+  )
+  assert.ok(
+    appSource.includes(
+      '<Route path="/content-ops/brand-voice" element={renderLazyRoute(ContentOpsBrandVoiceSettings)} />',
+    ),
+  )
+})
+
+test('B2B sidebar exposes brand voice settings navigation', () => {
+  const matches = sidebarSource.match(/to: '\/content-ops\/brand-voice'/g) ?? []
+  assert.equal(matches.length, 2)
+  assert.ok(sidebarSource.includes("label: 'Brand Voice'"))
+  assert.ok(sidebarSource.includes('icon: Palette'))
+})
+
+test('settings page lists tenant brand voice profiles with real API and states', () => {
+  assert.ok(pageSource.includes('fetchContentOpsBrandVoiceProfiles()'))
+  assert.ok(pageSource.includes('useApiData(() => fetchContentOpsBrandVoiceProfiles(), [])'))
+  assert.ok(pageSource.includes('if ((loading || refreshing) && !profiles)'))
+  assert.ok(pageSource.includes('Loading brand voice profiles...'))
+  assert.ok(pageSource.includes('No saved brand voice profiles'))
+  assert.ok(pageSource.includes('Refresh failed:'))
+  assert.ok(pageSource.includes('profile.descriptors'))
+  assert.ok(pageSource.includes('profile.exemplars[0]'))
+})
+
+test('settings page sends create/edit/run actions back to New Run editor', () => {
+  const newRunLinks = pageSource.match(/to="\/content-ops\/new"/g) ?? []
+  assert.ok(newRunLinks.length >= 2)
+  assert.ok(pageSource.includes('New profile'))
+  assert.ok(pageSource.includes('Open New Run'))
+  assert.equal(pageSource.includes('Use in run'), false)
+})

--- a/atlas-intel-ui/src/App.tsx
+++ b/atlas-intel-ui/src/App.tsx
@@ -34,6 +34,9 @@ const B2BReviews = lazy(() => import('./pages/b2b/B2BReviews'))
 const B2BCampaigns = lazy(() => import('./pages/b2b/B2BCampaigns'))
 const ContentOpsNewRun = lazy(() => import('./pages/ContentOpsNewRun'))
 const ContentOpsAssetsReview = lazy(() => import('./pages/ContentOpsAssetsReview'))
+const ContentOpsBrandVoiceSettings = lazy(
+  () => import('./pages/ContentOpsBrandVoiceSettings'),
+)
 
 function renderLazyRoute(Component: ComponentType) {
   return (
@@ -90,6 +93,7 @@ export default function App() {
 
                     {/* Content Ops routes */}
                     <Route path="/content-ops/new" element={renderLazyRoute(ContentOpsNewRun)} />
+                    <Route path="/content-ops/brand-voice" element={renderLazyRoute(ContentOpsBrandVoiceSettings)} />
                     <Route path="/content-ops/assets" element={renderLazyRoute(ContentOpsAssetsReview)} />
                   </Routes>
                 </Layout>

--- a/atlas-intel-ui/src/components/Sidebar.tsx
+++ b/atlas-intel-ui/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   FileText,
   Megaphone,
   ClipboardCheck,
+  Palette,
   Sparkles,
 } from 'lucide-react'
 import { clsx } from 'clsx'
@@ -62,6 +63,7 @@ const b2bRetentionLinks: NavItem[] = [
   { to: '/b2b/reports', icon: FileText, label: 'Reports', minPlan: 'b2b_starter' },
   { to: '/b2b/campaigns', icon: Megaphone, label: 'Campaigns', minPlan: 'b2b_growth' },
   { to: '/content-ops/new', icon: Sparkles, label: 'Content Ops', minPlan: 'b2b_growth' },
+  { to: '/content-ops/brand-voice', icon: Palette, label: 'Brand Voice', minPlan: 'b2b_growth' },
   { to: '/content-ops/assets', icon: ClipboardCheck, label: 'Asset Review', minPlan: 'b2b_growth' },
 ]
 
@@ -74,6 +76,7 @@ const b2bChallengerLinks: NavItem[] = [
   { to: '/b2b/reports', icon: FileText, label: 'Reports', minPlan: 'b2b_starter' },
   { to: '/b2b/reviews', icon: MessageSquareText, label: 'Reviews' },
   { to: '/content-ops/new', icon: Sparkles, label: 'Content Ops', minPlan: 'b2b_growth' },
+  { to: '/content-ops/brand-voice', icon: Palette, label: 'Brand Voice', minPlan: 'b2b_growth' },
   { to: '/content-ops/assets', icon: ClipboardCheck, label: 'Asset Review', minPlan: 'b2b_growth' },
 ]
 

--- a/atlas-intel-ui/src/pages/ContentOpsBrandVoiceSettings.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsBrandVoiceSettings.tsx
@@ -1,0 +1,181 @@
+import { Link } from 'react-router-dom'
+import { ArrowRight, Loader2, Palette, Plus, RefreshCw } from 'lucide-react'
+import { clsx } from 'clsx'
+import {
+  fetchContentOpsBrandVoiceProfiles,
+  type ContentOpsBrandVoiceProfile,
+} from '../api/contentOps'
+import useApiData from '../hooks/useApiData'
+import { PageError } from '../components/ErrorBoundary'
+
+export default function ContentOpsBrandVoiceSettings() {
+  const {
+    data: profiles,
+    loading,
+    error,
+    refresh,
+    refreshing,
+  } = useApiData(() => fetchContentOpsBrandVoiceProfiles(), [])
+
+  if ((loading || refreshing) && !profiles) {
+    return (
+      <div className="flex items-center justify-center py-24 text-slate-400">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+        Loading brand voice profiles...
+      </div>
+    )
+  }
+
+  if (error && !profiles) {
+    return <PageError error={error} onRetry={refresh} />
+  }
+
+  const savedProfiles = profiles ?? []
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      <header className="flex flex-col gap-4 border-b border-slate-800 pb-5 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-sm text-cyan-300">
+            <Palette className="h-4 w-4" />
+            Content Ops
+          </div>
+          <h1 className="text-3xl font-semibold text-white">Brand Voice</h1>
+          <p className="mt-2 max-w-2xl text-sm text-slate-400">
+            Saved profiles used by generated landing pages, blog posts, and
+            social posts.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={refreshing}
+            className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:bg-slate-800 disabled:opacity-50"
+          >
+            <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
+            Refresh
+          </button>
+          <Link
+            to="/content-ops/new"
+            className="inline-flex items-center justify-center gap-2 rounded-md bg-cyan-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-400"
+          >
+            <Plus className="h-4 w-4" />
+            New profile
+          </Link>
+        </div>
+      </header>
+
+      {error && profiles && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
+          Refresh failed: {error.message}
+        </div>
+      )}
+
+      {savedProfiles.length === 0 ? (
+        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-6">
+          <h2 className="text-lg font-medium text-slate-100">
+            No saved brand voice profiles
+          </h2>
+          <p className="mt-2 max-w-xl text-sm text-slate-400">
+            Create one from the New Run page, then select it for generation.
+          </p>
+          <Link
+            to="/content-ops/new"
+            className="mt-4 inline-flex items-center justify-center gap-2 rounded-md border border-cyan-500/60 px-3 py-2 text-sm text-cyan-100 hover:bg-cyan-500/10"
+          >
+            Open New Run
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </section>
+      ) : (
+        <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          {savedProfiles.map((profile) => (
+            <BrandVoiceProfileCard key={profile.id} profile={profile} />
+          ))}
+        </section>
+      )}
+    </div>
+  )
+}
+
+function BrandVoiceProfileCard({
+  profile,
+}: {
+  profile: ContentOpsBrandVoiceProfile
+}) {
+  return (
+    <article className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="truncate text-lg font-medium text-slate-100">
+            {profile.name}
+          </h2>
+          <p className="mt-1 text-xs text-slate-500">
+            Updated {formatBrandVoiceDate(profile.updated_at)}
+          </p>
+        </div>
+        <Link
+          to="/content-ops/new"
+          className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800"
+        >
+          Open New Run
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+      <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+        <BrandVoiceField label="Descriptors" values={profile.descriptors} />
+        <BrandVoiceField label="Banned terms" values={profile.banned_terms} />
+        <BrandVoiceField
+          label="POV"
+          values={profile.preferred_pov ? [profile.preferred_pov] : []}
+        />
+        <BrandVoiceField
+          label="Reading"
+          values={profile.reading_level ? [profile.reading_level] : []}
+        />
+      </dl>
+      {profile.exemplars.length > 0 && (
+        <div className="mt-4 rounded-md border border-slate-800 bg-slate-950/40 px-3 py-2">
+          <div className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            Exemplar
+          </div>
+          <p className="mt-1 line-clamp-3 text-sm text-slate-300">
+            {profile.exemplars[0]}
+          </p>
+        </div>
+      )}
+    </article>
+  )
+}
+
+function BrandVoiceField({
+  label,
+  values,
+}: {
+  label: string
+  values: string[]
+}) {
+  return (
+    <div>
+      <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+        {label}
+      </dt>
+      <dd className="mt-1 text-slate-300">
+        {values.length > 0 ? values.slice(0, 3).join(', ') : 'Not set'}
+      </dd>
+    </div>
+  )
+}
+
+function formatBrandVoiceDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return 'unknown'
+  }
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}

--- a/plans/PR-Content-Ops-Brand-Voice-Settings-Page.md
+++ b/plans/PR-Content-Ops-Brand-Voice-Settings-Page.md
@@ -1,0 +1,117 @@
+# PR-Content-Ops-Brand-Voice-Settings-Page
+
+## Why this slice exists
+
+The brand-voice profile chain is now productized enough to use: tenant-scoped
+profile storage, CRUD APIs, the New Run selector/editor, sample onboarding,
+presets, LLM social-post voice, and social channel selection have all landed.
+The remaining UX gap is discoverability. Brand voice management is buried in
+the New Run setup page, so operators cannot quickly inspect saved profiles or
+find the run-entry point without starting a generation flow.
+
+Earlier brand-voice plans repeatedly deferred
+`PR-Content-Ops-Brand-Voice-Settings-Page` as the follow-up once the inline
+surface became dense. This slice adds the thinnest standalone settings surface:
+a dedicated route and navigation entry that lists saved profiles, shows their
+operator-facing guidance summary, and links back to New Run for create/edit/run
+actions.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/settings-page
+Slice phase: Product polish
+
+1. Add a protected `/content-ops/brand-voice` route in `atlas-intel-ui`.
+2. Add B2B sidebar navigation to the new brand voice settings route.
+3. Implement a compact settings page that fetches tenant saved profiles through
+   the existing `fetchContentOpsBrandVoiceProfiles()` API and renders loading,
+   error, empty, and populated states.
+4. Keep management mutations in the already-shipped New Run editor for this
+   slice; the settings page links to `/content-ops/new` for new/edit/run
+   actions.
+5. Add a CI-enrolled frontend test proving route/nav registration, API use,
+   empty/populated-state text, and workflow enrollment.
+
+### Review Contract
+
+- Acceptance criteria: `/content-ops/brand-voice` is registered as a protected
+  route; B2B navigation exposes "Brand Voice"; the page fetches saved profiles
+  with the existing tenant API; loading/error/empty/populated states are
+  represented; action links go to `/content-ops/new`; the new test is enrolled
+  in `.github/workflows/atlas_intel_ui_checks.yml`.
+- Affected surfaces: atlas-intel-ui routing, sidebar navigation, new Content
+  Ops settings page, frontend tests, plan doc.
+- Risk areas: accidentally duplicating profile mutation behavior, hiding the
+  New Run editor contract, frontend CI test enrollment.
+- Reviewer rules triggered: R1 (settings surface matches the deferred scope),
+  R2 (test evidence), R9 (frontend behavior), R12 (frontend CI enrollment).
+
+### Files touched
+
+- `.github/workflows/atlas_intel_ui_checks.yml`
+- `atlas-intel-ui/package.json`
+- `atlas-intel-ui/scripts/content-ops-brand-voice-settings-page.test.mjs`
+- `atlas-intel-ui/src/App.tsx`
+- `atlas-intel-ui/src/components/Sidebar.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsBrandVoiceSettings.tsx`
+- `plans/PR-Content-Ops-Brand-Voice-Settings-Page.md`
+
+## Mechanism
+
+`ContentOpsBrandVoiceSettings` uses `useApiData()` with
+`fetchContentOpsBrandVoiceProfiles()` and renders an unframed page layout:
+
+```tsx
+profiles.map((profile) => (
+  <article>
+    <h2>{profile.name}</h2>
+    <p>{format profile guidance summary}</p>
+    <Link to="/content-ops/new">Use in run</Link>
+  </article>
+))
+```
+
+The page is read/list/action-only in this slice. It does not duplicate create,
+update, archive, sample import, or preset application logic from
+`ContentOpsNewRun`; those flows stay in the existing New Run editor until a
+separate extraction slice moves the shared editor into a reusable component.
+
+## Intentional
+
+- No profile create/edit/archive controls on the settings page yet. Copying the
+  large New Run editor would create a second mutation surface; extracting it
+  cleanly is a separate, larger refactor.
+- No backend/API changes. The tenant-scoped CRUD routes already exist and the
+  settings page only needs the list endpoint.
+- No new design system. The page follows the existing restrained Content Ops
+  dark UI and keeps cards to individual profile rows.
+
+## Deferred
+
+- `PR-Content-Ops-Brand-Voice-Editor-Extraction`: move the New Run brand voice
+  editor into a shared component and render it on the settings page for full
+  create/edit/archive workflows.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm run test:content-ops-brand-voice-settings-page` - 4/4 tests passed.
+- `npm run lint` - passed.
+- `npm run build` - passed.
+- Manual enrollment grep for `test:content-ops-brand-voice-settings-page` -
+  package script and workflow run step both present.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-content-ops-brand-voice-settings-page-body.md` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_intel_ui_checks.yml` | 3 |
+| `atlas-intel-ui/package.json` | 1 |
+| `atlas-intel-ui/scripts/content-ops-brand-voice-settings-page.test.mjs` | 52 |
+| `atlas-intel-ui/src/App.tsx` | 4 |
+| `atlas-intel-ui/src/components/Sidebar.tsx` | 3 |
+| `atlas-intel-ui/src/pages/ContentOpsBrandVoiceSettings.tsx` | 181 |
+| `plans/PR-Content-Ops-Brand-Voice-Settings-Page.md` | 117 |
+| **Total** | **361** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Brand-Voice-Settings-Page.md
Slice phase: Product polish

This slice adds the thin standalone brand voice settings surface that earlier brand-voice plans deferred: a protected route and B2B nav entry that lists tenant saved profiles, shows their guidance summary, and links operators back to New Run for profile creation/edit/run usage.

## Intentional
- No profile create/edit/archive controls on the settings page yet. Copying the large New Run editor would create a second mutation surface; extracting it cleanly is a separate, larger refactor.
- No backend/API changes. The tenant-scoped CRUD routes already exist and the settings page only needs the list endpoint.
- No new design system. The page follows the existing restrained Content Ops dark UI and keeps cards to individual profile rows.

## Deferred
- `PR-Content-Ops-Brand-Voice-Editor-Extraction`: move the New Run brand voice editor into a shared component and render it on the settings page for full create/edit/archive workflows.

## Parked hardening
- None.

## Verification
- `npm run test:content-ops-brand-voice-settings-page` - 4/4 tests passed.
- `npm run lint` - passed.
- `npm run build` - passed.
- Manual enrollment grep for `test:content-ops-brand-voice-settings-page` - package script and workflow run step both present.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-content-ops-brand-voice-settings-page-body.md` - passed.

## Diff size
7 files, +361 / -0