### PR TITLE
Content-Ops Review Service Wiring

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_review_workflow_checks.yml"
       - "atlas_brain/_content_ops_review_workflow.py"
+      - "extracted_content_pipeline/campaign_ports.py"
       - "extracted_content_pipeline/claims_map.py"
       - "extracted_content_pipeline/content_pr.py"
       - "extracted_content_pipeline/review_contract.py"
@@ -15,6 +16,7 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_review_workflow_checks.yml"
       - "atlas_brain/_content_ops_review_workflow.py"
+      - "extracted_content_pipeline/campaign_ports.py"
       - "extracted_content_pipeline/claims_map.py"
       - "extracted_content_pipeline/content_pr.py"
       - "extracted_content_pipeline/review_contract.py"

--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -1,0 +1,46 @@
+name: Atlas Content Ops Review Workflow Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_content_ops_review_workflow_checks.yml"
+      - "atlas_brain/_content_ops_review_workflow.py"
+      - "extracted_content_pipeline/claims_map.py"
+      - "extracted_content_pipeline/content_pr.py"
+      - "extracted_content_pipeline/review_contract.py"
+      - "tests/test_atlas_content_ops_review_workflow.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_content_ops_review_workflow_checks.yml"
+      - "atlas_brain/_content_ops_review_workflow.py"
+      - "extracted_content_pipeline/claims_map.py"
+      - "extracted_content_pipeline/content_pr.py"
+      - "extracted_content_pipeline/review_contract.py"
+      - "tests/test_atlas_content_ops_review_workflow.py"
+
+jobs:
+  atlas-content-ops-review-workflow-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Content Ops review workflow tests
+        run: |
+          python -m pytest \
+            tests/test_atlas_content_ops_review_workflow.py \
+            -q

