### PR TITLE
Brand Voice Severity Gate

### DIFF
--- a/atlas_brain/brand/voice_validator.py
+++ b/atlas_brain/brand/voice_validator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 
 SEVERITIES = frozenset({"BLOCKER", "MAJOR", "NIT"})
+BLOCKING_SEVERITIES = frozenset({"BLOCKER", "MAJOR"})
 
 
 @dataclass(frozen=True)
@@ -270,6 +271,13 @@ class BrandVoiceValidator:
         return findings
 
 
+def _print_findings(findings: list[BrandVoiceFinding]) -> None:
+    for finding in findings:
+        print(f"  - [{finding.severity}] {finding.rule_id}: {finding.message}")
+        if finding.suggestion:
+            print(f"    suggestion: {finding.suggestion}")
+
+
 def main():
     """
     Command-line interface for the BrandVoiceValidator.
@@ -308,14 +316,33 @@ def main():
 
     validator = BrandVoiceValidator(config_path=args.config)
     findings = validator.validate(content_to_validate, args.type)
+    blocking_findings = [
+        finding for finding in findings if finding.severity in BLOCKING_SEVERITIES
+    ]
+    advisory_findings = [
+        finding for finding in findings if finding.severity not in BLOCKING_SEVERITIES
+    ]
 
-    if findings:
-        print(f"FAIL: Found {len(findings)} brand voice violations in {args.file}:")
-        for finding in findings:
-            print(f"  - [{finding.severity}] {finding.rule_id}: {finding.message}")
-            if finding.suggestion:
-                print(f"    suggestion: {finding.suggestion}")
+    if blocking_findings:
+        print(
+            f"FAIL: Found {len(blocking_findings)} blocking brand voice "
+            f"violations in {args.file}:"
+        )
+        _print_findings(blocking_findings)
+        if advisory_findings:
+            print(
+                f"WARN: Found {len(advisory_findings)} advisory brand voice "
+                f"findings in {args.file}:"
+            )
+            _print_findings(advisory_findings)
         exit(1)
+    elif advisory_findings:
+        print(
+            f"WARN: Found {len(advisory_findings)} advisory brand voice "
+            f"findings in {args.file}:"
+        )
+        _print_findings(advisory_findings)
+        exit(0)
     else:
         print(f"PASS: {args.file} is on-brand.")
         exit(0)

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -7,7 +7,9 @@ On-brand marketing copy, checked automatically on every pull request.
 Each file under `marketing/<type>/` is validated against the codified Atlas
 brand voice in `atlas_brain/skills/brand/brand_voice.yml` by the
 `Marketing Content Voice Check` workflow. A pull request that introduces a
-brand-voice violation fails the check and names the specific rule that fired.
+`BLOCKER` or `MAJOR` brand-voice violation fails the check and names the
+specific rule that fired. `NIT` findings print as advisory warnings with
+suggested fixes, but do not fail the workflow.
 
 | Directory | Type | Extra rule |
 |---|---|---|

--- a/plans/PR-Brand-Voice-Severity-Gate.md
+++ b/plans/PR-Brand-Voice-Severity-Gate.md
@@ -1,0 +1,98 @@
+# PR-Brand-Voice-Severity-Gate
+
+## Why this slice exists
+
+PR #1348 made `vocabulary.use` actionable by emitting `NIT` findings with
+replacement suggestions, but the CLI still exits 1 on every finding. That means
+the new suggestion path is technically advisory in metadata while still blocking
+the marketing content workflow.
+
+This slice closes the first deferred item from
+`plans/PR-Brand-Voice-Suggested-Fixes.md`: severity-aware workflow behavior that
+can warn on `NIT` findings without failing CI.
+
+## Scope (this PR)
+
+Ownership lane: content-marketing/brand-voice-checks
+Slice phase: Vertical slice
+
+1. Keep validator findings unchanged: `BLOCKER`, `MAJOR`, and `NIT` are still
+   emitted by `BrandVoiceValidator.validate()`.
+2. Change the CLI gate so only `BLOCKER` and `MAJOR` findings fail by default.
+3. Print `NIT` findings as advisory warnings, including existing suggestion
+   lines, while returning exit 0 when no blocking finding exists.
+4. Add focused CLI tests for advisory-only, blocking-only, and mixed severity
+   behavior.
+5. Update the marketing guide so marketers know `NIT` is advisory and
+   `MAJOR`/`BLOCKER` still block.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A file with only `NIT` findings prints warnings and exits 0.
+  - [ ] A file with `MAJOR` or `BLOCKER` findings still prints failures and exits 1.
+  - [ ] Mixed blocking plus advisory findings exit 1 while still printing both groups.
+  - [ ] Suggestion text remains visible for advisory `NIT` findings.
+- Affected surfaces: brand-voice CLI, marketing content workflow exit behavior, marketing guide.
+- Risk areas: accidentally weakening blocking brand checks, hiding advisory suggestions, confusing CLI output.
+- Reviewer rules triggered: R1, R2, R10, R12.
+
+### Files touched
+
+- `atlas_brain/brand/voice_validator.py`
+- `marketing/README.md`
+- `plans/PR-Brand-Voice-Severity-Gate.md`
+- `tests/test_brand_voice_validator.py`
+
+## Mechanism
+
+The validator already returns structured findings with severities. This slice
+keeps that API stable and changes only CLI interpretation:
+
+```python
+blocking = [f for f in findings if f.severity in {"BLOCKER", "MAJOR"}]
+advisory = [f for f in findings if f.severity not in {"BLOCKER", "MAJOR"}]
+```
+
+The CLI prints blocking findings under a `FAIL` heading and advisory findings
+under a `WARN` heading. Exit status is determined only by whether the blocking
+list is non-empty. The existing workflow continues to call the CLI unchanged,
+so `NIT` findings become workflow warnings without a workflow-specific branch.
+
+## Intentional
+
+- No workflow YAML change is needed; the workflow already delegates pass/fail to
+  the CLI exit code.
+- The validator API stays unchanged so any future JSON/reporting slice can reuse
+  the same structured findings.
+- The default blocking severities are hard-coded to `BLOCKER` and `MAJOR` for
+  this slice; per-run severity configuration remains out of scope.
+
+## Deferred
+
+- Runtime configuration for strict local runs that fail on `NIT`.
+- JSON CLI/report mode for structured downstream consumers.
+- Stem-aware vocabulary patterns owned in YAML.
+- Larger marketing corpus expansion.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_brand_voice_validator.py -q` -- 61 passed.
+- Four seed CLI checks for landing page, blog post, release notes, and tweet --
+  PASS.
+- Advisory-only CLI smoke for `predictable` exits 0 and prints `WARN` plus the
+  suggestion line.
+- Blocking CLI smoke for `game-changer!!` exits 1 and prints `FAIL`.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-brand-voice-severity-gate-body.md` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/brand/voice_validator.py` | 41 |
+| `marketing/README.md` | 4 |
+| `plans/PR-Brand-Voice-Severity-Gate.md` | 98 |
+| `tests/test_brand_voice_validator.py` | 20 |
+| **Total** | **163** |

--- a/tests/test_brand_voice_validator.py
+++ b/tests/test_brand_voice_validator.py
@@ -882,7 +882,7 @@ def test_cli_returns_one_for_brand_voice_violations(tmp_path):
     result = _run_cli("--file", str(content), "--type", "landing_page")
 
     assert result.returncode == 1
-    assert "FAIL: Found" in result.stdout
+    assert "FAIL: Found 3 blocking brand voice violations" in result.stdout
     assert "[BLOCKER] vocabulary.avoid.game-changer" in result.stdout
     assert "Contains forbidden word: 'game-changer'" in result.stdout
     assert "[MAJOR] no_excessive_punctuation" in result.stdout
@@ -898,9 +898,25 @@ def test_cli_prints_suggestion_for_discouraged_vocabulary(tmp_path):
 
     result = _run_cli("--file", str(content), "--type", "blog_post")
 
-    assert result.returncode == 1
+    assert result.returncode == 0
+    assert "WARN: Found 1 advisory brand voice findings" in result.stdout
     assert "[NIT] vocabulary.use.predictable" in result.stdout
     assert "Prefer 'deterministic' over 'predictable'" in result.stdout
+    assert "suggestion: Use 'deterministic' instead of 'predictable'" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_returns_one_for_mixed_blocking_and_advisory_findings(tmp_path):
+    content = tmp_path / "mixed_blog_post.md"
+    content.write_text("The result is predictable and a game-changer.")
+
+    result = _run_cli("--file", str(content), "--type", "blog_post")
+
+    assert result.returncode == 1
+    assert "FAIL: Found 1 blocking brand voice violations" in result.stdout
+    assert "[BLOCKER] vocabulary.avoid.game-changer" in result.stdout
+    assert "WARN: Found 1 advisory brand voice findings" in result.stdout
+    assert "[NIT] vocabulary.use.predictable" in result.stdout
     assert "suggestion: Use 'deterministic' instead of 'predictable'" in result.stdout
     assert result.stderr == ""
 


### PR DESCRIPTION
Plan: plans/PR-Brand-Voice-Severity-Gate.md
Slice phase: Vertical slice

Makes the brand voice CLI severity-aware so `NIT` findings print as advisory warnings and exit 0, while `MAJOR` and `BLOCKER` findings still fail the marketing workflow.

## Intentional

- No workflow YAML change; the workflow already delegates pass/fail to the CLI exit code.
- Validator findings and severities remain unchanged.
- Runtime strict mode for failing on `NIT` remains deferred.

## Deferred

- Runtime configuration for strict local runs that fail on `NIT`.
- JSON CLI/report mode for structured downstream consumers.
- Stem-aware vocabulary patterns owned in YAML.
- Larger marketing corpus expansion.

## Parked hardening

- None.

## Verification

- `python -m pytest tests/test_brand_voice_validator.py -q` -- 61 passed.
- Four seed CLI checks for landing page, blog post, release notes, and tweet -- PASS.
- Advisory-only CLI smoke for `predictable` exits 0 and prints `WARN` plus the suggestion line.
- Blocking CLI smoke for `game-changer!!` exits 1 and prints `FAIL`.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-brand-voice-severity-gate-body.md` -- passed.

## Diff size

4 files, +153 / -10.