### PR TITLE
Content-Ops MCP OAuth Transport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -633,6 +633,13 @@ python -m atlas_brain.mcp.content_ops_marketer_verify_server
 
 # SSE HTTP mode (port 8068, requires ATLAS_MCP_AUTH_TOKEN)
 ATLAS_MCP_AUTH_TOKEN=<token> python -m atlas_brain.mcp.content_ops_marketer_verify_server --sse
+
+# OAuth mode for remote connector transport
+ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE=oauth \
+ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL=<public-issuer-url> \
+ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL=<public-resource-url>/mcp \
+ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=<long-operator-token> \
+python -m atlas_brain.mcp.content_ops_marketer_verify_server --sse
 ```
 
 Tools: `verify_draft`
@@ -640,8 +647,10 @@ Tools: `verify_draft`
 This verify-only marketer surface accepts structured draft evidence for one
 configured tenant binding and returns the deterministic Content Ops review
 verdict. It deliberately omits generation, publishing, approval, checkout,
-search/fetch adapters, and registry mutation. OAuth connector binding and
-dual-client public route smokes are deferred to the rollout slice.
+search/fetch adapters, and registry mutation. OAuth mode adds the server-side
+connector auth boundary and operator approval gate; public launcher scripts,
+dual-client route smokes, and token-derived tenant binding are deferred to the
+rollout slice.
 
 ### Intelligence MCP Server (33 tools)
 ```bash

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -5215,6 +5215,37 @@ class MCPConfig(BaseSettings):
             "resolution."
         ),
     )
+    content_ops_marketer_verify_auth_mode: str = Field(
+        default="bearer",
+        description=(
+            "HTTP auth mode for verify-only Content Ops marketer MCP: bearer "
+            "for direct clients or oauth for remote connector clients."
+        ),
+    )
+    content_ops_marketer_verify_oauth_issuer_url: str = Field(
+        default="",
+        description="OAuth issuer URL for verify-only Content Ops marketer MCP.",
+    )
+    content_ops_marketer_verify_oauth_resource_url: str = Field(
+        default="",
+        description=(
+            "OAuth protected resource URL for verify-only Content Ops marketer MCP."
+        ),
+    )
+    content_ops_marketer_verify_oauth_approval_token: str = Field(
+        default="",
+        description=(
+            "Operator approval token for verify-only Content Ops marketer MCP "
+            "OAuth connector authorization."
+        ),
+    )
+    content_ops_marketer_verify_oauth_state_file: str = Field(
+        default="",
+        description=(
+            "Optional local OAuth state file for verify-only Content Ops "
+            "marketer MCP client registrations and refresh tokens."
+        ),
+    )
     intelligence_port: int = Field(default=8061, description="Port for Intelligence MCP server (SSE transport)")
     b2b_churn_port: int = Field(default=8062, description="Port for B2B Churn Intelligence MCP server (SSE transport)")
     scraper_enabled: bool = Field(default=True, description="Enable Universal Scraper MCP server")

