### PR TITLE
Real Snapshot Customer Wording

### DIFF
--- a/plans/PR-Real-Snapshot-Customer-Wording.md
+++ b/plans/PR-Real-Snapshot-Customer-Wording.md
@@ -1,0 +1,110 @@
+# PR-Real-Snapshot-Customer-Wording
+
+## Why this slice exists
+
+The real locked FAQ deflection Snapshot page already receives
+`top_questions[].customer_wording`, but the current UI only exposes those
+phrases inside each ranked row. The user asked for parity with the `/snapshot`
+demo by adding a bounded "Customer wording" list/card that makes the actual
+ticket phrases visible as a long-tail help-desk SEO target list without
+inventing search terms or promising volume/ranking/traffic.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Product polish
+
+1. Add a compact customer-wording card/list to the real locked Snapshot result
+   page, derived only from `snapshot.top_questions[].customer_wording`, trimmed,
+   filtered for non-empty phrases, and capped at five examples.
+2. Keep the existing ranked-row customer wording unchanged and do not touch
+   ATLAS schema/projection, Checkout, paid-gate, artifact, or generator code.
+3. Extend the existing `portfolio-ui` result-page smoke/source assertions so the
+   visible card label, derivation expression, accessible list marker, bounded
+   rendering, and no-invented-terms fail-closed copy are covered.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] The locked React Snapshot page renders a "Customer wording" card near
+        the ranked question list when a real snapshot is available.
+  - [ ] The grouped phrases are derived from
+        `snapshot.top_questions.map((question) => question.customer_wording.trim())`,
+        exclude empty phrases, and render at most five examples.
+  - [ ] Empty wording/example state fails closed with copy that says no invented
+        SEO terms are displayed.
+  - [ ] Row-level customer wording in ranked questions remains unchanged.
+  - [ ] The hosted HTML renderer used by the deployed rewrite keeps the same
+        visible doctrine for real snapshot payloads.
+- Affected surfaces: frontend, portfolio hosted result renderer, source-level
+  smoke tests.
+- Risk areas: frontend copy/accessibility, privacy boundary, CI enrollment.
+- Reviewer rules triggered: R1, R2, R9, R12.
+
+### Files touched
+
+- `plans/PR-Real-Snapshot-Customer-Wording.md`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+- `portfolio-ui/src/pages/FaqDeflectionResult.tsx`
+
+## Mechanism
+
+`FaqDeflectionResult.tsx` derives `customerWordingExamples` with a `useMemo`
+from the already-validated snapshot rows:
+
+```tsx
+snapshot.top_questions
+  .map((question) => question.customer_wording.trim())
+  .filter((phrase) => phrase.length > 0)
+  .slice(0, 5)
+```
+
+The available-snapshot block renders a small "Customer wording" card before the
+ranked rows. The card uses `aria-label="Customer wording examples"` on the list
+and uses fail-closed copy instead of synthetic keywords if no real phrases are
+present.
+
+The hosted API HTML renderer mirrors the same source-only list because
+`portfolio-ui/vercel.json` rewrites result URLs to
+`api/content-ops/deflection/result-page.js`. The renderer keeps escaping all
+phrases and leaves the existing row-level `item.customer_wording` output intact.
+
+## Intentional
+
+- No keyword volume, ranking, traffic, or savings claims are added. The wording
+  is described only as observed ticket phrasing that can inform help-center
+  titles and internal-search synonyms.
+- No schema/projection changes are made because `customer_wording` is already
+  present in the locked snapshot contract.
+- The existing `test:deflection-result` script is extended instead of adding a
+  new `test:*` script, so no portfolio workflow enrollment change is needed.
+
+## Deferred
+
+- The existing `HARDENING.md` item for `atlas-intel-ui` npm audit
+  vulnerabilities is unrelated to `portfolio-ui/faq-deflection` and remains
+  parked.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-result --prefix portfolio-ui` - 17 checks passed.
+- `npm run build --prefix portfolio-ui` - passed after hydrating local
+  `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`; Vite
+  emitted the existing large-chunk advisory and skipped sitemap generation
+  because no `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` was set.
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed advisory review
+  before commit.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-real-snapshot-customer-wording-body.md`
+  - passed before push.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Real-Snapshot-Customer-Wording.md` | 110 |
+| `portfolio-ui/api/content-ops/deflection/result-page.js` | 35 |
+| `portfolio-ui/scripts/faq-deflection-result-page.test.mjs` | 64 |
+| `portfolio-ui/src/pages/FaqDeflectionResult.tsx` | 49 |
+| **Total** | **258** |

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -42,6 +42,30 @@ function formatNumber(value) {
   return Number.isFinite(value) ? String(value) : "0";
 }
 
+function customerWordingExamples(questions) {
+  return questions
+    .map((question) => clean(question && question.customer_wording))
+    .filter((phrase) => phrase.length > 0)
+    .slice(0, 5);
+}
+
+function renderCustomerWordingCard(questions) {
+  const examples = customerWordingExamples(questions);
+  return `<div class="customer-wording-card">
+            <div class="customer-wording-header">
+              <p>Customer wording</p>
+              <span>Actual ticket phrases only</span>
+            </div>
+            ${
+              examples.length > 0
+                ? `<ul class="customer-wording-list" aria-label="Customer wording examples">
+                    ${examples.map((phrase) => `<li>${escapeHtml(phrase)}</li>`).join("")}
+                  </ul>`
+                : `<p class="muted">No customer wording examples are shown because this snapshot did not include real ticket phrases. No invented SEO terms are displayed.</p>`
+            }
+          </div>`;
+}
+
 function renderSnapshot(report) {
   if (!report || !report.ok || !report.snapshot) {
     return `<section class="snapshot" aria-labelledby="snapshot-title">
