### PR TITLE
Content-Ops MCP Live Dual-Client Rollout

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -13,10 +13,12 @@ on:
       - "extracted_content_pipeline/review_contract.py"
       - "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
       - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
+      - "scripts/check_content_ops_marketer_verify_dual_client_rollout.py"
       - "scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
+      - "tests/test_check_content_ops_marketer_verify_dual_client_rollout.py"
       - "tests/test_content_ops_marketer_verify_launcher_contract.py"
       - "tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "tests/test_mcp_content_ops_marketer_verify.py"
@@ -34,10 +36,12 @@ on:
       - "extracted_content_pipeline/review_contract.py"
       - "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
       - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
+      - "scripts/check_content_ops_marketer_verify_dual_client_rollout.py"
       - "scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
+      - "tests/test_check_content_ops_marketer_verify_dual_client_rollout.py"
       - "tests/test_content_ops_marketer_verify_launcher_contract.py"
       - "tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "tests/test_mcp_content_ops_marketer_verify.py"
@@ -65,6 +69,7 @@ jobs:
         run: |
           python -m pytest \
             tests/test_atlas_content_ops_review_workflow.py \
+            tests/test_check_content_ops_marketer_verify_dual_client_rollout.py \
             tests/test_check_content_ops_marketer_verify_oauth_e2e.py \
             tests/test_content_ops_marketer_verify_launcher_contract.py \
             tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py \

--- a/plans/PR-Content-Ops-MCP-Live-Dual-Client-Rollout.md
+++ b/plans/PR-Content-Ops-MCP-Live-Dual-Client-Rollout.md
@@ -1,0 +1,84 @@
+# PR-Content-Ops-MCP-Live-Dual-Client-Rollout
+
+## Why this slice exists
+
+#1353 is past the rich verifier, ChatGPT adapter, OAuth rollout, adapter port
+env, and adapter help-text slices. The remaining gap is one operator-safe proof
+that both public connector surfaces can be smoke tested together without
+mutating draft content or printing approval secrets.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a dual-client rollout checker that delegates to the existing
+   no-mutation OAuth e2e checker for `claude-rich` and
+   `chatgpt-search-fetch`.
+2. Require separate rich and adapter issuer/resource URL pairs, reject identical
+   resource URLs, and prefer approval-token file handoff.
+3. Add deterministic tests for command construction, missing inputs, identical
+   resource rejection, fail-fast behavior, and secret redaction.
+4. Enroll the new checker tests in the extracted wrapper and dedicated workflow.
+
+### Files touched
+
+- `plans/PR-Content-Ops-MCP-Live-Dual-Client-Rollout.md`
+- `scripts/check_content_ops_marketer_verify_dual_client_rollout.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+- `tests/test_check_content_ops_marketer_verify_dual_client_rollout.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The wrapper invokes both profiles against their matching URL pairs.
+  - [ ] Missing inputs and identical resource URLs fail before any smoke call.
+  - [ ] Either profile failure blocks rollout success.
+  - [ ] Output omits literal approval-token values, and new tests are enrolled.
+- Affected surfaces: operator smoke script / OAuth rollout runbook / CI.
+- Risk areas: public connector rollout / approval-token handling / CI
+  enrollment / false-green smoke reporting.
+- Reviewer rules triggered: R1, R2, R3, R10, R12
+
+## Mechanism
+
+The new script parses two public URL pairs and one approval-token handoff, builds
+one argument vector per client profile, and calls the existing OAuth e2e checker
+in sequence. It stops on the first non-zero result and prints only profile
+labels plus public URLs.
+
+## Intentional
+
+- No live credentials, generated draft content, MCP tool calls, or OAuth logic
+  are added; this wrapper is runbook glue.
+- Shared issuers remain allowed because distinct resources are the surface guard.
+
+## Deferred
+
+- Manually captured live run artifacts and durable verdict/session persistence
+  remain deferred until public registrations or restart-safe fetch need them.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: python -m pytest tests/test_check_content_ops_marketer_verify_dual_client_rollout.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py -q
+  - 24 passed in 0.49s
+- Passed: python -m py_compile scripts/check_content_ops_marketer_verify_dual_client_rollout.py
+- Passed: git diff --check
+- Passed: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_dual_client_rollout.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q
+  - 92 passed in 0.91s
+- Passed: bash scripts/run_extracted_pipeline_checks.sh
+  - 295 passed in 1.70s for extracted_reasoning_core
+  - 3517 passed, 10 skipped in 58.93s for extracted_content_pipeline
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_live_dual_client_rollout_pr_body.md
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 84 |
+| Rollout checker | 180 |
+| Tests | 129 |
+| CI/script enrollment | 6 |
+| **Total** | **399** |

