### PR TITLE
Content-Ops MCP ChatGPT Search Fetch Adapter

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_review_workflow_checks.yml"
       - "atlas_brain/_content_ops_review_workflow.py"
+      - "atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py"
       - "atlas_brain/mcp/content_ops_marketer_verify_server.py"
       - "extracted_content_pipeline/campaign_ports.py"
       - "extracted_content_pipeline/claims_map.py"
@@ -23,6 +24,7 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_review_workflow_checks.yml"
       - "atlas_brain/_content_ops_review_workflow.py"
+      - "atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py"
       - "atlas_brain/mcp/content_ops_marketer_verify_server.py"
       - "extracted_content_pipeline/campaign_ports.py"
       - "extracted_content_pipeline/claims_map.py"

--- a/atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
@@ -1,0 +1,246 @@
+"""ChatGPT-compatible search/fetch adapter for Content Ops draft verification."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from . import content_ops_marketer_verify_server as verify_server
+
+
+CONTRACT_ID = "content-ops-verify-draft-contract"
+_RESULT_PREFIX = "content-ops-verdict:"
+
+
+@dataclass(frozen=True)
+class _CachedVerdict:
+    account_id: str
+    payload: dict[str, Any]
+
+
+_verdict_cache: dict[str, _CachedVerdict] = {}
+
+mcp = FastMCP(
+    "atlas-content-ops-marketer-verify-chatgpt",
+    instructions=(
+        "ChatGPT-compatible Content Ops verification adapter. Search accepts a "
+        "structured JSON review request and returns a tenant-bound verdict ID; "
+        "fetch returns the cached verdict document. This adapter cannot "
+        "generate, publish, approve, unlock, or mutate claim-registry rows."
+    ),
+    lifespan=verify_server._lifespan,
+)
+
+
+@mcp.tool(structured_output=True)
+async def search(query: str = "", limit: int = 10) -> dict[str, Any]:
+    """Search or submit one structured Content Ops review request."""
+    request_payload = _json_object(query)
+    if request_payload is None:
+        return _contract_search_result(query=query, limit=limit)
+
+    account_id = await _resolve_account_id()
+    if account_id is None:
+        return _failure_payload(
+            "account_binding_required",
+            "A single Content Ops account binding is required before drafts can be verified.",
+            results=[],
+        )
+
+    result = await verify_server.run_content_ops_review_for_bound_tenant(
+        verify_server._review_request_from_tool_args(
+            asset_id=request_payload.get("asset_id"),
+            rule_packet=request_payload.get("rule_packet"),
+            coverage=request_payload.get("coverage"),
+            extracted_claims=request_payload.get("extracted_claims"),
+            quality_reports=request_payload.get("quality_reports"),
+            brand_voice_payload=request_payload.get("brand_voice_payload"),
+            comments=request_payload.get("comments"),
+            as_of=request_payload.get("as_of"),
+        ),
+        account_resolver=verify_server.StaticContentOpsMarketerAccountResolver(account_id),
+        registry_reader=verify_server._get_registry_reader(),
+    )
+    verdict = result.as_dict()
+    verdict_id = _verdict_id(account_id=account_id, request_payload=request_payload)
+    _verdict_cache[verdict_id] = _CachedVerdict(account_id=account_id, payload=verdict)
+    decision = _clean(verdict.get("decision")) or "unknown"
+    return {
+        "results": [
+            {
+                "id": verdict_id,
+                "title": f"Content Ops verification: {decision}",
+                "url": _result_url(verdict_id),
+            }
+        ][:_bounded_limit(limit)],
+        "metadata": {
+            "ok": True,
+            "mode": "verification",
+            "decision": decision,
+            "count": 1,
+        },
+    }
+
+
+@mcp.tool(structured_output=True)
+async def fetch(id: str) -> dict[str, Any]:
+    """Fetch the adapter contract or a cached tenant-bound verdict document."""
+    document_id = _clean(id)
+    if not document_id:
+        return _failure_payload("id_required", "fetch requires a contract or verdict ID.")
+    if document_id == CONTRACT_ID:
+        return _contract_document()
+
+    account_id = await _resolve_account_id()
+    if account_id is None:
+        return _failure_payload(
+            "account_binding_required",
+            "A single Content Ops account binding is required before verdicts can be fetched.",
+        )
+
+    cached = _verdict_cache.get(document_id)
+    if cached is None or cached.account_id != account_id:
+        return _failure_payload(
+            "verdict_not_found",
+            "No cached Content Ops verdict was found for this ID in the bound account.",
+        )
+
+    return {
+        "id": document_id,
+        "title": _verdict_title(cached.payload),
+        "text": _verdict_text(cached.payload),
+        "url": _result_url(document_id),
+        "metadata": {
+            "ok": True,
+            "found": True,
+            "verdict": cached.payload,
+        },
+    }
+
+
+async def _resolve_account_id() -> str | None:
+    resolver = verify_server._get_account_resolver()
+    return _clean(await resolver.resolve_account_id()) or None
+
+
+def _json_object(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return dict(decoded) if isinstance(decoded, dict) else None
+
+
+def _contract_search_result(*, query: Any, limit: Any) -> dict[str, Any]:
+    return {
+        "results": [
+            {
+                "id": CONTRACT_ID,
+                "title": "Content Ops verify draft JSON contract",
+                "url": _result_url(CONTRACT_ID),
+            }
+        ][:_bounded_limit(limit)],
+        "metadata": {
+            "ok": True,
+            "mode": "contract",
+            "query": _clean(query),
+            "count": 1,
+        },
+    }
+
+
+def _contract_document() -> dict[str, Any]:
+    text = (
+        "Submit one JSON object through search with these fields: asset_id, "
+        "rule_packet, coverage, extracted_claims, quality_reports, "
+        "brand_voice_payload, comments, and as_of. The adapter returns a "
+        "tenant-bound verdict ID. Call fetch with that ID to read the full "
+        "Content Ops review verdict."
+    )
+    return {
+        "id": CONTRACT_ID,
+        "title": "Content Ops verify draft JSON contract",
+        "text": text,
+        "url": _result_url(CONTRACT_ID),
+        "metadata": {
+            "ok": True,
+            "found": True,
+            "type": "adapter_contract",
+            "accepted_fields": [
+                "asset_id",
+                "rule_packet",
+                "coverage",
+                "extracted_claims",
+                "quality_reports",
+                "brand_voice_payload",
+                "comments",
+                "as_of",
+            ],
+        },
+    }
+
+
+def _failure_payload(
+    code: str,
+    message: str,
+    *,
+    results: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "metadata": {
+            "ok": False,
+            "error": code,
+            "message": message,
+        },
+    }
+    if results is not None:
+        payload["results"] = results
+    return payload
+
+
+def _verdict_id(*, account_id: str, request_payload: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        {"account_id": account_id, "request": request_payload},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:24]
+    return f"{_RESULT_PREFIX}{digest}"
+
+
+def _verdict_title(payload: dict[str, Any]) -> str:
+    decision = _clean(payload.get("decision")) or "unknown"
+    asset_id = _clean(payload.get("asset_id")) or "draft"
+    return f"Content Ops verification for {asset_id}: {decision}"
+
+
+def _verdict_text(payload: dict[str, Any]) -> str:
+    decision = _clean(payload.get("decision")) or "unknown"
+    reasons = payload.get("reasons")
+    reason_lines = [str(reason) for reason in reasons] if isinstance(reasons, list) else []
+    if not reason_lines:
+        reason_lines = ["No blocking reasons returned."]
+    return "Decision: " + decision + "\nReasons:\n- " + "\n- ".join(reason_lines)
+
+
+def _result_url(document_id: str) -> str:
+    return f"atlas://content-ops/marketer-verify/{document_id}"
+
+
+def _bounded_limit(value: Any) -> int:
+    return max(1, min(value if isinstance(value, int) else 10, 10))
+
+
+def _clean(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/plans/PR-Content-Ops-MCP-ChatGPT-Search-Fetch-Adapter.md
+++ b/plans/PR-Content-Ops-MCP-ChatGPT-Search-Fetch-Adapter.md
@@ -1,0 +1,88 @@
+# PR-Content-Ops-MCP-ChatGPT-Search-Fetch-Adapter
+
+## Why this slice exists
+
+#1398 pinned the dual-client contract from #1353: Claude rich uses the current `verify_draft` tool surface, while the proven ChatGPT connector profile requires a separate search/fetch surface. That profile now exists in the OAuth e2e checker, but no server surface satisfies it.
+
+This slice builds the deterministic adapter surface first. It keeps the existing Claude-rich verifier unchanged and adds a separate ChatGPT-shaped MCP module with only search and fetch tools. The adapter delegates verification to the same tenant-bound review backend and stores only an in-process verdict handoff for the follow-up fetch.
+
+This PR is expected to exceed the 400 LOC target because the adapter surface and the tenant-isolation tests are not safely separable: without the tests, the first ChatGPT-shaped verifier would have an unproven cross-tenant fetch boundary.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+1. Add a separate Content Ops marketer ChatGPT adapter MCP module exposing exactly search and fetch.
+2. Map a JSON review request submitted through search into the existing tenant-bound verify backend.
+3. Cache the resulting verdict by tenant-bound result ID so fetch can return the full verdict document without exposing another tenant's result.
+4. Return a static adapter contract document when search receives no JSON review request.
+5. Enroll adapter tests in the extracted pipeline wrapper and dedicated Content Ops review workflow.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-ChatGPT-Search-Fetch-Adapter.md`
+- `atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py`
+- `tests/test_mcp_content_ops_marketer_verify.py`
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The adapter exposes exactly search and fetch, and does not expose `verify_draft`, generation, publishing, checkout, or registry mutation tools.
+  - [ ] A JSON review request submitted through search delegates to the existing review backend for the bound tenant.
+  - [ ] A successful search returns a result ID that fetch can use to return the full verdict document.
+  - [ ] Fetch fails closed for missing account binding, unknown IDs, and cached results owned by another tenant.
+  - [ ] The standalone adapter server reuses the verifier server lifespan so registry reads run with the same database initialization path.
+  - [ ] Non-JSON search input returns the adapter contract document instead of running verification.
+  - [ ] Existing Claude-rich `verify_draft` tests and tool-surface contract remain unchanged.
+  - [ ] The new adapter tests run in the extracted pipeline wrapper and dedicated Content Ops review workflow.
+- Affected surfaces: MCP / tenant isolation / review workflow adapter / tests / CI.
+- Risk areas: security / public tool-surface compatibility / tenant isolation / maintainability / CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12
+
+## Mechanism
+
+The new module owns a separate FastMCP instance and imports the existing verifier module for request coercion, account resolution, registry-reader resolution, review-service delegation, and database lifespan management. Search first checks whether the query is a decoded JSON object. If it is not, search returns one static contract result that describes the adapter input shape. If it is JSON, the adapter resolves the tenant, builds the same review request the rich verifier uses, runs the review service, writes the verdict payload to an in-memory cache keyed by a deterministic result ID, and returns that result in ChatGPT search shape.
+
+Fetch resolves the tenant again before reading the cache. Missing account binding, unknown IDs, and account mismatches return non-success metadata rather than a verdict. The cache is intentionally process-local in this slice; durable verdict/session persistence remains a follow-up.
+
+## Intentional
+
+- This is a separate adapter surface, not extra tools on the Claude-rich verifier. The existing verifier remains a one-tool server.
+- This PR does not add public OAuth launcher/discovery wiring for the adapter. It proves the tool surface and backend mapping first.
+- The process-local cache is enough for the adapter's first two-call vertical path and is explicitly not a durable verdict ledger.
+- The adapter accepts JSON in search because ChatGPT's proven connector shape gives us search and fetch only.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-ChatGPT-Adapter-OAuth-Rollout`: add public OAuth/launcher/discovery/e2e wiring for the adapter server.
+- `PR-Content-Ops-MCP-Verdict-Session-Persistence`: replace process-local verdict handoff with tenant-scoped durable storage if live connector use needs restart-safe fetch.
+- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after both public surfaces exist.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_mcp_content_ops_marketer_verify.py -q
+  - 28 passed in 0.24s
+- Passed: python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
+- Passed: git diff --check
+- Passed: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 73 passed in 0.66s
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.68s for extracted_reasoning_core
+  - 3481 passed, 10 skipped in 57.51s for extracted_content_pipeline
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_chatgpt_adapter_pr_body.md
+  - local PR review passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 88 |
+| Adapter server | 246 |
+| Adapter tests | 129 |
+| CI enrollment | 2 |
+| **Total** | **465** |
+
+This is over the normal 400 LOC target for the reason named in Why this slice exists.

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import types
+import json
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -19,6 +20,7 @@ class _MockFastMCP:
     def __init__(self, *args, **kwargs) -> None:
         self.settings = MagicMock()
         self._tool_manager = _MockToolManager()
+        self.lifespan = kwargs.get("lifespan")
 
     def tool(self, *args, **kwargs):
         def _register(fn):
@@ -106,6 +108,7 @@ _shared_auth_mod.OAuthToken = _OAuthRecord
 sys.modules.setdefault("mcp.shared.auth", _shared_auth_mod)
 
 from atlas_brain.config import settings
+from atlas_brain.mcp import content_ops_marketer_verify_chatgpt_adapter_server as adapter
 from atlas_brain.mcp import content_ops_marketer_verify_server as verify
 from atlas_brain.mcp.auth import BearerAuthMiddleware
 from atlas_brain.mcp.content_ops_marketer_verify_oauth import (
@@ -119,6 +122,7 @@ from extracted_content_pipeline.review_contract import RiskTier
 
 
 VERIFY_TOOLS = {"verify_draft"}
+CHATGPT_ADAPTER_TOOLS = {"search", "fetch"}
 DENIED_TOOLS = {
     "add_registry_claim",
     "approve",
@@ -161,6 +165,7 @@ def _reset_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     verify.mcp.settings.transport_security = None
     verify.mcp._auth_server_provider = None
     verify.mcp._token_verifier = None
+    adapter._verdict_cache.clear()
 
 
 def _tool_names() -> set[str]:
@@ -199,6 +204,130 @@ def _valid_payload() -> dict[str, object]:
 def test_content_ops_marketer_verify_exposes_exact_tool_surface() -> None:
     assert _tool_names() == VERIFY_TOOLS
     assert _tool_names().isdisjoint(DENIED_TOOLS)
+
+
+def test_chatgpt_adapter_exposes_exact_search_fetch_surface() -> None:
+    tool_names = set(adapter.mcp._tool_manager._tools)
+
+    assert tool_names == CHATGPT_ADAPTER_TOOLS
+    assert tool_names.isdisjoint(VERIFY_TOOLS)
+    assert tool_names.isdisjoint(DENIED_TOOLS - {"fetch", "search"})
+
+
+def test_chatgpt_adapter_reuses_verifier_database_lifespan() -> None:
+    assert adapter.mcp.lifespan is verify._lifespan
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_adapter_non_json_search_returns_contract_document() -> None:
+    result = await adapter.search(query="how do I verify a draft?", limit=10)
+    fetched = await adapter.fetch(adapter.CONTRACT_ID)
+
+    assert result["metadata"] == {
+        "ok": True,
+        "mode": "contract",
+        "query": "how do I verify a draft?",
+        "count": 1,
+    }
+    assert result["results"] == [
+        {
+            "id": adapter.CONTRACT_ID,
+            "title": "Content Ops verify draft JSON contract",
+            "url": f"atlas://content-ops/marketer-verify/{adapter.CONTRACT_ID}",
+        }
+    ]
+    assert fetched["metadata"]["ok"] is True
+    assert fetched["metadata"]["type"] == "adapter_contract"
+    assert "asset_id" in fetched["metadata"]["accepted_fields"]
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_adapter_search_delegates_to_bound_tenant_and_fetches_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver(" acct-1 "),
+    )
+
+    search_result = await adapter.search(query=json.dumps(_valid_payload()), limit=5)
+    verdict_id = search_result["results"][0]["id"]
+    fetched = await adapter.fetch(verdict_id)
+
+    assert search_result["metadata"]["ok"] is True
+    assert search_result["metadata"]["mode"] == "verification"
+    assert search_result["metadata"]["decision"] == "approved"
+    assert verdict_id.startswith("content-ops-verdict:")
+    assert fetched["metadata"]["ok"] is True
+    assert fetched["metadata"]["found"] is True
+    assert fetched["metadata"]["verdict"]["decision"] == "approved"
+    assert "Decision: approved" in fetched["text"]
+    assert reader.scopes == [TenantScope(account_id="acct-1")]
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_adapter_blocks_json_search_without_account_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver(" "),
+    )
+
+    result = await adapter.search(query=json.dumps(_valid_payload()))
+
+    assert result["results"] == []
+    assert result["metadata"]["ok"] is False
+    assert result["metadata"]["error"] == "account_binding_required"
+    assert reader.scopes == []
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_adapter_fetch_fails_closed_for_other_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver("acct-1"),
+    )
+    search_result = await adapter.search(query=json.dumps(_valid_payload()))
+    verdict_id = search_result["results"][0]["id"]
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver("acct-2"),
+    )
+
+    fetched = await adapter.fetch(verdict_id)
+
+    assert fetched["metadata"]["ok"] is False
+    assert fetched["metadata"]["error"] == "verdict_not_found"
+    assert "verdict" not in fetched["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_adapter_fetch_requires_bound_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver(" "),
+    )
+
+    fetched = await adapter.fetch("content-ops-verdict:missing")
+
+    assert fetched["metadata"]["ok"] is False
+    assert fetched["metadata"]["error"] == "account_binding_required"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-ChatGPT-Search-Fetch-Adapter.md
Slice phase: Vertical slice

Adds the deterministic ChatGPT-compatible Content Ops marketer verify adapter from the #1353 dual-client plan: a separate search/fetch MCP surface that keeps the Claude-rich verifier unchanged, delegates JSON review requests to the existing tenant-bound review backend, and fails closed on missing account binding, unknown verdict IDs, or cross-tenant fetch attempts. Review update: the standalone adapter now reuses the verifier server lifespan so database-backed registry reads initialize through the same path as the rich verifier.

## Intentional
- This is a separate adapter surface, not extra tools on the Claude-rich verifier. The existing verifier remains a one-tool server.
- This PR does not add public OAuth launcher/discovery wiring for the adapter. It proves the tool surface and backend mapping first.
- The process-local cache is enough for the adapter's first two-call vertical path and is explicitly not a durable verdict ledger.
- The adapter accepts JSON in search because ChatGPT's proven connector shape gives us search and fetch only.

## Deferred
- `PR-Content-Ops-MCP-ChatGPT-Adapter-OAuth-Rollout`: add public OAuth/launcher/discovery/e2e wiring for the adapter server.
- `PR-Content-Ops-MCP-Verdict-Session-Persistence`: replace process-local verdict handoff with tenant-scoped durable storage if live connector use needs restart-safe fetch.
- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after both public surfaces exist.

## Parked hardening
- None.

## Verification
- Passed: `python -m pytest tests/test_mcp_content_ops_marketer_verify.py -q`
  - 28 passed in 0.24s
- Passed: `python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py`
- Passed: `git diff --check`
- Passed: `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_mcp_content_ops_marketer_verify.py -q`
  - 73 passed in 0.66s
- Passed: `bash scripts/run_extracted_pipeline_checks.sh`
  - 295 passed in 1.68s for extracted_reasoning_core
  - 3481 passed, 10 skipped in 57.51s for extracted_content_pipeline
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_chatgpt_adapter_pr_body.md`
  - local PR review passed

## Diff size
4 files, +465 / -0