@@ -60,6 +84,9 @@ function renderSnapshot(report) {
             <div><span>Evidence-backed answers</span><strong>${escapeHtml(formatNumber(summary.drafted_answer_count))}</strong></div>
             <div><span>Needs support proof</span><strong>${escapeHtml(formatNumber(summary.no_proven_answer_count))}</strong></div>
           </div>
+          <h3>Help-desk SEO targeting list</h3>
+          <p class="muted">Use actual customer phrases from the uploaded tickets for help-center titles, internal-search synonyms, and FAQ wording. No keyword volume, ranking, or traffic promise is implied.</p>
+          ${renderCustomerWordingCard(questions)}
           <div class="questions">
             ${questions
               .map(
@@ -191,6 +218,12 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     .metrics div { border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; padding: 14px; background: rgba(2, 6, 23, .35); }
     .metrics span { display: block; color: rgba(226, 232, 240, .66); font-size: 13px; }
     .metrics strong { display: block; margin-top: 8px; font-size: 28px; }
+    .customer-wording-card { margin: 18px 0 24px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(2, 6, 23, .35); padding: 18px; }
+    .customer-wording-header { display: flex; gap: 10px; align-items: baseline; justify-content: space-between; }
+    .customer-wording-header p { margin: 0; font-weight: 700; }
+    .customer-wording-header span { color: #86efac; font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+    .customer-wording-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 16px 0 0; padding: 0; list-style: none; }
+    .customer-wording-list li { border: 1px solid rgba(30, 41, 59, .9); border-radius: 6px; background: rgba(15, 23, 42, .62); padding: 9px 11px; color: #f8fafc; line-height: 1.45; }
     .questions { display: grid; gap: 14px; }
     .questions article { border-top: 1px solid rgba(30, 41, 59, .9); padding-top: 14px; }
     .questions h3 { margin: 6px 0; font-size: 17px; }
@@ -200,7 +233,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     .notice { margin-top: 20px; border-radius: 8px; padding: 14px 16px; color: #fde68a; background: rgba(251, 191, 36, .1); border: 1px solid rgba(251, 191, 36, .28); }
     .success { color: #bbf7d0; background: rgba(34, 197, 94, .1); border-color: rgba(34, 197, 94, .28); }
     .muted { color: rgba(226, 232, 240, .68); line-height: 1.65; }
-    @media (max-width: 820px) { .grid, .metrics { grid-template-columns: 1fr; } .shell { padding-top: 32px; } }
+    @media (max-width: 820px) { .grid, .metrics, .customer-wording-list { grid-template-columns: 1fr; } .shell { padding-top: 32px; } .customer-wording-header { align-items: flex-start; flex-direction: column; } }
   </style>
 </head>
 <body>

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -121,6 +121,70 @@ await test("snapshot guard names paid report fields that must not render pre-pay
   assert.match(pageSource, /collectForbiddenKeys/);
 });
 
+await test("real snapshot page groups bounded customer wording examples", () => {
+  const compactPageSource = pageSource.replace(/\s+/g, " ");
+  for (const source of [pageSource, resultPageSource]) {
+    assert.match(source, /Customer wording/);
+    assert.match(source, /Help-desk SEO targeting list/);
+    assert.match(source, /aria-label="Customer wording examples"/);
+    assert.match(source, /No invented\s+SEO terms are displayed/);
+    assert.doesNotMatch(source, /guaranteed (keyword|ranking|traffic|search)/i);
+  }
+  assert.match(pageSource, /customerWordingExamples/);
+  assert.match(
+    compactPageSource,
+    /top_questions\s*\.map\(\(question\) => question\.customer_wording\.trim\(\)\)/,
+  );
+  assert.match(pageSource, /\.slice\(0, 5\)/);
+
+  const topQuestions = Array.from({ length: 6 }, (_, index) => ({
+    rank: index + 1,
+    question: `Question ${index + 1}`,
+    weighted_frequency: 6 - index,
+    customer_wording: `customer phrase ${index + 1}`,
+  }));
+  const html = renderResultPage({
+    requestId: "content-ops-abc123",
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    report: {
+      ok: true,
+      snapshot: {
+        summary: { generated: 6, drafted_answer_count: 2, no_proven_answer_count: 4 },
+        top_questions: topQuestions,
+      },
+      artifact_status: "locked",
+    },
+  });
+  assert.match(html, /Help-desk SEO targeting list/);
+  assert.match(html, /Customer wording/);
+  assert.match(html, /aria-label="Customer wording examples"/);
+  assert.match(html, /No keyword volume, ranking, or traffic promise is implied/);
+  const list = html.match(
+    /<ul class="customer-wording-list" aria-label="Customer wording examples">([\s\S]*?)<\/ul>/,
+  );
+  assert.ok(list, "customer wording examples list must render");
+  assert.match(list[1], /customer phrase 1/);
+  assert.match(list[1], /customer phrase 5/);
+  assert.doesNotMatch(list[1], /customer phrase 6/);
+  assert.match(html, /customer phrase 6/);
+
+  const emptyHtml = renderResultPage({
+    requestId: "content-ops-abc123",
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    report: {
+      ok: true,
+      snapshot: {
+        summary: { generated: 0, drafted_answer_count: 0, no_proven_answer_count: 0 },
+        top_questions: [],
+      },
+      artifact_status: "locked",
+    },
+  });
+  assert.match(emptyHtml, /No customer wording examples are shown/);
+  assert.match(emptyHtml, /No invented SEO terms are displayed/);
+  assert.doesNotMatch(emptyHtml, /aria-label="Customer wording examples"/);
+});
+
 await test("checkout endpoint validates request and configured account identifiers", async () => {
   const env = { ATLAS_ACCOUNT_ID: "2b2b950d-f64b-4852-bc30-f92a34cdf169" };
   const valid = validatePayload({

--- a/portfolio-ui/src/pages/FaqDeflectionResult.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionResult.tsx
@@ -167,6 +167,14 @@ export default function FaqDeflectionResult() {
     ];
   }, [snapshotState]);
 
+  const customerWordingExamples = useMemo(() => {
+    if (snapshotState.status !== "available") return [];
+    return snapshotState.snapshot.top_questions
+      .map((question) => question.customer_wording.trim())
+      .filter((phrase) => phrase.length > 0)
+      .slice(0, 5);
+  }, [snapshotState]);
+
   const startCheckout = async () => {
     if (!requestId) return;
     setCheckout({ status: "submitting" });
@@ -279,7 +287,46 @@ export default function FaqDeflectionResult() {
 
             {snapshotState.status === "available" && (
               <div className="mt-10">
-                <h2 className="text-xl font-semibold text-white">Top repeated questions</h2>
+                <h2 className="text-xl font-semibold text-white">
+                  Help-desk SEO targeting list
+                </h2>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-surface-200/75">
+                  Use actual customer phrases from the uploaded tickets for
+                  help-center titles, internal-search synonyms, and FAQ wording.
+                  No keyword volume, ranking, or traffic promise is implied.
+                </p>
+                <div className="mt-5 rounded-lg border border-surface-700/60 bg-surface-800/40 p-5">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                    <p className="text-sm font-semibold text-white">Customer wording</p>
+                    <p className="text-xs font-medium uppercase tracking-[0.14em] text-primary-300">
+                      Actual ticket phrases only
+                    </p>
+                  </div>
+                  {customerWordingExamples.length > 0 ? (
+                    <ul
+                      aria-label="Customer wording examples"
+                      className="mt-4 grid gap-2 text-sm leading-6 text-surface-100 sm:grid-cols-2"
+                    >
+                      {customerWordingExamples.map((phrase, index) => (
+                        <li
+                          key={`${phrase}-${index}`}
+                          className="rounded-md border border-surface-700/60 bg-surface-900/35 px-3 py-2"
+                        >
+                          {phrase}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-4 text-sm leading-6 text-surface-200/75">
+                      No customer wording examples are shown because this
+                      snapshot did not include real ticket phrases. No invented
+                      SEO terms are displayed.
+                    </p>
+                  )}
+                </div>
+                <h3 className="mt-8 text-lg font-semibold text-white">
+                  Top repeated questions
+                </h3>
                 <div className="mt-4 divide-y divide-surface-700/60 rounded-lg border border-surface-700/60 bg-surface-800/30">
                   {snapshotState.snapshot.top_questions.map((item) => (
                     <article key={`${item.rank}-${item.question}`} className="p-5">


### PR DESCRIPTION
Plan: plans/PR-Real-Snapshot-Customer-Wording.md
Slice phase: Product polish

Adds the bounded "Customer wording" card to the real locked FAQ deflection
Snapshot page so actual uploaded-ticket phrases are visibly grouped as a
long-tail help-desk SEO target list, without inventing terms or promising
keyword volume, ranking, or traffic.

## Intentional
- Uses only observed `snapshot.top_questions[].customer_wording` values.
- Leaves schema/projection, Checkout, paid-gate, artifact, generator code, and
  row-level ranked-question wording unchanged.
- Extends existing `portfolio-ui` `test:deflection-result` coverage instead of
  adding a new `test:*` script, so no workflow enrollment change is needed.

## Deferred
- Existing `HARDENING.md` `atlas-intel-ui` npm audit vulnerabilities remain
  parked because they are outside `portfolio-ui/faq-deflection`.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-result --prefix portfolio-ui` - 17 checks passed.
- `npm run build --prefix portfolio-ui` - passed after hydrating local
  `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`; Vite
  emitted the existing large-chunk advisory and skipped sitemap generation
  because no `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` was set.
- `bash scripts/local_pr_review.sh --allow-dirty` - passed advisory review
  before commit.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-real-snapshot-customer-wording-body.md`
  - passed before push.
- `bash scripts/push_pr.sh /tmp/pr-real-snapshot-customer-wording-body.md -u origin HEAD`
  - passed local review/pre-push review and pushed branch.

## Diff size
4 files, +256 / -2
