### PR TITLE
Deflection raw CSV cluster preview

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1865,6 +1865,8 @@ def _with_deflection_submit_diagnostics(
                 "included_row_count",
                 "skipped_row_count",
                 "source_period",
+                "top_ticket_clusters",
+                "cluster_quality",
             )
             if key in package_metadata
         })

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -304,6 +304,9 @@
       "target": "extracted_content_pipeline/campaign_source_adapters.py"
     },
     {
+      "target": "extracted_content_pipeline/support_ticket_clustering.py"
+    },
+    {
       "target": "extracted_content_pipeline/ticket_faq_markdown.py"
     },
     {

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -1,0 +1,609 @@
+"""Deterministic clustering helpers for support-ticket source rows."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from html import unescape
+from html.parser import HTMLParser
+import re
+from typing import Any
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_HTML_SIGNAL_RE = re.compile(
+    r"</?(?:p|br|div|span|ul|ol|li|table|tr|td|th|strong|em|b|i|a|blockquote|pre|code|html|body)\b",
+    re.IGNORECASE,
+)
+_TAG_FALLBACK_RE = re.compile(r"</?[^>]+>")
+_COMPACT_KEY_RE = re.compile(r"[^a-z0-9]+")
+_PHRASE_FOLDS = (
+    (re.compile(r"\blog\s+in\b", re.IGNORECASE), "login"),
+    (re.compile(r"\bsign\s+in\b", re.IGNORECASE), "login"),
+    (re.compile(r"\bsingle[-\s]?sign[-\s]?on\b", re.IGNORECASE), "sso"),
+    (re.compile(r"\bsingle\s+sign\s+on\b", re.IGNORECASE), "sso"),
+    (re.compile(r"\be[-\s]?mail\b", re.IGNORECASE), "email"),
+    (re.compile(r"\btwo[-\s]?factor\b", re.IGNORECASE), "2fa"),
+)
+_STOPWORDS = {
+    "a",
+    "able",
+    "account",
+    "about",
+    "again",
+    "agent",
+    "after",
+    "all",
+    "an",
+    "and",
+    "any",
+    "are",
+    "as",
+    "at",
+    "be",
+    "been",
+    "before",
+    "but",
+    "by",
+    "can",
+    "cannot",
+    "cant",
+    "case",
+    "client",
+    "could",
+    "customer",
+    "do",
+    "does",
+    "doing",
+    "done",
+    "find",
+    "for",
+    "from",
+    "get",
+    "getting",
+    "got",
+    "had",
+    "has",
+    "have",
+    "having",
+    "hello",
+    "help",
+    "hi",
+    "how",
+    "i",
+    "in",
+    "into",
+    "is",
+    "it",
+    "its",
+    "me",
+    "my",
+    "need",
+    "needs",
+    "not",
+    "of",
+    "on",
+    "or",
+    "our",
+    "page",
+    "please",
+    "problem",
+    "question",
+    "request",
+    "screen",
+    "support",
+    "team",
+    "thanks",
+    "thank",
+    "that",
+    "the",
+    "their",
+    "there",
+    "this",
+    "ticket",
+    "to",
+    "try",
+    "trying",
+    "unable",
+    "use",
+    "using",
+    "we",
+    "what",
+    "when",
+    "where",
+    "why",
+    "will",
+    "with",
+    "work",
+    "working",
+    "works",
+    "would",
+    "you",
+}
+_TOKEN_FOLDS = {
+    "address": "",
+    "automate": "automation",
+    "automated": "automation",
+    "automating": "automation",
+    "billed": "billing",
+    "bill": "billing",
+    "bills": "billing",
+    "charge": "billing",
+    "charged": "billing",
+    "charges": "billing",
+    "cancellation": "cancel",
+    "cancelled": "cancel",
+    "cancelling": "cancel",
+    "cancels": "cancel",
+    "chart": "dashboard",
+    "charts": "dashboard",
+    "change": "update",
+    "changed": "update",
+    "changing": "update",
+    "credential": "login",
+    "credentials": "login",
+    "download": "export",
+    "downloaded": "export",
+    "downloading": "export",
+    "downloads": "export",
+    "edit": "update",
+    "edited": "update",
+    "editing": "update",
+    "exported": "export",
+    "exporting": "export",
+    "exports": "export",
+    "invitation": "invite",
+    "invitations": "invite",
+    "invoices": "invoice",
+    "integrations": "api",
+    "integration": "api",
+    "modifying": "update",
+    "modify": "update",
+    "modified": "update",
+    "payments": "payment",
+    "pwd": "password",
+    "reporting": "report",
+    "reports": "report",
+    "renew": "renewal",
+    "renewed": "renewal",
+    "renewing": "renewal",
+    "renews": "renewal",
+    "resetting": "reset",
+    "resets": "reset",
+    "signin": "login",
+    "signins": "login",
+    "saml": "sso",
+    "updated": "update",
+    "updating": "update",
+    "webhook": "api",
+    "webhooks": "api",
+}
+_SINGLE_TOKEN_CLUSTER_LABELS = {
+    "billing",
+    "cancel",
+    "email",
+    "export",
+    "api",
+    "invite",
+    "invoice",
+    "login",
+    "password",
+    "payment",
+    "refund",
+    "subscription",
+}
+_LOW_SIGNAL_ANCHOR_TOKENS = {
+    "arrive",
+    "broken",
+    "error",
+    "failed",
+    "failure",
+    "missing",
+    "never",
+    "new",
+    "out",
+    "report",
+    "return",
+    "same",
+    "update",
+}
+_EXPLICIT_LABEL_KEYS = ("pain_category", "category", "intent", "topic")
+_TEXT_KEYS = (
+    "source_title",
+    "title",
+    "subject",
+    "ticket_subject",
+    "question",
+    "text",
+    "description",
+    "message",
+    "body",
+    "content",
+    "summary",
+)
+
+
+@dataclass(frozen=True)
+class SupportTicketClusterHint:
+    """Stable row-level cluster hint."""
+
+    key: str
+    label: str
+    source: str
+    tokens: frozenset[str] = frozenset()
+
+
+@dataclass
+class _ClusterBucket:
+    key: str
+    label: str
+    source: str
+    count: int = 0
+    token_sets: list[frozenset[str]] = field(default_factory=list)
+    token_counts: Counter[str] = field(default_factory=Counter)
+
+
+class _HTMLTextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del attrs
+        lowered = tag.lower()
+        if lowered in {"script", "style"}:
+            self._skip_depth += 1
+        if lowered in {"br", "p", "div", "li", "tr", "td", "th"}:
+            self.parts.append(" ")
+
+    def handle_endtag(self, tag: str) -> None:
+        lowered = tag.lower()
+        if lowered in {"script", "style"} and self._skip_depth:
+            self._skip_depth -= 1
+        if lowered in {"p", "div", "li", "tr", "td", "th"}:
+            self.parts.append(" ")
+
+    def handle_data(self, data: str) -> None:
+        if not self._skip_depth:
+            self.parts.append(data)
+
+
+def support_ticket_plain_text(value: Any) -> str:
+    """Return compact readable text from plain or common HTML ticket bodies."""
+
+    raw = str(value or "")
+    if not raw.strip():
+        return ""
+    text = unescape(raw)
+    if not _HTML_SIGNAL_RE.search(text):
+        return _compact(text)
+    parser = _HTMLTextExtractor()
+    try:
+        parser.feed(text)
+        parser.close()
+        parsed = "".join(parser.parts)
+    except Exception:
+        parsed = _TAG_FALLBACK_RE.sub(" ", text)
+    return _compact(parsed)
+
+
+def support_ticket_tokens(value: Any) -> frozenset[str]:
+    text = support_ticket_plain_text(value).lower()
+    for pattern, replacement in _PHRASE_FOLDS:
+        text = pattern.sub(replacement, text)
+    tokens: set[str] = set()
+    for raw in _TOKEN_RE.findall(text):
+        token = _TOKEN_FOLDS.get(raw, raw)
+        if not token:
+            continue
+        if token in _STOPWORDS:
+            continue
+        if token.endswith("s") and len(token) > 3 and not token.endswith("ss"):
+            token = token[:-1]
+        token = _TOKEN_FOLDS.get(token, token)
+        if not token or token in _STOPWORDS or len(token) < 2:
+            continue
+        tokens.add(token)
+    return frozenset(tokens)
+
+
+def support_ticket_cluster_hint(row: Mapping[str, Any]) -> SupportTicketClusterHint | None:
+    """Derive a deterministic cluster hint for one support-ticket row."""
+
+    existing = support_ticket_plain_text(row.get("support_ticket_cluster"))
+    if existing:
+        key = support_ticket_plain_text(row.get("support_ticket_cluster_key"))
+        return SupportTicketClusterHint(
+            key=key or f"cluster:{_compact_key(existing)}",
+            label=existing,
+            source=support_ticket_plain_text(row.get("support_ticket_cluster_source")) or "provided",
+        )
+
+    explicit = _first_text(row, _EXPLICIT_LABEL_KEYS)
+    if explicit:
+        return SupportTicketClusterHint(
+            key=f"explicit:{_compact_key(explicit)}",
+            label=explicit,
+            source="explicit",
+        )
+
+    tokens = _row_tokens(row)
+    if len(tokens) < 2:
+        if len(tokens) == 1:
+            token = next(iter(tokens))
+            if token in _SINGLE_TOKEN_CLUSTER_LABELS:
+                return SupportTicketClusterHint(
+                    key=f"keyword:{_compact_key(token)}",
+                    label=token,
+                    source="keyword",
+                    tokens=tokens,
+                )
+        return None
+    label = _label_from_tokens(tokens)
+    return SupportTicketClusterHint(
+        key=f"tokens:{_compact_key(label)}",
+        label=label,
+        source="token_set",
+        tokens=tokens,
+    )
+
+
+def assign_support_ticket_clusters(
+    rows: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    """Return rows annotated with stable deterministic support-ticket clusters."""
+
+    buckets: list[_ClusterBucket] = []
+    assignments: list[_ClusterBucket | None] = []
+    hints = tuple(support_ticket_cluster_hint(row) for row in rows)
+    token_row_counts = _token_row_counts(hints)
+
+    for hint in hints:
+        if hint is None:
+            assignments.append(None)
+            continue
+        bucket = _bucket_for_hint(
+            buckets,
+            hint,
+            token_row_counts=token_row_counts,
+        )
+        bucket.count += 1
+        if hint.tokens:
+            bucket.token_sets.append(hint.tokens)
+            bucket.token_counts.update(hint.tokens)
+        assignments.append(bucket)
+
+    out: list[dict[str, Any]] = []
+    for row, bucket in zip(rows, assignments, strict=False):
+        next_row = dict(row)
+        if bucket is not None:
+            label = _bucket_label(bucket)
+            next_row["support_ticket_cluster"] = label
+            next_row["support_ticket_cluster_key"] = _bucket_key(bucket, label)
+            next_row["support_ticket_cluster_source"] = bucket.source
+        out.append(next_row)
+    return tuple(out)
+
+
+def support_ticket_cluster_summary(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    limit: int = 12,
+) -> list[dict[str, Any]]:
+    """Return bounded top-cluster counts for preview/diagnostics output."""
+
+    annotated = _ensure_clustered(rows)
+    counts: Counter[str] = Counter()
+    labels: dict[str, str] = {}
+    uncategorized_count = 0
+    for row in annotated:
+        label = support_ticket_plain_text(row.get("support_ticket_cluster"))
+        if not label:
+            uncategorized_count += 1
+            continue
+        key = support_ticket_plain_text(row.get("support_ticket_cluster_key")) or label.lower()
+        labels.setdefault(key, label)
+        counts[key] += 1
+
+    clusters = [
+        {"label": labels[key], "count": count}
+        for key, count in counts.most_common(max(1, limit))
+    ]
+    shown_count = sum(int(item["count"]) for item in clusters)
+    remaining_count = sum(counts.values()) - shown_count
+    if remaining_count > 0:
+        clusters.append({"label": "remaining", "count": remaining_count})
+    if uncategorized_count > 0:
+        clusters.append({"label": "uncategorized", "count": uncategorized_count})
+    return clusters
+
+
+def support_ticket_cluster_quality(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    """Return compact quality counters for pre-check diagnostics."""
+
+    annotated = _ensure_clustered(rows)
+    counts: Counter[str] = Counter()
+    uncategorized_count = 0
+    for row in annotated:
+        label = support_ticket_plain_text(row.get("support_ticket_cluster"))
+        if not label:
+            uncategorized_count += 1
+            continue
+        key = support_ticket_plain_text(row.get("support_ticket_cluster_key")) or label.lower()
+        counts[key] += 1
+    cluster_counts = tuple(counts.values())
+    return {
+        "clustered_row_count": sum(cluster_counts),
+        "uncategorized_row_count": uncategorized_count,
+        "cluster_count": len(cluster_counts),
+        "singleton_cluster_count": sum(1 for count in cluster_counts if count == 1),
+        "largest_cluster_count": max(cluster_counts, default=0),
+    }
+
+
+def _ensure_clustered(rows: Sequence[Mapping[str, Any]]) -> tuple[dict[str, Any], ...]:
+    if any(support_ticket_plain_text(row.get("support_ticket_cluster")) for row in rows):
+        return tuple(dict(row) for row in rows)
+    return assign_support_ticket_clusters(rows)
+
+
+def _bucket_for_hint(
+    buckets: list[_ClusterBucket],
+    hint: SupportTicketClusterHint,
+    *,
+    token_row_counts: Counter[str],
+) -> _ClusterBucket:
+    if hint.source != "token_set":
+        for bucket in buckets:
+            if bucket.key == hint.key:
+                return bucket
+        bucket = _ClusterBucket(key=hint.key, label=hint.label, source=hint.source)
+        buckets.append(bucket)
+        return bucket
+
+    match = _matching_token_bucket(
+        buckets,
+        hint.tokens,
+        token_row_counts=token_row_counts,
+    )
+    if match is not None:
+        bucket, anchor = match
+        if anchor:
+            bucket.key = f"anchor:{_compact_key(anchor)}"
+            bucket.label = anchor
+            bucket.source = "token_anchor"
+        return bucket
+    bucket = _ClusterBucket(key=hint.key, label=hint.label, source=hint.source)
+    buckets.append(bucket)
+    return bucket
+
+
+def _matching_token_bucket(
+    buckets: Sequence[_ClusterBucket],
+    tokens: frozenset[str],
+    *,
+    token_row_counts: Counter[str],
+) -> tuple[_ClusterBucket, str] | None:
+    best_overlap: tuple[float, int, _ClusterBucket] | None = None
+    best_anchor: tuple[int, int, str, _ClusterBucket] | None = None
+    for bucket in buckets:
+        if bucket.source not in {"token_set", "token_anchor"}:
+            continue
+        for existing in bucket.token_sets:
+            common = len(tokens & existing)
+            if common >= 2:
+                overlap = common / max(1, min(len(tokens), len(existing)))
+                if overlap >= 0.6:
+                    score = (overlap, common, bucket)
+                    if best_overlap is None or score[:2] > best_overlap[:2]:
+                        best_overlap = score
+                    continue
+            anchor = _shared_anchor(tokens & existing, token_row_counts)
+            if anchor:
+                score = (-token_row_counts[anchor], -len(anchor), anchor, bucket)
+                if best_anchor is None or score[:3] < best_anchor[:3]:
+                    best_anchor = score
+    if best_overlap is not None:
+        return best_overlap[2], ""
+    if best_anchor is not None:
+        return best_anchor[3], best_anchor[2]
+    return None
+
+
+def _bucket_label(bucket: _ClusterBucket) -> str:
+    if bucket.source == "token_anchor":
+        return bucket.label
+    if bucket.source != "token_set" or not bucket.token_counts:
+        return bucket.label
+    return _label_from_counter(bucket.token_counts)
+
+
+def _bucket_key(bucket: _ClusterBucket, label: str) -> str:
+    if bucket.source == "token_set":
+        return f"tokens:{_compact_key(label)}"
+    return bucket.key
+
+
+def _row_tokens(row: Mapping[str, Any]) -> frozenset[str]:
+    parts: list[str] = []
+    for key in _TEXT_KEYS:
+        value = support_ticket_plain_text(row.get(key))
+        if value:
+            parts.append(value)
+    source_id = support_ticket_plain_text(row.get("source_id"))
+    source_title = support_ticket_plain_text(row.get("source_title"))
+    if source_title and source_title != source_id:
+        parts.append(source_title)
+    return support_ticket_tokens(" ".join(part for part in parts if part))
+
+
+def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = support_ticket_plain_text(row.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _label_from_tokens(tokens: frozenset[str]) -> str:
+    return " ".join(sorted(tokens)[:4])
+
+
+def _label_from_counter(counts: Counter[str]) -> str:
+    selected = [
+        token
+        for token, _count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:4]
+    ]
+    return " ".join(sorted(selected))
+
+
+def _shared_anchor(tokens: frozenset[str], token_row_counts: Counter[str]) -> str:
+    candidates = [
+        token
+        for token in tokens
+        if _is_anchor_candidate(token, token_row_counts)
+    ]
+    if not candidates:
+        return ""
+    return min(candidates, key=lambda token: (-token_row_counts[token], -len(token), token))
+
+
+def _is_anchor_candidate(token: str, token_row_counts: Counter[str]) -> bool:
+    return (
+        token_row_counts[token] >= 2
+        and token not in _LOW_SIGNAL_ANCHOR_TOKENS
+        and not token.isdigit()
+    )
+
+
+def _token_row_counts(
+    hints: Sequence[SupportTicketClusterHint | None],
+) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for hint in hints:
+        if hint is None or hint.source != "token_set":
+            continue
+        counts.update(hint.tokens)
+    return counts
+
+
+def _compact(value: Any) -> str:
+    return _WHITESPACE_RE.sub(" ", str(value or "")).strip()
+
+
+def _compact_key(value: Any) -> str:
+    return _COMPACT_KEY_RE.sub("-", support_ticket_plain_text(value).lower()).strip("-")
+
+
+__all__ = [
+    "SupportTicketClusterHint",
+    "assign_support_ticket_clusters",
+    "support_ticket_cluster_hint",
+    "support_ticket_cluster_quality",
+    "support_ticket_cluster_summary",
+    "support_ticket_plain_text",
+    "support_ticket_tokens",
+]

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -9,13 +9,18 @@ the existing FAQ, landing-page, and blog planners already understand.
 from __future__ import annotations
 
 import re
-from collections import Counter
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime
 from typing import Any
 
 from .campaign_source_adapters import source_material_to_source_rows
 from .content_ops_input_provider import ContentOpsInputPackage
+from .support_ticket_clustering import (
+    assign_support_ticket_clusters,
+    support_ticket_cluster_quality,
+    support_ticket_cluster_summary,
+    support_ticket_plain_text,
+)
 from .support_ticket_context_contract import (
     SUPPORT_TICKET_DEFAULT_TOPIC,
     UPLOADED_SUPPORT_TICKETS_SOURCE_PERIOD,
@@ -207,6 +212,7 @@ def build_support_ticket_input_package(
         })
     skipped_row_count = len(raw_rows[:max_rows]) - len(normalized_rows)
     truncated_row_count = max(0, len(raw_rows) - max_rows)
+    normalized_rows = list(assign_support_ticket_clusters(normalized_rows))
     has_valid_date_window = _all_rows_have_dates(normalized_rows)
     source_period = (
         f"Last {window_days} days of support tickets"
@@ -293,6 +299,8 @@ def build_support_ticket_input_package(
             "support_ticket_resolution_evidence_count": resolution_evidence_count,
             "has_measured_outcomes": measured_outcome_count > 0,
             "measured_outcome_count": measured_outcome_count,
+            "top_ticket_clusters": top_ticket_clusters,
+            "cluster_quality": support_ticket_cluster_quality(normalized_rows),
         },
         warnings=tuple(warnings),
     )
@@ -308,7 +316,7 @@ def _rows_from_source_material(source_material: Any) -> list[Any]:
 def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     if not isinstance(row, Mapping):
         return {}
-    source_title = _first_text(row, _SOURCE_TITLE_KEYS)
+    source_title = support_ticket_plain_text(_first_text(row, _SOURCE_TITLE_KEYS))
     text = _ticket_text(row, source_title=source_title)
     if not text:
         return {}
@@ -321,7 +329,10 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     }
     resolution_text = _first_text(row, _RESOLUTION_TEXT_KEYS)
     if resolution_text:
-        normalized["resolution_text"] = _clip_text(resolution_text, max_chars=500)
+        normalized["resolution_text"] = _clip_text(
+            support_ticket_plain_text(resolution_text),
+            max_chars=500,
+        )
     measured_outcome = _evidence_text(_first_value(row, _MEASURED_OUTCOME_KEYS))
     if measured_outcome:
         normalized["measured_outcome"] = _clip_text(measured_outcome, max_chars=500)
@@ -347,13 +358,13 @@ def _ticket_text(row: Mapping[str, Any], *, source_title: str) -> str:
     parts: list[str] = []
     if source_title:
         parts.append(source_title)
-    body = _first_text(row, _TEXT_KEYS)
+    body = support_ticket_plain_text(_first_text(row, _TEXT_KEYS))
     if body and body.lower() != source_title.lower():
         parts.append(body)
     comments = _comments_text(row)
     if comments:
         parts.append(comments)
-    return _compact("\n".join(parts))
+    return support_ticket_plain_text("\n".join(parts))
 
 
 def _comments_text(row: Mapping[str, Any]) -> str:
@@ -369,8 +380,8 @@ def _comments_text(row: Mapping[str, Any]) -> str:
         else:
             text = _clean(item)
         if text:
-            parts.append(text)
-    return _compact("\n".join(parts))
+            parts.append(support_ticket_plain_text(text))
+    return support_ticket_plain_text("\n".join(parts))
 
 
 def _ticket_questions(rows: Sequence[Mapping[str, Any]], *, limit: int = 6) -> list[str]:
@@ -413,39 +424,7 @@ def _top_ticket_clusters(
     *,
     limit: int = 12,
 ) -> list[dict[str, Any]]:
-    counts: Counter[str] = Counter()
-    labels: dict[str, str] = {}
-    uncategorized_count = 0
-    for row in rows:
-        label = _cluster_label(row)
-        if not label:
-            uncategorized_count += 1
-            continue
-        key = label.lower()
-        labels.setdefault(key, label)
-        counts[key] += 1
-    clusters = [
-        {"label": labels[key], "count": count}
-        for key, count in counts.most_common(max(1, limit))
-    ]
-    shown_count = sum(int(item["count"]) for item in clusters)
-    remaining_count = sum(counts.values()) - shown_count
-    if remaining_count > 0:
-        clusters.append({"label": "remaining", "count": remaining_count})
-    if uncategorized_count > 0:
-        clusters.append({"label": "uncategorized", "count": uncategorized_count})
-    return clusters
-
-
-def _cluster_label(row: Mapping[str, Any]) -> str:
-    pain_category = _clean(row.get("pain_category"))
-    if pain_category:
-        return pain_category
-    source_title = _clean(row.get("source_title"))
-    source_id = _clean(row.get("source_id"))
-    if source_title and source_title != source_id:
-        return source_title
-    return ""
+    return support_ticket_cluster_summary(rows, limit=limit)
 
 
 def _customer_wording_examples(

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -14,6 +14,7 @@ from .campaign_source_adapters import (
     source_material_to_source_rows,
     source_rows_to_campaign_opportunities,
 )
+from .support_ticket_clustering import support_ticket_plain_text
 from .ticket_faq_ports import TicketFAQDraft, TicketFAQRepository
 
 
@@ -434,7 +435,7 @@ def build_ticket_faq_markdown(
             # Empty allowed set means "no filter" rather than "reject all".
             if allowed and source_type not in allowed:
                 continue
-            text = _compact(evidence.get("text"))
+            text = support_ticket_plain_text(evidence.get("text"))
             if not text:
                 continue
             source_id = _clean(
@@ -460,7 +461,9 @@ def build_ticket_faq_markdown(
                 "source_id": source_id or "unknown",
                 "source_key": source_key,
                 "source_type": source_type,
-                "source_title": _clean(evidence.get("source_title") or opportunity.get("source_title")),
+                "source_title": support_ticket_plain_text(
+                    evidence.get("source_title") or opportunity.get("source_title")
+                ),
                 "source_date": source_date.isoformat() if source_date is not None else "",
                 "evidence_group_key": evidence_group_key,
                 "results_count": _first_present(evidence, opportunity, key="results_count"),
@@ -543,6 +546,9 @@ def _topic(
     *,
     intent_rules: Sequence[tuple[str, Sequence[str]]],
 ) -> str:
+    provided_cluster = _provided_support_ticket_cluster_topic(opportunity, evidence)
+    if provided_cluster:
+        return provided_cluster.lower()
     intent = _intent_topic(opportunity, evidence, intent_rules=intent_rules)
     if intent:
         return intent
@@ -553,6 +559,16 @@ def _topic(
             if text:
                 return text.lower()
     return (_compact(evidence.get("source_title") or opportunity.get("source_title")) or "customer support issues").lower()
+
+
+def _provided_support_ticket_cluster_topic(
+    *rows: Mapping[str, Any],
+) -> str:
+    for row in rows:
+        value = support_ticket_plain_text(row.get("support_ticket_cluster"))
+        if value:
+            return value
+    return ""
 
 
 def _evidence_group_key(resolution_text: Any) -> str:
@@ -837,7 +853,7 @@ def _source_weight(*rows: Mapping[str, Any]) -> int:
 def _resolution_text(*rows: Mapping[str, Any]) -> str:
     for row in rows:
         for key in _RESOLUTION_TEXT_KEYS:
-            text = _compact(_field_value(row, key))
+            text = support_ticket_plain_text(_field_value(row, key))
             if text:
                 return text
     return ""
@@ -845,9 +861,9 @@ def _resolution_text(*rows: Mapping[str, Any]) -> str:
 
 def _resolution_texts(rows: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
     values = (
-        _compact(row.get("resolution_text"))
+        support_ticket_plain_text(row.get("resolution_text"))
         for row in rows
-        if _compact(row.get("resolution_text"))
+        if support_ticket_plain_text(row.get("resolution_text"))
     )
     return tuple(dict.fromkeys(values))
 
@@ -1875,7 +1891,7 @@ def _rendered_ticket_source_count(items: Sequence[Mapping[str, Any]]) -> int:
 
 
 def _quote(value: Any, *, limit: int = 220) -> str:
-    text = _compact(value)
+    text = support_ticket_plain_text(value)
     if len(text) > limit:
         text = f"{text[:limit].rstrip()}..."
     return f'"{text}"'

--- a/plans/PR-Deflection-Raw-CSV-Cluster-Preview.md
+++ b/plans/PR-Deflection-Raw-CSV-Cluster-Preview.md
@@ -1,0 +1,166 @@
+# PR-Deflection-Raw-CSV-Cluster-Preview
+
+## Why this slice exists
+
+#1386 names the next launch-gating deflection slice: report quality on raw,
+untagged CSVs plus #1384 CSV ingestion/preview discipline. The active public
+funnel in `atlas-portfolio` does not parse CSV rows client-side; it uploads the
+raw CSV to private Blob, then posts those bytes to ATLAS
+`/content-ops/deflection-reports/submit`. That means the report-quality fix
+belongs in the ATLAS deflection submit/report path, not as a detached frontend
+cleanup.
+
+PR #1391 already landed the P0 CSV parser hardening (BOM, cp1252 fallback,
+delimiter sniffing, fail-loud parse errors). The remaining production risk is
+semantic but still deterministic: untagged real help-desk exports fragment into
+singletons because the support-ticket package preview clusters by explicit
+`pain_category` or exact title, and the FAQ report fallback can also use exact
+subject text. A buyer can then see a weak or sparse preview before checkout, and
+the paid report can rank near-duplicate questions as separate issues.
+
+This PR exceeds the 400 LOC soft cap because the launch-gating behavior is one
+end-to-end contract: the same deterministic grouping must be created in the
+support-ticket input package, consumed by the paid FAQ report, exposed in the
+deflection submit diagnostics/snapshot path, and proven by paired regression
+tests. Splitting the helper from the report/submit tests would leave an
+unreviewable half-fix on the paid funnel path.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Add deterministic, no-LLM support-ticket clustering for the deflection
+   submit/report path. Explicit categories still win, but untagged rows get a
+   token-set/keyword cluster hint based on normalized customer wording instead
+   of exact subject text.
+2. Thread the cluster hint into `TicketFAQMarkdownService` so the locked
+   snapshot and paid FAQ report group the same raw-ticket clusters that the
+   input-provider preview reports.
+3. Strip common HTML ticket-body markup during support-ticket normalization so
+   Zendesk/Help Scout/Freshdesk exports do not feed tags into clustering,
+   customer wording examples, or report evidence.
+4. Add messy untagged CSV/report tests that prove repeated raw questions group
+   together and that reply-less tickets still produce non-empty review-needed
+   answer drafts.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Active deflection path is named and preserved:
+        `atlas-portfolio` raw CSV bytes -> ATLAS multipart
+        `/deflection-reports/submit` -> `build_support_ticket_input_package`
+        -> `TicketFAQMarkdownService`.
+  - [ ] No LLM, embedding, Ollama, or model-backed clustering is introduced;
+        clustering is deterministic token/keyword logic.
+  - [ ] Untagged raw support-ticket rows with varied wording but shared intent
+        group into the same preview cluster and the same FAQ report item.
+  - [ ] Explicit `pain_category`/category labels remain authoritative for
+        tagged rows.
+  - [ ] HTML body text is normalized to readable customer wording before
+        clustering/evidence output.
+  - [ ] Sparse/reply-less tickets still generate non-empty
+        `draft_needs_review` answers rather than empty paid-report sections.
+  - [ ] Parser hardening from #1391 remains unchanged except where reused by
+        tests.
+- Affected surfaces: extracted package support-ticket normalization,
+  deterministic FAQ report generation, deflection submit diagnostics/snapshot
+  proof; no DB, billing, Stripe, MCP, or portfolio UI mutation in this PR.
+- Risk areas: public API backcompat, report quality, deterministic grouping
+  false positives, extracted-package CI enrollment.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/support_ticket_clustering.py`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Raw-CSV-Cluster-Preview.md`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_smoke_content_ops_support_ticket_package.py`
+
+## Mechanism
+
+Introduce a small package-owned clustering helper that:
+
+1. converts HTML-ish ticket text to plain text with the standard library;
+2. tokenizes customer wording with stopword removal, light synonym folding, and
+   simple singularization;
+3. prefers explicit category labels when present;
+4. groups untagged rows by deterministic token-set overlap; and
+5. exposes a stable `support_ticket_cluster`/`support_ticket_cluster_key` hint
+   for downstream FAQ generation.
+
+`build_support_ticket_input_package` applies the helper after row
+normalization. Its `top_ticket_clusters` preview uses the same grouping that it
+threads into each normalized `source_material` row. `TicketFAQMarkdownService`
+then prefers that hint before falling back to exact source title, so the free
+snapshot and paid report rank the same repeated raw-ticket cluster rather than
+splitting near-duplicate subjects.
+
+The tests use realistic messy rows (HTML body, varied subjects, no
+`pain_category`, no agent resolution) rather than the tagged demo fixture.
+
+## Intentional
+
+- No LLM, embedding, or model repair pass: the deflection trust story remains
+  deterministic and no customer ticket text leaves the stack for clustering.
+- This PR does not mutate Stripe, checkout, delivery, or portfolio UI code. The
+  active pre-check surface is the existing locked snapshot/results page after
+  submit and before checkout; a follow-up can improve how the portfolio renders
+  any extra backend diagnostics.
+- The clustering logic is conservative token overlap, not full semantic
+  clustering. False positives are riskier than a few separate clusters in a
+  paid support report.
+
+## Deferred
+
+- Portfolio rendering polish: if the product wants a separate cluster-quality
+  widget before the locked results page, build it in `atlas-portfolio` after
+  this backend response is proven.
+- Sanitized real provider exports: this PR adds messy representative fixtures;
+  a later validation slice should add sanitized Zendesk/Freshdesk/Help Scout
+  exports when available from real accounts.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_deflection_submit.py tests/test_smoke_content_ops_support_ticket_package.py
+  - 214 passed
+- Command: pytest tests/test_content_ops_deflection_report.py
+  - 36 passed
+- Command: pytest tests/test_smoke_content_ops_support_ticket_package.py
+  - 9 passed
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - passed
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - passed
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - `Atlas runtime import findings: 0`
+- Command: bash scripts/check_ascii_python.sh
+  - passed
+- Command: git diff --check
+  - passed
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - 3515 passed, 10 skipped, 1 warning
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 2 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 609 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 59 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 28 |
+| `plans/PR-Deflection-Raw-CSV-Cluster-Preview.md` | 166 |
+| `tests/test_extracted_content_deflection_submit.py` | 65 |
+| `tests/test_extracted_support_ticket_input_package.py` | 197 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 50 |
+| `tests/test_smoke_content_ops_support_ticket_package.py` | 4 |
+| **Total** | **1183** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -211,6 +211,13 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     assert "lead@acme.example" not in str(payload)
     assert payload["input_provider"]["metadata"] == {
         "blob_bytes": len(csv_data),
+        "cluster_quality": {
+            "cluster_count": 1,
+            "clustered_row_count": 2,
+            "largest_cluster_count": 2,
+            "singleton_cluster_count": 0,
+            "uncategorized_row_count": 0,
+        },
         "included_row_count": 2,
         "max_source_material_rows": 2,
         "skipped_row_count": 0,
@@ -219,6 +226,7 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
         "source_row_count": 3,
         "submitted_row_count": 2,
         "support_platform": "zendesk",
+        "top_ticket_clusters": [{"label": "exports", "count": 2}],
         "truncated_row_count": 1,
     }
     assert payload["input_provider"]["warnings"] == [{
@@ -301,6 +309,13 @@ async def test_deflection_submit_accepts_multipart_csv_bytes() -> None:
     assert "markdown" not in str(gated_result)
     assert "ticket-export-1" not in str(gated_result)
     assert payload["input_provider"]["metadata"] == {
+        "cluster_quality": {
+            "cluster_count": 1,
+            "clustered_row_count": 2,
+            "largest_cluster_count": 2,
+            "singleton_cluster_count": 0,
+            "uncategorized_row_count": 0,
+        },
         "included_row_count": 2,
         "max_source_material_rows": 2,
         "skipped_row_count": 0,
@@ -309,12 +324,62 @@ async def test_deflection_submit_accepts_multipart_csv_bytes() -> None:
         "source_row_count": 3,
         "submitted_row_count": 2,
         "support_platform": "help_scout",
+        "top_ticket_clusters": [{"label": "exports", "count": 2}],
         "truncated_row_count": 1,
         "uploaded_bytes": len(csv_data),
     }
 
     snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
     assert await snapshot.endpoint(request_id=payload["request_id"]) == gated_result["snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_surfaces_cluster_preview_for_messy_untagged_csv() -> None:
+    csv_data = _csv_bytes([
+        "ticket_id,subject,message",
+        "zd-1,Password reset help,<p>How do I reset my password?</p>",
+        "zd-2,Password reset not working,I cannot reset password from the login screen",
+        "hs-1,Change email address,Where do I update my email?",
+        "hs-2,Update account email,Need to change email address",
+    ])
+    store = InMemoryDeflectionReportArtifactStore()
+    router = _router(store)
+
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    request = _FormRequest({
+        "csv_file": _Upload(csv_data),
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+    })
+    payload = await submit.endpoint(request)
+
+    metadata = payload["input_provider"]["metadata"]
+    assert metadata["top_ticket_clusters"] == [
+        {"label": "login password reset", "count": 2},
+        {"label": "email update", "count": 2},
+    ]
+    assert metadata["cluster_quality"] == {
+        "cluster_count": 2,
+        "clustered_row_count": 4,
+        "largest_cluster_count": 2,
+        "singleton_cluster_count": 0,
+        "uncategorized_row_count": 0,
+    }
+
+    snapshot = payload["steps"][0]["result"]["snapshot"]
+    assert [
+        (item["ticket_count"], item["customer_wording"])
+        for item in snapshot["top_questions"]
+    ] == [
+        (2, "Password reset help How do I reset my password?"),
+        (2, "Change email address Where do I update my email?"),
+    ]
+    assert "<p>" not in str(snapshot)
+    assert payload["steps"][0]["result"]["full_report"] == {
+        "status": "locked",
+        "reason": "payment_required",
+    }
 
 
 def test_deflection_submit_fastapi_dispatch_accepts_multipart_csv_bytes() -> None:

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -66,7 +66,7 @@ def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
     assert request.inputs["measured_outcome_examples"] == []
     assert request.inputs["top_ticket_clusters"] == [
         {"label": "profile updates", "count": 1},
-        {"label": "Export dashboard", "count": 1},
+        {"label": "dashboard export renewal", "count": 1},
     ]
     assert request.inputs["customer_wording_examples"][0] == {
         "source_id": "ticket-1",
@@ -94,8 +94,19 @@ def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
         "vendor_name": "HelpDeskPro",
         "pain_category": "profile updates",
         "created_at": "2026-05-01",
+        "support_ticket_cluster": "profile updates",
+        "support_ticket_cluster_key": "explicit:profile-updates",
+        "support_ticket_cluster_source": "explicit",
     }
     assert package.metadata["included_row_count"] == 2
+    assert package.metadata["top_ticket_clusters"] == request.inputs["top_ticket_clusters"]
+    assert package.metadata["cluster_quality"] == {
+        "clustered_row_count": 2,
+        "uncategorized_row_count": 0,
+        "cluster_count": 2,
+        "singleton_cluster_count": 2,
+        "largest_cluster_count": 1,
+    }
 
 
 def test_support_ticket_bundle_inherits_parent_fields_and_comment_text() -> None:
@@ -127,6 +138,9 @@ def test_support_ticket_bundle_inherits_parent_fields_and_comment_text() -> None
             ),
             "company_name": "Riverbend Supply",
             "vendor_name": "LegacyCRM",
+            "support_ticket_cluster": "automation cleanup demo follow",
+            "support_ticket_cluster_key": "tokens:automation-cleanup-demo-follow",
+            "support_ticket_cluster_source": "token_set",
         }
     ]
     assert package.inputs["faq_questions"] == ["Can I automate demo follow-up?"]
@@ -359,6 +373,9 @@ def test_support_ticket_input_package_accepts_common_platform_csv_shapes() -> No
         ),
         "created_at": "2026-05-01T09:00:00Z",
         "contact_email": "maya@example.test",
+        "support_ticket_cluster": "code login mfa new",
+        "support_ticket_cluster_key": "tokens:code-login-mfa-new",
+        "support_ticket_cluster_source": "token_set",
     }
     assert rows[1]["source_id"] == "fd-200"
     assert rows[1]["source_title"] == "Where do I update billing?"
@@ -402,12 +419,185 @@ def test_support_ticket_clusters_do_not_use_synthetic_ticket_ids() -> None:
     ])
 
     assert package.inputs["top_ticket_clusters"] == [
-        {"label": "uncategorized", "count": 3}
+        {"label": "data export", "count": 1},
+        {"label": "billing", "count": 1},
+        {"label": "plan update", "count": 1},
     ]
+    assert all(
+        cluster["label"] not in {"ticket-1", "ticket-2", "ticket-3"}
+        for cluster in package.inputs["top_ticket_clusters"]
+    )
     assert package.inputs["customer_wording_examples"][0] == {
         "source_id": "ticket-1",
         "text": "How do I export data?",
     }
+
+
+def test_support_ticket_clusters_group_messy_untagged_export_rows() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "zd-1",
+            "subject": "Password reset help",
+            "description": "<p>How do I reset my password?</p>",
+        },
+        {
+            "ticket_id": "zd-2",
+            "subject": "Password reset not working",
+            "description": "I cannot reset password from the login screen",
+        },
+        {
+            "ticket_id": "hs-1",
+            "subject": "Change email address",
+            "description": "Where do I update my email?",
+        },
+        {
+            "ticket_id": "hs-2",
+            "subject": "Update account email",
+            "description": "Need to change email address",
+        },
+    ])
+
+    assert package.inputs["top_ticket_clusters"] == [
+        {"label": "login password reset", "count": 2},
+        {"label": "email update", "count": 2},
+    ]
+    assert package.metadata["cluster_quality"] == {
+        "clustered_row_count": 4,
+        "uncategorized_row_count": 0,
+        "cluster_count": 2,
+        "singleton_cluster_count": 0,
+        "largest_cluster_count": 2,
+    }
+    assert package.inputs["source_material"][0]["text"] == (
+        "Password reset help How do I reset my password?"
+    )
+    assert package.inputs["source_material"][0]["support_ticket_cluster"] == (
+        "login password reset"
+    )
+    assert "<p>" not in package.inputs["customer_wording_examples"][0]["text"]
+
+
+def test_support_ticket_clusters_group_topic_varied_anchor_rows() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "export-1",
+            "subject": "Attribution export blocked",
+            "description": "The attribution report export never starts.",
+        },
+        {
+            "ticket_id": "export-2",
+            "subject": "CSV export missing column",
+            "description": "The downloaded CSV leaves out the campaign column.",
+        },
+        {
+            "ticket_id": "export-3",
+            "subject": "Export timeout",
+            "description": "Report download times out before the file is ready.",
+        },
+        {
+            "ticket_id": "sso-1",
+            "subject": "SSO login loop",
+            "description": "Users return to the SSO screen after Okta.",
+        },
+        {
+            "ticket_id": "sso-2",
+            "subject": "SAML single sign on failure",
+            "description": "The identity provider rejects the SAML response.",
+        },
+        {
+            "ticket_id": "billing-1",
+            "subject": "Billing amount looks wrong",
+            "description": "The billing total changed after renewal.",
+        },
+        {
+            "ticket_id": "billing-2",
+            "subject": "Card charged twice this month",
+            "description": "The card was charged twice for the same workspace.",
+        },
+    ])
+
+    assert package.inputs["top_ticket_clusters"] == [
+        {"label": "export", "count": 3},
+        {"label": "sso", "count": 2},
+        {"label": "billing", "count": 2},
+    ]
+    assert package.metadata["cluster_quality"] == {
+        "clustered_row_count": 7,
+        "uncategorized_row_count": 0,
+        "cluster_count": 3,
+        "singleton_cluster_count": 0,
+        "largest_cluster_count": 3,
+    }
+    assert {
+        row["support_ticket_cluster"]
+        for row in package.inputs["source_material"]
+    } == {"export", "sso", "billing"}
+    assert all(
+        row["support_ticket_cluster_source"] == "token_anchor"
+        for row in package.inputs["source_material"]
+    )
+
+
+def test_support_ticket_clusters_derive_anchors_without_static_topic_list() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "login-1",
+            "subject": "Cannot log in",
+            "description": "Login fails after password reset.",
+        },
+        {
+            "ticket_id": "login-2",
+            "subject": "Login loop",
+            "description": "Users return to the same login page.",
+        },
+        {
+            "ticket_id": "login-3",
+            "subject": "Forgot credentials",
+            "description": "Login credentials reset email never arrives.",
+        },
+        {
+            "ticket_id": "api-1",
+            "subject": "Webhook not firing",
+            "description": "API callback never arrives.",
+        },
+        {
+            "ticket_id": "api-2",
+            "subject": "API 500 errors",
+            "description": "API request returns a 500 error.",
+        },
+        {
+            "ticket_id": "api-3",
+            "subject": "Integration broken",
+            "description": "API integration cannot sync records.",
+        },
+        {
+            "ticket_id": "dashboard-1",
+            "subject": "Dashboard blank",
+            "description": "Dashboard charts show a blank page.",
+        },
+        {
+            "ticket_id": "dashboard-2",
+            "subject": "Charts not loading",
+            "description": "Dashboard charts do not load.",
+        },
+    ])
+
+    assert package.inputs["top_ticket_clusters"] == [
+        {"label": "login", "count": 3},
+        {"label": "api", "count": 3},
+        {"label": "dashboard", "count": 2},
+    ]
+    assert package.metadata["cluster_quality"] == {
+        "clustered_row_count": 8,
+        "uncategorized_row_count": 0,
+        "cluster_count": 3,
+        "singleton_cluster_count": 0,
+        "largest_cluster_count": 3,
+    }
+    assert {
+        row["support_ticket_cluster"]
+        for row in package.inputs["source_material"]
+    } == {"login", "api", "dashboard"}
 
 
 def test_support_ticket_clusters_include_remaining_bucket() -> None:
@@ -574,6 +764,9 @@ def test_support_ticket_input_package_reports_skipped_and_truncated_rows() -> No
             "source_type": "support_ticket",
             "source_title": "ticket-2",
             "text": "How do I export data?",
+            "support_ticket_cluster": "data export",
+            "support_ticket_cluster_key": "tokens:data-export",
+            "support_ticket_cluster_source": "token_set",
         }
     ]
     assert package.metadata["source_row_count"] == 3

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -14,6 +14,9 @@ from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.support_ticket_input_package import (
+    build_support_ticket_input_package,
+)
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
@@ -1872,6 +1875,53 @@ async def test_ticket_faq_service_generates_from_inline_source_material() -> Non
     assert result.as_dict()["generated"] == 1
     assert "How do I change my email address?" in result.markdown
     assert "`ticket-1` - Login email change" in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_groups_package_cluster_hints_for_raw_rows() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "zd-1",
+            "subject": "Password reset help",
+            "description": "<p>How do I reset my password?</p>",
+        },
+        {
+            "ticket_id": "zd-2",
+            "subject": "Password reset not working",
+            "description": "I cannot reset password from the login screen",
+        },
+        {
+            "ticket_id": "hs-1",
+            "subject": "Change email address",
+            "description": "Where do I update my email?",
+        },
+        {
+            "ticket_id": "hs-2",
+            "subject": "Update account email",
+            "description": "Need to change email address",
+        },
+    ])
+    service = TicketFAQMarkdownService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material=package.inputs["source_material"],
+        max_items=10,
+    )
+
+    assert [(item["topic"], item["ticket_count"]) for item in result.items] == [
+        ("login password reset", 2),
+        ("email update", 2),
+    ]
+    assert all(
+        item["answer_evidence_status"] == "draft_needs_review"
+        for item in result.items
+    )
+    assert all(item["answer"].strip() for item in result.items)
+    assert "<p>" not in result.markdown
+    assert "`zd-1` - Password reset help" in result.markdown
+    assert "`hs-2` - Update account email" in result.markdown
 
 
 @pytest.mark.asyncio

--- a/tests/test_smoke_content_ops_support_ticket_package.py
+++ b/tests/test_smoke_content_ops_support_ticket_package.py
@@ -76,7 +76,7 @@ def test_support_ticket_package_smoke_summarizes_undated_csv_without_window_filt
     assert summary["contact_email_count"] == 0
     assert summary["top_ticket_clusters"] == [
         {"label": "profile updates", "count": 1},
-        {"label": "Export dashboard", "count": 1},
+        {"label": "dashboard export renewal", "count": 1},
     ]
     assert summary["customer_wording_examples"][0] == {
         "source_id": "ticket-1",
@@ -257,7 +257,7 @@ def test_support_ticket_package_smoke_reports_cluster_rollup_and_truncation(
         {"label": "category-6", "count": 1},
         {"label": "category-7", "count": 1},
         {"label": "category-8", "count": 1},
-        {"label": "uncategorized", "count": 1},
+        {"label": "plan update", "count": 1},
     ]
     assert summary["warning_count"] == 1
     assert summary["warnings"][0]["code"] == "ticket_rows_truncated"


### PR DESCRIPTION
Plan: plans/PR-Deflection-Raw-CSV-Cluster-Preview.md
Slice phase: Production hardening

This hardens the active deflection paid-funnel path for raw, untagged support-ticket CSVs. `atlas-portfolio` still uploads raw CSV bytes to private Blob and ATLAS still receives the multipart CSV at `/deflection-reports/submit`; this PR adds deterministic support-ticket clustering inside the ATLAS submit/report path so the free locked snapshot and paid FAQ report group repeated raw-ticket issues instead of fragmenting near-duplicate subjects.

## Intentional
- No LLM, embedding, Ollama, or model repair pass: clustering stays deterministic and no customer ticket text leaves the stack.
- No Stripe, checkout, delivery, MCP, or portfolio UI mutation. The existing locked snapshot/results page remains the pre-payment proof surface.
- Conservative token-overlap grouping, not full semantic clustering. False positives are riskier than a few separate clusters in a support report.

## Deferred
- Portfolio rendering polish if we want a dedicated cluster-quality widget before the locked results page.
- Sanitized real Zendesk/Freshdesk/Help Scout exports once available from real accounts.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_deflection_submit.py tests/test_smoke_content_ops_support_ticket_package.py` - 214 passed
- `pytest tests/test_content_ops_deflection_report.py` - 36 passed
- `pytest tests/test_smoke_content_ops_support_ticket_package.py` - 9 passed
- `bash scripts/validate_extracted_content_pipeline.sh` - passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - `Atlas runtime import findings: 0`
- `bash scripts/check_ascii_python.sh` - passed
- `git diff --check` - passed
- `bash scripts/run_extracted_pipeline_checks.sh` - 3515 passed, 10 skipped, 1 warning

## Diff size
10 files, +1183 / -50
