### PR TITLE
Deflection live-proof report golden

### DIFF
--- a/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md
+++ b/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md
@@ -2,7 +2,7 @@
 
 ## Support Tax Confirmation
 
-ATLAS found 12 repeat-ticket hits across 4 ranked questions. At the Gartner $13.50 assisted-contact benchmark, that uploaded work sizes to about $162 of assisted-contact handling.
+This report found 12 repeat-ticket hits across 4 ranked questions. At the Gartner $13.50 assisted-contact benchmark, that uploaded work sizes to about $162 of assisted-contact handling.
 
 The source window is 2026-05-02 to 2026-05-08 (7 days). At the same measured daily pace, that is about $8,447 over 12 months.
 
@@ -20,7 +20,7 @@ docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20
 
 ## Your Help-Desk SEO Targeting List
 
-Use these source-backed phrases as help-center headings, internal-search synonyms, and FAQ wording. ATLAS mined them from the tickets you uploaded; it does not claim keyword volume, search rank, or traffic.
+Use these source-backed phrases as help-center headings, internal-search synonyms, and FAQ wording. These were mined from the tickets you uploaded; this report does not claim keyword volume, search rank, or traffic.
 
 1. How do I export attribution reports before our board meeting?
 2. Where can I download invoices for last quarter?

