### PR TITLE
Content Ops Brand Voice Editor Extraction

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs
@@ -58,6 +58,10 @@ const newRunSource = readFileSync(
   new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
   'utf8',
 )
+const managerSource = readFileSync(
+  new URL('../src/components/contentOps/BrandVoiceProfileManager.tsx', import.meta.url),
+  'utf8',
+)
 
 function installBrowserStubs() {
   Object.defineProperty(globalThis, 'localStorage', {
@@ -352,29 +356,35 @@ test('brand voice preset patch fills only empty guidance fields', () => {
   assert.equal(brandVoicePresetEditorPatch('missing'), null)
 })
 
-test('new run page renders brand voice profile selector wiring', () => {
-  assert.ok(newRunSource.includes('function BrandVoiceProfileSelector'))
-  assert.ok(newRunSource.includes('BRAND_VOICE_PROFILE_PRESETS'))
-  assert.ok(newRunSource.includes('brandVoicePresetEditorPatch'))
+test('brand voice manager owns shared profile editor wiring', () => {
+  assert.ok(managerSource.includes('export function BrandVoiceProfileManager'))
+  assert.ok(managerSource.includes('BRAND_VOICE_PROFILE_PRESETS'))
+  assert.ok(managerSource.includes('brandVoicePresetEditorPatch'))
+  assert.ok(managerSource.includes('fetchContentOpsBrandVoiceSampleUrl'))
+  assert.ok(managerSource.includes('createContentOpsBrandVoiceProfile'))
+  assert.ok(managerSource.includes('updateContentOpsBrandVoiceProfile'))
+  assert.ok(managerSource.includes('deleteContentOpsBrandVoiceProfile'))
+  assert.ok(managerSource.includes('Saved profile'))
+  assert.ok(managerSource.includes('No saved brand voice'))
+  assert.ok(managerSource.includes('New brand voice'))
+  assert.ok(managerSource.includes('Edit brand voice'))
+  assert.ok(managerSource.includes('Archive'))
+  assert.ok(managerSource.includes('Apply preset'))
+  assert.ok(managerSource.includes('Sample import'))
+  assert.ok(managerSource.includes('type="file"'))
+  assert.ok(managerSource.includes('Fetch URL'))
+  assert.ok(managerSource.includes('brandVoiceSampleFallbackName'))
+  assert.ok(managerSource.includes('sampleFetchTokenRef'))
+  assert.ok(managerSource.includes('invalidateSampleFetch'))
+  assert.ok(managerSource.includes('deriveBrandVoiceProfileEditorPatch'))
+  assert.ok(managerSource.includes('disabled={loading || mutating}'))
+  assert.ok(managerSource.includes('selectedProfileIdRef.current === archiveProfileId'))
+})
+
+test('new run page consumes shared brand voice manager for run selection', () => {
+  assert.ok(newRunSource.includes('BrandVoiceProfileManager'))
   assert.ok(newRunSource.includes('fetchContentOpsBrandVoiceProfiles'))
-  assert.ok(newRunSource.includes('fetchContentOpsBrandVoiceSampleUrl'))
-  assert.ok(newRunSource.includes('createContentOpsBrandVoiceProfile'))
-  assert.ok(newRunSource.includes('updateContentOpsBrandVoiceProfile'))
-  assert.ok(newRunSource.includes('deleteContentOpsBrandVoiceProfile'))
   assert.ok(newRunSource.includes('brandVoiceProfileId'))
-  assert.ok(newRunSource.includes('Saved profile'))
-  assert.ok(newRunSource.includes('No saved brand voice'))
-  assert.ok(newRunSource.includes('New brand voice'))
-  assert.ok(newRunSource.includes('Edit brand voice'))
-  assert.ok(newRunSource.includes('Archive'))
-  assert.ok(newRunSource.includes('Apply preset'))
-  assert.ok(newRunSource.includes('Sample import'))
-  assert.ok(newRunSource.includes('type="file"'))
-  assert.ok(newRunSource.includes('Fetch URL'))
-  assert.ok(newRunSource.includes('brandVoiceSampleFallbackName'))
-  assert.ok(newRunSource.includes('sampleFetchTokenRef'))
-  assert.ok(newRunSource.includes('invalidateSampleFetch'))
-  assert.ok(newRunSource.includes('deriveBrandVoiceProfileEditorPatch'))
-  assert.ok(newRunSource.includes('disabled={loading || mutating}'))
-  assert.ok(newRunSource.includes('selectedProfileIdRef.current === archiveProfileId'))
+  assert.equal(newRunSource.includes('function BrandVoiceProfileSelector'), false)
+  assert.equal(newRunSource.includes('function BrandVoiceProfileManager'), false)
 })

--- a/atlas-intel-ui/scripts/content-ops-brand-voice-settings-page.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-brand-voice-settings-page.test.mjs
@@ -11,6 +11,10 @@ const pageSource = readFileSync(
   new URL('../src/pages/ContentOpsBrandVoiceSettings.tsx', import.meta.url),
   'utf8',
 )
+const managerSource = readFileSync(
+  new URL('../src/components/contentOps/BrandVoiceProfileManager.tsx', import.meta.url),
+  'utf8',
+)
 
 test('brand voice settings page is registered as protected Content Ops route', () => {
   assert.ok(
@@ -37,16 +41,22 @@ test('settings page lists tenant brand voice profiles with real API and states',
   assert.ok(pageSource.includes('useApiData(() => fetchContentOpsBrandVoiceProfiles(), [])'))
   assert.ok(pageSource.includes('if ((loading || refreshing) && !profiles)'))
   assert.ok(pageSource.includes('Loading brand voice profiles...'))
+  assert.ok(pageSource.includes('BrandVoiceProfileManager'))
+  assert.ok(pageSource.includes('selectedProfileId'))
+  assert.ok(pageSource.includes('onChange={setSelectedProfileId}'))
   assert.ok(pageSource.includes('No saved brand voice profiles'))
   assert.ok(pageSource.includes('Refresh failed:'))
   assert.ok(pageSource.includes('profile.descriptors'))
   assert.ok(pageSource.includes('profile.exemplars[0]'))
 })
 
-test('settings page sends create/edit/run actions back to New Run editor', () => {
+test('settings page uses shared manager instead of routing management to New Run', () => {
   const newRunLinks = pageSource.match(/to="\/content-ops\/new"/g) ?? []
-  assert.ok(newRunLinks.length >= 2)
-  assert.ok(pageSource.includes('New profile'))
-  assert.ok(pageSource.includes('Open New Run'))
+  assert.equal(newRunLinks.length, 0)
+  assert.ok(pageSource.includes("selected ? 'Selected' : 'Manage'"))
+  assert.ok(managerSource.includes('New brand voice'))
+  assert.ok(managerSource.includes('Edit brand voice'))
+  assert.ok(managerSource.includes('Archive'))
+  assert.ok(managerSource.includes('fetchContentOpsBrandVoiceSampleUrl'))
   assert.equal(pageSource.includes('Use in run'), false)
 })

--- a/atlas-intel-ui/src/components/contentOps/BrandVoiceProfileManager.tsx
+++ b/atlas-intel-ui/src/components/contentOps/BrandVoiceProfileManager.tsx
@@ -1,0 +1,658 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from 'react'
+import {
+  FileUp,
+  Loader2,
+  Palette,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Save,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { clsx } from 'clsx'
+import {
+  createContentOpsBrandVoiceProfile,
+  deleteContentOpsBrandVoiceProfile,
+  fetchContentOpsBrandVoiceSampleUrl,
+  updateContentOpsBrandVoiceProfile,
+  type ContentOpsBrandVoiceProfile,
+} from '../../api/contentOps'
+import {
+  BRAND_VOICE_PROFILE_PRESETS,
+  applyBrandVoiceProfileEditorPatch,
+  blankBrandVoiceProfileEditorState,
+  brandVoicePresetEditorPatch,
+  brandVoiceProfileEditorRequest,
+  brandVoiceProfileEditorStateFromProfile,
+  canSaveBrandVoiceProfileEditor,
+  deriveBrandVoiceProfileEditorPatch,
+  type BrandVoiceProfileEditorState,
+} from '../../domain/contentOps'
+
+type BrandVoiceProfileMutationState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'archiving'; id: string }
+  | { kind: 'success'; message: string }
+  | { kind: 'error'; message: string }
+
+type BrandVoiceSampleImportState =
+  | { kind: 'idle' }
+  | { kind: 'loading'; message: string }
+  | { kind: 'loaded'; message: string }
+  | { kind: 'applied'; message: string }
+  | { kind: 'error'; message: string }
+
+type BrandVoicePresetApplyState =
+  | { kind: 'idle' }
+  | { kind: 'applied'; message: string }
+  | { kind: 'error'; message: string }
+
+export function BrandVoiceProfileManager({
+  profiles,
+  selectedProfileId,
+  loading,
+  refreshing,
+  error,
+  onRefresh,
+  onChange,
+}: {
+  profiles: ContentOpsBrandVoiceProfile[]
+  selectedProfileId: string | null
+  loading: boolean
+  refreshing: boolean
+  error: Error | null
+  onRefresh: () => void
+  onChange: (profileId: string | null) => void
+}) {
+  const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId)
+  const selectedProfileUnavailable = Boolean(selectedProfileId && !selectedProfile)
+  const missingSelectedProfile = Boolean(
+    selectedProfileUnavailable && !loading && !refreshing,
+  )
+  const [editor, setEditor] = useState<BrandVoiceProfileEditorState | null>(null)
+  const [mutationState, setMutationState] =
+    useState<BrandVoiceProfileMutationState>({ kind: 'idle' })
+  const [sampleText, setSampleText] = useState('')
+  const [sampleName, setSampleName] = useState('')
+  const [sampleUrl, setSampleUrl] = useState('')
+  const [selectedPresetId, setSelectedPresetId] = useState(
+    BRAND_VOICE_PROFILE_PRESETS[0]?.id ?? '',
+  )
+  const [presetApplyState, setPresetApplyState] =
+    useState<BrandVoicePresetApplyState>({ kind: 'idle' })
+  const [sampleImportState, setSampleImportState] =
+    useState<BrandVoiceSampleImportState>({ kind: 'idle' })
+  const mutating =
+    mutationState.kind === 'saving' || mutationState.kind === 'archiving'
+  const sampleFetching = sampleImportState.kind === 'loading'
+  const canSave = editor ? canSaveBrandVoiceProfileEditor(editor) : false
+  const selectedProfileIdRef = useRef(selectedProfileId)
+  const sampleFetchTokenRef = useRef(0)
+  useEffect(() => {
+    selectedProfileIdRef.current = selectedProfileId
+  }, [selectedProfileId])
+
+  const invalidateSampleFetch = () => {
+    sampleFetchTokenRef.current += 1
+  }
+
+  const resetSampleImport = () => {
+    invalidateSampleFetch()
+    setSampleText('')
+    setSampleName('')
+    setSampleUrl('')
+    setSampleImportState({ kind: 'idle' })
+  }
+
+  const startCreate = () => {
+    resetSampleImport()
+    setPresetApplyState({ kind: 'idle' })
+    setEditor(blankBrandVoiceProfileEditorState())
+    setMutationState({ kind: 'idle' })
+  }
+
+  const startEdit = () => {
+    if (!selectedProfile) return
+    resetSampleImport()
+    setPresetApplyState({ kind: 'idle' })
+    setEditor(brandVoiceProfileEditorStateFromProfile(selectedProfile))
+    setMutationState({ kind: 'idle' })
+  }
+
+  const updateEditor = (
+    field: keyof Omit<
+      BrandVoiceProfileEditorState,
+      'mode' | 'profileId' | 'metadata'
+    >,
+    value: string,
+  ) => {
+    setEditor((current) => (current ? { ...current, [field]: value } : current))
+  }
+
+  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!editor || !canSave || mutationState.kind === 'saving' || sampleFetching) {
+      return
+    }
+    const mode = editor.mode
+    setMutationState({ kind: 'saving' })
+    try {
+      const body = brandVoiceProfileEditorRequest(editor)
+      const profile =
+        mode === 'edit' && editor.profileId
+          ? await updateContentOpsBrandVoiceProfile(editor.profileId, body)
+          : await createContentOpsBrandVoiceProfile(body)
+      resetSampleImport()
+      onChange(profile.id)
+      setEditor(null)
+      setMutationState({
+        kind: 'success',
+        message:
+          mode === 'edit'
+            ? 'Brand voice profile updated.'
+            : 'Brand voice profile saved.',
+      })
+      onRefresh()
+    } catch (err) {
+      setMutationState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handleArchive = async () => {
+    if (!selectedProfile || mutationState.kind === 'archiving') return
+    const archiveProfileId = selectedProfile.id
+    const archiveProfileName = selectedProfile.name
+    if (
+      !window.confirm(`Archive brand voice profile "${archiveProfileName}"?`)
+    ) {
+      return
+    }
+    setMutationState({ kind: 'archiving', id: archiveProfileId })
+    try {
+      await deleteContentOpsBrandVoiceProfile(archiveProfileId)
+      if (selectedProfileIdRef.current === archiveProfileId) {
+        onChange(null)
+      }
+      if (editor?.profileId === archiveProfileId) {
+        resetSampleImport()
+        setEditor(null)
+      }
+      setMutationState({
+        kind: 'success',
+        message: 'Brand voice profile archived.',
+      })
+      onRefresh()
+    } catch (err) {
+      setMutationState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handleSampleFileChange = async (
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    try {
+      const text = await file.text()
+      setSampleText(text)
+      setSampleName(file.name)
+      setSampleImportState({ kind: 'loaded', message: `Loaded ${file.name}.` })
+    } catch (err) {
+      setSampleImportState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handleFetchSampleUrl = async () => {
+    const url = sampleUrl.trim()
+    if (!url) {
+      setSampleImportState({
+        kind: 'error',
+        message: 'Add a URL before fetching.',
+      })
+      return
+    }
+    const requestToken = sampleFetchTokenRef.current + 1
+    sampleFetchTokenRef.current = requestToken
+    setSampleImportState({ kind: 'loading', message: 'Fetching URL.' })
+    try {
+      const sample = await fetchContentOpsBrandVoiceSampleUrl({ url })
+      if (sampleFetchTokenRef.current !== requestToken) {
+        return
+      }
+      const fallbackName =
+        sample.title?.trim() || brandVoiceSampleFallbackName(sample.url)
+      setSampleText(sample.text)
+      setSampleName(fallbackName)
+      setSampleUrl(sample.url)
+      setSampleImportState({
+        kind: 'loaded',
+        message: `Loaded ${fallbackName}.`,
+      })
+    } catch (err) {
+      if (sampleFetchTokenRef.current !== requestToken) {
+        return
+      }
+      setSampleImportState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handleApplyPreset = () => {
+    const patch = brandVoicePresetEditorPatch(selectedPresetId)
+    if (!patch) {
+      setPresetApplyState({
+        kind: 'error',
+        message: 'Select a preset before applying.',
+      })
+      return
+    }
+    setEditor((current) =>
+      current ? applyBrandVoiceProfileEditorPatch(current, patch) : current,
+    )
+    setPresetApplyState({
+      kind: 'applied',
+      message: 'Preset applied to empty profile fields.',
+    })
+  }
+
+  const handleApplySample = () => {
+    if (!sampleText.trim()) {
+      setSampleImportState({
+        kind: 'error',
+        message: 'Add sample copy before applying.',
+      })
+      return
+    }
+    const patch = deriveBrandVoiceProfileEditorPatch(sampleText, {
+      fallbackName: sampleName,
+    })
+    setEditor((current) =>
+      current ? applyBrandVoiceProfileEditorPatch(current, patch) : current,
+    )
+    setSampleImportState({
+      kind: 'applied',
+      message: 'Sample applied to empty profile fields.',
+    })
+  }
+
+  return (
+    <section className="mb-8 rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-medium text-slate-100">
+            <Palette className="h-4 w-4 text-cyan-300" />
+            Brand voice
+          </h2>
+          {selectedProfile && (
+            <p className="mt-1 text-xs text-slate-500">
+              {formatBrandVoiceProfileSummary(selectedProfile)}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={startCreate}
+            disabled={mutating}
+            className="flex items-center justify-center gap-2 rounded-md border border-cyan-500/60 px-2.5 py-1 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New
+          </button>
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={loading || refreshing || mutating}
+            className="flex items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+          >
+            <RefreshCw className={clsx('h-3.5 w-3.5', refreshing && 'animate-spin')} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {error && !loading && (
+        <div className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          Brand voice profiles unavailable: {error.message}
+        </div>
+      )}
+      {missingSelectedProfile && (
+        <div className="mb-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
+          Selected brand voice profile was not found for this tenant.
+        </div>
+      )}
+
+      <label className="block text-sm">
+        <span className="text-slate-300">Saved profile</span>
+        <select
+          value={selectedProfileId ?? ''}
+          disabled={loading || mutating}
+          onChange={(event) => onChange(event.target.value || null)}
+          className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+        >
+          <option value="">
+            {loading ? 'Loading profiles...' : 'No saved brand voice'}
+          </option>
+          {selectedProfileUnavailable && (
+            <option value={selectedProfileId ?? ''}>
+              Selected profile unavailable
+            </option>
+          )}
+          {profiles.map((profile) => (
+            <option key={profile.id} value={profile.id}>
+              {profile.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={startEdit}
+          disabled={!selectedProfile || loading || mutating}
+          className="flex items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+          Edit selected
+        </button>
+        <button
+          type="button"
+          onClick={handleArchive}
+          disabled={!selectedProfile || loading || mutating}
+          className="flex items-center justify-center gap-2 rounded-md border border-rose-500/50 px-2.5 py-1 text-xs text-rose-100 hover:bg-rose-500/10 disabled:opacity-50"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          Archive
+        </button>
+      </div>
+
+      {mutationState.kind === 'success' && (
+        <div className="mt-3 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-100">
+          {mutationState.message}
+        </div>
+      )}
+      {mutationState.kind === 'error' && (
+        <div className="mt-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
+          {mutationState.message}
+        </div>
+      )}
+
+      {editor && (
+        <form onSubmit={handleSave} className="mt-4 space-y-3 border-t border-slate-800 pt-4">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-medium text-slate-100">
+              {editor.mode === 'edit' ? 'Edit brand voice' : 'New brand voice'}
+            </h3>
+            <button
+              type="button"
+              onClick={() => {
+                resetSampleImport()
+                setEditor(null)
+              }}
+              disabled={mutating}
+              className="flex items-center justify-center gap-1.5 rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+            >
+              <X className="h-3.5 w-3.5" />
+              Cancel
+            </button>
+          </div>
+
+          <div className="rounded-md border border-slate-800 bg-slate-950/40 p-3">
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+              <label className="block text-sm">
+                <span className="text-slate-300">Preset</span>
+                <select
+                  value={selectedPresetId}
+                  onChange={(event) => {
+                    setSelectedPresetId(event.target.value)
+                    setPresetApplyState({ kind: 'idle' })
+                  }}
+                  disabled={mutating}
+                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+                >
+                  {BRAND_VOICE_PROFILE_PRESETS.map((preset) => (
+                    <option key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                onClick={handleApplyPreset}
+                disabled={!selectedPresetId || mutating}
+                className="flex h-9 items-center justify-center gap-2 self-end rounded-md border border-cyan-500/60 px-2.5 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
+              >
+                <Palette className="h-3.5 w-3.5" />
+                Apply preset
+              </button>
+            </div>
+            {presetApplyState.kind !== 'idle' && (
+              <div
+                className={clsx(
+                  'mt-2 text-xs',
+                  presetApplyState.kind === 'error'
+                    ? 'text-rose-200'
+                    : 'text-slate-400',
+                )}
+              >
+                {presetApplyState.message}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-md border border-slate-800 bg-slate-950/40 p-3">
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                Sample import
+              </h4>
+              <label className="flex cursor-pointer items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800">
+                <FileUp className="h-3.5 w-3.5" />
+                Load file
+                <input
+                  type="file"
+                  accept=".txt,.md,text/plain,text/markdown"
+                  disabled={mutating || sampleFetching}
+                  onChange={handleSampleFileChange}
+                  className="sr-only"
+                />
+              </label>
+            </div>
+            <div className="mb-2 grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+              <label className="block text-sm">
+                <span className="text-slate-300">URL</span>
+                <input
+                  type="url"
+                  value={sampleUrl}
+                  onChange={(event) => {
+                    setSampleUrl(event.target.value)
+                    setSampleImportState({ kind: 'idle' })
+                  }}
+                  disabled={mutating || sampleFetching}
+                  placeholder="https://example.com/about"
+                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={handleFetchSampleUrl}
+                disabled={!sampleUrl.trim() || mutating || sampleFetching}
+                className="flex h-9 items-center justify-center gap-2 self-end rounded-md border border-slate-700 px-2.5 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+              >
+                {sampleFetching ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Search className="h-3.5 w-3.5" />
+                )}
+                Fetch URL
+              </button>
+            </div>
+            <textarea
+              value={sampleText}
+              onChange={(event) => {
+                setSampleText(event.target.value)
+                setSampleName('')
+                setSampleImportState({ kind: 'idle' })
+              }}
+              disabled={mutating || sampleFetching}
+              rows={4}
+              placeholder="Paste customer copy samples here."
+              className="w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+            />
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+              {sampleImportState.kind !== 'idle' ? (
+                <span
+                  className={clsx(
+                    'text-xs',
+                    sampleImportState.kind === 'error'
+                      ? 'text-rose-200'
+                      : 'text-slate-400',
+                  )}
+                >
+                  {sampleImportState.message}
+                </span>
+              ) : (
+                <span className="text-xs text-slate-500">
+                  Fields already filled stay unchanged.
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={handleApplySample}
+                disabled={!sampleText.trim() || mutating || sampleFetching}
+                className="flex items-center justify-center gap-2 rounded-md border border-cyan-500/60 px-2.5 py-1 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
+              >
+                <Palette className="h-3.5 w-3.5" />
+                Apply sample
+              </button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            <label className="block text-sm">
+              <span className="text-slate-300">Name</span>
+              <input
+                value={editor.name}
+                onChange={(event) => updateEditor('name', event.target.value)}
+                disabled={mutating}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-300">Preferred POV</span>
+              <input
+                value={editor.preferredPov}
+                onChange={(event) => updateEditor('preferredPov', event.target.value)}
+                disabled={mutating}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-300">Reading level</span>
+              <input
+                value={editor.readingLevel}
+                onChange={(event) => updateEditor('readingLevel', event.target.value)}
+                disabled={mutating}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+              />
+            </label>
+            <label className="block text-sm lg:col-span-2">
+              <span className="text-slate-300">Descriptors</span>
+              <textarea
+                value={editor.descriptorsText}
+                onChange={(event) => updateEditor('descriptorsText', event.target.value)}
+                disabled={mutating}
+                rows={3}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-300">Exemplars</span>
+              <textarea
+                value={editor.exemplarsText}
+                onChange={(event) => updateEditor('exemplarsText', event.target.value)}
+                disabled={mutating}
+                rows={4}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-300">Banned terms</span>
+              <textarea
+                value={editor.bannedTermsText}
+                onChange={(event) => updateEditor('bannedTermsText', event.target.value)}
+                disabled={mutating}
+                rows={4}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
+              />
+            </label>
+          </div>
+
+          {!canSave && (
+            <p className="text-xs text-slate-500">
+              Name and at least one guidance field are required.
+            </p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={!canSave || mutating || sampleFetching}
+              className="flex items-center justify-center gap-2 rounded-md bg-cyan-500 px-3 py-1.5 text-sm font-medium text-slate-950 hover:bg-cyan-400 disabled:opacity-50"
+            >
+              <Save className="h-4 w-4" />
+              {mutationState.kind === 'saving' ? 'Saving' : 'Save profile'}
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  )
+}
+
+function formatBrandVoiceProfileSummary(
+  profile: ContentOpsBrandVoiceProfile,
+): string {
+  const parts: string[] = []
+  if (profile.descriptors.length > 0) {
+    parts.push(profile.descriptors.slice(0, 3).join(', '))
+  }
+  if (profile.preferred_pov) {
+    parts.push(profile.preferred_pov.replaceAll('_', ' '))
+  }
+  if (profile.reading_level) {
+    parts.push(profile.reading_level)
+  }
+  return parts.length > 0 ? parts.join(' - ') : 'Saved profile selected'
+}
+
+function brandVoiceSampleFallbackName(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname.replace(/^www\./, '') || 'sample URL'
+  } catch {
+    return 'sample URL'
+  }
+}

--- a/atlas-intel-ui/src/pages/ContentOpsBrandVoiceSettings.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsBrandVoiceSettings.tsx
@@ -1,5 +1,5 @@
-import { Link } from 'react-router-dom'
-import { ArrowRight, Loader2, Palette, Plus, RefreshCw } from 'lucide-react'
+import { useState } from 'react'
+import { Loader2, Palette, RefreshCw } from 'lucide-react'
 import { clsx } from 'clsx'
 import {
   fetchContentOpsBrandVoiceProfiles,
@@ -7,8 +7,10 @@ import {
 } from '../api/contentOps'
 import useApiData from '../hooks/useApiData'
 import { PageError } from '../components/ErrorBoundary'
+import { BrandVoiceProfileManager } from '../components/contentOps/BrandVoiceProfileManager'
 
 export default function ContentOpsBrandVoiceSettings() {
+  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null)
   const {
     data: profiles,
     loading,
@@ -56,13 +58,6 @@ export default function ContentOpsBrandVoiceSettings() {
             <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
             Refresh
           </button>
-          <Link
-            to="/content-ops/new"
-            className="inline-flex items-center justify-center gap-2 rounded-md bg-cyan-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-400"
-          >
-            <Plus className="h-4 w-4" />
-            New profile
-          </Link>
         </div>
       </header>
 
@@ -72,26 +67,34 @@ export default function ContentOpsBrandVoiceSettings() {
         </div>
       )}
 
+      <BrandVoiceProfileManager
+        profiles={savedProfiles}
+        selectedProfileId={selectedProfileId}
+        loading={loading}
+        refreshing={refreshing}
+        error={error}
+        onRefresh={refresh}
+        onChange={setSelectedProfileId}
+      />
+
       {savedProfiles.length === 0 ? (
         <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-6">
           <h2 className="text-lg font-medium text-slate-100">
             No saved brand voice profiles
           </h2>
           <p className="mt-2 max-w-xl text-sm text-slate-400">
-            Create one from the New Run page, then select it for generation.
+            Create one with the manager above, then select it for generation.
           </p>
-          <Link
-            to="/content-ops/new"
-            className="mt-4 inline-flex items-center justify-center gap-2 rounded-md border border-cyan-500/60 px-3 py-2 text-sm text-cyan-100 hover:bg-cyan-500/10"
-          >
-            Open New Run
-            <ArrowRight className="h-4 w-4" />
-          </Link>
         </section>
       ) : (
         <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           {savedProfiles.map((profile) => (
-            <BrandVoiceProfileCard key={profile.id} profile={profile} />
+            <BrandVoiceProfileCard
+              key={profile.id}
+              profile={profile}
+              selected={profile.id === selectedProfileId}
+              onSelect={() => setSelectedProfileId(profile.id)}
+            />
           ))}
         </section>
       )}
@@ -101,11 +104,20 @@ export default function ContentOpsBrandVoiceSettings() {
 
 function BrandVoiceProfileCard({
   profile,
+  selected,
+  onSelect,
 }: {
   profile: ContentOpsBrandVoiceProfile
+  selected: boolean
+  onSelect: () => void
 }) {
   return (
-    <article className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+    <article
+      className={clsx(
+        'rounded-lg border bg-slate-900/60 p-4',
+        selected ? 'border-cyan-500/70' : 'border-slate-800',
+      )}
+    >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <h2 className="truncate text-lg font-medium text-slate-100">
@@ -115,13 +127,13 @@ function BrandVoiceProfileCard({
             Updated {formatBrandVoiceDate(profile.updated_at)}
           </p>
         </div>
-        <Link
-          to="/content-ops/new"
+        <button
+          type="button"
+          onClick={onSelect}
           className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800"
         >
-          Open New Run
-          <ArrowRight className="h-3.5 w-3.5" />
-        </Link>
+          {selected ? 'Selected' : 'Manage'}
+        </button>
       </div>
       <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
         <BrandVoiceField label="Descriptors" values={profile.descriptors} />

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1,10 +1,8 @@
 import {
-  useEffect,
   useMemo,
   useRef,
   useState,
   type ChangeEvent,
-  type FormEvent,
 } from 'react'
 import { Link } from 'react-router-dom'
 import {
@@ -12,23 +10,15 @@ import {
   FileUp,
   KeyRound,
   Loader2,
-  Palette,
-  Pencil,
   Play,
-  Plus,
   RefreshCw,
-  Save,
   Search,
   Trash2,
   Upload,
-  X,
 } from 'lucide-react'
 import { clsx } from 'clsx'
 import {
-  createContentOpsBrandVoiceProfile,
-  deleteContentOpsBrandVoiceProfile,
   executeContentOpsRun,
-  fetchContentOpsBrandVoiceSampleUrl,
   fetchContentOpsBrandVoiceProfiles,
   fetchContentOpsZendeskCredentials,
   fetchGeneratedAssetDrafts,
@@ -42,7 +32,6 @@ import {
   previewContentOpsRun,
   revokeContentOpsZendeskCredential,
   saveContentOpsZendeskCredential,
-  updateContentOpsBrandVoiceProfile,
 } from '../api/contentOps'
 import { fetchTrackedVendors, type TrackedVendor } from '../api/b2bClient'
 import {
@@ -72,17 +61,9 @@ import {
   FAQ_INTENT_RULES_INPUT,
   FAQ_RESOLUTION_EVIDENCE_STATUS,
   FAQ_VOCABULARY_GAP_RULES_INPUT,
-  BRAND_VOICE_PROFILE_PRESETS,
   DEFAULT_SOCIAL_POST_CHANNELS,
   SOCIAL_POST_CHANNEL_OPTIONS,
   SOCIAL_POST_OUTPUT,
-  applyBrandVoiceProfileEditorPatch,
-  blankBrandVoiceProfileEditorState,
-  brandVoicePresetEditorPatch,
-  brandVoiceProfileEditorRequest,
-  brandVoiceProfileEditorStateFromProfile,
-  canSaveBrandVoiceProfileEditor,
-  deriveBrandVoiceProfileEditorPatch,
   normalizeSocialPostChannels,
   requestWithSocialPostChannels,
   type ContentOpsCatalog,
@@ -104,11 +85,9 @@ import {
   type GenerationPlan,
   type GenerationPlanStep,
   type ContentOpsUsageBudgetEvaluation,
-  type BrandVoiceProfileEditorState,
   type SocialPostChannelId,
 } from '../domain/contentOps'
 import type {
-  ContentOpsBrandVoiceProfile,
   ContentOpsZendeskCredential,
   GeneratedAssetDraft,
   GeneratedAssetType,
@@ -127,6 +106,7 @@ import {
   type ParsedInputsJsonObject,
   type UpdatedInputsJson,
 } from './contentOpsSourceMode'
+import { BrandVoiceProfileManager } from '../components/contentOps/BrandVoiceProfileManager'
 
 type SubmitState =
   | { kind: 'idle' }
@@ -178,25 +158,6 @@ type ZendeskCredentialMutationState =
   | { kind: 'saving' }
   | { kind: 'revoking'; id: string }
   | { kind: 'success'; message: string }
-  | { kind: 'error'; message: string }
-
-type BrandVoiceProfileMutationState =
-  | { kind: 'idle' }
-  | { kind: 'saving' }
-  | { kind: 'archiving'; id: string }
-  | { kind: 'success'; message: string }
-  | { kind: 'error'; message: string }
-
-type BrandVoiceSampleImportState =
-  | { kind: 'idle' }
-  | { kind: 'loading'; message: string }
-  | { kind: 'loaded'; message: string }
-  | { kind: 'applied'; message: string }
-  | { kind: 'error'; message: string }
-
-type BrandVoicePresetApplyState =
-  | { kind: 'idle' }
-  | { kind: 'applied'; message: string }
   | { kind: 'error'; message: string }
 
 const DEFAULT_INPUTS_JSON = '{\n  \n}'
@@ -1094,7 +1055,7 @@ export default function ContentOpsNewRun() {
         error={zendeskCredentialsError}
         onRefresh={refreshZendeskCredentials}
       />
-      <BrandVoiceProfileSelector
+      <BrandVoiceProfileManager
         profiles={brandVoiceProfiles ?? []}
         selectedProfileId={request.brandVoiceProfileId}
         loading={brandVoiceProfilesLoading}
@@ -1987,581 +1948,6 @@ function UsageSummaryCard({
   )
 }
 
-function BrandVoiceProfileSelector({
-  profiles,
-  selectedProfileId,
-  loading,
-  refreshing,
-  error,
-  onRefresh,
-  onChange,
-}: {
-  profiles: ContentOpsBrandVoiceProfile[]
-  selectedProfileId: string | null
-  loading: boolean
-  refreshing: boolean
-  error: Error | null
-  onRefresh: () => void
-  onChange: (profileId: string | null) => void
-}) {
-  const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId)
-  const selectedProfileUnavailable = Boolean(selectedProfileId && !selectedProfile)
-  const missingSelectedProfile = Boolean(
-    selectedProfileUnavailable && !loading && !refreshing,
-  )
-  const [editor, setEditor] = useState<BrandVoiceProfileEditorState | null>(null)
-  const [mutationState, setMutationState] =
-    useState<BrandVoiceProfileMutationState>({ kind: 'idle' })
-  const [sampleText, setSampleText] = useState('')
-  const [sampleName, setSampleName] = useState('')
-  const [sampleUrl, setSampleUrl] = useState('')
-  const [selectedPresetId, setSelectedPresetId] = useState(
-    BRAND_VOICE_PROFILE_PRESETS[0]?.id ?? '',
-  )
-  const [presetApplyState, setPresetApplyState] =
-    useState<BrandVoicePresetApplyState>({ kind: 'idle' })
-  const [sampleImportState, setSampleImportState] =
-    useState<BrandVoiceSampleImportState>({ kind: 'idle' })
-  const mutating =
-    mutationState.kind === 'saving' || mutationState.kind === 'archiving'
-  const sampleFetching = sampleImportState.kind === 'loading'
-  const canSave = editor ? canSaveBrandVoiceProfileEditor(editor) : false
-  const selectedProfileIdRef = useRef(selectedProfileId)
-  const sampleFetchTokenRef = useRef(0)
-  useEffect(() => {
-    selectedProfileIdRef.current = selectedProfileId
-  }, [selectedProfileId])
-
-  const invalidateSampleFetch = () => {
-    sampleFetchTokenRef.current += 1
-  }
-
-  const resetSampleImport = () => {
-    invalidateSampleFetch()
-    setSampleText('')
-    setSampleName('')
-    setSampleUrl('')
-    setSampleImportState({ kind: 'idle' })
-  }
-
-  const startCreate = () => {
-    resetSampleImport()
-    setPresetApplyState({ kind: 'idle' })
-    setEditor(blankBrandVoiceProfileEditorState())
-    setMutationState({ kind: 'idle' })
-  }
-
-  const startEdit = () => {
-    if (!selectedProfile) return
-    resetSampleImport()
-    setPresetApplyState({ kind: 'idle' })
-    setEditor(brandVoiceProfileEditorStateFromProfile(selectedProfile))
-    setMutationState({ kind: 'idle' })
-  }
-
-  const updateEditor = (
-    field: keyof Omit<
-      BrandVoiceProfileEditorState,
-      'mode' | 'profileId' | 'metadata'
-    >,
-    value: string,
-  ) => {
-    setEditor((current) => (current ? { ...current, [field]: value } : current))
-  }
-
-  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!editor || !canSave || mutationState.kind === 'saving' || sampleFetching) {
-      return
-    }
-    const mode = editor.mode
-    setMutationState({ kind: 'saving' })
-    try {
-      const body = brandVoiceProfileEditorRequest(editor)
-      const profile =
-        mode === 'edit' && editor.profileId
-          ? await updateContentOpsBrandVoiceProfile(editor.profileId, body)
-          : await createContentOpsBrandVoiceProfile(body)
-      resetSampleImport()
-      onChange(profile.id)
-      setEditor(null)
-      setMutationState({
-        kind: 'success',
-        message:
-          mode === 'edit'
-            ? 'Brand voice profile updated.'
-            : 'Brand voice profile saved.',
-      })
-      onRefresh()
-    } catch (err) {
-      setMutationState({
-        kind: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
-
-  const handleArchive = async () => {
-    if (!selectedProfile || mutationState.kind === 'archiving') return
-    const archiveProfileId = selectedProfile.id
-    const archiveProfileName = selectedProfile.name
-    if (
-      !window.confirm(`Archive brand voice profile "${archiveProfileName}"?`)
-    ) {
-      return
-    }
-    setMutationState({ kind: 'archiving', id: archiveProfileId })
-    try {
-      await deleteContentOpsBrandVoiceProfile(archiveProfileId)
-      if (selectedProfileIdRef.current === archiveProfileId) {
-        onChange(null)
-      }
-      if (editor?.profileId === archiveProfileId) {
-        resetSampleImport()
-        setEditor(null)
-      }
-      setMutationState({
-        kind: 'success',
-        message: 'Brand voice profile archived.',
-      })
-      onRefresh()
-    } catch (err) {
-      setMutationState({
-        kind: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
-
-  const handleSampleFileChange = async (
-    event: ChangeEvent<HTMLInputElement>,
-  ) => {
-    const file = event.target.files?.[0]
-    event.target.value = ''
-    if (!file) return
-    try {
-      const text = await file.text()
-      setSampleText(text)
-      setSampleName(file.name)
-      setSampleImportState({ kind: 'loaded', message: `Loaded ${file.name}.` })
-    } catch (err) {
-      setSampleImportState({
-        kind: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
-
-  const handleFetchSampleUrl = async () => {
-    const url = sampleUrl.trim()
-    if (!url) {
-      setSampleImportState({
-        kind: 'error',
-        message: 'Add a URL before fetching.',
-      })
-      return
-    }
-    const requestToken = sampleFetchTokenRef.current + 1
-    sampleFetchTokenRef.current = requestToken
-    setSampleImportState({ kind: 'loading', message: 'Fetching URL.' })
-    try {
-      const sample = await fetchContentOpsBrandVoiceSampleUrl({ url })
-      if (sampleFetchTokenRef.current !== requestToken) {
-        return
-      }
-      const fallbackName =
-        sample.title?.trim() || brandVoiceSampleFallbackName(sample.url)
-      setSampleText(sample.text)
-      setSampleName(fallbackName)
-      setSampleUrl(sample.url)
-      setSampleImportState({
-        kind: 'loaded',
-        message: `Loaded ${fallbackName}.`,
-      })
-    } catch (err) {
-      if (sampleFetchTokenRef.current !== requestToken) {
-        return
-      }
-      setSampleImportState({
-        kind: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
-
-  const handleApplyPreset = () => {
-    const patch = brandVoicePresetEditorPatch(selectedPresetId)
-    if (!patch) {
-      setPresetApplyState({
-        kind: 'error',
-        message: 'Select a preset before applying.',
-      })
-      return
-    }
-    setEditor((current) =>
-      current ? applyBrandVoiceProfileEditorPatch(current, patch) : current,
-    )
-    setPresetApplyState({
-      kind: 'applied',
-      message: 'Preset applied to empty profile fields.',
-    })
-  }
-
-  const handleApplySample = () => {
-    if (!sampleText.trim()) {
-      setSampleImportState({
-        kind: 'error',
-        message: 'Add sample copy before applying.',
-      })
-      return
-    }
-    const patch = deriveBrandVoiceProfileEditorPatch(sampleText, {
-      fallbackName: sampleName,
-    })
-    setEditor((current) =>
-      current ? applyBrandVoiceProfileEditorPatch(current, patch) : current,
-    )
-    setSampleImportState({
-      kind: 'applied',
-      message: 'Sample applied to empty profile fields.',
-    })
-  }
-
-  return (
-    <section className="mb-8 rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="flex items-center gap-2 text-sm font-medium text-slate-100">
-            <Palette className="h-4 w-4 text-cyan-300" />
-            Brand voice
-          </h2>
-          {selectedProfile && (
-            <p className="mt-1 text-xs text-slate-500">
-              {formatBrandVoiceProfileSummary(selectedProfile)}
-            </p>
-          )}
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={startCreate}
-            disabled={mutating}
-            className="flex items-center justify-center gap-2 rounded-md border border-cyan-500/60 px-2.5 py-1 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
-          >
-            <Plus className="h-3.5 w-3.5" />
-            New
-          </button>
-          <button
-            type="button"
-            onClick={onRefresh}
-            disabled={loading || refreshing || mutating}
-            className="flex items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
-          >
-            <RefreshCw className={clsx('h-3.5 w-3.5', refreshing && 'animate-spin')} />
-            Refresh
-          </button>
-        </div>
-      </div>
-
-      {error && !loading && (
-        <div className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-          Brand voice profiles unavailable: {error.message}
-        </div>
-      )}
-      {missingSelectedProfile && (
-        <div className="mb-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
-          Selected brand voice profile was not found for this tenant.
-        </div>
-      )}
-
-      <label className="block text-sm">
-        <span className="text-slate-300">Saved profile</span>
-        <select
-          value={selectedProfileId ?? ''}
-          disabled={loading || mutating}
-          onChange={(event) => onChange(event.target.value || null)}
-          className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-        >
-          <option value="">
-            {loading ? 'Loading profiles...' : 'No saved brand voice'}
-          </option>
-          {selectedProfileUnavailable && (
-            <option value={selectedProfileId ?? ''}>
-              Selected profile unavailable
-            </option>
-          )}
-          {profiles.map((profile) => (
-            <option key={profile.id} value={profile.id}>
-              {profile.name}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      <div className="mt-3 flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          onClick={startEdit}
-          disabled={!selectedProfile || loading || mutating}
-          className="flex items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
-        >
-          <Pencil className="h-3.5 w-3.5" />
-          Edit selected
-        </button>
-        <button
-          type="button"
-          onClick={handleArchive}
-          disabled={!selectedProfile || loading || mutating}
-          className="flex items-center justify-center gap-2 rounded-md border border-rose-500/50 px-2.5 py-1 text-xs text-rose-100 hover:bg-rose-500/10 disabled:opacity-50"
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-          Archive
-        </button>
-      </div>
-
-      {mutationState.kind === 'success' && (
-        <div className="mt-3 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-100">
-          {mutationState.message}
-        </div>
-      )}
-      {mutationState.kind === 'error' && (
-        <div className="mt-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
-          {mutationState.message}
-        </div>
-      )}
-
-      {editor && (
-        <form onSubmit={handleSave} className="mt-4 space-y-3 border-t border-slate-800 pt-4">
-          <div className="flex items-center justify-between gap-3">
-            <h3 className="text-sm font-medium text-slate-100">
-              {editor.mode === 'edit' ? 'Edit brand voice' : 'New brand voice'}
-            </h3>
-            <button
-              type="button"
-              onClick={() => {
-                resetSampleImport()
-                setEditor(null)
-              }}
-              disabled={mutating}
-              className="flex items-center justify-center gap-1.5 rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
-            >
-              <X className="h-3.5 w-3.5" />
-              Cancel
-            </button>
-          </div>
-
-          <div className="rounded-md border border-slate-800 bg-slate-950/40 p-3">
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-              <label className="block text-sm">
-                <span className="text-slate-300">Preset</span>
-                <select
-                  value={selectedPresetId}
-                  onChange={(event) => {
-                    setSelectedPresetId(event.target.value)
-                    setPresetApplyState({ kind: 'idle' })
-                  }}
-                  disabled={mutating}
-                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-                >
-                  {BRAND_VOICE_PROFILE_PRESETS.map((preset) => (
-                    <option key={preset.id} value={preset.id}>
-                      {preset.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <button
-                type="button"
-                onClick={handleApplyPreset}
-                disabled={!selectedPresetId || mutating}
-                className="flex h-9 items-center justify-center gap-2 self-end rounded-md border border-cyan-500/60 px-2.5 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
-              >
-                <Palette className="h-3.5 w-3.5" />
-                Apply preset
-              </button>
-            </div>
-            {presetApplyState.kind !== 'idle' && (
-              <div
-                className={clsx(
-                  'mt-2 text-xs',
-                  presetApplyState.kind === 'error'
-                    ? 'text-rose-200'
-                    : 'text-slate-400',
-                )}
-              >
-                {presetApplyState.message}
-              </div>
-            )}
-          </div>
-
-          <div className="rounded-md border border-slate-800 bg-slate-950/40 p-3">
-            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-              <h4 className="text-xs font-medium uppercase tracking-wide text-slate-400">
-                Sample import
-              </h4>
-              <label className="flex cursor-pointer items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800">
-                <FileUp className="h-3.5 w-3.5" />
-                Load file
-                <input
-                  type="file"
-                  accept=".txt,.md,text/plain,text/markdown"
-                  disabled={mutating || sampleFetching}
-                  onChange={handleSampleFileChange}
-                  className="sr-only"
-                />
-              </label>
-            </div>
-            <div className="mb-2 grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-              <label className="block text-sm">
-                <span className="text-slate-300">URL</span>
-                <input
-                  type="url"
-                  value={sampleUrl}
-                  onChange={(event) => {
-                    setSampleUrl(event.target.value)
-                    setSampleImportState({ kind: 'idle' })
-                  }}
-                  disabled={mutating || sampleFetching}
-                  placeholder="https://example.com/about"
-                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-                />
-              </label>
-              <button
-                type="button"
-                onClick={handleFetchSampleUrl}
-                disabled={!sampleUrl.trim() || mutating || sampleFetching}
-                className="flex h-9 items-center justify-center gap-2 self-end rounded-md border border-slate-700 px-2.5 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
-              >
-                {sampleFetching ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Search className="h-3.5 w-3.5" />
-                )}
-                Fetch URL
-              </button>
-            </div>
-            <textarea
-              value={sampleText}
-              onChange={(event) => {
-                setSampleText(event.target.value)
-                setSampleName('')
-                setSampleImportState({ kind: 'idle' })
-              }}
-              disabled={mutating || sampleFetching}
-              rows={4}
-              placeholder="Paste customer copy samples here."
-              className="w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-            />
-            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
-              {sampleImportState.kind !== 'idle' ? (
-                <span
-                  className={clsx(
-                    'text-xs',
-                    sampleImportState.kind === 'error'
-                      ? 'text-rose-200'
-                      : 'text-slate-400',
-                  )}
-                >
-                  {sampleImportState.message}
-                </span>
-              ) : (
-                <span className="text-xs text-slate-500">
-                  Fields already filled stay unchanged.
-                </span>
-              )}
-              <button
-                type="button"
-                onClick={handleApplySample}
-                disabled={!sampleText.trim() || mutating || sampleFetching}
-                className="flex items-center justify-center gap-2 rounded-md border border-cyan-500/60 px-2.5 py-1 text-xs text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
-              >
-                <Palette className="h-3.5 w-3.5" />
-                Apply sample
-              </button>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-            <label className="block text-sm">
-              <span className="text-slate-300">Name</span>
-              <input
-                value={editor.name}
-                onChange={(event) => updateEditor('name', event.target.value)}
-                disabled={mutating}
-                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-              />
-            </label>
-            <label className="block text-sm">
-              <span className="text-slate-300">Preferred POV</span>
-              <input
-                value={editor.preferredPov}
-                onChange={(event) => updateEditor('preferredPov', event.target.value)}
-                disabled={mutating}
-                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-              />
-            </label>
-            <label className="block text-sm">
-              <span className="text-slate-300">Reading level</span>
-              <input
-                value={editor.readingLevel}
-                onChange={(event) => updateEditor('readingLevel', event.target.value)}
-                disabled={mutating}
-                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-              />
-            </label>
-            <label className="block text-sm lg:col-span-2">
-              <span className="text-slate-300">Descriptors</span>
-              <textarea
-                value={editor.descriptorsText}
-                onChange={(event) => updateEditor('descriptorsText', event.target.value)}
-                disabled={mutating}
-                rows={3}
-                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-              />
-            </label>
-            <label className="block text-sm">
-              <span className="text-slate-300">Exemplars</span>
-              <textarea
-                value={editor.exemplarsText}
-                onChange={(event) => updateEditor('exemplarsText', event.target.value)}
-                disabled={mutating}
-                rows={4}
-                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-              />
-            </label>
-            <label className="block text-sm">
-              <span className="text-slate-300">Banned terms</span>
-              <textarea
-                value={editor.bannedTermsText}
-                onChange={(event) => updateEditor('bannedTermsText', event.target.value)}
-                disabled={mutating}
-                rows={4}
-                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none disabled:opacity-50"
-              />
-            </label>
-          </div>
-
-          {!canSave && (
-            <p className="text-xs text-slate-500">
-              Name and at least one guidance field are required.
-            </p>
-          )}
-
-          <div className="flex justify-end">
-            <button
-              type="submit"
-              disabled={!canSave || mutating || sampleFetching}
-              className="flex items-center justify-center gap-2 rounded-md bg-cyan-500 px-3 py-1.5 text-sm font-medium text-slate-950 hover:bg-cyan-400 disabled:opacity-50"
-            >
-              <Save className="h-4 w-4" />
-              {mutationState.kind === 'saving' ? 'Saving' : 'Save profile'}
-            </button>
-          </div>
-        </form>
-      )}
-    </section>
-  )
-}
 
 function ZendeskCredentialCard({
   credentials,
@@ -3481,30 +2867,6 @@ function formatCredentialDate(value: string | null | undefined): string {
   return date.toLocaleDateString()
 }
 
-function formatBrandVoiceProfileSummary(
-  profile: ContentOpsBrandVoiceProfile,
-): string {
-  const parts: string[] = []
-  if (profile.descriptors.length > 0) {
-    parts.push(profile.descriptors.slice(0, 3).join(', '))
-  }
-  if (profile.preferred_pov) {
-    parts.push(profile.preferred_pov.replaceAll('_', ' '))
-  }
-  if (profile.reading_level) {
-    parts.push(profile.reading_level)
-  }
-  return parts.length > 0 ? parts.join(' - ') : 'Saved profile selected'
-}
-
-function brandVoiceSampleFallbackName(url: string): string {
-  try {
-    const parsed = new URL(url)
-    return parsed.hostname.replace(/^www\./, '') || 'sample URL'
-  } catch {
-    return 'sample URL'
-  }
-}
 
 function formatZendeskCredentialEndpoint(
   credential: ContentOpsZendeskCredential,

--- a/plans/PR-Content-Ops-Brand-Voice-Editor-Extraction.md
+++ b/plans/PR-Content-Ops-Brand-Voice-Editor-Extraction.md
@@ -1,0 +1,129 @@
+# PR-Content-Ops-Brand-Voice-Editor-Extraction
+
+## Why this slice exists
+
+`PR-Content-Ops-Brand-Voice-Settings-Page` added a dedicated
+`/content-ops/brand-voice` settings surface, but intentionally left full
+create/edit/archive workflows deferred back to the New Run page. That still
+forces operators to leave the settings page to manage the saved profiles they
+are viewing.
+
+This slice closes that deferred item by extracting the already-shipped New Run
+brand voice selector/editor into a shared frontend component and rendering that
+same component on the settings page. The diff is expected to exceed the 400 LOC
+soft cap because the safe implementation is a move-heavy extraction of the
+existing editor markup and mutation wiring rather than a second, smaller
+reimplementation. The behavior change remains narrow: settings gets the same
+tenant-scoped create/edit/archive/sample-import workflow New Run already uses.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/brand-voice/editor-extraction
+Slice phase: Product polish
+
+1. Move the New Run brand voice selector/editor into a shared
+   `BrandVoiceProfileManager` component under `atlas-intel-ui/src/components`.
+2. Keep New Run wired to that shared component for run profile selection.
+3. Render the same shared component on `/content-ops/brand-voice` so settings
+   can create, edit, archive, refresh, and sample-import saved profiles without
+   navigating to New Run.
+4. Update the existing enrolled frontend tests to prove the shared component is
+   the single editor surface and both pages consume it.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] New Run still renders brand voice selection and threads selected
+        `brandVoiceProfileId` into the run request.
+  - [ ] Settings renders the shared brand voice manager and no longer routes
+        create/edit back to `/content-ops/new`.
+  - [ ] Create/update/delete/sample URL actions remain wired to the existing
+        tenant-scoped brand voice API helpers.
+  - [ ] The shared component preserves loading, stale-error, missing-selection,
+        success, error, preset, and sample-import states from the existing New
+        Run editor.
+  - [ ] Existing enrolled brand voice frontend tests cover the shared component
+        and both page integrations.
+- Affected surfaces: frontend.
+- Risk areas: frontend behavior, maintainability, CI enrollment.
+- Reviewer rules triggered: R1, R2, R9, R10, R12.
+
+### Files touched
+
+- `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs`
+- `atlas-intel-ui/scripts/content-ops-brand-voice-settings-page.test.mjs`
+- `atlas-intel-ui/src/components/contentOps/BrandVoiceProfileManager.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsBrandVoiceSettings.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `plans/PR-Content-Ops-Brand-Voice-Editor-Extraction.md`
+
+## Mechanism
+
+The existing inline `BrandVoiceProfileSelector` implementation moves into a
+new shared `BrandVoiceProfileManager` component. The component keeps the same
+prop contract New Run already uses:
+
+```tsx
+<BrandVoiceProfileManager
+  profiles={brandVoiceProfiles ?? []}
+  selectedProfileId={request.brandVoiceProfileId}
+  loading={brandVoiceProfilesLoading}
+  refreshing={brandVoiceProfilesRefreshing}
+  error={brandVoiceProfilesError}
+  onRefresh={refreshBrandVoiceProfiles}
+  onChange={handleBrandVoiceProfileChange}
+/>
+```
+
+The shared component owns only local editor/mutation/sample-import UI state and
+continues to call the existing `createContentOpsBrandVoiceProfile`,
+`updateContentOpsBrandVoiceProfile`, `deleteContentOpsBrandVoiceProfile`, and
+`fetchContentOpsBrandVoiceSampleUrl` API helpers. New Run keeps its existing
+profile-list loader and selected-id state. Settings uses its existing
+`useApiData(fetchContentOpsBrandVoiceProfiles)` loader plus a local selected id
+and renders the manager above the profile inventory cards.
+
+## Intentional
+
+- This PR does not add URL deep-linking from a settings card into New Run. The
+  point of the slice is to remove that management detour by making settings the
+  management surface.
+- The settings page keeps the profile inventory cards as a scan-friendly
+  overview and adds the shared manager above them instead of turning every card
+  into its own editor. A single editor avoids duplicate mutation controls on
+  the page.
+- The diff is larger than 400 LOC because it moves an existing editor rather
+  than duplicating or partially reimplementing it.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci` - installed locked UI dependencies in the new
+  worktree; reported existing npm audit findings, no dependency changes made.
+- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector`
+  - 12/12 tests passed.
+- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-settings-page`
+  - 4/4 tests passed.
+- `cd atlas-intel-ui && npm run lint` - passed.
+- `cd atlas-intel-ui && npm run build` - passed.
+- Manual workflow grep for both existing brand voice test scripts in
+  `.github/workflows/atlas_intel_ui_checks.yml` - both scripts enrolled.
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-brand-voice-editor-extraction.md`
+  - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas-intel-ui/scripts/content-ops-brand-voice-profile-selector.test.mjs` | 56 |
+| `atlas-intel-ui/scripts/content-ops-brand-voice-settings-page.test.mjs` | 18 |
+| `atlas-intel-ui/src/components/contentOps/BrandVoiceProfileManager.tsx` | 658 |
+| `atlas-intel-ui/src/pages/ContentOpsBrandVoiceSettings.tsx` | 60 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 642 |
+| `plans/PR-Content-Ops-Brand-Voice-Editor-Extraction.md` | 129 |
+| **Total** | **1563** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Brand-Voice-Editor-Extraction.md
Slice phase: Product polish

This closes the settings-page deferred item by extracting the already-shipped
New Run brand voice selector/editor into a shared `BrandVoiceProfileManager`
component, then rendering that same component on `/content-ops/brand-voice`.
Settings can now create, edit, archive, refresh, and sample-import saved brand
voice profiles without sending operators back to New Run, while New Run keeps
using the same component for run profile selection.

## Intentional
- This does not add URL deep-linking from settings cards into New Run; the
  management detour is removed instead.
- Settings keeps scan-friendly inventory cards and uses one shared manager
  above them rather than putting duplicate mutation controls on every card.
- The diff exceeds the 400 LOC soft cap because this is a move-heavy extraction
  of the existing editor, not a second implementation.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- `cd atlas-intel-ui && npm ci` - installed locked UI dependencies in the new
  worktree; existing npm audit findings reported, no dependency changes made.
- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-profile-selector`
  - 12/12 tests passed.
- `cd atlas-intel-ui && npm run test:content-ops-brand-voice-settings-page`
  - 4/4 tests passed.
- `cd atlas-intel-ui && npm run lint` - passed.
- `cd atlas-intel-ui && npm run build` - passed.
- Manual workflow grep for `test:content-ops-brand-voice-profile-selector` and
  `test:content-ops-brand-voice-settings-page` in
  `.github/workflows/atlas_intel_ui_checks.yml` - both enrolled.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-brand-voice-editor-extraction.md`
  - passed.

## Diff size
6 files, +872 / -691.
