### PR TITLE
Content-Ops MCP ChatGPT Adapter Help Text

### DIFF
--- a/plans/PR-Content-Ops-MCP-ChatGPT-Adapter-Help-Text.md
+++ b/plans/PR-Content-Ops-MCP-ChatGPT-Adapter-Help-Text.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-MCP-ChatGPT-Adapter-Help-Text
+
+## Why this slice exists
+
+#1407 fixed the ChatGPT adapter launcher's port resolution, but review caught one remaining operator-facing drift: `--help` still inherited rich-verifier help text for port, issuer URL, and resource URL defaults. The runtime now uses the adapter port env/default and adapter OAuth paths, so stale help can send operators to env keys that no longer control the adapter launcher.
+
+This slice fixes the documentation at the executable boundary before live dual-client connector smokes.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Override the ChatGPT adapter launcher's inherited help text for `--port`, `--issuer-url`, and `--resource-url`.
+2. Add regression coverage that `--help` names the adapter port env/default and adapter OAuth defaults, not the rich verifier values.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-ChatGPT-Adapter-Help-Text.md`
+- `scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
+- `tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Adapter launcher `--help` names `ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_CHATGPT_PORT`.
+  - [ ] Adapter launcher `--help` names the 8069 adapter default.
+  - [ ] Adapter launcher `--help` names the ChatGPT adapter issuer/resource defaults.
+  - [ ] Adapter launcher `--help` no longer describes the rich verifier port env/default as the adapter override path.
+  - [ ] Runtime port resolution behavior from #1407 remains unchanged.
+- Affected surfaces: MCP launcher / operator runbook defaults / tests.
+- Risk areas: public connector rollout / operator runbook drift.
+- Reviewer rules triggered: R1, R2, R5, R12
+
+## Mechanism
+
+The adapter launcher already reuses the rich verifier parser for common arguments. After constructing that parser, this slice rewrites the help strings for the adapter-specific defaults while leaving argument names and parsing behavior unchanged. The test exercises the real parser's formatted help output.
+
+## Intentional
+
+- This PR changes help text only; it does not change launch-time env precedence.
+- The adapter launcher continues to reuse the rich verifier parser and validation helpers for shared security behavior.
+- No new CI enrollment is needed because the touched test file is already enrolled in the extracted wrapper and dedicated Content Ops workflow.
+
+## Deferred
+
+- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after this help-text drift is closed.
+- Durable verdict/session persistence remains deferred unless live connector use needs restart-safe fetch.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_content_ops_marketer_verify_launcher_contract.py -q
+  - 14 passed in 0.46s
+- Passed: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 86 passed in 0.72s
+- Passed: python -m py_compile scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+- Passed: git diff --check
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.69s for extracted_reasoning_core
+  - 3511 passed, 10 skipped in 57.52s for extracted_content_pipeline
+- Planned: bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_chatgpt_adapter_help_text_pr_body.md
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 71 |
+| Launcher | 23 |
+| Tests | 13 |
+| **Total** | **107** |

--- a/scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
@@ -42,7 +42,30 @@ def _build_parser() -> argparse.ArgumentParser:
         "verify search/fetch adapter in OAuth connector mode."
     )
     parser.set_defaults(port=None, issuer_url=None, resource_url=None)
+    _set_option_help(
+        parser,
+        "--port",
+        f"Bind port. Defaults to env {ADAPTER_PORT_ENV} or {DEFAULT_PORT}.",
+    )
+    _set_option_help(
+        parser,
+        "--issuer-url",
+        f"OAuth issuer URL. Defaults to env value or {DEFAULT_ISSUER_URL}.",
+    )
+    _set_option_help(
+        parser,
+        "--resource-url",
+        f"OAuth resource URL. Defaults to env value or {DEFAULT_RESOURCE_URL}.",
+    )
     return parser
+
+
+def _set_option_help(parser: argparse.ArgumentParser, option: str, help_text: str) -> None:
+    for action in parser._actions:
+        if option in action.option_strings:
+            action.help = help_text
+            return
+    raise RuntimeError(f"adapter launcher parser missing {option}")
 
 
 def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:

--- a/tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
+++ b/tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py
@@ -110,6 +110,19 @@ def test_adapter_launcher_cli_port_overrides_dedicated_env(tmp_path) -> None:
     assert config.env[module.RUNTIME_PORT_ENV] == "8071"
 
 
+def test_adapter_launcher_help_names_adapter_defaults() -> None:
+    module = _load_script_module()
+
+    help_text = module._build_parser().format_help()
+
+    assert module.ADAPTER_PORT_ENV in help_text
+    assert "8069" in help_text
+    assert "marketer-chatgpt" in help_text
+    assert "marketer-chatgpt/mcp" in help_text
+    assert "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_PORT or 8068" not in help_text
+    assert "marketer/mcp" not in help_text
+
+
 def test_adapter_launcher_reuses_hardened_env_validation() -> None:
     module = _load_script_module()
     env = _valid_env(module)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-ChatGPT-Adapter-Help-Text.md
Slice phase: Production hardening

Fixes the #1407 review NIT at the operator boundary: the ChatGPT adapter launcher now rewrites inherited `--help` text for `--port`, `--issuer-url`, and `--resource-url` so the parser documents the adapter port env/default and adapter OAuth paths instead of rich-verifier defaults.

## Intentional
- This PR changes help text only; it does not change launch-time env precedence.
- The adapter launcher continues to reuse the rich verifier parser and validation helpers for shared security behavior.
- No new CI enrollment is needed because the touched test file is already enrolled in the extracted wrapper and dedicated Content Ops workflow.

## Deferred
- `PR-Content-Ops-MCP-Live-Dual-Client-Rollout`: run public OAuth smokes against real Claude and ChatGPT connector registrations after this help-text drift is closed.
- Durable verdict/session persistence remains deferred unless live connector use needs restart-safe fetch.

## Parked hardening
- None.

## Verification
- Passed: `python -m pytest tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_content_ops_marketer_verify_launcher_contract.py -q`
  - 14 passed in 0.46s
- Passed: `python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q`
  - 86 passed in 0.72s
- Passed: `python -m py_compile scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`
- Passed: `git diff --check`
- Passed: `bash scripts/run_extracted_pipeline_checks.sh`
  - 295 passed in 1.69s for extracted_reasoning_core
  - 3511 passed, 10 skipped in 57.52s for extracted_content_pipeline
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_chatgpt_adapter_help_text_pr_body.md`
  - local PR review passed

## Diff size
3 files, +107 / -0