### PR TITLE
Content-Ops MCP ChatGPT Adapter OAuth Rollout

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -13,10 +13,12 @@ on:
       - "extracted_content_pipeline/review_contract.py"
       - "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
       - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
+      - "scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
       - "tests/test_content_ops_marketer_verify_launcher_contract.py"
+      - "tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "tests/test_mcp_content_ops_marketer_verify.py"
   push:
     branches:
@@ -32,10 +34,12 @@ on:
       - "extracted_content_pipeline/review_contract.py"
       - "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
       - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
+      - "scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
       - "tests/test_content_ops_marketer_verify_launcher_contract.py"
+      - "tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "tests/test_mcp_content_ops_marketer_verify.py"
 
 jobs:
@@ -63,5 +67,6 @@ jobs:
             tests/test_atlas_content_ops_review_workflow.py \
             tests/test_check_content_ops_marketer_verify_oauth_e2e.py \
             tests/test_content_ops_marketer_verify_launcher_contract.py \
+            tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py \
             tests/test_mcp_content_ops_marketer_verify.py \
             -q

--- a/atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from dataclasses import dataclass
 from typing import Any
 
@@ -34,6 +35,12 @@ mcp = FastMCP(
     ),
     lifespan=verify_server._lifespan,
 )
+
+
+@mcp.custom_route("/oauth/approve", methods=["GET", "POST"], include_in_schema=False)
+async def _oauth_approve(request):
+    """Operator approval page for remote OAuth connectors."""
+    return await verify_server._oauth_approve(request)
 
 
 @mcp.tool(structured_output=True)
@@ -242,5 +249,52 @@ def _clean(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+def _streamable_http_app():
+    """Build the authenticated streamable HTTP app for ChatGPT adapter tools."""
+    if verify_server._http_auth_mode() == verify_server._AUTH_MODE_OAUTH:
+        verify_server._configure_oauth_auth(target_mcp=mcp)
+        return mcp.streamable_http_app()
+
+    from .auth import BearerAuthMiddleware
+
+    return BearerAuthMiddleware(
+        mcp.streamable_http_app(),
+        token=verify_server._require_http_auth_token(),
+    )
+
+
 if __name__ == "__main__":
-    mcp.run(transport="stdio")
+    if "--sse" in sys.argv:
+        import anyio
+        import uvicorn
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        from ..config import settings
+        from ..config_defaults import (
+            DEFAULT_CONTENT_OPS_MARKETER_VERIFY_PORT,
+            DEFAULT_MCP_HOST,
+        )
+
+        host = settings.mcp.host or DEFAULT_MCP_HOST
+        port = settings.mcp.content_ops_marketer_verify_port or DEFAULT_CONTENT_OPS_MARKETER_VERIFY_PORT
+
+        mcp.settings.host = host
+        mcp.settings.port = port
+        if verify_server._http_auth_mode() == verify_server._AUTH_MODE_BEARER:
+            mcp.settings.transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=False,
+            )
+
+        async def _serve():
+            config = uvicorn.Config(
+                _streamable_http_app(),
+                host=host,
+                port=port,
+                log_level="info",
+            )
+            server = uvicorn.Server(config)
+            await server.serve()
+
+        anyio.run(_serve)
+    else:
+        mcp.run(transport="stdio")

--- a/atlas_brain/mcp/content_ops_marketer_verify_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_server.py
@@ -230,7 +230,7 @@ def _require_http_auth_token() -> str:
     return token
 
 
-def _configure_oauth_auth():
+def _configure_oauth_auth(target_mcp: Any | None = None):
     """Configure FastMCP OAuth auth for remote connector clients."""
     global _oauth_provider
 
@@ -260,22 +260,21 @@ def _configure_oauth_auth():
             "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID is required in oauth "
             "mode to issue tenant-bound tokens"
         )
