### PR TITLE
Deflection delivery reconciliation

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
@@ -4,18 +4,28 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
+      - "atlas_brain/autonomous/scheduler.py"
+      - "atlas_brain/autonomous/tasks/__init__.py"
+      - "atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py"
+      - "atlas_brain/config.py"
       - "atlas_brain/content_ops_deflection_delivery.py"
       - "scripts/send_content_ops_deflection_report_deliveries.py"
       - "tests/test_atlas_content_ops_deflection_delivery.py"
+      - "tests/test_deflection_report_delivery_task.py"
       - "tests/test_send_content_ops_deflection_report_deliveries.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
+      - "atlas_brain/autonomous/scheduler.py"
+      - "atlas_brain/autonomous/tasks/__init__.py"
+      - "atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py"
+      - "atlas_brain/config.py"
       - "atlas_brain/content_ops_deflection_delivery.py"
       - "scripts/send_content_ops_deflection_report_deliveries.py"
       - "tests/test_atlas_content_ops_deflection_delivery.py"
+      - "tests/test_deflection_report_delivery_task.py"
       - "tests/test_send_content_ops_deflection_report_deliveries.py"
 
 jobs:
@@ -41,5 +51,6 @@ jobs:
         run: |
           python -m pytest \
             tests/test_atlas_content_ops_deflection_delivery.py \
+            tests/test_deflection_report_delivery_task.py \
             tests/test_send_content_ops_deflection_report_deliveries.py \
             -q

--- a/atlas_brain/autonomous/scheduler.py
+++ b/atlas_brain/autonomous/scheduler.py
@@ -742,6 +742,19 @@ class TaskScheduler:
             },
         },
         {
+            "name": "content_ops_deflection_report_delivery",
+            "description": "Deliver queued paid Content Ops deflection reports to buyer inboxes",
+            "task_type": "builtin",
+            "schedule_type": "interval",
+            "interval_seconds": None,  # resolved from settings.deflection_delivery.interval_seconds
+            "timeout_seconds": 300,
+            "enabled": False,  # opt-in via ATLAS_DEFLECTION_DELIVERY_ENABLED
+            "metadata": {
+                "builtin_handler": "content_ops_deflection_report_delivery",
+                "notify_tags": "email,content_ops,deflection",
+            },
+        },
+        {
             "name": "b2b_scrape_target_pruning",
             "description": "Disable low-yield scrape targets based on recent scrape outcomes",
             "task_type": "builtin",
@@ -963,6 +976,7 @@ class TaskScheduler:
                 "b2b_churn_alert": settings.b2b_alert.interval_seconds,
                 "b2b_report_subscription_delivery": settings.b2b_report_delivery.interval_seconds,
                 "b2b_watchlist_alert_delivery": settings.b2b_watchlist_delivery.interval_seconds,
+                "content_ops_deflection_report_delivery": settings.deflection_delivery.interval_seconds,
                 "b2b_scrape_target_pruning": settings.b2b_scrape.source_low_yield_pruning_interval_seconds,
                 "b2b_parser_upgrade_maintenance": settings.b2b_scrape.parser_upgrade_maintenance_interval_seconds,
                 "llm_provider_cost_sync": settings.provider_cost.interval_seconds,
@@ -974,6 +988,13 @@ class TaskScheduler:
                 "content_ops_faq_macro_writeback_scheduled_publish": (
                     settings.b2b_campaign.content_ops_faq_macro_writeback_scheduled_enabled
                 ),
+                "content_ops_deflection_report_delivery": settings.deflection_delivery.enabled,
+            }
+            _enabled_config_keys = {
+                "content_ops_faq_macro_writeback_scheduled_publish": (
+                    "settings.b2b_campaign.content_ops_faq_macro_writeback_scheduled_enabled"
+                ),
+                "content_ops_deflection_report_delivery": "settings.deflection_delivery.enabled",
             }
 
             # Resolve configurable cron expressions at runtime
@@ -1014,6 +1035,10 @@ class TaskScheduler:
                     task_def = {**task_def, "interval_seconds": _interval_overrides[task_def["name"]]}
                 if task_def["name"] in _enabled_overrides:
                     task_def = {**task_def, "enabled": _enabled_overrides[task_def["name"]]}
+                    metadata = dict(task_def.get("metadata") or {})
+                    metadata.setdefault("enabled_config_key", _enabled_config_keys[task_def["name"]])
+                    metadata.setdefault("enabled_config_value", bool(task_def["enabled"]))
+                    task_def = {**task_def, "metadata": metadata}
                 existing = await repo.get_by_name(task_def["name"])
                 if existing is not None:
                     # Merge any new metadata keys from the definition into the existing row.
@@ -1027,8 +1052,25 @@ class TaskScheduler:
                     code_timeout = task_def.get("timeout_seconds", 120)
                     db_timeout = existing.timeout_seconds or 120
                     timeout_changed = code_timeout != db_timeout
