### PR TITLE
Content Ops Output Variations Sales Brief

### DIFF
--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -622,7 +622,37 @@ async def _dispatch_sales_brief(
         kwargs["brand_voice"] = brand_voice
     if "source_material" in request.inputs:
         kwargs["source_material"] = request.inputs.get("source_material")
+    if request.variant_count > 1:
+        return await _dispatch_sales_brief_variants(
+            service=service,
+            request=request,
+            kwargs=kwargs,
+        )
     return await service.generate(**kwargs)
+
+
+async def _dispatch_sales_brief_variants(
+    *,
+    service: Any,
+    request: ContentOpsRequest,
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    async def generate_variant(angle: VariantAngle) -> Any:
+        return await service.generate(
+            variant_angle=angle.instruction,
+            **kwargs,
+        )
+
+    requested_default = max(1, int(request.limit or 1))
+    return await _dispatch_output_variants(
+        request=request,
+        generate_variant=generate_variant,
+        requested_default=requested_default,
+        failure_label="all_sales_brief_variants_failed",
+        empty_warning=(
+            "No sales-brief variants generated; all requested variants were blocked or skipped."
+        ),
+    )
 
 
 async def _dispatch_landing_page(

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -511,7 +511,7 @@ def _item_multiplier_for_output(
     inputs: Mapping[str, Any],
     variant_count: int = 1,
 ) -> int:
-    if output_id in {"blog_post", "landing_page"}:
+    if output_id in {"blog_post", "landing_page", "sales_brief"}:
         return normalize_variant_count(variant_count)
     if output_id != "social_post":
         return 1

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -457,6 +457,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_gates_enabled": request.require_quality_gates,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_variant_config_for_request(request),
                 **_brand_voice_config_for_request(request),
                 **_reasoning_config_for_output(output, request),
             },

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -200,8 +200,22 @@ def _has_prompt_reasoning_context(payload: Mapping[str, Any]) -> bool:
     return isinstance(payload.get("campaign_reasoning_context"), Mapping)
 
 
-def _sales_brief_user_prompt(prior_invalid_response: str = "") -> str:
+def _sales_brief_user_prompt(
+    prior_invalid_response: str = "",
+    *,
+    variant_angle: str | None = None,
+) -> str:
     prompt = "Generate one sales brief from the opportunity above."
+    resolved_variant_angle = str(variant_angle or "").strip()
+    if resolved_variant_angle:
+        prompt = (
+            f"{prompt}\n\n"
+            "Variant angle:\n"
+            f"- {resolved_variant_angle}\n"
+            "Use this angle to change framing and emphasis only. Keep the same "
+            "opportunity facts, supplied evidence, buying context, and "
+            "truthfulness limits."
+        )
     return retry_prompt_with_invalid_response(
         prompt,
         prior_invalid_response=prior_invalid_response,
@@ -261,6 +275,7 @@ class SalesBriefGenerationService:
         quality_gates_enabled: bool | None = None,
         source_material: Any = None,
         brand_voice: Mapping[str, Any] | BrandVoiceProfile | None = None,
+        variant_angle: str | None = None,
     ) -> SalesBriefGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -295,6 +310,7 @@ class SalesBriefGenerationService:
             brand_voice,
             scope=scope,
         )
+        resolved_variant_angle = str(variant_angle or "").strip() or None
 
         requested = int(limit or self._config.limit)
         source_opportunities = _opportunities_from_source_material(
@@ -348,6 +364,7 @@ class SalesBriefGenerationService:
                     parse_retry_attempts=resolved_parse_retry_attempts,
                     parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                     brand_voice=resolved_brand_voice,
+                    variant_angle=resolved_variant_angle,
                 )
             except Exception as exc:
                 skipped += 1
@@ -452,6 +469,7 @@ class SalesBriefGenerationService:
         parse_retry_attempts: int,
         parse_retry_response_excerpt_chars: int,
         brand_voice: BrandVoiceProfile | None = None,
+        variant_angle: str | None = None,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
         # Single source for the opportunity payload: in the system prompt
@@ -466,34 +484,44 @@ class SalesBriefGenerationService:
         attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
+        resolved_variant_angle = str(variant_angle or "").strip()
         for attempt_no in range(1, attempts + 1):
+            metadata: dict[str, Any] = {
+                "target_mode": target_mode,
+                "target_id": opportunity_target_id(opportunity),
+                "skill_name": self._config.skill_name,
+                "asset_type": "sales_brief",
+                "attempt_no": attempt_no,
+            }
+            if resolved_variant_angle:
+                metadata["variant_angle"] = resolved_variant_angle
             response = await self._llm.complete(
                 [
                     LLMMessage(role="system", content=system_prompt),
                     LLMMessage(
                         role="user",
-                        content=_sales_brief_user_prompt(last_response),
+                        content=_sales_brief_user_prompt(
+                            last_response,
+                            variant_angle=resolved_variant_angle,
+                        ),
                     ),
                 ],
                 max_tokens=max_tokens,
                 temperature=temperature,
-                metadata={
-                    "target_mode": target_mode,
-                    "target_id": opportunity_target_id(opportunity),
-                    "skill_name": self._config.skill_name,
-                    "asset_type": "sales_brief",
-                    "attempt_no": attempt_no,
-                },
+                metadata=metadata,
             )
             total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_sales_brief_response(response.content)
             if parsed:
-                return brand_voice_result_metadata({
+                result_payload = {
                     **parsed,
                     "_model": response.model,
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
-                }, brand_voice)
+                }
+                if resolved_variant_angle:
+                    result_payload["_variant_angle"] = resolved_variant_angle
+                return brand_voice_result_metadata(result_payload, brand_voice)
             last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
@@ -573,6 +601,9 @@ class SalesBriefGenerationService:
             "brand_voice_profile": parsed.get("_brand_voice_profile"),
             "brand_voice_audit": parsed.get("_brand_voice_audit"),
         }