-    mcp.settings.transport_security = _oauth_transport_security_settings(
+    configured_mcp = target_mcp or mcp
+    configured_mcp.settings.transport_security = _oauth_transport_security_settings(
         issuer_url=issuer_url,
         resource_url=resource_url,
     )
 
-    if _oauth_provider is not None:
-        return _oauth_provider
-
-    provider = ContentOpsMarketerVerifyOAuthProvider(
-        issuer_url=issuer_url,
-        approval_token=approval_token,
-        account_id=account_id,
-        scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
-        state_file=state_file,
-    )
-    mcp.settings.auth = AuthSettings(
+    if _oauth_provider is None:
+        _oauth_provider = ContentOpsMarketerVerifyOAuthProvider(
+            issuer_url=issuer_url,
+            approval_token=approval_token,
+            account_id=account_id,
+            scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+            state_file=state_file,
+        )
+    configured_mcp.settings.auth = AuthSettings(
         issuer_url=as_any_http_url(issuer_url),
         resource_server_url=as_any_http_url(resource_url),
         required_scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
@@ -285,10 +284,9 @@ def _configure_oauth_auth():
             default_scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
         ),
     )
-    mcp._auth_server_provider = provider
-    mcp._token_verifier = ProviderTokenVerifier(provider)
-    _oauth_provider = provider
-    return provider
+    configured_mcp._auth_server_provider = _oauth_provider
+    configured_mcp._token_verifier = ProviderTokenVerifier(_oauth_provider)
+    return _oauth_provider
 
 
 def _oauth_transport_security_settings(*, issuer_url: str, resource_url: str):

--- a/plans/PR-Content-Ops-MCP-ChatGPT-Adapter-OAuth-Rollout.md
+++ b/plans/PR-Content-Ops-MCP-ChatGPT-Adapter-OAuth-Rollout.md
@@ -1,0 +1,94 @@
+# PR-Content-Ops-MCP-ChatGPT-Adapter-OAuth-Rollout
+
+## Why this slice exists
+
+#1401 landed the ChatGPT-compatible search/fetch adapter, but it is still only a local tool module. #1353 now has both halves of the dual-client decision on main: Claude rich uses the existing `verify_draft` OAuth surface, while ChatGPT proven connector mode uses the new search/fetch adapter. The remaining gap before a live dual-client rollout is making the adapter independently runnable through the same public OAuth launcher and checker path.
+
+This slice keeps the rollout deterministic and local-testable. It does not register live external clients and it does not add a durable verdict ledger. It only makes the adapter server routable in OAuth mode, gives operators a ChatGPT-specific launcher path, and pins the launcher output to the existing discovery/e2e checker contract.
+
+This PR exceeds the normal 400 LOC target because the adapter HTTP entrypoint, dedicated launcher, and offline launcher-contract tests are one production-hardening unit: without the tests, the public operator command could drift from the already-built checker profile and silently point ChatGPT at the wrong surface.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add Streamable HTTP entrypoint support to the ChatGPT adapter module so it can run as its own OAuth-protected MCP server.
+2. Reuse the existing Content Ops marketer verify OAuth provider, tenant account binding, and database lifespan instead of adding a second auth model.
+3. Add an operator launcher for the ChatGPT adapter with separate default path/port guidance and a `chatgpt-search-fetch` e2e command.
+4. Extend launcher/checker contract tests so the adapter launcher output is parsed by the existing discovery and e2e checker parsers.
+5. Enroll the new launcher coverage in the extracted pipeline wrapper and dedicated Content Ops review workflow.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-ChatGPT-Adapter-OAuth-Rollout.md`
+- `atlas_brain/mcp/content_ops_marketer_verify_server.py`
+- `atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py`
+- `scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
+- `scripts/start_content_ops_marketer_verify_oauth_server.py`
+- `tests/test_mcp_content_ops_marketer_verify.py`
+- `tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
+- `tests/test_content_ops_marketer_verify_launcher_contract.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The adapter can build its own authenticated Streamable HTTP app in OAuth mode.
+  - [ ] The adapter OAuth path reuses the verifier OAuth provider, required scope, account binding, and token verifier behavior.
+  - [ ] The adapter launcher starts the adapter module, not the rich verifier module.
+  - [ ] The adapter launcher prints discovery and e2e smoke commands whose resource URL and client profile match the ChatGPT search/fetch adapter surface.
+  - [ ] Existing Claude-rich launcher behavior remains unchanged.
+  - [ ] The Claude-rich launcher points ChatGPT rollout guidance to the dedicated adapter launcher instead of printing a stale direct ChatGPT e2e command.
+  - [ ] New tests run in the extracted pipeline wrapper and dedicated Content Ops review workflow.
+- Affected surfaces: MCP / OAuth launcher / auth configuration / public connector smoke tooling / tests / CI.
+- Risk areas: security / tenant isolation / public tool-surface compatibility / operator runbook drift / CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12
+
+## Mechanism
+
+The adapter module will expose the same HTTP serving shape as the rich verifier, but it will bind that shape to the adapter FastMCP instance. OAuth setup stays centralized in the verifier module: a small verifier helper will configure auth settings and token verification on a supplied MCP instance while continuing to use the existing provider, scope, approval token, account id, and state-file settings. The verifier's own server remains the default caller of that helper, so the rich surface behavior stays unchanged.
+
+The adapter launcher will mirror the existing marketer verify launcher with ChatGPT-specific defaults. It will still set the existing Content Ops marketer verify OAuth env keys because the provider and tenant binding are shared, but it will launch the adapter module and print the e2e command with the `chatgpt-search-fetch` profile. The launcher-contract tests parse the printed commands through the real checker parsers so command drift fails locally.
+
+## Intentional
+
+- This PR does not add a second OAuth provider namespace. The adapter is another transport over the same verify-only tenant binding, not a different product authority.
+- The launcher uses separate defaults for adapter path and port so the rich verifier and ChatGPT adapter can be run as separate processes with separate per-process env.
+- The existing e2e checker already knows the `chatgpt-search-fetch` profile; this PR wires the adapter to that checker instead of creating a duplicate checker.
+- Durable verdict/session persistence stays out of scope because #1401's process-local handoff is enough for the first public adapter smoke.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after the adapter launcher exists.
+- `PR-Content-Ops-MCP-Verdict-Session-Persistence`: replace process-local verdict handoff with tenant-scoped durable storage if live connector use needs restart-safe fetch.
+- Optional approval-page account picker remains deferred unless one long-running process must approve multiple tenant accounts.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_mcp_content_ops_marketer_verify.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py -q
+  - 58 passed in 0.67s
+- Passed: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 82 passed in 0.75s
+- Passed: python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+- Passed: git diff --check
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.69s for extracted_reasoning_core
+  - 3503 passed, 10 skipped in 59.16s for extracted_content_pipeline
+- Planned: bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_chatgpt_adapter_oauth_rollout_pr_body.md
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 94 |
+| Adapter HTTP entrypoint and shared auth helper | 88 |
+| Adapter launcher | 159 |
+| Claude-rich launcher guidance | 11 |
+| Tests | 272 |
+| CI enrollment | 6 |
+| **Total** | **630** |
+
+This is over the normal 400 LOC target for the reason named in Why this slice exists.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -105,6 +105,7 @@ pytest \
   tests/test_extracted_content_ops_execution_smoke.py \
   tests/test_atlas_content_ops_infrastructure.py \
   tests/test_atlas_content_ops_review_workflow.py \
+  tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py \
   tests/test_start_content_ops_marketer_verify_oauth_server.py \
   tests/test_content_ops_marketer_verify_launcher_contract.py \
   tests/test_check_content_ops_marketer_verify_oauth_discovery.py \

--- a/scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Start the ChatGPT Content Ops marketer verify adapter in OAuth mode."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import start_content_ops_marketer_verify_oauth_server as rich_launcher
+
+
+DEFAULT_HOST = rich_launcher.DEFAULT_HOST
+DEFAULT_PORT = "8069"
+DEFAULT_ISSUER_URL = "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer-chatgpt"
+DEFAULT_RESOURCE_URL = (
+    "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer-chatgpt/mcp"
+)
+LaunchConfig = rich_launcher.LaunchConfig
+REQUIRED_KEYS = rich_launcher.REQUIRED_KEYS
+_build_base_parser = rich_launcher._build_parser
+_funnel_app_path = rich_launcher._funnel_app_path
+_funnel_metadata_path = rich_launcher._funnel_metadata_path
+_load_dotenv_files = rich_launcher._load_dotenv_files
+_masked_env_report = rich_launcher._masked_env_report
+_read_secret_file = rich_launcher._read_secret_file
+_validate_env = rich_launcher._validate_env
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = _build_base_parser()
+    parser.description = (
+        "Load Atlas dotenv files and start the ChatGPT Content Ops marketer "
+        "verify search/fetch adapter in OAuth connector mode."
+    )
+    parser.set_defaults(port=None, issuer_url=None, resource_url=None)
+    return parser
+
+
+def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:
+    env_files = [Path(path) for path in (args.env_file or [".env", ".env.local"])]
+    env = _load_dotenv_files(env_files)
+    env.update(rich_launcher.os.environ)
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE"] = "oauth"
+    env["ATLAS_MCP_HOST"] = (args.host or env.get("ATLAS_MCP_HOST") or DEFAULT_HOST).strip()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"] = (
+        args.port or env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT") or DEFAULT_PORT
+    ).strip()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] = (
+        args.issuer_url
+        or env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL")
+        or DEFAULT_ISSUER_URL
+    ).strip()
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"] = (
+        args.resource_url
+        or env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL")
+        or DEFAULT_RESOURCE_URL
+    ).strip()
+    if args.approval_token_file:
+        env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN"] = _read_secret_file(
+            args.approval_token_file
+        )
+    return LaunchConfig(
+        env=env,
+        python=args.python,
+        host=env["ATLAS_MCP_HOST"],
+        port=env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"],
+        dry_run=args.dry_run,
+        approval_token_file=args.approval_token_file,
+    )
+
+
+def _server_command(config: LaunchConfig) -> list[str]:
+    return [
+        config.python,
+        "-m",
+        "atlas_brain.mcp.content_ops_marketer_verify_chatgpt_adapter_server",
+        "--sse",
+    ]
+
+
+def _print_operator_guidance(config: LaunchConfig) -> None:
+    issuer_url = config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"]
+    resource_url = config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"]
+    app_path = _funnel_app_path(resource_url)
+    metadata_path = _funnel_metadata_path(resource_url)
+    print("Content Ops marketer verify ChatGPT adapter OAuth launch configuration:")
+    for line in _masked_env_report(config.env):
+        print(f"- {line}")
+    print(f"- ATLAS_MCP_HOST={config.host}")
+    print(f"- ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT={config.port}")
+    print()
+    print("Required Funnel route for the ChatGPT adapter path:")
+    print("tailscale funnel --bg --yes \\")
+    if app_path == "/":
+        print(f"  http://127.0.0.1:{config.port}")
+    else:
+        print(f"  --set-path {app_path} \\")
+        print(f"  http://127.0.0.1:{config.port}")
+    print()
+    print("Required Funnel route for protected-resource metadata:")
+    print("tailscale funnel --bg --yes \\")
+    print(f"  --set-path {metadata_path} \\")
+    print(f"  http://127.0.0.1:{config.port}{metadata_path}")
+    print()
+    print("After startup, verify public discovery:")
+    print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_discovery.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url}")
+    print()
+    print("OAuth e2e smoke for ChatGPT search/fetch connector profile:")
+    print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url} \\")
+    print("  --client-profile chatgpt-search-fetch \\")
+    token_file = config.approval_token_file or "/path/to/local-approval-token"
+    print(f"  --approval-token-file {shlex.quote(token_file)}")
+    if config.approval_token_file is None:
+        print(
+            "If the approval token came from .env/--env-file, write it to a local token "
+            "file or export ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN "
+            "and pass --approval-token."
+        )
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = _build_launch_config(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    errors = _validate_env(config.env)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 2
+
+    _print_operator_guidance(config)
+    command = _server_command(config)
+    print()
+    print("Starting server:")
+    print(" ".join(command))
+    if config.dry_run:
+        print("dry-run: server not started")
+        return 0
+
+    return subprocess.call(command, env=config.env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/start_content_ops_marketer_verify_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_oauth_server.py
@@ -292,12 +292,11 @@ def _print_operator_guidance(config: LaunchConfig) -> None:
             "and pass --approval-token."
         )
     print()
-    print("After a ChatGPT search/fetch adapter exists, verify that surface with:")
-    print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_e2e.py \\")
-    print(f"  --issuer-url {issuer_url} \\")
-    print(f"  --resource-url {resource_url} \\")
-    print("  --client-profile chatgpt-search-fetch \\")
-    print("  --approval-token-file /path/to/local-approval-token")
+    print("For ChatGPT search/fetch adapter rollout, use the dedicated adapter launcher:")
+    print(
+        ".venv/bin/python scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py "
+        "--dry-run"
+    )
 
 
 def _main(argv: list[str] | None = None) -> int:

--- a/tests/test_content_ops_marketer_verify_launcher_contract.py
+++ b/tests/test_content_ops_marketer_verify_launcher_contract.py
@@ -33,12 +33,8 @@ def _load_script_module(script_name: str):
 def _valid_launcher_env(launcher) -> dict[str, str]:
     return {
         "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE": "oauth",
-        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL": (
-            "https://atlas.example.com/content-ops-marketer"
-        ),
-        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL": (
-            "https://atlas.example.com/content-ops-marketer/mcp"
-        ),
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL": launcher.DEFAULT_ISSUER_URL,
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL": launcher.DEFAULT_RESOURCE_URL,
         "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN": (
             "approval-token-with-enough-entropy"
         ),
