### PR TITLE
Content Ops Output Variations Landing Page

### DIFF
--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -635,9 +635,10 @@ async def _dispatch_landing_page(
     filters: Mapping[str, Any] | None,
 ) -> Any:
     del filters  # unused: landing pages take a campaign, not a target_mode
+    campaign = _marketing_campaign_from_inputs(request.inputs)
     kwargs: dict[str, Any] = {
         "scope": scope,
-        "campaign": _marketing_campaign_from_inputs(request.inputs),
+        "campaign": campaign,
         "temperature": _step_config_float(step.config, "temperature"),
         "max_tokens": _step_config_int(step.config, "max_tokens"),
         "parse_retry_attempts": _step_config_int(step.config, "parse_retry_attempts"),
@@ -649,7 +650,102 @@ async def _dispatch_landing_page(
     }
     if brand_voice is not None:
         kwargs["brand_voice"] = brand_voice
+    if request.variant_count > 1:
+        return await _dispatch_landing_page_variants(
+            service=service,
+            request=request,
+            kwargs=kwargs,
+        )
     return await service.generate(**kwargs)
+
+
+async def _dispatch_landing_page_variants(
+    *,
+    service: Any,
+    request: ContentOpsRequest,
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    variant_results: list[dict[str, Any]] = []
+    saved_ids: list[str] = []
+    errors: list[dict[str, Any]] = []
+    consumed_reasoning: list[dict[str, Any]] = []
+    requested = 0
+    generated = 0
+    skipped = 0
+    reasoning_contexts_used = 0
+    caught_exceptions = 0
+
+    for angle in selected_variant_angles(request.variant_count):
+        angle_data = angle.as_dict()
+        try:
+            result = await service.generate(
+                variant_angle=angle.instruction,
+                **kwargs,
+            )
+            result_data = _result_dict(result)
+        except Exception as exc:
+            caught_exceptions += 1
+            error = _landing_page_variant_error(angle, str(exc), type(exc).__name__)
+            result_data = {
+                "requested": 1,
+                "generated": 0,
+                "skipped": 1,
+                "saved_ids": [],
+                "errors": [error],
+            }
+
+        variant_result = dict(result_data)
+        variant_result["variant_angle"] = angle_data
+        variant_results.append(variant_result)
+        requested += _result_int(result_data, "requested", default=1)
+        generated += _result_int(result_data, "generated")
+        skipped += _result_int(result_data, "skipped")
+        reasoning_contexts_used += _result_int(result_data, "reasoning_contexts_used")
+        saved_ids.extend(_result_strings(result_data, "saved_ids"))
+        for error in _result_mappings(result_data, "errors"):
+            tagged = dict(error)
+            tagged.setdefault("variant_angle", angle.id)
+            tagged.setdefault("variant_label", angle.label)
+            errors.append(tagged)
+        consumed_reasoning.extend(
+            _result_mappings(result_data, "consumed_reasoning_contexts")
+        )
+
+    aggregate: dict[str, Any] = {
+        "requested": requested,
+        "generated": generated,
+        "skipped": skipped,
+        "reasoning_contexts_used": reasoning_contexts_used,
+        "saved_ids": saved_ids,
+        "errors": errors,
+        "variant_count": len(variant_results),
+        "variant_results": variant_results,
+    }
+    if consumed_reasoning:
+        aggregate["consumed_reasoning_contexts"] = consumed_reasoning
+    if generated == 0:
+        aggregate["warnings"] = [
+            "No landing-page variants generated; all requested variants were blocked or skipped."
+        ]
+        if caught_exceptions:
+            raise _ContentOpsStepResultFailure(
+                "all_landing_page_variants_failed",
+                aggregate,
+            )
+    return aggregate
+
+
+def _landing_page_variant_error(
+    angle: VariantAngle,
+    reason: str,
+    error_type: str,
+) -> dict[str, str]:
+    return {
+        "variant_angle": angle.id,
+        "variant_label": angle.label,
+        "reason": reason,
+        "error_type": error_type,
+    }
 
 
 async def _dispatch_blog_post(

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -511,7 +511,7 @@ def _item_multiplier_for_output(
     inputs: Mapping[str, Any],
     variant_count: int = 1,
 ) -> int:
-    if output_id == "blog_post":
+    if output_id in {"blog_post", "landing_page"}:
         return normalize_variant_count(variant_count)
     if output_id != "social_post":
         return 1

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -204,7 +204,7 @@ def _blog_post_config_for_request(request: ContentOpsRequest) -> BlogPostGenerat
     return BlogPostGenerationConfig(limit=request.limit)
 
 
-def _blog_variant_config_for_request(request: ContentOpsRequest) -> dict[str, Any]:
+def _variant_config_for_request(request: ContentOpsRequest) -> dict[str, Any]:
     if request.variant_count <= 1:
         return {}
     angles = selected_variant_angles(request.variant_count)
@@ -437,6 +437,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_repair_attempts": config.quality_repair_attempts,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_variant_config_for_request(request),
                 **_brand_voice_config_for_request(request),
                 **_reasoning_config_for_output(output, request),
             },
@@ -476,7 +477,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
                 "topic": request.inputs.get("topic"),
-                **_blog_variant_config_for_request(request),
+                **_variant_config_for_request(request),
                 **_brand_voice_config_for_request(request),
                 **_reasoning_config_for_output(output, request),
             },

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -200,8 +200,19 @@ def _landing_page_user_prompt(
     prior_invalid_response: str = "",
     *,
     quality_blockers: Sequence[str] = (),
+    variant_angle: str | None = None,
 ) -> str:
     prompt = "Generate one landing page from the marketing campaign above."
+    resolved_variant_angle = str(variant_angle or "").strip()
+    if resolved_variant_angle:
+        prompt = (
+            f"{prompt}\n\n"
+            "Variant angle:\n"
+            f"- {resolved_variant_angle}\n"
+            "Use this angle to change framing and emphasis only. Keep the same "
+            "campaign facts, supplied evidence, CTA intent, and truthfulness "
+            "limits."
+        )
     if quality_blockers:
         blockers = "\n".join(f"- {str(item)}" for item in quality_blockers)
         prompt = (
@@ -289,6 +300,7 @@ class LandingPageGenerationService:
         quality_gates_enabled: bool | None = None,
         quality_repair_attempts: int | None = None,
         brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
+        variant_angle: str | None = None,
     ) -> LandingPageGenerationResult:
         # PR-OptionA-2: per-call LLM-tuning overrides; None falls through.
         resolved_temperature = (
@@ -326,6 +338,7 @@ class LandingPageGenerationService:
             brand_voice,
             scope=scope,
         )
+        resolved_variant_angle = str(variant_angle or "").strip() or None
 
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -378,6 +391,7 @@ class LandingPageGenerationService:
                     quality_blockers=quality_blockers,
                     quality_repair_attempt_no=repair_attempt_no,
                     brand_voice=resolved_brand_voice,
+                    variant_angle=resolved_variant_angle,
                 )
             except Exception as exc:
                 return LandingPageGenerationResult(
@@ -766,6 +780,7 @@ class LandingPageGenerationService:
         quality_blockers: Sequence[str] = (),
         quality_repair_attempt_no: int = 0,
         brand_voice: BrandVoiceProfile | None = None,
+        variant_angle: str | None = None,
     ) -> dict[str, Any] | None:
         campaign_json = json.dumps(dict(campaign_payload), separators=(",", ":"), default=str)
         # Single source for the campaign payload: in the system prompt
