### PR TITLE
Workflow Single Push Review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,14 +269,18 @@ rather than hand-formatting:
   `git diff` (tracked vs merge-base plus untracked). Run after
   implementation; `--check` mode fails if the plan is out of sync
   (CI-gateable).
-- `bash scripts/push_pr.sh <pr-body-file> [git-push-args]` — runs
-  `local_pr_review.sh` with the body file, then pushes with
+- `bash scripts/push_pr.sh <pr-body-file> [git-push-args]` — pushes with
   `ATLAS_CURRENT_PR_BODY_FILE` exported so the installed pre-push hook
-  validates the same body. The wrapper does **not** add `--no-verify`;
-  callers must not pass `--no-verify` through the forwarded push args.
+  validates the same body. With the managed Atlas hook installed, the hook is
+  the **single** local-review runner; if the managed hook is missing or
+  intentionally skipped, the wrapper runs `local_pr_review.sh` before pushing.
+  The wrapper rejects `--no-verify`.
 
 Flow: `bash scripts/new_pr_plan.sh` -> implement ->
 `python scripts/sync_pr_plan.py` -> `bash scripts/push_pr.sh`.
+Do **not** run a separate manual `local_pr_review.sh` immediately before
+`push_pr.sh`; that duplicates the same mechanical bundle and burns context.
+Use manual local review for ad hoc triage or when you are not about to push.
 
 ### 3b. Per-package guardrails
 
@@ -297,7 +301,7 @@ to triage.
 ### 3c. Local review before PR
 
 Before opening or updating a PR, the builder runs the mechanical local
-review bundle:
+review bundle exactly once:
 
 ```bash
 bash scripts/local_pr_review.sh
@@ -319,6 +323,9 @@ bash scripts/install_local_pr_hook.sh
 The installer refuses to overwrite unmanaged hooks unless `--force` is
 passed. The installed hook can be bypassed intentionally with
 `ATLAS_SKIP_LOCAL_PR_REVIEW=1 git push`.
+When using `scripts/push_pr.sh`, that skip does not drop local review
+entirely: the wrapper runs the bundle before the push because the hook will
+skip.
 
 After the mechanical bundle passes, hand the branch to a separate local
 reviewer session for judgment review. The reviewer should read the plan

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -37,15 +37,22 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >      scaffolds the 7-section `plans/PR-<Slice>.md` → implement →
 >      `python scripts/sync_pr_plan.py plans/PR-<Slice>.md` rewrites
 >      `### Files touched` + the diff-size table from the real diff →
->      `bash scripts/push_pr.sh <pr-body-file> -u origin HEAD` runs
->      `local_pr_review.sh` and pushes with `ATLAS_CURRENT_PR_BODY_FILE`
->      exported so the pre-push hook validates the same body. Reconstructing
->      the plan shape by hand or pushing without the body env is what burns
->      the formatting/failed-push loop. See AGENTS.md §3a.2.
+>      `bash scripts/push_pr.sh <pr-body-file> -u origin HEAD` pushes with
+>      `ATLAS_CURRENT_PR_BODY_FILE` exported so the managed pre-push hook can
+>      run `local_pr_review.sh` once with the same body context. If the managed
+>      hook is missing or intentionally skipped, the wrapper runs local review
+>      before pushing. Reconstructing the plan shape by hand or pushing
+>      without the body env is what burns the formatting/failed-push loop. See
+>      AGENTS.md §3a.2.
 >
 > 6. **Context discipline (keeps the session from compacting mid-work):**
 >    - After opening or updating a PR, **stop** — do not poll CI or wait for review (AGENTS.md §3c). Report the PR URL + the local checks you already ran, then hand back to the operator; resume only on the operator's signal.
 >    - During iteration, read **targeted ranges** of large files (e.g. `control_surfaces.py` is ~1.4k lines), not whole files; and run the **single relevant test file**, not the full suite. Run the full `run_extracted_pipeline_checks.sh` gauntlet **once**, right before pushing — not on every change.
