### PR TITLE
Brand Voice Structured Findings

### DIFF
--- a/atlas_brain/brand/__init__.py
+++ b/atlas_brain/brand/__init__.py
@@ -1,5 +1,5 @@
 """Lightweight brand utilities."""
 
-from .voice_validator import BrandVoiceValidator
+from .voice_validator import BrandVoiceFinding, BrandVoiceValidator
 
-__all__ = ["BrandVoiceValidator"]
+__all__ = ["BrandVoiceFinding", "BrandVoiceValidator"]

--- a/atlas_brain/brand/voice_validator.py
+++ b/atlas_brain/brand/voice_validator.py
@@ -1,7 +1,22 @@
 import yaml
 import re
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
+
+
+SEVERITIES = frozenset({"BLOCKER", "MAJOR", "NIT"})
+
+
+@dataclass(frozen=True)
+class BrandVoiceFinding:
+    rule_id: str
+    severity: str
+    category: str
+    message: str
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class BrandVoiceValidator:
@@ -41,13 +56,18 @@ class BrandVoiceValidator:
                         f"{section}[{index}] must be a mapping, got "
                         f"{type(rule).__name__}"
                     )
-                missing = {"pattern", "description"} - rule.keys()
+                required = {"id", "pattern", "description"}
+                if section == "content_rules":
+                    required.add("applies_to")
+                missing = required - rule.keys()
                 if missing:
                     rule_id = rule.get("id", "<unnamed>")
                     raise ValueError(
                         f"{section}[{index}] (id={rule_id!r}) missing required "
                         f"keys: {sorted(missing)}"
                     )
+                if not str(rule["id"]).strip():
+                    raise ValueError(f"{section}[{index}] has an empty rule id")
                 if section == "tone_rules" and rule.get("fail_on_match", True) is not True:
                     rule_id = rule.get("id", "<unnamed>")
                     raise ValueError(
@@ -55,6 +75,13 @@ class BrandVoiceValidator:
                         "fail_on_match or set it to true; tone rules only fail "
                         "on matches"
                     )
+                self._normalize_severity(
+                    rule.get("severity"),
+                    default=self._default_severity(section),
+                    section=section,
+                    index=index,
+                    rule_id=str(rule["id"]),
+                )
                 try:
                     re.compile(rule["pattern"])
                 except re.error as exc:
@@ -64,7 +91,42 @@ class BrandVoiceValidator:
                         f"regex pattern: {exc}"
                     ) from exc
 
-    def validate(self, text: str, content_type: str) -> list[str]:
+    @staticmethod
+    def _default_severity(section: str) -> str:
+        if section == "tone_rules":
+            return "MAJOR"
+        return "BLOCKER"
+
+    @staticmethod
+    def _normalize_severity(
+        value: object,
+        *,
+        default: str,
+        section: str,
+        index: int,
+        rule_id: str,
+    ) -> str:
+        if value is None:
+            return default
+        severity = str(value).upper()
+        if severity not in SEVERITIES:
+            allowed = ", ".join(sorted(SEVERITIES))
+            raise ValueError(
+                f"{section}[{index}] (id={rule_id!r}) has invalid severity "
+                f"{value!r}; expected one of: {allowed}"
+            )
+        return severity
+
+    def _rule_severity(self, rule: dict, *, section: str, default: str) -> str:
+        return self._normalize_severity(
+            rule.get("severity"),
+            default=default,
+            section=section,
+            index=-1,
+            rule_id=str(rule["id"]),
+        )
+
+    def validate(self, text: str, content_type: str) -> list[BrandVoiceFinding]:
         """
         Validates a piece of text against the loaded brand voice rules.
 
@@ -73,13 +135,13 @@ class BrandVoiceValidator:
             content_type: The type of content (e.g., 'landing_page', 'blog_post').
 
         Returns:
-            A list of string descriptions of any violations found. An empty
-            list means the content is on-brand.
+            A list of structured findings. An empty list means the content is
+            on-brand.
         """
         if not isinstance(text, str):
             raise TypeError("text must be str")
 
-        violations = []
+        findings = []
         lower_text = text.lower()
 
         # 1. Forbidden vocabulary -- whole-word match. Unanchored substring
