### PR TITLE
Content-Ops Verify Draft Rich Schema

### DIFF
--- a/atlas_brain/mcp/content_ops_marketer_verify_server.py
+++ b/atlas_brain/mcp/content_ops_marketer_verify_server.py
@@ -8,10 +8,11 @@ from collections.abc import Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import date
-from typing import Any
+from typing import Annotated, Any
 from urllib.parse import urlparse
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 from extracted_content_pipeline.claims_map import ExtractedClaim
 from extracted_content_pipeline.content_pr import (
@@ -54,6 +55,150 @@ _MALFORMED_COVERAGE_RULE_PREFIX = "MALFORMED-COVERAGE"
 _registry_reader_override: TenantClaimRegistryReader | None = None
 _account_resolver_override: ContentOpsAccountResolver | None = None
 _oauth_provider = None
+_QUALITY_FINDING_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "code": {"type": "string"},
+        "message": {"type": "string"},
+        "severity": {
+            "type": "string",
+            "enum": ["blocker", "warning", "info"],
+        },
+        "field_name": {"type": "string"},
+    },
+}
+_QUALITY_REPORT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "passed": {"type": "boolean"},
+        "findings": {
+            "type": "array",
+            "items": _QUALITY_FINDING_SCHEMA,
+        },
+    },
+}
+VERIFY_DRAFT_PARAMETER_SCHEMA: dict[str, dict[str, Any]] = {
+    "asset_id": {
+        "type": "string",
+        "examples": ["landing-page-hero-v3"],
+    },
+    "rule_packet": {
+        "type": "object",
+        "properties": {
+            "brief": {"type": "string"},
+            "brand_voice": {"type": "string"},
+            "claim_registry": {"type": "string"},
+            "compliance": {"type": "string"},
+            "channel_schema": {"type": "string"},
+        },
+    },
+    "coverage": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "rule_id": {"type": "string"},
+                "requirement": {"type": "string"},
+                "required": {"type": "boolean", "default": True},
+                "status": {
+                    "type": "string",
+                    "enum": ["pass", "fail", "not_applicable", "unresolved"],
+                },
+                "evidence": {"type": "string"},
+            },
+        },
+    },
+    "extracted_claims": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string"},
+                "location": {"type": "string"},
+                "registry_id": {"type": "string"},
+            },
+        },
+    },
+    "quality_reports": {
+        "anyOf": [
+            _QUALITY_REPORT_SCHEMA,
+            {
+                "type": "array",
+                "items": _QUALITY_REPORT_SCHEMA,
+            },
+        ],
+    },
+    "brand_voice_payload": {
+        "type": "object",
+        "properties": {
+            "passed": {"type": "boolean"},
+            "warnings": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "banned_terms": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+    },
+    "comments": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "enum": [
+                        "brief",
+                        "brand_rule",
+                        "claim_registry",
+                        "compliance",
+                        "channel_constraint",
+                        "performance_hypothesis",
+                        "editorial_judgment",
+                        "nit",
+                    ],
+                },
+                "message": {"type": "string"},
+                "evidence": {"type": "string"},
+                "blocking": {"type": "boolean", "default": False},
+            },
+        },
+    },
+    "as_of": {
+        "type": "string",
+        "format": "date",
+        "examples": ["2026-06-09"],
+    },
+}
+_VERIFY_DRAFT_PARAMETER_DESCRIPTIONS = {
+    "asset_id": "Stable identifier for the draft or asset being reviewed.",
+    "rule_packet": "Pinned rule-packet version ids used for this review.",
+    "coverage": "Requirement coverage rows extracted from the draft.",
+    "extracted_claims": "Claims extracted from the draft and mapped to the tenant registry.",
+    "quality_reports": "Deterministic quality-gate reports for the draft.",
+    "brand_voice_payload": "Brand-voice audit result for the draft.",
+    "comments": "Reviewer comments or blocking findings to include in the verdict.",
+    "as_of": "ISO review date used for registry expiration checks.",
+}
+
+
+def _schema_field(name: str):
+    return Field(
+        description=_VERIFY_DRAFT_PARAMETER_DESCRIPTIONS[name],
+        json_schema_extra=VERIFY_DRAFT_PARAMETER_SCHEMA[name],
+    )
+
+
+AssetIdArg = Annotated[Any, _schema_field("asset_id")]
+RulePacketArg = Annotated[Any, _schema_field("rule_packet")]
+CoverageArg = Annotated[Any, _schema_field("coverage")]
+ExtractedClaimsArg = Annotated[Any, _schema_field("extracted_claims")]
+QualityReportsArg = Annotated[Any, _schema_field("quality_reports")]
+BrandVoicePayloadArg = Annotated[Any, _schema_field("brand_voice_payload")]
+CommentsArg = Annotated[Any, _schema_field("comments")]
+AsOfArg = Annotated[Any, _schema_field("as_of")]
 
 
 @dataclass(frozen=True)