--- a/scripts/check_content_ops_marketer_verify_dual_client_rollout.py
+++ b/scripts/check_content_ops_marketer_verify_dual_client_rollout.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Run both Content Ops marketer verify public OAuth profile smokes."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_oauth_e2e():
+    path = ROOT / "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
+    spec = importlib.util.spec_from_file_location(
+        "check_content_ops_marketer_verify_oauth_e2e",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load OAuth e2e checker from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_oauth_e2e = _load_oauth_e2e()
+CLAUDE_RICH_PROFILE = _oauth_e2e.CLAUDE_RICH_PROFILE
+CHATGPT_SEARCH_FETCH_PROFILE = _oauth_e2e.CHATGPT_SEARCH_FETCH_PROFILE
+
+
+def _strip(value: str) -> str:
+    return value.strip().rstrip("/")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run Claude rich plus ChatGPT search/fetch OAuth list-tools smokes."
+    )
+    for flag, help_text in (
+        ("--rich-issuer-url", "Claude rich verifier OAuth issuer URL."),
+        ("--rich-resource-url", "Claude rich verifier MCP resource URL."),
+        ("--chatgpt-adapter-issuer-url", "ChatGPT adapter OAuth issuer URL."),
+        ("--chatgpt-adapter-resource-url", "ChatGPT adapter MCP resource URL."),
+    ):
+        parser.add_argument(flag, default="", help=help_text)
+    parser.add_argument(
+        "--approval-token-file",
+        default="",
+        help="Read the operator approval token from a local file.",
+    )
+    parser.add_argument(
+        "--approval-token",
+        default="",
+        help="Operator approval token. This value is not printed.",
+    )
+    parser.add_argument(
+        "--redirect-uri",
+        default=_oauth_e2e.DEFAULT_REDIRECT_URI,
+        help=f"OAuth redirect URI. Default: {_oauth_e2e.DEFAULT_REDIRECT_URI}.",
+    )
+    parser.add_argument(
+        "--scope",
+        default=_oauth_e2e.DEFAULT_SCOPE,
+        help=f"Required OAuth scope. Default: {_oauth_e2e.DEFAULT_SCOPE}.",
+    )
+    parser.add_argument("--timeout", type=float, default=10.0)
+    return parser
+
+
+def _value(args: argparse.Namespace, attr: str) -> str:
+    value = getattr(args, attr)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _validate_args(args: argparse.Namespace) -> list[str]:
+    required = {
+        "rich_issuer_url": "--rich-issuer-url",
+        "rich_resource_url": "--rich-resource-url",
+        "chatgpt_adapter_issuer_url": "--chatgpt-adapter-issuer-url",
+        "chatgpt_adapter_resource_url": "--chatgpt-adapter-resource-url",
+    }
+    missing = [flag for attr, flag in required.items() if not _value(args, attr)]
+    if not _value(args, "approval_token_file") and not _value(args, "approval_token"):
+        missing.append("--approval-token-file or --approval-token")
+    if missing:
+        return ["missing required values: " + ", ".join(missing)]
+    if _strip(args.rich_resource_url) == _strip(args.chatgpt_adapter_resource_url):
+        return ["rich and ChatGPT adapter resource URLs must be different"]
+    return []
+
+
+def _secret_argv(args: argparse.Namespace) -> tuple[str, str]:
+    if _value(args, "approval_token_file"):
+        return "--approval-token-file", args.approval_token_file.strip()
+    return "--approval-token", args.approval_token.strip()
+
+
+def _checker_argv(
+    *,
+    issuer_url: str,
+    resource_url: str,
+    profile: str,
+    args: argparse.Namespace,
+) -> list[str]:
+    secret_flag, secret_value = _secret_argv(args)
+    return [
+        "--issuer-url",
+        _strip(issuer_url),
+        "--resource-url",
+        _strip(resource_url),
+        "--client-profile",
+        profile,
+        secret_flag,
+        secret_value,
+        "--redirect-uri",
+        args.redirect_uri.strip(),
+        "--scope",
+        args.scope.strip(),
+        "--timeout",
+        str(args.timeout),
+    ]
+
+
+def _invocations_from_args(args: argparse.Namespace) -> tuple[tuple[str, str, str, str, list[str]], ...]:
+    return (
+        (
+            "Claude rich verifier",
+            CLAUDE_RICH_PROFILE,
+            _strip(args.rich_issuer_url),
+            _strip(args.rich_resource_url),
+            _checker_argv(
+                issuer_url=args.rich_issuer_url,
+                resource_url=args.rich_resource_url,
+                profile=CLAUDE_RICH_PROFILE,
+                args=args,
+            ),
+        ),
+        (
+            "ChatGPT search/fetch adapter",
+            CHATGPT_SEARCH_FETCH_PROFILE,
+            _strip(args.chatgpt_adapter_issuer_url),
+            _strip(args.chatgpt_adapter_resource_url),
+            _checker_argv(
+                issuer_url=args.chatgpt_adapter_issuer_url,
+                resource_url=args.chatgpt_adapter_resource_url,
+                profile=CHATGPT_SEARCH_FETCH_PROFILE,
+                args=args,
+            ),
+        ),
+    )
+
+
+def _run_invocations(invocations, runner) -> int:
+    for label, profile, issuer_url, resource_url, checker_argv in invocations:
+        print(f"Running {label} smoke ({profile})")
+        print(f"- issuer: {issuer_url}")
+        print(f"- resource: {resource_url}")
+        result = runner(checker_argv)
+        if result != 0:
+            print(f"Dual-client rollout smoke failed for {profile}", file=sys.stderr)
+            return result
+    print("OK: Content Ops marketer verify dual-client rollout smoke completed")
+    return 0
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    errors = _validate_args(args)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 2
+    return _run_invocations(_invocations_from_args(args), _oauth_e2e._main)
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -110,6 +110,7 @@ pytest \
   tests/test_content_ops_marketer_verify_launcher_contract.py \
   tests/test_check_content_ops_marketer_verify_oauth_discovery.py \
   tests/test_check_content_ops_marketer_verify_oauth_e2e.py \
