### PR TITLE
Content-Ops Review Status Mapping

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -52,6 +52,7 @@ from ..quote_card_export import export_quote_card_drafts
 from ..quote_card_postgres import PostgresQuoteCardRepository
 from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
+from ..review_contract import ReviewDecision
 from ..sales_brief_export import export_sales_brief_drafts
 from ..sales_brief_postgres import PostgresSalesBriefRepository
 from ..social_post_export import export_social_post_drafts
@@ -83,6 +84,14 @@ ASSET_CHOICES = (
     "faq_markdown",
 )
 logger = logging.getLogger(__name__)
+
+_REVIEW_DECISION_STATUS: Mapping[ReviewDecision, str] = {
+    ReviewDecision.APPROVED: "approved",
+    ReviewDecision.APPROVED_WITH_EXCEPTION: "approved",
+    ReviewDecision.REVISION_REQUIRED: "rejected",
+    ReviewDecision.BLOCKED: "queued",
+    ReviewDecision.ESCALATED: "queued",
+}
 
 
 def _require_fastapi() -> None:
@@ -229,6 +238,43 @@ def _review_status(value: Any) -> str:
     if not status:
         raise HTTPException(status_code=400, detail="status is required")
     return status
+
+
+def generated_asset_status_for_review_decision(value: Any) -> str:
+    """Map a content review decision onto the generated-asset lifecycle status."""
+
+    if isinstance(value, ReviewDecision):
+        cleaned = value.value
+    elif isinstance(value, str):
+        cleaned = _clean(value)
+    else:
+        cleaned = ""
+    if not cleaned:
+        raise ValueError("review_decision is required")
+    for decision, status in _REVIEW_DECISION_STATUS.items():
+        if decision == cleaned:
+            return status
+    allowed = ", ".join(decision.value for decision in ReviewDecision)
+    raise ValueError(f"review_decision must be one of {allowed}")
+
+
+def _review_status_from_payload(payload: Mapping[str, Any]) -> str:
+    if "status" in payload:
+        return _review_status(payload.get("status"))
+    decision_value = (
+        payload.get("review_decision")
+        if "review_decision" in payload
+        else payload.get("decision")
+    )
+    if "review_decision" not in payload and "decision" not in payload:
+        raise HTTPException(
+            status_code=400,
+            detail="status or review_decision is required",
+        )
+    try:
+        return generated_asset_status_for_review_decision(decision_value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _review_ids(value: Any) -> tuple[str, ...]:
@@ -430,7 +476,7 @@ def create_generated_asset_router(
         asset_id = _clean(payload.get("id") or payload.get("asset_id"))
         if not asset_id:
             raise HTTPException(status_code=400, detail="id is required")
-        status = _review_status(payload.get("status"))
+        status = _review_status_from_payload(payload)
         updated = await _update_asset_status(
             asset_name,
             pool,
@@ -536,7 +582,7 @@ def create_generated_asset_router(
                     f"({resolved_config.max_batch_size})"
                 ),
         )
-        status = _review_status(payload.get("status"))
+        status = _review_status_from_payload(payload)
         valid_ids, invalid_ids = _partition_uuid_ids(ids)
         updated = set(await _update_asset_statuses(
             asset_name,
@@ -1077,4 +1123,5 @@ __all__ = [
     "GeneratedAssetApiConfig",
     "create_generated_asset_router",
     "create_public_landing_page_router",
+    "generated_asset_status_for_review_decision",
 ]

--- a/plans/PR-Content-Ops-Review-Status-Mapping.md
+++ b/plans/PR-Content-Ops-Review-Status-Mapping.md
@@ -1,0 +1,119 @@
+# PR - Content-Ops Review Status Mapping
+
+## Why this slice exists
+
+Issue #1353 identifies the next wiring gap after the tenant claim registry:
+`ReviewDecision` and generated-asset lifecycle statuses still speak different
+vocabularies. The deterministic review service now returns accountable review
+decisions, but the generated-asset review routes still only accept arbitrary
+host status strings. Without an explicit mapping, future callers can either
+invent ad hoc status values or accidentally treat a blocked verdict as a normal
+review update.
+
+This slice keeps the MCP transport out and closes only the lifecycle vocabulary
+seam. The generated-assets API remains backward-compatible for existing
+host-defined statuses, while a caller that has a review verdict can pass that
+decision directly and get the correct lifecycle status.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+Add deterministic review-decision status mapping to the existing generated-asset
+review routes:
+
+1. Add a small mapping from `ReviewDecision` values to existing lifecycle
+   status strings.
+2. Let single and batch generated-asset review payloads provide
+   `review_decision` or `decision` instead of `status`.
+3. Preserve current behavior when callers provide `status`, including custom
+   host-defined statuses.
+4. Prove every decision branch, decoded string input, unknown-decision
+   rejection, and current custom-status behavior with focused tests.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `APPROVED` and `APPROVED_WITH_EXCEPTION` map to `approved`.
+  - [ ] `REVISION_REQUIRED` maps to `rejected`.
+  - [ ] `BLOCKED` and `ESCALATED` map to `queued`, never `approved`.
+  - [ ] Plain decoded decision strings behave the same as enum values.
+  - [ ] Unknown decisions fail with a 400 instead of silently storing them.
+  - [ ] Existing explicit `status` payloads keep working unchanged.
+  - [ ] No MCP transport, LLM, DB migration, or claim extraction is introduced.
+- Affected surfaces: API, generated-asset lifecycle status updates, CI coverage.
+- Risk areas: backcompat, decoded input robustness, silent approval, maintainability.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_content_asset_api.py`
+- `plans/PR-Content-Ops-Review-Status-Mapping.md`
+
+## Mechanism
+
+The generated-assets API will keep accepting explicit `status` values exactly
+as it does today. If `status` is absent, it will look for `review_decision` and
+then `decision`, normalize the value by equality against `ReviewDecision`, and
+write the mapped lifecycle status.
+
+The mapping is intentionally conservative:
+
+| Review decision | Generated-asset status |
+|---|---|
+| `approved` | `approved` |
+| `approved_with_exception` | `approved` |
+| `revision_required` | `rejected` |
+| `blocked` | `queued` |
+| `escalated` | `queued` |
+
+`blocked` means the review itself is incomplete or untrustworthy, so the asset
+stays in the queue rather than becoming approved or content-rejected.
+`escalated` is also a queue state because it needs human handling.
+
+## Intentional
+
+- This does not make generated-asset review routes run the review workflow yet.
+  It only gives service/tool callers a safe vocabulary bridge once they have a
+  verdict.
+- Explicit `status` still wins over `review_decision` to preserve existing host
+  callers and operational scripts.
+- The existing generated-assets status vocabulary remains host-extensible; this
+  slice adds a safe path for review decisions, not a global enum lock.
+- Cross-layer router callers are unaffected because the router factory
+  signature is unchanged and explicit `status` payload behavior is preserved;
+  focused host generated-assets and hosted-workflow tests cover those callers.
+
+## Deferred
+
+- `PR-Content-Ops-Quality-Gate-Coverage-Rows`: map deterministic quality-gate
+  and brand-voice findings into Content-PR coverage rows.
+- `PR-Content-Ops-Tenant-Binding-Bridge`: reconcile MCP/OAuth tenant binding
+  with the `TenantScope` used by host services.
+- `PR-Marketer-Verification-MCP`: expose verify-only marketer tools after the
+  service, registry, status mapping, tenant binding, and coverage-row wiring are
+  in place.
+- Parked hardening: none expected unless implementation surfaces non-blocking
+  generated-asset status audit gaps.
+
+## Verification
+
+- Focused generated-asset API pytest command -- 110 passed.
+- Focused host generated-assets API pytest command -- 16 passed.
+- Focused hosted-workflow API pytest command -- 3 passed.
+- Extracted pipeline CI enrollment audit command -- 155 matching tests are
+  enrolled.
+- Extracted package guardrail commands -- validation, Atlas reasoning import
+  ban, standalone audit, and ASCII policy passed.
+- Local PR review command with a prepared PR body file -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/generated_assets.py` | 51 |
+| `tests/test_extracted_content_asset_api.py` | 119 |
+| `plans/PR-Content-Ops-Review-Status-Mapping.md` | 119 |
+| **Total** | **289** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -26,6 +26,7 @@ from extracted_content_pipeline.faq_macro_writeback import (
     MacroPublishResult,
     MacroPublishStatus,
 )
+from extracted_content_pipeline.review_contract import ReviewDecision
 
 
 BATCH_REPORT_ID_1 = "11111111-1111-1111-1111-111111111111"
@@ -2619,6 +2620,124 @@ def test_generated_asset_router_rejects_empty_review_status() -> None:
 
     assert response.status_code == 400
     assert response.json()["detail"] == "status is required"
+
+
+@pytest.mark.parametrize(
+    ("decision", "expected_status"),
+    [
+        (ReviewDecision.APPROVED, "approved"),
+        (ReviewDecision.APPROVED_WITH_EXCEPTION, "approved"),
+        (ReviewDecision.REVISION_REQUIRED, "rejected"),
+        (ReviewDecision.BLOCKED, "queued"),
+        (ReviewDecision.ESCALATED, "queued"),
+        ("approved", "approved"),
+        ("revision_required", "rejected"),
+    ],
+)
+def test_generated_asset_status_for_review_decision_maps_lifecycle_status(
+    decision: object,
+    expected_status: str,
+) -> None:
+    assert (
+        asset_api.generated_asset_status_for_review_decision(decision)
+        == expected_status
+    )
+
+
+def test_generated_asset_status_for_review_decision_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="review_decision must be one of"):
+        asset_api.generated_asset_status_for_review_decision("ship_it")
+
+
+@pytest.mark.parametrize(
+    ("decision_key", "decision", "expected_status"),
+    [
+        ("review_decision", "approved", "approved"),
+        ("review_decision", "approved_with_exception", "approved"),
+        ("review_decision", "revision_required", "rejected"),
+        ("review_decision", "blocked", "queued"),
+        ("review_decision", "escalated", "queued"),
+        ("decision", "revision_required", "rejected"),
+    ],
+)
+def test_generated_asset_router_maps_review_decision_to_status(
+    decision_key: str,
+    decision: str,
+    expected_status: str,
+) -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/report/drafts/review",
+        json={"id": "report-uuid-1", decision_key: decision},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == expected_status
+    query, args = pool.execute_calls[0]
+    assert "UPDATE reports" in query
+    assert args == ("report-uuid-1", expected_status, "acct_1")
+
+
+def test_generated_asset_router_status_payload_wins_over_review_decision() -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/report/drafts/review",
+        json={
+            "id": "report-uuid-1",
+            "status": "published",
+            "review_decision": "revision_required",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "published"
+    assert pool.execute_calls[0][1] == ("report-uuid-1", "published", "acct_1")
+
+
+def test_generated_asset_router_rejects_unknown_review_decision() -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/report/drafts/review",
+        json={"id": "report-uuid-1", "review_decision": "ship_it"},
+    )
+
+    assert response.status_code == 400
+    assert "review_decision must be one of" in response.json()["detail"]
+    assert pool.execute_calls == []
+
+
+def test_generated_asset_router_requires_status_or_review_decision() -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/report/drafts/review",
+        json={"id": "report-uuid-1"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "status or review_decision is required"
+    assert pool.execute_calls == []
+
+
+def test_generated_asset_router_batch_maps_review_decision_to_status() -> None:
+    pool = _Pool(rows=[{"id": BATCH_REPORT_ID_1}, {"id": BATCH_REPORT_ID_2}])
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/report/drafts/review-batch",
+        json={
+            "ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2],
+            "review_decision": "revision_required",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "rejected"
+    query, args = pool.fetch_calls[0]
+    assert "UPDATE reports" in query
+    assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "rejected", "acct_1")
 
 
 def test_generated_asset_router_rejects_unknown_export_format() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Status-Mapping.md
Slice phase: Vertical slice

Adds an additive bridge from `ReviewDecision` verdicts to generated-asset lifecycle statuses so service/tool callers can pass `review_decision` or `decision` while existing explicit `status` payloads continue to work unchanged.

## Intentional
- Explicit `status` wins over `review_decision` to preserve host-defined statuses and existing scripts.
- `blocked` and `escalated` map to `queued`, never `approved`.
- No MCP transport, LLM, DB migration, claim extraction, or review-workflow execution is introduced in this slice.

## Deferred
- `PR-Content-Ops-Quality-Gate-Coverage-Rows`: map deterministic quality-gate and brand-voice findings into Content-PR coverage rows.
- `PR-Content-Ops-Tenant-Binding-Bridge`: reconcile MCP/OAuth tenant binding with `TenantScope`.
- `PR-Marketer-Verification-MCP`: expose verify-only marketer tools after the remaining seams are wired.

## Parked hardening
- None.

## Verification
- Focused generated-asset API pytest: 110 passed.
- Focused host generated-assets API pytest: 16 passed.
- Focused hosted-workflow API pytest: 3 passed.
- Extracted pipeline CI enrollment audit: 155 matching tests enrolled.
- Extracted package guardrails: validation, import ban, standalone audit, ASCII passed.
- Local PR review: passed.

## Diff size
3 files, +287 / -2