### PR TITLE
Brand Voice Strict Mode

### DIFF
--- a/atlas_brain/brand/voice_validator.py
+++ b/atlas_brain/brand/voice_validator.py
@@ -304,6 +304,11 @@ def main():
         default=Path(__file__).parent.parent / "skills/brand/brand_voice.yml",
         help="Path to the brand_voice.yml configuration file.",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on advisory NIT findings instead of warning only.",
+    )
 
     args = parser.parse_args()
 
@@ -337,12 +342,14 @@ def main():
             _print_findings(advisory_findings)
         exit(1)
     elif advisory_findings:
+        status = "FAIL" if args.strict else "WARN"
+        strict_note = " in strict mode" if args.strict else ""
         print(
-            f"WARN: Found {len(advisory_findings)} advisory brand voice "
-            f"findings in {args.file}:"
+            f"{status}: Found {len(advisory_findings)} advisory brand voice "
+            f"findings{strict_note} in {args.file}:"
         )
         _print_findings(advisory_findings)
-        exit(0)
+        exit(1 if args.strict else 0)
     else:
         print(f"PASS: {args.file} is on-brand.")
         exit(0)

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -29,3 +29,10 @@ No code change is required.
     python atlas_brain/brand/voice_validator.py \
       --file marketing/landing_pages/atlas-platform.md \
       --type landing_page
+
+Use strict mode when advisory `NIT` findings should fail the local run:
+
+    python atlas_brain/brand/voice_validator.py \
+      --file marketing/blog_posts/why-deterministic-checks.md \
+      --type blog_post \
+      --strict

