### PR TITLE
Review rule fix the class not example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ named in Deferred or explicitly marked none.
 **Rule results (triggered rules only, see docs/REVIEWER_RULES.md):**
 - R1 Requirements match: Pass/Fail/N-A
 - R2 Test evidence: Pass/Fail/N-A
-- R3 Security/auth ... R12 Deployment+CI enrollment: Pass/Fail/N-A
+- R3 Security/auth ... R13 Fix-the-class: Pass/Fail/N-A
 (List only the rules the changed paths trigger; cite file:line on any Fail.)
 
 **AI reconciliation:** AI findings reviewed: Y/N. All fixed or waived: Y/N.
@@ -420,6 +420,15 @@ Locked-in regression tests for deferred follow-ups should name the
 future slice in their docstring (e.g. *"after PR-Foo-V2 lands this
 test is removed"*) so the test's lifetime is explicit.
 
+Test quality is part of the contract. For meaningful logic changes, a
+single trivial happy-path assertion is not enough. Add realistic
+non-happy-path coverage proportional to the risk: negative cases,
+malformed/sparse inputs, boundary values, varied producer shapes,
+failure branches, and representative real-world fixtures. If the slice
+intentionally ships only happy-path coverage, the plan's `Intentional`
+or `Deferred` section must say why that is acceptable and what will
+cover the missing cases.
+
 **CI enrollment is part of test authoring — same PR.** A test only
 protects the codebase if CI runs it. The Atlas Intel UI workflow
 (`.github/workflows/atlas_intel_ui_checks.yml`) runs an **explicit
@@ -550,13 +559,33 @@ If a branch is intentionally not covered in the PR, the plan's `Intentional` or
 `Deferred` section must name why it is safe to leave out and what future slice
 will cover it. "Covered by the happy path" is not enough for detection logic.
 
+### 3j. Class fixes need unseen probes
+
+When a review finding names a defect class rather than one isolated example,
+the builder must prove the class is fixed, not only the cited case. Before
+claiming the fix complete:
+
+1. Reproduce the reviewer-cited example.
+2. Generate or write **5-10 same-class cases the reviewer did not mention**.
+   Prefer property/parametrized tests that generate the cases; if that is not
+   practical, use fresh fixtures and explain why they exercise the class.
+   The cases must be diverse enough to exercise the class, not trivial
+   near-duplicates of the cited example.
+3. Add the proof to CI-facing tests or a committed artifact whenever possible.
+4. If only the cited example was tested, say so explicitly and do not claim the
+   class is fixed.
+
+Hardcoding the reviewer's strings, values, paths, or exact examples is an R13
+failure (`docs/REVIEWER_RULES.md`). A fix that can pass only the visible review
+example is not done.
+
 ---
 
 ## 4. Reviewer workflow
 
 The reviewer's job is **not** "review the code" -- it is to **prove whether
 the PR satisfies its Review Contract and violates none of the rules in
-`docs/REVIEWER_RULES.md`.** Every finding cites a rule ID (R1-R12) and maps to
+`docs/REVIEWER_RULES.md`.** Every finding cites a rule ID (R1-R13) and maps to
 a verdict level (BLOCKER / MAJOR / NIT). The rule matrix and AI reconciliation
 go in the §2a template.
 
@@ -783,7 +812,7 @@ defines:
 
 Read `docs/REVIEWER_RULES.md` before your first review. Your job is
 not "review the code" -- it is to prove the PR satisfies its Review
-Contract and violates none of R1-R12. Cite a rule ID on every finding.
+Contract and violates none of R1-R13. Cite a rule ID on every finding.
 
 Read AUDITOR_PROMPT.md for the cross-cutting audit checks
 (canonical / integration / scope / debt). Apply both lenses.

--- a/REVIEW_MISSES.md
+++ b/REVIEW_MISSES.md
@@ -36,6 +36,7 @@ the same way a builder's repeated lapse gets front-loaded into the bootstrap.
 | Date | Escaped issue | Missed by (human / AI / CI) | Root cause | New gate added | Owner |
 |---|---|---|---|---|---|
 | _seed_ | _First real entry goes here. Until then this row documents the format._ | - | - | - | - |
+| 2026-06-09 | Repeated "fixed the cited example, not the class" pattern across blog-prose quality and raw-ticket clustering recall review rounds. | human/process | Review comments supplied concrete examples without making hardcoding unable to pass; builder did not self-probe with unseen same-class cases before claiming done. | R13 in `docs/REVIEWER_RULES.md` + AGENTS/bootstrap self-probe requirement for 5-10 unseen same-class cases. | reviewer + builder |
 
 ## Lifecycle (so this stays a queue, not an archive)
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -2,7 +2,7 @@
 
 > The reviewer's job is **not** to "review the code." It is to **prove whether
 > the PR satisfies its Review Contract and violates none of the rules below.**
-> Every review finding cites a rule ID (R1-R12). This pack is the checklist the
+> Every review finding cites a rule ID (R1-R13). This pack is the checklist the
 > reviewer runs; the recurring-lapse list in `docs/SESSION_BOOTSTRAP.md` is the
 > same checklist front-loaded into the builder so the repeats stop.
 
@@ -56,8 +56,10 @@ cleanups beyond the slice's contract.
 Every meaningful behavior change has a test, or a documented reason it cannot.
 **Block if:** new logic has no direct test; a bug fix has no regression test; a
 critical path has only manual testing; tests assert implementation details
-instead of behavior. For detectors/validators/gates, the failure branch is
-proven to fire (`AGENTS.md` 3i), not just the happy path.
+instead of behavior; tests cover only a trivial happy path while realistic
+negative, edge, malformed, sparse, or varied-input cases remain unexercised.
+For detectors/validators/gates, the failure branch is proven to fire
+(`AGENTS.md` 3i), not just the happy path.
 
 ### R3 - Security and authorization
 Any user input, permission check, token, secret, file upload, webhook, or admin
@@ -132,6 +134,18 @@ high-risk change; **a new or renamed test is not wired into the CI workflow that
 runs it** (adding a `test:*` script does not make CI run it - the matching
 `run:` step ships in the same PR).
 
+### R13 - Fix the class, not the example
+Review findings that identify a defect class must be fixed at the class level,
+not by hardcoding the reviewer's cited strings, values, paths, or examples.
+**Block if:** the patch hardcodes the reviewer's example values; the tests reuse
+only the examples named in the finding; the mechanism cannot pass a held-out
+same-class probe; or the builder claims the class is fixed without showing
+fresh same-class cases the reviewer did not provide. Preferred proof is a
+property/parametrized test that generates cases; when generation is not
+practical, use multiple unseen fixtures plus a short explanation of the
+generalized mechanism. Generated or unseen cases must be diverse enough to
+exercise the class, not trivial near-duplicates that satisfy the easy path.
+
 ---
 
 ## Path-based rule triggers
@@ -151,11 +165,29 @@ these for the paths it touches:
 | `atlas_brain/config.py`, env/config | R11, R12 |
 | `scripts/audit_*.py`, `scripts/check_*.py`, evaluators / gate predicates | R2 (failure-branch fixtures per `AGENTS.md` 3h/3i), R10 |
 | `extracted_*/` synced files | R1, R10 (manifest sync discipline) |
+| Review comments that name a defect class ("all X", "class of Y", "same failure mode") | R13 (held-out/propertied proof that the class, not only the example, is fixed) |
 
 Phase 1 of this convention is documentation + reviewer discipline. A later
 slice adds a mechanical audit that derives the required rule IDs from the diff
 and fails when the plan's triggered-rules line omits one (see
 `AGENTS.md` 4 and the workflow-redesign issue).