@@ -131,14 +276,14 @@ async def _oauth_approve(request):
 
 @mcp.tool(structured_output=True)
 async def verify_draft(
-    asset_id: Any = "",
-    rule_packet: Any = None,
-    coverage: Any = None,
-    extracted_claims: Any = None,
-    quality_reports: Any = None,
-    brand_voice_payload: Any = None,
-    comments: Any = None,
-    as_of: Any = "",
+    asset_id: AssetIdArg = "",
+    rule_packet: RulePacketArg = None,
+    coverage: CoverageArg = None,
+    extracted_claims: ExtractedClaimsArg = None,
+    quality_reports: QualityReportsArg = None,
+    brand_voice_payload: BrandVoicePayloadArg = None,
+    comments: CommentsArg = None,
+    as_of: AsOfArg = "",
 ) -> dict[str, Any]:
     """Verify structured draft evidence for the bound tenant."""
 

--- a/plans/PR-Content-Ops-Verify-Draft-Rich-Schema.md
+++ b/plans/PR-Content-Ops-Verify-Draft-Rich-Schema.md
@@ -1,0 +1,84 @@
+# PR-Content-Ops-Verify-Draft-Rich-Schema
+
+## Why this slice exists
+
+#1433 closed the ChatGPT adapter contract gap. The Claude-rich `verify_draft`
+tool still exposed only eight shallow parameters, hiding nested payload shapes.
+
+This slice closes that presentation gap without changing verifier behavior,
+tenant binding, OAuth, or decoded-input tolerance.
+
+The diff is slightly above 400 LOC because the review fix added required
+contract-to-backend regression tests for both schema P2s and a Python 3.10
+annotation-wrapper assertion fix.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Product polish
+
+1. Add nested schema hints and descriptions to existing `verify_draft`
+   parameters.
+2. Keep decoded-input tolerance: malformed values still reach existing
+   normalizers and fail closed rather than raising at schema validation.
+3. Prove the schema hints match backend-accepted payload shapes.
+4. Leave the ChatGPT `search` and `fetch` adapter contract unchanged.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Verify-Draft-Rich-Schema.md`
+- `atlas_brain/mcp/content_ops_marketer_verify_server.py`
+- `tests/test_mcp_content_ops_marketer_verify.py`
+
+### Review Contract
+
+- Acceptance criteria: rich schema hints exist, backend field names match,
+  malformed inputs fail closed, and the ChatGPT adapter is unchanged.
+- Affected surfaces: Content Ops marketer Claude-rich MCP tool schema.
+- Risk areas: MCP schema compatibility, usability, decoded-input tolerance.
+- Reviewer rules triggered: R1, R2, R5
+
+## Mechanism
+
+Use Pydantic field metadata on `Any`-typed tool parameters. FastMCP publishes
+the richer JSON-schema descriptions, while Pydantic still accepts decoded values
+of any type and the existing normalizers decide how to fail closed.
+
+The metadata mirrors backend field names for rule packets, coverage rows,
+claims, quality reports, brand voice, comments, and the ISO review date.
+
+## Intentional
+
+- This is schema presentation only: no new fields, renames, or verdict changes.
+- Parameters remain `Any`-typed at validation time so decoded non-object inputs
+  still flow to the existing fail-closed normalizers.
+- This does not modify the ChatGPT adapter contract from #1433.
+- This does not start #1435 reliability-gate work.
+- AI reconciliation: rebase fixed stale branches; schema fixes resolved both P2s;
+  CI fix made annotation assertions portable across Python versions.
+
+## Deferred
+
+- #1435 reliability-gate work remains parked until labeled triples exist.
+- Explicit adapter mode discriminators remain deferred unless live usage proves
+  the #1433 contract example is still confusing.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: focused MCP tests for `tests/test_mcp_content_ops_marketer_verify.py`
+  (38 passed after review fix).
+- Passed: real FastMCP schema smoke for `verify_draft` nested parameter hints.
+- Passed: dedicated Content Ops MCP workflow pytest sweep (96 passed after
+  review fix).
+- Passed: extracted pipeline wrapper `scripts/run_extracted_pipeline_checks.sh`
+  (3569 passed, 10 skipped after review fix).
+- Passed: py_compile for `atlas_brain/mcp/content_ops_marketer_verify_server.py`.
+- Passed: `git diff --check`.
+- Pending: body-aware `scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| Area | LOC |
+| --- | ---: |
+| Total | 413 |

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import Annotated, Any, get_args, get_origin, get_type_hints
 from unittest.mock import MagicMock
 
 import pytest
