### PR TITLE
Content-Ops report claim ID ledger validation

### DIFF
--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -192,7 +192,7 @@ def _section_local_claim_id(section_id: str, index: int) -> str:
     return f"{slug}_claim_{index}"
 
 
-def _narrative_plan_claim_ids_by_section(
+def _narrative_plan_claim_ids(
     opportunity: Mapping[str, Any] | None,
 ) -> dict[str, tuple[str, ...]]:
     if opportunity is None:
@@ -516,22 +516,49 @@ class ReportGenerationService:
         default_report_type: str | None = None,
         opportunity: Mapping[str, Any] | None = None,
     ) -> ReportDraft:
-        plan_claim_ids_by_section = _narrative_plan_claim_ids_by_section(opportunity)
+        plan_claim_ids_by_section = _narrative_plan_claim_ids(opportunity)
         built_sections: list[ReportSection] = []
         for index, section in enumerate(parsed.get("sections") or (), start=1):
             if not isinstance(section, Mapping):
                 continue
             section_id = str(section.get("id") or "").strip()
             evidence_ids = _clean_id_values(section.get("evidence_ids"))
-            claim_ids = _clean_id_values(section.get("claim_ids"))
+            model_claim_ids = _clean_id_values(section.get("claim_ids"))
+            plan_claim_ids = plan_claim_ids_by_section.get(section_id, ())
+            claim_ids: tuple[str, ...] = ()
             metadata = dict(section.get("metadata") or {})
-            if not claim_ids:
-                claim_ids = plan_claim_ids_by_section.get(section_id, ())
+            dropped_model_claim_ids: tuple[str, ...] = ()
+            if model_claim_ids and plan_claim_ids:
+                claim_ids = tuple(
+                    claim_id
+                    for claim_id in model_claim_ids
+                    if claim_id in plan_claim_ids
+                )
+                dropped_model_claim_ids = tuple(
+                    claim_id
+                    for claim_id in model_claim_ids
+                    if claim_id not in plan_claim_ids
+                )
                 if claim_ids:
+                    metadata["claim_id_source"] = "model_verified"
+            elif model_claim_ids:
+                dropped_model_claim_ids = model_claim_ids
+            if not claim_ids:
+                claim_ids = plan_claim_ids
+                if plan_claim_ids:
                     metadata["claim_id_source"] = "narrative_plan"
             if not claim_ids and evidence_ids:
                 claim_ids = (_section_local_claim_id(section_id, index),)
                 metadata["claim_id_source"] = "derived_section"
