### PR TITLE
Content-Ops MCP Claude Public Client Metadata

### DIFF
--- a/atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
@@ -253,7 +253,7 @@ def _streamable_http_app():
     """Build the authenticated streamable HTTP app for ChatGPT adapter tools."""
     if verify_server._http_auth_mode() == verify_server._AUTH_MODE_OAUTH:
         verify_server._configure_oauth_auth(target_mcp=mcp)
-        return mcp.streamable_http_app()
+        return verify_server._apply_content_ops_public_client_metadata(mcp.streamable_http_app())
 
     from .auth import BearerAuthMiddleware
 

--- a/atlas_brain/mcp/content_ops_marketer_verify_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_server.py
@@ -39,6 +39,8 @@ logger = logging.getLogger("atlas.mcp.content_ops.marketer_verify")
 _AUTH_MODE_BEARER = "bearer"
 _AUTH_MODE_OAUTH = "oauth"
 _MIN_HTTP_AUTH_TOKEN_LENGTH = 24
+_OAUTH_AUTHORIZATION_METADATA_PATH = "/.well-known/oauth-authorization-server"
+_PUBLIC_CLIENT_TOKEN_AUTH_METHODS = ("none", "client_secret_post", "client_secret_basic")
 _PLACEHOLDER_HTTP_AUTH_TOKENS = {
     "<token>",
     "changeme",
@@ -184,7 +186,7 @@ def _streamable_http_app():
     """Build the authenticated streamable HTTP app for verify-only tools."""
     if _http_auth_mode() == _AUTH_MODE_OAUTH:
         _configure_oauth_auth()
-        return mcp.streamable_http_app()
+        return _apply_content_ops_public_client_metadata(mcp.streamable_http_app())
 
     from .auth import BearerAuthMiddleware
 
@@ -287,6 +289,80 @@ def _configure_oauth_auth(target_mcp: Any | None = None):
     configured_mcp._auth_server_provider = _oauth_provider
     configured_mcp._token_verifier = ProviderTokenVerifier(_oauth_provider)
     return _oauth_provider
+
+
+def _content_ops_oauth_metadata(*, issuer_url: str, scopes: list[str]) -> dict[str, Any]:
+    """Return OAuth metadata matching FastMCP's routes plus public clients."""
+    issuer = issuer_url.strip().rstrip("/")
+    return {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/authorize",
+        "token_endpoint": f"{issuer}/token",
+        "registration_endpoint": f"{issuer}/register",
+        "scopes_supported": scopes,
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": list(_PUBLIC_CLIENT_TOKEN_AUTH_METHODS),
+        "code_challenge_methods_supported": ["S256"],
+    }
+
+
+def _oauth_metadata_cors_headers() -> dict[str, str]:
+    return {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Headers": "mcp-protocol-version",
+    }
+
+
+def _content_ops_oauth_metadata_endpoint(*, issuer_url: str, scopes: list[str]):
+    async def _metadata(request):
+        from starlette.responses import JSONResponse, Response
+
+        if request.method == "OPTIONS":
+            return Response(status_code=204, headers=_oauth_metadata_cors_headers())
+        return JSONResponse(
+            _content_ops_oauth_metadata(issuer_url=issuer_url, scopes=scopes),
+            headers=_oauth_metadata_cors_headers(),
+        )
+
+    return _metadata
+
+
+def _apply_content_ops_public_client_metadata(app):
+    """Replace FastMCP's auth metadata route with Content Ops public-client metadata."""
+    router = getattr(app, "router", None)
+    routes = list(getattr(router, "routes", []) or [])
+    if router is None or not routes:
+        return app
+
+    from starlette.routing import Route
+
+    from ..config import settings
+    from .content_ops_marketer_verify_oauth import DEFAULT_CONTENT_OPS_VERIFY_SCOPE
+
+    issuer_url = _clean(settings.mcp.content_ops_marketer_verify_oauth_issuer_url)
+    metadata_route = Route(
+        _OAUTH_AUTHORIZATION_METADATA_PATH,
+        endpoint=_content_ops_oauth_metadata_endpoint(
+            issuer_url=issuer_url,
+            scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+        ),
+        methods=["GET", "OPTIONS"],
+        include_in_schema=False,
+    )
+    replacement = []
+    replaced = False
+    for route in routes:
+        if getattr(route, "path", "") == _OAUTH_AUTHORIZATION_METADATA_PATH:
+            replacement.append(metadata_route)
+            replaced = True
+        else:
+            replacement.append(route)
+    if not replaced:
+        replacement.insert(0, metadata_route)
+    router.routes = replacement
+    return app
 
 
 def _oauth_transport_security_settings(*, issuer_url: str, resource_url: str):

--- a/plans/PR-Content-Ops-MCP-Claude-Public-Client-Metadata.md
+++ b/plans/PR-Content-Ops-MCP-Claude-Public-Client-Metadata.md
@@ -1,0 +1,62 @@
+# PR-Content-Ops-MCP-Claude-Public-Client-Metadata
+
+## Why this slice exists
+Live Claude.ai setup still required manual OAuth Client ID settings because the
+authorization-server metadata advertised only confidential-client token auth
+methods. The Content Ops OAuth provider can already register and exchange public
+clients using `token_endpoint_auth_method=none`, so the metadata should stop
+hiding that supported path.
+
+## Scope (this PR)
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+Advertise public-client OAuth metadata for the Content Ops marketer verifier and
+ChatGPT adapter without changing token exchange, registration, approval, or MCP
+tool behavior.
+
+### Files touched
+- `plans/PR-Content-Ops-MCP-Claude-Public-Client-Metadata.md`
+- `atlas_brain/mcp/content_ops_marketer_verify_server.py`
+- `atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py`
+- `tests/test_mcp_content_ops_marketer_verify.py`
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Content Ops OAuth metadata includes `none` in token endpoint auth methods.
+  - [ ] Confidential-client methods remain advertised for existing ChatGPT/invoicing-style clients.
+  - [ ] Registration, token, approval, and protected-resource routes remain present.
+  - [ ] Bearer-mode behavior is unchanged.
+- Affected surfaces: Content Ops marketer OAuth metadata only.
+- Risk areas: OAuth discovery, connector compatibility, backcompat.
+- Reviewer rules triggered: R1, R2, R5, R10, R13
+
+## Mechanism
+After FastMCP builds the OAuth Starlette app, replace only the built-in
+authorization-server metadata route for the Content Ops app with an equivalent
+metadata response that also lists `none`. The underlying MCP OAuth provider and
+token authenticator already support public clients, so this is an advertisement
+fix rather than a new auth path.
+
+## Intentional
+This does not fork the upstream MCP OAuth handlers or alter dynamic client
+registration defaults. Clients that omit `token_endpoint_auth_method` still get
+the upstream confidential-client default; clients that request `none` can
+discover that the server supports it.
+
+## Deferred
+Full automatic Claude DCR live verification remains a live-connector artifact
+step after this metadata is deployed. Parked hardening: none.
+
+## Verification
+- Passed: focused Content Ops MCP metadata tests, 32 passed.
+- Passed: py_compile for the server modules.
+- Passed: git diff whitespace check.
+- Passed: local PR review with body file.
+
+## Estimated diff size
+| Area | Estimated LOC |
+| --- | ---: |
+| Total | ~186 |
+
+4 files, +184 / -2.

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -676,6 +676,50 @@ def test_content_ops_marketer_verify_oauth_mode_configures_fastmcp_auth(
     assert verify.mcp._token_verifier.provider is provider
 
 
+def test_content_ops_oauth_metadata_advertises_public_and_confidential_clients() -> None:
+    metadata = verify._content_ops_oauth_metadata(
+        issuer_url="https://atlas.example.com/content-ops-marketer/",
+        scopes=[DEFAULT_CONTENT_OPS_VERIFY_SCOPE],
+    )
+
+    assert metadata["issuer"] == "https://atlas.example.com/content-ops-marketer"
+    assert metadata["authorization_endpoint"] == "https://atlas.example.com/content-ops-marketer/authorize"
+    assert metadata["token_endpoint"] == "https://atlas.example.com/content-ops-marketer/token"
+    assert metadata["registration_endpoint"] == "https://atlas.example.com/content-ops-marketer/register"
+    assert metadata["token_endpoint_auth_methods_supported"] == [
+        "none",
+        "client_secret_post",
+        "client_secret_basic",
+    ]
+    assert metadata["code_challenge_methods_supported"] == ["S256"]
+
+
+@pytest.mark.asyncio
+async def test_content_ops_public_client_metadata_replaces_only_auth_metadata_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_metadata = types.SimpleNamespace(path="/.well-known/oauth-authorization-server")
+    token_route = types.SimpleNamespace(path="/token")
+    app = types.SimpleNamespace(router=types.SimpleNamespace(routes=[old_metadata, token_route]))
+    monkeypatch.setattr(
+        settings.mcp,
+        "content_ops_marketer_verify_oauth_issuer_url",
+        "https://atlas.example.com/content-ops-marketer",
+    )
+
+    patched = verify._apply_content_ops_public_client_metadata(app)
+    metadata_route, remaining_route = patched.router.routes
+    response = await metadata_route.endpoint(types.SimpleNamespace(method="GET"))
+    options = await metadata_route.endpoint(types.SimpleNamespace(method="OPTIONS"))
+
+    assert patched is app
+    assert metadata_route.path == "/.well-known/oauth-authorization-server"
+    assert remaining_route is token_route
+    assert json.loads(response.body)["token_endpoint_auth_methods_supported"][0] == "none"
+    assert response.headers["access-control-allow-origin"] == "*"
+    assert options.status_code == 204
+
+
 def test_chatgpt_adapter_oauth_mode_configures_adapter_fastmcp_auth(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-MCP-Claude-Public-Client-Metadata.md
Slice phase: Production hardening

Advertises the public-client OAuth path that the Content Ops provider already supports. The built-in FastMCP metadata only listed confidential-client methods, which made hosted Claude fall back to manual OAuth Client ID setup even though `token_endpoint_auth_method=none` registration/exchange works.

## Intentional
- No OAuth token, approval, registration, or MCP tool behavior changes.
- Confidential-client methods remain advertised for existing connector clients.
- Clients that omit `token_endpoint_auth_method` still receive the upstream confidential-client registration default.

## Deferred
- Full automatic Claude DCR live verification remains a live-connector artifact step after this metadata is deployed.

## Parked hardening
- None.

## Verification
- Passed: focused Content Ops MCP metadata tests, 32 passed.
- Passed: py_compile for the server modules.
- Passed: git diff whitespace check.
- Passed: local PR review with body file.

## Diff size
4 files, +184 / -2