+
+---
+
+## Class-defect review framing
+
+When a reviewer finds a class defect, the finding should say so explicitly:
+"This is a CLASS defect; the example below is illustrative, not the target."
+Name the cited example, name at least one visible same-class probe, and state
+that the reviewer may keep a held-out probe for re-review. This prevents the
+review comment from becoming a hardcoding target.
+
+The reviewer should reject a "fixed" response that only proves the cited
+example. Before LGTM on an R13-triggering finding, verify one of:
+
+- a property/parametrized test generates diverse same-class cases;
+- unseen fixtures cover varied cases not listed in the original finding; or
+- the reviewer reran a held-out probe and the verdict records it.
 
 ---
 

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -27,9 +27,11 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >    - **Lookup-and-backfill fails safe on ambiguity:** match an external resource only on a *unique* result; 0 *or* >1 matches → don't guess.
 >    - **Per-tenant credentials fail closed:** an unprovisioned tenant must not silently borrow shared/global credentials.
 >    - **CI is truth:** "passed locally" ≠ green. Run the test the way CI does and check `gh pr checks` is green before claiming done.
+>    - **Tests must be meaningful, not just green:** for logic changes, a trivial happy-path test is not enough. Add negative/edge/malformed/sparse/varied-input coverage proportional to risk, or explicitly name why it is deferred.
 >    - **Fixtures must match real producer output**, not hand-crafted shapes.
 >    - **The PR body's stated safety claim must be *enforced in code*, not just named.**
 >    - **Content Ops live model route:** generated-content validation must use the configured cloud/OpenRouter route (currently Claude via OpenRouter), not local Ollama/qwen. For live smokes, set `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false` so a missing cloud route fails closed instead of silently falling back to a local model.