@@ -777,6 +792,17 @@ class LandingPageGenerationService:
         last_response = ""
         total_usage: dict[str, Any] = {}
         for attempt_no in range(1, attempts + 1):
+            metadata: dict[str, Any] = {
+                "campaign_name": campaign_payload.get("name"),
+                "skill_name": self._config.skill_name,
+                "asset_type": "landing_page",
+                "target_mode": _TARGET_MODE,
+                "attempt_no": attempt_no,
+                "quality_repair_attempt_no": quality_repair_attempt_no,
+            }
+            resolved_variant_angle = str(variant_angle or "").strip()
+            if resolved_variant_angle:
+                metadata["variant_angle"] = resolved_variant_angle
             response = await self._llm.complete(
                 [
                     LLMMessage(role="system", content=system_prompt),
@@ -785,29 +811,26 @@ class LandingPageGenerationService:
                         content=_landing_page_user_prompt(
                             last_response,
                             quality_blockers=quality_blockers,
+                            variant_angle=variant_angle,
                         ),
                     ),
                 ],
                 max_tokens=max_tokens,
                 temperature=temperature,
-                metadata={
-                    "campaign_name": campaign_payload.get("name"),
-                    "skill_name": self._config.skill_name,
-                    "asset_type": "landing_page",
-                    "target_mode": _TARGET_MODE,
-                    "attempt_no": attempt_no,
-                    "quality_repair_attempt_no": quality_repair_attempt_no,
-                },
+                metadata=metadata,
             )
             total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_landing_page_response(response.content)
             if parsed:
