### PR TITLE
Content-Ops Tenant Binding Bridge

### DIFF
--- a/atlas_brain/_content_ops_review_workflow.py
+++ b/atlas_brain/_content_ops_review_workflow.py
@@ -52,6 +52,13 @@ class TenantClaimRegistryReader(Protocol):
         """Return registry claims keyed by registry id."""
 
 
+class ContentOpsAccountResolver(Protocol):
+    """Resolve the connector-bound tenant account for one service call."""
+
+    async def resolve_account_id(self) -> Any:
+        """Return the bound account ID, or a missing value when unavailable."""
+
+
 @dataclass(frozen=True)
 class ContentOpsReviewRequest:
     """Structured request a future marketer MCP tool can pass through."""
@@ -64,6 +71,26 @@ class ContentOpsReviewRequest:
     extracted_claims: tuple[ExtractedClaim, ...] = ()
     comments: tuple[ReviewComment, ...] = ()
     as_of: date | None = None
+
+
+async def run_content_ops_review_for_bound_tenant(
+    request: ContentOpsReviewRequest,
+    *,
+    account_resolver: ContentOpsAccountResolver,
+    registry_reader: TenantClaimRegistryReader,
+) -> ContentOpsReviewResult:
+    """Resolve connector tenant binding before running the review service."""
+
+    try:
+        account_id = await account_resolver.resolve_account_id()
+    except Exception:
+        return _blocked_result(request, "tenant binding resolution failed")
+
+    return await run_content_ops_review(
+        request,
+        scope=_tenant_scope_from_account_binding(account_id),
+        registry_reader=registry_reader,
+    )
 
 
 @dataclass(frozen=True)
@@ -161,6 +188,13 @@ def _scope_account_id(scope: TenantScope | None) -> str:
     return value.strip()
 
 
+def _tenant_scope_from_account_binding(account_id: Any) -> TenantScope | None:
+    account = account_id.strip() if isinstance(account_id, str) else ""
+    if not account:
+        return None
+    return TenantScope(account_id=account)
+
+
 def _coverage_rows_for_request(request: ContentOpsReviewRequest) -> tuple[CoverageRow, ...]:
     rows = list(request.coverage or ())
     for report in _items(request.quality_reports):
@@ -215,9 +249,11 @@ def _value(value: Any) -> Any:
 
 
 __all__ = [
+    "ContentOpsAccountResolver",
     "ContentOpsReviewRequest",
     "ContentOpsReviewResult",
     "TenantClaimRegistryReadError",
     "TenantClaimRegistryReader",
     "run_content_ops_review",
+    "run_content_ops_review_for_bound_tenant",
 ]