--- a/atlas_brain/_content_ops_review_workflow.py
+++ b/atlas_brain/_content_ops_review_workflow.py
@@ -1,0 +1,189 @@
+"""Host wiring for the Content Ops review-contract engine.
+
+The extracted package owns the deterministic review logic. This module is the
+first host callable around it: tenant scope comes from Atlas, approved claims
+come from an injected tenant registry reader, and the verdict still delegates to
+the pure Content-PR engine.
+
+No DB, FastAPI, MCP, or LLM code lives here. Those layers should wrap this
+service instead of reimplementing review logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Mapping, Protocol
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.claims_map import (
+    ExtractedClaim,
+    MappedClaim,
+    RegistryClaim,
+    build_claims_map,
+)
+from extracted_content_pipeline.content_pr import (
+    ContentPR,
+    CoverageRow,
+    ReviewComment,
+    RulePacketVersions,
+    review_verdict,
+    verdict_reasons,
+)
+from extracted_content_pipeline.review_contract import ReviewDecision
+
+
+class TenantClaimRegistryReader(Protocol):
+    """Read approved marketing claims for one tenant scope."""
+
+    async def list_registry_claims(
+        self,
+        *,
+        scope: TenantScope,
+    ) -> Mapping[str, RegistryClaim]:
+        """Return registry claims keyed by registry id."""
+
+
+@dataclass(frozen=True)
+class ContentOpsReviewRequest:
+    """Structured request a future marketer MCP tool can pass through."""
+
+    asset_id: str = ""
+    rule_packet: RulePacketVersions = RulePacketVersions()
+    coverage: tuple[CoverageRow, ...] = ()
+    extracted_claims: tuple[ExtractedClaim, ...] = ()
+    comments: tuple[ReviewComment, ...] = ()
+    as_of: date | None = None
+
+
+@dataclass(frozen=True)
+class ContentOpsReviewResult:
+    """Tool-shaped review result plus the Content-PR envelope."""
+
+    decision: ReviewDecision
+    reasons: tuple[str, ...]
+    mapped_claims: tuple[MappedClaim, ...]
+    content_pr: ContentPR
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible shape for future transport wrappers."""
+
+        return {
+            "ok": self.decision == ReviewDecision.APPROVED,
+            "decision": _value(self.decision),
+            "reasons": list(self.reasons),
+            "mapped_claims": [_mapped_claim_as_dict(claim) for claim in self.mapped_claims],
+            "content_pr": {
+                "asset_id": self.content_pr.asset_id,
+                "rule_packet": {
+                    "brief": self.content_pr.rule_packet.brief,
+                    "brand_voice": self.content_pr.rule_packet.brand_voice,
+                    "claim_registry": self.content_pr.rule_packet.claim_registry,
+                    "compliance": self.content_pr.rule_packet.compliance,
+                    "channel_schema": self.content_pr.rule_packet.channel_schema,
+                },
+                "coverage": [_coverage_row_as_dict(row) for row in self.content_pr.coverage],
+                "comments": [_comment_as_dict(comment) for comment in self.content_pr.comments],
+            },
+        }
+
+
+async def run_content_ops_review(
+    request: ContentOpsReviewRequest,
+    *,
+    scope: TenantScope | None,
+    registry_reader: TenantClaimRegistryReader,
+) -> ContentOpsReviewResult:
+    """Build a tenant claims map and compute the deterministic review verdict."""
+
+    if not _scope_account_id(scope):
+        return _blocked_result(request, "tenant scope required")
+
+    registry = await registry_reader.list_registry_claims(scope=scope)
+    mapped_claims = build_claims_map(
+        request.extracted_claims,
+        registry,
+        as_of=request.as_of or date.today(),
+    )
+    content_pr = ContentPR(
+        asset_id=request.asset_id,
+        rule_packet=request.rule_packet,
+        coverage=request.coverage,
+        claims=mapped_claims,
+        comments=request.comments,
+    )
+    decision = review_verdict(content_pr)
+    return ContentOpsReviewResult(
+        decision=decision,
+        reasons=verdict_reasons(content_pr),
+        mapped_claims=mapped_claims,
+        content_pr=content_pr,
+    )
+
+
+def _blocked_result(
+    request: ContentOpsReviewRequest,
+    reason: str,
+) -> ContentOpsReviewResult:
+    content_pr = ContentPR(
+        asset_id=request.asset_id,
+        rule_packet=request.rule_packet,
+        coverage=request.coverage,
+        claims=(),
+        comments=request.comments,
+    )
+    return ContentOpsReviewResult(
+        decision=ReviewDecision.BLOCKED,
+        reasons=(reason,),
+        mapped_claims=(),
+        content_pr=content_pr,
+    )
+
+
+def _scope_account_id(scope: TenantScope | None) -> str:
+    value = getattr(scope, "account_id", None)
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _mapped_claim_as_dict(claim: MappedClaim) -> dict[str, Any]:
+    return {
+        "text": claim.text,
+        "location": claim.location,
+        "registry_id": claim.registry_id,
+        "approved_wording": claim.approved_wording,
+        "status": _value(claim.status),
+        "risk_tier": _value(claim.risk_tier),
+    }
+
+
+def _coverage_row_as_dict(row: CoverageRow) -> dict[str, Any]:
+    return {
+        "rule_id": row.rule_id,
+        "requirement": row.requirement,
+        "required": row.required,
+        "status": _value(row.status),
+        "evidence": row.evidence,
+    }
+
+
+def _comment_as_dict(comment: ReviewComment) -> dict[str, Any]:
+    return {
+        "category": _value(comment.category),
+        "message": comment.message,
+        "evidence": comment.evidence,
+        "blocking": comment.blocking,
+    }
+
+
+def _value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+__all__ = [
+    "ContentOpsReviewRequest",
+    "ContentOpsReviewResult",
+    "TenantClaimRegistryReader",
+    "run_content_ops_review",
+]