+        variant_angle = str(parsed.get("_variant_angle") or "").strip()
+        if variant_angle:
+            metadata["variant_angle"] = variant_angle
         if opportunity is not None:
             context = normalize_campaign_reasoning_context(opportunity)
             metadata.update(campaign_reasoning_context_metadata(context))

--- a/plans/PR-Content-Ops-Output-Variations-Sales-Brief.md
+++ b/plans/PR-Content-Ops-Output-Variations-Sales-Brief.md
@@ -1,0 +1,133 @@
+# PR-Content-Ops-Output-Variations-Sales-Brief
+
+## Why this slice exists
+
+The merged `PR-Content-Ops-Output-Variations.md` plan called for deterministic
+output variations across blog posts, landing pages, and sales briefs. PR #1347
+landed blog variants, PR #1349 landed landing-page variants, and PR #1351
+removed their duplicated fan-out loop before adding a third generator.
+
+This PR adds the remaining generator parity slice: sales-brief preview/plan and
+execution now honor `variant_count`, and `SalesBriefGenerationService.generate`
+gets the same optional `variant_angle` prompt/metadata threading already used by
+blog and landing-page generation. It reuses the shared fan-out helper rather
+than copying per-angle aggregation logic again.
+
+The full diff may exceed the 400 LOC soft cap because this is the final
+vertical slice across preview, plan, execution, generator prompt metadata, and
+focused R2/R12 tests. The implementation itself should stay narrow; the bulk is
+plan and regression coverage needed to prove sales briefs match the already
+merged output-variation contract.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/output-variations/sales-brief
+Slice phase: Vertical slice
+
+1. Make sales-brief preview cost and generation-plan metadata scale by the
+   selected deterministic variant angles when `variant_count > 1`.
+2. Fan out sales-brief execution once per selected angle through the shared
+   `_dispatch_output_variants` helper, preserving per-item failure isolation and
+   all-raising step/run failure behavior.
+3. Add `variant_angle: str | None = None` to
+   `SalesBriefGenerationService.generate(...)`, thread it into the LLM prompt,
+   LLM metadata, parsed metadata, and saved draft metadata.
+4. Keep `variant_count == 1` as the existing single sales-brief call and keep
+   blog/landing-page behavior unchanged in this slice.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Sales-brief preview cost multiplies by the normalized variant count.
+  - [ ] Sales-brief generation-plan steps expose `variant_count` and
+        `variant_angles` when variants are requested.
+  - [ ] `execute_content_ops_request` calls the sales-brief service once per
+        selected angle, passes each angle instruction as `variant_angle`, and
+        aggregates `variant_results`, counts, saved ids, errors, warnings, and
+        consumed reasoning context.
+  - [ ] One failed sales-brief variant does not abort sibling variants.
+  - [ ] If every sales-brief variant raises an exception, the step/run fails
+        while preserving the aggregate diagnostic result.
+  - [ ] `SalesBriefGenerationService.generate(..., variant_angle=...)`
+        injects the angle into the user prompt and preserves it in LLM call
+        metadata and saved draft metadata; `None` is a no-op.
+  - [ ] Existing blog and landing-page variant behavior is not changed.
+- Affected surfaces: extracted package preview cost, generation-plan metadata,
+  sales-brief execution dispatcher, sales-brief prompt/metadata, tests.
+- Risk areas: cost accounting, execution result contract, prompt truthfulness,
+  backward compatibility for existing sales-brief callers.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/sales_brief_generation.py`
+- `plans/PR-Content-Ops-Output-Variations-Sales-Brief.md`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_sales_brief_generation.py`
+
+## Mechanism
+
+Preview cost expands the existing variant multiplier from blog/landing-page to
+sales briefs. Generation-plan config reuses `_variant_config_for_request`, so
+the selected deterministic angle metadata is visible before execution.
+
+`_dispatch_sales_brief` keeps its current single service call when
+`variant_count == 1`. For multi-variant requests it builds the same kwargs as
+today, then passes a sales-brief callback into `_dispatch_output_variants`. The
+callback calls `SalesBriefGenerationService.generate(...,
+variant_angle=angle.instruction, **kwargs)`. The shared helper owns aggregate
+counts, `variant_results`, saved ids, errors, warnings, consumed reasoning
+contexts, partial failure isolation, and all-raising step failure status.
+
+The sales-brief generator accepts an optional `variant_angle` string. When
+present, `_sales_brief_user_prompt` adds a short "Variant angle" instruction
+that tells the model to change framing while preserving the same opportunity
+facts and supplied evidence. The same angle is sent in LLM metadata, carried on
+the parsed payload, and written into `SalesBriefDraft.metadata`. Empty or
+`None` values are ignored so existing callers keep current behavior.
+
+## Intentional
+
+- This is sales-brief parity, not ranking, A/B serving, or variant persistence.
+  Those were explicitly deferred in the parent output-variations plan.
+- The executor does not duplicate sales-brief quality-gate logic. Each per-angle
+  service call still owns parse and quality-gate decisions; the executor only
+  aggregates the public result contract.
+- The prompt angle changes framing only. It must preserve the same opportunity
+  facts and supplied evidence so variants do not invent new claims.
+
+## Deferred
+
+- Persistent variant grouping (`variant_group_id`) and a past-run variants view.
+- Auto-ranking / recommended winner and A/B serving/analytics.
+- Product UI affordances for comparing all generated variants after execution.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_sales_brief_generation.py -q` -- PASS, 211 tests.
+- Command: `scripts/validate_extracted_content_pipeline.sh` via bash -- PASS.
+- Command: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- PASS.
+- Command: `python scripts/audit_extracted_standalone.py --fail-on-debt` -- PASS.
+- Command: `scripts/check_ascii_python.sh` via bash -- PASS.
+- Command: `scripts/run_extracted_pipeline_checks.sh` via bash -- PASS, 3,242 passed / 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/content_ops_execution.py` | 30 |
+| `extracted_content_pipeline/control_surfaces.py` | 2 |
+| `extracted_content_pipeline/generation_plan.py` | 1 |
+| `extracted_content_pipeline/sales_brief_generation.py` | 53 |
+| `plans/PR-Content-Ops-Output-Variations-Sales-Brief.md` | 133 |
+| `tests/test_extracted_content_control_surfaces.py` | 4 |
+| `tests/test_extracted_content_generation_plan.py` | 20 |
+| `tests/test_extracted_content_ops_execution.py` | 159 |
+| `tests/test_extracted_sales_brief_generation.py` | 26 |
+| **Total** | **428** |

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -104,7 +104,7 @@ def test_preview_scales_landing_page_cost_by_variant_count():
     assert preview["normalized_request"]["variant_count"] == 2
 
 