@@ -103,8 +99,8 @@ def test_launcher_discovery_command_satisfies_discovery_checker_parser(
         ".venv/bin/python",
         "scripts/check_content_ops_marketer_verify_oauth_discovery.py",
     ]
-    assert args.issuer_url == "https://atlas.example.com/content-ops-marketer"
-    assert args.resource_url == "https://atlas.example.com/content-ops-marketer/mcp"
+    assert args.issuer_url == launcher.DEFAULT_ISSUER_URL
+    assert args.resource_url == launcher.DEFAULT_RESOURCE_URL
 
 
 def test_launcher_e2e_command_satisfies_e2e_checker_parser(
@@ -124,12 +120,14 @@ def test_launcher_e2e_command_satisfies_e2e_checker_parser(
         ".venv/bin/python",
         "scripts/check_content_ops_marketer_verify_oauth_e2e.py",
     ]
-    assert args.issuer_url == "https://atlas.example.com/content-ops-marketer"
-    assert args.resource_url == "https://atlas.example.com/content-ops-marketer/mcp"
+    assert args.issuer_url == launcher.DEFAULT_ISSUER_URL
+    assert args.resource_url == launcher.DEFAULT_RESOURCE_URL
     assert args.client_profile == "claude-rich"
     assert args.approval_token_file == "/path/to/local-approval-token"
     assert args.approval_token == ""
-    assert "chatgpt-search-fetch" in _operator_guidance(launcher)
+    assert "start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py" in (
+        _operator_guidance(launcher)
+    )
 
 
 def test_launcher_required_env_covers_server_oauth_account_binding(monkeypatch) -> None:
@@ -168,3 +166,52 @@ def test_launcher_required_env_covers_server_oauth_account_binding(monkeypatch) 
     ]
     with pytest.raises(RuntimeError, match="ACCOUNT_ID"):
         verify._configure_oauth_auth()
