### PR TITLE
Content-Ops MCP Token Tenant Binding

### DIFF
--- a/atlas_brain/mcp/content_ops_marketer_verify_oauth.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_oauth.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import os
 import time
 from html import escape
 from pathlib import Path
 
+from mcp.server.auth.provider import TokenError
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, Response
 
@@ -29,10 +32,14 @@ class ContentOpsMarketerVerifyOAuthProvider(InvoicingReadonlyOAuthProvider):
         issuer_url: str,
         approval_token: str,
         scopes: list[str] | None = None,
+        account_id: str = "",
         authorization_ttl_seconds: int = 300,
         access_token_ttl_seconds: int = 3600,
         state_file: str | Path | None = None,
     ) -> None:
+        self.account_id = _clean(account_id)
+        self._access_token_account_ids: dict[str, str] = {}
+        self._refresh_token_account_ids: dict[str, str] = {}
         super().__init__(
             issuer_url=issuer_url,
             approval_token=approval_token,
@@ -41,6 +48,104 @@ class ContentOpsMarketerVerifyOAuthProvider(InvoicingReadonlyOAuthProvider):
             access_token_ttl_seconds=access_token_ttl_seconds,
             state_file=state_file,
         )
+
+    async def exchange_authorization_code(self, client, authorization_code):
+        account_id = self.account_id
+        if not account_id:
+            raise TokenError("invalid_grant", "authorization code is not tenant-bound")
+        token = await super().exchange_authorization_code(client, authorization_code)
+        self._record_token_binding(
+            access_token=token.access_token,
+            refresh_token=token.refresh_token,
+            account_id=account_id,
+        )
+        self._save_state()
+        return token
+
+    async def exchange_refresh_token(self, client, refresh_token, scopes):
+        account_id = _clean(self._refresh_token_account_ids.get(refresh_token.token))
+        if not account_id:
+            raise TokenError("invalid_grant", "refresh token is not tenant-bound")
+        token = await super().exchange_refresh_token(client, refresh_token, scopes)
+        self._record_token_binding(
+            access_token=token.access_token,
+            refresh_token=token.refresh_token,
+            account_id=account_id,
+        )
+        self._save_state()
+        return token
+
+    async def revoke_token(self, token) -> None:
+        await super().revoke_token(token)
+        token_value = _clean(getattr(token, "token", ""))
+        if token_value:
+            self._access_token_account_ids.pop(token_value, None)
+            self._refresh_token_account_ids.pop(token_value, None)
+            self._save_state()
+
+    def account_id_for_access_token(self, access_token: str) -> str | None:
+        return _clean(self._access_token_account_ids.get(access_token)) or None
+
+    def _record_token_binding(
+        self,
+        *,
+        access_token: str,
+        refresh_token: str | None,
+        account_id: str,
+    ) -> None:
+        account_id = _clean(account_id)
+        if not account_id:
+            return
+        self._access_token_account_ids[access_token] = account_id
+        if refresh_token:
+            self._refresh_token_account_ids[refresh_token] = account_id
+
+    def _load_state(self) -> None:
+        super()._load_state()
+        if self.state_file is None or not self.state_file.exists():
+            return
+        try:
+            data = json.loads(self.state_file.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"could not load OAuth state file {self.state_file}") from exc
+        bindings = data.get("content_ops_refresh_token_account_ids", {})
+        if not isinstance(bindings, dict):
+            raise RuntimeError("OAuth state content_ops_refresh_token_account_ids must be a JSON object")
+        for token, account_id in bindings.items():
+            if not isinstance(token, str) or not isinstance(account_id, str):
+                raise RuntimeError(
+                    "OAuth state content_ops_refresh_token_account_ids must map tokens to account ids"
+                )
+            if token in self._refresh_tokens and _clean(account_id):
+                self._refresh_token_account_ids[token] = _clean(account_id)
+
+    def _save_state(self) -> None:
+        super()._save_state()
+        if self.state_file is None:
+            return
+        try:
+            data = json.loads(self.state_file.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"could not update OAuth state file {self.state_file}") from exc
+        data["content_ops_refresh_token_account_ids"] = {
+            token: account_id
+            for token, account_id in sorted(self._refresh_token_account_ids.items())
+            if token in self._refresh_tokens and _clean(account_id)
+        }
+        tmp_path = self.state_file.with_name(f"{self.state_file.name}.tmp")
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+        except Exception:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            raise
+        os.replace(tmp_path, self.state_file)
+        os.chmod(self.state_file, 0o600)
 
 
 def approval_page(
@@ -115,3 +220,7 @@ __all__ = [
     "handle_approval_request",
     "validate_oauth_settings",
 ]
+
+
+def _clean(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""

--- a/atlas_brain/mcp/content_ops_marketer_verify_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_server.py
@@ -25,6 +25,7 @@ from extracted_content_pipeline.content_pr import (
 from .._content_ops_claim_registry import ContentOpsClaimRegistryRepository
 from .._content_ops_review_workflow import (
     ContentOpsReviewRequest,
+    ContentOpsAccountResolver,
     TenantClaimRegistryReader,
     run_content_ops_review_for_bound_tenant,
 )
@@ -49,7 +50,7 @@ _PLACEHOLDER_HTTP_AUTH_TOKENS = {
 }
 _MALFORMED_COVERAGE_RULE_PREFIX = "MALFORMED-COVERAGE"
 _registry_reader_override: TenantClaimRegistryReader | None = None
-_account_resolver_override: "StaticContentOpsMarketerAccountResolver | None" = None
+_account_resolver_override: ContentOpsAccountResolver | None = None
 _oauth_provider = None
 
 
@@ -70,6 +71,25 @@ class ConfiguredContentOpsMarketerAccountResolver:
         from ..config import settings
 
         return _clean(settings.mcp.content_ops_marketer_verify_account_id) or None
+
+
+@dataclass(frozen=True)
+class OAuthContentOpsMarketerAccountResolver:
+    """Resolve the bound tenant account from the authenticated OAuth token."""
+
+    provider: Any
+    access_token: Any | None = None
+
+    async def resolve_account_id(self) -> str | None:
+        token = self.access_token
+        if token is None:
+            from mcp.server.auth.middleware.auth_context import get_access_token
+
+            token = get_access_token()
+        token_value = _clean(getattr(token, "token", ""))
+        if not token_value:
+            return None
+        return _clean(self.provider.account_id_for_access_token(token_value)) or None
 
 
 @asynccontextmanager
@@ -228,12 +248,18 @@ def _configure_oauth_auth():
     issuer_url = _clean(settings.mcp.content_ops_marketer_verify_oauth_issuer_url)
     resource_url = _clean(settings.mcp.content_ops_marketer_verify_oauth_resource_url)
     approval_token = _clean(settings.mcp.content_ops_marketer_verify_oauth_approval_token)
+    account_id = _clean(settings.mcp.content_ops_marketer_verify_account_id)
     state_file = _clean(settings.mcp.content_ops_marketer_verify_oauth_state_file) or None
     validate_oauth_settings(
         issuer_url=issuer_url,
         resource_server_url=resource_url,
         approval_token=approval_token,
     )
+    if not account_id:
+        raise RuntimeError(
+            "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID is required in oauth "
+            "mode to issue tenant-bound tokens"
+        )
     mcp.settings.transport_security = _oauth_transport_security_settings(
         issuer_url=issuer_url,
         resource_url=resource_url,
@@ -245,6 +271,7 @@ def _configure_oauth_auth():
     provider = ContentOpsMarketerVerifyOAuthProvider(
         issuer_url=issuer_url,
         approval_token=approval_token,
+        account_id=account_id,
         scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
         state_file=state_file,
     )
@@ -300,7 +327,12 @@ def _host_header_variants(url: str) -> set[str]:
 
 
 def _get_account_resolver():
-    return _account_resolver_override or ConfiguredContentOpsMarketerAccountResolver()
+    if _account_resolver_override is not None:
+        return _account_resolver_override
+    if _http_auth_mode() == _AUTH_MODE_OAUTH:
+        provider = _oauth_provider or _configure_oauth_auth()
+        return OAuthContentOpsMarketerAccountResolver(provider=provider)
+    return ConfiguredContentOpsMarketerAccountResolver()
 
 
 def _get_registry_reader() -> TenantClaimRegistryReader:

--- a/plans/PR-Content-Ops-MCP-Token-Tenant-Binding.md
+++ b/plans/PR-Content-Ops-MCP-Token-Tenant-Binding.md
@@ -1,0 +1,95 @@
+# PR-Content-Ops-MCP-Token-Tenant-Binding
+
+## Why this slice exists
+
+#1390 completed the public OAuth e2e smoke for the verify-only Content Ops marketer MCP connector. The remaining #1353 rollout gap is tenant/account binding: OAuth-mode tool calls still rely on the configured account resolver at review time instead of deriving tenant scope from the authenticated OAuth token.
+
+This slice closes that transport-hardening gap before broader dual-client connector smokes. It keeps bearer/direct mode unchanged, but OAuth mode must stamp the bound tenant onto issued token state and resolve the review-service tenant from the current access token.
+
+Review follow-up: the launcher must validate the same account binding required by server startup, so this PR carries that operator-facing gate instead of leaving a dry-run/server-start mismatch.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add tenant binding metadata to the Content Ops marketer OAuth provider for access and refresh tokens.
+2. In OAuth mode, resolve the review-service account from the current authenticated OAuth access token instead of the direct configured resolver.
+3. Fail closed when OAuth mode is missing the account binding needed to mint tenant-bound tokens.
+4. Preserve bearer/direct mode behavior for local and non-OAuth clients.
+5. Require and report the account binding in the OAuth launcher dry-run path.
+6. Prove token binding, refresh-token preservation, missing-token blocking, bearer-mode fallback, and launcher account validation with focused tests.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-Token-Tenant-Binding.md`
+- `atlas_brain/mcp/content_ops_marketer_verify_oauth.py`
+- `atlas_brain/mcp/content_ops_marketer_verify_server.py`
+- `scripts/start_content_ops_marketer_verify_oauth_server.py`
+- `tests/test_mcp_content_ops_marketer_verify.py`
+- `tests/test_start_content_ops_marketer_verify_oauth_server.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] OAuth-issued access tokens carry a tenant account binding.
+  - [ ] Refresh-token exchange preserves the same tenant binding for new access tokens.
+  - [ ] OAuth-mode review calls without an authenticated tenant-bound token block before registry reads.
+  - [ ] OAuth mode fails fast if no account binding exists for token issuance.
+  - [ ] The OAuth launcher rejects missing account binding before starting the server.
+  - [ ] Bearer/direct mode continues to use the configured direct resolver.
+- Affected surfaces: MCP / auth / tenant scope / scripts tests.
+- Risk areas: security / tenant isolation / connector rollout / config.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R11, R12
+
+## Mechanism
+
+The Content Ops marketer OAuth provider records the configured account id when it mints an access token, stores the same account id for the refresh token, and restores refresh-token bindings from the OAuth state file. The provider exposes a small account lookup by access-token value.
+
+The MCP server keeps the existing configured resolver for bearer mode. In OAuth mode it returns a token-bound resolver that reads the current MCP authenticated access token from the MCP auth context and asks the provider for the tenant binding. Missing token, missing provider binding, or missing configured account id all fail closed by producing no account id; the existing review service then blocks with `tenant scope required`.
+
+The launcher mirrors the server startup contract by listing the account id in its required env report and rejecting empty values during dry-run validation.
+
+## Intentional
+
+- The source of the tenant account is still the operator-configured single-tenant binding at token issuance time. This PR changes the tool-call path to token-bound resolution; a multi-tenant account picker in the approval page is deferred.
+- The tool payload still does not accept tenant ids.
+- This does not add ChatGPT search/fetch adapters, dual-client live-client smokes, or `verify_draft` e2e tool calls.
+- Cross-layer caller hints are same-method-name references in other OAuth providers/tests; this slice changes only the Content Ops marketer provider/server and its focused MCP tests cover the changed paths.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-Dual-Client-Smoke`: run public OAuth flows against both Claude and the chosen ChatGPT connector surface.
+- `PR-Content-Ops-MCP-Approval-Account-Picker`: optional future approval-page account selection if one process needs to approve different tenant accounts per client.
+- `PR-Content-Ops-MCP-Connector-Boundary-Smoke`: optional bearer/auth boundary smoke if rollout needs a narrower regression check.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_mcp_content_ops_marketer_verify.py -q
+  - 21 passed in 0.28s
+- Passed after review fix: python -m pytest tests/test_start_content_ops_marketer_verify_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 38 passed in 0.33s
+- Passed: python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_oauth.py atlas_brain/mcp/content_ops_marketer_verify_server.py
+- Passed after review fix: python -m py_compile scripts/start_content_ops_marketer_verify_oauth_server.py
+- Passed: git diff --check
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.69s for extracted_reasoning_core
+  - 3433 passed, 10 skipped in 57.51s for extracted_content_pipeline
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_token_tenant_binding_pr_body.md
+  - local PR review passed
+- Passed after review fix: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_token_tenant_binding_pr_body.md
+  - local PR review passed
+
+## Estimated diff size
+
+| Area | Actual LOC |
+|---|---:|
+| OAuth provider token binding | +109 |
+| MCP server resolver switch | +34 / -2 |
+| Focused tests | +203 |
+| Launcher account-id gate | +3 |
+| Plan doc | +95 |
+| **Total** | **446** |
+
+This may exceed the normal 400 LOC target after the launcher review fix. The overage is deliberate because the server validation and operator launcher validation are one contract: splitting them would leave a known dry-run/server-start mismatch in the reviewed PR.

--- a/scripts/start_content_ops_marketer_verify_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_oauth_server.py
@@ -30,6 +30,7 @@ REQUIRED_KEYS = (
     "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL",
     "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL",
     "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN",
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID",
 )
 
 
@@ -179,6 +180,8 @@ def _validate_env(env: Mapping[str, str]) -> list[str]:
             "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN must be at least "
             f"{MIN_APPROVAL_TOKEN_LENGTH} characters"
         )
+    if not env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID", "").strip():
+        errors.append("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID is required in oauth mode")
     port = env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT", DEFAULT_PORT).strip()
     try:
         parsed_port = int(port)

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import types
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -47,6 +48,9 @@ class _OAuthBase:
 class _OAuthRecord:
     def __init__(self, **kwargs) -> None:
         self.__dict__.update(kwargs)
+
+    def model_dump(self, mode="json"):
+        return dict(self.__dict__)
 
 
 class _OAuthException(Exception):
@@ -105,6 +109,7 @@ from atlas_brain.config import settings
 from atlas_brain.mcp import content_ops_marketer_verify_server as verify
 from atlas_brain.mcp.auth import BearerAuthMiddleware
 from atlas_brain.mcp.content_ops_marketer_verify_oauth import (
+    ContentOpsMarketerVerifyOAuthProvider,
     DEFAULT_CONTENT_OPS_VERIFY_SCOPE,
     validate_oauth_settings,
 )
@@ -146,6 +151,7 @@ def _reset_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(verify, "_registry_reader_override", None)
     monkeypatch.setattr(verify, "_account_resolver_override", None)
     monkeypatch.setattr(verify, "_oauth_provider", None)
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_account_id", "")
     monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "bearer")
     monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_oauth_issuer_url", "")
     monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_oauth_resource_url", "")
@@ -353,6 +359,145 @@ def test_content_ops_marketer_verify_oauth_settings_require_approval_token() -> 
         )
 
 
+@pytest.mark.asyncio
+async def test_content_ops_marketer_oauth_provider_binds_access_and_refresh_tokens() -> None:
+    provider = ContentOpsMarketerVerifyOAuthProvider(
+        issuer_url="https://atlas.example.com/content-ops-marketer",
+        approval_token="approval-token-with-enough-entropy",
+        account_id=" acct-oauth ",
+    )
+    client = _OAuthRecord(client_id="client-1")
+    params = _OAuthRecord(
+        scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+        code_challenge="challenge-1",
+        redirect_uri="https://chat.openai.com/aip/callback",
+        redirect_uri_provided_explicitly=True,
+        resource="https://atlas.example.com/content-ops-marketer/mcp",
+        state="state-1",
+    )
+
+    await provider.authorize(client, params)
+    request_id = next(iter(provider._pending))
+    provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = next(iter(provider._authorization_codes))
+    authorization_code = await provider.load_authorization_code(client, code)
+    token = await provider.exchange_authorization_code(client, authorization_code)
+
+    refresh = await provider.load_refresh_token(client, token.refresh_token)
+    refreshed = await provider.exchange_refresh_token(client, refresh, [])
+
+    assert provider.account_id == "acct-oauth"
+    assert provider.account_id_for_access_token(token.access_token) == "acct-oauth"
+    assert provider.account_id_for_access_token(refreshed.access_token) == "acct-oauth"
+
+
+@pytest.mark.asyncio
+async def test_content_ops_marketer_oauth_provider_rejects_unbound_tokens() -> None:
+    provider = ContentOpsMarketerVerifyOAuthProvider(
+        issuer_url="https://atlas.example.com/content-ops-marketer",
+        approval_token="approval-token-with-enough-entropy",
+        account_id="",
+    )
+    client = _OAuthRecord(client_id="client-1")
+    params = _OAuthRecord(
+        scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+        code_challenge="challenge-1",
+        redirect_uri="https://chat.openai.com/aip/callback",
+        redirect_uri_provided_explicitly=True,
+        resource="https://atlas.example.com/content-ops-marketer/mcp",
+        state="state-1",
+    )
+
+    await provider.authorize(client, params)
+    request_id = next(iter(provider._pending))
+    provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = next(iter(provider._authorization_codes))
+    authorization_code = await provider.load_authorization_code(client, code)
+
+    with pytest.raises(_OAuthException, match="tenant-bound"):
+        await provider.exchange_authorization_code(client, authorization_code)
+
+
+@pytest.mark.asyncio
+async def test_verify_draft_oauth_resolves_scope_from_access_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    provider = ContentOpsMarketerVerifyOAuthProvider(
+        issuer_url="https://atlas.example.com/content-ops-marketer",
+        approval_token="approval-token-with-enough-entropy",
+        account_id="acct-token",
+    )
+    provider._record_token_binding(
+        access_token="access-token-1",
+        refresh_token="refresh-token-1",
+        account_id="acct-token",
+    )
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(verify, "_oauth_provider", provider)
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "oauth")
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_account_id", "acct-config")
+    monkeypatch.setitem(
+        sys.modules,
+        "mcp.server.auth.middleware.auth_context",
+        types.SimpleNamespace(get_access_token=lambda: _OAuthRecord(token="access-token-1")),
+    )
+
+    payload = await verify.verify_draft(**_valid_payload())
+
+    assert payload["ok"] is True
+    assert reader.scopes == [TenantScope(account_id="acct-token")]
+
+
+@pytest.mark.asyncio
+async def test_verify_draft_oauth_blocks_without_bound_access_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    provider = ContentOpsMarketerVerifyOAuthProvider(
+        issuer_url="https://atlas.example.com/content-ops-marketer",
+        approval_token="approval-token-with-enough-entropy",
+        account_id="acct-token",
+    )
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(verify, "_oauth_provider", provider)
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "oauth")
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_account_id", "acct-config")
+    monkeypatch.setitem(
+        sys.modules,
+        "mcp.server.auth.middleware.auth_context",
+        types.SimpleNamespace(get_access_token=lambda: _OAuthRecord(token="unknown-token")),
+    )
+
+    payload = await verify.verify_draft(**_valid_payload())
+
+    assert payload["ok"] is False
+    assert payload["decision"] == "blocked"
+    assert payload["reasons"] == ["tenant scope required"]
+    assert reader.scopes == []
+
+
+@pytest.mark.asyncio
+async def test_bearer_mode_keeps_configured_account_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "bearer")
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_account_id", "acct-config")
+
+    payload = await verify.verify_draft(**_valid_payload())
+
+    assert payload["ok"] is True
+    assert reader.scopes == [TenantScope(account_id="acct-config")]
+
+
 def test_content_ops_marketer_verify_oauth_mode_configures_fastmcp_auth(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -374,6 +519,7 @@ def test_content_ops_marketer_verify_oauth_mode_configures_fastmcp_auth(
         "content_ops_marketer_verify_oauth_approval_token",
         "approval-token-with-enough-entropy",
     )
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_account_id", "acct-oauth")
     monkeypatch.setattr(
         settings.mcp,
         "content_ops_marketer_verify_oauth_state_file",
@@ -385,6 +531,7 @@ def test_content_ops_marketer_verify_oauth_mode_configures_fastmcp_auth(
 
     assert not isinstance(app, BearerAuthMiddleware)
     assert provider is not None
+    assert provider.account_id == "acct-oauth"
     assert provider.scopes == [DEFAULT_CONTENT_OPS_VERIFY_SCOPE]
     assert provider.state_file == state_file
     assert verify.mcp.settings.auth.required_scopes == [DEFAULT_CONTENT_OPS_VERIFY_SCOPE]
@@ -394,6 +541,31 @@ def test_content_ops_marketer_verify_oauth_mode_configures_fastmcp_auth(
     ]
     assert verify.mcp._auth_server_provider is provider
     assert verify.mcp._token_verifier.provider is provider
+
+
+def test_content_ops_marketer_verify_oauth_mode_requires_account_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "oauth")
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_issuer_url",
+        "https://atlas.example.com/content-ops-marketer",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_resource_url",
+        "https://atlas.example.com/content-ops-marketer/mcp",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_approval_token",
+        "approval-token-with-enough-entropy",
+    )
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_account_id", "")
+
+    with pytest.raises(RuntimeError, match="ACCOUNT_ID"):
+        verify._streamable_http_app()
 
 
 def test_content_ops_marketer_verify_oauth_transport_security_allows_configured_hosts() -> None:

--- a/tests/test_start_content_ops_marketer_verify_oauth_server.py
+++ b/tests/test_start_content_ops_marketer_verify_oauth_server.py
@@ -49,6 +49,7 @@ def _valid_env():
         "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN": (
             "approval-token-with-enough-entropy"
         ),
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID": "acct-content-ops-demo",
         "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT": "8068",
     }
 
@@ -69,6 +70,34 @@ def test_validate_env_rejects_short_token_and_bad_port() -> None:
 
     assert any("APPROVAL_TOKEN" in error for error in errors)
     assert any("between 1 and 65535" in error for error in errors)
+
+
+def test_validate_env_rejects_missing_account_id() -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID"] = " "
+
+    errors = module._validate_env(env)
+
+    assert errors == [
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID is required in oauth mode"
+    ]
+
+
+def test_main_dry_run_rejects_missing_account_id(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    monkeypatch.setenv(
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN",
+        "approval-token-with-enough-entropy",
+    )
+    monkeypatch.delenv("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID", raising=False)
+
+    exit_code = module._main(["--dry-run"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID is required" in captured.err
+    assert "Starting server:" not in captured.out
 
 
 def test_validate_env_rejects_non_oauth_mode_and_non_public_urls() -> None:
@@ -248,6 +277,7 @@ def test_guidance_masks_secrets_and_prints_content_ops_smokes(capsys) -> None:
 
     captured = capsys.readouterr()
     assert "SET len=34" in captured.out
+    assert "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID=acct-content-ops-demo" in captured.out
     assert "approval-token-with-enough-entropy" not in captured.out
     assert "bearer-token-value-that-must-not-print" not in captured.out
     assert "--set-path /content-ops-marketer" in captured.out
@@ -287,6 +317,7 @@ def test_main_dry_run_does_not_start_subprocess(monkeypatch, tmp_path, capsys) -
                 "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=approval-token-with-enough-entropy",
                 "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL=https://atlas.example.com/content-ops-marketer",
                 "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL=https://atlas.example.com/content-ops-marketer/mcp",
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID=acct-content-ops-demo",
             ]
         )
         + "\n"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-Token-Tenant-Binding.md
Slice phase: Production hardening

Ownership lane: content-ops/review-contract

Adds token-derived tenant binding for the verify-only Content Ops marketer MCP OAuth path. OAuth-issued access tokens now carry a tenant account binding, refresh-token exchange preserves that binding, and OAuth-mode review calls resolve tenant scope from the current authenticated access token instead of the direct configured resolver. Review follow-up also propagates the same account binding requirement into the OAuth launcher dry-run path so operators fail before server startup.

## Intentional
- Bearer/direct mode still uses the configured account resolver for local and non-OAuth clients.
- The operator-configured single-tenant account remains the source at token issuance time; this PR changes the tool-call path to token-bound resolution.
- Tool payloads still do not accept tenant ids.
- ChatGPT search/fetch adapters, dual-client live-client smokes, approval-page account picking, and `verify_draft` e2e tool calls remain deferred.
- Cross-layer caller hints are same-method-name references in other OAuth providers/tests; this slice changes only the Content Ops marketer provider/server and its focused MCP tests cover the changed paths.
- Diff exceeds the normal 400 LOC target because the launcher review fix is the same validation contract as the server-side account gate.

## Deferred
- `PR-Content-Ops-MCP-Dual-Client-Smoke`: run public OAuth flows against both Claude and the chosen ChatGPT connector surface.
- `PR-Content-Ops-MCP-Approval-Account-Picker`: optional future approval-page account selection if one process needs to approve different tenant accounts per client.
- `PR-Content-Ops-MCP-Connector-Boundary-Smoke`: optional bearer/auth boundary smoke if rollout needs a narrower regression check.

## Parked hardening
- None.

## AI Reconciliation
- Findings: none.
- All findings fixed or waived: yes.

## Verification
- `python -m pytest tests/test_mcp_content_ops_marketer_verify.py -q` -> 21 passed in 0.28s
- `python -m pytest tests/test_start_content_ops_marketer_verify_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q` -> 38 passed in 0.33s
- `python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_oauth.py atlas_brain/mcp/content_ops_marketer_verify_server.py`
- `python -m py_compile scripts/start_content_ops_marketer_verify_oauth_server.py`
- `git diff --check`
- `bash scripts/run_extracted_pipeline_checks.sh` -> 295 passed in 1.69s for extracted_reasoning_core; 3433 passed, 10 skipped in 57.51s for extracted_content_pipeline
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_token_tenant_binding_pr_body.md` -> local PR review passed
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_token_tenant_binding_pr_body.md` after review fix -> local PR review passed

## Diff size
446 LOC across 6 files (+444 / -2).