+>    - **Fix the class, not the example:** when review names a defect class, do not hardcode the reviewer's cited strings/values or test only the cited example. Reproduce the cited case, then generate or write 5-10 same-class cases the reviewer did not mention (property/parametrized tests preferred) and include that proof before claiming done. The cases must be diverse enough to exercise the class, not trivial near-duplicates. If you only tested the cited example, say so.
 >
 > 5. **Plan first** (`plans/PR-<Slice>.md`, the 7 sections, <400 LOC soft cap), open PRs ready-for-review (not draft), and run the per-package validation gauntlet before pushing (see CLAUDE.md "Per-package validation gauntlets").
 >    - **PR-prep helpers — use these; don't hand-format the plan shape or push raw:**

--- a/plans/PR-Review-Rule-Fix-Class-Not-Example.md
+++ b/plans/PR-Review-Rule-Fix-Class-Not-Example.md
@@ -1,0 +1,114 @@
+# PR-Review-Rule-Fix-Class-Not-Example
+
+## Why this slice exists
+
+The same review failure pattern has now repeated across two quality lanes:
+blog-prose/content-quality fixes and raw-ticket clustering recall. In both
+cases, the implementation first fixed the reviewer's cited example instead of
+the defect class, and only generalized after another reviewer probe. That makes
+the process gap explicit: the review contract needs to make hardcoding the
+example unable to pass.
+
+This slice turns that recurrence into review mechanism rather than another
+one-off reminder. It strengthens the test-evidence gate against trivial
+happy-path-only proof, adds R13 to the reviewer rules, front-loads the builder
+self-probe requirement, and logs the pattern in `REVIEW_MISSES.md` as the first
+real flywheel entry.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/review-contract
+Slice phase: Workflow/process
+
+1. Strengthen R2/AGENTS/bootstrap so meaningful logic changes need non-trivial,
+   realistic coverage beyond the happy path.
+2. Add R13, "fix the class, not the example," to `docs/REVIEWER_RULES.md`.
+3. Add builder self-probe discipline for class fixes to `AGENTS.md` and the
+   fresh-session bootstrap.
+4. Add the repeated fix-the-cited-example pattern to `REVIEW_MISSES.md`.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Reviewer rules include R13 and define automatic failure for
+        hardcoding reviewer-cited strings, reusing only reviewer examples as
+        tests, or failing a held-out/unseen probe.
+  - [ ] R2 rejects trivial happy-path-only tests for meaningful logic changes
+        when realistic negative/edge/malformed/sparse/varied-input cases are
+        left unexercised.
+  - [ ] Builder workflow requires 5-10 unseen same-class probes before claiming
+        a class fix complete, with explicit disclosure if only the cited example
+        was tested.
+  - [ ] Generated/unseen class-fix probes must be diverse enough to exercise
+        the class, not trivial near-duplicates.
+  - [ ] Reviewer guidance tells reviewers to frame class defects with an
+        example plus held-out probe discipline, not a single target example.
+  - [ ] Review miss ledger records the recurring blog-prose and clustering
+        "fix the cited example" pattern and names R13/bootstrap as the durable
+        gate.
+- Affected surfaces: developer workflow docs, reviewer rule pack, review miss
+  ledger.
+- Risk areas: process drift, review discipline, PR contract clarity.
+- Reviewer rules triggered: R1, R10.
+
+### Files touched
+
+- `AGENTS.md`
+- `REVIEW_MISSES.md`
+- `docs/REVIEWER_RULES.md`
+- `docs/SESSION_BOOTSTRAP.md`
+- `plans/PR-Review-Rule-Fix-Class-Not-Example.md`
+
+## Mechanism
+
+R2 is tightened so test evidence must exercise realistic non-happy-path
+behavior for meaningful logic changes. R13 is added as a reviewer rule after
+R12 so future review findings can cite a named fail condition instead of
+relying on ad hoc judgment. The rule requires class-level fixes to include
+held-out or generated/parametrized probes and declares hardcoded reviewer
+examples insufficient.
+
+The builder workflow and bootstrap add the reciprocal self-check: when a review
+finding is about a defect class, the builder must generate 5-10 diverse unseen
+same-class cases the reviewer did not mention, verify them, and include that
+proof before claiming the fix complete.
+
+`REVIEW_MISSES.md` gets the first real row so the pattern is visible in the
+reviewer flywheel.
+
+## Intentional
+
+- This is documentation/process only. It does not add a mechanical audit yet
+  because detecting "hardcoded the reviewer's example" generally needs
+  reviewer-held probes or property-style tests, not simple static analysis.
+- The rule requires property/parametrized or held-out probes where possible,
+  but leaves exact mechanics to the slice because some domains cannot generate
+  valid randomized cases safely. It still requires those probes to be diverse
+  enough to exercise the class.
+
+## Deferred
+
+- Mechanical support for R13, if useful later: templates/checkers that nudge
+  reviewers to record held-out probes or property-test evidence in the verdict.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python scripts/sync_pr_plan.py plans/PR-Review-Rule-Fix-Class-Not-Example.md
+  - passed; plan files and diff-size table updated from the real diff.
+- Command: rg -n "R13|Fix the class|Class fixes need unseen probes|fixed the cited example|5-10 same-class|happy path|diverse enough" AGENTS.md docs/REVIEWER_RULES.md docs/SESSION_BOOTSTRAP.md REVIEW_MISSES.md plans/PR-Review-Rule-Fix-Class-Not-Example.md
+  - passed; R13/self-probe/ledger language is present in the intended files.
+- Command: git diff --check
+  - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 35 |
+| `REVIEW_MISSES.md` | 1 |
+| `docs/REVIEWER_RULES.md` | 38 |
+| `docs/SESSION_BOOTSTRAP.md` | 2 |
+| `plans/PR-Review-Rule-Fix-Class-Not-Example.md` | 114 |
+| **Total** | **190** |


