### PR TITLE
Content-Ops MCP Launcher Contract Guard

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -10,7 +10,11 @@ on:
       - "extracted_content_pipeline/claims_map.py"
       - "extracted_content_pipeline/content_pr.py"
       - "extracted_content_pipeline/review_contract.py"
+      - "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
+      - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
+      - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
+      - "tests/test_content_ops_marketer_verify_launcher_contract.py"
       - "tests/test_mcp_content_ops_marketer_verify.py"
   push:
     branches:
@@ -23,7 +27,11 @@ on:
       - "extracted_content_pipeline/claims_map.py"
       - "extracted_content_pipeline/content_pr.py"
       - "extracted_content_pipeline/review_contract.py"
+      - "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
+      - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
+      - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
+      - "tests/test_content_ops_marketer_verify_launcher_contract.py"
       - "tests/test_mcp_content_ops_marketer_verify.py"
 
 jobs:
@@ -49,5 +57,6 @@ jobs:
         run: |
           python -m pytest \
             tests/test_atlas_content_ops_review_workflow.py \
+            tests/test_content_ops_marketer_verify_launcher_contract.py \
             tests/test_mcp_content_ops_marketer_verify.py \
             -q

--- a/plans/PR-Content-Ops-MCP-Launcher-Contract-Guard.md
+++ b/plans/PR-Content-Ops-MCP-Launcher-Contract-Guard.md
@@ -1,0 +1,89 @@
+# PR-Content-Ops-MCP-Launcher-Contract-Guard
+
+## Why this slice exists
+
+#1395 merged the token-bound tenant gate for the verify-only Content Ops marketer MCP OAuth path. Its review also identified the third recurring launcher/runbook drift in this OAuth arc: server or checker validation tightened, but the operator launcher still printed a dry-run command that did not satisfy the downstream contract.
+
+This slice turns that review finding into mechanism before the dual-client connector smoke. The launcher output, downstream checker argument parsers, and server-required OAuth account binding should fail in tests when they drift apart.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add a focused deterministic test that parses the Content Ops marketer OAuth launcher dry-run commands through the real discovery and e2e checker parsers.
+2. Add a focused deterministic test that proves the launcher required-env report includes the account binding required by the OAuth server startup path.
+3. Enroll the new test file and the launcher/checker script drift surfaces in the extracted pipeline check wrapper and the dedicated Content Ops review workflow so CI exercises the guard when those scripts change.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-Launcher-Contract-Guard.md`
+- `tests/test_content_ops_marketer_verify_launcher_contract.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The launcher's printed discovery command is accepted by the real discovery checker parser.
+  - [ ] The launcher's printed e2e command is accepted by the real e2e checker parser and carries an approval-token file path.
+  - [ ] The launcher required-env report includes the account binding required before OAuth server startup.
+  - [ ] The new guard is enrolled in the extracted pipeline check wrapper and the dedicated Content Ops review workflow.
+- Affected surfaces: tests / launcher contract / checker contract / CI enrollment.
+- Risk areas: deployment safety / backcompat / maintainability.
+- Reviewer rules triggered: R1, R2, R5, R10, R12
+
+## Mechanism
+
+The test imports the launcher and checker modules directly, builds a deterministic dry-run launch config, captures the launcher's operator guidance, reconstructs the printed multi-line Python commands, and feeds those argument lists through the real checker parsers. If the launcher drops a required checker flag again, the parser/config assertion fails.
+
+A second assertion pins the server account-binding requirement at the launcher boundary: the required-env report must include `ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID`, and a whitespace-only value must remain invalid through the launcher validator. The parser tests clear checker env defaults before constructing parsers so ambient shell state cannot satisfy or invalidate the command contract.
+
+## Intentional
+
+- This PR does not change launcher, checker, OAuth provider, or MCP server behavior.
+- The guard stays deterministic and offline; it does not start the server, call Tailscale, hit public URLs, or perform OAuth network traffic.
+- It only covers the Content Ops marketer verify OAuth launcher. Invoicing launchers can get the same pattern later if needed.
+- The test reconstructs commands from printed operator guidance because the drift class is specifically the human-facing dry-run/runbook output.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-Dual-Client-Smoke`: run public OAuth flows against both Claude and the chosen ChatGPT connector surface after this guard is in place.
+- `PR-Content-Ops-MCP-Launcher-Contract-Shared-Helper`: optional future extraction if another launcher needs the same guard shape.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_content_ops_marketer_verify_launcher_contract.py -q
+  - 3 passed in 0.37s
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.66s for extracted_reasoning_core
+  - 3449 passed, 10 skipped in 58.57s for extracted_content_pipeline
+- Passed after workflow enrollment fix: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 48 passed in 0.35s
+- Passed after workflow enrollment fix: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_launcher_contract_guard_pr_body.md
+  - local PR review passed
+- Passed after local reviewer fix: python -m pytest tests/test_content_ops_marketer_verify_launcher_contract.py -q
+  - 3 passed in 0.35s
+- Passed after local reviewer fix: env ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=ambient-token python -m pytest tests/test_content_ops_marketer_verify_launcher_contract.py -q
+  - 3 passed in 0.35s
+- Passed after local reviewer fix: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 48 passed in 0.35s
+- Passed after local reviewer fix: python -m py_compile tests/test_content_ops_marketer_verify_launcher_contract.py
+- Passed after local reviewer fix: git diff --check
+- Passed after local reviewer fix: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.69s for extracted_reasoning_core
+  - 3449 passed, 10 skipped in 58.12s for extracted_content_pipeline
+- Passed after local reviewer fix: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_launcher_contract_guard_pr_body.md
+  - local PR review passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | +89 |
+| Contract guard tests | +168 |
+| CI enrollment | +10 |
+| **Total** | **267** |
+
+This is under the normal 400 LOC target.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -106,6 +106,7 @@ pytest \
   tests/test_atlas_content_ops_infrastructure.py \
   tests/test_atlas_content_ops_review_workflow.py \
   tests/test_start_content_ops_marketer_verify_oauth_server.py \
+  tests/test_content_ops_marketer_verify_launcher_contract.py \
   tests/test_check_content_ops_marketer_verify_oauth_discovery.py \
   tests/test_check_content_ops_marketer_verify_oauth_e2e.py \
   tests/test_mcp_content_ops_marketer_verify.py \

--- a/tests/test_content_ops_marketer_verify_launcher_contract.py
+++ b/tests/test_content_ops_marketer_verify_launcher_contract.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import shlex
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACCOUNT_ID_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID"
+CHECKER_ENV_KEYS = (
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL",
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL",
+    "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN",
+)
+
+
+def _load_script_module(script_name: str):
+    path = ROOT / "scripts" / script_name
+    module_name = script_name.removesuffix(".py")
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_launcher_env(launcher) -> dict[str, str]:
+    return {
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE": "oauth",
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL": (
+            "https://atlas.example.com/content-ops-marketer"
+        ),
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL": (
+            "https://atlas.example.com/content-ops-marketer/mcp"
+        ),
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN": (
+            "approval-token-with-enough-entropy"
+        ),
+        ACCOUNT_ID_ENV: "acct-content-ops-demo",
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT": launcher.DEFAULT_PORT,
+    }
+
+
+def _operator_guidance(launcher) -> str:
+    config = launcher.LaunchConfig(
+        env=_valid_launcher_env(launcher),
+        python="/venv/bin/python",
+        host="0.0.0.0",
+        port="9000",
+        dry_run=True,
+    )
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        launcher._print_operator_guidance(config)
+    return buffer.getvalue()
+
+
+def _command_for_script(output: str, script_name: str) -> list[str]:
+    lines = output.splitlines()
+    try:
+        start = next(index for index, line in enumerate(lines) if script_name in line)
+    except StopIteration as exc:  # pragma: no cover - assertion clarity
+        raise AssertionError(f"operator guidance missing {script_name}") from exc
+
+    command_parts: list[str] = []
+    for line in lines[start:]:
+        stripped = line.strip()
+        if not stripped:
+            break
+        if stripped.endswith("\\"):
+            command_parts.append(stripped[:-1].strip())
+            continue
+        command_parts.append(stripped)
+        break
+    return shlex.split(" ".join(command_parts))
+
+
+def _clear_checker_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in CHECKER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_launcher_discovery_command_satisfies_discovery_checker_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_checker_env(monkeypatch)
+    launcher = _load_script_module("start_content_ops_marketer_verify_oauth_server.py")
+    discovery = _load_script_module("check_content_ops_marketer_verify_oauth_discovery.py")
+
+    command = _command_for_script(
+        _operator_guidance(launcher),
+        "scripts/check_content_ops_marketer_verify_oauth_discovery.py",
+    )
+    args = discovery._build_parser().parse_args(command[2:])
+
+    assert command[:2] == [
+        ".venv/bin/python",
+        "scripts/check_content_ops_marketer_verify_oauth_discovery.py",
+    ]
+    assert args.issuer_url == "https://atlas.example.com/content-ops-marketer"
+    assert args.resource_url == "https://atlas.example.com/content-ops-marketer/mcp"
+
+
+def test_launcher_e2e_command_satisfies_e2e_checker_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_checker_env(monkeypatch)
+    launcher = _load_script_module("start_content_ops_marketer_verify_oauth_server.py")
+    e2e = _load_script_module("check_content_ops_marketer_verify_oauth_e2e.py")
+
+    command = _command_for_script(
+        _operator_guidance(launcher),
+        "scripts/check_content_ops_marketer_verify_oauth_e2e.py",
+    )
+    args = e2e._build_parser().parse_args(command[2:])
+
+    assert command[:2] == [
+        ".venv/bin/python",
+        "scripts/check_content_ops_marketer_verify_oauth_e2e.py",
+    ]
+    assert args.issuer_url == "https://atlas.example.com/content-ops-marketer"
+    assert args.resource_url == "https://atlas.example.com/content-ops-marketer/mcp"
+    assert args.approval_token_file == "/path/to/local-approval-token"
+    assert args.approval_token == ""
+
+
+def test_launcher_required_env_covers_server_oauth_account_binding(monkeypatch) -> None:
+    launcher = _load_script_module("start_content_ops_marketer_verify_oauth_server.py")
+    from atlas_brain.config import settings
+    from atlas_brain.mcp import content_ops_marketer_verify_server as verify
+
+    monkeypatch.setattr(verify, "_oauth_provider", None)
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "oauth")
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_issuer_url",
+        "https://atlas.example.com/content-ops-marketer",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_resource_url",
+        "https://atlas.example.com/content-ops-marketer/mcp",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_approval_token",
+        "approval-token-with-enough-entropy",
+    )
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_account_id", "")
+
+    env = _valid_launcher_env(launcher)
+    env[ACCOUNT_ID_ENV] = " "
+
+    assert ACCOUNT_ID_ENV in launcher.REQUIRED_KEYS
+    assert f"{ACCOUNT_ID_ENV}=acct-content-ops-demo" in launcher._masked_env_report(
+        _valid_launcher_env(launcher)
+    )
+    assert launcher._validate_env(env) == [
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID is required in oauth mode"
+    ]
+    with pytest.raises(RuntimeError, match="ACCOUNT_ID"):
+        verify._configure_oauth_auth()


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-Launcher-Contract-Guard.md
Slice phase: Production hardening

Ownership lane: content-ops/review-contract

Adds a deterministic guard for the recurring Content Ops marketer OAuth launcher drift class seen across #1389, #1390, and #1395. The launcher dry-run output is now tested against the real discovery/e2e checker parsers, and the launcher required-env report is pinned to the server's OAuth account-binding requirement.

## Intentional
- Test-only production hardening; no launcher, checker, OAuth provider, or MCP server behavior changes.
- The guard stays offline and deterministic. It does not start the server, call Tailscale, hit public URLs, or perform OAuth network traffic.
- The scope is only the Content Ops marketer verify OAuth launcher. Shared helper extraction is deferred until another launcher needs this pattern.

## Deferred
- `PR-Content-Ops-MCP-Dual-Client-Smoke`: run public OAuth flows against both Claude and the chosen ChatGPT connector surface after this guard is in place.
- `PR-Content-Ops-MCP-Launcher-Contract-Shared-Helper`: optional future extraction if another launcher needs the same guard shape.

## Parked hardening
- None.

## AI Reconciliation
- Findings: none.
- All findings fixed or waived: yes.

## Verification
- `python -m pytest tests/test_content_ops_marketer_verify_launcher_contract.py -q` -> 3 passed in 0.37s
- `env ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN=ambient-token python -m pytest tests/test_content_ops_marketer_verify_launcher_contract.py -q` -> 3 passed in 0.35s
- `python -m py_compile tests/test_content_ops_marketer_verify_launcher_contract.py`
- `bash scripts/run_extracted_pipeline_checks.sh` -> 295 passed in 1.66s for extracted_reasoning_core; 3449 passed, 10 skipped in 58.57s for extracted_content_pipeline
- `bash scripts/run_extracted_pipeline_checks.sh` after local reviewer fix -> 295 passed in 1.69s for extracted_reasoning_core; 3449 passed, 10 skipped in 58.12s for extracted_content_pipeline
- `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_mcp_content_ops_marketer_verify.py -q` -> 48 passed in 0.35s
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_launcher_contract_guard_pr_body.md` -> local PR review passed before local reviewer fixes
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_launcher_contract_guard_pr_body.md` after local reviewer fix -> local PR review passed

## Diff size
267 LOC across 4 files (+267 / -0).