### PR TITLE
Deflection CSV ingestion hardening

### DIFF
--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 import csv
 from dataclasses import dataclass
+from io import StringIO
 import json
 from pathlib import Path
 from typing import Any, Literal
@@ -17,6 +18,8 @@ from .campaign_ports import TenantScope
 
 
 CustomerDataFormat = Literal["auto", "json", "csv"]
+_CSV_DETECT_DELIMITERS = ",;\t|"
+_CSV_SNIFFER_SAMPLE_CHARS = 65_536
 
 
 @dataclass(frozen=True)
@@ -214,21 +217,63 @@ def _load_json_rows(path: Path) -> list[Any]:
 
 
 def _load_csv_rows(path: Path) -> list[dict[str, Any]]:
+    return _load_csv_dict_rows(path, value_coercer=_coerce_csv_value)
+
+
+def _load_csv_dict_rows(
+    path: Path,
+    *,
+    value_coercer: Callable[[Any], Any] | None = None,
+) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    with path.open(newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if not reader.fieldnames:
-            return []
-        for row in reader:
-            cleaned: dict[str, Any] = {}
-            for key, value in row.items():
-                if key is None:
-                    continue
-                cleaned_value = _coerce_csv_value(value)
-                if cleaned_value not in (None, ""):
-                    cleaned[str(key)] = cleaned_value
-            rows.append(cleaned)
+    text = _read_csv_text(path)
+    if not text.strip():
+        raise ValueError("CSV customer data must include a header row.")
+    reader = csv.DictReader(
+        StringIO(text),
+        dialect=_detect_csv_dialect(text),
+    )
+    fieldnames = tuple(
+        str(field).strip()
+        for field in (reader.fieldnames or ())
+        if field is not None and str(field).strip()
+    )
+    if not fieldnames:
+        raise ValueError("CSV customer data must include a header row.")
+    for row_index, row in enumerate(reader, start=2):
+        if row.get(None):
+            raise ValueError(
+                f"CSV row {row_index} has more cells than the header; "
+                "check the delimiter and header row."
+            )
+        cleaned: dict[str, Any] = {}
+        for key, value in row.items():
+            if key is None:
+                continue
+            cleaned_key = str(key).strip()
+            if not cleaned_key:
+                continue
+            cleaned_value = value_coercer(value) if value_coercer else value
+            if cleaned_value not in (None, ""):
+                cleaned[cleaned_key] = cleaned_value
+        rows.append(cleaned)
     return rows
+
+
+def _read_csv_text(path: Path) -> str:
+    data = path.read_bytes()
+    try:
+        return data.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return data.decode("cp1252", errors="replace")
+
+
+def _detect_csv_dialect(text: str) -> csv.Dialect:
+    sample = text[:_CSV_SNIFFER_SAMPLE_CHARS]
+    try:
+        return csv.Sniffer().sniff(sample, delimiters=_CSV_DETECT_DELIMITERS)
+    except csv.Error:
+        return csv.excel
 
 
 def _coerce_csv_value(value: Any) -> Any:

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-import csv
 import json
 from pathlib import Path
 import re
@@ -12,6 +11,7 @@ from typing import Any, Literal
 from .campaign_customer_data import (
     CampaignOpportunityLoadResult,
     CampaignOpportunityWarning,
+    _load_csv_dict_rows,
     normalize_campaign_opportunity_rows,
 )
 from .campaign_opportunities import normalize_campaign_opportunity
@@ -694,18 +694,7 @@ def _is_safe_parent_value(value: Any) -> bool:
 
 
 def _load_source_csv_rows(path: Path) -> list[dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
-    with path.open(newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        if not reader.fieldnames:
-            return rows
-        for row in reader:
-            rows.append({
-                str(key): value
-                for key, value in row.items()
-                if key is not None and value not in (None, "")
-            })
-    return rows
+    return _load_csv_dict_rows(path)
 
 
 def _resolve_format(

--- a/plans/PR-Deflection-CSV-Ingestion-Hardening.md
+++ b/plans/PR-Deflection-CSV-Ingestion-Hardening.md
@@ -1,0 +1,123 @@
+# PR-Deflection-CSV-Ingestion-Hardening
+
+## Why this slice exists
+
+#1384 calls out that the support-ticket CSV ingestion path is fragile on common
+provider exports before launch: UTF-8 BOM can corrupt the first header,
+Windows/Excel cp1252 bytes can crash parsing, semicolon-delimited exports can
+collapse into one column, and leading metadata rows can silently produce a bad
+report. #1386 lists CSV ingestion as a launch-readiness gate, so this slice
+closes the parser-hardening P0s before moving to broader preview/product work.
+
+## Scope (this PR)
+
+Ownership lane: deflection/go-live
+Slice phase: Production hardening
+
+1. Harden the package-owned CSV dict loaders used by opportunity imports and
+   source-row/support-ticket imports.
+2. Decode UTF-8 BOM correctly, fall back for cp1252/latin-1 style exports, and
+   detect common delimiters (`comma`, `semicolon`, `tab`, `pipe`) before
+   `csv.DictReader` runs.
+3. Fail loudly with a clear `ValueError` when a CSV has no usable header or rows
+   contain more cells than the header, instead of silently returning misleading
+   one-column/partial rows.
+4. Add focused regression coverage for the internal loader and the public
+   deflection submit handoff path.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `plans/PR-Deflection-CSV-Ingestion-Hardening.md`
+- `tests/test_extracted_campaign_customer_data.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+### Review Contract
+
+Acceptance criteria:
+- A UTF-8 BOM export maps the first header normally.
+- A cp1252/latin-1 style export with smart punctuation loads without crashing.
+- A semicolon-delimited support-ticket CSV reaches the deflection submit route
+  as normal source rows.
+- A leading metadata/header-mismatch CSV fails with a clear parse error instead
+  of silently producing malformed rows.
+- Existing JSON/JSONL parsing and quoted comma/multiline CSV behavior remain
+  unchanged.
+
+Affected surfaces:
+- Extracted Content Pipeline CSV ingestion.
+- ATLAS deflection submit route CSV parsing.
+
+Risk areas:
+- Delimiter detection must not break normal comma CSVs with quoted commas.
+- Fail-loud header mismatch behavior changes formerly silent bad parses into
+  `400`/`ValueError` failures.
+- Extracted package ownership requires the package gauntlet before push.
+
+Reviewer rules triggered: R1 Requirements match; R2 Test evidence; R3 Security/privacy; R5 Backward compatibility; R6 Error handling; R10 Maintainability.
+
+## Mechanism
+
+Add a shared private CSV dict-row loader in
+`extracted_content_pipeline/campaign_customer_data.py`:
+
+```python
+text = _read_csv_text(path)          # utf-8-sig, then cp1252 fallback
+dialect = csv.Sniffer().sniff(...)   # bounded delimiter set
+reader = csv.DictReader(StringIO(text), dialect=dialect)
+```
+
+Both `campaign_customer_data._load_csv_rows(...)` and
+`campaign_source_adapters._load_source_csv_rows(...)` use that helper so the
+opportunity import path and the source-row/support-ticket path get the same
+decode, delimiter, and header-mismatch behavior. The deflection submit route
+already catches `ValueError` from `load_source_rows_from_file(...)` and returns
+the existing bounded parse-error copy.
+
+## Intentional
+
+- No charset-detection dependency is added; cp1252 fallback with replacement is
+  enough for the Windows/Excel byte patterns called out in #1384 without
+  expanding dependencies.
+- Header mismatch now fails closed. That can reject malformed unquoted-comma
+  rows, but it prevents paid reports from being built on silently truncated
+  ticket text.
+- The shared helper remains private to the extracted package. This is parser
+  hardening, not a new public API.
+
+## Deferred
+
+- #1384: HTML stripping for ticket bodies before clustering.
+- #1384: sanitized real Zendesk/Intercom/Help Scout/Freshdesk export fixtures.
+- #1384/#1386: making `inspect` a full pre-payment preview/validation gate.
+- #1386: structural checkout authorization before charge.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_campaign_customer_data.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_deflection_submit.py -q`
+  - passed; 101 tests cover BOM, cp1252 fallback, semicolon delimiter,
+    quoted comma/multiline preservation, metadata-row fail-loud behavior, and
+    deflection submit upload parsing.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-bodies/deflection-csv-ingestion-hardening.md`
+  - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_customer_data.py` | 73 |
+| `extracted_content_pipeline/campaign_source_adapters.py` | 15 |
+| `plans/PR-Deflection-CSV-Ingestion-Hardening.md` | 123 |
+| `tests/test_extracted_campaign_customer_data.py` | 71 |
+| `tests/test_extracted_campaign_source_adapters.py` | 44 |
+| `tests/test_extracted_content_deflection_submit.py` | 38 |
+| **Total** | **364** |

--- a/tests/test_extracted_campaign_customer_data.py
+++ b/tests/test_extracted_campaign_customer_data.py
@@ -82,6 +82,77 @@ def test_load_campaign_opportunities_from_csv_coerces_json_cells_and_warns(
     assert loaded.warnings[0].row_index == 2
 
 
+def test_load_campaign_opportunities_from_csv_strips_utf8_bom_header(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "opportunities.csv"
+    path.write_bytes(
+        (
+            "\ufeffid,company,vendor,email\n"
+            "opp-1,Acme,HubSpot,buyer@example.com\n"
+        ).encode("utf-8")
+    )
+
+    loaded = load_campaign_opportunities_from_file(path)
+
+    assert loaded.warnings == ()
+    assert loaded.opportunities[0]["target_id"] == "opp-1"
+    assert loaded.opportunities[0]["company_name"] == "Acme"
+
+
+def test_load_campaign_opportunities_from_csv_falls_back_for_cp1252_exports(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "opportunities.csv"
+    path.write_bytes(
+        (
+            "id,company,vendor,email,pain_category\n"
+            "opp-1,Acme,HubSpot,buyer@example.com,Buyer\u2019s renewal costs rose\n"
+        ).encode("cp1252")
+    )
+
+    loaded = load_campaign_opportunities_from_file(path)
+
+    assert loaded.warnings == ()
+    assert loaded.opportunities[0]["pain_points"] == ["Buyer\u2019s renewal costs rose"]
+
+
+def test_load_campaign_opportunities_from_semicolon_csv_detects_delimiter(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "opportunities.csv"
+    path.write_text(
+        "\n".join([
+            "id;company;vendor;email;pain_category",
+            "opp-1;Acme;HubSpot;buyer@example.com;pricing",
+        ]),
+        encoding="utf-8",
+    )
+
+    loaded = load_campaign_opportunities_from_file(path)
+
+    assert loaded.warnings == ()
+    assert loaded.opportunities[0]["target_id"] == "opp-1"
+    assert loaded.opportunities[0]["vendor_name"] == "HubSpot"
+
+
+def test_load_campaign_opportunities_from_csv_fails_on_leading_metadata_row(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "opportunities.csv"
+    path.write_text(
+        "\n".join([
+            "Zendesk ticket export",
+            "id,company,vendor,email",
+            "opp-1,Acme,HubSpot,buyer@example.com",
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="more cells than the header"):
+        load_campaign_opportunities_from_file(path)
+
+
 def test_normalize_campaign_opportunity_rows_skips_non_object_rows() -> None:
     loaded = normalize_campaign_opportunity_rows(
         [

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -10,6 +10,7 @@ import pytest
 from extracted_content_pipeline import campaign_source_adapters as adapters
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
+    load_source_rows_from_file,
     parse_default_fields,
     parse_default_fields_with_booking_url_or_exit,
     parse_default_fields_or_exit,
@@ -221,6 +222,49 @@ def test_source_rows_normalize_and_warn_for_missing_text() -> None:
     assert first["target_mode"] == "vendor_retention"
     assert first["evidence"][0]["source_type"] == "transcript"
     assert "missing_source_text" in [warning.code for warning in loaded.warnings]
+
+
+def test_load_source_rows_from_semicolon_csv_detects_support_ticket_export(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets.csv"
+    path.write_text(
+        "\n".join([
+            "ticket_id;subject;message",
+            "ticket-1;Export help;How do I export attribution reports?",
+        ]),
+        encoding="utf-8",
+    )
+
+    rows = load_source_rows_from_file(path, file_format="csv")
+
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": "How do I export attribution reports?",
+    }]
+
+
+def test_load_source_rows_preserves_quoted_commas_and_multiline_text(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets.csv"
+    path.write_text(
+        "\n".join([
+            "ticket_id,subject,message",
+            'ticket-1,Export help,"How do I export, then download',
+            'the attribution report?"',
+        ]),
+        encoding="utf-8",
+    )
+
+    rows = load_source_rows_from_file(path, file_format="csv")
+
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": "How do I export, then download\nthe attribution report?",
+    }]
 
 
 def test_source_row_maps_provider_complaint_narrative_aliases() -> None:

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -103,6 +103,44 @@ def _install_public_dns(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(api_module.socket, "getaddrinfo", _getaddrinfo)
 
 
+@pytest.mark.asyncio
+async def test_deflection_submit_upload_parses_bom_semicolon_csv() -> None:
+    data = (
+        "\ufeffticket_id;subject;message\n"
+        "ticket-1;Export help;How do I export attribution reports?\n"
+    ).encode("utf-8")
+
+    rows, byte_count = await api_module._load_deflection_submit_upload_rows(
+        _Upload(data),
+        max_bytes=1024,
+    )
+
+    assert byte_count == len(data)
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": "How do I export attribution reports?",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_upload_fails_loud_on_metadata_header() -> None:
+    data = _csv_bytes([
+        "Zendesk ticket export",
+        "ticket_id,subject,message",
+        "ticket-1,Export help,How do I export attribution reports?",
+    ])
+
+    with pytest.raises(api_module.HTTPException) as excinfo:
+        await api_module._load_deflection_submit_upload_rows(
+            _Upload(data),
+            max_bytes=1024,
+        )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == "Uploaded CSV could not be parsed."
+
+
 def _router(
     store: InMemoryDeflectionReportArtifactStore,
 ):


### PR DESCRIPTION
Plan: plans/PR-Deflection-CSV-Ingestion-Hardening.md
Slice phase: Production hardening

Refs #1384 and #1386. Hardens the deflection/support-ticket CSV parser path for common provider exports before launch: BOM headers, cp1252 bytes, semicolon delimiters, quoted comma/multiline preservation, and fail-loud metadata/header mismatches.

## Intentional
- No charset-detection dependency is added; cp1252 fallback with replacement covers the Windows/Excel byte patterns from #1384 without expanding dependencies.
- Header mismatch now fails closed; malformed unquoted-comma rows may be rejected, but paid reports should not be built on silently truncated ticket text.
- The shared CSV helper remains private to extracted_content_pipeline.

## Deferred
- #1384: HTML stripping for ticket bodies before clustering.
- #1384: sanitized real Zendesk/Intercom/Help Scout/Freshdesk export fixtures.
- #1384/#1386: making `inspect` a full pre-payment preview/validation gate.
- #1386: structural checkout authorization before charge.

## Parked hardening
- None.

## AI reconciliation
- No automated-review findings yet; nothing to reconcile before the PR exists.

## Verification
- `python -m pytest tests/test_extracted_campaign_customer_data.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_deflection_submit.py -q`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `git diff --check`
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-bodies/deflection-csv-ingestion-hardening.md`

## Diff size
6 files, +337 / -27