@@ -205,9 +206,74 @@ def _valid_payload() -> dict[str, object]:
     }
 
 
+def _annotated_args(hint):
+    if get_origin(hint) is Annotated:
+        return get_args(hint)
+    for item in get_args(hint):
+        if get_origin(item) is Annotated:
+            return get_args(item)
+    raise AssertionError(f"expected Annotated hint, got {hint!r}")
+
+
 def test_content_ops_marketer_verify_exposes_exact_tool_surface() -> None:
     assert _tool_names() == VERIFY_TOOLS
     assert _tool_names().isdisjoint(DENIED_TOOLS)
+
+
+def test_verify_draft_schema_hints_cover_nested_payload_shape() -> None:
+    schema = verify.VERIFY_DRAFT_PARAMETER_SCHEMA
+    hints = get_type_hints(verify.verify_draft, include_extras=True)
+
+    assert set(schema) == {
+        "asset_id",
+        "rule_packet",
+        "coverage",
+        "extracted_claims",
+        "quality_reports",
+        "brand_voice_payload",
+        "comments",
+        "as_of",
+    }
+    assert schema["coverage"]["items"]["properties"]["status"]["enum"] == [
+        "pass",
+        "fail",
+        "not_applicable",
+        "unresolved",
+    ]
+    assert set(schema["rule_packet"]["properties"]) == {
+        "brief",
+        "brand_voice",
+        "claim_registry",
+        "compliance",
+        "channel_schema",
+    }
+    quality_report_schema = schema["quality_reports"]["anyOf"][0]
+    quality_report_array_schema = schema["quality_reports"]["anyOf"][1]
+    finding_schema = quality_report_schema["properties"]["findings"]["items"]
+
+    assert set(quality_report_schema["properties"]) == {"passed", "findings"}
+    assert quality_report_array_schema["items"] == quality_report_schema
+    assert set(finding_schema["properties"]) == {
+        "code",
+        "message",
+        "severity",
+        "field_name",
+    }
+    assert finding_schema["properties"]["severity"]["enum"] == ["blocker", "warning", "info"]
+    assert set(schema["brand_voice_payload"]["properties"]) == {
+        "passed",
+        "warnings",
+        "banned_terms",
+    }
+    assert "editorial_judgment" in schema["comments"]["items"]["properties"]["category"]["enum"]
+    assert schema["as_of"]["format"] == "date"
+
+    for name, parameter_schema in schema.items():
+        args = _annotated_args(hints[name])
+        assert args[0] is Any
+        field_info = args[1]
+        assert field_info.description
+        assert field_info.json_schema_extra == parameter_schema
 
 
 def test_chatgpt_adapter_exposes_exact_search_fetch_surface() -> None:
@@ -301,6 +367,72 @@ async def test_chatgpt_adapter_contract_example_submits_without_schema_shape_blo
     assert "Missing brand voice audit passed flag" not in reasons
     assert "QUALITY-GATE:report" in coverage_rule_ids
     assert "BRAND-VOICE:audit" in coverage_rule_ids
+    assert reader.scopes == [TenantScope(account_id="acct-1")]
+
+
+@pytest.mark.asyncio
+async def test_verify_draft_accepts_adapter_contract_example_quality_report_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver("acct-1"),
+    )
+    contract = await adapter.fetch(adapter.CONTRACT_ID)
+
+    result = await verify.verify_draft(**contract["metadata"]["example"])
+    reasons = "\n".join(str(reason) for reason in result["reasons"])
+
+    assert result["ok"] is True
+    assert result["decision"] == "approved"
+    assert "MALFORMED-COVERAGE" not in reasons
+    assert "QUALITY-GATE:malformed-finding" not in reasons
+    assert "Missing quality report passed flag" not in reasons
+    assert "Missing brand voice audit passed flag" not in reasons
+    assert reader.scopes == [TenantScope(account_id="acct-1")]
+
+
+@pytest.mark.asyncio
+async def test_verify_draft_schema_quality_finding_objects_avoid_malformed_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver("acct-1"),
+    )
+    payload = _valid_payload()
+    payload["quality_reports"] = {
+        "passed": True,
+        "findings": [
+            {
+                "code": "tone-note",
+                "message": "Minor tone note",
+                "severity": "info",
+                "field_name": "body",
+            }
+        ],
+    }
+    payload["brand_voice_payload"] = {
+        "passed": True,
+        "warnings": [],
+        "banned_terms": [],
+    }
+
+    result = await verify.verify_draft(**payload)
+    coverage_rule_ids = {
+        row["rule_id"] for row in result["content_pr"]["coverage"] if isinstance(row, dict)
+    }
+
+    assert result["ok"] is True
+    assert result["decision"] == "approved"
+    assert "QUALITY-GATE:malformed-finding-1" not in coverage_rule_ids
+    assert "QUALITY-GATE:tone-note" in coverage_rule_ids
     assert reader.scopes == [TenantScope(account_id="acct-1")]
 
 
