### PR TITLE
Deflection refund dispute revocation

### DIFF
--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -728,12 +728,24 @@ async def _handle_content_ops_deflection_report_payment_revoked(
 ) -> None:
     """Relock a deflection report after a refund or dispute webhook."""
 
+    if event_type == "charge.refunded" and not _stripe_charge_refund_is_full(obj):
+        logger.info(
+            "Deflection report partial refund observed without revocation: "
+            "event_type=%s object=%s amount_refunded=%s amount_captured=%s",
+            event_type,
+            _stripe_text(obj, "id") or "<missing>",
+            _stripe_object_value(obj, "amount_refunded"),
+            _stripe_object_value(obj, "amount_captured")
+            or _stripe_object_value(obj, "amount"),
+        )
+        return
+
     meta, payment_reference = _content_ops_deflection_revocation_metadata(
         stripe_module,
         obj,
     )
     if meta.get("source") != "content_ops_deflection_report":
-        logger.warning(
+        logger.info(
             "Deflection report payment revocation could not be mapped: "
             "event_type=%s object=%s payment_intent=%s",
             event_type,
@@ -856,11 +868,37 @@ def _checkout_session_for_payment_intent(
             "Deflection report payment revocation checkout lookup failed: payment_intent=%s",
             payment_intent,
         )
-        return None
+        raise HTTPException(
+            status_code=503,
+            detail="Deflection report payment revocation lookup failed",
+        )
     data = _stripe_object_value(sessions, "data")
     if isinstance(data, Sequence) and data:
         return data[0]
     return None
+
+
+def _stripe_charge_refund_is_full(obj: Any) -> bool:
+    if _stripe_object_value(obj, "refunded") is True:
+        return True
+    amount_refunded = _stripe_int(obj, "amount_refunded")
+    amount_captured = _stripe_int(obj, "amount_captured") or _stripe_int(obj, "amount")
+    return (
+        amount_refunded is not None
+        and amount_captured is not None
+        and amount_captured > 0
+        and amount_refunded >= amount_captured
+    )
+
+
+def _stripe_int(obj: Any, key: str) -> int | None:
+    value = _stripe_object_value(obj, key)
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _payment_intent_from_payment_event(obj: Any) -> str:

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -2,7 +2,7 @@
 
 import logging
 import uuid as _uuid
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from hashlib import sha256
 from typing import Any
 
@@ -425,6 +425,14 @@ async def stripe_webhook(request: Request):
         if meta.get("source") == "content_ops_deflection_report":
             _log_content_ops_deflection_report_async_payment_failed(obj, meta)
 
+    elif event_type in {"charge.refunded", "charge.dispute.created"}:
+        await _handle_content_ops_deflection_report_payment_revoked(
+            pool,
+            stripe,
+            obj,
+            event_type=event_type,
+        )
+
     elif event_type == "invoice.paid":
         account_id = await _handle_invoice_paid(pool, obj)
 
@@ -709,6 +717,165 @@ async def _queue_content_ops_deflection_report_delivery(
         payment_reference,
     )
     return "queued"
+
+
+async def _handle_content_ops_deflection_report_payment_revoked(
+    pool: Any,
+    stripe_module: Any,
+    obj: Any,
+    *,
+    event_type: str,
+) -> None:
+    """Relock a deflection report after a refund or dispute webhook."""
+
+    meta, payment_reference = _content_ops_deflection_revocation_metadata(
+        stripe_module,
+        obj,
+    )
+    if meta.get("source") != "content_ops_deflection_report":
+        logger.warning(
+            "Deflection report payment revocation could not be mapped: "
+            "event_type=%s object=%s payment_intent=%s",
+            event_type,
+            _stripe_text(obj, "id") or "<missing>",
+            _payment_intent_from_payment_event(obj) or "<missing>",
+        )
+        return
+
+    account_id_text = _clean_metadata(meta.get("account_id"))
+    request_id = _clean_metadata(meta.get("request_id"))
+    if not account_id_text or not request_id:
+        logger.error(
+            "Deflection report payment revocation missing account_id/request_id: "
+            "event_type=%s object=%s",
+            event_type,
+            _stripe_text(obj, "id") or "<missing>",
+        )
+        return
+    try:
+        _uuid.UUID(account_id_text)
+    except ValueError:
+        logger.error(
+            "Deflection report payment revocation has invalid account_id: "
+            "event_type=%s account=%s object=%s",
+            event_type,
+            account_id_text,
+            _stripe_text(obj, "id") or "<missing>",
+        )
+        return
+
+    store = PostgresDeflectionReportArtifactStore(pool=pool)
+    revoked = await store.mark_unpaid(
+        account_id=account_id_text,
+        request_id=request_id,
+        payment_reference=payment_reference,
+    )
+    if not revoked:
+        logger.error(
+            "Deflection report payment revocation missed report: "
+            "event_type=%s account=%s request=%s payment_reference=%s object=%s",
+            event_type,
+            account_id_text,
+            request_id,
+            payment_reference or "<missing>",
+            _stripe_text(obj, "id") or "<missing>",
+        )
+        return
+
+    await _cancel_content_ops_deflection_report_delivery(
+        pool,
+        account_id=account_id_text,
+        request_id=request_id,
+        event_type=event_type,
+    )
+    logger.warning(
+        "Deflection report access revoked after Stripe payment reversal: "
+        "event_type=%s account=%s request=%s payment_reference=%s object=%s",
+        event_type,
+        account_id_text,
+        request_id,
+        payment_reference or "<missing>",
+        _stripe_text(obj, "id") or "<missing>",
+    )
+
+
+async def _cancel_content_ops_deflection_report_delivery(
+    pool: Any,
+    *,
+    account_id: str,
+    request_id: str,
+    event_type: str,
+) -> None:
+    await pool.execute(
+        """
+        UPDATE content_ops_deflection_report_deliveries
+        SET delivery_status = 'revoked',
+            delivery_error = $3,
+            updated_at = NOW()
+        WHERE account_id = $1
+          AND request_id = $2
+          AND delivery_status IN ('pending', 'sending')
+        """,
+        account_id,
+        request_id,
+        f"payment_revoked:{event_type}",
+    )
+
+
+def _content_ops_deflection_revocation_metadata(
+    stripe_module: Any,
+    obj: Any,
+) -> tuple[Mapping[str, Any], str | None]:
+    payment_intent = _payment_intent_from_payment_event(obj)
+    session = _checkout_session_for_payment_intent(stripe_module, payment_intent)
+    if session is not None:
+        meta = _stripe_metadata(session)
+        if meta.get("source") == "content_ops_deflection_report":
+            return meta, _stripe_text(session, "id") or None
+
+    meta = _stripe_metadata(obj)
+    if meta.get("source") == "content_ops_deflection_report":
+        return meta, None
+    return {}, None
+
+
+def _checkout_session_for_payment_intent(
+    stripe_module: Any,
+    payment_intent: str,
+) -> Any | None:
+    if not payment_intent:
+        return None
+    try:
+        sessions = stripe_module.checkout.Session.list(
+            payment_intent=payment_intent,
+            limit=1,
+            timeout=10,
+        )
+    except Exception:
+        logger.exception(
+            "Deflection report payment revocation checkout lookup failed: payment_intent=%s",
+            payment_intent,
+        )
+        return None
+    data = _stripe_object_value(sessions, "data")
+    if isinstance(data, Sequence) and data:
+        return data[0]
+    return None
+
+
+def _payment_intent_from_payment_event(obj: Any) -> str:
+    payment_intent = _stripe_text(obj, "payment_intent")
+    if payment_intent:
+        return payment_intent
+    charge = _stripe_object_value(obj, "charge")
+    if charge is not None and not isinstance(charge, str):
+        return _stripe_text(charge, "payment_intent")
+    return ""
+
+
+def _stripe_metadata(obj: Any) -> Mapping[str, Any]:
+    metadata = _stripe_object_value(obj, "metadata")
+    return metadata if isinstance(metadata, Mapping) else {}
 
 
 def _log_content_ops_deflection_report_payment_pending(

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -79,6 +79,15 @@ async def send_pending_deflection_report_deliveries(
                 artifact=data.get("artifact"),
                 request_id=request_id,
             )
+            if not await _confirm_delivery_still_sendable(pool, account_id, request_id):
+                logger.warning(
+                    "Deflection report delivery skipped before send: "
+                    "account=%s request=%s",
+                    account_id,
+                    request_id,
+                )
+                failed += 1
+                continue
             result = await sender.send(
                 _send_request(
                     account_id=account_id,
@@ -265,6 +274,30 @@ async def _mark_failed(pool: Any, account_id: str, request_id: str, error: str) 
         request_id,
         _bounded_text(error),
     )
+
+
+async def _confirm_delivery_still_sendable(
+    pool: Any,
+    account_id: str,
+    request_id: str,
+) -> bool:
+    row = await pool.fetchrow(
+        """
+        UPDATE content_ops_deflection_report_deliveries d
+        SET updated_at = NOW()
+        FROM content_ops_deflection_reports r
+        WHERE d.account_id = $1
+          AND d.request_id = $2
+          AND r.account_id = d.account_id
+          AND r.request_id = d.request_id
+          AND d.delivery_status = 'sending'
+          AND r.paid = true
+        RETURNING d.request_id
+        """,
+        account_id,
+        request_id,
+    )
+    return row is not None
 
 
 def _validate_config(config: DeflectionReportDeliveryConfig) -> None:

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -88,6 +88,15 @@ class DeflectionReportArtifactStore(Protocol):
     ) -> bool:
         """Mark a report paid. Returns False when no tenant/request row exists."""
 
+    async def mark_unpaid(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        payment_reference: str | None = None,
+    ) -> bool:
+        """Relock a paid report. Returns False when no matching row exists."""
+
 
 class InMemoryDeflectionReportArtifactStore:
     """Test store with the same tenant/request semantics as the Postgres store."""
@@ -191,6 +200,35 @@ class InMemoryDeflectionReportArtifactStore:
             artifact=dict(row.artifact or {}) if row.artifact is not None else None,
             paid=True,
             payment_reference=_clean(payment_reference) or row.payment_reference,
+            delivery_email=row.delivery_email,
+        )
+        return True
+
+    async def mark_unpaid(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        payment_reference: str | None = None,
+    ) -> bool:
+        key = (account_id, request_id)
+        row = self._rows.get(key)
+        if row is None:
+            return False
+        expected_reference = _clean(payment_reference)
+        if (
+            expected_reference
+            and row.payment_reference
+            and row.payment_reference != expected_reference
+        ):
+            return False
+        self._rows[key] = DeflectionReportAccessRecord(
+            account_id=row.account_id,
+            request_id=row.request_id,
+            snapshot=dict(row.snapshot),
+            artifact=dict(row.artifact or {}) if row.artifact is not None else None,
+            paid=False,
+            payment_reference=row.payment_reference,
             delivery_email=row.delivery_email,
         )
         return True
@@ -322,7 +360,34 @@ class PostgresDeflectionReportArtifactStore:
             """,
             account_id,
             request_id,
-            _clean(payment_reference),
+            _clean(payment_reference) or None,
+        )
+        return parse_command_tag(result)
+
+    async def mark_unpaid(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        payment_reference: str | None = None,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE content_ops_deflection_reports
+            SET paid = false,
+                paid_at = NULL,
+                updated_at = NOW()
+            WHERE account_id = $1
+              AND request_id = $2
+              AND (
+                $3::text IS NULL
+                OR payment_reference IS NULL
+                OR payment_reference = $3
+              )
+            """,
+            account_id,
+            request_id,
+            _clean(payment_reference) or None,
         )
         return parse_command_tag(result)
 

--- a/plans/PR-Deflection-Refund-Dispute-Revocation.md
+++ b/plans/PR-Deflection-Refund-Dispute-Revocation.md
@@ -12,9 +12,10 @@ path for refund/dispute webhooks while keeping the paid gate server-owned.
 
 This intentionally exceeds the 400 LOC soft cap because the refund/dispute
 event class has several safety branches that must be proven in the same slice:
-direct metadata, Checkout Session lookup by `payment_intent`, unmapped events,
-delivery cancellation, and duplicate-event idempotency. Splitting the tests
-from the handler would leave a payment revocation path under-proven.
+direct metadata, Checkout Session lookup by `payment_intent`, lookup failure,
+partial refund no-op, delivery cancellation, in-flight delivery recheck,
+unmapped events, and duplicate-event idempotency. Splitting the tests from the
+handler would leave a payment revocation path under-proven.
 
 ## Scope (this PR)
 
@@ -29,11 +30,17 @@ Slice phase: Production hardening
    looking up the Checkout Session from the event's `payment_intent` because
    the portfolio checkout currently stores the deflection metadata on the
    Checkout Session.
-4. Emit structured revocation/missing-mapping logs and preserve the existing
+4. Treat only full `charge.refunded` reversals as access revocations; partial
+   refunds are observed without relocking the report.
+5. Emit structured revocation/missing-mapping logs and preserve the existing
    `billing_events` audit row for idempotency and operator traceability.
-5. Add focused regression tests for refund revocation, dispute revocation,
-   metadata fallback through `payment_intent`, missing metadata no-unlock, and
-   duplicate-event idempotency.
+6. Recheck report paid state and delivery status immediately before sending a
+   queued paid-report email so an in-flight delivery fails closed after
+   revocation.
+7. Add focused regression tests for refund revocation, dispute revocation,
+   metadata fallback through `payment_intent`, lookup failure retry,
+   partial-refund no-op, missing metadata no-unlock, in-flight delivery
+   suppression, and duplicate-event idempotency.
 
 ### Review Contract
 
@@ -45,15 +52,22 @@ Slice phase: Production hardening
   - [ ] Refund/dispute events can map through Checkout Session lookup by
         `payment_intent` when the Charge/Dispute object does not carry
         deflection metadata directly.
+  - [ ] Checkout lookup failures raise a 503 so Stripe retries instead of
+        silently leaving a report unlocked.
+  - [ ] Partial refunds do not revoke report access or cancel delivery.
   - [ ] Matching refund/dispute events cancel pending/sending delivery rows so
         a revoked report is not emailed after access is relocked.
+  - [ ] The delivery worker rechecks `paid=true` and `delivery_status=sending`
+        immediately before `sender.send` and suppresses an in-flight send when
+        revocation wins the race.
   - [ ] Unknown or unmapped refund/dispute events do not unlock, requeue
-        delivery, or mutate unrelated reports; they log an incident-shaped
-        warning/error and still get the existing Stripe event audit row.
+        delivery, or mutate unrelated reports; they log operator-readable
+        context and still get the existing Stripe event audit row.
   - [ ] Already-processed refund/dispute event IDs remain idempotent and do not
         run a second revocation.
 - Affected surfaces: Stripe webhook routing, deflection report access storage,
-  paid-funnel observability/audit logs, billing webhook tests.
+  paid-funnel observability/audit logs, billing webhook tests, report delivery
+  worker tests.
 - Risk areas: false-positive revocation, webhook idempotency, Stripe lookup
   failures, audit logging after side effects, account/request isolation.
 - Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R10.
@@ -61,10 +75,12 @@ Slice phase: Production hardening
 ### Files touched
 
 - `atlas_brain/api/billing.py`
+- `atlas_brain/content_ops_deflection_delivery.py`
 - `extracted_content_pipeline/deflection_report_access.py`
 - `plans/PR-Deflection-Refund-Dispute-Revocation.md`
 - `tests/test_atlas_billing_content_ops_deflection_paid_flow.py`
 - `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
 - `tests/test_content_ops_deflection_report.py`
 
 ## Mechanism
@@ -86,15 +102,25 @@ only.
 
 The revocation helper rejects malformed or unmapped events without mutating
 reports, logs stable operator-readable context, and then lets the existing
-webhook audit insert record the Stripe event. Duplicate event IDs still return
-`already_processed` before side effects through the existing billing-events
-idempotency gate.
+webhook audit insert record the Stripe event. Checkout lookup failures raise a
+503 so Stripe retries instead of recording a false-green no-op. Duplicate event
+IDs still return `already_processed` before side effects through the existing
+billing-events idempotency gate.
+
+For delivery, the worker still claims rows as `sending`, but it performs a
+second guarded database transition immediately before `sender.send`. That
+transition only returns a row while the delivery is still `sending` and the
+joined report is still `paid=true`, so a refund/dispute that lands after claim
+but before send suppresses the email.
 
 ## Intentional
 
 - This slice does not add new report-state columns such as `revoked_at` or
   `revocation_reason`; relocking the existing `paid` flag is the narrow launch
   fix and preserves the current artifact contract.
+- Partial refunds are logged and audited but do not relock the report. A
+  refund revokes access only when Stripe marks the Charge fully refunded or the
+  refunded amount covers the captured amount.
 - The handler uses a Stripe Checkout Session lookup as a fallback instead of
   changing the portfolio checkout metadata shape in this ATLAS PR. A portfolio
   follow-up can add `payment_intent_data[metadata]` to make Charge events
@@ -112,6 +138,9 @@ idempotency gate.
 
 - #1386 follow-up: route paid-funnel incident events into the production alert
   sink once the sink contract is selected.
+- #1386 follow-up: add a dispute-closed/manual-restore path. This slice makes
+  revocation one-way for disputes so disputed access fails closed until an
+  operator restores it.
 - Portfolio follow-up: copy deflection metadata onto `payment_intent_data` so
   refund/dispute Charge events are self-describing without a Checkout Session
   lookup.
@@ -121,12 +150,15 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q`
-  - Result: `34 passed, 1 warning in 2.39s`.
+  - Result: `36 passed, 1 warning in 2.37s`.
+- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q`
+  - Result: `12 passed in 0.19s`.
 - `python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q`
-  - Result: `1 passed, 1 warning in 2.44s`.
+  - Result: `1 passed, 1 warning in 2.57s`.
 - `python -m pytest tests/test_content_ops_deflection_report.py -q`
-  - Result: `37 passed in 0.15s`.
-- Python compile check for `atlas_brain/api/billing.py` and
+  - Result: `37 passed in 0.16s`.
+- Python compile check for `atlas_brain/api/billing.py`,
+  `atlas_brain/content_ops_deflection_delivery.py`, and
   `extracted_content_pipeline/deflection_report_access.py`
   - Result: passed.
 - `git diff --check`
@@ -144,10 +176,12 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/api/billing.py` | 169 |
+| `atlas_brain/api/billing.py` | 207 |
+| `atlas_brain/content_ops_deflection_delivery.py` | 33 |
 | `extracted_content_pipeline/deflection_report_access.py` | 67 |
-| `plans/PR-Deflection-Refund-Dispute-Revocation.md` | 153 |
+| `plans/PR-Deflection-Refund-Dispute-Revocation.md` | 187 |
 | `tests/test_atlas_billing_content_ops_deflection_paid_flow.py` | 2 |
-| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 296 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 419 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 39 |
 | `tests/test_content_ops_deflection_report.py` | 35 |
-| **Total** | **722** |
+| **Total** | **989** |

--- a/plans/PR-Deflection-Refund-Dispute-Revocation.md
+++ b/plans/PR-Deflection-Refund-Dispute-Revocation.md
@@ -1,0 +1,153 @@
+# PR-Deflection-Refund-Dispute-Revocation
+
+## Why this slice exists
+
+Issue #1386 calls out the launch-gating paid-funnel gap: a buyer can pay,
+unlock the full deflection report, then receive a refund or file a dispute and
+keep access because the Stripe webhook path has `mark_paid` but no inverse.
+
+Earlier #1386 slices already handled checkout authorization, async payment
+success, and delivery scheduling. This slice closes the concrete revocation
+path for refund/dispute webhooks while keeping the paid gate server-owned.
+
+This intentionally exceeds the 400 LOC soft cap because the refund/dispute
+event class has several safety branches that must be proven in the same slice:
+direct metadata, Checkout Session lookup by `payment_intent`, unmapped events,
+delivery cancellation, and duplicate-event idempotency. Splitting the tests
+from the handler would leave a payment revocation path under-proven.
+
+## Scope (this PR)
+
+Ownership lane: go-live-deflection-cleanup
+Slice phase: Production hardening
+
+1. Add an account/request-scoped `mark_unpaid` storage transition for
+   paid-gated deflection reports.
+2. Route Stripe `charge.refunded` and `charge.dispute.created` events for
+   `content_ops_deflection_report` purchases to revoke report access.
+3. Resolve Charge/Dispute events through direct metadata when present, or by
+   looking up the Checkout Session from the event's `payment_intent` because
+   the portfolio checkout currently stores the deflection metadata on the
+   Checkout Session.
+4. Emit structured revocation/missing-mapping logs and preserve the existing
+   `billing_events` audit row for idempotency and operator traceability.
+5. Add focused regression tests for refund revocation, dispute revocation,
+   metadata fallback through `payment_intent`, missing metadata no-unlock, and
+   duplicate-event idempotency.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A paid deflection report becomes locked again when a matching
+        `charge.refunded` event arrives.
+  - [ ] A paid deflection report becomes locked again when a matching
+        `charge.dispute.created` event arrives.
+  - [ ] Refund/dispute events can map through Checkout Session lookup by
+        `payment_intent` when the Charge/Dispute object does not carry
+        deflection metadata directly.
+  - [ ] Matching refund/dispute events cancel pending/sending delivery rows so
+        a revoked report is not emailed after access is relocked.
+  - [ ] Unknown or unmapped refund/dispute events do not unlock, requeue
+        delivery, or mutate unrelated reports; they log an incident-shaped
+        warning/error and still get the existing Stripe event audit row.
+  - [ ] Already-processed refund/dispute event IDs remain idempotent and do not
+        run a second revocation.
+- Affected surfaces: Stripe webhook routing, deflection report access storage,
+  paid-funnel observability/audit logs, billing webhook tests.
+- Risk areas: false-positive revocation, webhook idempotency, Stripe lookup
+  failures, audit logging after side effects, account/request isolation.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R10.
+
+### Files touched
+
+- `atlas_brain/api/billing.py`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `plans/PR-Deflection-Refund-Dispute-Revocation.md`
+- `tests/test_atlas_billing_content_ops_deflection_paid_flow.py`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+`DeflectionReportArtifactStore` gains a `mark_unpaid` inverse to the
+existing `mark_paid()` transition. The Postgres implementation updates only the
+matching `(account_id, request_id)` row, sets `paid=false`, clears `paid_at`,
+and leaves the artifact/snapshot in place so the existing artifact route locks
+the report again without data deletion.
+
+The Stripe webhook router handles `charge.refunded` and
+`charge.dispute.created`. For deflection events it extracts
+`source/account_id/request_id` from object metadata when present. When that
+metadata is absent, it reads the event's `payment_intent`, asks Stripe for the
+related Checkout Session, and uses the original Checkout Session metadata and
+session ID as the payment reference. That matches the current portfolio
+checkout implementation, which sets `metadata[...]` on the Checkout Session
+only.
+
+The revocation helper rejects malformed or unmapped events without mutating
+reports, logs stable operator-readable context, and then lets the existing
+webhook audit insert record the Stripe event. Duplicate event IDs still return
+`already_processed` before side effects through the existing billing-events
+idempotency gate.
+
+## Intentional
+
+- This slice does not add new report-state columns such as `revoked_at` or
+  `revocation_reason`; relocking the existing `paid` flag is the narrow launch
+  fix and preserves the current artifact contract.
+- The handler uses a Stripe Checkout Session lookup as a fallback instead of
+  changing the portfolio checkout metadata shape in this ATLAS PR. A portfolio
+  follow-up can add `payment_intent_data[metadata]` to make Charge events
+  self-describing, but ATLAS still needs the fallback for already-created
+  sessions.
+- The observability in this slice is the webhook audit row plus structured
+  warning/error logs for revocation, missing metadata, lookup failures, and
+  revoke misses. A production alert sink remains separate because no dedicated
+  paid-funnel alert sink exists in this repo yet.
+- The paid-flow smoke assertion is refreshed for the already-landed
+  resolution-evidence summary fields so this slice can keep using that adjacent
+  paid-gate smoke as verification.
+
+## Deferred
+
+- #1386 follow-up: route paid-funnel incident events into the production alert
+  sink once the sink contract is selected.
+- Portfolio follow-up: copy deflection metadata onto `payment_intent_data` so
+  refund/dispute Charge events are self-describing without a Checkout Session
+  lookup.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q`
+  - Result: `34 passed, 1 warning in 2.39s`.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q`
+  - Result: `1 passed, 1 warning in 2.44s`.
+- `python -m pytest tests/test_content_ops_deflection_report.py -q`
+  - Result: `37 passed in 0.15s`.
+- Python compile check for `atlas_brain/api/billing.py` and
+  `extracted_content_pipeline/deflection_report_access.py`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.
+- `scripts/validate_extracted_content_pipeline.sh` via bash
+  - Result: passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - Result: passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+  - Result: passed, 0 findings.
+- `scripts/check_ascii_python.sh` via bash
+  - Result: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/billing.py` | 169 |
+| `extracted_content_pipeline/deflection_report_access.py` | 67 |
+| `plans/PR-Deflection-Refund-Dispute-Revocation.md` | 153 |
+| `tests/test_atlas_billing_content_ops_deflection_paid_flow.py` | 2 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 296 |
+| `tests/test_content_ops_deflection_report.py` | 35 |
+| **Total** | **722** |

--- a/tests/test_atlas_billing_content_ops_deflection_paid_flow.py
+++ b/tests/test_atlas_billing_content_ops_deflection_paid_flow.py
@@ -198,6 +198,8 @@ async def test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks(
         "drafted_answer_count": 1,
         "no_proven_answer_count": 2,
         "repeat_ticket_count": 4,
+        "support_ticket_resolution_evidence_count": 1,
+        "support_ticket_resolution_evidence_present": True,
     }
     encoded_gated_result = str(gated_result)
     assert "markdown" not in encoded_gated_result

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sys
 import uuid
 from types import SimpleNamespace
@@ -136,26 +137,47 @@ def _payment_event_object(
     object_id: str = "ch_test_deflection_refund",
     payment_intent: str = "pi_test_deflection",
     metadata: dict[str, str] | None = None,
+    refunded: bool | None = None,
+    amount_refunded: int | None = None,
+    amount_captured: int | None = None,
 ) -> SimpleNamespace:
+    payload = {
+        "id": object_id,
+        "payment_intent": payment_intent,
+        "metadata": dict(metadata or {}),
+    }
+    if refunded is not None:
+        payload["refunded"] = refunded
+    if amount_refunded is not None:
+        payload["amount_refunded"] = amount_refunded
+    if amount_captured is not None:
+        payload["amount_captured"] = amount_captured
     return SimpleNamespace(
         id=object_id,
         payment_intent=payment_intent,
         metadata=metadata or {},
-        to_dict=lambda: {
-            "id": object_id,
-            "payment_intent": payment_intent,
-            "metadata": dict(metadata or {}),
-        },
+        refunded=refunded,
+        amount_refunded=amount_refunded,
+        amount_captured=amount_captured,
+        to_dict=lambda: dict(payload),
     )
 
 
 class _CheckoutSessionList:
-    def __init__(self, sessions: list[Any] | None = None) -> None:
+    def __init__(
+        self,
+        sessions: list[Any] | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
         self.sessions = sessions or []
+        self.error = error
         self.calls: list[dict[str, Any]] = []
 
     def list(self, **kwargs: Any) -> SimpleNamespace:
         self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
         return SimpleNamespace(data=list(self.sessions))
 
 
@@ -163,8 +185,9 @@ def _stripe_module_for_event(
     event: Any,
     *,
     checkout_sessions: list[Any] | None = None,
+    checkout_error: Exception | None = None,
 ) -> tuple[SimpleNamespace, _CheckoutSessionList]:
-    session_list = _CheckoutSessionList(checkout_sessions)
+    session_list = _CheckoutSessionList(checkout_sessions, error=checkout_error)
 
     class _Webhook:
         @staticmethod
@@ -721,7 +744,12 @@ async def test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout
         account_id=account_id,
         session_id="cs_test_deflection_refunded",
     )
-    charge = _payment_event_object(payment_intent="pi_test_refunded")
+    charge = _payment_event_object(
+        payment_intent="pi_test_refunded",
+        refunded=True,
+        amount_refunded=150000,
+        amount_captured=150000,
+    )
     event = SimpleNamespace(
         id="evt_deflection_refunded",
         type="charge.refunded",
@@ -785,6 +813,95 @@ async def test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout
 
 
 @pytest.mark.asyncio
+async def test_stripe_webhook_partial_refund_keeps_deflection_report_paid(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="atlas.api.billing")
+    account_id = str(uuid.uuid4())
+    checkout_session = _session(account_id=account_id)
+    charge = _payment_event_object(
+        payment_intent="pi_test_partial_refund",
+        refunded=False,
+        amount_refunded=50000,
+        amount_captured=150000,
+    )
+    event = SimpleNamespace(
+        id="evt_deflection_partial_refund",
+        type="charge.refunded",
+        data=SimpleNamespace(object=charge),
+    )
+    fake_stripe, session_list = _stripe_module_for_event(
+        event,
+        checkout_sessions=[checkout_session],
+    )
+    pool = _Pool()
+    pool.add_report(account_id=account_id, paid=True, payment_reference="cs_test")
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+    )
+
+    assert response == {"status": "ok"}
+    assert session_list.calls == []
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
+    update_calls = [
+        call
+        for call in pool.execute_calls
+        if "UPDATE content_ops_deflection_reports" in call[0]
+    ]
+    assert update_calls == []
+    billing_event_calls = [
+        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
+    ]
+    assert billing_event_calls[0][1][1] == "evt_deflection_partial_refund"
+    assert "partial refund observed without revocation" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_refund_lookup_failure_retries_without_unlocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    charge = _payment_event_object(
+        payment_intent="pi_lookup_down",
+        refunded=True,
+        amount_refunded=150000,
+        amount_captured=150000,
+    )
+    event = SimpleNamespace(
+        id="evt_deflection_refund_lookup_down",
+        type="charge.refunded",
+        data=SimpleNamespace(object=charge),
+    )
+    fake_stripe, session_list = _stripe_module_for_event(
+        event,
+        checkout_error=RuntimeError("stripe down"),
+    )
+    pool = _Pool()
+    pool.add_report(account_id=account_id, paid=True, payment_reference="cs_test")
+
+    with pytest.raises(billing.HTTPException) as exc:
+        await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
+
+    assert exc.value.status_code == 503
+    assert session_list.calls == [
+        {"payment_intent": "pi_lookup_down", "limit": 1, "timeout": 10}
+    ]
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
+    assert pool.execute_calls == []
+    assert pool.processed_event_ids == set()
+
+
+@pytest.mark.asyncio
 async def test_stripe_webhook_dispute_relocks_paid_deflection_report_from_direct_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -831,8 +948,14 @@ async def test_stripe_webhook_unmapped_refund_is_observed_without_mutating_repor
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    caplog.set_level(logging.INFO, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    charge = _payment_event_object(payment_intent="pi_missing_metadata")
+    charge = _payment_event_object(
+        payment_intent="pi_missing_metadata",
+        refunded=True,
+        amount_refunded=150000,
+        amount_captured=150000,
+    )
     event = SimpleNamespace(
         id="evt_deflection_refund_unmapped",
         type="charge.refunded",

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -42,10 +42,27 @@ class _Pool:
         if "UPDATE content_ops_deflection_reports" in query:
             account_id, request_id, payment_reference = args
             row = self.report_rows.get((str(account_id), str(request_id)))
+            if row is None:
+                return "UPDATE 0"
+            if "SET paid = false" in query:
+                if payment_reference and row.get("payment_reference") not in {
+                    None,
+                    payment_reference,
+                }:
+                    return "UPDATE 0"
+                row["paid"] = False
+                return "UPDATE 1"
             if row is not None:
                 row["paid"] = True
                 row["payment_reference"] = payment_reference
             return self.update_result
+        if "UPDATE content_ops_deflection_report_deliveries" in query:
+            account_id, request_id, delivery_error = args
+            row = self.delivery_rows.get((str(account_id), str(request_id)))
+            if row is not None and row.get("delivery_status") in {"pending", "sending"}:
+                row["delivery_status"] = "revoked"
+                row["delivery_error"] = delivery_error
+            return "UPDATE 1"
         if "INSERT INTO content_ops_deflection_report_deliveries" in query:
             account_id, request_id, payment_reference = args
             self.delivery_rows[(str(account_id), str(request_id))] = {
@@ -67,14 +84,16 @@ class _Pool:
         account_id: str,
         request_id: str = "req-123",
         delivery_email: str | None = "buyer@example.com",
+        paid: bool = False,
+        payment_reference: str | None = None,
     ) -> None:
         self.report_rows[(account_id, request_id)] = {
             "account_id": account_id,
             "request_id": request_id,
             "snapshot": {},
             "artifact": {},
-            "paid": False,
-            "payment_reference": None,
+            "paid": paid,
+            "payment_reference": payment_reference,
             "delivery_email": delivery_email,
         }
 
@@ -110,6 +129,82 @@ def _session(
             "metadata": dict(metadata),
         },
     )
+
+
+def _payment_event_object(
+    *,
+    object_id: str = "ch_test_deflection_refund",
+    payment_intent: str = "pi_test_deflection",
+    metadata: dict[str, str] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=object_id,
+        payment_intent=payment_intent,
+        metadata=metadata or {},
+        to_dict=lambda: {
+            "id": object_id,
+            "payment_intent": payment_intent,
+            "metadata": dict(metadata or {}),
+        },
+    )
+
+
+class _CheckoutSessionList:
+    def __init__(self, sessions: list[Any] | None = None) -> None:
+        self.sessions = sessions or []
+        self.calls: list[dict[str, Any]] = []
+
+    def list(self, **kwargs: Any) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        return SimpleNamespace(data=list(self.sessions))
+
+
+def _stripe_module_for_event(
+    event: Any,
+    *,
+    checkout_sessions: list[Any] | None = None,
+) -> tuple[SimpleNamespace, _CheckoutSessionList]:
+    session_list = _CheckoutSessionList(checkout_sessions)
+
+    class _Webhook:
+        @staticmethod
+        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
+            return event
+
+    return (
+        SimpleNamespace(
+            Webhook=_Webhook,
+            checkout=SimpleNamespace(Session=session_list),
+            api_key="",
+        ),
+        session_list,
+    )
+
+
+async def _run_stripe_webhook(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    event: Any,
+    pool: _Pool,
+    stripe_module: Any,
+) -> dict[str, Any]:
+    request = SimpleNamespace(
+        headers={"stripe-signature": "valid"},
+        body=lambda: _body(),
+    )
+
+    async def _body() -> bytes:
+        return b"{}"
+
+    monkeypatch.setitem(sys.modules, "stripe", stripe_module)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_webhook_secret",
+        "whsec_test",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+    return await billing.stripe_webhook(request)
 
 
 @pytest.mark.asyncio
@@ -614,6 +709,203 @@ async def test_stripe_webhook_deflection_async_failure_is_observed_without_unloc
     assert insert_args[2] == "checkout.session.async_payment_failed"
     assert pool.report_rows[(account_id, "req-123")]["paid"] is False
     assert pool.delivery_rows == {}
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    account_id = str(uuid.uuid4())
+    checkout_session = _session(
+        account_id=account_id,
+        session_id="cs_test_deflection_refunded",
+    )
+    charge = _payment_event_object(payment_intent="pi_test_refunded")
+    event = SimpleNamespace(
+        id="evt_deflection_refunded",
+        type="charge.refunded",
+        data=SimpleNamespace(object=charge),
+    )
+    fake_stripe, session_list = _stripe_module_for_event(
+        event,
+        checkout_sessions=[checkout_session],
+    )
+    pool = _Pool()
+    pool.add_report(
+        account_id=account_id,
+        paid=True,
+        payment_reference="cs_test_deflection_refunded",
+    )
+    pool.delivery_rows[(account_id, "req-123")] = {
+        "account_id": account_id,
+        "request_id": "req-123",
+        "payment_reference": "cs_test_deflection_refunded",
+        "delivery_status": "pending",
+    }
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+    )
+
+    assert response == {"status": "ok"}
+    assert session_list.calls == [
+        {"payment_intent": "pi_test_refunded", "limit": 1, "timeout": 10}
+    ]
+    update_calls = [
+        call for call in pool.execute_calls if "UPDATE content_ops_deflection_reports" in call[0]
+    ]
+    delivery_update_calls = [
+        call
+        for call in pool.execute_calls
+        if "UPDATE content_ops_deflection_report_deliveries" in call[0]
+    ]
+    billing_event_calls = [
+        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
+    ]
+    assert update_calls[0][1] == (
+        account_id,
+        "req-123",
+        "cs_test_deflection_refunded",
+    )
+    assert "SET paid = false" in update_calls[0][0]
+    assert delivery_update_calls[0][1] == (
+        account_id,
+        "req-123",
+        "payment_revoked:charge.refunded",
+    )
+    assert billing_event_calls[0][1][1] == "evt_deflection_refunded"
+    assert billing_event_calls[0][1][2] == "charge.refunded"
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
+    assert pool.delivery_rows[(account_id, "req-123")]["delivery_status"] == "revoked"
+    assert "access revoked after Stripe payment reversal" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_dispute_relocks_paid_deflection_report_from_direct_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    dispute = _payment_event_object(
+        object_id="du_test_deflection",
+        metadata={
+            "source": "content_ops_deflection_report",
+            "account_id": account_id,
+            "request_id": "req-123",
+        },
+    )
+    event = SimpleNamespace(
+        id="evt_deflection_dispute",
+        type="charge.dispute.created",
+        data=SimpleNamespace(object=dispute),
+    )
+    fake_stripe, session_list = _stripe_module_for_event(event, checkout_sessions=[])
+    pool = _Pool()
+    pool.add_report(account_id=account_id, paid=True, payment_reference=None)
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+    )
+
+    assert response == {"status": "ok"}
+    assert session_list.calls == [
+        {"payment_intent": "pi_test_deflection", "limit": 1, "timeout": 10}
+    ]
+    update_calls = [
+        call for call in pool.execute_calls if "UPDATE content_ops_deflection_reports" in call[0]
+    ]
+    assert update_calls[0][1] == (account_id, "req-123", None)
+    assert "SET paid = false" in update_calls[0][0]
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
+    assert pool.delivery_rows == {}
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_unmapped_refund_is_observed_without_mutating_reports(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    account_id = str(uuid.uuid4())
+    charge = _payment_event_object(payment_intent="pi_missing_metadata")
+    event = SimpleNamespace(
+        id="evt_deflection_refund_unmapped",
+        type="charge.refunded",
+        data=SimpleNamespace(object=charge),
+    )
+    fake_stripe, _session_list = _stripe_module_for_event(event, checkout_sessions=[])
+    pool = _Pool()
+    pool.add_report(
+        account_id=account_id,
+        paid=True,
+        payment_reference="cs_unrelated",
+    )
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+    )
+
+    assert response == {"status": "ok"}
+    assert "could not be mapped" in caplog.text
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
+    assert [
+        call for call in pool.execute_calls if "UPDATE content_ops_deflection_reports" in call[0]
+    ] == []
+    assert [
+        call
+        for call in pool.execute_calls
+        if "UPDATE content_ops_deflection_report_deliveries" in call[0]
+    ] == []
+    billing_event_calls = [
+        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
+    ]
+    assert billing_event_calls[0][1][1] == "evt_deflection_refund_unmapped"
+    assert billing_event_calls[0][1][2] == "charge.refunded"
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_skips_processed_refund_before_revocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    checkout_session = _session(account_id=account_id)
+    charge = _payment_event_object()
+    event = SimpleNamespace(
+        id="evt_deflection_refund_duplicate",
+        type="charge.refunded",
+        data=SimpleNamespace(object=charge),
+    )
+    fake_stripe, session_list = _stripe_module_for_event(
+        event,
+        checkout_sessions=[checkout_session],
+    )
+    pool = _Pool()
+    pool.add_report(
+        account_id=account_id,
+        paid=True,
+        payment_reference="cs_test_deflection",
+    )
+    pool.processed_event_ids.add("evt_deflection_refund_duplicate")
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+    )
+
+    assert response == {"status": "already_processed"}
+    assert session_list.calls == []
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
+    assert pool.execute_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -18,9 +18,11 @@ from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
 
 
 class _Pool:
-    def __init__(self, rows: list[dict[str, Any]]) -> None:
+    def __init__(self, rows: list[dict[str, Any]], *, sendable: bool = True) -> None:
         self.rows = rows
+        self.sendable = sendable
         self.fetch_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.fetchrow_calls: list[tuple[str, tuple[Any, ...]]] = []
         self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
 
     async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
@@ -29,6 +31,16 @@ class _Pool:
         assert "content_ops_deflection_reports" in query
         assert "r.artifact" in query
         return self.rows[: int(args[0])]
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
+        self.fetchrow_calls.append((query, args))
+        assert "content_ops_deflection_report_deliveries" in query
+        assert "content_ops_deflection_reports" in query
+        assert "delivery_status = 'sending'" in query
+        assert "r.paid = true" in query
+        if not self.sendable:
+            return None
+        return {"request_id": args[1]}
 
     async def execute(self, query: str, *args: Any) -> str:
         self.execute_calls.append((query, args))
@@ -107,6 +119,9 @@ async def test_delivery_worker_sends_pending_paid_report_link(
     assert "SET delivery_status = 'sending'" in claim_query
     assert claim_args == (20,)
     assert len(sender.requests) == 1
+    confirm_query, confirm_args = pool.fetchrow_calls[0]
+    assert "RETURNING d.request_id" in confirm_query
+    assert confirm_args == ("acct-123", "content-ops-abc123")
     request = sender.requests[0]
     assert request.to_email == "buyer@example.com"
     assert request.from_email == "Atlas Content Ops <reports@example.com>"
@@ -202,6 +217,28 @@ async def test_delivery_worker_dry_run_does_not_send_or_update() -> None:
     assert "WHERE d.delivery_status = 'pending'" in pending_query
     assert pending_args == (20,)
     assert sender.requests == []
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_rechecks_paid_and_status_before_sending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = _Pool([_row()], sendable=False)
+    sender = _Sender()
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-fake-bytes")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.scanned == 1
+    assert summary.sent == 0
+    assert summary.failed == 1
+    assert sender.requests == []
+    assert pool.fetchrow_calls
     assert pool.execute_calls == []
 
 

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -808,6 +808,15 @@ async def test_postgres_deflection_report_store_round_trips_paid_gate() -> None:
                 key = (str(account_id), str(request_id))
                 if key not in self.rows:
                     return "UPDATE 0"
+                if "SET paid = false" in query:
+                    stored_reference = self.rows[key].get("payment_reference")
+                    if payment_reference and stored_reference not in {
+                        None,
+                        payment_reference,
+                    }:
+                        return "UPDATE 0"
+                    self.rows[key]["paid"] = False
+                    return "UPDATE 1"
                 self.rows[key]["paid"] = True
                 self.rows[key]["payment_reference"] = payment_reference
                 return "UPDATE 1"
@@ -892,7 +901,28 @@ async def test_postgres_deflection_report_store_round_trips_paid_gate() -> None:
     assert preserved.delivery_email == "buyer@example.com"
     assert preserved.paid is True
     assert preserved.payment_reference == "checkout-session:test"
+    assert await store.mark_unpaid(
+        account_id="acct-1",
+        request_id="request-1",
+        payment_reference="other-checkout-session",
+    ) is False
+    assert await store.mark_unpaid(
+        account_id="acct-1",
+        request_id="request-1",
+        payment_reference="checkout-session:test",
+    ) is True
+    relocked = await store.get_artifact_record(
+        account_id="acct-1",
+        request_id="request-1",
+    )
+    assert relocked is not None
+    assert relocked.paid is False
+    assert relocked.payment_reference == "checkout-session:test"
     assert await store.mark_paid(
+        account_id="acct-1",
+        request_id="missing",
+    ) is False
+    assert await store.mark_unpaid(
         account_id="acct-1",
         request_id="missing",
     ) is False
@@ -920,6 +950,7 @@ async def test_in_memory_list_reports_filters_tenant_paid_state_and_orders_newes
         artifact={},
     )
     await store.mark_paid(account_id="acct-1", request_id="request-old")
+    await store.mark_unpaid(account_id="acct-1", request_id="request-old")
 
     all_rows = await store.list_reports(account_id="acct-1", limit=10)
     paid_rows = await store.list_reports(account_id="acct-1", limit=10, paid=True)
@@ -927,8 +958,8 @@ async def test_in_memory_list_reports_filters_tenant_paid_state_and_orders_newes
     unbounded_rows = await store.list_reports(account_id="acct-1", limit=None)
 
     assert [row.request_id for row in all_rows] == ["request-new", "request-old"]
-    assert [row.request_id for row in paid_rows] == ["request-old"]
-    assert [row.request_id for row in unpaid_rows] == ["request-new"]
+    assert [row.request_id for row in paid_rows] == []
+    assert [row.request_id for row in unpaid_rows] == ["request-new", "request-old"]
     assert [row.request_id for row in unbounded_rows] == ["request-new", "request-old"]
 
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-Refund-Dispute-Revocation.md
Slice phase: Production hardening

Close the #1386 launch-gating gap where a buyer could pay for a deflection report, receive a refund or file a dispute, and keep report access. This adds the inverse paid-state transition, routes full refund/dispute Stripe events through the deflection report paid gate, suppresses pending and in-flight delivery after revocation, and keeps unmapped/partial reversal events observable without mutating unrelated reports.

## Intentional
- This slice relocks via the existing `paid` flag instead of adding new report-state columns.
- Partial refunds are logged and audited but do not revoke access; full refunds and disputes do.
- Checkout Session lookup remains as a fallback because portfolio metadata currently lives on the Checkout Session, not every Charge object.
- Lookup failures raise 503 so Stripe retries instead of recording a false-green no-op.
- Dispute revocation is one-way for this slice; manual/closed-dispute restoration is deferred.

## Deferred
- #1386 follow-up: route paid-funnel incident events into the production alert sink once the sink contract is selected.
- #1386 follow-up: add a dispute-closed/manual-restore path.
- Portfolio follow-up: copy deflection metadata onto `payment_intent_data`.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 36 passed, 1 warning.
- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 12 passed.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` - 1 passed, 1 warning.
- `python -m pytest tests/test_content_ops_deflection_report.py -q` - 37 passed.
- `python -m py_compile atlas_brain/api/billing.py atlas_brain/content_ops_deflection_delivery.py extracted_content_pipeline/deflection_report_access.py` - passed.
- `git diff --check` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed, 0 findings.
- `bash scripts/check_ascii_python.sh` - passed.

## Diff size
8 files, +982 / -7.