+
+
+def test_chatgpt_adapter_launcher_discovery_command_satisfies_checker_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_checker_env(monkeypatch)
+    launcher = _load_script_module(
+        "start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
+    )
+    discovery = _load_script_module("check_content_ops_marketer_verify_oauth_discovery.py")
+
+    command = _command_for_script(
+        _operator_guidance(launcher),
+        "scripts/check_content_ops_marketer_verify_oauth_discovery.py",
+    )
+    args = discovery._build_parser().parse_args(command[2:])
+
+    assert command[:2] == [
+        ".venv/bin/python",
+        "scripts/check_content_ops_marketer_verify_oauth_discovery.py",
+    ]
+    assert args.issuer_url == launcher.DEFAULT_ISSUER_URL
+    assert args.resource_url == launcher.DEFAULT_RESOURCE_URL
+
+
+def test_chatgpt_adapter_launcher_e2e_command_satisfies_checker_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_checker_env(monkeypatch)
+    launcher = _load_script_module(
+        "start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
+    )
+    e2e = _load_script_module("check_content_ops_marketer_verify_oauth_e2e.py")
+
+    command = _command_for_script(
+        _operator_guidance(launcher),
+        "scripts/check_content_ops_marketer_verify_oauth_e2e.py",
+    )
+    args = e2e._build_parser().parse_args(command[2:])
+
+    assert command[:2] == [
+        ".venv/bin/python",
+        "scripts/check_content_ops_marketer_verify_oauth_e2e.py",
+    ]
+    assert args.issuer_url == launcher.DEFAULT_ISSUER_URL
+    assert args.resource_url == launcher.DEFAULT_RESOURCE_URL
+    assert args.client_profile == "chatgpt-search-fetch"
+    assert args.approval_token_file == "/path/to/local-approval-token"
+    assert args.approval_token == ""

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -165,6 +165,10 @@ def _reset_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     verify.mcp.settings.transport_security = None
     verify.mcp._auth_server_provider = None
     verify.mcp._token_verifier = None