@@ -459,6 +591,40 @@ async def test_verify_draft_malformed_decoded_rows_block_without_raising(
     assert payload["decision"] == "blocked"
     assert "rule packet not pinned" in payload["reasons"][0]
     assert "unresolved required coverage: VOICE-01" in payload["reasons"]
+    assert "1 blocking comment(s)" in payload["reasons"]
+    assert reader.scopes == [TenantScope(account_id="acct-1")]
+
+
+@pytest.mark.asyncio
+async def test_verify_draft_schema_hints_do_not_make_decoded_inputs_strict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader = _RegistryReader(scopes=[])
+    monkeypatch.setattr(verify, "_registry_reader_override", reader)
+    monkeypatch.setattr(
+        verify,
+        "_account_resolver_override",
+        verify.StaticContentOpsMarketerAccountResolver("acct-1"),
+    )
+
+    payload = await verify.verify_draft(
+        asset_id=123,
+        rule_packet="not-a-rule-packet",
+        coverage={"status": "pass"},
+        extracted_claims="not-claim-rows",
+        quality_reports=123,
+        brand_voice_payload="not-a-brand-audit",
+        comments={"category": "nit", "blocking": True},
+        as_of=[],
+    )
+
+    assert payload["ok"] is False
+    assert payload["decision"] == "blocked"
+    assert "rule packet not pinned" in payload["reasons"][0]
+    assert any(
+        reason.startswith("unresolved required coverage: MALFORMED-COVERAGE-1")
+        for reason in payload["reasons"]
+    )
     assert "1 blocking comment(s)" in payload["reasons"]
     assert reader.scopes == [TenantScope(account_id="acct-1")]
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Verify-Draft-Rich-Schema.md
Slice phase: Product polish

The Claude-rich `verify_draft` tool exposed the right eight parameters, but its generated schema did not explain the nested payload shapes. This PR adds backend-aligned schema hints and descriptions while keeping every parameter decoded-input tolerant and leaving verifier behavior unchanged.

## Intentional
- The public tool surface remains exactly one Claude-rich tool named `verify_draft`.
- Parameters remain `Any` at validation time; the schema is richer, but malformed decoded inputs still reach the existing fail-closed normalizers.
- The ChatGPT `search` and `fetch` adapter contract from #1433 is unchanged.
- #1435 reliability-gate work remains deferred.
- AI reconciliation: fixed the reviewer BLOCKER by rebasing onto current `origin/main`; fixed the two reviewer MAJOR / Codex P2 findings by making `quality_reports` accept one report object or an array and by documenting finding objects with `code`, `message`, `severity`, and `field_name`; fixed the CI-only Python 3.10 annotation wrapper assertion.

## Deferred
- #1435 reliability-gate work waits for operator-labeled claim and evidence triples.
- Explicit adapter mode discriminators remain deferred unless live usage proves the #1433 contract example is still confusing.

## Parked hardening
- None.

## Verification
- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_mcp_content_ops_marketer_verify.py -q` (38 passed after review fix)
- Real FastMCP schema smoke for `verify_draft` nested parameter hints
- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_atlas_content_ops_review_workflow.py tests/test_check_content_ops_marketer_verify_oauth_e2e.py tests/test_content_ops_marketer_verify_launcher_contract.py tests/test_start_content_ops_marketer_verify_chatgpt_adapter_oauth_server.py tests/test_mcp_content_ops_marketer_verify.py -q` (96 passed after review fix)
- `bash scripts/run_extracted_pipeline_checks.sh` (3569 passed, 10 skipped after review fix)
- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile atlas_brain/mcp/content_ops_marketer_verify_server.py`
- `git diff --check`
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_verify_draft_rich_schema_pr_body.md`

## Diff size
3 files, +404 / -9.
