### PR TITLE
Gate A Live Convergence Proof

### DIFF
--- a/docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md
+++ b/docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md
@@ -11,11 +11,12 @@ reviewer owns the product-quality judgment against the exported drafts.
 
 Review-response note: the first #1383 proof run exposed that the seeded
 support-ticket blog source summary still contained debug generation wording
-and that the blog debug-source detector missed the exact live phrase. This
-refresh includes the detector/source-summary hardening and reruns the same
-selected outputs. The rerun blocked a bad blog candidate on
-`support_ticket_generated_content:debug_source_narration` and exported only the
-saved drafts listed below.
+and that the blog debug-source detector missed the exact live phrase. The next
+review showed that quote-specific detection was not enough: passing blog
+variants could still narrate uploaded/source mechanics. This refresh makes the
+support-ticket prose instruction unconditional, removes upload/source-row copy
+from the live seed, broadens the detector to the source-mechanics class, and
+reruns the same selected outputs.
 
 Raw artifacts:
 
@@ -66,22 +67,18 @@ review ids. `summary.json` reports `ok=true`.
 | Output | Saved ids | Exported rows | Review status |
 |---|---:|---:|---|
 | landing_page | 3 | 3 | approved, no missing ids |
-| blog_post | 2 | 2 | approved, no missing ids |
+| blog_post | 3 | 3 | approved, no missing ids |
 | sales_brief | 3 | 3 | approved, no missing ids |
 
-Blocked variants recorded by the harness:
+No selected-output variants were blocked in the final run. `summary.json`
+records 3 generated variants for each selected output with empty per-variant
+error lists.
 
-| Output | Variant | Blocker |
-|---|---|---|
-| blog_post | pain_led | `geo_citable_section_structure_missing`, `support_ticket_generated_content:debug_source_narration` |
-
-The blocked variants are preserved in `summary.json` under
-`variant_summary`. The blocked blog candidate includes the exact debug-source
-shape found in review ("In the uploaded tickets, 35 of 36 rows...") and was not
-saved or exported. The exported blog samples were also checked for the known
-debug-generation phrases `rows were included for generation`,
-`uploaded ticket CSV can produce`, and `Your uploaded tickets contain`; none
-were present.
+The exported blog samples were checked for source-mechanics/debug-generation
+phrases including `uploaded tickets`, `uploaded ticket set`, `source rows`,
+`usable rows`, `included rows`, `rows were included`, `we ingested`,
+`you sent`, `support ticket export`, and `source mechanics`; none were present
+in public blog content or the full blog export JSON.
 
 ## Samples
 
@@ -89,24 +86,25 @@ Landing-page exports:
 
 | Variant | Draft id | Title | Hero headline | Brand voice |
 |---|---|---|---|---|
-| pain_led | `49e324c1-f331-404d-bfa4-dcbcb5387027` | "Stop Answering the Same Support Tickets Every Week" | "Your team answers the same questions every week" | passed |
-| outcome_led | `2b09400f-a8b9-4787-86dd-ca655686d246` | "Cut Repeat Support Tickets with Review-Ready FAQ Answers" | "Turn repeat support tickets into approved FAQ answers" | passed |
-| social_proof | `a1181e5e-91e3-49d0-9ad1-1c5494783330` | "35 Support Tickets Showed the Same 9 FAQ Gaps - Here's Your Audit" | "Your repeat tickets already told you what's missing" | passed |
+| pain_led | `d8b20a0d-44c5-42ee-ae7a-b29251426db8` | "Support Ticket FAQ Gap Audit - Turn Repeat Tickets Into Approved Answers" | "Your repeat tickets show the FAQ gaps" | passed |
+| outcome_led | `067c7531-b8c7-4b88-acaf-4f7643cd43f6` | "Cut Repeat Support Tickets with FAQ Gap Audit" | "Turn Repeat Support Tickets into Approved FAQ Answers" | passed |
+| social_proof | `104b8793-9015-4aac-abab-41917dd38309` | "Support Ticket FAQ Gap Audit - Turn Repeat Questions Into Approved Answers" | "Your repeat tickets already show the FAQ gaps" | passed |
 
 Blog exports:
 
 | Variant | Draft id | Title | Opening heading | Brand voice |
 |---|---|---|---|---|
-| outcome_led | `2f9ec4e3-475a-4046-9e01-182757d1de20` | "Support Ticket FAQ Gaps: What Your Repeat Tickets Reveal Before Renewal" | "What your repeat support questions show" | passed |
-| social_proof | `44d56e20-d9c8-4626-8e39-e894cb8fd085` | "Support Ticket FAQ Gaps: What Your Repeat Tickets Reveal Before Renewal" | "What repeat support questions show" | passed |
+| pain_led | `0501c17f-90c9-4318-9d15-e3253160a4e5` | "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal" | "What repeat support questions show" | passed |
+| outcome_led | `2f9ec4e3-475a-4046-9e01-182757d1de20` | "Support Ticket FAQ Gaps: What Your Repeat Questions Reveal Before Renewal" | "What repeat support questions show" | passed |
+| social_proof | `44d56e20-d9c8-4626-8e39-e894cb8fd085` | "Support Ticket FAQ Gaps: What 36 Repeat Tickets Reveal Before Renewal" | "What repeat support questions show" | passed |
 
 Sales-brief exports:
 
 | Variant | Draft id | Headline | Brief type | Brand voice |
 |---|---|---|---|---|
-| pain_led | `33044118-629f-491d-ada6-0aa3fc838222` | "Your RevOps lead hit a reporting wall before their board meeting. Export friction at renewal time is churn friction." | renewal | passed |
-| outcome_led | `e71d3a76-e32a-4891-8879-e6b99d9e58af` | "Your RevOps lead needs attribution exports before the board meeting. Support ticket shows renewal-stage reporting gap." | renewal | passed |
-| social_proof | `8744dc21-df4e-424e-9a9d-e5cada717886` | "RevOps lead needs attribution exports before board meeting. Support ticket signals reporting gap risk at renewal." | renewal | passed |
+| pain_led | `3fc2cbe9-eca0-42ee-8804-2b63c9af9057` | "Your RevOps lead hit a wall exporting attribution data right before a board meeting. That's your renewal conversation starter." | renewal | passed |
+| outcome_led | `490247f3-19bf-4c0e-b532-e78c369cf989` | "Your RevOps lead needs attribution exports before the board meeting. Renewal window is your leverage to fix the blocker." | renewal | passed |
+| social_proof | `2689157c-2473-44e9-bc75-3f786b105aae` | "RevOps lead blocked on attribution exports days before board meeting. Support ticket shows renewal-risk friction." | renewal | passed |
 
 ## Reviewer Notes
 
@@ -118,7 +116,7 @@ drafts directly for:
 - variant distinction in title, body, and section order;
 - grounded counts only;
 - second-person voice;
-- whether the one blocked blog variant should keep Gate A from passing.
+- whether the 3/3 exported samples meet the GOOD bar.
 
 The artifact set is complete enough for a reviewer to judge the real samples
 without rerunning the live generation.

--- a/docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md
+++ b/docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md
@@ -1,0 +1,124 @@
+# Gate A Live Convergence Proof: Post-Fix Reconfirm
+
+Date: 2026-06-08
+
+Issue: #1357 / #1376 follow-up
+
+Lane: `content-ops/gate-a-output-quality`
+
+Verdict: **Not self-certified**. The harness completed with `ok=true`, but the
+reviewer owns the product-quality judgment against the exported drafts.
+
+Review-response note: the first #1383 proof run exposed that the seeded
+support-ticket blog source summary still contained debug generation wording
+and that the blog debug-source detector missed the exact live phrase. This
+refresh includes the detector/source-summary hardening and reruns the same
+selected outputs. The rerun blocked a bad blog candidate on
+`support_ticket_generated_content:debug_source_narration` and exported only the
+saved drafts listed below.
+
+Raw artifacts:
+
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json`
+
+## Run
+
+Command:
+
+```bash
+EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false \
+python scripts/smoke_content_ops_gate_a_live_quality.py \
+  --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 \
+  --user-id 11111111-1111-4111-8111-111111111111 \
+  --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --output-dir tmp/content_ops_gate_a_reconfirm_20260608 \
+  --outputs landing_page,blog_post,sales_brief \
+  --variant-count 3 \
+  --quality-repair-attempts 1 \
+  --max-cost-usd 20.00 \
+  --json
+```
+
+Runtime route:
+
+- Real local Postgres: existing Atlas DB pool from `.env` / `.env.local`.
+- Real model route: `anthropic/claude-sonnet-4-5`.
+- Local Ollama fallback disabled:
+  `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false`.
+- Source material: `support_ticket_saas_demo_sources.csv`, 36 support-ticket rows.
+- Outputs requested: `landing_page`, `blog_post`, `sales_brief`.
+- Excluded output: `email_campaign`.
+- Variant request: `variant_count=3`.
+- Budget cap: `--max-cost-usd 20.00`; not triggered.
+
+## Structural Result
+
+The harness completed execution, review, and exact export with no missing
+review ids. `summary.json` reports `ok=true`.
+
+| Output | Saved ids | Exported rows | Review status |
+|---|---:|---:|---|
+| landing_page | 3 | 3 | approved, no missing ids |
+| blog_post | 2 | 2 | approved, no missing ids |
+| sales_brief | 3 | 3 | approved, no missing ids |
+
+Blocked variants recorded by the harness:
+
+| Output | Variant | Blocker |
+|---|---|---|
+| blog_post | pain_led | `geo_citable_section_structure_missing`, `support_ticket_generated_content:debug_source_narration` |
+
+The blocked variants are preserved in `summary.json` under
+`variant_summary`. The blocked blog candidate includes the exact debug-source
+shape found in review ("In the uploaded tickets, 35 of 36 rows...") and was not
+saved or exported. The exported blog samples were also checked for the known
+debug-generation phrases `rows were included for generation`,
+`uploaded ticket CSV can produce`, and `Your uploaded tickets contain`; none
+were present.
+
+## Samples
+
+Landing-page exports:
+
+| Variant | Draft id | Title | Hero headline | Brand voice |
+|---|---|---|---|---|
+| pain_led | `49e324c1-f331-404d-bfa4-dcbcb5387027` | "Stop Answering the Same Support Tickets Every Week" | "Your team answers the same questions every week" | passed |
+| outcome_led | `2b09400f-a8b9-4787-86dd-ca655686d246` | "Cut Repeat Support Tickets with Review-Ready FAQ Answers" | "Turn repeat support tickets into approved FAQ answers" | passed |
+| social_proof | `a1181e5e-91e3-49d0-9ad1-1c5494783330` | "35 Support Tickets Showed the Same 9 FAQ Gaps - Here's Your Audit" | "Your repeat tickets already told you what's missing" | passed |
+
+Blog exports:
+
+| Variant | Draft id | Title | Opening heading | Brand voice |
+|---|---|---|---|---|
+| outcome_led | `2f9ec4e3-475a-4046-9e01-182757d1de20` | "Support Ticket FAQ Gaps: What Your Repeat Tickets Reveal Before Renewal" | "What your repeat support questions show" | passed |
+| social_proof | `44d56e20-d9c8-4626-8e39-e894cb8fd085` | "Support Ticket FAQ Gaps: What Your Repeat Tickets Reveal Before Renewal" | "What repeat support questions show" | passed |
+
+Sales-brief exports:
+
+| Variant | Draft id | Headline | Brief type | Brand voice |
+|---|---|---|---|---|
+| pain_led | `33044118-629f-491d-ada6-0aa3fc838222` | "Your RevOps lead hit a reporting wall before their board meeting. Export friction at renewal time is churn friction." | renewal | passed |
+| outcome_led | `e71d3a76-e32a-4891-8879-e6b99d9e58af` | "Your RevOps lead needs attribution exports before the board meeting. Support ticket shows renewal-stage reporting gap." | renewal | passed |
+| social_proof | `8744dc21-df4e-424e-9a9d-e5cada717886` | "RevOps lead needs attribution exports before board meeting. Support ticket signals reporting gap risk at renewal." | renewal | passed |
+
+## Reviewer Notes
+
+This run is meant to confirm the post-fix convergence signal against the #1360
+failure baseline, not to certify final product quality. Review the exported
+drafts directly for:
+
+- publishable openings with no debug-source narration;
+- variant distinction in title, body, and section order;
+- grounded counts only;
+- second-person voice;
+- whether the one blocked blog variant should keep Gate A from passing.
+
+The artifact set is complete enough for a reviewer to judge the real samples
+without rerunning the live generation.

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json
@@ -1,0 +1,433 @@
+{
+  "errors": [],
+  "plan": {
+    "can_execute": true,
+    "limit": 1,
+    "preview": {
+      "blocked_outputs": [],
+      "can_run": true,
+      "estimated_cost_usd": 12.6,
+      "missing_inputs": [],
+      "normalized_request": {
+        "account_usage_budget_days": 7,
+        "account_usage_budget_usd": null,
+        "allow_unimplemented_outputs": false,
+        "brand_voice_profile_id": null,
+        "content_ops_cache_policy": null,
+        "ingestion_profile": "existing_evidence",
+        "limit": 1,
+        "max_cost_usd": 20.0,
+        "outputs": [
+          "landing_page",
+          "blog_post",
+          "sales_brief"
+        ],
+        "preset": null,
+        "reasoning_preset": null,
+        "require_quality_gates": true,
+        "target_mode": "vendor_retention",
+        "variant_count": 3
+      },
+      "outputs": [
+        "landing_page",
+        "blog_post",
+        "sales_brief"
+      ],
+      "warnings": []
+    },
+    "steps": [
+      {
+        "config": {
+          "brand_voice_profile_id": "gate-a-sharp-support-operator",
+          "max_tokens": 4096,
+          "parse_retry_attempts": 1,
+          "parse_retry_response_excerpt_chars": 800,
+          "quality_gates_enabled": true,
+          "quality_repair_attempts": 1,
+          "skill_name": "digest/landing_page_generation",
+          "temperature": 0.3,
+          "variant_angles": [
+            {
+              "id": "pain_led",
+              "instruction": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step.",
+              "label": "Pain-led"
+            },
+            {
+              "id": "outcome_led",
+              "instruction": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result.",
+              "label": "Outcome-led"
+            },
+            {
+              "id": "social_proof",
+              "instruction": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials.",
+              "label": "Social-proof-led"
+            }
+          ],
+          "variant_count": 3
+        },
+        "output": "landing_page",
+        "reason": "",
+        "runner": "LandingPageGenerationService.generate",
+        "status": "runnable"
+      },
+      {
+        "config": {
+          "brand_voice_profile_id": "gate-a-sharp-support-operator",
+          "limit": 1,
+          "max_tokens": 4096,
+          "parse_retry_attempts": 1,
+          "parse_retry_response_excerpt_chars": 800,
+          "quality_gates_enabled": true,
+          "quality_repair_attempts": 2,
+          "skill_name": "digest/blog_post_generation",
+          "temperature": 0.3,
+          "topic": "Support ticket FAQ gaps: what repeat tickets reveal before renewal",
+          "variant_angles": [
+            {
+              "id": "pain_led",
+              "instruction": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step.",
+              "label": "Pain-led"
+            },
+            {
+              "id": "outcome_led",
+              "instruction": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result.",
+              "label": "Outcome-led"
+            },
+            {
+              "id": "social_proof",
+              "instruction": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials.",
+              "label": "Social-proof-led"
+            }
+          ],
+          "variant_count": 3
+        },
+        "output": "blog_post",
+        "reason": "",
+        "runner": "BlogPostGenerationService.generate",
+        "status": "runnable"
+      },
+      {
+        "config": {
+          "brand_voice_profile_id": "gate-a-sharp-support-operator",
+          "default_brief_type": "renewal",
+          "limit": 1,
+          "max_tokens": 4096,
+          "parse_retry_attempts": 1,
+          "parse_retry_response_excerpt_chars": 800,
+          "quality_gates_enabled": true,
+          "skill_name": "digest/sales_brief_generation",
+          "temperature": 0.3,
+          "variant_angles": [
+            {
+              "id": "pain_led",
+              "instruction": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step.",
+              "label": "Pain-led"
+            },
+            {
+              "id": "outcome_led",
+              "instruction": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result.",
+              "label": "Outcome-led"
+            },
+            {
+              "id": "social_proof",
+              "instruction": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials.",
+              "label": "Social-proof-led"
+            }
+          ],
+          "variant_count": 3
+        },
+        "output": "sales_brief",
+        "reason": "",
+        "runner": "SalesBriefGenerationService.generate",
+        "status": "runnable"
+      }
+    ],
+    "target_mode": "vendor_retention"
+  },
+  "status": "completed",
+  "steps": [
+    {
+      "error": "",
+      "output": "landing_page",
+      "reasoning": {
+        "contexts_used": 0,
+        "provider_configured": false,
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": true
+      },
+      "result": {
+        "errors": [],
+        "generated": 3,
+        "reasoning_contexts_used": 0,
+        "requested": 3,
+        "saved_ids": [
+          "49e324c1-f331-404d-bfa4-dcbcb5387027",
+          "2b09400f-a8b9-4787-86dd-ca655686d246",
+          "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+        ],
+        "skipped": 0,
+        "variant_count": 3,
+        "variant_results": [
+          {
+            "errors": [],
+            "generated": 1,
+            "quality_repair_history": [
+              {
+                "attempt": 0,
+                "blockers": [],
+                "passed": true,
+                "repair_issues": []
+              }
+            ],
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [
+              "49e324c1-f331-404d-bfa4-dcbcb5387027"
+            ],
+            "skipped": 0,
+            "variant_angle": {
+              "id": "pain_led",
+              "instruction": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step.",
+              "label": "Pain-led"
+            }
+          },
+          {
+            "errors": [],
+            "generated": 1,
+            "quality_repair_history": [
+              {
+                "attempt": 0,
+                "blockers": [],
+                "passed": true,
+                "repair_issues": []
+              }
+            ],
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [
+              "2b09400f-a8b9-4787-86dd-ca655686d246"
+            ],
+            "skipped": 0,
+            "variant_angle": {
+              "id": "outcome_led",
+              "instruction": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result.",
+              "label": "Outcome-led"
+            }
+          },
+          {
+            "errors": [],
+            "generated": 1,
+            "quality_repair_history": [
+              {
+                "attempt": 0,
+                "blockers": [],
+                "passed": true,
+                "repair_issues": []
+              }
+            ],
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [
+              "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+            ],
+            "skipped": 0,
+            "variant_angle": {
+              "id": "social_proof",
+              "instruction": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials.",
+              "label": "Social-proof-led"
+            }
+          }
+        ]
+      },
+      "runner": "LandingPageGenerationService.generate",
+      "status": "completed"
+    },
+    {
+      "error": "",
+      "output": "blog_post",
+      "reasoning": {
+        "contexts_used": 0,
+        "provider_configured": false,
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": true
+      },
+      "result": {
+        "errors": [
+          {
+            "blockers": [
+              "geo_citable_section_structure_missing",
+              "support_ticket_generated_content:debug_source_narration"
+            ],
+            "blueprint_id": "0da54d85-706c-43e9-aa59-036b182b2d87",
+            "failed_candidate": {
+              "content_excerpt_head": "## What repeat support questions show\n\nYour customers ask the same questions repeatedly. In the uploaded tickets, 35 of 36 rows include direct customer questions. Nine clusters appear with equal frequency: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster represents a gap where your help center does not answer the question.\n\nThe reporting export cluster includes questions such as \"How do I export attribution reports before our board meeting?\" and \"Why is the campaign CSV export missing source and owner columns?\" The dashboard freshness cluster includes \"Why has our pipeline dashboard not refreshed since yesterday?\" and \"How do we check whether the warehouse sync is delayed?\" These are not edge cases. They are repeated patterns in the provided ticket set.\n\nThe uploaded tickets show which questions appear most often in this sample. They do not prove how often those questions appear across your full support queue. They show what customers asked in the provided set.\n\n## Which FAQ gaps should be reviewed first\n\nPrioritize by observed ticket volume. In this set, nine clusters are tied at 4 tickets each. You cannot rank tied clusters by business impact, activation risk, or workflow blocking without measured outcome evidence. The blueprint does not include that evidence. Review all nine tied clusters bef",
+              "content_excerpt_tail": "d resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after publishing. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming causality.\n\nThe uploaded tickets do not include a dated source window, so do not add fixed checkpoints. Watch for changes in ticket patterns and adjust your FAQ content based on what you observe.\n\nIf a cluster continues to generate tickets after you publish an FAQ entry, that is a signal. The answer may need clearer wording, the question may need a different title, or the FAQ page may need better navigation. Use those signals to refine your content.",
+              "content_truncated": true,
+              "generation_parse_attempts": 1,
+              "generation_quality_repair_attempts": 2,
+              "seo_title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal",
+              "slug": "",
+              "target_keyword": "support ticket faq gaps",
+              "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
+              "topic_type": "",
+              "word_count": 924
+            },
+            "reason": "quality_blocked",
+            "variant_angle": "pain_led",
+            "variant_label": "Pain-led"
+          }
+        ],
+        "generated": 2,
+        "reasoning_contexts_used": 0,
+        "requested": 3,
+        "saved_ids": [
+          "2f9ec4e3-475a-4046-9e01-182757d1de20",
+          "44d56e20-d9c8-4626-8e39-e894cb8fd085"
+        ],
+        "skipped": 1,
+        "variant_count": 3,
+        "variant_results": [
+          {
+            "errors": [
+              {
+                "blockers": [
+                  "geo_citable_section_structure_missing",
+                  "support_ticket_generated_content:debug_source_narration"
+                ],
+                "blueprint_id": "0da54d85-706c-43e9-aa59-036b182b2d87",
+                "failed_candidate": {
+                  "content_excerpt_head": "## What repeat support questions show\n\nYour customers ask the same questions repeatedly. In the uploaded tickets, 35 of 36 rows include direct customer questions. Nine clusters appear with equal frequency: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster represents a gap where your help center does not answer the question.\n\nThe reporting export cluster includes questions such as \"How do I export attribution reports before our board meeting?\" and \"Why is the campaign CSV export missing source and owner columns?\" The dashboard freshness cluster includes \"Why has our pipeline dashboard not refreshed since yesterday?\" and \"How do we check whether the warehouse sync is delayed?\" These are not edge cases. They are repeated patterns in the provided ticket set.\n\nThe uploaded tickets show which questions appear most often in this sample. They do not prove how often those questions appear across your full support queue. They show what customers asked in the provided set.\n\n## Which FAQ gaps should be reviewed first\n\nPrioritize by observed ticket volume. In this set, nine clusters are tied at 4 tickets each. You cannot rank tied clusters by business impact, activation risk, or workflow blocking without measured outcome evidence. The blueprint does not include that evidence. Review all nine tied clusters bef",
+                  "content_excerpt_tail": "d resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after publishing. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming causality.\n\nThe uploaded tickets do not include a dated source window, so do not add fixed checkpoints. Watch for changes in ticket patterns and adjust your FAQ content based on what you observe.\n\nIf a cluster continues to generate tickets after you publish an FAQ entry, that is a signal. The answer may need clearer wording, the question may need a different title, or the FAQ page may need better navigation. Use those signals to refine your content.",
+                  "content_truncated": true,
+                  "generation_parse_attempts": 1,
+                  "generation_quality_repair_attempts": 2,
+                  "seo_title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal",
+                  "slug": "",
+                  "target_keyword": "support ticket faq gaps",
+                  "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
+                  "topic_type": "",
+                  "word_count": 924
+                },
+                "reason": "quality_blocked"
+              }
+            ],
+            "generated": 0,
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [],
+            "skipped": 1,
+            "variant_angle": {
+              "id": "pain_led",
+              "instruction": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step.",
+              "label": "Pain-led"
+            }
+          },
+          {
+            "errors": [],
+            "generated": 1,
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [
+              "2f9ec4e3-475a-4046-9e01-182757d1de20"
+            ],
+            "skipped": 0,
+            "variant_angle": {
+              "id": "outcome_led",
+              "instruction": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result.",
+              "label": "Outcome-led"
+            }
+          },
+          {
+            "errors": [],
+            "generated": 1,
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [
+              "44d56e20-d9c8-4626-8e39-e894cb8fd085"
+            ],
+            "skipped": 0,
+            "variant_angle": {
+              "id": "social_proof",
+              "instruction": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials.",
+              "label": "Social-proof-led"
+            }
+          }
+        ]
+      },
+      "runner": "BlogPostGenerationService.generate",
+      "status": "completed"
+    },
+    {
+      "error": "",
+      "output": "sales_brief",
+      "reasoning": {
+        "contexts_used": 0,
+        "provider_configured": false,
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": true
+      },
+      "result": {
+        "errors": [],
+        "generated": 3,
+        "reasoning_contexts_used": 0,
+        "requested": 3,
+        "saved_ids": [
+          "33044118-629f-491d-ada6-0aa3fc838222",
+          "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+          "8744dc21-df4e-424e-9a9d-e5cada717886"
+        ],
+        "skipped": 0,
+        "variant_count": 3,
+        "variant_results": [
+          {
+            "errors": [],
+            "generated": 1,
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [
+              "33044118-629f-491d-ada6-0aa3fc838222"
+            ],
+            "skipped": 0,
+            "variant_angle": {
+              "id": "pain_led",
+              "instruction": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step.",
+              "label": "Pain-led"
+            }
+          },
+          {
+            "errors": [],
+            "generated": 1,
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [
+              "e71d3a76-e32a-4891-8879-e6b99d9e58af"
+            ],
+            "skipped": 0,
+            "variant_angle": {
+              "id": "outcome_led",
+              "instruction": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result.",
+              "label": "Outcome-led"
+            }
+          },
+          {
+            "errors": [],
+            "generated": 1,
+            "reasoning_contexts_used": 0,
+            "requested": 1,
+            "saved_ids": [
+              "8744dc21-df4e-424e-9a9d-e5cada717886"
+            ],
+            "skipped": 0,
+            "variant_angle": {
+              "id": "social_proof",
+              "instruction": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials.",
+              "label": "Social-proof-led"
+            }
+          }
+        ]
+      },
+      "runner": "SalesBriefGenerationService.generate",
+      "status": "completed"
+    }
+  ]
+}

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json
@@ -161,9 +161,9 @@
         "reasoning_contexts_used": 0,
         "requested": 3,
         "saved_ids": [
-          "49e324c1-f331-404d-bfa4-dcbcb5387027",
-          "2b09400f-a8b9-4787-86dd-ca655686d246",
-          "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+          "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
+          "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
+          "104b8793-9015-4aac-abab-41917dd38309"
         ],
         "skipped": 0,
         "variant_count": 3,
@@ -174,6 +174,18 @@
             "quality_repair_history": [
               {
                 "attempt": 0,
+                "blockers": [
+                  "seo_aeo_readiness:meta_description",
+                  "geo_readiness:section_semantics"
+                ],
+                "passed": false,
+                "repair_issues": [
+                  "seo_aeo_readiness:meta_description",
+                  "geo_readiness:section_semantics"
+                ]
+              },
+              {
+                "attempt": 1,
                 "blockers": [],
                 "passed": true,
                 "repair_issues": []
@@ -182,7 +194,7 @@
             "reasoning_contexts_used": 0,
             "requested": 1,
             "saved_ids": [
-              "49e324c1-f331-404d-bfa4-dcbcb5387027"
+              "d8b20a0d-44c5-42ee-ae7a-b29251426db8"
             ],
             "skipped": 0,
             "variant_angle": {
@@ -205,7 +217,7 @@
             "reasoning_contexts_used": 0,
             "requested": 1,
             "saved_ids": [
-              "2b09400f-a8b9-4787-86dd-ca655686d246"
+              "067c7531-b8c7-4b88-acaf-4f7643cd43f6"
             ],
             "skipped": 0,
             "variant_angle": {
@@ -228,7 +240,7 @@
             "reasoning_contexts_used": 0,
             "requested": 1,
             "saved_ids": [
-              "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+              "104b8793-9015-4aac-abab-41917dd38309"
             ],
             "skipped": 0,
             "variant_angle": {
@@ -252,70 +264,27 @@
         "service_supports_reasoning": true
       },
       "result": {
-        "errors": [
-          {
-            "blockers": [
-              "geo_citable_section_structure_missing",
-              "support_ticket_generated_content:debug_source_narration"
-            ],
-            "blueprint_id": "0da54d85-706c-43e9-aa59-036b182b2d87",
-            "failed_candidate": {
-              "content_excerpt_head": "## What repeat support questions show\n\nYour customers ask the same questions repeatedly. In the uploaded tickets, 35 of 36 rows include direct customer questions. Nine clusters appear with equal frequency: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster represents a gap where your help center does not answer the question.\n\nThe reporting export cluster includes questions such as \"How do I export attribution reports before our board meeting?\" and \"Why is the campaign CSV export missing source and owner columns?\" The dashboard freshness cluster includes \"Why has our pipeline dashboard not refreshed since yesterday?\" and \"How do we check whether the warehouse sync is delayed?\" These are not edge cases. They are repeated patterns in the provided ticket set.\n\nThe uploaded tickets show which questions appear most often in this sample. They do not prove how often those questions appear across your full support queue. They show what customers asked in the provided set.\n\n## Which FAQ gaps should be reviewed first\n\nPrioritize by observed ticket volume. In this set, nine clusters are tied at 4 tickets each. You cannot rank tied clusters by business impact, activation risk, or workflow blocking without measured outcome evidence. The blueprint does not include that evidence. Review all nine tied clusters bef",
-              "content_excerpt_tail": "d resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after publishing. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming causality.\n\nThe uploaded tickets do not include a dated source window, so do not add fixed checkpoints. Watch for changes in ticket patterns and adjust your FAQ content based on what you observe.\n\nIf a cluster continues to generate tickets after you publish an FAQ entry, that is a signal. The answer may need clearer wording, the question may need a different title, or the FAQ page may need better navigation. Use those signals to refine your content.",
-              "content_truncated": true,
-              "generation_parse_attempts": 1,
-              "generation_quality_repair_attempts": 2,
-              "seo_title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal",
-              "slug": "",
-              "target_keyword": "support ticket faq gaps",
-              "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
-              "topic_type": "",
-              "word_count": 924
-            },
-            "reason": "quality_blocked",
-            "variant_angle": "pain_led",
-            "variant_label": "Pain-led"
-          }
-        ],
-        "generated": 2,
+        "errors": [],
+        "generated": 3,
         "reasoning_contexts_used": 0,
         "requested": 3,
         "saved_ids": [
+          "0501c17f-90c9-4318-9d15-e3253160a4e5",
           "2f9ec4e3-475a-4046-9e01-182757d1de20",
           "44d56e20-d9c8-4626-8e39-e894cb8fd085"
         ],
-        "skipped": 1,
+        "skipped": 0,
         "variant_count": 3,
         "variant_results": [
           {
-            "errors": [
-              {
-                "blockers": [
-                  "geo_citable_section_structure_missing",
-                  "support_ticket_generated_content:debug_source_narration"
-                ],
-                "blueprint_id": "0da54d85-706c-43e9-aa59-036b182b2d87",
-                "failed_candidate": {
-                  "content_excerpt_head": "## What repeat support questions show\n\nYour customers ask the same questions repeatedly. In the uploaded tickets, 35 of 36 rows include direct customer questions. Nine clusters appear with equal frequency: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster represents a gap where your help center does not answer the question.\n\nThe reporting export cluster includes questions such as \"How do I export attribution reports before our board meeting?\" and \"Why is the campaign CSV export missing source and owner columns?\" The dashboard freshness cluster includes \"Why has our pipeline dashboard not refreshed since yesterday?\" and \"How do we check whether the warehouse sync is delayed?\" These are not edge cases. They are repeated patterns in the provided ticket set.\n\nThe uploaded tickets show which questions appear most often in this sample. They do not prove how often those questions appear across your full support queue. They show what customers asked in the provided set.\n\n## Which FAQ gaps should be reviewed first\n\nPrioritize by observed ticket volume. In this set, nine clusters are tied at 4 tickets each. You cannot rank tied clusters by business impact, activation risk, or workflow blocking without measured outcome evidence. The blueprint does not include that evidence. Review all nine tied clusters bef",
-                  "content_excerpt_tail": "d resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after publishing. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming causality.\n\nThe uploaded tickets do not include a dated source window, so do not add fixed checkpoints. Watch for changes in ticket patterns and adjust your FAQ content based on what you observe.\n\nIf a cluster continues to generate tickets after you publish an FAQ entry, that is a signal. The answer may need clearer wording, the question may need a different title, or the FAQ page may need better navigation. Use those signals to refine your content.",
-                  "content_truncated": true,
-                  "generation_parse_attempts": 1,
-                  "generation_quality_repair_attempts": 2,
-                  "seo_title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal",
-                  "slug": "",
-                  "target_keyword": "support ticket faq gaps",
-                  "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
-                  "topic_type": "",
-                  "word_count": 924
-                },
-                "reason": "quality_blocked"
-              }
-            ],
-            "generated": 0,
+            "errors": [],
+            "generated": 1,
             "reasoning_contexts_used": 0,
             "requested": 1,
-            "saved_ids": [],
-            "skipped": 1,
+            "saved_ids": [
+              "0501c17f-90c9-4318-9d15-e3253160a4e5"
+            ],
+            "skipped": 0,
             "variant_angle": {
               "id": "pain_led",
               "instruction": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step.",
@@ -372,9 +341,9 @@
         "reasoning_contexts_used": 0,
         "requested": 3,
         "saved_ids": [
-          "33044118-629f-491d-ada6-0aa3fc838222",
-          "e71d3a76-e32a-4891-8879-e6b99d9e58af",
-          "8744dc21-df4e-424e-9a9d-e5cada717886"
+          "3fc2cbe9-eca0-42ee-8804-2b63c9af9057",
+          "490247f3-19bf-4c0e-b532-e78c369cf989",
+          "2689157c-2473-44e9-bc75-3f786b105aae"
         ],
         "skipped": 0,
         "variant_count": 3,
@@ -385,7 +354,7 @@
             "reasoning_contexts_used": 0,
             "requested": 1,
             "saved_ids": [
-              "33044118-629f-491d-ada6-0aa3fc838222"
+              "3fc2cbe9-eca0-42ee-8804-2b63c9af9057"
             ],
             "skipped": 0,
             "variant_angle": {
@@ -400,7 +369,7 @@
             "reasoning_contexts_used": 0,
             "requested": 1,
             "saved_ids": [
-              "e71d3a76-e32a-4891-8879-e6b99d9e58af"
+              "490247f3-19bf-4c0e-b532-e78c369cf989"
             ],
             "skipped": 0,
             "variant_angle": {
@@ -415,7 +384,7 @@
             "reasoning_contexts_used": 0,
             "requested": 1,
             "saved_ids": [
-              "8744dc21-df4e-424e-9a9d-e5cada717886"
+              "2689157c-2473-44e9-bc75-3f786b105aae"
             ],
             "skipped": 0,
             "variant_angle": {

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json
@@ -1,0 +1,831 @@
+{
+  "count": 2,
+  "filters": {
+    "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    "id": [
+      "2f9ec4e3-475a-4046-9e01-182757d1de20",
+      "44d56e20-d9c8-4626-8e39-e894cb8fd085"
+    ],
+    "ids": [
+      "2f9ec4e3-475a-4046-9e01-182757d1de20",
+      "44d56e20-d9c8-4626-8e39-e894cb8fd085"
+    ]
+  },
+  "limit": 2,
+  "rows": [
+    {
+      "chart_count": 0,
+      "charts": [],
+      "content": "## What repeat support questions show\n\nSupport ticket FAQ gaps appear when customers ask the same questions across multiple tickets. The uploaded tickets include 36 source rows and 36 usable ticket rows. 35 rows contain direct customer questions. Those questions cluster into 9 repeated patterns: reporting export (4 tickets), dashboard freshness (4), sso setup (4), permissions and seats (4), api and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster shows where your help center lacks a published answer.\n\nCustomers ask the same questions in their own words. One customer wrote, \"Attribution export blocked. How do I export attribution reports before our board meeting?\" Another asked, \"Why is the campaign CSV export missing source and owner columns?\" A third wanted to know, \"Can I schedule an attribution report export for finance?\" A fourth questioned, \"Why can analysts view dashboards but not export reports?\"\n\nThose four tickets all fall into the reporting export cluster. The pattern repeats across dashboard freshness: \"Why has our pipeline dashboard not refreshed since yesterday?\" and \"How do we check whether the warehouse sync is delayed?\" The customer wording changes, but the underlying question stays the same.\n\nThe uploaded tickets do not include support resolutions. You see what customers asked, not what the team answered. That means each cluster shows a repeated question, not a proven fix.\n\n## Which FAQ gaps should be reviewed first\n\nSupport ticket FAQ gaps tied at the same count require your team to choose review order by verification capacity, not by observed volume alone. All 9 clusters are tied at 4 tickets each. The observed counts do not rank one cluster above another. Your team should review clusters in the order that matches your verification capacity and customer-facing priority.\n\nThe tied clusters are:\n\n- **Reporting export** (4 tickets) -- customers ask how to export attribution reports, why CSV exports miss columns, whether scheduled exports exist, and why analysts cannot export.\n- **Dashboard freshness** (4 tickets) -- customers ask why dashboards show stale data and how to check warehouse sync lag.\n- **SSO setup** (4 tickets) -- customers ask setup questions the uploaded tickets do not detail further.\n- **Permissions and seats** (4 tickets) -- customers ask permission and seat questions the uploaded tickets do not detail further.\n- **API and webhooks** (4 tickets) -- customers ask API and webhook questions the uploaded tickets do not detail further.\n- **Integration sync** (4 tickets) -- customers ask integration sync questions the uploaded tickets do not detail further.\n- **Data import** (4 tickets) -- customers ask data import questions the uploaded tickets do not detail further.\n- **Workflow automation** (4 tickets) -- customers ask workflow automation questions the uploaded tickets do not detail further.\n- **Billing and plan management** (4 tickets) -- customers ask billing and plan questions the uploaded tickets do not detail further.\n\nStart with the clusters your team can verify fastest. If your support lead knows the reporting export resolution by heart, review that cluster first. If SSO setup requires product and security sign-off, review that cluster last.\n\n## Draft FAQ shells to verify\n\nThe uploaded tickets support 6 first-pass FAQ entries. Each entry uses customer wording from the observed tickets. Each answer stays as a review-needed shell until your support team adds the verified resolution.\n\n### Reporting export\n\n**Draft question:** How do I export attribution reports before our board meeting?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-001, saas-demo-002, saas-demo-003\n\n**Customer wording examples:**\n> \"Attribution export blocked. How do I export attribution reports before our board meeting?\" -- verified customer\n\n> \"CSV export missing fields. Why is the campaign CSV export missing source and owner columns?\" -- verified customer\n\n> \"Export scheduled report. Can I schedule an attribution report export for finance?\" -- verified customer\n\n### Dashboard freshness\n\n**Draft question:** Why has our pipeline dashboard not refreshed since yesterday?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-005, saas-demo-006\n\n**Customer wording examples:**\n> \"Dashboard stale data. Why has our pipeline dashboard not refreshed since yesterday?\" -- verified customer\n\n> \"Warehouse sync lag. How do we check whether the warehouse sync is delayed?\" -- verified customer\n\n### SSO setup\n\n**Draft question:** What should the team verify for sso setup?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Permissions and seats\n\n**Draft question:** What should the team verify for permissions and seats?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Draft question:** What should the team verify for api and webhooks?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after you publish. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming the FAQ entries caused the change.\n\nWatch the signals. If new tickets still ask the same questions, the FAQ entry may need clearer wording, better placement, or a different resolution. If new tickets shift to different questions, the FAQ entry may be addressing the observed gap.\n\nThe uploaded tickets do not include a dated source window. Track the signals when your team has capacity to review them.",
+      "data_context": {
+        "_known_vendors": [],
+        "allowed_claims": [
+          "observed support-ticket clusters and counts from the provided ticket set",
+          "customer wording copied from the provided tickets",
+          "review-needed draft FAQ shells",
+          "support-team verification work before publishing",
+          "metrics to watch after publishing, without claiming those metrics improved"
+        ],
+        "category": "support tickets",
+        "customer_wording_examples": [
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-001",
+            "source_title": "Attribution export blocked",
+            "text": "Attribution export blocked How do I export attribution reports before our board meeting?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-002",
+            "source_title": "CSV export missing fields",
+            "text": "CSV export missing fields Why is the campaign CSV export missing source and owner columns?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-003",
+            "source_title": "Export scheduled report",
+            "text": "Export scheduled report Can I schedule a weekly attribution report export for finance?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-004",
+            "source_title": "Dashboard export permissions",
+            "text": "Dashboard export permissions Why can analysts view dashboards but not export reports?"
+          },
+          {
+            "pain_category": "dashboard freshness",
+            "source_id": "saas-demo-005",
+            "source_title": "Dashboard stale data",
+            "text": "Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?"
+          },
+          {
+            "pain_category": "dashboard freshness",
+            "source_id": "saas-demo-006",
+            "source_title": "Warehouse sync lag",
+            "text": "Warehouse sync lag How do we check whether the warehouse sync is delayed?"
+          }
+        ],
+        "deep_enriched_count": 36,
+        "draft_answer_guidance": "Draft answer - support team should add the verified resolution before publishing.",
+        "draft_faq_shells": [
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "reporting export",
+            "draft_question": "How do I export attribution reports before our board meeting?",
+            "observed_ticket_count": 4,
+            "source_ids": [
+              "saas-demo-001",
+              "saas-demo-002",
+              "saas-demo-003"
+            ],
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "dashboard freshness",
+            "draft_question": "Why has our pipeline dashboard not refreshed since yesterday?",
+            "observed_ticket_count": 4,
+            "source_ids": [
+              "saas-demo-005",
+              "saas-demo-006"
+            ],
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "sso setup",
+            "draft_question": "What should the team verify for sso setup?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "permissions and seats",
+            "draft_question": "What should the team verify for permissions and seats?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "api and webhooks",
+            "draft_question": "What should the team verify for api and webhooks?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "integration sync",
+            "draft_question": "What should the team verify for integration sync?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          }
+        ],
+        "faq_questions": [
+          "What happens after I upload the CSV?",
+          "Does FAQ Report publish automatically?"
+        ],
+        "forbidden_claims": [
+          "future ticket reduction or deflection",
+          "prevented tickets or fewer repeat questions",
+          "churn, retention, upgrade, referral, ROI, or capacity outcomes",
+          "claims that FAQ entries help customers find answers or avoid tickets",
+          "claims that customers can find answers themselves because an FAQ exists",
+          "faster resolution or customers finding answers without opening tickets",
+          "claims that FAQ entries reduce how often the team answers a question",
+          "claims that FAQ entries perform better in search without measured evidence",
+          "claims that lower repeat tickets prove an FAQ entry is working",
+          "claims that unresolved questions delay activation or block workflows",
+          "claims that FAQ entries create self-service options or search-result visibility",
+          "claims that FAQ entries are discoverable, rank for keywords, or are working",
+          "fixed calendar windows, rolling periods, or future tracking intervals when provided tickets are undated",
+          "prioritization by business impact, activation delay, workflow blocking, or friction reduction without evidence",
+          "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence"
+        ],
+        "has_dated_window": false,
+        "has_measured_outcomes": false,
+        "included_ticket_row_count": 36,
+        "measured_outcome_count": 0,
+        "measured_outcome_examples": [],
+        "measurement_guidance": [
+          "Track new tickets by the same observed cluster labels after publishing.",
+          "Review FAQ page traffic and customer feedback as signals to inspect.",
+          "Compare future tickets against the observed clusters without claiming causality.",
+          "Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints unless the provided tickets include a dated source window."
+        ],
+        "question_like_ticket_count": 35,
+        "required_section_outline": [
+          {
+            "allowed_source_fields": [
+              "source_row_count",
+              "included_ticket_row_count",
+              "question_like_ticket_count",
+              "top_clusters"
+            ],
+            "claim_boundary": "Describe observed rows, repeated clusters, and customer wording only.",
+            "heading": "What repeat support questions show",
+            "id": "observed-ticket-patterns"
+          },
+          {
+            "allowed_source_fields": [
+              "top_clusters",
+              "draft_faq_shells"
+            ],
+            "claim_boundary": "Order by observed ticket count only; do not infer business impact.",
+            "heading": "Which FAQ gaps should be reviewed first",
+            "id": "faq-gap-review-order"
+          },
+          {
+            "allowed_source_fields": [
+              "draft_faq_shells",
+              "customer_wording_examples"
+            ],
+            "claim_boundary": "Use review-needed placeholders until support adds verified resolutions.",
+            "heading": "Draft FAQ shells to verify",
+            "id": "draft-faq-shells"
+          },
+          {
+            "allowed_source_fields": [
+              "measurement_guidance"
+            ],
+            "claim_boundary": "Frame metrics as future signals to watch, not outcomes already caused.",
+            "heading": "What to measure after publishing",
+            "id": "post-publication-measurement"
+          }
+        ],
+        "review_period": "uploaded tickets",
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "source": "support_ticket_provider",
+        "source_period": "Last 90 days of support tickets",
+        "source_row_count": 36,
+        "support_ticket_blog_mode": "descriptive_no_outcome",
+        "support_ticket_resolution_evidence_count": 0,
+        "support_ticket_resolution_evidence_present": false,
+        "support_ticket_resolution_examples": [],
+        "top_clusters": [
+          {
+            "count": 4,
+            "label": "reporting export"
+          },
+          {
+            "count": 4,
+            "label": "dashboard freshness"
+          },
+          {
+            "count": 4,
+            "label": "sso setup"
+          },
+          {
+            "count": 4,
+            "label": "permissions and seats"
+          },
+          {
+            "count": 4,
+            "label": "api and webhooks"
+          },
+          {
+            "count": 4,
+            "label": "integration sync"
+          },
+          {
+            "count": 4,
+            "label": "data import"
+          },
+          {
+            "count": 4,
+            "label": "workflow automation"
+          },
+          {
+            "count": 4,
+            "label": "billing and plan management"
+          }
+        ],
+        "top_ticket_clusters": [
+          {
+            "count": 4,
+            "label": "reporting export"
+          },
+          {
+            "count": 4,
+            "label": "dashboard freshness"
+          },
+          {
+            "count": 4,
+            "label": "sso setup"
+          },
+          {
+            "count": 4,
+            "label": "permissions and seats"
+          },
+          {
+            "count": 4,
+            "label": "api and webhooks"
+          },
+          {
+            "count": 4,
+            "label": "integration sync"
+          },
+          {
+            "count": 4,
+            "label": "data import"
+          },
+          {
+            "count": 4,
+            "label": "workflow automation"
+          },
+          {
+            "count": 4,
+            "label": "billing and plan management"
+          }
+        ],
+        "topic": "Support ticket FAQ gaps: what repeat tickets reveal before renewal",
+        "total_reviews_analyzed": 36
+      },
+      "description": "36 uploaded support tickets show 9 repeated question clusters. Draft FAQ shells need support-team review before publishing.",
+      "generation_input_tokens": 18331,
+      "generation_output_tokens": 3910,
+      "generation_parse_attempts": 1,
+      "generation_total_tokens": null,
+      "geo_readiness": {
+        "checks": {
+          "answer_first_sections": true,
+          "citable_section_structure": true,
+          "citation_safety": true,
+          "entity_clarity": true,
+          "evidence_specificity": true,
+          "faq_coverage": true,
+          "freshness_context": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "id": "44d56e20-d9c8-4626-8e39-e894cb8fd085",
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "faq": [
+          {
+            "answer": "The uploaded tickets show 35 direct customer questions across 9 repeated clusters: reporting export, dashboard freshness, sso setup, permissions and seats, api and webhooks, integration sync, data import, workflow automation, and billing and plan management. Each cluster appears 4 times.",
+            "question": "What do 36 uploaded support tickets reveal about FAQ gaps?"
+          },
+          {
+            "answer": "All 9 clusters are tied at 4 tickets each. Review order should follow your team's verification capacity and customer-facing priority, not the observed counts alone.",
+            "question": "Which FAQ gaps should a small team review first?"
+          },
+          {
+            "answer": "Each draft answer shell should preserve customer wording from the uploaded tickets and stay as a review-needed placeholder until the support team adds the verified resolution, approved customer-facing wording, and support owner review.",
+            "question": "What should draft FAQ answer shells include?"
+          }
+        ],
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_quality_repair_attempts": 1,
+        "generation_usage": {
+          "billable_input_tokens": 6,
+          "cache_write_tokens": 8079,
+          "cached_tokens": 10246,
+          "input_tokens": 18331,
+          "output_tokens": 3910,
+          "reasoning_tokens": 0
+        },
+        "secondary_keywords": [
+          "repeat support tickets",
+          "faq planning",
+          "customer questions"
+        ],
+        "seo_description": "36 uploaded support tickets show 9 repeated question clusters. Draft FAQ shells need support-team review before publishing.",
+        "seo_title": "Support Ticket FAQ Gaps: 36 Tickets Analyzed",
+        "target_keyword": "support ticket faq gaps",
+        "variant_angle": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials."
+      },
+      "output_checks": {
+        "aeo_structure_detected": true,
+        "faq_ready": true,
+        "secondary_keywords_present": true,
+        "seo_description_ready": true,
+        "seo_title_ready": true,
+        "target_keyword_present": true
+      },
+      "passed_output_checks": 6,
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "seo_aeo_readiness": {
+        "checks": {
+          "aeo_structure_detected": true,
+          "faq_ready": true,
+          "secondary_keywords_present": true,
+          "seo_description_ready": true,
+          "seo_title_ready": true,
+          "target_keyword_present": true
+        },
+        "missing": [],
+        "passed": 6,
+        "status": "ready",
+        "total": 6
+      },
+      "slug": "content-ops-support-ticket-live-smoke-2b2b950d-f64b-4852-bc30-f92a34cdf169-social-proof-led",
+      "status": "approved",
+      "tag_count": 3,
+      "tags": [
+        "repeat support tickets",
+        "faq planning",
+        "customer questions"
+      ],
+      "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
+      "topic_type": "content_ops_support_ticket_faq"
+    },
+    {
+      "chart_count": 0,
+      "charts": [],
+      "content": "## What repeat support questions show\n\nSupport ticket FAQ gaps appear when your team answers the same question multiple times without publishing a customer-facing answer. In the uploaded tickets, 36 source rows include 35 direct customer questions that reveal support ticket FAQ gaps across nine repeated clusters: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster represents a gap where your team answers the same question multiple times without a published FAQ entry to reference.\n\nCustomer wording shows what people ask before they open a ticket. One customer wrote: \"Attribution export blocked How do I export attribution reports before our board meeting?\" Another asked: \"Why has our pipeline dashboard not refreshed since yesterday?\" These questions repeat because no published FAQ entry addresses them.\n\nThe uploaded tickets do not include support resolutions. You see the repeated questions, but not the verified answers your team gave. That means you can identify the support ticket FAQ gaps, but you cannot publish the answers until your support lead reviews and approves the resolution steps.\n\n## Which FAQ gaps should be reviewed first\n\nWhen support ticket FAQ gaps are tied by observed volume, prioritize by your team's capacity and the clusters where you already have verified resolutions ready to publish. All nine clusters in the uploaded tickets are tied at 4 tickets each, so you cannot rank support ticket FAQ gaps by observed ticket volume alone. Instead, start with the clusters where your support lead can add the verified resolution fastest, then move to the remaining support ticket FAQ gaps as capacity allows.\n\nThe tied clusters are:\n\n- **Reporting export** (4 tickets) -- Questions about exporting attribution reports, missing CSV fields, scheduled exports, and export permissions.\n- **Dashboard freshness** (4 tickets) -- Questions about stale dashboard data and warehouse sync lag.\n- **SSO setup** (4 tickets) -- Questions the team should verify for SSO setup.\n- **Permissions and seats** (4 tickets) -- Questions the team should verify for permissions and seats.\n- **API and webhooks** (4 tickets) -- Questions the team should verify for API and webhooks.\n- **Integration sync** (4 tickets) -- Questions the team should verify for integration sync.\n- **Data import** (4 tickets) -- Questions the team should verify for data import.\n- **Workflow automation** (4 tickets) -- Questions the team should verify for workflow automation.\n- **Billing and plan management** (4 tickets) -- Questions the team should verify for billing and plan management.\n\nStart with the clusters where your support lead can add the verified resolution fastest. The other clusters wait until you have the approved answer steps.\n\n## Draft FAQ shells to verify\n\nThe observed ticket set supports up to 6 first-pass FAQ entries. Each shell preserves customer wording and waits for the support team to add the verified resolution before publishing.\n\n### Reporting export\n\n**Observed ticket count:** 4\n\n**Draft question:** How do I export attribution reports before our board meeting?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-001, saas-demo-002, saas-demo-003\n\n### Dashboard freshness\n\n**Observed ticket count:** 4\n\n**Draft question:** Why has our pipeline dashboard not refreshed since yesterday?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-005, saas-demo-006\n\n### SSO setup\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for SSO setup?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Permissions and seats\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for permissions and seats?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\nEach shell waits for your support lead to add the verified resolution. Do not publish placeholder answers. Customers need the real fix, not a draft.\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after you publish. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming the FAQ entry caused the change.\n\nDo not assume ticket volume will decline. Watch whether the same clusters still appear in your queue. If they do, the FAQ entry may need clearer wording, better placement, or a different answer format. If they do not, note the change and keep watching.\n\nThe uploaded tickets do not include a dated source window. Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints. Track the clusters as long as your team needs the signal.",
+      "data_context": {
+        "_known_vendors": [],
+        "allowed_claims": [
+          "observed support-ticket clusters and counts from the provided ticket set",
+          "customer wording copied from the provided tickets",
+          "review-needed draft FAQ shells",
+          "support-team verification work before publishing",
+          "metrics to watch after publishing, without claiming those metrics improved"
+        ],
+        "category": "support tickets",
+        "customer_wording_examples": [
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-001",
+            "source_title": "Attribution export blocked",
+            "text": "Attribution export blocked How do I export attribution reports before our board meeting?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-002",
+            "source_title": "CSV export missing fields",
+            "text": "CSV export missing fields Why is the campaign CSV export missing source and owner columns?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-003",
+            "source_title": "Export scheduled report",
+            "text": "Export scheduled report Can I schedule a weekly attribution report export for finance?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-004",
+            "source_title": "Dashboard export permissions",
+            "text": "Dashboard export permissions Why can analysts view dashboards but not export reports?"
+          },
+          {
+            "pain_category": "dashboard freshness",
+            "source_id": "saas-demo-005",
+            "source_title": "Dashboard stale data",
+            "text": "Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?"
+          },
+          {
+            "pain_category": "dashboard freshness",
+            "source_id": "saas-demo-006",
+            "source_title": "Warehouse sync lag",
+            "text": "Warehouse sync lag How do we check whether the warehouse sync is delayed?"
+          }
+        ],
+        "deep_enriched_count": 36,
+        "draft_answer_guidance": "Draft answer - support team should add the verified resolution before publishing.",
+        "draft_faq_shells": [
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "reporting export",
+            "draft_question": "How do I export attribution reports before our board meeting?",
+            "observed_ticket_count": 4,
+            "source_ids": [
+              "saas-demo-001",
+              "saas-demo-002",
+              "saas-demo-003"
+            ],
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "dashboard freshness",
+            "draft_question": "Why has our pipeline dashboard not refreshed since yesterday?",
+            "observed_ticket_count": 4,
+            "source_ids": [
+              "saas-demo-005",
+              "saas-demo-006"
+            ],
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "sso setup",
+            "draft_question": "What should the team verify for sso setup?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "permissions and seats",
+            "draft_question": "What should the team verify for permissions and seats?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "api and webhooks",
+            "draft_question": "What should the team verify for api and webhooks?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "integration sync",
+            "draft_question": "What should the team verify for integration sync?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          }
+        ],
+        "faq_questions": [
+          "What happens after I upload the CSV?",
+          "Does FAQ Report publish automatically?"
+        ],
+        "forbidden_claims": [
+          "future ticket reduction or deflection",
+          "prevented tickets or fewer repeat questions",
+          "churn, retention, upgrade, referral, ROI, or capacity outcomes",
+          "claims that FAQ entries help customers find answers or avoid tickets",
+          "claims that customers can find answers themselves because an FAQ exists",
+          "faster resolution or customers finding answers without opening tickets",
+          "claims that FAQ entries reduce how often the team answers a question",
+          "claims that FAQ entries perform better in search without measured evidence",
+          "claims that lower repeat tickets prove an FAQ entry is working",
+          "claims that unresolved questions delay activation or block workflows",
+          "claims that FAQ entries create self-service options or search-result visibility",
+          "claims that FAQ entries are discoverable, rank for keywords, or are working",
+          "fixed calendar windows, rolling periods, or future tracking intervals when provided tickets are undated",
+          "prioritization by business impact, activation delay, workflow blocking, or friction reduction without evidence",
+          "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence"
+        ],
+        "has_dated_window": false,
+        "has_measured_outcomes": false,
+        "included_ticket_row_count": 36,
+        "measured_outcome_count": 0,
+        "measured_outcome_examples": [],
+        "measurement_guidance": [
+          "Track new tickets by the same observed cluster labels after publishing.",
+          "Review FAQ page traffic and customer feedback as signals to inspect.",
+          "Compare future tickets against the observed clusters without claiming causality.",
+          "Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints unless the provided tickets include a dated source window."
+        ],
+        "question_like_ticket_count": 35,
+        "required_section_outline": [
+          {
+            "allowed_source_fields": [
+              "source_row_count",
+              "included_ticket_row_count",
+              "question_like_ticket_count",
+              "top_clusters"
+            ],
+            "claim_boundary": "Describe observed rows, repeated clusters, and customer wording only.",
+            "heading": "What repeat support questions show",
+            "id": "observed-ticket-patterns"
+          },
+          {
+            "allowed_source_fields": [
+              "top_clusters",
+              "draft_faq_shells"
+            ],
+            "claim_boundary": "Order by observed ticket count only; do not infer business impact.",
+            "heading": "Which FAQ gaps should be reviewed first",
+            "id": "faq-gap-review-order"
+          },
+          {
+            "allowed_source_fields": [
+              "draft_faq_shells",
+              "customer_wording_examples"
+            ],
+            "claim_boundary": "Use review-needed placeholders until support adds verified resolutions.",
+            "heading": "Draft FAQ shells to verify",
+            "id": "draft-faq-shells"
+          },
+          {
+            "allowed_source_fields": [
+              "measurement_guidance"
+            ],
+            "claim_boundary": "Frame metrics as future signals to watch, not outcomes already caused.",
+            "heading": "What to measure after publishing",
+            "id": "post-publication-measurement"
+          }
+        ],
+        "review_period": "uploaded tickets",
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "source": "support_ticket_provider",
+        "source_period": "Last 90 days of support tickets",
+        "source_row_count": 36,
+        "support_ticket_blog_mode": "descriptive_no_outcome",
+        "support_ticket_resolution_evidence_count": 0,
+        "support_ticket_resolution_evidence_present": false,
+        "support_ticket_resolution_examples": [],
+        "top_clusters": [
+          {
+            "count": 4,
+            "label": "reporting export"
+          },
+          {
+            "count": 4,
+            "label": "dashboard freshness"
+          },
+          {
+            "count": 4,
+            "label": "sso setup"
+          },
+          {
+            "count": 4,
+            "label": "permissions and seats"
+          },
+          {
+            "count": 4,
+            "label": "api and webhooks"
+          },
+          {
+            "count": 4,
+            "label": "integration sync"
+          },
+          {
+            "count": 4,
+            "label": "data import"
+          },
+          {
+            "count": 4,
+            "label": "workflow automation"
+          },
+          {
+            "count": 4,
+            "label": "billing and plan management"
+          }
+        ],
+        "top_ticket_clusters": [
+          {
+            "count": 4,
+            "label": "reporting export"
+          },
+          {
+            "count": 4,
+            "label": "dashboard freshness"
+          },
+          {
+            "count": 4,
+            "label": "sso setup"
+          },
+          {
+            "count": 4,
+            "label": "permissions and seats"
+          },
+          {
+            "count": 4,
+            "label": "api and webhooks"
+          },
+          {
+            "count": 4,
+            "label": "integration sync"
+          },
+          {
+            "count": 4,
+            "label": "data import"
+          },
+          {
+            "count": 4,
+            "label": "workflow automation"
+          },
+          {
+            "count": 4,
+            "label": "billing and plan management"
+          }
+        ],
+        "topic": "Support ticket FAQ gaps: what repeat tickets reveal before renewal",
+        "total_reviews_analyzed": 36
+      },
+      "description": "36 uploaded support tickets reveal 9 repeated question clusters. Review-needed FAQ shells show which gaps to verify first.",
+      "generation_input_tokens": 17887,
+      "generation_output_tokens": 3644,
+      "generation_parse_attempts": 1,
+      "generation_total_tokens": null,
+      "geo_readiness": {
+        "checks": {
+          "answer_first_sections": true,
+          "citable_section_structure": true,
+          "citation_safety": true,
+          "entity_clarity": true,
+          "evidence_specificity": true,
+          "faq_coverage": true,
+          "freshness_context": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "id": "2f9ec4e3-475a-4046-9e01-182757d1de20",
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "faq": [
+          {
+            "answer": "In the uploaded tickets, 36 source rows include 35 direct customer questions. Nine clusters appear repeatedly: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4).",
+            "question": "What do repeat support tickets reveal about FAQ gaps?"
+          },
+          {
+            "answer": "All nine clusters are tied at 4 tickets each. Prioritize by your team's capacity and the clusters where you already have verified resolutions ready to publish.",
+            "question": "Which FAQ gaps should a small team fix first?"
+          },
+          {
+            "answer": "The uploaded ticket set supports up to 6 first-pass FAQ entries. Each shell preserves customer wording and waits for the support team to add the verified resolution before publishing.",
+            "question": "How should old tickets become review-ready FAQ shells?"
+          }
+        ],
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_quality_repair_attempts": 1,
+        "generation_usage": {
+          "billable_input_tokens": 6,
+          "cache_write_tokens": 7635,
+          "cached_tokens": 10246,
+          "input_tokens": 17887,
+          "output_tokens": 3644,
+          "reasoning_tokens": 0
+        },
+        "secondary_keywords": [
+          "repeat support questions",
+          "faq planning",
+          "support ticket analysis"
+        ],
+        "seo_description": "36 uploaded support tickets reveal 9 repeated question clusters and review-needed FAQ shells for verification.",
+        "seo_title": "Support Ticket FAQ Gaps: Repeat Questions Analysis",
+        "target_keyword": "support ticket faq gaps",
+        "variant_angle": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result."
+      },
+      "output_checks": {
+        "aeo_structure_detected": true,
+        "faq_ready": true,
+        "secondary_keywords_present": true,
+        "seo_description_ready": true,
+        "seo_title_ready": true,
+        "target_keyword_present": true
+      },
+      "passed_output_checks": 6,
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "seo_aeo_readiness": {
+        "checks": {
+          "aeo_structure_detected": true,
+          "faq_ready": true,
+          "secondary_keywords_present": true,
+          "seo_description_ready": true,
+          "seo_title_ready": true,
+          "target_keyword_present": true
+        },
+        "missing": [],
+        "passed": 6,
+        "status": "ready",
+        "total": 6
+      },
+      "slug": "content-ops-support-ticket-live-smoke-2b2b950d-f64b-4852-bc30-f92a34cdf169-outcome-led",
+      "status": "approved",
+      "tag_count": 3,
+      "tags": [
+        "repeat support questions",
+        "faq planning",
+        "support ticket analysis"
+      ],
+      "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
+      "topic_type": "content_ops_support_ticket_faq"
+    }
+  ]
+}

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json
@@ -1,22 +1,24 @@
 {
-  "count": 2,
+  "count": 3,
   "filters": {
     "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
     "id": [
+      "0501c17f-90c9-4318-9d15-e3253160a4e5",
       "2f9ec4e3-475a-4046-9e01-182757d1de20",
       "44d56e20-d9c8-4626-8e39-e894cb8fd085"
     ],
     "ids": [
+      "0501c17f-90c9-4318-9d15-e3253160a4e5",
       "2f9ec4e3-475a-4046-9e01-182757d1de20",
       "44d56e20-d9c8-4626-8e39-e894cb8fd085"
     ]
   },
-  "limit": 2,
+  "limit": 3,
   "rows": [
     {
       "chart_count": 0,
       "charts": [],
-      "content": "## What repeat support questions show\n\nSupport ticket FAQ gaps appear when customers ask the same questions across multiple tickets. The uploaded tickets include 36 source rows and 36 usable ticket rows. 35 rows contain direct customer questions. Those questions cluster into 9 repeated patterns: reporting export (4 tickets), dashboard freshness (4), sso setup (4), permissions and seats (4), api and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster shows where your help center lacks a published answer.\n\nCustomers ask the same questions in their own words. One customer wrote, \"Attribution export blocked. How do I export attribution reports before our board meeting?\" Another asked, \"Why is the campaign CSV export missing source and owner columns?\" A third wanted to know, \"Can I schedule an attribution report export for finance?\" A fourth questioned, \"Why can analysts view dashboards but not export reports?\"\n\nThose four tickets all fall into the reporting export cluster. The pattern repeats across dashboard freshness: \"Why has our pipeline dashboard not refreshed since yesterday?\" and \"How do we check whether the warehouse sync is delayed?\" The customer wording changes, but the underlying question stays the same.\n\nThe uploaded tickets do not include support resolutions. You see what customers asked, not what the team answered. That means each cluster shows a repeated question, not a proven fix.\n\n## Which FAQ gaps should be reviewed first\n\nSupport ticket FAQ gaps tied at the same count require your team to choose review order by verification capacity, not by observed volume alone. All 9 clusters are tied at 4 tickets each. The observed counts do not rank one cluster above another. Your team should review clusters in the order that matches your verification capacity and customer-facing priority.\n\nThe tied clusters are:\n\n- **Reporting export** (4 tickets) -- customers ask how to export attribution reports, why CSV exports miss columns, whether scheduled exports exist, and why analysts cannot export.\n- **Dashboard freshness** (4 tickets) -- customers ask why dashboards show stale data and how to check warehouse sync lag.\n- **SSO setup** (4 tickets) -- customers ask setup questions the uploaded tickets do not detail further.\n- **Permissions and seats** (4 tickets) -- customers ask permission and seat questions the uploaded tickets do not detail further.\n- **API and webhooks** (4 tickets) -- customers ask API and webhook questions the uploaded tickets do not detail further.\n- **Integration sync** (4 tickets) -- customers ask integration sync questions the uploaded tickets do not detail further.\n- **Data import** (4 tickets) -- customers ask data import questions the uploaded tickets do not detail further.\n- **Workflow automation** (4 tickets) -- customers ask workflow automation questions the uploaded tickets do not detail further.\n- **Billing and plan management** (4 tickets) -- customers ask billing and plan questions the uploaded tickets do not detail further.\n\nStart with the clusters your team can verify fastest. If your support lead knows the reporting export resolution by heart, review that cluster first. If SSO setup requires product and security sign-off, review that cluster last.\n\n## Draft FAQ shells to verify\n\nThe uploaded tickets support 6 first-pass FAQ entries. Each entry uses customer wording from the observed tickets. Each answer stays as a review-needed shell until your support team adds the verified resolution.\n\n### Reporting export\n\n**Draft question:** How do I export attribution reports before our board meeting?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-001, saas-demo-002, saas-demo-003\n\n**Customer wording examples:**\n> \"Attribution export blocked. How do I export attribution reports before our board meeting?\" -- verified customer\n\n> \"CSV export missing fields. Why is the campaign CSV export missing source and owner columns?\" -- verified customer\n\n> \"Export scheduled report. Can I schedule an attribution report export for finance?\" -- verified customer\n\n### Dashboard freshness\n\n**Draft question:** Why has our pipeline dashboard not refreshed since yesterday?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-005, saas-demo-006\n\n**Customer wording examples:**\n> \"Dashboard stale data. Why has our pipeline dashboard not refreshed since yesterday?\" -- verified customer\n\n> \"Warehouse sync lag. How do we check whether the warehouse sync is delayed?\" -- verified customer\n\n### SSO setup\n\n**Draft question:** What should the team verify for sso setup?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Permissions and seats\n\n**Draft question:** What should the team verify for permissions and seats?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Draft question:** What should the team verify for api and webhooks?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer -- support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after you publish. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming the FAQ entries caused the change.\n\nWatch the signals. If new tickets still ask the same questions, the FAQ entry may need clearer wording, better placement, or a different resolution. If new tickets shift to different questions, the FAQ entry may be addressing the observed gap.\n\nThe uploaded tickets do not include a dated source window. Track the signals when your team has capacity to review them.",
+      "content": "## What repeat support questions show\n\nSupport ticket FAQ gaps appear when the same customer question repeats without a published answer. In 36 support tickets, 35 direct customer questions repeated across nine clusters: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster ties at four tickets. The sample contains 36 total tickets. Without resolution evidence, each answer should preserve customer language, stay as a review-needed shell, and wait for your support team to add the verified resolution.\n\nCustomers ask the same questions in their own words. One customer wrote: *\"Attribution export blocked How do I export attribution reports before our board meeting?\"* Another asked: *\"CSV export missing fields Why is the campaign CSV export missing source and owner columns?\"* A third wanted to know: *\"Export scheduled report Can I schedule a weekly attribution report export for finance?\"* All three questions fall into the reporting export cluster.\n\nDashboard freshness questions follow a similar pattern. One ticket said: *\"Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?\"* Another asked: *\"Warehouse sync lag How do we check whether the warehouse sync is delayed?\"* Both customers needed the same information about dashboard refresh behavior.\n\nThe observed ticket set supports up to six first-pass FAQ entries from customer wording. Each draft should preserve customer language and wait for your support team to add the verified resolution before publishing.\n\n## Which FAQ gaps should be reviewed first\n\nWhen you prioritize support ticket FAQ gaps, start with the clusters that match your team's current focus or upcoming product changes. All nine observed clusters tie at four tickets each: reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management. The provided evidence does not support ranking one cluster above another. If your team is preparing for a board meeting or finance review, start with reporting export. If you are onboarding enterprise customers, start with SSO setup or permissions and seats. If you are launching a new integration, start with integration sync or API and webhooks.\n\nThe tied clusters are:\n\n- **Reporting export** (4 tickets) -- Questions about exporting attribution reports, missing CSV fields, scheduled exports, and export permissions.\n- **Dashboard freshness** (4 tickets) -- Questions about stale dashboard data and warehouse sync lag.\n- **SSO setup** (4 tickets) -- Questions your support team should verify for SSO setup.\n- **Permissions and seats** (4 tickets) -- Questions your support team should verify for permissions and seats.\n- **API and webhooks** (4 tickets) -- Questions your support team should verify for API and webhooks.\n- **Integration sync** (4 tickets) -- Questions your support team should verify for integration sync.\n- **Data import** (4 tickets) -- Questions your support team should verify for data import.\n- **Workflow automation** (4 tickets) -- Questions your support team should verify for workflow automation.\n- **Billing and plan management** (4 tickets) -- Questions your support team should verify for billing and plan management.\n\nThe observed ticket counts show which questions repeated in this sample. They do not prove which questions appear most often across your full support queue or which questions will repeat after you publish FAQ entries.\n\n## Draft FAQ shells to verify\n\nEach draft FAQ shell below preserves customer wording and waits for your support team to add the verified resolution. Support ticket FAQ gaps become publishable entries only after your team verifies the resolution, approves the customer-facing wording, and completes the support owner review. Do not publish concrete steps, UI paths, menu names, or capability claims without resolution evidence. The six draft shells below show the customer questions that repeated most clearly in the observed ticket set.\n\n### Reporting export (4 tickets)\n\n**Draft question:** How do I export attribution reports before our board meeting?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-001, saas-demo-002, saas-demo-003\n\n### Dashboard freshness (4 tickets)\n\n**Draft question:** Why has our pipeline dashboard not refreshed since yesterday?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-005, saas-demo-006\n\n### SSO setup (4 tickets)\n\n**Draft question:** What should the team verify for SSO setup?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Permissions and seats (4 tickets)\n\n**Draft question:** What should the team verify for permissions and seats?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks (4 tickets)\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync (4 tickets)\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nAfter you publish FAQ entries, track new tickets by the same observed cluster labels to see whether support ticket FAQ gaps remain or shift. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming the FAQ entries caused any change. The observed ticket set shows what repeated before you published FAQ entries. It does not prove what will happen after you publish. Measurement tells you whether the FAQ entries are working.\n\nDo not assume ticket volume will decline, customers will find the FAQ entries, or the entries will rank for keywords. Those outcomes require measurement over time. Watch for:\n\n- New tickets that match the same cluster labels (reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, billing and plan management).\n- FAQ page views and time on page for each published entry.\n- Customer feedback on whether the FAQ answer resolved their question.\n- Support team notes on whether customers reference the FAQ entry in follow-up tickets.\n\nCompare future ticket counts to the observed baseline (four tickets per cluster in this sample) without claiming causality. If a cluster's ticket count stays the same or increases, inspect whether the FAQ answer is incomplete, hard to find, or mismatched to customer wording.",
       "data_context": {
         "_known_vendors": [],
         "allowed_claims": [
@@ -145,7 +147,7 @@
           }
         ],
         "faq_questions": [
-          "What happens after I upload the CSV?",
+          "What happens after I provide ticket data?",
           "Does FAQ Report publish automatically?"
         ],
         "forbidden_claims": [
@@ -162,7 +164,7 @@
           "claims that FAQ entries create self-service options or search-result visibility",
           "claims that FAQ entries are discoverable, rank for keywords, or are working",
           "fixed calendar windows, rolling periods, or future tracking intervals when provided tickets are undated",
-          "prioritization by business impact, activation delay, workflow blocking, or friction reduction without evidence",
+          "unsupported priority rankings or operational-impact rankings when observed counts are tied",
           "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence"
         ],
         "has_dated_window": false,
@@ -174,7 +176,7 @@
           "Track new tickets by the same observed cluster labels after publishing.",
           "Review FAQ page traffic and customer feedback as signals to inspect.",
           "Compare future tickets against the observed clusters without claiming causality.",
-          "Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints unless the provided tickets include a dated source window."
+          "Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints unless `data_context.has_dated_window` is true."
         ],
         "question_like_ticket_count": 35,
         "required_section_outline": [
@@ -194,7 +196,7 @@
               "top_clusters",
               "draft_faq_shells"
             ],
-            "claim_boundary": "Order by observed ticket count only; do not infer business impact.",
+            "claim_boundary": "Order by observed ticket count only; when counts tie, say no evidence-based rank is available.",
             "heading": "Which FAQ gaps should be reviewed first",
             "id": "faq-gap-review-order"
           },
@@ -216,7 +218,7 @@
             "id": "post-publication-measurement"
           }
         ],
-        "review_period": "uploaded tickets",
+        "review_period": "observed support-ticket sample",
         "scope": {
           "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
           "user_id": "11111111-1111-4111-8111-111111111111"
@@ -307,9 +309,9 @@
         "topic": "Support ticket FAQ gaps: what repeat tickets reveal before renewal",
         "total_reviews_analyzed": 36
       },
-      "description": "36 uploaded support tickets show 9 repeated question clusters. Draft FAQ shells need support-team review before publishing.",
-      "generation_input_tokens": 18331,
-      "generation_output_tokens": 3910,
+      "description": "In 36 support tickets, 35 direct customer questions repeated across nine clusters. See which FAQ gaps appeared most often and what to verify before publishing.",
+      "generation_input_tokens": 18394,
+      "generation_output_tokens": 4150,
       "generation_parse_attempts": 1,
       "generation_total_tokens": null,
       "geo_readiness": {
@@ -350,16 +352,16 @@
         },
         "faq": [
           {
-            "answer": "The uploaded tickets show 35 direct customer questions across 9 repeated clusters: reporting export, dashboard freshness, sso setup, permissions and seats, api and webhooks, integration sync, data import, workflow automation, and billing and plan management. Each cluster appears 4 times.",
-            "question": "What do 36 uploaded support tickets reveal about FAQ gaps?"
+            "answer": "In 36 support tickets, 35 include direct customer questions. Nine clusters repeated: reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management. Each cluster appeared four times.",
+            "question": "What do 36 support tickets show about missing FAQ entries?"
           },
           {
-            "answer": "All 9 clusters are tied at 4 tickets each. Review order should follow your team's verification capacity and customer-facing priority, not the observed counts alone.",
+            "answer": "All nine observed clusters tie at four tickets each. The provided evidence does not support ranking one cluster above another. Review any cluster that matches your team's current priorities or upcoming product changes.",
             "question": "Which FAQ gaps should a small team review first?"
           },
           {
-            "answer": "Each draft answer shell should preserve customer wording from the uploaded tickets and stay as a review-needed placeholder until the support team adds the verified resolution, approved customer-facing wording, and support owner review.",
-            "question": "What should draft FAQ answer shells include?"
+            "answer": "Each draft answer should preserve customer wording, stay as a review-needed shell, and wait for the support team to add the verified resolution. Do not publish concrete steps, UI paths, or capability claims without resolution evidence.",
+            "question": "What should draft FAQ answers include before publishing?"
           }
         ],
         "generation_model": "anthropic/claude-sonnet-4-5",
@@ -367,19 +369,19 @@
         "generation_quality_repair_attempts": 1,
         "generation_usage": {
           "billable_input_tokens": 6,
-          "cache_write_tokens": 8079,
+          "cache_write_tokens": 8142,
           "cached_tokens": 10246,
-          "input_tokens": 18331,
-          "output_tokens": 3910,
+          "input_tokens": 18394,
+          "output_tokens": 4150,
           "reasoning_tokens": 0
         },
         "secondary_keywords": [
-          "repeat support tickets",
-          "faq planning",
-          "customer questions"
+          "repeat support questions",
+          "faq planning from tickets",
+          "customer question clusters"
         ],
-        "seo_description": "36 uploaded support tickets show 9 repeated question clusters. Draft FAQ shells need support-team review before publishing.",
-        "seo_title": "Support Ticket FAQ Gaps: 36 Tickets Analyzed",
+        "seo_description": "36 support tickets reveal 9 repeated question clusters. See which FAQ gaps to review first and what to verify before publishing.",
+        "seo_title": "Support Ticket FAQ Gaps: 36 Repeat Questions Analyzed",
         "target_keyword": "support ticket faq gaps",
         "variant_angle": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials."
       },
@@ -413,17 +415,17 @@
       "status": "approved",
       "tag_count": 3,
       "tags": [
-        "repeat support tickets",
-        "faq planning",
-        "customer questions"
+        "repeat support questions",
+        "faq planning from tickets",
+        "customer question clusters"
       ],
-      "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
+      "title": "Support Ticket FAQ Gaps: What 36 Repeat Tickets Reveal Before Renewal",
       "topic_type": "content_ops_support_ticket_faq"
     },
     {
       "chart_count": 0,
       "charts": [],
-      "content": "## What repeat support questions show\n\nSupport ticket FAQ gaps appear when your team answers the same question multiple times without publishing a customer-facing answer. In the uploaded tickets, 36 source rows include 35 direct customer questions that reveal support ticket FAQ gaps across nine repeated clusters: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster represents a gap where your team answers the same question multiple times without a published FAQ entry to reference.\n\nCustomer wording shows what people ask before they open a ticket. One customer wrote: \"Attribution export blocked How do I export attribution reports before our board meeting?\" Another asked: \"Why has our pipeline dashboard not refreshed since yesterday?\" These questions repeat because no published FAQ entry addresses them.\n\nThe uploaded tickets do not include support resolutions. You see the repeated questions, but not the verified answers your team gave. That means you can identify the support ticket FAQ gaps, but you cannot publish the answers until your support lead reviews and approves the resolution steps.\n\n## Which FAQ gaps should be reviewed first\n\nWhen support ticket FAQ gaps are tied by observed volume, prioritize by your team's capacity and the clusters where you already have verified resolutions ready to publish. All nine clusters in the uploaded tickets are tied at 4 tickets each, so you cannot rank support ticket FAQ gaps by observed ticket volume alone. Instead, start with the clusters where your support lead can add the verified resolution fastest, then move to the remaining support ticket FAQ gaps as capacity allows.\n\nThe tied clusters are:\n\n- **Reporting export** (4 tickets) -- Questions about exporting attribution reports, missing CSV fields, scheduled exports, and export permissions.\n- **Dashboard freshness** (4 tickets) -- Questions about stale dashboard data and warehouse sync lag.\n- **SSO setup** (4 tickets) -- Questions the team should verify for SSO setup.\n- **Permissions and seats** (4 tickets) -- Questions the team should verify for permissions and seats.\n- **API and webhooks** (4 tickets) -- Questions the team should verify for API and webhooks.\n- **Integration sync** (4 tickets) -- Questions the team should verify for integration sync.\n- **Data import** (4 tickets) -- Questions the team should verify for data import.\n- **Workflow automation** (4 tickets) -- Questions the team should verify for workflow automation.\n- **Billing and plan management** (4 tickets) -- Questions the team should verify for billing and plan management.\n\nStart with the clusters where your support lead can add the verified resolution fastest. The other clusters wait until you have the approved answer steps.\n\n## Draft FAQ shells to verify\n\nThe observed ticket set supports up to 6 first-pass FAQ entries. Each shell preserves customer wording and waits for the support team to add the verified resolution before publishing.\n\n### Reporting export\n\n**Observed ticket count:** 4\n\n**Draft question:** How do I export attribution reports before our board meeting?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-001, saas-demo-002, saas-demo-003\n\n### Dashboard freshness\n\n**Observed ticket count:** 4\n\n**Draft question:** Why has our pipeline dashboard not refreshed since yesterday?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n**Source tickets:** saas-demo-005, saas-demo-006\n\n### SSO setup\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for SSO setup?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Permissions and seats\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for permissions and seats?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\nEach shell waits for your support lead to add the verified resolution. Do not publish placeholder answers. Customers need the real fix, not a draft.\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after you publish. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming the FAQ entry caused the change.\n\nDo not assume ticket volume will decline. Watch whether the same clusters still appear in your queue. If they do, the FAQ entry may need clearer wording, better placement, or a different answer format. If they do not, note the change and keep watching.\n\nThe uploaded tickets do not include a dated source window. Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints. Track the clusters as long as your team needs the signal.",
+      "content": "## What repeat support questions show\n\nIn 36 support tickets, 35 direct customer questions repeated across nine clusters. Your support ticket FAQ gaps appear when the same question shows up multiple times without a published answer. The observed clusters are: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster appeared four times in the observed set.\n\nCustomer wording shows the exact language your customers use when they hit a gap. One ticket asked, \"How do I export attribution reports before our board meeting?\" Another said, \"Why is the campaign CSV export missing source and owner columns?\" A third asked, \"Can I schedule a weekly attribution report export for finance?\" Those three tickets all cluster under reporting export.\n\nDashboard freshness questions followed a similar pattern. One ticket said, \"Why has our pipeline dashboard not refreshed since yesterday?\" Another asked, \"How do we check whether the warehouse sync is delayed?\" Both tickets point to the same missing answer about dashboard refresh timing and warehouse sync status.\n\nThe observed ticket set contains 36 total rows. 35 of those rows include direct customer questions. The remaining row did not follow a question format. Nine distinct clusters emerged from the 35 question-like tickets. Each cluster appeared four times.\n\n## Which FAQ gaps your team should review first\n\nYour support ticket FAQ gaps should be reviewed in order of observed ticket volume. In this sample, all nine clusters appeared four times. When observed counts are tied, the provided evidence does not support ranking one cluster above another. Your review order should follow operational priority or customer impact, not ticket volume alone.\n\nThe tied clusters are:\n\n- **Reporting export** (4 tickets) -- Questions about attribution report export, CSV field mapping, scheduled exports, and export permissions.\n- **Dashboard freshness** (4 tickets) -- Questions about dashboard refresh timing, warehouse sync lag, and stale data.\n- **SSO setup** (4 tickets) -- Questions about SSO configuration and access.\n- **Permissions and seats** (4 tickets) -- Questions about role assignments and seat limits.\n- **API and webhooks** (4 tickets) -- Questions about API access and webhook configuration.\n- **Integration sync** (4 tickets) -- Questions about third-party integration sync status.\n- **Data import** (4 tickets) -- Questions about bulk data import and field mapping.\n- **Workflow automation** (4 tickets) -- Questions about automation rules and triggers.\n- **Billing and plan management** (4 tickets) -- Questions about plan changes and billing cycles.\n\nWithout resolution evidence in the original tickets, your support team should verify which clusters represent the highest operational risk or customer impact. A cluster with four tickets may be less urgent than a cluster with two tickets if the four-ticket cluster has a known workaround and the two-ticket cluster blocks activation.\n\nThe observed ticket set does not include resolution evidence. Each answer shell should stay as a review-needed placeholder until your support team adds the verified resolution.\n\n## Draft FAQ shells your team should verify\n\nDraft FAQ shells preserve customer wording and mark answer content as review-needed. Without resolution evidence in the original tickets, answer steps should not be invented. Your support team should add verified resolutions before publishing.\n\nSix draft FAQ shells emerged from the observed ticket clusters:\n\n### Reporting export\n\n**Draft question:** How do I export attribution reports before our board meeting?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:** Verified resolution, approved customer-facing wording, support owner review.\n\n**Source tickets:** saas-demo-001, saas-demo-002, saas-demo-003\n\n**Customer wording examples:**\n\n> \"How do I export attribution reports before our board meeting?\" -- saas-demo-001\n\n> \"Why is the campaign CSV export missing source and owner columns?\" -- saas-demo-002\n\n> \"Can I schedule a weekly attribution report export for finance?\" -- saas-demo-003\n\n### Dashboard freshness\n\n**Draft question:** Why has our pipeline dashboard not refreshed since yesterday?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:** Verified resolution, approved customer-facing wording, support owner review.\n\n**Source tickets:** saas-demo-005, saas-demo-006\n\n**Customer wording examples:**\n\n> \"Why has our pipeline dashboard not refreshed since yesterday?\" -- saas-demo-005\n\n> \"How do we check whether the warehouse sync is delayed?\" -- saas-demo-006\n\n### SSO setup\n\n**Draft question:** What should the team verify for SSO setup?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:** Verified resolution, approved customer-facing wording, support owner review.\n\n### Permissions and seats\n\n**Draft question:** What should the team verify for permissions and seats?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:** Verified resolution, approved customer-facing wording, support owner review.\n\n### API and webhooks\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:** Verified resolution, approved customer-facing wording, support owner review.\n\n### Integration sync\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:** Verified resolution, approved customer-facing wording, support owner review.\n\nEach draft FAQ shell should be reviewed by your support team before publishing. Your team should confirm the resolution, approve the customer-facing wording, and assign a support owner to maintain the entry.\n\n## What your team should measure after publishing\n\nAfter you publish FAQ entries, track new tickets by the same observed cluster labels. Compare future tickets against the observed clusters without claiming causality. Review your FAQ page traffic and customer feedback as signals to inspect.\n\nMeasurement should focus on observational signals:\n\n- **New tickets by cluster label** -- Track whether new tickets still use the same language as the observed clusters. If your reporting export tickets continue to ask \"How do I export attribution reports?\" after you publish the FAQ entry, inspect whether the entry matches the question your customers are asking.\n- **FAQ page traffic** -- Review page views and time on page for each published FAQ entry. Track traffic as a signal to inspect, not as proof the entry is working.\n- **Customer feedback** -- Review thumbs-up/thumbs-down ratings, comments, or follow-up tickets that reference the FAQ entry. Negative feedback signals the answer needs revision.\n\nFrame metrics as future signals your team should watch. The observed ticket set does not include a dated window. Track new tickets by cluster label after you publish and review FAQ page traffic as a signal to inspect.\n\nIf future tickets by the same cluster label decline after you publish, that is one signal to inspect. If future tickets remain steady or increase, inspect whether the entry matches the language your customers use when they search.",
       "data_context": {
         "_known_vendors": [],
         "allowed_claims": [
@@ -552,7 +554,7 @@
           }
         ],
         "faq_questions": [
-          "What happens after I upload the CSV?",
+          "What happens after I provide ticket data?",
           "Does FAQ Report publish automatically?"
         ],
         "forbidden_claims": [
@@ -569,7 +571,7 @@
           "claims that FAQ entries create self-service options or search-result visibility",
           "claims that FAQ entries are discoverable, rank for keywords, or are working",
           "fixed calendar windows, rolling periods, or future tracking intervals when provided tickets are undated",
-          "prioritization by business impact, activation delay, workflow blocking, or friction reduction without evidence",
+          "unsupported priority rankings or operational-impact rankings when observed counts are tied",
           "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence"
         ],
         "has_dated_window": false,
@@ -581,7 +583,7 @@
           "Track new tickets by the same observed cluster labels after publishing.",
           "Review FAQ page traffic and customer feedback as signals to inspect.",
           "Compare future tickets against the observed clusters without claiming causality.",
-          "Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints unless the provided tickets include a dated source window."
+          "Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints unless `data_context.has_dated_window` is true."
         ],
         "question_like_ticket_count": 35,
         "required_section_outline": [
@@ -601,7 +603,7 @@
               "top_clusters",
               "draft_faq_shells"
             ],
-            "claim_boundary": "Order by observed ticket count only; do not infer business impact.",
+            "claim_boundary": "Order by observed ticket count only; when counts tie, say no evidence-based rank is available.",
             "heading": "Which FAQ gaps should be reviewed first",
             "id": "faq-gap-review-order"
           },
@@ -623,7 +625,7 @@
             "id": "post-publication-measurement"
           }
         ],
-        "review_period": "uploaded tickets",
+        "review_period": "observed support-ticket sample",
         "scope": {
           "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
           "user_id": "11111111-1111-4111-8111-111111111111"
@@ -714,9 +716,9 @@
         "topic": "Support ticket FAQ gaps: what repeat tickets reveal before renewal",
         "total_reviews_analyzed": 36
       },
-      "description": "36 uploaded support tickets reveal 9 repeated question clusters. Review-needed FAQ shells show which gaps to verify first.",
-      "generation_input_tokens": 17887,
-      "generation_output_tokens": 3644,
+      "description": "In 36 support tickets, 35 direct customer questions repeated across nine clusters. Review-needed FAQ shells show which gaps your team should fix first.",
+      "generation_input_tokens": 18868,
+      "generation_output_tokens": 4442,
       "generation_parse_attempts": 1,
       "generation_total_tokens": null,
       "geo_readiness": {
@@ -757,16 +759,16 @@
         },
         "faq": [
           {
-            "answer": "In the uploaded tickets, 36 source rows include 35 direct customer questions. Nine clusters appear repeatedly: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4).",
+            "answer": "In 36 support tickets, 35 include direct customer questions that repeated across nine clusters: reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management. Each cluster appeared four times in the observed set.",
             "question": "What do repeat support tickets reveal about FAQ gaps?"
           },
           {
-            "answer": "All nine clusters are tied at 4 tickets each. Prioritize by your team's capacity and the clusters where you already have verified resolutions ready to publish.",
-            "question": "Which FAQ gaps should a small team fix first?"
+            "answer": "Copy customer wording from repeated ticket clusters, draft review-needed answer shells, and have your support team add verified resolutions before publishing. Without resolution evidence in the original tickets, answer content should stay as placeholders until your support team confirms the fix.",
+            "question": "How should your support team turn old tickets into FAQ entries?"
           },
           {
-            "answer": "The uploaded ticket set supports up to 6 first-pass FAQ entries. Each shell preserves customer wording and waits for the support team to add the verified resolution before publishing.",
-            "question": "How should old tickets become review-ready FAQ shells?"
+            "answer": "When observed ticket counts are tied\u2014as they are in this sample, where all nine clusters appeared four times\u2014the provided evidence does not support ranking one cluster above another. Your review order should follow operational priority or customer impact, not ticket volume alone.",
+            "question": "Which FAQ gaps should your team review first when ticket counts are tied?"
           }
         ],
         "generation_model": "anthropic/claude-sonnet-4-5",
@@ -774,19 +776,19 @@
         "generation_quality_repair_attempts": 1,
         "generation_usage": {
           "billable_input_tokens": 6,
-          "cache_write_tokens": 7635,
+          "cache_write_tokens": 8616,
           "cached_tokens": 10246,
-          "input_tokens": 17887,
-          "output_tokens": 3644,
+          "input_tokens": 18868,
+          "output_tokens": 4442,
           "reasoning_tokens": 0
         },
         "secondary_keywords": [
           "repeat support questions",
-          "faq planning",
-          "support ticket analysis"
+          "faq planning from tickets",
+          "customer question clusters"
         ],
-        "seo_description": "36 uploaded support tickets reveal 9 repeated question clusters and review-needed FAQ shells for verification.",
-        "seo_title": "Support Ticket FAQ Gaps: Repeat Questions Analysis",
+        "seo_description": "36 support tickets show 35 repeated customer questions across 9 clusters. Draft FAQ shells reveal which gaps need your support-team review first.",
+        "seo_title": "Support Ticket FAQ Gaps: What Your Repeat Questions Show",
         "target_keyword": "support ticket faq gaps",
         "variant_angle": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result."
       },
@@ -821,8 +823,415 @@
       "tag_count": 3,
       "tags": [
         "repeat support questions",
-        "faq planning",
-        "support ticket analysis"
+        "faq planning from tickets",
+        "customer question clusters"
+      ],
+      "title": "Support Ticket FAQ Gaps: What Your Repeat Questions Reveal Before Renewal",
+      "topic_type": "content_ops_support_ticket_faq"
+    },
+    {
+      "chart_count": 0,
+      "charts": [],
+      "content": "## What repeat support questions show\n\nYour customers ask the same questions. In 36 support tickets, 35 include direct customer questions that repeated across nine clusters. Support ticket FAQ gaps appear when your help center does not answer what customers keep asking. The observed clusters are reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4).\n\nEach cluster represents a gap between what your customers need and what your published answers cover. The customer wording shows the friction:\n\n> \"Attribution export blocked How do I export attribution reports before our board meeting?\" -- saas-demo-001\n\n> \"Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?\" -- saas-demo-005\n\n> \"CSV export missing fields Why is the campaign CSV export missing source and owner columns?\" -- saas-demo-002\n\nThese are not edge cases. They are repeated patterns in a small sample. When the same question appears multiple times in 36 tickets, your help center is missing an answer your customers expect.\n\nThe observed ticket set contains 36 total tickets. 35 of those tickets include direct customer questions. That ratio signals a documentation gap, not a product defect. Your customers are asking before they can act.\n\n## Which FAQ gaps should be reviewed first\n\nPrioritize FAQ work by observed ticket volume in your support ticket FAQ gaps review. In this sample, nine clusters each appeared in 4 tickets: reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management.\n\nWhen counts tie, the provided evidence does not support ranking one cluster above another. You cannot say reporting export is more urgent than dashboard freshness based on this sample. Both appeared 4 times. Both deserve review.\n\nStart with the clusters your support team can verify fastest. If your team already knows the verified resolution for reporting export questions, draft that FAQ entry first. If SSO setup requires cross-team review, queue it after the entries your support lead can approve alone.\n\nThe observed ticket counts show which questions repeated. They do not prove which questions block renewals, cause churn, or delay activation. Use the counts to order your review work, not to estimate business impact.\n\nFor tied clusters, review customer wording to break the tie. If one cluster uses consistent language across all 4 tickets and another cluster shows 4 different phrasings, the consistent cluster may be easier to answer in one FAQ entry.\n\n## Draft FAQ shells to verify\n\nThe observed ticket set supports up to 6 first-pass FAQ entries from customer wording. Each entry below is a review-needed shell. Your support team should add the verified resolution before publishing.\n\n### Reporting export\n\n**Observed ticket count:** 4\n\n**Draft question:** How do I export attribution reports before our board meeting?\n\n**Customer wording examples:**\n- \"Attribution export blocked How do I export attribution reports before our board meeting?\" (saas-demo-001)\n- \"CSV export missing fields Why is the campaign CSV export missing source and owner columns?\" (saas-demo-002)\n- \"Export scheduled report Can I schedule a weekly attribution report export for finance?\" (saas-demo-003)\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Dashboard freshness\n\n**Observed ticket count:** 4\n\n**Draft question:** Why has our pipeline dashboard not refreshed since yesterday?\n\n**Customer wording examples:**\n- \"Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?\" (saas-demo-005)\n- \"Warehouse sync lag How do we check whether the warehouse sync is delayed?\" (saas-demo-006)\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### SSO setup\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for SSO setup?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Permissions and seats\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for permissions and seats?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after publishing your FAQ entries. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming causality.\n\nDo not assume ticket volume will decline. The observed tickets show repeated questions, not proven outcomes. Measure whether the same clusters appear in future tickets at the same rate, a higher rate, or a lower rate. That comparison is a signal to inspect, not proof the FAQ entry is working.\n\nWatch for these signals:\n- New tickets tagged with the same cluster labels (reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync)\n- Customer feedback on published FAQ entries\n- Support team observations about whether customers reference the new FAQ entries in follow-up tickets\n\nThese signals tell you whether to revise the FAQ entry, add more detail, or investigate a different root cause. They do not prove the FAQ entry reduced ticket volume, improved search visibility, or helped customers find answers without opening tickets.\n\nCompare future tickets against the observed clusters. If reporting export tickets continue at the same rate after you publish the FAQ entry, the entry may need clearer wording, better placement, or a different answer. If reporting export tickets stop appearing, inspect whether the FAQ entry, a product change, or a different factor caused the shift.\n\nThe observed ticket set shows what customers asked. Future ticket patterns will show whether your published answers matched what they needed.",
+      "data_context": {
+        "_known_vendors": [],
+        "allowed_claims": [
+          "observed support-ticket clusters and counts from the provided ticket set",
+          "customer wording copied from the provided tickets",
+          "review-needed draft FAQ shells",
+          "support-team verification work before publishing",
+          "metrics to watch after publishing, without claiming those metrics improved"
+        ],
+        "category": "support tickets",
+        "customer_wording_examples": [
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-001",
+            "source_title": "Attribution export blocked",
+            "text": "Attribution export blocked How do I export attribution reports before our board meeting?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-002",
+            "source_title": "CSV export missing fields",
+            "text": "CSV export missing fields Why is the campaign CSV export missing source and owner columns?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-003",
+            "source_title": "Export scheduled report",
+            "text": "Export scheduled report Can I schedule a weekly attribution report export for finance?"
+          },
+          {
+            "pain_category": "reporting export",
+            "source_id": "saas-demo-004",
+            "source_title": "Dashboard export permissions",
+            "text": "Dashboard export permissions Why can analysts view dashboards but not export reports?"
+          },
+          {
+            "pain_category": "dashboard freshness",
+            "source_id": "saas-demo-005",
+            "source_title": "Dashboard stale data",
+            "text": "Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?"
+          },
+          {
+            "pain_category": "dashboard freshness",
+            "source_id": "saas-demo-006",
+            "source_title": "Warehouse sync lag",
+            "text": "Warehouse sync lag How do we check whether the warehouse sync is delayed?"
+          }
+        ],
+        "deep_enriched_count": 36,
+        "draft_answer_guidance": "Draft answer - support team should add the verified resolution before publishing.",
+        "draft_faq_shells": [
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "reporting export",
+            "draft_question": "How do I export attribution reports before our board meeting?",
+            "observed_ticket_count": 4,
+            "source_ids": [
+              "saas-demo-001",
+              "saas-demo-002",
+              "saas-demo-003"
+            ],
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "dashboard freshness",
+            "draft_question": "Why has our pipeline dashboard not refreshed since yesterday?",
+            "observed_ticket_count": 4,
+            "source_ids": [
+              "saas-demo-005",
+              "saas-demo-006"
+            ],
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "sso setup",
+            "draft_question": "What should the team verify for sso setup?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "permissions and seats",
+            "draft_question": "What should the team verify for permissions and seats?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "api and webhooks",
+            "draft_question": "What should the team verify for api and webhooks?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          },
+          {
+            "answer_shell": "Draft answer - support team should add the verified resolution before publishing.",
+            "cluster": "integration sync",
+            "draft_question": "What should the team verify for integration sync?",
+            "observed_ticket_count": 4,
+            "verification_needed": [
+              "verified resolution",
+              "approved customer-facing wording",
+              "support owner review"
+            ]
+          }
+        ],
+        "faq_questions": [
+          "What happens after I provide ticket data?",
+          "Does FAQ Report publish automatically?"
+        ],
+        "forbidden_claims": [
+          "future ticket reduction or deflection",
+          "prevented tickets or fewer repeat questions",
+          "churn, retention, upgrade, referral, ROI, or capacity outcomes",
+          "claims that FAQ entries help customers find answers or avoid tickets",
+          "claims that customers can find answers themselves because an FAQ exists",
+          "faster resolution or customers finding answers without opening tickets",
+          "claims that FAQ entries reduce how often the team answers a question",
+          "claims that FAQ entries perform better in search without measured evidence",
+          "claims that lower repeat tickets prove an FAQ entry is working",
+          "claims that unresolved questions delay activation or block workflows",
+          "claims that FAQ entries create self-service options or search-result visibility",
+          "claims that FAQ entries are discoverable, rank for keywords, or are working",
+          "fixed calendar windows, rolling periods, or future tracking intervals when provided tickets are undated",
+          "unsupported priority rankings or operational-impact rankings when observed counts are tied",
+          "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence"
+        ],
+        "has_dated_window": false,
+        "has_measured_outcomes": false,
+        "included_ticket_row_count": 36,
+        "measured_outcome_count": 0,
+        "measured_outcome_examples": [],
+        "measurement_guidance": [
+          "Track new tickets by the same observed cluster labels after publishing.",
+          "Review FAQ page traffic and customer feedback as signals to inspect.",
+          "Compare future tickets against the observed clusters without claiming causality.",
+          "Do not add fixed day, week, month, 30-day, 60-day, or 90-day checkpoints unless `data_context.has_dated_window` is true."
+        ],
+        "question_like_ticket_count": 35,
+        "required_section_outline": [
+          {
+            "allowed_source_fields": [
+              "source_row_count",
+              "included_ticket_row_count",
+              "question_like_ticket_count",
+              "top_clusters"
+            ],
+            "claim_boundary": "Describe observed rows, repeated clusters, and customer wording only.",
+            "heading": "What repeat support questions show",
+            "id": "observed-ticket-patterns"
+          },
+          {
+            "allowed_source_fields": [
+              "top_clusters",
+              "draft_faq_shells"
+            ],
+            "claim_boundary": "Order by observed ticket count only; when counts tie, say no evidence-based rank is available.",
+            "heading": "Which FAQ gaps should be reviewed first",
+            "id": "faq-gap-review-order"
+          },
+          {
+            "allowed_source_fields": [
+              "draft_faq_shells",
+              "customer_wording_examples"
+            ],
+            "claim_boundary": "Use review-needed placeholders until support adds verified resolutions.",
+            "heading": "Draft FAQ shells to verify",
+            "id": "draft-faq-shells"
+          },
+          {
+            "allowed_source_fields": [
+              "measurement_guidance"
+            ],
+            "claim_boundary": "Frame metrics as future signals to watch, not outcomes already caused.",
+            "heading": "What to measure after publishing",
+            "id": "post-publication-measurement"
+          }
+        ],
+        "review_period": "observed support-ticket sample",
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "source": "support_ticket_provider",
+        "source_period": "Last 90 days of support tickets",
+        "source_row_count": 36,
+        "support_ticket_blog_mode": "descriptive_no_outcome",
+        "support_ticket_resolution_evidence_count": 0,
+        "support_ticket_resolution_evidence_present": false,
+        "support_ticket_resolution_examples": [],
+        "top_clusters": [
+          {
+            "count": 4,
+            "label": "reporting export"
+          },
+          {
+            "count": 4,
+            "label": "dashboard freshness"
+          },
+          {
+            "count": 4,
+            "label": "sso setup"
+          },
+          {
+            "count": 4,
+            "label": "permissions and seats"
+          },
+          {
+            "count": 4,
+            "label": "api and webhooks"
+          },
+          {
+            "count": 4,
+            "label": "integration sync"
+          },
+          {
+            "count": 4,
+            "label": "data import"
+          },
+          {
+            "count": 4,
+            "label": "workflow automation"
+          },
+          {
+            "count": 4,
+            "label": "billing and plan management"
+          }
+        ],
+        "top_ticket_clusters": [
+          {
+            "count": 4,
+            "label": "reporting export"
+          },
+          {
+            "count": 4,
+            "label": "dashboard freshness"
+          },
+          {
+            "count": 4,
+            "label": "sso setup"
+          },
+          {
+            "count": 4,
+            "label": "permissions and seats"
+          },
+          {
+            "count": 4,
+            "label": "api and webhooks"
+          },
+          {
+            "count": 4,
+            "label": "integration sync"
+          },
+          {
+            "count": 4,
+            "label": "data import"
+          },
+          {
+            "count": 4,
+            "label": "workflow automation"
+          },
+          {
+            "count": 4,
+            "label": "billing and plan management"
+          }
+        ],
+        "topic": "Support ticket FAQ gaps: what repeat tickets reveal before renewal",
+        "total_reviews_analyzed": 36
+      },
+      "description": "In 36 support tickets, 35 direct customer questions repeated across nine clusters. See which FAQ gaps to review first.",
+      "generation_input_tokens": 8133,
+      "generation_output_tokens": 2146,
+      "generation_parse_attempts": 1,
+      "generation_total_tokens": null,
+      "geo_readiness": {
+        "checks": {
+          "answer_first_sections": true,
+          "citable_section_structure": true,
+          "citation_safety": true,
+          "entity_clarity": true,
+          "evidence_specificity": true,
+          "faq_coverage": true,
+          "freshness_context": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "id": "0501c17f-90c9-4318-9d15-e3253160a4e5",
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "faq": [
+          {
+            "answer": "In 36 support tickets, 35 include direct customer questions that repeated across nine clusters. The highest-volume clusters are reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management\u2014each appearing in 4 tickets.",
+            "question": "What do repeat support tickets reveal about FAQ gaps?"
+          },
+          {
+            "answer": "Copy customer wording from observed tickets, group by cluster, and create draft FAQ shells. Each answer should stay as a review-needed placeholder until the support team adds the verified resolution. The observed ticket set supports up to 6 first-pass FAQ entries from customer language.",
+            "question": "How should old tickets become review-ready FAQ shells?"
+          },
+          {
+            "answer": "Prioritize by observed ticket volume. In this sample, reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management each appeared in 4 tickets. When counts tie, the provided evidence does not support ranking one cluster above another.",
+            "question": "Which FAQ gaps should a small team fix first?"
+          }
+        ],
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_quality_repair_attempts": 0,
+        "generation_usage": {
+          "billable_input_tokens": 3,
+          "cache_write_tokens": 3007,
+          "cached_tokens": 5123,
+          "input_tokens": 8133,
+          "output_tokens": 2146,
+          "reasoning_tokens": 0
+        },
+        "secondary_keywords": [
+          "repeat support tickets",
+          "faq planning from tickets",
+          "customer question clusters"
+        ],
+        "seo_description": "36 support tickets show 35 repeated customer questions across 9 clusters. Review-ready FAQ shells for reporting export, dashboard freshness, and SSO setup.",
+        "seo_title": "Support Ticket FAQ Gaps: What Repeat Questions Show",
+        "target_keyword": "support ticket faq gaps",
+        "variant_angle": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step."
+      },
+      "output_checks": {
+        "aeo_structure_detected": true,
+        "faq_ready": true,
+        "secondary_keywords_present": true,
+        "seo_description_ready": true,
+        "seo_title_ready": true,
+        "target_keyword_present": true
+      },
+      "passed_output_checks": 6,
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "seo_aeo_readiness": {
+        "checks": {
+          "aeo_structure_detected": true,
+          "faq_ready": true,
+          "secondary_keywords_present": true,
+          "seo_description_ready": true,
+          "seo_title_ready": true,
+          "target_keyword_present": true
+        },
+        "missing": [],
+        "passed": 6,
+        "status": "ready",
+        "total": 6
+      },
+      "slug": "content-ops-support-ticket-live-smoke-2b2b950d-f64b-4852-bc30-f92a34cdf169-pain-led",
+      "status": "approved",
+      "tag_count": 3,
+      "tags": [
+        "repeat support tickets",
+        "faq planning from tickets",
+        "customer question clusters"
       ],
       "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
       "topic_type": "content_ops_support_ticket_faq"

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json
@@ -1,0 +1,1258 @@
+{
+  "count": 3,
+  "filters": {
+    "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    "id": [
+      "49e324c1-f331-404d-bfa4-dcbcb5387027",
+      "2b09400f-a8b9-4787-86dd-ca655686d246",
+      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+    ],
+    "ids": [
+      "49e324c1-f331-404d-bfa4-dcbcb5387027",
+      "2b09400f-a8b9-4787-86dd-ca655686d246",
+      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+    ]
+  },
+  "limit": 3,
+  "rows": [
+    {
+      "campaign_name": "Support Ticket FAQ Gap Audit",
+      "cta": {
+        "label": "Upload Ticket CSV \u2014 Get the Gap Audit",
+        "url": "/systems/ai-content-ops/intake",
+        "variant": "primary"
+      },
+      "generation_input_tokens": 3797,
+      "generation_output_tokens": 2664,
+      "generation_parse_attempts": 1,
+      "generation_quality_repair_attempts": 0,
+      "generation_quality_repair_history": [
+        {
+          "attempt": 0,
+          "blockers": [],
+          "passed": true,
+          "repair_issues": []
+        }
+      ],
+      "generation_total_tokens": null,
+      "geo_readiness": {
+        "checks": {
+          "answer_extractability": true,
+          "audience_entity_clarity": true,
+          "claim_safety": true,
+          "conversion_path_clarity": true,
+          "offer_entity_clarity": true,
+          "section_semantics": true,
+          "trust_signal_visibility": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "hero": {
+        "cta_label": "Upload Ticket CSV \u2014 Get the Gap Audit",
+        "cta_url": "/systems/ai-content-ops/intake",
+        "headline": "Your repeat tickets already told you what's missing",
+        "subheadline": "Upload 90 days of support CSV and get a review-ready FAQ audit showing which questions cost you the most repeat volume."
+      },
+      "id": "a1181e5e-91e3-49d0-9ad1-1c5494783330",
+      "meta": {
+        "description": "Upload 90 days of support tickets and get a prioritized FAQ audit showing which repeat questions cost you the most volume. Draft shells included.",
+        "og_image_url": "",
+        "title_tag": "Support Ticket FAQ Gap Audit \u2014 Find Repeat Questions"
+      },
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "campaign_name": "Support Ticket FAQ Gap Audit",
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_quality_repair_attempts": 0,
+        "generation_quality_repair_history": [
+          {
+            "attempt": 0,
+            "blockers": [],
+            "passed": true,
+            "repair_issues": []
+          }
+        ],
+        "generation_usage": {
+          "billable_input_tokens": 126,
+          "cache_write_tokens": 0,
+          "cached_tokens": 3671,
+          "input_tokens": 3797,
+          "output_tokens": 2664,
+          "reasoning_tokens": 0
+        },
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "source_context": {
+          "customer_wording_examples": [
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-001",
+              "source_title": "Attribution export blocked",
+              "text": "Attribution export blocked How do I export attribution reports before our board meeting?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-002",
+              "source_title": "CSV export missing fields",
+              "text": "CSV export missing fields Why is the campaign CSV export missing source and owner columns?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-003",
+              "source_title": "Export scheduled report",
+              "text": "Export scheduled report Can I schedule a weekly attribution report export for finance?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-004",
+              "source_title": "Dashboard export permissions",
+              "text": "Dashboard export permissions Why can analysts view dashboards but not export reports?"
+            },
+            {
+              "pain_category": "dashboard freshness",
+              "source_id": "saas-demo-005",
+              "source_title": "Dashboard stale data",
+              "text": "Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?"
+            },
+            {
+              "pain_category": "dashboard freshness",
+              "source_id": "saas-demo-006",
+              "source_title": "Warehouse sync lag",
+              "text": "Warehouse sync lag How do we check whether the warehouse sync is delayed?"
+            }
+          ],
+          "has_dated_window": false,
+          "has_measured_outcomes": false,
+          "included_ticket_row_count": 36,
+          "measured_outcome_count": 0,
+          "question_like_ticket_count": 35,
+          "skipped_ticket_row_count": 0,
+          "source_row_count": 36,
+          "support_ticket_resolution_evidence_count": 0,
+          "support_ticket_resolution_evidence_present": false,
+          "top_ticket_clusters": [
+            {
+              "count": 4,
+              "label": "reporting export"
+            },
+            {
+              "count": 4,
+              "label": "dashboard freshness"
+            },
+            {
+              "count": 4,
+              "label": "sso setup"
+            },
+            {
+              "count": 4,
+              "label": "permissions and seats"
+            },
+            {
+              "count": 4,
+              "label": "api and webhooks"
+            },
+            {
+              "count": 4,
+              "label": "integration sync"
+            },
+            {
+              "count": 4,
+              "label": "data import"
+            },
+            {
+              "count": 4,
+              "label": "workflow automation"
+            },
+            {
+              "count": 4,
+              "label": "billing and plan management"
+            }
+          ],
+          "truncated_ticket_row_count": 0
+        },
+        "variant_angle": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials."
+      },
+      "output_checks": {
+        "answer_first_hero": true,
+        "audience_specificity": true,
+        "meta_description": true,
+        "metadata_consistency": true,
+        "objection_coverage": true,
+        "problem_solution_clarity": true,
+        "slug_quality": true,
+        "title_tag": true
+      },
+      "passed_output_checks": 8,
+      "persona": "SaaS support leaders carrying a repeat-ticket backlog",
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "reference_count": 0,
+      "reference_ids": [],
+      "section_count": 8,
+      "sections": [
+        {
+          "body_markdown": "In the uploaded tickets, 35 out of 36 were question-shaped and clustered into 9 repeat patterns including reporting export, dashboard freshness, SSO setup, and permissions. When the same question appears four times in one quarter, you're carrying FAQ debt that costs another reply each time.\n\nIn the uploaded tickets, 35 out of 36 were question-shaped, and they clustered into 9 repeat patterns: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). When the same question appears four times in one quarter, you're carrying FAQ debt. Each repeat costs another reply, another context switch, and another chance the customer gives up before asking.\n\nThe audit shows you which clusters represent the highest repeat risk and gives you draft FAQ shells for each one. You decide which answers to write first.",
+          "id": "observed_ticket_pattern",
+          "metadata": {
+            "answer_summary": "In the uploaded tickets, 35 out of 36 were question-shaped and clustered into 9 repeat patterns including reporting export, dashboard freshness, SSO setup, and permissions. When the same question appears four times in one quarter, you're carrying FAQ debt that costs another reply each time.",
+            "kind": "problem",
+            "order": 1,
+            "primary_question": "What did the uploaded support tickets show about repeat questions?"
+          },
+          "title": "What 36 uploaded tickets revealed about repeat support load"
+        },
+        {
+          "body_markdown": "Uploaded tickets show exact customer phrasing such as \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\" and \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\" The audit preserves this wording so FAQ answers match the search terms customers already use.\n\nSupport leaders know that help-center language rarely matches the way customers phrase the problem. Here's what the uploaded tickets said:\n\n- \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields \u2014 Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report \u2014 Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions \u2014 Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag \u2014 How do we check whether the warehouse sync is delayed?\"\n\nThe audit preserves this wording so you can write FAQ answers that match the search terms customers already use. You're not guessing what they'll type \u2014 you're seeing what they typed.",
+          "id": "customer_wording_examples",
+          "metadata": {
+            "answer_summary": "Uploaded tickets show exact customer phrasing such as \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\" and \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\" The audit preserves this wording so FAQ answers match the search terms customers already use.",
+            "kind": "proof",
+            "order": 2,
+            "primary_question": "How do customers phrase the repeat questions in their own words?"
+          },
+          "title": "How customers actually asked the questions"
+        },
+        {
+          "body_markdown": "The audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell with the customer's original question wording, the ticket count, and a placeholder for the verified answer. You add the procedural steps and route the draft to your review queue.\n\nThe Support Ticket FAQ Gap Audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell that includes the customer's original question wording, the ticket count, and a placeholder for the verified answer. The shell says \"Draft answer \u2014 support team should add the verified resolution before publishing\" because the uploaded tickets contain customer questions but not verified support resolutions.\n\nYou decide which clusters to write first, add the procedural steps your team already knows, and route the draft to your review queue. The audit does not publish automatically. It gives you the structure so you can focus on writing the answer instead of hunting for the pattern.",
+          "id": "solution_faq_audit_output",
+          "metadata": {
+            "answer_summary": "The audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell with the customer's original question wording, the ticket count, and a placeholder for the verified answer. You add the procedural steps and route the draft to your review queue.",
+            "kind": "solution",
+            "order": 3,
+            "primary_question": "What does the FAQ Gap Audit deliver?"
+          },
+          "title": "What you get: draft FAQ shells tied to repeat ticket clusters"
+        },
+        {
+          "body_markdown": "Export your support tickets as CSV, upload at the intake link, and get an audit report showing repeat clusters ranked by ticket count. Review the clusters, write the verified answers with procedural steps your team knows, and route to your review queue. The audit does not publish automatically.\n\n1. Export your support tickets as CSV. Include ticket ID, subject line, and body text. The audit needs at least 30 days of tickets; 90 days gives better cluster confidence.\n2. Upload the CSV at the intake link. The system reads the ticket text, identifies question-shaped tickets, and groups them by topic similarity.\n3. Get the audit report. It shows repeat clusters ranked by ticket count, preserves customer wording, and generates draft FAQ shells for each cluster.\n4. Review the clusters. Decide which FAQ gaps represent the highest repeat risk or the easiest wins.\n5. Write the verified answers. Add the procedural steps, UI paths, or policy details your support team already knows.\n6. Route to your review queue. The audit does not publish automatically. You control what goes live and when.\n\nThe whole process takes the time it takes to export a CSV and decide which clusters to write first. Writing the answers is on you.",
+          "id": "how_it_works_upload_to_audit",
+          "metadata": {
+            "answer_summary": "Export your support tickets as CSV, upload at the intake link, and get an audit report showing repeat clusters ranked by ticket count. Review the clusters, write the verified answers with procedural steps your team knows, and route to your review queue. The audit does not publish automatically.",
+            "kind": "how_it_works",
+            "order": 4,
+            "primary_question": "How does the Support Ticket FAQ Gap Audit process work?"
+          },
+          "title": "How the audit process works"
+        },
+        {
+          "body_markdown": "No. The audit generates draft FAQ shells with customer question wording and a placeholder for the verified answer. You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center without your approval.\n\nNo. The audit generates draft FAQ shells with customer question wording and a placeholder that says \"Draft answer \u2014 support team should add the verified resolution before publishing.\" You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center, CMS, or knowledge base without your approval.\n\nThis matters because uploaded tickets show repeated questions but not verified support resolutions. The audit can tell you which questions cost you the most repeat volume, but it cannot write the procedural steps, permission rules, or UI paths that make the answer useful. That's your team's job.",
+          "id": "objection_auto_publish_risk",
+          "metadata": {
+            "answer_summary": "No. The audit generates draft FAQ shells with customer question wording and a placeholder for the verified answer. You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center without your approval.",
+            "kind": "objection",
+            "order": 5,
+            "primary_question": "Will this publish FAQ answers automatically?"
+          },
+          "title": "Does the audit publish FAQ answers automatically?"
+        },
+        {
+          "body_markdown": "No. The audit is built for support leaders without a dedicated docs team. It shows which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. If you have one person who can export a CSV and write three FAQ answers in a week, you have enough capacity.\n\nNo. The audit is built for support leaders who do not have a dedicated docs team. It shows you which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. Your support team already knows the verified resolutions \u2014 the audit just surfaces the pattern and gives you the draft structure.\n\nIf you have one person who can export a CSV, review a cluster list, and write three FAQ answers in a week, you have enough capacity to use this. The audit does not require ongoing maintenance, a content ops hire, or a full-time docs person. It requires deciding which repeat questions to answer first.",
+          "id": "objection_full_time_docs_person",
+          "metadata": {
+            "answer_summary": "No. The audit is built for support leaders without a dedicated docs team. It shows which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. If you have one person who can export a CSV and write three FAQ answers in a week, you have enough capacity.",
+            "kind": "objection",
+            "order": 6,
+            "primary_question": "Do we need a full-time docs person to use the FAQ Gap Audit?"
+          },
+          "title": "Do we need a full-time docs person to use this?"
+        },
+        {
+          "body_markdown": "The system reads the ticket text, identifies question-shaped tickets, groups them by topic similarity, and ranks clusters by ticket count. You get an audit report showing repeat patterns and draft FAQ shells. You review the clusters, add verified answers, and route to your review queue.\n\nAfter you upload the CSV, the system reads the ticket text and identifies question-shaped tickets. It groups them by topic similarity and ranks the clusters by ticket count. You get an audit report that shows the repeat patterns, preserves customer wording, and generates draft FAQ shells for each cluster.\n\nThe report does not include verified answers because the uploaded tickets contain customer questions but not support resolutions. You review the clusters, decide which FAQ gaps to write first, add the procedural steps your team knows, and route the draft to your review queue. The audit does not publish automatically.",
+          "id": "faq_after_upload",
+          "metadata": {
+            "answer_summary": "The system reads the ticket text, identifies question-shaped tickets, groups them by topic similarity, and ranks clusters by ticket count. You get an audit report showing repeat patterns and draft FAQ shells. You review the clusters, add verified answers, and route to your review queue.",
+            "kind": "faq",
+            "order": 7,
+            "primary_question": "What happens after I upload the CSV?"
+          },
+          "title": "What happens after I upload the CSV?"
+        },
+        {
+          "body_markdown": "Upload your support ticket CSV and get the audit report. It shows you which repeat questions cost you the most volume, preserves customer wording, and gives you draft FAQ shells for each cluster. You decide which answers to write first.\n\nThe audit does not publish automatically. It does not require a full-time docs person. It requires deciding which FAQ gaps represent the highest repeat risk and writing the verified answers your support team already knows.\n\nIf you're carrying a repeat-ticket backlog and you want to see the pattern, upload the CSV.",
+          "id": "conversion_next_action",
+          "metadata": {
+            "answer_summary": "",
+            "kind": "conversion",
+            "order": 8,
+            "primary_question": ""
+          },
+          "title": "Get your FAQ gap audit"
+        }
+      ],
+      "seo_aeo_readiness": {
+        "checks": {
+          "answer_first_hero": true,
+          "audience_specificity": true,
+          "meta_description": true,
+          "metadata_consistency": true,
+          "objection_coverage": true,
+          "problem_solution_clarity": true,
+          "slug_quality": true,
+          "title_tag": true
+        },
+        "missing": [],
+        "passed": 8,
+        "status": "ready",
+        "total": 8
+      },
+      "slug": "support-ticket-faq-gap-audit",
+      "status": "approved",
+      "structured_data": {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebPage",
+            "about": {
+              "@type": "Thing",
+              "name": "Turn repeat support tickets into approved FAQ answers"
+            },
+            "audience": {
+              "@type": "Audience",
+              "audienceType": "SaaS support leaders carrying a repeat-ticket backlog"
+            },
+            "description": "Upload 90 days of support tickets and get a prioritized FAQ audit showing which repeat questions cost you the most volume. Draft shells included.",
+            "hasPart": [
+              {
+                "@type": "WebPageElement",
+                "additionalType": "problem",
+                "name": "What 36 uploaded tickets revealed about repeat support load",
+                "position": 1,
+                "text": "In the uploaded tickets, 35 out of 36 were question-shaped and clustered into 9 repeat patterns including reporting export, dashboard freshness, SSO setup, and permissions. When the same question appears four times in one quarter, you're carrying FAQ debt that costs another reply each time.\n\nIn the uploaded tickets, 35 out of 36 were question-shaped, and they clustered into 9 repeat patterns: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). When the same question appears four times in one quarter, you're carrying FAQ debt. Each repeat costs another reply, another context switch, and another chance the customer gives up before asking.\n\nThe audit shows you which clusters represent the highest repeat risk and gives you draft FAQ shells for each one. You decide which answers to write first."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "proof",
+                "name": "How customers actually asked the questions",
+                "position": 2,
+                "text": "Uploaded tickets show exact customer phrasing such as \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\" and \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\" The audit preserves this wording so FAQ answers match the search terms customers already use.\n\nSupport leaders know that help-center language rarely matches the way customers phrase the problem. Here's what the uploaded tickets said:\n\n- \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields \u2014 Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report \u2014 Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions \u2014 Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag \u2014 How do we check whether the warehouse sync is delayed?\"\n\nThe audit preserves this wording so you can write FAQ answers that match the search terms customers already use. You're not guessing what they'll type \u2014 you're seeing what they typed."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "solution",
+                "name": "What you get: draft FAQ shells tied to repeat ticket clusters",
+                "position": 3,
+                "text": "The audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell with the customer's original question wording, the ticket count, and a placeholder for the verified answer. You add the procedural steps and route the draft to your review queue.\n\nThe Support Ticket FAQ Gap Audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell that includes the customer's original question wording, the ticket count, and a placeholder for the verified answer. The shell says \"Draft answer \u2014 support team should add the verified resolution before publishing\" because the uploaded tickets contain customer questions but not verified support resolutions.\n\nYou decide which clusters to write first, add the procedural steps your team already knows, and route the draft to your review queue. The audit does not publish automatically. It gives you the structure so you can focus on writing the answer instead of hunting for the pattern."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "how_it_works",
+                "name": "How the audit process works",
+                "position": 4,
+                "text": "Export your support tickets as CSV, upload at the intake link, and get an audit report showing repeat clusters ranked by ticket count. Review the clusters, write the verified answers with procedural steps your team knows, and route to your review queue. The audit does not publish automatically.\n\n1. Export your support tickets as CSV. Include ticket ID, subject line, and body text. The audit needs at least 30 days of tickets; 90 days gives better cluster confidence.\n2. Upload the CSV at the intake link. The system reads the ticket text, identifies question-shaped tickets, and groups them by topic similarity.\n3. Get the audit report. It shows repeat clusters ranked by ticket count, preserves customer wording, and generates draft FAQ shells for each cluster.\n4. Review the clusters. Decide which FAQ gaps represent the highest repeat risk or the easiest wins.\n5. Write the verified answers. Add the procedural steps, UI paths, or policy details your support team already knows.\n6. Route to your review queue. The audit does not publish automatically. You control what goes live and when.\n\nThe whole process takes the time it takes to export a CSV and decide which clusters to write first. Writing the answers is on you."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "objection",
+                "name": "Does the audit publish FAQ answers automatically?",
+                "position": 5,
+                "text": "No. The audit generates draft FAQ shells with customer question wording and a placeholder for the verified answer. You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center without your approval.\n\nNo. The audit generates draft FAQ shells with customer question wording and a placeholder that says \"Draft answer \u2014 support team should add the verified resolution before publishing.\" You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center, CMS, or knowledge base without your approval.\n\nThis matters because uploaded tickets show repeated questions but not verified support resolutions. The audit can tell you which questions cost you the most repeat volume, but it cannot write the procedural steps, permission rules, or UI paths that make the answer useful. That's your team's job."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "objection",
+                "name": "Do we need a full-time docs person to use this?",
+                "position": 6,
+                "text": "No. The audit is built for support leaders without a dedicated docs team. It shows which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. If you have one person who can export a CSV and write three FAQ answers in a week, you have enough capacity.\n\nNo. The audit is built for support leaders who do not have a dedicated docs team. It shows you which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. Your support team already knows the verified resolutions \u2014 the audit just surfaces the pattern and gives you the draft structure.\n\nIf you have one person who can export a CSV, review a cluster list, and write three FAQ answers in a week, you have enough capacity to use this. The audit does not require ongoing maintenance, a content ops hire, or a full-time docs person. It requires deciding which repeat questions to answer first."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "faq",
+                "name": "What happens after I upload the CSV?",
+                "position": 7,
+                "text": "The system reads the ticket text, identifies question-shaped tickets, groups them by topic similarity, and ranks clusters by ticket count. You get an audit report showing repeat patterns and draft FAQ shells. You review the clusters, add verified answers, and route to your review queue.\n\nAfter you upload the CSV, the system reads the ticket text and identifies question-shaped tickets. It groups them by topic similarity and ranks the clusters by ticket count. You get an audit report that shows the repeat patterns, preserves customer wording, and generates draft FAQ shells for each cluster.\n\nThe report does not include verified answers because the uploaded tickets contain customer questions but not support resolutions. You review the clusters, decide which FAQ gaps to write first, add the procedural steps your team knows, and route the draft to your review queue. The audit does not publish automatically."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "conversion",
+                "name": "Get your FAQ gap audit",
+                "position": 8,
+                "text": "Upload your support ticket CSV and get the audit report. It shows you which repeat questions cost you the most volume, preserves customer wording, and gives you draft FAQ shells for each cluster. You decide which answers to write first.\n\nThe audit does not publish automatically. It does not require a full-time docs person. It requires deciding which FAQ gaps represent the highest repeat risk and writing the verified answers your support team already knows.\n\nIf you're carrying a repeat-ticket backlog and you want to see the pattern, upload the CSV."
+              }
+            ],
+            "name": "Support Ticket FAQ Gap Audit \u2014 Find Repeat Questions",
+            "potentialAction": {
+              "@type": "Action",
+              "name": "Upload Ticket CSV \u2014 Get the Gap Audit",
+              "target": "/systems/ai-content-ops/intake"
+            }
+          },
+          {
+            "@type": "FAQPage",
+            "mainEntity": [
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "In the uploaded tickets, 35 out of 36 were question-shaped and clustered into 9 repeat patterns including reporting export, dashboard freshness, SSO setup, and permissions. When the same question appears four times in one quarter, you're carrying FAQ debt that costs another reply each time."
+                },
+                "name": "What did the uploaded support tickets show about repeat questions?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "The audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell with the customer's original question wording, the ticket count, and a placeholder for the verified answer. You add the procedural steps and route the draft to your review queue."
+                },
+                "name": "What does the FAQ Gap Audit deliver?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Export your support tickets as CSV, upload at the intake link, and get an audit report showing repeat clusters ranked by ticket count. Review the clusters, write the verified answers with procedural steps your team knows, and route to your review queue. The audit does not publish automatically."
+                },
+                "name": "How does the Support Ticket FAQ Gap Audit process work?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. The audit generates draft FAQ shells with customer question wording and a placeholder for the verified answer. You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center without your approval."
+                },
+                "name": "Will this publish FAQ answers automatically?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. The audit is built for support leaders without a dedicated docs team. It shows which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. If you have one person who can export a CSV and write three FAQ answers in a week, you have enough capacity."
+                },
+                "name": "Do we need a full-time docs person to use the FAQ Gap Audit?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "The system reads the ticket text, identifies question-shaped tickets, groups them by topic similarity, and ranks clusters by ticket count. You get an audit report showing repeat patterns and draft FAQ shells. You review the clusters, add verified answers, and route to your review queue."
+                },
+                "name": "What happens after I upload the CSV?"
+              }
+            ],
+            "name": "35 Support Tickets Showed the Same 9 FAQ Gaps \u2014 Here's Your Audit FAQs"
+          }
+        ]
+      },
+      "title": "35 Support Tickets Showed the Same 9 FAQ Gaps \u2014 Here's Your Audit",
+      "value_prop": "Turn repeat support tickets into approved FAQ answers"
+    },
+    {
+      "campaign_name": "Support Ticket FAQ Gap Audit",
+      "cta": {
+        "label": "Upload Ticket CSV -- Get the Gap Audit",
+        "url": "/systems/ai-content-ops/intake",
+        "variant": "primary"
+      },
+      "generation_input_tokens": 3797,
+      "generation_output_tokens": 2150,
+      "generation_parse_attempts": 1,
+      "generation_quality_repair_attempts": 0,
+      "generation_quality_repair_history": [
+        {
+          "attempt": 0,
+          "blockers": [],
+          "passed": true,
+          "repair_issues": []
+        }
+      ],
+      "generation_total_tokens": null,
+      "geo_readiness": {
+        "checks": {
+          "answer_extractability": true,
+          "audience_entity_clarity": true,
+          "claim_safety": true,
+          "conversion_path_clarity": true,
+          "offer_entity_clarity": true,
+          "section_semantics": true,
+          "trust_signal_visibility": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "hero": {
+        "cta_label": "Upload Ticket CSV -- Get the Gap Audit",
+        "cta_url": "/systems/ai-content-ops/intake",
+        "headline": "Turn repeat support tickets into approved FAQ answers",
+        "subheadline": "Upload your last 90 days of support tickets and get a gap audit showing which repeated questions need FAQ coverage\u2014no guesswork, no manual tagging."
+      },
+      "id": "2b09400f-a8b9-4787-86dd-ca655686d246",
+      "meta": {
+        "description": "Upload your support tickets and get a gap audit showing which repeated questions need FAQ coverage. Review-ready draft answers, no automatic publishing.",
+        "og_image_url": "",
+        "title_tag": "Support Ticket FAQ Gap Audit | Cut Repeat Tickets"
+      },
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "campaign_name": "Support Ticket FAQ Gap Audit",
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_quality_repair_attempts": 0,
+        "generation_quality_repair_history": [
+          {
+            "attempt": 0,
+            "blockers": [],
+            "passed": true,
+            "repair_issues": []
+          }
+        ],
+        "generation_usage": {
+          "billable_input_tokens": 126,
+          "cache_write_tokens": 0,
+          "cached_tokens": 3671,
+          "input_tokens": 3797,
+          "output_tokens": 2150,
+          "reasoning_tokens": 0
+        },
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "source_context": {
+          "customer_wording_examples": [
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-001",
+              "source_title": "Attribution export blocked",
+              "text": "Attribution export blocked How do I export attribution reports before our board meeting?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-002",
+              "source_title": "CSV export missing fields",
+              "text": "CSV export missing fields Why is the campaign CSV export missing source and owner columns?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-003",
+              "source_title": "Export scheduled report",
+              "text": "Export scheduled report Can I schedule a weekly attribution report export for finance?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-004",
+              "source_title": "Dashboard export permissions",
+              "text": "Dashboard export permissions Why can analysts view dashboards but not export reports?"
+            },
+            {
+              "pain_category": "dashboard freshness",
+              "source_id": "saas-demo-005",
+              "source_title": "Dashboard stale data",
+              "text": "Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?"
+            },
+            {
+              "pain_category": "dashboard freshness",
+              "source_id": "saas-demo-006",
+              "source_title": "Warehouse sync lag",
+              "text": "Warehouse sync lag How do we check whether the warehouse sync is delayed?"
+            }
+          ],
+          "has_dated_window": false,
+          "has_measured_outcomes": false,
+          "included_ticket_row_count": 36,
+          "measured_outcome_count": 0,
+          "question_like_ticket_count": 35,
+          "skipped_ticket_row_count": 0,
+          "source_row_count": 36,
+          "support_ticket_resolution_evidence_count": 0,
+          "support_ticket_resolution_evidence_present": false,
+          "top_ticket_clusters": [
+            {
+              "count": 4,
+              "label": "reporting export"
+            },
+            {
+              "count": 4,
+              "label": "dashboard freshness"
+            },
+            {
+              "count": 4,
+              "label": "sso setup"
+            },
+            {
+              "count": 4,
+              "label": "permissions and seats"
+            },
+            {
+              "count": 4,
+              "label": "api and webhooks"
+            },
+            {
+              "count": 4,
+              "label": "integration sync"
+            },
+            {
+              "count": 4,
+              "label": "data import"
+            },
+            {
+              "count": 4,
+              "label": "workflow automation"
+            },
+            {
+              "count": 4,
+              "label": "billing and plan management"
+            }
+          ],
+          "truncated_ticket_row_count": 0
+        },
+        "variant_angle": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result."
+      },
+      "output_checks": {
+        "answer_first_hero": true,
+        "audience_specificity": true,
+        "meta_description": true,
+        "metadata_consistency": true,
+        "objection_coverage": true,
+        "problem_solution_clarity": true,
+        "slug_quality": true,
+        "title_tag": true
+      },
+      "passed_output_checks": 8,
+      "persona": "SaaS support leaders carrying a repeat-ticket backlog",
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "reference_count": 0,
+      "reference_ids": [],
+      "section_count": 6,
+      "sections": [
+        {
+          "body_markdown": "When the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters appeared four times each, meaning your team is writing the same answer multiple times instead of publishing it once.\n\nWhen the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management\u2014each appeared four times. That pattern means your team is writing the same answer multiple times instead of publishing it once.\n\nThe risk is not just queue length. It is that your support leads do not know which gaps to close first, so the backlog keeps the same shape. You need the repeated questions ranked by frequency so you can decide which FAQ answers to write and review.",
+          "id": "repeat_ticket_risk",
+          "metadata": {
+            "answer_summary": "When the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters appeared four times each, meaning your team is writing the same answer multiple times instead of publishing it once.",
+            "kind": "problem",
+            "order": 1,
+            "primary_question": "Why do the same support questions keep coming back?"
+          },
+          "title": "Repeat tickets expose the same gaps every week"
+        },
+        {
+          "body_markdown": "The Support Ticket FAQ Gap Audit takes your uploaded ticket CSV and returns a ranked list of repeated questions with customer wording preserved. You see which questions appeared most often, what language your customers used, and which gaps carry the highest repeat risk.\n\nThe audit does not publish automatically. It gives you review-ready draft FAQ shells so your support team can add the verified resolution before you publish. That means you control what goes live, and you can prioritize the gaps that matter most to your queue.\n\nThe outcome is a clear next action: write and review the FAQ answers for the top repeat clusters, then track whether ticket volume changes after publication.",
+          "id": "gap_audit_outcome",
+          "metadata": {
+            "answer_summary": "The Support Ticket FAQ Gap Audit takes your uploaded ticket CSV and returns a ranked list of repeated questions with customer wording preserved. You see which questions appeared most often, what language your customers used, and which gaps carry the highest repeat risk.",
+            "kind": "solution",
+            "order": 2,
+            "primary_question": "What does the gap audit show me?"
+          },
+          "title": "The gap audit shows which repeated questions need FAQ coverage"
+        },
+        {
+          "body_markdown": "Export your support tickets as a CSV, upload it at the intake link, and the audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording. You get a gap report showing the top repeat clusters and draft FAQ answer shells, then your support team adds the verified resolution before publishing.\n\n1. Export your support tickets as a CSV. Include ticket title, body, and any tags or categories you already use.\n2. Upload the CSV at [/systems/ai-content-ops/intake](/systems/ai-content-ops/intake). The audit runs on the uploaded tickets\u2014no live system access required.\n3. The audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording so you see the exact language your customers used.\n4. You get a gap report showing the top repeat clusters and draft FAQ answer shells. The drafts include the customer question but not the verified resolution\u2014your support team adds that before publishing.\n5. Review the draft answers, add the verified steps, and publish the FAQ entries to your help center.\n6. Track whether ticket volume changes after publication. The audit does not predict future ticket reduction, but it gives you the baseline to measure it.\n\nThe whole process takes the time it takes to export a CSV, upload it, review the gap report, and write the verified answers. No full-time docs person required.",
+          "id": "how_the_audit_works",
+          "metadata": {
+            "answer_summary": "Export your support tickets as a CSV, upload it at the intake link, and the audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording. You get a gap report showing the top repeat clusters and draft FAQ answer shells, then your support team adds the verified resolution before publishing.",
+            "kind": "how_it_works",
+            "order": 3,
+            "primary_question": "How does the gap audit work?"
+          },
+          "title": "Upload tickets, get the gap audit, review and publish answers"
+        },
+        {
+          "body_markdown": "The audit preserves the exact language your customers used so you can write FAQ answers that match their search terms. Here are examples from the uploaded tickets:\n\n**Reporting export:**\n- \"Attribution export blocked How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions Why can analysts view dashboards but not export reports?\"\n\n**Dashboard freshness:**\n- \"Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag How do we check whether the warehouse sync is delayed?\"\n\nThese are the questions your customers are asking. The gap audit ranks them by frequency so you know which ones to answer first.",
+          "id": "customer_wording_proof",
+          "metadata": {
+            "answer_summary": "",
+            "kind": "proof",
+            "order": 4,
+            "primary_question": ""
+          },
+          "title": "Customer wording from the uploaded tickets"
+        },
+        {
+          "body_markdown": "No. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.\n\n**Will this publish automatically?**\n\nNo. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.\n\n**Do we need a full-time docs person?**\n\nNo. The gap audit is built for support leads who do not have a dedicated docs team. You upload the ticket CSV, review the gap report, and your support team writes the verified answers. The audit does the clustering and ranking work so you do not have to tag tickets manually or guess which gaps matter most.\n\n**What happens after I upload the CSV?**\n\nThe audit runs on the uploaded tickets and returns a gap report showing the top repeat clusters, customer wording examples, and draft FAQ answer shells. You review the report, prioritize the gaps, and write the verified answers. The audit does not access your live support system or publish anything automatically.\n\n**Does FAQ Report publish automatically?**\n\nNo. The gap audit gives you review-ready draft FAQ shells, and you add the verified resolution before publishing. You control the publication process and the help center content.",
+          "id": "objections_and_control",
+          "metadata": {
+            "answer_summary": "No. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.",
+            "kind": "objection",
+            "order": 5,
+            "primary_question": "Will this publish automatically?"
+          },
+          "title": "You control what gets published and when"
+        },
+        {
+          "body_markdown": "The gap audit runs on your uploaded support tickets. You get a ranked list of repeated questions, customer wording examples, and draft FAQ answer shells. Your support team adds the verified resolution, you publish the answers, and you track whether ticket volume changes.\n\nNo live system access. No automatic publishing. No full-time docs person required.\n\n[Upload your ticket CSV and get the gap audit](/systems/ai-content-ops/intake).",
+          "id": "next_action",
+          "metadata": {
+            "answer_summary": "",
+            "kind": "conversion",
+            "order": 6,
+            "primary_question": ""
+          },
+          "title": "Upload your ticket CSV and get the gap audit"
+        }
+      ],
+      "seo_aeo_readiness": {
+        "checks": {
+          "answer_first_hero": true,
+          "audience_specificity": true,
+          "meta_description": true,
+          "metadata_consistency": true,
+          "objection_coverage": true,
+          "problem_solution_clarity": true,
+          "slug_quality": true,
+          "title_tag": true
+        },
+        "missing": [],
+        "passed": 8,
+        "status": "ready",
+        "total": 8
+      },
+      "slug": "support-ticket-faq-gap-audit",
+      "status": "approved",
+      "structured_data": {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebPage",
+            "about": {
+              "@type": "Thing",
+              "name": "Turn repeat support tickets into approved FAQ answers"
+            },
+            "audience": {
+              "@type": "Audience",
+              "audienceType": "SaaS support leaders carrying a repeat-ticket backlog"
+            },
+            "description": "Upload your support tickets and get a gap audit showing which repeated questions need FAQ coverage. Review-ready draft answers, no automatic publishing.",
+            "hasPart": [
+              {
+                "@type": "WebPageElement",
+                "additionalType": "problem",
+                "name": "Repeat tickets expose the same gaps every week",
+                "position": 1,
+                "text": "When the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters appeared four times each, meaning your team is writing the same answer multiple times instead of publishing it once.\n\nWhen the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management\u2014each appeared four times. That pattern means your team is writing the same answer multiple times instead of publishing it once.\n\nThe risk is not just queue length. It is that your support leads do not know which gaps to close first, so the backlog keeps the same shape. You need the repeated questions ranked by frequency so you can decide which FAQ answers to write and review."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "solution",
+                "name": "The gap audit shows which repeated questions need FAQ coverage",
+                "position": 2,
+                "text": "The Support Ticket FAQ Gap Audit takes your uploaded ticket CSV and returns a ranked list of repeated questions with customer wording preserved. You see which questions appeared most often, what language your customers used, and which gaps carry the highest repeat risk.\n\nThe audit does not publish automatically. It gives you review-ready draft FAQ shells so your support team can add the verified resolution before you publish. That means you control what goes live, and you can prioritize the gaps that matter most to your queue.\n\nThe outcome is a clear next action: write and review the FAQ answers for the top repeat clusters, then track whether ticket volume changes after publication."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "how_it_works",
+                "name": "Upload tickets, get the gap audit, review and publish answers",
+                "position": 3,
+                "text": "Export your support tickets as a CSV, upload it at the intake link, and the audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording. You get a gap report showing the top repeat clusters and draft FAQ answer shells, then your support team adds the verified resolution before publishing.\n\n1. Export your support tickets as a CSV. Include ticket title, body, and any tags or categories you already use.\n2. Upload the CSV at [/systems/ai-content-ops/intake](/systems/ai-content-ops/intake). The audit runs on the uploaded tickets\u2014no live system access required.\n3. The audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording so you see the exact language your customers used.\n4. You get a gap report showing the top repeat clusters and draft FAQ answer shells. The drafts include the customer question but not the verified resolution\u2014your support team adds that before publishing.\n5. Review the draft answers, add the verified steps, and publish the FAQ entries to your help center.\n6. Track whether ticket volume changes after publication. The audit does not predict future ticket reduction, but it gives you the baseline to measure it.\n\nThe whole process takes the time it takes to export a CSV, upload it, review the gap report, and write the verified answers. No full-time docs person required."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "proof",
+                "name": "Customer wording from the uploaded tickets",
+                "position": 4,
+                "text": "The audit preserves the exact language your customers used so you can write FAQ answers that match their search terms. Here are examples from the uploaded tickets:\n\n**Reporting export:**\n- \"Attribution export blocked How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions Why can analysts view dashboards but not export reports?\"\n\n**Dashboard freshness:**\n- \"Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag How do we check whether the warehouse sync is delayed?\"\n\nThese are the questions your customers are asking. The gap audit ranks them by frequency so you know which ones to answer first."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "objection",
+                "name": "You control what gets published and when",
+                "position": 5,
+                "text": "No. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.\n\n**Will this publish automatically?**\n\nNo. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.\n\n**Do we need a full-time docs person?**\n\nNo. The gap audit is built for support leads who do not have a dedicated docs team. You upload the ticket CSV, review the gap report, and your support team writes the verified answers. The audit does the clustering and ranking work so you do not have to tag tickets manually or guess which gaps matter most.\n\n**What happens after I upload the CSV?**\n\nThe audit runs on the uploaded tickets and returns a gap report showing the top repeat clusters, customer wording examples, and draft FAQ answer shells. You review the report, prioritize the gaps, and write the verified answers. The audit does not access your live support system or publish anything automatically.\n\n**Does FAQ Report publish automatically?**\n\nNo. The gap audit gives you review-ready draft FAQ shells, and you add the verified resolution before publishing. You control the publication process and the help center content."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "conversion",
+                "name": "Upload your ticket CSV and get the gap audit",
+                "position": 6,
+                "text": "The gap audit runs on your uploaded support tickets. You get a ranked list of repeated questions, customer wording examples, and draft FAQ answer shells. Your support team adds the verified resolution, you publish the answers, and you track whether ticket volume changes.\n\nNo live system access. No automatic publishing. No full-time docs person required.\n\n[Upload your ticket CSV and get the gap audit](/systems/ai-content-ops/intake)."
+              }
+            ],
+            "name": "Support Ticket FAQ Gap Audit | Cut Repeat Tickets",
+            "potentialAction": {
+              "@type": "Action",
+              "name": "Upload Ticket CSV -- Get the Gap Audit",
+              "target": "/systems/ai-content-ops/intake"
+            }
+          },
+          {
+            "@type": "FAQPage",
+            "mainEntity": [
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "When the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters appeared four times each, meaning your team is writing the same answer multiple times instead of publishing it once."
+                },
+                "name": "Why do the same support questions keep coming back?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "The Support Ticket FAQ Gap Audit takes your uploaded ticket CSV and returns a ranked list of repeated questions with customer wording preserved. You see which questions appeared most often, what language your customers used, and which gaps carry the highest repeat risk."
+                },
+                "name": "What does the gap audit show me?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Export your support tickets as a CSV, upload it at the intake link, and the audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording. You get a gap report showing the top repeat clusters and draft FAQ answer shells, then your support team adds the verified resolution before publishing."
+                },
+                "name": "How does the gap audit work?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval."
+                },
+                "name": "Will this publish automatically?"
+              }
+            ],
+            "name": "Cut Repeat Support Tickets with Review-Ready FAQ Answers FAQs"
+          }
+        ]
+      },
+      "title": "Cut Repeat Support Tickets with Review-Ready FAQ Answers",
+      "value_prop": "Turn repeat support tickets into approved FAQ answers"
+    },
+    {
+      "campaign_name": "Support Ticket FAQ Gap Audit",
+      "cta": {
+        "label": "Upload Ticket CSV -- Get the Gap Audit",
+        "url": "/systems/ai-content-ops/intake",
+        "variant": "primary"
+      },
+      "generation_input_tokens": 3797,
+      "generation_output_tokens": 1679,
+      "generation_parse_attempts": 1,
+      "generation_quality_repair_attempts": 0,
+      "generation_quality_repair_history": [
+        {
+          "attempt": 0,
+          "blockers": [],
+          "passed": true,
+          "repair_issues": []
+        }
+      ],
+      "generation_total_tokens": null,
+      "geo_readiness": {
+        "checks": {
+          "answer_extractability": true,
+          "audience_entity_clarity": true,
+          "claim_safety": true,
+          "conversion_path_clarity": true,
+          "offer_entity_clarity": true,
+          "section_semantics": true,
+          "trust_signal_visibility": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "hero": {
+        "cta_label": "Upload Ticket CSV -- Get the Gap Audit",
+        "cta_url": "/systems/ai-content-ops/intake",
+        "headline": "Your team answers the same questions every week",
+        "subheadline": "Upload your ticket CSV and see which repeat questions need approved FAQ answers before they hit the queue again."
+      },
+      "id": "49e324c1-f331-404d-bfa4-dcbcb5387027",
+      "meta": {
+        "description": "Upload your ticket CSV and see which repeat questions need approved FAQ answers. Turn support ticket patterns into help-center coverage.",
+        "og_image_url": "",
+        "title_tag": "Stop Answering the Same Support Tickets Every Week"
+      },
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "campaign_name": "Support Ticket FAQ Gap Audit",
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_quality_repair_attempts": 0,
+        "generation_quality_repair_history": [
+          {
+            "attempt": 0,
+            "blockers": [],
+            "passed": true,
+            "repair_issues": []
+          }
+        ],
+        "generation_usage": {
+          "billable_input_tokens": 126,
+          "cache_write_tokens": 3671,
+          "cached_tokens": 0,
+          "input_tokens": 3797,
+          "output_tokens": 1679,
+          "reasoning_tokens": 0
+        },
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "source_context": {
+          "customer_wording_examples": [
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-001",
+              "source_title": "Attribution export blocked",
+              "text": "Attribution export blocked How do I export attribution reports before our board meeting?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-002",
+              "source_title": "CSV export missing fields",
+              "text": "CSV export missing fields Why is the campaign CSV export missing source and owner columns?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-003",
+              "source_title": "Export scheduled report",
+              "text": "Export scheduled report Can I schedule a weekly attribution report export for finance?"
+            },
+            {
+              "pain_category": "reporting export",
+              "source_id": "saas-demo-004",
+              "source_title": "Dashboard export permissions",
+              "text": "Dashboard export permissions Why can analysts view dashboards but not export reports?"
+            },
+            {
+              "pain_category": "dashboard freshness",
+              "source_id": "saas-demo-005",
+              "source_title": "Dashboard stale data",
+              "text": "Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?"
+            },
+            {
+              "pain_category": "dashboard freshness",
+              "source_id": "saas-demo-006",
+              "source_title": "Warehouse sync lag",
+              "text": "Warehouse sync lag How do we check whether the warehouse sync is delayed?"
+            }
+          ],
+          "has_dated_window": false,
+          "has_measured_outcomes": false,
+          "included_ticket_row_count": 36,
+          "measured_outcome_count": 0,
+          "question_like_ticket_count": 35,
+          "skipped_ticket_row_count": 0,
+          "source_row_count": 36,
+          "support_ticket_resolution_evidence_count": 0,
+          "support_ticket_resolution_evidence_present": false,
+          "top_ticket_clusters": [
+            {
+              "count": 4,
+              "label": "reporting export"
+            },
+            {
+              "count": 4,
+              "label": "dashboard freshness"
+            },
+            {
+              "count": 4,
+              "label": "sso setup"
+            },
+            {
+              "count": 4,
+              "label": "permissions and seats"
+            },
+            {
+              "count": 4,
+              "label": "api and webhooks"
+            },
+            {
+              "count": 4,
+              "label": "integration sync"
+            },
+            {
+              "count": 4,
+              "label": "data import"
+            },
+            {
+              "count": 4,
+              "label": "workflow automation"
+            },
+            {
+              "count": 4,
+              "label": "billing and plan management"
+            }
+          ],
+          "truncated_ticket_row_count": 0
+        },
+        "variant_angle": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step."
+      },
+      "output_checks": {
+        "answer_first_hero": true,
+        "audience_specificity": true,
+        "meta_description": true,
+        "metadata_consistency": true,
+        "objection_coverage": true,
+        "problem_solution_clarity": true,
+        "slug_quality": true,
+        "title_tag": true
+      },
+      "passed_output_checks": 8,
+      "persona": "SaaS support leaders carrying a repeat-ticket backlog",
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "reference_count": 0,
+      "reference_ids": [],
+      "section_count": 6,
+      "sections": [
+        {
+          "body_markdown": "The same questions come back because your help center does not have approved answers yet. In the uploaded tickets, 35 out of 36 were question-shaped, and the top 9 clusters each appeared 4 times.\n\nYour support team closes tickets, but the same questions come back. In the uploaded tickets, 35 out of 36 were question-shaped. The top clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, billing and plan management\u2014each appeared 4 times. When the same question hits the queue multiple times, your team writes the same answer multiple times. The backlog does not shrink because the help center does not have the answer yet.",
+          "id": "repeat_ticket_backlog",
+          "metadata": {
+            "answer_summary": "The same questions come back because your help center does not have approved answers yet. In the uploaded tickets, 35 out of 36 were question-shaped, and the top 9 clusters each appeared 4 times.",
+            "kind": "problem",
+            "order": 1,
+            "primary_question": "Why do we keep getting the same support tickets?"
+          },
+          "title": "The repeat-ticket backlog keeps growing"
+        },
+        {
+          "body_markdown": "Customers describe the friction they hit, not your internal product names. Examples from uploaded tickets include \"Attribution export blocked,\" \"CSV export missing fields,\" \"Dashboard stale data,\" and \"Warehouse sync lag.\"\n\nYour customers do not use your internal product names. They describe the friction they hit:\n\n- \"Attribution export blocked\u2014How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields\u2014Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report\u2014Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions\u2014Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data\u2014Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag\u2014How do we check whether the warehouse sync is delayed?\"\n\nThese are real ticket titles from the uploaded CSV. When your help center does not match this wording, customers open a ticket instead of finding the answer.",
+          "id": "customer_wording_examples",
+          "metadata": {
+            "answer_summary": "Customers describe the friction they hit, not your internal product names. Examples from uploaded tickets include \"Attribution export blocked,\" \"CSV export missing fields,\" \"Dashboard stale data,\" and \"Warehouse sync lag.\"",
+            "kind": "problem",
+            "order": 2,
+            "primary_question": "What exact wording do customers use when they ask these questions?"
+          },
+          "title": "Here is how your customers ask the question"
+        },
+        {
+          "body_markdown": "The audit groups question-shaped tickets by topic, counts repeat clusters, and pulls customer wording. You get review-ready FAQ shells with the customer's question and a placeholder for your team to add the verified resolution before publishing.\n\nUpload your support ticket CSV. The audit groups question-shaped tickets by topic, counts how many times each cluster appeared, and pulls the customer wording. You see which repeat questions do not have help-center answers yet. The audit does not publish anything. It gives your team a list of review-ready FAQ shells with the customer's exact question and a placeholder for the verified resolution. Your support team adds the correct answer, reviews it, and decides when to publish.",
+          "id": "gap_audit_process",
+          "metadata": {
+            "answer_summary": "The audit groups question-shaped tickets by topic, counts repeat clusters, and pulls customer wording. You get review-ready FAQ shells with the customer's question and a placeholder for your team to add the verified resolution before publishing.",
+            "kind": "how_it_works",
+            "order": 3,
+            "primary_question": "What happens after I upload the CSV?"
+          },
+          "title": "The audit shows which questions need answers"
+        },
+        {
+          "body_markdown": "No. The audit gives you review-ready FAQ shells with customer questions and placeholders. Your team adds the verified resolution, reviews it, and decides when to publish. Nothing goes live without your approval.\n\nThe audit does not push answers to your help center. It does not write procedural steps or guess at product details. Each FAQ shell says \"Draft answer\u2014support team should add the verified resolution before publishing.\" Your team reviews the question, writes or pastes the correct answer, checks it, and publishes when ready. You control what goes live and when.",
+          "id": "no_auto_publish",
+          "metadata": {
+            "answer_summary": "No. The audit gives you review-ready FAQ shells with customer questions and placeholders. Your team adds the verified resolution, reviews it, and decides when to publish. Nothing goes live without your approval.",
+            "kind": "objection",
+            "order": 4,
+            "primary_question": "Will this publish automatically?"
+          },
+          "title": "Nothing publishes without your approval"
+        },
+        {
+          "body_markdown": "No. Your support team already knows the answers. The audit removes the noticing and drafting work. A support lead or senior agent can review the FAQ shells and publish the verified answers without hiring a dedicated docs writer.\n\nYour support team already knows the answers. The audit removes the step where someone has to notice the pattern, remember to write it down, and find time to draft the FAQ. The audit does that noticing and drafting work. Your team reviews the question, confirms the answer is correct, and publishes. The support lead or a senior agent can handle the review queue without hiring a dedicated docs writer.",
+          "id": "no_fulltime_docs_person",
+          "metadata": {
+            "answer_summary": "No. Your support team already knows the answers. The audit removes the noticing and drafting work. A support lead or senior agent can review the FAQ shells and publish the verified answers without hiring a dedicated docs writer.",
+            "kind": "objection",
+            "order": 5,
+            "primary_question": "Do we need a full-time docs person?"
+          },
+          "title": "You do not need a full-time docs person"
+        },
+        {
+          "body_markdown": "Export your support tickets as CSV. Upload the file. The audit runs and shows you which questions appeared multiple times, how your customers worded them, and which ones need help-center answers. You decide which FAQ answers to write first and when to publish them. No auto-publish. No placeholder content. No fake procedural steps. Just the repeat-question evidence and the review-ready FAQ shells your team needs to close the gap.",
+          "id": "next_action",
+          "metadata": {
+            "answer_summary": "",
+            "kind": "conversion",
+            "order": 6,
+            "primary_question": ""
+          },
+          "title": "Upload your ticket CSV and see the repeat-question clusters"
+        }
+      ],
+      "seo_aeo_readiness": {
+        "checks": {
+          "answer_first_hero": true,
+          "audience_specificity": true,
+          "meta_description": true,
+          "metadata_consistency": true,
+          "objection_coverage": true,
+          "problem_solution_clarity": true,
+          "slug_quality": true,
+          "title_tag": true
+        },
+        "missing": [],
+        "passed": 8,
+        "status": "ready",
+        "total": 8
+      },
+      "slug": "support-ticket-faq-gap-audit",
+      "status": "approved",
+      "structured_data": {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebPage",
+            "about": {
+              "@type": "Thing",
+              "name": "Turn repeat support tickets into approved FAQ answers"
+            },
+            "audience": {
+              "@type": "Audience",
+              "audienceType": "SaaS support leaders carrying a repeat-ticket backlog"
+            },
+            "description": "Upload your ticket CSV and see which repeat questions need approved FAQ answers. Turn support ticket patterns into help-center coverage.",
+            "hasPart": [
+              {
+                "@type": "WebPageElement",
+                "additionalType": "problem",
+                "name": "The repeat-ticket backlog keeps growing",
+                "position": 1,
+                "text": "The same questions come back because your help center does not have approved answers yet. In the uploaded tickets, 35 out of 36 were question-shaped, and the top 9 clusters each appeared 4 times.\n\nYour support team closes tickets, but the same questions come back. In the uploaded tickets, 35 out of 36 were question-shaped. The top clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, billing and plan management\u2014each appeared 4 times. When the same question hits the queue multiple times, your team writes the same answer multiple times. The backlog does not shrink because the help center does not have the answer yet."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "problem",
+                "name": "Here is how your customers ask the question",
+                "position": 2,
+                "text": "Customers describe the friction they hit, not your internal product names. Examples from uploaded tickets include \"Attribution export blocked,\" \"CSV export missing fields,\" \"Dashboard stale data,\" and \"Warehouse sync lag.\"\n\nYour customers do not use your internal product names. They describe the friction they hit:\n\n- \"Attribution export blocked\u2014How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields\u2014Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report\u2014Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions\u2014Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data\u2014Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag\u2014How do we check whether the warehouse sync is delayed?\"\n\nThese are real ticket titles from the uploaded CSV. When your help center does not match this wording, customers open a ticket instead of finding the answer."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "how_it_works",
+                "name": "The audit shows which questions need answers",
+                "position": 3,
+                "text": "The audit groups question-shaped tickets by topic, counts repeat clusters, and pulls customer wording. You get review-ready FAQ shells with the customer's question and a placeholder for your team to add the verified resolution before publishing.\n\nUpload your support ticket CSV. The audit groups question-shaped tickets by topic, counts how many times each cluster appeared, and pulls the customer wording. You see which repeat questions do not have help-center answers yet. The audit does not publish anything. It gives your team a list of review-ready FAQ shells with the customer's exact question and a placeholder for the verified resolution. Your support team adds the correct answer, reviews it, and decides when to publish."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "objection",
+                "name": "Nothing publishes without your approval",
+                "position": 4,
+                "text": "No. The audit gives you review-ready FAQ shells with customer questions and placeholders. Your team adds the verified resolution, reviews it, and decides when to publish. Nothing goes live without your approval.\n\nThe audit does not push answers to your help center. It does not write procedural steps or guess at product details. Each FAQ shell says \"Draft answer\u2014support team should add the verified resolution before publishing.\" Your team reviews the question, writes or pastes the correct answer, checks it, and publishes when ready. You control what goes live and when."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "objection",
+                "name": "You do not need a full-time docs person",
+                "position": 5,
+                "text": "No. Your support team already knows the answers. The audit removes the noticing and drafting work. A support lead or senior agent can review the FAQ shells and publish the verified answers without hiring a dedicated docs writer.\n\nYour support team already knows the answers. The audit removes the step where someone has to notice the pattern, remember to write it down, and find time to draft the FAQ. The audit does that noticing and drafting work. Your team reviews the question, confirms the answer is correct, and publishes. The support lead or a senior agent can handle the review queue without hiring a dedicated docs writer."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "conversion",
+                "name": "Upload your ticket CSV and see the repeat-question clusters",
+                "position": 6,
+                "text": "Export your support tickets as CSV. Upload the file. The audit runs and shows you which questions appeared multiple times, how your customers worded them, and which ones need help-center answers. You decide which FAQ answers to write first and when to publish them. No auto-publish. No placeholder content. No fake procedural steps. Just the repeat-question evidence and the review-ready FAQ shells your team needs to close the gap."
+              }
+            ],
+            "name": "Stop Answering the Same Support Tickets Every Week",
+            "potentialAction": {
+              "@type": "Action",
+              "name": "Upload Ticket CSV -- Get the Gap Audit",
+              "target": "/systems/ai-content-ops/intake"
+            }
+          },
+          {
+            "@type": "FAQPage",
+            "mainEntity": [
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "The same questions come back because your help center does not have approved answers yet. In the uploaded tickets, 35 out of 36 were question-shaped, and the top 9 clusters each appeared 4 times."
+                },
+                "name": "Why do we keep getting the same support tickets?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Customers describe the friction they hit, not your internal product names. Examples from uploaded tickets include \"Attribution export blocked,\" \"CSV export missing fields,\" \"Dashboard stale data,\" and \"Warehouse sync lag.\""
+                },
+                "name": "What exact wording do customers use when they ask these questions?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "The audit groups question-shaped tickets by topic, counts repeat clusters, and pulls customer wording. You get review-ready FAQ shells with the customer's question and a placeholder for your team to add the verified resolution before publishing."
+                },
+                "name": "What happens after I upload the CSV?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. The audit gives you review-ready FAQ shells with customer questions and placeholders. Your team adds the verified resolution, reviews it, and decides when to publish. Nothing goes live without your approval."
+                },
+                "name": "Will this publish automatically?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. Your support team already knows the answers. The audit removes the noticing and drafting work. A support lead or senior agent can review the FAQ shells and publish the verified answers without hiring a dedicated docs writer."
+                },
+                "name": "Do we need a full-time docs person?"
+              }
+            ],
+            "name": "Stop Answering the Same Support Tickets Every Week FAQs"
+          }
+        ]
+      },
+      "title": "Stop Answering the Same Support Tickets Every Week",
+      "value_prop": "Turn repeat support tickets into approved FAQ answers"
+    }
+  ]
+}

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json
@@ -3,14 +3,14 @@
   "filters": {
     "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
     "id": [
-      "49e324c1-f331-404d-bfa4-dcbcb5387027",
-      "2b09400f-a8b9-4787-86dd-ca655686d246",
-      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+      "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
+      "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
+      "104b8793-9015-4aac-abab-41917dd38309"
     ],
     "ids": [
-      "49e324c1-f331-404d-bfa4-dcbcb5387027",
-      "2b09400f-a8b9-4787-86dd-ca655686d246",
-      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+      "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
+      "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
+      "104b8793-9015-4aac-abab-41917dd38309"
     ]
   },
   "limit": 3,
@@ -18,12 +18,12 @@
     {
       "campaign_name": "Support Ticket FAQ Gap Audit",
       "cta": {
-        "label": "Upload Ticket CSV \u2014 Get the Gap Audit",
+        "label": "Upload Ticket CSV -- Get the Gap Audit",
         "url": "/systems/ai-content-ops/intake",
         "variant": "primary"
       },
       "generation_input_tokens": 3797,
-      "generation_output_tokens": 2664,
+      "generation_output_tokens": 2522,
       "generation_parse_attempts": 1,
       "generation_quality_repair_attempts": 0,
       "generation_quality_repair_history": [
@@ -51,16 +51,16 @@
         "total": 7
       },
       "hero": {
-        "cta_label": "Upload Ticket CSV \u2014 Get the Gap Audit",
+        "cta_label": "Upload Ticket CSV -- Get the Gap Audit",
         "cta_url": "/systems/ai-content-ops/intake",
-        "headline": "Your repeat tickets already told you what's missing",
-        "subheadline": "Upload 90 days of support CSV and get a review-ready FAQ audit showing which questions cost you the most repeat volume."
+        "headline": "Your repeat tickets already show the FAQ gaps",
+        "subheadline": "Upload your last 90 days of support tickets and get a gap audit that shows which questions repeat most and which answers your help center is missing."
       },
-      "id": "a1181e5e-91e3-49d0-9ad1-1c5494783330",
+      "id": "104b8793-9015-4aac-abab-41917dd38309",
       "meta": {
-        "description": "Upload 90 days of support tickets and get a prioritized FAQ audit showing which repeat questions cost you the most volume. Draft shells included.",
+        "description": "Upload your support ticket CSV and get a gap audit that shows which questions repeat most and which FAQ answers your help center is missing.",
         "og_image_url": "",
-        "title_tag": "Support Ticket FAQ Gap Audit \u2014 Find Repeat Questions"
+        "title_tag": "Support Ticket FAQ Gap Audit \u2013 Turn Repeat Questions Into Answers"
       },
       "metadata": {
         "brand_voice_audit": {
@@ -99,7 +99,7 @@
           "cache_write_tokens": 0,
           "cached_tokens": 3671,
           "input_tokens": 3797,
-          "output_tokens": 2664,
+          "output_tokens": 2522,
           "reasoning_tokens": 0
         },
         "scope": {
@@ -213,95 +213,106 @@
       "reasoning_wedge": null,
       "reference_count": 0,
       "reference_ids": [],
-      "section_count": 8,
+      "section_count": 9,
       "sections": [
         {
-          "body_markdown": "In the uploaded tickets, 35 out of 36 were question-shaped and clustered into 9 repeat patterns including reporting export, dashboard freshness, SSO setup, and permissions. When the same question appears four times in one quarter, you're carrying FAQ debt that costs another reply each time.\n\nIn the uploaded tickets, 35 out of 36 were question-shaped, and they clustered into 9 repeat patterns: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). When the same question appears four times in one quarter, you're carrying FAQ debt. Each repeat costs another reply, another context switch, and another chance the customer gives up before asking.\n\nThe audit shows you which clusters represent the highest repeat risk and gives you draft FAQ shells for each one. You decide which answers to write first.",
-          "id": "observed_ticket_pattern",
+          "body_markdown": "Support teams see the same questions every week because the help center does not have the answer or the answer is not findable. In the uploaded tickets, 35 of 36 tickets were question-shaped, and the top clusters repeated 4 times each.\n\nSupport teams see the same questions every week. In the uploaded tickets, 35 of 36 tickets were question-shaped. The top clusters were reporting export (4 tickets), dashboard freshness (4 tickets), SSO setup (4 tickets), permissions and seats (4 tickets), API and webhooks (4 tickets), integration sync (4 tickets), data import (4 tickets), workflow automation (4 tickets), and billing and plan management (4 tickets). When the same question appears multiple times, your help center does not have the answer or the answer is not findable.\n\nRepeat questions are not a training problem. They are a documentation gap. The ticket queue shows you where the gaps are.",
+          "id": "observed_repeat_pattern",
           "metadata": {
-            "answer_summary": "In the uploaded tickets, 35 out of 36 were question-shaped and clustered into 9 repeat patterns including reporting export, dashboard freshness, SSO setup, and permissions. When the same question appears four times in one quarter, you're carrying FAQ debt that costs another reply each time.",
+            "answer_summary": "Support teams see the same questions every week because the help center does not have the answer or the answer is not findable. In the uploaded tickets, 35 of 36 tickets were question-shaped, and the top clusters repeated 4 times each.",
             "kind": "problem",
             "order": 1,
-            "primary_question": "What did the uploaded support tickets show about repeat questions?"
+            "primary_question": "Why do support teams keep answering the same questions?"
           },
-          "title": "What 36 uploaded tickets revealed about repeat support load"
+          "title": "Support teams see the same questions every week"
         },
         {
-          "body_markdown": "Uploaded tickets show exact customer phrasing such as \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\" and \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\" The audit preserves this wording so FAQ answers match the search terms customers already use.\n\nSupport leaders know that help-center language rarely matches the way customers phrase the problem. Here's what the uploaded tickets said:\n\n- \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields \u2014 Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report \u2014 Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions \u2014 Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag \u2014 How do we check whether the warehouse sync is delayed?\"\n\nThe audit preserves this wording so you can write FAQ answers that match the search terms customers already use. You're not guessing what they'll type \u2014 you're seeing what they typed.",
-          "id": "customer_wording_examples",
+          "body_markdown": "Here is how customers describe the problem. These examples come from the uploaded tickets:\n\n- \"Attribution export blocked \u2013 How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields \u2013 Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report \u2013 Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions \u2013 Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data \u2013 Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag \u2013 How do we check whether the warehouse sync is delayed?\"\n\nThese are not edge cases. They are the questions your customers ask when the help center does not answer them first.",
+          "id": "customer_wording_evidence",
           "metadata": {
-            "answer_summary": "Uploaded tickets show exact customer phrasing such as \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\" and \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\" The audit preserves this wording so FAQ answers match the search terms customers already use.",
+            "answer_summary": "",
             "kind": "proof",
             "order": 2,
-            "primary_question": "How do customers phrase the repeat questions in their own words?"
+            "primary_question": ""
           },
-          "title": "How customers actually asked the questions"
+          "title": "Here is how customers describe the problem"
         },
         {
-          "body_markdown": "The audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell with the customer's original question wording, the ticket count, and a placeholder for the verified answer. You add the procedural steps and route the draft to your review queue.\n\nThe Support Ticket FAQ Gap Audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell that includes the customer's original question wording, the ticket count, and a placeholder for the verified answer. The shell says \"Draft answer \u2014 support team should add the verified resolution before publishing\" because the uploaded tickets contain customer questions but not verified support resolutions.\n\nYou decide which clusters to write first, add the procedural steps your team already knows, and route the draft to your review queue. The audit does not publish automatically. It gives you the structure so you can focus on writing the answer instead of hunting for the pattern.",
-          "id": "solution_faq_audit_output",
+          "body_markdown": "The gap audit clusters repeat questions, ranks them by frequency, and drafts review-ready FAQ answer shells. You see the top gaps, the customer wording, and the draft answers your support team should verify before publishing.\n\nThe gap audit shows which FAQ answers to write. You upload your support ticket CSV. The audit clusters the repeat questions, ranks them by frequency, and drafts review-ready FAQ answer shells. You see the top gaps, the customer wording, and the draft answers your support team should verify before publishing.\n\nThe audit does not publish automatically. It gives your support lead the repeat-question list and the draft answers. Your team reviews the drafts, adds the verified resolution steps, and approves publication. The audit turns the repeat-ticket backlog into a prioritized FAQ roadmap.",
+          "id": "gap_audit_solution",
           "metadata": {
-            "answer_summary": "The audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell with the customer's original question wording, the ticket count, and a placeholder for the verified answer. You add the procedural steps and route the draft to your review queue.",
+            "answer_summary": "The gap audit clusters repeat questions, ranks them by frequency, and drafts review-ready FAQ answer shells. You see the top gaps, the customer wording, and the draft answers your support team should verify before publishing.",
             "kind": "solution",
             "order": 3,
-            "primary_question": "What does the FAQ Gap Audit deliver?"
+            "primary_question": "What does the gap audit give me?"
           },
-          "title": "What you get: draft FAQ shells tied to repeat ticket clusters"
+          "title": "The gap audit shows which FAQ answers to write"
         },
         {
-          "body_markdown": "Export your support tickets as CSV, upload at the intake link, and get an audit report showing repeat clusters ranked by ticket count. Review the clusters, write the verified answers with procedural steps your team knows, and route to your review queue. The audit does not publish automatically.\n\n1. Export your support tickets as CSV. Include ticket ID, subject line, and body text. The audit needs at least 30 days of tickets; 90 days gives better cluster confidence.\n2. Upload the CSV at the intake link. The system reads the ticket text, identifies question-shaped tickets, and groups them by topic similarity.\n3. Get the audit report. It shows repeat clusters ranked by ticket count, preserves customer wording, and generates draft FAQ shells for each cluster.\n4. Review the clusters. Decide which FAQ gaps represent the highest repeat risk or the easiest wins.\n5. Write the verified answers. Add the procedural steps, UI paths, or policy details your support team already knows.\n6. Route to your review queue. The audit does not publish automatically. You control what goes live and when.\n\nThe whole process takes the time it takes to export a CSV and decide which clusters to write first. Writing the answers is on you.",
-          "id": "how_it_works_upload_to_audit",
+          "body_markdown": "You upload your support ticket CSV. The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication.\n\nHow the audit process works:\n\n1. You export your support ticket CSV from the last 90 days.\n2. You upload the CSV at [/systems/ai-content-ops/intake](/systems/ai-content-ops/intake).\n3. The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells.\n4. You receive the gap audit report with the top clusters, customer wording examples, and draft answers.\n5. Your support team reviews each draft answer, adds the verified resolution steps, and approves publication.\n\nThe audit does not write final procedural steps or publish answers without your approval. It shows you the repeat-question exposure and gives you the draft structure. Your team owns the verification and publication decision.",
+          "id": "how_it_works",
           "metadata": {
-            "answer_summary": "Export your support tickets as CSV, upload at the intake link, and get an audit report showing repeat clusters ranked by ticket count. Review the clusters, write the verified answers with procedural steps your team knows, and route to your review queue. The audit does not publish automatically.",
+            "answer_summary": "You upload your support ticket CSV. The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication.",
             "kind": "how_it_works",
             "order": 4,
-            "primary_question": "How does the Support Ticket FAQ Gap Audit process work?"
+            "primary_question": "How does the audit process work?"
           },
           "title": "How the audit process works"
         },
         {
-          "body_markdown": "No. The audit generates draft FAQ shells with customer question wording and a placeholder for the verified answer. You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center without your approval.\n\nNo. The audit generates draft FAQ shells with customer question wording and a placeholder that says \"Draft answer \u2014 support team should add the verified resolution before publishing.\" You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center, CMS, or knowledge base without your approval.\n\nThis matters because uploaded tickets show repeated questions but not verified support resolutions. The audit can tell you which questions cost you the most repeat volume, but it cannot write the procedural steps, permission rules, or UI paths that make the answer useful. That's your team's job.",
-          "id": "objection_auto_publish_risk",
+          "body_markdown": "The audit does not publish automatically. It drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.\n\nThe audit does not publish automatically. It drafts review-ready FAQ answer shells and shows you the repeat-question clusters. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.\n\nThe draft answers include the customer question and a placeholder for the verified resolution. Your team adds the exact UI paths, permission rules, menu names, and fix instructions before publishing. The audit gives you the repeat-question list and the draft structure. Your team gives the answer the accuracy.",
+          "id": "objection_auto_publish",
           "metadata": {
-            "answer_summary": "No. The audit generates draft FAQ shells with customer question wording and a placeholder for the verified answer. You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center without your approval.",
+            "answer_summary": "The audit does not publish automatically. It drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.",
             "kind": "objection",
             "order": 5,
-            "primary_question": "Will this publish FAQ answers automatically?"
+            "primary_question": "Will this publish automatically?"
           },
-          "title": "Does the audit publish FAQ answers automatically?"
+          "title": "The audit does not publish automatically"
         },
         {
-          "body_markdown": "No. The audit is built for support leaders without a dedicated docs team. It shows which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. If you have one person who can export a CSV and write three FAQ answers in a week, you have enough capacity.\n\nNo. The audit is built for support leaders who do not have a dedicated docs team. It shows you which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. Your support team already knows the verified resolutions \u2014 the audit just surfaces the pattern and gives you the draft structure.\n\nIf you have one person who can export a CSV, review a cluster list, and write three FAQ answers in a week, you have enough capacity to use this. The audit does not require ongoing maintenance, a content ops hire, or a full-time docs person. It requires deciding which repeat questions to answer first.",
-          "id": "objection_full_time_docs_person",
+          "body_markdown": "You do not need a full-time docs person. The audit drafts the FAQ answer shells. Your support team already knows the verified resolutions. They review the draft, add the fix steps, and approve publication. The audit turns the repeat-ticket backlog into a prioritized FAQ roadmap without hiring a dedicated docs writer.\n\nThe support lead owns the review and approval. The audit removes the blank-page problem and the prioritization guesswork. Your team focuses on verifying the answers, not finding the gaps.",
+          "id": "objection_fulltime_docs",
           "metadata": {
-            "answer_summary": "No. The audit is built for support leaders without a dedicated docs team. It shows which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. If you have one person who can export a CSV and write three FAQ answers in a week, you have enough capacity.",
+            "answer_summary": "You do not need a full-time docs person. The audit drafts the FAQ answer shells. Your support team already knows the verified resolutions. They review the draft, add the fix steps, and approve publication.",
             "kind": "objection",
             "order": 6,
-            "primary_question": "Do we need a full-time docs person to use the FAQ Gap Audit?"
+            "primary_question": "Do we need a full-time docs person?"
           },
-          "title": "Do we need a full-time docs person to use this?"
+          "title": "You do not need a full-time docs person"
         },
         {
-          "body_markdown": "The system reads the ticket text, identifies question-shaped tickets, groups them by topic similarity, and ranks clusters by ticket count. You get an audit report showing repeat patterns and draft FAQ shells. You review the clusters, add verified answers, and route to your review queue.\n\nAfter you upload the CSV, the system reads the ticket text and identifies question-shaped tickets. It groups them by topic similarity and ranks the clusters by ticket count. You get an audit report that shows the repeat patterns, preserves customer wording, and generates draft FAQ shells for each cluster.\n\nThe report does not include verified answers because the uploaded tickets contain customer questions but not support resolutions. You review the clusters, decide which FAQ gaps to write first, add the procedural steps your team knows, and route the draft to your review queue. The audit does not publish automatically.",
+          "body_markdown": "The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. You receive the gap audit report with the top clusters, customer wording examples, and draft answers for your team to review.\n\nWhat happens after I provide ticket data? The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. You receive the gap audit report with the top clusters, customer wording examples, and draft answers. Your support team reviews each draft, adds the verified resolution steps, and approves publication.\n\nThe audit does not write final procedural steps or publish answers without your approval. It shows you the repeat-question exposure and gives you the draft structure.",
           "id": "faq_after_upload",
           "metadata": {
-            "answer_summary": "The system reads the ticket text, identifies question-shaped tickets, groups them by topic similarity, and ranks clusters by ticket count. You get an audit report showing repeat patterns and draft FAQ shells. You review the clusters, add verified answers, and route to your review queue.",
+            "answer_summary": "The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. You receive the gap audit report with the top clusters, customer wording examples, and draft answers for your team to review.",
             "kind": "faq",
             "order": 7,
-            "primary_question": "What happens after I upload the CSV?"
+            "primary_question": "What happens after I provide ticket data?"
           },
-          "title": "What happens after I upload the CSV?"
+          "title": "What happens after I provide ticket data?"
         },
         {
-          "body_markdown": "Upload your support ticket CSV and get the audit report. It shows you which repeat questions cost you the most volume, preserves customer wording, and gives you draft FAQ shells for each cluster. You decide which answers to write first.\n\nThe audit does not publish automatically. It does not require a full-time docs person. It requires deciding which FAQ gaps represent the highest repeat risk and writing the verified answers your support team already knows.\n\nIf you're carrying a repeat-ticket backlog and you want to see the pattern, upload the CSV.",
-          "id": "conversion_next_action",
+          "body_markdown": "No. The audit drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.\n\nDoes FAQ Report publish automatically? No. The audit drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.\n\nThe draft answers include the customer question and a placeholder for the verified resolution. Your team adds the exact fix instructions before publishing.",
+          "id": "faq_auto_publish",
+          "metadata": {
+            "answer_summary": "No. The audit drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.",
+            "kind": "faq",
+            "order": 8,
+            "primary_question": "Does FAQ Report publish automatically?"
+          },
+          "title": "Does FAQ Report publish automatically?"
+        },
+        {
+          "body_markdown": "Upload your ticket CSV and get the gap audit. You will see the top repeat-question clusters, the customer wording, and the draft FAQ answers your support team should verify before publishing. The audit turns the repeat-ticket backlog into a prioritized FAQ roadmap.\n\nNo credit card. No setup call. Upload the CSV at [/systems/ai-content-ops/intake](/systems/ai-content-ops/intake) and get the gap audit.",
+          "id": "conversion_cta",
           "metadata": {
             "answer_summary": "",
             "kind": "conversion",
-            "order": 8,
+            "order": 9,
             "primary_question": ""
           },
-          "title": "Get your FAQ gap audit"
+          "title": "Upload your ticket CSV and get the gap audit"
         }
       ],
       "seo_aeo_readiness": {
@@ -335,69 +346,76 @@
               "@type": "Audience",
               "audienceType": "SaaS support leaders carrying a repeat-ticket backlog"
             },
-            "description": "Upload 90 days of support tickets and get a prioritized FAQ audit showing which repeat questions cost you the most volume. Draft shells included.",
+            "description": "Upload your support ticket CSV and get a gap audit that shows which questions repeat most and which FAQ answers your help center is missing.",
             "hasPart": [
               {
                 "@type": "WebPageElement",
                 "additionalType": "problem",
-                "name": "What 36 uploaded tickets revealed about repeat support load",
+                "name": "Support teams see the same questions every week",
                 "position": 1,
-                "text": "In the uploaded tickets, 35 out of 36 were question-shaped and clustered into 9 repeat patterns including reporting export, dashboard freshness, SSO setup, and permissions. When the same question appears four times in one quarter, you're carrying FAQ debt that costs another reply each time.\n\nIn the uploaded tickets, 35 out of 36 were question-shaped, and they clustered into 9 repeat patterns: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). When the same question appears four times in one quarter, you're carrying FAQ debt. Each repeat costs another reply, another context switch, and another chance the customer gives up before asking.\n\nThe audit shows you which clusters represent the highest repeat risk and gives you draft FAQ shells for each one. You decide which answers to write first."
+                "text": "Support teams see the same questions every week because the help center does not have the answer or the answer is not findable. In the uploaded tickets, 35 of 36 tickets were question-shaped, and the top clusters repeated 4 times each.\n\nSupport teams see the same questions every week. In the uploaded tickets, 35 of 36 tickets were question-shaped. The top clusters were reporting export (4 tickets), dashboard freshness (4 tickets), SSO setup (4 tickets), permissions and seats (4 tickets), API and webhooks (4 tickets), integration sync (4 tickets), data import (4 tickets), workflow automation (4 tickets), and billing and plan management (4 tickets). When the same question appears multiple times, your help center does not have the answer or the answer is not findable.\n\nRepeat questions are not a training problem. They are a documentation gap. The ticket queue shows you where the gaps are."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "proof",
-                "name": "How customers actually asked the questions",
+                "name": "Here is how customers describe the problem",
                 "position": 2,
-                "text": "Uploaded tickets show exact customer phrasing such as \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\" and \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\" The audit preserves this wording so FAQ answers match the search terms customers already use.\n\nSupport leaders know that help-center language rarely matches the way customers phrase the problem. Here's what the uploaded tickets said:\n\n- \"Attribution export blocked \u2014 How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields \u2014 Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report \u2014 Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions \u2014 Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data \u2014 Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag \u2014 How do we check whether the warehouse sync is delayed?\"\n\nThe audit preserves this wording so you can write FAQ answers that match the search terms customers already use. You're not guessing what they'll type \u2014 you're seeing what they typed."
+                "text": "Here is how customers describe the problem. These examples come from the uploaded tickets:\n\n- \"Attribution export blocked \u2013 How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields \u2013 Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report \u2013 Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions \u2013 Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data \u2013 Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag \u2013 How do we check whether the warehouse sync is delayed?\"\n\nThese are not edge cases. They are the questions your customers ask when the help center does not answer them first."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "solution",
-                "name": "What you get: draft FAQ shells tied to repeat ticket clusters",
+                "name": "The gap audit shows which FAQ answers to write",
                 "position": 3,
-                "text": "The audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell with the customer's original question wording, the ticket count, and a placeholder for the verified answer. You add the procedural steps and route the draft to your review queue.\n\nThe Support Ticket FAQ Gap Audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell that includes the customer's original question wording, the ticket count, and a placeholder for the verified answer. The shell says \"Draft answer \u2014 support team should add the verified resolution before publishing\" because the uploaded tickets contain customer questions but not verified support resolutions.\n\nYou decide which clusters to write first, add the procedural steps your team already knows, and route the draft to your review queue. The audit does not publish automatically. It gives you the structure so you can focus on writing the answer instead of hunting for the pattern."
+                "text": "The gap audit clusters repeat questions, ranks them by frequency, and drafts review-ready FAQ answer shells. You see the top gaps, the customer wording, and the draft answers your support team should verify before publishing.\n\nThe gap audit shows which FAQ answers to write. You upload your support ticket CSV. The audit clusters the repeat questions, ranks them by frequency, and drafts review-ready FAQ answer shells. You see the top gaps, the customer wording, and the draft answers your support team should verify before publishing.\n\nThe audit does not publish automatically. It gives your support lead the repeat-question list and the draft answers. Your team reviews the drafts, adds the verified resolution steps, and approves publication. The audit turns the repeat-ticket backlog into a prioritized FAQ roadmap."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "how_it_works",
                 "name": "How the audit process works",
                 "position": 4,
-                "text": "Export your support tickets as CSV, upload at the intake link, and get an audit report showing repeat clusters ranked by ticket count. Review the clusters, write the verified answers with procedural steps your team knows, and route to your review queue. The audit does not publish automatically.\n\n1. Export your support tickets as CSV. Include ticket ID, subject line, and body text. The audit needs at least 30 days of tickets; 90 days gives better cluster confidence.\n2. Upload the CSV at the intake link. The system reads the ticket text, identifies question-shaped tickets, and groups them by topic similarity.\n3. Get the audit report. It shows repeat clusters ranked by ticket count, preserves customer wording, and generates draft FAQ shells for each cluster.\n4. Review the clusters. Decide which FAQ gaps represent the highest repeat risk or the easiest wins.\n5. Write the verified answers. Add the procedural steps, UI paths, or policy details your support team already knows.\n6. Route to your review queue. The audit does not publish automatically. You control what goes live and when.\n\nThe whole process takes the time it takes to export a CSV and decide which clusters to write first. Writing the answers is on you."
+                "text": "You upload your support ticket CSV. The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication.\n\nHow the audit process works:\n\n1. You export your support ticket CSV from the last 90 days.\n2. You upload the CSV at [/systems/ai-content-ops/intake](/systems/ai-content-ops/intake).\n3. The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells.\n4. You receive the gap audit report with the top clusters, customer wording examples, and draft answers.\n5. Your support team reviews each draft answer, adds the verified resolution steps, and approves publication.\n\nThe audit does not write final procedural steps or publish answers without your approval. It shows you the repeat-question exposure and gives you the draft structure. Your team owns the verification and publication decision."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "objection",
-                "name": "Does the audit publish FAQ answers automatically?",
+                "name": "The audit does not publish automatically",
                 "position": 5,
-                "text": "No. The audit generates draft FAQ shells with customer question wording and a placeholder for the verified answer. You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center without your approval.\n\nNo. The audit generates draft FAQ shells with customer question wording and a placeholder that says \"Draft answer \u2014 support team should add the verified resolution before publishing.\" You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center, CMS, or knowledge base without your approval.\n\nThis matters because uploaded tickets show repeated questions but not verified support resolutions. The audit can tell you which questions cost you the most repeat volume, but it cannot write the procedural steps, permission rules, or UI paths that make the answer useful. That's your team's job."
+                "text": "The audit does not publish automatically. It drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.\n\nThe audit does not publish automatically. It drafts review-ready FAQ answer shells and shows you the repeat-question clusters. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.\n\nThe draft answers include the customer question and a placeholder for the verified resolution. Your team adds the exact UI paths, permission rules, menu names, and fix instructions before publishing. The audit gives you the repeat-question list and the draft structure. Your team gives the answer the accuracy."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "objection",
-                "name": "Do we need a full-time docs person to use this?",
+                "name": "You do not need a full-time docs person",
                 "position": 6,
-                "text": "No. The audit is built for support leaders without a dedicated docs team. It shows which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. If you have one person who can export a CSV and write three FAQ answers in a week, you have enough capacity.\n\nNo. The audit is built for support leaders who do not have a dedicated docs team. It shows you which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. Your support team already knows the verified resolutions \u2014 the audit just surfaces the pattern and gives you the draft structure.\n\nIf you have one person who can export a CSV, review a cluster list, and write three FAQ answers in a week, you have enough capacity to use this. The audit does not require ongoing maintenance, a content ops hire, or a full-time docs person. It requires deciding which repeat questions to answer first."
+                "text": "You do not need a full-time docs person. The audit drafts the FAQ answer shells. Your support team already knows the verified resolutions. They review the draft, add the fix steps, and approve publication. The audit turns the repeat-ticket backlog into a prioritized FAQ roadmap without hiring a dedicated docs writer.\n\nThe support lead owns the review and approval. The audit removes the blank-page problem and the prioritization guesswork. Your team focuses on verifying the answers, not finding the gaps."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "faq",
-                "name": "What happens after I upload the CSV?",
+                "name": "What happens after I provide ticket data?",
                 "position": 7,
-                "text": "The system reads the ticket text, identifies question-shaped tickets, groups them by topic similarity, and ranks clusters by ticket count. You get an audit report showing repeat patterns and draft FAQ shells. You review the clusters, add verified answers, and route to your review queue.\n\nAfter you upload the CSV, the system reads the ticket text and identifies question-shaped tickets. It groups them by topic similarity and ranks the clusters by ticket count. You get an audit report that shows the repeat patterns, preserves customer wording, and generates draft FAQ shells for each cluster.\n\nThe report does not include verified answers because the uploaded tickets contain customer questions but not support resolutions. You review the clusters, decide which FAQ gaps to write first, add the procedural steps your team knows, and route the draft to your review queue. The audit does not publish automatically."
+                "text": "The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. You receive the gap audit report with the top clusters, customer wording examples, and draft answers for your team to review.\n\nWhat happens after I provide ticket data? The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. You receive the gap audit report with the top clusters, customer wording examples, and draft answers. Your support team reviews each draft, adds the verified resolution steps, and approves publication.\n\nThe audit does not write final procedural steps or publish answers without your approval. It shows you the repeat-question exposure and gives you the draft structure."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "faq",
+                "name": "Does FAQ Report publish automatically?",
+                "position": 8,
+                "text": "No. The audit drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.\n\nDoes FAQ Report publish automatically? No. The audit drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when.\n\nThe draft answers include the customer question and a placeholder for the verified resolution. Your team adds the exact fix instructions before publishing."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "conversion",
-                "name": "Get your FAQ gap audit",
-                "position": 8,
-                "text": "Upload your support ticket CSV and get the audit report. It shows you which repeat questions cost you the most volume, preserves customer wording, and gives you draft FAQ shells for each cluster. You decide which answers to write first.\n\nThe audit does not publish automatically. It does not require a full-time docs person. It requires deciding which FAQ gaps represent the highest repeat risk and writing the verified answers your support team already knows.\n\nIf you're carrying a repeat-ticket backlog and you want to see the pattern, upload the CSV."
+                "name": "Upload your ticket CSV and get the gap audit",
+                "position": 9,
+                "text": "Upload your ticket CSV and get the gap audit. You will see the top repeat-question clusters, the customer wording, and the draft FAQ answers your support team should verify before publishing. The audit turns the repeat-ticket backlog into a prioritized FAQ roadmap.\n\nNo credit card. No setup call. Upload the CSV at [/systems/ai-content-ops/intake](/systems/ai-content-ops/intake) and get the gap audit."
               }
             ],
-            "name": "Support Ticket FAQ Gap Audit \u2014 Find Repeat Questions",
+            "name": "Support Ticket FAQ Gap Audit \u2013 Turn Repeat Questions Into Answers",
             "potentialAction": {
               "@type": "Action",
-              "name": "Upload Ticket CSV \u2014 Get the Gap Audit",
+              "name": "Upload Ticket CSV -- Get the Gap Audit",
               "target": "/systems/ai-content-ops/intake"
             }
           },
@@ -408,56 +426,64 @@
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "In the uploaded tickets, 35 out of 36 were question-shaped and clustered into 9 repeat patterns including reporting export, dashboard freshness, SSO setup, and permissions. When the same question appears four times in one quarter, you're carrying FAQ debt that costs another reply each time."
+                  "text": "Support teams see the same questions every week because the help center does not have the answer or the answer is not findable. In the uploaded tickets, 35 of 36 tickets were question-shaped, and the top clusters repeated 4 times each."
                 },
-                "name": "What did the uploaded support tickets show about repeat questions?"
+                "name": "Why do support teams keep answering the same questions?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "The audit turns your uploaded CSV into a prioritized list of FAQ opportunities. For each repeat cluster, you get a draft FAQ shell with the customer's original question wording, the ticket count, and a placeholder for the verified answer. You add the procedural steps and route the draft to your review queue."
+                  "text": "The gap audit clusters repeat questions, ranks them by frequency, and drafts review-ready FAQ answer shells. You see the top gaps, the customer wording, and the draft answers your support team should verify before publishing."
                 },
-                "name": "What does the FAQ Gap Audit deliver?"
+                "name": "What does the gap audit give me?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "Export your support tickets as CSV, upload at the intake link, and get an audit report showing repeat clusters ranked by ticket count. Review the clusters, write the verified answers with procedural steps your team knows, and route to your review queue. The audit does not publish automatically."
+                  "text": "You upload your support ticket CSV. The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication."
                 },
-                "name": "How does the Support Ticket FAQ Gap Audit process work?"
+                "name": "How does the audit process work?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "No. The audit generates draft FAQ shells with customer question wording and a placeholder for the verified answer. You write the verified answer, review it, and decide when it goes live. The audit does not touch your help center without your approval."
+                  "text": "The audit does not publish automatically. It drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when."
                 },
-                "name": "Will this publish FAQ answers automatically?"
+                "name": "Will this publish automatically?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "No. The audit is built for support leaders without a dedicated docs team. It shows which FAQ gaps cost you the most repeat tickets so you can prioritize the answers that matter. If you have one person who can export a CSV and write three FAQ answers in a week, you have enough capacity."
+                  "text": "You do not need a full-time docs person. The audit drafts the FAQ answer shells. Your support team already knows the verified resolutions. They review the draft, add the fix steps, and approve publication."
                 },
-                "name": "Do we need a full-time docs person to use the FAQ Gap Audit?"
+                "name": "Do we need a full-time docs person?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "The system reads the ticket text, identifies question-shaped tickets, groups them by topic similarity, and ranks clusters by ticket count. You get an audit report showing repeat patterns and draft FAQ shells. You review the clusters, add verified answers, and route to your review queue."
+                  "text": "The audit clusters question-shaped tickets, ranks the top repeat patterns, and drafts FAQ answer shells. You receive the gap audit report with the top clusters, customer wording examples, and draft answers for your team to review."
                 },
-                "name": "What happens after I upload the CSV?"
+                "name": "What happens after I provide ticket data?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. The audit drafts review-ready FAQ answer shells. Your support team reviews each draft, adds the verified resolution steps, and approves publication. You control what goes live and when."
+                },
+                "name": "Does FAQ Report publish automatically?"
               }
             ],
-            "name": "35 Support Tickets Showed the Same 9 FAQ Gaps \u2014 Here's Your Audit FAQs"
+            "name": "Support Ticket FAQ Gap Audit \u2013 Turn Repeat Questions Into Approved Answers FAQs"
           }
         ]
       },
-      "title": "35 Support Tickets Showed the Same 9 FAQ Gaps \u2014 Here's Your Audit",
+      "title": "Support Ticket FAQ Gap Audit \u2013 Turn Repeat Questions Into Approved Answers",
       "value_prop": "Turn repeat support tickets into approved FAQ answers"
     },
     {
@@ -468,7 +494,7 @@
         "variant": "primary"
       },
       "generation_input_tokens": 3797,
-      "generation_output_tokens": 2150,
+      "generation_output_tokens": 2015,
       "generation_parse_attempts": 1,
       "generation_quality_repair_attempts": 0,
       "generation_quality_repair_history": [
@@ -498,12 +524,12 @@
       "hero": {
         "cta_label": "Upload Ticket CSV -- Get the Gap Audit",
         "cta_url": "/systems/ai-content-ops/intake",
-        "headline": "Turn repeat support tickets into approved FAQ answers",
-        "subheadline": "Upload your last 90 days of support tickets and get a gap audit showing which repeated questions need FAQ coverage\u2014no guesswork, no manual tagging."
+        "headline": "Turn Repeat Support Tickets into Approved FAQ Answers",
+        "subheadline": "Upload your last 90 days of support tickets and get a gap audit showing which repeat questions need FAQ answers before they hit your queue again."
       },
-      "id": "2b09400f-a8b9-4787-86dd-ca655686d246",
+      "id": "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
       "meta": {
-        "description": "Upload your support tickets and get a gap audit showing which repeated questions need FAQ coverage. Review-ready draft answers, no automatic publishing.",
+        "description": "Upload your support tickets and get a gap audit showing which repeat questions need FAQ answers. Turn repeat support tickets into approved FAQ answers.",
         "og_image_url": "",
         "title_tag": "Support Ticket FAQ Gap Audit | Cut Repeat Tickets"
       },
@@ -544,7 +570,7 @@
           "cache_write_tokens": 0,
           "cached_tokens": 3671,
           "input_tokens": 3797,
-          "output_tokens": 2150,
+          "output_tokens": 2015,
           "reasoning_tokens": 0
         },
         "scope": {
@@ -658,73 +684,84 @@
       "reasoning_wedge": null,
       "reference_count": 0,
       "reference_ids": [],
-      "section_count": 6,
+      "section_count": 7,
       "sections": [
         {
-          "body_markdown": "When the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters appeared four times each, meaning your team is writing the same answer multiple times instead of publishing it once.\n\nWhen the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management\u2014each appeared four times. That pattern means your team is writing the same answer multiple times instead of publishing it once.\n\nThe risk is not just queue length. It is that your support leads do not know which gaps to close first, so the backlog keeps the same shape. You need the repeated questions ranked by frequency so you can decide which FAQ answers to write and review.",
-          "id": "repeat_ticket_risk",
+          "body_markdown": "Repeat support tickets eat capacity you don't have. When the same questions come in week after week, your team answers the same issue multiple times instead of shipping new work. The uploaded ticket set shows 35 question-like tickets across 9 clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management. Four tickets in each cluster means the same problem is landing on your team repeatedly. Without published FAQ answers, every new customer who hits that gap opens another ticket.",
+          "id": "repeat_ticket_cost",
           "metadata": {
-            "answer_summary": "When the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters appeared four times each, meaning your team is writing the same answer multiple times instead of publishing it once.",
+            "answer_summary": "Repeat support tickets eat capacity you don't have. When the same questions come in week after week, your team answers the same issue multiple times instead of shipping new work.",
             "kind": "problem",
             "order": 1,
-            "primary_question": "Why do the same support questions keep coming back?"
+            "primary_question": "Why do repeat support tickets matter?"
           },
-          "title": "Repeat tickets expose the same gaps every week"
+          "title": "Repeat Support Tickets Eat Capacity You Don't Have"
         },
         {
-          "body_markdown": "The Support Ticket FAQ Gap Audit takes your uploaded ticket CSV and returns a ranked list of repeated questions with customer wording preserved. You see which questions appeared most often, what language your customers used, and which gaps carry the highest repeat risk.\n\nThe audit does not publish automatically. It gives you review-ready draft FAQ shells so your support team can add the verified resolution before you publish. That means you control what goes live, and you can prioritize the gaps that matter most to your queue.\n\nThe outcome is a clear next action: write and review the FAQ answers for the top repeat clusters, then track whether ticket volume changes after publication.",
-          "id": "gap_audit_outcome",
+          "body_markdown": "The Gap Audit shows which repeat questions need FAQ answers. You upload a CSV of your support tickets. The audit clusters the question-like tickets by topic, ranks them by repeat count, and pulls the exact customer wording so you see the problem the way your users describe it. The output is a list of FAQ opportunities with draft answer shells your support team can review and approve before publishing. This does not publish automatically. You control what goes live.\n\nThe audit uses the uploaded tickets to identify repeated questions and likely FAQ opportunities. It does not prove future support volume will drop or that tickets will be prevented. Track whether ticket volume changes after you publish the approved answers.",
+          "id": "faq_gap_audit_outcome",
           "metadata": {
-            "answer_summary": "The Support Ticket FAQ Gap Audit takes your uploaded ticket CSV and returns a ranked list of repeated questions with customer wording preserved. You see which questions appeared most often, what language your customers used, and which gaps carry the highest repeat risk.",
+            "answer_summary": "The Gap Audit shows which repeat questions need FAQ answers. You upload a CSV of your support tickets. The audit clusters the question-like tickets by topic, ranks them by repeat count, and pulls the exact customer wording so you see the problem the way your users describe it.",
             "kind": "solution",
             "order": 2,
-            "primary_question": "What does the gap audit show me?"
+            "primary_question": "What does the FAQ gap audit do?"
           },
-          "title": "The gap audit shows which repeated questions need FAQ coverage"
+          "title": "The Gap Audit Shows Which Repeat Questions Need FAQ Answers"
         },
         {
-          "body_markdown": "Export your support tickets as a CSV, upload it at the intake link, and the audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording. You get a gap report showing the top repeat clusters and draft FAQ answer shells, then your support team adds the verified resolution before publishing.\n\n1. Export your support tickets as a CSV. Include ticket title, body, and any tags or categories you already use.\n2. Upload the CSV at [/systems/ai-content-ops/intake](/systems/ai-content-ops/intake). The audit runs on the uploaded tickets\u2014no live system access required.\n3. The audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording so you see the exact language your customers used.\n4. You get a gap report showing the top repeat clusters and draft FAQ answer shells. The drafts include the customer question but not the verified resolution\u2014your support team adds that before publishing.\n5. Review the draft answers, add the verified steps, and publish the FAQ entries to your help center.\n6. Track whether ticket volume changes after publication. The audit does not predict future ticket reduction, but it gives you the baseline to measure it.\n\nThe whole process takes the time it takes to export a CSV, upload it, review the gap report, and write the verified answers. No full-time docs person required.",
+          "body_markdown": "Upload a CSV export of your support tickets from the last 90 days. The audit reads the ticket text, filters for question-like entries, and groups them into topic clusters. You get a ranked list of repeat question clusters with customer wording examples and draft answer shells.\n\nExample clusters from the uploaded ticket set:\n\n- **Reporting export** (4 tickets): \"How do I export attribution reports before our board meeting?\" / \"Why is the campaign CSV export missing source and owner columns?\" / \"Can I schedule a weekly attribution report export for finance?\" / \"Why can analysts view dashboards but not export reports?\"\n- **Dashboard freshness** (4 tickets): \"Why has our pipeline dashboard not refreshed since yesterday?\" / \"How do we check whether the warehouse sync is delayed?\"\n- **SSO setup** (4 tickets)\n- **Permissions and seats** (4 tickets)\n- **API and webhooks** (4 tickets)\n- **Integration sync** (4 tickets)\n- **Data import** (4 tickets)\n- **Workflow automation** (4 tickets)\n- **Billing and plan management** (4 tickets)\n\nThe audit does not write final procedural steps or UI paths. Your support team adds the verified resolution before publishing. You do not need a full-time docs person to use this. The audit gives you the repeat question list and draft shells. Your team reviews and approves the answers.",
           "id": "how_the_audit_works",
           "metadata": {
-            "answer_summary": "Export your support tickets as a CSV, upload it at the intake link, and the audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording. You get a gap report showing the top repeat clusters and draft FAQ answer shells, then your support team adds the verified resolution before publishing.",
+            "answer_summary": "Upload a CSV export of your support tickets from the last 90 days. The audit reads the ticket text, filters for question-like entries, and groups them into topic clusters. You get a ranked list of repeat question clusters with customer wording examples and draft answer shells.",
             "kind": "how_it_works",
             "order": 3,
-            "primary_question": "How does the gap audit work?"
+            "primary_question": "How does the FAQ gap audit work?"
           },
-          "title": "Upload tickets, get the gap audit, review and publish answers"
+          "title": "How the Audit Works"
         },
         {
-          "body_markdown": "The audit preserves the exact language your customers used so you can write FAQ answers that match their search terms. Here are examples from the uploaded tickets:\n\n**Reporting export:**\n- \"Attribution export blocked How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions Why can analysts view dashboards but not export reports?\"\n\n**Dashboard freshness:**\n- \"Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag How do we check whether the warehouse sync is delayed?\"\n\nThese are the questions your customers are asking. The gap audit ranks them by frequency so you know which ones to answer first.",
-          "id": "customer_wording_proof",
+          "body_markdown": "No. The audit produces draft answer shells that your support team reviews and approves before publishing. You control what goes live. The audit does not push content to your help center without your approval.",
+          "id": "objection_automatic_publishing",
           "metadata": {
-            "answer_summary": "",
-            "kind": "proof",
-            "order": 4,
-            "primary_question": ""
-          },
-          "title": "Customer wording from the uploaded tickets"
-        },
-        {
-          "body_markdown": "No. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.\n\n**Will this publish automatically?**\n\nNo. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.\n\n**Do we need a full-time docs person?**\n\nNo. The gap audit is built for support leads who do not have a dedicated docs team. You upload the ticket CSV, review the gap report, and your support team writes the verified answers. The audit does the clustering and ranking work so you do not have to tag tickets manually or guess which gaps matter most.\n\n**What happens after I upload the CSV?**\n\nThe audit runs on the uploaded tickets and returns a gap report showing the top repeat clusters, customer wording examples, and draft FAQ answer shells. You review the report, prioritize the gaps, and write the verified answers. The audit does not access your live support system or publish anything automatically.\n\n**Does FAQ Report publish automatically?**\n\nNo. The gap audit gives you review-ready draft FAQ shells, and you add the verified resolution before publishing. You control the publication process and the help center content.",
-          "id": "objections_and_control",
-          "metadata": {
-            "answer_summary": "No. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.",
+            "answer_summary": "No. The audit produces draft answer shells that your support team reviews and approves before publishing. You control what goes live. The audit does not push content to your help center without your approval.",
             "kind": "objection",
-            "order": 5,
+            "order": 4,
             "primary_question": "Will this publish automatically?"
           },
-          "title": "You control what gets published and when"
+          "title": "Will This Publish Automatically?"
         },
         {
-          "body_markdown": "The gap audit runs on your uploaded support tickets. You get a ranked list of repeated questions, customer wording examples, and draft FAQ answer shells. Your support team adds the verified resolution, you publish the answers, and you track whether ticket volume changes.\n\nNo live system access. No automatic publishing. No full-time docs person required.\n\n[Upload your ticket CSV and get the gap audit](/systems/ai-content-ops/intake).",
-          "id": "next_action",
+          "body_markdown": "No. The audit gives you the repeat question list and draft answer shells. Your support team reviews and approves the answers. You do not need a dedicated documentation hire to use this.",
+          "id": "objection_fulltime_docs_person",
+          "metadata": {
+            "answer_summary": "No. The audit gives you the repeat question list and draft answer shells. Your support team reviews and approves the answers. You do not need a dedicated documentation hire to use this.",
+            "kind": "objection",
+            "order": 5,
+            "primary_question": "Do we need a full-time docs person?"
+          },
+          "title": "Do We Need a Full-Time Docs Person?"
+        },
+        {
+          "body_markdown": "You upload a CSV of your support tickets. The audit processes the file, clusters question-like tickets by topic, ranks them by repeat count, and returns a gap audit report with customer wording examples and draft answer shells. Your support team reviews the draft answers, adds verified resolutions, and approves them for publishing. The audit does not publish automatically.",
+          "id": "faq_after_ticket_data",
+          "metadata": {
+            "answer_summary": "You upload a CSV of your support tickets. The audit processes the file, clusters question-like tickets by topic, ranks them by repeat count, and returns a gap audit report with customer wording examples and draft answer shells.",
+            "kind": "faq",
+            "order": 6,
+            "primary_question": "What happens after I provide ticket data?"
+          },
+          "title": "What Happens After I Provide Ticket Data?"
+        },
+        {
+          "body_markdown": "Upload your support ticket CSV and get the gap audit showing which repeat questions need FAQ answers. The audit uses the uploaded tickets to identify repeated questions and likely FAQ opportunities. Track whether ticket volume changes after you publish the approved answers.\n\n[Upload Ticket CSV -- Get the Gap Audit](/systems/ai-content-ops/intake)",
+          "id": "conversion_next_step",
           "metadata": {
             "answer_summary": "",
             "kind": "conversion",
-            "order": 6,
+            "order": 7,
             "primary_question": ""
           },
-          "title": "Upload your ticket CSV and get the gap audit"
+          "title": "Get Your FAQ Gap Audit"
         }
       ],
       "seo_aeo_readiness": {
@@ -758,49 +795,56 @@
               "@type": "Audience",
               "audienceType": "SaaS support leaders carrying a repeat-ticket backlog"
             },
-            "description": "Upload your support tickets and get a gap audit showing which repeated questions need FAQ coverage. Review-ready draft answers, no automatic publishing.",
+            "description": "Upload your support tickets and get a gap audit showing which repeat questions need FAQ answers. Turn repeat support tickets into approved FAQ answers.",
             "hasPart": [
               {
                 "@type": "WebPageElement",
                 "additionalType": "problem",
-                "name": "Repeat tickets expose the same gaps every week",
+                "name": "Repeat Support Tickets Eat Capacity You Don't Have",
                 "position": 1,
-                "text": "When the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters appeared four times each, meaning your team is writing the same answer multiple times instead of publishing it once.\n\nWhen the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management\u2014each appeared four times. That pattern means your team is writing the same answer multiple times instead of publishing it once.\n\nThe risk is not just queue length. It is that your support leads do not know which gaps to close first, so the backlog keeps the same shape. You need the repeated questions ranked by frequency so you can decide which FAQ answers to write and review."
+                "text": "Repeat support tickets eat capacity you don't have. When the same questions come in week after week, your team answers the same issue multiple times instead of shipping new work. The uploaded ticket set shows 35 question-like tickets across 9 clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, and billing and plan management. Four tickets in each cluster means the same problem is landing on your team repeatedly. Without published FAQ answers, every new customer who hits that gap opens another ticket."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "solution",
-                "name": "The gap audit shows which repeated questions need FAQ coverage",
+                "name": "The Gap Audit Shows Which Repeat Questions Need FAQ Answers",
                 "position": 2,
-                "text": "The Support Ticket FAQ Gap Audit takes your uploaded ticket CSV and returns a ranked list of repeated questions with customer wording preserved. You see which questions appeared most often, what language your customers used, and which gaps carry the highest repeat risk.\n\nThe audit does not publish automatically. It gives you review-ready draft FAQ shells so your support team can add the verified resolution before you publish. That means you control what goes live, and you can prioritize the gaps that matter most to your queue.\n\nThe outcome is a clear next action: write and review the FAQ answers for the top repeat clusters, then track whether ticket volume changes after publication."
+                "text": "The Gap Audit shows which repeat questions need FAQ answers. You upload a CSV of your support tickets. The audit clusters the question-like tickets by topic, ranks them by repeat count, and pulls the exact customer wording so you see the problem the way your users describe it. The output is a list of FAQ opportunities with draft answer shells your support team can review and approve before publishing. This does not publish automatically. You control what goes live.\n\nThe audit uses the uploaded tickets to identify repeated questions and likely FAQ opportunities. It does not prove future support volume will drop or that tickets will be prevented. Track whether ticket volume changes after you publish the approved answers."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "how_it_works",
-                "name": "Upload tickets, get the gap audit, review and publish answers",
+                "name": "How the Audit Works",
                 "position": 3,
-                "text": "Export your support tickets as a CSV, upload it at the intake link, and the audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording. You get a gap report showing the top repeat clusters and draft FAQ answer shells, then your support team adds the verified resolution before publishing.\n\n1. Export your support tickets as a CSV. Include ticket title, body, and any tags or categories you already use.\n2. Upload the CSV at [/systems/ai-content-ops/intake](/systems/ai-content-ops/intake). The audit runs on the uploaded tickets\u2014no live system access required.\n3. The audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording so you see the exact language your customers used.\n4. You get a gap report showing the top repeat clusters and draft FAQ answer shells. The drafts include the customer question but not the verified resolution\u2014your support team adds that before publishing.\n5. Review the draft answers, add the verified steps, and publish the FAQ entries to your help center.\n6. Track whether ticket volume changes after publication. The audit does not predict future ticket reduction, but it gives you the baseline to measure it.\n\nThe whole process takes the time it takes to export a CSV, upload it, review the gap report, and write the verified answers. No full-time docs person required."
-              },
-              {
-                "@type": "WebPageElement",
-                "additionalType": "proof",
-                "name": "Customer wording from the uploaded tickets",
-                "position": 4,
-                "text": "The audit preserves the exact language your customers used so you can write FAQ answers that match their search terms. Here are examples from the uploaded tickets:\n\n**Reporting export:**\n- \"Attribution export blocked How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions Why can analysts view dashboards but not export reports?\"\n\n**Dashboard freshness:**\n- \"Dashboard stale data Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag How do we check whether the warehouse sync is delayed?\"\n\nThese are the questions your customers are asking. The gap audit ranks them by frequency so you know which ones to answer first."
+                "text": "Upload a CSV export of your support tickets from the last 90 days. The audit reads the ticket text, filters for question-like entries, and groups them into topic clusters. You get a ranked list of repeat question clusters with customer wording examples and draft answer shells.\n\nExample clusters from the uploaded ticket set:\n\n- **Reporting export** (4 tickets): \"How do I export attribution reports before our board meeting?\" / \"Why is the campaign CSV export missing source and owner columns?\" / \"Can I schedule a weekly attribution report export for finance?\" / \"Why can analysts view dashboards but not export reports?\"\n- **Dashboard freshness** (4 tickets): \"Why has our pipeline dashboard not refreshed since yesterday?\" / \"How do we check whether the warehouse sync is delayed?\"\n- **SSO setup** (4 tickets)\n- **Permissions and seats** (4 tickets)\n- **API and webhooks** (4 tickets)\n- **Integration sync** (4 tickets)\n- **Data import** (4 tickets)\n- **Workflow automation** (4 tickets)\n- **Billing and plan management** (4 tickets)\n\nThe audit does not write final procedural steps or UI paths. Your support team adds the verified resolution before publishing. You do not need a full-time docs person to use this. The audit gives you the repeat question list and draft shells. Your team reviews and approves the answers."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "objection",
-                "name": "You control what gets published and when",
+                "name": "Will This Publish Automatically?",
+                "position": 4,
+                "text": "No. The audit produces draft answer shells that your support team reviews and approves before publishing. You control what goes live. The audit does not push content to your help center without your approval."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "objection",
+                "name": "Do We Need a Full-Time Docs Person?",
                 "position": 5,
-                "text": "No. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.\n\n**Will this publish automatically?**\n\nNo. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval.\n\n**Do we need a full-time docs person?**\n\nNo. The gap audit is built for support leads who do not have a dedicated docs team. You upload the ticket CSV, review the gap report, and your support team writes the verified answers. The audit does the clustering and ranking work so you do not have to tag tickets manually or guess which gaps matter most.\n\n**What happens after I upload the CSV?**\n\nThe audit runs on the uploaded tickets and returns a gap report showing the top repeat clusters, customer wording examples, and draft FAQ answer shells. You review the report, prioritize the gaps, and write the verified answers. The audit does not access your live support system or publish anything automatically.\n\n**Does FAQ Report publish automatically?**\n\nNo. The gap audit gives you review-ready draft FAQ shells, and you add the verified resolution before publishing. You control the publication process and the help center content."
+                "text": "No. The audit gives you the repeat question list and draft answer shells. Your support team reviews and approves the answers. You do not need a dedicated documentation hire to use this."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "faq",
+                "name": "What Happens After I Provide Ticket Data?",
+                "position": 6,
+                "text": "You upload a CSV of your support tickets. The audit processes the file, clusters question-like tickets by topic, ranks them by repeat count, and returns a gap audit report with customer wording examples and draft answer shells. Your support team reviews the draft answers, adds verified resolutions, and approves them for publishing. The audit does not publish automatically."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "conversion",
-                "name": "Upload your ticket CSV and get the gap audit",
-                "position": 6,
-                "text": "The gap audit runs on your uploaded support tickets. You get a ranked list of repeated questions, customer wording examples, and draft FAQ answer shells. Your support team adds the verified resolution, you publish the answers, and you track whether ticket volume changes.\n\nNo live system access. No automatic publishing. No full-time docs person required.\n\n[Upload your ticket CSV and get the gap audit](/systems/ai-content-ops/intake)."
+                "name": "Get Your FAQ Gap Audit",
+                "position": 7,
+                "text": "Upload your support ticket CSV and get the gap audit showing which repeat questions need FAQ answers. The audit uses the uploaded tickets to identify repeated questions and likely FAQ opportunities. Track whether ticket volume changes after you publish the approved answers.\n\n[Upload Ticket CSV -- Get the Gap Audit](/systems/ai-content-ops/intake)"
               }
             ],
             "name": "Support Ticket FAQ Gap Audit | Cut Repeat Tickets",
@@ -817,40 +861,56 @@
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "When the same questions come back week after week, your support queue carries questions that should have been answered once. In the uploaded tickets, 35 out of 36 tickets were question-shaped, and the top clusters appeared four times each, meaning your team is writing the same answer multiple times instead of publishing it once."
+                  "text": "Repeat support tickets eat capacity you don't have. When the same questions come in week after week, your team answers the same issue multiple times instead of shipping new work."
                 },
-                "name": "Why do the same support questions keep coming back?"
+                "name": "Why do repeat support tickets matter?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "The Support Ticket FAQ Gap Audit takes your uploaded ticket CSV and returns a ranked list of repeated questions with customer wording preserved. You see which questions appeared most often, what language your customers used, and which gaps carry the highest repeat risk."
+                  "text": "The Gap Audit shows which repeat questions need FAQ answers. You upload a CSV of your support tickets. The audit clusters the question-like tickets by topic, ranks them by repeat count, and pulls the exact customer wording so you see the problem the way your users describe it."
                 },
-                "name": "What does the gap audit show me?"
+                "name": "What does the FAQ gap audit do?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "Export your support tickets as a CSV, upload it at the intake link, and the audit clusters question-like tickets by topic, ranks them by frequency, and preserves customer wording. You get a gap report showing the top repeat clusters and draft FAQ answer shells, then your support team adds the verified resolution before publishing."
+                  "text": "Upload a CSV export of your support tickets from the last 90 days. The audit reads the ticket text, filters for question-like entries, and groups them into topic clusters. You get a ranked list of repeat question clusters with customer wording examples and draft answer shells."
                 },
-                "name": "How does the gap audit work?"
+                "name": "How does the FAQ gap audit work?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "No. The gap audit returns draft FAQ answer shells with the customer question included, but your support team must add the verified resolution before you publish. You decide which answers to write, which to review, and which to publish. Nothing goes live without your approval."
+                  "text": "No. The audit produces draft answer shells that your support team reviews and approves before publishing. You control what goes live. The audit does not push content to your help center without your approval."
                 },
                 "name": "Will this publish automatically?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. The audit gives you the repeat question list and draft answer shells. Your support team reviews and approves the answers. You do not need a dedicated documentation hire to use this."
+                },
+                "name": "Do we need a full-time docs person?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "You upload a CSV of your support tickets. The audit processes the file, clusters question-like tickets by topic, ranks them by repeat count, and returns a gap audit report with customer wording examples and draft answer shells."
+                },
+                "name": "What happens after I provide ticket data?"
               }
             ],
-            "name": "Cut Repeat Support Tickets with Review-Ready FAQ Answers FAQs"
+            "name": "Cut Repeat Support Tickets with FAQ Gap Audit FAQs"
           }
         ]
       },
-      "title": "Cut Repeat Support Tickets with Review-Ready FAQ Answers",
+      "title": "Cut Repeat Support Tickets with FAQ Gap Audit",
       "value_prop": "Turn repeat support tickets into approved FAQ answers"
     },
     {
@@ -860,13 +920,25 @@
         "url": "/systems/ai-content-ops/intake",
         "variant": "primary"
       },
-      "generation_input_tokens": 3797,
-      "generation_output_tokens": 1679,
-      "generation_parse_attempts": 1,
-      "generation_quality_repair_attempts": 0,
+      "generation_input_tokens": 7774,
+      "generation_output_tokens": 5056,
+      "generation_parse_attempts": 2,
+      "generation_quality_repair_attempts": 1,
       "generation_quality_repair_history": [
         {
           "attempt": 0,
+          "blockers": [
+            "seo_aeo_readiness:meta_description",
+            "geo_readiness:section_semantics"
+          ],
+          "passed": false,
+          "repair_issues": [
+            "seo_aeo_readiness:meta_description",
+            "geo_readiness:section_semantics"
+          ]
+        },
+        {
+          "attempt": 1,
           "blockers": [],
           "passed": true,
           "repair_issues": []
@@ -891,14 +963,14 @@
       "hero": {
         "cta_label": "Upload Ticket CSV -- Get the Gap Audit",
         "cta_url": "/systems/ai-content-ops/intake",
-        "headline": "Your team answers the same questions every week",
-        "subheadline": "Upload your ticket CSV and see which repeat questions need approved FAQ answers before they hit the queue again."
+        "headline": "Your repeat tickets show the FAQ gaps",
+        "subheadline": "Upload your last 90 days of support tickets and get a gap audit that shows which repeat questions need approved FAQ answers."
       },
-      "id": "49e324c1-f331-404d-bfa4-dcbcb5387027",
+      "id": "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
       "meta": {
-        "description": "Upload your ticket CSV and see which repeat questions need approved FAQ answers. Turn support ticket patterns into help-center coverage.",
+        "description": "Upload your last 90 days of support tickets and get a gap audit showing which repeat questions need approved FAQ answers. No auto-publish. Support lead reviews and approves.",
         "og_image_url": "",
-        "title_tag": "Stop Answering the Same Support Tickets Every Week"
+        "title_tag": "Support Ticket FAQ Gap Audit \u2013 Turn Repeat Tickets Into Answers"
       },
       "metadata": {
         "brand_voice_audit": {
@@ -922,22 +994,34 @@
         },
         "campaign_name": "Support Ticket FAQ Gap Audit",
         "generation_model": "anthropic/claude-sonnet-4-5",
-        "generation_parse_attempts": 1,
-        "generation_quality_repair_attempts": 0,
+        "generation_parse_attempts": 2,
+        "generation_quality_repair_attempts": 1,
         "generation_quality_repair_history": [
           {
             "attempt": 0,
+            "blockers": [
+              "seo_aeo_readiness:meta_description",
+              "geo_readiness:section_semantics"
+            ],
+            "passed": false,
+            "repair_issues": [
+              "seo_aeo_readiness:meta_description",
+              "geo_readiness:section_semantics"
+            ]
+          },
+          {
+            "attempt": 1,
             "blockers": [],
             "passed": true,
             "repair_issues": []
           }
         ],
         "generation_usage": {
-          "billable_input_tokens": 126,
-          "cache_write_tokens": 3671,
-          "cached_tokens": 0,
-          "input_tokens": 3797,
-          "output_tokens": 1679,
+          "billable_input_tokens": 129,
+          "cache_write_tokens": 303,
+          "cached_tokens": 7342,
+          "input_tokens": 7774,
+          "output_tokens": 5056,
           "reasoning_tokens": 0
         },
         "scope": {
@@ -1051,73 +1135,106 @@
       "reasoning_wedge": null,
       "reference_count": 0,
       "reference_ids": [],
-      "section_count": 6,
+      "section_count": 9,
       "sections": [
         {
-          "body_markdown": "The same questions come back because your help center does not have approved answers yet. In the uploaded tickets, 35 out of 36 were question-shaped, and the top 9 clusters each appeared 4 times.\n\nYour support team closes tickets, but the same questions come back. In the uploaded tickets, 35 out of 36 were question-shaped. The top clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, billing and plan management\u2014each appeared 4 times. When the same question hits the queue multiple times, your team writes the same answer multiple times. The backlog does not shrink because the help center does not have the answer yet.",
+          "body_markdown": "When the same questions appear in your support queue week after week, your help center has a gap. Your team answers the question once, closes the ticket, then answers it again for the next customer. The backlog grows. The team burns time. Customers wait.\n\nThe uploaded ticket data shows the pattern. In the last 90 days, 35 of 36 tickets were question-shaped. The top clusters: reporting export (4 tickets), dashboard freshness (4 tickets), SSO setup (4 tickets), permissions and seats (4 tickets), API and webhooks (4 tickets), integration sync (4 tickets), data import (4 tickets), workflow automation (4 tickets), billing and plan management (4 tickets).\n\nEach cluster is a repeat question your help center does not answer. Each repeat question is a risk. Customers open tickets because the answer is not in the help center. Your team answers the same question multiple times. The queue does not shrink.\n\nThe gap audit shows which repeat questions need approved FAQ answers. It does not publish automatically. It does not require a full-time docs person. It shows the support lead the next action.",
           "id": "repeat_ticket_backlog",
           "metadata": {
-            "answer_summary": "The same questions come back because your help center does not have approved answers yet. In the uploaded tickets, 35 out of 36 were question-shaped, and the top 9 clusters each appeared 4 times.",
+            "answer_summary": "When the same questions appear in your support queue week after week, your help center has a gap. Your team answers the question once, closes the ticket, then answers it again for the next customer. The backlog grows. The team burns time. Customers wait.",
             "kind": "problem",
             "order": 1,
-            "primary_question": "Why do we keep getting the same support tickets?"
+            "primary_question": "Why do the same support questions keep appearing in the ticket queue?"
           },
-          "title": "The repeat-ticket backlog keeps growing"
+          "title": "The repeat-ticket backlog exposes missing help-center answers"
         },
         {
-          "body_markdown": "Customers describe the friction they hit, not your internal product names. Examples from uploaded tickets include \"Attribution export blocked,\" \"CSV export missing fields,\" \"Dashboard stale data,\" and \"Warehouse sync lag.\"\n\nYour customers do not use your internal product names. They describe the friction they hit:\n\n- \"Attribution export blocked\u2014How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields\u2014Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report\u2014Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions\u2014Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data\u2014Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag\u2014How do we check whether the warehouse sync is delayed?\"\n\nThese are real ticket titles from the uploaded CSV. When your help center does not match this wording, customers open a ticket instead of finding the answer.",
-          "id": "customer_wording_examples",
+          "body_markdown": "The uploaded tickets preserve how customers describe the problem. Here are six examples:\n\n- **Attribution export blocked**: \"How do I export attribution reports before our board meeting?\"\n- **CSV export missing fields**: \"Why is the campaign CSV export missing source and owner columns?\"\n- **Export scheduled report**: \"Can I schedule a weekly attribution report export for finance?\"\n- **Dashboard export permissions**: \"Why can analysts view dashboards but not export reports?\"\n- **Dashboard stale data**: \"Why has our pipeline dashboard not refreshed since yesterday?\"\n- **Warehouse sync lag**: \"How do we check whether the warehouse sync is delayed?\"\n\nThese are not paraphrases. This is the language customers use when the help center does not have the answer. The gap audit uses this wording to draft review-ready FAQ shells. The support lead reviews the draft, adds the verified resolution, and approves publication.",
+          "id": "customer_wording_evidence",
           "metadata": {
-            "answer_summary": "Customers describe the friction they hit, not your internal product names. Examples from uploaded tickets include \"Attribution export blocked,\" \"CSV export missing fields,\" \"Dashboard stale data,\" and \"Warehouse sync lag.\"",
-            "kind": "problem",
+            "answer_summary": "",
+            "kind": "proof",
             "order": 2,
-            "primary_question": "What exact wording do customers use when they ask these questions?"
+            "primary_question": ""
           },
-          "title": "Here is how your customers ask the question"
+          "title": "Customer wording shows the exact friction"
         },
         {
-          "body_markdown": "The audit groups question-shaped tickets by topic, counts repeat clusters, and pulls customer wording. You get review-ready FAQ shells with the customer's question and a placeholder for your team to add the verified resolution before publishing.\n\nUpload your support ticket CSV. The audit groups question-shaped tickets by topic, counts how many times each cluster appeared, and pulls the customer wording. You see which repeat questions do not have help-center answers yet. The audit does not publish anything. It gives your team a list of review-ready FAQ shells with the customer's exact question and a placeholder for the verified resolution. Your support team adds the correct answer, reviews it, and decides when to publish.",
-          "id": "gap_audit_process",
+          "body_markdown": "The gap audit identifies the highest-risk repeat questions and drafts FAQ answer shells for support review. It does not publish automatically. It does not write concrete procedural steps, UI paths, menu names, permission rules, or exact fix instructions. The draft says: \"Draft answer \u2013 support team should add the verified resolution before publishing.\"\n\nThe support lead reviews each draft, adds the verified resolution from the team's internal docs or runbook, and approves publication. The approved answer goes into the help center. The next customer who searches for that question finds the answer without opening a ticket.\n\nThe audit does not prove future support volume will drop. It does not prove customers will churn less or upgrade more. It shows which repeat questions need approved answers. The support lead tracks whether ticket volume changes after publication.",
+          "id": "gap_audit_output",
           "metadata": {
-            "answer_summary": "The audit groups question-shaped tickets by topic, counts repeat clusters, and pulls customer wording. You get review-ready FAQ shells with the customer's question and a placeholder for your team to add the verified resolution before publishing.",
-            "kind": "how_it_works",
+            "answer_summary": "The gap audit identifies the highest-risk repeat questions and drafts FAQ answer shells for support review. It does not publish automatically. It does not write concrete procedural steps, UI paths, menu names, permission rules, or exact fix instructions.",
+            "kind": "solution",
             "order": 3,
-            "primary_question": "What happens after I upload the CSV?"
+            "primary_question": "What does the gap audit deliver?"
           },
-          "title": "The audit shows which questions need answers"
+          "title": "The gap audit turns repeat tickets into review-ready FAQ drafts"
         },
         {
-          "body_markdown": "No. The audit gives you review-ready FAQ shells with customer questions and placeholders. Your team adds the verified resolution, reviews it, and decides when to publish. Nothing goes live without your approval.\n\nThe audit does not push answers to your help center. It does not write procedural steps or guess at product details. Each FAQ shell says \"Draft answer\u2014support team should add the verified resolution before publishing.\" Your team reviews the question, writes or pastes the correct answer, checks it, and publishes when ready. You control what goes live and when.",
-          "id": "no_auto_publish",
+          "body_markdown": "Upload a CSV export of your last 90 days of support tickets. The audit clusters question-shaped tickets by topic, ranks clusters by repeat count, and drafts FAQ answer shells using customer wording. The support lead reviews each draft, adds the verified resolution, and approves publication. The approved answer goes into the help center.\n\nThe audit does not require a full-time docs person. The support lead owns the review and approval. The audit does not publish automatically. The support lead decides which answers are ready and which need more work.\n\nThe audit does not invent product details, UI paths, or permission rules. The draft says: \"Draft answer \u2013 support team should add the verified resolution before publishing.\" The support lead adds the verified resolution from the team's internal docs or runbook.",
+          "id": "how_the_audit_works",
           "metadata": {
-            "answer_summary": "No. The audit gives you review-ready FAQ shells with customer questions and placeholders. Your team adds the verified resolution, reviews it, and decides when to publish. Nothing goes live without your approval.",
-            "kind": "objection",
+            "answer_summary": "Upload a CSV export of your last 90 days of support tickets. The audit clusters question-shaped tickets by topic, ranks clusters by repeat count, and drafts FAQ answer shells using customer wording. The support lead reviews each draft, adds the verified resolution, and approves publication.",
+            "kind": "how_it_works",
             "order": 4,
-            "primary_question": "Will this publish automatically?"
+            "primary_question": "How does the support ticket FAQ gap audit work?"
           },
-          "title": "Nothing publishes without your approval"
+          "title": "How the audit works"
         },
         {
-          "body_markdown": "No. Your support team already knows the answers. The audit removes the noticing and drafting work. A support lead or senior agent can review the FAQ shells and publish the verified answers without hiring a dedicated docs writer.\n\nYour support team already knows the answers. The audit removes the step where someone has to notice the pattern, remember to write it down, and find time to draft the FAQ. The audit does that noticing and drafting work. Your team reviews the question, confirms the answer is correct, and publishes. The support lead or a senior agent can handle the review queue without hiring a dedicated docs writer.",
-          "id": "no_fulltime_docs_person",
+          "body_markdown": "No. The gap audit drafts FAQ answer shells for support review. It does not publish automatically. The support lead reviews each draft, adds the verified resolution, and approves publication. The support lead decides which answers are ready and which need more work.\n\nThe audit does not write concrete procedural steps, UI paths, menu names, permission rules, or exact fix instructions. The draft says: \"Draft answer \u2013 support team should add the verified resolution before publishing.\" The support lead adds the verified resolution from the team's internal docs or runbook.",
+          "id": "objection_auto_publish",
           "metadata": {
-            "answer_summary": "No. Your support team already knows the answers. The audit removes the noticing and drafting work. A support lead or senior agent can review the FAQ shells and publish the verified answers without hiring a dedicated docs writer.",
+            "answer_summary": "No. The gap audit drafts FAQ answer shells for support review. It does not publish automatically. The support lead reviews each draft, adds the verified resolution, and approves publication.",
             "kind": "objection",
             "order": 5,
-            "primary_question": "Do we need a full-time docs person?"
+            "primary_question": "Will this publish automatically?"
           },
-          "title": "You do not need a full-time docs person"
+          "title": "Will this publish automatically?"
         },
         {
-          "body_markdown": "Export your support tickets as CSV. Upload the file. The audit runs and shows you which questions appeared multiple times, how your customers worded them, and which ones need help-center answers. You decide which FAQ answers to write first and when to publish them. No auto-publish. No placeholder content. No fake procedural steps. Just the repeat-question evidence and the review-ready FAQ shells your team needs to close the gap.",
+          "body_markdown": "No. The support lead owns the review and approval. The audit drafts FAQ answer shells using customer wording and repeat-ticket evidence. The support lead reviews each draft, adds the verified resolution from the team's internal docs or runbook, and approves publication. The audit does not require a full-time docs person.\n\nThe support lead decides which answers are ready and which need more work. The audit does not publish automatically. The support lead controls the publication schedule.",
+          "id": "objection_fulltime_docs",
+          "metadata": {
+            "answer_summary": "No. The support lead owns the review and approval. The audit drafts FAQ answer shells using customer wording and repeat-ticket evidence. The support lead reviews each draft, adds the verified resolution from the team's internal docs or runbook, and approves publication.",
+            "kind": "objection",
+            "order": 6,
+            "primary_question": "Do we need a full-time docs person?"
+          },
+          "title": "Do we need a full-time docs person?"
+        },
+        {
+          "body_markdown": "The audit clusters question-shaped tickets by topic, ranks clusters by repeat count, and drafts FAQ answer shells using customer wording. You receive the gap audit report. The report shows which repeat questions need approved FAQ answers. You review each draft, add the verified resolution from your team's internal docs or runbook, and approve publication. The approved answer goes into the help center.\n\nThe audit does not publish automatically. You decide which answers are ready and which need more work. You control the publication schedule.",
+          "id": "faq_after_upload",
+          "metadata": {
+            "answer_summary": "The audit clusters question-shaped tickets by topic, ranks clusters by repeat count, and drafts FAQ answer shells using customer wording. You receive the gap audit report. The report shows which repeat questions need approved FAQ answers.",
+            "kind": "faq",
+            "order": 7,
+            "primary_question": "What happens after I provide ticket data?"
+          },
+          "title": "What happens after I provide ticket data?"
+        },
+        {
+          "body_markdown": "No. The gap audit drafts FAQ answer shells for support review. It does not publish automatically. You review each draft, add the verified resolution, and approve publication. You decide which answers are ready and which need more work. You control the publication schedule.\n\nThe audit does not write concrete procedural steps, UI paths, menu names, permission rules, or exact fix instructions. The draft says: \"Draft answer \u2013 support team should add the verified resolution before publishing.\" You add the verified resolution from your team's internal docs or runbook.",
+          "id": "faq_auto_publish",
+          "metadata": {
+            "answer_summary": "No. The gap audit drafts FAQ answer shells for support review. It does not publish automatically. You review each draft, add the verified resolution, and approve publication. You decide which answers are ready and which need more work.",
+            "kind": "faq",
+            "order": 8,
+            "primary_question": "Does FAQ Report publish automatically?"
+          },
+          "title": "Does FAQ Report publish automatically?"
+        },
+        {
+          "body_markdown": "The repeat-ticket backlog shows the FAQ gaps. The gap audit shows which repeat questions need approved answers. Upload your last 90 days of support tickets. Get the gap audit. Review the drafts. Add the verified resolutions. Approve publication. Track whether ticket volume changes after publication.\n\nThe audit does not publish automatically. You own the review and approval. You decide which answers are ready. You control the publication schedule.\n\n[Upload Ticket CSV -- Get the Gap Audit](/systems/ai-content-ops/intake)",
           "id": "next_action",
           "metadata": {
             "answer_summary": "",
             "kind": "conversion",
-            "order": 6,
+            "order": 9,
             "primary_question": ""
           },
-          "title": "Upload your ticket CSV and see the repeat-question clusters"
+          "title": "Upload your ticket CSV and get the gap audit"
         }
       ],
       "seo_aeo_readiness": {
@@ -1151,52 +1268,73 @@
               "@type": "Audience",
               "audienceType": "SaaS support leaders carrying a repeat-ticket backlog"
             },
-            "description": "Upload your ticket CSV and see which repeat questions need approved FAQ answers. Turn support ticket patterns into help-center coverage.",
+            "description": "Upload your last 90 days of support tickets and get a gap audit showing which repeat questions need approved FAQ answers. No auto-publish. Support lead reviews and approves.",
             "hasPart": [
               {
                 "@type": "WebPageElement",
                 "additionalType": "problem",
-                "name": "The repeat-ticket backlog keeps growing",
+                "name": "The repeat-ticket backlog exposes missing help-center answers",
                 "position": 1,
-                "text": "The same questions come back because your help center does not have approved answers yet. In the uploaded tickets, 35 out of 36 were question-shaped, and the top 9 clusters each appeared 4 times.\n\nYour support team closes tickets, but the same questions come back. In the uploaded tickets, 35 out of 36 were question-shaped. The top clusters\u2014reporting export, dashboard freshness, SSO setup, permissions and seats, API and webhooks, integration sync, data import, workflow automation, billing and plan management\u2014each appeared 4 times. When the same question hits the queue multiple times, your team writes the same answer multiple times. The backlog does not shrink because the help center does not have the answer yet."
+                "text": "When the same questions appear in your support queue week after week, your help center has a gap. Your team answers the question once, closes the ticket, then answers it again for the next customer. The backlog grows. The team burns time. Customers wait.\n\nThe uploaded ticket data shows the pattern. In the last 90 days, 35 of 36 tickets were question-shaped. The top clusters: reporting export (4 tickets), dashboard freshness (4 tickets), SSO setup (4 tickets), permissions and seats (4 tickets), API and webhooks (4 tickets), integration sync (4 tickets), data import (4 tickets), workflow automation (4 tickets), billing and plan management (4 tickets).\n\nEach cluster is a repeat question your help center does not answer. Each repeat question is a risk. Customers open tickets because the answer is not in the help center. Your team answers the same question multiple times. The queue does not shrink.\n\nThe gap audit shows which repeat questions need approved FAQ answers. It does not publish automatically. It does not require a full-time docs person. It shows the support lead the next action."
               },
               {
                 "@type": "WebPageElement",
-                "additionalType": "problem",
-                "name": "Here is how your customers ask the question",
+                "additionalType": "proof",
+                "name": "Customer wording shows the exact friction",
                 "position": 2,
-                "text": "Customers describe the friction they hit, not your internal product names. Examples from uploaded tickets include \"Attribution export blocked,\" \"CSV export missing fields,\" \"Dashboard stale data,\" and \"Warehouse sync lag.\"\n\nYour customers do not use your internal product names. They describe the friction they hit:\n\n- \"Attribution export blocked\u2014How do I export attribution reports before our board meeting?\"\n- \"CSV export missing fields\u2014Why is the campaign CSV export missing source and owner columns?\"\n- \"Export scheduled report\u2014Can I schedule a weekly attribution report export for finance?\"\n- \"Dashboard export permissions\u2014Why can analysts view dashboards but not export reports?\"\n- \"Dashboard stale data\u2014Why has our pipeline dashboard not refreshed since yesterday?\"\n- \"Warehouse sync lag\u2014How do we check whether the warehouse sync is delayed?\"\n\nThese are real ticket titles from the uploaded CSV. When your help center does not match this wording, customers open a ticket instead of finding the answer."
+                "text": "The uploaded tickets preserve how customers describe the problem. Here are six examples:\n\n- **Attribution export blocked**: \"How do I export attribution reports before our board meeting?\"\n- **CSV export missing fields**: \"Why is the campaign CSV export missing source and owner columns?\"\n- **Export scheduled report**: \"Can I schedule a weekly attribution report export for finance?\"\n- **Dashboard export permissions**: \"Why can analysts view dashboards but not export reports?\"\n- **Dashboard stale data**: \"Why has our pipeline dashboard not refreshed since yesterday?\"\n- **Warehouse sync lag**: \"How do we check whether the warehouse sync is delayed?\"\n\nThese are not paraphrases. This is the language customers use when the help center does not have the answer. The gap audit uses this wording to draft review-ready FAQ shells. The support lead reviews the draft, adds the verified resolution, and approves publication."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "solution",
+                "name": "The gap audit turns repeat tickets into review-ready FAQ drafts",
+                "position": 3,
+                "text": "The gap audit identifies the highest-risk repeat questions and drafts FAQ answer shells for support review. It does not publish automatically. It does not write concrete procedural steps, UI paths, menu names, permission rules, or exact fix instructions. The draft says: \"Draft answer \u2013 support team should add the verified resolution before publishing.\"\n\nThe support lead reviews each draft, adds the verified resolution from the team's internal docs or runbook, and approves publication. The approved answer goes into the help center. The next customer who searches for that question finds the answer without opening a ticket.\n\nThe audit does not prove future support volume will drop. It does not prove customers will churn less or upgrade more. It shows which repeat questions need approved answers. The support lead tracks whether ticket volume changes after publication."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "how_it_works",
-                "name": "The audit shows which questions need answers",
-                "position": 3,
-                "text": "The audit groups question-shaped tickets by topic, counts repeat clusters, and pulls customer wording. You get review-ready FAQ shells with the customer's question and a placeholder for your team to add the verified resolution before publishing.\n\nUpload your support ticket CSV. The audit groups question-shaped tickets by topic, counts how many times each cluster appeared, and pulls the customer wording. You see which repeat questions do not have help-center answers yet. The audit does not publish anything. It gives your team a list of review-ready FAQ shells with the customer's exact question and a placeholder for the verified resolution. Your support team adds the correct answer, reviews it, and decides when to publish."
-              },
-              {
-                "@type": "WebPageElement",
-                "additionalType": "objection",
-                "name": "Nothing publishes without your approval",
+                "name": "How the audit works",
                 "position": 4,
-                "text": "No. The audit gives you review-ready FAQ shells with customer questions and placeholders. Your team adds the verified resolution, reviews it, and decides when to publish. Nothing goes live without your approval.\n\nThe audit does not push answers to your help center. It does not write procedural steps or guess at product details. Each FAQ shell says \"Draft answer\u2014support team should add the verified resolution before publishing.\" Your team reviews the question, writes or pastes the correct answer, checks it, and publishes when ready. You control what goes live and when."
+                "text": "Upload a CSV export of your last 90 days of support tickets. The audit clusters question-shaped tickets by topic, ranks clusters by repeat count, and drafts FAQ answer shells using customer wording. The support lead reviews each draft, adds the verified resolution, and approves publication. The approved answer goes into the help center.\n\nThe audit does not require a full-time docs person. The support lead owns the review and approval. The audit does not publish automatically. The support lead decides which answers are ready and which need more work.\n\nThe audit does not invent product details, UI paths, or permission rules. The draft says: \"Draft answer \u2013 support team should add the verified resolution before publishing.\" The support lead adds the verified resolution from the team's internal docs or runbook."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "objection",
-                "name": "You do not need a full-time docs person",
+                "name": "Will this publish automatically?",
                 "position": 5,
-                "text": "No. Your support team already knows the answers. The audit removes the noticing and drafting work. A support lead or senior agent can review the FAQ shells and publish the verified answers without hiring a dedicated docs writer.\n\nYour support team already knows the answers. The audit removes the step where someone has to notice the pattern, remember to write it down, and find time to draft the FAQ. The audit does that noticing and drafting work. Your team reviews the question, confirms the answer is correct, and publishes. The support lead or a senior agent can handle the review queue without hiring a dedicated docs writer."
+                "text": "No. The gap audit drafts FAQ answer shells for support review. It does not publish automatically. The support lead reviews each draft, adds the verified resolution, and approves publication. The support lead decides which answers are ready and which need more work.\n\nThe audit does not write concrete procedural steps, UI paths, menu names, permission rules, or exact fix instructions. The draft says: \"Draft answer \u2013 support team should add the verified resolution before publishing.\" The support lead adds the verified resolution from the team's internal docs or runbook."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "objection",
+                "name": "Do we need a full-time docs person?",
+                "position": 6,
+                "text": "No. The support lead owns the review and approval. The audit drafts FAQ answer shells using customer wording and repeat-ticket evidence. The support lead reviews each draft, adds the verified resolution from the team's internal docs or runbook, and approves publication. The audit does not require a full-time docs person.\n\nThe support lead decides which answers are ready and which need more work. The audit does not publish automatically. The support lead controls the publication schedule."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "faq",
+                "name": "What happens after I provide ticket data?",
+                "position": 7,
+                "text": "The audit clusters question-shaped tickets by topic, ranks clusters by repeat count, and drafts FAQ answer shells using customer wording. You receive the gap audit report. The report shows which repeat questions need approved FAQ answers. You review each draft, add the verified resolution from your team's internal docs or runbook, and approve publication. The approved answer goes into the help center.\n\nThe audit does not publish automatically. You decide which answers are ready and which need more work. You control the publication schedule."
+              },
+              {
+                "@type": "WebPageElement",
+                "additionalType": "faq",
+                "name": "Does FAQ Report publish automatically?",
+                "position": 8,
+                "text": "No. The gap audit drafts FAQ answer shells for support review. It does not publish automatically. You review each draft, add the verified resolution, and approve publication. You decide which answers are ready and which need more work. You control the publication schedule.\n\nThe audit does not write concrete procedural steps, UI paths, menu names, permission rules, or exact fix instructions. The draft says: \"Draft answer \u2013 support team should add the verified resolution before publishing.\" You add the verified resolution from your team's internal docs or runbook."
               },
               {
                 "@type": "WebPageElement",
                 "additionalType": "conversion",
-                "name": "Upload your ticket CSV and see the repeat-question clusters",
-                "position": 6,
-                "text": "Export your support tickets as CSV. Upload the file. The audit runs and shows you which questions appeared multiple times, how your customers worded them, and which ones need help-center answers. You decide which FAQ answers to write first and when to publish them. No auto-publish. No placeholder content. No fake procedural steps. Just the repeat-question evidence and the review-ready FAQ shells your team needs to close the gap."
+                "name": "Upload your ticket CSV and get the gap audit",
+                "position": 9,
+                "text": "The repeat-ticket backlog shows the FAQ gaps. The gap audit shows which repeat questions need approved answers. Upload your last 90 days of support tickets. Get the gap audit. Review the drafts. Add the verified resolutions. Approve publication. Track whether ticket volume changes after publication.\n\nThe audit does not publish automatically. You own the review and approval. You decide which answers are ready. You control the publication schedule.\n\n[Upload Ticket CSV -- Get the Gap Audit](/systems/ai-content-ops/intake)"
               }
             ],
-            "name": "Stop Answering the Same Support Tickets Every Week",
+            "name": "Support Ticket FAQ Gap Audit \u2013 Turn Repeat Tickets Into Answers",
             "potentialAction": {
               "@type": "Action",
               "name": "Upload Ticket CSV -- Get the Gap Audit",
@@ -1210,31 +1348,31 @@
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "The same questions come back because your help center does not have approved answers yet. In the uploaded tickets, 35 out of 36 were question-shaped, and the top 9 clusters each appeared 4 times."
+                  "text": "When the same questions appear in your support queue week after week, your help center has a gap. Your team answers the question once, closes the ticket, then answers it again for the next customer. The backlog grows. The team burns time. Customers wait."
                 },
-                "name": "Why do we keep getting the same support tickets?"
+                "name": "Why do the same support questions keep appearing in the ticket queue?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "Customers describe the friction they hit, not your internal product names. Examples from uploaded tickets include \"Attribution export blocked,\" \"CSV export missing fields,\" \"Dashboard stale data,\" and \"Warehouse sync lag.\""
+                  "text": "The gap audit identifies the highest-risk repeat questions and drafts FAQ answer shells for support review. It does not publish automatically. It does not write concrete procedural steps, UI paths, menu names, permission rules, or exact fix instructions."
                 },
-                "name": "What exact wording do customers use when they ask these questions?"
+                "name": "What does the gap audit deliver?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "The audit groups question-shaped tickets by topic, counts repeat clusters, and pulls customer wording. You get review-ready FAQ shells with the customer's question and a placeholder for your team to add the verified resolution before publishing."
+                  "text": "Upload a CSV export of your last 90 days of support tickets. The audit clusters question-shaped tickets by topic, ranks clusters by repeat count, and drafts FAQ answer shells using customer wording. The support lead reviews each draft, adds the verified resolution, and approves publication."
                 },
-                "name": "What happens after I upload the CSV?"
+                "name": "How does the support ticket FAQ gap audit work?"
               },
               {
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "No. The audit gives you review-ready FAQ shells with customer questions and placeholders. Your team adds the verified resolution, reviews it, and decides when to publish. Nothing goes live without your approval."
+                  "text": "No. The gap audit drafts FAQ answer shells for support review. It does not publish automatically. The support lead reviews each draft, adds the verified resolution, and approves publication."
                 },
                 "name": "Will this publish automatically?"
               },
@@ -1242,16 +1380,32 @@
                 "@type": "Question",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "No. Your support team already knows the answers. The audit removes the noticing and drafting work. A support lead or senior agent can review the FAQ shells and publish the verified answers without hiring a dedicated docs writer."
+                  "text": "No. The support lead owns the review and approval. The audit drafts FAQ answer shells using customer wording and repeat-ticket evidence. The support lead reviews each draft, adds the verified resolution from the team's internal docs or runbook, and approves publication."
                 },
                 "name": "Do we need a full-time docs person?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "The audit clusters question-shaped tickets by topic, ranks clusters by repeat count, and drafts FAQ answer shells using customer wording. You receive the gap audit report. The report shows which repeat questions need approved FAQ answers."
+                },
+                "name": "What happens after I provide ticket data?"
+              },
+              {
+                "@type": "Question",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. The gap audit drafts FAQ answer shells for support review. It does not publish automatically. You review each draft, add the verified resolution, and approve publication. You decide which answers are ready and which need more work."
+                },
+                "name": "Does FAQ Report publish automatically?"
               }
             ],
-            "name": "Stop Answering the Same Support Tickets Every Week FAQs"
+            "name": "Support Ticket FAQ Gap Audit \u2013 Turn Repeat Tickets Into Approved Answers FAQs"
           }
         ]
       },
-      "title": "Stop Answering the Same Support Tickets Every Week",
+      "title": "Support Ticket FAQ Gap Audit \u2013 Turn Repeat Tickets Into Approved Answers",
       "value_prop": "Turn repeat support tickets into approved FAQ answers"
     }
   ]

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json
@@ -1,0 +1,367 @@
+{
+  "count": 3,
+  "filters": {
+    "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    "id": [
+      "33044118-629f-491d-ada6-0aa3fc838222",
+      "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+      "8744dc21-df4e-424e-9a9d-e5cada717886"
+    ],
+    "target_mode": "vendor_retention"
+  },
+  "limit": 100,
+  "rows": [
+    {
+      "brief_type": "renewal",
+      "generation_input_tokens": 1842,
+      "generation_output_tokens": 626,
+      "generation_parse_attempts": 1,
+      "generation_total_tokens": null,
+      "headline": "RevOps lead needs attribution exports before board meeting. Support ticket signals reporting gap risk at renewal.",
+      "id": "8744dc21-df4e-424e-9a9d-e5cada717886",
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "confidence": 0.78,
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_usage": {
+          "billable_input_tokens": 144,
+          "cache_write_tokens": 0,
+          "cached_tokens": 1698,
+          "input_tokens": 1842,
+          "output_tokens": 626,
+          "reasoning_tokens": 0
+        },
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "target_id": "saas-demo-001",
+        "target_mode": "vendor_retention",
+        "variant_angle": "Social-proof-led: frame the post around observed customer or market signals without adding unsupported testimonials."
+      },
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "reference_count": 1,
+      "reference_ids": [
+        "saas-demo-001"
+      ],
+      "section_count": 5,
+      "sections": [
+        {
+          "body_markdown": "Atlas Supply. Morgan Reyes is the Revenue Operations Lead. Your contact email is ops@atlas-supply.example. This is a retention opportunity tied to a support ticket (saas-demo-001).",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "account_context",
+          "metadata": {
+            "order": 1
+          },
+          "title": "Account Context"
+        },
+        {
+          "body_markdown": "Morgan opened a support ticket asking how to export attribution reports before a board meeting. The ticket title is \"Attribution export blocked.\" The question points to a reporting export gap under time pressure.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "recent_signals",
+          "metadata": {},
+          "title": "Recent Signals"
+        },
+        {
+          "body_markdown": "Lead with the board meeting deadline. Ask what attribution data the board expects and whether the current export covers it. Position your export workflow as the fix before the meeting. Do not promise features you have not shipped. If your product does not export attribution reports, say so and offer a workaround or timeline.",
+          "claim_ids": [],
+          "evidence_ids": [],
+          "id": "talking_points",
+          "metadata": {},
+          "title": "Talking Points"
+        },
+        {
+          "body_markdown": "Morgan may already be evaluating tools that export attribution out of the box. If your export is manual or requires engineering work, she will ask why she is paying for a product that cannot deliver board-ready reports. Prepare a specific answer about export roadmap and timing.",
+          "claim_ids": [],
+          "evidence_ids": [],
+          "id": "risks_and_objections",
+          "metadata": {},
+          "title": "Risks and Objections"
+        },
+        {
+          "body_markdown": "Reply to the support ticket with a clear export path or escalation timeline. Offer a call to walk through the export workflow before the board meeting. If you cannot solve the export problem before renewal, surface the risk to your renewal team now.",
+          "claim_ids": [],
+          "evidence_ids": [],
+          "id": "next_actions",
+          "metadata": {},
+          "title": "Next Actions"
+        }
+      ],
+      "status": "approved",
+      "target_id": "saas-demo-001",
+      "target_mode": "vendor_retention",
+      "title": "Renewal brief: Atlas Supply -- board-driven export pressure"
+    },
+    {
+      "brief_type": "renewal",
+      "generation_input_tokens": 1842,
+      "generation_output_tokens": 742,
+      "generation_parse_attempts": 1,
+      "generation_total_tokens": null,
+      "headline": "Your RevOps lead needs attribution exports before the board meeting. Support ticket shows renewal-stage reporting gap.",
+      "id": "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "confidence": 0.78,
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_usage": {
+          "billable_input_tokens": 144,
+          "cache_write_tokens": 0,
+          "cached_tokens": 1698,
+          "input_tokens": 1842,
+          "output_tokens": 742,
+          "reasoning_tokens": 0
+        },
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "target_id": "saas-demo-001",
+        "target_mode": "vendor_retention",
+        "variant_angle": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result."
+      },
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "reference_count": 1,
+      "reference_ids": [
+        "saas-demo-001"
+      ],
+      "section_count": 5,
+      "sections": [
+        {
+          "body_markdown": "Atlas Supply. Morgan Reyes is the Revenue Operations Lead. Your contact is actively using FlowPilot for attribution reporting and hit a blocker trying to export data before a board meeting.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "account_context",
+          "metadata": {
+            "order": 1
+          },
+          "title": "Account Context"
+        },
+        {
+          "body_markdown": "Support ticket filed: \"How do I export attribution reports before our board meeting?\" The ticket shows Morgan cannot get attribution data out of the platform when board reporting deadlines are live. This is a renewal-stage exposure point -- if your product blocks board prep, you create a switching window.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "recent_signals",
+          "metadata": {
+            "order": 2
+          },
+          "title": "Recent Signals"
+        },
+        {
+          "body_markdown": "Lead with the board meeting deadline. Ask Morgan what attribution metrics the board expects and whether FlowPilot's current export limits are blocking that prep work. If the export feature is gated or broken, you need to fix it before the renewal conversation starts. Do not let a support ticket turn into a renewal objection.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "talking_points",
+          "metadata": {
+            "order": 3
+          },
+          "title": "Talking Points"
+        },
+        {
+          "body_markdown": "Morgan's job is to deliver board-ready attribution reporting. If your platform cannot export the data she needs, she will evaluate tools that can. The support ticket is the early warning. The objection comes later when she says \"we need a platform that supports our board cadence.\"",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "risks_and_objections",
+          "metadata": {
+            "order": 4
+          },
+          "title": "Risks and Objections"
+        },
+        {
+          "body_markdown": "1. Check the support ticket status and resolution timeline. 2. Reach out to Morgan directly -- acknowledge the export blocker and confirm whether it is resolved. 3. If the feature is gated, discuss upgrade or early access. 4. Schedule a renewal check-in before the board meeting date to confirm FlowPilot meets her reporting requirements.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "next_actions",
+          "metadata": {
+            "order": 5
+          },
+          "title": "Next Actions"
+        }
+      ],
+      "status": "approved",
+      "target_id": "saas-demo-001",
+      "target_mode": "vendor_retention",
+      "title": "Renewal brief: Atlas Supply -- Board reporting pressure"
+    },
+    {
+      "brief_type": "renewal",
+      "generation_input_tokens": 1842,
+      "generation_output_tokens": 684,
+      "generation_parse_attempts": 1,
+      "generation_total_tokens": null,
+      "headline": "Your RevOps lead hit a reporting wall before their board meeting. Export friction at renewal time is churn friction.",
+      "id": "33044118-629f-491d-ada6-0aa3fc838222",
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "confidence": 0.85,
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_usage": {
+          "billable_input_tokens": 144,
+          "cache_write_tokens": 1698,
+          "cached_tokens": 0,
+          "input_tokens": 1842,
+          "output_tokens": 684,
+          "reasoning_tokens": 0
+        },
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "target_id": "saas-demo-001",
+        "target_mode": "vendor_retention",
+        "variant_angle": "Pain-led: open with the customer's current friction, then show how the evidence supports the recommended next step."
+      },
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "reference_count": 1,
+      "reference_ids": [
+        "saas-demo-001"
+      ],
+      "section_count": 5,
+      "sections": [
+        {
+          "body_markdown": "Atlas Supply. Morgan Reyes is the Revenue Operations Lead. They use FlowPilot. You are the vendor retention contact.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "account_context",
+          "metadata": {
+            "order": 1
+          },
+          "title": "Account Context"
+        },
+        {
+          "body_markdown": "Morgan opened a support ticket asking how to export attribution reports before a board meeting. The ticket is titled \"Attribution export blocked.\" This is a reporting export pain point surfacing at a high-stakes moment.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "recent_signals",
+          "metadata": {
+            "order": 2
+          },
+          "title": "Recent Signals"
+        },
+        {
+          "body_markdown": "Lead with the export block. Ask what reporting Morgan needs for the board and whether the current export limits are creating workarounds. If they are manually rebuilding attribution data outside your tool, that is a renewal risk. Offer to unblock the export or show them the feature they need. Do not wait for the renewal window to fix this.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "talking_points",
+          "metadata": {
+            "order": 3
+          },
+          "title": "Talking Points"
+        },
+        {
+          "body_markdown": "If Morgan cannot export the data they need, they will find a tool that can. Board reporting is not optional. If you do not solve this before the meeting, you become the friction story they tell the board.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "risks_and_objections",
+          "metadata": {
+            "order": 4
+          },
+          "title": "Risks and Objections"
+        },
+        {
+          "body_markdown": "Reply to the support ticket directly. Offer a call to walk through the export options or escalate the feature request. Ask when the board meeting is. If the export is not possible today, give Morgan a timeline and a workaround. Do not let this ticket sit.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "next_actions",
+          "metadata": {
+            "order": 5
+          },
+          "title": "Next Actions"
+        }
+      ],
+      "status": "approved",
+      "target_id": "saas-demo-001",
+      "target_mode": "vendor_retention",
+      "title": "Renewal brief: Atlas Supply -- Export block risk"
+    }
+  ]
+}

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json
@@ -3,9 +3,9 @@
   "filters": {
     "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
     "id": [
-      "33044118-629f-491d-ada6-0aa3fc838222",
-      "e71d3a76-e32a-4891-8879-e6b99d9e58af",
-      "8744dc21-df4e-424e-9a9d-e5cada717886"
+      "3fc2cbe9-eca0-42ee-8804-2b63c9af9057",
+      "490247f3-19bf-4c0e-b532-e78c369cf989",
+      "2689157c-2473-44e9-bc75-3f786b105aae"
     ],
     "target_mode": "vendor_retention"
   },
@@ -14,11 +14,11 @@
     {
       "brief_type": "renewal",
       "generation_input_tokens": 1842,
-      "generation_output_tokens": 626,
+      "generation_output_tokens": 782,
       "generation_parse_attempts": 1,
       "generation_total_tokens": null,
-      "headline": "RevOps lead needs attribution exports before board meeting. Support ticket signals reporting gap risk at renewal.",
-      "id": "8744dc21-df4e-424e-9a9d-e5cada717886",
+      "headline": "RevOps lead blocked on attribution exports days before board meeting. Support ticket shows renewal-risk friction.",
+      "id": "2689157c-2473-44e9-bc75-3f786b105aae",
       "metadata": {
         "brand_voice_audit": {
           "banned_terms": [],
@@ -47,7 +47,7 @@
           "cache_write_tokens": 0,
           "cached_tokens": 1698,
           "input_tokens": 1842,
-          "output_tokens": 626,
+          "output_tokens": 782,
           "reasoning_tokens": 0
         },
         "scope": {
@@ -68,7 +68,7 @@
       "section_count": 5,
       "sections": [
         {
-          "body_markdown": "Atlas Supply. Morgan Reyes is the Revenue Operations Lead. Your contact email is ops@atlas-supply.example. This is a retention opportunity tied to a support ticket (saas-demo-001).",
+          "body_markdown": "Atlas Supply. Morgan Reyes is the Revenue Operations Lead. Your account uses FlowPilot. Morgan reached out through support, not through their account team.",
           "claim_ids": [],
           "evidence_ids": [
             "saas-demo-001"
@@ -80,53 +80,189 @@
           "title": "Account Context"
         },
         {
-          "body_markdown": "Morgan opened a support ticket asking how to export attribution reports before a board meeting. The ticket title is \"Attribution export blocked.\" The question points to a reporting export gap under time pressure.",
+          "body_markdown": "Morgan filed a support ticket asking how to export attribution reports before a board meeting. The ticket title is \"Attribution export blocked.\" The question is direct: \"How do I export attribution reports before our board meeting?\" This is a time-sensitive ask tied to executive visibility.",
           "claim_ids": [],
           "evidence_ids": [
             "saas-demo-001"
           ],
           "id": "recent_signals",
-          "metadata": {},
+          "metadata": {
+            "order": 2
+          },
           "title": "Recent Signals"
         },
         {
-          "body_markdown": "Lead with the board meeting deadline. Ask what attribution data the board expects and whether the current export covers it. Position your export workflow as the fix before the meeting. Do not promise features you have not shipped. If your product does not export attribution reports, say so and offer a workaround or timeline.",
+          "body_markdown": "Lead with the board deadline. Morgan is under pressure to deliver attribution data to executives. If your product blocks a basic export workflow, that friction becomes a renewal conversation. Ask what reporting Morgan needs to deliver and when. Confirm whether the export limitation is a product gap or a configuration issue. If it is a gap, own it and give Morgan a workaround or timeline. If it is a config issue, fix it before the board meeting.",
           "claim_ids": [],
-          "evidence_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
           "id": "talking_points",
-          "metadata": {},
+          "metadata": {
+            "order": 3
+          },
           "title": "Talking Points"
         },
         {
-          "body_markdown": "Morgan may already be evaluating tools that export attribution out of the box. If your export is manual or requires engineering work, she will ask why she is paying for a product that cannot deliver board-ready reports. Prepare a specific answer about export roadmap and timing.",
+          "body_markdown": "Morgan went to support, not to you. That means the relationship is transactional, not strategic. If the export issue is not resolved before the board meeting, Morgan will present incomplete data or explain why FlowPilot could not deliver. Either outcome damages your renewal position. Expect Morgan to ask whether competitors offer better reporting exports. Do not promise features you cannot ship before renewal.",
           "claim_ids": [],
-          "evidence_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
           "id": "risks_and_objections",
-          "metadata": {},
+          "metadata": {
+            "order": 4
+          },
           "title": "Risks and Objections"
         },
         {
-          "body_markdown": "Reply to the support ticket with a clear export path or escalation timeline. Offer a call to walk through the export workflow before the board meeting. If you cannot solve the export problem before renewal, surface the risk to your renewal team now.",
+          "body_markdown": "Reach out to Morgan today. Reference the support ticket. Offer to walk through the export workflow or escalate to product if the limitation is real. Ask when the board meeting is scheduled. If you cannot solve the export issue before the meeting, give Morgan a manual workaround and a timeline for the permanent fix. Use this conversation to move from support-ticket relationship to renewal-stage partnership.",
           "claim_ids": [],
-          "evidence_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
           "id": "next_actions",
-          "metadata": {},
+          "metadata": {
+            "order": 5
+          },
           "title": "Next Actions"
         }
       ],
       "status": "approved",
       "target_id": "saas-demo-001",
       "target_mode": "vendor_retention",
-      "title": "Renewal brief: Atlas Supply -- board-driven export pressure"
+      "title": "Renewal brief: Atlas Supply -- Board reporting pressure"
     },
     {
       "brief_type": "renewal",
       "generation_input_tokens": 1842,
-      "generation_output_tokens": 742,
+      "generation_output_tokens": 794,
       "generation_parse_attempts": 1,
       "generation_total_tokens": null,
-      "headline": "Your RevOps lead needs attribution exports before the board meeting. Support ticket shows renewal-stage reporting gap.",
-      "id": "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+      "headline": "Your RevOps lead needs attribution exports before the board meeting. Renewal window is your leverage to fix the blocker.",
+      "id": "490247f3-19bf-4c0e-b532-e78c369cf989",
+      "metadata": {
+        "brand_voice_audit": {
+          "banned_terms": [],
+          "passed": true,
+          "warnings": []
+        },
+        "brand_voice_profile": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "descriptors": [
+            "plainspoken",
+            "skeptical",
+            "operator-led",
+            "specific",
+            "short sentences"
+          ],
+          "id": "gate-a-sharp-support-operator",
+          "name": "Sharp Support Operator",
+          "preferred_pov": "second_person",
+          "reading_level": "concise"
+        },
+        "confidence": 0.88,
+        "generation_model": "anthropic/claude-sonnet-4-5",
+        "generation_parse_attempts": 1,
+        "generation_usage": {
+          "billable_input_tokens": 144,
+          "cache_write_tokens": 0,
+          "cached_tokens": 1698,
+          "input_tokens": 1842,
+          "output_tokens": 794,
+          "reasoning_tokens": 0
+        },
+        "scope": {
+          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+          "user_id": "11111111-1111-4111-8111-111111111111"
+        },
+        "target_id": "saas-demo-001",
+        "target_mode": "vendor_retention",
+        "variant_angle": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result."
+      },
+      "reasoning_confidence": null,
+      "reasoning_context_used": false,
+      "reasoning_wedge": null,
+      "reference_count": 1,
+      "reference_ids": [
+        "saas-demo-001"
+      ],
+      "section_count": 5,
+      "sections": [
+        {
+          "body_markdown": "Atlas Supply. Morgan Reyes is the Revenue Operations Lead. Your point of contact. The account is using FlowPilot for attribution tracking.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "account_context",
+          "metadata": {
+            "order": 1
+          },
+          "title": "Account Context"
+        },
+        {
+          "body_markdown": "Support ticket filed: \"How do I export attribution reports before our board meeting?\" The export function is blocked. Morgan needs the data before the board convenes. This is not a feature request. This is a blocker with a deadline.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "recent_signals",
+          "metadata": {
+            "order": 2
+          },
+          "title": "Recent Signals"
+        },
+        {
+          "body_markdown": "Lead with the board deadline. Ask Morgan what format the board expects and when they present. Confirm whether the export blocker is a permissions issue, a product gap, or a configuration miss. If it is a product gap, you need to decide whether to escalate for a workaround or acknowledge the limitation. Do not promise a fix you cannot deliver before the board meeting. If you can unblock the export, do it now. If you cannot, tell Morgan what the alternative is and what you will do after the meeting.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "talking_points",
+          "metadata": {
+            "order": 3
+          },
+          "title": "Talking Points"
+        },
+        {
+          "body_markdown": "If the export stays blocked and Morgan cannot present attribution data to the board, you have handed the account a renewal objection. Board-level visibility failures stick. Morgan will remember that FlowPilot could not deliver the report when it mattered. If a competitor can export attribution data without friction, Morgan will evaluate them.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "risks_and_objections",
+          "metadata": {
+            "order": 4
+          },
+          "title": "Risks and Objections"
+        },
+        {
+          "body_markdown": "Call Morgan today. Get the board meeting date. Confirm the export blocker with support or product. If you can fix it, fix it before the meeting. If you cannot, offer a manual export, a screen-share walkthrough, or another path to get Morgan the data. Document what you deliver. Follow up after the board meeting to confirm Morgan presented successfully. Use this interaction to tee up the renewal conversation with proof that you respond when it matters.",
+          "claim_ids": [],
+          "evidence_ids": [
+            "saas-demo-001"
+          ],
+          "id": "next_actions",
+          "metadata": {
+            "order": 5
+          },
+          "title": "Next Actions"
+        }
+      ],
+      "status": "approved",
+      "target_id": "saas-demo-001",
+      "target_mode": "vendor_retention",
+      "title": "Renewal brief: Atlas Supply -- Board reporting pressure"
+    },
+    {
+      "brief_type": "renewal",
+      "generation_input_tokens": 1842,
+      "generation_output_tokens": 682,
+      "generation_parse_attempts": 1,
+      "generation_total_tokens": null,
+      "headline": "Your RevOps lead hit a wall exporting attribution data right before a board meeting. That's your renewal conversation starter.",
+      "id": "3fc2cbe9-eca0-42ee-8804-2b63c9af9057",
       "metadata": {
         "brand_voice_audit": {
           "banned_terms": [],
@@ -155,129 +291,7 @@
           "cache_write_tokens": 0,
           "cached_tokens": 1698,
           "input_tokens": 1842,
-          "output_tokens": 742,
-          "reasoning_tokens": 0
-        },
-        "scope": {
-          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
-          "user_id": "11111111-1111-4111-8111-111111111111"
-        },
-        "target_id": "saas-demo-001",
-        "target_mode": "vendor_retention",
-        "variant_angle": "Outcome-led: lead with the business result the audience wants, then connect the supporting evidence to that result."
-      },
-      "reasoning_confidence": null,
-      "reasoning_context_used": false,
-      "reasoning_wedge": null,
-      "reference_count": 1,
-      "reference_ids": [
-        "saas-demo-001"
-      ],
-      "section_count": 5,
-      "sections": [
-        {
-          "body_markdown": "Atlas Supply. Morgan Reyes is the Revenue Operations Lead. Your contact is actively using FlowPilot for attribution reporting and hit a blocker trying to export data before a board meeting.",
-          "claim_ids": [],
-          "evidence_ids": [
-            "saas-demo-001"
-          ],
-          "id": "account_context",
-          "metadata": {
-            "order": 1
-          },
-          "title": "Account Context"
-        },
-        {
-          "body_markdown": "Support ticket filed: \"How do I export attribution reports before our board meeting?\" The ticket shows Morgan cannot get attribution data out of the platform when board reporting deadlines are live. This is a renewal-stage exposure point -- if your product blocks board prep, you create a switching window.",
-          "claim_ids": [],
-          "evidence_ids": [
-            "saas-demo-001"
-          ],
-          "id": "recent_signals",
-          "metadata": {
-            "order": 2
-          },
-          "title": "Recent Signals"
-        },
-        {
-          "body_markdown": "Lead with the board meeting deadline. Ask Morgan what attribution metrics the board expects and whether FlowPilot's current export limits are blocking that prep work. If the export feature is gated or broken, you need to fix it before the renewal conversation starts. Do not let a support ticket turn into a renewal objection.",
-          "claim_ids": [],
-          "evidence_ids": [
-            "saas-demo-001"
-          ],
-          "id": "talking_points",
-          "metadata": {
-            "order": 3
-          },
-          "title": "Talking Points"
-        },
-        {
-          "body_markdown": "Morgan's job is to deliver board-ready attribution reporting. If your platform cannot export the data she needs, she will evaluate tools that can. The support ticket is the early warning. The objection comes later when she says \"we need a platform that supports our board cadence.\"",
-          "claim_ids": [],
-          "evidence_ids": [
-            "saas-demo-001"
-          ],
-          "id": "risks_and_objections",
-          "metadata": {
-            "order": 4
-          },
-          "title": "Risks and Objections"
-        },
-        {
-          "body_markdown": "1. Check the support ticket status and resolution timeline. 2. Reach out to Morgan directly -- acknowledge the export blocker and confirm whether it is resolved. 3. If the feature is gated, discuss upgrade or early access. 4. Schedule a renewal check-in before the board meeting date to confirm FlowPilot meets her reporting requirements.",
-          "claim_ids": [],
-          "evidence_ids": [
-            "saas-demo-001"
-          ],
-          "id": "next_actions",
-          "metadata": {
-            "order": 5
-          },
-          "title": "Next Actions"
-        }
-      ],
-      "status": "approved",
-      "target_id": "saas-demo-001",
-      "target_mode": "vendor_retention",
-      "title": "Renewal brief: Atlas Supply -- Board reporting pressure"
-    },
-    {
-      "brief_type": "renewal",
-      "generation_input_tokens": 1842,
-      "generation_output_tokens": 684,
-      "generation_parse_attempts": 1,
-      "generation_total_tokens": null,
-      "headline": "Your RevOps lead hit a reporting wall before their board meeting. Export friction at renewal time is churn friction.",
-      "id": "33044118-629f-491d-ada6-0aa3fc838222",
-      "metadata": {
-        "brand_voice_audit": {
-          "banned_terms": [],
-          "passed": true,
-          "warnings": []
-        },
-        "brand_voice_profile": {
-          "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
-          "descriptors": [
-            "plainspoken",
-            "skeptical",
-            "operator-led",
-            "specific",
-            "short sentences"
-          ],
-          "id": "gate-a-sharp-support-operator",
-          "name": "Sharp Support Operator",
-          "preferred_pov": "second_person",
-          "reading_level": "concise"
-        },
-        "confidence": 0.85,
-        "generation_model": "anthropic/claude-sonnet-4-5",
-        "generation_parse_attempts": 1,
-        "generation_usage": {
-          "billable_input_tokens": 144,
-          "cache_write_tokens": 1698,
-          "cached_tokens": 0,
-          "input_tokens": 1842,
-          "output_tokens": 684,
+          "output_tokens": 682,
           "reasoning_tokens": 0
         },
         "scope": {
@@ -298,7 +312,7 @@
       "section_count": 5,
       "sections": [
         {
-          "body_markdown": "Atlas Supply. Morgan Reyes is the Revenue Operations Lead. They use FlowPilot. You are the vendor retention contact.",
+          "body_markdown": "Atlas Supply. Morgan Reyes runs Revenue Operations. Your product is FlowPilot. Morgan's title signals they own reporting pipelines and board-level data delivery.",
           "claim_ids": [],
           "evidence_ids": [
             "saas-demo-001"
@@ -310,7 +324,7 @@
           "title": "Account Context"
         },
         {
-          "body_markdown": "Morgan opened a support ticket asking how to export attribution reports before a board meeting. The ticket is titled \"Attribution export blocked.\" This is a reporting export pain point surfacing at a high-stakes moment.",
+          "body_markdown": "Morgan opened a support ticket asking how to export attribution reports before a board meeting. The ticket describes the export as blocked. That means your product stood between Morgan and a high-stakes deadline.",
           "claim_ids": [],
           "evidence_ids": [
             "saas-demo-001"
@@ -322,7 +336,7 @@
           "title": "Recent Signals"
         },
         {
-          "body_markdown": "Lead with the export block. Ask what reporting Morgan needs for the board and whether the current export limits are creating workarounds. If they are manually rebuilding attribution data outside your tool, that is a renewal risk. Offer to unblock the export or show them the feature they need. Do not wait for the renewal window to fix this.",
+          "body_markdown": "Lead with the export friction. Ask Morgan what happened in that board meeting. Ask if the attribution gap is still open. Then ask what other reporting deadlines are coming. If Morgan had to work around your product once, they will work around it again or replace it.",
           "claim_ids": [],
           "evidence_ids": [
             "saas-demo-001"
@@ -334,11 +348,9 @@
           "title": "Talking Points"
         },
         {
-          "body_markdown": "If Morgan cannot export the data they need, they will find a tool that can. Board reporting is not optional. If you do not solve this before the meeting, you become the friction story they tell the board.",
+          "body_markdown": "Morgan may say the export issue was resolved. If so, ask how long the workaround took and whether it scales. If the fix required manual steps, the friction is still there. RevOps leads do not tolerate repeated manual export loops.",
           "claim_ids": [],
-          "evidence_ids": [
-            "saas-demo-001"
-          ],
+          "evidence_ids": [],
           "id": "risks_and_objections",
           "metadata": {
             "order": 4
@@ -346,7 +358,7 @@
           "title": "Risks and Objections"
         },
         {
-          "body_markdown": "Reply to the support ticket directly. Offer a call to walk through the export options or escalate the feature request. Ask when the board meeting is. If the export is not possible today, give Morgan a timeline and a workaround. Do not let this ticket sit.",
+          "body_markdown": "Reference the support ticket by ID. Ask Morgan to walk you through the export blocker and the board meeting outcome. Offer a product review focused on reporting workflows. If Morgan describes other attribution gaps, map those to your renewal conversation. If Morgan does not see the friction as urgent, you have a renewal risk.",
           "claim_ids": [],
           "evidence_ids": [
             "saas-demo-001"
@@ -361,7 +373,7 @@
       "status": "approved",
       "target_id": "saas-demo-001",
       "target_mode": "vendor_retention",
-      "title": "Renewal brief: Atlas Supply -- Export block risk"
+      "title": "Renewal brief: Atlas Supply -- Export friction before board"
     }
   ]
 }

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json
@@ -1,0 +1,39 @@
+{
+  "blog_post": {
+    "missing_ids": [],
+    "requested_ids": [
+      "2f9ec4e3-475a-4046-9e01-182757d1de20",
+      "44d56e20-d9c8-4626-8e39-e894cb8fd085"
+    ],
+    "updated_ids": [
+      "44d56e20-d9c8-4626-8e39-e894cb8fd085",
+      "2f9ec4e3-475a-4046-9e01-182757d1de20"
+    ]
+  },
+  "landing_page": {
+    "missing_ids": [],
+    "requested_ids": [
+      "49e324c1-f331-404d-bfa4-dcbcb5387027",
+      "2b09400f-a8b9-4787-86dd-ca655686d246",
+      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+    ],
+    "updated_ids": [
+      "49e324c1-f331-404d-bfa4-dcbcb5387027",
+      "2b09400f-a8b9-4787-86dd-ca655686d246",
+      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+    ]
+  },
+  "sales_brief": {
+    "missing_ids": [],
+    "requested_ids": [
+      "33044118-629f-491d-ada6-0aa3fc838222",
+      "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+      "8744dc21-df4e-424e-9a9d-e5cada717886"
+    ],
+    "updated_ids": [
+      "8744dc21-df4e-424e-9a9d-e5cada717886",
+      "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+      "33044118-629f-491d-ada6-0aa3fc838222"
+    ]
+  }
+}

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json
@@ -2,38 +2,40 @@
   "blog_post": {
     "missing_ids": [],
     "requested_ids": [
+      "0501c17f-90c9-4318-9d15-e3253160a4e5",
       "2f9ec4e3-475a-4046-9e01-182757d1de20",
       "44d56e20-d9c8-4626-8e39-e894cb8fd085"
     ],
     "updated_ids": [
       "44d56e20-d9c8-4626-8e39-e894cb8fd085",
-      "2f9ec4e3-475a-4046-9e01-182757d1de20"
+      "2f9ec4e3-475a-4046-9e01-182757d1de20",
+      "0501c17f-90c9-4318-9d15-e3253160a4e5"
     ]
   },
   "landing_page": {
     "missing_ids": [],
     "requested_ids": [
-      "49e324c1-f331-404d-bfa4-dcbcb5387027",
-      "2b09400f-a8b9-4787-86dd-ca655686d246",
-      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+      "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
+      "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
+      "104b8793-9015-4aac-abab-41917dd38309"
     ],
     "updated_ids": [
-      "49e324c1-f331-404d-bfa4-dcbcb5387027",
-      "2b09400f-a8b9-4787-86dd-ca655686d246",
-      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+      "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
+      "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
+      "104b8793-9015-4aac-abab-41917dd38309"
     ]
   },
   "sales_brief": {
     "missing_ids": [],
     "requested_ids": [
-      "33044118-629f-491d-ada6-0aa3fc838222",
-      "e71d3a76-e32a-4891-8879-e6b99d9e58af",
-      "8744dc21-df4e-424e-9a9d-e5cada717886"
+      "3fc2cbe9-eca0-42ee-8804-2b63c9af9057",
+      "490247f3-19bf-4c0e-b532-e78c369cf989",
+      "2689157c-2473-44e9-bc75-3f786b105aae"
     ],
     "updated_ids": [
-      "8744dc21-df4e-424e-9a9d-e5cada717886",
-      "e71d3a76-e32a-4891-8879-e6b99d9e58af",
-      "33044118-629f-491d-ada6-0aa3fc838222"
+      "3fc2cbe9-eca0-42ee-8804-2b63c9af9057",
+      "490247f3-19bf-4c0e-b532-e78c369cf989",
+      "2689157c-2473-44e9-bc75-3f786b105aae"
     ]
   }
 }

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json
@@ -1,0 +1,214 @@
+{
+  "account_id": "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+  "budget": {
+    "account_usage_budget_days": 7,
+    "account_usage_budget_usd": null,
+    "max_cost_usd": 20.0,
+    "messages": [],
+    "triggered": false
+  },
+  "configured_outputs": [
+    "email_campaign",
+    "blog_post",
+    "report",
+    "landing_page",
+    "sales_brief",
+    "social_post",
+    "ad_copy",
+    "quote_card",
+    "stat_card",
+    "signal_extraction",
+    "faq_markdown",
+    "faq_deflection_report"
+  ],
+  "errors": [],
+  "export_counts": {
+    "blog_post": 2,
+    "landing_page": 3,
+    "sales_brief": 3
+  },
+  "issue": 1357,
+  "ok": true,
+  "output_dir": "tmp/content_ops_gate_a_reconfirm_20260608",
+  "required_outputs": [
+    "landing_page",
+    "blog_post",
+    "sales_brief"
+  ],
+  "review": {
+    "blog_post": {
+      "missing_ids": [],
+      "requested_ids": [
+        "2f9ec4e3-475a-4046-9e01-182757d1de20",
+        "44d56e20-d9c8-4626-8e39-e894cb8fd085"
+      ],
+      "updated_ids": [
+        "44d56e20-d9c8-4626-8e39-e894cb8fd085",
+        "2f9ec4e3-475a-4046-9e01-182757d1de20"
+      ]
+    },
+    "landing_page": {
+      "missing_ids": [],
+      "requested_ids": [
+        "49e324c1-f331-404d-bfa4-dcbcb5387027",
+        "2b09400f-a8b9-4787-86dd-ca655686d246",
+        "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+      ],
+      "updated_ids": [
+        "49e324c1-f331-404d-bfa4-dcbcb5387027",
+        "2b09400f-a8b9-4787-86dd-ca655686d246",
+        "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+      ]
+    },
+    "sales_brief": {
+      "missing_ids": [],
+      "requested_ids": [
+        "33044118-629f-491d-ada6-0aa3fc838222",
+        "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+        "8744dc21-df4e-424e-9a9d-e5cada717886"
+      ],
+      "updated_ids": [
+        "8744dc21-df4e-424e-9a9d-e5cada717886",
+        "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+        "33044118-629f-491d-ada6-0aa3fc838222"
+      ]
+    }
+  },
+  "saved_ids": {
+    "blog_post": [
+      "2f9ec4e3-475a-4046-9e01-182757d1de20",
+      "44d56e20-d9c8-4626-8e39-e894cb8fd085"
+    ],
+    "landing_page": [
+      "49e324c1-f331-404d-bfa4-dcbcb5387027",
+      "2b09400f-a8b9-4787-86dd-ca655686d246",
+      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+    ],
+    "sales_brief": [
+      "33044118-629f-491d-ada6-0aa3fc838222",
+      "e71d3a76-e32a-4891-8879-e6b99d9e58af",
+      "8744dc21-df4e-424e-9a9d-e5cada717886"
+    ]
+  },
+  "seeded_blog_blueprint": {
+    "saved_ids": [
+      "0da54d85-706c-43e9-aa59-036b182b2d87"
+    ],
+    "slug": "content-ops-support-ticket-live-smoke-2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    "target_mode": "vendor_retention",
+    "topic": "Support-ticket questions customers keep asking",
+    "topic_type": "content_ops_support_ticket_faq"
+  },
+  "status": "passed",
+  "support_ticket_csv": "extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv",
+  "variant_count": 3,
+  "variant_summary": {
+    "blog_post": {
+      "variant_count": 3,
+      "variants": [
+        {
+          "errors": [
+            {
+              "blockers": [
+                "geo_citable_section_structure_missing",
+                "support_ticket_generated_content:debug_source_narration"
+              ],
+              "blueprint_id": "0da54d85-706c-43e9-aa59-036b182b2d87",
+              "failed_candidate": {
+                "content_excerpt_head": "## What repeat support questions show\n\nYour customers ask the same questions repeatedly. In the uploaded tickets, 35 of 36 rows include direct customer questions. Nine clusters appear with equal frequency: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster represents a gap where your help center does not answer the question.\n\nThe reporting export cluster includes questions such as \"How do I export attribution reports before our board meeting?\" and \"Why is the campaign CSV export missing source and owner columns?\" The dashboard freshness cluster includes \"Why has our pipeline dashboard not refreshed since yesterday?\" and \"How do we check whether the warehouse sync is delayed?\" These are not edge cases. They are repeated patterns in the provided ticket set.\n\nThe uploaded tickets show which questions appear most often in this sample. They do not prove how often those questions appear across your full support queue. They show what customers asked in the provided set.\n\n## Which FAQ gaps should be reviewed first\n\nPrioritize by observed ticket volume. In this set, nine clusters are tied at 4 tickets each. You cannot rank tied clusters by business impact, activation risk, or workflow blocking without measured outcome evidence. The blueprint does not include that evidence. Review all nine tied clusters bef",
+                "content_excerpt_tail": "d resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after publishing. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming causality.\n\nThe uploaded tickets do not include a dated source window, so do not add fixed checkpoints. Watch for changes in ticket patterns and adjust your FAQ content based on what you observe.\n\nIf a cluster continues to generate tickets after you publish an FAQ entry, that is a signal. The answer may need clearer wording, the question may need a different title, or the FAQ page may need better navigation. Use those signals to refine your content.",
+                "content_truncated": true,
+                "generation_parse_attempts": 1,
+                "generation_quality_repair_attempts": 2,
+                "seo_title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal",
+                "slug": "",
+                "target_keyword": "support ticket faq gaps",
+                "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
+                "topic_type": "",
+                "word_count": 924
+              },
+              "reason": "quality_blocked"
+            }
+          ],
+          "generated": 0,
+          "saved_ids": [],
+          "variant_angle": "pain_led"
+        },
+        {
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "2f9ec4e3-475a-4046-9e01-182757d1de20"
+          ],
+          "variant_angle": "outcome_led"
+        },
+        {
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "44d56e20-d9c8-4626-8e39-e894cb8fd085"
+          ],
+          "variant_angle": "social_proof"
+        }
+      ]
+    },
+    "landing_page": {
+      "variant_count": 3,
+      "variants": [
+        {
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "49e324c1-f331-404d-bfa4-dcbcb5387027"
+          ],
+          "variant_angle": "pain_led"
+        },
+        {
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "2b09400f-a8b9-4787-86dd-ca655686d246"
+          ],
+          "variant_angle": "outcome_led"
+        },
+        {
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+          ],
+          "variant_angle": "social_proof"
+        }
+      ]
+    },
+    "sales_brief": {
+      "variant_count": 3,
+      "variants": [
+        {
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "33044118-629f-491d-ada6-0aa3fc838222"
+          ],
+          "variant_angle": "pain_led"
+        },
+        {
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "e71d3a76-e32a-4891-8879-e6b99d9e58af"
+          ],
+          "variant_angle": "outcome_led"
+        },
+        {
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "8744dc21-df4e-424e-9a9d-e5cada717886"
+          ],
+          "variant_angle": "social_proof"
+        }
+      ]
+    }
+  }
+}

--- a/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json
+++ b/docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json
@@ -23,7 +23,7 @@
   ],
   "errors": [],
   "export_counts": {
-    "blog_post": 2,
+    "blog_post": 3,
     "landing_page": 3,
     "sales_brief": 3
   },
@@ -39,55 +39,58 @@
     "blog_post": {
       "missing_ids": [],
       "requested_ids": [
+        "0501c17f-90c9-4318-9d15-e3253160a4e5",
         "2f9ec4e3-475a-4046-9e01-182757d1de20",
         "44d56e20-d9c8-4626-8e39-e894cb8fd085"
       ],
       "updated_ids": [
         "44d56e20-d9c8-4626-8e39-e894cb8fd085",
-        "2f9ec4e3-475a-4046-9e01-182757d1de20"
+        "2f9ec4e3-475a-4046-9e01-182757d1de20",
+        "0501c17f-90c9-4318-9d15-e3253160a4e5"
       ]
     },
     "landing_page": {
       "missing_ids": [],
       "requested_ids": [
-        "49e324c1-f331-404d-bfa4-dcbcb5387027",
-        "2b09400f-a8b9-4787-86dd-ca655686d246",
-        "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+        "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
+        "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
+        "104b8793-9015-4aac-abab-41917dd38309"
       ],
       "updated_ids": [
-        "49e324c1-f331-404d-bfa4-dcbcb5387027",
-        "2b09400f-a8b9-4787-86dd-ca655686d246",
-        "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+        "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
+        "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
+        "104b8793-9015-4aac-abab-41917dd38309"
       ]
     },
     "sales_brief": {
       "missing_ids": [],
       "requested_ids": [
-        "33044118-629f-491d-ada6-0aa3fc838222",
-        "e71d3a76-e32a-4891-8879-e6b99d9e58af",
-        "8744dc21-df4e-424e-9a9d-e5cada717886"
+        "3fc2cbe9-eca0-42ee-8804-2b63c9af9057",
+        "490247f3-19bf-4c0e-b532-e78c369cf989",
+        "2689157c-2473-44e9-bc75-3f786b105aae"
       ],
       "updated_ids": [
-        "8744dc21-df4e-424e-9a9d-e5cada717886",
-        "e71d3a76-e32a-4891-8879-e6b99d9e58af",
-        "33044118-629f-491d-ada6-0aa3fc838222"
+        "3fc2cbe9-eca0-42ee-8804-2b63c9af9057",
+        "490247f3-19bf-4c0e-b532-e78c369cf989",
+        "2689157c-2473-44e9-bc75-3f786b105aae"
       ]
     }
   },
   "saved_ids": {
     "blog_post": [
+      "0501c17f-90c9-4318-9d15-e3253160a4e5",
       "2f9ec4e3-475a-4046-9e01-182757d1de20",
       "44d56e20-d9c8-4626-8e39-e894cb8fd085"
     ],
     "landing_page": [
-      "49e324c1-f331-404d-bfa4-dcbcb5387027",
-      "2b09400f-a8b9-4787-86dd-ca655686d246",
-      "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+      "d8b20a0d-44c5-42ee-ae7a-b29251426db8",
+      "067c7531-b8c7-4b88-acaf-4f7643cd43f6",
+      "104b8793-9015-4aac-abab-41917dd38309"
     ],
     "sales_brief": [
-      "33044118-629f-491d-ada6-0aa3fc838222",
-      "e71d3a76-e32a-4891-8879-e6b99d9e58af",
-      "8744dc21-df4e-424e-9a9d-e5cada717886"
+      "3fc2cbe9-eca0-42ee-8804-2b63c9af9057",
+      "490247f3-19bf-4c0e-b532-e78c369cf989",
+      "2689157c-2473-44e9-bc75-3f786b105aae"
     ]
   },
   "seeded_blog_blueprint": {
@@ -107,31 +110,11 @@
       "variant_count": 3,
       "variants": [
         {
-          "errors": [
-            {
-              "blockers": [
-                "geo_citable_section_structure_missing",
-                "support_ticket_generated_content:debug_source_narration"
-              ],
-              "blueprint_id": "0da54d85-706c-43e9-aa59-036b182b2d87",
-              "failed_candidate": {
-                "content_excerpt_head": "## What repeat support questions show\n\nYour customers ask the same questions repeatedly. In the uploaded tickets, 35 of 36 rows include direct customer questions. Nine clusters appear with equal frequency: reporting export (4 tickets), dashboard freshness (4), SSO setup (4), permissions and seats (4), API and webhooks (4), integration sync (4), data import (4), workflow automation (4), and billing and plan management (4). Each cluster represents a gap where your help center does not answer the question.\n\nThe reporting export cluster includes questions such as \"How do I export attribution reports before our board meeting?\" and \"Why is the campaign CSV export missing source and owner columns?\" The dashboard freshness cluster includes \"Why has our pipeline dashboard not refreshed since yesterday?\" and \"How do we check whether the warehouse sync is delayed?\" These are not edge cases. They are repeated patterns in the provided ticket set.\n\nThe uploaded tickets show which questions appear most often in this sample. They do not prove how often those questions appear across your full support queue. They show what customers asked in the provided set.\n\n## Which FAQ gaps should be reviewed first\n\nPrioritize by observed ticket volume. In this set, nine clusters are tied at 4 tickets each. You cannot rank tied clusters by business impact, activation risk, or workflow blocking without measured outcome evidence. The blueprint does not include that evidence. Review all nine tied clusters bef",
-                "content_excerpt_tail": "d resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### API and webhooks\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for API and webhooks?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n### Integration sync\n\n**Observed ticket count:** 4\n\n**Draft question:** What should the team verify for integration sync?\n\n**Answer shell:** Draft answer - support team should add the verified resolution before publishing.\n\n**Verification needed:**\n- Verified resolution\n- Approved customer-facing wording\n- Support owner review\n\n## What to measure after publishing\n\nTrack new tickets by the same observed cluster labels after publishing. Review FAQ page traffic and customer feedback as signals to inspect. Compare future tickets against the observed clusters without claiming causality.\n\nThe uploaded tickets do not include a dated source window, so do not add fixed checkpoints. Watch for changes in ticket patterns and adjust your FAQ content based on what you observe.\n\nIf a cluster continues to generate tickets after you publish an FAQ entry, that is a signal. The answer may need clearer wording, the question may need a different title, or the FAQ page may need better navigation. Use those signals to refine your content.",
-                "content_truncated": true,
-                "generation_parse_attempts": 1,
-                "generation_quality_repair_attempts": 2,
-                "seo_title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal",
-                "slug": "",
-                "target_keyword": "support ticket faq gaps",
-                "title": "Support Ticket FAQ Gaps: What Repeat Tickets Reveal Before Renewal",
-                "topic_type": "",
-                "word_count": 924
-              },
-              "reason": "quality_blocked"
-            }
+          "errors": [],
+          "generated": 1,
+          "saved_ids": [
+            "0501c17f-90c9-4318-9d15-e3253160a4e5"
           ],
-          "generated": 0,
-          "saved_ids": [],
           "variant_angle": "pain_led"
         },
         {
@@ -159,7 +142,7 @@
           "errors": [],
           "generated": 1,
           "saved_ids": [
-            "49e324c1-f331-404d-bfa4-dcbcb5387027"
+            "d8b20a0d-44c5-42ee-ae7a-b29251426db8"
           ],
           "variant_angle": "pain_led"
         },
@@ -167,7 +150,7 @@
           "errors": [],
           "generated": 1,
           "saved_ids": [
-            "2b09400f-a8b9-4787-86dd-ca655686d246"
+            "067c7531-b8c7-4b88-acaf-4f7643cd43f6"
           ],
           "variant_angle": "outcome_led"
         },
@@ -175,7 +158,7 @@
           "errors": [],
           "generated": 1,
           "saved_ids": [
-            "a1181e5e-91e3-49d0-9ad1-1c5494783330"
+            "104b8793-9015-4aac-abab-41917dd38309"
           ],
           "variant_angle": "social_proof"
         }
@@ -188,7 +171,7 @@
           "errors": [],
           "generated": 1,
           "saved_ids": [
-            "33044118-629f-491d-ada6-0aa3fc838222"
+            "3fc2cbe9-eca0-42ee-8804-2b63c9af9057"
           ],
           "variant_angle": "pain_led"
         },
@@ -196,7 +179,7 @@
           "errors": [],
           "generated": 1,
           "saved_ids": [
-            "e71d3a76-e32a-4891-8879-e6b99d9e58af"
+            "490247f3-19bf-4c0e-b532-e78c369cf989"
           ],
           "variant_angle": "outcome_led"
         },
@@ -204,7 +187,7 @@
           "errors": [],
           "generated": 1,
           "saved_ids": [
-            "8744dc21-df4e-424e-9a9d-e5cada717886"
+            "2689157c-2473-44e9-bc75-3f786b105aae"
           ],
           "variant_angle": "social_proof"
         }

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -163,11 +163,17 @@ _SUPPORT_TICKET_DESCRIPTIVE_CONTRACT_KEYS = (
 )
 _SUPPORT_TICKET_DEBUG_SOURCE_NARRATION_PATTERNS = (
     re.compile(
-        r"\bthe uploaded (?:\d+\s+)?"
+        r"\b(?:the|your|these) uploaded (?:\d+\s+)?"
         r"(?:csv|file|support[- ]tickets?|support[- ]ticket rows?|"
         r"ticket rows?|records?|data|dataset) "
         r"(?:contains?|shows?|includes?|reveals?|surfaces?)\b"
     ),
+    re.compile(r"\b\d+\s+rows? were included for generation\b"),
+    re.compile(
+        r"\bin (?:your |the )?uploaded tickets?,?\s+\d+\s+of\s+\d+\s+rows? "
+        r"(?:contains?|shows?|includes?|included)\b"
+    ),
+    re.compile(r"\bthe uploaded ticket csv can produce\b"),
     re.compile(
         r"\b(?:analysis of|looking at) (?:the )?(?:uploaded )?(?:\d+\s+)?"
         r"(?:support[- ]tickets?|ticket rows?|records?|data|dataset)\b"

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -86,7 +86,7 @@ _SUPPORT_TICKET_DESCRIPTIVE_FORBIDDEN_CLAIMS = (
         "fixed calendar windows, rolling periods, or future tracking intervals "
         "when provided tickets are undated"
     ),
-    "prioritization by business impact, activation delay, workflow blocking, or friction reduction without evidence",
+    "unsupported priority rankings or operational-impact rankings when observed counts are tied",
     "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence",
 )
 _SUPPORT_TICKET_DRAFT_ANSWER_GUIDANCE = (
@@ -111,7 +111,8 @@ _SUPPORT_TICKET_REQUIRED_SECTION_OUTLINE = (
         "heading": "Which FAQ gaps should be reviewed first",
         "allowed_source_fields": ("top_clusters", "draft_faq_shells"),
         "claim_boundary": (
-            "Order by observed ticket count only; do not infer business impact."
+            "Order by observed ticket count only; when counts tie, say no "
+            "evidence-based rank is available."
         ),
     },
     {
@@ -137,7 +138,7 @@ _SUPPORT_TICKET_MEASUREMENT_GUIDANCE = (
     "Compare future tickets against the observed clusters without claiming causality.",
     (
         "Do not add fixed day, week, month, 30-day, 60-day, or 90-day "
-        "checkpoints unless the provided tickets include a dated source window."
+        "checkpoints unless `data_context.has_dated_window` is true."
     ),
 )
 _SUPPORT_TICKET_MAX_DRAFT_FAQ_SHELLS = 6
@@ -151,6 +152,11 @@ _SUPPORT_TICKET_GENERIC_LABEL_WORDS = frozenset({
     "ticket",
     "tickets",
 })
+_SUPPORT_TICKET_UPLOAD_CONTEXT_LABELS = frozenset({
+    "uploaded support tickets",
+    "uploaded tickets",
+})
+_SUPPORT_TICKET_OBSERVED_SAMPLE_LABEL = "observed support-ticket sample"
 _SUPPORT_TICKET_SYNTHETIC_CLUSTER_LABELS = frozenset({"remaining", "uncategorized"})
 _SUPPORT_TICKET_DESCRIPTIVE_CONTRACT_KEYS = (
     "support_ticket_blog_mode",
@@ -164,16 +170,24 @@ _SUPPORT_TICKET_DESCRIPTIVE_CONTRACT_KEYS = (
 _SUPPORT_TICKET_DEBUG_SOURCE_NARRATION_PATTERNS = (
     re.compile(
         r"\b(?:the|your|these) uploaded (?:\d+\s+)?"
-        r"(?:csv|file|support[- ]tickets?|support[- ]ticket rows?|"
-        r"ticket rows?|records?|data|dataset) "
-        r"(?:contains?|shows?|includes?|reveals?|surfaces?)\b"
+        r"(?:csv|ticket\s+csv|file|support[- ]tickets?|support[- ]ticket rows?|"
+        r"ticket\s+set|tickets?|ticket rows?|records?|data|dataset|set) "
+        r"(?:contains?|shows?|includes?|reveals?|surfaces?|produces?|"
+        r"appears?|can\s+produce|do(?:es)?\s+not\s+include)\b"
     ),
-    re.compile(r"\b\d+\s+rows? were included for generation\b"),
+    re.compile(
+        r"\buploaded tickets?(?:\s+in\s+this\s+sample)?\s+"
+        r"do(?:es)?\s+not\s+include\b"
+    ),
+    re.compile(r"\b(?:the|your|these)?\s*uploaded (?:ticket\s+)?set\b"),
+    re.compile(
+        r"\b\d+\s+rows?\s+(?:were\s+)?"
+        r"(?:included|used|loaded|ingested)\s+for\s+generation\b"
+    ),
     re.compile(
         r"\bin (?:your |the )?uploaded tickets?,?\s+\d+\s+of\s+\d+\s+rows? "
         r"(?:contains?|shows?|includes?|included)\b"
     ),
-    re.compile(r"\bthe uploaded ticket csv can produce\b"),
     re.compile(
         r"\b(?:analysis of|looking at) (?:the )?(?:uploaded )?(?:\d+\s+)?"
         r"(?:support[- ]tickets?|ticket rows?|records?|data|dataset)\b"
@@ -192,6 +206,19 @@ _SUPPORT_TICKET_DEBUG_SOURCE_NARRATION_PATTERNS = (
         r"\bthis export of (?:\d+\s+)?support[- ]tickets? "
         r"(?:contains?|shows?|includes?|reveals?|surfaces?)\b"
     ),
+    re.compile(
+        r"\b(?:the|our|your|this) support[- ]ticket export "
+        r"(?:contains?|shows?|includes?|reveals?|surfaces?|holds|has|carries)\b"
+    ),
+    re.compile(r"\b(?:source|usable|included)\s+(?:ticket\s+)?rows?\b"),
+    re.compile(
+        r"\b(?:across|from)\s+(?:the\s+)?\d+\s+(?:tickets?|records?) "
+        r"(?:we\s+)?(?:ingested|uploaded|loaded|received)\b"
+    ),
+    re.compile(
+        r"\bfrom\s+(?:the\s+)?\d+\s+(?:records?|tickets?)\s+you\s+sent\b"
+    ),
+    re.compile(r"\b(?:records?|tickets?)\s+you\s+sent\b"),
 )
 
 
@@ -1190,7 +1217,20 @@ def _merged_blog_data_context(
 ) -> dict[str, Any]:
     data_context = _mapping_dict(parsed.get("data_context"))
     data_context.update(_mapping_dict(blueprint.get("data_context")))
+    if _is_support_ticket_blog_context(data_context):
+        data_context = _support_ticket_blog_public_data_context(data_context)
     return data_context
+
+
+def _support_ticket_blog_public_data_context(
+    data_context: Mapping[str, Any],
+) -> dict[str, Any]:
+    normalized = dict(data_context)
+    for key in ("source_period", "review_period"):
+        value = str(normalized.get(key) or "").strip().lower()
+        if value in _SUPPORT_TICKET_UPLOAD_CONTEXT_LABELS:
+            normalized[key] = _SUPPORT_TICKET_OBSERVED_SAMPLE_LABEL
+    return normalized
 
 
 def _blueprint_with_data_context(
@@ -1441,23 +1481,39 @@ def _with_support_ticket_descriptive_prompt_addendum(
     blueprint: Mapping[str, Any],
 ) -> str:
     data_context = _mapping_dict(blueprint.get("data_context"))
-    if not support_ticket_descriptive_blog_contract(data_context):
+    if not _is_support_ticket_blog_context(data_context):
         return prompt
-    return (
+    support_ticket_prompt = (
         f"{prompt}\n\n"
+        "Support-ticket customer-facing prose instructions:\n"
+        "- Write publishable customer-facing article prose from the first "
+        "sentence. Do not open by narrating the upload, CSV, export, rows, "
+        "records, dataset, analysis process, or source mechanics. Do not "
+        "describe tickets as uploaded, ingested, sent, source rows, usable "
+        "rows, or included rows in customer-facing copy. Never write the phrase "
+        "`uploaded tickets`; frame observed counts and clusters as evidence for "
+        "the reader.\n"
+        "- When counts matter, say what support tickets show in plain customer "
+        "language, such as `In 36 support tickets, 35 direct customer "
+        "questions repeated across nine clusters.`\n"
+        "- For each H2 section, write a 40-120 word paragraph immediately after "
+        "the heading and include the exact `target_keyword` phrase naturally in "
+        "that paragraph.\n"
+        "- Apply this prose rule to the title, description, metadata, H2 "
+        "sections, FAQ metadata, tags, and chart copy."
+    )
+    if not support_ticket_descriptive_blog_contract(data_context):
+        return support_ticket_prompt
+    return (
+        f"{support_ticket_prompt}\n\n"
         "Support-ticket descriptive mode instructions:\n"
         "- Write a descriptive support-ticket FAQ planning brief, not a "
         "persuasive ROI article.\n"
-        "- Write publishable customer-facing article prose from the first "
-        "sentence. Do not open by narrating the upload, CSV, export, rows, "
-        "records, dataset, analysis process, or source mechanics; frame "
-        "observed counts and clusters as evidence for the reader.\n"
         "- Use only observed ticket counts, observed clusters, copied customer "
         "wording, and review-needed FAQ shells from the blueprint.\n"
-        "- If clusters have the same count, say they are tied. Do not rank tied "
-        "clusters by business impact, activation risk, workflow blocking, "
-        "friction reduction, deal impact, or customer value unless the blueprint "
-        "contains measured outcome evidence for that ranking.\n"
+        "- If clusters have the same count, say they are tied and that the "
+        "provided evidence does not support ranking one tied cluster above "
+        "another.\n"
         "- If the blueprint lacks resolution evidence, keep answer content as "
         "draft placeholders for support-team review. Do not invent UI paths, "
         "setup steps, feature behavior, or exact resolutions.\n"

--- a/extracted_content_pipeline/brand_voice.py
+++ b/extracted_content_pipeline/brand_voice.py
@@ -128,6 +128,22 @@ def brand_voice_prompt_block(profile: BrandVoiceProfile | None) -> str:
         lines.append("Descriptors: " + ", ".join(profile.descriptors))
     if profile.preferred_pov:
         lines.append(f"Preferred POV: {profile.preferred_pov}")
+        if profile.preferred_pov == "second_person":
+            lines.append(
+                "POV instruction: write reader-facing copy in second person. "
+                "Use `you` or `your` naturally in the title, headline, body, "
+                "sections, and FAQ copy where those fields exist."
+            )
+        elif profile.preferred_pov == "first_person":
+            lines.append(
+                "POV instruction: write reader-facing copy in first person when "
+                "a direct company or team perspective is appropriate."
+            )
+        elif profile.preferred_pov == "third_person":
+            lines.append(
+                "POV instruction: avoid direct address; keep reader-facing copy "
+                "in third person where possible."
+            )
     if profile.reading_level:
         lines.append(f"Reading level: {profile.reading_level}")
     if profile.banned_terms:

--- a/plans/PR-Gate-A-Live-Convergence-Proof.md
+++ b/plans/PR-Gate-A-Live-Convergence-Proof.md
@@ -19,7 +19,10 @@ blog debug-source detector missed the exact live phrase "rows were included
 for generation", and the live smoke seed still exposed that debug wording in
 the source summary. The same review cycle also exposed a second-person sales
 brief instability where the shared brand-voice prompt was too implicit. This
-PR now closes those narrow gates and refreshes the proof artifacts.
+PR now closes those gates and the follow-up review finding that quote-specific
+blog detection still let upload/source-mechanics narration through passing
+exports. The final artifacts rerun the same selected outputs after moving
+support-ticket blog prose prevention into the unconditional prompt path.
 
 This PR may exceed the 400 LOC soft cap because the raw JSON outputs are the
 point of the slice. The artifacts are indivisible evidence, while the code
@@ -38,12 +41,16 @@ Slice phase: Functional validation
 3. Commit the exact run artifacts under `docs/extraction/validation/fixtures/`
    plus a markdown report with the command, resolved model, structural result,
    and sample pointers.
-4. Harden the support-ticket blog debug-source detector for the exact live
-   phrase and remove debug "included for generation" wording from the smoke
-   seed blueprint.
+4. Harden the support-ticket blog source-mechanics prevention path so the
+   support-ticket prose prompt fires unconditionally, the detector covers the
+   upload/source-row class, and the smoke seed no longer hands that wording to
+   the model.
 5. Make the shared second-person brand-voice prompt explicit enough for
    sales-brief generation to satisfy the existing enforcement gate.
-6. Do not self-certify product acceptance. The reviewer owns the GOOD-bar
+6. Keep the existing GEO/citable-section gate intact by prompting
+   support-ticket blog H2 sections to satisfy the required target-keyword
+   paragraph shape.
+7. Do not self-certify product acceptance. The reviewer owns the GOOD-bar
    judgment against the exported drafts.
 
 ### Review Contract
@@ -60,9 +67,11 @@ Slice phase: Functional validation
         claiming product pass/fail beyond the harness result.
   - [ ] The run excludes `email_campaign` so its unverified input-fit cannot
         mask the three-generator convergence signal.
-  - [ ] The refreshed run proves the bad blog prose candidate is blocked with
-        `support_ticket_generated_content:debug_source_narration`.
-  - [ ] Tests cover the exact live debug phrases and allowed near-misses.
+  - [ ] The refreshed run exports all three blog variants with no
+        source-mechanics/debug-source phrases in public blog content or the
+        full blog export JSON.
+  - [ ] Tests cover the exact live debug phrases, generalized
+        upload/source-mechanics shapes, and allowed near-misses.
 - Affected surfaces: validation artifacts, support-ticket blog generation
   gates, support-ticket live-smoke seed copy, shared brand-voice prompt
   guidance, and focused tests.
@@ -87,6 +96,7 @@ Slice phase: Functional validation
 - `scripts/smoke_content_ops_live_generation.py`
 - `tests/test_extracted_blog_generation.py`
 - `tests/test_extracted_brand_voice.py`
+- `tests/test_extracted_content_ops_live_execute_harness.py`
 - `tests/test_extracted_sales_brief_generation.py`
 - `tests/test_smoke_content_ops_live_generation.py`
 
@@ -110,11 +120,16 @@ and summarized in
 Review-response mechanics:
 
 - `extracted_content_pipeline/blog_generation.py` expands the existing
-  support-ticket debug-source narration patterns to catch the exact live
-  phrases from review, while paired tests preserve allowed near-misses.
+  support-ticket debug-source narration patterns to catch the generalized
+  upload/source-mechanics class from review, while paired tests preserve
+  allowed near-misses.
+- `extracted_content_pipeline/blog_generation.py` also applies
+  support-ticket customer-facing prose instructions before the descriptive
+  no-outcome contract check, prompts the existing GEO H2 target-keyword shape,
+  and normalizes blog-export upload-period labels to observed-sample wording.
 - `scripts/smoke_content_ops_live_generation.py` rewrites the seeded blog
-  blueprint summaries so the model no longer sees "rows were included for
-  generation" or "uploaded ticket CSV can produce" as source copy to repeat.
+  blueprint summaries so the model no longer sees upload, CSV, source-row, or
+  generation mechanics as source copy to repeat.
 - `extracted_content_pipeline/brand_voice.py` keeps the existing audit/blocker
   contract but makes second-person prompt guidance explicit (`you` / `your`)
   before sales-brief generation, so compliant drafts are more likely to pass
@@ -130,9 +145,9 @@ Review-response mechanics:
   changing the model variable.
 - Do not write a product-quality verdict. The report can state structural
   counts and sample excerpts, but the GOOD-bar judgment remains reviewer-owned.
-- The refreshed live run still permits a blocked variant. The blocked
-  `pain_led` blog candidate is evidence that the #1373-style gate fired, not a
-  saved customer-facing draft.
+- Preserve the quality gates instead of weakening them. The blog fix improves
+  first-pass prompt compliance and broadens deterministic detection; it does
+  not lower the generated-content, brand-voice, or GEO gates.
 
 ## Deferred
 
@@ -166,35 +181,41 @@ Parked hardening:
 
 ## Verification
 
-- `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false python scripts/smoke_content_ops_gate_a_live_quality.py --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 --user-id 11111111-1111-4111-8111-111111111111 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --output-dir tmp/content_ops_gate_a_reconfirm_20260608 --outputs landing_page,blog_post,sales_brief --variant-count 3 --quality-repair-attempts 1 --max-cost-usd 20.00 --json` - PASS (`summary.json` reports `ok=true`; selected outputs only).
-- `python -m pytest tests/test_extracted_blog_generation.py tests/test_extracted_brand_voice.py tests/test_extracted_sales_brief_generation.py tests/test_smoke_content_ops_live_generation.py tests/test_smoke_content_ops_gate_a_live_quality.py -q` - PASS (193 passed).
+- `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false python scripts/smoke_content_ops_gate_a_live_quality.py --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 --user-id 11111111-1111-4111-8111-111111111111 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --output-dir tmp/content_ops_gate_a_reconfirm_20260608 --outputs landing_page,blog_post,sales_brief --variant-count 3 --quality-repair-attempts 1 --max-cost-usd 20.00 --json` - PASS (`summary.json` reports `ok=true`; `export_counts` are `blog_post=3`, `landing_page=3`, `sales_brief=3`; selected outputs only).
+- `python -m pytest tests/test_extracted_blog_generation.py tests/test_extracted_brand_voice.py tests/test_extracted_sales_brief_generation.py tests/test_smoke_content_ops_live_generation.py tests/test_smoke_content_ops_gate_a_live_quality.py -q` - PASS (203 passed).
 - `for f in docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/*.json; do python -m json.tool "$f" >/dev/null || exit 1; done` - PASS.
 - `jq` model-route check over `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json`, `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json`, and `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json` with filter `map([.. | objects | .generation_model? // empty]) | add | unique` - PASS (`anthropic/claude-sonnet-4-5`).
-- `rg` check for known bad phrases in `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` - PASS (no matches for `rows were included for generation`, `uploaded ticket CSV can produce`, or `Your uploaded tickets contain`).
+- Blog public-content source-mechanics phrase check against `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` - PASS (no matches for upload/source-row/debug-source mechanics).
+- Blog full-export source-mechanics phrase check against `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` - PASS (no matches for upload/source-row/debug-source mechanics).
 - `bash` `scripts/validate_extracted_content_pipeline.sh` - PASS.
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
 - `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS.
 - `bash` `scripts/check_ascii_python.sh` - PASS.
-- `bash` `scripts/run_extracted_pipeline_checks.sh` - PASS (`extracted_reasoning_core`: 295 passed; `extracted_content_pipeline`: 3370 passed, 10 skipped, 1 known `pynvml` warning).
+- `python -m pytest tests/test_extracted_content_ops_live_execute_harness.py::test_support_ticket_provider_feeds_real_blog_post_generation -q` - PASS (1 passed).
+- `bash` `scripts/run_extracted_pipeline_checks.sh` - PASS (`extracted_reasoning_core`: 295 passed; `extracted_content_pipeline`: 3380 passed, 10 skipped, 1 known `pynvml` warning).
 - `bash scripts/push_pr.sh tmp/gate-a-live-convergence-proof-pr-body.md --force-with-lease origin claude/pr-gate-a-live-convergence-proof` - runs the managed pre-push hook once before pushing.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md` | 124 |
-| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json` | 433 |
-| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` | 831 |
-| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json` | 1258 |
-| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json` | 367 |
-| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json` | 39 |
-| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json` | 214 |
-| `extracted_content_pipeline/blog_generation.py` | 8 |
+| `docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md` | 122 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json` | 402 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` | 1240 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json` | 1412 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json` | 379 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json` | 41 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json` | 197 |
+| `extracted_content_pipeline/blog_generation.py` | 96 |
 | `extracted_content_pipeline/brand_voice.py` | 16 |
-| `plans/PR-Gate-A-Live-Convergence-Proof.md` | 200 |
-| `scripts/smoke_content_ops_live_generation.py` | 6 |
-| `tests/test_extracted_blog_generation.py` | 11 |
+| `plans/PR-Gate-A-Live-Convergence-Proof.md` | 217 |
+| `scripts/smoke_content_ops_live_generation.py` | 24 |
+| `tests/test_extracted_blog_generation.py` | 67 |
 | `tests/test_extracted_brand_voice.py` | 1 |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | 2 |
 | `tests/test_extracted_sales_brief_generation.py` | 33 |
-| `tests/test_smoke_content_ops_live_generation.py` | 7 |
-| **Total** | **3548** |
+| `tests/test_smoke_content_ops_live_generation.py` | 18 |
+| **Total** | **4268** |
+
+PR-scope diff summary from the merge base: 16 files, +4230/-37. The overage is
+raw validation evidence; code/test changes are the narrow review-response fix.

--- a/plans/PR-Gate-A-Live-Convergence-Proof.md
+++ b/plans/PR-Gate-A-Live-Convergence-Proof.md
@@ -1,0 +1,200 @@
+# PR-Gate-A-Live-Convergence-Proof
+
+## Why this slice exists
+
+The #1360 Gate A live output-quality proof failed on the support-ticket SaaS
+demo payload: blog variants collapsed, one blog variant was blocked, landing
+variants were not meaningfully distinct enough, sales briefs drifted from the
+requested brief type, and brand voice missed second-person in some outputs.
+
+The fix wave has since landed: blog persistence, sales-brief type lock/prompt
+steering, second-person brand voice, blog publishable-prose prevention,
+landing-page variant distinctness, and the #1378 harness `--outputs` selector.
+The operator explicitly assigned the next step in #1378: run the live
+convergence proof for `landing_page`, `blog_post`, and `sales_brief`, commit
+the generated artifacts, and let the reviewer judge the real samples.
+
+The first #1383 proof run then surfaced an actionable gap: the support-ticket
+blog debug-source detector missed the exact live phrase "rows were included
+for generation", and the live smoke seed still exposed that debug wording in
+the source summary. The same review cycle also exposed a second-person sales
+brief instability where the shared brand-voice prompt was too implicit. This
+PR now closes those narrow gates and refreshes the proof artifacts.
+
+This PR may exceed the 400 LOC soft cap because the raw JSON outputs are the
+point of the slice. The artifacts are indivisible evidence, while the code
+changes are the minimum needed to make the proof exercise the intended gates.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/gate-a-output-quality
+Slice phase: Functional validation
+
+1. Run `scripts/smoke_content_ops_gate_a_live_quality.py` against the real
+   local database/model route with `--outputs landing_page,blog_post,sales_brief`.
+2. Disable local Ollama fallback with
+   `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false` and use the configured
+   Sonnet route from `.env` / `.env.local`.
+3. Commit the exact run artifacts under `docs/extraction/validation/fixtures/`
+   plus a markdown report with the command, resolved model, structural result,
+   and sample pointers.
+4. Harden the support-ticket blog debug-source detector for the exact live
+   phrase and remove debug "included for generation" wording from the smoke
+   seed blueprint.
+5. Make the shared second-person brand-voice prompt explicit enough for
+   sales-brief generation to satisfy the existing enforcement gate.
+6. Do not self-certify product acceptance. The reviewer owns the GOOD-bar
+   judgment against the exported drafts.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The committed command includes
+        `--outputs landing_page,blog_post,sales_brief`.
+  - [ ] The artifact set includes `execution-result.json`,
+        `review-results.json`, `summary.json`, and per-output exports for each
+        selected output that the harness produced.
+  - [ ] The report records the resolved model route and that local Ollama
+        fallback was disabled.
+  - [ ] The report surfaces real samples and structural results without
+        claiming product pass/fail beyond the harness result.
+  - [ ] The run excludes `email_campaign` so its unverified input-fit cannot
+        mask the three-generator convergence signal.
+  - [ ] The refreshed run proves the bad blog prose candidate is blocked with
+        `support_ticket_generated_content:debug_source_narration`.
+  - [ ] Tests cover the exact live debug phrases and allowed near-misses.
+- Affected surfaces: validation artifacts, support-ticket blog generation
+  gates, support-ticket live-smoke seed copy, shared brand-voice prompt
+  guidance, and focused tests.
+- Risk areas: accidental local model fallback, missing artifacts, conflating
+  structural harness `ok` with human product acceptance, over-broad debug
+  prose detection, and weakening brand-voice enforcement instead of improving
+  prompt compliance.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json`
+- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json`
+- `extracted_content_pipeline/blog_generation.py`
+- `extracted_content_pipeline/brand_voice.py`
+- `plans/PR-Gate-A-Live-Convergence-Proof.md`
+- `scripts/smoke_content_ops_live_generation.py`
+- `tests/test_extracted_blog_generation.py`
+- `tests/test_extracted_brand_voice.py`
+- `tests/test_extracted_sales_brief_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+
+## Mechanism
+
+The script executes the real Content Ops service builder, persists generated
+drafts to the configured Postgres database, reviews the saved ids, exports the
+reviewed drafts exactly, and writes JSON artifacts to the selected output
+directory.
+
+This slice runs the script from the PR worktree with absolute `--env-file`
+paths to the primary checkout's existing `.env` and `.env.local`. That avoids
+copying secrets into the worktree while keeping the run equivalent to a clean
+main checkout with those env files present.
+
+After the run, the artifacts are copied into
+`docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/`
+and summarized in
+`docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md`.
+
+Review-response mechanics:
+
+- `extracted_content_pipeline/blog_generation.py` expands the existing
+  support-ticket debug-source narration patterns to catch the exact live
+  phrases from review, while paired tests preserve allowed near-misses.
+- `scripts/smoke_content_ops_live_generation.py` rewrites the seeded blog
+  blueprint summaries so the model no longer sees "rows were included for
+  generation" or "uploaded ticket CSV can produce" as source copy to repeat.
+- `extracted_content_pipeline/brand_voice.py` keeps the existing audit/blocker
+  contract but makes second-person prompt guidance explicit (`you` / `your`)
+  before sales-brief generation, so compliant drafts are more likely to pass
+  the already-enforced gate.
+
+## Intentional
+
+- Exclude `email_campaign` from this convergence run. #1378 made it selectable,
+  but its support-ticket input-fit is intentionally separate from this
+  three-generator proof.
+- Use Sonnet via the configured cloud/OpenRouter route, not Haiku and not local
+  Ollama, so the run compares the fix wave against the #1360 baseline without
+  changing the model variable.
+- Do not write a product-quality verdict. The report can state structural
+  counts and sample excerpts, but the GOOD-bar judgment remains reviewer-owned.
+- The refreshed live run still permits a blocked variant. The blocked
+  `pain_led` blog candidate is evidence that the #1373-style gate fired, not a
+  saved customer-facing draft.
+
+## Deferred
+
+- Separate `--outputs email_campaign` live validation if the operator wants to
+  prove campaign input-fit on the support-ticket payload.
+- Separate Haiku / cheaper-model ship-readiness pass after the Sonnet
+  convergence signal is reviewed.
+- Landing-page prose-prevention and section dedup remain separate product
+  hardening if the reviewer wants those rough edges promoted after judging the
+  refreshed proof.
+- Same-lane `HARDENING.md` items considered:
+  - "Blog output uses debug-style source narration instead of publishable
+    prose" was promoted into this PR and addressed by the detector/source-seed
+    hardening plus refreshed proof artifacts.
+  - "Brand-voice second-person guidance is not consistently honored" was
+    promoted for the sales-brief instability found during this review and
+    addressed with explicit second-person prompt guidance.
+  - "Landing-page variants pass audits but are not meaningfully distinct" was
+    addressed by the already-landed #1375 fix and rechecked here with three
+    exported landing variants; the separate section-title prose and section
+    dedup rough edges stay parked for a future landing polish slice.
+  - "Gate A needs a messy-ticket grounding rerun" stays parked because this
+    proof intentionally reruns the clean SaaS fixture that failed in #1360 to
+    isolate fix-wave convergence before changing the input distribution.
+
+Parked hardening:
+
+- `HARDENING.md` - Gate A needs a messy-ticket grounding rerun.
+- Landing-page section-title prose prevention and section dedup from the #1383
+  reviewer notes.
+
+## Verification
+
+- `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false python scripts/smoke_content_ops_gate_a_live_quality.py --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 --user-id 11111111-1111-4111-8111-111111111111 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --output-dir tmp/content_ops_gate_a_reconfirm_20260608 --outputs landing_page,blog_post,sales_brief --variant-count 3 --quality-repair-attempts 1 --max-cost-usd 20.00 --json` - PASS (`summary.json` reports `ok=true`; selected outputs only).
+- `python -m pytest tests/test_extracted_blog_generation.py tests/test_extracted_brand_voice.py tests/test_extracted_sales_brief_generation.py tests/test_smoke_content_ops_live_generation.py tests/test_smoke_content_ops_gate_a_live_quality.py -q` - PASS (193 passed).
+- `for f in docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/*.json; do python -m json.tool "$f" >/dev/null || exit 1; done` - PASS.
+- `jq` model-route check over `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json`, `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json`, and `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json` with filter `map([.. | objects | .generation_model? // empty]) | add | unique` - PASS (`anthropic/claude-sonnet-4-5`).
+- `rg` check for known bad phrases in `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` - PASS (no matches for `rows were included for generation`, `uploaded ticket CSV can produce`, or `Your uploaded tickets contain`).
+- `bash` `scripts/validate_extracted_content_pipeline.sh` - PASS.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS.
+- `bash` `scripts/check_ascii_python.sh` - PASS.
+- `bash` `scripts/run_extracted_pipeline_checks.sh` - PASS (`extracted_reasoning_core`: 295 passed; `extracted_content_pipeline`: 3370 passed, 10 skipped, 1 known `pynvml` warning).
+- `bash scripts/push_pr.sh tmp/gate-a-live-convergence-proof-pr-body.md --force-with-lease origin claude/pr-gate-a-live-convergence-proof` - runs the managed pre-push hook once before pushing.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md` | 124 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/execution-result.json` | 433 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` | 831 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json` | 1258 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json` | 367 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/review-results.json` | 39 |
+| `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/summary.json` | 214 |
+| `extracted_content_pipeline/blog_generation.py` | 8 |
+| `extracted_content_pipeline/brand_voice.py` | 16 |
+| `plans/PR-Gate-A-Live-Convergence-Proof.md` | 200 |
+| `scripts/smoke_content_ops_live_generation.py` | 6 |
+| `tests/test_extracted_blog_generation.py` | 11 |
+| `tests/test_extracted_brand_voice.py` | 1 |
+| `tests/test_extracted_sales_brief_generation.py` | 33 |
+| `tests/test_smoke_content_ops_live_generation.py` | 7 |
+| **Total** | **3548** |

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -56,7 +56,7 @@ DEFAULT_LANDING_PAGE_INPUTS: Mapping[str, Any] = {
         "Do we need a full-time docs person?",
     ],
     "faq_questions": [
-        "What happens after I upload the CSV?",
+        "What happens after I provide ticket data?",
         "Does FAQ Report publish automatically?",
     ],
     "source_period": "Last 90 days of support tickets",
@@ -694,7 +694,7 @@ def _default_blog_blueprint_payload() -> dict[str, Any]:
                 "id": "publishable-answer-process",
                 "heading": "How should old tickets become customer-ready answers?",
                 "goal": (
-                    "Show the operational path from CSV upload to clustered "
+                    "Show the operational path from ticket intake to clustered "
                     "questions, customer wording, draft answers, and review."
                 ),
                 "key_stats": {
@@ -743,17 +743,19 @@ def _support_ticket_blog_blueprint_payload(
     cluster_summary = _cluster_summary(top_clusters)
     faq_questions = list(inputs.get("faq_questions") or [])
     draft_faq_entries = min(12, max(1, len(faq_questions) or included_row_count))
+    has_valid_date_window = bool(inputs.get("has_dated_window"))
     source_period = str(
         inputs.get("source_period") or UPLOADED_SUPPORT_TICKETS_SOURCE_PERIOD
     )
-    has_valid_date_window = bool(inputs.get("has_dated_window"))
+    if not has_valid_date_window:
+        source_period = "observed support-ticket sample"
     resolution_evidence_present = bool(
         inputs.get("support_ticket_resolution_evidence_present")
     )
     review_period = (
         SUPPORT_TICKET_LAST_90_DAYS_REVIEW_PERIOD
         if has_valid_date_window
-        else UPLOADED_TICKETS_REVIEW_PERIOD
+        else "observed support-ticket sample"
     )
     data_context = {
         "review_period": review_period,
@@ -793,7 +795,7 @@ def _support_ticket_blog_blueprint_payload(
                 "id": "repeat-ticket-patterns",
                 "heading": "What do repeat support tickets reveal?",
                 "goal": (
-                    "Explain what the uploaded support-ticket rows show about "
+                    "Explain what the observed support-ticket sample shows about "
                     "customer questions and missing customer-facing answers."
                 ),
                 "key_stats": {
@@ -804,9 +806,9 @@ def _support_ticket_blog_blueprint_payload(
                 },
                 "chart_ids": [],
                 "data_summary": (
-                    f"The support-ticket set includes {source_row_count} source "
-                    f"rows and {included_row_count} usable ticket rows. "
-                    f"{question_like_count} rows include direct customer questions. "
+                    f"In {included_row_count} support tickets, "
+                    f"{question_like_count} include direct customer questions. "
+                    f"The original sample contains {source_row_count} total tickets. "
                     f"Top observed clusters: {cluster_summary}."
                 ),
             },
@@ -821,7 +823,7 @@ def _support_ticket_blog_blueprint_payload(
                 "chart_ids": [],
                 "data_summary": (
                     "Prioritize FAQ work by observed ticket volume. In this "
-                    f"CSV, the highest-volume clusters are: {cluster_summary}. "
+                    f"sample, the highest-volume clusters are: {cluster_summary}. "
                     "Those clusters should be reviewed before lower-volume or "
                     "one-off questions."
                 ),
@@ -830,7 +832,7 @@ def _support_ticket_blog_blueprint_payload(
                 "id": "publishable-answer-process",
                 "heading": "How should old tickets become review-ready FAQ shells?",
                 "goal": (
-                    "Show the operational path from CSV upload to clustered "
+                    "Show the operational path from ticket intake to clustered "
                     "questions, customer wording, review-needed draft answer "
                     "shells, and support-team verification."
                 ),

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -804,8 +804,8 @@ def _support_ticket_blog_blueprint_payload(
                 },
                 "chart_ids": [],
                 "data_summary": (
-                    f"The uploaded CSV contains {source_row_count} support-ticket "
-                    f"rows; {included_row_count} rows were included for generation. "
+                    f"The support-ticket set includes {source_row_count} source "
+                    f"rows and {included_row_count} usable ticket rows. "
                     f"{question_like_count} rows include direct customer questions. "
                     f"Top observed clusters: {cluster_summary}."
                 ),
@@ -843,7 +843,7 @@ def _support_ticket_blog_blueprint_payload(
                 },
                 "chart_ids": [],
                 "data_summary": (
-                    f"The uploaded ticket CSV can produce up to {draft_faq_entries} "
+                    f"The observed ticket set supports up to {draft_faq_entries} "
                     "first-pass FAQ entries from observed customer wording. "
                     + (
                         "Each answer should preserve customer language, use the "

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -1201,6 +1201,15 @@ async def test_generate_blocks_support_ticket_debug_source_narration_without_sav
     "Looking at the uploaded records, 36 tickets cluster into account questions.",
     "The uploaded CSV reveals nine clusters across 36 rows.",
     "This export of 36 support tickets surfaces nine themes.",
+    (
+        "Your uploaded tickets contain 36 support-ticket rows; 36 rows were "
+        "included for generation. 35 rows include direct customer questions."
+    ),
+    "In uploaded tickets, 35 of 36 rows include direct customer questions.",
+    (
+        "The uploaded ticket CSV can produce up to 6 first-pass FAQ entries "
+        "from observed customer wording."
+    ),
 ])
 def test_support_ticket_debug_source_narration_blocks_varied_openings(opening: str) -> None:
     parsed = json.loads(
@@ -1218,6 +1227,8 @@ def test_support_ticket_debug_source_narration_blocks_varied_openings(opening: s
     "Support tickets show repeated account and reporting questions.",
     "In 36 support tickets, account and reporting questions repeat.",
     "Customers keep asking account and reporting questions in support tickets.",
+    "Support tickets include 35 direct customer questions across 36 rows.",
+    "The ticket set supports six first-pass FAQ shells for team review.",
 ])
 def test_support_ticket_debug_source_narration_allows_publishable_evidence(
     opening: str,

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -8,10 +8,12 @@ from extracted_content_pipeline.blog_generation import (
     BlogPostGenerationConfig,
     BlogPostGenerationService,
     _blog_failure_candidate_snapshot,
+    _blog_generation_prompts,
     _blog_quality_repair_guidance,
     _is_support_ticket_blog_context,
     _normalize_blog_metadata,
     _quality_policy_for_context,
+    _support_ticket_blog_public_data_context,
     _support_ticket_debug_source_narration_blockers,
     parse_blog_post_response,
     support_ticket_descriptive_blog_contract,
@@ -496,7 +498,7 @@ def test_support_ticket_descriptive_blog_contract_requires_no_outcome_or_resolut
         "Compare future tickets against the observed clusters without claiming causality.",
         (
             "Do not add fixed day, week, month, 30-day, 60-day, or 90-day "
-            "checkpoints unless the provided tickets include a dated source window."
+            "checkpoints unless `data_context.has_dated_window` is true."
         ),
     ]
     assert support_ticket_descriptive_blog_contract({
@@ -1210,6 +1212,14 @@ async def test_generate_blocks_support_ticket_debug_source_narration_without_sav
         "The uploaded ticket CSV can produce up to 6 first-pass FAQ entries "
         "from observed customer wording."
     ),
+    "Our support ticket export holds 36 rows; 35 carry direct questions.",
+    "Across the 36 tickets we ingested, nine question clusters recur.",
+    "From the 36 records you sent, nine repeat themes emerge.",
+    "The uploaded tickets include 36 source rows and 36 usable ticket rows.",
+    "Support-ticket source rows reveal nine recurring themes.",
+    "Each cluster appeared four times in the uploaded ticket set.",
+    "The uploaded tickets do not include calendar dates.",
+    "The uploaded tickets in this sample do not include calendar dates.",
 ])
 def test_support_ticket_debug_source_narration_blocks_varied_openings(opening: str) -> None:
     parsed = json.loads(
@@ -1379,15 +1389,55 @@ async def test_generate_puts_support_ticket_descriptive_contract_in_prompt() -> 
     assert '"draft_faq_shells":' in user_prompt
     assert '"measurement_guidance":' in user_prompt
     assert "Support-ticket descriptive mode instructions:" in user_prompt
+    assert "Support-ticket customer-facing prose instructions:" in user_prompt
     assert "publishable customer-facing article prose" in user_prompt
     assert "Do not open by narrating the upload, CSV, export, rows" in user_prompt
-    assert "Do not rank tied clusters by business impact" in user_prompt
+    assert "source rows, usable rows, or included rows" in user_prompt
+    assert "Never write the phrase `uploaded tickets`" in user_prompt
+    assert "include the exact `target_keyword` phrase naturally" in user_prompt
+    assert "does not support ranking one tied cluster above another" in user_prompt
     assert (
         "Use `data_context.required_section_outline` as the H2 section order"
         in user_prompt
     )
     assert "Measurement language must be observational only" in user_prompt
     assert "metadata, FAQ metadata, tags, and chart copy" in user_prompt
+
+
+def test_support_ticket_prose_prompt_addendum_fires_without_descriptive_contract() -> None:
+    blueprint = _support_ticket_blueprint()
+    blueprint["data_context"]["has_measured_outcomes"] = True
+    for key in (
+        "support_ticket_blog_mode",
+        "allowed_claims",
+        "forbidden_claims",
+        "draft_answer_guidance",
+        "required_section_outline",
+        "draft_faq_shells",
+        "measurement_guidance",
+    ):
+        blueprint["data_context"].pop(key, None)
+
+    _system_prompt, user_prompt = _blog_generation_prompts(
+        "Generate from {blueprint_json} about {topic}.",
+        blueprint=blueprint,
+    )
+
+    assert "Support-ticket customer-facing prose instructions:" in user_prompt
+    assert "publishable customer-facing article prose" in user_prompt
+    assert "source rows, usable rows, or included rows" in user_prompt
+    assert "Support-ticket descriptive mode instructions:" not in user_prompt
+
+
+def test_support_ticket_blog_public_context_renames_upload_period_labels() -> None:
+    normalized = _support_ticket_blog_public_data_context({
+        "source": "support_ticket_provider",
+        "source_period": "Uploaded support tickets",
+        "review_period": "uploaded tickets",
+    })
+
+    assert normalized["source_period"] == "observed support-ticket sample"
+    assert normalized["review_period"] == "observed support-ticket sample"
 
 
 @pytest.mark.asyncio
@@ -1495,7 +1545,7 @@ async def test_quality_repair_prompt_keeps_support_ticket_descriptive_contract()
     assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in retry_prompt
     assert "follow its `allowed_claims`, `forbidden_claims`, and `draft_answer_guidance`" in retry_prompt
     assert "Support-ticket descriptive mode instructions:" in retry_prompt
-    assert "Do not rank tied clusters by business impact" in retry_prompt
+    assert "does not support ranking one tied cluster above another" in retry_prompt
     assert (
         "Use `data_context.required_section_outline` as the H2 section order"
         in retry_prompt

--- a/tests/test_extracted_brand_voice.py
+++ b/tests/test_extracted_brand_voice.py
@@ -42,6 +42,7 @@ def test_brand_voice_profile_normalizes_prompt_block_and_audit_metadata() -> Non
     block = brand_voice_prompt_block(profile)
     assert "Use this profile as style guidance only" in block
     assert "Do not omit or alter grounded claims" in block
+    assert "Use `you` or `your` naturally" in block
     assert "operator-led" in block
     assert "Ignored fourth sample" not in block
     assert apply_brand_voice_to_system_prompt("Base\n{brand_voice}", profile) == (

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -498,7 +498,7 @@ async def test_support_ticket_provider_feeds_real_blog_post_generation() -> None
         "customer support FAQ",
         "repeat support questions",
     ]
-    assert draft.data_context["source_period"] == "Uploaded support tickets"
+    assert draft.data_context["source_period"] == "observed support-ticket sample"
     assert draft.data_context["source"] == "support_ticket_provider"
     assert draft.data_context["included_ticket_row_count"] == 4
     assert draft.data_context["top_clusters"]

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -565,6 +565,39 @@ async def test_generate_persists_second_person_brand_voice_compliant_brief() -> 
 
 
 @pytest.mark.asyncio
+async def test_generate_prompts_second_person_brand_voice_explicitly() -> None:
+    response = json.dumps({
+        "title": "Your Acme renewal brief",
+        "headline": "Your renewal window needs a precise next step",
+        "brief_type": "renewal",
+        "sections": [
+            {
+                "id": "account_context",
+                "title": "Your Account Context",
+                "body_markdown": "You have renewal pressure to address this week.",
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, _sales_briefs, llm, _skills, _rp = _service(responses=[response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        brand_voice={
+            "account_id": "acct-1",
+            "preferred_pov": "second_person",
+        },
+    )
+
+    assert result.generated == 1
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "Preferred POV: second_person" in system_prompt
+    assert "Use `you` or `your` naturally" in system_prompt
+
+
+@pytest.mark.asyncio
 async def test_generate_blocks_when_response_omits_headline() -> None:
     """End-to-end: parser accepts the candidate, quality pack fires no_headline."""
     response = json.dumps({

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -1311,8 +1311,8 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
     assert "42%" not in serialized
     assert payload["data_context"]["source_row_count"] == 2
     assert payload["data_context"]["question_like_ticket_count"] == 2
-    assert payload["data_context"]["review_period"] == "uploaded tickets"
-    assert payload["data_context"]["source_period"] == "Uploaded support tickets"
+    assert payload["data_context"]["review_period"] == "observed support-ticket sample"
+    assert payload["data_context"]["source_period"] == "observed support-ticket sample"
     assert payload["data_context"]["has_dated_window"] is False
     assert payload["data_context"]["has_measured_outcomes"] is False
     assert payload["data_context"]["measured_outcome_count"] == 0
@@ -1354,7 +1354,7 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
         "Compare future tickets against the observed clusters without claiming causality.",
         (
             "Do not add fixed day, week, month, 30-day, 60-day, or 90-day "
-            "checkpoints unless the provided tickets include a dated source window."
+            "checkpoints unless `data_context.has_dated_window` is true."
         ),
     ]
     assert "report_date" not in payload["data_context"]
@@ -1372,14 +1372,19 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
         "question_like_rows": 2,
         "cluster_count": 2,
     }
-    assert "2 source rows" in first_section["data_summary"]
-    assert "2 usable ticket rows" in first_section["data_summary"]
+    assert "In 2 support tickets" in first_section["data_summary"]
+    assert "2 include direct customer questions" in first_section["data_summary"]
+    assert "2 source rows" not in first_section["data_summary"]
+    assert "2 usable ticket rows" not in first_section["data_summary"]
     assert "rows were included for generation" not in first_section["data_summary"]
+    assert "uploaded" not in first_section["goal"].lower()
     process_section = payload["sections"][2]
     assert "source_window_days" not in process_section["key_stats"]
     assert process_section["heading"] == "How should old tickets become review-ready FAQ shells?"
     assert "observed ticket set supports" in process_section["data_summary"]
     assert "uploaded ticket CSV can produce" not in process_section["data_summary"]
+    assert "In this CSV" not in payload["sections"][1]["data_summary"]
+    assert "In this sample" in payload["sections"][1]["data_summary"]
     assert "review-needed shell" in process_section["data_summary"]
 
 

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -1372,11 +1372,14 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
         "question_like_rows": 2,
         "cluster_count": 2,
     }
-    assert "2 support-ticket rows" in first_section["data_summary"]
-    assert "2 rows were included for generation" in first_section["data_summary"]
+    assert "2 source rows" in first_section["data_summary"]
+    assert "2 usable ticket rows" in first_section["data_summary"]
+    assert "rows were included for generation" not in first_section["data_summary"]
     process_section = payload["sections"][2]
     assert "source_window_days" not in process_section["key_stats"]
     assert process_section["heading"] == "How should old tickets become review-ready FAQ shells?"
+    assert "observed ticket set supports" in process_section["data_summary"]
+    assert "uploaded ticket CSV can produce" not in process_section["data_summary"]
     assert "review-needed shell" in process_section["data_summary"]
 
 


### PR DESCRIPTION
Plan: plans/PR-Gate-A-Live-Convergence-Proof.md
Slice phase: Functional validation

This PR updates the Gate A live convergence proof after review found the blog prose guard missed upload/source-mechanics narration. It now makes support-ticket blog prose prevention unconditional, broadens the detector beyond quoted examples, removes upload/source-row wording from the live seed, keeps the existing GEO and brand-voice gates intact, reruns the same Sonnet-only proof for `landing_page`, `blog_post`, and `sales_brief`, and refreshes the committed execution/review/export artifacts. `email_campaign` remains excluded via `--outputs`.

Proof artifact: `docs/extraction/validation/content_ops_gate_a_reconfirm_2026-06-08.md`

Generated samples:
- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json`
- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json`
- `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json`

## Intentional
- No product-quality pass/fail is self-certified here. The harness reported `ok=true`, but the reviewer owns the GOOD-bar judgment against the exported drafts.
- The refreshed live run preserves the existing quality gates rather than weakening them; the final artifact set has 3/3 saved variants for blog, landing, and sales brief.
- `email_campaign` is excluded from this convergence run; campaign input-fit remains a separate optional follow-up.
- Env files are referenced by absolute path during the run; secrets are not copied into the worktree or committed.

## Deferred
- Separate `--outputs email_campaign` live validation if the operator wants campaign input-fit proof.
- Separate Haiku / cheaper-model ship-readiness pass after the Sonnet convergence signal is reviewed.
- Landing-page prose-prevention and section dedup remain separate hardening if the reviewer wants those rough edges promoted after judging the refreshed proof.
- Same-lane `HARDENING.md` review:
  - Blog debug-source narration was promoted and fixed in this PR.
  - Sales-brief second-person instability was promoted and fixed in this PR.
  - Landing-page variant distinctness was already addressed by #1375 and rechecked here; remaining landing prose/dedup rough edges stay deferred.
  - Messy-ticket grounding rerun stays parked because this proof intentionally reruns the clean #1360 SaaS fixture before changing input distribution.

## Parked hardening
- `HARDENING.md` - Gate A needs a messy-ticket grounding rerun.
- Landing-page section-title prose prevention and section dedup from the #1383 reviewer notes.

## Verification
- `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false python scripts/smoke_content_ops_gate_a_live_quality.py --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 --user-id 11111111-1111-4111-8111-111111111111 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --output-dir tmp/content_ops_gate_a_reconfirm_20260608 --outputs landing_page,blog_post,sales_brief --variant-count 3 --quality-repair-attempts 1 --max-cost-usd 20.00 --json` - PASS (`summary.json` reports `ok=true`; `export_counts` are `blog_post=3`, `landing_page=3`, `sales_brief=3`; selected outputs only).
- `python -m pytest tests/test_extracted_blog_generation.py tests/test_extracted_brand_voice.py tests/test_extracted_sales_brief_generation.py tests/test_smoke_content_ops_live_generation.py tests/test_smoke_content_ops_gate_a_live_quality.py -q` - PASS (203 passed).
- `for f in docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/*.json; do python -m json.tool "$f" >/dev/null || exit 1; done` - PASS.
- `jq` model-route check over `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json`, `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-landing_page.json`, and `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-sales_brief.json` with filter `map([.. | objects | .generation_model? // empty]) | add | unique` - PASS (`anthropic/claude-sonnet-4-5`).
- Blog public-content source-mechanics phrase check against `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` - PASS (no upload/source-row/debug-source mechanics).
- Blog full-export source-mechanics phrase check against `docs/extraction/validation/fixtures/content_ops_gate_a_reconfirm_20260608/export-blog_post.json` - PASS (no upload/source-row/debug-source mechanics).
- `bash scripts/validate_extracted_content_pipeline.sh` - PASS.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - PASS.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - PASS.
- `bash scripts/check_ascii_python.sh` - PASS.
- `python -m pytest tests/test_extracted_content_ops_live_execute_harness.py::test_support_ticket_provider_feeds_real_blog_post_generation -q` - PASS (1 passed).
- `bash scripts/run_extracted_pipeline_checks.sh` - PASS (`extracted_reasoning_core`: 295 passed; `extracted_content_pipeline`: 3380 passed, 10 skipped, 1 known `pynvml` warning).
- `bash scripts/push_pr.sh tmp/gate-a-live-convergence-proof-pr-body.md --force-with-lease origin claude/pr-gate-a-live-convergence-proof` - runs the managed pre-push hook once before pushing.

## Diff size
16 files, 4268 LOC from the PR merge-base (+4230/-37). The overage is raw validation evidence; code/test changes are the narrow review-response fix.
