### PR TITLE
Deflection full-thread export guidance

### DIFF
--- a/plans/PR-Deflection-Full-Thread-Export-Guidance.md
+++ b/plans/PR-Deflection-Full-Thread-Export-Guidance.md
@@ -1,0 +1,107 @@
+# PR-Deflection-Full-Thread-Export-Guidance
+
+## Why this slice exists
+
+Issue #1419 split the publishable-answer launch gate into three parts:
+pre-payment resolution-evidence diagnostics, a deterministic proof run with
+resolution-bearing source rows, and customer-facing export guidance. The first
+two are already on `main` via #1424/#1428/#1430; the remaining small gap is the
+intake surface still says only "support-ticket CSV".
+
+That wording is incomplete for buyers. A CSV with inbound questions can produce
+cluster diagnostics and a gap list, but publishable answer drafts require full
+ticket threads with agent replies or resolved notes. This slice makes that
+expectation visible before upload so customers do not mistake a question-only
+export for the publishable-answer lane.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering-raw-data
+Slice phase: Product polish
+
+1. Update the portfolio FAQ-deflection upload page copy to ask for full ticket
+   threads, agent replies, and resolved ticket notes.
+2. Keep the existing resolution-evidence honesty: question-only exports still
+   produce a locked preview/gap-list signal, not a promise of publishable
+   answers.
+3. Pin the guidance in the upload-shell test that is already enrolled in
+   `.github/workflows/portfolio_ui_checks.yml`.
+4. Do not change upload mechanics, private Blob handling, checkout, result
+   rendering, PDF/email delivery, or deterministic report generation.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The upload page names full ticket threads and agent replies/resolved
+        notes as the best input for publishable answers.
+  - [ ] The copy still preserves the no-LLM deterministic trust story.
+  - [ ] The copy explicitly warns that question-only exports can produce a
+        gap list but not publishable answer drafts.
+  - [ ] The upload-shell test asserts those phrases so the guidance cannot
+        regress silently.
+  - [ ] `.github/workflows/portfolio_ui_checks.yml` already runs the touched
+        test script.
+- Affected surfaces: portfolio upload-page text and its existing shell test.
+- Risk areas: overpromising that every export yields publishable answers,
+  drifting into paid delivery/PDF lanes, or adding untested marketing copy.
+- Reviewer rules triggered: R1, R9, R12, R13.
+
+### Files touched
+
+- `plans/PR-Deflection-Full-Thread-Export-Guidance.md`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+
+## Mechanism
+
+The upload page already carries the guarded flow copy and private Blob
+explanation. This PR adds one compact guidance block near the CSV picker with
+the source-shape rule:
+
+- best input: full ticket threads with customer question and agent reply or
+  resolved note columns;
+- question-only input: still accepted for clustering/gap diagnostics, but it
+  cannot produce publishable answers unless resolution evidence is present.
+
+The existing `test:deflection-upload-shell` source-level test asserts the new
+phrases and already runs in
+`.github/workflows/portfolio_ui_checks.yml`, so no new CI enrollment is needed.
+
+## Intentional
+
+- This is product guidance only. The backend already computes and displays the
+  resolution-evidence lane signal; this slice does not duplicate that logic.
+- This does not block question-only uploads. They are valid for gap-list
+  analysis and preview diagnostics, but the buyer should know what they will
+  get before paying.
+- This does not touch `atlas-portfolio`; this repo's `portfolio-ui` copy is
+  the in-repo surface covered by the current CI contract.
+
+## Deferred
+
+- Operator-supplied production upload/payment/delivery proof remains outside
+  this slice; it is a live-run activity, not copy guidance.
+- Any matching copy change in the separate `canfieldjuan/atlas-portfolio`
+  deployment repo remains outside this repo and should be applied there if the
+  deployed source has diverged.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm --prefix portfolio-ui run test:deflection-upload-shell`
+  - Result: passed; 20 upload/private-Blob shell assertions.
+- `npm --prefix portfolio-ui run build`
+  - Result: passed; Vite emitted the existing large-chunk warning and skipped
+    sitemap generation because no site URL env was set.
+- `scripts/local_pr_review.sh` with the current PR body file.
+  - Result: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Full-Thread-Export-Guidance.md` | 107 |
+| `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` | 5 |
+| `portfolio-ui/src/pages/FaqDeflectionUpload.tsx` | 14 |
+| **Total** | **126** |

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -147,6 +147,7 @@ await test("upload shell exposes live submit markers and avoids browser credenti
     "data-atlas-deflection-submit",
     "data-atlas-deflection-upload-endpoint",
     "data-atlas-deflection-upload-progress",
+    "data-atlas-deflection-export-guidance",
     "data-atlas-deflection-retry",
   ]) {
     assert.match(uploadSource, new RegExp(marker));
@@ -166,6 +167,10 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.match(uploadSource, /not\s+chatbot interpretation/);
   assert.match(uploadSource, /100% Deterministic Engine/);
   assert.match(uploadSource, /This tool does not use LLMs or generative AI[\s\S]*deterministic clustering/);
+  assert.match(uploadSource, /full ticket threads[\s\S]*customer questions[\s\S]*agent replies/);
+  assert.match(uploadSource, /resolution text[\s\S]*resolved ticket notes/);
+  assert.match(uploadSource, /Question-only exports[\s\S]*clustering[\s\S]*gap\s+list/);
+  assert.match(uploadSource, /publishable answers require uploaded resolution\s+evidence/);
   assert.doesNotMatch(uploadSource, /exact mathematical clustering/);
   assert.match(uploadSource, /Workspace routing is handled server-side/);
   assert.match(uploadSource, /Your browser never[\s\S]*receives ATLAS service tokens/);

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -254,6 +254,20 @@ export default function FaqDeflectionUpload() {
                 accept=".csv,text/csv"
                 onChange={(event) => setUpload(fileState(event.target.files?.[0]))}
               />
+              <div
+                className="mt-4 space-y-2 text-xs leading-5 text-surface-200/70"
+                data-atlas-deflection-export-guidance
+              >
+                <p className="font-semibold text-surface-100">
+                  Best input: full ticket threads with customer questions plus
+                  agent replies, resolution text, or resolved ticket notes.
+                </p>
+                <p>
+                  Question-only exports still work for clustering and a gap
+                  list, but publishable answers require uploaded resolution
+                  evidence.
+                </p>
+              </div>
               <div className="mt-4 rounded-md border border-primary-500/30 bg-primary-500/10 px-4 py-3">
                 <p className="text-sm font-semibold text-primary-100">
                   🛡️ 100% Deterministic Engine


### PR DESCRIPTION
Plan: plans/PR-Deflection-Full-Thread-Export-Guidance.md
Slice phase: Product polish

Closes the remaining #1419 intake-guidance gap in this repo: the FAQ deflection upload page now tells buyers that publishable answers require full ticket threads with agent replies or resolved notes, while question-only exports are still useful for clustering and gap-list diagnostics.

## Intentional
- Product guidance only; upload, private Blob handling, checkout, result rendering, PDF/email delivery, and deterministic report generation stay unchanged.
- Question-only uploads remain accepted because they are valid for preview diagnostics and gap-list analysis.
- This updates the in-repo `portfolio-ui` surface only; any matching deployed `atlas-portfolio` copy change remains outside this repo if that source has diverged.

## Deferred
- Operator-supplied production upload/payment/delivery proof remains outside this slice.
- Matching copy changes in the separate `canfieldjuan/atlas-portfolio` repo remain outside this repo.

## Parked hardening
- None.

## Verification
- `npm --prefix portfolio-ui run test:deflection-upload-shell`
  - Result: passed; 20 upload/private-Blob shell assertions.
- `npm --prefix portfolio-ui run build`
  - Result: passed; Vite emitted the existing large-chunk warning and skipped sitemap generation because no site URL env was set.
- `scripts/local_pr_review.sh` with the current PR body file.
  - Result: passed.

## Diff size
3 files, +126 / -0
