### PR TITLE
Dev workflow open PR stdin wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,9 +275,17 @@ rather than hand-formatting:
   the **single** local-review runner; if the managed hook is missing or
   intentionally skipped, the wrapper runs `local_pr_review.sh` before pushing.
   The wrapper rejects `--no-verify`.
+- `bash scripts/open_pr.sh <pr-body-file> [gh-pr-create-args...]` — creates a
+  PR for the current branch, or updates the existing PR body, using
+  `--body-file - < <pr-body-file>`. Do not hand-roll
+  `gh pr create/edit --body-file <path>`; under sandboxing `gh` can fail to
+  open direct file paths. The shell redirect reads the file and `gh` receives
+  the body on stdin. If the PR already exists, this wrapper updates only the
+  body; use `gh pr edit` manually for title/base/label changes.
 
 Flow: `bash scripts/new_pr_plan.sh` -> implement ->
-`python scripts/sync_pr_plan.py` -> `bash scripts/push_pr.sh`.
+`python scripts/sync_pr_plan.py` -> `bash scripts/push_pr.sh` ->
+`bash scripts/open_pr.sh`.
 Do **not** run a separate manual `local_pr_review.sh` immediately before
 `push_pr.sh`; that duplicates the same mechanical bundle and burns context.
 Use manual local review for ad hoc triage or when you are not about to push.

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -46,6 +46,11 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >      before pushing. Reconstructing the plan shape by hand or pushing
 >      without the body env is what burns the formatting/failed-push loop. See
 >      AGENTS.md §3a.2.
+>      After the push, open or update GitHub with
+>      `bash scripts/open_pr.sh <pr-body-file> [gh-pr-create-args...]`. Never
+>      hand-roll `gh pr create/edit --body-file <path>`; use the wrapper, or
+>      the stdin shape `--body-file - < file`, so `gh` reads fd 0 instead of
+>      opening a sandboxed file path.
 >
 > 6. **Context discipline (keeps the session from compacting mid-work):**
 >    - After opening or updating a PR, **stop** — do not poll CI or wait for review (AGENTS.md §3c). Report the PR URL + the local checks you already ran, then hand back to the operator; resume only on the operator's signal.

