### PR TITLE
Content-Ops MCP OAuth E2E

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -648,17 +648,22 @@ python -m atlas_brain.mcp.content_ops_marketer_verify_server --sse
 .venv/bin/python scripts/check_content_ops_marketer_verify_oauth_discovery.py \
   --issuer-url <public-issuer-url> \
   --resource-url <public-resource-url>/mcp
+
+# OAuth e2e smoke (registration + approval + token + list_tools; no draft reads)
+.venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \
+  --issuer-url <public-issuer-url> \
+  --resource-url <public-resource-url>/mcp \
+  --approval-token-file /path/to/local-approval-token
 ```
 
 Tools: `verify_draft`
 
 This verify-only marketer surface accepts structured draft evidence for one
 configured tenant binding and returns the deterministic Content Ops review
-verdict. It deliberately omits generation, publishing, approval, checkout,
-search/fetch adapters, and registry mutation. OAuth mode adds the server-side
-connector auth boundary and operator approval gate; public launcher scripts,
-dual-client route smokes, and token-derived tenant binding are deferred to the
-rollout slice.
+verdict. It deliberately omits generation, publishing, checkout, search/fetch
+adapters, and registry mutation. OAuth mode adds the server-side connector auth
+boundary and operator approval gate; dual-client route smokes and token-derived
+tenant binding are deferred to later rollout slices.
 
 ### Intelligence MCP Server (33 tools)
 ```bash

