### PR TITLE
Content-Ops MCP Dual-Client Smoke

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
+      - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
       - "tests/test_content_ops_marketer_verify_launcher_contract.py"
       - "tests/test_mcp_content_ops_marketer_verify.py"
   push:
@@ -31,6 +32,7 @@ on:
       - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
+      - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
       - "tests/test_content_ops_marketer_verify_launcher_contract.py"
       - "tests/test_mcp_content_ops_marketer_verify.py"
 
@@ -57,6 +59,7 @@ jobs:
         run: |
           python -m pytest \
             tests/test_atlas_content_ops_review_workflow.py \
+            tests/test_check_content_ops_marketer_verify_oauth_e2e.py \
             tests/test_content_ops_marketer_verify_launcher_contract.py \
             tests/test_mcp_content_ops_marketer_verify.py \
             -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,6 +653,14 @@ python -m atlas_brain.mcp.content_ops_marketer_verify_server --sse
 .venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \
   --issuer-url <public-issuer-url> \
   --resource-url <public-resource-url>/mcp \
+  --client-profile claude-rich \
+  --approval-token-file /path/to/local-approval-token
+
+# ChatGPT proven connector adapter smoke once a search/fetch surface exists
+.venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \
+  --issuer-url <public-issuer-url> \
+  --resource-url <public-resource-url>/mcp \
+  --client-profile chatgpt-search-fetch \
   --approval-token-file /path/to/local-approval-token
 ```
 
@@ -662,8 +670,9 @@ This verify-only marketer surface accepts structured draft evidence for one
 configured tenant binding and returns the deterministic Content Ops review
 verdict. It deliberately omits generation, publishing, checkout, search/fetch
 adapters, and registry mutation. OAuth mode adds the server-side connector auth
-boundary and operator approval gate; dual-client route smokes and token-derived
-tenant binding are deferred to later rollout slices.
+boundary, operator approval gate, and token-bound tenant binding. The current
+Claude-rich e2e profile expects exactly `verify_draft`; the deferred ChatGPT
+profile expects a separate adapter surface with exactly search and fetch.
 
 ### Intelligence MCP Server (33 tools)
 ```bash

