### PR TITLE
Gate A Sales Brief Type Lock

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -68,15 +68,6 @@ register under `docs/technical-debt/`.
 - Owner/session: Codex Gate A live output-quality proof
 - Found during: PR-Gate-A-Live-Output-Quality-Proof
 
-### Sales brief live generation drifts from requested renewal brief type
-- File/location: `extracted_content_pipeline/sales_brief_generation.py`
-- Description: Gate A requested `inputs.brief_type=renewal`; all three exported sales briefs stored `brief_type=pre_call` because the model's parsed JSON won over the configured default.
-- Why it matters: review/export proves persistence, but the output contract can ignore the operator's requested sales-brief mode.
-- Effort: S
-- Category: correctness
-- Owner/session: Codex Gate A live output-quality proof
-- Found during: PR-Gate-A-Live-Output-Quality-Proof
-
 ## 2026-05-29
 
 ### atlas-intel-ui npm audit vulnerabilities

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -588,12 +588,13 @@ class SalesBriefGenerationService:
                 v = str(evidence_id).strip()
                 if v and v not in ref_seen:
                     ref_seen.append(v)
-        # Per-call override (when present and non-empty) wins over the
-        # construction-time default. PR-OptionA-1: makes the plan's
-        # step.config["default_brief_type"] load-bearing at dispatch time.
-        # The LLM's own `brief_type` JSON field still wins when present.
-        configured_default = (default_brief_type or "").strip() or self._config.default_brief_type
-        brief_type = str(parsed.get("brief_type") or configured_default)
+        # Per-call override (when present and non-empty) is the requested
+        # output contract from the run plan. The model field remains only a
+        # fallback for callers that did not request a specific brief type.
+        requested_default = (default_brief_type or "").strip()
+        model_brief_type = str(parsed.get("brief_type") or "").strip()
+        configured_default = str(self._config.default_brief_type or "").strip()
+        brief_type = requested_default or model_brief_type or configured_default
         metadata: dict[str, Any] = {
             "generation_model": parsed.get("_model"),
             "generation_usage": parsed.get("_usage") or {},

--- a/plans/PR-Gate-A-Sales-Brief-Type-Lock.md
+++ b/plans/PR-Gate-A-Sales-Brief-Type-Lock.md
@@ -1,0 +1,120 @@
+# PR-Gate-A-Sales-Brief-Type-Lock
+
+## Why this slice exists
+
+Gate A live validation found that sales brief generation accepted
+`inputs.brief_type=renewal`, but all exported sales briefs stored
+`brief_type=pre_call` because the model-returned JSON field won over the
+requested/default brief type. That breaks the output contract: the operator can
+ask for a renewal brief and still persist a pre-call brief if the model drifts.
+
+This slice closes the parked `HARDENING.md` finding
+`Sales brief live generation drifts from requested renewal brief type` by making
+the requested/default brief type authoritative whenever it is provided.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/gate-a-output-quality
+Slice phase: Production hardening
+
+1. Change sales brief draft construction so a non-empty per-call
+   `default_brief_type` wins over the LLM's parsed `brief_type`.
+2. Preserve the construction-time default fallback when the per-call override is
+   absent.
+3. Keep the LLM's parsed `brief_type` only as a fallback when no requested/default
+   type exists.
+4. Update focused sales-brief generation tests to prove the requested brief type
+   overrides a conflicting model field.
+5. Remove the resolved Gate A hardening entry.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A generation request with `default_brief_type="renewal"` persists
+        `brief_type="renewal"` even when the LLM returns `"pre_call"`.
+  - [ ] The existing config default fallback still fills `brief_type` when the
+        per-call default and model field are absent.
+  - [ ] Variant-angle metadata, quality checks, source material routing, and
+        persistence calls are unchanged.
+  - [ ] The resolved `HARDENING.md` entry is removed without changing unrelated
+        parked items.
+- Affected surfaces: extracted content pipeline sales brief generation; Gate A
+  validation quality; persisted sales brief metadata.
+- Risk areas: backcompat for callers that intentionally trusted model-provided
+  brief types; test/CI enrollment for extracted package checks.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `HARDENING.md`
+- `extracted_content_pipeline/sales_brief_generation.py`
+- `plans/PR-Gate-A-Sales-Brief-Type-Lock.md`
+- `tests/test_extracted_sales_brief_generation.py`
+
+## Mechanism
+
+`SalesBriefGenerationService.generate(...)` already resolves the requested
+brief type from `generation_plan.py` into the `default_brief_type` argument and
+passes it to `_build_draft(...)`. The bug is only the precedence inside
+`_build_draft(...)`.
+
+The draft builder now resolves:
+
+```text
+per-call requested brief type -> model brief_type -> service config default
+```
+
+That keeps the requested run shape load-bearing. If no caller provides a
+per-call requested type, the model field still works as before; if neither
+exists, the existing `SalesBriefGenerationConfig.default_brief_type` fallback
+remains.
+
+## Intentional
+
+- This does not add a new `brief_type` validator or enum. Existing callers and
+  stored rows already use string values; this slice only fixes precedence.
+- This does not change the prompt. The model may still emit a conflicting
+  `brief_type`; the persisted contract ignores that conflict when the caller
+  supplied an explicit requested/default type.
+- No live Gate A rerun is included. The focused regression test proves the
+  precise bug; a future Gate A rerun can validate output quality end to end.
+- Cross-layer caller hints were inspected. Host wiring references are
+  unaffected because the `SalesBriefGenerationService` constructor and
+  `generate(...)` port are unchanged; the full extracted check covered
+  content-ops execution and sales-brief export callers. Same-name
+  `_build_draft` hints in other generators are regex false positives, not
+  shared call sites.
+
+## Deferred
+
+- Gate A rerun on messy tickets remains parked separately in `HARDENING.md`.
+- Broader brand-voice POV failures and samey variant quality are separate Gate A
+  hardening slices.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_sales_brief_generation.py -q` -
+  PASS; `30 passed in 0.10s` after rebasing onto current `origin/main`.
+- `bash scripts/validate_extracted_content_pipeline.sh` - PASS; mapped files
+  matched `atlas_brain` sources and hard Atlas imports were clean.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - PASS; `forbid_atlas_reasoning_imports: clean`.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS;
+  `Atlas runtime import findings: 0`.
+- `bash scripts/check_ascii_python.sh` - PASS; ASCII check passed for
+  `extracted_content_pipeline` Python files.
+- `bash scripts/run_extracted_pipeline_checks.sh` - PASS; package wrapper
+  completed with `3250 passed, 10 skipped, 1 warning`.
+- Pending before push: `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `HARDENING.md` | 9 |
+| `extracted_content_pipeline/sales_brief_generation.py` | 13 |
+| `plans/PR-Gate-A-Sales-Brief-Type-Lock.md` | 120 |
+| `tests/test_extracted_sales_brief_generation.py` | 24 |
+| **Total** | **166** |

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -680,8 +680,8 @@ async def test_generate_per_call_default_brief_type_override_when_llm_omits_type
 
 
 @pytest.mark.asyncio
-async def test_generate_llm_supplied_brief_type_still_wins_over_per_call_override():
-    """The per-call override only fills in when the LLM omits `brief_type`."""
+async def test_generate_per_call_default_brief_type_wins_over_model_type():
+    """The requested plan brief_type is authoritative when the model drifts."""
 
     service, _intel, sales_briefs, _llm, _skills, _rp = _service(
         responses=[_valid_brief_json(brief_type="pre_call")],
@@ -691,7 +691,25 @@ async def test_generate_llm_supplied_brief_type_still_wins_over_per_call_overrid
     await service.generate(
         scope=TenantScope(account_id="acct-1"),
         target_mode="vendor",
-        default_brief_type="renewal",  # ignored: LLM supplied pre_call
+        default_brief_type="renewal",
+    )
+
+    saved_drafts = sales_briefs.saved[0]["drafts"]
+    assert saved_drafts[0].brief_type == "renewal"
+
+
+@pytest.mark.asyncio
+async def test_generate_llm_supplied_brief_type_still_wins_without_per_call_override():
+    """When no requested brief_type is supplied, the model field remains a fallback."""
+
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=[_valid_brief_json(brief_type="pre_call")],
+        config=SalesBriefGenerationConfig(default_brief_type="discovery"),
+    )
+
+    await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
     )
 
     saved_drafts = sales_briefs.saved[0]["drafts"]


