### PR TITLE
Content-Ops MCP OAuth Launcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,6 +641,9 @@ ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL=<public-resource-url>/m
 ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=<long-operator-token> \
 python -m atlas_brain.mcp.content_ops_marketer_verify_server --sse
 
+# Operator launcher (loads .env/.env.local, validates OAuth config, prints smokes)
+.venv/bin/python scripts/start_content_ops_marketer_verify_oauth_server.py --dry-run
+
 # OAuth public-discovery smoke (metadata + 401 challenge; no draft reads)
 .venv/bin/python scripts/check_content_ops_marketer_verify_oauth_discovery.py \
   --issuer-url <public-issuer-url> \

--- a/plans/PR-Content-Ops-MCP-OAuth-Launcher.md
+++ b/plans/PR-Content-Ops-MCP-OAuth-Launcher.md
@@ -1,0 +1,82 @@
+# PR-Content-Ops-MCP-OAuth-Launcher
+
+## Why this slice exists
+
+#1387 added server-side OAuth mode for the verify-only marketer MCP server, and #1388 added public discovery verification. The #1353 delivery tracker still requires an operator-safe launcher before this connector is practical to run against a public Funnel URL. Operators need one command that loads Atlas dotenv files, forces the correct OAuth mode, validates the public issuer/resource/approval settings, masks secrets, and prints the exact public smoke commands.
+
+This is the next smallest production-hardening slice in the OAuth rollout. It deliberately stops before token exchange and live client flows so the launcher can be reviewed independently from the later e2e smoke.
+
+This slice is expected to exceed the normal 400 LOC target because the operator CLI, secret masking, validation branches, Funnel route rendering, and failure-branch tests need to land together. Splitting tests from the launcher would violate the detector coverage rule for this config/security surface.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add a Content Ops Marketer Verify OAuth launcher script modeled on the draft-writer launcher.
+2. Force OAuth mode for the marketer verify server, validate public URLs, validate the approval token length, and validate the configured port before launching.
+3. Print masked operator configuration, path-preserving Tailscale Funnel route commands, the existing discovery smoke command, and the planned e2e smoke command.
+4. Enroll focused launcher tests in the extracted pipeline wrapper.
+5. Document the launcher command in the Content Ops Marketer Verify MCP section.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-OAuth-Launcher.md`
+- `CLAUDE.md`
+- `scripts/start_content_ops_marketer_verify_oauth_server.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_start_content_ops_marketer_verify_oauth_server.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The launcher defaults to the marketer verify public issuer/resource URLs and port without requiring shell-sourced env.
+  - [ ] The launcher forces `ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE=oauth`.
+  - [ ] The launcher rejects missing or short approval tokens and invalid ports before starting the server process.
+  - [ ] Operator output masks bearer and approval token values while still showing which required settings are present.
+  - [ ] Operator output prints the content-ops discovery smoke command and a placeholder e2e command for the later e2e slice.
+  - [ ] The server command launches `atlas_brain.mcp.content_ops_marketer_verify_server` with `--sse`.
+- Affected surfaces: MCP / auth / scripts / docs / CI.
+- Risk areas: security / config / deployment safety / CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R11, R12
+
+## Mechanism
+
+The new launcher follows the existing draft-writer operator launcher shape with content-ops-specific constants, env var names, default URLs, server module, and smoke command names. It loads `.env` and `.env.local` by default, lets explicit CLI flags override dotenv/process values where appropriate, and supports an approval-token file so operators can avoid placing secrets in shell history.
+
+The script only validates and starts the existing MCP server. It does not add new auth behavior to the server, does not exchange tokens, and does not call `verify_draft`.
+
+## Intentional
+
+- This slice prints the planned e2e smoke command before the e2e checker exists. That keeps operator runbooks stable while the actual token-exchange smoke remains a separate reviewable PR.
+- The launcher uses the same lightweight dotenv parsing pattern as the draft-writer precedent instead of adding a dependency.
+- The launcher keeps the current single-bound-tenant server model; token-derived tenant binding stays deferred.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-OAuth-E2E`: dynamic registration, approval, token exchange, and list-tools smoke.
+- `PR-Content-Ops-MCP-Token-Tenant-Binding`: derive tenant account binding from OAuth token/client state instead of the current configured account binding.
+- `PR-Content-Ops-MCP-Dual-Client-Smoke`: run the public OAuth flow against both Claude and the chosen ChatGPT connector surface after the e2e checker exists.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_start_content_ops_marketer_verify_oauth_server.py -q -- 14 passed.
+- python -m pytest tests/test_start_content_ops_marketer_verify_oauth_server.py tests/test_check_content_ops_marketer_verify_oauth_discovery.py tests/test_mcp_content_ops_marketer_verify.py -q -- 34 passed.
+- python -m py_compile scripts/start_content_ops_marketer_verify_oauth_server.py -- passed.
+- python scripts/start_content_ops_marketer_verify_oauth_server.py --help -- passed.
+- git diff --check -- passed.
+- bash scripts/run_extracted_pipeline_checks.sh -- 3388 passed, 10 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_launcher_pr_body.md -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Launcher script | ~308 |
+| Launcher tests | ~304 |
+| Docs and CI enrollment | ~4 |
+| Plan doc | ~82 |
+| **Total** | **~698** |
+
+See Why for the over-budget justification.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -105,6 +105,7 @@ pytest \
   tests/test_extracted_content_ops_execution_smoke.py \
   tests/test_atlas_content_ops_infrastructure.py \
   tests/test_atlas_content_ops_review_workflow.py \
+  tests/test_start_content_ops_marketer_verify_oauth_server.py \
   tests/test_check_content_ops_marketer_verify_oauth_discovery.py \
   tests/test_mcp_content_ops_marketer_verify.py \
   tests/test_content_ops_claim_registry.py \

--- a/scripts/start_content_ops_marketer_verify_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_oauth_server.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Start the Content Ops marketer verify MCP server in OAuth mode."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = "8068"
+DEFAULT_ISSUER_URL = "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer"
+DEFAULT_RESOURCE_URL = "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer/mcp"
+PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource"
+MIN_APPROVAL_TOKEN_LENGTH = 24
+LOCAL_HTTP_HOSTS = {"localhost", "127.0.0.1", "::1"}
+SECRET_KEYS = {
+    "ATLAS_MCP_AUTH_TOKEN",
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN",
+}
+REQUIRED_KEYS = (
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE",
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL",
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL",
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN",
+)
+
+
+@dataclass(frozen=True)
+class LaunchConfig:
+    env: dict[str, str]
+    python: str
+    host: str
+    port: str
+    dry_run: bool
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Load Atlas dotenv files and start the Content Ops marketer verify "
+            "MCP server in OAuth connector mode."
+        )
+    )
+    parser.add_argument(
+        "--env-file",
+        action="append",
+        default=None,
+        help="Dotenv file to load. May be repeated. Defaults to .env then .env.local.",
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable used to launch the MCP server. Defaults to the current interpreter.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help=f"Bind host. Defaults to env ATLAS_MCP_HOST or {DEFAULT_HOST}.",
+    )
+    parser.add_argument(
+        "--port",
+        default=None,
+        help=f"Bind port. Defaults to env ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT or {DEFAULT_PORT}.",
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=None,
+        help=f"OAuth issuer URL. Defaults to env value or {DEFAULT_ISSUER_URL}.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=None,
+        help=f"OAuth resource URL. Defaults to env value or {DEFAULT_RESOURCE_URL}.",
+    )
+    parser.add_argument(
+        "--approval-token-file",
+        default=None,
+        help=(
+            "Read ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN "
+            "from this local file. Prefer this over putting approval secrets "
+            "in shell history."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and print the launch/smoke commands without starting the server.",
+    )
+    return parser
+
+
+def _parse_dotenv_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    key, value = stripped.split("=", 1)
+    key = key.strip()
+    value = value.strip()
+    if not key:
+        return None
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return key, value
+
+
+def _load_dotenv_files(paths: list[Path]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for path in paths:
+        if not path.exists():
+            continue
+        for line in path.read_text().splitlines():
+            parsed = _parse_dotenv_line(line)
+            if parsed is None:
+                continue
+            key, value = parsed
+            values[key] = value
+    return values
+
+
+def _read_secret_file(path: str) -> str:
+    secret_path = Path(path)
+    try:
+        value = secret_path.read_text().strip()
+    except OSError as exc:
+        raise ValueError(f"could not read approval token file {secret_path}") from exc
+    if not value:
+        raise ValueError(f"approval token file {secret_path} is empty")
+    return value
+
+
+def _masked_env_report(env: Mapping[str, str], keys: tuple[str, ...] = REQUIRED_KEYS) -> list[str]:
+    lines: list[str] = []
+    for key in keys:
+        value = env.get(key, "")
+        if key in SECRET_KEYS:
+            state = f"SET len={len(value)}" if value else "MISSING"
+        else:
+            state = value or "MISSING"
+        lines.append(f"{key}={state}")
+    return lines
+
+
+def _is_https_or_local_http(url: str) -> bool:
+    parsed = urlparse(url.strip())
+    if parsed.scheme == "https" and parsed.hostname:
+        return True
+    if parsed.scheme == "http" and parsed.hostname in LOCAL_HTTP_HOSTS:
+        return True
+    return False
+
+
+def _validate_env(env: Mapping[str, str]) -> list[str]:
+    errors: list[str] = []
+    mode = env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE", "").strip().lower()
+    if mode != "oauth":
+        errors.append("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE must be oauth")
+    issuer = env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL", "").strip()
+    if not _is_https_or_local_http(issuer):
+        errors.append(
+            "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL must be HTTPS or localhost HTTP"
+        )
+    resource = env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL", "").strip()
+    if not _is_https_or_local_http(resource):
+        errors.append(
+            "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL must be HTTPS or localhost HTTP"
+        )
+    approval_token = env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN", "").strip()
+    if len(approval_token) < MIN_APPROVAL_TOKEN_LENGTH:
+        errors.append(
+            "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN must be at least "
+            f"{MIN_APPROVAL_TOKEN_LENGTH} characters"
+        )
+    port = env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT", DEFAULT_PORT).strip()
+    try:
+        parsed_port = int(port)
+    except ValueError:
+        errors.append("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT must be an integer")
+    else:
+        if parsed_port <= 0 or parsed_port > 65535:
+            errors.append("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT must be between 1 and 65535")
+    return errors
+
+
+def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:
+    env_files = [Path(path) for path in (args.env_file or [".env", ".env.local"])]
+    env = _load_dotenv_files(env_files)
+    env.update(os.environ)
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE"] = "oauth"
+    env["ATLAS_MCP_HOST"] = (args.host or env.get("ATLAS_MCP_HOST") or DEFAULT_HOST).strip()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"] = (
+        args.port or env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT") or DEFAULT_PORT
+    ).strip()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] = (
+        args.issuer_url
+        or env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL")
+        or DEFAULT_ISSUER_URL
+    ).strip()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"] = (
+        args.resource_url
+        or env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL")
+        or DEFAULT_RESOURCE_URL
+    ).strip()
+    if args.approval_token_file:
+        env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN"] = _read_secret_file(
+            args.approval_token_file
+        )
+    return LaunchConfig(
+        env=env,
+        python=args.python,
+        host=env["ATLAS_MCP_HOST"],
+        port=env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"],
+        dry_run=args.dry_run,
+    )
+
+
+def _server_command(config: LaunchConfig) -> list[str]:
+    return [
+        config.python,
+        "-m",
+        "atlas_brain.mcp.content_ops_marketer_verify_server",
+        "--sse",
+    ]
+
+
+def _funnel_app_path(resource_url: str) -> str:
+    path = urlparse(resource_url.strip()).path.rstrip("/")
+    if path.endswith("/mcp"):
+        path = path[: -len("/mcp")]
+    return path or "/"
+
+
+def _funnel_metadata_path(resource_url: str) -> str:
+    app_path = _funnel_app_path(resource_url)
+    if app_path == "/":
+        return PROTECTED_RESOURCE_METADATA_PATH
+    return f"{PROTECTED_RESOURCE_METADATA_PATH}{app_path}"
+
+
+def _print_operator_guidance(config: LaunchConfig) -> None:
+    issuer_url = config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"]
+    resource_url = config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"]
+    app_path = _funnel_app_path(resource_url)
+    metadata_path = _funnel_metadata_path(resource_url)
+    print("Content Ops marketer verify OAuth launch configuration:")
+    for line in _masked_env_report(config.env):
+        print(f"- {line}")
+    print(f"- ATLAS_MCP_HOST={config.host}")
+    print(f"- ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT={config.port}")
+    print()
+    print("Required Funnel route for the marketer verify connector path:")
+    print("tailscale funnel --bg --yes \\")
+    if app_path == "/":
+        print(f"  http://127.0.0.1:{config.port}")
+    else:
+        print(f"  --set-path {app_path} \\")
+        print(f"  http://127.0.0.1:{config.port}")
+    print()
+    print("Required Funnel route for protected-resource metadata:")
+    print("tailscale funnel --bg --yes \\")
+    print(f"  --set-path {metadata_path} \\")
+    print(f"  http://127.0.0.1:{config.port}{metadata_path}")
+    print()
+    print("After startup, verify public discovery:")
+    print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_discovery.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url}")
+    print()
+    print("Planned next-slice OAuth e2e smoke:")
+    print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url}")
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = _build_launch_config(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    errors = _validate_env(config.env)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 2
+
+    _print_operator_guidance(config)
+    command = _server_command(config)
+    print()
+    print("Starting server:")
+    print(" ".join(command))
+    if config.dry_run:
+        print("dry-run: server not started")
+        return 0
+
+    return subprocess.call(command, env=config.env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_start_content_ops_marketer_verify_oauth_server.py
+++ b/tests/test_start_content_ops_marketer_verify_oauth_server.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/start_content_ops_marketer_verify_oauth_server.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "start_content_ops_marketer_verify_oauth_server",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "env_file": [],
+        "python": "/venv/bin/python",
+        "host": None,
+        "port": None,
+        "issuer_url": None,
+        "resource_url": None,
+        "approval_token_file": None,
+        "dry_run": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _valid_env():
+    return {
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE": "oauth",
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL": (
+            "https://atlas.example.com/content-ops-marketer"
+        ),
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL": (
+            "https://atlas.example.com/content-ops-marketer/mcp"
+        ),
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN": (
+            "approval-token-with-enough-entropy"
+        ),
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT": "8068",
+    }
+
+
+def test_validate_env_accepts_content_ops_oauth_config() -> None:
+    module = _load_script_module()
+
+    assert module._validate_env(_valid_env()) == []
+
+
+def test_validate_env_rejects_short_token_and_bad_port() -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN"] = "short"
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"] = "70000"
+
+    errors = module._validate_env(env)
+
+    assert any("APPROVAL_TOKEN" in error for error in errors)
+    assert any("between 1 and 65535" in error for error in errors)
+
+
+def test_validate_env_rejects_non_oauth_mode_and_non_public_urls() -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE"] = "bearer"
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] = "http://example.com"
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"] = "ftp://example.com/mcp"
+
+    errors = module._validate_env(env)
+
+    assert any("AUTH_MODE must be oauth" in error for error in errors)
+    assert any("ISSUER_URL must be HTTPS" in error for error in errors)
+    assert any("RESOURCE_URL must be HTTPS" in error for error in errors)
+
+
+def test_validate_env_rejects_localhost_prefix_attack_urls() -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] = (
+        "http://localhost.evil.example.com/content-ops-marketer"
+    )
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"] = (
+        "http://127.0.0.1.evil.example.com/content-ops-marketer/mcp"
+    )
+
+    errors = module._validate_env(env)
+
+    assert any("ISSUER_URL must be HTTPS" in error for error in errors)
+    assert any("RESOURCE_URL must be HTTPS" in error for error in errors)
+
+
+def test_validate_env_accepts_exact_localhost_http_urls() -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] = (
+        "http://localhost:8068/content-ops-marketer"
+    )
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"] = (
+        "http://127.0.0.1:8068/content-ops-marketer/mcp"
+    )
+
+    assert module._validate_env(env) == []
+
+
+def test_build_launch_config_loads_env_files_and_forces_oauth(tmp_path, monkeypatch) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE=bearer",
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=approval-token-with-enough-entropy",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.delenv(
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN",
+        raising=False,
+    )
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)], port="9000"))
+
+    assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE"] == "oauth"
+    assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"] == "9000"
+    assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] == (
+        module.DEFAULT_ISSUER_URL
+    )
+
+
+def test_build_launch_config_process_env_overrides_env_file(tmp_path, monkeypatch) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=approval-token-from-file",
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL=https://file.example.com/content-ops-marketer",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN",
+        "approval-token-from-process-env",
+    )
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)]))
+
+    assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN"] == (
+        "approval-token-from-process-env"
+    )
+    assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] == (
+        "https://file.example.com/content-ops-marketer"
+    )
+
+
+def test_build_launch_config_reads_approval_token_file(tmp_path, monkeypatch) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "content-ops-token"
+    token_file.write_text("approval-token-from-local-secret-file\n")
+    monkeypatch.delenv(
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN",
+        raising=False,
+    )
+
+    config = module._build_launch_config(
+        _args(env_file=[], approval_token_file=str(token_file))
+    )
+
+    assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN"] == (
+        "approval-token-from-local-secret-file"
+    )
+
+
+def test_build_launch_config_rejects_empty_approval_token_file(tmp_path) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "content-ops-token"
+    token_file.write_text("\n")
+
+    try:
+        module._build_launch_config(_args(env_file=[], approval_token_file=str(token_file)))
+    except ValueError as exc:
+        assert "is empty" in str(exc)
+        assert "content-ops-token" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
+
+
+def test_server_command_uses_content_ops_marketer_verify_module() -> None:
+    module = _load_script_module()
+    config = module.LaunchConfig(
+        env=_valid_env(),
+        python="/custom/python",
+        host="0.0.0.0",
+        port="8068",
+        dry_run=False,
+    )
+
+    assert module._server_command(config) == [
+        "/custom/python",
+        "-m",
+        "atlas_brain.mcp.content_ops_marketer_verify_server",
+        "--sse",
+    ]
+
+
+def test_funnel_paths_derive_parent_path_for_mcp_resource() -> None:
+    module = _load_script_module()
+
+    assert module._funnel_app_path("https://atlas.example.com/content-ops-marketer/mcp") == (
+        "/content-ops-marketer"
+    )
+    assert module._funnel_app_path("http://127.0.0.1:8068/mcp") == "/"
+    assert module._funnel_metadata_path("https://atlas.example.com/content-ops-marketer/mcp") == (
+        "/.well-known/oauth-protected-resource/content-ops-marketer"
+    )
+    assert module._funnel_metadata_path("http://127.0.0.1:8068/mcp") == (
+        "/.well-known/oauth-protected-resource"
+    )
+
+
+def test_guidance_masks_secrets_and_prints_content_ops_smokes(capsys) -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_AUTH_TOKEN"] = "bearer-token-value-that-must-not-print"
+    config = module.LaunchConfig(
+        env=env,
+        python="/venv/bin/python",
+        host="0.0.0.0",
+        port="9000",
+        dry_run=True,
+    )
+
+    module._print_operator_guidance(config)
+
+    captured = capsys.readouterr()
+    assert "SET len=34" in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out
+    assert "bearer-token-value-that-must-not-print" not in captured.out
+    assert "--set-path /content-ops-marketer" in captured.out
+    assert "http://127.0.0.1:9000" in captured.out
+    assert "--set-path /.well-known/oauth-protected-resource/content-ops-marketer" in captured.out
+    assert "check_content_ops_marketer_verify_oauth_discovery.py" in captured.out
+    assert "check_content_ops_marketer_verify_oauth_e2e.py" in captured.out
+
+
+def test_main_dry_run_does_not_start_subprocess(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=approval-token-with-enough-entropy",
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL=https://atlas.example.com/content-ops-marketer",
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL=https://atlas.example.com/content-ops-marketer/mcp",
+            ]
+        )
+        + "\n"
+    )
+
+    def fail_call(*_args, **_kwargs):
+        raise AssertionError("subprocess touched")
+
+    monkeypatch.setattr(module.subprocess, "call", fail_call)
+
+    result = module._main(["--env-file", str(env_file), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "dry-run: server not started" in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out
+
+
+def test_main_returns_validation_errors_before_subprocess(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=short\n"
+    )
+
+    def fail_call(*_args, **_kwargs):
+        raise AssertionError("subprocess touched")
+
+    monkeypatch.setattr(module.subprocess, "call", fail_call)
+
+    result = module._main(["--env-file", str(env_file)])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "APPROVAL_TOKEN" in captured.err
+    assert "short" not in captured.err


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-OAuth-Launcher.md
Slice phase: Production hardening
Ownership lane: content-ops/review-contract

This adds the operator launcher for the verify-only Content Ops marketer MCP OAuth rollout. The launcher loads Atlas dotenv files, forces marketer verify OAuth mode, validates public issuer/resource/approval/port settings, masks secrets, prints the required Tailscale Funnel routes, and prints the discovery plus planned e2e smoke commands. Token exchange, list-tools smoke, live client flows, and token-derived tenant binding stay deferred.

## Intentional
- The planned e2e command is printed before the e2e checker lands so the operator launcher/runbook shape is stable across rollout slices.
- The launcher uses the existing lightweight dotenv parsing pattern from the draft-writer precedent instead of adding a dependency.
- The launcher keeps the current single-bound-tenant server model; token-derived tenant binding stays deferred.

## Deferred
- `PR-Content-Ops-MCP-OAuth-E2E`: dynamic registration, approval, token exchange, and list-tools smoke.
- `PR-Content-Ops-MCP-Token-Tenant-Binding`: derive tenant account binding from OAuth token/client state instead of the current configured account binding.
- `PR-Content-Ops-MCP-Dual-Client-Smoke`: run the public OAuth flow against both Claude and the chosen ChatGPT connector surface after the e2e checker exists.

## Parked hardening
- None.

## AI Reconciliation
- Fixed Codex P2 / reviewer MAJOR: launcher URL validation now parses issuer/resource URLs and allows HTTP only for exact local hosts, so localhost-prefix subdomain attacks are rejected.
- All fixed or waived: Yes.

## Verification
- `python -m pytest tests/test_start_content_ops_marketer_verify_oauth_server.py -q` -- 14 passed.
- `python -m pytest tests/test_start_content_ops_marketer_verify_oauth_server.py tests/test_check_content_ops_marketer_verify_oauth_discovery.py tests/test_mcp_content_ops_marketer_verify.py -q` -- 34 passed.
- `python -m py_compile scripts/start_content_ops_marketer_verify_oauth_server.py` -- passed.
- `python scripts/start_content_ops_marketer_verify_oauth_server.py --help` -- passed.
- `git diff --check` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 3388 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_launcher_pr_body.md` -- passed.

## Diff size
5 files, about +698 / -2.