+  tests/test_check_content_ops_marketer_verify_dual_client_rollout.py \
   tests/test_mcp_content_ops_marketer_verify.py \
   tests/test_content_ops_claim_registry.py \
   tests/test_atlas_content_ops_generated_assets_api.py \

--- a/tests/test_check_content_ops_marketer_verify_dual_client_rollout.py
+++ b/tests/test_check_content_ops_marketer_verify_dual_client_rollout.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_content_ops_marketer_verify_dual_client_rollout.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_content_ops_marketer_verify_dual_client_rollout",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _argv(*extra: str) -> list[str]:
+    return [
+        "--rich-issuer-url",
+        "https://atlas.example.com/content-ops-marketer/",
+        "--rich-resource-url",
+        "https://atlas.example.com/content-ops-marketer/mcp/",
+        "--chatgpt-adapter-issuer-url",
+        "https://atlas.example.com/content-ops-marketer-chatgpt/",
+        "--chatgpt-adapter-resource-url",
+        "https://atlas.example.com/content-ops-marketer-chatgpt/mcp/",
+        *extra,
+    ]
+
+
+def test_main_runs_both_profiles_with_token_file(monkeypatch) -> None:
+    module = _load_script_module()
+    calls: list[list[str]] = []
+    monkeypatch.setattr(module._oauth_e2e, "_main", lambda argv: calls.append(argv) or 0)
+
+    result = module._main(_argv("--approval-token-file", "/tmp/token-file"))
+
+    assert result == 0
+    assert [call[call.index("--client-profile") + 1] for call in calls] == [
+        module.CLAUDE_RICH_PROFILE,
+        module.CHATGPT_SEARCH_FETCH_PROFILE,
+    ]
+    assert all("--approval-token-file" in call for call in calls)
+    assert all("/tmp/token-file" in call for call in calls)
+    assert calls[0][calls[0].index("--resource-url") + 1] != (
+        calls[1][calls[1].index("--resource-url") + 1]
+    )
+
+
+def test_main_requires_values_before_smoke_invocation(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(module, "_run_invocations", lambda *_args: 99)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    for flag in (
+        "--rich-issuer-url",
+        "--rich-resource-url",
+        "--chatgpt-adapter-issuer-url",
+        "--chatgpt-adapter-resource-url",
+        "--approval-token-file or --approval-token",
+    ):
+        assert flag in captured.err
+
+
+def test_main_rejects_identical_resource_urls_before_smoke_invocation(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(module, "_run_invocations", lambda *_args: 99)
+
+    result = module._main(
+        _argv(
+            "--chatgpt-adapter-resource-url",
+            "https://atlas.example.com/content-ops-marketer/mcp",
+            "--approval-token-file",
+            "/tmp/token-file",
+        )
+    )
+
+    assert result == 2
+    assert "resource URLs must be different" in capsys.readouterr().err
+
+
+def test_main_does_not_print_literal_token(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(module._oauth_e2e, "_main", lambda _argv: 0)
+
+    result = module._main(_argv("--approval-token", "literal-secret-token-value"))
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "dual-client rollout smoke completed" in captured.out
+    assert "literal-secret-token-value" not in captured.out
+    assert "literal-secret-token-value" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("results", "expected_calls", "profile"),
+    [([1], 1, "claude-rich"), ([0, 1], 2, "chatgpt-search-fetch")],
+)
+def test_profile_failure_blocks_success(results, expected_calls, profile, capsys) -> None:
+    module = _load_script_module()
+    calls: list[list[str]] = []
+    args = module._build_parser().parse_args(_argv("--approval-token-file", "/tmp/token-file"))
+
+    def fake_checker(argv: list[str]) -> int:
+        calls.append(argv)
+        return results[len(calls) - 1]
+
+    result = module._run_invocations(module._invocations_from_args(args), fake_checker)
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert len(calls) == expected_calls
+    assert f"failed for {profile}" in captured.err
+    assert "dual-client rollout smoke completed" not in captured.out


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-Live-Dual-Client-Rollout.md
Slice phase: Functional validation

Adds a dual-client rollout checker that delegates to the existing no-mutation OAuth e2e checker for both public Content Ops marketer surfaces: Claude rich `verify_draft` and ChatGPT `search`/`fetch` adapter. The wrapper requires distinct resource URLs, fails before any smoke invocation when inputs are missing, stops on either profile failure, and avoids printing literal approval tokens.

## Intentional
- No live credentials, generated draft content, or MCP tool calls are added.
- MCP/OAuth behavior stays in the existing checker; this wrapper is runbook glue.
- Shared issuers remain allowed because distinct resources are the surface guard.

## Deferred
- Manually captured live run artifacts remain an operator action after public Claude and ChatGPT connector registrations are available.
- Durable verdict/session persistence remains deferred unless live connector use needs restart-safe fetch.

## Parked hardening
- None.

## Verification
- Passed: python -m pytest tests/test_check_content_ops_marketer_verify_dual_client_rollout.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py -q
  - 24 passed in 0.49s
- Passed: python -m py_compile scripts/check_content_ops_marketer_verify_dual_client_rollout.py
- Passed: git diff --check
- Passed: python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_dual_client_rollout.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q
  - 92 passed in 0.91s
- Passed: bash scripts/run_extracted_pipeline_checks.sh
  - 295 passed in 1.70s for extracted_reasoning_core
  - 3517 passed, 10 skipped in 58.93s for extracted_content_pipeline
- Passed: bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_mcp_live_dual_client_rollout_pr_body.md

## Diff size
5 files, +399 / -0