### PR TITLE
Gate A Email Campaign Live Harness

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -24,6 +24,7 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..campaign_ports import LLMClient, SkillStore, TenantScope
+from ..campaign_postgres_review import review_campaign_drafts
 from ..ad_copy_export import export_ad_copy_drafts
 from ..ad_copy_postgres import PostgresAdCopyRepository
 from ..blog_post_export import export_blog_post_drafts
@@ -73,6 +74,7 @@ MacroPublishProviderFactory = Callable[
 ]
 
 ASSET_CHOICES = (
+    "email_campaign",
     "blog_post",
     "report",
     "landing_page",
@@ -942,6 +944,14 @@ async def _update_asset_status(
     status: str,
     scope: TenantScope,
 ) -> bool:
+    if asset == "email_campaign":
+        result = await review_campaign_drafts(
+            pool,
+            campaign_ids=[asset_id],
+            status=_campaign_review_status(status),
+            scope=scope,
+        )
+        return bool(result.rows)
     if asset == "blog_post":
         return await PostgresBlogPostRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "report":
@@ -971,6 +981,14 @@ async def _update_asset_statuses(
     status: str,
     scope: TenantScope,
 ) -> Sequence[str]:
+    if asset == "email_campaign":
+        result = await review_campaign_drafts(
+            pool,
+            campaign_ids=asset_ids,
+            status=_campaign_review_status(status),
+            scope=scope,
+        )
+        return [str(row.get("id") or "").strip() for row in result.rows if row.get("id")]
     if asset == "blog_post":
         return await PostgresBlogPostRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "report":
@@ -990,6 +1008,21 @@ async def _update_asset_statuses(
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_statuses(asset_ids, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
+
+
+def _campaign_review_status(status: str) -> str:
+    cleaned = _clean(status).lower()
+    if cleaned == "canceled":
+        cleaned = "cancelled"
+    if cleaned in {"approved", "queued", "cancelled", "expired"}:
+        return cleaned
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            "email_campaign review status must be one of "
+            "approved, queued, cancelled, expired"
+        ),
+    )
 
 
 def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -982,6 +982,9 @@ async def _update_asset_statuses(
     scope: TenantScope,
 ) -> Sequence[str]:
     if asset == "email_campaign":
+        if not asset_ids:
+            _campaign_review_status(status)
+            return ()
         result = await review_campaign_drafts(
             pool,
             campaign_ids=asset_ids,

--- a/plans/PR-Gate-A-Email-Campaign-Live-Harness.md
+++ b/plans/PR-Gate-A-Email-Campaign-Live-Harness.md
@@ -1,0 +1,109 @@
+# PR-Gate-A-Email-Campaign-Live-Harness
+
+## Why this slice exists
+
+Issue #1376 calls out that `email_campaign` generates through
+`content_ops_execution.py`, but the Gate A live-quality harness cannot review
+or export its saved campaign drafts. Campaign output is sequence-shaped: one
+run can save multiple campaign rows, and the existing helpers are
+`review_campaign_drafts(...)` / `list_campaign_drafts(...)`, not the generic
+repository shape used by landing pages, blogs, and sales briefs.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/gate-a-output-quality
+Slice phase: Production hardening
+
+1. Add `email_campaign` to generated-asset review support by delegating to
+   `review_campaign_drafts(...)`.
+2. Add `email_campaign` to the Gate A harness outputs and export block, using
+   `list_campaign_drafts(...)` filtered to this run's saved ids.
+3. Make persistence checks sequence-aware: email campaigns must export every
+   saved unique draft id and fail on duplicate/collapsed ids, while sibling
+   outputs keep the variant-count rule.
+4. Add focused tests for review delegation, unsupported status rejection,
+   review handoff, export filtering, and duplicate sequence detection.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `review_saved_ids(...)` can approve saved `email_campaign` draft ids.
+  - [ ] The generated-asset branch calls `review_campaign_drafts(...)` with
+        `campaign_ids`, tenant scope, and the requested supported status.
+  - [ ] `export_saved_drafts(...)` exports only saved email campaign ids from
+        the current Gate A run.
+  - [ ] Sequence persistence fails closed on duplicate saved ids or missing
+        exported rows.
+  - [ ] This PR does not run or self-certify live campaign output quality.
+- Affected surfaces: generated asset review internals, Gate A live-quality
+  harness plumbing, and focused tests.
+- Risk areas: sequence rows mistaken for one-draft variants, campaign review
+  status vocabulary, and drifting into #1377's review-contract PR.
+- Reviewer rules triggered: R1, R2, R6, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/api/generated_assets.py`
+- `plans/PR-Gate-A-Email-Campaign-Live-Harness.md`
+- `scripts/smoke_content_ops_gate_a_live_quality.py`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+- `tests/test_smoke_content_ops_gate_a_live_quality.py`
+
+## Mechanism
+
+`_update_asset_statuses("email_campaign", ...)` calls
+`review_campaign_drafts(...)` and returns updated row ids, preserving the
+existing `review_saved_ids(...)` missing-id check. The harness imports
+`list_campaign_drafts(...)`, exports reviewed `approved` campaign rows for the
+current `target_mode`, and filters the result to the run's saved ids.
+
+`SEQUENCE_OUTPUTS = {"email_campaign"}` skips the sibling multiple-variant
+requirement for campaign rows and routes persistence through
+`_sequence_persistence_errors(...)`, which compares saved id entries, unique
+ids, and exported row count.
+
+## Intentional
+
+- Reuse campaign review/export helpers; do not create `export_campaign_drafts`
+  or a fake generic campaign repository.
+- Do not run the live Gate A proof or judge campaign copy quality. The live run
+  remains reviewer-owned per issue #1376.
+- Issue #1376 mentions `report`, but the current harness and archived #1360
+  plan cover `landing_page`, `blog_post`, and `sales_brief`. This slice adds
+  the issue-title gap, `email_campaign`, without expanding report coverage too.
+- `email_campaign` accepts only statuses supported by `review_campaign_drafts`:
+  `approved`, `queued`, `cancelled`, and `expired`.
+- Cross-layer caller hints are same-name collisions; no non-diff caller invokes these private harness helpers.
+- Do not touch #1377's `atlas_brain/_content_ops_review_workflow.py` lane.
+
+## Deferred
+
+- Reviewer-owned live Gate A run with the updated harness and real exported
+  email campaign sequence.
+- Follow-up if the support-ticket Gate A payload produces empty or degenerate
+  campaign opportunities in the live run.
+- Report coverage if the operator wants this script expanded beyond #1360.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_smoke_content_ops_gate_a_live_quality.py -q` - PASS (`9 passed`).
+- `python -m pytest tests/test_atlas_content_ops_generated_assets_api.py -q` - PASS (`18 passed`, one `pynvml` warning).
+- `scripts/validate_extracted_content_pipeline.sh` - PASS (run with `bash`).
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS (`Atlas runtime import findings: 0`).
+- `scripts/check_ascii_python.sh` - PASS (run with `bash`).
+- `scripts/run_extracted_pipeline_checks.sh` - PASS (run with `bash`; `extracted_reasoning_core`: `295 passed`; `extracted_content_pipeline`: `3335 passed, 10 skipped`; one `pynvml` warning).
+- `scripts/local_pr_review.sh` - PASS (with current PR body file).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/generated_assets.py` | 33 |
+| `plans/PR-Gate-A-Email-Campaign-Live-Harness.md` | 109 |
+| `scripts/smoke_content_ops_gate_a_live_quality.py` | 48 |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | 81 |
+| `tests/test_smoke_content_ops_gate_a_live_quality.py` | 127 |
+| **Total** | **398** |

--- a/plans/PR-Gate-A-Email-Campaign-Live-Harness.md
+++ b/plans/PR-Gate-A-Email-Campaign-Live-Harness.md
@@ -9,6 +9,12 @@ run can save multiple campaign rows, and the existing helpers are
 `review_campaign_drafts(...)` / `list_campaign_drafts(...)`, not the generic
 repository shape used by landing pages, blogs, and sales briefs.
 
+The final diff exceeds the 400 LOC soft cap because review feedback added two
+must-fix safety points to the same surface: empty email-campaign batch updates
+must not 500, and the live harness needs an `--outputs` selector so the next
+convergence proof can isolate the already-converged generators without editing
+the script.
+
 ## Scope (this PR)
 
 Ownership lane: content-ops/gate-a-output-quality
@@ -23,6 +29,9 @@ Slice phase: Production hardening
    outputs keep the variant-count rule.
 4. Add focused tests for review delegation, unsupported status rejection,
    review handoff, export filtering, and duplicate sequence detection.
+5. Address review feedback: empty email-campaign batch updates return no
+   updates instead of delegating into the campaign normalizer, and the harness
+   accepts `--outputs` to select the proof set for a run.
 
 ### Review Contract
 
@@ -34,6 +43,11 @@ Slice phase: Production hardening
         the current Gate A run.
   - [ ] Sequence persistence fails closed on duplicate saved ids or missing
         exported rows.
+  - [ ] Malformed-only email campaign review batches keep the existing
+        missing-id response path instead of raising from an empty campaign id
+        list.
+  - [ ] `--outputs` can run a selected subset of Gate A outputs, and summary /
+        review / persistence checks only require that selected set.
   - [ ] This PR does not run or self-certify live campaign output quality.
 - Affected surfaces: generated asset review internals, Gate A live-quality
   harness plumbing, and focused tests.
@@ -62,6 +76,16 @@ requirement for campaign rows and routes persistence through
 `_sequence_persistence_errors(...)`, which compares saved id entries, unique
 ids, and exported row count.
 
+`--outputs` defaults to the full Gate A set, but resolves to a validated tuple
+that is threaded into payload construction, configured-output checks,
+saved-id extraction, summary, review errors, and persistence checks. That keeps
+the default all-output coverage while allowing a live convergence run to choose
+`landing_page,blog_post,sales_brief`.
+
+The email-campaign batch updater returns `()` before delegating when the route
+has no valid UUID ids to review. It still maps the requested campaign status
+first, so unsupported campaign review statuses remain a 400.
+
 ## Intentional
 
 - Reuse campaign review/export helpers; do not create `export_campaign_drafts`
@@ -81,29 +105,29 @@ ids, and exported row count.
 - Reviewer-owned live Gate A run with the updated harness and real exported
   email campaign sequence.
 - Follow-up if the support-ticket Gate A payload produces empty or degenerate
-  campaign opportunities in the live run.
+  campaign opportunities in an `--outputs email_campaign` live run.
 - Report coverage if the operator wants this script expanded beyond #1360.
 
 Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_smoke_content_ops_gate_a_live_quality.py -q` - PASS (`9 passed`).
-- `python -m pytest tests/test_atlas_content_ops_generated_assets_api.py -q` - PASS (`18 passed`, one `pynvml` warning).
+- `python -m pytest tests/test_smoke_content_ops_gate_a_live_quality.py -q` - PASS (`12 passed`).
+- `python -m pytest tests/test_atlas_content_ops_generated_assets_api.py -q` - PASS (`19 passed`, one `pynvml` warning).
 - `scripts/validate_extracted_content_pipeline.sh` - PASS (run with `bash`).
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
 - `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS (`Atlas runtime import findings: 0`).
 - `scripts/check_ascii_python.sh` - PASS (run with `bash`).
-- `scripts/run_extracted_pipeline_checks.sh` - PASS (run with `bash`; `extracted_reasoning_core`: `295 passed`; `extracted_content_pipeline`: `3335 passed, 10 skipped`; one `pynvml` warning).
+- `scripts/run_extracted_pipeline_checks.sh` - PASS (run with `bash`; `extracted_reasoning_core`: `295 passed`; `extracted_content_pipeline`: `3354 passed, 10 skipped`; one `pynvml` warning).
 - `scripts/local_pr_review.sh` - PASS (with current PR body file).
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/api/generated_assets.py` | 33 |
-| `plans/PR-Gate-A-Email-Campaign-Live-Harness.md` | 109 |
-| `scripts/smoke_content_ops_gate_a_live_quality.py` | 48 |
-| `tests/test_atlas_content_ops_generated_assets_api.py` | 81 |
-| `tests/test_smoke_content_ops_gate_a_live_quality.py` | 127 |
-| **Total** | **398** |
+| `extracted_content_pipeline/api/generated_assets.py` | 36 |
+| `plans/PR-Gate-A-Email-Campaign-Live-Harness.md` | 133 |
+| `scripts/smoke_content_ops_gate_a_live_quality.py` | 127 |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | 111 |
+| `tests/test_smoke_content_ops_gate_a_live_quality.py` | 171 |
+| **Total** | **578** |

--- a/scripts/smoke_content_ops_gate_a_live_quality.py
+++ b/scripts/smoke_content_ops_gate_a_live_quality.py
@@ -58,6 +58,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Content Ops target_mode for the live run.",
     )
     parser.add_argument(
+        "--outputs",
+        default=",".join(DEFAULT_OUTPUTS),
+        help="Comma-separated outputs to run. Defaults to all Gate A outputs.",
+    )
+    parser.add_argument(
         "--support-ticket-csv",
         type=Path,
         default=DEFAULT_SUPPORT_TICKET_CSV,
@@ -152,6 +157,27 @@ def _default_brand_voice(account_id: str) -> dict[str, Any]:
     }
 
 
+def _resolve_outputs(raw_outputs: str | Sequence[str]) -> tuple[str, ...]:
+    if isinstance(raw_outputs, str):
+        candidates = raw_outputs.split(",")
+    else:
+        candidates = list(raw_outputs)
+    outputs = tuple(
+        dict.fromkeys(str(output).strip() for output in candidates if str(output).strip())
+    )
+    if not outputs:
+        raise ValueError("at least one output is required")
+    unsupported = [output for output in outputs if output not in DEFAULT_OUTPUTS]
+    if unsupported:
+        raise ValueError(
+            "unsupported output(s): "
+            + ", ".join(unsupported)
+            + "; expected one of "
+            + ", ".join(DEFAULT_OUTPUTS)
+        )
+    return outputs
+
+
 def build_gate_a_payload(
     *,
     account_id: str,
@@ -159,6 +185,7 @@ def build_gate_a_payload(
     target_mode: str,
     variant_count: int,
     quality_repair_attempts: int,
+    outputs: Sequence[str] = DEFAULT_OUTPUTS,
     max_cost_usd: float | None = None,
     account_usage_budget_usd: float | None = None,
     account_usage_budget_days: int = 7,
@@ -167,6 +194,7 @@ def build_gate_a_payload(
         raise ValueError("variant_count must be greater than 1")
     if quality_repair_attempts < 0:
         raise ValueError("quality_repair_attempts must be >= 0")
+    selected_outputs = _resolve_outputs(outputs)
 
     inputs = {
         **dict(DEFAULT_LANDING_PAGE_INPUTS),
@@ -191,7 +219,7 @@ def build_gate_a_payload(
         "cta_url": "/systems/ai-content-ops/intake",
     }
     payload: dict[str, Any] = {
-        "outputs": list(DEFAULT_OUTPUTS),
+        "outputs": list(selected_outputs),
         "target_mode": target_mode,
         "limit": 1,
         "variant_count": variant_count,
@@ -209,6 +237,10 @@ def build_gate_a_payload(
 async def run_gate_a_live_quality(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     if int(args.variant_count) <= 1:
         raise SystemExit("--variant-count must be greater than 1")
+    try:
+        selected_outputs = _resolve_outputs(str(args.outputs or ""))
+    except ValueError as exc:
+        raise SystemExit(f"--outputs: {exc}") from None
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -221,6 +253,7 @@ async def run_gate_a_live_quality(args: argparse.Namespace) -> tuple[int, dict[s
         or "vendor_retention",
         variant_count=int(args.variant_count),
         quality_repair_attempts=int(args.quality_repair_attempts),
+        outputs=selected_outputs,
         max_cost_usd=args.max_cost_usd,
         account_usage_budget_usd=args.account_usage_budget_usd,
         account_usage_budget_days=int(args.account_usage_budget_days),
@@ -245,7 +278,7 @@ async def run_gate_a_live_quality(args: argparse.Namespace) -> tuple[int, dict[s
         services = services_factory()
         configured_outputs = tuple(services.configured_outputs())
         missing_outputs = [
-            output for output in DEFAULT_OUTPUTS if output not in configured_outputs
+            output for output in selected_outputs if output not in configured_outputs
         ]
         if missing_outputs:
             errors.append(
@@ -258,6 +291,7 @@ async def run_gate_a_live_quality(args: argparse.Namespace) -> tuple[int, dict[s
                 payload,
                 account_id=str(args.account_id or "").strip(),
                 variant_count=int(args.variant_count),
+                outputs=selected_outputs,
             )
             seeded_blog_blueprint = await _seed_default_blog_blueprint(args, scope)
             _align_blog_payload_to_seed(payload, seeded_blog_blueprint)
@@ -271,13 +305,15 @@ async def run_gate_a_live_quality(args: argparse.Namespace) -> tuple[int, dict[s
                 },
             )
             _write_json(output_dir / "execution-result.json", execution_result)
-            saved_ids = saved_ids_by_output(execution_result)
-            errors.extend(_execution_errors(execution_result, saved_ids))
+            saved_ids = saved_ids_by_output(execution_result, outputs=selected_outputs)
+            errors.extend(
+                _execution_errors(execution_result, saved_ids, outputs=selected_outputs)
+            )
             if not errors:
                 pool = _current_db_pool()
                 reviewed = await review_saved_ids(pool, scope, saved_ids)
                 _write_json(output_dir / "review-results.json", reviewed)
-                errors.extend(_review_errors(reviewed))
+                errors.extend(_review_errors(reviewed, outputs=selected_outputs))
                 exports = await export_saved_drafts(
                     pool,
                     scope=scope,
@@ -292,6 +328,7 @@ async def run_gate_a_live_quality(args: argparse.Namespace) -> tuple[int, dict[s
                         execution_result,
                         saved_ids=saved_ids,
                         exports=exports,
+                        outputs=selected_outputs,
                     )
                 )
     except Exception as exc:  # live proof must preserve failure details.
@@ -306,12 +343,12 @@ async def run_gate_a_live_quality(args: argparse.Namespace) -> tuple[int, dict[s
         "account_id": str(args.account_id or "").strip(),
         "support_ticket_csv": str(Path(args.support_ticket_csv)),
         "output_dir": str(output_dir),
-        "required_outputs": list(DEFAULT_OUTPUTS),
+        "required_outputs": list(selected_outputs),
         "configured_outputs": list(configured_outputs),
         "variant_count": int(args.variant_count),
         "seeded_blog_blueprint": dict(seeded_blog_blueprint or {}),
-        "saved_ids": saved_ids_by_output(execution_result),
-        "variant_summary": variant_summary(execution_result),
+        "saved_ids": saved_ids_by_output(execution_result, outputs=selected_outputs),
+        "variant_summary": variant_summary(execution_result, outputs=selected_outputs),
         "review": reviewed,
         "export_counts": {
             output: int(_mapping(export).get("count") or 0)
@@ -335,8 +372,9 @@ def _reassert_gate_a_controls(
     *,
     account_id: str,
     variant_count: int,
+    outputs: Sequence[str],
 ) -> None:
-    payload["outputs"] = list(DEFAULT_OUTPUTS)
+    payload["outputs"] = list(outputs)
     payload["limit"] = 1
     payload["variant_count"] = variant_count
     inputs = payload.setdefault("inputs", {})
@@ -365,9 +403,13 @@ def saved_ids_by_output(
     return ids_by_output
 
 
-def variant_summary(result: Mapping[str, Any] | None) -> dict[str, Any]:
+def variant_summary(
+    result: Mapping[str, Any] | None,
+    *,
+    outputs: Sequence[str] = DEFAULT_OUTPUTS,
+) -> dict[str, Any]:
     summary: dict[str, Any] = {}
-    for output in DEFAULT_OUTPUTS:
+    for output in outputs:
         payload = _step_payload(result, output)
         variants = payload.get("variant_results") or ()
         if isinstance(variants, (str, bytes)) or not isinstance(variants, Sequence):
@@ -519,13 +561,15 @@ async def export_saved_drafts(
 def _execution_errors(
     result: Mapping[str, Any] | None,
     saved_ids: Mapping[str, Sequence[str]],
+    *,
+    outputs: Sequence[str] = DEFAULT_OUTPUTS,
 ) -> list[str]:
     if not isinstance(result, Mapping):
         return ["execution returned no result"]
     errors: list[str] = []
     if result.get("status") != "completed":
         errors.append(f"execution status was {result.get('status')!r}, not 'completed'")
-    for output in DEFAULT_OUTPUTS:
+    for output in outputs:
         step = _step(result, output)
         if not step:
             errors.append(f"execution result did not include {output}")
@@ -540,9 +584,13 @@ def _execution_errors(
     return errors
 
 
-def _review_errors(reviewed: Mapping[str, Any]) -> list[str]:
+def _review_errors(
+    reviewed: Mapping[str, Any],
+    *,
+    outputs: Sequence[str] = DEFAULT_OUTPUTS,
+) -> list[str]:
     errors: list[str] = []
-    for output in DEFAULT_OUTPUTS:
+    for output in outputs:
         review = _mapping(reviewed.get(output))
         missing = list(review.get("missing_ids") or ())
         if missing:
@@ -555,9 +603,10 @@ def variant_persistence_errors(
     *,
     saved_ids: Mapping[str, Sequence[str]],
     exports: Mapping[str, Mapping[str, Any]],
+    outputs: Sequence[str] = DEFAULT_OUTPUTS,
 ) -> list[str]:
     errors: list[str] = []
-    for output in DEFAULT_OUTPUTS:
+    for output in outputs:
         if output in SEQUENCE_OUTPUTS:
             errors.extend(_sequence_persistence_errors(output, saved_ids, exports))
             continue

--- a/scripts/smoke_content_ops_gate_a_live_quality.py
+++ b/scripts/smoke_content_ops_gate_a_live_quality.py
@@ -31,7 +31,8 @@ from smoke_content_ops_live_generation import (  # noqa: E402
 )
 
 
-DEFAULT_OUTPUTS = ("landing_page", "blog_post", "sales_brief")
+DEFAULT_OUTPUTS = ("email_campaign", "landing_page", "blog_post", "sales_brief")
+SEQUENCE_OUTPUTS = frozenset({"email_campaign"})
 DEFAULT_SUPPORT_TICKET_CSV = (
     ROOT / "extracted_content_pipeline" / "examples" / "support_ticket_saas_demo_sources.csv"
 )
@@ -443,6 +444,9 @@ async def export_saved_drafts(
     from extracted_content_pipeline.blog_post_postgres import (  # noqa: PLC0415
         PostgresBlogPostRepository,
     )
+    from extracted_content_pipeline.campaign_postgres_export import (  # noqa: PLC0415
+        list_campaign_drafts,
+    )
     from extracted_content_pipeline.landing_page_export import (  # noqa: PLC0415
         export_landing_page_drafts,
     )
@@ -457,6 +461,19 @@ async def export_saved_drafts(
     )
 
     exports: dict[str, Mapping[str, Any]] = {}
+    campaign_ids = saved_ids.get("email_campaign") or ()
+    if campaign_ids:
+        export = await list_campaign_drafts(
+            pool,
+            scope=scope,
+            statuses=("approved",),
+            target_mode=target_mode,
+            limit=max(100, len(campaign_ids)),
+        )
+        exports["email_campaign"] = _filter_saved_draft_export_rows(
+            export.as_dict(),
+            campaign_ids,
+        )
     landing_ids = saved_ids.get("landing_page") or ()
     if landing_ids:
         export = await export_landing_page_drafts(
@@ -518,7 +535,7 @@ def _execution_errors(
         if not saved_ids.get(output):
             errors.append(f"{output} returned no saved_ids")
         payload = _step_payload(result, output)
-        if int(payload.get("variant_count") or 0) <= 1:
+        if output not in SEQUENCE_OUTPUTS and int(payload.get("variant_count") or 0) <= 1:
             errors.append(f"{output} did not report multiple variants")
     return errors
 
@@ -541,6 +558,9 @@ def variant_persistence_errors(
 ) -> list[str]:
     errors: list[str] = []
     for output in DEFAULT_OUTPUTS:
+        if output in SEQUENCE_OUTPUTS:
+            errors.extend(_sequence_persistence_errors(output, saved_ids, exports))
+            continue
         successful_variants = _successful_variant_count(result, output)
         if successful_variants <= 1:
             continue
@@ -560,6 +580,30 @@ def variant_persistence_errors(
                 f"{export_count} exported row(s)"
             )
     return errors
+
+
+def _sequence_persistence_errors(
+    output: str,
+    saved_ids: Mapping[str, Sequence[str]],
+    exports: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    raw_ids = [
+        str(item).strip()
+        for item in saved_ids.get(output, ())
+        if str(item).strip()
+    ]
+    if not raw_ids:
+        return []
+    unique_ids = tuple(dict.fromkeys(raw_ids))
+    export_count = int(_mapping(exports.get(output)).get("count") or 0)
+    if len(unique_ids) == len(raw_ids) and export_count >= len(raw_ids):
+        return []
+    return [
+        f"{output} sequence persistence collapsed: "
+        f"{len(raw_ids)} saved id entr{'y' if len(raw_ids) == 1 else 'ies'}, "
+        f"{len(unique_ids)} unique saved id(s), "
+        f"{export_count} exported row(s)"
+    ]
 
 
 def _successful_variant_count(result: Mapping[str, Any] | None, output: str) -> int:

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -177,6 +177,11 @@ class _MemoryLandingPageRepository:
         return None
 
 
+class _CampaignReviewResult:
+    def __init__(self, rows: tuple[dict[str, Any], ...]) -> None:
+        self.rows = rows
+
+
 def test_api_aggregator_mounts_generated_asset_routes() -> None:
     api_pkg = _fresh_api_package()
 
@@ -187,6 +192,82 @@ def test_api_aggregator_mounts_generated_asset_routes() -> None:
     assert "/content-assets/{asset}/drafts/review" in paths
     assert "/content-assets/landing_page/public/sitemap.xml" in paths
     assert "/content-assets/landing_page/public/{landing_page_id}" in paths
+
+
+@pytest.mark.asyncio
+async def test_email_campaign_batch_review_delegates_to_campaign_review(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from extracted_content_pipeline.api import generated_assets
+
+    campaign_ids = (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def _review_campaign_drafts(pool: Any, **kwargs: Any) -> _CampaignReviewResult:
+        calls.append({"pool": pool, **kwargs})
+        return _CampaignReviewResult((
+            {"id": campaign_ids[0]},
+            {"id": campaign_ids[1]},
+        ))
+
+    monkeypatch.setattr(
+        generated_assets,
+        "review_campaign_drafts",
+        _review_campaign_drafts,
+    )
+
+    pool = object()
+    scope = TenantScope(account_id="acct-campaign-review")
+    updated = await generated_assets._update_asset_statuses(
+        "email_campaign",
+        pool,
+        asset_ids=campaign_ids,
+        status="approved",
+        scope=scope,
+    )
+
+    assert updated == list(campaign_ids)
+    assert calls == [{
+        "pool": pool,
+        "campaign_ids": campaign_ids,
+        "status": "approved",
+        "scope": scope,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_email_campaign_review_rejects_unsupported_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from extracted_content_pipeline.api import generated_assets
+
+    calls: list[dict[str, Any]] = []
+
+    async def _review_campaign_drafts(pool: Any, **kwargs: Any) -> _CampaignReviewResult:
+        calls.append({"pool": pool, **kwargs})
+        return _CampaignReviewResult(())
+
+    monkeypatch.setattr(
+        generated_assets,
+        "review_campaign_drafts",
+        _review_campaign_drafts,
+    )
+
+    with pytest.raises(generated_assets.HTTPException) as exc_info:
+        await generated_assets._update_asset_statuses(
+            "email_campaign",
+            object(),
+            asset_ids=("11111111-1111-4111-8111-111111111111",),
+            status="rejected",
+            scope=TenantScope(account_id="acct-campaign-review"),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "email_campaign review status" in exc_info.value.detail
+    assert calls == []
 
 
 def test_generated_asset_routes_use_shared_content_ops_auth_scope_and_pool() -> None:

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -239,6 +239,36 @@ async def test_email_campaign_batch_review_delegates_to_campaign_review(
 
 
 @pytest.mark.asyncio
+async def test_email_campaign_batch_review_empty_ids_does_not_delegate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from extracted_content_pipeline.api import generated_assets
+
+    calls: list[dict[str, Any]] = []
+
+    async def _review_campaign_drafts(pool: Any, **kwargs: Any) -> _CampaignReviewResult:
+        calls.append({"pool": pool, **kwargs})
+        return _CampaignReviewResult(())
+
+    monkeypatch.setattr(
+        generated_assets,
+        "review_campaign_drafts",
+        _review_campaign_drafts,
+    )
+
+    updated = await generated_assets._update_asset_statuses(
+        "email_campaign",
+        object(),
+        asset_ids=(),
+        status="approved",
+        scope=TenantScope(account_id="acct-campaign-review"),
+    )
+
+    assert updated == ()
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_email_campaign_review_rejects_unsupported_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_smoke_content_ops_gate_a_live_quality.py
+++ b/tests/test_smoke_content_ops_gate_a_live_quality.py
@@ -34,7 +34,12 @@ def test_build_gate_a_payload_sets_top_level_variants_and_brand_voice() -> None:
         max_cost_usd=1.25,
     )
 
-    assert payload["outputs"] == ["landing_page", "blog_post", "sales_brief"]
+    assert payload["outputs"] == [
+        "email_campaign",
+        "landing_page",
+        "blog_post",
+        "sales_brief",
+    ]
     assert payload["variant_count"] == 3
     assert payload["max_cost_usd"] == 1.25
     assert payload["inputs"]["target_account"] == "SaaS support team with repeat ticket backlog"
@@ -58,6 +63,11 @@ def test_saved_ids_by_output_reads_aggregate_variant_saved_ids() -> None:
     result = {
         "status": "completed",
         "steps": [
+            {
+                "output": "email_campaign",
+                "status": "completed",
+                "result": {"saved_ids": ["campaign-1", "campaign-2"]},
+            },
             {
                 "output": "landing_page",
                 "status": "completed",
@@ -84,6 +94,7 @@ def test_saved_ids_by_output_reads_aggregate_variant_saved_ids() -> None:
     }
 
     assert smoke.saved_ids_by_output(result) == {
+        "email_campaign": ["campaign-1", "campaign-2"],
         "landing_page": ["lp-1", "lp-2", "lp-3"],
         "blog_post": ["blog-1"],
         "sales_brief": ["brief-1"],
@@ -91,6 +102,9 @@ def test_saved_ids_by_output_reads_aggregate_variant_saved_ids() -> None:
     assert smoke.variant_summary(result)["landing_page"]["variants"][0][
         "variant_angle"
     ] == "pain_led"
+    assert "email_campaign did not report multiple variants" not in (
+        smoke._execution_errors(result, smoke.saved_ids_by_output(result))
+    )
 
 
 @pytest.mark.asyncio
@@ -124,6 +138,56 @@ async def test_review_saved_ids_reports_missing_updates(
     assert smoke._review_errors(reviewed) == [
         "landing_page review update missed ids: lp-2"
     ]
+
+
+@pytest.mark.asyncio
+async def test_review_saved_ids_threads_email_campaign_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_update_statuses(
+        asset: str,
+        pool: Any,
+        *,
+        asset_ids: list[str],
+        status: str,
+        scope: Any,
+    ) -> list[str]:
+        calls.append({
+            "asset": asset,
+            "pool": pool,
+            "asset_ids": asset_ids,
+            "status": status,
+            "scope": scope,
+        })
+        return list(asset_ids)
+
+    monkeypatch.setattr(
+        "extracted_content_pipeline.api.generated_assets._update_asset_statuses",
+        _fake_update_statuses,
+    )
+
+    pool = object()
+    scope = object()
+    reviewed = await smoke.review_saved_ids(
+        pool,
+        scope,
+        {"email_campaign": ["campaign-1", "campaign-2"]},
+    )
+
+    assert reviewed["email_campaign"]["updated_ids"] == [
+        "campaign-1",
+        "campaign-2",
+    ]
+    assert reviewed["email_campaign"]["missing_ids"] == []
+    assert calls == [{
+        "asset": "email_campaign",
+        "pool": pool,
+        "asset_ids": ["campaign-1", "campaign-2"],
+        "status": "approved",
+        "scope": scope,
+    }]
 
 
 def test_filter_saved_draft_export_rows_fails_closed_on_missing_id() -> None:
@@ -161,4 +225,65 @@ def test_variant_persistence_errors_fail_on_duplicate_saved_ids() -> None:
         "blog_post variant persistence collapsed: "
         "2 successful variant(s), 2 saved id entries, "
         "1 unique saved id(s), 1 exported row(s)"
+    ]
+
+
+class _ExportResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"count": len(self.rows), "filters": {}, "rows": list(self.rows)}
+
+
+@pytest.mark.asyncio
+async def test_export_saved_drafts_exports_email_campaign_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_list_campaign_drafts(pool: Any, **kwargs: Any) -> _ExportResult:
+        calls.append({"pool": pool, **kwargs})
+        return _ExportResult([
+            {"id": "campaign-1", "subject": "First"},
+            {"id": "campaign-2", "subject": "Second"},
+            {"id": "other-campaign", "subject": "Other"},
+        ])
+
+    monkeypatch.setattr(
+        "extracted_content_pipeline.campaign_postgres_export.list_campaign_drafts",
+        _fake_list_campaign_drafts,
+    )
+
+    pool = object()
+    scope = object()
+    exports = await smoke.export_saved_drafts(
+        pool,
+        scope=scope,
+        target_mode="vendor_retention",
+        saved_ids={"email_campaign": ["campaign-1", "campaign-2"]},
+    )
+
+    assert calls == [{
+        "pool": pool,
+        "scope": scope,
+        "statuses": ("approved",),
+        "target_mode": "vendor_retention",
+        "limit": 100,
+    }]
+    assert exports["email_campaign"]["count"] == 2
+    assert [row["id"] for row in exports["email_campaign"]["rows"]] == [
+        "campaign-1",
+        "campaign-2",
+    ]
+
+
+def test_variant_persistence_errors_fail_on_duplicate_email_sequence_ids() -> None:
+    assert smoke.variant_persistence_errors(
+        {"status": "completed"},
+        saved_ids={"email_campaign": ["campaign-1", "campaign-1"]},
+        exports={"email_campaign": {"count": 1}},
+    ) == [
+        "email_campaign sequence persistence collapsed: "
+        "2 saved id entries, 1 unique saved id(s), 1 exported row(s)"
     ]

--- a/tests/test_smoke_content_ops_gate_a_live_quality.py
+++ b/tests/test_smoke_content_ops_gate_a_live_quality.py
@@ -48,6 +48,26 @@ def test_build_gate_a_payload_sets_top_level_variants_and_brand_voice() -> None:
     assert payload["inputs"]["source_material"][0]["Ticket ID"] == "ticket-1"
 
 
+def test_build_gate_a_payload_accepts_selected_outputs() -> None:
+    payload = smoke.build_gate_a_payload(
+        account_id="acct-gate-a",
+        support_ticket_rows=[],
+        target_mode="vendor_retention",
+        variant_count=3,
+        quality_repair_attempts=1,
+        outputs=("landing_page", "blog_post", "sales_brief"),
+    )
+
+    assert payload["outputs"] == ["landing_page", "blog_post", "sales_brief"]
+
+
+def test_resolve_outputs_rejects_empty_or_unsupported_selection() -> None:
+    with pytest.raises(ValueError, match="at least one output"):
+        smoke._resolve_outputs(" , ")
+    with pytest.raises(ValueError, match="unsupported output"):
+        smoke._resolve_outputs("landing_page,unknown")
+
+
 def test_build_gate_a_payload_requires_multiple_variants() -> None:
     with pytest.raises(ValueError, match="variant_count"):
         smoke.build_gate_a_payload(
@@ -105,6 +125,30 @@ def test_saved_ids_by_output_reads_aggregate_variant_saved_ids() -> None:
     assert "email_campaign did not report multiple variants" not in (
         smoke._execution_errors(result, smoke.saved_ids_by_output(result))
     )
+
+
+def test_execution_errors_respect_selected_outputs() -> None:
+    result = {
+        "status": "completed",
+        "steps": [
+            {
+                "output": "blog_post",
+                "status": "completed",
+                "result": {
+                    "variant_count": 3,
+                    "saved_ids": ["blog-1", "blog-2", "blog-3"],
+                },
+            },
+        ],
+    }
+
+    saved_ids = smoke.saved_ids_by_output(result, outputs=("blog_post",))
+
+    assert saved_ids == {"blog_post": ["blog-1", "blog-2", "blog-3"]}
+    assert smoke._execution_errors(result, saved_ids, outputs=("blog_post",)) == []
+    assert smoke.variant_summary(result, outputs=("blog_post",)) == {
+        "blog_post": {"variant_count": 3, "variants": []}
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Gate-A-Email-Campaign-Live-Harness.md
Slice phase: Production hardening

Refs #1376. `email_campaign` needs to enter the Gate A live-quality harness after generation. This adapts the existing sequence-shaped campaign review/export helpers so saved campaign draft rows can be approved, exported, and checked without pretending campaigns are single-draft assets. The review update also adds `--outputs` so the next convergence proof can isolate a selected output set, and keeps malformed-only campaign review batches on the existing missing-id path instead of 500ing.

## Intentional
- Reuses `review_campaign_drafts` and `list_campaign_drafts`; no fake generic campaign repository or `export_campaign_drafts` shim.
- No live Gate A run or campaign-copy quality judgment in this PR; that remains reviewer-owned.
- Keeps report coverage out of this slice because the current harness and archived #1360 proof cover `landing_page`, `blog_post`, and `sales_brief`; this adds the issue-title gap, `email_campaign`.
- `email_campaign` review accepts only campaign-supported statuses: `approved`, `queued`, `cancelled`, and `expired`.
- `--outputs` defaults to all Gate A outputs; operators can select `landing_page,blog_post,sales_brief` for convergence or `email_campaign` for campaign-only validation.
- Cross-layer caller hints for `_execution_errors` and test helper methods are same-name collisions; no non-diff caller invokes these private harness helpers.
- Does not touch #1377's review-contract lane.

## Deferred
- Reviewer-owned live Gate A run with the updated harness and real exported email campaign sequence.
- Follow-up if the support-ticket Gate A payload produces empty or degenerate campaign opportunities in an `--outputs email_campaign` live run.
- Report coverage if the operator wants this script expanded beyond #1360.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_gate_a_live_quality.py -q` - PASS (`12 passed`).
- `python -m pytest tests/test_atlas_content_ops_generated_assets_api.py -q` - PASS (`19 passed`, one `pynvml` warning).
- `scripts/validate_extracted_content_pipeline.sh` - PASS (run with `bash`).
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS (`Atlas runtime import findings: 0`).
- `scripts/check_ascii_python.sh` - PASS (run with `bash`).
- `scripts/run_extracted_pipeline_checks.sh` - PASS (run with `bash`; `extracted_reasoning_core`: `295 passed`; `extracted_content_pipeline`: `3354 passed, 10 skipped`; one `pynvml` warning).
- `scripts/local_pr_review.sh` - PASS (with current PR body file).

## Diff size
5 files, +560 / -18 (578 LOC total; overage justified in the plan because the review fixes are in the same harness/API surface).