### PR DESCRIPTION
Plan: plans/PR-Review-Rule-Fix-Class-Not-Example.md
Slice phase: Workflow/process

This turns the repeated "fixed the cited example, not the defect class" review miss into a named gate, and tightens the broader test-evidence gate so meaningful logic changes cannot pass with trivial happy-path-only coverage. The same pattern showed up in blog-prose quality and raw-ticket clustering recall, so this adds R13 to the reviewer rules, adds the reciprocal builder self-probe requirement, and logs the pattern in the review miss ledger.

## Intentional
- Documentation/process only. No mechanical audit yet because class-level generalization usually needs held-out probes or property-style tests rather than static analysis.
- The rule prefers property/parametrized tests but allows fresh unseen fixtures when generated cases are not practical for the domain; either way, the cases must be diverse enough to exercise the class.

## Deferred
- Mechanical support for R13, if useful later: templates/checkers that nudge reviewers to record held-out probes or property-test evidence in the verdict.

## Parked hardening
- None.

## Verification
- `python scripts/sync_pr_plan.py plans/PR-Review-Rule-Fix-Class-Not-Example.md` - passed
- `rg -n "R13|Fix the class|Class fixes need unseen probes|fixed the cited example|5-10 same-class|happy path|diverse enough" AGENTS.md docs/REVIEWER_RULES.md docs/SESSION_BOOTSTRAP.md REVIEW_MISSES.md plans/PR-Review-Rule-Fix-Class-Not-Example.md` - passed
- `git diff --check` - passed

## Diff size
5 files, +184 / -6
