### PR TITLE
Gate A Blog Publishable Prose Gate

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -63,8 +63,8 @@ _SUPPORT_TICKET_QUESTION_RE = re.compile(
 )
 SUPPORT_TICKET_DESCRIPTIVE_BLOG_MODE = "descriptive_no_outcome"
 _SUPPORT_TICKET_DESCRIPTIVE_ALLOWED_CLAIMS = (
-    "observed support-ticket clusters and counts from the uploaded rows",
-    "customer wording copied from the uploaded tickets",
+    "observed support-ticket clusters and counts from the provided ticket set",
+    "customer wording copied from the provided tickets",
     "review-needed draft FAQ shells",
     "support-team verification work before publishing",
     "metrics to watch after publishing, without claiming those metrics improved",
@@ -84,7 +84,7 @@ _SUPPORT_TICKET_DESCRIPTIVE_FORBIDDEN_CLAIMS = (
     "claims that FAQ entries are discoverable, rank for keywords, or are working",
     (
         "fixed calendar windows, rolling periods, or future tracking intervals "
-        "when uploaded tickets are undated"
+        "when provided tickets are undated"
     ),
     "prioritization by business impact, activation delay, workflow blocking, or friction reduction without evidence",
     "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence",
@@ -95,7 +95,7 @@ _SUPPORT_TICKET_DRAFT_ANSWER_GUIDANCE = (
 _SUPPORT_TICKET_REQUIRED_SECTION_OUTLINE = (
     {
         "id": "observed-ticket-patterns",
-        "heading": "What the uploaded support tickets show",
+        "heading": "What repeat support questions show",
         "allowed_source_fields": (
             "source_row_count",
             "included_ticket_row_count",
@@ -137,7 +137,7 @@ _SUPPORT_TICKET_MEASUREMENT_GUIDANCE = (
     "Compare future tickets against the observed clusters without claiming causality.",
     (
         "Do not add fixed day, week, month, 30-day, 60-day, or 90-day "
-        "checkpoints unless the uploaded tickets include a dated source window."
+        "checkpoints unless the provided tickets include a dated source window."
     ),
 )
 _SUPPORT_TICKET_MAX_DRAFT_FAQ_SHELLS = 6
@@ -160,6 +160,32 @@ _SUPPORT_TICKET_DESCRIPTIVE_CONTRACT_KEYS = (
     "required_section_outline",
     "draft_faq_shells",
     "measurement_guidance",
+)
+_SUPPORT_TICKET_DEBUG_SOURCE_NARRATION_PATTERNS = (
+    re.compile(
+        r"\bthe uploaded (?:\d+\s+)?"
+        r"(?:csv|file|support[- ]tickets?|support[- ]ticket rows?|"
+        r"ticket rows?|records?|data|dataset) "
+        r"(?:contains?|shows?|includes?|reveals?|surfaces?)\b"
+    ),
+    re.compile(
+        r"\b(?:analysis of|looking at) (?:the )?(?:uploaded )?(?:\d+\s+)?"
+        r"(?:support[- ]tickets?|ticket rows?|records?|data|dataset)\b"
+        r".{0,80}\b(?:contains?|shows?|includes?|reveals?|surfaces?|clusters?)\b"
+    ),
+    re.compile(
+        r"\b(?:the )?dataset of (?:\d+\s+)?(?:support[- ])?tickets? "
+        r"(?:contains?|shows?|includes?|reveals?|surfaces?)\b"
+    ),
+    re.compile(r"\bacross (?:the )?(?:\d+\s+)?rows? in the export\b"),
+    re.compile(
+        r"\bthe support[- ]ticket data "
+        r"(?:contains?|shows?|includes?|reveals?|surfaces?)\b"
+    ),
+    re.compile(
+        r"\bthis export of (?:\d+\s+)?support[- ]tickets? "
+        r"(?:contains?|shows?|includes?|reveals?|surfaces?)\b"
+    ),
 )
 
 
@@ -359,6 +385,13 @@ def _blog_quality_repair_guidance(blockers: Sequence[str]) -> str:
                 "`allowed_claims`, `forbidden_claims`, and `draft_answer_guidance` "
                 "instead of writing benefit or outcome claims."
             )
+            if code.endswith(":debug_source_narration"):
+                instructions.append(
+                    "- Rewrite the draft as publishable customer-facing article prose. "
+                    "Do not open by narrating the upload, CSV, rows, file, or source "
+                    "mechanics. Preserve grounded support-ticket counts and clusters, "
+                    "but frame them as evidence for the reader."
+                )
         elif code.startswith("brand_voice:"):
             if code == "brand_voice:preferred_pov_second_person_not_detected":
                 instructions.append(
@@ -1120,7 +1153,29 @@ def _support_ticket_generated_content_blockers(
         f"support_ticket_generated_content:{error}"
         for error in errors
         if error
-    )
+    ) + _support_ticket_debug_source_narration_blockers(parsed)
+
+
+def _support_ticket_debug_source_narration_blockers(
+    parsed: Mapping[str, Any],
+) -> tuple[str, ...]:
+    text = " ".join(_public_blog_text_parts(parsed)).lower()
+    if any(pattern.search(text) for pattern in _SUPPORT_TICKET_DEBUG_SOURCE_NARRATION_PATTERNS):
+        return ("support_ticket_generated_content:debug_source_narration",)
+    return ()
+
+
+def _public_blog_text_parts(parsed: Mapping[str, Any]) -> tuple[str, ...]:
+    parts = [
+        parsed.get("title"),
+        parsed.get("description"),
+        parsed.get("seo_title"),
+        parsed.get("seo_description"),
+        parsed.get("content"),
+    ]
+    for faq in _mapping_list(parsed.get("faq")):
+        parts.extend((faq.get("question"), faq.get("answer")))
+    return tuple(str(part).strip() for part in parts if str(part or "").strip())
 
 
 def _merged_blog_data_context(
@@ -1387,6 +1442,10 @@ def _with_support_ticket_descriptive_prompt_addendum(
         "Support-ticket descriptive mode instructions:\n"
         "- Write a descriptive support-ticket FAQ planning brief, not a "
         "persuasive ROI article.\n"
+        "- Write publishable customer-facing article prose from the first "
+        "sentence. Do not open by narrating the upload, CSV, export, rows, "
+        "records, dataset, analysis process, or source mechanics; frame "
+        "observed counts and clusters as evidence for the reader.\n"
         "- Use only observed ticket counts, observed clusters, copied customer "
         "wording, and review-needed FAQ shells from the blueprint.\n"
         "- If clusters have the same count, say they are tied. Do not rank tied "

--- a/plans/PR-Gate-A-Blog-Publishable-Prose-Gate.md
+++ b/plans/PR-Gate-A-Blog-Publishable-Prose-Gate.md
@@ -1,0 +1,122 @@
+# PR-Gate-A-Blog-Publishable-Prose-Gate
+
+## Why this slice exists
+
+Gate A live output-quality proof exported an approved blog draft whose opening
+read like internal harness narration: "The uploaded CSV contains 36
+support-ticket rows...". That can pass structural blog checks while still being
+unshippable customer-facing prose.
+
+This slice prevents that class in the initial support-ticket prompt, promotes
+debug/source-upload narration into a blog quality blocker, then uses the
+existing blog repair loop to rewrite misses into publishable prose before
+persistence.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/gate-a-output-quality
+Slice phase: Production hardening
+
+1. Detect internal upload/source narration in blog title, description, content,
+   FAQ answers, and metadata text that would be visible to readers.
+2. Add publishable-prose instructions to the initial support-ticket descriptive
+   prompt so the model does not open by narrating uploads, rows, exports, or
+   source mechanics.
+3. Feed the blocker into the existing blog quality check/repair path.
+4. Add focused tests for block-without-repair, repair-with-guidance, varied
+   source-mechanics phrasings, and near-misses that can mention support-ticket
+   evidence without debug narration.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A blog draft that opens with "The uploaded CSV contains..." is
+        `quality_blocked` and not saved when repair is disabled.
+  - [ ] With repair enabled, the retry prompt names the debug-prose blocker and
+        asks for publishable customer-facing prose while preserving evidence.
+  - [ ] The initial support-ticket prompt asks for publishable customer-facing
+        prose and forbids opening with upload/CSV/export/row/source mechanics.
+  - [ ] Realistic variants such as "The uploaded CSV reveals...", "Analysis of
+        the 36 support tickets reveals...", and "This export of 36 support
+        tickets surfaces..." are blocked.
+  - [ ] A repaired draft that describes support-ticket evidence in publishable
+        language persists.
+  - [ ] A near-miss sentence such as "support tickets show account and
+        reporting questions" remains allowed.
+- Affected surfaces: blog generation support-ticket quality blockers, repair
+  guidance, focused extracted blog tests.
+- Risk areas: over-blocking grounded support-ticket evidence, adding prompt-only
+  guidance without deterministic enforcement, reintroducing false-green output.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/blog_generation.py`
+- `plans/PR-Gate-A-Blog-Publishable-Prose-Gate.md`
+- `tests/test_extracted_blog_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+
+## Mechanism
+
+Add the publishable-prose rule to the existing support-ticket descriptive
+prompt addendum and remove "uploaded support tickets" from the generated H2
+contract so prevention happens before the LLM writes the first draft.
+
+Add a deterministic helper near the existing support-ticket blog blockers. It
+scans public blog text for source-debug lead-ins such as:
+
+```text
+The uploaded CSV contains ...
+The uploaded CSV reveals ...
+Analysis of the 36 support tickets reveals ...
+This export of 36 support tickets surfaces ...
+```
+
+The helper returns a namespaced blocker
+`support_ticket_generated_content:debug_source_narration`. Blog quality checks
+append that blocker to the existing support-ticket generated-content blockers.
+The repair guidance tells the LLM to rewrite the prose for a customer-facing
+article without narrating the upload, CSV, rows, or internal source mechanics.
+
+## Intentional
+
+- This is still not a broad style classifier. Prevention is in the initial
+  prompt; the deterministic backstop blocks the realistic source-mechanics
+  openings from review while keeping normal support-ticket evidence allowed.
+- This does not change support-ticket evidence grounding. The repaired blog may
+  still cite ticket counts and clusters; it just must not read like a harness
+  report about uploaded files.
+- This does not rerun Gate A live validation. The messy-ticket rerun remains
+  deferred until the structural output-quality fixes land.
+
+## Deferred
+
+- Gate A landing-page variant distinctness remains the next structural quality
+  fix.
+- Gate A messy-ticket rerun remains deferred until blog and landing-page output
+  quality blockers are in place.
+- Issue #1357's report/email_campaign full-factory proof remains deferred until
+  the known 3-generator quality misses are structurally addressed.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_blog_generation.py -q` - PASS (`94 passed`).
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py::test_support_ticket_blog_blueprint_payload_uses_csv_counts -q` - PASS (`1 passed`).
+- `bash scripts/validate_extracted_content_pipeline.sh` - PASS.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS (`Atlas runtime import findings: 0`).
+- `bash scripts/check_ascii_python.sh` - PASS.
+- `bash scripts/run_extracted_pipeline_checks.sh` - PASS (`extracted_reasoning_core`: `295 passed`; `extracted_content_pipeline`: `3303 passed, 10 skipped`; one `pynvml` warning).
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/gate-a-blog-publishable-prose-gate-pr-body.md` - PASS (no non-diff caller references).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/blog_generation.py` | 71 |
+| `plans/PR-Gate-A-Blog-Publishable-Prose-Gate.md` | 122 |
+| `tests/test_extracted_blog_generation.py` | 159 |
+| `tests/test_smoke_content_ops_live_generation.py` | 4 |
+| **Total** | **356** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -12,6 +12,7 @@ from extracted_content_pipeline.blog_generation import (
     _is_support_ticket_blog_context,
     _normalize_blog_metadata,
     _quality_policy_for_context,
+    _support_ticket_debug_source_narration_blockers,
     parse_blog_post_response,
     support_ticket_descriptive_blog_contract,
 )
@@ -158,7 +159,7 @@ def _valid_content() -> str:
 def _valid_support_ticket_content(extra: str = "") -> str:
     body = (
         "## What do repeat support tickets show?\n\n"
-        "In the last 90 days, the uploaded 3 support tickets show account "
+        "In the last 90 days, 3 support tickets show account "
         "and reporting questions that customers keep asking. The clearest "
         "answer is that these teams need FAQ entries written in customer "
         "wording before another customer has to email support for the same "
@@ -177,13 +178,13 @@ def _valid_support_ticket_content(extra: str = "") -> str:
 def _large_support_ticket_descriptive_content(word_count: int = 1_000) -> str:
     sentence = (
         "Customers asked support about account email changes, billing exports, "
-        "and report access in the uploaded ticket rows. "
+        "and report access in the provided ticket set. "
     )
     words = sentence.split()
     repeated = (words * ((word_count // len(words)) + 1))[:word_count]
     midpoint = max(1, len(repeated) // 2)
     return (
-        "## What do the uploaded support tickets show?\n\n"
+        "## What repeat support questions show?\n\n"
         + " ".join(repeated[:midpoint])
         + "\n\n## Which repeated questions need clearer answers?\n\n"
         + " ".join(repeated[midpoint:])
@@ -461,12 +462,12 @@ def test_support_ticket_descriptive_blog_contract_requires_no_outcome_or_resolut
     )
     assert (
         "fixed calendar windows, rolling periods, or future tracking intervals "
-        "when uploaded tickets are undated"
+        "when provided tickets are undated"
         in contract["forbidden_claims"]
     )
     assert contract["draft_answer_guidance"].startswith("Draft answer -")
     assert [section["heading"] for section in contract["required_section_outline"]] == [
-        "What the uploaded support tickets show",
+        "What repeat support questions show",
         "Which FAQ gaps should be reviewed first",
         "Draft FAQ shells to verify",
         "What to measure after publishing",
@@ -495,7 +496,7 @@ def test_support_ticket_descriptive_blog_contract_requires_no_outcome_or_resolut
         "Compare future tickets against the observed clusters without claiming causality.",
         (
             "Do not add fixed day, week, month, 30-day, 60-day, or 90-day "
-            "checkpoints unless the uploaded tickets include a dated source window."
+            "checkpoints unless the provided tickets include a dated source window."
         ),
     ]
     assert support_ticket_descriptive_blog_contract({
@@ -1159,6 +1160,150 @@ async def test_generate_repairs_support_ticket_generated_content_failure() -> No
 
 
 @pytest.mark.asyncio
+async def test_generate_blocks_support_ticket_debug_source_narration_without_saving() -> None:
+    content = (
+        "The uploaded support-ticket rows show repeated "
+        "account and reporting questions.\n\n"
+        + _valid_support_ticket_content()
+    )
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        rows=[_support_ticket_blueprint()],
+        responses=[_valid_support_ticket_blog_json(content=content)],
+        config=BlogPostGenerationConfig(
+            parse_retry_attempts=0,
+            quality_repair_attempts=0,
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
+        ),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert "support_ticket_generated_content:debug_source_narration" in result.errors[0]["blockers"]
+    assert blog_posts.saved == []
+
+
+@pytest.mark.parametrize("opening", [
+    "The uploaded CSV contains 36 support-ticket rows with account questions.",
+    "Analysis of the 36 support tickets reveals nine clusters.",
+    "The dataset of 36 tickets shows the same questions coming back.",
+    "Across the 36 rows in the export, nine clusters appear.",
+    "The support ticket data reveals nine recurring topics.",
+    "Looking at the uploaded records, 36 tickets cluster into account questions.",
+    "The uploaded CSV reveals nine clusters across 36 rows.",
+    "This export of 36 support tickets surfaces nine themes.",
+])
+def test_support_ticket_debug_source_narration_blocks_varied_openings(opening: str) -> None:
+    parsed = json.loads(
+        _valid_support_ticket_blog_json(
+            content=f"{opening}\n\n{_valid_support_ticket_content()}"
+        )
+    )
+
+    assert _support_ticket_debug_source_narration_blockers(parsed) == (
+        "support_ticket_generated_content:debug_source_narration",
+    )
+
+
+@pytest.mark.parametrize("opening", [
+    "Support tickets show repeated account and reporting questions.",
+    "In 36 support tickets, account and reporting questions repeat.",
+    "Customers keep asking account and reporting questions in support tickets.",
+])
+def test_support_ticket_debug_source_narration_allows_publishable_evidence(
+    opening: str,
+) -> None:
+    parsed = json.loads(
+        _valid_support_ticket_blog_json(
+            content=f"{opening}\n\n{_valid_support_ticket_content()}"
+        )
+    )
+
+    assert _support_ticket_debug_source_narration_blockers(parsed) == ()
+
+
+@pytest.mark.asyncio
+async def test_generate_repairs_support_ticket_debug_source_narration() -> None:
+    content = (
+        "The uploaded support tickets contain 36 rows with repeated account "
+        "and reporting questions.\n\n"
+        + _valid_support_ticket_content()
+    )
+    repaired_content = (
+        "Support tickets show repeated account and reporting questions that "
+        "customers keep asking.\n\n"
+        + _valid_support_ticket_content()
+    )
+    service, _blueprints, blog_posts, llm, _skills = _service(
+        rows=[_support_ticket_blueprint()],
+        responses=[
+            _valid_support_ticket_blog_json(content=content),
+            _valid_support_ticket_blog_json(content=repaired_content),
+        ],
+        config=BlogPostGenerationConfig(
+            quality_repair_attempts=1,
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
+        ),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+    )
+
+    assert result.generated == 1
+    assert result.errors == ()
+    retry_prompt = llm.calls[1]["messages"][1].content
+    assert "support_ticket_generated_content:debug_source_narration" in retry_prompt
+    assert "publishable customer-facing article prose" in retry_prompt
+    draft = blog_posts.saved[0]["drafts"][0]
+    assert draft.metadata["generation_quality_repair_attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_allows_support_ticket_evidence_without_debug_narration() -> None:
+    content = (
+        "Support tickets show repeated account and reporting questions that "
+        "customers keep asking.\n\n"
+        + _valid_support_ticket_content()
+    )
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        rows=[_support_ticket_blueprint()],
+        responses=[_valid_support_ticket_blog_json(content=content)],
+        config=BlogPostGenerationConfig(
+            quality_repair_attempts=0,
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
+        ),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+    )
+
+    assert result.generated == 1
+    assert result.errors == ()
+    assert blog_posts.saved
+
+
+@pytest.mark.asyncio
 async def test_generate_saves_descriptive_support_ticket_blog_without_outcome_or_resolution_evidence() -> None:
     descriptive_content = _valid_support_ticket_content(
         "Teams with fewer tickets may have a simpler support queue, but this "
@@ -1223,6 +1368,8 @@ async def test_generate_puts_support_ticket_descriptive_contract_in_prompt() -> 
     assert '"draft_faq_shells":' in user_prompt
     assert '"measurement_guidance":' in user_prompt
     assert "Support-ticket descriptive mode instructions:" in user_prompt
+    assert "publishable customer-facing article prose" in user_prompt
+    assert "Do not open by narrating the upload, CSV, export, rows" in user_prompt
     assert "Do not rank tied clusters by business impact" in user_prompt
     assert (
         "Use `data_context.required_section_outline` as the H2 section order"

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -1328,7 +1328,7 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
         section["heading"]
         for section in payload["data_context"]["required_section_outline"]
     ] == [
-        "What the uploaded support tickets show",
+        "What repeat support questions show",
         "Which FAQ gaps should be reviewed first",
         "Draft FAQ shells to verify",
         "What to measure after publishing",
@@ -1354,7 +1354,7 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
         "Compare future tickets against the observed clusters without claiming causality.",
         (
             "Do not add fixed day, week, month, 30-day, 60-day, or 90-day "
-            "checkpoints unless the uploaded tickets include a dated source window."
+            "checkpoints unless the provided tickets include a dated source window."
         ),
     ]
     assert "report_date" not in payload["data_context"]


### PR DESCRIPTION
Plan: plans/PR-Gate-A-Blog-Publishable-Prose-Gate.md
Slice phase: Production hardening

Gate A live proof found an approved blog draft opening with internal upload narration ("The uploaded CSV contains 36 support-ticket rows..."). This prevents source-mechanics openings in the initial support-ticket prompt, keeps a deterministic quality backstop for varied upload/export/analysis phrasings, routes misses through the existing repair loop, and proves the near-miss path where support-ticket evidence can still be described in publishable language.

## Intentional
- Prevention is in the initial support-ticket prompt; the detector is a deterministic backstop for concrete source-upload narration, not a broad prose-style classifier.
- Support-ticket evidence remains allowed; the blocker targets harness/file/upload narration, not grounded ticket counts or clusters.
- No new live Gate A run in this PR; the messy-ticket rerun waits until the structural output-quality fixes land.

## Deferred
- Gate A landing-page variant distinctness remains the next structural quality fix.
- Gate A messy-ticket rerun remains deferred until blog and landing-page output quality blockers are in place.
- Issue #1357's report/email_campaign full-factory proof remains deferred until the known 3-generator quality misses are structurally addressed.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes.
- Fixed Codex P2: hyphenated `support-ticket rows` upload narration is now blocked.
- Fixed human MAJOR: the initial support-ticket prompt now prevents upload/CSV/export/row/source-mechanics openings, the support-ticket section contract no longer uses "uploaded support tickets" as an H2, and the backstop covers the varied debug-style openings listed in review.

## Verification
- `python -m pytest tests/test_extracted_blog_generation.py -q` - PASS (`94 passed`).
- `python -m pytest tests/test_smoke_content_ops_live_generation.py::test_support_ticket_blog_blueprint_payload_uses_csv_counts -q` - PASS (`1 passed`).
- `bash scripts/validate_extracted_content_pipeline.sh` - PASS.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS (`Atlas runtime import findings: 0`).
- `bash scripts/check_ascii_python.sh` - PASS.
- `bash scripts/run_extracted_pipeline_checks.sh` - PASS (`extracted_reasoning_core`: `295 passed`; `extracted_content_pipeline`: `3303 passed, 10 skipped`; one `pynvml` warning).
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/gate-a-blog-publishable-prose-gate-pr-body.md` - PASS (no non-diff caller references).

## Diff size
4 files, 356 LOC total.