@@ -89,12 +151,28 @@ class BrandVoiceValidator:
         #    'non-disruptive' is itself a boundary, so 'disrupt' no longer fires).
         for word in (self.config.get("vocabulary") or {}).get("avoid") or []:
             if re.search(r"\b" + re.escape(word) + r"\b", lower_text):
-                violations.append(f"Contains forbidden word: '{word}'")
+                findings.append(
+                    BrandVoiceFinding(
+                        rule_id=f"vocabulary.avoid.{word}",
+                        severity="BLOCKER",
+                        category="vocabulary",
+                        message=f"Contains forbidden word: '{word}'",
+                    )
+                )
 
         # 2. Tone rules (regex-based).
         for rule in self.config.get("tone_rules") or []:
             if re.search(rule["pattern"], text, re.IGNORECASE):
-                violations.append(f"Tone violation: {rule['description']}")
+                findings.append(
+                    BrandVoiceFinding(
+                        rule_id=str(rule["id"]),
+                        severity=self._rule_severity(
+                            rule, section="tone_rules", default="MAJOR"
+                        ),
+                        category="tone",
+                        message=f"Tone violation: {rule['description']}",
+                    )
+                )
 
         # 3. Content-specific rules.
         for rule in self.config.get("content_rules") or []:
@@ -108,13 +186,31 @@ class BrandVoiceValidator:
 
             # Fails if the pattern is found (e.g., "don't use future tense").
             if fail_on_match and pattern_found:
-                violations.append(f"Content rule violation: {rule['description']}")
+                findings.append(
+                    BrandVoiceFinding(
+                        rule_id=str(rule["id"]),
+                        severity=self._rule_severity(
+                            rule, section="content_rules", default="BLOCKER"
+                        ),
+                        category="content",
+                        message=f"Content rule violation: {rule['description']}",
+                    )
+                )
 
             # Fails if the pattern is NOT found (e.g., "must mention extensibility").
             elif not fail_on_match and not pattern_found:
-                violations.append(f"Content rule violation: {rule['description']}")
+                findings.append(
+                    BrandVoiceFinding(
+                        rule_id=str(rule["id"]),
+                        severity=self._rule_severity(
+                            rule, section="content_rules", default="BLOCKER"
+                        ),
+                        category="content",
+                        message=f"Content rule violation: {rule['description']}",
+                    )
+                )
 
-        return violations
+        return findings
 
 
 def main():
@@ -154,12 +250,12 @@ def main():
         content_to_validate = f.read()
 
     validator = BrandVoiceValidator(config_path=args.config)
-    violations = validator.validate(content_to_validate, args.type)
+    findings = validator.validate(content_to_validate, args.type)
 
-    if violations:
-        print(f"FAIL: Found {len(violations)} brand voice violations in {args.file}:")
-        for violation in violations:
-            print(f"  - {violation}")
+    if findings:
+        print(f"FAIL: Found {len(findings)} brand voice violations in {args.file}:")
+        for finding in findings:
+            print(f"  - [{finding.severity}] {finding.rule_id}: {finding.message}")
         exit(1)
     else:
         print(f"PASS: {args.file} is on-brand.")

