### PR TITLE
Deflection resolution evidence absent assertions

### DIFF
--- a/plans/PR-Deflection-Resolution-Evidence-Absent-Assertions.md
+++ b/plans/PR-Deflection-Resolution-Evidence-Absent-Assertions.md
@@ -1,0 +1,80 @@
+# PR-Deflection-Resolution-Evidence-Absent-Assertions
+
+## Why this slice exists
+
+PR #1424 exposed the support-ticket resolution-evidence signal in the
+pre-payment deflection preview, but the review found the absent branch was not
+asserted strongly enough. A mutation that forced the signal to always render as
+"Present" could still pass the touched Python and result-page tests. This
+follow-up pins the exact launch gate that protects question-only exports from
+looking like publishable-answer reports.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Robust testing
+
+1. Add backend absent-direction assertions for question-only deflection
+   snapshots and the stored submit snapshot boundary.
+2. Add hosted result-page assertions for the absent label and "gap list only"
+   warning copy.
+3. Keep this as test-only coverage for the already-merged #1424 behavior.
+
+### Review Contract
+
+- A forced always-present regression must fail in Python.
+- A forced always-present hosted result page must fail in the `.mjs` test.
+- The slice stays in the clustering/raw-data preview lane and does not touch
+  PDF, email, delivery-worker, or paid attachment work.
+
+- Reviewer rules triggered: R10, R13.
+
+### Files touched
+
+- `plans/PR-Deflection-Resolution-Evidence-Absent-Assertions.md`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+The backend snapshot test builds a report whose FAQ items are all
+`draft_needs_review`, then asserts the unpaid snapshot summary reports
+`support_ticket_resolution_evidence_present == False` and count `0`. The submit
+test now also reads the stored snapshot route and asserts it matches the
+question-only snapshot returned at submit time. The hosted result-page test
+renders an absent-evidence snapshot and asserts the rendered diagnostic includes
+the false marker, "Absent" label, and "gap list only" warning copy.
+
+## Intentional
+
+- This PR does not change production code. The #1424 implementation is already
+  merged; this slice closes the reviewer-found test blind spot.
+- This PR does not rerun the full deflection harness or extracted CI mirror,
+  because the change is test-only and the focused mutation target is narrower.
+
+## Deferred
+
+- #1419 part 2: live proof on a real resolution-bearing export that produces
+  publishable answer groups.
+- In-lane residual: finish HTML normalization so raw tags cannot reach clustered
+  text/output on HTML-heavy exports.
+- In-lane residual: improve deterministic synonym grouping for themes with no
+  shared tokens.
+
+Parked hardening: none.
+
+## Verification
+
+- Review follow-up absent-signal pytest - 2 passed.
+- Review follow-up result page test - 18 checks passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Resolution-Evidence-Absent-Assertions.md` | 80 |
+| `portfolio-ui/scripts/faq-deflection-result-page.test.mjs` | 35 |
+| `tests/test_content_ops_deflection_report.py` | 38 |
+| `tests/test_extracted_content_deflection_submit.py` | 3 |
+| **Total** | **156** |

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -210,6 +210,41 @@ await test("real snapshot page groups bounded customer wording examples", () => 
   assert.doesNotMatch(emptyHtml, /aria-label="Customer wording examples"/);
 });
 
+await test("hosted result page flags absent resolution evidence as gap list only", () => {
+  const html = renderResultPage({
+    requestId: "content-ops-question-only",
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    report: {
+      ok: true,
+      snapshot: {
+        summary: {
+          generated: 2,
+          drafted_answer_count: 0,
+          no_proven_answer_count: 2,
+          support_ticket_resolution_evidence_present: false,
+          support_ticket_resolution_evidence_count: 0,
+        },
+        top_questions: [
+          {
+            rank: 1,
+            question: "How do I reset my password?",
+            weighted_frequency: 5,
+            customer_wording: "Password reset help How do I reset my password?",
+          },
+        ],
+      },
+      artifact_status: "locked",
+    },
+  });
+
+  assert.match(html, /data-atlas-deflection-resolution-evidence/);
+  assert.match(html, /data-resolution-evidence-present="false"/);
+  assert.match(html, /Resolution evidence/);
+  assert.match(html, /Absent/);
+  assert.match(html, /gap list only/);
+  assert.match(html, /publishable answers need agent replies or resolved ticket notes/);
+});
+
 await test("checkout endpoint validates request and configured account identifiers", async () => {
   const env = { ATLAS_ACCOUNT_ID: "2b2b950d-f64b-4852-bc30-f92a34cdf169" };
   const valid = validatePayload({

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -366,6 +366,44 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
     assert "source_ids" not in encoded
 
 
+def test_deflection_snapshot_marks_question_only_exports_absent_resolution_evidence() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=2,
+        ticket_source_count=2,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "How do I reset my password?",
+                "question_source": "customer_wording",
+                "weighted_frequency": 5,
+                "ticket_count": 2,
+                "steps": ["Review before publishing."],
+                "evidence_quotes": ("ticket-login-1 asked how to reset a password",),
+                "source_ids": ("ticket-login-1",),
+                "answer_evidence_status": "draft_needs_review",
+            },
+            {
+                "question": "Where do I update my email?",
+                "question_source": "customer_wording",
+                "weighted_frequency": 4,
+                "ticket_count": 2,
+                "steps": ["Review before publishing."],
+                "evidence_quotes": ("ticket-email-1 asked where to update email",),
+                "source_ids": ("ticket-email-1",),
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ),
+    )
+
+    snapshot = build_deflection_snapshot(build_deflection_report_artifact(result)).as_dict()
+
+    assert snapshot["summary"]["support_ticket_resolution_evidence_count"] == 0
+    assert snapshot["summary"]["support_ticket_resolution_evidence_present"] is False
+    assert snapshot["summary"]["drafted_answer_count"] == 0
+    assert snapshot["summary"]["no_proven_answer_count"] == 2
+
+
 def test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions() -> None:
     result = TicketFAQMarkdownResult(
         markdown="# FAQ",

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -391,6 +391,9 @@ async def test_deflection_submit_surfaces_cluster_preview_for_messy_untagged_csv
         "reason": "payment_required",
     }
 
+    stored_snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
+    assert await stored_snapshot.endpoint(request_id=payload["request_id"]) == snapshot
+
 
 def test_deflection_submit_fastapi_dispatch_accepts_multipart_csv_bytes() -> None:
     csv_data = _csv_bytes([


### PR DESCRIPTION
Plan: plans/PR-Deflection-Resolution-Evidence-Absent-Assertions.md
Slice phase: Robust testing

PR #1424 exposed the pre-payment resolution-evidence signal, but review found the absent branch was not asserted strongly enough. This test-only follow-up pins the question-only export path so an always-present regression fails in both backend snapshot coverage and the hosted result page test.

## Intentional
- Test-only follow-up to the already-merged #1424 implementation.
- Focused checks instead of the full deflection gauntlet because the mutation target is assertion coverage.

## Deferred
- #1419 part 2: live proof on a real resolution-bearing export that produces publishable answer groups.
- HTML normalization and deterministic synonym grouping remain separate in-lane residuals.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_marks_question_only_exports_absent_resolution_evidence tests/test_extracted_content_deflection_submit.py::test_deflection_submit_surfaces_cluster_preview_for_messy_untagged_csv -q` - 2 passed.
- `npm run test:deflection-result --prefix portfolio-ui` - 18 checks passed.

## Diff size
4 files, +156 / -0
