### PR TITLE
Content-Ops report claim IDs

### DIFF
--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -171,6 +171,47 @@ def _report_user_prompt(prior_invalid_response: str = "") -> str:
     )
 
 
+def _clean_id_values(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        values = value
+    else:
+        values = (value,)
+    return tuple(
+        text
+        for item in values
+        if (text := str(item or "").strip())
+    )
+
+
+def _section_local_claim_id(section_id: str, index: int) -> str:
+    slug = re.sub(r"[^0-9A-Za-z]+", "_", section_id).strip("_").lower()
+    if not slug:
+        return f"section_{index}_claim"
+    return f"{slug}_claim_{index}"
+
+
+def _narrative_plan_claim_ids_by_section(
+    opportunity: Mapping[str, Any] | None,
+) -> dict[str, tuple[str, ...]]:
+    if opportunity is None:
+        return {}
+    context = normalize_campaign_reasoning_context(opportunity)
+    plan = context.canonical_reasoning.get("narrative_plan")
+    if not isinstance(plan, Mapping):
+        return {}
+    by_section: dict[str, tuple[str, ...]] = {}
+    for section in plan.get("sections") or ():
+        if not isinstance(section, Mapping):
+            continue
+        section_id = str(section.get("id") or "").strip()
+        claim_ids = _clean_id_values(section.get("claim_ids"))
+        if section_id and claim_ids:
+            by_section[section_id] = claim_ids
+    return by_section
+
+
 class ReportGenerationService:
     """Generate structured report drafts through product-owned ports."""
 
@@ -475,18 +516,33 @@ class ReportGenerationService:
         default_report_type: str | None = None,
         opportunity: Mapping[str, Any] | None = None,
     ) -> ReportDraft:
