### PR TITLE
Content-Ops Claim Registry Persistence

### DIFF
--- a/.github/workflows/atlas_content_ops_claim_registry_checks.yml
+++ b/.github/workflows/atlas_content_ops_claim_registry_checks.yml
@@ -1,0 +1,52 @@
+name: Atlas Content Ops Claim Registry Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_content_ops_claim_registry_checks.yml"
+      - "atlas_brain/_content_ops_claim_registry.py"
+      - "atlas_brain/_content_ops_review_workflow.py"
+      - "atlas_brain/storage/migrations/334_content_ops_claim_registry.sql"
+      - "extracted_content_pipeline/campaign_ports.py"
+      - "extracted_content_pipeline/claims_map.py"
+      - "extracted_content_pipeline/content_pr.py"
+      - "extracted_content_pipeline/review_contract.py"
+      - "tests/test_content_ops_claim_registry.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_content_ops_claim_registry_checks.yml"
+      - "atlas_brain/_content_ops_claim_registry.py"
+      - "atlas_brain/_content_ops_review_workflow.py"
+      - "atlas_brain/storage/migrations/334_content_ops_claim_registry.sql"
+      - "extracted_content_pipeline/campaign_ports.py"
+      - "extracted_content_pipeline/claims_map.py"
+      - "extracted_content_pipeline/content_pr.py"
+      - "extracted_content_pipeline/review_contract.py"
+      - "tests/test_content_ops_claim_registry.py"
+
+jobs:
+  atlas-content-ops-claim-registry-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Content Ops claim registry tests
+        run: |
+          python -m pytest \
+            tests/test_content_ops_claim_registry.py \
+            -q

--- a/atlas_brain/_content_ops_claim_registry.py
+++ b/atlas_brain/_content_ops_claim_registry.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Any, Mapping, Optional
 
+from atlas_brain._content_ops_review_workflow import TenantClaimRegistryReadError
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.claims_map import RegistryClaim
 from extracted_content_pipeline.review_contract import RiskTier
@@ -63,9 +64,13 @@ class ContentOpsClaimRegistryRepository:
         account_id = _scope_account_uuid(scope)
         if account_id is None:
             logger.warning("claim registry read: invalid tenant scope")
-            return {}
+            raise TenantClaimRegistryReadError("valid tenant scope required")
 
-        records = await list_registry_claim_records(self._pool, account_id=account_id)
+        try:
+            records = await list_registry_claim_records(self._pool, account_id=account_id)
+        except Exception as exc:
+            logger.exception("claim registry read failed")
+            raise TenantClaimRegistryReadError("claim registry read failed") from exc
         claims: dict[str, RegistryClaim] = {}
         for record in records:
             if not record.registry_id or record.registry_id in claims:
@@ -216,7 +221,7 @@ def _validated_claim(payload: Mapping[str, Any]) -> _ValidatedClaim:
     if not isinstance(payload, Mapping):
         raise ValueError("Claim registry payload must be an object")
 
-    registry_id = _clean(payload.get("registry_id"))
+    registry_id = _clean_registry_id(payload.get("registry_id"))
     if not registry_id:
         raise ValueError("Claim registry id is required")
 
