### PR TITLE
Gate A Sales Brief Type Prompt Steering

### DIFF
--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -214,9 +214,9 @@ def _sales_brief_user_prompt(
             "Requested brief type:\n"
             f"- {resolved_brief_type}: "
             f"{_brief_type_prompt_guidance(resolved_brief_type)}\n"
-            "Use only the supplied opportunity evidence; do not invent contract "
-            "dates, renewal windows, competitor names, or timelines that are not "
-            "in the data."
+            "Use only the supplied opportunity evidence; do not invent "
+            "contract dates, renewal windows, competitor names, or timelines "
+            "that are not in the data."
         )
     resolved_variant_angle = str(variant_angle or "").strip()
     if resolved_variant_angle:

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -203,9 +203,18 @@ def _has_prompt_reasoning_context(payload: Mapping[str, Any]) -> bool:
 def _sales_brief_user_prompt(
     prior_invalid_response: str = "",
     *,
+    brief_type: str | None = None,
     variant_angle: str | None = None,
 ) -> str:
     prompt = "Generate one sales brief from the opportunity above."
+    resolved_brief_type = str(brief_type or "").strip()
+    if resolved_brief_type:
+        prompt = (
+            f"{prompt}\n\n"
+            "Requested brief type:\n"
+            f"- {resolved_brief_type}: "
+            f"{_brief_type_prompt_guidance(resolved_brief_type)}"
+        )
     resolved_variant_angle = str(variant_angle or "").strip()
     if resolved_variant_angle:
         prompt = (
@@ -223,6 +232,34 @@ def _sales_brief_user_prompt(
             "The previous response could not be parsed as the required JSON object. "
             "Return one JSON object with non-empty title and sections."
         ),
+    )
+
+
+def _brief_type_prompt_guidance(brief_type: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(brief_type or "").lower()).strip("_")
+    guidance = {
+        "pre_call": (
+            "write for the 30 seconds before a sales call: account context, "
+            "why now, questions to ask, objections, and next actions."
+        ),
+        "renewal": (
+            "write for renewal-stage retention, expansion, contract timing, "
+            "renewal risk, and the account-specific reason to act before the "
+            "renewal window closes."
+        ),
+        "displacement": (
+            "write for a competitive displacement motion: incumbent pain, "
+            "switching trigger, competitor risk, proof points, and the safest "
+            "next step."
+        ),
+        "discovery": (
+            "write for discovery: unknowns to validate, buyer pain hypotheses, "
+            "questions to ask, and evidence that should shape qualification."
+        ),
+    }
+    return guidance.get(
+        normalized,
+        "write the brief so its substance matches this requested sales motion.",
     )
 
 
@@ -311,6 +348,7 @@ class SalesBriefGenerationService:
             scope=scope,
         )
         resolved_variant_angle = str(variant_angle or "").strip() or None
+        requested_brief_type = str(default_brief_type or "").strip() or None
 
         requested = int(limit or self._config.limit)
         source_opportunities = _opportunities_from_source_material(
@@ -364,6 +402,7 @@ class SalesBriefGenerationService:
                     parse_retry_attempts=resolved_parse_retry_attempts,
                     parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                     brand_voice=resolved_brand_voice,
+                    brief_type=requested_brief_type,
                     variant_angle=resolved_variant_angle,
                 )
             except Exception as exc:
@@ -469,6 +508,7 @@ class SalesBriefGenerationService:
         parse_retry_attempts: int,
         parse_retry_response_excerpt_chars: int,
         brand_voice: BrandVoiceProfile | None = None,
+        brief_type: str | None = None,
         variant_angle: str | None = None,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
@@ -502,6 +542,7 @@ class SalesBriefGenerationService:
                         role="user",
                         content=_sales_brief_user_prompt(
                             last_response,
+                            brief_type=brief_type,
                             variant_angle=resolved_variant_angle,
                         ),
                     ),

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -213,7 +213,10 @@ def _sales_brief_user_prompt(
             f"{prompt}\n\n"
             "Requested brief type:\n"
             f"- {resolved_brief_type}: "
-            f"{_brief_type_prompt_guidance(resolved_brief_type)}"
+            f"{_brief_type_prompt_guidance(resolved_brief_type)}\n"
+            "Use only the supplied opportunity evidence; do not invent contract "
+            "dates, renewal windows, competitor names, or timelines that are not "
+            "in the data."
         )
     resolved_variant_angle = str(variant_angle or "").strip()
     if resolved_variant_angle:

