### PR TITLE
Content Ops Output Variations Blog Only

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -518,6 +518,7 @@ if BaseModel is not None:
         reasoning_preset: ReasoningPreset | None = Field(default=None)
         outputs: tuple[str, ...] = Field(default_factory=tuple, max_length=20)
         limit: int = Field(1, ge=1, le=1000)
+        variant_count: int = Field(1, ge=1)
         max_cost_usd: float | None = Field(default=None, gt=0)
         account_usage_budget_usd: float | None = Field(default=None, gt=0)
         account_usage_budget_days: int = Field(7, ge=1, le=90)

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -485,6 +485,7 @@ class BlogPostGenerationService:
         topic: str | None = None,
         data_context: Mapping[str, Any] | None = None,
         brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
+        variant_angle: str | None = None,
     ) -> BlogPostGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -525,6 +526,7 @@ class BlogPostGenerationService:
         # PR-Blog-Topic-Per-Call: operator-supplied topic for this run.
         # Empty string when None so prompt substitution is a clean no-op.
         resolved_topic = (topic or "").strip()
+        resolved_variant_angle = (variant_angle or "").strip()
         trusted_data_context = _mapping_dict(data_context)
         resolved_brand_voice = brand_voice_profile_from_mapping(
             brand_voice,
@@ -563,6 +565,7 @@ class BlogPostGenerationService:
                     parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                     topic=resolved_topic,
                     brand_voice=resolved_brand_voice,
+                    variant_angle=resolved_variant_angle,
                 )
             except Exception as exc:
                 skipped += 1
@@ -596,6 +599,7 @@ class BlogPostGenerationService:
                             quality_repair_attempt_no=repair_attempt_no,
                             topic=resolved_topic,
                             brand_voice=resolved_brand_voice,
+                            variant_angle=resolved_variant_angle,
                         )
                     except Exception as exc:
                         skipped += 1
@@ -705,12 +709,14 @@ class BlogPostGenerationService:
         parse_retry_response_excerpt_chars: int,
         topic: str = "",
         brand_voice: BrandVoiceProfile | None = None,
+        variant_angle: str = "",
     ) -> dict[str, Any] | None:
         system_prompt, base_user_prompt = _blog_generation_prompts(
             prompt_template,
             blueprint=blueprint,
             topic=topic,
             brand_voice=brand_voice,
+            variant_angle=variant_angle,
         )
         attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
@@ -735,6 +741,7 @@ class BlogPostGenerationService:
                     "skill_name": self._config.skill_name,
                     "asset_type": "blog_post",
                     "attempt_no": attempt_no,
+                    **({"variant_angle": variant_angle} if variant_angle else {}),
                 },
             )
             total_usage = accumulate_usage(total_usage, response.usage)
@@ -746,6 +753,7 @@ class BlogPostGenerationService:
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
                     "_quality_repair_attempts": 0,
+                    **({"_variant_angle": variant_angle} if variant_angle else {}),
                 }, brand_voice)
             last_response = clip_invalid_response(
                 response.content,
@@ -766,6 +774,7 @@ class BlogPostGenerationService:
         quality_repair_attempt_no: int,
         topic: str = "",
         brand_voice: BrandVoiceProfile | None = None,
+        variant_angle: str = "",
     ) -> dict[str, Any] | None:
         blockers = tuple(str(item) for item in quality.get("blockers") or () if item)
         if not blockers:
@@ -776,6 +785,7 @@ class BlogPostGenerationService:
             blueprint=blueprint,
             topic=topic,
             brand_voice=brand_voice,
+            variant_angle=variant_angle,
         )
         response = await self._llm.complete(
             [
@@ -798,6 +808,7 @@ class BlogPostGenerationService:
                 "asset_type": "blog_post",
                 "attempt_no": parse_attempts_used + quality_repair_attempt_no,
                 "quality_repair_attempt_no": quality_repair_attempt_no,
+                **({"variant_angle": variant_angle} if variant_angle else {}),
             },
         )
         repaired = parse_blog_post_response(response.content)
@@ -812,6 +823,7 @@ class BlogPostGenerationService:
             ),
             "_parse_attempts": parse_attempts_used,
             "_quality_repair_attempts": int(parsed.get("_quality_repair_attempts") or 0) + 1,
+            **({"_variant_angle": variant_angle} if variant_angle else {}),
         }, brand_voice)
 
     def _quality_check(
@@ -874,6 +886,9 @@ class BlogPostGenerationService:
             "brand_voice_profile": parsed.get("_brand_voice_profile"),
             "brand_voice_audit": parsed.get("_brand_voice_audit"),
         }