--- a/plans/PR-Content-Ops-MCP-OAuth-E2E.md
+++ b/plans/PR-Content-Ops-MCP-OAuth-E2E.md
@@ -1,0 +1,101 @@
+# PR-Content-Ops-MCP-OAuth-E2E
+
+## Why this slice exists
+
+#1387 added the verify-only marketer MCP OAuth transport, #1388 added public discovery validation, and #1389 added the operator launcher. The #1353 delivery tracker now calls for the no-mutation OAuth e2e smoke: prove the public OAuth flow can dynamically register a client, route through the operator approval gate, exchange an authorization code for a token, and use that token to list the MCP tool surface.
+
+This slice is production hardening for connector rollout. It deliberately lists tools only; it must not call `verify_draft` or submit draft content.
+
+This PR exceeds the normal 400 LOC target because the new checker is security/config validation around OAuth and connector exposure. Keeping the checker, command documentation, CI enrollment, and focused failure-branch fixtures together is the smallest defensible slice that proves the e2e smoke fails closed before rollout.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add a Content Ops marketer verify OAuth e2e smoke script for public connector rollout.
+2. Reuse the existing draft-writer OAuth e2e transport helpers while supplying content-ops env vars, scope, client name, and exact tool surface.
+3. Prove config missing values, approval token file handling, token exchange failure, tool-surface failures, and the registration to list-tools sequence with focused tests.
+4. Enroll the new e2e tests in the extracted pipeline wrapper.
+5. Document the e2e smoke command in the Content Ops Marketer Verify MCP section.
+6. Propagate the required approval-token handoff into the launcher-printed e2e command so the operator runbook matches the checker interface.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-OAuth-E2E.md`
+- `CLAUDE.md`
+- `scripts/check_content_ops_marketer_verify_oauth_e2e.py`
+- `scripts/start_content_ops_marketer_verify_oauth_server.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_check_content_ops_marketer_verify_oauth_e2e.py`
+- `tests/test_start_content_ops_marketer_verify_oauth_server.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The checker uses content-ops env vars and the `content_ops.review.verify` scope.
+  - [ ] The checker refuses missing issuer/resource/approval-token values before network transport.
+  - [ ] The checker reads an approval token from a local file without printing the secret.
+  - [ ] The checker performs the OAuth registration, authorization, approval, token exchange, and authenticated list-tools sequence.
+  - [ ] The checker accepts exactly the verify-only tool surface `verify_draft`.
+  - [ ] The checker does not call `verify_draft` or any draft/content mutation path.
+  - [ ] The launcher-printed e2e command includes the required approval-token handoff.
+- Affected surfaces: MCP / auth / scripts / docs / CI.
+- Risk areas: security / config / deployment safety / CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R11, R12
+
+## Mechanism
+
+The new checker loads the existing draft-writer OAuth e2e module by file path and reuses its generic transport helpers for client registration, PKCE authorization, approval, token exchange, and authenticated MCP tool listing. The Content Ops wrapper owns only the content-specific command-line parser, environment variable names, default scope, exact expected tool set, no-mutation surface checks, and operator-facing output.
+
+Tests mock the network helper boundaries and sequence functions rather than making public HTTP calls. Live operators can run the script against the public URL after the launcher and discovery smoke pass.
+
+The launcher carries the optional approval-token-file path through `LaunchConfig` for operator guidance only. Its printed e2e command now includes `--approval-token-file`: either the exact quoted path passed to the launcher or a placeholder plus explicit env/export guidance when the token came from dotenv or process env.
+
+## Intentional
+
+- This is a no-mutation e2e smoke. It lists tools only and intentionally does not call `verify_draft`.
+- The script reuses the draft-writer e2e helpers instead of extracting a shared library in this slice.
+- This does not settle ChatGPT search/fetch adapters or token-derived tenant binding.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-Token-Tenant-Binding`: derive tenant account binding from OAuth token/client state instead of the current configured account binding.
+- `PR-Content-Ops-MCP-Dual-Client-Smoke`: run public OAuth flows against both Claude and the chosen ChatGPT connector surface.
+- `PR-Content-Ops-MCP-Connector-Boundary-Smoke`: optional bearer/auth boundary smoke if needed after e2e hardening.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_check_content_ops_marketer_verify_oauth_e2e.py -q
+  - 13 passed in 0.26s
+- Passed: python -m pytest tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_check_content_ops_marketer_verify_oauth_discovery.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 33 passed in 0.50s
+- Passed: python -m py_compile scripts/check_content_ops_marketer_verify_oauth_e2e.py
+- Passed: python scripts/check_content_ops_marketer_verify_oauth_e2e.py --help
+- Passed: git diff --check
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.75s for extracted_reasoning_core
+  - 3417 passed, 10 skipped in 58.70s for extracted_content_pipeline
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_e2e_pr_body.md
+  - local PR review passed
+- Passed after review fix: python -m pytest tests/test_start_content_ops_marketer_verify_oauth_server.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py -q
+  - 28 passed in 0.31s
+- Passed after review fix: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.70s for extracted_reasoning_core
+  - 3418 passed, 10 skipped in 57.29s for extracted_content_pipeline
+- Passed after review fix: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_e2e_pr_body.md
+  - local PR review passed
+
+## Estimated diff size
+
+| Area | Actual LOC |
+|---|---:|
+| E2E checker | +221 |
+| Checker tests | +289 |
+| Launcher review fix | +33 / -1 |
+| Docs and CI enrollment | +11 / -5 |
+| Plan doc | +101 |
+| **Total** | **661** |
+
+This is 7 files, +655 / -6. It exceeds the normal 400 LOC target for the reason named in Why this slice exists.

--- a/scripts/check_content_ops_marketer_verify_oauth_e2e.py
+++ b/scripts/check_content_ops_marketer_verify_oauth_e2e.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Run a no-mutation OAuth e2e smoke for the Content Ops marketer verify MCP connector."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_draft_writer_e2e():
+    path = ROOT / "scripts/check_invoicing_draft_writer_oauth_e2e.py"
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_draft_writer_oauth_e2e",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load OAuth e2e helper from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_draft_e2e = _load_draft_writer_e2e()
+AuthorizationRequest = _draft_e2e.AuthorizationRequest
+OAuthE2EConfig = _draft_e2e.OAuthE2EConfig
+RegisteredClient = _draft_e2e.RegisteredClient
+TokenResult = _draft_e2e.TokenResult
+_approve_authorization = _draft_e2e._approve_authorization
+_exchange_token = _draft_e2e._exchange_token
+_list_mcp_tools = _draft_e2e._list_mcp_tools
+_post_json = _draft_e2e._post_json
+_read_secret_file = _draft_e2e._read_secret_file
+_start_authorization = _draft_e2e._start_authorization
+_strip_trailing_slash = _draft_e2e._strip_trailing_slash
+
+
+DEFAULT_SCOPE = "content_ops.review.verify"
+DEFAULT_REDIRECT_URI = _draft_e2e.DEFAULT_REDIRECT_URI
+EXPECTED_TOOLS = {"verify_draft"}
+DENIED_TOOLS = {
+    "add_registry_claim",
+    "define_experiment",
+    "generate_asset",
+    "publish_asset",
+    "run_gates",
+    "start_brief",
+    "update_registry_claim",
+    "verify_and_publish",
+}
+ISSUER_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"
+RESOURCE_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"
+APPROVAL_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a public OAuth e2e smoke for the Content Ops marketer verify "
+            "MCP connector. This lists tools only and does not submit draft content."
+        )
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=os.environ.get(ISSUER_ENV, ""),
+        help=f"Public OAuth issuer URL. Defaults to {ISSUER_ENV}.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=os.environ.get(RESOURCE_ENV, ""),
+        help=f"Public Streamable HTTP MCP resource URL. Defaults to {RESOURCE_ENV}.",
+    )
+    parser.add_argument(
+        "--approval-token",
+        default=os.environ.get(APPROVAL_ENV, ""),
+        help=f"Operator approval token. Defaults to {APPROVAL_ENV}.",
+    )
+    parser.add_argument(
+        "--approval-token-file",
+        default="",
+        help=(
+            "Read the operator approval token from this local file. Prefer this "
+            "over passing approval secrets directly on the command line."
+        ),
+    )
+    parser.add_argument(
+        "--redirect-uri",
+        default=DEFAULT_REDIRECT_URI,
+        help=f"OAuth redirect URI to register. Default: {DEFAULT_REDIRECT_URI}.",
+    )
+    parser.add_argument(
+        "--scope",
+        default=DEFAULT_SCOPE,
+        help=f"Required OAuth scope. Default: {DEFAULT_SCOPE}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds. Default: 10.",
+    )
+    return parser
+
+
+def _config_from_args(args: argparse.Namespace) -> Any:
+    issuer_url = _strip_trailing_slash(args.issuer_url)
+    resource_url = _strip_trailing_slash(args.resource_url)
+    approval_token = (
+        _read_secret_file(args.approval_token_file)
+        if args.approval_token_file
+        else args.approval_token.strip()
+    )
+    redirect_uri = args.redirect_uri.strip()
+    scope = args.scope.strip()
+    missing: list[str] = []
+    if not issuer_url:
+        missing.append(f"--issuer-url or {ISSUER_ENV}")
+    if not resource_url:
+        missing.append(f"--resource-url or {RESOURCE_ENV}")
+    if not approval_token:
+        missing.append(f"--approval-token-file, --approval-token, or {APPROVAL_ENV}")
+    if not redirect_uri:
+        missing.append("--redirect-uri")
+    if not scope:
+        missing.append("--scope")
+    if missing:
+        raise ValueError("missing required values: " + ", ".join(missing))
+    return OAuthE2EConfig(
+        issuer_url=issuer_url,
+        resource_url=resource_url,
+        approval_token=approval_token,
+        redirect_uri=redirect_uri,
+        scope=scope,
+        timeout=args.timeout,
+    )
+
+
+def _register_client(config: Any) -> Any:
+    status, _headers, body = _post_json(
+        f"{config.issuer_url}/register",
+        {
+            "client_name": "Atlas Content Ops marketer verify OAuth e2e smoke",
+            "redirect_uris": [config.redirect_uri],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "scope": config.scope,
+        },
+        config.timeout,
+    )
+    if status not in {200, 201}:
+        raise RuntimeError(f"client registration returned HTTP {status}")
+    client_id = str(body.get("client_id") or "")
+    client_secret = str(body.get("client_secret") or "")
+    if not client_id or not client_secret:
+        raise RuntimeError("client registration response missing client_id or client_secret")
+    return RegisteredClient(client_id=client_id, client_secret=client_secret)
+
+
+def _tool_surface_errors(tool_names: set[str]) -> list[str]:
+    errors: list[str] = []
+    missing = sorted(EXPECTED_TOOLS - tool_names)
+    extra = sorted(tool_names - EXPECTED_TOOLS)
+    denied = sorted(tool_names & DENIED_TOOLS)
+    if missing:
+        errors.append("missing Content Ops marketer verify tools: " + ", ".join(missing))
+    if extra:
+        errors.append("unexpected tools exposed: " + ", ".join(extra))
+    if denied:
+        errors.append("denied tools exposed: " + ", ".join(denied))
+    return errors
+
+
+async def _run_smoke(config: Any) -> set[str]:
+    client = _register_client(config)
+    auth = _start_authorization(config, client)
+    code = _approve_authorization(config, auth)
+    token = _exchange_token(config, client, auth, code)
+    return await _list_mcp_tools(config, token.access_token)
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = _config_from_args(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    try:
+        tool_names = asyncio.run(_run_smoke(config))
+    except Exception as exc:
+        print(f"OAuth e2e smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _tool_surface_errors(tool_names)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("OK: Content Ops marketer verify OAuth e2e smoke completed")
+    print("- dynamic client registration succeeded")
+    print("- operator approval and token exchange succeeded")
+    print(f"- OAuth-authenticated MCP session exposes {len(tool_names)} verify-only tool")
+    for name in sorted(tool_names):
+        print(f"- {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -107,6 +107,7 @@ pytest \
   tests/test_atlas_content_ops_review_workflow.py \
   tests/test_start_content_ops_marketer_verify_oauth_server.py \
   tests/test_check_content_ops_marketer_verify_oauth_discovery.py \
+  tests/test_check_content_ops_marketer_verify_oauth_e2e.py \
   tests/test_mcp_content_ops_marketer_verify.py \
   tests/test_content_ops_claim_registry.py \
   tests/test_atlas_content_ops_generated_assets_api.py \

--- a/scripts/start_content_ops_marketer_verify_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_oauth_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 from collections.abc import Mapping
@@ -39,6 +40,7 @@ class LaunchConfig:
     host: str
     port: str
     dry_run: bool
+    approval_token_file: str | None = None
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -217,6 +219,7 @@ def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:
         host=env["ATLAS_MCP_HOST"],
         port=env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"],
         dry_run=args.dry_run,
+        approval_token_file=args.approval_token_file,
     )
 
 
@@ -275,7 +278,15 @@ def _print_operator_guidance(config: LaunchConfig) -> None:
     print("Planned next-slice OAuth e2e smoke:")
     print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \\")
     print(f"  --issuer-url {issuer_url} \\")
-    print(f"  --resource-url {resource_url}")
+    print(f"  --resource-url {resource_url} \\")
+    token_file = config.approval_token_file or "/path/to/local-approval-token"
+    print(f"  --approval-token-file {shlex.quote(token_file)}")
+    if config.approval_token_file is None:
+        print(
+            "If the approval token came from .env/--env-file, write it to a local token "
+            "file or export ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN "
+            "and pass --approval-token."
+        )
 
 
 def _main(argv: list[str] | None = None) -> int:

--- a/tests/test_check_content_ops_marketer_verify_oauth_e2e.py
+++ b/tests/test_check_content_ops_marketer_verify_oauth_e2e.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_content_ops_marketer_verify_oauth_e2e",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "issuer_url": "https://atlas.example.com/content-ops-marketer",
+        "resource_url": "https://atlas.example.com/content-ops-marketer/mcp",
+        "approval_token": "approval-token-with-enough-entropy",
+        "approval_token_file": "",
+        "redirect_uri": "https://chat.openai.com/aip/callback",
+        "scope": "content_ops.review.verify",
+        "timeout": 10.0,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_content_ops_e2e_defaults_to_verify_scope() -> None:
+    module = _load_script_module()
+
+    assert module.DEFAULT_SCOPE == "content_ops.review.verify"
+    assert module.EXPECTED_TOOLS == {"verify_draft"}
+
+
+def test_config_from_args_requires_content_ops_values() -> None:
+    module = _load_script_module()
+
+    try:
+        module._config_from_args(
+            _args(
+                issuer_url="",
+                resource_url="",
+                approval_token="",
+            )
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
+
+    assert "--issuer-url" in message
+    assert module.ISSUER_ENV in message
+    assert "--resource-url" in message
+    assert module.RESOURCE_ENV in message
+    assert "--approval-token" in message
+    assert module.APPROVAL_ENV in message
+
+
+def test_config_from_args_reads_approval_token_file(tmp_path) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "content-ops-token"
+    token_file.write_text("approval-token-from-local-secret-file\n")
+
+    config = module._config_from_args(
+        _args(
+            approval_token="",
+            approval_token_file=str(token_file),
+        )
+    )
+
+    assert config.approval_token == "approval-token-from-local-secret-file"
+
+
+def test_config_from_args_rejects_empty_approval_token_file(tmp_path) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "content-ops-token"
+    token_file.write_text("\n")
+
+    try:
+        module._config_from_args(_args(approval_token_file=str(token_file)))
+    except ValueError as exc:
+        assert "is empty" in str(exc)
+        assert "content-ops-token" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
+
+
+def test_register_client_uses_content_ops_client_name(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    captured = {}
+
+    def fake_post_json(url, payload, timeout):
+        captured["url"] = url
+        captured["payload"] = payload
+        captured["timeout"] = timeout
+        return 201, {}, {"client_id": "client-1", "client_secret": "secret-1"}
+
+    monkeypatch.setattr(module, "_post_json", fake_post_json)
+
+    client = module._register_client(config)
+
+    assert client.client_id == "client-1"
+    assert captured["url"] == "https://atlas.example.com/content-ops-marketer/register"
+    assert captured["payload"]["client_name"] == (
+        "Atlas Content Ops marketer verify OAuth e2e smoke"
+    )
+    assert captured["payload"]["scope"] == "content_ops.review.verify"
+
+
+def test_register_client_requires_client_secret(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+
+    monkeypatch.setattr(
+        module,
+        "_post_json",
+        lambda *_args, **_kwargs: (201, {}, {"client_id": "client-1"}),
+    )
+
+    try:
+        module._register_client(config)
+    except RuntimeError as exc:
+        assert "missing client_id or client_secret" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_exchange_token_requires_bearer_access_token(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    client = module.RegisteredClient(client_id="client-1", client_secret="secret-1")
+    auth = module.AuthorizationRequest(approval_url="url", request_id="req-1", verifier="verifier-1")
+
+    monkeypatch.setattr(
+        module._draft_e2e,
+        "_post_form",
+        lambda *_args, **_kwargs: (
+            200,
+            {},
+            '{"token_type":"Bearer","scope":"content_ops.review.verify"}',
+        ),
+    )
+
+    try:
+        module._exchange_token(config, client, auth, "code-1")
+    except RuntimeError as exc:
+        assert "missing access_token" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_tool_surface_errors_accept_exact_verify_tool() -> None:
+    module = _load_script_module()
+
+    assert module._tool_surface_errors({"verify_draft"}) == []
+
+
+def test_tool_surface_errors_reject_extra_and_denied_tools() -> None:
+    module = _load_script_module()
+
+    errors = module._tool_surface_errors({"verify_draft", "start_brief", "surprise_tool"})
+
+    assert "unexpected tools exposed: start_brief, surprise_tool" in errors
+    assert "denied tools exposed: start_brief" in errors
+
+
+def test_main_requires_config_before_network(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fail_run(*_args, **_kwargs):
+        raise AssertionError("network touched")
+
+    monkeypatch.delenv(module.ISSUER_ENV, raising=False)
+    monkeypatch.delenv(module.RESOURCE_ENV, raising=False)
+    monkeypatch.delenv(module.APPROVAL_ENV, raising=False)
+    monkeypatch.setattr(module, "_run_smoke", fail_run)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "--issuer-url" in captured.err
+
+
+def test_main_reports_success_without_printing_secrets(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_config):
+        return {"verify_draft"}
+
+    monkeypatch.setattr(module, "_run_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--issuer-url",
+            "https://atlas.example.com/content-ops-marketer",
+            "--resource-url",
+            "https://atlas.example.com/content-ops-marketer/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Content Ops marketer verify OAuth e2e smoke completed" in captured.out
+    assert "secret-approval-token-value" not in captured.out
+    assert "verify_draft" in captured.out
+
+
+def test_main_reports_tool_surface_errors(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_config):
+        return {"verify_draft", "start_brief"}
+
+    monkeypatch.setattr(module, "_run_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--issuer-url",
+            "https://atlas.example.com/content-ops-marketer",
+            "--resource-url",
+            "https://atlas.example.com/content-ops-marketer/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "unexpected tools exposed: start_brief" in captured.err
+    assert "denied tools exposed: start_brief" in captured.err
+
+
+def test_run_smoke_sequence_lists_tools_without_calling_verify_draft(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    calls: list[str] = []
+
+    def fake_register(_config):
+        calls.append("register")
+        return module.RegisteredClient(client_id="client-1", client_secret="secret-1")
+
+    def fake_start(_config, client):
+        calls.append(f"authorize:{client.client_id}")
+        return module.AuthorizationRequest(approval_url="url", request_id="req-1", verifier="verifier-1")
+
+    def fake_approve(_config, auth):
+        calls.append(f"approve:{auth.request_id}")
+        return "code-1"
+
+    def fake_exchange(_config, client, auth, code):
+        calls.append(f"token:{client.client_id}:{auth.request_id}:{code}")
+        return module.TokenResult(access_token="access-token-1", scope="content_ops.review.verify")
+
+    async def fake_list(_config, token):
+        calls.append(f"list:{token}")
+        return {"verify_draft"}
+
+    monkeypatch.setattr(module, "_register_client", fake_register)
+    monkeypatch.setattr(module, "_start_authorization", fake_start)
+    monkeypatch.setattr(module, "_approve_authorization", fake_approve)
+    monkeypatch.setattr(module, "_exchange_token", fake_exchange)
+    monkeypatch.setattr(module, "_list_mcp_tools", fake_list)
+
+    result = asyncio.run(module._run_smoke(config))
+
+    assert result == {"verify_draft"}
+    assert calls == [
+        "register",
+        "authorize:client-1",
+        "approve:req-1",
+        "token:client-1:req-1:code-1",
+        "list:access-token-1",
+    ]

--- a/tests/test_start_content_ops_marketer_verify_oauth_server.py
+++ b/tests/test_start_content_ops_marketer_verify_oauth_server.py
@@ -255,6 +255,27 @@ def test_guidance_masks_secrets_and_prints_content_ops_smokes(capsys) -> None:
     assert "--set-path /.well-known/oauth-protected-resource/content-ops-marketer" in captured.out
     assert "check_content_ops_marketer_verify_oauth_discovery.py" in captured.out
     assert "check_content_ops_marketer_verify_oauth_e2e.py" in captured.out
+    assert "--approval-token-file /path/to/local-approval-token" in captured.out
+    assert "pass --approval-token" in captured.out
+
+
+def test_guidance_prints_e2e_approval_token_file_path(capsys) -> None:
+    module = _load_script_module()
+    config = module.LaunchConfig(
+        env=_valid_env(),
+        python="/venv/bin/python",
+        host="0.0.0.0",
+        port="9000",
+        dry_run=True,
+        approval_token_file="/tmp/content ops token",
+    )
+
+    module._print_operator_guidance(config)
+
+    captured = capsys.readouterr()
+    assert "--approval-token-file '/tmp/content ops token'" in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out
+    assert "pass --approval-token" not in captured.out
 
 
 def test_main_dry_run_does_not_start_subprocess(monkeypatch, tmp_path, capsys) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-OAuth-E2E.md
Slice phase: Production hardening

Ownership lane: content-ops/review-contract

Adds the no-mutation OAuth e2e smoke for the Content Ops marketer verify MCP connector. The checker reuses the existing draft-writer OAuth transport helpers, supplies the content-ops scope/env/tool surface, and verifies dynamic registration through authenticated MCP list-tools without reading or mutating draft content.

Review update: the launcher-printed e2e command now includes the required approval-token handoff, so the operator runbook matches the checker interface.

## Intentional
- This smoke lists tools only and does not call `verify_draft`.
- The helper reuse stays file-local for this slice instead of extracting a shared OAuth e2e library.
- ChatGPT search/fetch adapters and token-derived tenant binding stay out of scope.

## Deferred
- `PR-Content-Ops-MCP-Token-Tenant-Binding`: derive tenant account binding from OAuth token/client state.
- `PR-Content-Ops-MCP-Dual-Client-Smoke`: run public OAuth flows against both Claude and the chosen ChatGPT connector surface.
- `PR-Content-Ops-MCP-Connector-Boundary-Smoke`: optional bearer/auth boundary smoke if needed after e2e hardening.

## Parked hardening
- None.

## AI Reconciliation
- Findings: none.
- All findings fixed or waived: yes.

## Verification
- `python -m pytest tests/test_check_content_ops_marketer_verify_oauth_e2e.py -q` -> 13 passed in 0.26s
- `python -m pytest tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_check_content_ops_marketer_verify_oauth_discovery.py tests/test_mcp_content_ops_marketer_verify.py -q` -> 33 passed in 0.50s
- `python -m py_compile scripts/check_content_ops_marketer_verify_oauth_e2e.py`
- `python scripts/check_content_ops_marketer_verify_oauth_e2e.py --help`
- `git diff --check`
- `bash scripts/run_extracted_pipeline_checks.sh` -> 295 passed in 1.75s for extracted_reasoning_core; 3417 passed, 10 skipped in 58.70s for extracted_content_pipeline
- Review fix: `python -m pytest tests/test_start_content_ops_marketer_verify_oauth_server.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py -q` -> 28 passed in 0.31s
- Review fix: `bash scripts/run_extracted_pipeline_checks.sh` -> 295 passed in 1.70s for extracted_reasoning_core; 3418 passed, 10 skipped in 57.29s for extracted_content_pipeline
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_oauth_e2e_pr_body.md` -> local PR review passed

## Diff size
661 LOC across 7 files (+655 / -6). Over the normal 400 LOC target because this is OAuth/security/config validation code and the checker ships with focused failure-branch fixtures in the same slice.