### PR TITLE
Brand Voice JSON Report

### DIFF
--- a/atlas_brain/brand/voice_validator.py
+++ b/atlas_brain/brand/voice_validator.py
@@ -1,8 +1,10 @@
-import yaml
-import re
 import argparse
+import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
 
 
 SEVERITIES = frozenset({"BLOCKER", "MAJOR", "NIT"})
@@ -290,6 +292,98 @@ def _print_advisory_findings(
     _print_findings(findings)
 
 
+def _exit_code(
+    blocking_findings: list[BrandVoiceFinding],
+    advisory_findings: list[BrandVoiceFinding],
+    *,
+    strict: bool,
+) -> int:
+    if blocking_findings or (strict and advisory_findings):
+        return 1
+    return 0
+
+
+def _result_status(
+    blocking_findings: list[BrandVoiceFinding],
+    advisory_findings: list[BrandVoiceFinding],
+    *,
+    strict: bool,
+) -> str:
+    if blocking_findings or (strict and advisory_findings):
+        return "fail"
+    if advisory_findings:
+        return "warn"
+    return "pass"
+
+
+def _finding_payload(finding: BrandVoiceFinding) -> dict[str, str | None]:
+    return {
+        "rule_id": finding.rule_id,
+        "severity": finding.severity,
+        "category": finding.category,
+        "message": finding.message,
+        "suggestion": finding.suggestion,
+    }
+
+
+def _print_json_result(
+    *,
+    file_path: Path,
+    content_type: str,
+    strict: bool,
+    blocking_findings: list[BrandVoiceFinding],
+    advisory_findings: list[BrandVoiceFinding],
+    exit_code: int,
+) -> None:
+    payload = {
+        "ok": exit_code == 0,
+        "status": _result_status(
+            blocking_findings, advisory_findings, strict=strict
+        ),
+        "file": str(file_path),
+        "content_type": content_type,
+        "strict": strict,
+        "summary": {
+            "total": len(blocking_findings) + len(advisory_findings),
+            "blocking": len(blocking_findings),
+            "advisory": len(advisory_findings),
+        },
+        "findings": [
+            _finding_payload(finding)
+            for finding in [*blocking_findings, *advisory_findings]
+        ],
+    }
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _print_json_error(
+    *,
+    file_path: Path,
+    content_type: str,
+    strict: bool,
+    code: str,
+    message: str,
+) -> None:
+    payload = {
+        "ok": False,
+        "status": "error",
+        "file": str(file_path),
+        "content_type": content_type,
+        "strict": strict,
+        "summary": {
+            "total": 0,
+            "blocking": 0,
+            "advisory": 0,
+        },
+        "findings": [],
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+    print(json.dumps(payload, sort_keys=True))
+
+
 def main():
     """
     Command-line interface for the BrandVoiceValidator.
@@ -321,24 +415,67 @@ def main():
         action="store_true",
         help="Fail on advisory NIT findings instead of warning only.",
     )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for validation results.",
+    )
 
     args = parser.parse_args()
 
     if not args.file.exists():
-        print(f"Error: File not found at {args.file}")
+        message = f"File not found at {args.file}"
+        if args.format == "json":
+            _print_json_error(
+                file_path=args.file,
+                content_type=args.type,
+                strict=args.strict,
+                code="file_not_found",
+                message=message,
+            )
+        else:
+            print(f"Error: {message}")
         exit(1)
 
     with open(args.file, "r") as f:
         content_to_validate = f.read()
 
-    validator = BrandVoiceValidator(config_path=args.config)
-    findings = validator.validate(content_to_validate, args.type)
+    try:
+        validator = BrandVoiceValidator(config_path=args.config)
+        findings = validator.validate(content_to_validate, args.type)
+    except (ValueError, TypeError, yaml.YAMLError, FileNotFoundError) as exc:
+        if args.format == "json":
+            _print_json_error(
+                file_path=args.file,
+                content_type=args.type,
+                strict=args.strict,
+                code="invalid_config",
+                message=str(exc),
+            )
+        else:
+            print(f"Error: {exc}")
+        exit(1)
     blocking_findings = [
         finding for finding in findings if finding.severity in BLOCKING_SEVERITIES
     ]
     advisory_findings = [
         finding for finding in findings if finding.severity not in BLOCKING_SEVERITIES
     ]
+    exit_code = _exit_code(
+        blocking_findings, advisory_findings, strict=args.strict
+    )
+
+    if args.format == "json":
+        _print_json_result(
+            file_path=args.file,
+            content_type=args.type,
+            strict=args.strict,
+            blocking_findings=blocking_findings,
+            advisory_findings=advisory_findings,
+            exit_code=exit_code,
+        )
+        exit(exit_code)
 
     if blocking_findings:
         print(
@@ -350,13 +487,13 @@ def main():
             _print_advisory_findings(
                 advisory_findings, args.file, strict=args.strict
             )
-        exit(1)
+        exit(exit_code)
     elif advisory_findings:
         _print_advisory_findings(advisory_findings, args.file, strict=args.strict)
-        exit(1 if args.strict else 0)
+        exit(exit_code)
     else:
         print(f"PASS: {args.file} is on-brand.")
-        exit(0)
+        exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -36,3 +36,10 @@ Use strict mode when advisory `NIT` findings should fail the local run:
       --file marketing/blog_posts/why-deterministic-checks.md \
       --type blog_post \
       --strict
+
+For structured counts and finding metadata:
+
+    python atlas_brain/brand/voice_validator.py \
+      --file marketing/blog_posts/why-deterministic-checks.md \
+      --type blog_post \
+      --format json

--- a/plans/PR-Brand-Voice-Json-Report.md
+++ b/plans/PR-Brand-Voice-Json-Report.md
@@ -1,0 +1,110 @@
+# PR-Brand-Voice-Json-Report
+
+## Why this slice exists
+
+PR #1354 explicitly deferred JSON CLI/report mode. The brand-voice gate is now
+readable in CI logs, but scripts still have to scrape text to count findings,
+inspect severities, or surface suggestions. This slice adds a thin
+machine-readable result path while preserving default text output and exit
+codes.
+
+Review on #1356 found that malformed config errors still escaped as tracebacks
+under `--format json`. This update keeps the slice in the same lane by making
+reachable setup failures parseable too. The estimated diff is now over the 400
+LOC soft cap because the review fix adds bad-config regression tests for both
+shape-invalid YAML and syntax-invalid YAML.
+
+## Scope (this PR)
+
+Ownership lane: content-marketing/brand-voice-checks
+Slice phase: Vertical slice
+
+1. Add a `--format {text,json}` CLI option to
+   `atlas_brain/brand/voice_validator.py`, defaulting to today's text output.
+2. Emit a JSON validation-result envelope with `ok`, `status`, `file`,
+   `content_type`, `strict`, `summary`, and a `findings` array carrying each
+   finding's structured fields.
+3. Preserve the existing default/strict exit-code matrix for clean,
+   advisory-only, blocking-only, and mixed findings.
+4. Make `--format json` fail closed with a parseable `error` envelope when the
+   requested input file is missing or the brand-voice config is invalid.
+5. Add focused CLI tests that parse real stdout as JSON for clean,
+   advisory-default, advisory-strict, mixed blocking/advisory, missing-file,
+   bad-config-shape, and bad-config-syntax cases.
+6. Document the local JSON command in the marketing README.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Text mode remains the default and existing text CLI assertions pass.
+  - [ ] Clean JSON exits 0 with `ok: true`, `status: pass`, zero counts, and no findings.
+  - [ ] Advisory JSON exits 0 by default with `status: warn` and suggestion metadata.
+  - [ ] Advisory JSON exits 1 under `--strict` with `status: fail`.
+  - [ ] Mixed JSON exits 1 and reports blocking/advisory counts plus all fields.
+  - [ ] Missing-file JSON exits 1 with a parseable `error` object.
+  - [ ] Bad-config JSON exits 1 with a parseable `invalid_config` error object.
+- Affected surfaces: brand-voice CLI, validator tests, marketing guide.
+- Risk areas: changed default CLI behavior, contradictory JSON/exit status,
+  missing suggestion metadata, unparseable error output.
+- Reviewer rules triggered: R1, R2, R10, R11.
+
+### Files touched
+
+- `atlas_brain/brand/voice_validator.py`
+- `marketing/README.md`
+- `plans/PR-Brand-Voice-Json-Report.md`
+- `tests/test_brand_voice_validator.py`
+
+## Mechanism
+
+The CLI already splits `BrandVoiceFinding` objects into blocking and advisory
+groups. This PR reuses that split, adds a finding serializer, derives
+`exit_code`/`status` once, and renders either the existing text helpers or one
+JSON object with `ok`, `status`, `content_type`, `summary`, `findings`, and
+optional `error`. The CLI wraps validator construction/validation errors so
+bad configs return `invalid_config` envelopes in JSON mode and clean `Error:`
+lines in text mode. JSON mode exits with the same code the text path would
+return for the same findings and strict flag.
+
+## Intentional
+
+- The option is named `--format` instead of a standalone `--json` flag because
+  it leaves room for future formats without adding mutually exclusive switches.
+- Missing input files get `file_not_found`; invalid config/setup failures get
+  `invalid_config` so downstream consumers can distinguish read failures from
+  config failures without parsing tracebacks.
+- No workflow change yet; CI should stay optimized for readable failure logs
+  until a downstream consumer needs JSON artifacts.
+
+## Deferred
+
+- Stem-aware vocabulary patterns.
+- Larger marketing corpus expansion.
+- Workflow-level strict policy if needed later.
+- A JSON `schema_version` field if/when a downstream consumer needs schema
+  negotiation.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_brand_voice_validator.py -q` -- 72 passed.
+- Seed content CLI checks for landing page, blog post, release notes, and tweet
+  -- PASS.
+- JSON CLI smokes for clean, advisory, mixed, and missing-file outputs with
+  `--format json` -- passed; exit codes were clean:0, advisory:0, mixed:1,
+  missing:1.
+- Review-fix JSON CLI smokes for bad config shape and bad YAML syntax with
+  `--format json` -- passed; exit codes were bad_shape:1, bad_syntax:1.
+- `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>`
+  -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/brand/voice_validator.py` | 153 |
+| `marketing/README.md` | 7 |
+| `plans/PR-Brand-Voice-Json-Report.md` | 110 |
+| `tests/test_brand_voice_validator.py` | 230 |
+| **Total** | **500** |

--- a/tests/test_brand_voice_validator.py
+++ b/tests/test_brand_voice_validator.py
@@ -1,5 +1,6 @@
 """Failure-detection suite for BrandVoiceValidator (AGENTS.md 3i)."""
 
+import json
 import subprocess
 import sys
 import textwrap
@@ -44,6 +45,10 @@ def _messages(findings: list[BrandVoiceFinding]) -> list[str]:
 def _only_finding(findings: list[BrandVoiceFinding]) -> BrandVoiceFinding:
     assert len(findings) == 1
     return findings[0]
+
+
+def _json_stdout(result: subprocess.CompletedProcess[str]) -> dict:
+    return json.loads(result.stdout)
 
 
 # ---------------------------------------------------------------------------
@@ -981,4 +986,229 @@ def test_cli_returns_one_for_missing_file(tmp_path):
 
     assert result.returncode == 1
     assert f"Error: File not found at {missing}" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_json_returns_clean_result_envelope(tmp_path):
+    content = tmp_path / "clean_landing_page.md"
+    content.write_text("Atlas is built around extensibility from day one.")
+
+    result = _run_cli(
+        "--file", str(content), "--type", "landing_page", "--format", "json"
+    )
+
+    payload = _json_stdout(result)
+    assert result.returncode == 0
+    assert payload == {
+        "content_type": "landing_page",
+        "file": str(content),
+        "findings": [],
+        "ok": True,
+        "status": "pass",
+        "strict": False,
+        "summary": {
+            "advisory": 0,
+            "blocking": 0,
+            "total": 0,
+        },
+    }
+    assert result.stderr == ""
+
+
+def test_cli_json_reports_advisory_findings_without_failing_by_default(tmp_path):
+    content = tmp_path / "discouraged_blog_post.md"
+    content.write_text("The result is predictable for operators.")
+
+    result = _run_cli(
+        "--file", str(content), "--type", "blog_post", "--format", "json"
+    )
+
+    payload = _json_stdout(result)
+    assert result.returncode == 0
+    assert payload["ok"] is True
+    assert payload["status"] == "warn"
+    assert payload["strict"] is False
+    assert payload["summary"] == {
+        "advisory": 1,
+        "blocking": 0,
+        "total": 1,
+    }
+    assert payload["findings"] == [
+        {
+            "category": "vocabulary",
+            "message": "Prefer 'deterministic' over 'predictable'",
+            "rule_id": "vocabulary.use.predictable",
+            "severity": "NIT",
+            "suggestion": "Use 'deterministic' instead of 'predictable'",
+        }
+    ]
+    assert result.stderr == ""
+
+
+def test_cli_json_strict_reports_advisory_findings_as_failure(tmp_path):
+    content = tmp_path / "strict_discouraged_blog_post.md"
+    content.write_text("The result is predictable for operators.")
+
+    result = _run_cli(
+        "--file",
+        str(content),
+        "--type",
+        "blog_post",
+        "--strict",
+        "--format",
+        "json",
+    )
+
+    payload = _json_stdout(result)
+    assert result.returncode == 1
+    assert payload["ok"] is False
+    assert payload["status"] == "fail"
+    assert payload["strict"] is True
+    assert payload["summary"] == {
+        "advisory": 1,
+        "blocking": 0,
+        "total": 1,
+    }
+    assert payload["findings"][0]["rule_id"] == "vocabulary.use.predictable"
+    assert payload["findings"][0]["suggestion"] == (
+        "Use 'deterministic' instead of 'predictable'"
+    )
+    assert result.stderr == ""
+
+
+def test_cli_json_reports_mixed_blocking_and_advisory_findings(tmp_path):
+    content = tmp_path / "mixed_blog_post.md"
+    content.write_text("The result is predictable and a game-changer.")
+
+    result = _run_cli(
+        "--file", str(content), "--type", "blog_post", "--format", "json"
+    )
+
+    payload = _json_stdout(result)
+    assert result.returncode == 1
+    assert payload["ok"] is False
+    assert payload["status"] == "fail"
+    assert payload["summary"] == {
+        "advisory": 1,
+        "blocking": 1,
+        "total": 2,
+    }
+    assert payload["findings"] == [
+        {
+            "category": "vocabulary",
+            "message": "Contains forbidden word: 'game-changer'",
+            "rule_id": "vocabulary.avoid.game-changer",
+            "severity": "BLOCKER",
+            "suggestion": None,
+        },
+        {
+            "category": "vocabulary",
+            "message": "Prefer 'deterministic' over 'predictable'",
+            "rule_id": "vocabulary.use.predictable",
+            "severity": "NIT",
+            "suggestion": "Use 'deterministic' instead of 'predictable'",
+        },
+    ]
+    assert result.stderr == ""
+
+
+def test_cli_json_reports_missing_file_as_error_envelope(tmp_path):
+    missing = tmp_path / "missing.md"
+
+    result = _run_cli(
+        "--file", str(missing), "--type", "blog_post", "--format", "json"
+    )
+
+    payload = _json_stdout(result)
+    assert result.returncode == 1
+    assert payload == {
+        "content_type": "blog_post",
+        "error": {
+            "code": "file_not_found",
+            "message": f"File not found at {missing}",
+        },
+        "file": str(missing),
+        "findings": [],
+        "ok": False,
+        "status": "error",
+        "strict": False,
+        "summary": {
+            "advisory": 0,
+            "blocking": 0,
+            "total": 0,
+        },
+    }
+    assert result.stderr == ""
+
+
+def test_cli_json_reports_bad_config_shape_as_error_envelope(tmp_path):
+    content = tmp_path / "clean_blog_post.md"
+    content.write_text("A deterministic capability dispatch system.")
+    config = _write_config(
+        tmp_path,
+        """
+        vocabulary:
+          avoid: []
+        tone_rules:
+          - id: "bad"
+        content_rules: []
+        """,
+        name="bad_shape.yml",
+    )
+
+    result = _run_cli(
+        "--file",
+        str(content),
+        "--type",
+        "blog_post",
+        "--config",
+        str(config),
+        "--format",
+        "json",
+    )
+
+    payload = _json_stdout(result)
+    assert result.returncode == 1
+    assert payload["ok"] is False
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "invalid_config"
+    assert "tone_rules[0]" in payload["error"]["message"]
+    assert "missing required" in payload["error"]["message"]
+    assert payload["findings"] == []
+    assert payload["summary"] == {
+        "advisory": 0,
+        "blocking": 0,
+        "total": 0,
+    }
+    assert result.stderr == ""
+
+
+def test_cli_json_reports_bad_config_yaml_as_error_envelope(tmp_path):
+    content = tmp_path / "clean_blog_post.md"
+    content.write_text("A deterministic capability dispatch system.")
+    config = tmp_path / "bad_syntax.yml"
+    config.write_text("vocabulary:\n  avoid: [unterminated\n")
+
+    result = _run_cli(
+        "--file",
+        str(content),
+        "--type",
+        "blog_post",
+        "--config",
+        str(config),
+        "--format",
+        "json",
+    )
+
+    payload = _json_stdout(result)
+    assert result.returncode == 1
+    assert payload["ok"] is False
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "invalid_config"
+    assert payload["findings"] == []
+    assert payload["summary"] == {
+        "advisory": 0,
+        "blocking": 0,
+        "total": 0,
+    }
     assert result.stderr == ""


### PR DESCRIPTION
Plan: plans/PR-Brand-Voice-Json-Report.md
Slice phase: Vertical slice

Adds `--format json` to the brand-voice validator so scripts can consume structured validation results without scraping text output, while preserving text mode as the default and keeping the current exit-code matrix. Review feedback also wraps malformed config failures in parseable JSON error envelopes.

## Intentional

- The option is named `--format` instead of a standalone `--json` flag so future formats can fit the same switch.
- Missing input files use `file_not_found`; invalid config/setup failures use `invalid_config`.
- No workflow change yet; CI keeps readable text logs until a downstream consumer needs JSON artifacts.

## Deferred

- Stem-aware vocabulary patterns.
- Larger marketing corpus expansion.
- Workflow-level strict policy if needed later.
- A JSON `schema_version` field if/when a downstream consumer needs schema negotiation.

## Parked hardening

- None.

## Verification

- `python -m pytest tests/test_brand_voice_validator.py -q` -- 72 passed.
- Seed content CLI checks for landing page, blog post, release notes, and tweet -- PASS.
- JSON CLI smokes for clean, advisory, mixed, and missing-file outputs with `--format json` -- passed; exit codes were clean:0, advisory:0, mixed:1, missing:1.
- Review-fix JSON CLI smokes for bad config shape and bad YAML syntax with `--format json` -- passed; exit codes were bad_shape:1, bad_syntax:1.
- `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>` -- passed.

## Diff size

4 files, +492 / -8.