-def test_preview_does_not_scale_sales_brief_by_variant_count():
+def test_preview_scales_sales_brief_cost_by_variant_count():
     preview = preview_from_mapping({
         "outputs": ["sales_brief"],
         "variant_count": 3,
@@ -112,7 +112,7 @@ def test_preview_does_not_scale_sales_brief_by_variant_count():
     })
 
     assert preview["can_run"] is True
-    assert preview["estimated_cost_usd"] == 0.7
+    assert preview["estimated_cost_usd"] == 2.1
     assert preview["normalized_request"]["variant_count"] == 3
 
 

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -372,6 +372,26 @@ def test_plan_includes_landing_page_variant_angle_metadata_when_requested():
     ]
 
 
+def test_plan_includes_sales_brief_variant_angle_metadata_when_requested():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "variant_count": 2,
+            "inputs": {
+                "target_account": "Acme",
+                "brief_type": "renewal",
+            },
+        }
+    )
+
+    config = plan["steps"][0]["config"]
+    assert config["variant_count"] == 2
+    assert config["variant_angles"] == [
+        VARIANT_ANGLES[0].as_dict(),
+        VARIANT_ANGLES[1].as_dict(),
+    ]
+
+
 def test_plan_stays_non_executable_when_preview_fails_budget():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -143,6 +143,46 @@ class _VariantBlogService:
         }
 
 
