### PR TITLE
Content-Ops MCP OAuth Discovery Smoke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -640,6 +640,11 @@ ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL=<public-issuer-url> \
 ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL=<public-resource-url>/mcp \
 ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=<long-operator-token> \
 python -m atlas_brain.mcp.content_ops_marketer_verify_server --sse
+
+# OAuth public-discovery smoke (metadata + 401 challenge; no draft reads)
+.venv/bin/python scripts/check_content_ops_marketer_verify_oauth_discovery.py \
+  --issuer-url <public-issuer-url> \
+  --resource-url <public-resource-url>/mcp
 ```
 
 Tools: `verify_draft`

--- a/atlas_brain/mcp/content_ops_marketer_verify_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_server.py
@@ -292,6 +292,10 @@ def _host_header_variants(url: str) -> set[str]:
             variants.add(f"{parsed.hostname}:443")
         elif parsed.scheme == "http":
             variants.add(f"{parsed.hostname}:80")
+    elif (parsed.scheme == "https" and parsed.port == 443) or (
+        parsed.scheme == "http" and parsed.port == 80
+    ):
+        variants.add(parsed.hostname)
     return {variant for variant in variants if variant}
 
 

--- a/plans/PR-Content-Ops-MCP-OAuth-Discovery-Smoke.md
+++ b/plans/PR-Content-Ops-MCP-OAuth-Discovery-Smoke.md
@@ -1,0 +1,79 @@
+# PR-Content-Ops-MCP-OAuth-Discovery-Smoke
+
+## Why this slice exists
+
+#1387 added server-side OAuth mode for the verify-only marketer MCP server. The next #1353 delivery gap is public connector rollout verification. This slice starts that rollout with the lowest-risk smoke: a marketer-specific OAuth discovery checker that validates the public issuer metadata, protected-resource metadata, and unauthenticated MCP challenge before any approval, token exchange, or tool call happens.
+
+The #1387 review also left a non-blocking DNS allow-list NIT for explicit default ports. This slice touches the same transport surface, so it closes that small restrictive-host edge here instead of carrying it forward.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add a marketer verify OAuth discovery smoke script for public metadata and 401 challenge validation.
+2. Enroll focused checker tests proving happy path, missing config, and bad challenge failures.
+3. Document the discovery smoke command in the marketer MCP section.
+4. Fix the explicit default-port DNS allow-list NIT from #1387 and cover it with a focused test.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-OAuth-Discovery-Smoke.md`
+- `CLAUDE.md`
+- `atlas_brain/mcp/content_ops_marketer_verify_server.py`
+- `scripts/check_content_ops_marketer_verify_oauth_discovery.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_check_content_ops_marketer_verify_oauth_discovery.py`
+- `tests/test_mcp_content_ops_marketer_verify.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The new checker validates authorization metadata, protected-resource metadata, and unauthenticated MCP `WWW-Authenticate` resource metadata.
+  - [ ] The checker refuses to run without issuer/resource URLs before touching network transport.
+  - [ ] The checker uses the marketer verify scope `content_ops.review.verify`, not invoicing scopes.
+  - [ ] Explicit default-port OAuth URLs allow both bare host and canonical host:port variants.
+  - [ ] The existing MCP tool surface remains exactly `verify_draft`.
+- Affected surfaces: MCP / auth / scripts / docs / CI.
+- Risk areas: security / config / CI enrollment / deployment safety.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R11, R12
+
+## Mechanism
+
+The new checker reuses the existing OAuth metadata validation helpers from the draft-writer discovery checker but supplies content-ops-specific environment names, default scope, operator messages, and output. It does not complete OAuth approval or call any MCP tools; it only proves the public discovery documents and unauthenticated challenge are routable and internally consistent.
+
+The DNS allow-list fix keeps the #1387 behavior for implicit-port URLs and adds the bare hostname when an operator explicitly configures the scheme default port, such as `https://example.com:443`.
+
+## Intentional
+
+- This is discovery smoke only; it does not add the operator launcher, Funnel route checker, OAuth e2e token exchange, or dual-client connector smoke.
+- The script validates live URLs when run by an operator, but tests mock network helpers and prove the checker branches without external calls.
+- The script reuses existing metadata helper behavior instead of refactoring the invoicing checker into a shared library in this slice.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-OAuth-Launcher`: operator launcher that forces OAuth mode, masks secrets, and prints Funnel/discovery/e2e commands.
+- `PR-Content-Ops-MCP-OAuth-E2E`: dynamic registration, approval, token exchange, and list-tools smoke.
+- `PR-Content-Ops-MCP-Token-Tenant-Binding`: derive tenant account binding from OAuth token/client state.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_check_content_ops_marketer_verify_oauth_discovery.py tests/test_mcp_content_ops_marketer_verify.py -q -- 20 passed.
+- python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_discovery.py tests/test_mcp_content_ops_marketer_verify.py tests/test_content_ops_claim_registry.py -q -- 64 passed.
+- python -m py_compile scripts/check_content_ops_marketer_verify_oauth_discovery.py atlas_brain/mcp/content_ops_marketer_verify_server.py -- passed.
+- python scripts/check_content_ops_marketer_verify_oauth_discovery.py --help -- passed.
+- git diff --check -- passed.
+- bash scripts/run_extracted_pipeline_checks.sh -- 3374 passed, 10 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_discovery_smoke_pr_body.md -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Discovery checker | ~116 |
+| Checker tests | ~154 |
+| DNS NIT + test | ~14 |
+| Docs and CI enrollment | ~6 |
+| Plan doc | ~79 |
+| **Total** | **~369** |

--- a/scripts/check_content_ops_marketer_verify_oauth_discovery.py
+++ b/scripts/check_content_ops_marketer_verify_oauth_discovery.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Verify public OAuth discovery for the Content Ops marketer verify MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_draft_writer_checker():
+    path = ROOT / "scripts/check_invoicing_draft_writer_oauth_discovery.py"
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_draft_writer_oauth_discovery",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load OAuth discovery helper from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_draft_checker = _load_draft_writer_checker()
+_authorization_metadata_url = _draft_checker._authorization_metadata_url
+_fetch_json = _draft_checker._fetch_json
+_metadata_errors = _draft_checker._metadata_errors
+_probe_mcp_unauthenticated = _draft_checker._probe_mcp_unauthenticated
+_protected_resource_metadata_url = _draft_checker._protected_resource_metadata_url
+_strip_trailing_slash = _draft_checker._strip_trailing_slash
+
+
+DEFAULT_SCOPE = "content_ops.review.verify"
+ISSUER_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"
+RESOURCE_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Smoke-check OAuth discovery for the Content Ops marketer verify MCP connector."
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=os.environ.get(ISSUER_ENV, ""),
+        help=f"Public OAuth issuer URL. Defaults to {ISSUER_ENV}.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=os.environ.get(RESOURCE_ENV, ""),
+        help=f"Public Streamable HTTP MCP resource URL. Defaults to {RESOURCE_ENV}.",
+    )
+    parser.add_argument(
+        "--scope",
+        default=DEFAULT_SCOPE,
+        help=f"Required OAuth scope. Default: {DEFAULT_SCOPE}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds. Default: 10.",
+    )
+    return parser
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    issuer_url = _strip_trailing_slash(args.issuer_url)
+    resource_url = _strip_trailing_slash(args.resource_url)
+    if not issuer_url:
+        print(f"--issuer-url or {ISSUER_ENV} is required", file=sys.stderr)
+        return 2
+    if not resource_url:
+        print(f"--resource-url or {RESOURCE_ENV} is required", file=sys.stderr)
+        return 2
+
+    auth_url = _authorization_metadata_url(issuer_url)
+    protected_url = _protected_resource_metadata_url(resource_url)
+    try:
+        auth_metadata = _fetch_json(auth_url, args.timeout)
+        resource_metadata = _fetch_json(protected_url, args.timeout)
+        mcp_status, mcp_headers = _probe_mcp_unauthenticated(resource_url, args.timeout)
+    except Exception as exc:
+        print(f"OAuth discovery smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _metadata_errors(
+        issuer_url=issuer_url,
+        resource_url=resource_url,
+        scope=args.scope,
+        auth_metadata=auth_metadata,
+        resource_metadata=resource_metadata,
+        mcp_status=mcp_status,
+        mcp_headers=mcp_headers,
+    )
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("OK: Content Ops marketer verify OAuth discovery is routable")
+    print(f"- authorization metadata: {auth_url}")
+    print(f"- protected resource metadata: {protected_url}")
+    print(f"- MCP resource: {resource_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -105,6 +105,7 @@ pytest \
   tests/test_extracted_content_ops_execution_smoke.py \
   tests/test_atlas_content_ops_infrastructure.py \
   tests/test_atlas_content_ops_review_workflow.py \
+  tests/test_check_content_ops_marketer_verify_oauth_discovery.py \
   tests/test_mcp_content_ops_marketer_verify.py \
   tests/test_content_ops_claim_registry.py \
   tests/test_atlas_content_ops_generated_assets_api.py \

--- a/tests/test_check_content_ops_marketer_verify_oauth_discovery.py
+++ b/tests/test_check_content_ops_marketer_verify_oauth_discovery.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_content_ops_marketer_verify_oauth_discovery",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_content_ops_discovery_defaults_to_verify_scope() -> None:
+    module = _load_script_module()
+
+    assert module.DEFAULT_SCOPE == "content_ops.review.verify"
+
+
+def test_metadata_errors_accept_expected_content_ops_discovery_documents() -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/content-ops-marketer"
+    resource = "https://atlas.example.com/content-ops-marketer/mcp"
+
+    errors = module._metadata_errors(
+        issuer_url=issuer,
+        resource_url=resource,
+        scope=module.DEFAULT_SCOPE,
+        auth_metadata={
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+            "registration_endpoint": f"{issuer}/register",
+            "scopes_supported": [module.DEFAULT_SCOPE],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+        },
+        resource_metadata={
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": [module.DEFAULT_SCOPE],
+        },
+        mcp_status=401,
+        mcp_headers={
+            "www-authenticate": (
+                'Bearer resource_metadata="https://atlas.example.com/.well-known/'
+                'oauth-protected-resource/content-ops-marketer/mcp"'
+            )
+        },
+    )
+
+    assert errors == []
+
+
+def test_metadata_errors_reject_missing_content_ops_resource_challenge() -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/content-ops-marketer"
+    resource = "https://atlas.example.com/content-ops-marketer/mcp"
+
+    errors = module._metadata_errors(
+        issuer_url=issuer,
+        resource_url=resource,
+        scope=module.DEFAULT_SCOPE,
+        auth_metadata={
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+            "registration_endpoint": f"{issuer}/register",
+            "scopes_supported": [module.DEFAULT_SCOPE],
+            "grant_types_supported": ["authorization_code"],
+        },
+        resource_metadata={
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": [module.DEFAULT_SCOPE],
+        },
+        mcp_status=401,
+        mcp_headers={"www-authenticate": "Bearer"},
+    )
+
+    assert errors == [
+        "WWW-Authenticate header missing resource_metadata="
+        "https://atlas.example.com/.well-known/oauth-protected-resource/content-ops-marketer/mcp"
+    ]
+
+
+def test_main_requires_content_ops_urls_before_network(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("network touched")
+
+    monkeypatch.delenv(module.ISSUER_ENV, raising=False)
+    monkeypatch.delenv(module.RESOURCE_ENV, raising=False)
+    monkeypatch.setattr(module, "_fetch_json", fail_fetch)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert module.ISSUER_ENV in captured.err
+
+
+def test_main_reports_success_for_valid_content_ops_public_discovery(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/content-ops-marketer"
+    resource = "https://atlas.example.com/content-ops-marketer/mcp"
+
+    def fake_fetch(url: str, _timeout: float):
+        if url.endswith("/.well-known/oauth-authorization-server"):
+            return {
+                "issuer": issuer,
+                "authorization_endpoint": f"{issuer}/authorize",
+                "token_endpoint": f"{issuer}/token",
+                "registration_endpoint": f"{issuer}/register",
+                "scopes_supported": [module.DEFAULT_SCOPE],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+            }
+        return {
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": [module.DEFAULT_SCOPE],
+        }
+
+    monkeypatch.setattr(module, "_fetch_json", fake_fetch)
+    monkeypatch.setattr(
+        module,
+        "_probe_mcp_unauthenticated",
+        lambda *_args: (
+            401,
+            {
+                "www-authenticate": (
+                    'Bearer resource_metadata="https://atlas.example.com/.well-known/'
+                    'oauth-protected-resource/content-ops-marketer/mcp"'
+                )
+            },
+        ),
+    )
+
+    result = module._main(["--issuer-url", issuer, "--resource-url", resource])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Content Ops marketer verify OAuth discovery is routable" in captured.out

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -408,3 +408,13 @@ def test_content_ops_marketer_verify_oauth_transport_security_allows_configured_
     assert "localhost:*" in transport.allowed_hosts
     assert "127.0.0.1:*" in transport.allowed_hosts
     assert "evil.example.com" not in transport.allowed_hosts
+
+
+def test_content_ops_marketer_verify_oauth_transport_security_allows_explicit_default_port() -> None:
+    transport = verify._oauth_transport_security_settings(
+        issuer_url="https://atlas-brain.tailc7bd29.ts.net:443/content-ops-marketer",
+        resource_url="https://atlas-brain.tailc7bd29.ts.net:443/content-ops-marketer/mcp",
+    )
+
+    assert "atlas-brain.tailc7bd29.ts.net" in transport.allowed_hosts
+    assert "atlas-brain.tailc7bd29.ts.net:443" in transport.allowed_hosts


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-OAuth-Discovery-Smoke.md
Slice phase: Production hardening
Ownership lane: content-ops/review-contract

This starts the marketer MCP public rollout checks by adding a Content Ops OAuth discovery smoke. The checker validates issuer metadata, protected-resource metadata, and the unauthenticated MCP challenge for the verify-only public resource before any approval, token exchange, or tool call. It also fixes the #1387 DNS allow-list NIT for explicit default ports.

## Intentional
- This is discovery smoke only; it does not add the operator launcher, Funnel route checker, OAuth e2e token exchange, or dual-client connector smoke.
- The script validates live URLs when run by an operator, but tests mock network helpers and prove checker branches without external calls.
- The script reuses existing metadata helper behavior instead of refactoring the invoicing checker into a shared library in this slice.

## Deferred
- `PR-Content-Ops-MCP-OAuth-Launcher`: operator launcher that forces OAuth mode, masks secrets, and prints Funnel/discovery/e2e commands.
- `PR-Content-Ops-MCP-OAuth-E2E`: dynamic registration, approval, token exchange, and list-tools smoke.
- `PR-Content-Ops-MCP-Token-Tenant-Binding`: derive tenant account binding from OAuth token/client state.

## Parked hardening
- None.

## AI Reconciliation
- Fixed #1387 reviewer NIT: explicit default-port OAuth URLs now allow both bare host and canonical host:port variants.
- All fixed or waived: Yes.

## Verification
- `python -m pytest tests/test_check_content_ops_marketer_verify_oauth_discovery.py tests/test_mcp_content_ops_marketer_verify.py -q` -- 20 passed.
- `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_discovery.py tests/test_mcp_content_ops_marketer_verify.py tests/test_content_ops_claim_registry.py -q` -- 64 passed.
- `python -m py_compile scripts/check_content_ops_marketer_verify_oauth_discovery.py atlas_brain/mcp/content_ops_marketer_verify_server.py` -- passed.
- `python scripts/check_content_ops_marketer_verify_oauth_discovery.py --help` -- passed.
- `git diff --check` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 3374 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_discovery_smoke_pr_body.md` -- passed.

## Diff size
7 files, +369 / -0.