+                    existing_enabled = bool(existing.enabled)
+                    desired_enabled = bool(task_def.get("enabled", True))
+                    last_config_enabled = existing_meta.get("enabled_config_value")
+                    enabled_config_managed = bool(default_meta.get("enabled_config_key"))
+                    enabled_changed = (
+                        enabled_config_managed
+                        and existing_enabled != desired_enabled
+                        and (
+                            last_config_enabled is None
+                            or existing_enabled == bool(last_config_enabled)
+                        )
+                    )
+                    if (
+                        enabled_config_managed
+                        and existing_meta.get("enabled_config_value") != desired_enabled
+                    ):
+                        new_keys["enabled_config_value"] = desired_enabled
 
-                    if new_keys or timeout_changed:
+                    if new_keys or timeout_changed or enabled_changed:
                         from ..storage.database import get_db_pool
                         pool = get_db_pool()
                         if not pool.is_initialized:
@@ -1056,6 +1098,14 @@ class TaskScheduler:
                                     "Synced timeout_seconds for task '%s': %d -> %d",
                                     task_def["name"], db_timeout, code_timeout,
                                 )
+                            if enabled_changed:
+                                updated = await repo.update(existing.id, enabled=desired_enabled)
+                                logger.info(
+                                    "Synced enabled for task '%s': %s -> %s",
+                                    task_def["name"], existing_enabled, desired_enabled,
+                                )
+                                if updated is not None:
+                                    await self.register_and_schedule(updated)
                     continue
 
                 task = await repo.create(
@@ -1115,6 +1165,7 @@ class TaskScheduler:
                 "b2b_churn_alert": settings.b2b_alert.interval_seconds,
                 "b2b_report_subscription_delivery": settings.b2b_report_delivery.interval_seconds,
                 "b2b_watchlist_alert_delivery": settings.b2b_watchlist_delivery.interval_seconds,
+                "content_ops_deflection_report_delivery": settings.deflection_delivery.interval_seconds,
                 "b2b_scrape_target_pruning": settings.b2b_scrape.source_low_yield_pruning_interval_seconds,
                 "b2b_parser_upgrade_maintenance": settings.b2b_scrape.parser_upgrade_maintenance_interval_seconds,
                 "content_ops_faq_macro_writeback_scheduled_publish": (

--- a/atlas_brain/autonomous/tasks/__init__.py
+++ b/atlas_brain/autonomous/tasks/__init__.py
@@ -43,6 +43,7 @@ _BUILTIN_TASKS = [
     ("b2b_tenant_report", "run", "b2b_tenant_report"),
     ("b2b_report_subscription_delivery", "run", "b2b_report_subscription_delivery"),
     ("b2b_watchlist_alert_delivery", "run", "b2b_watchlist_alert_delivery"),
+    ("content_ops_deflection_report_delivery", "run", "content_ops_deflection_report_delivery"),
     ("consumer_weekly_digest", "run", "consumer_weekly_digest"),
     ("consumer_signal_alerts", "run", "consumer_signal_alerts"),
     ("trial_nurture", "run", "trial_nurture"),

--- a/atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py
+++ b/atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py
@@ -1,0 +1,130 @@
+"""Scheduled delivery for queued paid Content Ops deflection reports."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
+from extracted_content_pipeline.campaign_sender import create_campaign_sender
+
+from ...config import settings
+from ...content_ops_deflection_delivery import (
+    DeflectionReportDeliveryConfig,
+    send_pending_deflection_report_deliveries,
+)
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+
+logger = logging.getLogger("atlas.tasks.content_ops_deflection_report_delivery")
+
+
+class _DryRunSender:
+    async def send(self, _request: SendRequest) -> SendResult:
+        raise RuntimeError("dry-run deflection delivery should not send email")
+
+
+def _task_metadata(task: ScheduledTask | Any) -> dict[str, Any]:
+    metadata = getattr(task, "metadata", None)
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _dry_run_enabled(task: ScheduledTask | Any) -> bool:
+    metadata = _task_metadata(task)
+    if "dry_run" in metadata:
+        return bool(metadata.get("dry_run"))
+    return bool(settings.deflection_delivery.dry_run)
+
+
+def _configured(value: Any) -> bool:
+    return bool(str(value or "").strip())
+
+
+def _missing_config(*, dry_run: bool) -> list[str]:
+    cfg = settings.deflection_delivery
+    missing: list[str] = []
+    if not _configured(cfg.from_email):
+        missing.append("from_email")
+    if not _configured(cfg.subject):
+        missing.append("subject")
+    if not (_configured(cfg.result_base_url) or _configured(cfg.result_url_template)):
+        missing.append("result_base_url_or_template")
+    if not dry_run and not _configured(cfg.resend_api_key):
+        missing.append("resend_api_key")
+    return missing
+
+
+def _delivery_config(*, dry_run: bool) -> DeflectionReportDeliveryConfig:
+    cfg = settings.deflection_delivery
+    return DeflectionReportDeliveryConfig(
+        from_email=str(cfg.from_email or "").strip(),
+        result_base_url=str(cfg.result_base_url or "").strip(),
+        result_url_template=str(cfg.result_url_template or "").strip(),
+        reply_to=str(cfg.reply_to or "").strip() or None,
+        subject=str(cfg.subject or "").strip(),
+        limit=int(cfg.limit),
+        dry_run=dry_run,
+    )
+
+
+def _sender(*, dry_run: bool) -> Any:
+    cfg = settings.deflection_delivery
+    if dry_run:
+        return _DryRunSender()
+    return create_campaign_sender(
+        "resend",
+        {
+            "api_key": cfg.resend_api_key,
+            "api_url": cfg.resend_api_url,
+            "timeout_seconds": cfg.resend_timeout_seconds,
+        },
+    )
+
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Drain queued paid deflection report deliveries through the configured ESP."""
+
+    cfg = settings.deflection_delivery
+    if not cfg.enabled:
+        return {"_skip_synthesis": "Deflection report delivery disabled"}
+
+    dry_run = _dry_run_enabled(task)
+    missing = _missing_config(dry_run=dry_run)
+    if missing:
+        return {
+            "_skip_synthesis": "Deflection report delivery config missing",
+            "missing": missing,
+            "dry_run": dry_run,
+        }
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready", "dry_run": dry_run}
+
+    try:
+        summary = await send_pending_deflection_report_deliveries(
+            pool,
+            sender=_sender(dry_run=dry_run),
+            config=_delivery_config(dry_run=dry_run),
+        )
+    except Exception as exc:
+        logger.exception("Queued deflection report delivery failed")
+        return {
+            "_skip_synthesis": "Deflection report delivery failed",
+            "error": str(exc)[:500],
+            "dry_run": dry_run,
+        }
+
+    payload = {
+        "scanned": summary.scanned,
+        "sent": summary.sent,
+        "failed": summary.failed,
+        "dry_run": summary.dry_run,
+        "dry_run_enabled": dry_run,
+    }
+    if summary.scanned == 0:
+        return {
+            "_skip_synthesis": "No pending deflection report deliveries",
+            **payload,
+        }
+    return {"_skip_synthesis": "Deflection report delivery complete", **payload}

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4005,6 +4005,27 @@ class B2BReportDeliveryConfig(BaseSettings):
     )
 
 
+class DeflectionDeliveryConfig(BaseSettings):
+    """Paid Content Ops deflection report delivery scheduler configuration."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_DEFLECTION_DELIVERY_", env_file=ENV_FILES, extra="ignore"
+    )
+
+    enabled: bool = Field(default=False, description="Enable queued paid deflection report delivery")
+    interval_seconds: int = Field(default=300, ge=60, le=86400, description="How often to drain pending paid-report delivery rows")
+    limit: int = Field(default=20, ge=1, le=250, description="Maximum queued paid-report deliveries processed per task run")
+    dry_run: bool = Field(default=True, description="Claim-read delivery rows without sending email")
+    from_email: str = Field(default="", description="Verified sender for paid deflection report delivery emails")
+    reply_to: str = Field(default="", description="Optional Reply-To address for deflection delivery emails")
+    subject: str = Field(default="Your FAQ deflection report is ready", description="Subject for paid deflection report delivery emails")
+    result_base_url: str = Field(default="", description="Portfolio base URL used to build deflection result links")
+    result_url_template: str = Field(default="", description="Optional full result URL template containing {request_id}")
+    resend_api_key: str = Field(default="", description="Resend API key for live paid deflection report delivery")
+    resend_api_url: str = Field(default="https://api.resend.com/emails", description="Resend email send API URL")
+    resend_timeout_seconds: float = Field(default=30.0, ge=1.0, le=300.0, description="Timeout for Resend email send requests")
+
+
 class B2BWebhookConfig(BaseSettings):
     """B2B outbound webhook delivery configuration."""
 
@@ -5719,6 +5740,7 @@ class Settings(BaseSettings):
     b2b_alert: B2BAlertConfig = Field(default_factory=B2BAlertConfig)
     b2b_watchlist_delivery: B2BWatchlistDeliveryConfig = Field(default_factory=B2BWatchlistDeliveryConfig)
     b2b_report_delivery: B2BReportDeliveryConfig = Field(default_factory=B2BReportDeliveryConfig)
+    deflection_delivery: DeflectionDeliveryConfig = Field(default_factory=DeflectionDeliveryConfig)
     b2b_webhook: B2BWebhookConfig = Field(default_factory=B2BWebhookConfig)
     crm_event: CRMEventConfig = Field(default_factory=CRMEventConfig)
     b2b_scrape: B2BScrapeConfig = Field(default_factory=B2BScrapeConfig)

--- a/plans/PR-Deflection-Delivery-Reconciliation.md
+++ b/plans/PR-Deflection-Delivery-Reconciliation.md
@@ -1,0 +1,159 @@
+# PR-Deflection-Delivery-Reconciliation
+
+## Why this slice exists
+
+#1386 deferred the paid deflection report delivery URL/scheduler reconciliation
+after #1397 wired Stripe paid events to enqueue delivery rows. #1400 then made
+the launch-readiness proof explicit: the operator needs a queued paid-report
+delivery to send automatically to canfieldjuan24@gmail.com and link to the live
+unlocked result route, with any stubbed or missing path called out rather than
+papered over with a one-off send.
+
+The existing delivery worker can send pending rows and already builds the live
+portfolio result route, but it is only reachable through a manual script. This
+slice promotes that worker into the autonomous scheduler lane and locks the URL
+contract with tests so the go-live path is automatic once the task is enabled.
+
+Diff budget note: this lands above the 400 LOC target because the slice needs a
+new plan doc, a new autonomous task wrapper, focused negative/positive tests for
+fail-closed config, scheduler registration, live sender wiring, result URL
+drift, and the reviewer-requested existing-row opt-in regression. Splitting
+those tests away would leave the go-live wiring unprotected.
+
+## Scope (this PR)
+
+Ownership lane: deflection/go-live
+Slice phase: Production hardening
+
+1. Add typed deflection delivery scheduler settings and a disabled-by-default
+   builtin interval task that drains queued paid-report delivery rows.
+2. Add an autonomous task handler that uses the existing delivery worker,
+   campaign sender, DB pool, and live result-route builder; no hand-fired
+   delivery path is introduced.
+3. Lock the default result URL contract to
+   `/systems/support-ticket-deflection/results/{request_id}?checkout=success`
+   and keep explicit template override support for deployment-specific URLs.
+4. Add focused tests for scheduler seeding, task registration/config gating,
+   CLI URL wiring, and the delivery URL contract.
+
+### Review Contract
+
+Acceptance criteria:
+- `content_ops_deflection_report_delivery` is registered as a builtin
+  autonomous task, seeded as a disabled interval task, and gets its interval
+  from typed `ATLAS_DEFLECTION_DELIVERY_*` settings.
+- The autonomous handler returns a clear disabled/config-missing summary when
+  not enabled or not fully configured, without sending emails.
+- When enabled and configured, the handler calls
+  `send_pending_deflection_report_deliveries` with the real DB pool,
+  campaign sender, configured limit, dry-run flag, and result URL settings.
+- Default delivery links point at the live portfolio result route rather than
+  the old FAQ service path.
+- Tests prove the above; #1400's live inbox send remains a post-deploy
+  verification step unless live credentials and DNS state are available in this
+  local run.
+
+Affected surfaces:
+- Autonomous scheduler default task seeding and builtin handler registration.
+- Deflection delivery config and result URL construction.
+- CLI smoke coverage for the manual delivery script remains intact.
+
+Risk areas:
+- Sending emails while config is incomplete or the task is still disabled.
+- Seeding an enabled production job accidentally.
+- Delivering stale or incorrect result URLs.
+- Drift between the script worker and scheduler worker.
+
+Reviewer rules triggered: R1, R2, R6, R8, R11, R12.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml`
+- `atlas_brain/autonomous/scheduler.py`
+- `atlas_brain/autonomous/tasks/__init__.py`
+- `atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py`
+- `atlas_brain/config.py`
+- `plans/PR-Deflection-Delivery-Reconciliation.md`
+- `scripts/send_content_ops_deflection_report_deliveries.py`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_deflection_report_delivery_task.py`
+- `tests/test_scheduler.py`
+- `tests/test_send_content_ops_deflection_report_deliveries.py`
+
+## Mechanism
+
+Add a `DeflectionDeliveryConfig` settings model under the existing nested
+Atlas settings tree with `ATLAS_DEFLECTION_DELIVERY_` env bindings. The model
+owns the scheduler opt-in, interval, batch limit, dry-run mode, sender fields,
+and portfolio result URL settings.
+
+Seed `content_ops_deflection_report_delivery` as a disabled interval builtin in
+the scheduler, resolve its interval from settings, and register a new builtin
+task module. The module validates the typed settings, builds the campaign
+sender through the existing campaign sender service, gets the DB pool through
+the normal storage helper, and delegates all queue claiming / marking /
+rendering to `send_pending_deflection_report_deliveries`.
+
+The delivery URL remains centralized in
+`atlas_brain.content_ops_deflection_delivery.deflection_report_result_url`.
+Tests assert the default route and template override so future route drift is
+caught before a live send.
+
+## Intentional
+
+- The scheduler task remains disabled by default. Enabling live sends is an
+  operator/deployment action because #1400 requires real inbox, route, and
+  deliverability proof.
+- This PR does not seed a synthetic paid report or send a live email from local
+  tests. Local verification proves the automatic queue path and URL contract;
+  #1400 tracks the hands-on deployed proof.
+- The manual script stays available for dry-run/operations, but the slice does
+  not introduce a one-off send path that could be mistaken for automatic
+  fulfillment.
+
+## Deferred
+
+- #1400 live proof: after deployment has `ATLAS_DEFLECTION_DELIVERY_ENABLED`,
+  sender credentials, portfolio URL, and email DNS configured, trigger a real
+  paid report or seeded paid test report and confirm automatic delivery to
+  canfieldjuan24@gmail.com plus the unlocked result link.
+- Paid-funnel incident observability into the production alert sink remains a
+  later #1386 go-live slice.
+- Variant-aware authorization for partner checkout re-enable remains a later
+  #1386 go-live slice.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_deflection_report_delivery_task.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_scheduler.py::TestDefaults::test_deflection_delivery_default_seed_uses_typed_interval_and_opt_in -q`
+  - 24 passed, 1 warning.
+- `pytest tests/test_scheduler.py::TestDefaults::test_deflection_delivery_default_seed_uses_typed_interval_and_opt_in tests/test_scheduler.py::TestDefaults::test_config_managed_enabled_opt_in_syncs_existing_seeded_task tests/test_scheduler.py::TestDefaults::test_config_managed_enabled_sync_preserves_manual_disable_after_prior_sync -q`
+  - 3 passed, 1 warning.
+- `pytest tests/test_deflection_report_delivery_task.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py -q`
+  - 23 passed, 1 warning.
+- Broader exploratory run:
+  `pytest tests/test_deflection_report_delivery_task.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_scheduler.py -q`
+  - 59 passed, 2 failed in pre-existing `TestAutonomousApiRunNow`
+    retry/timeout cases unrelated to this slice.
+- `pytest tests/test_extracted_pipeline_route_ci_contract.py tests/test_audit_extracted_pipeline_ci_enrollment.py -q`
+  - 21 passed.
+- `bash scripts/local_pr_review.sh --allow-dirty`
+  - Passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml` | 11 |
+| `atlas_brain/autonomous/scheduler.py` | 53 |
+| `atlas_brain/autonomous/tasks/__init__.py` | 1 |
+| `atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py` | 130 |
+| `atlas_brain/config.py` | 22 |
+| `plans/PR-Deflection-Delivery-Reconciliation.md` | 159 |
+| `scripts/send_content_ops_deflection_report_deliveries.py` | 12 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 14 |
+| `tests/test_deflection_report_delivery_task.py` | 218 |
+| `tests/test_scheduler.py` | 167 |
+| `tests/test_send_content_ops_deflection_report_deliveries.py` | 18 |
+| **Total** | **805** |

--- a/scripts/send_content_ops_deflection_report_deliveries.py
+++ b/scripts/send_content_ops_deflection_report_deliveries.py
@@ -104,12 +104,18 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--result-base-url",
-        default=_env("ATLAS_DEFLECTION_PORTFOLIO_BASE_URL"),
+        default=_env(
+            "ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL",
+            "ATLAS_DEFLECTION_PORTFOLIO_BASE_URL",
+        ),
         help="Portfolio origin; production result path is appended.",
     )
     parser.add_argument(
         "--result-url-template",
-        default=_env("ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL_TEMPLATE"),
+        default=_env(
+            "ATLAS_DEFLECTION_DELIVERY_RESULT_URL_TEMPLATE",
+            "ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL_TEMPLATE",
+        ),
         help="Full result URL template containing {request_id}.",
     )
     parser.add_argument(
@@ -160,6 +166,8 @@ def _validate_args(args: argparse.Namespace) -> None:
     if not _configured(args.result_base_url) and not _configured(args.result_url_template):
         raise SystemExit(
             "Missing --result-base-url, --result-url-template, "
+            "ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL, "
+            "ATLAS_DEFLECTION_DELIVERY_RESULT_URL_TEMPLATE, "
             "ATLAS_DEFLECTION_PORTFOLIO_BASE_URL, or "
             "ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL_TEMPLATE"
         )

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -213,6 +213,20 @@ def test_deflection_report_result_url_uses_template_and_quotes_request_id() -> N
     assert url == "https://portfolio.example.com/r/content%20ops%2Fabc?checkout=success"
 
 
+def test_deflection_report_result_url_defaults_to_live_portfolio_result_route() -> None:
+    url = deflection_report_result_url(
+        request_id="content ops/abc",
+        config=_config(result_base_url="https://juancanfield.com/"),
+    )
+
+    assert (
+        url
+        == "https://juancanfield.com/systems/support-ticket-deflection/results/"
+        "content%20ops%2Fabc?checkout=success"
+    )
+    assert "/services/faq-deflection" not in url
+
+
 def test_deflection_report_result_url_requires_configured_destination() -> None:
     with pytest.raises(ValueError, match="result_base_url or result_url_template"):
         deflection_report_result_url(request_id="req-123", config=_config(result_base_url=""))

--- a/tests/test_deflection_report_delivery_task.py
+++ b/tests/test_deflection_report_delivery_task.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import atlas_brain.autonomous.tasks.content_ops_deflection_report_delivery as mod
+
+
+def _set_delivery_settings(monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> None:
+    values = {
+        "enabled": True,
+        "interval_seconds": 300,
+        "limit": 7,
+        "dry_run": True,
+        "from_email": "Atlas Content Ops <reports@example.com>",
+        "reply_to": "support@example.com",
+        "subject": "Your FAQ deflection report is ready",
+        "result_base_url": "https://juancanfield.com",
+        "result_url_template": "",
+        "resend_api_key": "",
+        "resend_api_url": "https://resend.example.test/emails",
+        "resend_timeout_seconds": 3.0,
+    }
+    values.update(overrides)
+    for name, value in values.items():
+        monkeypatch.setattr(mod.settings.deflection_delivery, name, value, raising=False)
+
+
+def test_deflection_delivery_task_is_registered_builtin() -> None:
+    from atlas_brain.autonomous.tasks import _BUILTIN_TASKS
+
+    assert (
+        "content_ops_deflection_report_delivery",
+        "run",
+        "content_ops_deflection_report_delivery",
+    ) in _BUILTIN_TASKS
+
+
+def test_deflection_delivery_default_task_seed_is_disabled_interval() -> None:
+    from atlas_brain.autonomous.scheduler import TaskScheduler
+
+    seed = next(
+        (
+            task
+            for task in TaskScheduler._DEFAULT_TASKS
+            if task.get("name") == "content_ops_deflection_report_delivery"
+        ),
+        None,
+    )
+
+    assert seed is not None
+    assert seed["task_type"] == "builtin"
+    assert seed["schedule_type"] == "interval"
+    assert seed["interval_seconds"] is None
+    assert seed["enabled"] is False
+    assert seed["timeout_seconds"] == 300
+    assert seed["metadata"]["builtin_handler"] == "content_ops_deflection_report_delivery"
+    assert seed["metadata"]["notify_tags"] == "email,content_ops,deflection"
+
+
+def test_deflection_delivery_registers_on_runner() -> None:
+    class _Recorder:
+        def __init__(self) -> None:
+            self.registered: dict[str, object] = {}
+
+        def register_builtin(self, name: str, handler: object) -> None:
+            self.registered[name] = handler
+
+    from atlas_brain.autonomous.tasks import register_builtin_tasks
+
+    runner = _Recorder()
+    register_builtin_tasks(runner)
+
+    handler = runner.registered["content_ops_deflection_report_delivery"]
+    assert callable(handler)
+    assert getattr(handler, "__name__", "") == "run"
+    assert handler.__module__.endswith("content_ops_deflection_report_delivery")
+
+
+@pytest.mark.asyncio
+async def test_run_skips_when_deflection_delivery_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_delivery_settings(monkeypatch, enabled=False)
+    get_pool = AsyncMock()
+    monkeypatch.setattr(mod, "get_db_pool", get_pool)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result == {"_skip_synthesis": "Deflection report delivery disabled"}
+    get_pool.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_fails_closed_before_db_when_required_config_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delivery_settings(
+        monkeypatch,
+        from_email=" ",
+        subject=" ",
+        result_base_url="",
+        result_url_template="",
+    )
+    get_pool = AsyncMock()
+    monkeypatch.setattr(mod, "get_db_pool", get_pool)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result == {
+        "_skip_synthesis": "Deflection report delivery config missing",
+        "missing": ["from_email", "subject", "result_base_url_or_template"],
+        "dry_run": True,
+    }
+    get_pool.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_delegates_to_queue_worker_in_dry_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delivery_settings(monkeypatch, result_url_template="https://juancanfield.com/result/{request_id}")
+    pool = SimpleNamespace(is_initialized=True)
+    calls: list[dict[str, Any]] = []
+
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+        calls.append(
+            {
+                "pool": pool_arg,
+                "sender_type": type(sender).__name__,
+                "from_email": config.from_email,
+                "reply_to": config.reply_to,
+                "subject": config.subject,
+                "result_base_url": config.result_base_url,
+                "result_url_template": config.result_url_template,
+                "limit": config.limit,
+                "dry_run": config.dry_run,
+            }
+        )
+        return SimpleNamespace(scanned=1, sent=0, failed=0, dry_run=1)
+
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "send_pending_deflection_report_deliveries", _send_pending)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result == {
+        "_skip_synthesis": "Deflection report delivery complete",
+        "scanned": 1,
+        "sent": 0,
+        "failed": 0,
+        "dry_run": 1,
+        "dry_run_enabled": True,
+    }
+    assert calls == [
+        {
+            "pool": pool,
+            "sender_type": "_DryRunSender",
+            "from_email": "Atlas Content Ops <reports@example.com>",
+            "reply_to": "support@example.com",
+            "subject": "Your FAQ deflection report is ready",
+            "result_base_url": "https://juancanfield.com",
+            "result_url_template": "https://juancanfield.com/result/{request_id}",
+            "limit": 7,
+            "dry_run": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_uses_resend_sender_for_live_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delivery_settings(monkeypatch, dry_run=False, resend_api_key="re_live")
+    pool = SimpleNamespace(is_initialized=True)
+    sender = object()
+    calls: list[dict[str, Any]] = []
+
+    def _create_sender(provider: str, config: dict[str, Any]) -> object:
+        calls.append({"provider": provider, "config": config})
+        return sender
+
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+        calls.append(
+            {
+                "pool": pool_arg,
+                "sender": sender,
+                "dry_run": config.dry_run,
+                "result_base_url": config.result_base_url,
+            }
+        )
+        return SimpleNamespace(scanned=0, sent=0, failed=0, dry_run=0)
+
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "create_campaign_sender", _create_sender)
+    monkeypatch.setattr(mod, "send_pending_deflection_report_deliveries", _send_pending)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result["_skip_synthesis"] == "No pending deflection report deliveries"
+    assert result["dry_run_enabled"] is False
+    assert calls == [
+        {
+            "provider": "resend",
+            "config": {
+                "api_key": "re_live",
+                "api_url": "https://resend.example.test/emails",
+                "timeout_seconds": 3.0,
+            },
+        },
+        {
+            "pool": pool,
+            "sender": sender,
+            "dry_run": False,
+            "result_base_url": "https://juancanfield.com",
+        },
+    ]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -782,3 +782,170 @@ class TestDefaults:
         assert create_kwargs["enabled"] is False
         assert create_kwargs["interval_seconds"] == 3600
         s.register_and_schedule.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("atlas_brain.storage.repositories.scheduled_task.get_scheduled_task_repo")
+    async def test_deflection_delivery_default_seed_uses_typed_interval_and_opt_in(self, mock_repo_fn, monkeypatch):
+        s = _scheduler()
+        s._DEFAULT_TASKS = [
+            {
+                "name": "content_ops_deflection_report_delivery",
+                "task_type": "builtin",
+                "schedule_type": "interval",
+                "interval_seconds": None,
+                "timeout_seconds": 300,
+                "enabled": False,
+                "metadata": {"builtin_handler": "content_ops_deflection_report_delivery"},
+            },
+        ]
+
+        repo = AsyncMock()
+        repo.get_by_name = AsyncMock(return_value=None)
+        repo.create = AsyncMock(
+            return_value=ScheduledTask(
+                id=uuid4(),
+                name="content_ops_deflection_report_delivery",
+                task_type="builtin",
+                schedule_type="interval",
+                interval_seconds=123,
+                timeout_seconds=300,
+                enabled=True,
+            )
+        )
+        mock_repo_fn.return_value = repo
+        monkeypatch.setattr(s, "register_and_schedule", AsyncMock())
+        from atlas_brain.config import settings
+
+        monkeypatch.setattr(settings.deflection_delivery, "enabled", True, raising=False)
+        monkeypatch.setattr(settings.deflection_delivery, "interval_seconds", 123, raising=False)
+        monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_interval_overrides", lambda: {})
+        monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_default_tasks", lambda: [])
+
+        await s._ensure_default_tasks()
+
+        create_kwargs = repo.create.await_args.kwargs
+        assert create_kwargs["enabled"] is True
+        assert create_kwargs["interval_seconds"] == 123
+        assert s.register_and_schedule.await_args.args[0].name == "content_ops_deflection_report_delivery"
+
+    @pytest.mark.asyncio
+    @patch("atlas_brain.storage.repositories.scheduled_task.get_scheduled_task_repo")
+    async def test_config_managed_enabled_opt_in_syncs_existing_seeded_task(
+        self, mock_repo_fn, monkeypatch
+    ):
+        s = _scheduler()
+        task_id = uuid4()
+        s._DEFAULT_TASKS = [
+            {
+                "name": "content_ops_deflection_report_delivery",
+                "task_type": "builtin",
+                "schedule_type": "interval",
+                "interval_seconds": None,
+                "timeout_seconds": 300,
+                "enabled": False,
+                "metadata": {"builtin_handler": "content_ops_deflection_report_delivery"},
+            },
+        ]
+        existing = ScheduledTask(
+            id=task_id,
+            name="content_ops_deflection_report_delivery",
+            task_type="builtin",
+            schedule_type="interval",
+            interval_seconds=300,
+            timeout_seconds=300,
+            enabled=False,
+            metadata={"builtin_handler": "content_ops_deflection_report_delivery"},
+        )
+        updated = ScheduledTask(
+            id=task_id,
+            name="content_ops_deflection_report_delivery",
+            task_type="builtin",
+            schedule_type="interval",
+            interval_seconds=300,
+            timeout_seconds=300,
+            enabled=True,
+            metadata={
+                "builtin_handler": "content_ops_deflection_report_delivery",
+                "enabled_config_key": "settings.deflection_delivery.enabled",
+                "enabled_config_value": True,
+            },
+        )
+        repo = AsyncMock()
+        repo.get_by_name = AsyncMock(return_value=existing)
+        repo.create = AsyncMock()
+        repo.update = AsyncMock(return_value=updated)
+        mock_repo_fn.return_value = repo
+        pool = _FakeExecPool()
+        monkeypatch.setattr("atlas_brain.storage.database.get_db_pool", lambda: pool)
+        monkeypatch.setattr(s, "register_and_schedule", AsyncMock())
+        from atlas_brain.config import settings
+
+        monkeypatch.setattr(settings.deflection_delivery, "enabled", True, raising=False)
+        monkeypatch.setattr(settings.deflection_delivery, "interval_seconds", 300, raising=False)
+        monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_interval_overrides", lambda: {})
+        monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_default_tasks", lambda: [])
+
+        await s._ensure_default_tasks()
+
+        repo.create.assert_not_awaited()
+        repo.update.assert_awaited_once_with(task_id, enabled=True)
+        metadata_update = pool.calls[0]
+        assert "UPDATE scheduled_tasks SET metadata" in metadata_update[0]
+        metadata = __import__("json").loads(metadata_update[1])
+        assert metadata["enabled_config_key"] == "settings.deflection_delivery.enabled"
+        assert metadata["enabled_config_value"] is True
+        assert s.register_and_schedule.await_args.args[0] is updated
+
+    @pytest.mark.asyncio
+    @patch("atlas_brain.storage.repositories.scheduled_task.get_scheduled_task_repo")
+    async def test_config_managed_enabled_sync_preserves_manual_disable_after_prior_sync(
+        self, mock_repo_fn, monkeypatch
+    ):
+        s = _scheduler()
+        task_id = uuid4()
+        s._DEFAULT_TASKS = [
+            {
+                "name": "content_ops_deflection_report_delivery",
+                "task_type": "builtin",
+                "schedule_type": "interval",
+                "interval_seconds": None,
+                "timeout_seconds": 300,
+                "enabled": False,
+                "metadata": {"builtin_handler": "content_ops_deflection_report_delivery"},
+            },
+        ]
+        existing = ScheduledTask(
+            id=task_id,
+            name="content_ops_deflection_report_delivery",
+            task_type="builtin",
+            schedule_type="interval",
+            interval_seconds=300,
+            timeout_seconds=300,
+            enabled=False,
+            metadata={
+                "builtin_handler": "content_ops_deflection_report_delivery",
+                "enabled_config_key": "settings.deflection_delivery.enabled",
+                "enabled_config_value": True,
+            },
+        )
+        repo = AsyncMock()
+        repo.get_by_name = AsyncMock(return_value=existing)
+        repo.create = AsyncMock()
+        repo.update = AsyncMock()
+        mock_repo_fn.return_value = repo
+        pool = _FakeExecPool()
+        monkeypatch.setattr("atlas_brain.storage.database.get_db_pool", lambda: pool)
+        monkeypatch.setattr(s, "register_and_schedule", AsyncMock())
+        from atlas_brain.config import settings
+
+        monkeypatch.setattr(settings.deflection_delivery, "enabled", True, raising=False)
+        monkeypatch.setattr(settings.deflection_delivery, "interval_seconds", 300, raising=False)
+        monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_interval_overrides", lambda: {})
+        monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_default_tasks", lambda: [])
+
+        await s._ensure_default_tasks()
+
+        repo.create.assert_not_awaited()
+        repo.update.assert_not_awaited()
+        s.register_and_schedule.assert_not_awaited()
+        assert pool.calls == []

--- a/tests/test_send_content_ops_deflection_report_deliveries.py
+++ b/tests/test_send_content_ops_deflection_report_deliveries.py
@@ -50,6 +50,24 @@ def test_parse_defaults_to_dry_run_and_env_config(monkeypatch: pytest.MonkeyPatc
     assert args.send is False
 
 
+def test_parse_prefers_typed_delivery_result_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL", "https://typed.example")
+    monkeypatch.setenv("ATLAS_DEFLECTION_PORTFOLIO_BASE_URL", "https://legacy.example")
+    monkeypatch.setenv(
+        "ATLAS_DEFLECTION_DELIVERY_RESULT_URL_TEMPLATE",
+        "https://typed.example/results/{request_id}",
+    )
+    monkeypatch.setenv(
+        "ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL_TEMPLATE",
+        "https://legacy.example/results/{request_id}",
+    )
+
+    args = send_cli._parse_args([])
+
+    assert args.result_base_url == "https://typed.example"
+    assert args.result_url_template == "https://typed.example/results/{request_id}"
+
+
 def test_validate_allows_dry_run_without_resend_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY", raising=False)
     args = send_cli._parse_args(_base_args())


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delivery-Reconciliation.md
Slice phase: Production hardening

Promotes the paid Content Ops deflection report delivery worker from a manual script-only path into an opt-in autonomous scheduler task, with typed delivery settings and a locked live result URL contract for the #1386/#1400 go-live lane.

## Intentional
- Scheduler delivery remains disabled by default and dry-run by default; live #1400 inbox proof is a deployment/operator action once sender credentials, DNS, and portfolio URL are configured.
- The PR reuses the existing queued delivery worker instead of introducing a hand-send path.
- Local tests prove automatic queue draining and URL wiring; they do not send a live email.

## Deferred
- #1400 live inbox proof after deployment has `ATLAS_DEFLECTION_DELIVERY_ENABLED`, `ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false`, sender credentials, portfolio URL, and email DNS configured.
- Paid-funnel incident observability into the production alert sink remains a later #1386 slice.
- Variant-aware authorization for partner checkout re-enable remains a later #1386 slice.

## Parked hardening
- None.

## Verification
- `pytest tests/test_deflection_report_delivery_task.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_scheduler.py::TestDefaults::test_deflection_delivery_default_seed_uses_typed_interval_and_opt_in -q` - 24 passed, 1 warning.
- `pytest tests/test_scheduler.py::TestDefaults::test_deflection_delivery_default_seed_uses_typed_interval_and_opt_in tests/test_scheduler.py::TestDefaults::test_config_managed_enabled_opt_in_syncs_existing_seeded_task tests/test_scheduler.py::TestDefaults::test_config_managed_enabled_sync_preserves_manual_disable_after_prior_sync -q` - 3 passed, 1 warning.
- `pytest tests/test_deflection_report_delivery_task.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py -q` - 23 passed, 1 warning.
- `pytest tests/test_extracted_pipeline_route_ci_contract.py tests/test_audit_extracted_pipeline_ci_enrollment.py -q` - 21 passed.
- `bash scripts/local_pr_review.sh --allow-dirty` - passed before commit.
- Broader exploratory run: `pytest tests/test_deflection_report_delivery_task.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_scheduler.py -q` - 59 passed, 2 failed in pre-existing `TestAutonomousApiRunNow` retry/timeout cases unrelated to this slice.

## Diff size
11 files, +639 / -2