### PR TITLE
Deflection inline HTML strip before clustering

### DIFF
--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -13,10 +13,18 @@ from typing import Any
 
 _WHITESPACE_RE = re.compile(r"\s+")
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
+_HTML_TAG_NAMES_RE = (
+    r"(?:a|abbr|article|aside|b|blockquote|body|br|button|cite|code|dd|"
+    r"del|div|dl|dt|em|figcaption|figure|footer|h[1-6]|header|hr|html|i|"
+    r"img|ins|li|main|mark|nav|ol|p|pre|s|section|small|span|strike|strong|"
+    r"sub|sup|table|tbody|td|tfoot|th|thead|time|tr|u|ul)"
+)
+_HTML_ATTR_RE = (
+    r"(?:\s+[a-z_:][a-z0-9_:.-]*\s*=\s*"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\s\"'=<>`]+))"
+)
 _HTML_SIGNAL_RE = re.compile(
-    r"</?(?:article|aside|blockquote|body|br|code|dd|div|dl|dt|em|footer|"
-    r"h[1-6]|header|html|i|li|main|nav|ol|p|pre|section|span|strong|table|"
-    r"tbody|td|tfoot|th|thead|tr|ul)\b",
+    rf"</?{_HTML_TAG_NAMES_RE}(?:{_HTML_ATTR_RE})*\s*/?>",
     re.IGNORECASE,
 )
 _HTML_CUSTOM_TAG_RE = re.compile(

--- a/plans/PR-Deflection-Inline-Html-Strip-Before-Clustering.md
+++ b/plans/PR-Deflection-Inline-Html-Strip-Before-Clustering.md
@@ -1,0 +1,120 @@
+# PR-Deflection-Inline-Html-Strip-Before-Clustering
+
+## Why this slice exists
+
+PR #1432 closed the broad provider-HTML strip path for support-ticket
+clustering, but review found the narrowing fix swung too far: with the
+catch-all paired-tag detector removed, common inline provider tags such as
+`<a href="...">` and `<b>` no longer count as HTML. On `origin/main`, a
+link-heavy ticket still produces cluster tokens like `href`, `http`, `token`,
+and URL fragments, which is exactly the #1416 pollution this lane exists to
+remove.
+
+This follow-up fixes the class rather than only the cited examples by auditing
+the inline provider tags that commonly appear in help-desk exports and pinning
+both strip-direction and preserve-direction behavior in tests.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering-html-normalization
+Slice phase: Production hardening
+
+1. Expand support-ticket HTML detection to include common inline provider tags
+   that can carry text or URL attributes into deterministic cluster tokens.
+2. Keep the #1432 fail-safe intact: arbitrary paired non-HTML/XML-like ticket
+   tags such as `<email>...</email>` and `<config>...</config>` must still
+   bypass `HTMLParser`.
+3. Add regression coverage proving inline links/bold markup strip from
+   readable text and do not leak attribute/URL fragments into
+   `support_ticket_tokens`.
+4. Keep the change scoped to the shared support-ticket normalization helper and
+   its extracted package tests; no LLM, no provider-specific parser, no UI
+   surface.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `<a href="...">`, `<b>`, and other common inline provider tags are
+        detected as HTML and stripped before source text and cluster tokens are
+        produced.
+  - [ ] URL and attribute fragments from links, such as `href`, `http`,
+        domains, query keys, or reset tokens, do not appear in
+        `support_ticket_tokens`.
+  - [ ] Literal paired non-HTML/XML-like tags such as
+        `<email>user@example.test</email>` and `<config>retries=3</config>`
+        remain preserved as non-HTML.
+  - [ ] Existing structural/custom provider HTML detection from #1432 remains
+        covered.
+- Affected surfaces: support-ticket text normalization and deterministic
+  clustering in `extracted_content_pipeline`.
+- Risk areas: under-stripping inline HTML, over-stripping XML/code-like ticket
+  content, token pollution from URL attributes, review-example-only fixes.
+- Reviewer rules triggered: R1, R2, R10, R13.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_clustering.py`
+- `plans/PR-Deflection-Inline-Html-Strip-Before-Clustering.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+
+## Mechanism
+
+The support-ticket plain-text helper already owns the shared normalization path used
+by source material, customer wording, FAQ questions, resolution evidence, and
+cluster tokens. This PR only adjusts `_HTML_SIGNAL_RE` so common inline HTML
+tags emitted by help-desk rich-text exports are treated as real HTML signals.
+
+When an inline tag is detected, the existing `HTMLParser` extractor removes the
+tag and attributes, keeps readable text, skips script/style bodies, and then
+compacts whitespace. The custom hyphenated provider-tag detector remains for
+wrapper components, and arbitrary non-hyphenated paired tags that are not in
+the known HTML set still bypass the parser.
+
+## Intentional
+
+- This PR keeps the #1432 known-tag approach instead of restoring the
+  catch-all paired-tag regex. The catch-all caused content loss for legitimate
+  XML/code-like support-ticket text.
+- This PR does not add a dependency such as BeautifulSoup/lxml. The existing
+  Python `HTMLParser` path is sufficient once detection recognizes common
+  provider inline tags.
+- This PR does not claim a full sanitized provider fixture sweep. It fixes and
+  tests the inline HTML class that review found after #1432.
+
+## Deferred
+
+- #1384 follow-up: sanitized real Zendesk/Intercom/Help Scout/Freshdesk
+  provider fixtures for the full parse-to-cluster path.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused support-ticket input pytest:
+  python -m pytest tests/test_extracted_support_ticket_input_package.py -q
+  - Result after review-thread fix: `40 passed in 0.31s`.
+- Extracted content package validation:
+  bash scripts/validate_extracted_content_pipeline.sh
+  - Result: passed.
+- Reasoning-import audit:
+  python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Result: clean.
+- Extracted standalone audit:
+  python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Result: `Atlas runtime import findings: 0`.
+- ASCII policy:
+  bash scripts/check_ascii_python.sh
+  - Result: passed.
+- Full extracted pipeline CI mirror:
+  bash scripts/run_extracted_pipeline_checks.sh
+  - Result after review-thread fix: `3563 passed, 10 skipped, 1 warning in 55.14s`.
+- Pending before push: local PR review via scripts/push_pr.sh.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_clustering.py` | 14 |
+| `plans/PR-Deflection-Inline-Html-Strip-Before-Clustering.md` | 120 |
+| `tests/test_extracted_support_ticket_input_package.py` | 73 |
+| **Total** | **207** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from extracted_content_pipeline.content_ops_input_provider import (
     content_ops_payload_from_input_package,
 )
@@ -8,6 +10,10 @@ from extracted_content_pipeline.control_surfaces import (
     request_from_mapping,
 )
 from extracted_content_pipeline.generation_plan import build_generation_plan
+from extracted_content_pipeline.support_ticket_clustering import (
+    support_ticket_plain_text,
+    support_ticket_tokens,
+)
 from extracted_content_pipeline.support_ticket_input_package import (
     DEFAULT_FAQ_REPORT_CTA_LABEL,
     build_support_ticket_input_package,
@@ -546,6 +552,73 @@ def test_support_ticket_input_package_strips_generic_provider_html_before_cluste
     assert "<" not in rows[0]["resolution_text"]
     assert package.inputs["customer_wording_examples"][0]["text"] == rows[0]["text"]
     assert package.inputs["faq_questions"][0] == "How do I reset my password?"
+
+
+def test_support_ticket_inline_provider_html_strips_link_attribute_tokens() -> None:
+    inline_html = (
+        'Please <a href="https://ex.com/reset?token=abc123xyz" '
+        'data-tracking-id="track-77">click here</a> to reset and '
+        "<b>confirm</b> your <u>email</u> <small>Use step</small> "
+        "<sup>2</sup><img src=\"https://cdn.example.test/screenshot.png\">"
+    )
+
+    assert support_ticket_plain_text(inline_html) == (
+        "Please click here to reset and confirm your email Use step 2"
+    )
+    tokens = support_ticket_tokens(inline_html)
+    assert {"click", "reset", "confirm", "email", "step"}.issubset(tokens)
+    assert tokens.isdisjoint(
+        {
+            "href",
+            "https",
+            "ex",
+            "com",
+            "token",
+            "abc123xyz",
+            "data",
+            "tracking",
+            "track",
+            "77",
+            "src",
+            "cdn",
+            "example",
+            "test",
+            "screenshot",
+            "png",
+        }
+    )
+    assert support_ticket_plain_text(
+        "Why did <email>user@example.test</email> fail when "
+        "<config>retries=3</config> was set?"
+    ) == (
+        "Why did <email>user@example.test</email> fail when "
+        "<config>retries=3</config> was set?"
+    )
+    assert support_ticket_plain_text("If a<b and c>d then fail") == (
+        "If a<b and c>d then fail"
+    )
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        ('Please <a href="https://example.test/reset">reset link</a>', "Please reset link"),
+        ('Use <b class="agent-note">billing portal</b>', "Use billing portal"),
+        ("Use <b>billing portal</b>", "Use billing portal"),
+        ("Use <u>account email</u>", "Use account email"),
+        ("Read the <small>agent note</small>", "Read the agent note"),
+        ("Step <sub>2</sub> is missing", "Step 2 is missing"),
+        ("Error <sup>TM</sup> appears", "Error TM appears"),
+        ('Screenshot <img src="https://cdn.example.test/a.png"> attached', "Screenshot attached"),
+        ("Old <s>legacy answer</s>", "Old legacy answer"),
+        ("Old <strike>legacy answer</strike>", "Old legacy answer"),
+    ],
+)
+def test_support_ticket_common_inline_provider_tags_are_html_signals(
+    html: str,
+    expected: str,
+) -> None:
+    assert support_ticket_plain_text(html) == expected
 
 
 def test_support_ticket_clusters_group_topic_varied_anchor_rows() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Inline-Html-Strip-Before-Clustering.md
Slice phase: Production hardening

Fixes the #1432/#1416 follow-up gap where inline provider HTML such as `<a href="...">` and `<b>` was no longer detected after the paired-tag catch-all was removed. The shared support-ticket normalization whitelist now recognizes common inline HTML tags while still preserving literal non-HTML/XML-like ticket tags.

## Intentional
- Keeps the known-HTML whitelist instead of restoring the unsafe paired-tag catch-all that stripped `<email>...</email>` and `<config>...</config>` ticket text.
- Does not add BeautifulSoup/lxml; the existing `HTMLParser` path is sufficient once detection recognizes inline provider tags.
- Does not claim a full sanitized provider fixture sweep; this closes the inline HTML class found after #1432.

## Deferred
- #1384 follow-up: sanitized real Zendesk/Intercom/Help Scout/Freshdesk provider fixtures for the full parse-to-cluster path.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_support_ticket_input_package.py -q`
  - Result after review-thread fix/rebase: `40 passed in 0.31s`.
- `bash scripts/validate_extracted_content_pipeline.sh`
  - Result: passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
  - Result: clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
  - Result: `Atlas runtime import findings: 0`.
- `bash scripts/check_ascii_python.sh`
  - Result: passed.
- `bash scripts/run_extracted_pipeline_checks.sh`
  - Result after review-thread fix: `3563 passed, 10 skipped, 1 warning in 55.14s`.
- `bash scripts/local_pr_review.sh` via `scripts/push_pr.sh`
  - Result: passed.

## Diff size
3 files, +204 / -3