+    adapter.mcp.settings.auth = None
+    adapter.mcp.settings.transport_security = None
+    adapter.mcp._auth_server_provider = None
+    adapter.mcp._token_verifier = None
     adapter._verdict_cache.clear()
 
 
@@ -670,6 +674,62 @@ def test_content_ops_marketer_verify_oauth_mode_configures_fastmcp_auth(
     ]
     assert verify.mcp._auth_server_provider is provider
     assert verify.mcp._token_verifier.provider is provider
+
+
+def test_chatgpt_adapter_oauth_mode_configures_adapter_fastmcp_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_file = tmp_path / "content-ops-marketer-chatgpt-oauth-state.json"
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "oauth")
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_issuer_url",
+        "https://atlas.example.com/content-ops-marketer-chatgpt",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_resource_url",
+        "https://atlas.example.com/content-ops-marketer-chatgpt/mcp",
+    )
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_approval_token",
+        "approval-token-with-enough-entropy",
+    )
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_account_id", "acct-oauth")
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_state_file",
+        str(state_file),
+    )
+
+    app = adapter._streamable_http_app()
+    provider = verify._oauth_provider
+
+    assert not isinstance(app, BearerAuthMiddleware)
+    assert provider is not None
+    assert provider.account_id == "acct-oauth"
+    assert provider.scopes == [DEFAULT_CONTENT_OPS_VERIFY_SCOPE]
+    assert provider.state_file == state_file
+    assert adapter.mcp.settings.auth.required_scopes == [DEFAULT_CONTENT_OPS_VERIFY_SCOPE]
+    assert adapter.mcp._auth_server_provider is provider
+    assert adapter.mcp._token_verifier.provider is provider
+
+
+def test_chatgpt_adapter_http_wraps_with_bearer_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.mcp, "content_ops_marketer_verify_auth_mode", "bearer")
+    monkeypatch.setattr(
+        settings.mcp,
+        "auth_token",
+        "content-ops-bearer-token-with-enough-entropy",
+    )
+
+    app = adapter._streamable_http_app()
+
+    assert isinstance(app, BearerAuthMiddleware)
 
 
 def test_content_ops_marketer_verify_oauth_mode_requires_account_binding(

--- a/tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+++ b/tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "start_content_ops_marketer_verify_chatgpt_adapter_oauth_server",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "env_file": [],
+        "python": "/venv/bin/python",
+        "host": None,
+        "port": None,
+        "issuer_url": None,
+        "resource_url": None,
+        "approval_token_file": None,
+        "dry_run": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _valid_env(module):
+    return {
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE": "oauth",
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL": module.DEFAULT_ISSUER_URL,
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL": module.DEFAULT_RESOURCE_URL,
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_APPROVAL_TOKEN": (
+            "approval-token-with-enough-entropy"
+        ),
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID": "acct-content-ops-demo",
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT": module.DEFAULT_PORT,
+    }
+
+
+def test_adapter_launcher_defaults_to_chatgpt_path_and_port() -> None:
+    module = _load_script_module()
+
+    config = module._build_launch_config(_args())
+
+    assert config.port == "8069"
+    assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] == (
+        "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer-chatgpt"
+    )
+    assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"] == (
+        "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer-chatgpt/mcp"
+    )
+
+
+def test_adapter_launcher_reuses_hardened_env_validation() -> None:
+    module = _load_script_module()
+    env = _valid_env(module)
+    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID"] = " "
+
+    assert module._validate_env(env) == [
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID is required in oauth mode"
+    ]
+
+
+def test_adapter_server_command_uses_chatgpt_adapter_module() -> None:
+    module = _load_script_module()
+    config = module.LaunchConfig(
+        env=_valid_env(module),
+        python="/custom/python",
+        host="0.0.0.0",
+        port="8069",
+        dry_run=False,
+    )
+
+    assert module._server_command(config) == [
+        "/custom/python",
+        "-m",
+        "atlas_brain.mcp.content_ops_marketer_verify_chatgpt_adapter_server",
+        "--sse",
+    ]
+
+
+def test_adapter_guidance_prints_chatgpt_profile_and_masks_secrets(capsys) -> None:
+    module = _load_script_module()
+    env = _valid_env(module)
+    config = module.LaunchConfig(
+        env=env,
+        python="/venv/bin/python",
+        host="0.0.0.0",
+        port="8069",
+        dry_run=True,
+    )
+
+    module._print_operator_guidance(config)
+
+    captured = capsys.readouterr()
+    assert "ChatGPT adapter OAuth launch configuration" in captured.out
+    assert "--set-path /content-ops-marketer-chatgpt" in captured.out
+    assert "chatgpt-search-fetch" in captured.out
+    assert "claude-rich" not in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out
+    assert "SET len=34" in captured.out
+
+
+def test_adapter_main_dry_run_does_not_start_subprocess(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "content-ops-token"
+    token_file.write_text("approval-token-with-enough-entropy\n")
+    monkeypatch.setenv(
+        "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_ACCOUNT_ID",
+        "acct-content-ops-demo",
+    )
+
+    def fail_call(*_args, **_kwargs):
+        raise AssertionError("subprocess touched")
+
+    monkeypatch.setattr(module.subprocess, "call", fail_call)
+
+    result = module._main(
+        [
+            "--approval-token-file",
+            str(token_file),
+            "--dry-run",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "dry-run: server not started" in captured.out
+    assert "content_ops_marketer_verify_chatgpt_adapter_server" in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-ChatGPT-Adapter-OAuth-Rollout.md
Slice phase: Production hardening

Makes the #1401 ChatGPT search/fetch adapter independently runnable through the public OAuth rollout path. The adapter now builds its own authenticated Streamable HTTP app while reusing the existing Content Ops marketer verify OAuth provider, tenant account binding, database lifespan, and checker profile. A dedicated adapter launcher prints ChatGPT-specific Funnel/discovery/e2e commands, and the Claude-rich launcher now points ChatGPT rollout guidance to that adapter launcher.

## Intentional
- This PR does not add a second OAuth provider namespace. The adapter is another transport over the same verify-only tenant binding, not a different product authority.
- The launcher uses separate defaults for adapter path and port so the rich verifier and ChatGPT adapter can be run as separate processes with separate per-process env.
- The existing e2e checker already knows the `chatgpt-search-fetch` profile; this PR wires the adapter to that checker instead of creating a duplicate checker.
- Durable verdict/session persistence stays out of scope because #1401's process-local handoff is enough for the first public adapter smoke.

## Deferred
- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after the adapter launcher exists.
- `PR-Content-Ops-MCP-Verdict-Session-Persistence`: replace process-local verdict handoff with tenant-scoped durable storage if live connector use needs restart-safe fetch.
- Optional approval-page account picker remains deferred unless one long-running process must approve multiple tenant accounts.

## Parked hardening
- None.

## Verification
- Passed: `python -m pytest tests/test_mcp_content_ops_marketer_verify.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py -q`
  - 58 passed in 0.67s
- Passed: `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q`
  - 82 passed in 0.75s
- Passed: `python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
- Passed: `git diff --check`
- Passed: `bash scripts/run_extracted_pipeline_checks.sh`
  - 295 passed in 1.69s for extracted_reasoning_core
  - 3503 passed, 10 skipped in 59.16s for extracted_content_pipeline
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_chatgpt_adapter_oauth_rollout_pr_body.md`
  - local PR review passed

## Diff size
10 files, +595 / -35