--- a/plans/PR-Content-Ops-Tenant-Binding-Bridge.md
+++ b/plans/PR-Content-Ops-Tenant-Binding-Bridge.md
@@ -1,0 +1,105 @@
+# PR - Content-Ops Tenant Binding Bridge
+
+## Why this slice exists
+
+#1377 made the review service tool-shaped, but future marketer MCP callers still
+need a safe way to turn connector tenant binding into the `TenantScope` the
+service and claim-registry reader already require. #1353 identifies this as the
+remaining service seam before MCP transport: FastAPI routes use a request
+ContextVar, while MCP precedents expose an account resolver. This slice bridges
+that resolver shape into the review service without starting the MCP server.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+Build the tenant-binding bridge for the review service:
+
+1. Add a small account-resolver protocol at the review-service boundary.
+2. Add a wrapper that resolves the bound account, builds a `TenantScope`, and
+   delegates to the existing review service.
+3. Fail closed before registry reads when the binding is missing, malformed, or
+   the resolver fails.
+4. Preserve the direct `scope=` service path for FastAPI callers and tests.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [x] A bound account resolver produces a `TenantScope` passed to the
+        registry reader.
+  - [x] Whitespace around the resolved account is trimmed before building scope.
+  - [x] Missing, blank, or non-string account binding blocks before registry
+        reads.
+  - [x] Resolver exceptions block before registry reads.
+  - [x] Existing direct-scope review service behavior remains unchanged.
+  - [x] No MCP transport, OAuth server, DB migration, LLM behavior, or
+        generated-asset mutation is added.
+- Affected surfaces: host review service, CI-covered service tests.
+- Risk areas: tenant isolation, fail-closed behavior, backcompat.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12.
+
+### Files touched
+
+- `atlas_brain/_content_ops_review_workflow.py`
+- `tests/test_atlas_content_ops_review_workflow.py`
+- `plans/PR-Content-Ops-Tenant-Binding-Bridge.md`
+
+## Mechanism
+
+The review workflow module gains a protocol for the deflection-style account
+resolver boundary and a wrapper that accepts a request, resolver, and registry
+reader. The wrapper resolves the account, converts a non-empty string into
+`TenantScope`, then delegates to the existing service path. If binding is absent
+or resolution raises, the wrapper returns the same blocked result shape used by
+the existing service and never calls the registry reader.
+
+The existing direct `scope=` entry point remains unchanged so FastAPI route
+callers keep using the already-wired ContextVar bridge.
+
+## Intentional
+
+- This is not the marketer MCP server and does not add OAuth routes, tokens, or
+  tool registration.
+- This does not change the claim-registry repository; it only ensures future
+  connector callers hand that repository a tenant scope.
+- The bridge accepts only account binding from an injected resolver, not an
+  account id from a draft/tool payload.
+
+## Deferred
+
+- `PR-Marketer-Verification-MCP`: expose verify-only tools after tenant binding
+  is available as service plumbing.
+- `PR-Content-Ops-MCP-OAuth-Transport`: settle dual-client connector transport
+  and OAuth token-to-tenant isolation.
+- Parked hardening: none expected.
+
+## Verification
+
+- Command: python -m pytest tests/test_atlas_content_ops_review_workflow.py -q
+  - Passed: 24 tests.
+- Command: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_atlas_content_ops_scope.py tests/test_content_ops_claim_registry.py -q
+  - Passed: 50 tests.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - Passed: 156 matching tests are enrolled.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed: mapped files match Atlas sources; hard Atlas imports clean.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed: clean.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed: Atlas runtime import findings 0.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed: extracted content pipeline Python files are ASCII.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Passed: 3345 tests, 10 skipped.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_tenant_binding_bridge_pr_body.md
+  - Passed: local PR review passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/_content_ops_review_workflow.py` | 36 |
+| `tests/test_atlas_content_ops_review_workflow.py` | 76 |
+| `plans/PR-Content-Ops-Tenant-Binding-Bridge.md` | 105 |
+| **Total** | **217** |

--- a/tests/test_atlas_content_ops_review_workflow.py
+++ b/tests/test_atlas_content_ops_review_workflow.py
@@ -9,6 +9,7 @@ from atlas_brain._content_ops_review_workflow import (
     ContentOpsReviewRequest,
     TenantClaimRegistryReadError,
     run_content_ops_review,
+    run_content_ops_review_for_bound_tenant,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.claims_map import ClaimStatus, ExtractedClaim, RegistryClaim
@@ -55,6 +56,25 @@ class _FailingRegistryReader:
     async def list_registry_claims(self, *, scope: TenantScope):
         self.scopes.append(scope)
         raise TenantClaimRegistryReadError("claim registry read failed")
+
+
+@dataclass
+class _AccountResolver:
+    account_id: object
+    calls: int = 0
+
+    async def resolve_account_id(self):
+        self.calls += 1
+        return self.account_id
+
+
+@dataclass
+class _FailingAccountResolver:
+    calls: int = 0
+
+    async def resolve_account_id(self):
+        self.calls += 1
+        raise RuntimeError("oauth token lookup failed")
 
 
 def _reader() -> _RegistryReader:
@@ -139,6 +159,62 @@ async def test_registry_reader_receives_tenant_scope_not_request_account_id() ->
     assert reader.scopes == [scope]
     assert result.content_pr.asset_id == "asset-1"
     assert result.mapped_claims[0].status == ClaimStatus.MATCH
+
+
+@pytest.mark.asyncio
+async def test_bound_tenant_review_uses_resolved_account_scope() -> None:
+    reader = _reader()
+    resolver = _AccountResolver(" acct-1 ")
+
+    result = await run_content_ops_review_for_bound_tenant(
+        _request(),
+        account_resolver=resolver,
+        registry_reader=reader,
+    )
+
+    assert result.decision == ReviewDecision.APPROVED
+    assert resolver.calls == 1
+    assert reader.scopes == [TenantScope(account_id="acct-1")]
+    assert result.mapped_claims[0].status == ClaimStatus.MATCH
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("account_id", [None, "", " ", 123])
+async def test_bound_tenant_review_blocks_missing_or_malformed_binding(
+    account_id: object,
+) -> None:
+    reader = _reader()
+    resolver = _AccountResolver(account_id)
+
+    result = await run_content_ops_review_for_bound_tenant(
+        _request(),
+        account_resolver=resolver,
+        registry_reader=reader,
+    )
+
+    assert result.decision == ReviewDecision.BLOCKED
+    assert result.reasons == ("tenant scope required",)
+    assert result.mapped_claims == ()
+    assert resolver.calls == 1
+    assert reader.scopes == []
+
+
+@pytest.mark.asyncio
+async def test_bound_tenant_review_blocks_resolver_failure_before_registry() -> None:
+    reader = _reader()
+    resolver = _FailingAccountResolver()
+
+    result = await run_content_ops_review_for_bound_tenant(
+        _request(),
+        account_resolver=resolver,
+        registry_reader=reader,
+    )
+
+    assert result.decision == ReviewDecision.BLOCKED
+    assert result.reasons == ("tenant binding resolution failed",)
+    assert result.mapped_claims == ()
+    assert resolver.calls == 1
+    assert reader.scopes == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Tenant-Binding-Bridge.md
Slice phase: Vertical slice
Ownership lane: content-ops/review-contract

This bridges connector-style tenant account binding into the existing content-ops review service. Future marketer MCP transport can resolve the bound account through an injected resolver, build a `TenantScope`, and delegate to the same review path without accepting tenant ids from draft payloads.

## Intentional
- This is not the marketer MCP server and does not add OAuth routes, tokens, or tool registration.
- This does not change the claim-registry repository; it only ensures future connector callers hand that repository a tenant scope.
- The bridge accepts only account binding from an injected resolver, not an account id from a draft/tool payload.

## Deferred
- `PR-Marketer-Verification-MCP`: expose verify-only tools after tenant binding is available as service plumbing.
- `PR-Content-Ops-MCP-OAuth-Transport`: settle dual-client connector transport and OAuth token-to-tenant isolation.

## Parked hardening
- None.

## AI Reconciliation
- No automated-review findings yet.

## Verification
- `python -m pytest tests/test_atlas_content_ops_review_workflow.py -q` -- 24 passed.
- `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_atlas_content_ops_scope.py tests/test_content_ops_claim_registry.py -q` -- 50 passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- OK, 156 matching tests are enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 3345 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_tenant_binding_bridge_pr_body.md` -- passed.

## Diff size
3 files, +217 / -0.