### PR TITLE
Content-Ops MCP Claude Hosted OAuth Compatibility

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -14,9 +14,11 @@ on:
       - "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
       - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
       - "scripts/check_content_ops_marketer_verify_dual_client_rollout.py"
+      - "scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py"
       - "scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
+      - "tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py"
       - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
       - "tests/test_check_content_ops_marketer_verify_dual_client_rollout.py"
       - "tests/test_content_ops_marketer_verify_launcher_contract.py"
@@ -37,9 +39,11 @@ on:
       - "scripts/check_content_ops_marketer_verify_oauth_discovery.py"
       - "scripts/check_content_ops_marketer_verify_oauth_e2e.py"
       - "scripts/check_content_ops_marketer_verify_dual_client_rollout.py"
+      - "scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py"
       - "scripts/start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py"
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
+      - "tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py"
       - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
       - "tests/test_check_content_ops_marketer_verify_dual_client_rollout.py"
       - "tests/test_content_ops_marketer_verify_launcher_contract.py"
@@ -69,6 +73,7 @@ jobs:
         run: |
           python -m pytest \
             tests/test_atlas_content_ops_review_workflow.py \
+            tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py \
             tests/test_check_content_ops_marketer_verify_dual_client_rollout.py \
             tests/test_check_content_ops_marketer_verify_oauth_e2e.py \
             tests/test_content_ops_marketer_verify_launcher_contract.py \

