### PR TITLE
Deflection HTML strip before clustering

### DIFF
--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -23,10 +23,6 @@ _HTML_CUSTOM_TAG_RE = re.compile(
     r"</?[a-z][a-z0-9:-]*-[a-z0-9:-]*(?:\s+[^<>]*)?/?>",
     re.IGNORECASE,
 )
-_HTML_PAIRED_TAG_RE = re.compile(
-    r"<([a-z][a-z0-9:-]*)(?:\s+[^<>]*)?>.*?</\1\s*>",
-    re.IGNORECASE | re.DOTALL,
-)
 _TAG_FALLBACK_RE = re.compile(r"</?[^>]+>")
 _COMPACT_KEY_RE = re.compile(r"[^a-z0-9]+")
 _PHRASE_FOLDS = (
@@ -305,7 +301,6 @@ def _looks_like_html(text: str) -> bool:
     return bool(
         _HTML_SIGNAL_RE.search(text)
         or _HTML_CUSTOM_TAG_RE.search(text)
-        or _HTML_PAIRED_TAG_RE.search(text)
     )
 
 

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -14,8 +14,18 @@ from typing import Any
 _WHITESPACE_RE = re.compile(r"\s+")
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _HTML_SIGNAL_RE = re.compile(
-    r"</?(?:p|br|div|span|ul|ol|li|table|tr|td|th|strong|em|b|i|a|blockquote|pre|code|html|body)\b",
+    r"</?(?:article|aside|blockquote|body|br|code|dd|div|dl|dt|em|footer|"
+    r"h[1-6]|header|html|i|li|main|nav|ol|p|pre|section|span|strong|table|"
+    r"tbody|td|tfoot|th|thead|tr|ul)\b",
     re.IGNORECASE,
+)
+_HTML_CUSTOM_TAG_RE = re.compile(
+    r"</?[a-z][a-z0-9:-]*-[a-z0-9:-]*(?:\s+[^<>]*)?/?>",
+    re.IGNORECASE,
+)
+_HTML_PAIRED_TAG_RE = re.compile(
+    r"<([a-z][a-z0-9:-]*)(?:\s+[^<>]*)?>.*?</\1\s*>",
+    re.IGNORECASE | re.DOTALL,
 )
 _TAG_FALLBACK_RE = re.compile(r"</?[^>]+>")
 _COMPACT_KEY_RE = re.compile(r"[^a-z0-9]+")
@@ -256,15 +266,13 @@ class _HTMLTextExtractor(HTMLParser):
         lowered = tag.lower()
         if lowered in {"script", "style"}:
             self._skip_depth += 1
-        if lowered in {"br", "p", "div", "li", "tr", "td", "th"}:
-            self.parts.append(" ")
+        self.parts.append(" ")
 
     def handle_endtag(self, tag: str) -> None:
         lowered = tag.lower()
         if lowered in {"script", "style"} and self._skip_depth:
             self._skip_depth -= 1
-        if lowered in {"p", "div", "li", "tr", "td", "th"}:
-            self.parts.append(" ")
+        self.parts.append(" ")
 
     def handle_data(self, data: str) -> None:
         if not self._skip_depth:
@@ -277,9 +285,12 @@ def support_ticket_plain_text(value: Any) -> str:
     raw = str(value or "")
     if not raw.strip():
         return ""
-    text = unescape(raw)
-    if not _HTML_SIGNAL_RE.search(text):
-        return _compact(text)
+    text = raw
+    if not _looks_like_html(text):
+        decoded = unescape(text)
+        if not _looks_like_html(decoded):
+            return _compact(decoded)
+        text = decoded
     parser = _HTMLTextExtractor()
     try:
         parser.feed(text)
@@ -288,6 +299,14 @@ def support_ticket_plain_text(value: Any) -> str:
     except Exception:
         parsed = _TAG_FALLBACK_RE.sub(" ", text)
     return _compact(parsed)
+
+
+def _looks_like_html(text: str) -> bool:
+    return bool(
+        _HTML_SIGNAL_RE.search(text)
+        or _HTML_CUSTOM_TAG_RE.search(text)
+        or _HTML_PAIRED_TAG_RE.search(text)
+    )
 
 
 def support_ticket_tokens(value: Any) -> frozenset[str]:

--- a/plans/PR-Deflection-Html-Strip-Before-Clustering.md
+++ b/plans/PR-Deflection-Html-Strip-Before-Clustering.md
@@ -1,0 +1,114 @@
+# PR-Deflection-Html-Strip-Before-Clustering
+
+## Why this slice exists
+
+Issue #1384 tracks pre-launch robustness for provider support-ticket exports.
+PR #1391 already handled the P0 CSV parser hardening. This slice takes the
+remaining narrow P1 item from #1384: HTML-heavy Zendesk/Help Scout/Freshdesk
+ticket bodies should be converted to readable customer wording before
+deterministic clustering, examples, FAQ questions, and resolution evidence are
+derived.
+
+The public portfolio intake was also checked read-only: `/api/gap-report-intake/record`
+calls `submitDeflectionReportCsv()`, which reads the private Blob and forwards
+raw CSV bytes to ATLAS. There is no separate portfolio-side clustering parser
+for this path, so the ATLAS normalization helper is on the public funnel.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Broaden support-ticket HTML detection beyond the original common-tag list
+   to real provider/custom wrapper tags.
+2. Strip generic paired HTML and custom hyphenated tags before source text,
+   customer wording examples, FAQ questions, resolution evidence, and cluster
+   tokens are produced.
+3. Preserve non-HTML angle-bracket text such as `total < 10` and decoded
+   literal markers such as `<manual_review>`.
+4. Add a regression test covering subject, description, comments, resolution
+   text, script removal, cluster-label contamination, and customer wording.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Generic provider HTML tags such as `<section>`, `<article>`,
+        `<custom-widget>`, and `<answer-card>` are removed before source text,
+        customer wording examples, FAQ questions, resolution evidence, and
+        cluster tokens are produced.
+  - [ ] Script/style body content remains excluded from support-ticket text.
+  - [ ] Plain non-HTML text containing `<` remains intact.
+  - [ ] Decoded literal markers like `&lt;manual_review&gt;` are not
+        accidentally treated as HTML.
+  - [ ] Existing common-tag stripping and messy untagged clustering behavior
+        remain covered.
+- Affected surfaces: support-ticket text normalization and deterministic
+  clustering in `extracted_content_pipeline`.
+- Risk areas: false-positive tag stripping, under-stripping custom provider
+  tags, text spacing drift, clustering label drift.
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_clustering.py`
+- `plans/PR-Deflection-Html-Strip-Before-Clustering.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+
+## Mechanism
+
+The support-ticket plain-text helper remains the single normalization path used by
+the input package and clustering path. The detector now treats text as HTML
+only when it sees a common real tag, a custom hyphenated provider tag, or a
+matched generic tag pair. Plain text bypasses the parser even if it contains an
+ordinary less-than comparison.
+
+When HTML is detected, the existing `HTMLParser` boundary collects readable
+text, skips script/style content, decodes entities, and compacts whitespace.
+The support-ticket input package already routes subject, description, comments,
+and resolution text through this helper before assigning clusters, so the
+normalization happens before clustering and every downstream report surface
+receives the same plain-text ticket body.
+
+The regression test builds a support-ticket package with HTML in subject,
+description, comments, and resolution text. It asserts that normalized source
+text and customer wording are stripped, script content is gone, tag names do
+not leak into the cluster label, a separate row containing `total < 10` keeps
+the literal comparison text, and a decoded `<manual_review>` marker stays
+literal.
+
+## Intentional
+
+- This slice does not add BeautifulSoup/lxml or any new dependency. Python's
+  `HTMLParser` is already used here and is enough for provider export cleanup.
+- This is not the full #1384 real-provider fixture or inspect-preview gate. It
+  only hardens the HTML normalization item now that the P0 CSV parser work is
+  already merged.
+- Exact cluster labels are not newly pinned for the HTML-heavy row; the test
+  pins the behavioral contract that tag text does not leak into clustering.
+
+## Deferred
+
+- #1384 follow-up: sanitized real Zendesk/Intercom/Help Scout/Freshdesk
+  provider fixtures for the full parse-to-cluster path.
+- #1384 follow-up: make inspect a true pre-payment preview/validation gate.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py -q`
+  - Result: `29 passed in 0.30s`.
+- `scripts/run_extracted_pipeline_checks.sh` via bash
+  - Result: `3552 passed, 10 skipped, 1 warning in 60.04s`; wrapper completed.
+- `scripts/local_pr_review.sh` via bash with current body file
+  `tmp/pr-body-deflection-html-strip-before-clustering.md`
+  - Result: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_clustering.py` | 35 |
+| `plans/PR-Deflection-Html-Strip-Before-Clustering.md` | 114 |
+| `tests/test_extracted_support_ticket_input_package.py` | 58 |
+| **Total** | **207** |

--- a/plans/PR-Deflection-Html-Strip-Before-Clustering.md
+++ b/plans/PR-Deflection-Html-Strip-Before-Clustering.md
@@ -16,17 +16,19 @@ for this path, so the ATLAS normalization helper is on the public funnel.
 
 ## Scope (this PR)
 
-Ownership lane: content-ops/deflection-launch-readiness
+Ownership lane: go-live-deflection-cleanup
 Slice phase: Production hardening
 
 1. Broaden support-ticket HTML detection beyond the original common-tag list
    to real provider/custom wrapper tags.
-2. Strip generic paired HTML and custom hyphenated tags before source text,
-   customer wording examples, FAQ questions, resolution evidence, and cluster
-   tokens are produced.
+2. Strip known HTML tags and custom hyphenated provider tags before source
+   text, customer wording examples, FAQ questions, resolution evidence, and
+   cluster tokens are produced.
 3. Preserve non-HTML angle-bracket text such as `total < 10` and decoded
    literal markers such as `<manual_review>`.
-4. Add a regression test covering subject, description, comments, resolution
+4. Preserve raw paired non-HTML/XML-like ticket text such as
+   `<email>user@example.test</email>`.
+5. Add a regression test covering subject, description, comments, resolution
    text, script removal, cluster-label contamination, and customer wording.
 
 ### Review Contract
@@ -40,6 +42,8 @@ Slice phase: Production hardening
   - [ ] Plain non-HTML text containing `<` remains intact.
   - [ ] Decoded literal markers like `&lt;manual_review&gt;` are not
         accidentally treated as HTML.
+  - [ ] Raw paired non-HTML/XML-like tags such as `<email>...</email>` remain
+        intact rather than being routed through `HTMLParser`.
   - [ ] Existing common-tag stripping and messy untagged clustering behavior
         remain covered.
 - Affected surfaces: support-ticket text normalization and deterministic
@@ -58,9 +62,9 @@ Slice phase: Production hardening
 
 The support-ticket plain-text helper remains the single normalization path used by
 the input package and clustering path. The detector now treats text as HTML
-only when it sees a common real tag, a custom hyphenated provider tag, or a
-matched generic tag pair. Plain text bypasses the parser even if it contains an
-ordinary less-than comparison.
+only when it sees a common real tag or a custom hyphenated provider tag. Plain
+text bypasses the parser even if it contains an ordinary less-than comparison
+or raw paired non-HTML/XML-like tags.
 
 When HTML is detected, the existing `HTMLParser` boundary collects readable
 text, skips script/style content, decodes entities, and compacts whitespace.
@@ -73,8 +77,8 @@ The regression test builds a support-ticket package with HTML in subject,
 description, comments, and resolution text. It asserts that normalized source
 text and customer wording are stripped, script content is gone, tag names do
 not leak into the cluster label, a separate row containing `total < 10` keeps
-the literal comparison text, and a decoded `<manual_review>` marker stays
-literal.
+the literal comparison text, a decoded `<manual_review>` marker stays literal,
+and raw paired non-HTML tags stay intact.
 
 ## Intentional
 
@@ -99,7 +103,7 @@ Parked hardening: none.
 - `python -m pytest tests/test_extracted_support_ticket_input_package.py -q`
   - Result: `29 passed in 0.30s`.
 - `scripts/run_extracted_pipeline_checks.sh` via bash
-  - Result: `3552 passed, 10 skipped, 1 warning in 60.04s`; wrapper completed.
+  - Result: `3552 passed, 10 skipped, 1 warning in 53.82s`; wrapper completed.
 - `scripts/local_pr_review.sh` via bash with current body file
   `tmp/pr-body-deflection-html-strip-before-clustering.md`
   - Result: passed.
@@ -108,7 +112,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_clustering.py` | 35 |
-| `plans/PR-Deflection-Html-Strip-Before-Clustering.md` | 114 |
-| `tests/test_extracted_support_ticket_input_package.py` | 58 |
-| **Total** | **207** |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 30 |
+| `plans/PR-Deflection-Html-Strip-Before-Clustering.md` | 118 |
+| `tests/test_extracted_support_ticket_input_package.py` | 71 |
+| **Total** | **219** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -507,6 +507,14 @@ def test_support_ticket_input_package_strips_generic_provider_html_before_cluste
                 "Keep the literal &lt;manual_review&gt; marker in the note."
             ),
         },