--- a/plans/PR-Content-Ops-Review-Service-Wiring.md
+++ b/plans/PR-Content-Ops-Review-Service-Wiring.md
@@ -1,0 +1,130 @@
+# PR - Content-Ops Review Service Wiring
+
+## Why this slice exists
+
+`docs/content_ops_operating_model.md` and issue #1338 say slices 1-4 landed the
+deterministic review-contract core, but the engine is still an island: the
+Content-PR verdict, claims map, and coverage matrix have no non-test caller.
+Issue #1353 narrows the delivery direction: the marketer MCP is future work,
+but the wiring phase must be built tenant-scoped and tool-shaped from day one so
+that the eventual MCP server is a thin transport wrapper.
+
+This slice starts the wiring phase instead of slice 5. Slice 5's calibration
+library and adversarial pass are useful, but optional for the verify-only v1;
+the blocking product gap is that a marketer's structured draft cannot yet be
+verified through a host service.
+
+The diff is over the 400 LOC soft cap because the tests prove each required
+failure branch of the service boundary: missing tenant scope, missing coverage,
+unresolved coverage, failed coverage, decoded string status, mismatched claims,
+expired claims, and blocking comments. The production service stays under 200
+LOC; the overage is the failure-detection proof AGENTS.md requires for gates
+plus the dedicated Atlas workflow enrollment required for a new test importing
+the host package.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+Add the first host-layer callable review workflow:
+
+1. Add a small Atlas service module that accepts a tenant scope, a structured
+   review request, and an injected tenant registry reader.
+2. Build a tenant-specific claims map from caller-provided structured claims and
+   registry entries, then delegate the final decision to the existing
+   deterministic Content-PR verdict engine.
+3. Return a tool-shaped result containing the decision, reasons, mapped claims,
+   and Content-PR envelope so a future MCP tool can wrap it without embedding
+   review logic.
+4. Prove tenant isolation and fail-closed behavior with focused tests.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The service requires a `TenantScope` with a non-empty account id before
+        reading any registry data.
+  - [ ] The registry reader receives the tenant scope, not a free-form account
+        id from the request payload.
+  - [ ] Caller-provided structured claims are mapped against the tenant
+        registry before the verdict is computed.
+  - [ ] Missing scope, missing coverage, unresolved coverage, failed coverage,
+        mismatched claims, expired claims, and blocking comments produce the
+        expected non-approval decisions.
+  - [ ] Decoded/string enum values continue to block by equality, not identity.
+  - [ ] No LLM, DB, FastAPI, or MCP transport logic is introduced in this
+        slice.
+- Affected surfaces: service, auth/tenant scope, CI enrollment.
+- Risk areas: tenant isolation, backcompat, decoded input robustness,
+  maintainability.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12.
+
+### Files touched
+
+- `atlas_brain/_content_ops_review_workflow.py`
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+- `tests/test_atlas_content_ops_review_workflow.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `plans/PR-Content-Ops-Review-Service-Wiring.md`
+
+## Mechanism
+
+The service owns only orchestration. It takes a typed request containing rule
+packet versions, coverage rows, extracted claims, comments, and an evaluation
+date. It asks an injected registry reader for that tenant's approved claims,
+uses the existing claims-map module to classify the draft claims, then builds a
+Content-PR and delegates the decision to the existing verdict engine.
+
+The tenant registry reader is a narrow port in this host service, not a
+database implementation. That gives the later Postgres registry slice a stable
+boundary to implement and gives the later MCP server a single callable service
+to wrap.
+
+## Intentional
+
+- This is wiring, not slice 5: calibration examples, adversarial pass models,
+  and model-disagreement orchestration stay out.
+- This does not build the marketer MCP server. Transport comes after the
+  service, registry persistence, tenant-binding bridge, and verdict/status
+  mapping are proven.
+- This does not add Postgres claim-registry persistence yet. The service is
+  tenant-scoped and registry-shaped now; the next slice plugs a tenant
+  Postgres repository into the reader port.
+- Claims extraction from prose remains caller-owned for v1. The marketer's
+  model must provide structured claims, matching issue #1353's "verify, don't
+  generate" decision.
+- The existing generated-assets lifecycle status strings are not changed here.
+
+## Deferred
+
+- `PR-Content-Ops-Claim-Registry-Persistence`: tenant-scoped claim/messaging
+  registry table plus CRUD/list repository that implements this slice's
+  registry-reader boundary.
+- `PR-Content-Ops-Review-Status-Mapping`: map review decisions onto the
+  generated-asset lifecycle vocabulary.
+- `PR-Content-Ops-Quality-Gate-Coverage-Rows`: map deterministic
+  `extracted_quality_gate` findings and brand-voice banned-term checks into
+  coverage rows.
+- `PR-Marketer-Verification-MCP`: write-capable OAuth MCP connector and tool
+  surface after the service and registry are wired.
+- Parked hardening: none expected unless implementation surfaces non-blocking
+  tenant-binding or observability gaps.
+
+## Verification
+
+- Focused pytest command for the review workflow test -- 10 passed.
+- Extracted pipeline CI enrollment audit command -- 154 matching tests are
+  enrolled.
+- ASCII Python policy command -- passed.
+- Local PR review command with the PR body file -- to run before push.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_review_workflow_checks.yml` | 46 |
+| `atlas_brain/_content_ops_review_workflow.py` | 189 |
+| `tests/test_atlas_content_ops_review_workflow.py` | 253 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `plans/PR-Content-Ops-Review-Service-Wiring.md` | 130 |
+| **Total** | **619** |