--- a/plans/PR-Dev-Workflow-Open-PR-Stdin-Wrapper.md
+++ b/plans/PR-Dev-Workflow-Open-PR-Stdin-Wrapper.md
@@ -1,0 +1,99 @@
+# PR-Dev-Workflow-Open-PR-Stdin-Wrapper
+
+## Why this slice exists
+
+Issue #1306 tracks PR-opening friction. The first pass added plan/push helpers,
+but the GitHub-side open/update step is still unwrapped, so builders keep
+hand-rolling `gh pr create --body-file <path>` after the push. In this sandbox
+shape, direct file-path body reads can fail inside `gh`; the stable form is
+`--body-file - < file`, where the shell opens the file and `gh` reads stdin.
+
+This slice closes that remaining workflow gap with a tiny wrapper and makes the
+builder contract explicit so the mistake is not reintroduced after compaction.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/pr-friction
+Slice phase: Workflow/process
+
+1. Add a PR open/update helper that creates the current-branch PR when missing
+   or updates the existing PR body when present.
+2. Ensure the helper always passes the PR body through stdin, never as a file
+   path argument to `gh`.
+3. Update builder-facing docs to use the wrapper and forbid raw
+   `gh pr create/edit --body-file <path>`.
+4. Add focused tests that fake `gh`, assert argv shape, and prove the body
+   content arrives on stdin for both create and edit flows.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `scripts/open_pr.sh` accepts a body file and defaults to the current
+        branch.
+  - [ ] Missing body files and direct body args fail with clear messages.
+  - [ ] Create flow invokes `gh pr create ... --body-file -` and feeds body
+        content on stdin.
+  - [ ] Existing-PR flow invokes `gh pr edit <branch> --body-file -` and feeds
+        body content on stdin.
+  - [ ] AGENTS/bootstrap docs tell builders to use the wrapper and avoid raw
+        direct-path `--body-file`.
+- Affected surfaces: builder workflow scripts, builder session docs, workflow
+  helper tests.
+- Risk areas: accidentally bypassing body env/local review semantics, or
+  making existing PR body updates accept create-only args silently.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/SESSION_BOOTSTRAP.md`
+- `plans/PR-Dev-Workflow-Open-PR-Stdin-Wrapper.md`
+- `scripts/open_pr.sh`
+- `tests/test_open_pr_wrapper.py`
+
+## Mechanism
+
+`scripts/open_pr.sh BODY_FILE [gh-pr-create-args...]` validates the body file,
+rejects direct body args, resolves the current branch, and checks whether a PR
+already exists for that branch:
+
+- Existing PR: `gh pr edit "$branch" --body-file - < "$body_file"`.
+- Missing PR: `gh pr create "$@" --body-file - < "$body_file"`.
+
+That means the shell opens the local body file and `gh` only reads fd 0. Tests
+copy the wrapper into a temporary git repo and place a fake `gh` first on
+`PATH`; the fake records argv and stdin so regressions to `--body-file <path>`
+fail without making network calls.
+
+## Intentional
+
+- This is a sibling `open_pr.sh` rather than folding PR creation into
+  `push_pr.sh`. Keeping push/local-review and GitHub PR creation separate
+  preserves the current single-local-review push semantics while still
+  removing the brittle hand-written `gh pr create/edit` step.
+- Existing-PR updates reject create-only args instead of guessing how to map
+  them to `gh pr edit`; body update is the safe shared path, and AGENTS now
+  names manual `gh pr edit` for title/base/label changes.
+
+## Deferred
+
+- None.
+
+Parked hardening: none.
+
+## Verification
+
+- Pending before push: targeted pytest wrapper suite covering
+  tests/test_open_pr_wrapper.py and tests/test_push_pr_wrapper.py.
+- Pending before push: push through scripts/push_pr.sh with the PR body file.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 10 |
+| `docs/SESSION_BOOTSTRAP.md` | 5 |
+| `plans/PR-Dev-Workflow-Open-PR-Stdin-Wrapper.md` | 99 |
+| `scripts/open_pr.sh` | 74 |
+| `tests/test_open_pr_wrapper.py` | 168 |
+| **Total** | **356** |

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Open or update a GitHub PR while feeding the body through stdin.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/open_pr.sh BODY_FILE [gh-pr-create-args...]
+
+Creates a PR for the current branch, or updates the existing PR body for that
+branch. The PR body is always passed as stdin (`--body-file - < BODY_FILE`) so
+the GitHub CLI never has to open BODY_FILE itself.
+
+Examples:
+  bash scripts/open_pr.sh tmp/pr-body-my-slice.md --title "My slice" --base main
+  bash scripts/open_pr.sh tmp/pr-body-my-slice.md
+
+Use scripts/push_pr.sh before this wrapper to push the branch with the local
+review body env wired into the pre-push hook.
+EOF
+}
+
+if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
+    exit 2
+fi
+
+body_file="$1"
+shift
+
+if [ ! -f "$body_file" ]; then
+    echo "open_pr.sh: PR body file not found: $body_file" >&2
+    echo "Create the body file first, then rerun this wrapper." >&2
+    exit 2
+fi
+
+for arg in "$@"; do
+    case "$arg" in
+        --body|--body-file|-b|-F)
+            echo "open_pr.sh: pass the PR body as BODY_FILE, not via $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+branch="$(git branch --show-current)"
+if [ -z "$branch" ]; then
+    echo "open_pr.sh: current checkout is detached; switch to a branch first" >&2
+    exit 2
+fi
+
+if gh pr view "$branch" >/dev/null 2>&1; then
+    if [ "$#" -gt 0 ]; then
+        echo "open_pr.sh: PR already exists for $branch; update body with no create args" >&2
+        echo "Use gh pr edit manually for title/base/label changes." >&2
+        exit 2
+    fi
+
+    if [ "${ATLAS_OPEN_PR_DRY_RUN:-}" = "1" ]; then
+        echo "DRY RUN: gh pr edit $branch --body-file - < $body_file"
+        exit 0
+    fi
+
+    gh pr edit "$branch" --body-file - < "$body_file"
+else
+    if [ "${ATLAS_OPEN_PR_DRY_RUN:-}" = "1" ]; then
+        echo "DRY RUN: gh pr create $* --body-file - < $body_file"
+        exit 0
+    fi
+
+    gh pr create "$@" --body-file - < "$body_file"
+fi

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from shutil import copy2
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "open_pr.sh"
+
+
+def test_open_pr_create_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        [
+            "bash",
+            "scripts/open_pr.sh",
+            str(body),
+            "--title",
+            "Workflow wrapper",
+            "--base",
+            "main",
+        ],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert log.read_text(encoding="utf-8").strip() == (
+        "pr create --title Workflow wrapper --base main --body-file -"
+    )
+    assert str(body) not in log.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_edit_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=0)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body)],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert log.read_text(encoding="utf-8").strip() == "pr edit main --body-file -"
+    assert str(body) not in log.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    env, _, _ = _fake_gh_env(tmp_path, view_exit=0)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "New title"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "PR already exists" in result.stderr
+
+
+def test_open_pr_rejects_direct_body_args(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    env, _, _ = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--body-file", str(body)],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "pass the PR body as BODY_FILE" in result.stderr
+
+
+def test_open_pr_missing_body_file_fails_clearly(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    missing = repo / "missing.md"
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(missing)],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "PR body file not found" in result.stderr
+    assert str(missing) in result.stderr
+
+
+def _write_fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    copy2(SCRIPT, repo / "scripts" / "open_pr.sh")
+    subprocess.run(
+        ["git", "init", "--initial-branch", "main"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return repo
+
+
+def _write_body(repo: Path) -> Path:
+    body = repo / "body.md"
+    body.write_text(
+        "Plan: plans/PR-Test.md\nSlice phase: Workflow/process\n",
+        encoding="utf-8",
+    )
+    return body
+
+
+def _fake_gh_env(
+    tmp_path: Path,
+    *,
+    view_exit: int,
+) -> tuple[dict[str, str], Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "gh-argv.txt"
+    stdin_capture = tmp_path / "gh-stdin.txt"
+    gh = bin_dir / "gh"
+    gh.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+    exit "${GH_VIEW_EXIT}"
+fi
+printf '%s\\n' "$*" > "${GH_ARGV_LOG}"
+cat > "${GH_STDIN_CAPTURE}"
+""",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "GH_VIEW_EXIT": str(view_exit),
+        "GH_ARGV_LOG": str(log),
+        "GH_STDIN_CAPTURE": str(stdin_capture),
+    }
+    return env, log, stdin_capture


### PR DESCRIPTION
Plan: plans/PR-Dev-Workflow-Open-PR-Stdin-Wrapper.md
Slice phase: Workflow/process
Refs: #1306

Issue #1306 still had one unwrapped PR-opening step: after `push_pr.sh`, builders could still hand-roll `gh pr create/edit --body-file <path>` and hit the sandbox file-open failure. This PR adds `scripts/open_pr.sh`, which creates or updates the current-branch PR while feeding the body through stdin with `--body-file - < file`, then documents that wrapper in the builder contract and bootstrap.

## Intentional
- `open_pr.sh` is a sibling wrapper instead of folding PR creation into `push_pr.sh`; push/local-review semantics stay stable, and GitHub PR creation gets its own narrow wrapper.
- Existing-PR updates reject create-only args instead of guessing how to map them to `gh pr edit`; body update is the safe shared path.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- `pytest tests/test_open_pr_wrapper.py tests/test_push_pr_wrapper.py` - 11 passed.
- `bash scripts/push_pr.sh tmp/pr-body-dev-workflow-open-pr-stdin-wrapper.md --force-with-lease origin HEAD:claude/pr-dev-workflow-open-pr-stdin-wrapper` - local review passed and branch pushed.

## Diff size
5 files, +355 / -1
