### PR TITLE
Gate A Brand Voice Second-Person Enforcement

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -20,6 +20,7 @@ from .brand_voice import (
     BrandVoiceProfile,
     apply_brand_voice_to_system_prompt,
     brand_voice_profile_from_mapping,
+    brand_voice_quality_blockers,
     brand_voice_result_metadata,
 )
 from .content_image_provider import (
@@ -358,6 +359,35 @@ def _blog_quality_repair_guidance(blockers: Sequence[str]) -> str:
                 "`allowed_claims`, `forbidden_claims`, and `draft_answer_guidance` "
                 "instead of writing benefit or outcome claims."
             )
+        elif code.startswith("brand_voice:"):
+            if code == "brand_voice:preferred_pov_second_person_not_detected":
+                instructions.append(
+                    "- Rewrite the draft in second-person voice. Use `you` or `your` "
+                    "naturally in the title, description, content, and FAQ copy where "
+                    "it fits, while preserving the supplied facts and evidence."
+                )
+            elif code.startswith("brand_voice:banned_term:"):
+                term = code.rsplit(":", 1)[-1]
+                instructions.append(
+                    f"- Remove the banned brand-voice term `{term}` from every field. "
+                    "Replace it with plain wording that preserves the same grounded "
+                    "meaning."
+                )
+            elif code == "brand_voice:reading_level_concise_exceeded":
+                instructions.append(
+                    "- Shorten long sentences and make the wording concise while "
+                    "preserving the grounded claims."
+                )
+            elif code == "brand_voice:reading_level_plain_exceeded":
+                instructions.append(
+                    "- Simplify long sentences into plain, accessible wording while "
+                    "preserving the grounded claims."
+                )
+            else:
+                instructions.append(
+                    "- Fix the brand-voice blocker without changing grounded claims, "
+                    "evidence, measurements, or source details."
+                )
     if not instructions:
         instructions.append(
             "- Fix each blocker directly while preserving the required blog JSON "
@@ -833,10 +863,11 @@ class BlogPostGenerationService:
         blueprint: Mapping[str, Any],
         quality_gates_enabled: bool = True,
     ) -> dict[str, Any]:
-        # PR-OptionA-5: opt out of the quality gate per call. Same shape
-        # as report / sales_brief / landing_page.
+        # PR-OptionA-5: callers can opt out of the generic quality gate,
+        # but selected brand voice remains a caller-visible contract.
         if not quality_gates_enabled:
