### PR TITLE
Add developer-first marketer LinkedIn positioning kit (personal reference, non-code)

### DIFF
--- a/docs/linkedin_developer_marketer_kit.md
+++ b/docs/linkedin_developer_marketer_kit.md
@@ -1,0 +1,166 @@
+# Developer-First Marketer — LinkedIn Positioning Kit
+
+> One conviction, three surfaces: the deflection product, the content operating model,
+> and this personal brand all run on the same thesis — **deterministic systems over
+> prompt-and-pray.** Marketing is software with a slower (but brutally honest) feedback loop.
+
+---
+
+## Positioning
+
+**Headline options**
+- *Developer-first marketer. I bring software's coherence discipline to content — so AI can't quietly lie to you.*
+- *Marketing mostly prompts and prays. I'm a developer building the checks-and-balances layer it never had.*
+
+**About (1 paragraph)**
+> I'm a developer before I'm a marketer. In software, you can't ship work that fails the
+> checks — there are invisible systems making sure the thing stays coherent, and even then,
+> drift creeps in the second you stop watching. Marketing has none of that, which is why it
+> prompts and prays. My bet is simple: marketing is just software with a slower feedback
+> loop — and the metrics are every bit as brutally honest as a failing test. So I apply the
+> same discipline: gate what you can check before you publish, let the market judge the rest,
+> and trace your winners so you can rebuild them on purpose instead of by accident.
+
+---
+
+## Post angles (engineering -> marketing "twins")
+
+| # | Dev principle | Marketing twin |
+|---|---|---|
+| 1 | CI gates (can't merge until checks pass) | a pre-publish checklist that *can't* be skipped |
+| 2 | Regression tests (a fixed bug can't return) | every content mistake becomes a permanent guardrail |
+| 3 | The winner flywheel (rebuild on purpose) | a library of proven hooks, not lucky one-offs |
+| 4 | Drift detection | brand voice rots one "good enough" post at a time |
+| 5 | Write the test before you trust the green | define what "worked" means *before* you publish |
+
+---
+
+## The anchored post (deflection report as the receipt)
+
+> **I'm a developer before I'm a marketer. That ruins AI content for me.**
+>
+> Not because the tools are bad — because I know what's missing.
+>
+> When I write code, a dozen invisible systems keep me from shipping something broken. Tests. Type checks. Gates that won't let me merge until the work is coherent. And even with all of that — if I stop paying attention, drift still creeps in.
+>
+> Marketing has none of it. It prompts and prays. You ask an LLM for copy, it hands you something confident and plausible, and you ship it — with no check that it's true, on-brand, or even consistent with what you said last week.
+>
+> So I built the thing I wished existed.
+>
+> Take a company's support tickets. I turn a raw CSV export into a ranked list of repeated support-ticket patterns, then draft reviewable FAQ/content candidates from the evidence customers already gave them.
+>
+> Here's the part that matters: it doesn't use an LLM to read your logs. It uses exact mathematical clustering. Every number ties to a real ticket. Draft answers trace to proven resolution history when it's present; gaps are flagged for review instead of dressed up as certainty. There's an evidence appendix so you can audit the whole thing.
+>
+> Why so strict? Because it's *your* data, feeding *public* content, behind a *real* spend decision. It has to be defensible — not a confident guess.
+>
+> That's the whole bet: marketing is software with a slower feedback loop. The metrics are brutally honest, same as a failing test — they just take longer to come back. So apply the same discipline. Gate what you can check before you publish. Let the market judge the rest. Trace the winners so you can rebuild them on purpose.
+>
+> The system doesn't replace the creative work. It clears everything that *isn't* creative off your plate, so your judgment goes where a machine genuinely can't follow.
+>
+> Prompt and pray is a strategy. It's just not a good one.
+>
+> *What's the one check you wish every marketer ran before hitting publish?*
+
+---
+
+## Post 1 — The pre-publish gate (CI gates)
+
+> In software, you physically *cannot* ship code that fails the checks. The merge button is greyed out until tests pass and the linter's happy. The system stops you — on purpose — before broken work reaches anyone.
+>
+> In marketing? You can publish a lie in 30 seconds. No gate. No check. Just a button that always works.
+>
+> That's not a discipline problem. It's a missing system. The most careful marketer alive is one busy afternoon away from shipping a claim nobody verified.
+>
+> So I stopped relying on attention and built the gate. Before anything publishes, it's checked against what a machine can actually verify: Does this claim match what we've approved? Is it on-brand? Is it consistent with what we said last week? Fail any of those and it doesn't go out — same as a failing test.
+>
+> It doesn't make the writing good. It makes the lies impossible.
+>
+> Your judgment is for the part a check can't see. Everything a check *can* see shouldn't depend on you having a good day.
+>
+> What would your "won't let me publish" checklist have on it?
+
+---
+
+## Post 2 — Don't let a fixed mistake come back (regression tests)
+
+> Every bug I fix in code becomes a test. The whole point: that exact mistake can never come back. Not "probably won't." Can't.
+>
+> Now look at marketing.
+>
+> The same wrong stat goes out every quarter. The same off-brand phrase keeps reappearing. The compliance line everyone "knows" to include gets forgotten the one time it matters. We fix these in a meeting, then re-fix them three months later — because nothing remembers.
+>
+> Marketing's institutional memory is a Slack message that scrolled away.
+>
+> So I gave it a memory. Every mistake that costs us once becomes a permanent check — a banned phrase, a required disclaimer, a claim that must match the registry. Make it once, and that mistake becomes structurally impossible to repeat.
+>
+> That's the difference between a team that gets it right and a team that gets it right *and stays* right.
+>
+> You don't rise to your standards. You fall to whatever your system remembers.
+>
+> What's the mistake your team keeps re-making that should've become a rule by now?
+
+---
+
+## Post 3 — Clone the winner (the flywheel)
+
+> If you can't explain *why* your best-performing post worked, you didn't win. You got lucky.
+>
+> And luck doesn't compound.
+>
+> This is the quiet tragedy of most content: something takes off, everyone's thrilled, and then... nothing. Nobody can say what made it land, so nobody can do it again. The win evaporates. Next month you're back to guessing.
+>
+> In software, a thing that works becomes a pattern you reuse on purpose. You don't rebuild it from scratch and hope — you reach for the proven component.
+>
+> Marketing can do the same, but only if you make the win *legible*. What was the hook structure? The promise? The proof? The audience? Write it down the moment it works, tag it, and it becomes an input — not a memory.
+>
+> Do that for a year and you stop having "viral moments." You start having a library.
+>
+> The goal was never one great post. It's a system where great posts are repeatable instead of accidental.
+>
+> Honestly — could you rebuild your best post on purpose right now? Or did it just... happen?
+
+---
+
+## Post 4 — Brand voice rots without a check (drift)
+
+> Nobody *decides* to go off-brand.
+>
+> It happens one "good enough" post at a time. A slightly punchier claim here. A tone that's a little off there. An LLM that's *mostly* right. Each one passes — because each one, alone, is fine.
+>
+> Six months later your content doesn't sound like you anymore, and you can't point to the moment it changed. Because there wasn't one. That's drift, and it's invisible by design.
+>
+> I learned this writing code, not copy. I run tools whose entire job is keeping a system coherent — and even *with* them, the moment my attention slips, things slide. Drift doesn't announce itself. It accumulates.
+>
+> Human attention is the worst possible defense against a slow problem. We notice cliffs, not slopes.
+>
+> So you need something louder than vigilance: a real check that compares every piece against your actual voice and your actual claims, every time — and flags the slide while it's still one post, not a rebrand.
+>
+> Your brand voice isn't degrading because anyone's careless. It's degrading because nothing's watching the slope.
+>
+> Where's the drift you haven't noticed yet?
+
+---
+
+## Post 5 — Write the test before you trust the green (define "worked" first)
+
+> Most marketers define success *after* the numbers come in.
+>
+> That's not data-driven. That's a horoscope. You ship, you wait, the metrics land, and then you write the story that makes them look like a plan. Up and to the right? "Strong engagement strategy." Flat? "Brand awareness play." The narrative always fits — because you wrote it last.
+>
+> Developers don't get to do this. You write the test *before* you trust the result. You decide what "passing" means up front, so the outcome stays honest — you can't move the goalposts after you see where the ball landed.
+>
+> Marketing can borrow this exactly. Before you publish, write it down: What's the hypothesis? The one metric that matters? Over what window? What number is a win, and what's a flop?
+>
+> Takes five minutes. And it turns a slow, noisy, arguable feedback loop into a verdict you can actually learn from.
+>
+> The metrics were always going to be brutally honest. The only question is whether you decided what they meant *before* — or after — they could embarrass you.
+>
+> Do you set your win condition before you hit publish? Honestly.
+
+---
+
+## Suggested cadence
+
+Don't post back-to-back — space ~2-3 days so the thesis builds. A story arc:
+**1 (the gate) -> 4 (drift, why you need it) -> 2 (memory) -> 3 (winners) -> 5 (define the win).**
+Problem -> why it's invisible -> the fix -> the compounding payoff -> the discipline that makes it real.

--- a/plans/PR-LinkedIn-Marketing-Kit.md
+++ b/plans/PR-LinkedIn-Marketing-Kit.md
@@ -1,0 +1,96 @@
+# PR-LinkedIn-Marketing-Kit
+
+## Why this slice exists
+
+PR #1385 was opened as a draft personal-reference artifact without the normal
+Atlas PR contract, then review blocked it for two concrete reasons: no
+plan-backed PR shape, and marketing copy that overstated the shipped deflection
+product outcome. This slice converts the artifact into an AGENTS-compliant docs
+PR and rewrites the deflection-report example to describe defensible
+capabilities rather than guaranteed ticket-volume or SEO outcomes.
+Follow-up review also caught a narrower truthfulness issue: the copy must not
+claim every answer traces to resolution history, because valid reports can flag
+draft answers for review when no proven resolution evidence exists.
+
+## Scope (this PR)
+
+Ownership lane: linkedin-marketing-kit/reference
+Slice phase: Product polish
+
+1. Land the LinkedIn positioning kit as a docs reference artifact, not product
+   code.
+2. Soften the anchored deflection-report post from outcome guarantees to
+   capability-level wording backed by current product behavior.
+3. Convert the PR body/plan shape from draft/no-review into the normal
+   AGENTS.md contract.
+
+### Review Contract
+
+Acceptance criteria:
+- The PR is ready for review, not draft.
+- The PR body starts with `Plan:` and `Slice phase:` and includes Intentional,
+  Deferred, Parked hardening, Verification, and Diff size sections.
+- The kit does not claim guaranteed fewer tickets, ticket prevention, or SEO
+  ranking outcomes.
+- The kit does not claim every answer is resolution-backed; it distinguishes
+  proven-resolution answers from review-needed gaps.
+- The artifact lives under `docs/`, not at repository root.
+
+Affected surfaces:
+- `docs/linkedin_developer_marketer_kit.md`
+- `plans/PR-LinkedIn-Marketing-Kit.md`
+
+Risk areas:
+- Marketing claim overreach: copy must stay at the defensible capability level.
+- Repository clutter: personal/reference material should not sit at root.
+
+Triggered reviewer rules:
+- R1 Requirements match
+- R2 Test evidence
+- R6 Output truthfulness
+- R14 Codebase verification
+
+### Files touched
+
+- `docs/linkedin_developer_marketer_kit.md`
+- `plans/PR-LinkedIn-Marketing-Kit.md`
+
+## Mechanism
+
+The existing kit remains a static Markdown reference. The only content behavior
+change is in the anchored support-ticket post: it now says the system identifies
+repeated support-ticket patterns and drafts reviewable FAQ/content candidates
+from uploaded evidence, instead of promising fewer repeat tickets or ranking.
+The evidence sentence also says draft answers trace to proven resolution
+history only when present, and that gaps are flagged for review.
+The file is moved under `docs/` so the repo root stays for project entry points
+and top-level contracts.
+
+## Intentional
+
+- No executable code or product surface changes. This is a reference/document
+  artifact, so verification is contract/diff hygiene rather than runtime tests.
+- The kit is not placed in `plans/` because it is not an in-flight PR plan; it
+  belongs under `docs/` if it lands in the repository at all.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- python scripts/sync_pr_plan.py plans/PR-LinkedIn-Marketing-Kit.md: passed.
+- python scripts/sync_pr_plan.py --check plans/PR-LinkedIn-Marketing-Kit.md: passed.
+- python scripts/audit_plan_doc.py plans/PR-LinkedIn-Marketing-Kit.md: passed.
+- git diff --check: passed.
+- bash scripts/push_pr.sh /tmp/atlas-pr-1385-body.md --force-with-lease origin HEAD: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/linkedin_developer_marketer_kit.md` | 166 |
+| `plans/PR-LinkedIn-Marketing-Kit.md` | 96 |
+| **Total** | **262** |


### PR DESCRIPTION
Plan: plans/PR-LinkedIn-Marketing-Kit.md
Slice phase: Product polish

PR #1385 was opened as a draft personal-reference artifact without the normal Atlas PR contract, and review blocked it for that process gap plus overclaiming deflection-report copy. This update converts it into a plan-backed docs PR, moves the kit under `docs/`, and rewrites the support-ticket example to describe defensible capabilities instead of guaranteed ticket reduction, SEO outcomes, or always-resolution-backed answers.

## Intentional
- Docs-only/reference artifact; no executable code or product behavior changes.
- The kit lands under `docs/` rather than repo root to avoid top-level clutter.
- Runtime tests are not applicable for this Markdown-only slice; verification is plan/body/diff hygiene.

## Deferred
- None.

## Parked hardening
- None.

## AI reconciliation
- Automated-review findings fixed: line-52 answer traceability overclaim narrowed to proven-resolution answers, with no-resolution gaps flagged for review. All fixed or waived: yes. Human review blockers addressed in code/body: AGENTS plan/body compliance and defensible marketing-claim wording.

## Verification
- `python scripts/sync_pr_plan.py plans/PR-LinkedIn-Marketing-Kit.md`: passed.
- `python scripts/sync_pr_plan.py --check plans/PR-LinkedIn-Marketing-Kit.md`: passed.
- `python scripts/audit_plan_doc.py plans/PR-LinkedIn-Marketing-Kit.md`: passed.
- `git diff --check`: passed.
- `bash scripts/push_pr.sh /tmp/atlas-pr-1385-body.md --force-with-lease origin HEAD`: passed.

## Diff size
2 files, +255 / -0