-        sections = tuple(
-            ReportSection(
-                id=str(s.get("id") or "").strip(),
-                title=str(s.get("title") or "").strip(),
-                body_markdown=str(s.get("body_markdown") or "").strip(),
-                claim_ids=tuple(str(c) for c in (s.get("claim_ids") or ())),
-                evidence_ids=tuple(str(e) for e in (s.get("evidence_ids") or ())),
-                metadata=dict(s.get("metadata") or {}),
+        plan_claim_ids_by_section = _narrative_plan_claim_ids_by_section(opportunity)
+        built_sections: list[ReportSection] = []
+        for index, section in enumerate(parsed.get("sections") or (), start=1):
+            if not isinstance(section, Mapping):
+                continue
+            section_id = str(section.get("id") or "").strip()
+            evidence_ids = _clean_id_values(section.get("evidence_ids"))
+            claim_ids = _clean_id_values(section.get("claim_ids"))
+            metadata = dict(section.get("metadata") or {})
+            if not claim_ids:
+                claim_ids = plan_claim_ids_by_section.get(section_id, ())
+                if claim_ids:
+                    metadata["claim_id_source"] = "narrative_plan"
+            if not claim_ids and evidence_ids:
+                claim_ids = (_section_local_claim_id(section_id, index),)
+                metadata["claim_id_source"] = "derived_section"
+            built_sections.append(
+                ReportSection(
+                    id=section_id,
+                    title=str(section.get("title") or "").strip(),
+                    body_markdown=str(section.get("body_markdown") or "").strip(),
+                    claim_ids=claim_ids,
+                    evidence_ids=evidence_ids,
+                    metadata=metadata,
+                )
             )
-            for s in parsed.get("sections") or ()
-            if isinstance(s, Mapping)
-        )
+        sections = tuple(built_sections)
         # Aggregate reference_ids: explicit list union per-section evidence ids.
         ref_seen: list[str] = []
         for value in parsed.get("reference_ids") or ():

--- a/extracted_content_pipeline/skills/digest/report_generation.md
+++ b/extracted_content_pipeline/skills/digest/report_generation.md
@@ -26,10 +26,11 @@ Field rules:
 - `title`: descriptive, includes the entity name; do NOT include date stamps unless the opportunity provides one.
 - `summary`: factual, evidence-grounded; no marketing language; reference specific findings rather than restating the opportunity.
 - `sections`: at least one. Each section needs a non-empty `title` and `body_markdown`. Cite supporting evidence in `evidence_ids` using the source ids that appear in the opportunity / reasoning context.
+- `sections[].claim_ids`: required for every evidence-backed section. If the reasoning context or narrative plan provides claim ids for the section, copy those ids exactly. If no upstream claim ids exist, emit one stable section-local id using `<section_id>_claim_<1-based section index>`; when the section id is blank or unavailable, use `section_<index>_claim`. Do not leave `claim_ids` empty when `evidence_ids` is non-empty.
 - `reference_ids`: union of every `evidence_ids` value across sections, plus any opportunity-level source ids you cited. No duplicates.
 - `report_type`: one of `vendor_pressure`, `market_intel`, `customer_health`, `account_brief`, or another snake_case label that fits the opportunity's `target_mode`. Default to `vendor_pressure` when in doubt.
 
-When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids` and `evidence_requirements`. Do not invent claim ids that aren't in the reasoning context.
+When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids` and `evidence_requirements`. Do not invent upstream claim-ledger ids that aren't in the reasoning context; use the section-local fallback only when the plan gives no claim ids for that section.
 
 Review/source-row evidence policy:
 - If opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence.

--- a/plans/PR-Content-Ops-Report-Claim-Ids.md
+++ b/plans/PR-Content-Ops-Report-Claim-Ids.md
@@ -1,0 +1,117 @@
+# PR-Content-Ops-Report-Claim-Ids
+
+## Why this slice exists
+
+PR #1399 proved the report generator can run through Gate A live coverage, but
+the exported report sections carried populated `evidence_ids` and empty
+`claim_ids`. That leaves the report artifact partially traceable: renderers and
+review tools can see which evidence was cited, but not which report-level claims
+the section is asserting. This production-hardening slice closes that live-proof
+gap without changing the larger quality gate or introducing a new claim-ledger
+product.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/report-traceability-hardening
+Slice phase: Production hardening
+
+1. Ensure `ReportGenerationService` persists non-empty section `claim_ids` for
+   evidence-backed sections even when the LLM omits the field.
+2. Preserve model/reasoning-supplied `claim_ids` exactly after string
+   normalization; do not rewrite authoritative IDs from a narrative plan.
+3. Mark runtime-derived claim IDs in section metadata so they are transparent
+   section-local traceability IDs, not fake upstream claim-ledger IDs.
+4. Tighten the report prompt so future LLM output emits the same fallback shape
+   the runtime enforces.
+5. Add focused report-generation regression tests for supplied IDs, missing IDs,
+   and blank section IDs.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] A section with supplied `claim_ids` persists those IDs unchanged.
+  - [ ] A section with `evidence_ids` but no `claim_ids` persists a stable,
+        non-empty section-local claim ID.
+  - [ ] A section whose `id` is blank still gets a deterministic fallback claim
+        ID based on section order.
+  - [ ] Runtime-derived claim IDs carry section metadata that makes the source
+        explicit.
+  - [ ] The report prompt instructs the model to emit claim IDs for every
+        section and names the same section-local fallback.
+- Affected surfaces: extracted content pipeline report generation and package
+  prompt.
+- Risk areas: traceability truthfulness, backward compatibility, extracted
+  package sync discipline.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/report_generation.py`
+- `extracted_content_pipeline/skills/digest/report_generation.md`
+- `plans/PR-Content-Ops-Report-Claim-Ids.md`
+- `tests/test_extracted_report_generation.py`
+
+## Mechanism
+
+`ReportGenerationService._build_draft` will normalize each parsed section
+through a small helper before constructing `ReportSection`.
+
+- Existing `claim_ids` are stripped, empty values are dropped, and order is
+  preserved.
+- If a section has no remaining `claim_ids` and the attached narrative plan has
+  claim IDs for the same section id, those plan IDs fill the gap.
+- If a section still has no remaining `claim_ids` but does have `evidence_ids`,
+  the helper derives one stable section-local ID from the section's own `id`
+  plus one-based section index. Blank/unsafe ids fall back to the section
+  index.
+- When a claim ID is derived, the section metadata receives
+  `claim_id_source=derived_section` so consumers can distinguish runtime
+  traceability from an upstream evidence-to-story claim ledger.
+- Sections with neither evidence nor claim ids remain unchanged; the existing
+  report quality pack already blocks no-reference outputs when quality gates are
+  enabled.
+
+The prompt change asks the model to emit `claim_ids` for every section and,
+when no reasoning-context claim IDs exist, use the same section-local pattern
+that the runtime fallback enforces.
+
+## Intentional
+
+- No quality-gate blocker is added in this slice. The quality pack already
+  enforces evidence references; this slice hardens persisted traceability
+  without turning historical prompt drift into a new generation blocker.
+- No new top-level claim ledger is invented. Derived IDs are section-local and
+  explicitly marked in metadata until `extracted_evidence_to_story` is wired
+  into reports.
+- No host/API/UI changes are included; the persisted `ReportSection` shape
+  already exposes `claim_ids` through `as_dict()`.
+- Cross-layer caller hints for `ReportGenerationService` and `_build_draft`
+  were inspected. Host factories, the live execute harness, and report export
+  consume the same `ReportDraft`/`ReportSection` shape; no caller-layer code
+  change is needed because `claim_ids` already serialize through
+  `ReportSection.as_dict()`.
+
+## Deferred
+
+- Full evidence-to-story claim-ledger integration remains deferred until
+  `extracted_evidence_to_story` is wired into report generation. That future
+  slice should replace derived section-local IDs with source-backed claim
+  ledger IDs.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_extracted_report_generation.py -- 29 passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- validation/import/audit
+  preflight passed; extracted reasoning core 295 passed; extracted content
+  pipeline 3485 passed, 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/report_generation.py` | 78 |
+| `extracted_content_pipeline/skills/digest/report_generation.md` | 3 |
+| `plans/PR-Content-Ops-Report-Claim-Ids.md` | 117 |
+| `tests/test_extracted_report_generation.py` | 109 |
+| **Total** | **307** |