--- a/plans/PR-Brand-Voice-Structured-Findings.md
+++ b/plans/PR-Brand-Voice-Structured-Findings.md
@@ -1,0 +1,96 @@
+# PR-Brand-Voice-Structured-Findings
+
+## Why this slice exists
+
+PR #1344 landed the deterministic brand-voice gate, but intentionally left
+validator results as flat strings. That was enough for a binary CI gate, but it
+blocks the next product steps named in the merged plan: severity levels,
+suggested fixes, rule-specific reporting, and cleaner marketer-facing output.
+
+This slice adds the smallest structured result model that keeps the current CI
+behavior intact while giving future slices stable fields to consume.
+
+The estimate is slightly over the 400 LOC soft cap because the return-type
+change touches the existing failure-detection suite broadly: every old
+message-based assertion must remain covered while the new structured fields get
+their own focused negative/config tests.
+
+## Scope (this PR)
+
+Ownership lane: content-marketing/brand-voice-checks
+Slice phase: Vertical slice
+
+1. Add a lightweight `BrandVoiceFinding` value object with `rule_id`,
+   `severity`, `category`, and `message` fields.
+2. Change `BrandVoiceValidator.validate(...)` to return findings instead of raw
+   strings while preserving binary pass/fail CLI behavior.
+3. Require stable rule IDs for configured tone/content rules and validate
+   optional rule severities against `BLOCKER`, `MAJOR`, and `NIT`.
+4. Update the existing validator tests to assert messages through the structured
+   findings and add focused tests for rule IDs, default severities, and invalid
+   severity detection.
+5. Update the CLI output to include severity and rule ID for each finding.
+
+### Files touched
+
+- `atlas_brain/brand/voice_validator.py`
+- `atlas_brain/brand/__init__.py`
+- `plans/PR-Brand-Voice-Structured-Findings.md`
+- `tests/test_brand_voice_validator.py`
+
+## Mechanism
+
+`BrandVoiceFinding` is a frozen dataclass. The validator emits:
+
+- vocabulary findings with rule IDs shaped as `vocabulary.avoid.<word>` and
+  default severity `BLOCKER`;
+- tone-rule findings using the configured rule `id` and default severity
+  `MAJOR`;
+- content-rule findings using the configured rule `id` and default severity
+  `BLOCKER`.
+
+The CLI still exits 1 when any finding exists and 0 when none exist, but each
+failure line includes `[SEVERITY] rule_id: message`. Tests keep the previous
+branch coverage and add structural assertions so this is not only cosmetic.
+
+## Intentional
+
+- This slice does not implement `vocabulary.use` suggested fixes. The structured
+  finding model is the substrate for that follow-up.
+- The CLI remains text output, not JSON. A JSON/reporting format can be its own
+  consumer-facing slice once fields settle.
+- `validate(...)` changes return type in this narrow brand package because PR
+  #1344 introduced the package and no in-tree caller consumes the return value
+  except tests and CLI. There is no compatibility shim for raw strings.
+- Severity is metadata only in this slice. The CI gate remains fail-on-any
+  finding so the existing workflow stays conservative.
+- Local cross-layer caller hints for `validate` and `main` are generic-name false
+  positives. They point at unrelated semantic-cache methods and script
+  entrypoints, not imports of `atlas_brain.brand.voice_validator`.
+
+## Deferred
+
+- Suggested-fix output for `vocabulary.use`.
+- Stem-aware vocabulary patterns owned in YAML.
+- JSON CLI/report mode for structured downstream consumers.
+- A larger content corpus beyond the four seed examples.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_brand_voice_validator.py -q` -- 52 passed.
+- `python atlas_brain/brand/voice_validator.py --file marketing/landing_pages/atlas-platform.md --type landing_page` -- PASS.
+- Negative CLI smoke with `This is a game-changer!!` exits 1 and prints the
+  expected `[BLOCKER]`/`[MAJOR]` structured rule lines.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-brand-voice-structured-findings-body.md` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/brand/__init__.py` | ~2 |
+| `atlas_brain/brand/voice_validator.py` | ~130 |
+| `plans/PR-Brand-Voice-Structured-Findings.md` | ~96 |
+| `tests/test_brand_voice_validator.py` | ~240 |
+| **Total** | **~472** |

--- a/tests/test_brand_voice_validator.py
+++ b/tests/test_brand_voice_validator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from atlas_brain.brand.voice_validator import BrandVoiceValidator
+from atlas_brain.brand.voice_validator import BrandVoiceFinding, BrandVoiceValidator
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -37,6 +37,15 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _messages(findings: list[BrandVoiceFinding]) -> list[str]:
+    return [finding.message for finding in findings]
+
+
+def _only_finding(findings: list[BrandVoiceFinding]) -> BrandVoiceFinding:
+    assert len(findings) == 1
+    return findings[0]
+
+
 # ---------------------------------------------------------------------------
 # Sanity: the real config is present and loadable (it is the substrate for the
 # "real shipped config" arm of this suite).
@@ -58,18 +67,29 @@ def test_real_shipped_brand_voice_yml_exists_and_loads():
 def test_forbidden_vocabulary_word_bites_on_real_config():
     """A shipped avoid-word used as a standalone word fires a violation."""
     validator = _real_validator()
-    violations = validator.validate("This is a game-changer for the team.", "blog_post")
-    assert "Contains forbidden word: 'game-changer'" in violations
+    findings = validator.validate("This is a game-changer for the team.", "blog_post")
+    assert "Contains forbidden word: 'game-changer'" in _messages(findings)
+
+
+def test_forbidden_vocabulary_finding_has_structured_fields():
+    validator = _real_validator()
+    finding = _only_finding(
+        validator.validate("This is a game-changer for the team.", "blog_post")
+    )
+    assert finding.rule_id == "vocabulary.avoid.game-changer"
+    assert finding.severity == "BLOCKER"
+    assert finding.category == "vocabulary"
+    assert finding.message == "Contains forbidden word: 'game-changer'"
 
 
 def test_clean_content_has_no_forbidden_vocabulary_false_positive():
     """On-brand prose containing no whole avoid-word yields no vocab violation."""
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "Our deterministic dispatch system ships a reliable migration path.",
         "blog_post",
     )
-    assert violations == []
+    assert findings == []
 
 
 # ===========================================================================
@@ -86,24 +106,33 @@ _EXCLAMATION_TONE_MSG = (
 def test_tone_excessive_punctuation_double_bang_branch_bites():
     """The '!!' alternation arm fires independently."""
     validator = _real_validator()
-    violations = validator.validate("This release is incredible!!", "blog_post")
-    assert _EXCLAMATION_TONE_MSG in violations
+    findings = validator.validate("This release is incredible!!", "blog_post")
+    assert _EXCLAMATION_TONE_MSG in _messages(findings)
+
+
+def test_tone_rule_finding_uses_rule_id_and_default_major_severity():
+    validator = _real_validator()
+    finding = _only_finding(validator.validate("This release is incredible!!", "blog_post"))
+    assert finding.rule_id == "no_excessive_punctuation"
+    assert finding.severity == "MAJOR"
+    assert finding.category == "tone"
+    assert finding.message == _EXCLAMATION_TONE_MSG
 
 
 def test_tone_excessive_punctuation_double_question_branch_bites():
     """The '\\?\\?' alternation arm fires independently."""
     validator = _real_validator()
-    violations = validator.validate("Did the build pass??", "blog_post")
-    assert _EXCLAMATION_TONE_MSG in violations
+    findings = validator.validate("Did the build pass??", "blog_post")
+    assert _EXCLAMATION_TONE_MSG in _messages(findings)
 
 
 def test_tone_excessive_punctuation_single_marks_are_clean():
     """A single ! and a single ? do not trip the excessive-punctuation rule."""
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "The build passed! Does that surprise you?", "blog_post"
     )
-    assert violations == []
+    assert findings == []
 
 
 # ===========================================================================
@@ -119,34 +148,34 @@ _CASUAL_TONE_MSG = "Tone violation: Avoid overly casual slang and filler words."
 
 def test_tone_casual_phrase_so_comma_branch_bites():
     validator = _real_validator()
-    violations = validator.validate("So, here is the summary.", "blog_post")
-    assert _CASUAL_TONE_MSG in violations
+    findings = validator.validate("So, here is the summary.", "blog_post")
+    assert _CASUAL_TONE_MSG in _messages(findings)
 
 
 def test_tone_casual_phrase_well_comma_branch_bites():
     validator = _real_validator()
-    violations = validator.validate("Well, that settles it.", "blog_post")
-    assert _CASUAL_TONE_MSG in violations
+    findings = validator.validate("Well, that settles it.", "blog_post")
+    assert _CASUAL_TONE_MSG in _messages(findings)
 
 
 def test_tone_casual_phrase_you_know_comma_branch_bites():
     validator = _real_validator()
-    violations = validator.validate("You know, it depends.", "blog_post")
-    assert _CASUAL_TONE_MSG in violations
+    findings = validator.validate("You know, it depends.", "blog_post")
+    assert _CASUAL_TONE_MSG in _messages(findings)
 
 
 def test_tone_casual_phrase_like_comma_branch_bites():
     validator = _real_validator()
-    violations = validator.validate("Like, the latency dropped.", "blog_post")
-    assert _CASUAL_TONE_MSG in violations
+    findings = validator.validate("Like, the latency dropped.", "blog_post")
+    assert _CASUAL_TONE_MSG in _messages(findings)
 
 
 def test_tone_casual_phrase_basically_bare_token_branch_bites():
     """The 'basically' arm has no trailing comma in the shipped pattern; it
     must still fire on the bare token."""
     validator = _real_validator()
-    violations = validator.validate("Basically it just works.", "blog_post")
-    assert _CASUAL_TONE_MSG in violations
+    findings = validator.validate("Basically it just works.", "blog_post")
+    assert _CASUAL_TONE_MSG in _messages(findings)
 
 
 def test_clean_content_has_no_casual_phrase_false_positive():
@@ -156,12 +185,12 @@ def test_clean_content_has_no_casual_phrase_false_positive():
     comma-suffixed arms.
     """
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "The system dispatches each request deterministically and returns a "
         "structured result.",
         "blog_post",
     )
-    assert violations == []
+    assert findings == []
 
 
 # ===========================================================================
@@ -181,38 +210,52 @@ def test_landing_page_must_mention_bites_when_extensibility_absent():
     """A landing page that never mentions extensibility fails the must-mention
     rule (fail_on_match: false branch)."""
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "Our product helps teams move faster with a clean dashboard.",
         "landing_page",
     )
-    assert _LANDING_MUST_MENTION_MSG in violations
+    assert _LANDING_MUST_MENTION_MSG in _messages(findings)
+
+
+def test_content_rule_finding_uses_rule_id_and_default_blocker_severity():
+    validator = _real_validator()
+    finding = _only_finding(
+        validator.validate(
+            "Our product helps teams move faster with a clean dashboard.",
+            "landing_page",
+        )
+    )
+    assert finding.rule_id == "landing_page_extensibility_mention"
+    assert finding.severity == "BLOCKER"
+    assert finding.category == "content"
+    assert finding.message == _LANDING_MUST_MENTION_MSG
 
 
 def test_landing_page_must_mention_satisfied_by_extensibility_arm():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "Atlas is built around extensibility from day one.", "landing_page"
     )
-    assert _LANDING_MUST_MENTION_MSG not in violations
-    assert violations == []
+    assert _LANDING_MUST_MENTION_MSG not in _messages(findings)
+    assert findings == []
 
 
 def test_landing_page_must_mention_satisfied_by_extensible_arm():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "Every component of the system is extensible.", "landing_page"
     )
-    assert _LANDING_MUST_MENTION_MSG not in violations
-    assert violations == []
+    assert _LANDING_MUST_MENTION_MSG not in _messages(findings)
+    assert findings == []
 
 
 def test_landing_page_must_mention_satisfied_by_pluggable_arm():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "Each capability is pluggable behind a typed port.", "landing_page"
     )
-    assert _LANDING_MUST_MENTION_MSG not in violations
-    assert violations == []
+    assert _LANDING_MUST_MENTION_MSG not in _messages(findings)
+    assert findings == []
 
 
 # ===========================================================================
@@ -229,36 +272,36 @@ _RELEASE_FUTURE_TENSE_MSG = (
 
 def test_release_notes_future_tense_will_be_branch_bites():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "Dark mode will be enabled for all tenants.", "release_notes"
     )
-    assert _RELEASE_FUTURE_TENSE_MSG in violations
+    assert _RELEASE_FUTURE_TENSE_MSG in _messages(findings)
 
 
 def test_release_notes_future_tense_coming_soon_branch_bites():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "A redesigned export view is coming soon.", "release_notes"
     )
-    assert _RELEASE_FUTURE_TENSE_MSG in violations
+    assert _RELEASE_FUTURE_TENSE_MSG in _messages(findings)
 
 
 def test_release_notes_future_tense_in_the_future_branch_bites():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "We may revisit this in the future.", "release_notes"
     )
-    assert _RELEASE_FUTURE_TENSE_MSG in violations
+    assert _RELEASE_FUTURE_TENSE_MSG in _messages(findings)
 
 
 def test_release_notes_past_tense_is_clean():
     """Shipped-feature, past-tense release copy with no future-tense arm passes."""
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "We added a deterministic export and fixed the dispatch retry path.",
         "release_notes",
     )
-    assert violations == []
+    assert findings == []
 
 
 # ===========================================================================
@@ -280,7 +323,7 @@ def test_isolated_forbidden_vocabulary_word_bites(tmp_path):
         """,
     )
     validator = BrandVoiceValidator(config_path=config)
-    assert validator.validate("Pure synergy across teams.", "blog_post") == [
+    assert _messages(validator.validate("Pure synergy across teams.", "blog_post")) == [
         "Contains forbidden word: 'synergy'"
     ]
 
@@ -315,7 +358,7 @@ def test_isolated_tone_rule_bites_and_reports_description(tmp_path):
         """,
     )
     validator = BrandVoiceValidator(config_path=config)
-    assert validator.validate("This is URGENT, act now.", "blog_post") == [
+    assert _messages(validator.validate("This is URGENT, act now.", "blog_post")) == [
         "Tone violation: Do not yell."
     ]
 
@@ -357,7 +400,9 @@ def test_isolated_content_rule_must_mention_bites_when_absent(tmp_path):
         """,
     )
     validator = BrandVoiceValidator(config_path=config)
-    assert validator.validate("A feature-rich landing page.", "landing_page") == [
+    assert _messages(
+        validator.validate("A feature-rich landing page.", "landing_page")
+    ) == [
         "Content rule violation: Landing pages must mention pricing."
     ]
     # Same rule satisfied when the term is present.
@@ -380,10 +425,86 @@ def test_isolated_content_rule_fail_on_match_true_bites_when_present(tmp_path):
         """,
     )
     validator = BrandVoiceValidator(config_path=config)
-    assert validator.validate("Ship date: TBD.", "release_notes") == [
+    assert _messages(validator.validate("Ship date: TBD.", "release_notes")) == [
         "Content rule violation: Release notes must not say TBD."
     ]
     assert validator.validate("Ship date: shipped.", "release_notes") == []
+
+
+def test_isolated_content_rule_custom_severity_is_normalized(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          avoid: []
+        tone_rules: []
+        content_rules:
+          - id: "prefer_specific_copy"
+            description: "Use specific copy."
+            applies_to: "landing_page"
+            pattern: "specific"
+            fail_on_match: false
+            severity: nit
+        """,
+    )
+    validator = BrandVoiceValidator(config_path=config)
+    finding = _only_finding(validator.validate("A generic landing page.", "landing_page"))
+    assert finding.rule_id == "prefer_specific_copy"
+    assert finding.severity == "NIT"
+    assert finding.category == "content"
+    assert finding.message == "Content rule violation: Use specific copy."
+
+
+def test_rule_invalid_severity_raises_value_error_at_load(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          avoid: []
+        tone_rules:
+          - id: "no_caps_yell"
+            description: "Do not yell."
+            pattern: "URGENT"
+            severity: urgent
+        content_rules: []
+        """,
+    )
+    with pytest.raises(ValueError, match="no_caps_yell.*invalid severity"):
+        BrandVoiceValidator(config_path=config)
+
+
+def test_rule_missing_id_raises_value_error_at_load(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          avoid: []
+        tone_rules:
+          - description: "Do not yell."
+            pattern: "URGENT"
+        content_rules: []
+        """,
+    )
+    with pytest.raises(ValueError, match="missing required.*id"):
+        BrandVoiceValidator(config_path=config)
+
+
+def test_content_rule_missing_applies_to_raises_value_error_at_load(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          avoid: []
+        tone_rules: []
+        content_rules:
+          - id: "missing_applies_to"
+            description: "Needs an applies_to field."
+            pattern: "pricing"
+            fail_on_match: false
+        """,
+    )
+    with pytest.raises(ValueError, match="missing_applies_to.*applies_to"):
+        BrandVoiceValidator(config_path=config)
 
 
 # ===========================================================================
@@ -400,26 +521,26 @@ def test_isolated_content_rule_fail_on_match_true_bites_when_present(tmp_path):
 
 def test_substring_footgun_transform_does_not_false_positive_on_transformer():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "The Transformer architecture powers our embeddings.", "blog_post"
     )
-    assert "Contains forbidden word: 'transform'" not in violations
+    assert "Contains forbidden word: 'transform'" not in _messages(findings)
 
 
 def test_substring_footgun_leverage_does_not_false_positive_on_deleverage():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "We help teams deleverage their technical debt.", "blog_post"
     )
-    assert "Contains forbidden word: 'leverage'" not in violations
+    assert "Contains forbidden word: 'leverage'" not in _messages(findings)
 
 
 def test_substring_footgun_disrupt_does_not_false_positive_on_non_disruptive():
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "Our non-disruptive migration path keeps you live.", "blog_post"
     )
-    assert "Contains forbidden word: 'disrupt'" not in violations
+    assert "Contains forbidden word: 'disrupt'" not in _messages(findings)
 
 
 def test_substring_word_boundary_still_catches_the_true_positive_standalone():
@@ -428,10 +549,10 @@ def test_substring_word_boundary_still_catches_the_true_positive_standalone():
     plain green assertion -- it locks the fix from over-correcting into a
     miss.)"""
     validator = _real_validator()
-    violations = validator.validate(
+    findings = validator.validate(
         "We will transform your workflow overnight.", "blog_post"
     )
-    assert "Contains forbidden word: 'transform'" in violations
+    assert "Contains forbidden word: 'transform'" in _messages(findings)
 
 
 # ===========================================================================
@@ -459,9 +580,11 @@ def test_content_rule_missing_fail_on_match_key_bans_on_match_not_inverts(tmp_pa
     validator = BrandVoiceValidator(config_path=config)
     msg = "Content rule violation: No future tense."
     # Intended: clean text (no banned phrase) must NOT be flagged.
-    assert msg not in validator.validate("This is clean shipped copy.", "blog_post")
+    assert msg not in _messages(
+        validator.validate("This is clean shipped copy.", "blog_post")
+    )
     # Intended: text containing the banned phrase MUST be flagged.
-    assert msg in validator.validate("This will be great.", "blog_post")
+    assert msg in _messages(validator.validate("This will be great.", "blog_post"))
 
 
 # ===========================================================================
@@ -536,7 +659,7 @@ def test_unknown_content_type_only_applies_global_rules(tmp_path):
     validator = BrandVoiceValidator(config_path=config)
     # The landing-only content_rule must NOT fire for an unrelated type, but
     # the global vocab rule still does.
-    assert validator.validate("Pure synergy here.", "email_blast") == [
+    assert _messages(validator.validate("Pure synergy here.", "email_blast")) == [
         "Contains forbidden word: 'synergy'"
     ]
 
@@ -663,8 +786,11 @@ def test_cli_returns_one_for_brand_voice_violations(tmp_path):
 
     assert result.returncode == 1
     assert "FAIL: Found" in result.stdout
+    assert "[BLOCKER] vocabulary.avoid.game-changer" in result.stdout
     assert "Contains forbidden word: 'game-changer'" in result.stdout
+    assert "[MAJOR] no_excessive_punctuation" in result.stdout
     assert _EXCLAMATION_TONE_MSG in result.stdout
+    assert "[BLOCKER] landing_page_extensibility_mention" in result.stdout
     assert _LANDING_MUST_MENTION_MSG in result.stdout
     assert result.stderr == ""
 


### PR DESCRIPTION
Plan: plans/PR-Brand-Voice-Structured-Findings.md
Slice phase: Vertical slice

Adds structured brand-voice findings so the validator can report stable `rule_id`, `severity`, `category`, and `message` fields instead of raw strings. The marketing CI behavior stays conservative: any finding still fails the CLI/workflow, but future suggested-fix and reporting slices now have a real contract to consume.

## Intentional

- `validate(...)` now returns `BrandVoiceFinding` objects; there is no raw-string compatibility shim because the package was introduced in #1344 and only in-tree tests/CLI consume it.
- Severity is metadata only in this slice; CI remains fail-on-any finding.
- CLI output stays text, not JSON.

## Deferred

- Suggested-fix output for `vocabulary.use`.
- Stem-aware vocabulary patterns owned in YAML.
- JSON CLI/report mode for structured downstream consumers.
- Larger marketing corpus expansion.

## Parked hardening

- None.

## Verification

- `python -m pytest tests/test_brand_voice_validator.py -q` -- 52 passed.
- `python -m py_compile atlas_brain/brand/voice_validator.py tests/test_brand_voice_validator.py` -- passed.
- `python atlas_brain/brand/voice_validator.py --file marketing/landing_pages/atlas-platform.md --type landing_page` -- PASS.
- Negative CLI smoke with `This is a game-changer!!` exits 1 and prints `[BLOCKER] vocabulary.avoid.game-changer`, `[MAJOR] no_excessive_punctuation`, and `[BLOCKER] landing_page_extensibility_mention`.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-brand-voice-structured-findings-body.md` -- passed.

## Diff size

4 files, +393 / -74.