### PR TITLE
Deflection resolution evidence preview

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -159,6 +159,8 @@
     "drafted_answer_count": 1,
     "generated": 2,
     "no_proven_answer_count": 1,
+    "support_ticket_resolution_evidence_count": 1,
+    "support_ticket_resolution_evidence_present": true,
     "output_checks": {
       "condensed": true,
       "has_action_items": true,

--- a/docs/frontend/content_ops_faq_deflection_snapshot_example.json
+++ b/docs/frontend/content_ops_faq_deflection_snapshot_example.json
@@ -7,7 +7,9 @@
     "repeat_ticket_count": 4,
     "source_date_end": "2026-05-15",
     "source_date_start": "2026-05-01",
-    "source_window_days": 15
+    "source_window_days": 15,
+    "support_ticket_resolution_evidence_count": 1,
+    "support_ticket_resolution_evidence_present": true
   },
   "teaser": {
     "full_answer": {

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -160,6 +160,8 @@ _INPUT_PROVIDER_RESPONSE_METADATA_KEYS = frozenset({
     "included_row_count",
     "skipped_row_count",
     "truncated_row_count",
+    "support_ticket_resolution_evidence_present",
+    "support_ticket_resolution_evidence_count",
 })
 _FAQ_SOURCE_MATERIAL_LIMITED_OUTPUTS = frozenset({
     "faq_markdown",
@@ -1185,6 +1187,9 @@ def create_content_ops_control_surface_router(
                 teaser_preview_count=(
                     resolved_config.deflection_snapshot_teaser_preview_count
                 ),
+                preview_summary_metadata=_deflection_resolution_preview_summary(
+                    payload_mapping
+                ),
                 delivery_email=_delivery_email_from_payload(payload_mapping),
             )
             result = _with_input_provider_diagnostics(result, payload_mapping)
@@ -1867,6 +1872,8 @@ def _with_deflection_submit_diagnostics(
                 "source_period",
                 "top_ticket_clusters",
                 "cluster_quality",
+                "support_ticket_resolution_evidence_present",
+                "support_ticket_resolution_evidence_count",
             )
             if key in package_metadata
         })
@@ -2660,6 +2667,7 @@ async def _gate_deflection_report_artifacts(
     request_id: str,
     top_n: int,
     teaser_preview_count: int,
+    preview_summary_metadata: Mapping[str, Any] | None = None,
     delivery_email: str | None = None,
 ) -> dict[str, Any]:
     gated = dict(result)
@@ -2686,6 +2694,10 @@ async def _gate_deflection_report_artifacts(
                 top_n=top_n,
                 teaser_preview_count=teaser_preview_count,
             ).as_dict()
+            if preview_summary_metadata:
+                snapshot_summary = dict(snapshot.get("summary") or {})
+                snapshot_summary.update(dict(preview_summary_metadata))
+                snapshot["summary"] = snapshot_summary
             await store.save_report(
                 account_id=account_id,
                 request_id=request_id,
@@ -2723,6 +2735,44 @@ def _delivery_email_from_payload(payload: Mapping[str, Any]) -> str | None:
     if not isinstance(inputs, Mapping):
         return None
     return _clean(inputs.get("contact_email")) or None
+
+
+def _deflection_resolution_preview_summary(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    inputs = payload.get("inputs")
+    if not isinstance(inputs, Mapping):
+        return {}
+    if (
+        "support_ticket_resolution_evidence_present" not in inputs
+        and "support_ticket_resolution_evidence_count" not in inputs
+    ):
+        return {}
+    count = _nonnegative_int(inputs.get("support_ticket_resolution_evidence_count"))
+    explicit_present = inputs.get("support_ticket_resolution_evidence_present")
+    present = (
+        explicit_present
+        if isinstance(explicit_present, bool)
+        else count > 0
+    )
+    return {
+        "support_ticket_resolution_evidence_present": bool(present),
+        "support_ticket_resolution_evidence_count": count,
+    }
+
+
+def _nonnegative_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, float) and value.is_integer():
+        return max(0, int(value))
+    if isinstance(value, str):
+        text = value.strip()
+        if text.isdigit():
+            return int(text)
+    return 0
 
 
 def _is_completed_deflection_report_step(step: Any) -> bool:

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -165,6 +165,12 @@ def build_deflection_snapshot(
         "generated": _int(summary.get("generated")),
         "drafted_answer_count": _int(summary.get("drafted_answer_count")),
         "no_proven_answer_count": _int(summary.get("no_proven_answer_count")),
+        "support_ticket_resolution_evidence_present": _resolution_evidence_present(
+            summary
+        ),
+        "support_ticket_resolution_evidence_count": _resolution_evidence_count(
+            summary
+        ),
         "repeat_ticket_count": sum(_ticket_count(item) for item in items),
     }
     source_date_window = _complete_source_date_window(summary, items)
@@ -259,6 +265,8 @@ def deflection_report_summary(faq_result: TicketFAQMarkdownResult) -> dict[str, 
         "ticket_source_count": int(faq_result.ticket_source_count),
         "drafted_answer_count": len(proven),
         "no_proven_answer_count": len(needs_review),
+        "support_ticket_resolution_evidence_present": len(proven) > 0,
+        "support_ticket_resolution_evidence_count": len(proven),
         "output_checks": dict(faq_result.output_checks),
         "top_question": _text(items[0].get("question")) if items else "",
         "top_opportunity_score": _int(items[0].get("opportunity_score")) if items else 0,
@@ -566,6 +574,19 @@ def _artifact_items(
     if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
         return ()
     return tuple(_item(item) for item in items if isinstance(item, Mapping))
+
+
+def _resolution_evidence_count(summary: Mapping[str, Any]) -> int:
+    if "support_ticket_resolution_evidence_count" in summary:
+        return _int(summary.get("support_ticket_resolution_evidence_count"))
+    return _int(summary.get("drafted_answer_count"))
+
+
+def _resolution_evidence_present(summary: Mapping[str, Any]) -> bool:
+    explicit = summary.get("support_ticket_resolution_evidence_present")
+    if isinstance(explicit, bool):
+        return explicit
+    return _resolution_evidence_count(summary) > 0
 
 
 def _snapshot_customer_wording(item: Mapping[str, Any], question: str) -> str:

--- a/plans/PR-Deflection-Resolution-Evidence-Preview-Signal.md
+++ b/plans/PR-Deflection-Resolution-Evidence-Preview-Signal.md
@@ -1,0 +1,126 @@
+# PR-Deflection-Resolution-Evidence-Preview-Signal
+
+## Why this slice exists
+
+Issue #1419 split the remaining publishable-answer gap into small launch gates.
+The input package already computes `support_ticket_resolution_evidence_present`
+and `support_ticket_resolution_evidence_count`, but the pre-payment deflection
+preview only surfaces cluster-quality diagnostics. A question-only export can
+therefore look payable even when it can only produce a gap list, not publishable
+answers. This slice exposes that existing resolution-evidence signal before
+checkout.
+
+Diff-size note: this exceeds the 400 LOC soft cap because the producer schema,
+stored snapshot, public proxy, React result page, and exact contract fixtures
+must change together or the preview gate fails open on one surface.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Add the already-computed support-ticket resolution-evidence present/count
+   values to the deflection submit preview diagnostics.
+2. Render that signal in the hosted pre-payment FAQ deflection result page next
+   to the free snapshot metrics, with absent evidence framed as "gap list only"
+   rather than publishable answers.
+3. Add focused backend and frontend tests for both present and absent evidence
+   so the preview cannot silently drop the launch gate.
+
+### Review Contract
+
+- The API response carries `resolution_evidence_present` and
+  `resolution_evidence_count` from producer metadata; it does not infer the
+  values from UI-only strings or paid report fields.
+- The pre-payment result page shows a visible resolution-evidence diagnostic
+  before checkout and distinguishes present vs absent evidence.
+- The copy stays in the clustering/raw-data lane and does not touch PDF,
+  email, delivery worker, or paid attachment code.
+- Tests cover both branches: present evidence and absent evidence.
+
+- Reviewer rules triggered: R1, R9, R10, R12.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `docs/frontend/content_ops_faq_deflection_snapshot_example.json`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Resolution-Evidence-Preview-Signal.md`
+- `portfolio-ui/api/content-ops/deflection/atlas-report.js`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+- `portfolio-ui/src/pages/FaqDeflectionResult.tsx`
+- `tests/test_atlas_content_ops_input_provider.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_extracted_content_ops_live_execute_harness.py`
+
+## Mechanism
+
+The deflection submit route already builds input-package metadata from the CSV
+rows before returning the snapshot. `_with_deflection_submit_diagnostics(...)`
+copies the existing metadata keys into explicit diagnostics fields next to
+`cluster_quality`. The deflection artifact gate also copies the same
+present/count pair into the unpaid snapshot summary before storing it, so the
+hosted result page can project and render the signal without reading paid
+artifact fields. The public proxy fails closed if the snapshot omits the two
+fields.
+
+## Intentional
+
+- This slice does not add new clustering, synonym handling, HTML normalization,
+  or LLM repair. Those are separate in-lane residuals after #1419 part 1.
+- This slice reuses producer metadata instead of re-scanning CSV rows in the UI;
+  the input package remains the source of truth for whether resolution evidence
+  exists.
+- This slice does not call or render the paid report artifact. The signal must
+  be available pre-payment from the unpaid snapshot/diagnostics envelope.
+
+## Deferred
+
+- #1419 part 2: live proof on a real resolution-bearing export that produces
+  publishable answer groups.
+- In-lane residual: finish HTML normalization so raw tags cannot reach clustered
+  text/output on HTML-heavy exports.
+- In-lane residual: improve deterministic synonym grouping for themes with no
+  shared tokens.
+
+Parked hardening: none.
+
+## Verification
+
+- Py compile for changed Python modules and tests - passed.
+- Node syntax check for changed deflection proxy/result files - passed.
+- Focused deflection submit/snapshot contract pytest - 23 passed.
+- Full deflection report contract pytest - 41 passed.
+- Focused preview metadata and live execute harness pytest - 2 passed.
+- Portfolio upload shell test - 20 checks passed.
+- Portfolio result page test - 17 checks passed.
+- Portfolio ATLAS proxy test - 17 checks passed.
+- Extracted content validation, reasoning import audit, standalone audit, and
+  ASCII check - passed.
+- Extracted CI mirror - 3538 passed, 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_deflection_report_example.json` | 2 |
+| `docs/frontend/content_ops_faq_deflection_snapshot_example.json` | 4 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 50 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 21 |
+| `plans/PR-Deflection-Resolution-Evidence-Preview-Signal.md` | 126 |
+| `portfolio-ui/api/content-ops/deflection/atlas-report.js` | 12 |
+| `portfolio-ui/api/content-ops/deflection/result-page.js` | 33 |
+| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 62 |
+| `portfolio-ui/scripts/faq-deflection-result-page.test.mjs` | 39 |
+| `portfolio-ui/src/pages/FaqDeflectionResult.tsx` | 55 |
+| `tests/test_atlas_content_ops_input_provider.py` | 2 |
+| `tests/test_content_ops_deflection_report.py` | 5 |
+| `tests/test_content_ops_faq_report_contract_docs.py` | 2 |
+| `tests/test_extracted_content_deflection_submit.py` | 24 |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | 2 |
+| **Total** | **439** |

--- a/portfolio-ui/api/content-ops/deflection/atlas-report.js
+++ b/portfolio-ui/api/content-ops/deflection/atlas-report.js
@@ -101,12 +101,18 @@ function projectSnapshot(snapshot) {
   const generated = finiteNumber(snapshot.summary.generated);
   const draftedAnswerCount = finiteNumber(snapshot.summary.drafted_answer_count);
   const noProvenAnswerCount = finiteNumber(snapshot.summary.no_proven_answer_count);
+  const resolutionEvidencePresent = snapshot.summary.support_ticket_resolution_evidence_present;
+  const resolutionEvidenceCount = finiteNumber(
+    snapshot.summary.support_ticket_resolution_evidence_count,
+  );
   if (
     generated === null ||
     draftedAnswerCount === null ||
-    noProvenAnswerCount === null
+    noProvenAnswerCount === null ||
+    typeof resolutionEvidencePresent !== "boolean" ||
+    resolutionEvidenceCount === null
   ) {
-    errors.push("snapshot.summary metrics must be finite numbers");
+    errors.push("snapshot.summary metrics must include finite counts and resolution evidence");
   }
 
   const topQuestions = snapshot.top_questions.map((item) => {
@@ -138,6 +144,8 @@ function projectSnapshot(snapshot) {
         generated,
         drafted_answer_count: draftedAnswerCount,
         no_proven_answer_count: noProvenAnswerCount,
+        support_ticket_resolution_evidence_present: resolutionEvidencePresent,
+        support_ticket_resolution_evidence_count: resolutionEvidenceCount,
       },
       top_questions: topQuestions,
     },

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -42,6 +42,10 @@ function formatNumber(value) {
   return Number.isFinite(value) ? String(value) : "0";
 }
 
+function finiteCount(value) {
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
 function customerWordingExamples(questions) {
   return questions
     .map((question) => clean(question && question.customer_wording))
@@ -66,6 +70,26 @@ function renderCustomerWordingCard(questions) {
           </div>`;
 }
 
+function renderResolutionEvidenceDiagnostic(summary) {
+  const present = summary.support_ticket_resolution_evidence_present === true;
+  const count = finiteCount(summary.support_ticket_resolution_evidence_count);
+  const label = present ? "Present" : "Absent";
+  const copy = present
+    ? `${formatNumber(count)} resolved ticket rows can support publishable answer drafting.`
+    : "This export supports a gap list only; publishable answers need agent replies or resolved ticket notes.";
+  return `<div
+            class="resolution-evidence ${present ? "present" : "absent"}"
+            data-atlas-deflection-resolution-evidence
+            data-resolution-evidence-present="${present ? "true" : "false"}"
+          >
+            <div>
+              <span>Resolution evidence</span>
+              <strong>${label}</strong>
+            </div>
+            <p>${escapeHtml(copy)}</p>
+          </div>`;
+}
+
 function renderSnapshot(report) {
   if (!report || !report.ok || !report.snapshot) {
     return `<section class="snapshot" aria-labelledby="snapshot-title">
@@ -84,6 +108,7 @@ function renderSnapshot(report) {
             <div><span>Evidence-backed answers</span><strong>${escapeHtml(formatNumber(summary.drafted_answer_count))}</strong></div>
             <div><span>Needs support proof</span><strong>${escapeHtml(formatNumber(summary.no_proven_answer_count))}</strong></div>
           </div>
+          ${renderResolutionEvidenceDiagnostic(summary)}
           <h2>Help-desk SEO targeting list</h2>
           <p class="muted">Use actual customer phrases from the uploaded tickets for help-center titles, internal-search synonyms, and FAQ wording. No keyword volume, ranking, or traffic promise is implied.</p>
           ${renderCustomerWordingCard(questions)}
@@ -218,6 +243,12 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     .metrics div { border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; padding: 14px; background: rgba(2, 6, 23, .35); }
     .metrics span { display: block; color: rgba(226, 232, 240, .66); font-size: 13px; }
     .metrics strong { display: block; margin-top: 8px; font-size: 28px; }
+    .resolution-evidence { display: flex; gap: 18px; justify-content: space-between; align-items: flex-start; margin: 0 0 24px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; padding: 16px; background: rgba(2, 6, 23, .35); }
+    .resolution-evidence span { display: block; color: rgba(226, 232, 240, .66); font-size: 13px; }
+    .resolution-evidence strong { display: block; margin-top: 6px; font-size: 18px; }
+    .resolution-evidence p { max-width: 560px; margin: 0; color: rgba(226, 232, 240, .75); line-height: 1.55; }
+    .resolution-evidence.present strong { color: #86efac; }
+    .resolution-evidence.absent strong { color: #fde68a; }
     .customer-wording-card { margin: 18px 0 24px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(2, 6, 23, .35); padding: 18px; }
     .customer-wording-header { display: flex; gap: 10px; align-items: baseline; justify-content: space-between; }
     .customer-wording-header p { margin: 0; font-weight: 700; }
@@ -233,7 +264,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     .notice { margin-top: 20px; border-radius: 8px; padding: 14px 16px; color: #fde68a; background: rgba(251, 191, 36, .1); border: 1px solid rgba(251, 191, 36, .28); }
     .success { color: #bbf7d0; background: rgba(34, 197, 94, .1); border-color: rgba(34, 197, 94, .28); }
     .muted { color: rgba(226, 232, 240, .68); line-height: 1.65; }
-    @media (max-width: 820px) { .grid, .metrics, .customer-wording-list { grid-template-columns: 1fr; } .shell { padding-top: 32px; } .customer-wording-header { align-items: flex-start; flex-direction: column; } }
+    @media (max-width: 820px) { .grid, .metrics, .customer-wording-list { grid-template-columns: 1fr; } .shell { padding-top: 32px; } .customer-wording-header, .resolution-evidence { align-items: flex-start; flex-direction: column; } }
   </style>
 </head>
 <body>

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -22,6 +22,8 @@ const SNAPSHOT = {
     generated: 3,
     drafted_answer_count: 2,
     no_proven_answer_count: 1,
+    support_ticket_resolution_evidence_present: true,
+    support_ticket_resolution_evidence_count: 2,
   },
   top_questions: [
     {
@@ -198,7 +200,31 @@ await test("snapshot projection only returns known safe fields", async () => {
   assert.equal(JSON.stringify(result).includes("markdown"), false);
   assert.equal(JSON.stringify(result).includes("answer_steps"), false);
   assert.deepEqual(snapshotErrors({ summary: {}, top_questions: [] }), [
-    "snapshot.summary metrics must be finite numbers",
+    "snapshot.summary metrics must include finite counts and resolution evidence",
+  ]);
+});
+
+await test("proxy rejects snapshots that omit resolution evidence diagnostics", async () => {
+  const missingResolutionEvidence = {
+    ...SNAPSHOT,
+    summary: {
+      generated: 3,
+      drafted_answer_count: 2,
+      no_proven_answer_count: 1,
+    },
+  };
+  const result = await loadDeflectionReport({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    env: ENV,
+    fetchImpl: mockFetch([response(missingResolutionEvidence, 200)]).fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 502);
+  assert.equal(result.error, "atlas_snapshot_contract_violation");
+  assert.deepEqual(result.details, [
+    "snapshot.summary metrics must include finite counts and resolution evidence",
   ]);
 });
 
@@ -297,6 +323,11 @@ await test("hosted result page renders real snapshot metrics from the proxy enve
     },
   });
   assert.match(html, /Questions found/);
+  assert.match(html, /data-atlas-deflection-resolution-evidence/);
+  assert.match(html, /data-resolution-evidence-present="true"/);
+  assert.match(html, /Resolution evidence/);
+  assert.match(html, /Present/);
+  assert.match(html, /2 resolved ticket rows can support publishable answer drafting/);
   assert.match(html, />3</);
   assert.match(html, /How do I reset billing access\?/);
   assert.match(html, /artifact_status/);
@@ -306,6 +337,35 @@ await test("hosted result page renders real snapshot metrics from the proxy enve
   assert.match(html, /Continue to Checkout/);
   assertUnlockCta(html, { disabled: false });
   assert.doesNotMatch(html, /# Paid report/);
+  assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
+});
+
+await test("hosted result page flags question-only exports as gap list only", () => {
+  const html = renderResultPage({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    report: {
+      ok: true,
+      snapshot: {
+        ...SNAPSHOT,
+        summary: {
+          ...SNAPSHOT.summary,
+          drafted_answer_count: 0,
+          no_proven_answer_count: 3,
+          support_ticket_resolution_evidence_present: false,
+          support_ticket_resolution_evidence_count: 0,
+        },
+      },
+      artifact_status: "locked",
+    },
+  });
+
+  assert.match(html, /data-atlas-deflection-resolution-evidence/);
+  assert.match(html, /data-resolution-evidence-present="false"/);
+  assert.match(html, /Resolution evidence/);
+  assert.match(html, /Absent/);
+  assert.match(html, /gap list only/);
+  assert.match(html, /publishable answers need agent replies or resolved ticket notes/);
   assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
 });
 

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -93,6 +93,9 @@ await test("result page exposes validation markers and checkout metadata", () =>
     assert.match(resultPageSource, new RegExp(marker));
     assert.match(html, new RegExp(marker));
   }
+  for (const source of [pageSource, resultPageSource]) {
+    assert.match(source, /data-atlas-deflection-resolution-evidence/);
+  }
   assert.match(pageSource, /content_ops_deflection_report/);
   assert.match(html, /content_ops_deflection_report/);
   assert.match(html, /content-ops-abc123/);
@@ -149,13 +152,23 @@ await test("real snapshot page groups bounded customer wording examples", () => 
     report: {
       ok: true,
       snapshot: {
-        summary: { generated: 6, drafted_answer_count: 2, no_proven_answer_count: 4 },
+        summary: {
+          generated: 6,
+          drafted_answer_count: 2,
+          no_proven_answer_count: 4,
+          support_ticket_resolution_evidence_present: true,
+          support_ticket_resolution_evidence_count: 2,
+        },
         top_questions: topQuestions,
       },
       artifact_status: "locked",
     },
   });
   assert.match(html, /Help-desk SEO targeting list/);
+  assert.match(html, /data-atlas-deflection-resolution-evidence/);
+  assert.match(html, /data-resolution-evidence-present="true"/);
+  assert.match(html, /Resolution evidence/);
+  assert.match(html, /Present/);
   assert.match(html, /Customer wording/);
   assert.match(html, /aria-label="Customer wording examples"/);
   assert.match(html, /No keyword volume, ranking, or traffic promise is implied/);
@@ -180,7 +193,13 @@ await test("real snapshot page groups bounded customer wording examples", () => 
     report: {
       ok: true,
       snapshot: {
-        summary: { generated: 0, drafted_answer_count: 0, no_proven_answer_count: 0 },
+        summary: {
+          generated: 0,
+          drafted_answer_count: 0,
+          no_proven_answer_count: 0,
+          support_ticket_resolution_evidence_present: false,
+          support_ticket_resolution_evidence_count: 0,
+        },
         top_questions: [],
       },
       artifact_status: "locked",
@@ -234,7 +253,13 @@ await test("hosted result page loads report with configured account when URL omi
         return JSON.stringify(
           calls.length === 1
             ? {
-                summary: { generated: 1, drafted_answer_count: 0, no_proven_answer_count: 1 },
+                summary: {
+                  generated: 1,
+                  drafted_answer_count: 0,
+                  no_proven_answer_count: 1,
+                  support_ticket_resolution_evidence_present: false,
+                  support_ticket_resolution_evidence_count: 0,
+                },
                 top_questions: [
                   {
                     rank: 1,
@@ -505,7 +530,13 @@ await test("hosted result page handles the Checkout cancel return token", () => 
     report: {
       ok: true,
       snapshot: {
-        summary: { generated: 1, drafted_answer_count: 0, no_proven_answer_count: 1 },
+        summary: {
+          generated: 1,
+          drafted_answer_count: 0,
+          no_proven_answer_count: 1,
+          support_ticket_resolution_evidence_present: false,
+          support_ticket_resolution_evidence_count: 0,
+        },
         top_questions: [],
       },
       artifact_status: "locked",

--- a/portfolio-ui/src/pages/FaqDeflectionResult.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionResult.tsx
@@ -32,6 +32,8 @@ type DeflectionSnapshot = {
     generated: number;
     drafted_answer_count: number;
     no_proven_answer_count: number;
+    support_ticket_resolution_evidence_present: boolean;
+    support_ticket_resolution_evidence_count: number;
   };
   top_questions: Array<{
     rank: number;
@@ -87,12 +89,21 @@ function parseSnapshot(value: unknown): SnapshotState {
   const generated = finiteNumber(value.summary.generated);
   const draftedAnswerCount = finiteNumber(value.summary.drafted_answer_count);
   const noProvenAnswerCount = finiteNumber(value.summary.no_proven_answer_count);
+  const resolutionEvidencePresent = value.summary.support_ticket_resolution_evidence_present;
+  const resolutionEvidenceCount = finiteNumber(
+    value.summary.support_ticket_resolution_evidence_count,
+  );
   if (
     generated === null ||
     draftedAnswerCount === null ||
-    noProvenAnswerCount === null
+    noProvenAnswerCount === null ||
+    typeof resolutionEvidencePresent !== "boolean" ||
+    resolutionEvidenceCount === null
   ) {
-    return { status: "invalid", reason: "Snapshot summary metrics were incomplete." };
+    return {
+      status: "invalid",
+      reason: "Snapshot summary metrics or resolution evidence were incomplete.",
+    };
   }
 
   const topQuestions = value.top_questions.map((item) => {
@@ -124,6 +135,8 @@ function parseSnapshot(value: unknown): SnapshotState {
         generated,
         drafted_answer_count: draftedAnswerCount,
         no_proven_answer_count: noProvenAnswerCount,
+        support_ticket_resolution_evidence_present: resolutionEvidencePresent,
+        support_ticket_resolution_evidence_count: resolutionEvidenceCount,
       },
       top_questions: topQuestions as DeflectionSnapshot["top_questions"],
     },
@@ -173,6 +186,20 @@ export default function FaqDeflectionResult() {
       .map((question) => question.customer_wording.trim())
       .filter((phrase) => phrase.length > 0)
       .slice(0, 5);
+  }, [snapshotState]);
+
+  const resolutionEvidence = useMemo(() => {
+    if (snapshotState.status !== "available") return null;
+    const { summary } = snapshotState.snapshot;
+    const present = summary.support_ticket_resolution_evidence_present;
+    const count = summary.support_ticket_resolution_evidence_count;
+    return {
+      present,
+      label: present ? "Present" : "Absent",
+      copy: present
+        ? `${formatCount(count)} resolved ticket rows can support publishable answer drafting.`
+        : "This export supports a gap list only; publishable answers need agent replies or resolved ticket notes.",
+    };
   }, [snapshotState]);
 
   const startCheckout = async () => {
@@ -277,6 +304,30 @@ export default function FaqDeflectionResult() {
                 </div>
               )}
             </div>
+
+            {resolutionEvidence && (
+              <div
+                className="mt-4 flex flex-col gap-3 rounded-lg border border-surface-700/60 bg-surface-800/40 p-5 sm:flex-row sm:items-start sm:justify-between"
+                data-atlas-deflection-resolution-evidence
+                data-resolution-evidence-present={resolutionEvidence.present ? "true" : "false"}
+              >
+                <div>
+                  <p className="text-sm text-surface-200/70">Resolution evidence</p>
+                  <p
+                    className={
+                      resolutionEvidence.present
+                        ? "mt-2 text-lg font-semibold text-primary-300"
+                        : "mt-2 text-lg font-semibold text-amber-200"
+                    }
+                  >
+                    {resolutionEvidence.label}
+                  </p>
+                </div>
+                <p className="max-w-xl text-sm leading-6 text-surface-200/75">
+                  {resolutionEvidence.copy}
+                </p>
+              </div>
+            )}
 
             {snapshotState.status === "invalid" && (
               <div className="mt-6 flex items-start gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100">

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -1085,6 +1085,8 @@ async def test_preview_route_surfaces_support_ticket_loader_truncation_warning()
             "source": "support_ticket_input_package",
             "source_period": "Uploaded support tickets",
             "source_row_count": 1005,
+            "support_ticket_resolution_evidence_count": 0,
+            "support_ticket_resolution_evidence_present": False,
             "truncated_row_count": 5,
         },
         "warnings": [{

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -339,6 +339,8 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
             "generated": 2,
             "drafted_answer_count": 1,
             "no_proven_answer_count": 1,
+            "support_ticket_resolution_evidence_count": 1,
+            "support_ticket_resolution_evidence_present": True,
             "repeat_ticket_count": 5,
         },
         "top_questions": [
@@ -360,7 +362,8 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
     }
     assert "Open Analytics" not in encoded
     assert "ticket-export-1" not in encoded
-    assert "evidence" not in encoded
+    assert "evidence_quotes" not in encoded
+    assert "source_ids" not in encoded
 
 
 def test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions() -> None:

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -206,6 +206,8 @@ def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() ->
         "source_date_start",
         "source_date_end",
         "source_window_days",
+        "support_ticket_resolution_evidence_count",
+        "support_ticket_resolution_evidence_present",
     }
     for question in payload["top_questions"]:
         assert set(question) == {

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -226,6 +226,8 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
         "source_row_count": 3,
         "submitted_row_count": 2,
         "support_platform": "zendesk",
+        "support_ticket_resolution_evidence_count": 2,
+        "support_ticket_resolution_evidence_present": True,
         "top_ticket_clusters": [{"label": "exports", "count": 2}],
         "truncated_row_count": 1,
     }
@@ -240,6 +242,8 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
     snapshot_payload = await snapshot.endpoint(request_id=payload["request_id"])
     assert snapshot_payload == gated_result["snapshot"]
+    assert snapshot_payload["summary"]["support_ticket_resolution_evidence_count"] == 2
+    assert snapshot_payload["summary"]["support_ticket_resolution_evidence_present"] is True
     assert "lead@acme.example" not in str(snapshot_payload)
     assert "lead@acme.example" not in str(gated_result["snapshot"])
 
@@ -320,13 +324,15 @@ async def test_deflection_submit_accepts_multipart_csv_bytes() -> None:
         "max_source_material_rows": 2,
         "skipped_row_count": 0,
         "source": "portfolio_deflection_submit",
-        "source_period": "Uploaded support tickets",
-        "source_row_count": 3,
-        "submitted_row_count": 2,
-        "support_platform": "help_scout",
-        "top_ticket_clusters": [{"label": "exports", "count": 2}],
-        "truncated_row_count": 1,
-        "uploaded_bytes": len(csv_data),
+            "source_period": "Uploaded support tickets",
+            "source_row_count": 3,
+            "submitted_row_count": 2,
+            "support_platform": "help_scout",
+            "support_ticket_resolution_evidence_count": 2,
+            "support_ticket_resolution_evidence_present": True,
+            "top_ticket_clusters": [{"label": "exports", "count": 2}],
+            "truncated_row_count": 1,
+            "uploaded_bytes": len(csv_data),
     }
 
     snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
@@ -366,8 +372,12 @@ async def test_deflection_submit_surfaces_cluster_preview_for_messy_untagged_csv
         "singleton_cluster_count": 0,
         "uncategorized_row_count": 0,
     }
+    assert metadata["support_ticket_resolution_evidence_count"] == 0
+    assert metadata["support_ticket_resolution_evidence_present"] is False
 
     snapshot = payload["steps"][0]["result"]["snapshot"]
+    assert snapshot["summary"]["support_ticket_resolution_evidence_count"] == 0
+    assert snapshot["summary"]["support_ticket_resolution_evidence_present"] is False
     assert [
         (item["ticket_count"], item["customer_wording"])
         for item in snapshot["top_questions"]

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -1019,6 +1019,8 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
         "generated": 4,
         "drafted_answer_count": 4,
         "no_proven_answer_count": 0,
+        "support_ticket_resolution_evidence_count": 4,
+        "support_ticket_resolution_evidence_present": True,
         "repeat_ticket_count": 4,
         "source_date_start": "2026-05-01",
         "source_date_end": "2026-05-20",


### PR DESCRIPTION
Plan: plans/PR-Deflection-Resolution-Evidence-Preview-Signal.md
Slice phase: Production hardening

Surface the already-computed support-ticket resolution-evidence signal in the pre-payment FAQ deflection preview. The submit diagnostics now carry the input-package present/count fields beside cluster quality, the stored unpaid snapshot includes the same launch gate, and the hosted result page renders present vs absent evidence before checkout so question-only exports self-select into gap-list mode instead of publishable-answer expectations.

## Intentional
- No PDF, email, delivery-worker, HTML normalization, synonym clustering, or paid-artifact rendering changes in this slice.
- The result page reads only unpaid snapshot summary fields; the proxy fails closed if the resolution-evidence fields are missing.
- Diff size is over the 400 LOC soft cap because producer schema, stored snapshot, public proxy, React rendering, and exact contract fixtures must change together.

## Deferred
- #1419 part 2: live proof on a real resolution-bearing export that produces publishable answer groups.
- In-lane residual: finish HTML normalization for HTML-heavy exports.
- In-lane residual: improve deterministic synonym grouping for themes with no shared tokens.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py extracted_content_pipeline/faq_deflection_report.py tests/test_extracted_content_deflection_submit.py tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py` - passed.
- `node --check portfolio-ui/api/content-ops/deflection/atlas-report.js && node --check portfolio-ui/api/content-ops/deflection/result-page.js && node --check portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs && node --check portfolio-ui/scripts/faq-deflection-result-page.test.mjs` - passed.
- `pytest tests/test_extracted_content_deflection_submit.py tests/test_content_ops_deflection_report.py::test_deflection_snapshot_strips_answers_evidence_and_sources tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_snapshot_example_matches_producer_shape -q` - 23 passed.
- `pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -q` - 41 passed.
- `pytest tests/test_atlas_content_ops_input_provider.py::test_preview_route_surfaces_support_ticket_loader_truncation_warning tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n -q` - 2 passed.
- `npm run test:deflection-upload-shell --prefix portfolio-ui` - 20 checks passed.
- `npm run test:deflection-result --prefix portfolio-ui` - 17 checks passed.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - 17 checks passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 3538 passed, 10 skipped.

## Diff size
15 files, +420 / -19.