--- a/plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md
+++ b/plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md
@@ -22,9 +22,11 @@ Slice phase: Production hardening
    user prompt.
 2. Add brief-type-specific guidance for the known motions:
    `pre_call`, `renewal`, `displacement`, and `discovery`.
-3. Keep no-request behavior unchanged: when no per-call brief type is supplied,
+3. Add a grounding guard so the motion-specific guidance does not invite
+   invented contract dates, renewal windows, competitor names, or timelines.
+4. Keep no-request behavior unchanged: when no per-call brief type is supplied,
    the prompt stays at its existing generic/default shape.
-4. Add focused tests proving renewal prompt steering and no-request backward
+5. Add focused tests proving renewal prompt steering and no-request backward
    compatibility.
 
 ### Review Contract
@@ -34,6 +36,8 @@ Slice phase: Production hardening
         explicit requested brief-type block in the user prompt.
   - [ ] The renewal prompt guidance mentions renewal-stage concerns such as
         retention, expansion, contract timing, or renewal risk.
+  - [ ] The brief-type guidance tells the model to use only supplied
+        opportunity evidence and not invent contract/timeline details.
   - [ ] A generation call without a per-call `default_brief_type` keeps the
         existing prompt free of a requested brief-type block.
   - [ ] Variant-angle prompt steering still works alongside brief-type
@@ -65,6 +69,8 @@ brief type:
 Requested brief type:
 - renewal: write for renewal-stage retention, expansion, contract timing, and
   renewal-risk discussion.
+Use only the supplied opportunity evidence; do not invent contract dates,
+renewal windows, competitor names, or timelines that are not in the data.
 ```
 
 Unknown values still get a generic "match this requested sales motion" line so
@@ -86,6 +92,9 @@ per-call requested brief type -> model brief_type -> service config default
   wiring with focused unit coverage; live acceptance belongs after the remaining
   Gate A quality slices.
 - This does not change persisted `brief_type` precedence from #1364.
+- This adds the review-requested grounding guard in the user prompt instead of
+  weakening the motion-specific guidance; the prompt can still steer toward a
+  motion, but only from supplied opportunity evidence.
 - Cross-layer caller hints were inspected for `SalesBriefGenerationService`.
   The changed parameters are optional keyword/defaulted prompt inputs, so
   existing constructor/generate callers keep the old behavior; the no-request
@@ -105,7 +114,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_extracted_sales_brief_generation.py -q` -
-  31 passed in 0.12s.
+  31 passed in 0.11s after adding the grounding-guard assertion.
 - `bash scripts/validate_extracted_content_pipeline.sh` - passed.
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
   - passed.