+>    - Before pushing, use `scripts/push_pr.sh` as the single local-review entry
+>      point. Do **not** run `local_pr_review.sh` manually and then immediately
+>      run `push_pr.sh`; the wrapper/hook path is responsible for exactly one
+>      mechanical local review. Manual local review is for triage when you are
+>      not pushing yet.
 >    - Keep the session short. If you've been alive across several PRs, expect to compact soon; finish the current slice, then let the operator restart you fresh with this bootstrap rather than running on.
 >
 > 7. **Teardown on merge (AGENTS.md §1g):** when your PR merges, tear down its worktree and branch the same session — **worktree first, then branch** (`git worktree remove <dir>` then `git branch -D <branch>`; deleting a branch still checked out in a worktree fails). `origin/main` is the only source of truth; local branches/worktrees are disposable. Leftover branches/worktrees drift behind main and turn into stale dirty state that mirrors already-landed PRs. Never `git clean -f` without a `git clean -nd` dry-run first — untracked secret files (`.env.bak-*`, `*.production.env`) live in the tree and a blanket clean deletes them.

--- a/plans/PR-Workflow-Single-Push-Review.md
+++ b/plans/PR-Workflow-Single-Push-Review.md
@@ -29,6 +29,9 @@ Slice phase: Workflow/process
   - [ ] With a managed Atlas pre-push hook present and not skipped,
         `push_pr.sh` does not run `local_pr_review.sh` before `git push`; the
         hook is the only runner.
+  - [ ] A marker-only but non-executable hook is not treated as managed; the
+        wrapper keeps the local-review fallback instead of letting Git ignore
+        the hook into a zero-review push.
   - [ ] With no managed hook, `push_pr.sh` still runs `local_pr_review.sh`
         before pushing, so local review is not silently lost.
   - [ ] With `ATLAS_SKIP_LOCAL_PR_REVIEW=1`, `push_pr.sh` runs local review
@@ -56,9 +59,9 @@ Slice phase: Workflow/process
 the managed `ATLAS_LOCAL_PR_REVIEW_HOOK` marker installed by
 `scripts/install_local_pr_hook.sh`.
 
-If that managed hook is present and `ATLAS_SKIP_LOCAL_PR_REVIEW` is not set,
-the wrapper exports `ATLAS_CURRENT_PR_BODY_FILE` and goes straight to
-`git push`; the hook runs `local_pr_review.sh` once with that body context.
+If that managed hook is present, executable, and `ATLAS_SKIP_LOCAL_PR_REVIEW`
+is not set, the wrapper exports `ATLAS_CURRENT_PR_BODY_FILE` and goes straight
+to `git push`; the hook runs `local_pr_review.sh` once with that body context.
 
 If the hook is missing, unmanaged, or would skip, the wrapper runs
 `local_pr_review.sh --current-pr-body-file <body>` itself before pushing. That
