### PR TITLE
Deflection badge wording: deterministic clustering

### DIFF
--- a/plans/PR-Deflection-Badge-Deterministic-Clustering.md
+++ b/plans/PR-Deflection-Badge-Deterministic-Clustering.md
@@ -28,7 +28,7 @@ Slice phase: Product polish
   - [ ] No mechanics change in intake upload/submit behavior.
 - Affected surfaces: `portfolio-ui` intake copy and upload-shell source test.
 - Risk areas: copy/test drift where wording changes without assertion updates.
-- Reviewer rule IDs triggered: R1, R2, R9, R12.
+- Reviewer rules triggered: R9, R12.
 
 ### Files touched
 

--- a/plans/PR-Deflection-Badge-Deterministic-Clustering.md
+++ b/plans/PR-Deflection-Badge-Deterministic-Clustering.md
@@ -1,0 +1,70 @@
+# PR-Deflection-Badge-Deterministic-Clustering
+
+## Why this slice exists
+
+Issue #1367 tracks deterministic messaging for the FAQ deflection intake trust
+badge. The existing subtext says "exact mathematical clustering," which is less
+precise than the more defensible claims-doctrine wording. This slice swaps that
+phrase to "deterministic clustering" and locks it with a source assertion.
+
+## Scope (this PR)
+
+Ownership lane: ai-content-ops/faq-support-ticket-deflection
+Slice phase: Product polish
+
+1. Update the `portfolio-ui` intake trust-badge subtext to use
+   "deterministic clustering" wording.
+2. Update the upload-shell source assertion to require deterministic-clustering
+   wording and reject the old exact-mathematical phrase.
+3. Keep upload behavior, submit flow, and endpoint contracts unchanged.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Badge subtext on the FAQ deflection intake page uses
+        "deterministic clustering" wording.
+  - [ ] Upload-shell test asserts deterministic-clustering wording and rejects
+        "exact mathematical clustering".
+  - [ ] No mechanics change in intake upload/submit behavior.
+- Affected surfaces: `portfolio-ui` intake copy and upload-shell source test.
+- Risk areas: copy/test drift where wording changes without assertion updates.
+- Reviewer rule IDs triggered: R1, R2, R9.
+
+### Files touched
+
+1. `plans/PR-Deflection-Badge-Deterministic-Clustering.md`
+2. `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+3. `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+Replace one phrase in the intake trust-badge paragraph and align the existing
+source-level test assertion to the new phrase while adding a negative assertion
+against the old wording.
+
+## Intentional
+
+- Copy/test-only update; no UI layout changes.
+- No route, API, payload, or analytics changes in this slice.
+
+## Deferred
+
+- Any broader copy harmonization beyond this phrase swap remains out of scope.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm --prefix portfolio-ui run test:deflection-upload-shell` - PASS.
+- `rg -n "deterministic clustering|exact mathematical clustering" portfolio-ui/src/pages/FaqDeflectionUpload.tsx portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+  - PASS; runtime + test now assert deterministic-clustering wording and reject
+    exact-mathematical wording.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Badge-Deterministic-Clustering.md` | ~77 |
+| `portfolio-ui/src/pages/FaqDeflectionUpload.tsx` | ~1 |
+| `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` | ~2 |
+| Total | ~80 |

--- a/plans/PR-Deflection-Badge-Deterministic-Clustering.md
+++ b/plans/PR-Deflection-Badge-Deterministic-Clustering.md
@@ -28,7 +28,7 @@ Slice phase: Product polish
   - [ ] No mechanics change in intake upload/submit behavior.
 - Affected surfaces: `portfolio-ui` intake copy and upload-shell source test.
 - Risk areas: copy/test drift where wording changes without assertion updates.
-- Reviewer rule IDs triggered: R1, R2, R9.
+- Reviewer rule IDs triggered: R1, R2, R9, R12.
 
 ### Files touched
 

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -165,7 +165,8 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.match(uploadSource, /repeatable clustering/);
   assert.match(uploadSource, /not\s+chatbot interpretation/);
   assert.match(uploadSource, /100% Deterministic Engine/);
-  assert.match(uploadSource, /This tool does not use LLMs or generative AI[\s\S]*exact mathematical clustering/);
+  assert.match(uploadSource, /This tool does not use LLMs or generative AI[\s\S]*deterministic clustering/);
+  assert.doesNotMatch(uploadSource, /exact mathematical clustering/);
   assert.match(uploadSource, /Workspace routing is handled server-side/);
   assert.match(uploadSource, /Your browser never[\s\S]*receives ATLAS service tokens/);
   assert.match(uploadSource, /Your CSV stays in private storage first/);

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -260,7 +260,7 @@ export default function FaqDeflectionUpload() {
                 </p>
                 <p className="mt-2 text-xs leading-5 text-primary-100/80">
                   This tool does not use LLMs or generative AI to analyze your
-                  logs. We use exact mathematical clustering to sort your data.
+                  logs. We use deterministic clustering to sort your data.
                 </p>
               </div>
               <span className="mt-3 block text-xs text-surface-200/60">


### PR DESCRIPTION
Plan: plans/PR-Deflection-Badge-Deterministic-Clustering.md
Slice phase: Product polish

Issue #1367 tracks deterministic trust-badge wording for the FAQ deflection intake. This slice tightens claims phrasing by replacing \"exact mathematical clustering\" with \"deterministic clustering\" and aligns upload-shell source assertions so the old phrase cannot silently return.

## Intentional
- Copy/test precision only; upload mechanics and submit behavior are unchanged.
- Scope is limited to the ATLAS portfolio-ui intake badge surface.

## Deferred
- Any broader copy harmonization beyond this exact phrase swap remains separate.

## Parked hardening
- None.

## Verification
- `npm --prefix portfolio-ui run test:deflection-upload-shell` - PASS.
- `rg -n "deterministic clustering|exact mathematical clustering" portfolio-ui/src/pages/FaqDeflectionUpload.tsx portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` - PASS; deterministic phrase present and old phrase rejected in test assertions.
- `bash scripts/push_pr.sh /tmp/atlas-badge-pr-body.md` - PASS.

## Diff size
3 files, +73 / -4