### PR TITLE
Deflection checkout authorization

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -237,6 +237,9 @@ try:
         deflection_checkout_amount_cents=(
             settings.saas_auth.stripe_content_ops_deflection_report_amount_cents
         ),
+        deflection_checkout_allowed_amount_cents=(
+            settings.saas_auth.stripe_content_ops_deflection_report_allowed_amount_cents
+        ),
         deflection_checkout_currency=(
             settings.saas_auth.stripe_content_ops_deflection_report_currency
         ),

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -233,7 +233,17 @@ try:
         ).strip()
         return policy or None
 
-    content_ops_config = ContentOpsControlSurfaceApiConfig()
+    content_ops_config = ContentOpsControlSurfaceApiConfig(
+        deflection_checkout_amount_cents=(
+            settings.saas_auth.stripe_content_ops_deflection_report_amount_cents
+        ),
+        deflection_checkout_currency=(
+            settings.saas_auth.stripe_content_ops_deflection_report_currency
+        ),
+        deflection_checkout_price_id=(
+            settings.saas_auth.stripe_content_ops_deflection_report_price_id
+        ),
+    )
     content_ops_router = create_content_ops_control_surface_router(
         config=content_ops_config,
         dependencies=[Depends(_capture_content_ops_auth_user)],

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -103,6 +103,10 @@ class SaaSAuthConfig(BaseSettings):
             "deflection report when no explicit allowed amount list is set"
         ),
     )