+class _VariantSalesBriefService:
+    def __init__(self, *, fail_on_angle: str = "") -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.fail_on_angle = fail_on_angle
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+        variant_angle: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.calls.append({
+            "scope": scope,
+            "target_mode": target_mode,
+            "limit": limit,
+            "filters": dict(filters or {}),
+            "variant_angle": variant_angle,
+            "kwargs": dict(kwargs),
+        })
+        if self.fail_on_angle and self.fail_on_angle in str(variant_angle or ""):
+            raise RuntimeError("sales brief variant failed")
+        call_no = len(self.calls)
+        return {
+            "requested": int(limit or 1),
+            "generated": 1,
+            "skipped": 0,
+            "reasoning_contexts_used": 1,
+            "consumed_reasoning_contexts": [{
+                "target_id": f"sales-brief-{call_no}",
+                "variant_angle": variant_angle,
+            }],
+            "saved_ids": [f"sales-brief-{call_no}"],
+            "errors": [],
+        }
+
+
 class _ReasoningAwareOpportunityService(_OpportunityService):
     def __init__(self, reasoning_context: Any | None = None) -> None:
         super().__init__()
@@ -2201,6 +2241,125 @@ async def test_execute_all_raising_landing_page_variants_fails_step_with_warning
     assert step["result"]["skipped"] == 3
     assert step["result"]["warnings"] == [
         "No landing-page variants generated; all requested variants were blocked or skipped."
+    ]
+    assert [
+        item["variant_angle"]["id"] for item in step["result"]["variant_results"]
+    ] == ["pain_led", "outcome_led", "social_proof"]
+    assert [item["variant_angle"] for item in step["result"]["errors"]] == [
+        "pain_led",
+        "outcome_led",
+        "social_proof",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_fans_out_sales_brief_variants_by_angle() -> None:
+    sales_brief = _VariantSalesBriefService()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "variant_count": 3,
+            "inputs": {
+                "target_account": "Acme",
+                "brief_type": "renewal",
+            },
+        },
+        services=ContentOpsExecutionServices(sales_brief=sales_brief),
+    )
+
+    step_result = result["steps"][0]["result"]
+    assert result["status"] == "completed"
+    assert len(sales_brief.calls) == 3
+    assert [call["variant_angle"] for call in sales_brief.calls] == [
+        VARIANT_ANGLES[0].instruction,
+        VARIANT_ANGLES[1].instruction,
+        VARIANT_ANGLES[2].instruction,
+    ]
+    assert [call["kwargs"]["default_brief_type"] for call in sales_brief.calls] == [
+        "renewal",
+        "renewal",
+        "renewal",
+    ]
+    assert step_result["variant_count"] == 3
+    assert step_result["requested"] == 3
+    assert step_result["generated"] == 3
+    assert step_result["skipped"] == 0
+    assert step_result["reasoning_contexts_used"] == 3
+    assert step_result["saved_ids"] == [
+        "sales-brief-1",
+        "sales-brief-2",
+        "sales-brief-3",
+    ]
+    assert [
+        item["variant_angle"]["id"] for item in step_result["variant_results"]
+    ] == ["pain_led", "outcome_led", "social_proof"]
+    assert [
+        item["target_id"] for item in step_result["consumed_reasoning_contexts"]
+    ] == ["sales-brief-1", "sales-brief-2", "sales-brief-3"]
+
+
+@pytest.mark.asyncio
+async def test_execute_sales_brief_variant_failure_does_not_abort_batch() -> None:
+    sales_brief = _VariantSalesBriefService(fail_on_angle="Outcome-led")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "variant_count": 3,
+            "inputs": {
+                "target_account": "Acme",
+                "brief_type": "renewal",
+            },
+        },
+        services=ContentOpsExecutionServices(sales_brief=sales_brief),
+    )
+
+    step_result = result["steps"][0]["result"]
+    assert result["status"] == "completed"
+    assert result["errors"] == []
+    assert len(sales_brief.calls) == 3
+    assert step_result["generated"] == 2
+    assert step_result["skipped"] == 1
+    assert step_result["saved_ids"] == ["sales-brief-1", "sales-brief-3"]
+    assert step_result["errors"] == [{
+        "variant_angle": "outcome_led",
+        "variant_label": "Outcome-led",
+        "reason": "sales brief variant failed",
+        "error_type": "RuntimeError",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_execute_all_raising_sales_brief_variants_fails_step_with_warning() -> None:
+    sales_brief = _VariantSalesBriefService(fail_on_angle="led")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "variant_count": 3,
+            "inputs": {
+                "target_account": "Acme",
+                "brief_type": "renewal",
+            },
+        },
+        services=ContentOpsExecutionServices(sales_brief=sales_brief),
+    )
+
+    step = result["steps"][0]
+    assert result["status"] == "failed"
+    assert result["errors"] == [{
+        "output": "sales_brief",
+        "runner": "SalesBriefGenerationService.generate",
+        "error": "all_sales_brief_variants_failed",
+        "reason": "all_sales_brief_variants_failed",
+    }]
+    assert step["status"] == "failed"
+    assert step["error"] == "all_sales_brief_variants_failed"
+    assert step["result"]["generated"] == 0
+    assert step["result"]["skipped"] == 3
+    assert step["result"]["warnings"] == [
+        "No sales-brief variants generated; all requested variants were blocked or skipped."
     ]
     assert [
         item["variant_angle"]["id"] for item in step["result"]["variant_results"]

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -273,6 +273,8 @@ async def test_generate_persists_one_brief_per_opportunity_via_save_drafts() -> 
     assert len(llm.calls) == 1
     assert llm.calls[0]["metadata"]["asset_type"] == "sales_brief"
     assert llm.calls[0]["metadata"]["target_mode"] == "vendor"
+    assert "variant_angle" not in llm.calls[0]["metadata"]
+    assert "Variant angle:" not in llm.calls[0]["messages"][1].content
     saved_drafts = sales_briefs.saved[0]["drafts"]
     assert len(saved_drafts) == 1
     draft = saved_drafts[0]
@@ -285,6 +287,30 @@ async def test_generate_persists_one_brief_per_opportunity_via_save_drafts() -> 
     assert draft.sections[0].id == "account_context"
     assert draft.metadata["generation_model"] == "test-model"
     assert draft.metadata["confidence"] == 0.82
+    assert "variant_angle" not in draft.metadata
+
+
+@pytest.mark.asyncio
+async def test_generate_threads_variant_angle_into_prompt_metadata_and_draft() -> None:
+    service, _intelligence, sales_briefs, llm, _skills, _rp = _service()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        variant_angle=(
+            "Outcome-led: emphasize measurable business impact while preserving "
+            "the opportunity facts."
+        ),
+    )
+
+    assert result.generated == 1
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "Variant angle:" in user_prompt
+    assert "Outcome-led: emphasize measurable business impact" in user_prompt
+    assert "Keep the same opportunity facts" in user_prompt
+    assert llm.calls[0]["metadata"]["variant_angle"].startswith("Outcome-led")
+    draft = sales_briefs.saved[0]["drafts"][0]
+    assert draft.metadata["variant_angle"].startswith("Outcome-led")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Output-Variations-Sales-Brief.md
Slice phase: Vertical slice

Adds the remaining sales-brief parity for deterministic output variations: preview cost, generation-plan metadata, execution fan-out through the shared helper from #1351, and `SalesBriefGenerationService.generate(..., variant_angle=...)` prompt/metadata threading.

## Intentional
- This is sales-brief parity, not ranking, A/B serving, or persistent variant grouping.
- Sales-brief quality gates remain inside the service; the executor only aggregates the public per-call result contract.
- Variant angle changes framing only and preserves opportunity facts and evidence.

## Deferred
- Persistent variant grouping (`variant_group_id`) and a past-run variants view.
- Auto-ranking / recommended winner and A/B serving/analytics.
- Product UI affordances for comparing all generated variants after execution.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_sales_brief_generation.py -q` -- PASS, 211 tests.
- `scripts/validate_extracted_content_pipeline.sh` via bash -- PASS.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- PASS.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- PASS.
- `scripts/check_ascii_python.sh` via bash -- PASS.
- `scripts/run_extracted_pipeline_checks.sh` via bash -- PASS, 3,242 passed / 10 skipped.

## Diff size
9 files, +414 / -14
