### PR TITLE
Brand Voice Suggested Fixes

### DIFF
--- a/atlas_brain/brand/voice_validator.py
+++ b/atlas_brain/brand/voice_validator.py
@@ -14,6 +14,7 @@ class BrandVoiceFinding:
     severity: str
     category: str
     message: str
+    suggestion: str | None = None
 
     def __str__(self) -> str:
         return self.message
@@ -49,6 +50,7 @@ class BrandVoiceValidator:
         KeyError/re.error part-way through validate() -- silently disabling every
         rule after it. Surface it clearly at construction instead.
         """
+        self._validate_vocabulary_use_shape()
         for section in ("tone_rules", "content_rules"):
             for index, rule in enumerate(self.config.get(section) or []):
                 if not isinstance(rule, dict):
@@ -90,6 +92,49 @@ class BrandVoiceValidator:
                         f"{section}[{index}] (id={rule_id!r}) has an invalid "
                         f"regex pattern: {exc}"
                     ) from exc
+
+    def _vocabulary_config(self) -> dict:
+        vocabulary = self.config.get("vocabulary")
+        if vocabulary is None:
+            return {}
+        if not isinstance(vocabulary, dict):
+            raise ValueError("vocabulary must be a mapping")
+        return vocabulary
+
+    def _vocabulary_use_entries(self) -> list[object]:
+        vocabulary = self._vocabulary_config()
+        if "use" not in vocabulary or vocabulary["use"] is None:
+            return []
+        use_entries = vocabulary["use"]
+        if not isinstance(use_entries, list):
+            raise ValueError("vocabulary.use must be a list of preferred-term mappings")
+        return use_entries
+
+    def _validate_vocabulary_use_shape(self) -> None:
+        use_entries = self._vocabulary_use_entries()
+        for index, entry in enumerate(use_entries):
+            self._vocabulary_use_pair(entry, index)
+
+    @staticmethod
+    def _vocabulary_use_pair(entry: object, index: int) -> tuple[str, str]:
+        if not isinstance(entry, dict) or len(entry) != 1:
+            raise ValueError(
+                f"vocabulary.use[{index}] must be a one-item mapping of "
+                "preferred term to discouraged term"
+            )
+        preferred, discouraged = next(iter(entry.items()))
+        if not isinstance(preferred, str) or not preferred.strip():
+            raise ValueError(f"vocabulary.use[{index}] has an empty preferred term")
+        if not isinstance(discouraged, str) or not discouraged.strip():
+            raise ValueError(f"vocabulary.use[{index}] has an empty discouraged term")
+        return preferred, discouraged
+
+    def _vocabulary_use_pairs(self) -> list[tuple[str, str]]:
+        use_entries = self._vocabulary_use_entries()
+        return [
+            self._vocabulary_use_pair(entry, index)
+            for index, entry in enumerate(use_entries)
+        ]
 
     @staticmethod
     def _default_severity(section: str) -> str:
@@ -149,7 +194,7 @@ class BrandVoiceValidator:
         #    'Transformer', 'disrupt' in 'non-disruptive', 'leverage' in
         #    'deleverage'); \b...\b anchors to word boundaries (the hyphen in
         #    'non-disruptive' is itself a boundary, so 'disrupt' no longer fires).
-        for word in (self.config.get("vocabulary") or {}).get("avoid") or []:
+        for word in self._vocabulary_config().get("avoid") or []:
             if re.search(r"\b" + re.escape(word) + r"\b", lower_text):
                 findings.append(
                     BrandVoiceFinding(
@@ -157,6 +202,18 @@ class BrandVoiceValidator:
                         severity="BLOCKER",
                         category="vocabulary",
                         message=f"Contains forbidden word: '{word}'",
+                    )
+                )
+
+        for preferred, discouraged in self._vocabulary_use_pairs():
+            if re.search(r"\b" + re.escape(discouraged) + r"\b", text, re.IGNORECASE):
+                findings.append(
+                    BrandVoiceFinding(
+                        rule_id=f"vocabulary.use.{discouraged}",
+                        severity="NIT",
+                        category="vocabulary",
+                        message=f"Prefer '{preferred}' over '{discouraged}'",
+                        suggestion=f"Use '{preferred}' instead of '{discouraged}'",
                     )
                 )
 
@@ -256,6 +313,8 @@ def main():
         print(f"FAIL: Found {len(findings)} brand voice violations in {args.file}:")
         for finding in findings:
             print(f"  - [{finding.severity}] {finding.rule_id}: {finding.message}")
+            if finding.suggestion:
+                print(f"    suggestion: {finding.suggestion}")
         exit(1)
     else:
         print(f"PASS: {args.file} is on-brand.")

--- a/atlas_brain/skills/brand/brand_voice.yml
+++ b/atlas_brain/skills/brand/brand_voice.yml
@@ -12,9 +12,8 @@ persona:
     is to be a trusted, expert partner.
 
 vocabulary:
-  # FUTURE (not yet enforced): preferred replacements for discouraged words.
-  # The validator does not read this block yet; it is reserved for the
-  # suggested-fix slice (see plans/PR-Content-Marketing-Brand-Voice-Checks.md).
+  # Preferred replacements for discouraged words. Each item is
+  # "preferred": "discouraged" and surfaces a suggested fix.
   use:
     - "deterministic": "predictable"
     - "capability": "feature"

--- a/marketing/blog_posts/why-deterministic-checks.md
+++ b/marketing/blog_posts/why-deterministic-checks.md
@@ -8,5 +8,5 @@ Atlas answers that with deterministic checks: a codified set of rules that runs
 on every change and fails the work when it drifts off-brand. The rules live in
 a config file your marketers own, not in code.
 
-The result is a predictable floor. A new writer, a busy week, or a rushed launch
+The result is a deterministic floor. A new writer, a busy week, or a rushed launch
 cannot quietly erode your voice, because the check runs the same way every time.

--- a/marketing/landing_pages/atlas-platform.md
+++ b/marketing/landing_pages/atlas-platform.md
@@ -1,4 +1,4 @@
-# Atlas: A Multi-Product Intelligence Platform
+# Atlas: A Multi-Product Intelligence System
 
 Atlas gives operators a single, extensible system for churn intelligence,
 content operations, and customer communications. Every component is pluggable
@@ -11,7 +11,7 @@ behind a typed port, so you can swap providers without rewriting your workflow.
 - Provider-agnostic. Email, calendar, and language models sit behind one port,
   so you are never locked in.
 - Built for extensibility. Add a capability, register it, and it works across
-  the platform.
+  the system.
 
-Atlas is a trusted partner for skilled operators who want predictable systems
+Atlas is a trusted partner for skilled operators who want deterministic systems
 and verifiable results.

--- a/plans/PR-Brand-Voice-Suggested-Fixes.md
+++ b/plans/PR-Brand-Voice-Suggested-Fixes.md
@@ -1,0 +1,115 @@
+# PR-Brand-Voice-Suggested-Fixes
+
+## Why this slice exists
+
+The brand-voice YAML has carried a `vocabulary.use` block since PR #1344, but it
+was intentionally marked FUTURE because flat string violations had nowhere clean
+to carry replacement guidance. PR #1346 added structured findings, so the next
+smallest lane slice is to make those existing preferred/discouraged vocabulary
+pairs actionable.
+
+This gives marketers a concrete repair hint instead of only a failure message,
+while keeping the CI gate deterministic and fail-closed.
+
+## Scope (this PR)
+
+Ownership lane: content-marketing/brand-voice-checks
+Slice phase: Vertical slice
+
+1. Add an optional `suggestion` field to `BrandVoiceFinding`.
+2. Implement `vocabulary.use` as preferred-to-discouraged mappings: when a
+   discouraged word appears, emit a finding that suggests the preferred term.
+3. Validate `vocabulary.use` shape at config load so malformed marketer-edited
+   YAML fails loudly instead of no-oping.
+4. Update CLI output to print the suggestion when a finding carries one.
+5. Add focused tests for suggestion fields, CLI output, malformed mapping
+   rejection, and clean preferred-term near-misses.
+6. Update the seeded marketing copy that used newly discouraged terms so the
+   existing corpus remains green once suggestions are enforced.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Discouraged `vocabulary.use` terms emit `NIT` findings with replacement suggestions.
+  - [ ] The CLI prints suggestion text when a finding carries one.
+  - [ ] Malformed `vocabulary.use` YAML fails at config load, including falsey non-list values.
+  - [ ] Existing whole-word vocabulary precision and seeded marketing checks stay green.
+- Affected surfaces: brand-voice validator, marketer-owned YAML config, text CLI output, seed marketing copy.
+- Risk areas: false positives, malformed config drift, CI gating behavior.
+- Reviewer rules triggered: R1, R2, R10, R11, R12.
+
+### Files touched
+
+- `atlas_brain/brand/voice_validator.py`
+- `atlas_brain/skills/brand/brand_voice.yml`
+- `marketing/blog_posts/why-deterministic-checks.md`
+- `marketing/landing_pages/atlas-platform.md`
+- `plans/PR-Brand-Voice-Suggested-Fixes.md`
+- `tests/test_brand_voice_validator.py`
+
+## Mechanism
+
+The YAML shape is already present:
+
+```yaml
+vocabulary:
+  use:
+    - "deterministic": "predictable"
+```
+
+This slice treats each item as `preferred: discouraged`. The validator checks
+for whole-word matches of the discouraged term and emits a structured finding:
+
+- `rule_id`: `vocabulary.use.<discouraged>`
+- `severity`: `NIT`
+- `category`: `vocabulary`
+- `message`: `Prefer '<preferred>' over '<discouraged>'`
+- `suggestion`: `Use '<preferred>' instead of '<discouraged>'`
+
+The CLI remains text and still exits 1 on any finding, but prints the suggestion
+under the finding line.
+
+## Intentional
+
+- Suggested fixes are advisory metadata, but they still fail the current CLI
+  gate because the workflow remains fail-on-any-finding. Separating advisory
+  severities from blocking workflow behavior is a later policy slice.
+- The existing `vocabulary.avoid` hard-block list remains unchanged.
+- This does not add stem-aware matching; all vocabulary matching stays
+  whole-word to preserve the precision fix from PR #1344.
+- The YAML orientation is now explicit: `use` means preferred term first,
+  discouraged term second.
+- Seed copy edits are limited to the terms this slice now enforces:
+  `platform` -> `system` and `predictable` -> `deterministic`.
+
+## Deferred
+
+- Severity-aware workflow behavior that can warn on `NIT` without failing CI.
+- Stem-aware vocabulary patterns owned in YAML.
+- JSON CLI/report mode for structured downstream consumers.
+- A larger content corpus beyond the four seed examples.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_brand_voice_validator.py -q` -- 60 passed.
+- `python atlas_brain/brand/voice_validator.py --file marketing/landing_pages/atlas-platform.md --type landing_page` -- PASS.
+- `python atlas_brain/brand/voice_validator.py --file marketing/blog_posts/why-deterministic-checks.md --type blog_post` -- PASS.
+- `python atlas_brain/brand/voice_validator.py --file marketing/release_notes/2026-06-release.md --type release_notes` -- PASS.
+- `python atlas_brain/brand/voice_validator.py --file marketing/tweets/launch-brand-voice-checks.md --type tweet` -- PASS.
+- Negative CLI smoke with `The result is predictable for operators.` exits 1 and
+  prints `[NIT] vocabulary.use.predictable` plus the suggestion line.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-brand-voice-suggested-fixes-body.md` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/brand/voice_validator.py` | ~62 |
+| `atlas_brain/skills/brand/brand_voice.yml` | ~6 |
+| `marketing/blog_posts/why-deterministic-checks.md` | ~2 |
+| `marketing/landing_pages/atlas-platform.md` | ~6 |
+| `plans/PR-Brand-Voice-Suggested-Fixes.md` | ~117 |
+| `tests/test_brand_voice_validator.py` | ~113 |
+| **Total** | **~306** |

--- a/tests/test_brand_voice_validator.py
+++ b/tests/test_brand_voice_validator.py
@@ -82,6 +82,27 @@ def test_forbidden_vocabulary_finding_has_structured_fields():
     assert finding.message == "Contains forbidden word: 'game-changer'"
 
 
+def test_suggested_vocabulary_finding_has_replacement_metadata():
+    validator = _real_validator()
+    finding = _only_finding(
+        validator.validate("The result is predictable for operators.", "blog_post")
+    )
+    assert finding.rule_id == "vocabulary.use.predictable"
+    assert finding.severity == "NIT"
+    assert finding.category == "vocabulary"
+    assert finding.message == "Prefer 'deterministic' over 'predictable'"
+    assert finding.suggestion == "Use 'deterministic' instead of 'predictable'"
+
+
+def test_preferred_vocabulary_terms_are_clean():
+    validator = _real_validator()
+    findings = validator.validate(
+        "A deterministic capability dispatch system gives operators a clear path.",
+        "blog_post",
+    )
+    assert findings == []
+
+
 def test_clean_content_has_no_forbidden_vocabulary_false_positive():
     """On-brand prose containing no whole avoid-word yields no vocab violation."""
     validator = _real_validator()
@@ -401,7 +422,7 @@ def test_isolated_content_rule_must_mention_bites_when_absent(tmp_path):
     )
     validator = BrandVoiceValidator(config_path=config)
     assert _messages(
-        validator.validate("A feature-rich landing page.", "landing_page")
+        validator.validate("A capability-rich landing page.", "landing_page")
     ) == [
         "Content rule violation: Landing pages must mention pricing."
     ]
@@ -470,6 +491,82 @@ def test_rule_invalid_severity_raises_value_error_at_load(tmp_path):
         """,
     )
     with pytest.raises(ValueError, match="no_caps_yell.*invalid severity"):