+    stripe_content_ops_deflection_report_price_id: str = Field(
+        default="",
+        description="Stripe Price ID for the one-time Content Ops FAQ deflection report",
+    )
     stripe_content_ops_deflection_report_allowed_amount_cents: str = Field(
         default="",
         description=(

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -354,6 +354,7 @@ class ContentOpsControlSurfaceApiConfig:
         DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT
     )
     deflection_checkout_amount_cents: int = 150000
+    deflection_checkout_allowed_amount_cents: str = ""
     deflection_checkout_currency: str = "usd"
     deflection_checkout_price_id: str = ""
     ingestion_import_max_concurrency: int = 8
@@ -1787,6 +1788,12 @@ def _deflection_checkout_terms(
             status_code=503,
             detail="Deflection checkout amount is not configured.",
         )
+    allowed_amounts = _deflection_checkout_allowed_amounts(config, amount_cents)
+    if amount_cents not in allowed_amounts:
+        raise HTTPException(
+            status_code=503,
+            detail="Deflection checkout amount is not accepted by the payment gate.",
+        )
     if len(currency) != 3 or not currency.isalpha():
         raise HTTPException(
             status_code=503,
@@ -1802,6 +1809,37 @@ def _deflection_checkout_terms(
         "currency": currency,
         "price_id": price_id,
     }
+
+
+def _deflection_checkout_allowed_amounts(
+    config: ContentOpsControlSurfaceApiConfig,
+    default_amount_cents: int,
+) -> tuple[int, ...]:
+    configured = _clean(config.deflection_checkout_allowed_amount_cents)
+    if not configured:
+        return (default_amount_cents,)
+    amounts: list[int] = []
+    for raw_part in configured.split(","):
+        part = raw_part.strip()
+        if not part:
+            raise HTTPException(
+                status_code=503,
+                detail="Deflection checkout allowed amounts are not configured.",
+            )
+        try:
+            amount_cents = int(part)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=503,
+                detail="Deflection checkout allowed amounts are not configured.",
+            ) from exc
+        if amount_cents <= 0:
+            raise HTTPException(
+                status_code=503,
+                detail="Deflection checkout allowed amounts are not configured.",
+            )
+        amounts.append(amount_cents)
+    return tuple(dict.fromkeys(amounts))
 
 
 def _with_deflection_submit_diagnostics(

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -353,6 +353,9 @@ class ContentOpsControlSurfaceApiConfig:
     deflection_snapshot_teaser_preview_count: int = (
         DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT
     )
+    deflection_checkout_amount_cents: int = 150000
+    deflection_checkout_currency: str = "usd"
+    deflection_checkout_price_id: str = ""
     ingestion_import_max_concurrency: int = 8
 
     def __post_init__(self) -> None:
@@ -406,6 +409,8 @@ class ContentOpsControlSurfaceApiConfig:
             raise ValueError(
                 "deflection_snapshot_teaser_preview_count must be non-negative"
             )
+        if self.deflection_checkout_amount_cents < 0:
+            raise ValueError("deflection_checkout_amount_cents cannot be negative")
         if self.ingestion_import_max_concurrency <= 0:
             raise ValueError("ingestion_import_max_concurrency must be positive")
         if not isinstance(
@@ -801,6 +806,35 @@ def create_content_ops_control_surface_router(
         if not record.paid:
             raise HTTPException(status_code=403, detail="Deflection report is locked.")
         return dict(record.artifact or {})
+
+    @router.post("/deflection-reports/{request_id}/checkout-authorization")
+    async def deflection_report_checkout_authorization(
+        request_id: str = PathParam(..., min_length=1, max_length=200),
+    ) -> dict[str, Any]:
+        checkout = _deflection_checkout_terms(resolved_config)
+        store = await _resolve_deflection_report_store(deflection_report_store_provider)
+        scope = await _resolve_scope(scope_provider)
+        record = await store.get_artifact_record(
+            account_id=_required_scope_account_id(scope),
+            request_id=request_id,
+        )
+        if record is None:
+            raise HTTPException(status_code=404, detail="Deflection report not found.")
+        if record.paid:
+            raise HTTPException(
+                status_code=409,
+                detail="Deflection report is already paid.",
+            )
+        if not record.artifact:
+            raise HTTPException(
+                status_code=409,
+                detail="Deflection report artifact is not available.",
+            )
+        return {
+            "request_id": request_id,
+            "status": "authorized",
+            "checkout": checkout,
+        }
 
     @router.post(
         "/deflection-reports/{request_id}/paid",
@@ -1734,6 +1768,40 @@ def _deflection_submit_rows_with_defaults(
 
 def _deflection_submit_title(data: Mapping[str, Any]) -> str:
     return f"{data['company_name']} Support Deflection Report"
+
+
+def _deflection_checkout_terms(
+    config: ContentOpsControlSurfaceApiConfig,
+) -> dict[str, Any]:
+    try:
+        amount_cents = int(config.deflection_checkout_amount_cents)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Deflection checkout amount is not configured.",
+        ) from exc
+    currency = (_clean(config.deflection_checkout_currency) or "").lower()
+    price_id = _clean(config.deflection_checkout_price_id)
+    if amount_cents <= 0:
+        raise HTTPException(
+            status_code=503,
+            detail="Deflection checkout amount is not configured.",
+        )
+    if len(currency) != 3 or not currency.isalpha():
+        raise HTTPException(
+            status_code=503,
+            detail="Deflection checkout currency is not configured.",
+        )
+    if not price_id:
+        raise HTTPException(
+            status_code=503,
+            detail="Deflection checkout price is not configured.",
+        )
+    return {
+        "amount_cents": amount_cents,
+        "currency": currency,
+        "price_id": price_id,
+    }
 
 
 def _with_deflection_submit_diagnostics(

--- a/plans/PR-Deflection-Checkout-Authorization.md
+++ b/plans/PR-Deflection-Checkout-Authorization.md
@@ -10,6 +10,10 @@ the source of truth before any Checkout Session is created.
 
 This slice adds the ATLAS-side authorization contract only. It gives the
 portfolio repo a single backend preflight to call before it talks to Stripe.
+The final diff is above the 400 LOC soft cap because review surfaced a
+payment-boundary contract gap: the authorization amount also has to reconcile
+with the webhook's accepted amount set before the portfolio repo can safely
+consume this contract.
 
 ## Scope (this PR)
 
@@ -23,8 +27,12 @@ Slice phase: Production hardening
 3. Return canonical `{amount_cents, currency, price_id}` from ATLAS so the
    portfolio route can build Stripe Checkout without its own price/currency
    judgment.
-4. Add focused negative tests proving missing, paid, artifactless, and
-   misconfigured states fail before a charge can be attempted.
+4. Reconcile the returned amount with the same allowed amount list the Stripe
+   webhook uses, so authorization cannot approve a charge amount the unlock
+   gate will later reject.
+5. Add focused negative tests proving missing, paid, artifactless,
+   amount-mismatched, and misconfigured states fail before a charge can be
+   attempted.
 
 ### Files touched
 
@@ -40,10 +48,14 @@ Acceptance criteria:
 - `POST /content-ops/deflection-reports/{request_id}/checkout-authorization`
   returns 200 only for a scoped report that exists, is unpaid, has an artifact,
   and has non-empty configured `amount_cents`, `currency`, and `price_id`.
+- `amount_cents` must be a member of the configured allowed amount set when an
+  allow-list exists; otherwise the default amount remains the single accepted
+  amount.
 - Missing report returns 404.
 - Already-paid report returns 409.
 - Missing/empty artifact returns 409.
-- Missing price ID / invalid amount / invalid currency returns 503.
+- Missing price ID / invalid amount / invalid currency / malformed allowed
+  amount list / amount not accepted by the payment gate returns 503.
 - Response contains no full report artifact, ticket text, delivery email, or
   Stripe secret.
 
@@ -66,7 +78,10 @@ Reviewer rules triggered: R1 Requirements match; R2 Test evidence; R3 Security/a
 
 Add `stripe_content_ops_deflection_report_price_id` to `SaaSAuthConfig`, then
 pass the deflection checkout terms from `atlas_brain/api/__init__.py` into
-`ContentOpsControlSurfaceApiConfig`.
+`ContentOpsControlSurfaceApiConfig`. The existing
+`stripe_content_ops_deflection_report_allowed_amount_cents` setting is passed
+through the same config so the authorization route can reject any
+`amount_cents` that the webhook's amount gate would not accept.
 
 The new route resolves the existing `DeflectionReportArtifactStore` and scoped
 account, loads the access record, and checks only lock/availability state. If
@@ -97,6 +112,10 @@ portfolio checkout route can consume in the next repo slice.
 - The route fails closed when no ATLAS price ID is configured. A portfolio
   fallback `price_data` path would preserve the two-decider class this issue is
   trying to remove.
+- `price_id` is the authoritative charge input for the future portfolio
+  Checkout Session. `amount_cents` is still returned for UI/display and
+  contract checks, but this route now verifies that value against the same
+  accepted amount set the webhook uses.
 
 ## Deferred
 
@@ -111,9 +130,9 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_returns_canonical_terms_only tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_closed_for_report_state tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_when_terms_misconfigured tests/test_extracted_content_control_surface_api.py::test_deflection_report_paid_route_uses_trusted_dependency -q`
-  - 8 passed.
+  - 12 passed.
 - `python -m pytest tests/test_extracted_content_control_surface_api.py -q`
-  - 139 passed, 1 skipped.
+  - 143 passed, 1 skipped.
 - `bash scripts/validate_extracted_content_pipeline.sh`
   - passed.
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
@@ -129,9 +148,9 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/api/__init__.py` | 12 |
+| `atlas_brain/api/__init__.py` | 15 |
 | `atlas_brain/config.py` | 4 |
-| `extracted_content_pipeline/api/control_surfaces.py` | 68 |
-| `plans/PR-Deflection-Checkout-Authorization.md` | 137 |
-| `tests/test_extracted_content_control_surface_api.py` | 145 |
-| **Total** | **366** |
+| `extracted_content_pipeline/api/control_surfaces.py` | 106 |
+| `plans/PR-Deflection-Checkout-Authorization.md` | 156 |
+| `tests/test_extracted_content_control_surface_api.py` | 180 |
+| **Total** | **461** |

--- a/plans/PR-Deflection-Checkout-Authorization.md
+++ b/plans/PR-Deflection-Checkout-Authorization.md
@@ -1,0 +1,137 @@
+# PR-Deflection-Checkout-Authorization
+
+## Why this slice exists
+
+#1386 identifies the paid funnel's root money-path risk: portfolio can create a
+Stripe Checkout session using its own report, price, and currency assumptions,
+then ATLAS can fail closed after payment because it independently validates
+stricter facts. The structural fix is "authorize before charge": ATLAS must be
+the source of truth before any Checkout Session is created.
+
+This slice adds the ATLAS-side authorization contract only. It gives the
+portfolio repo a single backend preflight to call before it talks to Stripe.
+
+## Scope (this PR)
+
+Ownership lane: deflection/go-live
+Slice phase: Production hardening
+
+1. Add a typed ATLAS deflection report Stripe Price ID setting.
+2. Add an authenticated ATLAS route that authorizes Checkout only when the
+   report exists for the scoped account, is still unpaid/locked, has a full
+   artifact, and checkout amount/currency/price config is complete.
+3. Return canonical `{amount_cents, currency, price_id}` from ATLAS so the
+   portfolio route can build Stripe Checkout without its own price/currency
+   judgment.
+4. Add focused negative tests proving missing, paid, artifactless, and
+   misconfigured states fail before a charge can be attempted.
+
+### Files touched
+
+- `atlas_brain/api/__init__.py`
+- `atlas_brain/config.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Checkout-Authorization.md`
+- `tests/test_extracted_content_control_surface_api.py`
+
+### Review Contract
+
+Acceptance criteria:
+- `POST /content-ops/deflection-reports/{request_id}/checkout-authorization`
+  returns 200 only for a scoped report that exists, is unpaid, has an artifact,
+  and has non-empty configured `amount_cents`, `currency`, and `price_id`.
+- Missing report returns 404.
+- Already-paid report returns 409.
+- Missing/empty artifact returns 409.
+- Missing price ID / invalid amount / invalid currency returns 503.
+- Response contains no full report artifact, ticket text, delivery email, or
+  Stripe secret.
+
+Affected surfaces:
+- Content Ops deflection report access API.
+- ATLAS typed SaaS/Stripe config for the one-time deflection report.
+- Future portfolio checkout handoff.
+
+Risk areas:
+- This is a payment boundary; fail-open behavior would allow pay-but-locked
+  incidents to continue.
+- The route must not expose the paid artifact or buyer email while authorizing
+  checkout.
+- The portfolio repo still needs a follow-up PR to call this route before
+  creating Stripe Checkout.
+
+Reviewer rules triggered: R1 Requirements match; R2 Test evidence; R3 Security/auth; R5 Backward compatibility; R8 Idempotency/payment state; R10 Maintainability; R11 Dependencies/config; R12 Deployment safety.
+
+## Mechanism
+
+Add `stripe_content_ops_deflection_report_price_id` to `SaaSAuthConfig`, then
+pass the deflection checkout terms from `atlas_brain/api/__init__.py` into
+`ContentOpsControlSurfaceApiConfig`.
+
+The new route resolves the existing `DeflectionReportArtifactStore` and scoped
+account, loads the access record, and checks only lock/availability state. If
+authorization succeeds, it returns a compact payload:
+
+```json
+{
+  "request_id": "...",
+  "status": "authorized",
+  "checkout": {
+    "amount_cents": 150000,
+    "currency": "usd",
+    "price_id": "price_..."
+  }
+}
+```
+
+The route does not call Stripe. It is the pre-payment truth contract the
+portfolio checkout route can consume in the next repo slice.
+
+## Intentional
+
+- This PR does not edit `portfolio-ui/api/content-ops/deflection/checkout.js`;
+  that is the next #1386 integration slice after the ATLAS contract exists.
+- This PR does not constrain Stripe `payment_method_types`; Stripe guidance
+  favors Checkout Sessions with dynamic payment methods. Async fulfillment
+  remains a separate #1386 webhook slice.
+- The route fails closed when no ATLAS price ID is configured. A portfolio
+  fallback `price_data` path would preserve the two-decider class this issue is
+  trying to remove.
+
+## Deferred
+
+- #1386 portfolio slice: call this authorization route before creating Stripe
+  Checkout and build the session from ATLAS-returned terms only.
+- #1386 webhook slice: fulfill delayed-payment success events and make amount /
+  currency / existence mismatches paid-funnel incidents.
+- #1386 delivery slice: reconcile result-page URL and delivery scheduling.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_returns_canonical_terms_only tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_closed_for_report_state tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_when_terms_misconfigured tests/test_extracted_content_control_surface_api.py::test_deflection_report_paid_route_uses_trusted_dependency -q`
+  - 8 passed.
+- `python -m pytest tests/test_extracted_content_control_surface_api.py -q`
+  - 139 passed, 1 skipped.
+- `bash scripts/validate_extracted_content_pipeline.sh`
+  - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+  - passed.
+- `bash scripts/check_ascii_python.sh`
+  - passed.
+- `git diff --check`
+  - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/__init__.py` | 12 |
+| `atlas_brain/config.py` | 4 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 68 |
+| `plans/PR-Deflection-Checkout-Authorization.md` | 137 |
+| `tests/test_extracted_content_control_surface_api.py` | 145 |
+| **Total** | **366** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -52,6 +52,27 @@ def _dependency_names(route) -> list[str]:
     ]
 
 
+def _checkout_authorization_route(
+    store: InMemoryDeflectionReportArtifactStore,
+    *,
+    config_kwargs: dict[str, object] | None = None,
+):
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            **(config_kwargs or {"deflection_checkout_price_id": "price_report"}),
+        ),
+        scope_provider=lambda: {"account_id": "acct-gate", "user_id": "user-gate"},
+        deflection_report_store_provider=lambda: store,
+    )
+    return _route(
+        router,
+        "/ops/deflection-reports/{request_id}/checkout-authorization",
+        "POST",
+    )
+
+
 class _UploadFile:
     def __init__(self, filename: str, content: bytes):
         self.filename = filename
@@ -2836,6 +2857,122 @@ async def test_deflection_report_artifact_route_is_locked_until_marked_paid():
     )
 
 
+@pytest.mark.asyncio
+async def test_deflection_checkout_authorization_returns_canonical_terms_only():
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-gate",
+        request_id="request-ready",
+        snapshot={"summary": {"generated": 1}},
+        artifact={"markdown": "# Full report", "faq_result": {"items": []}},
+        delivery_email="buyer@example.com",
+    )
+    route = _checkout_authorization_route(
+        store,
+        config_kwargs={
+            "deflection_checkout_amount_cents": 150000,
+            "deflection_checkout_currency": "USD",
+            "deflection_checkout_price_id": " price_deflection_report ",
+        },
+    )
+    payload = await route.endpoint(request_id="request-ready")
+
+    assert payload == {
+        "request_id": "request-ready",
+        "status": "authorized",
+        "checkout": {
+            "amount_cents": 150000,
+            "currency": "usd",
+            "price_id": "price_deflection_report",
+        },
+    }
+    assert "Full report" not in str(payload)
+    assert "buyer@example.com" not in str(payload)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "request_id", "status_code", "detail"),
+    [
+        ("missing", "missing-request", 404, "Deflection report not found."),
+        ("paid", "request-paid", 409, "Deflection report is already paid."),
+        (
+            "empty-artifact",
+            "request-empty-artifact",
+            409,
+            "Deflection report artifact is not available.",
+        ),
+    ],
+)
+async def test_deflection_checkout_authorization_fails_closed_for_report_state(
+    state: str,
+    request_id: str,
+    status_code: int,
+    detail: str,
+):
+    store = InMemoryDeflectionReportArtifactStore()
+    if state != "missing":
+        await store.save_report(
+            account_id="acct-gate",
+            request_id=request_id,
+            snapshot={"summary": {"generated": 1}},
+            artifact={} if state == "empty-artifact" else {"markdown": "# Full"},
+        )
+    if state == "paid":
+        await store.mark_paid(account_id="acct-gate", request_id=request_id)
+
+    route = _checkout_authorization_route(store)
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(request_id=request_id)
+
+    assert exc.value.status_code == status_code
+    assert exc.value.detail == detail
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_kwargs", "detail"),
+    [
+        (
+            {"deflection_checkout_price_id": ""},
+            "Deflection checkout price is not configured.",
+        ),
+        (
+            {
+                "deflection_checkout_amount_cents": 0,
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout amount is not configured.",
+        ),
+        (
+            {
+                "deflection_checkout_currency": "usdollar",
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout currency is not configured.",
+        ),
+    ],
+)
+async def test_deflection_checkout_authorization_fails_when_terms_misconfigured(
+    config_kwargs: dict[str, object],
+    detail: str,
+) -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-gate",
+        request_id="request-ready",
+        snapshot={"summary": {"generated": 1}},
+        artifact={"markdown": "# Full report"},
+    )
+
+    route = _checkout_authorization_route(store, config_kwargs=config_kwargs)
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(request_id="request-ready")
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == detail
+
+
 def test_deflection_report_paid_route_uses_trusted_dependency() -> None:
     async def _tenant_user() -> None:
         return None
@@ -2855,6 +2992,11 @@ def test_deflection_report_paid_route_uses_trusted_dependency() -> None:
         "/ops/deflection-reports/{request_id}/artifact",
         "GET",
     )
+    checkout_authorization_route = _route(
+        router,
+        "/ops/deflection-reports/{request_id}/checkout-authorization",
+        "POST",
+    )
     snapshot_route = _route(
         router,
         "/ops/deflection-reports/{request_id}/snapshot",
@@ -2864,6 +3006,9 @@ def test_deflection_report_paid_route_uses_trusted_dependency() -> None:
     assert "_tenant_user" in _dependency_names(paid_route)
     assert "_trusted_paid_release" in _dependency_names(paid_route)
     assert "_trusted_paid_release" not in _dependency_names(artifact_route)
+    assert "_trusted_paid_release" not in _dependency_names(
+        checkout_authorization_route
+    )
     assert "_trusted_paid_release" not in _dependency_names(snapshot_route)
 
 

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -2864,13 +2864,18 @@ async def test_deflection_checkout_authorization_returns_canonical_terms_only():
         account_id="acct-gate",
         request_id="request-ready",
         snapshot={"summary": {"generated": 1}},
-        artifact={"markdown": "# Full report", "faq_result": {"items": []}},
+        artifact={
+            "markdown": "# Full report",
+            "faq_result": {"items": []},
+            "ticket_text": "Customer ticket text",
+        },
         delivery_email="buyer@example.com",
     )
     route = _checkout_authorization_route(
         store,
         config_kwargs={
             "deflection_checkout_amount_cents": 150000,
+            "deflection_checkout_allowed_amount_cents": "149000,150000",
             "deflection_checkout_currency": "USD",
             "deflection_checkout_price_id": " price_deflection_report ",
         },
@@ -2887,6 +2892,7 @@ async def test_deflection_checkout_authorization_returns_canonical_terms_only():
         },
     }
     assert "Full report" not in str(payload)
+    assert "Customer ticket text" not in str(payload)
     assert "buyer@example.com" not in str(payload)
 
 
@@ -2950,6 +2956,35 @@ async def test_deflection_checkout_authorization_fails_closed_for_report_state(
                 "deflection_checkout_price_id": "price_deflection_report",
             },
             "Deflection checkout currency is not configured.",
+        ),
+        (
+            {
+                "deflection_checkout_amount_cents": 150000,
+                "deflection_checkout_allowed_amount_cents": "149000",
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout amount is not accepted by the payment gate.",
+        ),
+        (
+            {
+                "deflection_checkout_allowed_amount_cents": "150000,",
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout allowed amounts are not configured.",
+        ),
+        (
+            {
+                "deflection_checkout_allowed_amount_cents": "not-cents",
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout allowed amounts are not configured.",
+        ),
+        (
+            {
+                "deflection_checkout_allowed_amount_cents": "0",
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout allowed amounts are not configured.",
         ),
     ],
 )


### PR DESCRIPTION
Plan: plans/PR-Deflection-Checkout-Authorization.md
Slice phase: Production hardening

#1386 identifies the paid funnel's root money-path risk: portfolio can create
a Stripe Checkout session using its own report, price, and currency
assumptions, then ATLAS can fail closed after payment because it independently
validates stricter facts. This PR adds the ATLAS-side checkout authorization
contract so the portfolio route can preflight report state and use ATLAS'
canonical checkout terms before creating a Stripe session.

The final diff is above the 400 LOC soft cap because review surfaced a
payment-boundary contract gap: the authorization amount also has to reconcile
with the webhook's accepted amount set before the portfolio repo can safely
consume this contract.

## Intentional
- This PR does not edit `portfolio-ui/api/content-ops/deflection/checkout.js`;
  that is the next #1386 integration slice after the ATLAS contract exists.
- This PR does not constrain Stripe `payment_method_types`; Stripe guidance
  favors Checkout Sessions with dynamic payment methods. Async fulfillment
  remains a separate #1386 webhook slice.
- The route fails closed when no ATLAS price ID is configured. A portfolio
  fallback `price_data` path would preserve the two-decider class this issue is
  trying to remove.
- `price_id` is the authoritative charge input for the future portfolio
  Checkout Session. `amount_cents` is still returned for UI/display and
  contract checks, but this route now verifies that value against the same
  accepted amount set the webhook uses.

## Deferred
- #1386 portfolio slice: call this authorization route before creating Stripe
  Checkout and build the session from ATLAS-returned terms only.
- #1386 webhook slice: fulfill delayed-payment success events and make amount /
  currency / existence mismatches paid-funnel incidents.
- #1386 delivery slice: reconcile result-page URL and delivery scheduling.

## Parked hardening
- None.

## AI reconciliation
- MAJOR review finding on unreconciled `amount_cents` versus the webhook's
  accepted amount set is fixed in this push.
- All fixed or waived: yes.

## Verification
- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_returns_canonical_terms_only tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_closed_for_report_state tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_when_terms_misconfigured tests/test_extracted_content_control_surface_api.py::test_deflection_report_paid_route_uses_trusted_dependency -q`
  - 12 passed.
- `python -m pytest tests/test_extracted_content_control_surface_api.py -q`
  - 143 passed, 1 skipped.
- `bash scripts/validate_extracted_content_pipeline.sh`
  - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
  - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
  - passed.
- `bash scripts/check_ascii_python.sh`
  - passed.
- `git diff --check`
  - passed.

## Diff size
5 files, +461 / -0