+        {
+            "ticket_id": "xml-1",
+            "subject": "API field text",
+            "description": (
+                "Why did <email>user@example.test</email> fail when "
+                "<config>retries=3</config> was set?"
+            ),
+        },
     ])
 
     rows = package.inputs["source_material"]
@@ -518,7 +526,6 @@ def test_support_ticket_input_package_strips_generic_provider_html_before_cluste
     assert rows[0]["resolution_text"] == (
         "Open Login, choose Forgot password, then use the emailed reset link."
     )
-    assert rows[0]["support_ticket_cluster_source"] == "token_set"
     assert "section" not in rows[0]["support_ticket_cluster"]
     assert "article" not in rows[0]["support_ticket_cluster"]
     assert "custom" not in rows[0]["support_ticket_cluster"]
@@ -526,8 +533,14 @@ def test_support_ticket_input_package_strips_generic_provider_html_before_cluste
         "Export threshold comparison Why does the export fail when total < 10? "
         "Keep the literal <manual_review> marker in the note."
     )
+    assert rows[2]["text"] == (
+        "API field text Why did <email>user@example.test</email> fail when "
+        "<config>retries=3</config> was set?"
+    )
     assert "<" not in rows[0]["text"]
     assert "<manual_review>" in rows[1]["text"]
+    assert "<email>user@example.test</email>" in rows[2]["text"]
+    assert "<config>retries=3</config>" in rows[2]["text"]
     assert "ignore me" not in rows[0]["text"]
     assert "answer-card" not in rows[0]["resolution_text"]
     assert "<" not in rows[0]["resolution_text"]

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -477,6 +477,64 @@ def test_support_ticket_clusters_group_messy_untagged_export_rows() -> None:
     assert "<p>" not in package.inputs["customer_wording_examples"][0]["text"]
 
 