+            dropped_model_claim_ids = tuple(
+                claim_id
+                for claim_id in dropped_model_claim_ids
+                if claim_id not in claim_ids
+            )
+            if dropped_model_claim_ids:
+                metadata["dropped_unverified_claim_ids"] = list(
+                    dropped_model_claim_ids
+                )
             built_sections.append(
                 ReportSection(
                     id=section_id,

--- a/plans/PR-Content-Ops-Report-Claim-Id-Ledger-Validation.md
+++ b/plans/PR-Content-Ops-Report-Claim-Id-Ledger-Validation.md
@@ -1,0 +1,110 @@
+# PR-Content-Ops-Report-Claim-Id-Ledger-Validation
+
+## Why this slice exists
+
+PR #1403 closed the live report proof gap by ensuring evidence-backed report
+sections never persist empty `claim_ids`. Its review left one non-blocking but
+valid hardening NIT: model-supplied `claim_ids` are still copied through without
+checking whether they exist in the narrative-plan claim ledger. That makes the
+field prompt-trusted rather than verifiable. This slice turns the NIT into code:
+claim IDs copied from the model must either be verified against the same
+narrative-plan section or replaced by an explicitly tagged fallback.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/report-traceability-hardening
+Slice phase: Production hardening
+
+1. Validate model-supplied report section `claim_ids` against that same
+   section's narrative-plan `claim_ids` when they exist.
+2. Tag verified model claim IDs with `claim_id_source=model_verified`.
+3. Drop unverified model claim IDs and record them in metadata instead of
+   silently preserving dangling references.
+4. Keep the existing fallback order after validation: section-level
+   narrative-plan claim IDs, then deterministic section-local derived IDs for
+   evidence-backed sections.
+5. Add focused generator tests for verified, mixed, invalid, wrong-section, and
+   no-ledger model-supplied IDs.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] A model-supplied claim ID that exists in the same narrative-plan
+        section is persisted and tagged `claim_id_source=model_verified`.
+  - [ ] A model-supplied claim ID that exists only in a different
+        narrative-plan section is not persisted as an authoritative ID for the
+        current section.
+  - [ ] A model-supplied claim ID that is not in the section ledger is not
+        persisted as an authoritative claim ID.
+  - [ ] Dropped unverified model IDs are visible in section metadata.
+  - [ ] When model IDs are invalid, the existing fallback order still applies:
+        same-section narrative-plan IDs first, then derived section-local IDs
+        when evidence exists.
+  - [ ] If there is no narrative-plan ledger, arbitrary model-supplied IDs are
+        not trusted; evidence-backed sections get the deterministic derived
+        fallback instead.
+- Affected surfaces: extracted content pipeline report generation.
+- Risk areas: traceability truthfulness, backward compatibility, extracted
+  package behavior.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/report_generation.py`
+- `plans/PR-Content-Ops-Report-Claim-Id-Ledger-Validation.md`
+- `tests/test_extracted_report_generation.py`
+
+## Mechanism
+
+The #1403 helper returns the narrative-plan claim IDs keyed by section id.
+Section normalization then handles parsed `claim_ids` in this order:
+
+1. Clean the model-supplied IDs.
+2. If same-section narrative-plan claim IDs exist, keep only model IDs in that
+   section's claim-id set and tag the section `claim_id_source=model_verified`.
+3. Record any rejected model IDs under `dropped_unverified_claim_ids` so the
+   audit trail is explicit.
+4. If no verified IDs remain, copy the same-section narrative-plan IDs and tag
+   `claim_id_source=narrative_plan`.
+5. If no plan IDs remain and `evidence_ids` is non-empty, derive the existing
+   deterministic section-local ID and tag `claim_id_source=derived_section`.
+
+When no same-section ledger exists, model-supplied IDs are treated as
+unverified and the same fallback path applies. This keeps every persisted claim
+ID either same-section verified, directly copied from the narrative plan, or
+clearly derived.
+
+## Intentional
+
+- No new prompt change is included. The prompt already tells the model not to
+  invent upstream claim-ledger IDs; this slice makes that rule load-bearing in
+  code.
+- No quality-gate blocker is added. Invalid model IDs are normalized into a
+  safe persisted shape instead of failing generation, because the report still
+  has evidence-backed traceability after fallback.
+- No new claim ledger product is introduced. The only authoritative ledger for
+  this slice is the same-section claim list in the already-attached
+  `canonical_reasoning.narrative_plan`.
+
+## Deferred
+
+- Full `extracted_evidence_to_story` claim-ledger wiring remains deferred; this
+  slice only validates against the report's existing same-section
+  narrative-plan ledger.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_extracted_report_generation.py -- 33 passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- validation/import/audit
+  preflight passed; extracted reasoning core 295 passed; extracted content
+  pipeline 3498 passed, 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/report_generation.py` | 37 |
+| `plans/PR-Content-Ops-Report-Claim-Id-Ledger-Validation.md` | 110 |
+| `tests/test_extracted_report_generation.py` | 154 |
+| **Total** | **301** |

--- a/tests/test_extracted_report_generation.py
+++ b/tests/test_extracted_report_generation.py
@@ -530,14 +530,162 @@ async def test_generate_aggregates_section_evidence_ids_into_reference_ids() -> 
 
 
 @pytest.mark.asyncio
-async def test_generate_preserves_supplied_section_claim_ids() -> None:
-    service, _intel, reports, _llm, _skills, _rp = _service()
+async def test_generate_preserves_ledger_verified_model_claim_ids() -> None:
+    context = CampaignReasoningContext(
+        canonical_reasoning={
+            "narrative_plan": {
+                "claims": [{"claim_id": "c1"}],
+                "sections": [
+                    {"id": "findings", "title": "Findings", "claim_ids": ["c1"]}
+                ],
+            }
+        },
+    )
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        reasoning_context=context,
+    )
 
     await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
 
     section = reports.saved[0]["drafts"][0].sections[0]
     assert section.claim_ids == ("c1",)
