### PR TITLE
Content Ops Output Variations Shared Fanout

### DIFF
--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any
@@ -665,87 +665,21 @@ async def _dispatch_landing_page_variants(
     request: ContentOpsRequest,
     kwargs: Mapping[str, Any],
 ) -> dict[str, Any]:
-    variant_results: list[dict[str, Any]] = []
-    saved_ids: list[str] = []
-    errors: list[dict[str, Any]] = []
-    consumed_reasoning: list[dict[str, Any]] = []
-    requested = 0
-    generated = 0
-    skipped = 0
-    reasoning_contexts_used = 0
-    caught_exceptions = 0
-
-    for angle in selected_variant_angles(request.variant_count):
-        angle_data = angle.as_dict()
-        try:
-            result = await service.generate(
-                variant_angle=angle.instruction,
-                **kwargs,
-            )
-            result_data = _result_dict(result)
-        except Exception as exc:
-            caught_exceptions += 1
-            error = _landing_page_variant_error(angle, str(exc), type(exc).__name__)
-            result_data = {
-                "requested": 1,
-                "generated": 0,
-                "skipped": 1,
-                "saved_ids": [],
-                "errors": [error],
-            }
-
-        variant_result = dict(result_data)
-        variant_result["variant_angle"] = angle_data
-        variant_results.append(variant_result)
-        requested += _result_int(result_data, "requested", default=1)
-        generated += _result_int(result_data, "generated")
-        skipped += _result_int(result_data, "skipped")
-        reasoning_contexts_used += _result_int(result_data, "reasoning_contexts_used")
-        saved_ids.extend(_result_strings(result_data, "saved_ids"))
-        for error in _result_mappings(result_data, "errors"):
-            tagged = dict(error)
-            tagged.setdefault("variant_angle", angle.id)
-            tagged.setdefault("variant_label", angle.label)
-            errors.append(tagged)
-        consumed_reasoning.extend(
-            _result_mappings(result_data, "consumed_reasoning_contexts")
+    async def generate_variant(angle: VariantAngle) -> Any:
+        return await service.generate(
+            variant_angle=angle.instruction,
+            **kwargs,
         )
 
-    aggregate: dict[str, Any] = {
-        "requested": requested,
-        "generated": generated,
-        "skipped": skipped,
-        "reasoning_contexts_used": reasoning_contexts_used,
-        "saved_ids": saved_ids,
-        "errors": errors,
-        "variant_count": len(variant_results),
-        "variant_results": variant_results,
-    }
-    if consumed_reasoning:
-        aggregate["consumed_reasoning_contexts"] = consumed_reasoning
-    if generated == 0:
-        aggregate["warnings"] = [
+    return await _dispatch_output_variants(
+        request=request,
+        generate_variant=generate_variant,
+        requested_default=1,
+        failure_label="all_landing_page_variants_failed",
+        empty_warning=(
             "No landing-page variants generated; all requested variants were blocked or skipped."
-        ]
-        if caught_exceptions:
-            raise _ContentOpsStepResultFailure(
-                "all_landing_page_variants_failed",
-                aggregate,
-            )
-    return aggregate
-
-
-def _landing_page_variant_error(
-    angle: VariantAngle,
-    reason: str,
-    error_type: str,
-) -> dict[str, str]:
-    return {
-        "variant_angle": angle.id,
-        "variant_label": angle.label,
-        "reason": reason,
-        "error_type": error_type,
-    }
+        ),
+    )
 
 
 async def _dispatch_blog_post(
@@ -809,6 +743,36 @@ async def _dispatch_blog_post_variants(
     filters: Mapping[str, Any] | None,
     kwargs: Mapping[str, Any],
 ) -> dict[str, Any]:
+    async def generate_variant(angle: VariantAngle) -> Any:
+        return await service.generate(
+            scope=scope,
+            target_mode=request.target_mode,
+            limit=request.limit,
+            filters=filters,
+            variant_angle=angle.instruction,
+            **kwargs,
+        )
+
+    requested_default = max(1, int(request.limit or 1))
+    return await _dispatch_output_variants(
+        request=request,
+        generate_variant=generate_variant,
+        requested_default=requested_default,
+        failure_label="all_blog_variants_failed",
+        empty_warning=(
+            "No blog variants generated; all requested variants were blocked or skipped."
+        ),
+    )
+
+
+async def _dispatch_output_variants(
+    *,
+    request: ContentOpsRequest,
+    generate_variant: Callable[[VariantAngle], Awaitable[Any]],
+    requested_default: int,
+    failure_label: str,
+    empty_warning: str,
+) -> dict[str, Any]:
     variant_results: list[dict[str, Any]] = []
     saved_ids: list[str] = []
     errors: list[dict[str, Any]] = []
@@ -822,22 +786,15 @@ async def _dispatch_blog_post_variants(
     for angle in selected_variant_angles(request.variant_count):
         angle_data = angle.as_dict()
         try:
-            result = await service.generate(
-                scope=scope,
-                target_mode=request.target_mode,
-                limit=request.limit,
-                filters=filters,
-                variant_angle=angle.instruction,
-                **kwargs,
-            )
+            result = await generate_variant(angle)
             result_data = _result_dict(result)
         except Exception as exc:
             caught_exceptions += 1
-            error = _blog_variant_error(angle, str(exc), type(exc).__name__)
+            error = _variant_error(angle, str(exc), type(exc).__name__)
             result_data = {
-                "requested": max(1, int(request.limit or 1)),
+                "requested": requested_default,
                 "generated": 0,
-                "skipped": max(1, int(request.limit or 1)),
+                "skipped": requested_default,
                 "saved_ids": [],
                 "errors": [error],
             }
@@ -845,7 +802,7 @@ async def _dispatch_blog_post_variants(
         variant_result = dict(result_data)
         variant_result["variant_angle"] = angle_data
         variant_results.append(variant_result)
-        requested += _result_int(result_data, "requested", default=max(1, request.limit))
+        requested += _result_int(result_data, "requested", default=requested_default)
         generated += _result_int(result_data, "generated")
         skipped += _result_int(result_data, "skipped")
         reasoning_contexts_used += _result_int(result_data, "reasoning_contexts_used")
@@ -872,15 +829,13 @@ async def _dispatch_blog_post_variants(
     if consumed_reasoning:
         aggregate["consumed_reasoning_contexts"] = consumed_reasoning
     if generated == 0:
-        aggregate["warnings"] = [
-            "No blog variants generated; all requested variants were blocked or skipped."
-        ]
+        aggregate["warnings"] = [empty_warning]
         if caught_exceptions:
-            raise _ContentOpsStepResultFailure("all_blog_variants_failed", aggregate)
+            raise _ContentOpsStepResultFailure(failure_label, aggregate)
     return aggregate
 
 
-def _blog_variant_error(
+def _variant_error(
     angle: VariantAngle,
     reason: str,
     error_type: str,

--- a/plans/PR-Content-Ops-Output-Variations-Shared-Fanout.md
+++ b/plans/PR-Content-Ops-Output-Variations-Shared-Fanout.md
@@ -1,0 +1,108 @@
+# PR-Content-Ops-Output-Variations-Shared-Fanout
+
+## Why this slice exists
+
+PR #1347 added blog output variations and PR #1349 added landing-page output
+variations. The #1349 review was LGTM, but it called out one concrete NIT before
+the third generator: blog and landing-page fan-out now duplicate the same
+per-angle aggregation, caught-exception isolation, all-raising failure status,
+warning, saved-id collection, and error-tagging logic. Manually copying that
+logic into sales briefs would triple the exact surface that already cost one
+review cycle in #1347.
+
+This hardening slice removes that duplication before sales-brief parity. It
+does not add a new variation-capable output. It preserves the reviewed blog and
+landing-page result contracts, but moves the shared loop into one helper so the
+next generator composes with the same failure semantics instead of copying them.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/output-variations/shared-fanout
+Slice phase: Production hardening
+
+1. Extract one shared variant fan-out helper for the already-supported blog and
+   landing-page dispatchers.
+2. Keep the existing single-call behavior for `variant_count == 1`.
+3. Keep the public aggregate result shape unchanged for blog and landing-page
+   variants: counts, saved ids, per-angle `variant_results`, tagged errors,
+   warnings, and all-raising step failure status.
+4. Add or keep focused tests proving blog and landing-page fan-out, partial
+   failure isolation, and all-raising failure behavior through the public
+   executor.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Blog and landing-page variant requests still call their services once
+        per selected angle with the same kwargs they used before this refactor.
+  - [ ] Partial per-angle failures remain non-fatal for both outputs.
+  - [ ] All-raising blog variants still fail with `all_blog_variants_failed`.
+  - [ ] All-raising landing-page variants still fail with
+        `all_landing_page_variants_failed`.
+  - [ ] The shared helper has one implementation of aggregate counts, saved ids,
+        `variant_results`, tagged errors, warnings, and caught-exception status.
+  - [ ] No sales-brief behavior changes in this PR.
+- Affected surfaces: extracted package execution dispatcher and execution
+  regression tests.
+- Risk areas: behavior-preserving refactor, result contract drift, failure
+  status regressions.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/content_ops_execution.py`
+- `plans/PR-Content-Ops-Output-Variations-Shared-Fanout.md`
+
+## Mechanism
+
+Add one private helper in `content_ops_execution.py` that accepts the request,
+a per-angle async generation callback, the requested-count default, the
+all-raising failure label, and the all-zero warning message. The helper owns the
+loop over `selected_variant_angles`, calls the callback with each
+`VariantAngle`, converts results through the existing result helpers, tags
+per-angle errors, accumulates saved ids and consumed reasoning, and raises
+`_ContentOpsStepResultFailure` only when `generated == 0` and at least one
+variant call raised.
+
+The blog dispatcher passes a callback that calls the blog service with
+`scope`, `target_mode`, `limit`, `filters`, and the selected angle instruction.
+The landing-page dispatcher passes a callback that calls the landing-page
+service with its campaign kwargs and the selected angle instruction. Their
+single-call branches remain unchanged. The old blog/landing-specific variant
+loops collapse to thin wrappers around the helper so the warning text and
+failure labels stay output-specific.
+
+## Intentional
+
+- This PR is a refactor/hardening slice, not sales-brief parity. It removes the
+  copied logic first because the #1349 review explicitly warned against a third
+  copy.
+- The helper remains private to `content_ops_execution.py`; no new package port
+  or public API is needed.
+- Tests stay at the executor boundary instead of asserting private helper
+  internals. The risk is public behavior drift, so the public result contract is
+  the right proof point.
+
+## Deferred
+
+- Sales-brief `variant_angle` parity.
+- Persistent variant grouping (`variant_group_id`) and a past-run variants view.
+- Auto-ranking / recommended winner and A/B serving/analytics.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_extracted_content_ops_execution.py -q -- PASS, 74 tests.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- PASS.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- PASS.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- PASS.
+- Command: bash scripts/check_ascii_python.sh -- PASS.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- PASS, 3,237 passed / 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/content_ops_execution.py` | 147 |
+| `plans/PR-Content-Ops-Output-Variations-Shared-Fanout.md` | 108 |
+| **Total** | **255** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Output-Variations-Shared-Fanout.md
Slice phase: Production hardening

This addresses the #1349 review NIT before sales-brief parity: blog and landing-page variants now share one private fan-out helper for per-angle aggregation, tagged errors, saved ids, warnings, and all-raising failure status. Public behavior is unchanged.

## Intentional
- Refactor/hardening only; sales-brief parity remains deferred.
- The helper stays private to `content_ops_execution.py`; no new package port or public API.
- Tests stay at the executor boundary because the public result contract is the risk surface.

## Deferred
- Sales-brief `variant_angle` parity.
- Persistent variant grouping (`variant_group_id`) and a past-run variants view.
- Auto-ranking / recommended winner and A/B serving/analytics.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_ops_execution.py -q` -- PASS, 74 tests.
- `bash scripts/validate_extracted_content_pipeline.sh` -- PASS.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- PASS.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- PASS.
- `bash scripts/check_ascii_python.sh` -- PASS.
- `bash scripts/run_extracted_pipeline_checks.sh` -- PASS, 3,237 passed / 10 skipped.

## Diff size
2 files, +159 / -96
