### PR TITLE
Content-Ops Adapter Contract Example

### DIFF
--- a/atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py
@@ -15,6 +15,16 @@ from . import content_ops_marketer_verify_server as verify_server
 
 CONTRACT_ID = "content-ops-verify-draft-contract"
 _RESULT_PREFIX = "content-ops-verdict:"
+_ACCEPTED_FIELDS = (
+    "asset_id",
+    "rule_packet",
+    "coverage",
+    "extracted_claims",
+    "quality_reports",
+    "brand_voice_payload",
+    "comments",
+    "as_of",
+)
 
 
 @dataclass(frozen=True)
@@ -164,11 +174,14 @@ def _contract_search_result(*, query: Any, limit: Any) -> dict[str, Any]:
 
 def _contract_document() -> dict[str, Any]:
     text = (
-        "Submit one JSON object through search with these fields: asset_id, "
-        "rule_packet, coverage, extracted_claims, quality_reports, "
-        "brand_voice_payload, comments, and as_of. The adapter returns a "
-        "tenant-bound verdict ID. Call fetch with that ID to read the full "
-        "Content Ops review verdict."
+        "Empty or non-JSON search query values return this contract. A "
+        "JSON-encoded string whose decoded value is an object is treated as one "
+        "Content Ops review submission with these fields: asset_id, rule_packet, "
+        "coverage, extracted_claims, quality_reports, brand_voice_payload, "
+        "comments, and as_of. Pass submissions as query=json.dumps(example); "
+        "query is a string in the tool schema, not an object. The adapter "
+        "returns a tenant-bound verdict ID. Call fetch with that ID to read the "
+        "full Content Ops review verdict."
     )
     return {
         "id": CONTRACT_ID,
@@ -179,16 +192,142 @@ def _contract_document() -> dict[str, Any]:
             "ok": True,
             "found": True,
             "type": "adapter_contract",
-            "accepted_fields": [
-                "asset_id",
-                "rule_packet",
-                "coverage",
-                "extracted_claims",
-                "quality_reports",
-                "brand_voice_payload",
-                "comments",
-                "as_of",
-            ],
+            "accepted_fields": list(_ACCEPTED_FIELDS),
+            "dispatch": _contract_dispatch(),
+            "schema": _contract_schema(),
+            "example": _contract_example(),
+        },
+    }
+
+
+def _contract_dispatch() -> dict[str, Any]:
+    example = _contract_example()
+    return {
+        "contract_shape": {"query": ""},
+        "submit_shape": {"query": "<JSON-encoded string of an object matching schema/example>"},
+        "submit_example_query": json.dumps(example, sort_keys=True),
+        "rule": (
+            "empty or non-string-typed query returns this contract; a JSON-encoded "
+            "string whose decoded value is an object submits a review"
+        ),
+    }
+
+
+def _contract_example() -> dict[str, Any]:
+    return {
+        "asset_id": "draft-123",
+        "rule_packet": {
+            "brief": "rules/brief.v3",
+            "brand_voice": "rules/brand_voice.v2",
+            "claim_registry": "rules/claims.v5",
+            "compliance": "rules/compliance.v1",
+            "channel_schema": "rules/channel_schema.v2",
+        },
+        "coverage": [
+            {
+                "rule_id": "CLAIM-001",
+                "requirement": "Every claim must map to approved registry wording",
+                "required": True,
+                "status": "pass",
+                "evidence": "Claim mapped to approved registry entry feature.sso",
+            }
+        ],
+        "quality_reports": {
+            "passed": True,
+            "findings": [],
+        },
+        "brand_voice_payload": {
+            "passed": True,
+            "warnings": [],
+            "banned_terms": [],
+        },
+        "extracted_claims": [
+            {
+                "text": "SSO is included on every plan",
+                "location": "draft:section-2",
+                "registry_id": "feature.sso",
+            }
+        ],
+        "comments": [
+            {
+                "category": "nit",
+                "message": "Optional reviewer note",
+                "evidence": "",
+                "blocking": False,
+            }
+        ],
+        "as_of": "2026-06-09",
+    }
+
+
+def _contract_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": list(_ACCEPTED_FIELDS),
+        "properties": {
+            "asset_id": {"type": "string"},
+            "rule_packet": {
+                "type": "object",
+                "properties": {
+                    "brief": {"type": "string"},
+                    "brand_voice": {"type": "string"},
+                    "claim_registry": {"type": "string"},
+                    "compliance": {"type": "string"},
+                    "channel_schema": {"type": "string"},
+                },
+            },
+            "coverage": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "rule_id": {"type": "string"},
+                        "requirement": {"type": "string"},
+                        "required": {"type": "boolean"},
+                        "status": {"enum": ["pass", "fail", "not_applicable", "unresolved"]},
+                        "evidence": {"type": "string"},
+                    },
+                },
+            },
+            "extracted_claims": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string"},
+                        "location": {"type": "string"},
+                        "registry_id": {"type": "string"},
+                    },
+                },
+            },
+            "quality_reports": {
+                "type": "object",
+                "properties": {
+                    "passed": {"type": "boolean"},
+                    "findings": {"type": "array"},
+                },
+            },
+            "brand_voice_payload": {
+                "type": "object",
+                "properties": {
+                    "passed": {"type": "boolean"},
+                    "warnings": {"type": "array", "items": {"type": "string"}},
+                    "banned_terms": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+            "comments": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "category": {"type": "string"},
+                        "message": {"type": "string"},
+                        "evidence": {"type": "string"},
+                        "blocking": {"type": "boolean"},
+                    },
+                },
+            },
+            "as_of": {"type": "string", "format": "date"},
         },
     }
 