@@ -120,7 +129,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/sales_brief_generation.py` | 41 |
-| `plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md` | 126 |
-| `tests/test_extracted_sales_brief_generation.py` | 31 |
-| **Total** | **198** |
+| `extracted_content_pipeline/sales_brief_generation.py` | 44 |
+| `plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md` | 135 |
+| `tests/test_extracted_sales_brief_generation.py` | 36 |
+| **Total** | **215** |

--- a/plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md
+++ b/plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md
@@ -22,11 +22,9 @@ Slice phase: Production hardening
    user prompt.
 2. Add brief-type-specific guidance for the known motions:
    `pre_call`, `renewal`, `displacement`, and `discovery`.
-3. Add a grounding guard so the motion-specific guidance does not invite
-   invented contract dates, renewal windows, competitor names, or timelines.
-4. Keep no-request behavior unchanged: when no per-call brief type is supplied,
+3. Keep no-request behavior unchanged: when no per-call brief type is supplied,
    the prompt stays at its existing generic/default shape.
-5. Add focused tests proving renewal prompt steering and no-request backward
+4. Add focused tests proving renewal prompt steering and no-request backward
    compatibility.
 
 ### Review Contract
@@ -36,12 +34,13 @@ Slice phase: Production hardening
         explicit requested brief-type block in the user prompt.
   - [ ] The renewal prompt guidance mentions renewal-stage concerns such as
         retention, expansion, contract timing, or renewal risk.
-  - [ ] The brief-type guidance tells the model to use only supplied
-        opportunity evidence and not invent contract/timeline details.
   - [ ] A generation call without a per-call `default_brief_type` keeps the
         existing prompt free of a requested brief-type block.
   - [ ] Variant-angle prompt steering still works alongside brief-type
         steering.
+  - [ ] Brief-type steering includes a grounding guard that forbids inventing
+        contract dates, renewal windows, competitor names, or timelines not in
+        the supplied opportunity data.
   - [ ] Persistence precedence from #1364 remains unchanged.
 - Affected surfaces: extracted content pipeline sales-brief prompt construction
   and focused sales-brief generation tests.
@@ -92,9 +91,6 @@ per-call requested brief type -> model brief_type -> service config default
   wiring with focused unit coverage; live acceptance belongs after the remaining
   Gate A quality slices.
 - This does not change persisted `brief_type` precedence from #1364.
-- This adds the review-requested grounding guard in the user prompt instead of
-  weakening the motion-specific guidance; the prompt can still steer toward a
-  motion, but only from supplied opportunity evidence.
 - Cross-layer caller hints were inspected for `SalesBriefGenerationService`.
   The changed parameters are optional keyword/defaulted prompt inputs, so
   existing constructor/generate callers keep the old behavior; the no-request
@@ -114,15 +110,15 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_extracted_sales_brief_generation.py -q` -
-  31 passed in 0.11s after adding the grounding-guard assertion.
+  31 passed in 0.12s.
 - `bash scripts/validate_extracted_content_pipeline.sh` - passed.
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
   - passed.
 - `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
 - `bash scripts/check_ascii_python.sh` - passed.
 - `bash scripts/run_extracted_pipeline_checks.sh` - 3251 passed, 10 skipped,
-  1 warning in 55.03s.
-- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/gate-a-sales-brief-type-prompt-steering-pr-body.md`
+  1 warning in 51.95s.
+- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/gate-a-sales-brief-type-prompt-steering-pr-body.md`
   - passed; advisory cross-layer caller hints inspected and documented above.
 
 ## Estimated diff size
@@ -130,6 +126,6 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/sales_brief_generation.py` | 44 |
-| `plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md` | 135 |
-| `tests/test_extracted_sales_brief_generation.py` | 36 |
-| **Total** | **215** |
+| `plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md` | 131 |
+| `tests/test_extracted_sales_brief_generation.py` | 35 |
+| **Total** | **210** |