--- a/plans/PR-Brand-Voice-Strict-Mode.md
+++ b/plans/PR-Brand-Voice-Strict-Mode.md
@@ -1,0 +1,93 @@
+# PR-Brand-Voice-Strict-Mode
+
+## Why this slice exists
+
+PR #1350 made `NIT` findings advisory by default so suggested vocabulary fixes
+no longer fail the marketing workflow. The same plan deferred a strict local
+mode for teams that want advisory findings to block in manual checks or future
+automation.
+
+This slice adds that runtime knob without changing the default workflow
+behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-marketing/brand-voice-checks
+Slice phase: Vertical slice
+
+1. Add a CLI `--strict` flag to `atlas_brain/brand/voice_validator.py`.
+2. Keep default CLI behavior unchanged: `NIT` findings warn and exit 0.
+3. Make `--strict` fail when advisory `NIT` findings are present.
+4. Preserve blocking behavior for `BLOCKER` and `MAJOR` findings in both modes.
+5. Add focused CLI tests for strict advisory-only and strict clean runs.
+6. Update the marketing guide with the strict-mode local command.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Default `NIT`-only CLI runs still print `WARN` and exit 0.
+  - [ ] `--strict` with only `NIT` findings prints the advisory finding and exits 1.
+  - [ ] `--strict` on clean content still exits 0.
+  - [ ] `BLOCKER`/`MAJOR` findings still fail in default and strict modes.
+- Affected surfaces: brand-voice CLI, local marketing documentation, validator tests.
+- Risk areas: accidentally changing workflow defaults, hiding suggestions in strict mode, confusing exit codes.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `atlas_brain/brand/voice_validator.py`
+- `marketing/README.md`
+- `plans/PR-Brand-Voice-Strict-Mode.md`
+- `tests/test_brand_voice_validator.py`
+
+## Mechanism
+
+The CLI already splits findings into blocking and advisory groups. This slice
+adds a `--strict` boolean and changes only the advisory-only branch:
+
+```python
+if advisory_findings and args.strict:
+    print("FAIL: Found ... advisory ... in strict mode")
+    exit(1)
+```
+
+Mixed blocking/advisory files already exit 1 because blocking findings are
+present. Strict mode keeps printing advisory findings with suggestion lines so
+the stricter exit status does not reduce repair guidance.
+
+## Intentional
+
+- The marketing GitHub workflow remains default/non-strict. `NIT` remains
+  advisory in CI unless a future slice opts into strict behavior explicitly.
+- The validator API remains unchanged; this is a CLI interpretation option.
+- Strict mode is a single boolean, not a configurable severity threshold.
+
+## Deferred
+
+- JSON CLI/report mode for structured downstream consumers.
+- Stem-aware vocabulary patterns owned in YAML.
+- Larger marketing corpus expansion.
+- Workflow-level strict policy if the team later wants CI to fail on `NIT`.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_brand_voice_validator.py -q` -- 64 passed.
+- Four seed CLI checks for landing page, blog post, release notes, and tweet --
+  PASS.
+- Default advisory-only CLI smoke for `predictable` exits 0 and prints `WARN`.
+- Strict advisory-only CLI smoke for `predictable` exits 1 and prints `FAIL`
+  with the suggestion line.
+- Strict clean CLI smoke exits 0.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-brand-voice-strict-mode-body.md` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/brand/voice_validator.py` | 13 |
+| `marketing/README.md` | 7 |
+| `plans/PR-Brand-Voice-Strict-Mode.md` | 90 |
+| `tests/test_brand_voice_validator.py` | 37 |
+| **Total** | **147** |

--- a/tests/test_brand_voice_validator.py
+++ b/tests/test_brand_voice_validator.py
@@ -906,6 +906,43 @@ def test_cli_prints_suggestion_for_discouraged_vocabulary(tmp_path):
     assert result.stderr == ""
 
 
+def test_cli_strict_returns_one_for_discouraged_vocabulary(tmp_path):
+    content = tmp_path / "strict_discouraged_blog_post.md"
+    content.write_text("The result is predictable for operators.")
+
+    result = _run_cli("--file", str(content), "--type", "blog_post", "--strict")
+
+    assert result.returncode == 1
+    assert "FAIL: Found 1 advisory brand voice findings in strict mode" in result.stdout
+    assert "[NIT] vocabulary.use.predictable" in result.stdout
+    assert "suggestion: Use 'deterministic' instead of 'predictable'" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_strict_returns_zero_for_clean_file(tmp_path):
+    content = tmp_path / "strict_clean_landing_page.md"
+    content.write_text("Atlas is built around extensibility from day one.")
+
+    result = _run_cli("--file", str(content), "--type", "landing_page", "--strict")
+
+    assert result.returncode == 0
+    assert "PASS:" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_strict_keeps_blocking_findings_failing(tmp_path):
+    content = tmp_path / "strict_bad_landing_page.md"
+    content.write_text("This is a game-changer!!")
+
+    result = _run_cli("--file", str(content), "--type", "landing_page", "--strict")
+
+    assert result.returncode == 1
+    assert "FAIL: Found 3 blocking brand voice violations" in result.stdout
+    assert "[BLOCKER] vocabulary.avoid.game-changer" in result.stdout
+    assert "[MAJOR] no_excessive_punctuation" in result.stdout
+    assert result.stderr == ""
+
+
 def test_cli_returns_one_for_mixed_blocking_and_advisory_findings(tmp_path):
     content = tmp_path / "mixed_blog_post.md"
     content.write_text("The result is predictable and a game-changer.")


### PR DESCRIPTION
Plan: plans/PR-Brand-Voice-Strict-Mode.md
Slice phase: Vertical slice

Adds a brand voice CLI `--strict` flag so advisory `NIT` findings can fail local runs without changing the default marketing workflow behavior.

## Intentional

- GitHub workflow remains default/non-strict; `NIT` stays advisory in CI.
- Validator findings and severities remain unchanged.
- Strict mode is boolean, not a configurable severity threshold.

## Deferred

- JSON CLI/report mode for structured downstream consumers.
- Stem-aware vocabulary patterns owned in YAML.
- Larger marketing corpus expansion.
- Workflow-level strict policy if the team later wants CI to fail on `NIT`.

## Parked hardening

- None.

## Verification

- `python -m pytest tests/test_brand_voice_validator.py -q` -- 64 passed.
- Four seed CLI checks for landing page, blog post, release notes, and tweet -- PASS.
- Default advisory-only CLI smoke for `predictable` exits 0 and prints `WARN`.
- Strict advisory-only CLI smoke for `predictable` exits 1 and prints `FAIL` with the suggestion line.
- Strict clean CLI smoke exits 0.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-brand-voice-strict-mode-body.md` -- passed.

## Diff size

4 files, +147 / -3.