--- a/tests/test_extracted_report_generation.py
+++ b/tests/test_extracted_report_generation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -248,6 +249,16 @@ def test_parse_report_response_strips_think_blocks_before_decoding() -> None:
     parsed = parse_report_response(payload)
     assert parsed is not None
     assert parsed["title"] == "Title"
+
+
+def test_report_prompt_requires_section_claim_ids() -> None:
+    prompt = Path(
+        "extracted_content_pipeline/skills/digest/report_generation.md"
+    ).read_text(encoding="utf-8")
+
+    assert "sections[].claim_ids" in prompt
+    assert "required for every evidence-backed section" in prompt
+    assert "section-local fallback" in prompt
 
 
 # -----------------------
@@ -516,6 +527,104 @@ async def test_generate_aggregates_section_evidence_ids_into_reference_ids() -> 
     draft = reports.saved[0]["drafts"][0]
     # Top-level reference_ids preserved + section evidence ids unioned without dupes.
     assert draft.reference_ids == ("r0", "r1", "r2", "r3")
+
+
+@pytest.mark.asyncio
+async def test_generate_preserves_supplied_section_claim_ids() -> None:
+    service, _intel, reports, _llm, _skills, _rp = _service()
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    section = reports.saved[0]["drafts"][0].sections[0]
+    assert section.claim_ids == ("c1",)
+    assert "claim_id_source" not in section.metadata
+
+
+@pytest.mark.asyncio
+async def test_generate_derives_section_claim_id_when_evidence_section_omits_claim_ids() -> None:
+    response = json.dumps({
+        "title": "Title",
+        "summary": "Summary text long enough to be valid.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "pricing pressure",
+                "title": "Pricing pressure",
+                "body_markdown": "body",
+                "evidence_ids": ["r1", "r2"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, reports, _llm, _skills, _rp = _service(responses=[response])
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    section = reports.saved[0]["drafts"][0].sections[0]
+    assert section.claim_ids == ("pricing_pressure_claim_1",)
+    assert section.metadata["claim_id_source"] == "derived_section"
+
+
+@pytest.mark.asyncio
+async def test_generate_derives_section_claim_id_when_section_id_blank() -> None:
+    response = json.dumps({
+        "title": "Title",
+        "summary": "Summary text long enough to be valid.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "",
+                "title": "Pricing pressure",
+                "body_markdown": "body",
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, reports, _llm, _skills, _rp = _service(responses=[response])
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    section = reports.saved[0]["drafts"][0].sections[0]
+    assert section.claim_ids == ("section_1_claim",)
+    assert section.metadata["claim_id_source"] == "derived_section"
+
+
+@pytest.mark.asyncio
+async def test_generate_fills_missing_claim_ids_from_narrative_plan() -> None:
+    response = json.dumps({
+        "title": "Title",
+        "summary": "Summary text long enough to be valid.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "drivers",
+                "title": "Drivers",
+                "body_markdown": "body",
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    context = CampaignReasoningContext(
+        canonical_reasoning={
+            "narrative_plan": {
+                "sections": [
+                    {"id": "drivers", "title": "Drivers", "claim_ids": ["c-plan"]}
+                ]
+            }
+        },
+    )
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        responses=[response],
+        reasoning_context=context,
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    section = reports.saved[0]["drafts"][0].sections[0]
+    assert section.claim_ids == ("c-plan",)
+    assert section.metadata["claim_id_source"] == "narrative_plan"
 
 
 # -----------------------


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Report-Claim-Ids.md
Slice phase: Production hardening

PR #1399 proved the report generator can run through Gate A live coverage, but exported report sections still saved populated `evidence_ids` with empty `claim_ids`. This slice hardens the report draft boundary so evidence-backed sections persist claim traceability: supplied IDs are preserved, narrative-plan IDs fill matching section gaps, and only then does the runtime derive a transparent section-local fallback.

## Intentional
- No quality-gate blocker is added; this hardens persisted traceability without turning historical prompt drift into a new generation blocker.
- No top-level claim ledger is invented; derived IDs are section-local and marked until `extracted_evidence_to_story` is wired into reports.
- No host/API/UI changes are included; `ReportSection.as_dict()` already exposes `claim_ids`.

## Deferred
- Full evidence-to-story claim-ledger integration remains deferred until `extracted_evidence_to_story` is wired into report generation.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_report_generation.py` -- 29 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- validation/import/audit preflight passed; extracted reasoning core 295 passed; extracted content pipeline 3485 passed, 10 skipped.

## Diff size
4 files, +295 / -12