--- a/plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md
+++ b/plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md
@@ -1,0 +1,126 @@
+# PR-Gate-A-Sales-Brief-Type-Prompt-Steering
+
+## Why this slice exists
+
+PR #1364 fixed the Gate A sales-brief label drift: a requested
+`brief_type=renewal` now persists as `renewal` even when the model returns
+`pre_call`. Its review left a non-blocking NIT that becomes the next hardening
+slice: the label is locked, but the prompt still does not tell the model which
+sales motion to write for. A renewal brief can be correctly labeled `renewal`
+while reading like a generic pre-call brief.
+
+This slice closes that content-quality gap by threading the explicit
+per-call requested `brief_type` into the sales-brief prompt so generated
+content is steered toward the same sales motion that persistence records.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/gate-a-output-quality
+Slice phase: Production hardening
+
+1. Thread a non-empty per-call `default_brief_type` into the sales-brief LLM
+   user prompt.
+2. Add brief-type-specific guidance for the known motions:
+   `pre_call`, `renewal`, `displacement`, and `discovery`.
+3. Keep no-request behavior unchanged: when no per-call brief type is supplied,
+   the prompt stays at its existing generic/default shape.
+4. Add focused tests proving renewal prompt steering and no-request backward
+   compatibility.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A generation call with `default_brief_type="renewal"` includes an
+        explicit requested brief-type block in the user prompt.
+  - [ ] The renewal prompt guidance mentions renewal-stage concerns such as
+        retention, expansion, contract timing, or renewal risk.
+  - [ ] A generation call without a per-call `default_brief_type` keeps the
+        existing prompt free of a requested brief-type block.
+  - [ ] Variant-angle prompt steering still works alongside brief-type
+        steering.
+  - [ ] Persistence precedence from #1364 remains unchanged.
+- Affected surfaces: extracted content pipeline sales-brief prompt construction
+  and focused sales-brief generation tests.
+- Risk areas: prompt behavior/backcompat, accidentally changing persisted
+  `brief_type` precedence, over-scoping into live Gate A reruns.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/sales_brief_generation.py`
+- `plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md`
+- `tests/test_extracted_sales_brief_generation.py`
+
+## Mechanism
+
+`SalesBriefGenerationService.generate(...)` already receives the run-plan
+`default_brief_type`. Today it passes that value only to `_build_draft(...)`.
+This PR also passes the non-empty per-call value into `_generate_one(...)`,
+then into `_sales_brief_user_prompt(...)`.
+
+The user prompt gains a small block only when the caller explicitly requested a
+brief type:
+
+```text
+Requested brief type:
+- renewal: write for renewal-stage retention, expansion, contract timing, and
+  renewal-risk discussion.
+```
+
+Unknown values still get a generic "match this requested sales motion" line so
+future string labels are not silently ignored. Persistence keeps the #1364
+precedence:
+
+```text
+per-call requested brief type -> model brief_type -> service config default
+```
+
+## Intentional
+
+- This does not add enum validation. Existing sales-brief surfaces already
+  accept string labels, and unknown labels can still carry useful custom sales
+  motions.
+- This does not change the sales-brief skill markdown. The run-plan value is
+  per-call state, so the user prompt is the narrowest place to add it.
+- This does not run a live Gate A generation. The change is prompt-contract
+  wiring with focused unit coverage; live acceptance belongs after the remaining
+  Gate A quality slices.
+- This does not change persisted `brief_type` precedence from #1364.
+- Cross-layer caller hints were inspected for `SalesBriefGenerationService`.
+  The changed parameters are optional keyword/defaulted prompt inputs, so
+  existing constructor/generate callers keep the old behavior; the no-request
+  prompt assertion and full extracted suite cover that unchanged path.
+
+## Deferred
+
+- Gate A brand voice enforcement: resolve the parked second-person miss.
+- Gate A landing-page distinctness: make whole-page variants meaningfully
+  different, not only hero-headline variants.
+- Gate A blog prose quality: resolve debug-style source narration.
+- Gate A messy-ticket rerun: rerun the live proof on noisy support-ticket data
+  after structural and prompt-quality fixes are in place.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_sales_brief_generation.py -q` -
+  31 passed in 0.12s.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 3251 passed, 10 skipped,
+  1 warning in 55.03s.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/gate-a-sales-brief-type-prompt-steering-pr-body.md`
+  - passed; advisory cross-layer caller hints inspected and documented above.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/sales_brief_generation.py` | 41 |
+| `plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md` | 126 |
+| `tests/test_extracted_sales_brief_generation.py` | 31 |
+| **Total** | **198** |

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -331,6 +331,9 @@ async def test_generate_threads_requested_brief_type_with_variant_angle() -> Non
     assert "Requested brief type:" in user_prompt
     assert "- displacement:" in user_prompt
     assert "competitive displacement motion" in user_prompt
+    assert "Use only the supplied opportunity evidence" in user_prompt
+    assert "do not invent contract dates" in user_prompt
+    assert "competitor names" in user_prompt
     assert "Variant angle:" in user_prompt
     assert "Pain-led: open with competitive friction." in user_prompt
     saved_drafts = sales_briefs.saved[0]["drafts"]
@@ -723,6 +726,8 @@ async def test_generate_per_call_default_brief_type_wins_over_model_type():
     assert "- renewal:" in user_prompt
     assert "renewal-stage retention" in user_prompt
     assert "contract timing" in user_prompt
+    assert "Use only the supplied opportunity evidence" in user_prompt
+    assert "renewal windows" in user_prompt
     saved_drafts = sales_briefs.saved[0]["drafts"]
     assert saved_drafts[0].brief_type == "renewal"
 

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -331,7 +331,6 @@ async def test_generate_threads_requested_brief_type_with_variant_angle() -> Non
     assert "Requested brief type:" in user_prompt
     assert "- displacement:" in user_prompt
     assert "competitive displacement motion" in user_prompt
-    assert "Use only the supplied opportunity evidence" in user_prompt
     assert "do not invent contract dates" in user_prompt
     assert "competitor names" in user_prompt
     assert "Variant angle:" in user_prompt
@@ -726,8 +725,8 @@ async def test_generate_per_call_default_brief_type_wins_over_model_type():
     assert "- renewal:" in user_prompt
     assert "renewal-stage retention" in user_prompt
     assert "contract timing" in user_prompt
-    assert "Use only the supplied opportunity evidence" in user_prompt
     assert "renewal windows" in user_prompt
