### PR TITLE
Content-Ops MCP Claude Hosted PKCE Smoke

### DIFF
--- a/plans/PR-Content-Ops-MCP-Claude-Hosted-PKCE-Smoke.md
+++ b/plans/PR-Content-Ops-MCP-Claude-Hosted-PKCE-Smoke.md
@@ -1,0 +1,58 @@
+# PR-Content-Ops-MCP-Claude-Hosted-PKCE-Smoke
+
+## Why this slice exists
+PR #1422 merged with a non-blocking review NIT: the Claude-hosted OAuth checker
+uses a hardcoded placeholder challenge while declaring `code_challenge_method=S256`.
+Strict OAuth providers can reject that before the checker reaches the root-route
+behavior it is supposed to validate.
+
+## Scope (this PR)
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+Replace the checker placeholder with a valid generated S256 PKCE challenge and
+prove the generated authorize URL carries the expected challenge shape.
+
+### Files touched
+- `plans/PR-Content-Ops-MCP-Claude-Hosted-PKCE-Smoke.md`
+- `scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py`
+- `tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py`
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Checker generates a real verifier-derived S256 PKCE challenge.
+  - [ ] Authorize URL still targets root `/authorize` with the same resource and scope fields.
+  - [ ] Tests reject the previous placeholder shape by checking decoded query values.
+  - [ ] Existing redirect failure-branch coverage remains intact.
+- Affected surfaces: Claude-hosted OAuth compatibility checker only.
+- Risk areas: OAuth correctness, checker precision, maintainability.
+- Reviewer rules triggered: R2, R10, R13
+
+## Mechanism
+Add a small local PKCE helper using SHA-256 and base64url without padding, then
+call it from the checker before building the authorization URL. The helper stays
+inside the checker script because this is a smoke-tool concern, not shared MCP
+server behavior.
+
+## Intentional
+No live OAuth token exchange is added. This checker still validates the
+root-authorize redirect only; the full e2e checker remains the surface for
+registration, approval, token exchange, and tool listing.
+
+## Deferred
+Comprehensive probing of all five Claude root OAuth aliases remains deferred to
+a later root-route health-check slice if live operations show a need. Parked
+hardening: none.
+
+## Verification
+- Passed: focused checker pytest, 5 passed.
+- Passed: py_compile for the checker.
+- Passed: git diff whitespace check.
+- Passed: local PR review with body file.
+
+## Estimated diff size
+| Area | Estimated LOC |
+| --- | ---: |
+| Total | ~90 |
+
+3 files, +88 / -2.

--- a/scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py
+++ b/scripts/check_content_ops_marketer_verify_claude_hosted_oauth.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
 import os
+import secrets
 import sys
 import urllib.error
 import urllib.parse
@@ -50,6 +53,16 @@ def _authorization_url(
         }
     )
     return f"{root_url}/authorize?{query}"
+
+
+def _pkce_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _new_pkce_challenge() -> str:
+    verifier = secrets.token_urlsafe(64)
+    return _pkce_challenge(verifier)
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -128,7 +141,7 @@ def _main(argv: list[str] | None = None) -> int:
         redirect_uri=args.redirect_uri.strip(),
         scope=args.scope.strip(),
         state="content-ops-claude-hosted-smoke",
-        code_challenge="content-ops-claude-hosted-smoke-challenge",
+        code_challenge=_new_pkce_challenge(),
     )
     try:
         status, headers = _open_no_redirect(url, args.timeout)

--- a/tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py
+++ b/tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import urllib.parse
 from pathlib import Path
 
 
@@ -54,12 +55,25 @@ def test_redirect_errors_cover_failure_branches() -> None:
     assert "root authorize redirect missing request_id" in errors
 
 
+def test_pkce_challenge_uses_s256_shape() -> None:
+    module = _load_script_module()
+
+    challenge = module._pkce_challenge("verifier")
+
+    assert challenge == "iMnq5o6zALKXGivsnlom_0F5_WYda32GHkxlV7mq7hQ"
+    assert len(challenge) == 43
+    assert "=" not in challenge
+
+
 def test_main_reports_success_from_mocked_redirect(monkeypatch, capsys) -> None:
     module = _load_script_module()
 
     def fake_open(url: str, timeout: float):
         assert url.startswith("https://atlas.example.com/authorize?")
-        assert "resource=https%3A%2F%2Fatlas.example.com%2Fcontent-ops-marketer%2Fmcp" in url
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        assert query["resource"] == [RESOURCE]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["code_challenge"] == [module._pkce_challenge("verifier")]
         assert timeout == 3.0
         return (
             302,
@@ -67,6 +81,7 @@ def test_main_reports_success_from_mocked_redirect(monkeypatch, capsys) -> None:
         )
 
     monkeypatch.setattr(module, "_open_no_redirect", fake_open)
+    monkeypatch.setattr(module.secrets, "token_urlsafe", lambda _bytes: "verifier")
 
     result = module._main(
         [


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-Claude-Hosted-PKCE-Smoke.md
Slice phase: Production hardening

Closes the non-blocking #1422 review NIT by replacing the Claude-hosted OAuth checker's placeholder PKCE challenge with a verifier-derived S256 challenge. This keeps the checker focused on root OAuth routing instead of failing early against stricter OAuth providers because of malformed smoke input.

## Intentional
- No live token exchange is added; this remains a root authorize redirect checker.
- The PKCE helper stays local to the checker script because this is smoke-tool behavior.

## Deferred
- Comprehensive probing of all five Claude root OAuth aliases remains deferred to a later root-route health-check slice if live operations show a need.

## Parked hardening
- None.

## Verification
- Passed: focused checker pytest, 5 passed.
- Passed: py_compile for the checker.
- Passed: git diff whitespace check.
- Passed: local PR review with body file.

## Diff size
3 files, +88 / -2
