### PR TITLE
Live CI AI-reconciliation enforcement (#1328 Phase 5 follow-up)

### DIFF
--- a/.github/workflows/ai_reconciliation_live.yml
+++ b/.github/workflows/ai_reconciliation_live.yml
@@ -1,0 +1,40 @@
+name: AI Reconciliation (live)
+
+# Phase 5 of the review-workflow redesign (#1328): the live, CI-side half of the
+# AI-finding reconciliation gate. Fails when the PR body records the bot findings
+# as all fixed/waived (or carries no record) while unresolved Codex/Copilot
+# review threads still exist.
+#
+# Runs on `pull_request` as well as the review events so that, as a *required*
+# status check, it always runs and reports (a quiet PR with no bot threads
+# reports green instead of wedging the merge as "missing required check"), and
+# re-runs when a bot comment lands after the PR opens.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+  pull_request_review_comment:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  live-reconciliation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Live AI-reconciliation check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_ai_reconciliation_live.py \
+            --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/ai_reconciliation_live.yml
+++ b/.github/workflows/ai_reconciliation_live.yml
@@ -11,8 +11,11 @@ name: AI Reconciliation (live)
 # re-runs when a bot comment lands after the PR opens.
 
 on:
+  # `edited` is included so that when a reviewer fixes a failed check by editing
+  # only the PR body (adding the fixed/waived record), the required check re-runs
+  # instead of staying stale until the next push.
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   pull_request_review:
   pull_request_review_comment:
 

--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -39,4 +39,4 @@ jobs:
       - name: PR-review tooling unit tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio
-          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py -q
+          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,6 +643,14 @@ waived with a reason in the PR body.** The machine owns mechanical issues; the
 human owns intent mismatch, product logic, architecture, risky assumptions, and
 missing tests.
 
+This rule is enforced from both sides. Locally,
+`scripts/audit_ai_reconciliation.py` checks the PR body's reconciliation record
+is internally resolved. In CI, the `AI Reconciliation (live)` workflow
+(`scripts/check_ai_reconciliation_live.py`) reads the live Codex/Copilot review
+threads and fails when the body records the findings as all fixed/waived (or
+carries no record) while bot threads are still open -- closing the
+"omitted a real open finding" loophole the local check cannot see.
+
 ### 4b. Verdict frugality
 
 Post **one** review per push. Don't comment on the PR while CI is

--- a/plans/PR-Reviewer-Reconciliation-Live-CI.md
+++ b/plans/PR-Reviewer-Reconciliation-Live-CI.md
@@ -1,0 +1,142 @@
+# PR-Reviewer-Reconciliation-Live-CI
+
+## Why this slice exists
+
+Phase 2 of the review-workflow redesign (#1328) shipped
+`scripts/audit_ai_reconciliation.py`: a local gate that the PR body contains a
+well-formed "every AI finding fixed-or-waived" reconciliation block before LGTM.
+By design it only validates the *recorded text*. It never compares that block
+against the *actual open* Codex/Copilot findings on the PR. So a reviewer can
+write a clean reconciliation while real bot findings sit open, and nothing
+catches it. That is the loophole keeping operating-model gap (b) from being
+fully closed (named in the Deferred section of
+`plans/archive/PR-Reviewer-Reconciliation-Audit.md` as "CI-side reconciliation").
+
+This slice adds the live, CI-side check: fetch the real bot review threads,
+keep the ones still open, and fail when the recorded reconciliation omits any.
+Phase 2 validates the paperwork; this validates reality.
+
+Diff-budget overage (~575 LOC, over the 400 soft cap): the check script, its
+failure-proving fixtures, the required CI workflow, and the doc/cross-ref edits
+are one cohesive unit. Splitting the workflow from the script would leave
+unwired dead code, and splitting the tests from the script would violate R2.
+The script (~250) and its tests (~130) are the irreducible core.
+
+## Scope (this PR)
+
+Ownership lane: review-workflow/reconciliation-live-ci
+Slice phase: Workflow/process
+
+1. A script that fetches live Codex/Copilot review threads for a PR, filters to
+   unresolved findings, parses the PR body reconciliation block, and fails when
+   an open finding is unaccounted for.
+2. A GitHub Actions workflow that runs it on PR review/comment events with a
+   read-only token, as a required status check on the PR's final state.
+3. Failure-proving fixtures (`AGENTS.md` 3h) using mocked API payloads, so the
+   failure branch is tested without hitting live GitHub.
+4. Doc updates closing the Phase-2 "recorded-body only" caveat in
+   `AGENTS.md` 4a.1 and the "later slice" note in `docs/REVIEWER_RULES.md`.
+
+### Review Contract
+- Acceptance criteria: open bot thread + an all-clear or absent reconciliation
+  record -> non-zero exit naming the thread(s); no open bot threads -> exit 0;
+  body honestly acknowledges open findings -> exit 0 (the local audit owns
+  blocking that); resolved/outdated threads ignored; the new test runs in CI.
+- Affected surfaces: CI / config / observability. No app code, no DB, read-only
+  GitHub token only.
+- Risk areas: transient GitHub API failure, race with async bot comments, token
+  scope/secret handling.
+- Reviewer rules triggered: R2 (failure-branch fixtures), R3 (token handling),
+  R6 (API-error handling, no swallowed errors), R10 (maintainability), R12 (CI
+  actually runs the new test).
+
+### Files touched
+- `scripts/check_ai_reconciliation_live.py`
+- `tests/test_check_ai_reconciliation_live.py`
+- `.github/workflows/ai_reconciliation_live.yml`
+- `.github/workflows/pre_push_audit.yml`
+- `AGENTS.md`
+- `scripts/audit_ai_reconciliation.py`
+- `plans/PR-Reviewer-Reconciliation-Live-CI.md`
+
+## Mechanism
+
+Phase-2's `audit_ai_reconciliation.py` turned out to be section-level (resolved
+/ unresolved markers), not per-finding keys, so the enforcement model is the
+contradiction check, not fuzzy per-finding matching: fail when the body claims
+all-clear (or has no record) while open bot threads exist. "All threads must be
+GitHub-resolved" was rejected as self-resolvable by the PR author (a gameable
+rigor gate).
+
+`check_ai_reconciliation_live.py --pr <n>`:
+1. Fetch the PR review threads via `gh api graphql` (`reviewThreads` with
+   isResolved / isOutdated / path / line / author); filter to unresolved,
+   non-outdated threads authored by a configured bot (default `copilot`/`codex`,
+   substring match on login).
+2. Classify the PR body's reconciliation record by IMPORTING the Phase-2 module
+   (`extract_section` + `RESOLVED_RE` / `UNRESOLVED_RE`): claims_clear /
+   acknowledges_open / absent / unmarked. Reusing the module means local and
+   live cannot disagree on what a "resolved" record is.
+3. Fail (exit 1) when open bot threads exist AND the body is claims_clear (the
+   lie) or absent (no record), listing each open thread (path:line, author,
+   snippet). Pass (exit 0) when there are no open bot threads, or the body
+   honestly acknowledges open findings (the local audit owns blocking that).
+   Exit 2 on usage error or a GitHub API failure (retryable, never a silent
+   pass).
+
+The workflow triggers on `pull_request` (opened / synchronize / reopened /
+ready_for_review) plus `pull_request_review` and `pull_request_review_comment`,
+uses the repo `GITHUB_TOKEN` (pull-requests: read). The `pull_request` trigger is
+required so that, as a required status check, it always runs and reports (a quiet
+PR with no bot threads reports green instead of wedging the merge), and re-runs
+when a bot comment lands after open.
+
+## Intentional
+- Live counterpart to Phase 2's local audit, not a replacement. Local still
+  validates body shape early in the pre-push bundle; this validates against
+  reality once the PR and bot comments exist.
+- Fail posture (operator-approved): no bot findings present is a pass, not a
+  fail. A genuinely omitted open finding hard-fails (exit 1). A transient GitHub
+  API error exits 2 and is surfaced as retryable, so GitHub flakiness never
+  silently passes and never permanently walls a merge.
+- Required-check on final state (operator-approved): runs on review-comment /
+  review events and is evaluated on the PR's final state, not one-shot at open,
+  so a bot comment that lands after the PR opens is still enforced. This is a
+  required gate by design; it blocks merge when an open finding is unreconciled.
+- Bot findings stay advisory (gap b): never auto-resolves or auto-applies, only
+  enforces that a human accounted for each finding. No "auto-address all
+  comments" loop.
+- Reuse Phase-2's section parser (imported) so the local and live checks cannot
+  disagree on what a resolved reconciliation record looks like.
+- Bot author set is config, not hardcoded, so a new review bot can be added
+  without code changes.
+
+## Deferred
+- Trend / secondary reviewer metrics (turnaround, rework cycles) from issue 2b.
+  Separate slice.
+- Scheduling `summarize_review_misses.py --fail-on-ungated` in CI once the ledger
+  has real entries. Its own tiny slice.
+- Auto-requesting or re-running the bots. Out of scope.
+
+Parked hardening: none.
+
+## Verification
+- `tests/test_check_ai_reconciliation_live.py` with mocked API payloads:
+  omitted-open-finding -> exit 1 (failure branch proven); all-reconciled -> 0;
+  no-findings -> 0; waived-with-reason -> 0; resolved-thread-ignored -> 0;
+  API-error -> 2.
+- Read-only dry-run against a real PR showing correct pass/flag.
+- `scripts/check_ascii_python.sh` and `scripts/local_pr_review.sh` green.
+
+## Estimated diff size
+| Area | Est LOC |
+|---|---:|
+| Plan | ~145 |
+| Script | ~250 |
+| Tests + fixtures | ~130 |
+| Workflow + CI wiring | ~40 |
+| Doc edits | ~15 |
+| Total | ~580 |
+
+Over the 400 soft cap; overage justified in "Why this slice exists" (cohesive
+unit, splitting leaves dead code or violates R2).