-                return brand_voice_result_metadata({
+                result_payload = {
                     **parsed,
                     "_model": response.model,
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
-                }, brand_voice)
+                }
+                if resolved_variant_angle:
+                    result_payload["_variant_angle"] = resolved_variant_angle
+                return brand_voice_result_metadata(result_payload, brand_voice)
             last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
@@ -903,6 +926,9 @@ class LandingPageGenerationService:
             "brand_voice_profile": parsed.get("_brand_voice_profile"),
             "brand_voice_audit": parsed.get("_brand_voice_audit"),
         }
+        variant_angle = str(parsed.get("_variant_angle") or "").strip()
+        if variant_angle:
+            metadata["variant_angle"] = variant_angle
         if campaign_payload is not None:
             context = normalize_campaign_reasoning_context(campaign_payload)
             metadata.update(campaign_reasoning_context_metadata(context))

--- a/plans/PR-Content-Ops-Output-Variations-Landing-Page.md
+++ b/plans/PR-Content-Ops-Output-Variations-Landing-Page.md
@@ -1,0 +1,144 @@
+# PR-Content-Ops-Output-Variations-Landing-Page
+
+## Why this slice exists
+
+The merged `PR-Content-Ops-Output-Variations.md` plan called for output
+variations across blog posts, landing pages, and sales briefs, with an explicit
+fallback to land blog-only first if the full parity slice exceeded the 400 LOC
+budget. PR #1347 took that fallback and shipped blog variants through preview,
+plan, execution, and prompt metadata. Its Deferred section names
+landing-page `variant_angle` parity as the immediate follow-up.
+
+This PR adds that second generator. It keeps the slice narrow: landing-page
+preview/plan/execution now honors `variant_count`, and the landing-page
+generator gets the same optional `variant_angle` prompt/metadata threading that
+blog posts already have. Sales-brief parity and a shared multi-generator fan-out
+refactor remain deferred so this PR can prove the landing-page behavior without
+rewriting the already-reviewed blog path.
+
+The full diff is over the 400 LOC soft cap because the slice includes the plan
+doc plus focused R2/R12 regression tests for preview cost, plan metadata,
+execution fan-out, per-item failure isolation, all-raising failure status, and
+prompt metadata. The implementation code stays well under 400 LOC.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/output-variations/landing-page
+Slice phase: Vertical slice
+
+1. Make landing-page preview cost and generation-plan metadata scale by the
+   selected deterministic variant angles when `variant_count > 1`.
+2. Fan out landing-page execution once per selected angle, aggregate per-angle
+   results, preserve per-item failure isolation, and fail the step/run when all
+   requested landing-page variants raise.
+3. Add `variant_angle: str | None = None` to
+   `LandingPageGenerationService.generate(...)`, thread it into the LLM prompt,
+   LLM metadata, parsed metadata, and saved draft metadata.
+4. Keep `variant_count == 1` as the existing single landing-page call and keep
+   sales-brief behavior unchanged in this slice.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Landing-page preview cost multiplies by the normalized variant count;
+        sales brief remains unscaled until its own parity slice.
+  - [ ] Landing-page generation-plan steps expose `variant_count` and
+        `variant_angles` when variants are requested.
+  - [ ] `execute_content_ops_request` calls the landing-page service once per
+        selected angle, passes each angle instruction as `variant_angle`, and
+        aggregates `variant_results`, counts, saved ids, errors, and warnings.
+  - [ ] One failed landing-page variant does not abort sibling variants.
+  - [ ] If every landing-page variant raises an exception, the step/run fails
+        while preserving the aggregate diagnostic result.
+  - [ ] `LandingPageGenerationService.generate(..., variant_angle=...)`
+        injects the angle into the user prompt and preserves it in LLM call
+        metadata and saved draft metadata; `None` is a no-op.
+- Affected surfaces: extracted package preview cost, generation-plan metadata,
+  landing-page execution dispatcher, landing-page prompt/metadata, tests.
+- Risk areas: cost accounting, execution result contract, prompt truthfulness,
+  backward compatibility for existing landing-page callers.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/landing_page_generation.py`
+- `plans/PR-Content-Ops-Output-Variations-Landing-Page.md`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_landing_page_generation_smoke.py`
+
+## Mechanism
+
+Preview cost expands the existing item multiplier from blog-only to
+blog-or-landing-page. The generation plan reuses the deterministic
+`selected_variant_angles` catalogue and adds `variant_count` /
+`variant_angles` to landing-page step config when the count is greater than one.
+
+Runtime fan-out stays landing-page-local for this slice. `_dispatch_landing_page`
+preserves the existing single service call for `variant_count == 1`; for
+multi-variant requests it calls the landing-page service once per selected angle
+with `variant_angle=angle.instruction`, tags each per-call result with
+`angle.as_dict()`, and returns the same aggregate shape the blog variant path
+uses (`variant_count`, `variant_results`, total counts, saved ids, errors, and
+optional warnings). Caught per-angle exceptions become tagged errors so sibling
+variants still run. If every requested landing-page variant raises, the
+dispatcher raises `_ContentOpsStepResultFailure("all_landing_page_variants_failed", aggregate)`
+so the step/run status is failed while the aggregate remains attached to the
+failed step.
+
+The landing-page generator accepts an optional `variant_angle` string. When
+present, `_landing_page_user_prompt` adds a short "Variant angle" instruction
+that tells the model to change framing while preserving the same campaign facts
+and supplied evidence. The same angle is sent in LLM metadata, carried on the
+parsed payload, and written into the saved `LandingPageDraft.metadata`. Empty or
+`None` values are ignored so existing callers keep current behavior.
+
+## Intentional
+
+- This is landing-page parity, not the shared fan-out refactor. The PR touches
+  the minimum execution path required to prove landing-page variants without
+  rewriting blog variant code that just merged.
+- Sales-brief `variant_angle` parity remains separate. That generator has a
+  different input shape and should get its own focused tests.
+- The quality gate stays inside `LandingPageGenerationService`. The executor
+  does not duplicate landing-page quality logic; it only aggregates the
+  generated/skipped/errors contract the service already returns.
+- Variant angle changes framing only. The prompt explicitly preserves the same
+  campaign facts and supplied evidence so variants do not become new claims.
+
+## Deferred
+
+- Sales-brief `variant_angle` parity.
+- Shared multi-generator fan-out/aggregation refactor after landing-page parity
+  is reviewed.
+- Persistent variant grouping (`variant_group_id`) and a past-run variants view.
+- Auto-ranking / recommended winner and A/B serving/analytics.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_landing_page_generation_smoke.py -q -- PASS, 180 tests.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- PASS.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- PASS.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- PASS.
+- Command: bash scripts/check_ascii_python.sh -- PASS.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- PASS, 3,237 passed / 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/content_ops_execution.py` | 98 |
+| `extracted_content_pipeline/control_surfaces.py` | 2 |
+| `extracted_content_pipeline/generation_plan.py` | 5 |
+| `extracted_content_pipeline/landing_page_generation.py` | 46 |
+| `plans/PR-Content-Ops-Output-Variations-Landing-Page.md` | 144 |
+| `tests/test_extracted_content_control_surfaces.py` | 17 |
+| `tests/test_extracted_content_generation_plan.py` | 20 |
+| `tests/test_extracted_content_ops_execution.py` | 150 |
+| `tests/test_extracted_landing_page_generation_smoke.py` | 35 |
+| **Total** | **517** |

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -89,7 +89,22 @@ def test_preview_scales_blog_cost_by_variant_count():
     assert preview["normalized_request"]["variant_count"] == 3
 
 
-def test_preview_does_not_scale_non_blog_outputs_by_variant_count():
+def test_preview_scales_landing_page_cost_by_variant_count():
+    preview = preview_from_mapping({
+        "outputs": ["landing_page"],
+        "variant_count": 2,
+        "inputs": {
+            "offer": "Churn audit",
+            "audience": "B2B SaaS founders",
+        },
+    })
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 5.2
+    assert preview["normalized_request"]["variant_count"] == 2
+
+
+def test_preview_does_not_scale_sales_brief_by_variant_count():
     preview = preview_from_mapping({
         "outputs": ["sales_brief"],
         "variant_count": 3,

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -352,6 +352,26 @@ def test_plan_includes_blog_variant_angle_metadata_when_requested():
     ]
 
 
+def test_plan_includes_landing_page_variant_angle_metadata_when_requested():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "variant_count": 2,
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+            },
+        }
+    )
+
+    config = plan["steps"][0]["config"]
+    assert config["variant_count"] == 2
+    assert config["variant_angles"] == [
+        VARIANT_ANGLES[0].as_dict(),
+        VARIANT_ANGLES[1].as_dict(),
+    ]
+
+
 def test_plan_stays_non_executable_when_preview_fails_budget():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -364,6 +364,38 @@ class _LandingPageService:
         return _Result()
 
 
+class _VariantLandingPageService:
+    def __init__(self, *, fail_on_angle: str = "") -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.fail_on_angle = fail_on_angle
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        campaign: Any,
+        variant_angle: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.calls.append({
+            "scope": scope,
+            "campaign": campaign,
+            "variant_angle": variant_angle,
+            "kwargs": dict(kwargs),
+        })
+        if self.fail_on_angle and self.fail_on_angle in str(variant_angle or ""):
+            raise RuntimeError("landing variant failed")
+        call_no = len(self.calls)
+        return {
+            "requested": 1,
+            "generated": 1,
+            "skipped": 0,
+            "reasoning_contexts_used": 0,
+            "saved_ids": [f"landing-page-{call_no}"],
+            "errors": [],
+        }
+
+
 class _BarrierOpportunityService:
     def __init__(
         self,
@@ -2051,6 +2083,124 @@ async def test_execute_all_raising_blog_variants_fails_step_with_warning() -> No
     assert step["result"]["skipped"] == 3
     assert step["result"]["warnings"] == [
         "No blog variants generated; all requested variants were blocked or skipped."
+    ]
+    assert [
+        item["variant_angle"]["id"] for item in step["result"]["variant_results"]
+    ] == ["pain_led", "outcome_led", "social_proof"]
+    assert [item["variant_angle"] for item in step["result"]["errors"]] == [
+        "pain_led",
+        "outcome_led",
+        "social_proof",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_fans_out_landing_page_variants_by_angle() -> None:
+    landing = _VariantLandingPageService()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "variant_count": 3,
+            "inputs": {
+                "campaign_name": "Q3 retention page",
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+            },
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    step_result = result["steps"][0]["result"]
+    assert result["status"] == "completed"
+    assert len(landing.calls) == 3
+    assert [call["variant_angle"] for call in landing.calls] == [
+        VARIANT_ANGLES[0].instruction,
+        VARIANT_ANGLES[1].instruction,
+        VARIANT_ANGLES[2].instruction,
+    ]
+    assert [call["campaign"].name for call in landing.calls] == [
+        "Q3 retention page",
+        "Q3 retention page",
+        "Q3 retention page",
+    ]
+    assert step_result["variant_count"] == 3
+    assert step_result["requested"] == 3
+    assert step_result["generated"] == 3
+    assert step_result["skipped"] == 0
+    assert step_result["saved_ids"] == [
+        "landing-page-1",
+        "landing-page-2",
+        "landing-page-3",
+    ]
+    assert [
+        item["variant_angle"]["id"] for item in step_result["variant_results"]
+    ] == ["pain_led", "outcome_led", "social_proof"]
+
+
+@pytest.mark.asyncio
+async def test_execute_landing_page_variant_failure_does_not_abort_batch() -> None:
+    landing = _VariantLandingPageService(fail_on_angle="Outcome-led")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "variant_count": 3,
+            "inputs": {
+                "campaign_name": "Q3 retention page",
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+            },
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    step_result = result["steps"][0]["result"]
+    assert result["status"] == "completed"
+    assert result["errors"] == []
+    assert len(landing.calls) == 3
+    assert step_result["generated"] == 2
+    assert step_result["skipped"] == 1
+    assert step_result["saved_ids"] == ["landing-page-1", "landing-page-3"]
+    assert step_result["errors"] == [{
+        "variant_angle": "outcome_led",
+        "variant_label": "Outcome-led",
+        "reason": "landing variant failed",
+        "error_type": "RuntimeError",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_execute_all_raising_landing_page_variants_fails_step_with_warning() -> None:
+    landing = _VariantLandingPageService(fail_on_angle="led")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "variant_count": 3,
+            "inputs": {
+                "campaign_name": "Q3 retention page",
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+            },
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    step = result["steps"][0]
+    assert result["status"] == "failed"
+    assert result["errors"] == [{
+        "output": "landing_page",
+        "runner": "LandingPageGenerationService.generate",
+        "error": "all_landing_page_variants_failed",
+        "reason": "all_landing_page_variants_failed",
+    }]
+    assert step["status"] == "failed"
+    assert step["error"] == "all_landing_page_variants_failed"
+    assert step["result"]["generated"] == 0
+    assert step["result"]["skipped"] == 3
+    assert step["result"]["warnings"] == [
+        "No landing-page variants generated; all requested variants were blocked or skipped."
     ]
     assert [
         item["variant_angle"]["id"] for item in step["result"]["variant_results"]

--- a/tests/test_extracted_landing_page_generation_smoke.py
+++ b/tests/test_extracted_landing_page_generation_smoke.py
@@ -18,7 +18,8 @@ from extracted_content_pipeline.landing_page_export import (
 from extracted_content_pipeline.landing_page_generation import (
     LandingPageGenerationService,
 )
-from extracted_content_pipeline.landing_page_ports import LandingPageDraft
+from extracted_content_pipeline.landing_page_ports import LandingPageDraft, MarketingCampaign
+from extracted_content_pipeline.output_variations import VARIANT_ANGLES
 
 
 class _LandingPageStore:
@@ -169,6 +170,38 @@ def _landing_page_response(*, include_description: bool) -> str:
             "help-center answers for small SaaS teams."
         )
     return json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_landing_page_generation_threads_variant_angle_to_prompt_and_metadata() -> None:
+    store = _LandingPageStore()
+    llm = _LLM([_landing_page_response(include_description=True)])
+    service = LandingPageGenerationService(
+        landing_pages=store,
+        llm=llm,
+        skills=_Skills(),
+    )
+    angle = VARIANT_ANGLES[0].instruction
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        campaign=MarketingCampaign(
+            name="FAQ Report",
+            persona="Small SaaS support teams",
+            value_prop="Turn repeat tickets into reviewed answers",
+        ),
+        quality_gates_enabled=False,
+        variant_angle=angle,
+    )
+
+    assert result.generated == 1
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "Variant angle:" in user_prompt
+    assert angle in user_prompt
+    assert "Keep the same campaign facts" in user_prompt
+    assert llm.calls[0]["metadata"]["variant_angle"] == angle
+    saved_draft = store.saved[0]["drafts"][0]
+    assert saved_draft.metadata["variant_angle"] == angle
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Output-Variations-Landing-Page.md
Slice phase: Vertical slice

This follows the blog-only output-variations slice by adding landing-page parity: `variant_count` now scales landing-page preview cost and plan metadata, landing-page execution fans out one call per deterministic angle, and the landing-page generator threads `variant_angle` into prompt, LLM metadata, and saved draft metadata.

## Intentional
- Landing-page parity only; sales-brief parity and shared multi-generator fan-out are deferred.
- Quality gates remain inside `LandingPageGenerationService`; the executor aggregates the existing result contract.
- Variant angle changes framing only, with prompt wording that preserves the same campaign facts, supplied evidence, CTA intent, and truthfulness limits.

## Deferred
- Sales-brief `variant_angle` parity.
- Shared multi-generator fan-out/aggregation refactor after landing-page parity is reviewed.
- Persistent variant grouping (`variant_group_id`) and a past-run variants view.
- Auto-ranking / recommended winner and A/B serving/analytics.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_landing_page_generation_smoke.py -q` -- PASS, 180 tests.
- `bash scripts/validate_extracted_content_pipeline.sh` -- PASS.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- PASS.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- PASS.
- `bash scripts/check_ascii_python.sh` -- PASS.
- `bash scripts/run_extracted_pipeline_checks.sh` -- PASS, 3,237 passed / 10 skipped.

## Diff size
9 files, +501 / -16