--- a/plans/PR-Content-Ops-MCP-Claude-Hosted-OAuth-Compatibility.md
+++ b/plans/PR-Content-Ops-MCP-Claude-Hosted-OAuth-Compatibility.md
@@ -1,0 +1,60 @@
+# PR-Content-Ops-MCP-Claude-Hosted-OAuth-Compatibility
+
+## Why this slice exists
+Live Claude.ai setup exposed a #1415 rollout gap: hosted Claude used root OAuth
+endpoints while the rich verifier was documented under `/content-ops-marketer`.
+This slice makes the working root-alias path repeatable and testable.
+
+## Scope (this PR)
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+Add Claude-hosted root OAuth alias guidance to the rich launcher, a checker for
+the observed root authorization redirect, focused tests, and CI enrollment.
+
+### Files touched
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+- `plans/PR-Content-Ops-MCP-Claude-Hosted-OAuth-Compatibility.md`
+- `scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `scripts/start_content_ops_marketer_verify_oauth_server.py`
+- `tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py`
+- `tests/test_content_ops_marketer_verify_launcher_contract.py`
+- `tests/test_start_content_ops_marketer_verify_oauth_server.py`
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Launcher prints root OAuth Funnel aliases for Claude hosted connectors.
+  - [ ] Checker accepts root authorization redirects to the Content Ops approval path.
+  - [ ] Checker rejects missing approval redirects, wrong hosts, and non-redirect responses.
+  - [ ] Existing rich verifier and ChatGPT adapter commands remain compatible.
+- Affected surfaces: MCP OAuth rollout scripts, operator guidance, CI enrollment.
+- Risk areas: security, backcompat, deployment safety, maintainability.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12, R13
+
+## Mechanism
+The launcher prints deterministic root OAuth `tailscale funnel` aliases. The
+checker sends a Claude-hosted authorization request without following redirects
+and requires a redirect to the configured Content Ops approval path. Tests mock
+transport and cover success plus failure branches.
+
+## Intentional
+No MCP server changes; no generated OAuth client IDs or secrets; checker
+defaults to Claude's hosted callback URL and accepts overrides.
+
+## Deferred
+Public-client metadata changes and process-manager durability stay deferred. Parked hardening: none.
+
+## Verification
+- Passed: focused launcher/checker pytest, 29 passed.
+- Passed: dedicated Content Ops workflow pytest, 98 passed.
+- Passed: py_compile for launcher and checker.
+- Passed: extracted wrapper, 295 reasoning-core passed; 3540 content-pipeline passed, 10 skipped.
+- Passed: local PR review with body file.
+
+## Estimated diff size
+| Area | Estimated LOC |
+| --- | ---: |
+| Total | ~398 |
+
+8 files, +398 / -0.

--- a/scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py
+++ b/scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Check Claude hosted OAuth root-route compatibility for Content Ops MCP."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+
+
+DEFAULT_SCOPE = "content_ops.review.verify"
+DEFAULT_REDIRECT_URI = "https://claude.ai/api/mcp/auth_callback"
+ISSUER_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"
+RESOURCE_ENV = "ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"
+
+
+def _strip(url: str) -> str:
+    return str(url).strip().rstrip("/")
+
+
+def _approval_path(issuer_url: str) -> str:
+    path = urllib.parse.urlparse(_strip(issuer_url)).path.rstrip("/")
+    return f"{path}/oauth/approve" if path else "/oauth/approve"
+
+
+def _authorization_url(
+    *,
+    root_url: str,
+    resource_url: str,
+    client_id: str,
+    redirect_uri: str,
+    scope: str,
+    state: str,
+    code_challenge: str,
+) -> str:
+    query = urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+            "scope": scope,
+            "resource": resource_url,
+        }
+    )
+    return f"{root_url}/authorize?{query}"
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _open_no_redirect(url: str, timeout: float) -> tuple[int, Mapping[str, str]]:
+    opener = urllib.request.build_opener(_NoRedirect)
+    request = urllib.request.Request(url, headers={"Accept": "text/html"}, method="GET")
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            return response.status, response.headers
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.headers
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+
+def _redirect_errors(*, issuer_url: str, status: int, headers: Mapping[str, str]) -> list[str]:
+    if status not in {302, 303}:
+        return [f"root authorize returned HTTP {status}, expected 302 or 303"]
+    location = headers.get("location") or headers.get("Location") or ""
+    if not location:
+        return ["root authorize redirect missing Location header"]
+    parsed = urllib.parse.urlparse(location)
+    issuer = urllib.parse.urlparse(_strip(issuer_url))
+    errors: list[str] = []
+    if (parsed.scheme, parsed.netloc) != (issuer.scheme, issuer.netloc):
+        errors.append("root authorize redirect host does not match issuer host")
+    expected_path = _approval_path(issuer_url)
+    if parsed.path != expected_path:
+        errors.append(f"root authorize redirect path != {expected_path}")
+    if not urllib.parse.parse_qs(parsed.query).get("request_id", [""])[0]:
+        errors.append("root authorize redirect missing request_id")
+    return errors
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check Claude hosted OAuth root authorize routing.")
+    parser.add_argument("--issuer-url", default=os.environ.get(ISSUER_ENV, ""))
+    parser.add_argument("--resource-url", default=os.environ.get(RESOURCE_ENV, ""))
+    parser.add_argument("--public-root-url", default="")
+    parser.add_argument("--client-id", default="")
+    parser.add_argument("--redirect-uri", default=DEFAULT_REDIRECT_URI)
+    parser.add_argument("--scope", default=DEFAULT_SCOPE)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    return parser
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    issuer_url = _strip(args.issuer_url)
+    resource_url = _strip(args.resource_url)
+    root_source = _strip(args.public_root_url) or issuer_url
+    parsed_root = urllib.parse.urlparse(root_source)
+    root_url = urllib.parse.urlunparse((parsed_root.scheme, parsed_root.netloc, "", "", "", ""))
+    client_id = args.client_id.strip()
+    values = (
+        (f"--issuer-url or {ISSUER_ENV}", issuer_url),
+        (f"--resource-url or {RESOURCE_ENV}", resource_url),
+        ("--public-root-url or a valid issuer host", root_url),
+        ("--client-id", client_id),
+        ("--redirect-uri", args.redirect_uri.strip()),
+        ("--scope", args.scope.strip()),
+    )
+    missing = [label for label, value in values if not value]
+    if missing:
+        print("missing required values: " + ", ".join(missing), file=sys.stderr)
+        return 2
+
+    url = _authorization_url(
+        root_url=root_url,
+        resource_url=resource_url,
+        client_id=client_id,
+        redirect_uri=args.redirect_uri.strip(),
+        scope=args.scope.strip(),
+        state="content-ops-claude-hosted-smoke",
+        code_challenge="content-ops-claude-hosted-smoke-challenge",
+    )
+    try:
+        status, headers = _open_no_redirect(url, args.timeout)
+    except Exception as exc:
+        print(f"Claude hosted OAuth check failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _redirect_errors(issuer_url=issuer_url, status=status, headers=headers)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print("OK: Claude hosted OAuth root authorize route redirects to Content Ops approval")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -109,6 +109,7 @@ pytest \
   tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py \
   tests/test_start_content_ops_marketer_verify_oauth_server.py \
   tests/test_content_ops_marketer_verify_launcher_contract.py \
+  tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py \
   tests/test_check_content_ops_marketer_verify_oauth_discovery.py \
   tests/test_check_content_ops_marketer_verify_oauth_e2e.py \
   tests/test_check_content_ops_marketer_verify_dual_client_rollout.py \

--- a/scripts/start_content_ops_marketer_verify_oauth_server.py
+++ b/scripts/start_content_ops_marketer_verify_oauth_server.py
@@ -19,6 +19,13 @@ DEFAULT_PORT = "8068"
 DEFAULT_ISSUER_URL = "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer"
 DEFAULT_RESOURCE_URL = "https://atlas-brain.tailc7bd29.ts.net/content-ops-marketer/mcp"
 PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource"
+CLAUDE_HOSTED_ROOT_OAUTH_PATHS = (
+    "/.well-known/oauth-authorization-server",
+    "/register",
+    "/authorize",
+    "/token",
+    "/oauth/approve",
+)
 MIN_APPROVAL_TOKEN_LENGTH = 24
 LOCAL_HTTP_HOSTS = {"localhost", "127.0.0.1", "::1"}
 SECRET_KEYS = {
@@ -249,6 +256,11 @@ def _funnel_metadata_path(resource_url: str) -> str:
     return f"{PROTECTED_RESOURCE_METADATA_PATH}{app_path}"
 
 
+def _claude_hosted_root_oauth_routes() -> tuple[tuple[str, str], ...]:
+    """Root aliases Claude hosted connectors can require for manual clients."""
+    return tuple((path, path) for path in CLAUDE_HOSTED_ROOT_OAUTH_PATHS)
+
+
 def _print_operator_guidance(config: LaunchConfig) -> None:
     issuer_url = config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_ISSUER_URL"]
     resource_url = config.env["ATLAS_MCP_CONTENT_OPS_MARKETER_VERIFY_OAUTH_RESOURCE_URL"]
@@ -272,6 +284,23 @@ def _print_operator_guidance(config: LaunchConfig) -> None:
     print("tailscale funnel --bg --yes \\")
     print(f"  --set-path {metadata_path} \\")
     print(f"  http://127.0.0.1:{config.port}{metadata_path}")
+    print()
+    print("Claude hosted connector compatibility routes:")
+    for public_path, target_path in _claude_hosted_root_oauth_routes():
+        print("tailscale funnel --bg --yes \\")
+        print(f"  --set-path {public_path} \\")
+        print(f"  http://127.0.0.1:{config.port}{target_path}")
+    print()
+    print("Manual Claude hosted OAuth settings:")
+    print("- MCP URL: " + resource_url)
+    print("- OAuth Client Secret: leave blank")
+    print("- Redirect URI: https://claude.ai/api/mcp/auth_callback")
+    print()
+    print("After adding the Claude hosted compatibility routes, verify the root OAuth redirect:")
+    print(".venv/bin/python scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url} \\")
+    print("  --client-id <claude-hosted-oauth-client-id>")
     print()
     print("After startup, verify public discovery:")
     print(".venv/bin/python scripts/check_content_ops_marketer_verify_oauth_discovery.py \\")

--- a/tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py
+++ b/tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py"
+ISSUER = "https://atlas.example.com/content-ops-marketer"
+RESOURCE = "https://atlas.example.com/content-ops-marketer/mcp"
+APPROVAL = "https://atlas.example.com/content-ops-marketer/oauth/approve?request_id=req-1"
+BASE_ARGS = ["--issuer-url", ISSUER, "--resource-url", RESOURCE]
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_content_ops_marketer_verify_claude_hosted_oauth",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_redirect_errors_accepts_content_ops_approval_redirect() -> None:
+    module = _load_script_module()
+
+    assert module._redirect_errors(
+        issuer_url=ISSUER,
+        status=302,
+        headers={"Location": APPROVAL},
+    ) == []
+
+
+def test_redirect_errors_cover_failure_branches() -> None:
+    module = _load_script_module()
+
+    assert module._redirect_errors(
+        issuer_url=ISSUER,
+        status=502,
+        headers={},
+    ) == ["root authorize returned HTTP 502, expected 302 or 303"]
+    assert module._redirect_errors(issuer_url=ISSUER, status=303, headers={}) == ["root authorize redirect missing Location header"]
+    errors = module._redirect_errors(
+        issuer_url=ISSUER,
+        status=302,
+        headers={"Location": "https://evil.example.com/oauth/approve"},
+    )
+    assert "root authorize redirect host does not match issuer host" in errors
+    assert "root authorize redirect path != /content-ops-marketer/oauth/approve" in errors
+    assert "root authorize redirect missing request_id" in errors
+
+
+def test_main_reports_success_from_mocked_redirect(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fake_open(url: str, timeout: float):
+        assert url.startswith("https://atlas.example.com/authorize?")
+        assert "resource=https%3A%2F%2Fatlas.example.com%2Fcontent-ops-marketer%2Fmcp" in url
+        assert timeout == 3.0
+        return (
+            302,
+            {"Location": APPROVAL},
+        )
+
+    monkeypatch.setattr(module, "_open_no_redirect", fake_open)
+
+    result = module._main(
+        [
+            *BASE_ARGS,
+            "--client-id",
+            "client-1",
+            "--timeout",
+            "3",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "OK: Claude hosted OAuth root authorize route redirects" in captured.out
+
+
+def test_main_fails_on_missing_client_id_and_bad_redirect(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    result = module._main(
+        [
+            *BASE_ARGS,
+        ]
+    )
+
+    assert result == 2
+    assert "--client-id" in capsys.readouterr().err
+
+    monkeypatch.setattr(module, "_open_no_redirect", lambda *_args, **_kwargs: (200, {}))
+    result = module._main(
+        [
+            *BASE_ARGS,
+            "--client-id",
+            "client-1",
+        ]
+    )
+
+    assert result == 1
+    assert "root authorize returned HTTP 200" in capsys.readouterr().err

--- a/tests/test_content_ops_marketer_verify_launcher_contract.py
+++ b/tests/test_content_ops_marketer_verify_launcher_contract.py
@@ -130,6 +130,33 @@ def test_launcher_e2e_command_satisfies_e2e_checker_parser(
     )
 
 
+def test_launcher_claude_hosted_command_satisfies_checker_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_checker_env(monkeypatch)
+    launcher = _load_script_module("start_content_ops_marketer_verify_oauth_server.py")
+    checker = _load_script_module(
+        "check_content_ops_marketer_verify_claude_hosted_oauth.py"
+    )
+
+    command = _command_for_script(
+        _operator_guidance(launcher),
+        "scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py",
+    )
+    args = checker._build_parser().parse_args(
+        command[2:-2] + ["--client-id", "client-1"]
+    )
+
+    assert command[:2] == [
+        ".venv/bin/python",
+        "scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py",
+    ]
+    assert command[-2:] == ["--client-id", "<claude-hosted-oauth-client-id>"]
+    assert args.issuer_url == launcher.DEFAULT_ISSUER_URL
+    assert args.resource_url == launcher.DEFAULT_RESOURCE_URL
+    assert args.client_id == "client-1"
+
+
 def test_launcher_required_env_covers_server_oauth_account_binding(monkeypatch) -> None:
     launcher = _load_script_module("start_content_ops_marketer_verify_oauth_server.py")
     from atlas_brain.config import settings

--- a/tests/test_start_content_ops_marketer_verify_oauth_server.py
+++ b/tests/test_start_content_ops_marketer_verify_oauth_server.py
@@ -261,6 +261,18 @@ def test_funnel_paths_derive_parent_path_for_mcp_resource() -> None:
     )
 
 
+def test_claude_hosted_root_oauth_routes_cover_observed_paths() -> None:
+    module = _load_script_module()
+
+    assert module._claude_hosted_root_oauth_routes() == (
+        ("/.well-known/oauth-authorization-server", "/.well-known/oauth-authorization-server"),
+        ("/register", "/register"),
+        ("/authorize", "/authorize"),
+        ("/token", "/token"),
+        ("/oauth/approve", "/oauth/approve"),
+    )
+
+
 def test_guidance_masks_secrets_and_prints_content_ops_smokes(capsys) -> None:
     module = _load_script_module()
     env = _valid_env()
@@ -283,6 +295,14 @@ def test_guidance_masks_secrets_and_prints_content_ops_smokes(capsys) -> None:
     assert "--set-path /content-ops-marketer" in captured.out
     assert "http://127.0.0.1:9000" in captured.out
     assert "--set-path /.well-known/oauth-protected-resource/content-ops-marketer" in captured.out
+    assert "--set-path /.well-known/oauth-authorization-server" in captured.out
+    assert "--set-path /register" in captured.out
+    assert "--set-path /authorize" in captured.out
+    assert "--set-path /token" in captured.out
+    assert "--set-path /oauth/approve" in captured.out
+    assert "check_content_ops_marketer_verify_claude_hosted_oauth.py" in captured.out
+    assert "OAuth Client Secret: leave blank" in captured.out
+    assert "Redirect URI: https://claude.ai/api/mcp/auth_callback" in captured.out
     assert "check_content_ops_marketer_verify_oauth_discovery.py" in captured.out
     assert "check_content_ops_marketer_verify_oauth_e2e.py" in captured.out
     assert "--approval-token-file /path/to/local-approval-token" in captured.out


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-Claude-Hosted-OAuth-Compatibility.md
Slice phase: Production hardening

Codifies the live Claude.ai connector workaround where hosted Claude used root OAuth endpoints while the Content Ops rich verifier lived under `/content-ops-marketer`. The rich launcher now prints the required root Funnel aliases, and a checker validates that root authorization redirects to the Content Ops approval page.

## Intentional
- No MCP server changes; Funnel aliases are enough for the current server.
- No generated OAuth client IDs or secrets are committed.
- The checker defaults to Claude's hosted callback URL and accepts overrides.

## Deferred
- Public-client metadata changes for automatic Claude dynamic registration stay deferred.
- Process-manager durability for foreground MCP servers stays deferred.

## Parked hardening
- None.

## Verification
- Passed: focused launcher/checker pytest, 29 passed.
- Passed: dedicated Content Ops workflow pytest, 98 passed.
- Passed: py_compile for launcher and checker.
- Passed: extracted wrapper, 295 reasoning-core passed; 3540 content-pipeline passed, 10 skipped.
- Passed: local PR review with body file.

## Diff size
8 files, +398 / -0