--- a/scripts/audit_ai_reconciliation.py
+++ b/scripts/audit_ai_reconciliation.py
@@ -13,8 +13,10 @@ finding left unresolved, every waiver carrying a reason. Fail closed on a
 contradictory or empty reconciliation block so a recorded reconciliation can be
 trusted. With --require, also fail when the section is absent.
 
-Cross-checking the recorded reconciliation against the live bot threads is a
-CI-side follow-up (needs gh/API) and is intentionally out of scope here.
+Cross-checking the recorded reconciliation against the live bot threads is done
+by the CI-side companion `scripts/check_ai_reconciliation_live.py` (needs
+gh/API), which fails when this recorded reconciliation omits a still-open bot
+finding. This local audit owns the body-shape half; that one owns reality.
 """
 from __future__ import annotations
 

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Live, CI-side enforcement of the AI-finding reconciliation rule (#1328 Phase 5).
+
+The local audit (scripts/audit_ai_reconciliation.py) can only check that the PR
+body's reconciliation record is internally well-formed; it cannot see the live
+GitHub bot threads. This check closes that half: it fetches the real
+Codex/Copilot review threads and fails when the recorded reconciliation
+*omits a genuinely open finding* -- i.e. the body claims all-clear (or carries
+no reconciliation record at all) while unresolved bot threads still exist.
+
+It deliberately does NOT require every thread to be GitHub-"resolved": that is
+self-resolvable by the PR author and would be a gameable rigor gate. It catches
+the specific contradiction between a "resolved" body and open reality, which is
+exactly the deferred spec from plans/archive/PR-Reviewer-Reconciliation-Audit.md.
+
+Bot findings stay advisory (operating-model gap (b)): nothing here auto-resolves
+or auto-applies. It only enforces that a human accounted for what the bots
+raised.
+
+Exit codes: 0 = clean (no open bot threads, or the body honestly acknowledges
+open findings); 1 = contradiction (open bot threads + an all-clear/absent
+record); 2 = usage error or a GitHub API failure (retryable, never a silent
+pass).
+
+The body classifier reuses scripts/audit_ai_reconciliation.py by import so the
+local and live checks cannot disagree on what a "resolved" record looks like.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+_DEFAULT_BOTS = ("copilot", "codex")
+
+_THREADS_QUERY = """
+query($owner:String!,$name:String!,$pr:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:100){
+        nodes{
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first:1){ nodes{ author{ login } bodyText } }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _load_phase2():
+    """Import the local reconciliation auditor so the body classifier matches."""
+    path = Path(__file__).resolve().parent / "audit_ai_reconciliation.py"
+    spec = importlib.util.spec_from_file_location("audit_ai_reconciliation", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def classify_body(body: str) -> str:
+    """Return 'absent' | 'acknowledges_open' | 'claims_clear' | 'unmarked'.
+
+    Uses the Phase-2 section extractor + markers, so "what counts as a resolved
+    record" stays defined in exactly one place.
+    """
+    p2 = _load_phase2()
+    section = p2.extract_section(body)
+    if section is None:
+        return "absent"
+    if p2.UNRESOLVED_RE.search(section):
+        return "acknowledges_open"
+    if p2.RESOLVED_RE.search(section):
+        return "claims_clear"
+    return "unmarked"
+
+
+def open_bot_threads(nodes: Sequence[dict], bot_logins: Sequence[str]) -> list[dict]:
+    """Return unresolved, non-outdated review threads authored by a known bot.
+
+    `nodes` is the GraphQL reviewThreads node list; pure so it is unit-testable
+    without touching GitHub.
+    """
+    wanted = tuple(b.lower() for b in bot_logins)
+    found: list[dict] = []
+    for node in nodes or []:
+        if node.get("isResolved") or node.get("isOutdated"):
+            continue
+        comments = ((node.get("comments") or {}).get("nodes")) or []
+        author = ""
+        snippet = ""
+        if comments:
+            author = (((comments[0] or {}).get("author") or {}).get("login")) or ""
+            snippet = ((comments[0] or {}).get("bodyText") or "").strip().replace("\n", " ")
+        if not any(w in author.lower() for w in wanted):
+            continue
+        found.append(
+            {
+                "path": node.get("path") or "?",
+                "line": node.get("line"),
+                "author": author or "?",
+                "snippet": (snippet[:120] + "...") if len(snippet) > 120 else snippet,
+            }
+        )
+    return found
+
+
+def evaluate(nodes: Sequence[dict], body: str, bot_logins: Sequence[str]) -> tuple[int, list[str]]:
+    """Core decision (pure). Returns (exit_code, messages)."""
+    open_threads = open_bot_threads(nodes, bot_logins)
+    if not open_threads:
+        return 0, ["OK: no open automated-review (bot) threads on this PR."]
+
+    body_class = classify_body(body)
+    if body_class in ("acknowledges_open", "unmarked"):
+        # The body does not claim all-clear; the local audit owns blocking an
+        # unresolved/unmarked record. No contradiction to flag here.
+        return 0, [
+            f"OK: {len(open_threads)} open bot thread(s), and the reconciliation "
+            f"record does not claim all-clear ({body_class})."
+        ]
+
+    if body_class == "claims_clear":
+        lead = (
+            "reconciliation contradicts reality: the PR body records the "
+            "automated-review findings as all fixed/waived, but these bot threads "
+            "are still open:"
+        )
+    else:  # absent
+        lead = (
+            "no AI reconciliation record found, but these automated-review (bot) "
+            "threads are still open and unaccounted for:"
+        )
+    messages = [lead]
+    for t in open_threads:
+        loc = t["path"] if t["line"] is None else f"{t['path']}:{t['line']}"
+        messages.append(f"  - [{t['author']}] {loc}: {t['snippet']}")
+    messages.append(
+        "Resolve or explicitly waive (with a reason in the PR body) each finding "
+        "before merge (AGENTS.md 4a.1)."
+    )
+    return 1, messages
+
+
+def _gh(args: Sequence[str], gh: str) -> str:
+    proc = subprocess.run(
+        [gh, *args], capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or proc.stdout or "gh failed").strip())
+    return proc.stdout
+
+
+def fetch_threads(pr: int, owner: str, name: str, gh: str) -> list[dict]:
+    out = _gh(
+        [
+            "api", "graphql",
+            "-f", f"query={_THREADS_QUERY}",
+            "-F", f"owner={owner}",
+            "-F", f"name={name}",
+            "-F", f"pr={pr}",
+        ],
+        gh,
+    )
+    data = json.loads(out)
+    return (
+        ((((data.get("data") or {}).get("repository") or {}).get("pullRequest") or {})
+         .get("reviewThreads") or {}).get("nodes")
+    ) or []
+
+
+def fetch_body(pr: int, repo: str, gh: str) -> str:
+    out = _gh(["pr", "view", str(pr), "--repo", repo, "--json", "body", "-q", ".body"], gh)
+    return out
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--pr", type=int, help="PR number")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="owner/name (defaults to $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument(
+        "--bots",
+        default=os.environ.get("ATLAS_REVIEW_BOTS", ",".join(_DEFAULT_BOTS)),
+        help="comma-separated bot login substrings (default: copilot,codex)",
+    )
+    parser.add_argument("--gh", default="gh", help="path to the gh CLI")
+    parser.add_argument(
+        "--threads-file",
+        help="JSON file of reviewThreads nodes (test/dry-run; skips the live fetch)",
+    )
+    parser.add_argument(
+        "--body-file",
+        help="PR body file (test/dry-run; skips fetching the live body)",
+    )
+    args = parser.parse_args(argv)
+
+    bots = [b.strip() for b in (args.bots or "").split(",") if b.strip()]
+    if not bots:
+        print("live reconciliation: no bot logins configured", file=sys.stderr)
+        return 2
+
+    try:
+        if args.threads_file:
+            nodes = json.loads(Path(args.threads_file).read_text(encoding="utf-8"))
+        else:
+            if args.pr is None or not args.repo:
+                print(
+                    "live reconciliation: need --pr and --repo (or $GITHUB_REPOSITORY) "
+                    "when not using --threads-file",
+                    file=sys.stderr,
+                )
+                return 2
+            owner, _, name = args.repo.partition("/")
+            nodes = fetch_threads(args.pr, owner, name, args.gh)
+
+        if args.body_file:
+            body = Path(args.body_file).read_text(encoding="utf-8")
+        elif args.pr is not None and args.repo:
+            body = fetch_body(args.pr, args.repo, args.gh)
+        else:
+            body = ""
+    except (OSError, ValueError, RuntimeError) as exc:
+        print(f"live reconciliation: GitHub API/read error: {exc}", file=sys.stderr)
+        return 2
+
+    code, messages = evaluate(nodes, body, bots)
+    print("live AI reconciliation check")
+    print("-" * 60)
+    for line in messages:
+        print(line)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -39,10 +39,11 @@ from pathlib import Path
 _DEFAULT_BOTS = ("copilot", "codex")
 
 _THREADS_QUERY = """
-query($owner:String!,$name:String!,$pr:Int!){
+query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
   repository(owner:$owner,name:$name){
     pullRequest(number:$pr){
-      reviewThreads(first:100){
+      reviewThreads(first:100, after:$cursor){
+        pageInfo{ hasNextPage endCursor }
         nodes{
           isResolved
           isOutdated
@@ -55,6 +56,10 @@ query($owner:String!,$name:String!,$pr:Int!){
   }
 }
 """
+
+# Defensive cap on pagination (100 threads/page) so a pathological PR can never
+# loop unbounded; far above any real review.
+_MAX_THREAD_PAGES = 50
 
 
 def _load_phase2():
@@ -162,21 +167,33 @@ def _gh(args: Sequence[str], gh: str) -> str:
 
 
 def fetch_threads(pr: int, owner: str, name: str, gh: str) -> list[dict]:
-    out = _gh(
-        [
+    """Fetch ALL review threads, paginating so a PR with >100 threads cannot
+
+    hide an unresolved finding past the first page and pass as clear.
+    """
+    nodes: list[dict] = []
+    cursor: str | None = None
+    for _ in range(_MAX_THREAD_PAGES):
+        args = [
             "api", "graphql",
             "-f", f"query={_THREADS_QUERY}",
             "-F", f"owner={owner}",
             "-F", f"name={name}",
             "-F", f"pr={pr}",
-        ],
-        gh,
-    )
-    data = json.loads(out)
-    return (
-        ((((data.get("data") or {}).get("repository") or {}).get("pullRequest") or {})
-         .get("reviewThreads") or {}).get("nodes")
-    ) or []
+        ]
+        if cursor:
+            args += ["-F", f"cursor={cursor}"]
+        data = json.loads(_gh(args, gh))
+        threads = (
+            (((data.get("data") or {}).get("repository") or {}).get("pullRequest") or {})
+            .get("reviewThreads") or {}
+        )
+        nodes.extend(threads.get("nodes") or [])
+        page = threads.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            break
+        cursor = page.get("endCursor")
+    return nodes
 
 
 def fetch_body(pr: int, repo: str, gh: str) -> str:

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_ai_reconciliation_live.py"
+
+
+def load_check():
+    spec = importlib.util.spec_from_file_location("check_ai_reconciliation_live", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def thread(*, resolved=False, outdated=False, author="copilot-pull-request-reviewer[bot]",
+           path="atlas_brain/x.py", line=12, body="use the typed config field"):
+    return {
+        "isResolved": resolved,
+        "isOutdated": outdated,
+        "path": path,
+        "line": line,
+        "comments": {"nodes": [{"author": {"login": author}, "bodyText": body}]},
+    }
+
+
+BODY_CLEAR = "## AI reconciliation\n- All fixed or waived: Yes\n"
+BODY_OPEN = "## AI reconciliation\n- fixed or waived: No\n"
+BODY_ABSENT = "## Summary\njust a normal PR body\n"
+BOTS = ["copilot", "codex"]
+
+
+# --- open_bot_threads filtering -------------------------------------------
+
+def test_unresolved_bot_thread_counts():
+    c = load_check()
+    assert len(c.open_bot_threads([thread()], BOTS)) == 1
+
+
+def test_resolved_outdated_and_nonbot_excluded():
+    c = load_check()
+    nodes = [
+        thread(resolved=True),
+        thread(outdated=True),
+        thread(author="alice"),  # human reviewer, not a bot
+    ]
+    assert c.open_bot_threads(nodes, BOTS) == []
+
+
+def test_bot_login_substring_match():
+    c = load_check()
+    assert c.open_bot_threads([thread(author="chatgpt-codex-connector[bot]")], BOTS)
+
+
+# --- body classification (reuses Phase-2 parser) --------------------------
+
+def test_classify_body():
+    c = load_check()
+    assert c.classify_body(BODY_CLEAR) == "claims_clear"
+    assert c.classify_body(BODY_OPEN) == "acknowledges_open"
+    assert c.classify_body(BODY_ABSENT) == "absent"
+
+
+# --- evaluate: the failure branch (the lie) MUST fire ---------------------
+
+def test_open_thread_plus_clear_body_fails():
+    c = load_check()
+    code, msgs = c.evaluate([thread()], BODY_CLEAR, BOTS)
+    assert code == 1
+    assert any("contradicts reality" in m for m in msgs)
+    assert any("atlas_brain/x.py:12" in m for m in msgs)
+
+
+def test_open_thread_plus_absent_body_fails():
+    c = load_check()
+    code, msgs = c.evaluate([thread()], BODY_ABSENT, BOTS)
+    assert code == 1
+    assert any("no AI reconciliation record" in m for m in msgs)
+
+
+# --- evaluate: the pass branches ------------------------------------------
+
+def test_open_thread_but_body_acknowledges_open_passes():
+    # The body is honest about open findings; the local audit owns blocking it,
+    # so the live check does not double-flag.
+    c = load_check()
+    code, _ = c.evaluate([thread()], BODY_OPEN, BOTS)
+    assert code == 0
+
+
+def test_no_open_threads_passes_even_with_clear_body():
+    c = load_check()
+    code, _ = c.evaluate([thread(resolved=True)], BODY_CLEAR, BOTS)
+    assert code == 0
+
+
+# --- main() via injection (no live GitHub) --------------------------------
+
+def test_main_contradiction_exit_1(tmp_path):
+    c = load_check()
+    tf = tmp_path / "threads.json"
+    tf.write_text(json.dumps([thread()]), encoding="utf-8")
+    bf = tmp_path / "body.md"
+    bf.write_text(BODY_CLEAR, encoding="utf-8")
+    assert c.main(["--threads-file", str(tf), "--body-file", str(bf)]) == 1
+
+
+def test_main_clean_exit_0(tmp_path):
+    c = load_check()
+    tf = tmp_path / "threads.json"
+    tf.write_text(json.dumps([thread(resolved=True)]), encoding="utf-8")
+    bf = tmp_path / "body.md"
+    bf.write_text(BODY_CLEAR, encoding="utf-8")
+    assert c.main(["--threads-file", str(tf), "--body-file", str(bf)]) == 0
+
+
+def test_main_missing_pr_repo_exit_2():
+    c = load_check()
+    # No --threads-file and no --pr/--repo -> usage error, never a silent pass.
+    assert c.main(["--repo", "", "--gh", "false"]) == 2
+
+
+def test_main_empty_bots_exit_2(tmp_path):
+    c = load_check()
+    tf = tmp_path / "threads.json"
+    tf.write_text("[]", encoding="utf-8")
+    assert c.main(["--threads-file", str(tf), "--bots", "  "]) == 2

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -127,3 +127,35 @@ def test_main_empty_bots_exit_2(tmp_path):
     tf = tmp_path / "threads.json"
     tf.write_text("[]", encoding="utf-8")
     assert c.main(["--threads-file", str(tf), "--bots", "  "]) == 2
+
+
+# --- pagination: a thread past the first page must not be missed -----------
+
+def _page(nodes, *, has_next, cursor=None):
+    return json.dumps(
+        {"data": {"repository": {"pullRequest": {"reviewThreads": {
+            "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+            "nodes": nodes,
+        }}}}}
+    )
+
+
+def test_fetch_threads_paginates(monkeypatch):
+    c = load_check()
+    pages = [
+        _page([thread(path="page1.py")], has_next=True, cursor="C1"),
+        _page([thread(path="page2.py")], has_next=False),
+    ]
+    seen = {"n": 0, "cursors": []}
+
+    def fake_gh(args, gh):
+        # capture whether the cursor was forwarded on the second call
+        seen["cursors"].append("C1" in " ".join(args))
+        out = pages[seen["n"]]
+        seen["n"] += 1
+        return out
+
+    monkeypatch.setattr(c, "_gh", fake_gh)
+    nodes = c.fetch_threads(1431, "owner", "name", "gh")
+    assert len(nodes) == 2  # both pages collected, not just the first 100
+    assert seen["n"] == 2 and seen["cursors"] == [False, True]


### PR DESCRIPTION
Plan: plans/PR-Reviewer-Reconciliation-Live-CI.md

Slice phase: `Workflow/process`

Follow-up to #1328 (Phase 5). #1328's S1-S4 shipped; this adds the live, CI-side half those slices deferred.

## What
A required CI check (`scripts/check_ai_reconciliation_live.py` + `.github/workflows/ai_reconciliation_live.yml`) that reads the live Codex/Copilot review threads and fails when the PR body records the findings as all fixed/waived (or carries no record) while bot threads are still open.

Model (ii): catches the contradiction (all-clear body + open threads), not "every thread must be GitHub-resolved" (self-resolvable, gameable). Imports the Phase-2 section parser so local and live cannot disagree on "resolved". Triggers on `pull_request` (incl. `edited`) plus review events so the required check always runs and re-runs on a body-only fix.

## Verification
- `pytest tests/test_check_ai_reconciliation_live.py tests/test_audit_ai_reconciliation.py` -> 30 passed (the "lie" failure branch + pagination proven)
- `scripts/check_ascii_python.sh` -> clean; plan-doc audits green

## Diff budget
~600 LOC, over the 400 soft cap; justified in the plan's "Why" (cohesive unit).

## AI reconciliation
Codex findings on this PR, both fixed:
- `ai_reconciliation_live.yml:15` (P1, rerun on body edit) -- fixed: added `edited` to the `pull_request` trigger types.
- `check_ai_reconciliation_live.py:45` (P2, paginate threads) -- fixed: `fetch_threads` now paginates via `pageInfo`/`endCursor` (`test_fetch_threads_paginates`).
All fixed or waived: Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