--- a/plans/PR-Deflection-Live-Proof-Report-Golden.md
+++ b/plans/PR-Deflection-Live-Proof-Report-Golden.md
@@ -1,0 +1,105 @@
+# PR-Deflection-Live-Proof-Report-Golden
+
+## Why this slice exists
+
+Issue #1434 found that the committed resolution-evidence live-proof
+`report.md` fixture drifted after #1429 made paid deflection report prose
+brand-neutral. The generator now emits "This report found..." and "These were
+mined...", while the committed sample still says "ATLAS found..." and "ATLAS
+mined...".
+
+The current proof test only checks summary equality plus a report substring, so
+that buyer-facing fixture drift stayed green. This slice refreshes the fixture
+against the current deterministic generator and strengthens the test so future
+report prose changes cannot silently leave the committed proof stale.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering-raw-data
+Slice phase: Production hardening
+
+1. Regenerate the committed resolution-evidence proof artifacts from the
+   existing `source.csv` on current `origin/main`.
+2. Commit the refreshed `report.md` fixture, and include `summary.json` /
+   `result.json` only if the generator changes them.
+3. Strengthen the proof test to assert full `report.md` byte-for-byte equality
+   between regenerated output and the committed fixture.
+4. Do not change deflection report generation semantics, source rows, PDF,
+   email delivery, checkout, or live payment behavior.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Regenerating from the committed source CSV matches the committed
+        `report.md` fixture exactly.
+  - [ ] The test would fail on the #1434 stale-branding drift.
+  - [ ] Existing publishable-answer and no-proven-answer lane assertions stay
+        intact.
+  - [ ] The refreshed fixture stays deterministic and no LLM/local-model route
+        is introduced.
+- Affected surfaces: one proof fixture and its focused regression test.
+- Risk areas: accidentally changing source evidence, weakening the lane proof,
+  or drifting into delivery/payment work.
+- Reviewer rules triggered: R1, R2, R10, R13.
+
+### Files touched
+
+- `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md`
+- `plans/PR-Deflection-Live-Proof-Report-Golden.md`
+- `tests/test_content_ops_deflection_resolution_live_proof.py`
+
+## Mechanism
+
+The existing proof test already invokes `scripts/build_content_ops_deflection_report.py`
+against the committed source CSV and temporary output files. This PR adds the
+missing golden assertion:
+
+```python
+assert output.read_text(encoding="utf-8") == REPORT.read_text(encoding="utf-8")
+```
+
+The fixture is regenerated with the same CLI used by the original proof. Since
+the source rows and deterministic generator are unchanged, the expected
+behavioral metrics stay the same while the report prose sample catches up to
+current shipped output.
+
+## Intentional
+
+- This does not broaden #1419's proof fixture or source shape. The issue is
+  stale output locking, not missing data coverage.
+- This does not add a looser substring/contains matcher. The point is to make
+  any future report Markdown change explicit through a fixture refresh.
+- This does not touch live upload, Stripe, PDF, or email paths.
+
+## Deferred
+
+- Sanitized real-provider export fixtures remain deferred under #1384.
+- Operator-supplied production upload/payment/delivery proof remains separate
+  from this deterministic fixture lock.
+
+Parked hardening: none.
+
+## Verification
+
+- Regenerated the proof fixture with
+  `scripts/build_content_ops_deflection_report.py`.
+  - Result: passed; summary still reports `drafted_answer_count=2`,
+    `no_proven_answer_count=2`, and
+    `support_ticket_resolution_evidence_present=true`.
+- Focused proof pytest for
+  `tests/test_content_ops_deflection_resolution_live_proof.py`.
+  - Result: `3 passed in 0.08s`.
+- Full extracted pipeline CI mirror through
+  `scripts/run_extracted_pipeline_checks.sh`.
+  - Result: `3571 passed, 10 skipped, 1 warning in 60.16s`.
+- Local PR review with `scripts/local_pr_review.sh`.
+  - Result: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md` | 4 |
+| `plans/PR-Deflection-Live-Proof-Report-Golden.md` | 105 |
+| `tests/test_content_ops_deflection_resolution_live_proof.py` | 7 |
+| **Total** | **116** |

--- a/tests/test_content_ops_deflection_resolution_live_proof.py
+++ b/tests/test_content_ops_deflection_resolution_live_proof.py
@@ -132,9 +132,10 @@ def test_resolution_live_proof_regenerates_from_committed_csv(tmp_path: Path) ->
     output = tmp_path / "report.md"
     summary_output = tmp_path / "summary.json"
     result_output = tmp_path / "result.json"
+    source_arg = SOURCE.relative_to(ROOT).as_posix()
 
     exit_code = MODULE.main([
-        str(SOURCE),
+        source_arg,
         "--source-format",
         "csv",
         "--output",
@@ -153,6 +154,4 @@ def test_resolution_live_proof_regenerates_from_committed_csv(tmp_path: Path) ->
     assert regenerated["status"] == "ok"
     assert regenerated["failed_output_checks"] == []
     assert regenerated["summary"] == _json(SUMMARY)
-    assert "Publishable Help-Center Copy From Proven Resolutions" in output.read_text(
-        encoding="utf-8"
-    )
+    assert output.read_text(encoding="utf-8") == REPORT.read_text(encoding="utf-8")


### PR DESCRIPTION
Plan: plans/PR-Deflection-Live-Proof-Report-Golden.md
Slice phase: Production hardening

Closes #1434 by refreshing the stale resolution-evidence proof `report.md` fixture against the current brand-neutral deflection report generator, then strengthening the proof test so regenerated Markdown must match the committed fixture byte-for-byte.

## Intentional
- This only refreshes the proof fixture and strengthens the golden assertion.
- It does not change deflection report generation semantics, source rows, Stripe, PDF, email delivery, or live upload behavior.
- `summary.json` and `result.json` were regenerated and unchanged, so only `report.md` is committed.

## Deferred
- Sanitized real-provider export fixtures remain deferred under #1384.
- Operator-supplied production upload/payment/delivery proof remains separate from this deterministic fixture lock.

## Parked hardening
- None.

## Verification
- Regenerated the proof fixture with `scripts/build_content_ops_deflection_report.py`.
  - Result: passed; summary still reports `drafted_answer_count=2`, `no_proven_answer_count=2`, and `support_ticket_resolution_evidence_present=true`.
- Focused proof pytest for `tests/test_content_ops_deflection_resolution_live_proof.py`.
  - Result: `3 passed in 0.08s`.
- Full extracted pipeline CI mirror through `scripts/run_extracted_pipeline_checks.sh`.
  - Result: `3571 passed, 10 skipped, 1 warning in 60.16s`.
- Local PR review with `scripts/local_pr_review.sh`.
  - Result: passed.

## Diff size
3 files, +110 / -6