### PR DESCRIPTION
Plan: plans/PR-Gate-A-Sales-Brief-Type-Lock.md
Slice phase: Production hardening

Fixes the Gate A sales-brief contract drift where a request for `brief_type=renewal` could still persist the model-returned `pre_call` brief type.

## Intentional

- No new `brief_type` validator or enum; existing callers and stored rows use string values.
- No prompt change; conflicting model JSON is ignored only when the caller supplied an explicit requested/default type.
- No live Gate A rerun in this PR; focused regression tests prove the precise bug.
- Cross-layer caller hints were inspected; host wiring is unaffected because the constructor/generate port is unchanged, full extracted checks covered execution/export callers, and same-name `_build_draft` hints in other generators are regex false positives.

## Deferred

- Gate A rerun on messy tickets remains parked separately in `HARDENING.md`.
- Broader brand-voice POV failures and samey variant quality are separate Gate A hardening slices.

## Parked hardening

- None. This PR removes the resolved `HARDENING.md` item for sales brief type drift.

## Verification

- `python -m pytest tests/test_extracted_sales_brief_generation.py -q`: 30 passed.
- `bash scripts/validate_extracted_content_pipeline.sh`: passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`: passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt`: passed.
- `bash scripts/check_ascii_python.sh`: passed.
- `bash scripts/run_extracted_pipeline_checks.sh`: 3250 passed, 10 skipped, 1 warning.

## Diff size

4 files, +142 / -18.