--- a/plans/PR-Content-Ops-MCP-Dual-Client-Smoke.md
+++ b/plans/PR-Content-Ops-MCP-Dual-Client-Smoke.md
@@ -1,0 +1,86 @@
+# PR-Content-Ops-MCP-Dual-Client-Smoke
+
+## Why this slice exists
+
+#1353 names the remaining connector-specific gap after token-bound tenant binding and launcher drift guards: the verify-only Content Ops marketer MCP must be validated for Claude plus the chosen ChatGPT connector surface. The important product decision is already in the tracker: Claude can use the rich `verify_draft` tool directly, while the proven ChatGPT connector pattern in this repo is a `search` and `fetch` surface.
+
+This slice codifies that decision in the OAuth e2e smoke before any adapter work starts. The current server should keep passing the Claude rich profile, and the ChatGPT profile should fail closed unless the listed surface is the proven `search` and `fetch` pair.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Extend the Content Ops marketer verify OAuth e2e smoke with an explicit client-profile contract.
+2. Keep the default profile as Claude rich verify-only: exactly `verify_draft`, no generation, publishing, registry mutation, or adapter tools.
+3. Add the chosen ChatGPT proven connector profile: exactly `search` and `fetch`, with `verify_draft` treated as incompatible for that profile.
+4. Update launcher/operator docs so the current e2e command names the Claude rich profile and the deferred ChatGPT command names the `search` and `fetch` adapter requirement.
+5. Enroll the e2e test in the dedicated Content Ops review workflow because this PR changes the e2e checker contract.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-Dual-Client-Smoke.md`
+- `CLAUDE.md`
+- `scripts/check_content_ops_marketer_verify_oauth_e2e.py`
+- `scripts/start_content_ops_marketer_verify_oauth_server.py`
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+- `tests/test_check_content_ops_marketer_verify_oauth_e2e.py`
+- `tests/test_content_ops_marketer_verify_launcher_contract.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The OAuth e2e checker defaults to the Claude rich profile and still accepts exactly `verify_draft`.
+  - [ ] The checker can run in ChatGPT proven connector profile and accepts exactly `search` plus `fetch`.
+  - [ ] The ChatGPT proven profile rejects the current `verify_draft`-only surface with a clear incompatibility error.
+  - [ ] The Claude rich profile rejects `search` or `fetch` as unexpected extras so adapter tools do not leak into the rich verifier.
+  - [ ] The e2e smoke still performs registration, approval, token exchange, and list-tools only; it does not call draft verification.
+  - [ ] Launcher/docs output names the client profile explicitly.
+  - [ ] The focused e2e tests run in the extracted pipeline wrapper and the dedicated Content Ops review workflow.
+- Affected surfaces: MCP / auth smoke / operator launcher / docs / CI.
+- Risk areas: public tool-surface compatibility / deployment safety / backcompat / CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12
+
+## Mechanism
+
+The e2e checker gets a small client-profile table keyed by `claude-rich` and `chatgpt-search-fetch`. Each profile owns its expected tool set, denied tool set, and success wording. The existing OAuth flow remains unchanged: register a temporary client, route through operator approval, exchange the code, list MCP tools, and validate the returned tool names against the selected profile.
+
+Tests keep network transport mocked at the same boundaries as the existing e2e tests. The new fixtures exercise both profile happy paths, the ChatGPT rejection of a `verify_draft`-only surface, and the Claude rejection of adapter tools.
+
+## Intentional
+
+- This PR chooses the proven ChatGPT connector surface as `search` and `fetch`; it does not build that adapter.
+- The current live Content Ops marketer server is expected to pass `claude-rich`, not `chatgpt-search-fetch`.
+- This remains a no-mutation smoke. It lists tools only and does not call `verify_draft`.
+- The profile logic stays in the checker instead of the MCP server because this slice validates client compatibility; it does not change runtime behavior.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-ChatGPT-Search-Fetch-Adapter`: add the actual ChatGPT-compatible adapter surface that can satisfy the `chatgpt-search-fetch` profile.
+- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run the public OAuth smoke against real Claude and ChatGPT connector registrations once both surfaces exist.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py -q
+  - 21 passed in 0.66s
+- Passed: python -m py_compile scripts/check_content_ops_marketer_verify_oauth_e2e.py scripts/start_content_ops_marketer_verify_oauth_server.py
+- Passed: git diff --check
+- Passed: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 66 passed in 0.63s
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.66s for extracted_reasoning_core
+  - 3454 passed, 10 skipped in 56.77s for extracted_content_pipeline
+- Pending before PR: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_dual_client_smoke_pr_body.md
+
+## Estimated diff size
+
+| Area | Actual LOC |
+|---|---:|
+| Plan doc | 86 |
+| E2E checker profile contract | 85 |
+| Tests | 100 |
+| Launcher/docs/CI enrollment | 26 |
+| **Total** | **297** |
+
+This is under the normal 400 LOC target.

--- a/scripts/check_content_ops_marketer_verify_oauth_e2e.py
+++ b/scripts/check_content_ops_marketer_verify_oauth_e2e.py
@@ -8,6 +8,7 @@ import asyncio
 import importlib.util
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -45,8 +46,11 @@ _strip_trailing_slash = _draft_e2e._strip_trailing_slash
 
 DEFAULT_SCOPE = "content_ops.review.verify"
 DEFAULT_REDIRECT_URI = _draft_e2e.DEFAULT_REDIRECT_URI
-EXPECTED_TOOLS = {"verify_draft"}
-DENIED_TOOLS = {
+CLAUDE_RICH_PROFILE = "claude-rich"
+CHATGPT_SEARCH_FETCH_PROFILE = "chatgpt-search-fetch"
+EXPECTED_TOOLS = frozenset({"verify_draft"})
+CHATGPT_SEARCH_FETCH_TOOLS = frozenset({"fetch", "search"})
+DENIED_TOOLS = frozenset({
     "add_registry_claim",
     "define_experiment",
     "generate_asset",
@@ -55,10 +59,45 @@ DENIED_TOOLS = {
     "start_brief",
     "update_registry_claim",
     "verify_and_publish",
-}
+})
+ADAPTER_TOOLS = frozenset({"fetch", "search"})
 ISSUER_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"
 RESOURCE_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"
 APPROVAL_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN"
+
+
+@dataclass(frozen=True)
+class ClientProfile:
+    key: str
+    expected_tools: frozenset[str]
+    denied_tools: frozenset[str]
+    tool_noun: str
+
+
+CLIENT_PROFILES = {
+    CLAUDE_RICH_PROFILE: ClientProfile(
+        key=CLAUDE_RICH_PROFILE,
+        expected_tools=EXPECTED_TOOLS,
+        denied_tools=DENIED_TOOLS | ADAPTER_TOOLS,
+        tool_noun="verify-only tool",
+    ),
+    CHATGPT_SEARCH_FETCH_PROFILE: ClientProfile(
+        key=CHATGPT_SEARCH_FETCH_PROFILE,
+        expected_tools=CHATGPT_SEARCH_FETCH_TOOLS,
+        denied_tools=DENIED_TOOLS | EXPECTED_TOOLS,
+        tool_noun="adapter tools",
+    ),
+}
+
+
+def _client_profile(profile_key: str) -> ClientProfile:
+    try:
+        return CLIENT_PROFILES[profile_key]
+    except KeyError as exc:
+        choices = ", ".join(sorted(CLIENT_PROFILES))
+        raise ValueError(
+            f"unknown client profile {profile_key!r}; expected one of: {choices}"
+        ) from exc
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -100,6 +139,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--scope",
         default=DEFAULT_SCOPE,
         help=f"Required OAuth scope. Default: {DEFAULT_SCOPE}.",
+    )
+    parser.add_argument(
+        "--client-profile",
+        choices=sorted(CLIENT_PROFILES),
+        default=CLAUDE_RICH_PROFILE,
+        help=(
+            "Tool-surface contract to validate. Default: claude-rich. "
+            "Use chatgpt-search-fetch only against a ChatGPT adapter surface."
+        ),
     )
     parser.add_argument(
         "--timeout",
@@ -165,17 +213,28 @@ def _register_client(config: Any) -> Any:
     return RegisteredClient(client_id=client_id, client_secret=client_secret)
 
 
-def _tool_surface_errors(tool_names: set[str]) -> list[str]:
+def _tool_surface_errors(
+    tool_names: set[str],
+    profile_key: str = CLAUDE_RICH_PROFILE,
+) -> list[str]:
+    profile = _client_profile(profile_key)
     errors: list[str] = []
-    missing = sorted(EXPECTED_TOOLS - tool_names)
-    extra = sorted(tool_names - EXPECTED_TOOLS)
-    denied = sorted(tool_names & DENIED_TOOLS)
+    missing = sorted(profile.expected_tools - tool_names)
+    extra = sorted(tool_names - profile.expected_tools)
+    denied = sorted(tool_names & profile.denied_tools)
     if missing:
-        errors.append("missing Content Ops marketer verify tools: " + ", ".join(missing))
+        errors.append(
+            f"missing Content Ops marketer tools for {profile.key}: " + ", ".join(missing)
+        )
     if extra:
         errors.append("unexpected tools exposed: " + ", ".join(extra))
     if denied:
         errors.append("denied tools exposed: " + ", ".join(denied))
+    if profile.key == CHATGPT_SEARCH_FETCH_PROFILE and "verify_draft" in tool_names:
+        errors.append(
+            "chatgpt-search-fetch requires a search/fetch adapter surface; "
+            "verify_draft is Claude-rich only"
+        )
     return errors
 
 
@@ -202,16 +261,20 @@ def _main(argv: list[str] | None = None) -> int:
         print(f"OAuth e2e smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
         return 1
 
-    errors = _tool_surface_errors(tool_names)
+    errors = _tool_surface_errors(tool_names, args.client_profile)
     if errors:
         for error in errors:
             print(error, file=sys.stderr)
         return 1
 
-    print("OK: Content Ops marketer verify OAuth e2e smoke completed")
+    profile = _client_profile(args.client_profile)
+    print(f"OK: Content Ops marketer verify OAuth e2e smoke completed for {profile.key}")
     print("- dynamic client registration succeeded")
     print("- operator approval and token exchange succeeded")
-    print(f"- OAuth-authenticated MCP session exposes {len(tool_names)} verify-only tool")
+    print(
+        f"- OAuth-authenticated MCP session exposes {len(tool_names)} "
+        f"{profile.tool_noun}"
+    )
     for name in sorted(tool_names):
         print(f"- {name}")
     return 0

--- a/scripts/start_content_ops_marketer_verify_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_oauth_server.py
@@ -278,10 +278,11 @@ def _print_operator_guidance(config: LaunchConfig) -> None:
     print(f"  --issuer-url {issuer_url} \\")
     print(f"  --resource-url {resource_url}")
     print()
-    print("Planned next-slice OAuth e2e smoke:")
+    print("OAuth e2e smoke for Claude rich connector profile:")
     print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \\")
     print(f"  --issuer-url {issuer_url} \\")
     print(f"  --resource-url {resource_url} \\")
+    print("  --client-profile claude-rich \\")
     token_file = config.approval_token_file or "/path/to/local-approval-token"
     print(f"  --approval-token-file {shlex.quote(token_file)}")
     if config.approval_token_file is None:
@@ -290,6 +291,13 @@ def _print_operator_guidance(config: LaunchConfig) -> None:
             "file or export ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN "
             "and pass --approval-token."
         )
+    print()
+    print("After a ChatGPT search/fetch adapter exists, verify that surface with:")
+    print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url} \\")
+    print("  --client-profile chatgpt-search-fetch \\")
+    print("  --approval-token-file /path/to/local-approval-token")
 
 
 def _main(argv: list[str] | None = None) -> int:

--- a/tests/test_check_content_ops_marketer_verify_oauth_e2e.py
+++ b/tests/test_check_content_ops_marketer_verify_oauth_e2e.py
@@ -39,9 +39,11 @@ def _args(**overrides):
 
 def test_content_ops_e2e_defaults_to_verify_scope() -> None:
     module = _load_script_module()
+    args = module._build_parser().parse_args([])
 
     assert module.DEFAULT_SCOPE == "content_ops.review.verify"
     assert module.EXPECTED_TOOLS == {"verify_draft"}
+    assert args.client_profile == "claude-rich"
 
 
 def test_config_from_args_requires_content_ops_values() -> None:
@@ -168,6 +170,15 @@ def test_tool_surface_errors_accept_exact_verify_tool() -> None:
     assert module._tool_surface_errors({"verify_draft"}) == []
 
 
+def test_tool_surface_errors_accept_chatgpt_search_fetch_profile() -> None:
+    module = _load_script_module()
+
+    assert module._tool_surface_errors(
+        {"search", "fetch"},
+        module.CHATGPT_SEARCH_FETCH_PROFILE,
+    ) == []
+
+
 def test_tool_surface_errors_reject_extra_and_denied_tools() -> None:
     module = _load_script_module()
 
@@ -175,6 +186,32 @@ def test_tool_surface_errors_reject_extra_and_denied_tools() -> None:
 
     assert "unexpected tools exposed: start_brief, surprise_tool" in errors
     assert "denied tools exposed: start_brief" in errors
+
+
+def test_tool_surface_errors_chatgpt_profile_rejects_verify_draft_surface() -> None:
+    module = _load_script_module()
+
+    errors = module._tool_surface_errors(
+        {"verify_draft"},
+        module.CHATGPT_SEARCH_FETCH_PROFILE,
+    )
+
+    assert (
+        "missing Content Ops marketer tools for chatgpt-search-fetch: fetch, search"
+        in errors
+    )
+    assert "unexpected tools exposed: verify_draft" in errors
+    assert "denied tools exposed: verify_draft" in errors
+    assert any("requires a search/fetch adapter surface" in error for error in errors)
+
+
+def test_tool_surface_errors_claude_profile_rejects_adapter_tools() -> None:
+    module = _load_script_module()
+
+    errors = module._tool_surface_errors({"verify_draft", "fetch", "search"})
+
+    assert "unexpected tools exposed: fetch, search" in errors
+    assert "denied tools exposed: fetch, search" in errors
 
 
 def test_main_requires_config_before_network(monkeypatch, capsys) -> None:
@@ -216,9 +253,41 @@ def test_main_reports_success_without_printing_secrets(monkeypatch, capsys) -> N
 
     captured = capsys.readouterr()
     assert result == 0
-    assert "Content Ops marketer verify OAuth e2e smoke completed" in captured.out
+    assert (
+        "Content Ops marketer verify OAuth e2e smoke completed for claude-rich"
+        in captured.out
+    )
     assert "secret-approval-token-value" not in captured.out
     assert "verify_draft" in captured.out
+
+
+def test_main_reports_chatgpt_profile_success(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_config):
+        return {"search", "fetch"}
+
+    monkeypatch.setattr(module, "_run_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--issuer-url",
+            "https://atlas.example.com/content-ops-marketer",
+            "--resource-url",
+            "https://atlas.example.com/content-ops-marketer/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+            "--client-profile",
+            "chatgpt-search-fetch",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "completed for chatgpt-search-fetch" in captured.out
+    assert "adapter tools" in captured.out
+    assert "- fetch" in captured.out
+    assert "- search" in captured.out
 
 
 def test_main_reports_tool_surface_errors(monkeypatch, capsys) -> None:
@@ -244,6 +313,33 @@ def test_main_reports_tool_surface_errors(monkeypatch, capsys) -> None:
     assert result == 1
     assert "unexpected tools exposed: start_brief" in captured.err
     assert "denied tools exposed: start_brief" in captured.err
+
+
+def test_main_reports_chatgpt_profile_mismatch(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_config):
+        return {"verify_draft"}
+
+    monkeypatch.setattr(module, "_run_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--issuer-url",
+            "https://atlas.example.com/content-ops-marketer",
+            "--resource-url",
+            "https://atlas.example.com/content-ops-marketer/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+            "--client-profile",
+            "chatgpt-search-fetch",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "missing Content Ops marketer tools for chatgpt-search-fetch" in captured.err
+    assert "verify_draft is Claude-rich only" in captured.err
 
 
 def test_run_smoke_sequence_lists_tools_without_calling_verify_draft(monkeypatch) -> None:

--- a/tests/test_content_ops_marketer_verify_launcher_contract.py
+++ b/tests/test_content_ops_marketer_verify_launcher_contract.py
@@ -126,8 +126,10 @@ def test_launcher_e2e_command_satisfies_e2e_checker_parser(
     ]
     assert args.issuer_url == "https://atlas.example.com/content-ops-marketer"
     assert args.resource_url == "https://atlas.example.com/content-ops-marketer/mcp"
+    assert args.client_profile == "claude-rich"
     assert args.approval_token_file == "/path/to/local-approval-token"
     assert args.approval_token == ""
+    assert "chatgpt-search-fetch" in _operator_guidance(launcher)
 
 
 def test_launcher_required_env_covers_server_oauth_account_binding(monkeypatch) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-Dual-Client-Smoke.md
Slice phase: Functional validation

This codifies the dual-client connector decision from #1353 before building a ChatGPT adapter: the current OAuth verifier validates as a Claude rich `verify_draft` surface, while the chosen proven ChatGPT profile is a separate `search`/`fetch` surface that fails closed if pointed at the current `verify_draft`-only server.

## Intentional
- This PR chooses and validates the ChatGPT `search`/`fetch` contract, but does not build that adapter.
- The current live Content Ops marketer server is expected to pass `claude-rich`, not `chatgpt-search-fetch`.
- The e2e smoke still lists tools only and does not call `verify_draft`.

## Deferred
- `PR-Content-Ops-MCP-ChatGPT-Search-Fetch-Adapter`: add the actual ChatGPT-compatible adapter surface.
- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after both surfaces exist.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py -q` - 21 passed in 0.66s
- `python -m py_compile scripts/check_content_ops_marketer_verify_oauth_e2e.py scripts/start_content_ops_marketer_verify_oauth_server.py`
- `git diff --check`
- `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_mcp_content_ops_marketer_verify.py -q` - 66 passed in 0.63s
- `bash scripts/run_extracted_pipeline_checks.sh` - 295 passed; 3454 passed, 10 skipped
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content_ops_mcp_dual_client_smoke_pr_body.md` - passed

## Diff size
7 files, +282 / -15