+        variant_angle = str(parsed.get("_variant_angle") or "").strip()
+        if variant_angle:
+            metadata["variant_angle"] = variant_angle
         # PR-Blog-Reasoning-Parity: surface reasoning audit fields on
         # the draft metadata when the blueprint carried merged context.
         # Mirrors campaign / report / sales_brief metadata threading.
@@ -1279,6 +1294,7 @@ def _blog_generation_prompts(
     blueprint: Mapping[str, Any],
     topic: str = "",
     brand_voice: BrandVoiceProfile | None = None,
+    variant_angle: str = "",
 ) -> tuple[str, str]:
     blueprint_json = json.dumps(dict(blueprint), separators=(",", ":"), default=str)
     system_prompt = (
@@ -1295,6 +1311,17 @@ def _blog_generation_prompts(
         base_user_prompt_parts.extend((
             "",
             f"Operator-supplied topic focus: {topic}",
+        ))
+    variant_angle = (variant_angle or "").strip()
+    if variant_angle:
+        base_user_prompt_parts.extend((
+            "",
+            f"Variant angle: {variant_angle}",
+            (
+                "Write this as one alternative rendering of the same blueprint. "
+                "Keep the factual claims, evidence, and measurements grounded in "
+                "the supplied blueprint."
+            ),
         ))
     base_user_prompt = "\n".join(base_user_prompt_parts)
     base_user_prompt = _with_support_ticket_descriptive_prompt_addendum(

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -19,6 +19,7 @@ from .control_surfaces import OUTPUT_CATALOG, ContentOpsRequest, request_from_ma
 from .generation_plan import GenerationPlan, GenerationPlanStep, build_generation_plan
 from .landing_page_input_contract import LANDING_PAGE_CONTEXT_INPUT_KEYS
 from .landing_page_ports import MarketingCampaign
+from .output_variations import VariantAngle, selected_variant_angles
 from .reasoning_signals import REASONING_VALIDATION_BLOCKED
 from .support_ticket_context_contract import (
     SUPPORT_TICKET_CATEGORY,
@@ -58,6 +59,14 @@ _COMPETITIVE_SOURCE_TYPES = frozenset({
     "displacement_edge",
     "displacement_edges",
 })
+
+
+class _ContentOpsStepResultFailure(RuntimeError):
+    """Failure that still carries partial step diagnostics."""
+
+    def __init__(self, message: str, result: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.result = dict(result)
 
 
 @dataclass(frozen=True)
@@ -390,6 +399,18 @@ async def _execute_step(
             brand_voice=brand_voice,
             filters=filters,
         )
+    except _ContentOpsStepResultFailure as exc:
+        error = _step_error_dict(step, str(exc))
+        return (
+            _failed_step(
+                step,
+                str(exc),
+                service=service,
+                reasoning_provider_configured=reasoning_provider_configured,
+                result=exc.result,
+            ),
+            error,
+        )
     except Exception as exc:
         error = _step_error_dict(step, str(exc))
         return (
@@ -667,6 +688,14 @@ async def _dispatch_blog_post(
     )
     if data_context:
         kwargs["data_context"] = data_context
+    if request.variant_count > 1:
+        return await _dispatch_blog_post_variants(
+            service=service,
+            request=request,
+            scope=scope,
+            filters=filters,
+            kwargs=kwargs,
+        )
     return await service.generate(
         scope=scope,
         target_mode=request.target_mode,
@@ -674,6 +703,126 @@ async def _dispatch_blog_post(
         filters=filters,
         **kwargs,
     )
+
+
+async def _dispatch_blog_post_variants(
+    *,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    variant_results: list[dict[str, Any]] = []
+    saved_ids: list[str] = []
+    errors: list[dict[str, Any]] = []
+    consumed_reasoning: list[dict[str, Any]] = []
+    requested = 0
+    generated = 0
+    skipped = 0
+    reasoning_contexts_used = 0
+    caught_exceptions = 0
+
+    for angle in selected_variant_angles(request.variant_count):
+        angle_data = angle.as_dict()
+        try:
+            result = await service.generate(
+                scope=scope,
+                target_mode=request.target_mode,
+                limit=request.limit,
+                filters=filters,
+                variant_angle=angle.instruction,
+                **kwargs,
+            )
+            result_data = _result_dict(result)
+        except Exception as exc:
+            caught_exceptions += 1
+            error = _blog_variant_error(angle, str(exc), type(exc).__name__)
+            result_data = {
+                "requested": max(1, int(request.limit or 1)),
+                "generated": 0,
+                "skipped": max(1, int(request.limit or 1)),
+                "saved_ids": [],
+                "errors": [error],
+            }
+
+        variant_result = dict(result_data)
+        variant_result["variant_angle"] = angle_data
+        variant_results.append(variant_result)
+        requested += _result_int(result_data, "requested", default=max(1, request.limit))
+        generated += _result_int(result_data, "generated")
+        skipped += _result_int(result_data, "skipped")
+        reasoning_contexts_used += _result_int(result_data, "reasoning_contexts_used")
+        saved_ids.extend(_result_strings(result_data, "saved_ids"))
+        for error in _result_mappings(result_data, "errors"):
+            tagged = dict(error)
+            tagged.setdefault("variant_angle", angle.id)
+            tagged.setdefault("variant_label", angle.label)
+            errors.append(tagged)
+        consumed_reasoning.extend(
+            _result_mappings(result_data, "consumed_reasoning_contexts")
+        )
+
+    aggregate: dict[str, Any] = {
+        "requested": requested,
+        "generated": generated,
+        "skipped": skipped,
+        "reasoning_contexts_used": reasoning_contexts_used,
+        "saved_ids": saved_ids,
+        "errors": errors,
+        "variant_count": len(variant_results),
+        "variant_results": variant_results,
+    }
+    if consumed_reasoning:
+        aggregate["consumed_reasoning_contexts"] = consumed_reasoning
+    if generated == 0:
+        aggregate["warnings"] = [
+            "No blog variants generated; all requested variants were blocked or skipped."
+        ]
+        if caught_exceptions:
+            raise _ContentOpsStepResultFailure("all_blog_variants_failed", aggregate)
+    return aggregate
+
+
+def _blog_variant_error(
+    angle: VariantAngle,
+    reason: str,
+    error_type: str,
+) -> dict[str, str]:
+    return {
+        "variant_angle": angle.id,
+        "variant_label": angle.label,
+        "reason": reason,
+        "error_type": error_type,
+    }
+
+
+def _result_int(
+    data: Mapping[str, Any],
+    key: str,
+    *,
+    default: int = 0,
+) -> int:
+    try:
+        return int(data.get(key) if data.get(key) is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _result_strings(data: Mapping[str, Any], key: str) -> list[str]:
+    value = data.get(key)
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [str(item) for item in value if str(item)]
+    return []
+
+
+def _result_mappings(data: Mapping[str, Any], key: str) -> list[dict[str, Any]]:
+    value = data.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [dict(item) for item in value if isinstance(item, Mapping)]
 
 
 async def _dispatch_signal_extraction(
@@ -1315,11 +1464,13 @@ def _failed_step(
     *,
     service: Any | None,
     reasoning_provider_configured: bool,
+    result: Mapping[str, Any] | None = None,
 ) -> ContentOpsStepExecution:
     return ContentOpsStepExecution(
         output=step.output,
         runner=step.runner,
         status="failed",
+        result=dict(result or {}),
         error=error,
         reasoning=_step_reasoning_audit(
             step,

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -17,6 +17,7 @@ from .landing_page_repair_contract import (
     LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS_DEFAULT,
     landing_page_quality_repair_attempts_from_inputs,
 )
+from .output_variations import normalize_variant_count
 from .social_post_generation import normalize_social_post_channels
 
 SOCIAL_POST_BRAND_VOICE_UNIT_COST_USD = 0.08
@@ -61,6 +62,7 @@ class ContentOpsRequest:
     reasoning_preset: str | None = None
     outputs: tuple[str, ...] = ()
     limit: int = 1
+    variant_count: int = 1
     max_cost_usd: float | None = None
     account_usage_budget_usd: float | None = None
     account_usage_budget_days: int = 7
@@ -100,6 +102,7 @@ class ControlSurfacePreview:
                 "reasoning_preset": self.normalized_request.reasoning_preset,
                 "outputs": list(self.normalized_request.outputs),
                 "limit": self.normalized_request.limit,
+                "variant_count": self.normalized_request.variant_count,
                 "max_cost_usd": self.normalized_request.max_cost_usd,
                 "account_usage_budget_usd": (
                     self.normalized_request.account_usage_budget_usd
@@ -346,6 +349,7 @@ def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
     limit = int(payload.get("limit") if payload.get("limit") is not None else 1)
     if limit < 1:
         raise ValueError(f"limit must be at least 1; got {limit}")
+    variant_count = normalize_variant_count(payload.get("variant_count"))
 
     max_cost_usd = (
         float(payload["max_cost_usd"])
@@ -392,6 +396,7 @@ def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
         else None,
         outputs=normalize_outputs(payload.get("outputs")),
         limit=limit,
+        variant_count=variant_count,
         max_cost_usd=max_cost_usd,
         account_usage_budget_usd=account_usage_budget_usd,
         account_usage_budget_days=account_usage_budget_days,
@@ -504,7 +509,10 @@ def _item_multiplier_for_output(
     output_id: str,
     *,
     inputs: Mapping[str, Any],
+    variant_count: int = 1,
 ) -> int:
+    if output_id == "blog_post":
+        return normalize_variant_count(variant_count)
     if output_id != "social_post":
         return 1
     channels = inputs.get("social_channels")
@@ -518,6 +526,7 @@ def estimate_cost_usd(
     *,
     limit: int,
     inputs: Mapping[str, Any] | None = None,
+    variant_count: int = 1,
     require_quality_gates: bool = True,
     brand_voice_profile_id: str | None = None,
 ) -> float:
@@ -553,7 +562,11 @@ def estimate_cost_usd(
                 quality_repair_attempts=repair_attempts,
             )
             * max(1, limit)
-            * _item_multiplier_for_output(output_id, inputs=provided_inputs)
+            * _item_multiplier_for_output(
+                output_id,
+                inputs=provided_inputs,
+                variant_count=variant_count,
+            )
         )
     return total
 
@@ -634,7 +647,11 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
 
     if "social_post" in outputs and "social_post" not in blocked:
         try:
-            _item_multiplier_for_output("social_post", inputs=request.inputs)
+            _item_multiplier_for_output(
+                "social_post",
+                inputs=request.inputs,
+                variant_count=request.variant_count,
+            )
         except ValueError as exc:
             blocked.append("social_post")
             warnings.append(f"Unsupported social channel: {exc}")
@@ -645,6 +662,7 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
         selected_outputs,
         limit=request.limit,
         inputs=request.inputs,
+        variant_count=request.variant_count,
         require_quality_gates=request.require_quality_gates,
         brand_voice_profile_id=request.brand_voice_profile_id,
     )
@@ -677,6 +695,7 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
         reasoning_preset=request.reasoning_preset,
         outputs=selected_outputs,
         limit=request.limit,
+        variant_count=request.variant_count,
         max_cost_usd=request.max_cost_usd,
         account_usage_budget_usd=request.account_usage_budget_usd,
         account_usage_budget_days=request.account_usage_budget_days,

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -21,6 +21,7 @@ from .control_surfaces import (
     preview_control_surface,
     request_from_mapping,
 )
+from .output_variations import selected_variant_angles
 from .landing_page_generation import LandingPageGenerationConfig
 from .landing_page_repair_contract import (
     landing_page_quality_repair_attempts_from_inputs,
@@ -201,6 +202,16 @@ def _sales_brief_config_for_request(request: ContentOpsRequest) -> SalesBriefGen
 
 def _blog_post_config_for_request(request: ContentOpsRequest) -> BlogPostGenerationConfig:
     return BlogPostGenerationConfig(limit=request.limit)
+
+
+def _blog_variant_config_for_request(request: ContentOpsRequest) -> dict[str, Any]:
+    if request.variant_count <= 1:
+        return {}
+    angles = selected_variant_angles(request.variant_count)
+    return {
+        "variant_count": len(angles),
+        "variant_angles": [angle.as_dict() for angle in angles],
+    }
 
 
 def _brand_voice_config_for_request(request: ContentOpsRequest) -> dict[str, Any]:
@@ -465,6 +476,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
                 "topic": request.inputs.get("topic"),
+                **_blog_variant_config_for_request(request),
                 **_brand_voice_config_for_request(request),
                 **_reasoning_config_for_output(output, request),
             },

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -409,6 +409,9 @@
       "target": "extracted_content_pipeline/generation_plan.py"
     },
     {
+      "target": "extracted_content_pipeline/output_variations.py"
+    },
+    {
       "target": "extracted_content_pipeline/reasoning_policy.py"
     },
     {

--- a/extracted_content_pipeline/output_variations.py
+++ b/extracted_content_pipeline/output_variations.py
@@ -1,0 +1,89 @@
+"""Deterministic output-variation angle helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class VariantAngle:
+    """One deterministic framing angle for an output variation."""
+
+    id: str
+    label: str
+    instruction: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "instruction": self.instruction,
+        }
+
+
+VARIANT_ANGLES: tuple[VariantAngle, ...] = (
+    VariantAngle(
+        id="pain_led",
+        label="Pain-led",
+        instruction=(
+            "Pain-led: open with the customer's current friction, then show how "
+            "the evidence supports the recommended next step."
+        ),
+    ),
+    VariantAngle(
+        id="outcome_led",
+        label="Outcome-led",
+        instruction=(
+            "Outcome-led: lead with the business result the audience wants, then "
+            "connect the supporting evidence to that result."
+        ),
+    ),
+    VariantAngle(
+        id="social_proof",
+        label="Social-proof-led",
+        instruction=(
+            "Social-proof-led: frame the post around observed customer or market "
+            "signals without adding unsupported testimonials."
+        ),
+    ),
+    VariantAngle(
+        id="objection_handling",
+        label="Objection-handling",
+        instruction=(
+            "Objection-handling: anticipate the strongest buyer hesitation and "
+            "answer it with only the supplied evidence."
+        ),
+    ),
+    VariantAngle(
+        id="urgency_led",
+        label="Urgency-led",
+        instruction=(
+            "Urgency-led: emphasize why the audience should act now, but do not "
+            "invent time-sensitive claims absent from the blueprint."
+        ),
+    ),
+)
+
+
+def normalize_variant_count(value: Any = None) -> int:
+    """Return a positive variant count capped to the deterministic catalogue."""
+
+    raw = 1 if value in (None, "") else int(value)
+    if raw < 1:
+        raise ValueError(f"variant_count must be at least 1; got {raw}")
+    return min(raw, len(VARIANT_ANGLES))
+
+
+def selected_variant_angles(count: int) -> tuple[VariantAngle, ...]:
+    """Return the deterministic first-N variant angles."""
+
+    return VARIANT_ANGLES[:normalize_variant_count(count)]
+
+
+__all__ = [
+    "VARIANT_ANGLES",
+    "VariantAngle",
+    "normalize_variant_count",
+    "selected_variant_angles",
+]

--- a/plans/PR-Content-Ops-Output-Variations-Blog-Only.md
+++ b/plans/PR-Content-Ops-Output-Variations-Blog-Only.md
@@ -1,0 +1,146 @@
+# PR-Content-Ops-Output-Variations-Blog-Only
+
+## Why this slice exists
+
+The merged `PR-Content-Ops-Output-Variations.md` plan records the product ask:
+marketers need several alternative takes from one run spec, not only one
+take-it-or-leave-it draft. That plan also names a generator-parity fallback if
+the full blog + landing page + sales brief slice exceeds the 400 LOC budget.
+This PR takes that fallback deliberately: it proves deterministic
+output-variation fan-out for `blog_post` first, through the real Content Ops
+request -> preview -> plan -> execute -> blog prompt path, without touching the
+adjacent landing-page and sales-brief generator contracts yet.
+
+The full diff is over the 400 LOC soft cap because the complete vertical slice
+crosses five package surfaces (request, preview, plan, execution, generator) and
+ships focused regression tests for each contract. The implementation code stays
+under 400 LOC; the remaining bulk is the required plan plus R2/R12 test
+coverage.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/output-variations/blog-only
+Slice phase: Vertical slice
+
+1. Add a normalized `variant_count` request knob for Content Ops, capped to the
+   deterministic blog-angle catalogue.
+2. Thread blog-only selected variant angles into preview cost, generation-plan
+   metadata, execution fan-out, blog service prompts, LLM metadata, draft
+   metadata, and the step result aggregate.
+3. Keep `variant_count == 1` behavior as the existing single blog generation
+   call so current callers do not see a new optional kwarg unless they request
+   variants.
+4. Add focused extracted-package tests for request normalization/capping, blog
+   cost scaling, plan metadata, executor fan-out/failure isolation, and prompt
+   injection.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] `variant_count` defaults to 1, rejects values below 1, and caps values
+        above the angle catalogue size.
+  - [ ] Blog preview/plan cost and metadata scale by selected blog variants;
+        non-blog outputs do not get variant fan-out in this slice.
+  - [ ] `execute_content_ops_request` runs one blog generation per selected
+        angle when `variant_count > 1`, tags per-angle results, aggregates
+        saved ids/errors, and isolates one failed variant from the others.
+  - [ ] If every requested blog variant raises an exception, the step/run is
+        failed while preserving the aggregate warning and per-angle diagnostics.
+  - [ ] `BlogPostGenerationService.generate(..., variant_angle=...)` injects
+        the angle into the prompt and preserves it in generation/draft metadata.
+  - [ ] Existing single-variant blog execution remains backward-compatible.
+- Affected surfaces: extracted package API request model, preview/plan,
+  execution result shape, blog-generation prompt metadata, tests.
+- Risk areas: backcompat, cost accounting, result contract, prompt truthfulness.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/blog_generation.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/output_variations.py`
+- `plans/PR-Content-Ops-Output-Variations-Blog-Only.md`
+- `tests/test_extracted_blog_generation.py`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+
+## Mechanism
+
+`extracted_content_pipeline/output_variations.py` owns the small deterministic
+angle catalogue and normalization helpers. `ContentOpsRequest.variant_count`
+stores the capped request value and preview cost multiplies `blog_post` cost by
+that value only. The generation plan exposes the selected angle metadata in the
+blog step config so reviewers and UI callers can see the exact fan-out before
+execution.
+
+Runtime fan-out stays blog-local in this thin slice. `_dispatch_blog_post`
+preserves today's single call for `variant_count == 1`; when variants are
+requested, it calls the blog service once per selected angle, passes the angle
+instruction as `variant_angle`, catches per-angle failures, and returns an
+aggregate with `variant_results`, total generated/skipped/requested counts,
+combined `saved_ids`, combined `errors`, and a warning when every requested
+variant produces zero survivors. If the zero-survivor case came from caught
+provider/execution exceptions, the dispatcher raises a step-result failure so
+`ContentOpsExecutionResult.status` is `failed` while the failed step still
+includes the aggregate warning and per-angle diagnostics.
+
+The blog service accepts `variant_angle: str | None`. Non-empty angles are added
+to the user prompt as framing guidance while preserving the blueprint facts and
+evidence, included in LLM call metadata, carried through parsed result metadata,
+and written to draft metadata. `None` / empty angle is a no-op.
+
+## Intentional
+
+- Blog-only first. Landing-page and sales-brief parity are deferred exactly as
+  the merged full plan's fallback allowed.
+- Fan-out is in the blog dispatcher rather than centralized in the generic step
+  loop for this slice. Central fan-out becomes valuable once a second generator
+  supports `variant_angle`; before then it would add abstraction without reuse.
+- Quality gates remain inside `BlogPostGenerationService`. This slice does not
+  duplicate gate logic in the executor; blocked/unparseable variants surface via
+  the existing per-call skipped/errors fields and the aggregate all-zero warning.
+- The older `ATLAS-HARDENING.md` deep-dive source/corpus items were scanned and
+  left parked because they touch published deep-dive truthfulness, not the new
+  blog output-variation fan-out path.
+
+## Deferred
+
+- Landing-page `variant_angle` parity.
+- Sales-brief `variant_angle` parity.
+- Centralized multi-generator fan-out after at least one additional generator
+  supports variants.
+- Persistent variant grouping (`variant_group_id`) and a past-run variants view.
+- Auto-ranking / recommended winner and A/B serving/analytics.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_blog_generation.py -q` -- PASS, 250 tests.
+- Command: `scripts/validate_extracted_content_pipeline.sh` via bash -- PASS.
+- Command: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- PASS.
+- Command: `python scripts/audit_extracted_standalone.py --fail-on-debt` -- PASS.
+- Command: `scripts/check_ascii_python.sh` via bash -- PASS.
+- Command: `scripts/run_extracted_pipeline_checks.sh` via bash -- PASS, 3,231 passed / 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 1 |
+| `extracted_content_pipeline/blog_generation.py` | 27 |
+| `extracted_content_pipeline/content_ops_execution.py` | 151 |
+| `extracted_content_pipeline/control_surfaces.py` | 23 |
+| `extracted_content_pipeline/generation_plan.py` | 12 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/output_variations.py` | 89 |
+| `plans/PR-Content-Ops-Output-Variations-Blog-Only.md` | 146 |
+| `tests/test_extracted_blog_generation.py` | 21 |
+| `tests/test_extracted_content_control_surfaces.py` | 36 |
+| `tests/test_extracted_content_generation_plan.py` | 20 |
+| `tests/test_extracted_content_ops_execution.py` | 143 |
+| **Total** | **672** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -740,6 +740,27 @@ async def test_generate_persists_blog_drafts_via_ports() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_threads_variant_angle_to_prompt_and_metadata() -> None:
+    service, _blueprints, blog_posts, llm, _skills = _service()
+    angle = "Pain-led: open with the buyer friction."
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=1,
+        variant_angle=angle,
+    )
+
+    assert result.generated == 1
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert f"Variant angle: {angle}" in user_prompt
+    assert "same blueprint" in user_prompt
+    assert llm.calls[0]["metadata"]["variant_angle"] == angle
+    draft = blog_posts.saved[0]["drafts"][0]
+    assert draft.metadata["variant_angle"] == angle
+
+
+@pytest.mark.asyncio
 async def test_generate_attaches_optional_blog_cover_image_before_save() -> None:
     image_provider = _ImageProvider(
         ContentImageAsset(

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -7,6 +7,7 @@ from extracted_content_pipeline.control_surfaces import (
     preview_from_mapping,
     request_from_mapping,
 )
+from extracted_content_pipeline.output_variations import VARIANT_ANGLES
 
 
 def test_normalize_outputs_accepts_csv_and_dedupes():
@@ -63,6 +64,41 @@ def test_request_normalizes_content_ops_cache_policy():
 
     assert request.content_ops_cache_policy == "exact"
     assert preview["normalized_request"]["content_ops_cache_policy"] == "exact"
+
+
+def test_request_caps_variant_count_to_angle_catalogue():
+    request = request_from_mapping({"variant_count": len(VARIANT_ANGLES) + 10})
+
+    assert request.variant_count == len(VARIANT_ANGLES)
+
+
+def test_request_rejects_zero_variant_count():
+    with pytest.raises(ValueError, match="variant_count must be at least 1; got 0"):
+        request_from_mapping({"variant_count": 0})
+
+
+def test_preview_scales_blog_cost_by_variant_count():
+    preview = preview_from_mapping({
+        "outputs": ["blog_post"],
+        "variant_count": 3,
+        "inputs": {"topic": "Renewal pressure"},
+    })
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 2.7
+    assert preview["normalized_request"]["variant_count"] == 3
+
+
+def test_preview_does_not_scale_non_blog_outputs_by_variant_count():
+    preview = preview_from_mapping({
+        "outputs": ["sales_brief"],
+        "variant_count": 3,
+        "inputs": {"target_account": "Acme"},
+    })
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 0.7
+    assert preview["normalized_request"]["variant_count"] == 3
 
 
 def test_request_rejects_unsupported_content_ops_cache_policy():

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -1,6 +1,7 @@
 import pytest
 
 from extracted_content_pipeline.generation_plan import build_generation_plan_from_mapping
+from extracted_content_pipeline.output_variations import VARIANT_ANGLES
 from extracted_content_pipeline.reasoning_policy import (
     PACKAGED_REASONING_RUNTIME_OUTPUTS,
     packaged_reasoning_runtime_presets_for_output,
@@ -330,6 +331,25 @@ def test_plan_maps_blog_to_blog_generation_service():
         "parse_retry_response_excerpt_chars": 800,
         "topic": "Churn pressure",
     }
+
+
+def test_plan_includes_blog_variant_angle_metadata_when_requested():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["blog_post"],
+            "variant_count": 2,
+            "inputs": {
+                "topic": "Churn pressure",
+            },
+        }
+    )
+
+    config = plan["steps"][0]["config"]
+    assert config["variant_count"] == 2
+    assert config["variant_angles"] == [
+        VARIANT_ANGLES[0].as_dict(),
+        VARIANT_ANGLES[1].as_dict(),
+    ]
 
 
 def test_plan_stays_non_executable_when_preview_fails_budget():

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -19,6 +19,7 @@ from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
 )
+from extracted_content_pipeline.output_variations import VARIANT_ANGLES
 from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
 from extracted_content_pipeline.quote_card_generation import QuoteCardGenerationService
 from extracted_content_pipeline.signal_extraction import SignalExtractionService
@@ -104,6 +105,42 @@ class _OpportunityService:
             "extras": dict(extras),
         })
         return _Result()
+
+
+class _VariantBlogService:
+    def __init__(self, *, fail_on_angle: str = "") -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.fail_on_angle = fail_on_angle
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+        variant_angle: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.calls.append({
+            "scope": scope,
+            "target_mode": target_mode,
+            "limit": limit,
+            "filters": dict(filters or {}),
+            "variant_angle": variant_angle,
+            "kwargs": dict(kwargs),
+        })
+        if self.fail_on_angle and self.fail_on_angle in str(variant_angle or ""):
+            raise RuntimeError("variant failed")
+        call_no = len(self.calls)
+        return {
+            "requested": int(limit or 1),
+            "generated": 1,
+            "skipped": 0,
+            "reasoning_contexts_used": 0,
+            "saved_ids": [f"draft-{call_no}"],
+            "errors": [],
+        }
 
 
 class _ReasoningAwareOpportunityService(_OpportunityService):
@@ -1917,6 +1954,112 @@ async def test_execute_threads_topic_into_blog_post_dispatcher() -> None:
     assert call["topic"] == "Renewal pricing pressure"
     assert call["quality_repair_attempts"] == 2
     assert call["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_fans_out_blog_variants_by_angle() -> None:
+    blog = _VariantBlogService()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["blog_post"],
+            "variant_count": 3,
+            "inputs": {
+                "target_account": "Acme",
+                "topic": "Renewal pricing pressure",
+            },
+        },
+        services=ContentOpsExecutionServices(blog_post=blog),
+    )
+
+    step_result = result["steps"][0]["result"]
+    assert result["status"] == "completed"
+    assert len(blog.calls) == 3
+    assert [call["variant_angle"] for call in blog.calls] == [
+        VARIANT_ANGLES[0].instruction,
+        VARIANT_ANGLES[1].instruction,
+        VARIANT_ANGLES[2].instruction,
+    ]
+    assert step_result["variant_count"] == 3
+    assert step_result["requested"] == 3
+    assert step_result["generated"] == 3
+    assert step_result["skipped"] == 0
+    assert step_result["saved_ids"] == ["draft-1", "draft-2", "draft-3"]
+    assert [
+        item["variant_angle"]["id"] for item in step_result["variant_results"]
+    ] == ["pain_led", "outcome_led", "social_proof"]
+
+
+@pytest.mark.asyncio
+async def test_execute_blog_variant_failure_does_not_abort_batch() -> None:
+    blog = _VariantBlogService(fail_on_angle="Outcome-led")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["blog_post"],
+            "variant_count": 3,
+            "inputs": {
+                "target_account": "Acme",
+                "topic": "Renewal pricing pressure",
+            },
+        },
+        services=ContentOpsExecutionServices(blog_post=blog),
+    )
+
+    step_result = result["steps"][0]["result"]
+    assert result["status"] == "completed"
+    assert result["errors"] == []
+    assert len(blog.calls) == 3
+    assert step_result["generated"] == 2
+    assert step_result["skipped"] == 1
+    assert step_result["saved_ids"] == ["draft-1", "draft-3"]
+    assert step_result["errors"] == [{
+        "variant_angle": "outcome_led",
+        "variant_label": "Outcome-led",
+        "reason": "variant failed",
+        "error_type": "RuntimeError",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_execute_all_raising_blog_variants_fails_step_with_warning() -> None:
+    blog = _VariantBlogService(fail_on_angle="led")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["blog_post"],
+            "variant_count": 3,
+            "inputs": {
+                "target_account": "Acme",
+                "topic": "Renewal pricing pressure",
+            },
+        },
+        services=ContentOpsExecutionServices(blog_post=blog),
+    )
+
+    step = result["steps"][0]
+    assert result["status"] == "failed"
+    assert result["errors"] == [{
+        "output": "blog_post",
+        "runner": "BlogPostGenerationService.generate",
+        "error": "all_blog_variants_failed",
+        "reason": "all_blog_variants_failed",
+    }]
+    assert step["status"] == "failed"
+    assert step["error"] == "all_blog_variants_failed"
+    assert step["result"]["generated"] == 0
+    assert step["result"]["skipped"] == 3
+    assert step["result"]["warnings"] == [
+        "No blog variants generated; all requested variants were blocked or skipped."
+    ]
+    assert [
+        item["variant_angle"]["id"] for item in step["result"]["variant_results"]
+    ] == ["pain_led", "outcome_led", "social_proof"]
+    assert [item["variant_angle"] for item in step["result"]["errors"]] == [
+        "pain_led",
+        "outcome_led",
+        "social_proof",
+    ]
 
 
 # -----------------------


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Output-Variations-Blog-Only.md
Slice phase: Vertical slice

Implements the blog-only fallback from the merged output-variations plan: `variant_count` now creates deterministic blog-post alternatives from one run spec, with request normalization, preview cost scaling, plan metadata, per-angle execution fan-out, blog prompt/metadata threading, and regression tests. This update also addresses review feedback: the new helper is manifest-owned, and an all-exception variant run now fails the step/run while preserving the aggregate warning and per-angle diagnostics.

## Intentional
- Blog-only first; landing-page and sales-brief variant parity are deferred.
- Fan-out stays in the blog dispatcher for this first generator-only slice; central fan-out waits until another generator supports `variant_angle`.
- Quality gates remain inside `BlogPostGenerationService`; the executor aggregates existing per-call skipped/errors fields and adds an all-zero warning.
- Diff is over the 400 LOC soft cap because the complete vertical slice crosses request, preview, plan, execution, generator, manifest, and required test surfaces; implementation code remains under 400 LOC.

## Deferred
- Landing-page `variant_angle` parity.
- Sales-brief `variant_angle` parity.
- Centralized multi-generator fan-out after another generator supports variants.
- Persistent variant grouping and past-run variants view.
- Auto-ranking/recommended winner and A/B serving/analytics.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_blog_generation.py -q` -- PASS, 250 tests.
- `scripts/validate_extracted_content_pipeline.sh` via bash -- PASS.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- PASS.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- PASS.
- `scripts/check_ascii_python.sh` via bash -- PASS.
- `scripts/run_extracted_pipeline_checks.sh` via bash -- PASS, 3,231 passed / 10 skipped.

## Diff size
12 files, +670 / -2.
