### PR TITLE
Content-Ops MCP ChatGPT Adapter Port Env

### DIFF
--- a/plans/PR-Content-Ops-MCP-ChatGPT-Adapter-Port-Env.md
+++ b/plans/PR-Content-Ops-MCP-ChatGPT-Adapter-Port-Env.md
@@ -1,0 +1,73 @@
+# PR-Content-Ops-MCP-ChatGPT-Adapter-Port-Env
+
+## Why this slice exists
+
+#1405 merged the public OAuth launcher path for the ChatGPT search/fetch adapter. Review left one non-blocking but real launcher hardening issue: the adapter launcher loads `.env` and currently lets the rich verifier's shared `ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT=8068` override the adapter's documented `8069` default. That can make the rich verifier and adapter collide when an operator uses one shared dotenv file.
+
+This slice closes that follow-up before live dual-client connector smokes. It gives the adapter launcher a dedicated port env key while still passing the resolved value through the existing runtime port key expected by the MCP module.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add a launcher-only ChatGPT adapter port env key for `scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`.
+2. Make the adapter launcher prefer CLI `--port`, then the dedicated adapter port env, then the adapter default, ignoring the rich verifier port env for adapter defaulting.
+3. Keep the launched process compatible with the existing runtime config by writing the resolved adapter port to the shared runtime port env.
+4. Add regression tests for shared dotenv collision, dedicated env override, and CLI override precedence.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-ChatGPT-Adapter-Port-Env.md`
+- `scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
+- `tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A shared dotenv containing the rich verifier port does not change the adapter launcher's default port.
+  - [ ] The dedicated adapter port env can set the adapter launcher port.
+  - [ ] Explicit `--port` still wins over both env keys.
+  - [ ] The launched subprocess still receives `ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT` with the resolved adapter port.
+  - [ ] Existing adapter launcher validation and smoke guidance remain unchanged.
+- Affected surfaces: MCP launcher / operator rollout defaults / tests.
+- Risk areas: public connector rollout / operator runbook drift / CI enrollment.
+- Reviewer rules triggered: R1, R2, R5, R12
+
+## Mechanism
+
+The adapter launcher will define a dedicated env key for its port, then normalize that into the existing runtime env key after dotenv and process env are loaded. The MCP server module does not need a new settings field because the launcher is the process boundary: the adapter subprocess already reads the shared runtime port key through existing Atlas settings.
+
+## Intentional
+
+- This PR does not add a new Atlas settings field. The dedicated key is launcher-only and exists to resolve operator defaults before process start.
+- Directly running the adapter module with `--sse` still uses the existing runtime port setting. The supported public rollout path is the launcher.
+- This PR does not change issuer/resource URL env names; those are shared intentionally because both surfaces use the same verify-only OAuth provider semantics.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after launcher hardening.
+- Durable verdict/session persistence remains deferred unless live connector use needs restart-safe fetch.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_content_ops_marketer_verify_launcher_contract.py -q
+  - 13 passed in 0.47s
+- Passed: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 85 passed in 0.75s
+- Passed: python -m py_compile scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+- Passed: git diff --check
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.68s for extracted_reasoning_core
+  - 3510 passed, 10 skipped in 59.13s for extracted_content_pipeline
+- Planned: bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_chatgpt_adapter_port_env_pr_body.md
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 73 |
+| Launcher | 13 |
+| Tests | 48 |
+| **Total** | **134** |

--- a/scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
@@ -18,6 +18,8 @@ import start_content_ops_marketer_verify_oauth_server as rich_launcher
 
 DEFAULT_HOST = rich_launcher.DEFAULT_HOST
 DEFAULT_PORT = "8069"
+ADAPTER_PORT_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_CHATGPT_PORT"
+RUNTIME_PORT_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"
 DEFAULT_ISSUER_URL = "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer-chatgpt"
 DEFAULT_RESOURCE_URL = (
     "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer-chatgpt/mcp"
@@ -49,9 +51,9 @@ def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:
     env.update(rich_launcher.os.environ)
     env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_AUTH_MODE"] = "oauth"
     env["ATLAS_MCP_HOST"] = (args.host or env.get("ATLAS_MCP_HOST") or DEFAULT_HOST).strip()
-    env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"] = (
-        args.port or env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT") or DEFAULT_PORT
-    ).strip()
+    resolved_port = (args.port or env.get(ADAPTER_PORT_ENV) or DEFAULT_PORT).strip()
+    env[ADAPTER_PORT_ENV] = resolved_port
+    env[RUNTIME_PORT_ENV] = resolved_port
     env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] = (
         args.issuer_url
         or env.get("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL")
@@ -70,7 +72,7 @@ def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:
         env=env,
         python=args.python,
         host=env["ATLAS_MCP_HOST"],
-        port=env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT"],
+        port=env[RUNTIME_PORT_ENV],
         dry_run=args.dry_run,
         approval_token_file=args.approval_token_file,
     )
@@ -94,7 +96,8 @@ def _print_operator_guidance(config: LaunchConfig) -> None:
     for line in _masked_env_report(config.env):
         print(f"- {line}")
     print(f"- ATLAS_MCP_HOST={config.host}")
-    print(f"- ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT={config.port}")
+    print(f"- {ADAPTER_PORT_ENV}={config.port}")
+    print(f"- {RUNTIME_PORT_ENV}={config.port}")
     print()
     print("Required Funnel route for the ChatGPT adapter path:")
     print("tailscale funnel --bg --yes \\")

--- a/tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+++ b/tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
@@ -56,12 +56,58 @@ def test_adapter_launcher_defaults_to_chatgpt_path_and_port() -> None:
     config = module._build_launch_config(_args())
 
     assert config.port == "8069"
+    assert config.env[module.ADAPTER_PORT_ENV] == "8069"
+    assert config.env[module.RUNTIME_PORT_ENV] == "8069"
     assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"] == (
         "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer-chatgpt"
     )
     assert config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"] == (
         "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer-chatgpt/mcp"
     )
+
+
+def test_adapter_launcher_ignores_rich_port_from_shared_dotenv(tmp_path) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text("ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT=8068\n")
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)]))
+
+    assert config.port == "8069"
+    assert config.env[module.ADAPTER_PORT_ENV] == "8069"
+    assert config.env[module.RUNTIME_PORT_ENV] == "8069"
+
+
+def test_adapter_launcher_accepts_dedicated_adapter_port_env(tmp_path) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT=8068",
+                f"{module.ADAPTER_PORT_ENV}=8070",
+            ]
+        )
+        + "\n"
+    )
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)]))
+
+    assert config.port == "8070"
+    assert config.env[module.ADAPTER_PORT_ENV] == "8070"
+    assert config.env[module.RUNTIME_PORT_ENV] == "8070"
+
+
+def test_adapter_launcher_cli_port_overrides_dedicated_env(tmp_path) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{module.ADAPTER_PORT_ENV}=8070\n")
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)], port="8071"))
+
+    assert config.port == "8071"
+    assert config.env[module.ADAPTER_PORT_ENV] == "8071"
+    assert config.env[module.RUNTIME_PORT_ENV] == "8071"
 
 
 def test_adapter_launcher_reuses_hardened_env_validation() -> None:
@@ -108,6 +154,8 @@ def test_adapter_guidance_prints_chatgpt_profile_and_masks_secrets(capsys) -> No
     captured = capsys.readouterr()
     assert "ChatGPT adapter OAuth launch configuration" in captured.out
     assert "--set-path /content-ops-marketer-chatgpt" in captured.out
+    assert f"{module.ADAPTER_PORT_ENV}=8069" in captured.out
+    assert f"{module.RUNTIME_PORT_ENV}=8069" in captured.out
     assert "chatgpt-search-fetch" in captured.out
     assert "claude-rich" not in captured.out
     assert "approval-token-with-enough-entropy" not in captured.out


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-ChatGPT-Adapter-Port-Env.md
Slice phase: Production hardening

Closes the #1405 review NIT before live dual-client connector smokes: the ChatGPT adapter launcher now has a dedicated launcher-only port env key, `ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_CHATGPT_PORT`, so a shared `.env` with the rich verifier's `ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT=8068` no longer overrides the adapter's 8069 default. The launcher still writes the resolved adapter port into the existing runtime port env before starting the subprocess.

## Intentional
- This PR does not add a new Atlas settings field. The dedicated key is launcher-only and exists to resolve operator defaults before process start.
- Directly running the adapter module with `--sse` still uses the existing runtime port setting. The supported public rollout path is the launcher.
- This PR does not change issuer/resource URL env names; those are shared intentionally because both surfaces use the same verify-only OAuth provider semantics.

## Deferred
- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after launcher hardening.
- Durable verdict/session persistence remains deferred unless live connector use needs restart-safe fetch.

## Parked hardening
- None.

## Verification
- Passed: `python -m pytest tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_content_ops_marketer_verify_launcher_contract.py -q`
  - 13 passed in 0.47s
- Passed: `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q`
  - 85 passed in 0.75s
- Passed: `python -m py_compile scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
- Passed: `git diff --check`
- Passed: `bash scripts/run_extracted_pipeline_checks.sh`
  - 295 passed in 1.68s for extracted_reasoning_core
  - 3510 passed, 10 skipped in 59.13s for extracted_content_pipeline
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_chatgpt_adapter_port_env_pr_body.md`
  - local PR review passed

## Diff size
3 files, +129 / -5