### PR TITLE
Content-Ops Quality Gate Coverage Rows

### DIFF
--- a/extracted_content_pipeline/coverage_rows.py
+++ b/extracted_content_pipeline/coverage_rows.py
@@ -1,0 +1,144 @@
+"""Coverage-row adapters for deterministic content-review evidence."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from extracted_quality_gate.types import GateSeverity
+
+from .content_pr import CoverageRow, CoverageStatus
+
+_QUALITY_NAMESPACE = "QUALITY-GATE"
+_BRAND_VOICE_NAMESPACE = "BRAND-VOICE"
+
+
+def quality_gate_coverage_rows(
+    report: Any,
+    *,
+    rule_namespace: str = _QUALITY_NAMESPACE,
+) -> tuple[CoverageRow, ...]:
+    """Map a quality-gate report into Content-PR coverage rows."""
+
+    namespace = _clean(rule_namespace) or _QUALITY_NAMESPACE
+    if not (isinstance(report, Mapping) or hasattr(report, "passed")):
+        return (_row(namespace, "report", "quality report is present"),)
+
+    passed = _get(report, "passed")
+    passed = passed if isinstance(passed, bool) else None
+    rows: list[CoverageRow] = []
+    for index, finding in enumerate(_items(_get(report, "findings")), start=1):
+        code, message, severity, field = _finding_parts(finding)
+        if not (code or message or severity):
+            rows.append(_row(namespace, f"malformed-finding-{index}", "quality finding is well-formed"))
+        elif severity == GateSeverity.BLOCKER:
+            evidence = f"{message} ({field})" if message and field else message or field or code
+            rows.append(_row(namespace, code or message, message or "quality blocker", status=CoverageStatus.FAIL, evidence=evidence))
+        elif severity in (GateSeverity.WARNING, GateSeverity.INFO):
+            rows.append(_row(namespace, code or message, message or "quality finding", required=False, status=CoverageStatus.FAIL, evidence=message or code))
+        else:
+            rows.append(_row(namespace, code or message, "quality finding severity is known"))
+
+    if any(row.required and row.status == CoverageStatus.FAIL for row in rows):
+        return tuple(rows)
+    if passed is True:
+        return (_row(namespace, "report", "quality report passes deterministic gates", status=CoverageStatus.PASS, evidence="quality report passed"), *rows)
+    if passed is False:
+        return (_row(namespace, "report", "quality report passes deterministic gates", status=CoverageStatus.FAIL, evidence="quality report failed without blocker findings"), *rows)
+    return (_row(namespace, "report", "quality report passed flag is present"), *rows)
+
+
+def brand_voice_coverage_rows(
+    payload: Any,
+    *,
+    rule_namespace: str = _BRAND_VOICE_NAMESPACE,
+) -> tuple[CoverageRow, ...]:
+    """Map a brand-voice audit mapping into Content-PR coverage rows."""
+
+    namespace = _clean(rule_namespace) or _BRAND_VOICE_NAMESPACE
+    audit = _brand_voice_audit(payload)
+    if audit is None:
+        return (_row(namespace, "audit", "brand voice audit is present"),)
+
+    rows = [
+        _row(namespace, f"warning:{warning}", "brand voice warning", status=CoverageStatus.FAIL, evidence=warning)
+        for warning in _strings(audit.get("warnings"))
+    ]
+    rows.extend(
+        _row(namespace, f"banned-term:{term}", "brand voice banned term", status=CoverageStatus.FAIL, evidence=term)
+        for term in _strings(audit.get("banned_terms"))
+    )
+    if rows:
+        return tuple(rows)
+    if audit.get("passed") is True:
+        return (_row(namespace, "audit", "brand voice audit passes", status=CoverageStatus.PASS, evidence="brand voice audit passed"),)
+    if audit.get("passed") is False:
+        return (_row(namespace, "audit", "brand voice audit passes", status=CoverageStatus.FAIL, evidence="brand voice audit failed without findings"),)
+    return (_row(namespace, "audit", "brand voice audit passed flag is present"),)
+
+
+def _row(
+    namespace: str,
+    code: str,
+    requirement: str,
+    *,
+    required: bool = True,
+    status: CoverageStatus = CoverageStatus.UNRESOLVED,
+    evidence: str = "",
+) -> CoverageRow:
+    return CoverageRow(
+        rule_id=f"{namespace}:{_code(code)}",
+        requirement=requirement,
+        required=required,
+        status=status,
+        evidence=evidence or (requirement if status == CoverageStatus.FAIL else ""),
+    )
+
+
+def _finding_parts(value: Any) -> tuple[str, str, str, str]:
+    return (
+        _clean(_get(value, "code")),
+        _clean(_get(value, "message")),
+        _clean(_enum_value(_get(value, "severity"))).lower(),
+        _clean(_get(value, "field_name")),
+    )
+
+
+def _items(value: Any) -> tuple[Any, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, Mapping) or isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return tuple(value)
+    return (value,)
+
+
+def _brand_voice_audit(payload: Any) -> Mapping[str, Any] | None:
+    if not isinstance(payload, Mapping):
+        return None
+    audit = payload.get("_brand_voice_audit", payload.get("brand_voice_audit", payload))
+    return audit if isinstance(audit, Mapping) else None
+
+
+def _get(value: Any, key: str) -> Any:
+    return value.get(key) if isinstance(value, Mapping) else getattr(value, key, None)
+
+
+def _strings(value: Any) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(text for text in (_clean(v) for v in _items(value)) if text))
+
+
+def _code(value: str) -> str:
+    return "-".join("".join(char if char.isalnum() else "-" for char in _clean(value).lower()).split("-")) or "row"
+
+
+def _enum_value(value: Any) -> Any:
+    enum_value = getattr(value, "value", None)
+    return enum_value if isinstance(enum_value, str) else value
+
+
+def _clean(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+__all__ = ["brand_voice_coverage_rows", "quality_gate_coverage_rows"]

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -244,6 +244,9 @@
       "target": "extracted_content_pipeline/content_pr.py"
     },
     {
+      "target": "extracted_content_pipeline/coverage_rows.py"
+    },
+    {
       "target": "extracted_content_pipeline/blog_post_export.py"
     },
     {

--- a/plans/PR-Content-Ops-Quality-Gate-Coverage-Rows.md
+++ b/plans/PR-Content-Ops-Quality-Gate-Coverage-Rows.md
@@ -1,0 +1,95 @@
+# PR - Content-Ops Quality Gate Coverage Rows
+
+## Why this slice exists
+
+Issue #1353 says the deterministic quality packs and brand-voice audit already
+exist; the missing seam is turning their findings into `ContentPR` coverage
+rows. Without that adapter, the verdict engine stays dependent on hand-written
+coverage even when deterministic gate evidence is already available.
+
+This slice lands only the pure adapter. MCP transport, LLM-assisted review,
+service threading, and generated-asset mutation stay deferred.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+Add deterministic coverage-row adapters:
+
+1. Convert typed or decoded quality reports into resolved `CoverageRow` values.
+2. Convert brand-voice audit mappings into resolved `CoverageRow` values.
+3. Emit unresolved required rows for missing or malformed evidence.
+4. Keep warning/info quality findings visible as optional resolved rows.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Passing quality reports emit a required `pass` row.
+  - [ ] Blocker quality findings emit required `fail` rows.
+  - [ ] Warning/info quality findings emit optional resolved rows.
+  - [ ] Failed reports without blocker findings emit required `fail` rows.
+  - [ ] Missing/malformed reports emit unresolved required rows.
+  - [ ] Brand-voice warnings and banned terms emit required `fail` rows.
+  - [ ] Brand-voice pass emits a required `pass` row.
+  - [ ] No MCP, LLM, DB migration, tenant binding, or asset mutation is added.
+- Affected surfaces: extracted package pure adapter, CI enrollment.
+- Risk areas: silent approval, decoded input robustness, backcompat.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/coverage_rows.py`
+- `extracted_content_pipeline/manifest.json`
+- `tests/test_extracted_content_coverage_rows.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `plans/PR-Content-Ops-Quality-Gate-Coverage-Rows.md`
+
+## Mechanism
+
+The adapter reads quality reports structurally, so both value objects and
+decoded mapping payloads work. A passed report gets one required pass row.
+Blocker findings become required failures. Warning/info findings become optional
+resolved rows. A failed report with no structured blocker still becomes a
+required failure.
+
+Brand-voice audit mappings follow the same fail-closed shape: `passed: true`
+becomes a required pass; warnings and banned terms become required failures;
+missing or malformed audits become unresolved rows so `review_verdict` blocks.
+
+## Intentional
+
+- This does not run quality packs; callers still choose the asset-specific
+  pack.
+- This does not store or attach rows to a `ContentPR`; it only builds rows.
+- Missing evidence blocks as incomplete review evidence, not content failure.
+- Warning/info quality findings remain visible without blocking by themselves.
+
+## Deferred
+
+- `PR-Content-Ops-Review-Service-Gate-Rows`: thread these rows through the host
+  review workflow service.
+- `PR-Content-Ops-Tenant-Binding-Bridge`: reconcile connector tenant binding
+  with `TenantScope`.
+- `PR-Marketer-Verification-MCP`: expose verify-only marketer tools after the
+  remaining seams are wired.
+- Parked hardening: none expected.
+
+## Verification
+
+- Focused coverage-row and Content-PR pytest command -- 32 passed.
+- Extracted pipeline CI enrollment audit command -- 156 matching tests are
+  enrolled.
+- Extracted package guardrail commands -- validation, Atlas reasoning import
+  ban, standalone audit, and ASCII policy passed.
+- Local PR review command with a prepared PR body file -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/coverage_rows.py` | 144 |
+| `tests/test_extracted_content_coverage_rows.py` | 154 |
+| `plans/PR-Content-Ops-Quality-Gate-Coverage-Rows.md` | 95 |
+| manifest + CI enrollment | 4 |
+| **Total** | **397** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -20,6 +20,7 @@ pytest \
   tests/test_extracted_content_triage_experiment.py \
   tests/test_extracted_content_claims_map.py \
   tests/test_extracted_content_pr.py \
+  tests/test_extracted_content_coverage_rows.py \
   tests/test_extracted_campaign_visibility.py \
   tests/test_extracted_campaign_visibility_reader_cli.py \
   tests/test_extracted_campaign_manifest.py \

--- a/tests/test_extracted_content_coverage_rows.py
+++ b/tests/test_extracted_content_coverage_rows.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from extracted_content_pipeline.content_pr import (
+    ContentPR,
+    CoverageStatus,
+    RulePacketVersions,
+    review_verdict,
+)
+from extracted_content_pipeline.coverage_rows import (
+    brand_voice_coverage_rows,
+    quality_gate_coverage_rows,
+)
+from extracted_content_pipeline.review_contract import ReviewDecision
+from extracted_quality_gate.types import GateDecision, GateFinding, GateSeverity, QualityReport
+
+
+_PINNED = RulePacketVersions(
+    brief="brief-v1",
+    brand_voice="voice-v1",
+    claim_registry="claims-v1",
+    compliance="compliance-v1",
+    channel_schema="channel-v1",
+)
+
+
+def _verdict(rows):
+    return review_verdict(ContentPR(rule_packet=_PINNED, coverage=tuple(rows)))
+
+
+def test_quality_gate_pass_emits_required_pass_row() -> None:
+    rows = quality_gate_coverage_rows(QualityReport(passed=True, decision=GateDecision.PASS))
+
+    assert len(rows) == 1
+    assert rows[0].rule_id == "QUALITY-GATE:report"
+    assert rows[0].required is True
+    assert rows[0].status == CoverageStatus.PASS
+    assert rows[0].is_resolved() is True
+    assert _verdict(rows) is ReviewDecision.APPROVED
+
+
+def test_quality_gate_blocker_emits_required_fail_row() -> None:
+    rows = quality_gate_coverage_rows(
+        QualityReport(
+            passed=False,
+            decision=GateDecision.BLOCK,
+            findings=(
+                GateFinding(
+                    code="no_cta",
+                    message="CTA is missing",
+                    severity=GateSeverity.BLOCKER,
+                    field_name="cta",
+                ),
+            ),
+        )
+    )
+
+    assert rows[0].rule_id == "QUALITY-GATE:no-cta"
+    assert rows[0].required is True
+    assert rows[0].status == CoverageStatus.FAIL
+    assert "cta" in rows[0].evidence
+    assert _verdict(rows) is ReviewDecision.REVISION_REQUIRED
+
+
+def test_quality_gate_warnings_are_optional_resolved_rows() -> None:
+    rows = quality_gate_coverage_rows(
+        QualityReport(
+            passed=True,
+            decision=GateDecision.WARN,
+            findings=(
+                GateFinding("missing_confidence", "confidence missing", GateSeverity.WARNING),
+                GateFinding("word_count", "word count noted", GateSeverity.INFO),
+            ),
+        )
+    )
+
+    assert rows[0].status == CoverageStatus.PASS
+    assert [row.required for row in rows[1:]] == [False, False]
+    assert all(row.is_resolved() for row in rows)
+    assert _verdict(rows) is ReviewDecision.APPROVED
+
+
+def test_quality_gate_decoded_failures_do_not_pass() -> None:
+    failed_without_findings = quality_gate_coverage_rows(
+        {"passed": False, "decision": "block", "findings": []}
+    )
+    decoded_blocker = quality_gate_coverage_rows(
+        {
+            "passed": False,
+            "findings": [
+                {
+                    "code": "unsupported_claim",
+                    "message": "unsupported claim",
+                    "severity": "blocker",
+                }
+            ],
+        }
+    )
+
+    assert failed_without_findings[0].status == CoverageStatus.FAIL
+    assert decoded_blocker[0].status == CoverageStatus.FAIL
+    assert _verdict(failed_without_findings) is ReviewDecision.REVISION_REQUIRED
+    assert _verdict(decoded_blocker) is ReviewDecision.REVISION_REQUIRED
+
+
+def test_quality_gate_missing_malformed_and_unknown_inputs_block() -> None:
+    cases = (
+        None,
+        "not a report",
+        {"passed": "yes"},
+        {"passed": True, "findings": [{"code": "mystery", "severity": "maybe"}]},
+        {"passed": True, "findings": ["bad"]},
+    )
+
+    for report in cases:
+        rows = quality_gate_coverage_rows(report)
+        assert any(row.status == CoverageStatus.UNRESOLVED for row in rows)
+        assert _verdict(rows) is ReviewDecision.BLOCKED
+
+
+def test_brand_voice_pass_emits_required_pass_row() -> None:
+    for key in ("_brand_voice_audit", "brand_voice_audit"):
+        rows = brand_voice_coverage_rows({key: {"passed": True}})
+
+        assert rows[0].rule_id == "BRAND-VOICE:audit"
+        assert rows[0].status == CoverageStatus.PASS
+        assert rows[0].required is True
+        assert _verdict(rows) is ReviewDecision.APPROVED
+
+
+def test_brand_voice_warnings_and_banned_terms_emit_fail_rows() -> None:
+    rows = brand_voice_coverage_rows(
+        {
+            "_brand_voice_audit": {
+                "passed": False,
+                "warnings": ["preferred_pov_second_person_not_detected", None],
+                "banned_terms": ["synergy", "synergy", 5],
+            }
+        }
+    )
+
+    assert [row.rule_id for row in rows] == [
+        "BRAND-VOICE:warning-preferred-pov-second-person-not-detected",
+        "BRAND-VOICE:banned-term-synergy",
+    ]
+    assert all(row.required for row in rows)
+    assert all(row.status == CoverageStatus.FAIL for row in rows)
+    assert _verdict(rows) is ReviewDecision.REVISION_REQUIRED
+
+
+def test_brand_voice_missing_or_malformed_audit_blocks() -> None:
+    for payload in ({}, {"_brand_voice_audit": "bad"}, None):
+        rows = brand_voice_coverage_rows(payload)
+        assert rows[0].status == CoverageStatus.UNRESOLVED
+        assert _verdict(rows) is ReviewDecision.BLOCKED


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Quality-Gate-Coverage-Rows.md
Slice phase: Vertical slice

Adds pure deterministic adapters that map quality-gate reports and brand-voice audits into `ContentPR` coverage rows. Missing or malformed evidence emits unresolved required rows so the verdict engine blocks instead of approving silently.

## Intentional
- The adapter does not run quality packs; callers still choose the asset-specific pack.
- The adapter does not store or attach rows to a `ContentPR`; it only builds rows.
- Missing evidence blocks as incomplete review evidence, not content failure.
- Warning/info quality findings remain visible without blocking by themselves.

## Deferred
- `PR-Content-Ops-Review-Service-Gate-Rows`: thread these rows through the host review workflow service.
- `PR-Content-Ops-Tenant-Binding-Bridge`: reconcile connector tenant binding with `TenantScope`.
- `PR-Marketer-Verification-MCP`: expose verify-only marketer tools after the remaining seams are wired.

## Parked hardening
- None.

## AI reconciliation
- Codex P2 / reviewer MAJOR: production metadata stores brand voice audits under `brand_voice_audit`, not only `_brand_voice_audit`. Fixed by unwrapping both keys and adding the public metadata-shape regression to the pass-row test.
- All fixed or waived: Yes.

## Verification
- Focused coverage-row and Content-PR pytest: 32 passed.
- Extracted pipeline CI enrollment audit: 156 matching tests enrolled.
- Extracted package guardrails: validation, import ban, standalone audit, ASCII passed.
- Local PR review: passed.

## Diff size
5 files, +397 / -0