### PR TITLE
Content-Ops Claim Evidence Benchmark Core

### DIFF
--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -1,0 +1,403 @@
+"""Deterministic benchmark scoring for claim/evidence support checks.
+
+This module is intentionally pure. It does not call a model, read the claim
+registry, or expose an MCP tool. It only scores labeled benchmark triples and
+structured witness responses against the reliability thresholds from issue
+#1435.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Mapping, Sequence
+
+
+EASY = "easy"
+HARD = "hard"
+VALID_DIFFICULTIES = frozenset({EASY, HARD})
+CONFIDENCE_COUNTS_MIN = 4
+
+
+def _required_text(data: Mapping[str, object], key: str) -> str | None:
+    value = data.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _required_bool(data: Mapping[str, object], key: str) -> bool | None:
+    value = data.get(key)
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _required_confidence(data: Mapping[str, object], key: str) -> int | None:
+    value = data.get(key)
+    if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 5:
+        return value
+    return None
+
+
+def _accuracy(correct: int, total: int) -> float | None:
+    if total == 0:
+        return None
+    return correct / total
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceTriple:
+    """One hand-labeled benchmark item."""
+
+    triple_id: str
+    claim_id: str
+    evidence_quote: str
+    source_id: str
+    expected_supports: bool
+    difficulty: str
+
+    @classmethod
+    def from_mapping(
+        cls, data: object
+    ) -> tuple["ClaimEvidenceTriple | None", tuple[str, ...]]:
+        if not isinstance(data, Mapping):
+            return None, ("triple must be an object",)
+
+        errors: list[str] = []
+        triple_id = _required_text(data, "triple_id")
+        claim_id = _required_text(data, "claim_id")
+        evidence_quote = _required_text(data, "evidence_quote")
+        source_id = _required_text(data, "source_id")
+        expected_supports = _required_bool(data, "expected_supports")
+        difficulty = _required_text(data, "difficulty")
+
+        for key, value in (
+            ("triple_id", triple_id),
+            ("claim_id", claim_id),
+            ("evidence_quote", evidence_quote),
+            ("source_id", source_id),
+        ):
+            if value is None:
+                errors.append(f"{key} missing")
+        if expected_supports is None:
+            errors.append("expected_supports missing")
+        if difficulty not in VALID_DIFFICULTIES:
+            errors.append("difficulty must be easy or hard")
+        if errors:
+            return None, tuple(errors)
+
+        return (
+            cls(
+                triple_id=triple_id or "",
+                claim_id=claim_id or "",
+                evidence_quote=evidence_quote or "",
+                source_id=source_id or "",
+                expected_supports=bool(expected_supports),
+                difficulty=difficulty or "",
+            ),
+            (),
+        )
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceResponse:
+    """Structured model-witness response for one benchmark item."""
+
+    supports: bool
+    confidence: int
+    reason: str
+
+    @classmethod
+    def from_mapping(
+        cls, data: object
+    ) -> tuple["ClaimEvidenceResponse | None", tuple[str, ...]]:
+        if not isinstance(data, Mapping):
+            return None, ("response must be an object",)
+
+        errors: list[str] = []
+        supports = _required_bool(data, "supports")
+        confidence = _required_confidence(data, "confidence")
+        reason = _required_text(data, "reason")
+        if supports is None:
+            errors.append("supports missing")
+        if confidence is None:
+            errors.append("confidence must be an integer from 1 to 5")
+        if reason is None:
+            errors.append("reason missing")
+        if errors:
+            return None, tuple(errors)
+
+        return (
+            cls(
+                supports=bool(supports),
+                confidence=int(confidence or 0),
+                reason=reason or "",
+            ),
+            (),
+        )
+
+
+@dataclass(frozen=True)
+class BenchmarkThresholds:
+    easy_accuracy_min: float = 0.95
+    hard_accuracy_min: float = 0.75
+    inter_model_agreement_min: float = 0.85
+    intra_model_stability_min: float = 0.95
+    high_confidence_accuracy_min: float = 0.90
+
+
+DEFAULT_THRESHOLDS = BenchmarkThresholds()
+
+
+@dataclass(frozen=True)
+class ModelScore:
+    model_id: str
+    easy_accuracy: float | None
+    hard_accuracy: float | None
+    high_confidence_accuracy: float | None
+    easy_total: int
+    hard_total: int
+    high_confidence_total: int
+    missing_response_ids: tuple[str, ...]
+    low_confidence_response_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PairwiseAgreement:
+    left_model_id: str
+    right_model_id: str
+    agreement: float | None
+    total: int
+
+
+@dataclass(frozen=True)
+class StabilityScore:
+    model_id: str
+    stability: float | None
+    total: int
+
+
+@dataclass(frozen=True)
+class BenchmarkVerdict:
+    passed: bool
+    failure_reasons: tuple[str, ...]
+
+
+def score_model(
+    model_id: str,
+    triples: Sequence[ClaimEvidenceTriple],
+    responses: Mapping[str, ClaimEvidenceResponse],
+) -> ModelScore:
+    easy_total = hard_total = high_total = 0
+    easy_correct = hard_correct = high_correct = 0
+    missing: list[str] = []
+    low_confidence: list[str] = []
+
+    for triple in triples:
+        if triple.difficulty == EASY:
+            easy_total += 1
+        elif triple.difficulty == HARD:
+            hard_total += 1
+
+        response = responses.get(triple.triple_id)
+        if response is None:
+            missing.append(triple.triple_id)
+            continue
+
+        correct = response.supports == triple.expected_supports
+        if triple.difficulty == EASY and correct:
+            easy_correct += 1
+        elif triple.difficulty == HARD and correct:
+            hard_correct += 1
+
+        if response.confidence >= CONFIDENCE_COUNTS_MIN:
+            high_total += 1
+            if correct:
+                high_correct += 1
+        else:
+            low_confidence.append(triple.triple_id)
+
+    return ModelScore(
+        model_id=model_id,
+        easy_accuracy=_accuracy(easy_correct, easy_total),
+        hard_accuracy=_accuracy(hard_correct, hard_total),
+        high_confidence_accuracy=_accuracy(high_correct, high_total),
+        easy_total=easy_total,
+        hard_total=hard_total,
+        high_confidence_total=high_total,
+        missing_response_ids=tuple(missing),
+        low_confidence_response_ids=tuple(low_confidence),
+    )
+
+
+def pairwise_agreements(
+    triples: Sequence[ClaimEvidenceTriple],
+    model_responses: Mapping[str, Mapping[str, ClaimEvidenceResponse]],
+) -> tuple[PairwiseAgreement, ...]:
+    agreements: list[PairwiseAgreement] = []
+    for left, right in combinations(sorted(model_responses), 2):
+        total = len(triples)
+        matching = 0
+        for triple in triples:
+            left_response = model_responses[left].get(triple.triple_id)
+            right_response = model_responses[right].get(triple.triple_id)
+            if (
+                left_response is not None
+                and right_response is not None
+                and left_response.supports == right_response.supports
+            ):
+                matching += 1
+        agreements.append(
+            PairwiseAgreement(left, right, _accuracy(matching, total), total)
+        )
+    return tuple(agreements)
+
+
+def intra_model_stability(
+    model_id: str,
+    triples: Sequence[ClaimEvidenceTriple],
+    runs: Sequence[Mapping[str, ClaimEvidenceResponse]],
+) -> StabilityScore:
+    if len(runs) < 2:
+        return StabilityScore(model_id=model_id, stability=None, total=0)
+
+    total = 0
+    identical = 0
+    for left_run, right_run in combinations(runs, 2):
+        for triple in triples:
+            total += 1
+            left_response = left_run.get(triple.triple_id)
+            right_response = right_run.get(triple.triple_id)
+            if (
+                left_response is not None
+                and right_response is not None
+                and left_response.supports == right_response.supports
+            ):
+                identical += 1
+    return StabilityScore(
+        model_id=model_id,
+        stability=_accuracy(identical, total),
+        total=total,
+    )
+
+
+def evaluate_thresholds(
+    model_scores: Sequence[ModelScore],
+    agreements: Sequence[PairwiseAgreement],
+    stability_scores: Sequence[StabilityScore],
+    thresholds: BenchmarkThresholds = DEFAULT_THRESHOLDS,
+) -> BenchmarkVerdict:
+    reasons: list[str] = []
+    if not model_scores:
+        reasons.append("no model scores")
+    for score in model_scores:
+        _require_metric(
+            reasons,
+            score.model_id,
+            "easy accuracy",
+            score.easy_accuracy,
+            thresholds.easy_accuracy_min,
+        )
+        _require_metric(
+            reasons,
+            score.model_id,
+            "hard accuracy",
+            score.hard_accuracy,
+            thresholds.hard_accuracy_min,
+        )
+        _require_metric(
+            reasons,
+            score.model_id,
+            "high-confidence accuracy",
+            score.high_confidence_accuracy,
+            thresholds.high_confidence_accuracy_min,
+            strict=True,
+        )
+        if score.missing_response_ids:
+            reasons.append(f"{score.model_id}: missing responses")
+
+    _require_agreement_coverage(reasons, model_scores, agreements, thresholds)
+    _require_stability_coverage(reasons, model_scores, stability_scores, thresholds)
+    return BenchmarkVerdict(passed=not reasons, failure_reasons=tuple(reasons))
+
+
+def _require_agreement_coverage(
+    reasons: list[str],
+    model_scores: Sequence[ModelScore],
+    agreements: Sequence[PairwiseAgreement],
+    thresholds: BenchmarkThresholds,
+) -> None:
+    if len(model_scores) < 2:
+        reasons.append("inter-model agreement missing")
+        return
+
+    expected_pairs = {
+        frozenset((left.model_id, right.model_id))
+        for left, right in combinations(model_scores, 2)
+    }
+    seen_pairs = {
+        frozenset((agreement.left_model_id, agreement.right_model_id))
+        for agreement in agreements
+    }
+    for missing_pair in sorted(expected_pairs - seen_pairs, key=lambda pair: sorted(pair)):
+        left, right = sorted(missing_pair)
+        reasons.append(f"{left}/{right}: inter-model agreement missing")
+
+    for agreement in agreements:
+        pair = frozenset((agreement.left_model_id, agreement.right_model_id))
+        if pair not in expected_pairs:
+            continue
+        label = f"{agreement.left_model_id}/{agreement.right_model_id}"
+        _require_metric(
+            reasons,
+            label,
+            "inter-model agreement",
+            agreement.agreement,
+            thresholds.inter_model_agreement_min,
+        )
+
+
+def _require_stability_coverage(
+    reasons: list[str],
+    model_scores: Sequence[ModelScore],
+    stability_scores: Sequence[StabilityScore],
+    thresholds: BenchmarkThresholds,
+) -> None:
+    if not model_scores:
+        reasons.append("intra-model stability missing")
+        return
+
+    stability_by_model = {score.model_id: score for score in stability_scores}
+    for score in model_scores:
+        stability = stability_by_model.get(score.model_id)
+        if stability is None:
+            reasons.append(f"{score.model_id}: intra-model stability missing")
+            continue
+        _require_metric(
+            reasons,
+            stability.model_id,
+            "intra-model stability",
+            stability.stability,
+            thresholds.intra_model_stability_min,
+        )
+
+
+def _require_metric(
+    reasons: list[str],
+    owner: str,
+    metric: str,
+    value: float | None,
+    minimum: float,
+    *,
+    strict: bool = False,
+) -> None:
+    if value is None:
+        reasons.append(f"{owner}: {metric} missing")
+        return
+    if strict:
+        if value <= minimum:
+            reasons.append(f"{owner}: {metric} {value:.3f} not above {minimum:.3f}")
+        return
+    if value < minimum:
+        reasons.append(f"{owner}: {metric} {value:.3f} below {minimum:.3f}")

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -244,6 +244,9 @@
       "target": "extracted_content_pipeline/content_pr.py"
     },
     {
+      "target": "extracted_content_pipeline/claim_evidence_benchmark.py"
+    },
+    {
       "target": "extracted_content_pipeline/coverage_rows.py"
     },
     {

--- a/plans/PR-Content-Ops-Claim-Evidence-Benchmark-Core.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Benchmark-Core.md
@@ -1,0 +1,127 @@
+# PR-Content-Ops-Claim-Evidence-Benchmark-Core
+
+## Why this slice exists
+
+Issue #1435 defines the first possible structured-judgment slot for the
+Content Ops verifier: claim/evidence support verification. The important
+architecture rule is that the MCP server remains a deterministic referee; a
+model may only fill structured witness fields after empirical benchmarks show
+that current models answer the slot reliably.
+
+This PR lands the deterministic benchmark core only. It gives the lane a
+stable way to score hand-labeled triples and model responses against the
+precommitted thresholds before any runner, model call, rubric slot, or MCP
+surface exists.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a package-owned pure module for decoded benchmark triples, decoded
+   structured responses, per-model scoring, inter-model agreement,
+   intra-model stability, confidence calibration, and go/no-go threshold
+   evaluation.
+2. Keep all behavior deterministic and standalone: no Atlas imports, no DB,
+   no network, no model provider, no MCP server wiring.
+3. Enroll focused tests in the extracted pipeline CI list.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Decoded triples and responses tolerate missing or wrong-typed fields
+        without raising; missing fields are reported as invalid benchmark
+        input.
+  - [ ] Easy accuracy, hard accuracy, confidence-gated accuracy, inter-model
+        agreement, and intra-model stability are scored deterministically from
+        labeled triples and structured responses.
+  - [ ] Threshold evaluation fails closed when any required metric is absent or
+        below the #1435 thresholds.
+  - [ ] Low-confidence responses are excluded from confidence-gated verdict
+        credit.
+  - [ ] No model runner, verifier rubric integration, MCP tool, database, or
+        live provider call is introduced.
+- Affected surfaces: extracted package validation core and CI enrollment.
+- Risk areas: benchmark false-green, schema tolerance, future MCP contract
+  coupling.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Claim-Evidence-Benchmark-Core.md`
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/manifest.json`
+
+## Mechanism
+
+The module models three things:
+
+- benchmark triples with the operator label and difficulty bucket;
+- structured witness responses with support, confidence, and reason fields;
+- deterministic benchmark results that expose pass/fail status and reasons.
+
+Decoded-input helpers treat `None`, missing keys, non-strings, non-booleans,
+and non-integer confidence values as invalid input instead of raising. The
+scorer accepts valid triples and valid responses, counts missing responses as
+incorrect for the relevant accuracy bucket, and records those missing response
+IDs so threshold evaluation fails closed.
+
+Thresholds are encoded as data from #1435:
+
+- easy accuracy at least 95 percent;
+- hard accuracy at least 75 percent;
+- inter-model agreement at least 85 percent;
+- intra-model stability at least 95 percent;
+- high-confidence accuracy greater than 90 percent;
+- downstream verdict credit only for confidence 4 or 5.
+
+## Intentional
+
+- No prompt, JSON Schema, model adapter, or benchmark runner lands here. The
+  operator-labeled dataset is not available yet, and #1435 explicitly keeps
+  MCP wiring out of scope until benchmark results justify it.
+- The core accepts decoded mappings rather than raw JSON strings. Transport
+  parsing belongs to the future runner; this slice validates the deterministic
+  scorer contract.
+- Agreement is raw support-label agreement, not kappa or weighted agreement,
+  because #1435 commits to pairwise raw agreement.
+
+## Deferred
+
+- Operator-provided seed triples and final labels for the roughly 40-case
+  benchmark set.
+- Model runner, prompt, JSON Schema capture, result artifact export, and
+  go/no-go writeup.
+- Verifier rubric inclusion and MCP exposure, only if the benchmark passes the
+  reliability gate.
+- Parked hardening: none.
+
+## Verification
+
+Local verification:
+
+- pytest tests/test_extracted_content_claim_evidence_benchmark.py - 15 passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - 3586 passed, 10 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_benchmark_core_pr_body.md - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 127 |
+| Benchmark core | 403 |
+| Tests | 282 |
+| CI and manifest | 4 |
+| Total | 816 |
+
+This is over the usual target because the scorer is gate logic and AGENTS 3i
+requires negative fixtures for each failure branch in the same slice. The code
+surface stays package-local and deterministic, and splitting the detection
+branches from their tests would leave a false-green benchmark gate in the first
+PR.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -20,6 +20,7 @@ pytest \
   tests/test_extracted_content_triage_experiment.py \
   tests/test_extracted_content_claims_map.py \
   tests/test_extracted_content_pr.py \
+  tests/test_extracted_content_claim_evidence_benchmark.py \
   tests/test_extracted_content_coverage_rows.py \
   tests/test_extracted_campaign_visibility.py \
   tests/test_extracted_campaign_visibility_reader_cli.py \

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -1,0 +1,282 @@
+"""Tests for the claim/evidence structured-judgment benchmark core."""
+
+from __future__ import annotations
+
+from extracted_content_pipeline.claim_evidence_benchmark import (
+    EASY,
+    HARD,
+    BenchmarkThresholds,
+    ClaimEvidenceResponse,
+    ClaimEvidenceTriple,
+    ModelScore,
+    PairwiseAgreement,
+    StabilityScore,
+    evaluate_thresholds,
+    intra_model_stability,
+    pairwise_agreements,
+    score_model,
+)
+
+
+def _triple(triple_id: str, expected: bool, difficulty: str) -> ClaimEvidenceTriple:
+    return ClaimEvidenceTriple(
+        triple_id=triple_id,
+        claim_id=f"claim-{triple_id}",
+        evidence_quote=f"evidence {triple_id}",
+        source_id=f"source-{triple_id}",
+        expected_supports=expected,
+        difficulty=difficulty,
+    )
+
+
+def _response(supports: bool, confidence: int = 5) -> ClaimEvidenceResponse:
+    return ClaimEvidenceResponse(
+        supports=supports,
+        confidence=confidence,
+        reason="quote directly supports the claim",
+    )
+
+
+def _passing_score(model_id: str) -> ModelScore:
+    return ModelScore(model_id, 1.0, 0.8, 0.95, 30, 10, 40, (), ())
+
+
+def test_triple_decoder_accepts_valid_decoded_input() -> None:
+    triple, errors = ClaimEvidenceTriple.from_mapping(
+        {
+            "triple_id": "t1",
+            "claim_id": "c1",
+            "evidence_quote": "The product integrates with Salesforce.",
+            "source_id": "s1",
+            "expected_supports": True,
+            "difficulty": EASY,
+        }
+    )
+
+    assert errors == ()
+    assert triple is not None
+    assert triple.triple_id == "t1"
+    assert triple.expected_supports is True
+
+
+def test_triple_decoder_reports_missing_and_wrong_typed_fields() -> None:
+    triple, errors = ClaimEvidenceTriple.from_mapping(
+        {
+            "triple_id": None,
+            "claim_id": 10,
+            "evidence_quote": "",
+            "source_id": "s1",
+            "expected_supports": "yes",
+            "difficulty": "medium",
+        }
+    )
+
+    assert triple is None
+    assert errors == (
+        "triple_id missing",
+        "claim_id missing",
+        "evidence_quote missing",
+        "expected_supports missing",
+        "difficulty must be easy or hard",
+    )
+
+
+def test_triple_decoder_rejects_non_object_without_raising() -> None:
+    triple, errors = ClaimEvidenceTriple.from_mapping(None)
+
+    assert triple is None
+    assert errors == ("triple must be an object",)
+
+
+def test_response_decoder_accepts_valid_decoded_input() -> None:
+    response, errors = ClaimEvidenceResponse.from_mapping(
+        {"supports": False, "confidence": 4, "reason": "quote contradicts it"}
+    )
+
+    assert errors == ()
+    assert response == ClaimEvidenceResponse(
+        supports=False,
+        confidence=4,
+        reason="quote contradicts it",
+    )
+
+
+def test_response_decoder_reports_missing_and_wrong_typed_fields() -> None:
+    response, errors = ClaimEvidenceResponse.from_mapping(
+        {"supports": "false", "confidence": True, "reason": None}
+    )
+
+    assert response is None
+    assert errors == (
+        "supports missing",
+        "confidence must be an integer from 1 to 5",
+        "reason missing",
+    )
+
+
+def test_model_score_counts_easy_hard_and_high_confidence_accuracy() -> None:
+    triples = (
+        _triple("easy-pass", True, EASY),
+        _triple("easy-fail", True, EASY),
+        _triple("hard-pass", False, HARD),
+    )
+    score = score_model(
+        "claude",
+        triples,
+        {
+            "easy-pass": _response(True, 5),
+            "easy-fail": _response(False, 5),
+            "hard-pass": _response(False, 4),
+        },
+    )
+
+    assert score.easy_accuracy == 0.5
+    assert score.hard_accuracy == 1.0
+    assert score.high_confidence_accuracy == 2 / 3
+    assert score.missing_response_ids == ()
+
+
+def test_low_confidence_responses_do_not_count_toward_verdict_credit() -> None:
+    triples = (_triple("low", True, EASY), _triple("high", True, EASY))
+    score = score_model(
+        "gpt",
+        triples,
+        {"low": _response(True, 2), "high": _response(True, 4)},
+    )
+
+    assert score.high_confidence_total == 1
+    assert score.high_confidence_accuracy == 1.0
+    assert score.low_confidence_response_ids == ("low",)
+
+
+def test_missing_response_is_incorrect_and_recorded() -> None:
+    score = score_model("gpt", (_triple("missing", True, EASY),), {})
+
+    assert score.easy_accuracy == 0.0
+    assert score.high_confidence_accuracy is None
+    assert score.missing_response_ids == ("missing",)
+
+
+def test_pairwise_agreement_uses_full_set_and_missing_counts_as_disagreement() -> None:
+    triples = (_triple("a", True, EASY), _triple("b", False, HARD))
+    agreements = pairwise_agreements(
+        triples,
+        {
+            "claude": {"a": _response(True), "b": _response(False)},
+            "gpt": {"a": _response(True)},
+        },
+    )
+
+    assert len(agreements) == 1
+    assert agreements[0].left_model_id == "claude"
+    assert agreements[0].right_model_id == "gpt"
+    assert agreements[0].agreement == 0.5
+
+
+def test_intra_model_stability_scores_all_run_pairs() -> None:
+    triples = (_triple("a", True, EASY), _triple("b", False, HARD))
+    stability = intra_model_stability(
+        "opus",
+        triples,
+        (
+            {"a": _response(True), "b": _response(False)},
+            {"a": _response(True), "b": _response(True)},
+            {"a": _response(True), "b": _response(False)},
+        ),
+    )
+
+    assert stability.total == 6
+    assert stability.stability == 4 / 6
+
+
+def test_intra_model_stability_requires_at_least_two_runs() -> None:
+    stability = intra_model_stability("opus", (_triple("a", True, EASY),), ({},))
+
+    assert stability == StabilityScore(model_id="opus", stability=None, total=0)
+
+
+def test_threshold_evaluation_passes_when_all_metrics_pass() -> None:
+    verdict = evaluate_thresholds(
+        (
+            ModelScore("claude", 1.0, 0.8, 0.95, 30, 10, 40, (), ()),
+            ModelScore("gpt", 0.97, 0.8, 0.91, 30, 10, 38, (), ("t1",)),
+        ),
+        (
+            pairwise_agreements(
+                (_triple("a", True, EASY),),
+                {"claude": {"a": _response(True)}, "gpt": {"a": _response(True)}},
+            )[0],
+        ),
+        (
+            StabilityScore("claude", 0.96, 120),
+            StabilityScore("gpt", 0.97, 120),
+        ),
+    )
+
+    assert verdict.passed is True
+    assert verdict.failure_reasons == ()
+
+
+def test_threshold_evaluation_fails_each_required_metric_branch() -> None:
+    verdict = evaluate_thresholds(
+        (
+            ModelScore("claude", 0.94, 0.74, 0.90, 30, 10, 20, ("t1",), ()),
+            _passing_score("gpt"),
+        ),
+        pairwise_agreements(
+            (_triple("a", True, EASY), _triple("b", True, HARD)),
+            {
+                "claude": {"a": _response(True), "b": _response(True)},
+                "gpt": {"a": _response(True), "b": _response(False)},
+            },
+        ),
+        (
+            StabilityScore("claude", 0.94, 120),
+            StabilityScore("gpt", 0.96, 120),
+        ),
+    )
+
+    assert verdict.passed is False
+    assert verdict.failure_reasons == (
+        "claude: easy accuracy 0.940 below 0.950",
+        "claude: hard accuracy 0.740 below 0.750",
+        "claude: high-confidence accuracy 0.900 not above 0.900",
+        "claude: missing responses",
+        "claude/gpt: inter-model agreement 0.500 below 0.850",
+        "claude: intra-model stability 0.940 below 0.950",
+    )
+
+
+def test_threshold_evaluation_fails_closed_on_partial_coverage() -> None:
+    verdict = evaluate_thresholds(
+        (
+            _passing_score("gpt"),
+            _passing_score("opus"),
+            _passing_score("sonnet"),
+        ),
+        (PairwiseAgreement("opus", "sonnet", 0.92, 40),),
+        (StabilityScore("opus", 0.96, 120),),
+    )
+
+    assert verdict.passed is False
+    assert verdict.failure_reasons == (
+        "gpt/opus: inter-model agreement missing",
+        "gpt/sonnet: inter-model agreement missing",
+        "gpt: intra-model stability missing",
+        "sonnet: intra-model stability missing",
+    )
+
+
+def test_threshold_evaluation_fails_closed_when_required_metrics_are_absent() -> None:
+    verdict = evaluate_thresholds(
+        (),
+        (),
+        (),
+        BenchmarkThresholds(),
+    )
+
+    assert verdict.failure_reasons == (
+        "no model scores",
+        "inter-model agreement missing",
+        "intra-model stability missing",
+    )


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Benchmark-Core.md
Slice phase: Functional validation

Issue #1435 defines claim/evidence support verification as the first candidate structured-judgment slot, but only after empirical reliability gates pass. This PR lands the deterministic benchmark core only: decoded triples, decoded structured responses, scoring, agreement, stability, confidence calibration, and threshold verdicts. It does not add a runner, model calls, rubric wiring, or MCP exposure.

## Intentional
- Deterministic benchmark scoring only; no model runner, verifier rubric slot, MCP tool, DB, or provider call.
- Decoded mappings are the input boundary for this slice; transport parsing belongs to the future benchmark runner.
- Pairwise agreement is raw support-label agreement because #1435 commits to raw agreement as the threshold.

## Deferred
- Operator-labeled seed triples and the final roughly 40-case benchmark set.
- Model runner, prompt, JSON Schema capture, result artifact export, and go/no-go writeup.
- Verifier rubric inclusion and MCP exposure only after benchmark thresholds justify the slot.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_content_claim_evidence_benchmark.py - 15 passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/run_extracted_pipeline_checks.sh - 3586 passed, 10 skipped.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_benchmark_core_pr_body.md - passed.

## Diff size
5 files, +816 / -0. Over the usual target because this is gate logic and the same slice carries the negative fixtures required by AGENTS 3i plus the review-requested partial-coverage regression.
