### PR TITLE
Gate A Blog Variant Persistence

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -59,15 +59,6 @@ register under `docs/technical-debt/`.
 - Owner/session: Codex Gate A live output-quality proof
 - Found during: PR-Gate-A-Live-Output-Quality-Proof review
 
-### Blog post variants collapse to one persisted draft id
-- File/location: `extracted_content_pipeline/blog_post_postgres.py` / blog-post save path used by `BlogPostGenerationService.generate`.
-- Description: Gate A live validation generated two successful blog variants, but both returned `9c2cdf6c-9fbf-42db-8af8-6a59e850cf16`; the exact export contained one approved row, not distinct persisted variant rows.
-- Why it matters: `variant_count > 1` does not prove usable blog variants if the review/export surface collapses them into one draft by slug or blueprint identity.
-- Effort: M
-- Category: correctness
-- Owner/session: Codex Gate A live output-quality proof
-- Found during: PR-Gate-A-Live-Output-Quality-Proof
-
 ### Brand-voice second-person guidance is not consistently honored
 - File/location: `extracted_content_pipeline/brand_voice.py` audit surfaced from live blog and sales-brief exports.
 - Description: The Gate A profile requested `preferred_pov=second_person`. The exported blog draft and one sales brief had `brand_voice_audit.passed=false` with `preferred_pov_second_person_not_detected`.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -866,7 +866,11 @@ class BlogPostGenerationService:
         blueprint: Mapping[str, Any],
     ) -> BlogPostDraft:
         title = str(parsed.get("title") or "").strip()
-        slug = _slugify(parsed.get("slug") or blueprint.get("slug") or title)
+        variant_angle = str(parsed.get("_variant_angle") or "").strip()
+        slug = _slug_with_variant_suffix(
+            _slugify(parsed.get("slug") or blueprint.get("slug") or title),
+            variant_angle,
+        )
         topic_type = str(
             parsed.get("topic_type")
             or blueprint.get("topic_type")
@@ -886,7 +890,6 @@ class BlogPostGenerationService:
             "brand_voice_profile": parsed.get("_brand_voice_profile"),
             "brand_voice_audit": parsed.get("_brand_voice_audit"),
         }
-        variant_angle = str(parsed.get("_variant_angle") or "").strip()
         if variant_angle:
             metadata["variant_angle"] = variant_angle
         # PR-Blog-Reasoning-Parity: surface reasoning audit fields on
@@ -1399,6 +1402,23 @@ def _slugify(value: Any) -> str:
     if len(slug) > _MAX_SLUG_CHARS:
         slug = slug[:_MAX_SLUG_CHARS].rstrip("-")
     return slug or "blog-post"
+
+
+def _variant_slug_suffix(variant_angle: str) -> str:
+    label = str(variant_angle or "").strip().split(":", 1)[0]
+    suffix = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return suffix[:40].rstrip("-")
+
+
+def _slug_with_variant_suffix(base_slug: str, variant_angle: str) -> str:
+    suffix = _variant_slug_suffix(variant_angle)
+    if not suffix:
+        return base_slug
+    if base_slug == suffix or base_slug.endswith(f"-{suffix}"):
+        return base_slug
+    max_base_chars = _MAX_SLUG_CHARS - len(suffix) - 1
+    trimmed = base_slug[:max_base_chars].rstrip("-") or "blog-post"
+    return f"{trimmed}-{suffix}"
 
 
 def _string_tuple(value: Any) -> tuple[str, ...]:

--- a/plans/PR-Gate-A-Blog-Variant-Persistence.md
+++ b/plans/PR-Gate-A-Blog-Variant-Persistence.md
@@ -1,0 +1,129 @@
+# PR-Gate-A-Blog-Variant-Persistence
+
+## Why this slice exists
+
+PR-Gate-A-Live-Output-Quality-Proof proved the live Gate A path on real
+Postgres and the configured cloud/OpenRouter route, but the run failed a
+structural product requirement: two successful `blog_post` variants both
+returned the same persisted draft id and the exact export contained only one
+approved blog row. That means `variant_count > 1` can still collapse in the
+review/export surface, so marketers do not get distinct blog drafts to compare
+or approve.
+
+This slice promotes the matching `HARDENING.md` item into scope and fixes only
+that persistence failure. The other Gate A quality failures remain parked
+because they need prompt/evaluator/product-quality work, not draft identity
+hardening.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/gate-a-blog-variant-persistence
+Slice phase: Production hardening
+
+1. Make blog-post variant generation persist reviewable drafts under distinct,
+   deterministic slugs when `variant_angle` is present.
+2. Preserve the normal non-variant behavior where regenerating the same blog
+   slug updates the existing draft instead of creating duplicates.
+3. Add regression coverage proving variant angles with the same model-returned
+   slug no longer collapse before the repository upsert.
+4. Remove the resolved blog-variant persistence item from `HARDENING.md`.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A blog generation call with `variant_angle` appends a stable
+        human-readable variant suffix to the draft slug.
+  - [ ] Two variant generations for the same blueprint/model slug produce
+        distinct saved draft slugs, so the repository can return distinct ids.
+  - [ ] A non-variant generation keeps the existing slug unchanged.
+  - [ ] The existing `metadata.variant_angle` threading and LLM metadata remain
+        unchanged.
+  - [ ] The repository upsert contract is not weakened: same-tenant,
+        same-slug non-variant reruns still update rather than duplicate.
+- Affected surfaces: extracted blog generation, blog draft persistence keys,
+  generated-asset review/export identity indirectly.
+- Risk areas: backward compatibility of slugs, idempotency, variant slug
+  determinism, scope creep into unrelated Gate A quality fixes.
+- Reviewer rules triggered: R1, R2, R5, R8, R10.
+
+### Files touched
+
+- `HARDENING.md`
+- `extracted_content_pipeline/blog_generation.py`
+- `plans/PR-Gate-A-Blog-Variant-Persistence.md`
+- `tests/test_extracted_blog_generation.py`
+
+## Mechanism
+
+`BlogPostGenerationService.generate(...)` already threads
+`variant_angle` into the prompt, LLM metadata, parsed payload, and draft
+metadata. The collapse happens later because `_build_draft(...)` still uses the
+model/blueprint slug as-is, and `PostgresBlogPostRepository.save_drafts(...)`
+upserts on `blog_posts.slug`.
+
+The fix keeps the repository contract intact and changes only the generated
+variant draft key:
+
+```python
+base_slug = _slugify(parsed.get("slug") or blueprint.get("slug") or title)
+slug = _slug_with_variant_suffix(base_slug, variant_angle)
+```
+
+The suffix is derived deterministically from the leading variant label
+(`"Pain-led: ..."` -> `pain-led`, `"Outcome-led: ..."` -> `outcome-led`) and is
+appended only when `variant_angle` is present and the slug does not already end
+with that suffix. The helper preserves the existing 100-character slug cap by
+reserving room for `-<suffix>`.
+
+## Intentional
+
+- No database migration: the existing unique slug upsert remains the
+  persistence guard.
+- No repository rewrite: changing `ON CONFLICT (slug)` would risk the
+  non-variant idempotency contract. Variant identity is a generation concern.
+- No live Gate A rerun in this PR: this closes the structural duplicate-id
+  failure with focused regression tests; the next acceptance run should happen
+  after the remaining quality hardening slices.
+- No prompt-quality fixes: debug-style blog prose, brand-voice misses,
+  landing-page sameness, sales-brief type drift, and messy-ticket grounding are
+  separate product-quality failures.
+- Cross-layer caller hints were inspected. Host wiring references are
+  unaffected because the `BlogPostGenerationService` constructor and
+  `generate(...)` port are unchanged; content-ops execution coverage ran in the
+  full extracted check. Same-name `_build_draft`, `_service`, and test fake
+  `save_drafts` hints outside this module are regex false positives, not shared
+  call sites.
+
+## Deferred
+
+- Gate A blog prose quality: resolve the parked "debug-style source narration"
+  item before rerunning the acceptance gate.
+- Gate A brand voice enforcement: resolve the parked second-person miss.
+- Gate A sales brief mode fidelity: keep the requested `brief_type` from being
+  overwritten by model JSON.
+- Gate A landing-page distinctness: make whole-page variants meaningfully
+  different, not only hero-headline variants.
+- Gate A messy-ticket rerun: rerun the live proof on noisy support-ticket data
+  after the structural and quality fixes are in place.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_blog_generation.py -q`: 78 passed.
+- `bash scripts/validate_extracted_content_pipeline.sh`: passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`: passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`: passed.
+- `bash scripts/check_ascii_python.sh`: passed.
+- `bash scripts/run_extracted_pipeline_checks.sh`: 3249 passed, 10 skipped.
+- Pending before push: `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `HARDENING.md` | 9 |
+| `extracted_content_pipeline/blog_generation.py` | 24 |
+| `plans/PR-Gate-A-Blog-Variant-Persistence.md` | 129 |
+| `tests/test_extracted_blog_generation.py` | 47 |
+| **Total** | **209** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -55,6 +55,12 @@ class _BlogPosts:
         raise AssertionError("not used")
 
 