--- a/atlas_brain/mcp/content_ops_marketer_verify_oauth.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_oauth.py
@@ -1,0 +1,117 @@
+"""OAuth support for the Content Ops marketer verify MCP server."""
+
+from __future__ import annotations
+
+import time
+from html import escape
+from pathlib import Path
+
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, Response
+
+from .invoicing_readonly_oauth import (
+    InvoicingReadonlyOAuthProvider,
+    PendingAuthorization,
+    as_any_http_url,
+    handle_approval_request as _handle_approval_request,
+)
+
+
+DEFAULT_CONTENT_OPS_VERIFY_SCOPE = "content_ops.review.verify"
+
+
+class ContentOpsMarketerVerifyOAuthProvider(InvoicingReadonlyOAuthProvider):
+    """Single-tenant OAuth provider for marketer content verification."""
+
+    def __init__(
+        self,
+        *,
+        issuer_url: str,
+        approval_token: str,
+        scopes: list[str] | None = None,
+        authorization_ttl_seconds: int = 300,
+        access_token_ttl_seconds: int = 3600,
+        state_file: str | Path | None = None,
+    ) -> None:
+        super().__init__(
+            issuer_url=issuer_url,
+            approval_token=approval_token,
+            scopes=scopes or [DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+            authorization_ttl_seconds=authorization_ttl_seconds,
+            access_token_ttl_seconds=access_token_ttl_seconds,
+            state_file=state_file,
+        )
+
+
+def approval_page(
+    provider: ContentOpsMarketerVerifyOAuthProvider,
+    request_id: str,
+    *,
+    form_action: str | None = None,
+) -> Response:
+    pending = provider.pending_authorization(request_id)
+    if pending is None:
+        return HTMLResponse("<h1>Authorization request not found</h1>", status_code=404)
+    if pending.expires_at < time.time():
+        return HTMLResponse("<h1>Authorization request expired</h1>", status_code=410)
+
+    client = escape(pending.client_id)
+    scopes = escape(", ".join(pending.scopes))
+    request_value = escape(request_id)
+    action_attr = ""
+    if form_action is not None:
+        action_attr = f' action="{escape(form_action, quote=True)}"'
+    return HTMLResponse(
+        f"""
+<!doctype html>
+<html>
+  <head><title>Approve Atlas Content Verification Connector</title></head>
+  <body>
+    <h1>Approve Atlas content verification access</h1>
+    <p>Client: <code>{client}</code></p>
+    <p>Scopes: <code>{scopes}</code></p>
+    <p>This grants verify-only content review tools for one bound tenant. It does not grant content generation, publishing, approval, registry mutation, search, or fetch tools.</p>
+    <form method="post"{action_attr}>
+      <input type="hidden" name="request_id" value="{request_value}" />
+      <label>Approval token <input name="approval_token" type="password" /></label>
+      <button type="submit">Approve content verification connector</button>
+    </form>
+  </body>
+</html>
+""".strip()
+    )
+
+
+async def handle_approval_request(
+    provider: ContentOpsMarketerVerifyOAuthProvider,
+    request: Request,
+) -> Response:
+    """Handle GET/POST requests for the marketer verify approval page."""
+    if request.method == "GET":
+        request_id = request.query_params.get("request_id", "")
+        return approval_page(provider, request_id)
+    return await _handle_approval_request(provider, request)
+
+
+def validate_oauth_settings(*, issuer_url: str, resource_server_url: str, approval_token: str) -> None:
+    """Fail fast on missing OAuth settings before exposing content verdicts."""
+    if not issuer_url.strip():
+        raise RuntimeError("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL is required in oauth mode")
+    if not resource_server_url.strip():
+        raise RuntimeError("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL is required in oauth mode")
+    if len(approval_token.strip()) < 24:
+        raise RuntimeError(
+            "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN must be at least "
+            "24 characters in oauth mode"
+        )
+
+
+__all__ = [
+    "DEFAULT_CONTENT_OPS_VERIFY_SCOPE",
+    "ContentOpsMarketerVerifyOAuthProvider",
+    "PendingAuthorization",
+    "approval_page",
+    "as_any_http_url",
+    "handle_approval_request",
+    "validate_oauth_settings",
+]

--- a/atlas_brain/mcp/content_ops_marketer_verify_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_server.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import date
 from typing import Any
+from urllib.parse import urlparse
 
 from mcp.server.fastmcp import FastMCP
 
@@ -34,6 +35,8 @@ from ..config_defaults import (
 
 logger = logging.getLogger("atlas.mcp.content_ops.marketer_verify")
 
+_AUTH_MODE_BEARER = "bearer"
+_AUTH_MODE_OAUTH = "oauth"
 _MIN_HTTP_AUTH_TOKEN_LENGTH = 24
 _PLACEHOLDER_HTTP_AUTH_TOKENS = {
     "<token>",
@@ -47,6 +50,7 @@ _PLACEHOLDER_HTTP_AUTH_TOKENS = {
 _MALFORMED_COVERAGE_RULE_PREFIX = "MALFORMED-COVERAGE"
 _registry_reader_override: TenantClaimRegistryReader | None = None
 _account_resolver_override: "StaticContentOpsMarketerAccountResolver | None" = None
+_oauth_provider = None
 
 
 @dataclass(frozen=True)
@@ -89,6 +93,18 @@ mcp = FastMCP(
     ),
     lifespan=_lifespan,
 )
+
+
+@mcp.custom_route("/oauth/approve", methods=["GET", "POST"], include_in_schema=False)
+async def _oauth_approve(request):
+    """Operator approval page for remote OAuth connectors."""
+    if _oauth_provider is None:
+        from starlette.responses import HTMLResponse
+
+        return HTMLResponse("<h1>OAuth mode is not enabled</h1>", status_code=404)
+    from .content_ops_marketer_verify_oauth import handle_approval_request
+
+    return await handle_approval_request(_oauth_provider, request)
 
 
 @mcp.tool(structured_output=True)
@@ -146,12 +162,28 @@ def _review_request_from_tool_args(
 
 def _streamable_http_app():
     """Build the authenticated streamable HTTP app for verify-only tools."""
+    if _http_auth_mode() == _AUTH_MODE_OAUTH:
+        _configure_oauth_auth()
+        return mcp.streamable_http_app()
+
     from .auth import BearerAuthMiddleware
 
     return BearerAuthMiddleware(
         mcp.streamable_http_app(),
         token=_require_http_auth_token(),
     )
+
+
+def _http_auth_mode() -> str:
+    from ..config import settings
+
+    mode = _clean(settings.mcp.content_ops_marketer_verify_auth_mode).lower() or _AUTH_MODE_BEARER
+    if mode not in {_AUTH_MODE_BEARER, _AUTH_MODE_OAUTH}:
+        raise RuntimeError(
+            "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE must be either "
+            "'bearer' or 'oauth'"
+        )
+    return mode
 
 
 def _require_http_auth_token() -> str:
@@ -176,6 +208,91 @@ def _require_http_auth_token() -> str:
             "verify HTTP mode."
         )
     return token
+
+
+def _configure_oauth_auth():
+    """Configure FastMCP OAuth auth for remote connector clients."""
+    global _oauth_provider
+
+    from mcp.server.auth.provider import ProviderTokenVerifier
+    from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
+
+    from ..config import settings
+    from .content_ops_marketer_verify_oauth import (
+        DEFAULT_CONTENT_OPS_VERIFY_SCOPE,
+        ContentOpsMarketerVerifyOAuthProvider,
+        as_any_http_url,
+        validate_oauth_settings,
+    )
+
+    issuer_url = _clean(settings.mcp.content_ops_marketer_verify_oauth_issuer_url)
+    resource_url = _clean(settings.mcp.content_ops_marketer_verify_oauth_resource_url)
+    approval_token = _clean(settings.mcp.content_ops_marketer_verify_oauth_approval_token)
+    state_file = _clean(settings.mcp.content_ops_marketer_verify_oauth_state_file) or None
+    validate_oauth_settings(
+        issuer_url=issuer_url,
+        resource_server_url=resource_url,
+        approval_token=approval_token,
+    )
+    mcp.settings.transport_security = _oauth_transport_security_settings(
+        issuer_url=issuer_url,
+        resource_url=resource_url,
+    )
+
+    if _oauth_provider is not None:
+        return _oauth_provider
+
+    provider = ContentOpsMarketerVerifyOAuthProvider(
+        issuer_url=issuer_url,
+        approval_token=approval_token,
+        scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+        state_file=state_file,
+    )
+    mcp.settings.auth = AuthSettings(
+        issuer_url=as_any_http_url(issuer_url),
+        resource_server_url=as_any_http_url(resource_url),
+        required_scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+            default_scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+        ),
+    )
+    mcp._auth_server_provider = provider
+    mcp._token_verifier = ProviderTokenVerifier(provider)
+    _oauth_provider = provider
+    return provider
+
+
+def _oauth_transport_security_settings(*, issuer_url: str, resource_url: str):
+    """Allow configured OAuth hosts while keeping DNS rebinding protection on."""
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    allowed_hosts = {
+        "127.0.0.1:*",
+        "localhost:*",
+        "[::1]:*",
+    }
+    for url in (issuer_url, resource_url):
+        allowed_hosts.update(_host_header_variants(url))
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=sorted(allowed_hosts),
+    )
+
+
+def _host_header_variants(url: str) -> set[str]:
+    parsed = urlparse(url.strip())
+    if not parsed.hostname:
+        return set()
+    variants = {parsed.netloc}
+    if parsed.port is None:
+        variants.add(parsed.hostname)
+        if parsed.scheme == "https":
+            variants.add(f"{parsed.hostname}:443")
+        elif parsed.scheme == "http":
+            variants.add(f"{parsed.hostname}:80")
+    return {variant for variant in variants if variant}
 
 
 def _get_account_resolver():
@@ -340,9 +457,10 @@ if __name__ == "__main__":
 
         mcp.settings.host = host
         mcp.settings.port = port
-        mcp.settings.transport_security = TransportSecuritySettings(
-            enable_dns_rebinding_protection=False,
-        )
+        if _http_auth_mode() == _AUTH_MODE_BEARER:
+            mcp.settings.transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=False,
+            )
 
         async def _serve():
             config = uvicorn.Config(

--- a/plans/PR-Content-Ops-MCP-OAuth-Transport.md
+++ b/plans/PR-Content-Ops-MCP-OAuth-Transport.md
@@ -1,0 +1,80 @@
+# PR-Content-Ops-MCP-OAuth-Transport
+
+## Why this slice exists
+
+#1381 landed the verify-only marketer MCP shell, but it still exposes HTTP through bearer mode only. #1353 calls out secure connector transport as the next delivery-layer gap before marketer clients can use the workflow remotely. This slice lands the server-side OAuth mode and refusal gates first, so the later public rollout scripts can stay thin and test the already-existing server contract.
+
+The full dual-client public rollout is too large for one safe PR. This slice deliberately stops before public Tailscale Funnel scripts and live ChatGPT/Claude e2e smokes; it creates the authenticated server mode those follow-up scripts will exercise.
+
+This is slightly over the normal 400 LOC target because the server-side OAuth mode has to carry typed config, operator-facing docs, the OAuth helper, the server auth switch, and focused tests that stub MCP auth surfaces for extracted CI.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add content-specific OAuth provider wiring for the marketer verify MCP server with a verify-only scope and operator approval page.
+2. Add typed MCP config fields for marketer verify OAuth mode, issuer URL, resource URL, approval token, and optional state file.
+3. Switch the server HTTP path between bearer mode and OAuth mode without changing the single `verify_draft` tool surface.
+4. Keep OAuth mode fail-closed on missing/short approval config and keep DNS rebinding protection enabled for configured public hosts.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-OAuth-Transport.md`
+- `CLAUDE.md`
+- `atlas_brain/config.py`
+- `atlas_brain/mcp/content_ops_marketer_verify_oauth.py`
+- `atlas_brain/mcp/content_ops_marketer_verify_server.py`
+- `tests/test_mcp_content_ops_marketer_verify.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Bearer mode remains the default and still requires a production-shaped bearer token for HTTP.
+  - [ ] OAuth mode installs FastMCP auth settings with the content-ops verify scope and dynamic client registration enabled.
+  - [ ] OAuth mode refuses to start without issuer URL, resource URL, and a non-short approval token.
+  - [ ] OAuth transport security keeps DNS rebinding protection enabled and allows only localhost plus configured public OAuth/resource hosts.
+  - [ ] The MCP tool surface remains exactly `verify_draft`; no generation, publishing, approval, registry mutation, search, or fetch tools are added.
+- Affected surfaces: MCP / auth / config / tests.
+- Risk areas: security / tenant isolation / backcompat / config / CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R11, R12
+
+## Mechanism
+
+The server gets a content-specific OAuth helper that reuses the existing Atlas authorization-code provider shape and narrows it to a verify-only content scope. The MCP server reads typed settings from `settings.mcp`, validates OAuth settings before serving HTTP, installs FastMCP auth settings and token verification in OAuth mode, and keeps the previous bearer middleware path as the default.
+
+OAuth transport security is generated from the configured issuer/resource URLs. Localhost remains allowed for development, while public hosts must come from the configured URLs. The server keeps the account resolver and review-service delegation from #1381 unchanged, so this slice adds transport authentication without changing verdict behavior.
+
+## Intentional
+
+- This is the first server-side OAuth transport slice, not the full public connector rollout.
+- This does not add ChatGPT search/fetch adapters, public Funnel route scripts, live OAuth e2e scripts, or dual-client smoke commands.
+- This does not add server-side ContentPR sessions, claims extraction, registry mutation tools, or generation tools.
+- Token-bound multi-tenant account derivation remains deferred; this slice preserves the current one-bound-tenant server model and makes remote transport refuse unsafe OAuth configuration.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-OAuth-Smokes`: operator launcher, OAuth discovery smoke, public Funnel route smoke, and OAuth e2e smoke for the marketer verify server.
+- `PR-Content-Ops-MCP-Token-Tenant-Binding`: derive the tenant account binding from OAuth token/client state instead of the current one-bound-tenant server config.
+- `PR-Content-Ops-MCP-ChatGPT-Adapter`: decide and implement ChatGPT search/fetch compatibility if the rich tool connector path is not sufficient.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_mcp_content_ops_marketer_verify.py -q -- 14 passed.
+- python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_mcp_content_ops_marketer_verify.py tests/test_content_ops_claim_registry.py -q -- 58 passed.
+- python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_server.py atlas_brain/mcp/content_ops_marketer_verify_oauth.py -- passed.
+- git diff --check -- passed.
+- bash scripts/run_extracted_pipeline_checks.sh -- 3368 passed, 10 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_transport_pr_body.md -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| OAuth helper | ~117 |
+| Server auth-mode switch | ~124 |
+| Typed config and docs | ~44 |
+| Focused tests | ~152 |
+| Plan doc | ~75 |
+| **Total** | **~512** |

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 from datetime import date
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,6 +26,12 @@ class _MockFastMCP:
 
         return _register
 
+    def custom_route(self, *args, **kwargs):
+        def _register(fn):
+            return fn
+
+        return _register
+
     def streamable_http_app(self):
         return object()
 
@@ -32,15 +39,75 @@ class _MockFastMCP:
         return None
 
 
+class _OAuthBase:
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class _OAuthRecord:
+    def __init__(self, **kwargs) -> None:
+        self.__dict__.update(kwargs)
+
+
+class _OAuthException(Exception):
+    pass
+
+
+class _ProviderTokenVerifier:
+    def __init__(self, provider) -> None:
+        self.provider = provider
+
+
+class _ClientRegistrationOptions:
+    def __init__(self, **kwargs) -> None:
+        self.__dict__.update(kwargs)
+
+
+class _AuthSettings:
+    def __init__(self, **kwargs) -> None:
+        self.__dict__.update(kwargs)
+
+
+class _TransportSecuritySettings:
+    def __init__(self, **kwargs) -> None:
+        self.__dict__.update(kwargs)
+
+
 sys.modules.setdefault("mcp", MagicMock())
 sys.modules.setdefault("mcp.server", MagicMock())
 _fastmcp_mod = MagicMock()
 _fastmcp_mod.FastMCP = _MockFastMCP
 sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
+_auth_provider_mod = MagicMock()
+_auth_provider_mod.AccessToken = _OAuthRecord
+_auth_provider_mod.AuthorizationCode = _OAuthRecord
+_auth_provider_mod.AuthorizationParams = _OAuthRecord
+_auth_provider_mod.AuthorizeError = _OAuthException
+_auth_provider_mod.OAuthAuthorizationServerProvider = _OAuthBase
+_auth_provider_mod.ProviderTokenVerifier = _ProviderTokenVerifier
+_auth_provider_mod.RefreshToken = _OAuthRecord
+_auth_provider_mod.TokenError = _OAuthException
+_auth_provider_mod.construct_redirect_uri = lambda redirect_uri, **params: redirect_uri
+sys.modules.setdefault("mcp.server.auth.provider", _auth_provider_mod)
+_auth_settings_mod = MagicMock()
+_auth_settings_mod.AuthSettings = _AuthSettings
+_auth_settings_mod.ClientRegistrationOptions = _ClientRegistrationOptions
+sys.modules.setdefault("mcp.server.auth.settings", _auth_settings_mod)
+_transport_security_mod = MagicMock()
+_transport_security_mod.TransportSecuritySettings = _TransportSecuritySettings
+sys.modules.setdefault("mcp.server.transport_security", _transport_security_mod)
+_shared_auth_mod = MagicMock()
+_shared_auth_mod.OAuthClientInformationFull = _OAuthRecord
+_shared_auth_mod.OAuthToken = _OAuthRecord
+sys.modules.setdefault("mcp.shared.auth", _shared_auth_mod)
 
 from atlas_brain.config import settings
 from atlas_brain.mcp import content_ops_marketer_verify_server as verify
 from atlas_brain.mcp.auth import BearerAuthMiddleware
+from atlas_brain.mcp.content_ops_marketer_verify_oauth import (
+    DEFAULT_CONTENT_OPS_VERIFY_SCOPE,
+    validate_oauth_settings,
+)
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.claims_map import RegistryClaim
 from extracted_content_pipeline.review_contract import RiskTier
@@ -78,6 +145,16 @@ class _RegistryReader:
 def _reset_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(verify, "_registry_reader_override", None)
     monkeypatch.setattr(verify, "_account_resolver_override", None)
+    monkeypatch.setattr(verify, "_oauth_provider", None)
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "bearer")
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_oauth_issuer_url", "")
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_oauth_resource_url", "")
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_oauth_approval_token", "")
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_oauth_state_file", "")
+    verify.mcp.settings.auth = None
+    verify.mcp.settings.transport_security = None
+    verify.mcp._auth_server_provider = None
+    verify.mcp._token_verifier = None
 
 
 def _tool_names() -> set[str]:
@@ -256,3 +333,78 @@ def test_content_ops_marketer_verify_http_rejects_bad_tokens(
 
     with pytest.raises(RuntimeError):
         verify._streamable_http_app()
+
+
+def test_content_ops_marketer_verify_rejects_unknown_http_auth_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "wat")
+
+    with pytest.raises(RuntimeError, match="AUTH_MODE"):
+        verify._streamable_http_app()
+
+
+def test_content_ops_marketer_verify_oauth_settings_require_approval_token() -> None:
+    with pytest.raises(RuntimeError, match="OAUTH_APPROVAL_TOKEN"):
+        validate_oauth_settings(
+            issuer_url="https://atlas.example.com/content-ops-marketer",
+            resource_server_url="https://atlas.example.com/content-ops-marketer/mcp",
+            approval_token="short",
+        )
+
+
+def test_content_ops_marketer_verify_oauth_mode_configures_fastmcp_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_file = tmp_path / "content-ops-marketer-oauth-state.json"
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "oauth")
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_issuer_url",
+        "https://atlas.example.com/content-ops-marketer",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_resource_url",
+        "https://atlas.example.com/content-ops-marketer/mcp",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_approval_token",
+        "approval-token-with-enough-entropy",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_state_file",
+        str(state_file),
+    )
+
+    app = verify._streamable_http_app()
+    provider = verify._oauth_provider
+
+    assert not isinstance(app, BearerAuthMiddleware)
+    assert provider is not None
+    assert provider.scopes == [DEFAULT_CONTENT_OPS_VERIFY_SCOPE]
+    assert provider.state_file == state_file
+    assert verify.mcp.settings.auth.required_scopes == [DEFAULT_CONTENT_OPS_VERIFY_SCOPE]
+    assert verify.mcp.settings.auth.client_registration_options.enabled is True
+    assert verify.mcp.settings.auth.client_registration_options.valid_scopes == [
+        DEFAULT_CONTENT_OPS_VERIFY_SCOPE
+    ]
+    assert verify.mcp._auth_server_provider is provider
+    assert verify.mcp._token_verifier.provider is provider
+
+
+def test_content_ops_marketer_verify_oauth_transport_security_allows_configured_hosts() -> None:
+    transport = verify._oauth_transport_security_settings(
+        issuer_url="https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer",
+        resource_url="https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer/mcp",
+    )
+
+    assert transport.enable_dns_rebinding_protection is True
+    assert "atlas-brain.tailc7bd29.ts.net" in transport.allowed_hosts
+    assert "atlas-brain.tailc7bd29.ts.net:443" in transport.allowed_hosts
+    assert "localhost:*" in transport.allowed_hosts
+    assert "127.0.0.1:*" in transport.allowed_hosts
+    assert "evil.example.com" not in transport.allowed_hosts


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-OAuth-Transport.md
Slice phase: Production hardening
Ownership lane: content-ops/review-contract

This adds the first server-side OAuth transport hardening for the verify-only Content Ops marketer MCP server. Bearer mode remains the default, while OAuth mode now installs a content-specific verify scope, dynamic client registration, operator approval, typed config, and DNS-rebinding protection for configured public hosts.

## Intentional
- This is not the full public connector rollout, launcher, Funnel route smoke, or live OAuth e2e slice.
- This does not add ChatGPT search/fetch adapters, ContentPR sessions, claims extraction, registry mutation, or generation.
- Token-bound multi-tenant account derivation remains deferred; this slice preserves the current one-bound-tenant server model while making remote OAuth transport fail closed on unsafe config.

## Deferred
- `PR-Content-Ops-MCP-OAuth-Smokes`: operator launcher, OAuth discovery smoke, public Funnel route smoke, and OAuth e2e smoke for the marketer verify server.
- `PR-Content-Ops-MCP-Token-Tenant-Binding`: derive tenant account binding from OAuth token/client state instead of current one-bound-tenant server config.
- `PR-Content-Ops-MCP-ChatGPT-Adapter`: decide and implement ChatGPT search/fetch compatibility if the rich tool connector path is not sufficient.

## Parked hardening
- None.

## AI Reconciliation
- No findings.

## Verification
- `python -m pytest tests/test_mcp_content_ops_marketer_verify.py -q` -- 14 passed.
- `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_mcp_content_ops_marketer_verify.py tests/test_content_ops_claim_registry.py -q` -- 58 passed.
- `python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_server.py atlas_brain/mcp/content_ops_marketer_verify_oauth.py` -- passed.
- `git diff --check` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 3368 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_transport_pr_body.md` -- passed.

## Diff size
6 files, +512 / -5. Slightly over the normal target because the server-side OAuth mode has to carry typed config, operator-facing docs, the OAuth helper, the server auth switch, and focused tests that stub MCP auth surfaces for extracted CI.