+        BrandVoiceValidator(config_path=config)
+
+
+def test_vocabulary_use_non_list_raises_value_error_at_load(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          use: predictable
+          avoid: []
+        tone_rules: []
+        content_rules: []
+        """,
+    )
+    with pytest.raises(ValueError, match="vocabulary.use must be a list"):
+        BrandVoiceValidator(config_path=config)
+
+
+def test_vocabulary_use_empty_string_raises_value_error_at_load(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          use: ""
+          avoid: []
+        tone_rules: []
+        content_rules: []
+        """,
+    )
+    with pytest.raises(ValueError, match="vocabulary.use must be a list"):
+        BrandVoiceValidator(config_path=config)
+
+
+def test_vocabulary_non_mapping_raises_value_error_at_load(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary: []
+        tone_rules: []
+        content_rules: []
+        """,
+    )
+    with pytest.raises(ValueError, match="vocabulary must be a mapping"):
+        BrandVoiceValidator(config_path=config)
+
+
+def test_vocabulary_use_requires_one_item_mapping_at_load(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          use:
+            - deterministic: predictable
+              capability: feature
+          avoid: []
+        tone_rules: []
+        content_rules: []
+        """,
+    )
+    with pytest.raises(ValueError, match=r"vocabulary.use\[0\].*one-item mapping"):
+        BrandVoiceValidator(config_path=config)
+
+
+def test_vocabulary_use_empty_discouraged_term_raises_value_error(tmp_path):
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          use:
+            - deterministic: ""
+          avoid: []
+        tone_rules: []
+        content_rules: []
+        """,
+    )
+    with pytest.raises(ValueError, match=r"vocabulary.use\[0\].*discouraged"):
         BrandVoiceValidator(config_path=config)
 
 
@@ -792,6 +889,19 @@ def test_cli_returns_one_for_brand_voice_violations(tmp_path):
     assert _EXCLAMATION_TONE_MSG in result.stdout
     assert "[BLOCKER] landing_page_extensibility_mention" in result.stdout
     assert _LANDING_MUST_MENTION_MSG in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_prints_suggestion_for_discouraged_vocabulary(tmp_path):
+    content = tmp_path / "discouraged_blog_post.md"
+    content.write_text("The result is predictable for operators.")
+
+    result = _run_cli("--file", str(content), "--type", "blog_post")
+
+    assert result.returncode == 1
+    assert "[NIT] vocabulary.use.predictable" in result.stdout
+    assert "Prefer 'deterministic' over 'predictable'" in result.stdout
+    assert "suggestion: Use 'deterministic' instead of 'predictable'" in result.stdout
     assert result.stderr == ""
 
 


### PR DESCRIPTION
Plan: plans/PR-Brand-Voice-Suggested-Fixes.md
Slice phase: Vertical slice

Implements the existing `vocabulary.use` YAML block now that brand-voice findings are structured. Discouraged vocabulary terms emit NIT findings with a concrete replacement suggestion, and the CLI prints that suggestion while keeping the current fail-on-any-finding behavior.

## Intentional

- Suggested fixes are advisory metadata, but they still fail the current CLI gate; severity-aware workflow behavior is deferred.
- `vocabulary.use` is explicitly preferred term first, discouraged term second.
- Whole-word vocabulary matching stays in place; stem-aware matching remains deferred.
- Seed copy edits are limited to terms this slice now enforces.

## Deferred

- Severity-aware workflow behavior that can warn on `NIT` without failing CI.
- Stem-aware vocabulary patterns owned in YAML.
- JSON CLI/report mode for structured downstream consumers.
- Larger marketing corpus expansion.

## Parked hardening

- None.

## Verification

- `python -m pytest tests/test_brand_voice_validator.py -q` -- 60 passed.
- `python atlas_brain/brand/voice_validator.py --file marketing/landing_pages/atlas-platform.md --type landing_page` -- PASS.
- `python atlas_brain/brand/voice_validator.py --file marketing/blog_posts/why-deterministic-checks.md --type blog_post` -- PASS.
- `python atlas_brain/brand/voice_validator.py --file marketing/release_notes/2026-06-release.md --type release_notes` -- PASS.
- `python atlas_brain/brand/voice_validator.py --file marketing/tweets/launch-brand-voice-checks.md --type tweet` -- PASS.
- Negative CLI smoke with `The result is predictable for operators.` exits 1 and prints `[NIT] vocabulary.use.predictable` plus the suggestion line.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-brand-voice-suggested-fixes-body.md` -- passed.

## Diff size

6 files, +292 / -9.