-    assert "claim_id_source" not in section.metadata
+    assert section.metadata["claim_id_source"] == "model_verified"
+
+
+@pytest.mark.asyncio
+async def test_generate_drops_unverified_model_claim_ids_and_uses_plan_fallback() -> None:
+    response = json.dumps({
+        "title": "Title",
+        "summary": "Summary text long enough to be valid.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "drivers",
+                "title": "Drivers",
+                "body_markdown": "body",
+                "claim_ids": ["c-fake"],
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    context = CampaignReasoningContext(
+        canonical_reasoning={
+            "narrative_plan": {
+                "claims": [{"claim_id": "c-plan"}],
+                "sections": [
+                    {"id": "drivers", "title": "Drivers", "claim_ids": ["c-plan"]}
+                ],
+            }
+        },
+    )
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        responses=[response],
+        reasoning_context=context,
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    section = reports.saved[0]["drafts"][0].sections[0]
+    assert section.claim_ids == ("c-plan",)
+    assert section.metadata["claim_id_source"] == "narrative_plan"
+    assert section.metadata["dropped_unverified_claim_ids"] == ["c-fake"]
+
+
+@pytest.mark.asyncio
+async def test_generate_keeps_verified_model_claim_ids_and_drops_invalid_near_miss() -> None:
+    response = json.dumps({
+        "title": "Title",
+        "summary": "Summary text long enough to be valid.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "drivers",
+                "title": "Drivers",
+                "body_markdown": "body",
+                "claim_ids": ["c-plan", "c-fake"],
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    context = CampaignReasoningContext(
+        canonical_reasoning={
+            "narrative_plan": {
+                "claims": [{"claim_id": "c-plan"}],
+                "sections": [
+                    {"id": "drivers", "title": "Drivers", "claim_ids": ["c-plan"]}
+                ],
+            }
+        },
+    )
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        responses=[response],
+        reasoning_context=context,
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    section = reports.saved[0]["drafts"][0].sections[0]
+    assert section.claim_ids == ("c-plan",)
+    assert section.metadata["claim_id_source"] == "model_verified"
+    assert section.metadata["dropped_unverified_claim_ids"] == ["c-fake"]
+
+
+@pytest.mark.asyncio
+async def test_generate_drops_wrong_section_model_claim_ids() -> None:
+    response = json.dumps({
+        "title": "Title",
+        "summary": "Summary text long enough to be valid.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "drivers",
+                "title": "Drivers",
+                "body_markdown": "body",
+                "claim_ids": ["c-competitive"],
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    context = CampaignReasoningContext(
+        canonical_reasoning={
+            "narrative_plan": {
+                "sections": [
+                    {"id": "drivers", "title": "Drivers", "claim_ids": ["c-drivers"]},
+                    {
+                        "id": "competitive",
+                        "title": "Competitive",
+                        "claim_ids": ["c-competitive"],
+                    },
+                ]
+            }
+        },
+    )
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        responses=[response],
+        reasoning_context=context,
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    section = reports.saved[0]["drafts"][0].sections[0]
+    assert section.claim_ids == ("c-drivers",)
+    assert section.metadata["claim_id_source"] == "narrative_plan"
+    assert section.metadata["dropped_unverified_claim_ids"] == ["c-competitive"]
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_trust_model_claim_ids_when_no_ledger_exists() -> None:
+    service, _intel, reports, _llm, _skills, _rp = _service()
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    section = reports.saved[0]["drafts"][0].sections[0]
+    assert section.claim_ids == ("findings_claim_1",)
+    assert section.metadata["claim_id_source"] == "derived_section"
+    assert section.metadata["dropped_unverified_claim_ids"] == ["c1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Report-Claim-Id-Ledger-Validation.md
Slice phase: Production hardening

PR #1403 made report section `claim_ids` non-empty for evidence-backed sections, but model-supplied IDs were still trust-based. This slice validates model-supplied `claim_ids` against the same narrative-plan section before persisting them: same-section verified IDs are tagged `model_verified`, unverified or wrong-section IDs are recorded as dropped metadata, and the existing narrative-plan / derived-section fallback remains the safe path.

## Intentional
- No prompt change is included; the existing prompt rule is now enforced in code.
- No quality-gate blocker is added; invalid IDs normalize to a safe persisted shape instead of failing generation.
- No new claim ledger product is introduced; this validates only against the same-section claim IDs in `canonical_reasoning.narrative_plan`.

## Deferred
- Full `extracted_evidence_to_story` claim-ledger wiring remains deferred.

## Parked hardening
- None.

## Verification
- Command: pytest tests/test_extracted_report_generation.py -- 33 passed.
- Command: bash scripts/run_extracted_pipeline_checks.sh -- validation/import/audit preflight passed; extracted reasoning core 295 passed; extracted content pipeline 3498 passed, 10 skipped.

## Diff size
3 files, +293 / -8