+class _SlugIdBlogPosts(_BlogPosts):
+    async def save_drafts(self, drafts, *, scope):
+        self.saved.append({"drafts": list(drafts), "scope": scope})
+        return [draft.slug for draft in drafts]
+
+
 class _LLM:
     def __init__(self, responses):
         self.responses = list(responses)
@@ -294,9 +300,10 @@ def _service(
     config=None,
     reasoning_context=None,
     image_provider=None,
+    blog_posts=None,
 ):
     blueprints = _Blueprints(rows or [_blueprint()])
-    blog_posts = _BlogPosts()
+    blog_posts = blog_posts or _BlogPosts()
     llm = _LLM(responses or [_valid_blog_json()])
     if prompts is None:
         prompts = {"digest/blog_post_generation": "Write from {blueprint_json}"}
@@ -757,7 +764,45 @@ async def test_generate_threads_variant_angle_to_prompt_and_metadata() -> None:
     assert "same blueprint" in user_prompt
     assert llm.calls[0]["metadata"]["variant_angle"] == angle
     draft = blog_posts.saved[0]["drafts"][0]
+    assert draft.slug == "hubspot-pricing-pressure-pain-led"
     assert draft.metadata["variant_angle"] == angle
+
+
+@pytest.mark.asyncio
+async def test_generate_variant_angles_persist_under_distinct_slugs() -> None:
+    blog_posts = _SlugIdBlogPosts()
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        responses=[
+            _valid_blog_json(slug="hubspot-pricing-pressure"),
+            _valid_blog_json(slug="hubspot-pricing-pressure"),
+        ],
+        blog_posts=blog_posts,
+    )
+    scope = TenantScope(account_id="acct-1")
+
+    pain_result = await service.generate(
+        scope=scope,
+        target_mode="vendor_retention",
+        limit=1,
+        variant_angle="Pain-led: open with the buyer friction.",
+    )
+    outcome_result = await service.generate(
+        scope=scope,
+        target_mode="vendor_retention",
+        limit=1,
+        variant_angle="Outcome-led: lead with the business result.",
+    )
+
+    assert pain_result.saved_ids == ("hubspot-pricing-pressure-pain-led",)
+    assert outcome_result.saved_ids == ("hubspot-pricing-pressure-outcome-led",)
+    saved_slugs = [
+        saved["drafts"][0].slug
+        for saved in blog_posts.saved
+    ]
+    assert saved_slugs == [
+        "hubspot-pricing-pressure-pain-led",
+        "hubspot-pricing-pressure-outcome-led",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Gate-A-Blog-Variant-Persistence.md
Slice phase: Production hardening

Fixes the Gate A structural failure where multiple blog variants could collapse to one persisted draft id by giving variant generations deterministic slug suffixes before the existing slug upsert runs.

## Intentional

- No database migration: the existing unique slug upsert remains the persistence guard.
- No repository rewrite: same-slug non-variant reruns still update instead of duplicating.
- No live Gate A rerun in this PR; this closes the duplicate-id structural failure with focused regression tests.
- No prompt-quality fixes; the remaining Gate A quality failures stay parked for follow-up slices.
- Cross-layer caller hints were inspected; host wiring is unaffected because the constructor/generate port is unchanged, and same-name helper/test-fake hints outside this module are regex false positives.

## Deferred

- Gate A blog prose quality: resolve the parked debug-style source narration item before rerunning the acceptance gate.
- Gate A brand voice enforcement: resolve the parked second-person miss.
- Gate A sales brief mode fidelity: keep the requested `brief_type` from being overwritten by model JSON.
- Gate A landing-page distinctness: make whole-page variants meaningfully different.
- Gate A messy-ticket rerun: rerun the live proof on noisy support-ticket data after the structural and quality fixes are in place.

## Parked hardening

- None. This PR removes the resolved `HARDENING.md` item for blog variant draft-id collapse.

## Verification

- `python -m pytest tests/test_extracted_blog_generation.py -q`: 78 passed.
- `bash scripts/validate_extracted_content_pipeline.sh`: passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`: passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt`: passed.
- `bash scripts/check_ascii_python.sh`: passed.
- `bash scripts/run_extracted_pipeline_checks.sh`: 3249 passed, 10 skipped.

## Diff size

4 files, +150 / -12.