@@ -237,7 +242,7 @@ def _display_record(row: Any) -> ContentOpsClaimRegistryRecord:
     return ContentOpsClaimRegistryRecord(
         id=row["id"],
         account_id=row["account_id"],
-        registry_id=_clean(row["registry_id"]),
+        registry_id=_clean_registry_id(row["registry_id"]),
         approved_wording=_clean(row["approved_wording"]),
         risk_tier=_optional_risk_tier(row["risk_tier"]),
         expires_on=_optional_date(row["expires_on"]),
@@ -324,6 +329,12 @@ def _clean(value: Any) -> str:
     if not isinstance(value, str):
         return ""
     return " ".join(value.split())
+
+
+def _clean_registry_id(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower()
 
 
 __all__ = [

--- a/atlas_brain/_content_ops_claim_registry.py
+++ b/atlas_brain/_content_ops_claim_registry.py
@@ -1,0 +1,337 @@
+"""Tenant claim and messaging registry persistence for Content Ops review."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid as _uuid
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Mapping, Optional
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.claims_map import RegistryClaim
+from extracted_content_pipeline.review_contract import RiskTier
+
+logger = logging.getLogger("atlas.content_ops_claim_registry")
+
+
+@dataclass(frozen=True)
+class ContentOpsClaimRegistryRecord:
+    """Display-safe saved claim-registry row."""
+
+    id: _uuid.UUID
+    account_id: _uuid.UUID
+    registry_id: str
+    approved_wording: str
+    risk_tier: Optional[RiskTier]
+    expires_on: Optional[date]
+    metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    archived_at: Optional[datetime]
+
+    def as_registry_claim(self) -> RegistryClaim:
+        return RegistryClaim(
+            id=self.registry_id,
+            approved_wording=self.approved_wording,
+            risk_tier=self.risk_tier,
+            expiration=self.expires_on,
+        )
+
+
+@dataclass(frozen=True)
+class _ValidatedClaim:
+    registry_id: str
+    approved_wording: str
+    risk_tier: Optional[RiskTier]
+    expires_on: Optional[date]
+    metadata: dict[str, Any]
+
+
+class ContentOpsClaimRegistryRepository:
+    """Postgres-backed implementation of the review workflow registry reader."""
+
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+
+    async def list_registry_claims(
+        self,
+        *,
+        scope: TenantScope,
+    ) -> Mapping[str, RegistryClaim]:
+        account_id = _scope_account_uuid(scope)
+        if account_id is None:
+            logger.warning("claim registry read: invalid tenant scope")
+            return {}
+
+        records = await list_registry_claim_records(self._pool, account_id=account_id)
+        claims: dict[str, RegistryClaim] = {}
+        for record in records:
+            if not record.registry_id or record.registry_id in claims:
+                continue
+            claims[record.registry_id] = record.as_registry_claim()
+        return claims
+
+
+async def create_registry_claim(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    payload: Mapping[str, Any],
+) -> ContentOpsClaimRegistryRecord:
+    """Create one active claim-registry row for an account."""
+
+    claim = _validated_claim(payload)
+    row = await pool.fetchrow(
+        """
+        INSERT INTO content_ops_claim_registry (
+            account_id, registry_id, approved_wording, risk_tier,
+            expires_on, metadata
+        )
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+        RETURNING id, account_id, registry_id, approved_wording, risk_tier,
+                  expires_on, metadata, created_at, updated_at, archived_at
+        """,
+        account_id,
+        claim.registry_id,
+        claim.approved_wording,
+        _risk_tier_value(claim.risk_tier),
+        claim.expires_on,
+        _json_dump(claim.metadata),
+    )
+    return _display_record(row)
+
+
+async def update_registry_claim(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    claim_id: _uuid.UUID,
+    payload: Mapping[str, Any],
+) -> ContentOpsClaimRegistryRecord | None:
+    """Replace one active tenant claim row. Missing/cross-tenant rows return None."""
+
+    claim = _validated_claim(payload)
+    row = await pool.fetchrow(
+        """
+        UPDATE content_ops_claim_registry
+           SET registry_id = $3,
+               approved_wording = $4,
+               risk_tier = $5,
+               expires_on = $6,
+               metadata = $7::jsonb,
+               updated_at = NOW()
+         WHERE id = $1
+           AND account_id = $2
+           AND archived_at IS NULL
+        RETURNING id, account_id, registry_id, approved_wording, risk_tier,
+                  expires_on, metadata, created_at, updated_at, archived_at
+        """,
+        claim_id,
+        account_id,
+        claim.registry_id,
+        claim.approved_wording,
+        _risk_tier_value(claim.risk_tier),
+        claim.expires_on,
+        _json_dump(claim.metadata),
+    )
+    return _display_record(row) if row is not None else None
+
+
+async def list_registry_claim_records(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+) -> list[ContentOpsClaimRegistryRecord]:
+    """Return active claim-registry rows for one tenant."""
+
+    rows = await pool.fetch(
+        """
+        SELECT id, account_id, registry_id, approved_wording, risk_tier,
+               expires_on, metadata, created_at, updated_at, archived_at
+          FROM content_ops_claim_registry
+         WHERE account_id = $1
+           AND archived_at IS NULL
+         ORDER BY updated_at DESC
+        """,
+        account_id,
+    )
+    return [_display_record(row) for row in rows]
+
+
+async def expire_registry_claim(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    claim_id: _uuid.UUID,
+    expires_on: date | None = None,
+) -> ContentOpsClaimRegistryRecord | None:
+    """Set a tenant claim expiration date while keeping it readable."""
+
+    expiration = expires_on or date.today()
+    row = await pool.fetchrow(
+        """
+        UPDATE content_ops_claim_registry
+           SET expires_on = $3,
+               updated_at = NOW()
+         WHERE id = $1
+           AND account_id = $2
+           AND archived_at IS NULL
+        RETURNING id, account_id, registry_id, approved_wording, risk_tier,
+                  expires_on, metadata, created_at, updated_at, archived_at
+        """,
+        claim_id,
+        account_id,
+        expiration,
+    )
+    return _display_record(row) if row is not None else None
+
+
+async def archive_registry_claim(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    claim_id: _uuid.UUID,
+) -> bool:
+    """Soft-delete one tenant claim-registry row."""
+
+    row = await pool.fetchrow(
+        """
+        UPDATE content_ops_claim_registry
+           SET archived_at = NOW(),
+               updated_at = NOW()
+         WHERE id = $1
+           AND account_id = $2
+           AND archived_at IS NULL
+        RETURNING id
+        """,
+        claim_id,
+        account_id,
+    )
+    return row is not None
+
+
+def _validated_claim(payload: Mapping[str, Any]) -> _ValidatedClaim:
+    if not isinstance(payload, Mapping):
+        raise ValueError("Claim registry payload must be an object")
+
+    registry_id = _clean(payload.get("registry_id"))
+    if not registry_id:
+        raise ValueError("Claim registry id is required")
+
+    approved_wording = _clean(payload.get("approved_wording"))
+    if not approved_wording:
+        raise ValueError("Approved wording is required")
+
+    return _ValidatedClaim(
+        registry_id=registry_id,
+        approved_wording=approved_wording,
+        risk_tier=_optional_risk_tier(payload.get("risk_tier")),
+        expires_on=_optional_date(payload.get("expires_on")),
+        metadata=_metadata(payload.get("metadata")),
+    )
+
+
+def _display_record(row: Any) -> ContentOpsClaimRegistryRecord:
+    return ContentOpsClaimRegistryRecord(
+        id=row["id"],
+        account_id=row["account_id"],
+        registry_id=_clean(row["registry_id"]),
+        approved_wording=_clean(row["approved_wording"]),
+        risk_tier=_optional_risk_tier(row["risk_tier"]),
+        expires_on=_optional_date(row["expires_on"]),
+        metadata=_json_mapping(row["metadata"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        archived_at=row["archived_at"],
+    )
+
+
+def _scope_account_uuid(scope: TenantScope | None) -> _uuid.UUID | None:
+    value = getattr(scope, "account_id", None)
+    if not isinstance(value, str):
+        return None
+    try:
+        return _uuid.UUID(value.strip())
+    except ValueError:
+        return None
+
+
+def _optional_risk_tier(value: Any) -> RiskTier | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = _clean(value).casefold()
+    if not cleaned:
+        return None
+    for tier in RiskTier:
+        if tier == cleaned:
+            return tier
+    raise ValueError(f"Invalid risk tier: {value}")
+
+
+def _risk_tier_value(value: RiskTier | None) -> str | None:
+    return value.value if value is not None else None
+
+
+def _optional_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        cleaned = _clean(value)
+        if not cleaned:
+            return None
+        try:
+            return date.fromisoformat(cleaned)
+        except ValueError as exc:
+            raise ValueError(f"Invalid expiration date: {value}") from exc
+    return None
+
+
+def _metadata(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _json_dump(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    decoded = _decode_json(value, default={})
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _decode_json(value: Any, *, default: Any) -> Any:
+    if value is None:
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return default
+    return value
+
+
+def _clean(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split())
+
+
+__all__ = [
+    "ContentOpsClaimRegistryRecord",
+    "ContentOpsClaimRegistryRepository",
+    "archive_registry_claim",
+    "create_registry_claim",
+    "expire_registry_claim",
+    "list_registry_claim_records",
+    "update_registry_claim",
+]

--- a/atlas_brain/_content_ops_review_workflow.py
+++ b/atlas_brain/_content_ops_review_workflow.py
@@ -33,6 +33,10 @@ from extracted_content_pipeline.content_pr import (
 from extracted_content_pipeline.review_contract import ReviewDecision
 
 
+class TenantClaimRegistryReadError(RuntimeError):
+    """Raised when tenant registry data cannot be read safely."""
+
+
 class TenantClaimRegistryReader(Protocol):
     """Read approved marketing claims for one tenant scope."""
 
@@ -99,7 +103,10 @@ async def run_content_ops_review(
     if not _scope_account_id(scope):
         return _blocked_result(request, "tenant scope required")
 
-    registry = await registry_reader.list_registry_claims(scope=scope)
+    try:
+        registry = await registry_reader.list_registry_claims(scope=scope)
+    except TenantClaimRegistryReadError as exc:
+        return _blocked_result(request, str(exc) or "claim registry read failed")
     mapped_claims = build_claims_map(
         request.extracted_claims,
         registry,
@@ -184,6 +191,7 @@ def _value(value: Any) -> Any:
 __all__ = [
     "ContentOpsReviewRequest",
     "ContentOpsReviewResult",
+    "TenantClaimRegistryReadError",
     "TenantClaimRegistryReader",
     "run_content_ops_review",
 ]

--- a/atlas_brain/storage/migrations/334_content_ops_claim_registry.sql
+++ b/atlas_brain/storage/migrations/334_content_ops_claim_registry.sql
@@ -1,0 +1,36 @@
+-- Tenant-scoped claim and messaging registry for Content Ops review.
+--
+-- The extracted claims map owns deterministic status checks. This host table
+-- stores the approved wording per account so the review workflow can verify a
+-- marketer-provided structured claim list without an MCP transport owning
+-- business logic.
+
+CREATE TABLE IF NOT EXISTS content_ops_claim_registry (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id        UUID NOT NULL REFERENCES saas_accounts(id) ON DELETE CASCADE,
+    registry_id       TEXT NOT NULL,
+    approved_wording  TEXT NOT NULL,
+    risk_tier         TEXT,
+    expires_on        DATE,
+    metadata          JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    archived_at       TIMESTAMPTZ,
+    CONSTRAINT chk_content_ops_claim_registry_registry_id
+        CHECK (btrim(registry_id) <> ''),
+    CONSTRAINT chk_content_ops_claim_registry_approved_wording
+        CHECK (btrim(approved_wording) <> ''),
+    CONSTRAINT chk_content_ops_claim_registry_risk_tier
+        CHECK (
+            risk_tier IS NULL
+            OR risk_tier IN ('low', 'medium', 'high', 'critical')
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_ops_claim_registry_account_active
+    ON content_ops_claim_registry (account_id, updated_at DESC)
+    WHERE archived_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_content_ops_claim_registry_account_registry_id_active
+    ON content_ops_claim_registry (account_id, lower(btrim(registry_id)))
+    WHERE archived_at IS NULL;

--- a/plans/PR-Content-Ops-Claim-Registry-Persistence.md
+++ b/plans/PR-Content-Ops-Claim-Registry-Persistence.md
@@ -1,0 +1,131 @@
+# PR - Content-Ops Claim Registry Persistence
+
+## Why this slice exists
+
+Issue #1338 says the content-ops review-contract core has landed through the
+first wiring slice, but issue #1353 still calls out the largest integration gap:
+there is no tenant-owned claim and messaging registry store. PR #1363 created a
+host review service with an injected tenant registry reader; this slice plugs a
+real tenant-scoped Postgres-backed repository into that boundary so the review
+workflow can verify marketer-provided claims against durable approved wording.
+
+This is the next wiring slice rather than operating-model slice 5. Calibration
+examples and adversarial review are useful, but the verify-only marketer v1
+cannot be wired until approved claims can be persisted, listed, updated, and
+expired per tenant.
+
+The diff is expected to exceed the 400 LOC soft cap because this PR carries a
+deployable migration, the repository adapter, focused fake-pool tests for each
+tenant-scope mutation and failure branch, and a dedicated Atlas workflow so the
+host-package tests run in CI.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+Add the first durable tenant claim and messaging registry behind the existing
+review-service reader port:
+
+1. Add a tenant-scoped Postgres migration for active registry claims with
+   approved wording, risk tier, optional expiration date, metadata, timestamps,
+   and a soft-archive column.
+2. Add a small Atlas repository module that can create, update, list, expire,
+   and archive active registry claim records for one account.
+3. Expose a repository reader method that returns the existing
+   `RegistryClaim` mapping shape used by the deterministic claims map.
+4. Prove tenant isolation, decoded input handling, invalid-id fail-closed
+   behavior, and service compatibility with focused tests.
+5. Enroll the new tests in the extracted pipeline wrapper and a dedicated Atlas
+   workflow.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The migration stores registry claims with `account_id` and active-row
+        uniqueness scoped to one tenant.
+  - [ ] Create, update, expire, archive, and list operations filter by
+        `account_id` and never mutate a cross-tenant row.
+  - [ ] The repository reader implements the review-service registry reader
+        shape and returns claims keyed by registry id.
+  - [ ] Missing or invalid tenant scope fails closed without a database read.
+  - [ ] Decoded input treats missing or non-text optional fields as missing
+        rather than raising.
+  - [ ] Invalid risk-tier values fail before persistence.
+  - [ ] No LLM, FastAPI, MCP transport, or generated-asset lifecycle mapping is
+        introduced in this slice.
+- Affected surfaces: database, service, auth/tenant scope, CI enrollment.
+- Risk areas: tenant isolation, migration safety, decoded input robustness,
+  concurrency, backcompat, maintainability.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R8, R10, R12.
+
+### Files touched
+
+- `atlas_brain/_content_ops_claim_registry.py`
+- `atlas_brain/storage/migrations/334_content_ops_claim_registry.sql`
+- `.github/workflows/atlas_content_ops_claim_registry_checks.yml`
+- `tests/test_content_ops_claim_registry.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `plans/PR-Content-Ops-Claim-Registry-Persistence.md`
+
+## Mechanism
+
+The migration creates one active registry row per tenant and registry id. Active
+row uniqueness is enforced on normalized registry ids for each `account_id`
+while archived rows remain available for audit history. Expiration is separate
+from archiving: an expired claim remains readable so the claims map can emit an
+expired status instead of silently forgetting the claim.
+
+The repository follows the existing Content Ops persistence pattern: async pool
+methods, UUID tenant ids, display-safe dataclasses, JSONB metadata, and tenant
+scope in every mutation query. The reader method accepts a `TenantScope`,
+validates the account id, reads only active rows for that tenant, and converts
+them into the extracted package's `RegistryClaim` values without importing any
+transport layer.
+
+## Intentional
+
+- This does not build marketer MCP tools. The future MCP server should wrap the
+  review service and this repository instead of owning business logic.
+- This does not extract claims from prose. Issue #1353 keeps v1 verify-only, so
+  callers still provide structured claims.
+- Expiring a claim sets its expiration date but does not archive it. The review
+  engine must still see expired entries so expired claims block deterministically.
+- The migration introduces the table only; no backfill is needed because no
+  prior durable claim registry exists.
+
+## Deferred
+
+- `PR-Content-Ops-Review-Status-Mapping`: map review decisions onto generated
+  asset lifecycle statuses after the registry reader is real.
+- `PR-Content-Ops-Quality-Gate-Coverage-Rows`: map deterministic quality-gate
+  and brand-voice findings into Content-PR coverage rows.
+- `PR-Marketer-Verification-MCP`: expose verify-only marketer tools after the
+  service, registry, tenant-binding bridge, and status mapping are wired.
+- `PR-Content-Ops-Calibration-Library`: deterministic calibration/adversarial
+  examples from operating-model slice 5.
+- Parked hardening: none expected unless implementation surfaces non-blocking
+  registry observability or admin UI gaps.
+
+## Verification
+
+- Focused pytest command for the claim-registry persistence and review-service
+  workflow tests -- 28 passed.
+- Extracted pipeline CI enrollment audit command -- 155 matching tests are
+  enrolled.
+- Focused pytest command for the CI-enrollment audit regression tests -- 18
+  passed.
+- ASCII Python policy command -- passed.
+- Local PR review command with a prepared PR body file -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_claim_registry_checks.yml` | 52 |
+| `atlas_brain/_content_ops_claim_registry.py` | 337 |
+| `atlas_brain/storage/migrations/334_content_ops_claim_registry.sql` | 36 |
+| `tests/test_content_ops_claim_registry.py` | 367 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `plans/PR-Content-Ops-Claim-Registry-Persistence.md` | 128 |
+| **Total** | **921** |

--- a/plans/PR-Content-Ops-Claim-Registry-Persistence.md
+++ b/plans/PR-Content-Ops-Claim-Registry-Persistence.md
@@ -62,8 +62,10 @@ review-service reader port:
 ### Files touched
 
 - `atlas_brain/_content_ops_claim_registry.py`
+- `atlas_brain/_content_ops_review_workflow.py`
 - `atlas_brain/storage/migrations/334_content_ops_claim_registry.sql`
 - `.github/workflows/atlas_content_ops_claim_registry_checks.yml`
+- `tests/test_atlas_content_ops_review_workflow.py`
 - `tests/test_content_ops_claim_registry.py`
 - `scripts/run_extracted_pipeline_checks.sh`
 - `plans/PR-Content-Ops-Claim-Registry-Persistence.md`
@@ -82,6 +84,12 @@ scope in every mutation query. The reader method accepts a `TenantScope`,
 validates the account id, reads only active rows for that tenant, and converts
 them into the extracted package's `RegistryClaim` values without importing any
 transport layer.
+
+Post-review update: invalid or malformed tenant scope now raises a typed
+registry-read error, and the review-service boundary converts that into a
+blocked verdict instead of treating it as an empty registry. Registry ids are
+canonicalized to lowercased, trimmed values on write and read so the Python
+lookup key matches the database uniqueness contract.
 
 ## Intentional
 
@@ -110,7 +118,7 @@ transport layer.
 ## Verification
 
 - Focused pytest command for the claim-registry persistence and review-service
-  workflow tests -- 28 passed.
+  workflow tests -- 31 passed.
 - Extracted pipeline CI enrollment audit command -- 155 matching tests are
   enrolled.
 - Focused pytest command for the CI-enrollment audit regression tests -- 18
@@ -123,9 +131,11 @@ transport layer.
 | File | LOC |
 |---|---:|
 | `.github/workflows/atlas_content_ops_claim_registry_checks.yml` | 52 |
-| `atlas_brain/_content_ops_claim_registry.py` | 337 |
+| `atlas_brain/_content_ops_claim_registry.py` | 348 |
+| `atlas_brain/_content_ops_review_workflow.py` | 9 |
 | `atlas_brain/storage/migrations/334_content_ops_claim_registry.sql` | 36 |
-| `tests/test_content_ops_claim_registry.py` | 367 |
+| `tests/test_atlas_content_ops_review_workflow.py` | 31 |
+| `tests/test_content_ops_claim_registry.py` | 431 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `plans/PR-Content-Ops-Claim-Registry-Persistence.md` | 128 |
-| **Total** | **921** |
+| `plans/PR-Content-Ops-Claim-Registry-Persistence.md` | 141 |
+| **Total** | **1050** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -104,6 +104,7 @@ pytest \
   tests/test_extracted_content_ops_execution_smoke.py \
   tests/test_atlas_content_ops_infrastructure.py \
   tests/test_atlas_content_ops_review_workflow.py \
+  tests/test_content_ops_claim_registry.py \
   tests/test_atlas_content_ops_generated_assets_api.py \
   tests/test_atlas_content_ops_import_admission.py \
   tests/test_atlas_content_ops_input_provider.py \

--- a/tests/test_atlas_content_ops_review_workflow.py
+++ b/tests/test_atlas_content_ops_review_workflow.py
@@ -7,6 +7,7 @@ import pytest
 
 from atlas_brain._content_ops_review_workflow import (
     ContentOpsReviewRequest,
+    TenantClaimRegistryReadError,
     run_content_ops_review,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
@@ -41,6 +42,15 @@ class _RegistryReader:
         return self.registry
 
 
+@dataclass
+class _FailingRegistryReader:
+    scopes: list[TenantScope]
+
+    async def list_registry_claims(self, *, scope: TenantScope):
+        self.scopes.append(scope)
+        raise TenantClaimRegistryReadError("claim registry read failed")
+
+
 def _reader() -> _RegistryReader:
     return _RegistryReader(
         registry={
@@ -58,6 +68,10 @@ def _reader() -> _RegistryReader:
         },
         scopes=[],
     )
+
+
+def _failing_reader() -> _FailingRegistryReader:
+    return _FailingRegistryReader(scopes=[])
 
 
 def _pass_row(rule_id: str = "VOICE-01") -> CoverageRow:
@@ -119,6 +133,23 @@ async def test_registry_reader_receives_tenant_scope_not_request_account_id() ->
     assert reader.scopes == [scope]
     assert result.content_pr.asset_id == "asset-1"
     assert result.mapped_claims[0].status == ClaimStatus.MATCH
+
+
+@pytest.mark.asyncio
+async def test_registry_reader_failure_blocks_review() -> None:
+    reader = _failing_reader()
+    scope = TenantScope(account_id="acct-1")
+
+    result = await run_content_ops_review(
+        _request(),
+        scope=scope,
+        registry_reader=reader,
+    )
+
+    assert result.decision == ReviewDecision.BLOCKED
+    assert result.reasons == ("claim registry read failed",)
+    assert result.mapped_claims == ()
+    assert reader.scopes == [scope]
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_ops_claim_registry.py
+++ b/tests/test_content_ops_claim_registry.py
@@ -10,6 +10,7 @@ import pytest
 from atlas_brain import _content_ops_claim_registry as registry
 from atlas_brain._content_ops_review_workflow import (
     ContentOpsReviewRequest,
+    TenantClaimRegistryReadError,
     run_content_ops_review,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
@@ -45,6 +46,12 @@ class _Pool:
     async def fetch(self, query, *args):
         self.fetch_calls.append({"query": str(query), "args": args})
         return self.fetch_rows
+
+
+class _FailingFetchPool(_Pool):
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        raise RuntimeError("database unavailable")
 
 
 def _row(**overrides):
@@ -104,7 +111,11 @@ async def test_create_registry_claim_normalizes_and_inserts_claim() -> None:
     record = await registry.create_registry_claim(
         pool,
         account_id=account_id,
-        payload=_payload(risk_tier="HIGH", expires_on="2026-12-31"),
+        payload=_payload(
+            registry_id=" Feature.SSO ",
+            risk_tier="HIGH",
+            expires_on="2026-12-31",
+        ),
     )
 
     call = pool.fetchrow_calls[0]
@@ -208,11 +219,12 @@ async def test_update_registry_claim_returns_none_for_missing_row() -> None:
 @pytest.mark.asyncio
 async def test_list_registry_claim_records_returns_display_records() -> None:
     account_id = uuid.uuid4()
-    pool = _Pool(fetch_rows=[_row(account_id=account_id)])
+    pool = _Pool(fetch_rows=[_row(account_id=account_id, registry_id=" Feature.SSO ")])
 
     records = await registry.list_registry_claim_records(pool, account_id=account_id)
 
     assert records[0].account_id == account_id
+    assert records[0].registry_id == "feature.sso"
     assert records[0].metadata == {"source": "operator"}
     assert records[0].as_registry_claim().approved_wording == (
         "SSO is included on every plan"
@@ -290,10 +302,20 @@ async def test_repository_reader_fails_closed_on_invalid_tenant_scope(
     pool = _Pool(fetch_rows=[_row()])
     repository = registry.ContentOpsClaimRegistryRepository(pool)
 
-    claims = await repository.list_registry_claims(scope=scope)
+    with pytest.raises(TenantClaimRegistryReadError, match="valid tenant scope required"):
+        await repository.list_registry_claims(scope=scope)
 
-    assert claims == {}
     assert pool.fetch_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repository_reader_wraps_database_read_failure() -> None:
+    repository = registry.ContentOpsClaimRegistryRepository(_FailingFetchPool())
+
+    with pytest.raises(TenantClaimRegistryReadError, match="claim registry read failed"):
+        await repository.list_registry_claims(
+            scope=TenantScope(account_id=str(uuid.uuid4()))
+        )
 
 
 @pytest.mark.asyncio
@@ -304,7 +326,7 @@ async def test_repository_reader_returns_registry_claim_mapping() -> None:
         fetch_rows=[
             _row(
                 account_id=account_id,
-                registry_id="pricing.discount",
+                registry_id="Pricing.Discount",
                 approved_wording="Save up to 30% on eligible annual plans",
                 risk_tier="high",
                 expires_on=expiration,
@@ -328,7 +350,7 @@ async def test_repository_reader_returns_registry_claim_mapping() -> None:
 @pytest.mark.asyncio
 async def test_review_service_consumes_repository_reader() -> None:
     account_id = uuid.uuid4()
-    pool = _Pool(fetch_rows=[_row(account_id=account_id)])
+    pool = _Pool(fetch_rows=[_row(account_id=account_id, registry_id="Feature.SSO")])
     repository = registry.ContentOpsClaimRegistryRepository(pool)
 
     result = await run_content_ops_review(
@@ -365,3 +387,45 @@ async def test_review_service_consumes_repository_reader() -> None:
     assert result.decision == ReviewDecision.APPROVED
     assert result.mapped_claims[0].approved_wording == "SSO is included on every plan"
     assert pool.fetch_calls[0]["args"] == (account_id,)
+
+
+@pytest.mark.asyncio
+async def test_review_service_blocks_invalid_repository_scope() -> None:
+    pool = _Pool(fetch_rows=[_row()])
+    repository = registry.ContentOpsClaimRegistryRepository(pool)
+
+    result = await run_content_ops_review(
+        ContentOpsReviewRequest(
+            asset_id="asset-1",
+            rule_packet=RulePacketVersions(
+                brief="brief-v1",
+                brand_voice="voice-v1",
+                claim_registry="claims-db-v1",
+                compliance="compliance-v1",
+                channel_schema="channel-v1",
+            ),
+            coverage=(
+                CoverageRow(
+                    rule_id="CLAIM-01",
+                    requirement="Claim is registered",
+                    status=CoverageStatus.PASS,
+                    evidence="registry row",
+                ),
+            ),
+            extracted_claims=(
+                ExtractedClaim(
+                    text="SSO is included on every plan",
+                    location="hero",
+                    registry_id="feature.sso",
+                ),
+            ),
+            as_of=date(2026, 6, 7),
+        ),
+        scope=TenantScope(account_id="not-a-uuid"),
+        registry_reader=repository,
+    )
+
+    assert result.decision == ReviewDecision.BLOCKED
+    assert result.reasons == ("valid tenant scope required",)
+    assert result.mapped_claims == ()
+    assert pool.fetch_calls == []

--- a/tests/test_content_ops_claim_registry.py
+++ b/tests/test_content_ops_claim_registry.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+import json
+import uuid
+
+import pytest
+
+from atlas_brain import _content_ops_claim_registry as registry
+from atlas_brain._content_ops_review_workflow import (
+    ContentOpsReviewRequest,
+    run_content_ops_review,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.claims_map import ExtractedClaim
+from extracted_content_pipeline.content_pr import (
+    CoverageRow,
+    CoverageStatus,
+    RulePacketVersions,
+)
+from extracted_content_pipeline.review_contract import ReviewDecision, RiskTier
+
+
+MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain"
+    / "storage"
+    / "migrations"
+    / "334_content_ops_claim_registry.sql"
+)
+
+
+class _Pool:
+    def __init__(self, *, fetchrow_result=None, fetch_rows=None) -> None:
+        self.fetchrow_result = fetchrow_result
+        self.fetch_rows = list(fetch_rows or [])
+        self.fetchrow_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append({"query": str(query), "args": args})
+        return self.fetchrow_result
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        return self.fetch_rows
+
+
+def _row(**overrides):
+    row = {
+        "id": uuid.uuid4(),
+        "account_id": uuid.uuid4(),
+        "registry_id": "feature.sso",
+        "approved_wording": "SSO is included on every plan",
+        "risk_tier": "medium",
+        "expires_on": None,
+        "metadata": json.dumps({"source": "operator"}),
+        "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "updated_at": datetime(2026, 1, 2, tzinfo=timezone.utc),
+        "archived_at": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _payload(**overrides):
+    values = {
+        "registry_id": " feature.sso ",
+        "approved_wording": " SSO is included on every plan ",
+        "risk_tier": "medium",
+        "metadata": {"source": "operator"},
+    }
+    values.update(overrides)
+    return values
+
+
+def test_content_ops_claim_registry_migration_is_tenant_scoped() -> None:
+    sql = MIGRATION.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS content_ops_claim_registry" in sql
+    assert "account_id        UUID NOT NULL REFERENCES saas_accounts(id)" in sql
+    assert "approved_wording  TEXT NOT NULL" in sql
+    assert "expires_on        DATE" in sql
+    assert "archived_at       TIMESTAMPTZ" in sql
+    assert "chk_content_ops_claim_registry_risk_tier" in sql
+    assert "uq_content_ops_claim_registry_account_registry_id_active" in sql
+    assert "ON content_ops_claim_registry (account_id, lower(btrim(registry_id)))" in sql
+    assert "WHERE archived_at IS NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_create_registry_claim_normalizes_and_inserts_claim() -> None:
+    account_id = uuid.uuid4()
+    expiration = date(2026, 12, 31)
+    pool = _Pool(
+        fetchrow_result=_row(
+            account_id=account_id,
+            risk_tier="high",
+            expires_on=expiration,
+        )
+    )
+
+    record = await registry.create_registry_claim(
+        pool,
+        account_id=account_id,
+        payload=_payload(risk_tier="HIGH", expires_on="2026-12-31"),
+    )
+
+    call = pool.fetchrow_calls[0]
+    assert "INSERT INTO content_ops_claim_registry" in call["query"]
+    args = call["args"]
+    assert args[0] == account_id
+    assert args[1] == "feature.sso"
+    assert args[2] == "SSO is included on every plan"
+    assert args[3] == "high"
+    assert args[4] == expiration
+    assert json.loads(args[5]) == {"source": "operator"}
+    assert record.risk_tier == RiskTier.HIGH
+    assert record.as_registry_claim().expiration == expiration
+
+
+@pytest.mark.asyncio
+async def test_create_registry_claim_treats_non_text_optional_fields_as_missing() -> None:
+    account_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result=_row(account_id=account_id, risk_tier=None))
+
+    record = await registry.create_registry_claim(
+        pool,
+        account_id=account_id,
+        payload=_payload(risk_tier={"label": "medium"}, expires_on=123, metadata=[]),
+    )
+
+    args = pool.fetchrow_calls[0]["args"]
+    assert args[3] is None
+    assert args[4] is None
+    assert json.loads(args[5]) == {}
+    assert record.risk_tier is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (_payload(registry_id=None), "registry id is required"),
+        (_payload(registry_id=42), "registry id is required"),
+        (_payload(approved_wording=" "), "Approved wording is required"),
+        (_payload(risk_tier="severe"), "Invalid risk tier"),
+        (_payload(expires_on="06/07/2026"), "Invalid expiration date"),
+    ],
+)
+async def test_create_registry_claim_rejects_invalid_payload(
+    payload: dict,
+    message: str,
+) -> None:
+    pool = _Pool(fetchrow_result=_row())
+
+    with pytest.raises(ValueError, match=message):
+        await registry.create_registry_claim(
+            pool,
+            account_id=uuid.uuid4(),
+            payload=payload,
+        )
+
+    assert pool.fetchrow_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_registry_claim_is_tenant_scoped() -> None:
+    account_id = uuid.uuid4()
+    claim_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result=_row(id=claim_id, account_id=account_id))
+
+    record = await registry.update_registry_claim(
+        pool,
+        account_id=account_id,
+        claim_id=claim_id,
+        payload=_payload(approved_wording="SSO is available on Pro plans"),
+    )
+
+    assert record is not None
+    call = pool.fetchrow_calls[0]
+    compact_sql = " ".join(call["query"].split())
+    assert "UPDATE content_ops_claim_registry" in compact_sql
+    assert "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL" in compact_sql
+    assert call["args"][:4] == (
+        claim_id,
+        account_id,
+        "feature.sso",
+        "SSO is available on Pro plans",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_registry_claim_returns_none_for_missing_row() -> None:
+    pool = _Pool(fetchrow_result=None)
+
+    record = await registry.update_registry_claim(
+        pool,
+        account_id=uuid.uuid4(),
+        claim_id=uuid.uuid4(),
+        payload=_payload(),
+    )
+
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_list_registry_claim_records_returns_display_records() -> None:
+    account_id = uuid.uuid4()
+    pool = _Pool(fetch_rows=[_row(account_id=account_id)])
+
+    records = await registry.list_registry_claim_records(pool, account_id=account_id)
+
+    assert records[0].account_id == account_id
+    assert records[0].metadata == {"source": "operator"}
+    assert records[0].as_registry_claim().approved_wording == (
+        "SSO is included on every plan"
+    )
+    call = pool.fetch_calls[0]
+    assert "WHERE account_id = $1" in call["query"]
+    assert "archived_at IS NULL" in call["query"]
+    assert call["args"] == (account_id,)
+
+
+@pytest.mark.asyncio
+async def test_expire_registry_claim_is_tenant_scoped_and_remains_readable() -> None:
+    account_id = uuid.uuid4()
+    claim_id = uuid.uuid4()
+    expiration = date(2026, 6, 7)
+    pool = _Pool(
+        fetchrow_result=_row(
+            id=claim_id,
+            account_id=account_id,
+            expires_on=expiration,
+        )
+    )
+
+    record = await registry.expire_registry_claim(
+        pool,
+        account_id=account_id,
+        claim_id=claim_id,
+        expires_on=expiration,
+    )
+
+    assert record is not None
+    assert record.expires_on == expiration
+    call = pool.fetchrow_calls[0]
+    compact_sql = " ".join(call["query"].split())
+    assert "SET expires_on = $3" in compact_sql
+    assert "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL" in compact_sql
+    assert call["args"] == (claim_id, account_id, expiration)
+
+
+@pytest.mark.asyncio
+async def test_archive_registry_claim_is_tenant_scoped() -> None:
+    account_id = uuid.uuid4()
+    claim_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result={"id": claim_id})
+
+    archived = await registry.archive_registry_claim(
+        pool,
+        account_id=account_id,
+        claim_id=claim_id,
+    )
+
+    assert archived is True
+    call = pool.fetchrow_calls[0]
+    compact_sql = " ".join(call["query"].split())
+    assert "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL" in compact_sql
+    assert call["args"] == (claim_id, account_id)
+
+
+@pytest.mark.asyncio
+async def test_archive_registry_claim_returns_false_for_missing_row() -> None:
+    archived = await registry.archive_registry_claim(
+        _Pool(fetchrow_result=None),
+        account_id=uuid.uuid4(),
+        claim_id=uuid.uuid4(),
+    )
+
+    assert archived is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", [TenantScope(), TenantScope(account_id="not-a-uuid")])
+async def test_repository_reader_fails_closed_on_invalid_tenant_scope(
+    scope: TenantScope,
+) -> None:
+    pool = _Pool(fetch_rows=[_row()])
+    repository = registry.ContentOpsClaimRegistryRepository(pool)
+
+    claims = await repository.list_registry_claims(scope=scope)
+
+    assert claims == {}
+    assert pool.fetch_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repository_reader_returns_registry_claim_mapping() -> None:
+    account_id = uuid.uuid4()
+    expiration = date(2026, 12, 31)
+    pool = _Pool(
+        fetch_rows=[
+            _row(
+                account_id=account_id,
+                registry_id="pricing.discount",
+                approved_wording="Save up to 30% on eligible annual plans",
+                risk_tier="high",
+                expires_on=expiration,
+            )
+        ]
+    )
+    repository = registry.ContentOpsClaimRegistryRepository(pool)
+
+    claims = await repository.list_registry_claims(
+        scope=TenantScope(account_id=str(account_id))
+    )
+
+    assert tuple(claims) == ("pricing.discount",)
+    claim = claims["pricing.discount"]
+    assert claim.approved_wording == "Save up to 30% on eligible annual plans"
+    assert claim.risk_tier == RiskTier.HIGH
+    assert claim.expiration == expiration
+    assert pool.fetch_calls[0]["args"] == (account_id,)
+
+
+@pytest.mark.asyncio
+async def test_review_service_consumes_repository_reader() -> None:
+    account_id = uuid.uuid4()
+    pool = _Pool(fetch_rows=[_row(account_id=account_id)])
+    repository = registry.ContentOpsClaimRegistryRepository(pool)
+
+    result = await run_content_ops_review(
+        ContentOpsReviewRequest(
+            asset_id="asset-1",
+            rule_packet=RulePacketVersions(
+                brief="brief-v1",
+                brand_voice="voice-v1",
+                claim_registry="claims-db-v1",
+                compliance="compliance-v1",
+                channel_schema="channel-v1",
+            ),
+            coverage=(
+                CoverageRow(
+                    rule_id="CLAIM-01",
+                    requirement="Claim is registered",
+                    status=CoverageStatus.PASS,
+                    evidence="registry row",
+                ),
+            ),
+            extracted_claims=(
+                ExtractedClaim(
+                    text="SSO is included on every plan",
+                    location="hero",
+                    registry_id="feature.sso",
+                ),
+            ),
+            as_of=date(2026, 6, 7),
+        ),
+        scope=TenantScope(account_id=str(account_id)),
+        registry_reader=repository,
+    )
+
+    assert result.decision == ReviewDecision.APPROVED
+    assert result.mapped_claims[0].approved_wording == "SSO is included on every plan"
+    assert pool.fetch_calls[0]["args"] == (account_id,)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Registry-Persistence.md
Slice phase: Vertical slice

Adds tenant-scoped claim and messaging registry persistence behind the existing Content Ops review-service registry reader boundary, closing the next #1353 wiring gap without starting the future marketer MCP transport.

## Intentional
- No marketer MCP transport, LLM claim extraction, FastAPI route, or generated-asset lifecycle mapping in this slice.
- Expiring a claim sets its expiration date but keeps the row readable so the deterministic claims map can block expired approved wording.
- The migration introduces a new table only; no backfill is needed because no prior durable claim registry exists.

## Deferred
- `PR-Content-Ops-Review-Status-Mapping`: map review decisions onto generated-asset lifecycle statuses.
- `PR-Content-Ops-Quality-Gate-Coverage-Rows`: map deterministic quality-gate and brand-voice findings into Content-PR coverage rows.
- `PR-Marketer-Verification-MCP`: expose verify-only marketer tools after service, registry, tenant binding, and status mapping are wired.
- `PR-Content-Ops-Calibration-Library`: deterministic calibration/adversarial examples from operating-model slice 5.

## Parked hardening
- None.

## Verification
- Focused claim-registry plus review-workflow pytest: 31 passed.
- Extracted pipeline CI enrollment audit: 155 matching tests enrolled.
- CI-enrollment audit regression pytest: 18 passed.
- ASCII Python policy: passed.
- Local PR review: passed.

## AI Reconciliation
All findings fixed or waived: Yes.
- Fixed Codex P2 invalid tenant scope finding by raising a typed registry-read error from the repository reader and converting that failure into a blocked review verdict at the service boundary.
- Fixed Codex P2 registry-id canonicalization finding by lowercasing/trimming registry ids on write and read, with tests proving mixed-case rows match canonical extractor ids.

## Diff size
8 files, +1049 / -1