-            return {"passed": True, "blockers": ()}
+            blockers = brand_voice_quality_blockers(parsed)
+            return {"passed": not blockers, "blockers": blockers}
         context = _quality_context(parsed, blueprint)
         quality = evaluate_blog_post(
             QualityInput(
@@ -854,9 +885,18 @@ class BlogPostGenerationService:
             parsed,
             blueprint=blueprint,
         )
+        brand_voice_blockers = brand_voice_quality_blockers(parsed)
         return {
-            "passed": quality.passed and not support_ticket_blockers,
-            "blockers": tuple(f.message for f in quality.blockers) + support_ticket_blockers,
+            "passed": (
+                quality.passed
+                and not support_ticket_blockers
+                and not brand_voice_blockers
+            ),
+            "blockers": (
+                tuple(f.message for f in quality.blockers)
+                + support_ticket_blockers
+                + brand_voice_blockers
+            ),
         }
 
     def _build_draft(

--- a/extracted_content_pipeline/brand_voice.py
+++ b/extracted_content_pipeline/brand_voice.py
@@ -187,6 +187,24 @@ def brand_voice_audit(parsed: Mapping[str, Any], profile: BrandVoiceProfile) -> 
     }
 
 
+def brand_voice_quality_blockers(parsed: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return fail-visible blocker codes for failed brand-voice audits."""
+
+    audit = parsed.get("_brand_voice_audit")
+    if not isinstance(audit, Mapping) or audit.get("passed") is True:
+        return ()
+    blockers: list[str] = []
+    for warning in audit.get("warnings") or ():
+        warning_text = _clean(warning)
+        if warning_text:
+            blockers.append(f"brand_voice:{warning_text}")
+    for term in audit.get("banned_terms") or ():
+        term_text = _clean(term)
+        if term_text:
+            blockers.append(f"brand_voice:banned_term:{term_text}")
+    return tuple(dict.fromkeys(blockers))
+
+
 def _validate_scope(profile: BrandVoiceProfile, scope: TenantScope | None) -> None:
     expected = _clean(getattr(scope, "account_id", ""))
     if expected and profile.account_id and expected != profile.account_id:
@@ -254,7 +272,11 @@ def _flatten_text(value: Any) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, Mapping):
-        return " ".join(_flatten_text(item) for item in value.values())
+        return " ".join(
+            _flatten_text(item)
+            for key, item in value.items()
+            if not str(key).startswith("_")
+        )
     if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
         return " ".join(_flatten_text(item) for item in value)
     return ""
@@ -298,6 +320,7 @@ __all__ = [
     "BrandVoiceProfile",
     "apply_brand_voice_to_system_prompt",
     "brand_voice_audit",
+    "brand_voice_quality_blockers",
     "brand_voice_profile_from_mapping",
     "brand_voice_profile_metadata",
     "brand_voice_prompt_block",

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -51,6 +51,7 @@ from .brand_voice import (
     BrandVoiceProfile,
     apply_brand_voice_to_system_prompt,
     brand_voice_profile_from_mapping,
+    brand_voice_quality_blockers,
     brand_voice_result_metadata,
 )
 from .campaign_source_adapters import (
@@ -578,10 +579,11 @@ class SalesBriefGenerationService:
         *,
         quality_gates_enabled: bool = True,
     ) -> dict[str, Any]:
-        # PR-OptionA-4: opt out of the quality gate per call. Same shape
-        # as the landing-page service.
+        # PR-OptionA-4: callers can opt out of the generic quality gate,
+        # but selected brand voice remains a caller-visible contract.
         if not quality_gates_enabled:
-            return {"passed": True, "blockers": ()}
+            blockers = brand_voice_quality_blockers(parsed)
+            return {"passed": not blockers, "blockers": blockers}
         brief_input = QualityInput(
             artifact_type="sales_brief",
             context={
@@ -595,9 +597,10 @@ class SalesBriefGenerationService:
             },
         )
         report = evaluate_sales_brief(brief_input, policy=self._config.quality_policy)
+        brand_voice_blockers = brand_voice_quality_blockers(parsed)
         return {
-            "passed": report.passed,
-            "blockers": tuple(f.message for f in report.blockers),
+            "passed": report.passed and not brand_voice_blockers,
+            "blockers": tuple(f.message for f in report.blockers) + brand_voice_blockers,
         }
 
     def _build_draft(

--- a/plans/PR-Gate-A-Brand-Voice-Second-Person-Enforcement.md
+++ b/plans/PR-Gate-A-Brand-Voice-Second-Person-Enforcement.md
@@ -1,0 +1,138 @@
+# PR-Gate-A-Brand-Voice-Second-Person-Enforcement
+
+## Why this slice exists
+
+Gate A live output-quality proof found that the selected brand voice profile
+reached the LLM prompt, but live blog and sales-brief drafts could still miss
+the requested `preferred_pov=second_person`. Those drafts were persisted with
+`brand_voice_audit.passed=false`, which means the UI/review flow can show a
+selected brand voice while the generated asset did not actually honor it.
+
+This slice promotes failed brand-voice audit warnings into generation blockers
+for the two surfaces that missed in the live proof: blog posts and sales
+briefs. Blog generation already has a quality-repair loop, so it can repair a
+second-person miss before persistence. Sales briefs currently have no repair
+loop, so a miss fails visibly and does not save a draft that claims brand voice
+was applied.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/gate-a-output-quality
+Slice phase: Production hardening
+
+1. Convert failed brand-voice audits into deterministic quality blockers for
+   blog posts and sales briefs when a brand voice profile is supplied.
+2. Let blog generation use its existing repair loop to fix second-person POV
+   misses before persistence.
+3. Make sales-brief generation fail visibly on second-person POV misses instead
+   of persisting a draft with `brand_voice_audit.passed=false`.
+4. Add focused tests for blog repair, blog no-repair blocking, sales-brief
+   blocking, and compliant second-person pass-through.
+5. Address review feedback by keeping private generation metadata out of the
+   brand-voice audit text surface.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A parsed blog post with `preferred_pov=second_person` and no
+        `you`/`your` terms is treated as a quality blocker instead of being
+        persisted.
+  - [ ] Blog quality repair receives a concrete brand-voice repair instruction
+        and can persist a repaired second-person draft.
+  - [ ] A parsed sales brief with `preferred_pov=second_person` and no
+        `you`/`your` terms is skipped with a visible `quality_blocked` error.
+  - [ ] A compliant second-person draft for each surface still persists; no
+        brand voice means existing behavior is unchanged.
+- Affected surfaces: extracted brand-voice helpers, blog generation quality
+  checks/repair, sales-brief quality checks, focused extracted tests.
+- Risk areas: over-blocking content with no brand voice, disabling existing
+  blog quality repair, adding a hard dependency on live LLM behavior.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/blog_generation.py`
+- `extracted_content_pipeline/brand_voice.py`
+- `extracted_content_pipeline/sales_brief_generation.py`
+- `plans/PR-Gate-A-Brand-Voice-Second-Person-Enforcement.md`
+- `tests/test_extracted_blog_generation.py`
+- `tests/test_extracted_brand_voice.py`
+- `tests/test_extracted_sales_brief_generation.py`
+
+## Mechanism
+
+`brand_voice_result_metadata(...)` already attaches `_brand_voice_audit` to
+parsed LLM payloads when a profile is supplied. This PR adds a small helper in
+`brand_voice.py` that converts failed audit fields into deterministic blocker
+codes:
+
+```text
+brand_voice:preferred_pov_second_person_not_detected
+brand_voice:banned_term:<term>
+```
+
+The audit text flattener ignores underscore-prefixed private metadata fields
+such as `_variant_angle`, `_model`, and `_usage`; only user-facing draft fields
+can satisfy POV, banned-term, or reading-level checks.
+
+Blog generation appends those blockers to its existing quality blockers. If
+quality repair is enabled, the same repair loop asks the LLM to fix the brand
+voice miss, then re-runs the quality check before persistence. Sales-brief
+generation appends the same blockers to its quality check; because sales
+briefs do not have a repair loop yet, a failed brand-voice audit is skipped
+with `reason="quality_blocked"` and the blocker list in the error payload.
+
+## Intentional
+
+- This does not add a new LLM repair path to sales briefs. The narrow
+  production-hardening requirement is to stop persisting brand-voice misses;
+  a sales-brief repair loop is a larger follow-up.
+- This does not change the audit detector itself. The live miss was already
+  detected by `brand_voice_audit`; the gap was that generators treated the
+  failed audit as metadata only.
+- Failed brand-voice audits still block when a caller disables the generic
+  quality gate. A selected brand voice is a caller-visible contract, so the
+  generator must not persist output that its own brand-voice audit says failed.
+- Local review caller hints were inspected. Host references only construct the
+  blog/sales-brief services with unchanged signatures; the landing/report
+  `_quality_check` hits are same-name methods on other generator classes, not
+  call sites for the modified blog/sales-brief methods.
+- This does not run another live Gate A smoke. The slice is a deterministic
+  enforcement change; the messy-ticket rerun remains the later validation
+  artifact after the structural quality fixes land.
+
+## Deferred
+
+- Gate A landing-page distinctness: make whole-page variants meaningfully
+  different, not only hero-headline variants.
+- Gate A blog prose quality: resolve debug-style source narration.
+- Gate A messy-ticket rerun: rerun the live proof on noisy support-ticket data
+  after structural and prompt-quality fixes are in place.
+- Optional sales-brief brand-voice repair loop: add a repair attempt path if
+  product wants automatic repair instead of fail-visible skip for sales briefs.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_brand_voice.py tests/test_extracted_blog_generation.py tests/test_extracted_sales_brief_generation.py -q`
+  - PASS (`122 passed` after review fix).
+- `bash scripts/validate_extracted_content_pipeline.sh` - PASS.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS (`Atlas runtime import findings: 0`).
+- `bash scripts/check_ascii_python.sh` - PASS.
+- `bash scripts/run_extracted_pipeline_checks.sh` - PASS (`extracted_reasoning_core`: `295 passed`; `extracted_content_pipeline`: `3268 passed, 10 skipped`; one `pynvml` warning).
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/gate-a-brand-voice-second-person-enforcement-pr-body.md` - PASS; caller hints inspected as noted in Intentional.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/blog_generation.py` | 50 |
+| `extracted_content_pipeline/brand_voice.py` | 25 |
+| `extracted_content_pipeline/sales_brief_generation.py` | 13 |
+| `plans/PR-Gate-A-Brand-Voice-Second-Person-Enforcement.md` | 138 |
+| `tests/test_extracted_blog_generation.py` | 75 |
+| `tests/test_extracted_brand_voice.py` | 44 |
+| `tests/test_extracted_sales_brief_generation.py` | 54 |
+| **Total** | **399** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -1008,6 +1008,81 @@ async def test_generate_repairs_geo_quality_block_with_retry_budget() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_repairs_second_person_brand_voice_miss() -> None:
+    repaired_payload = json.loads(_valid_blog_json())
+    repaired_payload["title"] = "Your HubSpot Pricing Pressure Brief"
+    repaired_payload["description"] = (
+        "How you can read renewal pressure before your shortlist changes."
+    )
+    repaired_payload["content"] = (
+        "## What should you watch first?\n\n"
+        "You can read HubSpot pricing pressure through renewal friction, budget "
+        "concerns, and comparison shopping in the supplied evidence.\n\n"
+        + _valid_content()
+    )
+    service, _blueprints, blog_posts, llm, _skills = _service(
+        responses=[_valid_blog_json(), json.dumps(repaired_payload)],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
+            quality_repair_attempts=1,
+        ),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=1,
+        brand_voice={
+            "account_id": "acct-1",
+            "preferred_pov": "second_person",
+        },
+    )
+
+    assert result.generated == 1
+    assert result.errors == ()
+    assert len(llm.calls) == 2
+    retry_prompt = llm.calls[1]["messages"][1].content
+    assert "brand_voice:preferred_pov_second_person_not_detected" in retry_prompt
+    assert "Rewrite the draft in second-person voice" in retry_prompt
+    draft = blog_posts.saved[0]["drafts"][0]
+    assert draft.metadata["generation_quality_repair_attempts"] == 1
+    assert draft.metadata["brand_voice_audit"]["passed"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_blocks_second_person_brand_voice_miss_without_repair() -> None:
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        responses=[_valid_blog_json()],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
+            quality_repair_attempts=0,
+        ),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=1,
+        brand_voice={
+            "account_id": "acct-1",
+            "preferred_pov": "second_person",
+        },
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert "brand_voice:preferred_pov_second_person_not_detected" in result.errors[0]["blockers"]
+    assert blog_posts.saved == []
+
+
+@pytest.mark.asyncio
 async def test_generate_blocks_support_ticket_generated_content_failure_without_saving() -> None:
     service, _blueprints, blog_posts, _llm, _skills = _service(
         rows=[_support_ticket_blueprint()],

--- a/tests/test_extracted_brand_voice.py
+++ b/tests/test_extracted_brand_voice.py
@@ -6,6 +6,7 @@ from extracted_content_pipeline.brand_voice import (
     apply_brand_voice_to_system_prompt,
     brand_voice_profile_from_mapping,
     brand_voice_prompt_block,
+    brand_voice_quality_blockers,
     brand_voice_result_metadata,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
@@ -121,3 +122,46 @@ def test_brand_voice_audit_flags_reading_level_band() -> None:
 
     assert parsed["_brand_voice_audit"]["passed"] is False
     assert "reading_level_concise_exceeded" in parsed["_brand_voice_audit"]["warnings"]
+
+
+def test_brand_voice_audit_ignores_private_generation_metadata() -> None:
+    profile = brand_voice_profile_from_mapping(
+        {"id": "acme-main", "preferred_pov": "second_person"},
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    parsed = brand_voice_result_metadata(
+        {
+            "title": "Renewal risk brief",
+            "body": "The renewal risk is visible in repeated pricing complaints.",
+            "_variant_angle": "your renewal risk",
+        },
+        profile,
+    )
+
+    assert parsed["_brand_voice_audit"]["passed"] is False
+    assert "preferred_pov_second_person_not_detected" in parsed["_brand_voice_audit"]["warnings"]
+
+
+def test_brand_voice_quality_blockers_surface_failed_audit_fields() -> None:
+    parsed = {
+        "_brand_voice_audit": {
+            "passed": False,
+            "warnings": [
+                "preferred_pov_second_person_not_detected",
+                "preferred_pov_second_person_not_detected",
+                "",
+            ],
+            "banned_terms": ["synergy", "synergy", ""],
+        }
+    }
+
+    assert brand_voice_quality_blockers(parsed) == (
+        "brand_voice:preferred_pov_second_person_not_detected",
+        "brand_voice:banned_term:synergy",
+    )
+
+
+def test_brand_voice_quality_blockers_ignore_passed_or_missing_audits() -> None:
+    assert brand_voice_quality_blockers({}) == ()
+    assert brand_voice_quality_blockers({"_brand_voice_audit": {"passed": True}}) == ()

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -511,6 +511,60 @@ async def test_generate_skips_when_quality_pack_blocks_no_references() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_blocks_second_person_brand_voice_miss_without_saving() -> None:
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=[_valid_brief_json()]
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        brand_voice={
+            "account_id": "acct-1",
+            "preferred_pov": "second_person",
+        },
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert "brand_voice:preferred_pov_second_person_not_detected" in result.errors[0]["blockers"]
+    assert sales_briefs.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_persists_second_person_brand_voice_compliant_brief() -> None:
+    response = json.dumps({
+        "title": "Your Acme renewal brief",
+        "headline": "Your renewal window needs a precise next step",
+        "brief_type": "renewal",
+        "sections": [
+            {
+                "id": "account_context",
+                "title": "Your Account Context",
+                "body_markdown": "You have renewal pressure to address this week.",
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        brand_voice={
+            "account_id": "acct-1",
+            "preferred_pov": "second_person",
+        },
+    )
+
+    assert result.generated == 1
+    draft = sales_briefs.saved[0]["drafts"][0]
+    assert draft.metadata["brand_voice_audit"]["passed"] is True
+
+
+@pytest.mark.asyncio
 async def test_generate_blocks_when_response_omits_headline() -> None:
     """End-to-end: parser accepts the candidate, quality pack fires no_headline."""
     response = json.dumps({


### PR DESCRIPTION
Plan: plans/PR-Gate-A-Brand-Voice-Second-Person-Enforcement.md
Slice phase: Production hardening

Gate A live output-quality proof showed that selected second-person brand voice reached the prompt but could still persist as failed `_brand_voice_audit` metadata on blog and sales-brief drafts. This slice promotes failed brand-voice audit warnings into deterministic quality blockers for those two surfaces: blog can use its existing repair loop to fix the miss, while sales briefs fail visibly instead of saving a draft that did not honor the selected voice. The review update also keeps underscore-prefixed private generation metadata out of the brand-voice audit text surface, so `_variant_angle` cannot satisfy a POV check for otherwise off-voice public draft text.

## Intentional
- No new sales-brief repair loop; this slice stops bad persistence, and automatic sales-brief repair remains deferred.
- No brand-voice detector changes; the existing audit already found the live miss.
- Failed brand-voice audits still block when generic quality gates are disabled because selected brand voice is a caller-visible contract.
- Local review caller hints were inspected: host references only construct the blog/sales-brief services with unchanged signatures, and landing/report `_quality_check` hits are same-name methods on other generator classes.
- No new live Gate A smoke in this PR; the messy-ticket rerun stays deferred until structural quality fixes land.

## Deferred
- Gate A landing-page distinctness: make whole-page variants meaningfully different, not only hero-headline variants.
- Gate A blog prose quality: resolve debug-style source narration.
- Gate A messy-ticket rerun: rerun the live proof on noisy support-ticket data after structural and prompt-quality fixes are in place.
- Optional sales-brief brand-voice repair loop if product wants automatic repair instead of fail-visible skip.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_brand_voice.py tests/test_extracted_blog_generation.py tests/test_extracted_sales_brief_generation.py -q` - PASS (`122 passed`; rerun after review fix).
- `bash scripts/validate_extracted_content_pipeline.sh` - PASS.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS (`Atlas runtime import findings: 0`).
- `bash scripts/check_ascii_python.sh` - PASS.
- `bash scripts/run_extracted_pipeline_checks.sh` - PASS after review fix (`extracted_reasoning_core`: `295 passed`; `extracted_content_pipeline`: `3268 passed, 10 skipped`, one `pynvml` deprecation warning).
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/gate-a-brand-voice-second-person-enforcement-pr-body.md` - PASS; caller hints inspected as above.

## Diff size
7 files, +388 / -11 (399 LOC total).