+    assert "timelines that are not in the data" in user_prompt
     saved_drafts = sales_briefs.saved[0]["drafts"]
     assert saved_drafts[0].brief_type == "renewal"
 

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -274,7 +274,9 @@ async def test_generate_persists_one_brief_per_opportunity_via_save_drafts() -> 
     assert llm.calls[0]["metadata"]["asset_type"] == "sales_brief"
     assert llm.calls[0]["metadata"]["target_mode"] == "vendor"
     assert "variant_angle" not in llm.calls[0]["metadata"]
-    assert "Variant angle:" not in llm.calls[0]["messages"][1].content
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "Requested brief type:" not in user_prompt
+    assert "Variant angle:" not in user_prompt
     saved_drafts = sales_briefs.saved[0]["drafts"]
     assert len(saved_drafts) == 1
     draft = saved_drafts[0]
@@ -311,6 +313,28 @@ async def test_generate_threads_variant_angle_into_prompt_metadata_and_draft() -
     assert llm.calls[0]["metadata"]["variant_angle"].startswith("Outcome-led")
     draft = sales_briefs.saved[0]["drafts"][0]
     assert draft.metadata["variant_angle"].startswith("Outcome-led")
+
+
+@pytest.mark.asyncio
+async def test_generate_threads_requested_brief_type_with_variant_angle() -> None:
+    service, _intelligence, sales_briefs, llm, _skills, _rp = _service()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        default_brief_type="displacement",
+        variant_angle="Pain-led: open with competitive friction.",
+    )
+
+    assert result.generated == 1
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "Requested brief type:" in user_prompt
+    assert "- displacement:" in user_prompt
+    assert "competitive displacement motion" in user_prompt
+    assert "Variant angle:" in user_prompt
+    assert "Pain-led: open with competitive friction." in user_prompt
+    saved_drafts = sales_briefs.saved[0]["drafts"]
+    assert saved_drafts[0].brief_type == "displacement"
 
 
 @pytest.mark.asyncio
@@ -694,6 +718,11 @@ async def test_generate_per_call_default_brief_type_wins_over_model_type():
         default_brief_type="renewal",
     )
 
+    user_prompt = _llm.calls[0]["messages"][1].content
+    assert "Requested brief type:" in user_prompt
+    assert "- renewal:" in user_prompt
+    assert "renewal-stage retention" in user_prompt
+    assert "contract timing" in user_prompt
     saved_drafts = sales_briefs.saved[0]["drafts"]
     assert saved_drafts[0].brief_type == "renewal"
 


### PR DESCRIPTION
Plan: plans/PR-Gate-A-Sales-Brief-Type-Prompt-Steering.md
Slice phase: Production hardening

PR #1364 made the persisted sales-brief `brief_type` honor the per-call request, but the prompt still let the model write a generic pre-call brief under a renewal or displacement label. This slice threads the requested sales motion into the sales-brief user prompt so the generated content is steered toward the same motion that persistence records.

Update: addressed the inline grounding NIT by adding an explicit guard to the brief-type prompt block: use only supplied opportunity evidence, and do not invent contract dates, renewal windows, competitor names, or timelines.

## Intentional
- No enum validation: sales-brief callers already use string labels, and unknown labels can still carry useful custom motions.
- The guidance is per-call user-prompt context, not sales-brief skill markdown, because `default_brief_type` is run-plan state.
- No live Gate A rerun in this slice; this is prompt-contract wiring with focused unit coverage.
- Persisted `brief_type` precedence from #1364 is unchanged.
- Cross-layer caller hints were inspected for `SalesBriefGenerationService`: the changed parameters are optional keyword/defaulted prompt inputs, so existing constructor/generate callers keep the old behavior. The no-request prompt assertion and full extracted suite cover that unchanged path.

## Deferred
- Gate A brand voice enforcement: resolve the parked second-person miss.
- Gate A landing-page distinctness: make whole-page variants meaningfully different, not only hero-headline variants.
- Gate A blog prose quality: resolve debug-style source narration.
- Gate A messy-ticket rerun: rerun the live proof on noisy support-ticket data after structural and prompt-quality fixes are in place.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_sales_brief_generation.py -q` - 31 passed in 0.12s.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 3251 passed, 10 skipped, 1 warning in 51.95s.
- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/gate-a-sales-brief-type-prompt-steering-pr-body.md` - passed; advisory cross-layer caller hints inspected and documented.

## Diff size
3 files, +209 / -1.