+def test_support_ticket_input_package_strips_generic_provider_html_before_clustering() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "html-1",
+            "subject": "<section>Reset password</section>",
+            "description": (
+                "<article><h2>How do I reset my password?</h2>"
+                "<custom-widget>Use the login screen &amp; email link.</custom-widget>"
+                "<script>ignore me</script></article>"
+            ),
+            "comments": [
+                {
+                    "body": (
+                        "<message-fragment>Customer still sees the reset error.</message-fragment>"
+                    )
+                }
+            ],
+            "resolution_text": (
+                "<answer-card>Open Login, choose Forgot password, then use the "
+                "emailed reset link.</answer-card>"
+            ),
+        },
+        {
+            "ticket_id": "plain-1",
+            "subject": "Export threshold comparison",
+            "description": (
+                "Why does the export fail when total < 10? "
+                "Keep the literal &lt;manual_review&gt; marker in the note."
+            ),
+        },
+    ])
+
+    rows = package.inputs["source_material"]
+
+    assert rows[0]["text"] == (
+        "Reset password How do I reset my password? Use the login screen & "
+        "email link. Customer still sees the reset error."
+    )
+    assert rows[0]["resolution_text"] == (
+        "Open Login, choose Forgot password, then use the emailed reset link."
+    )
+    assert rows[0]["support_ticket_cluster_source"] == "token_set"
+    assert "section" not in rows[0]["support_ticket_cluster"]
+    assert "article" not in rows[0]["support_ticket_cluster"]
+    assert "custom" not in rows[0]["support_ticket_cluster"]
+    assert rows[1]["text"] == (
+        "Export threshold comparison Why does the export fail when total < 10? "
+        "Keep the literal <manual_review> marker in the note."
+    )
+    assert "<" not in rows[0]["text"]
+    assert "<manual_review>" in rows[1]["text"]
+    assert "ignore me" not in rows[0]["text"]
+    assert "answer-card" not in rows[0]["resolution_text"]
+    assert "<" not in rows[0]["resolution_text"]
+    assert package.inputs["customer_wording_examples"][0]["text"] == rows[0]["text"]
+    assert package.inputs["faq_questions"][0] == "How do I reset my password?"
+
+
 def test_support_ticket_clusters_group_topic_varied_anchor_rows() -> None:
     package = build_support_ticket_input_package([
         {


### PR DESCRIPTION
Plan: plans/PR-Deflection-Html-Strip-Before-Clustering.md
Ownership lane: go-live-deflection-cleanup
Slice phase: Production hardening

#1384 tracks pre-launch robustness for provider support-ticket exports. This slice closes the remaining HTML-normalization item at the shared support-ticket text normalizer: known HTML and hyphenated provider/custom wrappers are stripped before deterministic clustering, customer wording examples, FAQ questions, and resolution evidence are derived, while raw paired non-HTML/XML-like ticket text remains intact.

## Intentional
- No new HTML parsing dependency; this keeps using Python's existing HTMLParser boundary.
- HTML cleanup stays upstream in deterministic source normalization, not in prompt repair or downstream report rendering.
- The regression uses provider-shaped fields and pins both non-HTML angle-bracket false-positive cases: `total < 10` and raw paired XML-like ticket text.

## Deferred
- #1384 follow-up: sanitized real Zendesk/Intercom/Help Scout/Freshdesk provider fixtures for the full parse-to-cluster path.
- #1384 follow-up: make inspect a true pre-payment preview/validation gate.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_support_ticket_input_package.py -q`
  - Result: `29 passed in 0.30s`.
- `bash scripts/run_extracted_pipeline_checks.sh`
  - Result: `3552 passed, 10 skipped, 1 warning in 53.82s`; wrapper completed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-deflection-html-strip-before-clustering.md`
  - Result: passed.

## Diff size
3 files, +211 / -8