--- a/plans/PR-Content-Ops-Adapter-Contract-Example.md
+++ b/plans/PR-Content-Ops-Adapter-Contract-Example.md
@@ -1,0 +1,100 @@
+# PR-Content-Ops-Adapter-Contract-Example
+
+## Why this slice exists
+
+#1420 captured a live ChatGPT adapter usability gap: the adapter works
+end-to-end, but its contract document lists only top-level field names. The
+first real smoke submission therefore had to discover nested request shapes by
+getting blocked on malformed coverage, missing quality-report flags, and missing
+brand-voice flags.
+
+This slice closes the narrow adapter contract/documentation gap before changing
+the richer Claude verifier schema surface.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Product polish
+
+1. Keep the ChatGPT adapter tool surface exactly `search` and `fetch`.
+2. Keep current dispatch behavior: empty or non-JSON-string `query` returns the
+   contract document; a JSON-encoded string whose decoded value is an object
+   submits one review request.
+3. Add a concrete valid review-request example and dispatch metadata to the
+   contract document returned by `fetch`.
+4. Prove the example can be submitted through `search` without the schema-shape
+   blockers from #1420.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Adapter-Contract-Example.md`
+- `atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py`
+- `tests/test_mcp_content_ops_marketer_verify.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The adapter contract response keeps `accepted_fields` and adds a valid
+        example payload.
+  - [ ] The contract response describes the implicit dispatch rule without
+        changing dispatch behavior.
+  - [ ] The example payload uses backend-aligned nested field names for coverage,
+        quality reports, brand voice, claims, comments, and rule packet fields.
+  - [ ] Submitting the example through `search` avoids the #1420
+        schema-shape blockers.
+  - [ ] The ChatGPT adapter still exposes only `search` and `fetch`.
+- Affected surfaces: Content Ops marketer ChatGPT adapter contract metadata.
+- Risk areas: MCP contract compatibility, operator usability, backcompat.
+- Reviewer rules triggered: R1, R2, R5
+
+## Mechanism
+
+Add package-local adapter contract helpers that return the accepted top-level
+fields, dispatch description, and a minimal valid review-request example. The
+example should include passing quality and brand-voice evidence so the contract
+teaches the fields that live testing showed were missing.
+
+The `search` dispatch remains intentionally unchanged for this slice.
+JSON-encoded string payloads whose decoded value is an object keep submitting
+review requests; empty, non-string, or non-JSON payloads keep returning the
+contract search result.
+
+## Intentional
+
+- This does not add an explicit `mode` discriminator yet. That would be a
+  behavior change for live ChatGPT adapter payloads and belongs in a later
+  compatibility slice if needed.
+- This does not change the rich Claude `verify_draft` parameter schema. The
+  next planned slice can enrich that surface separately after this adapter
+  contract is stable.
+- This does not change tenant binding, OAuth, DCR, verdict caching, or tool
+  names.
+- AI reconciliation: fixed the reviewer MAJOR / Codex P2 by documenting that
+  `query` is a JSON-encoded string, adding `submit_example_query`, and pinning
+  the raw-object fallback case in tests.
+
+## Deferred
+
+- `PR-Content-Ops-Verify-Draft-Rich-Schema`: add richer nested schema hints to
+  the Claude rich verifier tool while preserving decoded-input tolerance.
+- Explicit adapter mode discriminator remains deferred unless live usage proves
+  implicit dispatch is still confusing after the contract example lands.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: focused MCP adapter pytest for `tests/test_mcp_content_ops_marketer_verify.py` (34 passed after review fix).
+- Passed: dedicated Content Ops MCP workflow pytest covering `tests/test_atlas_content_ops_review_workflow.py`, `tests/test_check_content_ops_marketer_verify_oauth_e2e.py`, `tests/test_content_ops_marketer_verify_launcher_contract.py`, `tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py`, and `tests/test_mcp_content_ops_marketer_verify.py` (92 passed after review fix).
+- Passed: extracted pipeline wrapper `scripts/run_extracted_pipeline_checks.sh` (3553 passed, 10 skipped after review fix).
+- Passed: py_compile for `atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py`.
+- Passed: `git diff --check`.
+- Passed: local PR review with body file `tmp/content_ops_adapter_contract_example_pr_body.md`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+| --- | ---: |
+| Plan doc | 100 |
+| Adapter contract helpers | 154 |
+| Tests | 59 |
+| Total | 313 |

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -243,6 +243,65 @@ async def test_chatgpt_adapter_non_json_search_returns_contract_document() -> No
     assert fetched["metadata"]["ok"] is True
     assert fetched["metadata"]["type"] == "adapter_contract"
     assert "asset_id" in fetched["metadata"]["accepted_fields"]
+    assert fetched["metadata"]["dispatch"]["contract_shape"] == {"query": ""}
+    assert "JSON-encoded string" in fetched["metadata"]["dispatch"]["submit_shape"]["query"]
+    assert "query=json.dumps(example)" in fetched["text"]
+    assert fetched["metadata"]["dispatch"]["submit_example_query"] == json.dumps(
+        fetched["metadata"]["example"],
+        sort_keys=True,
+    )
+    assert fetched["metadata"]["schema"]["properties"]["coverage"]["items"]["properties"][
+        "status"
+    ]["enum"] == ["pass", "fail", "not_applicable", "unresolved"]
+    assert fetched["metadata"]["example"]["quality_reports"]["passed"] is True
+    assert fetched["metadata"]["example"]["brand_voice_payload"]["passed"] is True
+    assert fetched["metadata"]["example"]["brand_voice_payload"]["warnings"] == []
+    assert fetched["metadata"]["example"]["brand_voice_payload"]["banned_terms"] == []
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_adapter_raw_object_query_returns_contract_instead_of_submission() -> None:
+    contract = await adapter.fetch(adapter.CONTRACT_ID)
+
+    result = await adapter.search(query=contract["metadata"]["example"])
+
+    assert result["metadata"]["ok"] is True
+    assert result["metadata"]["mode"] == "contract"
+    assert result["results"][0]["id"] == adapter.CONTRACT_ID
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_adapter_contract_example_submits_without_schema_shape_blockers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver("acct-1"),
+    )
+    contract = await adapter.fetch(adapter.CONTRACT_ID)
+
+    search_result = await adapter.search(query=json.dumps(contract["metadata"]["example"]))
+    verdict_id = search_result["results"][0]["id"]
+    fetched = await adapter.fetch(verdict_id)
+    verdict = fetched["metadata"]["verdict"]
+    reasons = "\n".join(str(reason) for reason in verdict["reasons"])
+    coverage_rule_ids = {
+        row["rule_id"] for row in verdict["content_pr"]["coverage"] if isinstance(row, dict)
+    }
+
+    assert search_result["metadata"]["ok"] is True
+    assert search_result["metadata"]["decision"] == "approved"
+    assert fetched["metadata"]["ok"] is True
+    assert verdict["decision"] == "approved"
+    assert "MALFORMED-COVERAGE" not in reasons
+    assert "Missing quality report passed flag" not in reasons
+    assert "Missing brand voice audit passed flag" not in reasons
+    assert "QUALITY-GATE:report" in coverage_rule_ids
+    assert "BRAND-VOICE:audit" in coverage_rule_ids
+    assert reader.scopes == [TenantScope(account_id="acct-1")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Adapter-Contract-Example.md
Slice phase: Product polish

#1420 showed that the ChatGPT adapter works mechanically but its contract document makes operators guess the nested request shape. This PR keeps the adapter behavior unchanged and adds a backend-aligned example, schema metadata, and dispatch description to the contract returned by `fetch("content-ops-verify-draft-contract")`.

## Intentional
- The adapter still exposes only `search` and `fetch`.
- Dispatch remains unchanged: empty or non-JSON-string `query` returns the contract; a JSON-encoded string whose decoded value is an object submits one review request.
- The rich Claude `verify_draft` schema surface is deferred to the next slice.
- AI reconciliation: fixed the reviewer MAJOR / Codex P2 by documenting that `query` is a JSON-encoded string, adding `submit_example_query`, and pinning the raw-object fallback case in tests.

## Deferred
- `PR-Content-Ops-Verify-Draft-Rich-Schema`: add richer nested schema hints to the Claude rich verifier tool while preserving decoded-input tolerance.
- Explicit adapter mode discriminator remains deferred unless live usage proves implicit dispatch is still confusing after the contract example lands.

## Parked hardening
- None.

## Verification
- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_mcp_content_ops_marketer_verify.py -q` (34 passed after review fix)
- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q` (92 passed after review fix)
- `bash scripts/run_extracted_pipeline_checks.sh` (3553 passed, 10 skipped after review fix)
- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py`
- `git diff --check`
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_adapter_contract_example_pr_body.md`

## Diff size
3 files, +313 / -15.
