### PR TITLE
Content-Ops Review Service Gate Rows

### DIFF
--- a/atlas_brain/_content_ops_review_workflow.py
+++ b/atlas_brain/_content_ops_review_workflow.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
-from typing import Any, Mapping, Protocol
+from typing import Any, Mapping, Protocol, Sequence
 
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.claims_map import (
@@ -29,6 +29,10 @@ from extracted_content_pipeline.content_pr import (
     RulePacketVersions,
     review_verdict,
     verdict_reasons,
+)
+from extracted_content_pipeline.coverage_rows import (
+    brand_voice_coverage_rows,
+    quality_gate_coverage_rows,
 )
 from extracted_content_pipeline.review_contract import ReviewDecision
 
@@ -55,6 +59,8 @@ class ContentOpsReviewRequest:
     asset_id: str = ""
     rule_packet: RulePacketVersions = RulePacketVersions()
     coverage: tuple[CoverageRow, ...] = ()
+    quality_reports: tuple[Any, ...] = ()
+    brand_voice_payload: Mapping[str, Any] | None = None
     extracted_claims: tuple[ExtractedClaim, ...] = ()
     comments: tuple[ReviewComment, ...] = ()
     as_of: date | None = None
@@ -112,10 +118,11 @@ async def run_content_ops_review(
         registry,
         as_of=request.as_of or date.today(),
     )
+    coverage = _coverage_rows_for_request(request)
     content_pr = ContentPR(
         asset_id=request.asset_id,
         rule_packet=request.rule_packet,
-        coverage=request.coverage,
+        coverage=coverage,
         claims=mapped_claims,
         comments=request.comments,
     )
@@ -135,7 +142,7 @@ def _blocked_result(
     content_pr = ContentPR(
         asset_id=request.asset_id,
         rule_packet=request.rule_packet,
-        coverage=request.coverage,
+        coverage=_coverage_rows_for_request(request),
         claims=(),
         comments=request.comments,
     )
@@ -152,6 +159,25 @@ def _scope_account_id(scope: TenantScope | None) -> str:
     if not isinstance(value, str):
         return ""
     return value.strip()
+
+
+def _coverage_rows_for_request(request: ContentOpsReviewRequest) -> tuple[CoverageRow, ...]:
+    rows = list(request.coverage or ())
+    for report in _items(request.quality_reports):
+        rows.extend(quality_gate_coverage_rows(report))
+    if request.brand_voice_payload is not None:
+        rows.extend(brand_voice_coverage_rows(request.brand_voice_payload))
+    return tuple(rows)
+
+
+def _items(value: Any) -> tuple[Any, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, Mapping) or isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return tuple(value)
+    return (value,)
 
 
 def _mapped_claim_as_dict(claim: MappedClaim) -> dict[str, Any]:

--- a/extracted_content_pipeline/coverage_rows.py
+++ b/extracted_content_pipeline/coverage_rows.py
@@ -10,6 +10,20 @@ from .content_pr import CoverageRow, CoverageStatus
 
 _QUALITY_NAMESPACE = "QUALITY-GATE"
 _BRAND_VOICE_NAMESPACE = "BRAND-VOICE"
+_QUALITY_BLOCKING_FIELDS = ("decision", "verdict", "outcome")
+_QUALITY_BLOCKING_VALUES = (
+    "approval_required",
+    "block",
+    "blocked",
+    "blocking",
+    "deny",
+    "denied",
+    "fail",
+    "failed",
+    "failure",
+    "reject",
+    "rejected",
+)
 
 
 def quality_gate_coverage_rows(
@@ -25,6 +39,7 @@ def quality_gate_coverage_rows(
 
     passed = _get(report, "passed")
     passed = passed if isinstance(passed, bool) else None
+    contradiction = _quality_gate_contradiction(report, passed)
     rows: list[CoverageRow] = []
     for index, finding in enumerate(_items(_get(report, "findings")), start=1):
         code, message, severity, field = _finding_parts(finding)
@@ -40,6 +55,17 @@ def quality_gate_coverage_rows(
 
     if any(row.required and row.status == CoverageStatus.FAIL for row in rows):
         return tuple(rows)
+    if contradiction is not None:
+        field, value = contradiction
+        return (
+            _row(
+                namespace,
+                f"contradictory-{field}",
+                f"quality report {field} agrees with passed flag",
+                evidence=f"passed=True but {field}={value}",
+            ),
+            *rows,
+        )
     if passed is True:
         return (_row(namespace, "report", "quality report passes deterministic gates", status=CoverageStatus.PASS, evidence="quality report passed"), *rows)
     if passed is False:
@@ -103,6 +129,16 @@ def _finding_parts(value: Any) -> tuple[str, str, str, str]:
     )
 
 
+def _quality_gate_contradiction(report: Any, passed: bool | None) -> tuple[str, str] | None:
+    if passed is not True:
+        return None
+    for field in _QUALITY_BLOCKING_FIELDS:
+        value = _signal_token(_get(report, field))
+        if value in _QUALITY_BLOCKING_VALUES:
+            return field, value
+    return None
+
+
 def _items(value: Any) -> tuple[Any, ...]:
     if value is None:
         return ()
@@ -135,6 +171,11 @@ def _code(value: str) -> str:
 def _enum_value(value: Any) -> Any:
     enum_value = getattr(value, "value", None)
     return enum_value if isinstance(enum_value, str) else value
+
+
+def _signal_token(value: Any) -> str:
+    raw = _clean(_enum_value(value)).lower()
+    return "_".join("".join(char if char.isalnum() else "_" for char in raw).split("_"))
 
 
 def _clean(value: Any) -> str:

--- a/plans/PR-Content-Ops-Review-Service-Gate-Rows.md
+++ b/plans/PR-Content-Ops-Review-Service-Gate-Rows.md
@@ -1,0 +1,125 @@
+# PR - Content-Ops Review Service Gate Rows
+
+## Why this slice exists
+
+PR #1374 landed pure coverage-row adapters for deterministic quality reports
+and brand-voice audits. The host review workflow service still only consumes
+caller-supplied `CoverageRow` values, so service callers would have to run the
+adapter themselves. This slice threads the adapter into the existing service
+boundary while keeping the service the single wrapper around `review_verdict`.
+Review feedback on #1377 found one silent-approval edge in the adapter: decoded
+quality-gate envelopes with `passed=True` plus a blocking `decision`, `verdict`,
+or `outcome` field could approve. This update keeps that rejection at the pure
+adapter boundary so future callers fail closed too.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+Wire deterministic gate evidence through the host review service:
+
+1. Add optional quality-report and brand-voice evidence fields to
+   `ContentOpsReviewRequest`.
+2. Append adapter-built rows to caller-supplied coverage rows before building
+   the `ContentPR`.
+3. Preserve existing caller-supplied coverage behavior and registry handling.
+4. Prove pass, failure, malformed-evidence, and public brand-voice metadata
+   paths through the service.
+5. Reject contradictory quality-gate envelopes before they can emit the sole
+   required pass row.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [x] A passing quality report can satisfy required coverage without a
+        hand-written row.
+  - [x] Caller-supplied coverage rows are preserved.
+  - [x] Blocker quality findings require revision through service verdicts.
+  - [x] Malformed supplied quality evidence blocks as unresolved coverage.
+  - [x] Contradictory decoded quality-gate evidence blocks as unresolved
+        coverage.
+  - [x] Public `brand_voice_audit` metadata produces a pass row through the
+        service.
+  - [x] Brand-voice warnings require revision through service verdicts.
+  - [x] Existing tenant scope and registry-reader behavior is unchanged.
+  - [x] No MCP transport, LLM, DB migration, or generated-asset mutation is
+        added.
+- Affected surfaces: host review service, coverage-row adapter, CI-covered
+  service and adapter tests.
+- Risk areas: silent approval, decoded input robustness, backcompat.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `atlas_brain/_content_ops_review_workflow.py`
+- `extracted_content_pipeline/coverage_rows.py`
+- `tests/test_atlas_content_ops_review_workflow.py`
+- `tests/test_extracted_content_coverage_rows.py`
+- `plans/PR-Content-Ops-Review-Service-Gate-Rows.md`
+
+## Mechanism
+
+`ContentOpsReviewRequest` gains two optional deterministic evidence inputs:
+quality reports as a tuple and a brand-voice payload. The service converts those
+inputs with `quality_gate_coverage_rows` and `brand_voice_coverage_rows`, appends
+the resulting rows after `request.coverage`, and passes the merged coverage into
+`ContentPR`.
+
+Absent optional evidence does not add rows, preserving existing callers.
+Supplying malformed evidence deliberately adds unresolved rows through the
+adapter so the verdict blocks instead of approving silently.
+The quality-gate adapter also checks decoded blocking-signal fields on otherwise
+passing reports and emits an unresolved `contradictory-*` row when the envelope
+claims both pass and block.
+
+## Intentional
+
+- This does not run quality packs; callers still choose the asset-specific pack.
+- This does not persist `ContentPR` state or mutate generated assets.
+- Caller-supplied coverage rows remain first in the merged matrix for stable
+  output order.
+- MCP transport and tenant/OAuth binding stay deferred.
+- Blocking-signal detection is limited to explicit quality-gate envelope fields;
+  `decision=warn` remains a nonblocking near-miss because warning findings are
+  already represented as optional resolved rows.
+
+## Deferred
+
+- `PR-Content-Ops-Tenant-Binding-Bridge`: reconcile connector tenant binding
+  with `TenantScope`.
+- `PR-Marketer-Verification-MCP`: expose verify-only marketer tools after the
+  remaining service and tenant seams are wired.
+- Parked hardening: none expected.
+
+## Verification
+
+- Command: python -m pytest tests/test_atlas_content_ops_review_workflow.py -q
+  - Passed: 17 tests.
+- Command: python -m pytest tests/test_extracted_content_coverage_rows.py tests/test_atlas_content_ops_review_workflow.py -q
+  - Passed: 28 tests.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - Passed: 156 matching tests are enrolled.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed: mapped files match Atlas sources; hard Atlas imports clean.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed: clean.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed: Atlas runtime import findings 0.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed: extracted content pipeline Python files are ASCII.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Passed: 3338 tests, 10 skipped.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_review_service_gate_rows_pr_body.md
+  - Passed: local PR review passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/_content_ops_review_workflow.py` | 32 |
+| `extracted_content_pipeline/coverage_rows.py` | 41 |
+| `tests/test_atlas_content_ops_review_workflow.py` | 140 |
+| `tests/test_extracted_content_coverage_rows.py` | 27 |
+| `plans/PR-Content-Ops-Review-Service-Gate-Rows.md` | 125 |
+| **Total** | **365** |

--- a/tests/test_atlas_content_ops_review_workflow.py
+++ b/tests/test_atlas_content_ops_review_workflow.py
@@ -20,6 +20,12 @@ from extracted_content_pipeline.content_pr import (
     RulePacketVersions,
 )
 from extracted_content_pipeline.review_contract import ReviewDecision, RiskTier
+from extracted_quality_gate.types import (
+    GateDecision,
+    GateFinding,
+    GateSeverity,
+    QualityReport,
+)
 
 
 _AS_OF = date(2026, 6, 7)
@@ -169,6 +175,140 @@ async def test_result_as_dict_is_tool_shaped() -> None:
     assert payload["mapped_claims"][0]["risk_tier"] == "medium"
     assert payload["content_pr"]["asset_id"] == "asset-1"
     assert payload["content_pr"]["coverage"][0]["status"] == "pass"
+
+
+@pytest.mark.asyncio
+async def test_quality_report_can_supply_required_coverage() -> None:
+    result = await run_content_ops_review(
+        _request(
+            coverage=(),
+            quality_reports=(QualityReport(passed=True, decision=GateDecision.PASS),),
+        ),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.APPROVED
+    assert [row.rule_id for row in result.content_pr.coverage] == [
+        "QUALITY-GATE:report",
+    ]
+    assert result.content_pr.coverage[0].status == CoverageStatus.PASS
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_coverage_is_preserved_before_quality_rows() -> None:
+    result = await run_content_ops_review(
+        _request(
+            coverage=(_pass_row("MANUAL-VOICE"),),
+            quality_reports=(QualityReport(passed=True, decision=GateDecision.PASS),),
+        ),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.APPROVED
+    assert [row.rule_id for row in result.content_pr.coverage] == [
+        "MANUAL-VOICE",
+        "QUALITY-GATE:report",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_quality_report_blocker_requires_revision() -> None:
+    result = await run_content_ops_review(
+        _request(
+            coverage=(),
+            quality_reports=(
+                QualityReport(
+                    passed=False,
+                    decision=GateDecision.BLOCK,
+                    findings=(
+                        GateFinding(
+                            code="no_cta",
+                            message="CTA is missing",
+                            severity=GateSeverity.BLOCKER,
+                            field_name="cta",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.REVISION_REQUIRED
+    assert result.content_pr.coverage[0].rule_id == "QUALITY-GATE:no-cta"
+    assert any("failed required coverage" in reason for reason in result.reasons)
+
+
+@pytest.mark.asyncio
+async def test_malformed_quality_evidence_blocks_as_unresolved_coverage() -> None:
+    result = await run_content_ops_review(
+        _request(coverage=(), quality_reports=(None,)),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.BLOCKED
+    assert result.content_pr.coverage[0].rule_id == "QUALITY-GATE:report"
+    assert result.content_pr.coverage[0].status == CoverageStatus.UNRESOLVED
+    assert any("unresolved required coverage" in reason for reason in result.reasons)
+
+
+@pytest.mark.asyncio
+async def test_contradictory_quality_evidence_blocks_as_unresolved_coverage() -> None:
+    result = await run_content_ops_review(
+        _request(coverage=(), quality_reports=({"passed": True, "decision": "block"},)),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.BLOCKED
+    assert result.content_pr.coverage[0].rule_id == "QUALITY-GATE:contradictory-decision"
+    assert result.content_pr.coverage[0].status == CoverageStatus.UNRESOLVED
+    assert any("unresolved required coverage" in reason for reason in result.reasons)
+
+
+@pytest.mark.asyncio
+async def test_brand_voice_public_metadata_can_supply_required_coverage() -> None:
+    result = await run_content_ops_review(
+        _request(
+            coverage=(),
+            brand_voice_payload={"brand_voice_audit": {"passed": True}},
+        ),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.APPROVED
+    assert [row.rule_id for row in result.content_pr.coverage] == [
+        "BRAND-VOICE:audit",
+    ]
+    assert result.content_pr.coverage[0].status == CoverageStatus.PASS
+
+
+@pytest.mark.asyncio
+async def test_brand_voice_warning_requires_revision() -> None:
+    result = await run_content_ops_review(
+        _request(
+            coverage=(),
+            brand_voice_payload={
+                "brand_voice_audit": {
+                    "passed": False,
+                    "warnings": ["preferred_pov_second_person_not_detected"],
+                }
+            },
+        ),
+        scope=TenantScope(account_id="acct-1"),
+        registry_reader=_reader(),
+    )
+
+    assert result.decision == ReviewDecision.REVISION_REQUIRED
+    assert result.content_pr.coverage[0].rule_id == (
+        "BRAND-VOICE:warning-preferred-pov-second-person-not-detected"
+    )
+    assert any("failed required coverage" in reason for reason in result.reasons)
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_coverage_rows.py
+++ b/tests/test_extracted_content_coverage_rows.py
@@ -117,6 +117,33 @@ def test_quality_gate_missing_malformed_and_unknown_inputs_block() -> None:
         assert _verdict(rows) is ReviewDecision.BLOCKED
 
 
+def test_quality_gate_contradictory_blocking_envelopes_block() -> None:
+    cases = (
+        {"passed": True, "decision": "rejected"},
+        {"passed": True, "decision": "blocked"},
+        {"passed": True, "findings": [], "decision": "block"},
+        {"passed": True, "verdict": "blocked"},
+        {"passed": True, "outcome": "fail"},
+        QualityReport(passed=True, decision=GateDecision.BLOCK),
+    )
+
+    for report in cases:
+        rows = quality_gate_coverage_rows(report)
+        assert rows[0].rule_id.startswith("QUALITY-GATE:contradictory-")
+        assert rows[0].status == CoverageStatus.UNRESOLVED
+        assert _verdict(rows) is ReviewDecision.BLOCKED
+
+
+def test_quality_gate_nonblocking_decision_near_miss_still_passes() -> None:
+    rows = quality_gate_coverage_rows(
+        {"passed": True, "decision": "warn", "findings": []}
+    )
+
+    assert rows[0].rule_id == "QUALITY-GATE:report"
+    assert rows[0].status == CoverageStatus.PASS
+    assert _verdict(rows) is ReviewDecision.APPROVED
+
+
 def test_brand_voice_pass_emits_required_pass_row() -> None:
     for key in ("_brand_voice_audit", "brand_voice_audit"):
         rows = brand_voice_coverage_rows({key: {"passed": True}})


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Service-Gate-Rows.md
Slice phase: Vertical slice
Ownership lane: content-ops/review-contract

This wires deterministic quality-gate and brand-voice evidence into the existing host review service so callers can pass evidence payloads directly and still get a `ContentPR` verdict from the single `review_verdict` wrapper. It also fixes the review-found contradiction edge where decoded quality-gate evidence could claim both `passed=True` and a blocking outcome.

## Intentional
- This does not run quality packs; callers still choose the asset-specific pack.
- This does not persist `ContentPR` state or mutate generated assets.
- Caller-supplied coverage rows remain first in the merged matrix for stable output order.
- MCP transport and tenant/OAuth binding stay deferred.
- Blocking-signal detection is limited to explicit quality-gate envelope fields; `decision=warn` remains a nonblocking near-miss.

## Deferred
- `PR-Content-Ops-Tenant-Binding-Bridge`: reconcile connector tenant binding with `TenantScope`.
- `PR-Marketer-Verification-MCP`: expose verify-only marketer tools after the remaining service and tenant seams are wired.

## Parked hardening
- None.

## AI Reconciliation
- Codex P2 / reviewer MAJOR on contradictory quality-gate envelopes: fixed in `extracted_content_pipeline/coverage_rows.py` by emitting an unresolved `QUALITY-GATE:contradictory-*` row when `passed=True` conflicts with blocking `decision`, `verdict`, or `outcome` fields. Added adapter fixtures and a host service regression.
- All findings fixed or waived: yes.

## Verification
- `python -m pytest tests/test_atlas_content_ops_review_workflow.py -q` -- 17 passed.
- `python -m pytest tests/test_extracted_content_coverage_rows.py tests/test_atlas_content_ops_review_workflow.py -q` -- 28 passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- OK, 156 matching tests are enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 3338 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_review_service_gate_rows_pr_body.md` -- passed.

## Diff size
5 files, +362 / -3.