@@ -85,7 +88,7 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_push_pr_wrapper.py tests/test_install_local_pr_hook.py -q` -- 10 passed.
+- `python -m pytest tests/test_push_pr_wrapper.py tests/test_install_local_pr_hook.py -q` -- 11 passed.
 - `ATLAS_PUSH_PR_DRY_RUN=1 bash scripts/push_pr.sh plans/PR-Workflow-Single-Push-Review.md -u origin HEAD` -- printed the managed-hook single-run path without a wrapper-side `local_pr_review.sh` command.
 - `bash scripts/push_pr.sh tmp/workflow-single-push-review-pr-body.md -u origin claude/pr-workflow-single-push-review` -- runs the managed pre-push hook once before pushing.
 
@@ -95,7 +98,7 @@ Parked hardening: none.
 |---|---:|
 | `AGENTS.md` | 17 |
 | `docs/SESSION_BOOTSTRAP.md` | 17 |
-| `plans/PR-Workflow-Single-Push-Review.md` | 101 |
+| `plans/PR-Workflow-Single-Push-Review.md` | 104 |
 | `scripts/push_pr.sh` | 42 |
-| `tests/test_push_pr_wrapper.py` | 98 |
-| **Total** | **275** |
+| `tests/test_push_pr_wrapper.py` | 123 |
+| **Total** | **303** |

--- a/plans/PR-Workflow-Single-Push-Review.md
+++ b/plans/PR-Workflow-Single-Push-Review.md
@@ -1,0 +1,101 @@
+# PR-Workflow-Single-Push-Review
+
+## Why this slice exists
+
+The Gate A email-campaign PR push path repeated the same mechanical local
+review bundle multiple times: once manually, once through `push_pr.sh`, and
+again through the installed pre-push hook. The operator called out that this
+will recur after compaction unless the rule is durable.
+
+This workflow slice removes the redundant wrapper-side local-review run when
+the managed hook is already installed, while preserving a fail-safe fallback
+when the hook is absent or explicitly skipped.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/pr-review-efficiency
+Slice phase: Workflow/process
+
+1. Update `scripts/push_pr.sh` so a managed Atlas pre-push hook is the single
+   local-review runner during a push.
+2. Keep wrapper-side local review as the fallback when the managed hook is
+   absent or `ATLAS_SKIP_LOCAL_PR_REVIEW=1` would bypass it.
+3. Lock the behavior in focused wrapper tests and document the compact-safe
+   rule in the builder contract/bootstrap.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] With a managed Atlas pre-push hook present and not skipped,
+        `push_pr.sh` does not run `local_pr_review.sh` before `git push`; the
+        hook is the only runner.
+  - [ ] With no managed hook, `push_pr.sh` still runs `local_pr_review.sh`
+        before pushing, so local review is not silently lost.
+  - [ ] With `ATLAS_SKIP_LOCAL_PR_REVIEW=1`, `push_pr.sh` runs local review
+        before pushing because the hook will intentionally skip.
+  - [ ] `push_pr.sh` rejects forwarded `--no-verify`, because relying on the
+        hook as the single runner cannot allow hook bypass.
+  - [ ] Fresh-session docs tell builders to use `push_pr.sh` and avoid a
+        separate manual local-review run immediately before the wrapper.
+- Affected surfaces: developer workflow scripts, local pre-push behavior,
+  builder bootstrap/contract docs.
+- Risk areas: CI/process enforcement, compaction discipline, failed-push loops.
+- Reviewer rules triggered: R1, R2, R10, R12.
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/SESSION_BOOTSTRAP.md`
+- `plans/PR-Workflow-Single-Push-Review.md`
+- `scripts/push_pr.sh`
+- `tests/test_push_pr_wrapper.py`
+
+## Mechanism
+
+`push_pr.sh` checks `.git/hooks/pre-push` via `git rev-parse --git-path` and
+the managed `ATLAS_LOCAL_PR_REVIEW_HOOK` marker installed by
+`scripts/install_local_pr_hook.sh`.
+
+If that managed hook is present and `ATLAS_SKIP_LOCAL_PR_REVIEW` is not set,
+the wrapper exports `ATLAS_CURRENT_PR_BODY_FILE` and goes straight to
+`git push`; the hook runs `local_pr_review.sh` once with that body context.
+
+If the hook is missing, unmanaged, or would skip, the wrapper runs
+`local_pr_review.sh --current-pr-body-file <body>` itself before pushing. That
+keeps the safety check while removing the duplicate work in the normal
+installed-hook path.
+
+The wrapper rejects forwarded `--no-verify` because that would bypass the
+managed hook after this slice makes the hook the normal single runner.
+
+## Intentional
+
+- The installed pre-push hook remains the source of enforcement for this
+  checkout. Removing the wrapper preflight unconditionally would skip local
+  review on checkouts without the managed hook, so this slice keeps the
+  fallback.
+- This PR does not change the full extracted gauntlet policy. It only prevents
+  duplicate mechanical local-review execution around `git push`.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_push_pr_wrapper.py tests/test_install_local_pr_hook.py -q` -- 10 passed.
+- `ATLAS_PUSH_PR_DRY_RUN=1 bash scripts/push_pr.sh plans/PR-Workflow-Single-Push-Review.md -u origin HEAD` -- printed the managed-hook single-run path without a wrapper-side `local_pr_review.sh` command.
+- `bash scripts/push_pr.sh tmp/workflow-single-push-review-pr-body.md -u origin claude/pr-workflow-single-push-review` -- runs the managed pre-push hook once before pushing.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 17 |
+| `docs/SESSION_BOOTSTRAP.md` | 17 |
+| `plans/PR-Workflow-Single-Push-Review.md` | 101 |
+| `scripts/push_pr.sh` | 42 |
+| `tests/test_push_pr_wrapper.py` | 98 |
+| **Total** | **275** |

--- a/scripts/push_pr.sh
+++ b/scripts/push_pr.sh
@@ -23,7 +23,7 @@ EOF
 has_managed_pre_push_hook() {
     local hook_path
     hook_path="$(git rev-parse --git-path hooks/pre-push)"
-    [ -f "$hook_path" ] && grep -q "ATLAS_LOCAL_PR_REVIEW_HOOK" "$hook_path"
+    [ -x "$hook_path" ] && grep -q "ATLAS_LOCAL_PR_REVIEW_HOOK" "$hook_path"
 }
 
 if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then

--- a/scripts/push_pr.sh
+++ b/scripts/push_pr.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Push a PR branch with the PR body env wired into local review and pre-push.
+# Push a PR branch with the PR body env wired into exactly one local review.
 
 set -euo pipefail
 
@@ -9,13 +9,21 @@ usage() {
     cat <<'EOF'
 Usage: bash scripts/push_pr.sh BODY_FILE [git-push-args...]
 
-Runs local PR review with BODY_FILE, then pushes with ATLAS_CURRENT_PR_BODY_FILE
-exported so the installed pre-push hook validates the same body.
+Pushes with ATLAS_CURRENT_PR_BODY_FILE exported so the installed pre-push hook
+validates the same body. When the managed hook is installed, the hook is the
+single local-review runner. Without that hook, this wrapper runs local review
+before pushing.
 
 Examples:
   bash scripts/push_pr.sh tmp/pr-body-my-slice.md -u origin HEAD
   bash scripts/push_pr.sh tmp/pr-body-my-slice.md -u origin claude/pr-my-slice
 EOF
+}
+
+has_managed_pre_push_hook() {
+    local hook_path
+    hook_path="$(git rev-parse --git-path hooks/pre-push)"
+    [ -f "$hook_path" ] && grep -q "ATLAS_LOCAL_PR_REVIEW_HOOK" "$hook_path"
 }
 
 if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
@@ -36,15 +44,35 @@ if [ "$#" -eq 0 ]; then
     set -- -u origin HEAD
 fi
 
+for arg in "$@"; do
+    if [ "$arg" = "--no-verify" ]; then
+        echo "push_pr.sh: refusing to forward --no-verify; local PR review must run once" >&2
+        exit 2
+    fi
+done
+
+run_wrapper_review=1
+if has_managed_pre_push_hook && [ "${ATLAS_SKIP_LOCAL_PR_REVIEW:-}" != "1" ]; then
+    run_wrapper_review=0
+fi
+
 if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
-    echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file bash scripts/local_pr_review.sh --current-pr-body-file $body_file"
+    if [ "$run_wrapper_review" -eq 1 ]; then
+        echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file bash scripts/local_pr_review.sh --current-pr-body-file $body_file"
+    else
+        echo "DRY RUN: managed pre-push hook will run local PR review once with body: $body_file"
+    fi
     echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file git push $*"
     exit 0
 fi
 
-echo "Running local PR review with PR body: $body_file"
-ATLAS_CURRENT_PR_BODY_FILE="$body_file" \
-    bash scripts/local_pr_review.sh --current-pr-body-file "$body_file"
+if [ "$run_wrapper_review" -eq 1 ]; then
+    echo "Running local PR review with PR body: $body_file"
+    ATLAS_CURRENT_PR_BODY_FILE="$body_file" \
+        bash scripts/local_pr_review.sh --current-pr-body-file "$body_file"
+else
+    echo "Managed pre-push hook detected; local PR review will run once in the hook."
+fi
 
 echo "Pushing with PR body env available to pre-push hook: $body_file"
 ATLAS_CURRENT_PR_BODY_FILE="$body_file" git push "$@"

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -79,6 +79,29 @@ def test_push_pr_dry_run_with_skip_env_keeps_wrapper_review(tmp_path: Path) -> N
     assert "managed pre-push hook will run local PR review once" not in result.stdout
 
 
+def test_push_pr_dry_run_with_non_executable_managed_hook_keeps_wrapper_review(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_managed_hook(repo, executable=False)
+    env = {**os.environ, "ATLAS_PUSH_PR_DRY_RUN": "1"}
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
+    assert f"--current-pr-body-file {body}" in result.stdout
+    assert "managed pre-push hook will run local PR review once" not in result.stdout
+
+
 def test_push_pr_rejects_no_verify(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_body(repo)
@@ -125,9 +148,11 @@ def _write_body(repo: Path) -> Path:
     return body
 
 
-def _write_managed_hook(repo: Path) -> None:
+def _write_managed_hook(repo: Path, *, executable: bool = True) -> None:
     hook = repo / ".git" / "hooks" / "pre-push"
     hook.write_text(
         "#!/usr/bin/env bash\n# ATLAS_LOCAL_PR_REVIEW_HOOK\n",
         encoding="utf-8",
     )
+    if executable:
+        hook.chmod(0o755)

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -3,20 +3,21 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
+from shutil import copy2
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "push_pr.sh"
 
 
-def test_push_pr_dry_run_wires_body_file_env(tmp_path: Path) -> None:
-    body = tmp_path / "body.md"
-    body.write_text("Plan: plans/PR-Test.md\nSlice phase: Workflow/process\n", encoding="utf-8")
+def test_push_pr_dry_run_without_managed_hook_runs_wrapper_review(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
     env = {**os.environ, "ATLAS_PUSH_PR_DRY_RUN": "1"}
 
     result = subprocess.run(
-        ["bash", str(SCRIPT), str(body), "-u", "origin", "HEAD"],
-        cwd=REPO_ROOT,
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
         env=env,
         check=False,
         capture_output=True,
@@ -27,6 +28,71 @@ def test_push_pr_dry_run_wires_body_file_env(tmp_path: Path) -> None:
     assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
     assert f"--current-pr-body-file {body}" in result.stdout
     assert "git push -u origin HEAD" in result.stdout
+
+
+def test_push_pr_dry_run_with_managed_hook_uses_hook_as_single_review_runner(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_managed_hook(repo)
+    env = {**os.environ, "ATLAS_PUSH_PR_DRY_RUN": "1"}
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "managed pre-push hook will run local PR review once" in result.stdout
+    assert "bash scripts/local_pr_review.sh" not in result.stdout
+    assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
+    assert "git push -u origin HEAD" in result.stdout
+
+
+def test_push_pr_dry_run_with_skip_env_keeps_wrapper_review(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_managed_hook(repo)
+    env = {
+        **os.environ,
+        "ATLAS_PUSH_PR_DRY_RUN": "1",
+        "ATLAS_SKIP_LOCAL_PR_REVIEW": "1",
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
+    assert f"--current-pr-body-file {body}" in result.stdout
+    assert "managed pre-push hook will run local PR review once" not in result.stdout
+
+
+def test_push_pr_rejects_no_verify(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--no-verify", "-u", "origin", "HEAD"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing to forward --no-verify" in result.stderr
 
 
 def test_push_pr_missing_body_file_fails_clearly(tmp_path: Path) -> None:
@@ -43,3 +109,25 @@ def test_push_pr_missing_body_file_fails_clearly(tmp_path: Path) -> None:
     assert result.returncode == 2
     assert "PR body file not found" in result.stderr
     assert str(missing) in result.stderr
+
+
+def _write_fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    copy2(SCRIPT, repo / "scripts" / "push_pr.sh")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    return repo
+
+
+def _write_body(repo: Path) -> Path:
+    body = repo / "body.md"
+    body.write_text("Plan: plans/PR-Test.md\nSlice phase: Workflow/process\n", encoding="utf-8")
+    return body
+
+
+def _write_managed_hook(repo: Path) -> None:
+    hook = repo / ".git" / "hooks" / "pre-push"
+    hook.write_text(
+        "#!/usr/bin/env bash\n# ATLAS_LOCAL_PR_REVIEW_HOOK\n",
+        encoding="utf-8",
+    )


### PR DESCRIPTION
Plan: plans/PR-Workflow-Single-Push-Review.md
Slice phase: Workflow/process

This workflow slice removes the duplicate local-review run around `scripts/push_pr.sh`: when the managed Atlas pre-push hook is installed and executable, the hook is the single mechanical local-review runner; when the hook is absent, non-executable, or skipped, the wrapper still runs local review before pushing. It also rejects forwarded `--no-verify`.

## Intentional
- The installed hook remains the normal enforcement point; the wrapper fallback protects checkouts without that managed hook.
- This does not change extracted-package gauntlet policy. It only prevents duplicate mechanical local-review execution around `git push`.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_push_pr_wrapper.py tests/test_install_local_pr_hook.py -q` -- 11 passed.
- `ATLAS_PUSH_PR_DRY_RUN=1 bash scripts/push_pr.sh plans/PR-Workflow-Single-Push-Review.md -u origin HEAD` -- printed the managed-hook single-run path without a wrapper-side `local_pr_review.sh` command.
- `bash scripts/push_pr.sh tmp/workflow-single-push-review-pr-body.md -u origin claude/pr-workflow-single-push-review` -- runs the managed pre-push hook once before pushing.

## Diff size
5 files, +281 / -22.