--- a/plans/PR-Content-Ops-Review-Service-Wiring.md
+++ b/plans/PR-Content-Ops-Review-Service-Wiring.md
@@ -122,9 +122,9 @@ to wrap.
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/atlas_content_ops_review_workflow_checks.yml` | 46 |
+| `.github/workflows/atlas_content_ops_review_workflow_checks.yml` | 48 |
 | `atlas_brain/_content_ops_review_workflow.py` | 189 |
 | `tests/test_atlas_content_ops_review_workflow.py` | 253 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `plans/PR-Content-Ops-Review-Service-Wiring.md` | 130 |
-| **Total** | **619** |
+| **Total** | **621** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -103,6 +103,7 @@ pytest \
   tests/test_extracted_content_ops_execution.py \
   tests/test_extracted_content_ops_execution_smoke.py \
   tests/test_atlas_content_ops_infrastructure.py \
+  tests/test_atlas_content_ops_review_workflow.py \
   tests/test_atlas_content_ops_generated_assets_api.py \
   tests/test_atlas_content_ops_import_admission.py \
   tests/test_atlas_content_ops_input_provider.py \

--- a/tests/test_atlas_content_ops_review_workflow.py
+++ b/tests/test_atlas_content_ops_review_workflow.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+import pytest
+
+from atlas_brain._content_ops_review_workflow import (
+    ContentOpsReviewRequest,
+    run_content_ops_review,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.claims_map import ClaimStatus, ExtractedClaim, RegistryClaim
+from extracted_content_pipeline.content_pr import (
+    CommentCategory,
+    CoverageRow,
+    CoverageStatus,
+    ReviewComment,
+    RulePacketVersions,
+)
+from extracted_content_pipeline.review_contract import ReviewDecision, RiskTier
+
+
+_AS_OF = date(2026, 6, 7)
+_PINNED = RulePacketVersions(
+    brief="brief-v1",
+    brand_voice="voice-v1",
+    claim_registry="claims-v1",
+    compliance="compliance-v1",
+    channel_schema="channel-v1",
+)
+
+
+@dataclass
+class _RegistryReader:
+    registry: dict[str, RegistryClaim]
+    scopes: list[TenantScope]
+
+    async def list_registry_claims(self, *, scope: TenantScope):
+        self.scopes.append(scope)
+        return self.registry
+
+
+def _reader() -> _RegistryReader:
+    return _RegistryReader(
+        registry={
+            "pricing.discount": RegistryClaim(
+                id="pricing.discount",
+                approved_wording="Save up to 30% on eligible annual plans",
+                risk_tier=RiskTier.HIGH,
+                expiration=date(2026, 1, 31),
+            ),
+            "feature.sso": RegistryClaim(
+                id="feature.sso",
+                approved_wording="SSO is included on every plan",
+                risk_tier=RiskTier.MEDIUM,
+            ),
+        },
+        scopes=[],
+    )
+
+
+def _pass_row(rule_id: str = "VOICE-01") -> CoverageRow:
+    return CoverageRow(
+        rule_id=rule_id,
+        requirement="Rule must be evidenced",
+        status=CoverageStatus.PASS,
+        evidence="quoted draft span",
+    )
+
+
+def _request(**overrides) -> ContentOpsReviewRequest:
+    values = {
+        "asset_id": "asset-1",
+        "rule_packet": _PINNED,
+        "coverage": (_pass_row(),),
+        "extracted_claims": (
+            ExtractedClaim(
+                text="SSO is included on every plan",
+                location="hero",
+                registry_id="feature.sso",
+            ),
+        ),
+        "comments": (),
+        "as_of": _AS_OF,
+    }
+    values.update(overrides)
+    return ContentOpsReviewRequest(**values)
+
+
+@pytest.mark.asyncio
+async def test_missing_tenant_scope_blocks_without_reading_registry() -> None:
+    reader = _reader()
+
+    result = await run_content_ops_review(
+        _request(),
+        scope=TenantScope(account_id=" "),
+        registry_reader=reader,
+    )
+
+    assert result.decision == ReviewDecision.BLOCKED
+    assert result.reasons == ("tenant scope required",)
+    assert result.mapped_claims == ()
+    assert reader.scopes == []
+
+
+@pytest.mark.asyncio
+async def test_registry_reader_receives_tenant_scope_not_request_account_id() -> None:
+    reader = _reader()
+    scope = TenantScope(account_id="acct-1", user_id="user-1")
+
+    result = await run_content_ops_review(
+        _request(),
+        scope=scope,
+        registry_reader=reader,
+    )
+
+    assert result.decision == ReviewDecision.APPROVED
+    assert reader.scopes == [scope]
+    assert result.content_pr.asset_id == "asset-1"
+    assert result.mapped_claims[0].status == ClaimStatus.MATCH
+
+
+@pytest.mark.asyncio
+async def test_result_as_dict_is_tool_shaped() -> None:
+    result = await run_content_ops_review(
+        _request(),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    payload = result.as_dict()
+
+    assert payload["ok"] is True
+    assert payload["decision"] == "approved"
+    assert payload["reasons"] == []
+    assert payload["mapped_claims"][0]["status"] == "match"
+    assert payload["mapped_claims"][0]["risk_tier"] == "medium"
+    assert payload["content_pr"]["asset_id"] == "asset-1"
+    assert payload["content_pr"]["coverage"][0]["status"] == "pass"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("review_request", "expected_reason"),
+    [
+        (
+            _request(coverage=()),
+            "missing coverage matrix",
+        ),
+        (
+            _request(coverage=(CoverageRow(rule_id="VOICE-02"),)),
+            "unresolved required coverage",
+        ),
+    ],
+)
+async def test_incomplete_review_blocks(
+    review_request: ContentOpsReviewRequest,
+    expected_reason: str,
+) -> None:
+    result = await run_content_ops_review(
+        review_request,
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.BLOCKED
+    assert any(expected_reason in reason for reason in result.reasons)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "review_request",
+    [
+        _request(
+            coverage=(
+                CoverageRow(
+                    rule_id="CLAIM-01",
+                    status=CoverageStatus.FAIL,
+                    evidence="discount overclaim",
+                ),
+            ),
+        ),
+        _request(
+            coverage=(
+                CoverageRow(
+                    rule_id="CLAIM-01",
+                    status="fail",
+                    evidence="decoded string status",
+                ),
+            ),
+        ),
+    ],
+)
+async def test_failed_coverage_requires_revision(
+    review_request: ContentOpsReviewRequest,
+) -> None:
+    result = await run_content_ops_review(
+        review_request,
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.REVISION_REQUIRED
+    assert any("failed required coverage" in reason for reason in result.reasons)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "claim",
+    [
+        ExtractedClaim(
+            text="Save 30% on all plans",
+            location="hero",
+            registry_id="pricing.discount",
+        ),
+        ExtractedClaim(
+            text="Save up to 30% on eligible annual plans",
+            location="hero",
+            registry_id="pricing.discount",
+        ),
+    ],
+)
+async def test_blocking_claims_require_revision(claim: ExtractedClaim) -> None:
+    result = await run_content_ops_review(
+        _request(extracted_claims=(claim,)),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.REVISION_REQUIRED
+    assert any("blocking claim" in reason for reason in result.reasons)
+
+
+@pytest.mark.asyncio
+async def test_blocking_comment_requires_revision() -> None:
+    result = await run_content_ops_review(
+        _request(
+            comments=(
+                ReviewComment(
+                    category=CommentCategory.BRIEF,
+                    message="Promise does not match brief",
+                    evidence="brief primary promise",
+                    blocking=True,
+                ),
+            ),
+        ),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.REVISION_REQUIRED
+    assert any("blocking comment" in reason for reason in result.reasons)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Service-Wiring.md
Slice phase: Vertical slice

Starts the content operating-model wiring phase by adding a host-layer review workflow service: it requires tenant scope, reads approved claims through an injected tenant registry reader, builds the tenant-specific claims map, and delegates the final decision to the existing deterministic Content-PR verdict engine.

## Intentional
- Host service only; no DB, FastAPI, MCP, or LLM transport logic.
- Claims extraction remains caller-owned for verify-only v1.
- Postgres claim-registry persistence and generated-asset status mapping are deferred.

## Deferred
- `PR-Content-Ops-Claim-Registry-Persistence`: tenant-scoped claim/messaging registry table plus CRUD/list repository that implements this slice's registry-reader boundary.
- `PR-Content-Ops-Review-Status-Mapping`: map review decisions onto the generated-asset lifecycle vocabulary.
- `PR-Content-Ops-Quality-Gate-Coverage-Rows`: map deterministic `extracted_quality_gate` findings and brand-voice banned-term checks into coverage rows.
- `PR-Marketer-Verification-MCP`: write-capable OAuth MCP connector and tool surface after the service and registry are wired.

## Parked hardening
- None.

## Verification
- `pytest tests/test_atlas_content_ops_review_workflow.py` -- 10 passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- 154 matching tests are enrolled.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-content-ops-review-service-wiring-body.md` -- passed.

## Diff size
5 files, +621 / -0.
