### PR TITLE
Deflection paid-funnel alert sink routing

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
+      - "atlas_brain/alerts/**"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py"
@@ -13,6 +14,7 @@ on:
       - "atlas_brain/deflection_pdf_renderer.py"
       - "scripts/send_content_ops_deflection_report_deliveries.py"
       - "tests/test_atlas_content_ops_deflection_delivery.py"
+      - "tests/test_alerts.py"
       - "tests/test_content_ops_deflection_incidents.py"
       - "tests/test_deflection_pdf_renderer.py"
       - "tests/test_deflection_report_delivery_task.py"
@@ -22,6 +24,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
+      - "atlas_brain/alerts/**"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py"
@@ -31,6 +34,7 @@ on:
       - "atlas_brain/deflection_pdf_renderer.py"
       - "scripts/send_content_ops_deflection_report_deliveries.py"
       - "tests/test_atlas_content_ops_deflection_delivery.py"
+      - "tests/test_alerts.py"
       - "tests/test_content_ops_deflection_incidents.py"
       - "tests/test_deflection_pdf_renderer.py"
       - "tests/test_deflection_report_delivery_task.py"
@@ -58,6 +62,7 @@ jobs:
       - name: Run Content Ops deflection delivery tests
         run: |
           python -m pytest \
+            tests/test_alerts.py \
             tests/test_atlas_content_ops_deflection_delivery.py \
             tests/test_content_ops_deflection_incidents.py \
             tests/test_deflection_pdf_renderer.py \

--- a/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml"
+      - "atlas_brain/alerts/**"
       - "atlas_brain/api/auth.py"
       - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
@@ -16,6 +17,7 @@ on:
       - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
       - "tests/test_atlas_billing_stripe_hardening.py"
+      - "tests/test_alerts.py"
       - "tests/test_b2b_vendor_briefing.py"
       - "tests/test_content_ops_deflection_incidents.py"
       - "tests/test_mcp_content_ops_deflection_readonly.py"
@@ -24,6 +26,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml"
+      - "atlas_brain/alerts/**"
       - "atlas_brain/api/auth.py"
       - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
@@ -36,6 +39,7 @@ on:
       - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
       - "tests/test_atlas_billing_stripe_hardening.py"
+      - "tests/test_alerts.py"
       - "tests/test_b2b_vendor_briefing.py"
       - "tests/test_content_ops_deflection_incidents.py"
       - "tests/test_mcp_content_ops_deflection_readonly.py"
@@ -62,9 +66,11 @@ jobs:
       - name: Run Content Ops deflection Stripe paid tests
         run: |
           python -m pytest \
+            tests/test_alerts.py \
             tests/test_atlas_billing_stripe_hardening.py \
             tests/test_b2b_vendor_briefing.py \
             tests/test_atlas_billing_content_ops_deflection_stripe_paid.py \
             tests/test_atlas_billing_content_ops_deflection_paid_flow.py \
+            tests/test_content_ops_deflection_incidents.py \
             tests/test_mcp_content_ops_deflection_readonly.py \
             -q

--- a/atlas_brain/alerts/__init__.py
+++ b/atlas_brain/alerts/__init__.py
@@ -20,6 +20,7 @@ from .events import (
     AlertEvent,
     AudioAlertEvent,
     HAStateAlertEvent,
+    PaidFunnelIncidentAlertEvent,
     PresenceAlertEvent,
     ReminderAlertEvent,
     SecurityAlertEvent,
@@ -47,6 +48,7 @@ __all__ = [
     "ReminderAlertEvent",
     "SecurityAlertEvent",
     "PresenceAlertEvent",
+    "PaidFunnelIncidentAlertEvent",
     # Rules
     "AlertRule",
     "create_vision_rule",

--- a/atlas_brain/alerts/events.py
+++ b/atlas_brain/alerts/events.py
@@ -259,3 +259,46 @@ class PresenceAlertEvent:
                 "person_name": person,
             },
         )
+
+
+@dataclass
+class PaidFunnelIncidentAlertEvent:
+    """Paid FAQ-deflection funnel incident for operator alerting."""
+
+    source_id: str
+    timestamp: datetime
+    incident_type: str
+    severity: str
+    account_id: str = ""
+    request_id: str = ""
+    event_type: str = "deflection_paid_funnel_incident"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def get_field(self, name: str, default: Any = None) -> Any:
+        """Get event-specific field for rule matching."""
+        field_map = {
+            "incident_type": self.incident_type,
+            "severity": self.severity,
+            "account_id": self.account_id,
+            "request_id": self.request_id,
+        }
+        return field_map.get(name, self.metadata.get(name, default))
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: dict[str, str],
+        *,
+        timestamp: Optional[datetime] = None,
+    ) -> "PaidFunnelIncidentAlertEvent":
+        """Create an alert event from a bounded paid-funnel incident payload."""
+        incident_type = payload.get("incident_type", "unknown")
+        return cls(
+            source_id=f"content_ops_deflection:{incident_type}",
+            timestamp=timestamp or datetime.now(timezone.utc),
+            incident_type=incident_type,
+            severity=payload.get("severity", "error"),
+            account_id=payload.get("account_id", ""),
+            request_id=payload.get("request_id", ""),
+            metadata=dict(payload),
+        )

--- a/atlas_brain/alerts/manager.py
+++ b/atlas_brain/alerts/manager.py
@@ -138,6 +138,19 @@ class AlertManager:
             priority=5,
         ))
 
+        self.add_rule(AlertRule(
+            name="deflection_paid_funnel_incident",
+            event_types=["deflection_paid_funnel_incident"],
+            source_pattern="*",
+            conditions={},
+            message_template=(
+                "Paid deflection funnel incident: {incident_type} ({severity}) "
+                "account={account_id} request={request_id}"
+            ),
+            cooldown_seconds=0,
+            priority=15,
+        ))
+
     def add_rule(self, rule: AlertRule) -> None:
         """Add or update an alert rule."""
         self._rules[rule.name] = rule

--- a/atlas_brain/alerts/rules.py
+++ b/atlas_brain/alerts/rules.py
@@ -127,7 +127,8 @@ class AlertRule:
 
         for key in ["class_name", "detection_type", "sound_class", "new_state",
                     "old_state", "domain", "label", "priority", "confidence",
-                    "message", "reminder_id", "repeat_pattern"]:
+                    "message", "reminder_id", "repeat_pattern",
+                    "incident_type", "severity", "account_id", "request_id"]:
             value = event.get_field(key)
             if value is not None:
                 format_data[key] = value

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 from ..auth.dependencies import AuthUser, require_auth
 from ..config import settings
-from ..content_ops_deflection_incidents import emit_deflection_paid_funnel_incident
+from ..content_ops_deflection_incidents import emit_deflection_paid_funnel_incident_alert
 from ..storage.database import get_db_pool
 from extracted_content_pipeline.deflection_report_access import (
     PostgresDeflectionReportArtifactStore,
@@ -651,7 +651,7 @@ async def _handle_content_ops_deflection_report_checkout_completed(
         )
         return
     if not _deflection_checkout_amount_is_valid(session):
-        emit_deflection_paid_funnel_incident(
+        await emit_deflection_paid_funnel_incident_alert(
             logger,
             incident_type="paid_report_checkout_terms_mismatch",
             severity="error",
@@ -674,7 +674,7 @@ async def _handle_content_ops_deflection_report_checkout_completed(
         payment_reference=session_id or None,
     )
     if not marked:
-        emit_deflection_paid_funnel_incident(
+        await emit_deflection_paid_funnel_incident_alert(
             logger,
             incident_type="paid_report_missing_after_payment",
             severity="error",
@@ -808,7 +808,7 @@ async def _handle_content_ops_deflection_report_payment_revoked(
         payment_reference=payment_reference,
     )
     if not revoked:
-        emit_deflection_paid_funnel_incident(
+        await emit_deflection_paid_funnel_incident_alert(
             logger,
             incident_type="paid_report_revocation_missed_report",
             severity="error",

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Literal, Mapping, Protocol
 from urllib.parse import quote
 
-from .content_ops_deflection_incidents import emit_deflection_paid_funnel_incident
+from .content_ops_deflection_incidents import emit_deflection_paid_funnel_incident_alert
 from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
 from extracted_content_pipeline.storage._jsonb_helpers import decode_jsonb_field
 
@@ -65,7 +65,7 @@ async def send_pending_deflection_report_deliveries(
         report_url = deflection_report_result_url(request_id=request_id, config=config)
         email = _clean(data.get("delivery_email"))
         if not bool(data.get("paid")):
-            _emit_delivery_incident(
+            await _emit_delivery_incident(
                 "paid_report_delivery_report_not_paid",
                 account_id=account_id,
                 request_id=request_id,
@@ -75,7 +75,7 @@ async def send_pending_deflection_report_deliveries(
             failed += 1
             continue
         if not email:
-            _emit_delivery_incident(
+            await _emit_delivery_incident(
                 "paid_report_delivery_missing_email",
                 account_id=account_id,
                 request_id=request_id,
@@ -93,7 +93,7 @@ async def send_pending_deflection_report_deliveries(
                 request_id=request_id,
             )
             if not await _confirm_delivery_still_sendable(pool, account_id, request_id):
-                _emit_delivery_incident(
+                await _emit_delivery_incident(
                     "paid_report_delivery_no_longer_sendable",
                     account_id=account_id,
                     request_id=request_id,
@@ -119,7 +119,7 @@ async def send_pending_deflection_report_deliveries(
             )
         except Exception as exc:
             error = _bounded_error(exc)
-            _emit_delivery_incident(
+            await _emit_delivery_incident(
                 "paid_report_delivery_send_failed",
                 account_id=account_id,
                 request_id=request_id,
@@ -327,7 +327,7 @@ async def _confirm_delivery_still_sendable(
     return row is not None
 
 
-def _emit_delivery_incident(
+async def _emit_delivery_incident(
     incident_type: str,
     *,
     account_id: str,
@@ -335,7 +335,7 @@ def _emit_delivery_incident(
     severity: Literal["error", "warning", "info"] = "error",
     **fields: Any,
 ) -> None:
-    emit_deflection_paid_funnel_incident(
+    await emit_deflection_paid_funnel_incident_alert(
         logger,
         incident_type=incident_type,
         severity=severity,

--- a/atlas_brain/content_ops_deflection_incidents.py
+++ b/atlas_brain/content_ops_deflection_incidents.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any, Literal
 
 
 INCIDENT_LOG_MARKER = "DEFLECTION_PAID_FUNNEL_INCIDENT"
+INCIDENT_ALERT_DISPATCH_TIMEOUT_SECONDS = 2.0
 MAX_INCIDENT_FIELD_CHARS = 240
 _Severity = Literal["error", "warning", "info"]
 
@@ -18,7 +20,7 @@ def emit_deflection_paid_funnel_incident(
     incident_type: str,
     severity: _Severity = "error",
     **fields: Any,
-) -> None:
+) -> dict[str, str]:
     """Emit a bounded structured incident record through an existing logger."""
 
     payload = _incident_payload(incident_type=incident_type, severity=severity, **fields)
@@ -29,6 +31,40 @@ def emit_deflection_paid_funnel_incident(
         logger.warning(message)
     else:
         logger.info(message)
+    return payload
+
+
+async def emit_deflection_paid_funnel_incident_alert(
+    logger: logging.Logger,
+    *,
+    incident_type: str,
+    severity: _Severity = "error",
+    **fields: Any,
+) -> dict[str, str]:
+    """Emit a paid-funnel incident log and route it to configured alert sinks."""
+    payload = emit_deflection_paid_funnel_incident(
+        logger,
+        incident_type=incident_type,
+        severity=severity,
+        **fields,
+    )
+    try:
+        from .alerts import PaidFunnelIncidentAlertEvent, get_alert_manager
+
+        await asyncio.wait_for(
+            get_alert_manager().process_event(
+                PaidFunnelIncidentAlertEvent.from_payload(payload)
+            ),
+            timeout=INCIDENT_ALERT_DISPATCH_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Deflection paid-funnel alert dispatch timed out after %.1fs",
+            INCIDENT_ALERT_DISPATCH_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        logger.warning("Deflection paid-funnel alert dispatch failed: %s", exc)
+    return payload
 
 
 def _incident_payload(

--- a/plans/PR-Deflection-Paid-Funnel-Alert-Sink.md
+++ b/plans/PR-Deflection-Paid-Funnel-Alert-Sink.md
@@ -1,0 +1,124 @@
+# PR-Deflection-Paid-Funnel-Alert-Sink
+
+## Why this slice exists
+
+#1386 still has one operational gap after #1445: paid-funnel failures now emit
+stable `DEFLECTION_PAID_FUNNEL_INCIDENT` log records, but those records are not
+routed into any notification surface. An operator still has to discover them by
+reading logs.
+
+This slice connects those records to the existing centralized alert manager so
+configured callbacks can surface paid-but-locked, delivery-suppressed, and
+revocation-miss incidents without changing money or delivery state transitions.
+
+## Scope (this PR)
+
+Ownership lane: go-live-deflection-cleanup
+Slice phase: Production hardening
+
+1. Add a paid-funnel incident alert event shape that carries only the bounded,
+   explicit incident fields already produced by #1445.
+2. Register a default centralized alert rule for paid-funnel incidents with no
+   cooldown, so every high-risk paid failure can notify when alerts are enabled.
+3. Route the existing #1445 incident call sites through a best-effort async alert
+   dispatch while preserving the existing structured log record even when alert
+   delivery is disabled or fails.
+4. Add focused tests for alert dispatch, alert-failure fallback, and the existing
+   billing/delivery incident branches.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Existing `DEFLECTION_PAID_FUNNEL_INCIDENT` logs still emit for payment,
+        revocation, and delivery failures.
+  - [ ] Enabled alerts receive a `deflection_paid_funnel_incident` event with
+        bounded metadata.
+  - [ ] Alert failures/timeouts are best-effort and bounded so slow sinks do not
+        hold the Stripe webhook or delivery worker indefinitely.
+  - [ ] The alert message names incident type, severity, account, and request
+        without raw tickets, evidence, buyer email, or provider error bodies.
+  - [ ] Tests cover successful routing, failures, and timeouts.
+- Affected surfaces: incident helper, alert event/rule formatting, Stripe and
+  delivery incident calls, focused tests, delivery/Stripe CI enrollment.
+- Risk areas: PII leakage, alert spam/cooldown behavior, money-path retry
+  semantics, and alert dependency failures blocking checkout/delivery.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R8.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml`
+- `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml`
+- `atlas_brain/alerts/__init__.py`
+- `atlas_brain/alerts/events.py`
+- `atlas_brain/alerts/manager.py`
+- `atlas_brain/alerts/rules.py`
+- `atlas_brain/api/billing.py`
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `atlas_brain/content_ops_deflection_incidents.py`
+- `plans/PR-Deflection-Paid-Funnel-Alert-Sink.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_alerts.py`
+- `tests/test_content_ops_deflection_incidents.py`
+
+## Mechanism
+
+`emit_deflection_paid_funnel_incident` keeps the bounded JSON log path and
+returns the payload it logged. A new async wrapper logs first, then creates a
+paid-funnel alert event from that payload and calls
+`AlertManager.process_event` with a short timeout. The wrapper catches failures
+and timeouts so alert delivery cannot hold a payment or delivery branch on a
+slow external sink.
+
+The alert manager gets a default `deflection_paid_funnel_incident` rule. The
+rule matches the new event type with zero cooldown and formats a short operator
+message from the bounded incident fields. Existing alert callbacks decide
+whether that becomes log-only, ntfy, webhook, or persisted alert output.
+
+## Intentional
+
+- No new alert transport or secret is added; this slice uses the existing
+  centralized alert manager and configured callbacks.
+- Alerts are routed after the structured log record is emitted, so the log
+  remains the fallback sink if `settings.alerts.enabled` is false.
+- Dispatch is best-effort and bounded. Alert-manager, persistence, callback, or
+  ntfy/webhook failures are operator-observable logs, not long-running
+  checkout/delivery blockers.
+
+## Deferred
+
+- #1386 follow-up: dispute-closed/manual-restore incident handling after a
+  restore path exists.
+- #1386 follow-up: scrub or omit provider error metadata before any future
+  transport routes full incident metadata off-box.
+
+Parked hardening: none.
+
+## Verification
+
+- Incident helper tests: `4 passed in 0.18s`.
+- Alert tests: `73 passed in 0.23s`.
+- Stripe-paid focused tests: `39 passed, 1 warning in 2.96s`.
+- Delivery focused tests: `12 passed in 0.43s`.
+- Delivery workflow command set: `105 passed, 1 warning in 2.78s`.
+- Stripe-paid workflow command set: `177 passed, 1 warning in 3.10s`.
+- Extracted pipeline runner: `3648 passed, 10 skipped, 1 warning in 55.17s`.
+- Python compile check for touched runtime modules: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml` | 5 |
+| `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml` | 6 |
+| `atlas_brain/alerts/__init__.py` | 2 |
+| `atlas_brain/alerts/events.py` | 43 |
+| `atlas_brain/alerts/manager.py` | 13 |
+| `atlas_brain/alerts/rules.py` | 3 |
+| `atlas_brain/api/billing.py` | 8 |
+| `atlas_brain/content_ops_deflection_delivery.py` | 14 |
+| `atlas_brain/content_ops_deflection_incidents.py` | 38 |
+| `plans/PR-Deflection-Paid-Funnel-Alert-Sink.md` | 124 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_alerts.py` | 25 |
+| `tests/test_content_ops_deflection_incidents.py` | 113 |
+| **Total** | **395** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -44,6 +44,7 @@ pytest \
   tests/test_smoke_content_ops_deflection_portfolio_result_page.py \
   tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py \
   tests/test_atlas_content_ops_deflection_delivery.py \
+  tests/test_alerts.py \
   tests/test_content_ops_deflection_incidents.py \
   tests/test_send_content_ops_deflection_report_deliveries.py \
   tests/test_extracted_ticket_faq_markdown.py \

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -17,6 +17,7 @@ from atlas_brain.alerts.events import (
     AlertEvent,
     AudioAlertEvent,
     HAStateAlertEvent,
+    PaidFunnelIncidentAlertEvent,
     PresenceAlertEvent,
     ReminderAlertEvent,
     SecurityAlertEvent,
@@ -568,6 +569,7 @@ class TestAlertManager:
             "reminder_due",
             "presence_arrival",
             "presence_departure",
+            "deflection_paid_funnel_incident",
         }
         assert expected_names.issubset(rule_names)
 
@@ -687,6 +689,29 @@ class TestAlertManager:
             result = await mgr.process_event(event)
 
         assert result == "Person detected!"
+
+    @pytest.mark.asyncio
+    async def test_process_event_triggers_paid_funnel_incident_rule(self):
+        mgr = AlertManager()
+        mgr.initialize()
+        event = PaidFunnelIncidentAlertEvent.from_payload({
+            "incident_type": "paid_report_missing_after_payment",
+            "severity": "error",
+            "account_id": "acct-123",
+            "request_id": "req-123",
+            "error": "provider echoed buyer@example.com",
+        })
+
+        with patch("atlas_brain.alerts.manager.settings") as mock_settings:
+            mock_settings.alerts.enabled = True
+            mock_settings.alerts.persist_alerts = False
+            result = await mgr.process_event(event)
+
+        assert result == (
+            "Paid deflection funnel incident: paid_report_missing_after_payment "
+            "(error) account=acct-123 request=req-123"
+        )
+        assert "buyer@example.com" not in result
 
     @pytest.mark.asyncio
     async def test_process_event_disabled(self):

--- a/tests/test_content_ops_deflection_incidents.py
+++ b/tests/test_content_ops_deflection_incidents.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import json
 import logging
+from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from atlas_brain.alerts import get_alert_manager, reset_alert_manager
 from atlas_brain.content_ops_deflection_incidents import (
     INCIDENT_LOG_MARKER,
     MAX_INCIDENT_FIELD_CHARS,
     emit_deflection_paid_funnel_incident,
+    emit_deflection_paid_funnel_incident_alert,
 )
 
 
@@ -48,3 +53,111 @@ def test_emit_deflection_paid_funnel_incident_logs_bounded_json(
     assert "missing" not in payload
     assert len(payload["error"]) == MAX_INCIDENT_FIELD_CHARS
     assert payload["error"].endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_emit_deflection_paid_funnel_incident_alert_routes_to_alert_manager(
+    caplog,
+) -> None:
+    reset_alert_manager()
+    logger = logging.getLogger("tests.deflection.incidents.alerts")
+    caplog.set_level(logging.ERROR, logger=logger.name)
+    callback = AsyncMock()
+    manager = get_alert_manager()
+    manager.register_callback(callback)
+
+    with patch("atlas_brain.alerts.manager.settings") as mock_settings:
+        mock_settings.alerts.enabled = True
+        mock_settings.alerts.persist_alerts = False
+        payload = await emit_deflection_paid_funnel_incident_alert(
+            logger,
+            incident_type="paid_report_missing_after_payment",
+            severity="error",
+            account_id="acct-123",
+            request_id="req-123",
+            error="provider echoed buyer@example.com",
+        )
+
+    assert payload["incident_type"] == "paid_report_missing_after_payment"
+    incident_record = next(
+        record for record in caplog.records if INCIDENT_LOG_MARKER in record.getMessage()
+    )
+    assert _incident_payload(incident_record)["request_id"] == "req-123"
+    callback.assert_awaited_once()
+    message, rule, event = callback.await_args.args
+    assert rule.name == "deflection_paid_funnel_incident"
+    assert event.event_type == "deflection_paid_funnel_incident"
+    assert event.metadata["error"] == "provider echoed buyer@example.com"
+    assert message == (
+        "Paid deflection funnel incident: paid_report_missing_after_payment "
+        "(error) account=acct-123 request=req-123"
+    )
+    assert "buyer@example.com" not in message
+
+
+@pytest.mark.asyncio
+async def test_emit_deflection_paid_funnel_incident_alert_fails_best_effort(
+    caplog,
+) -> None:
+    reset_alert_manager()
+    logger = logging.getLogger("tests.deflection.incidents.alert_failures")
+    caplog.set_level(logging.WARNING, logger=logger.name)
+
+    with patch(
+        "atlas_brain.alerts.manager.AlertManager.process_event",
+        new=AsyncMock(side_effect=RuntimeError("sink down")),
+    ):
+        payload = await emit_deflection_paid_funnel_incident_alert(
+            logger,
+            incident_type="paid_report_delivery_send_failed",
+            severity="warning",
+            account_id="acct-123",
+            request_id="req-123",
+        )
+
+    assert payload["incident_type"] == "paid_report_delivery_send_failed"
+    assert any(INCIDENT_LOG_MARKER in record.getMessage() for record in caplog.records)
+    assert any(
+        "Deflection paid-funnel alert dispatch failed: sink down" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_emit_deflection_paid_funnel_incident_alert_times_out_best_effort(
+    caplog,
+) -> None:
+    reset_alert_manager()
+    logger = logging.getLogger("tests.deflection.incidents.alert_timeouts")
+    caplog.set_level(logging.WARNING, logger=logger.name)
+
+    async def _hang(*_args, **_kwargs) -> None:
+        import asyncio
+
+        await asyncio.sleep(1)
+
+    with (
+        patch(
+            "atlas_brain.content_ops_deflection_incidents.INCIDENT_ALERT_DISPATCH_TIMEOUT_SECONDS",
+            0.01,
+        ),
+        patch(
+            "atlas_brain.alerts.manager.AlertManager.process_event",
+            new=AsyncMock(side_effect=_hang),
+        ),
+    ):
+        payload = await emit_deflection_paid_funnel_incident_alert(
+            logger,
+            incident_type="paid_report_missing_after_payment",
+            severity="error",
+            account_id="acct-123",
+            request_id="req-123",
+        )
+
+    assert payload["incident_type"] == "paid_report_missing_after_payment"
+    assert any(INCIDENT_LOG_MARKER in record.getMessage() for record in caplog.records)
+    assert any(
+        "Deflection paid-funnel alert dispatch timed out after 0.0s"
+        in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
Plan: plans/PR-Deflection-Paid-Funnel-Alert-Sink.md
Slice phase: Production hardening

#1386 still had an operator-signal gap after #1445: paid-funnel failures emitted stable `DEFLECTION_PAID_FUNNEL_INCIDENT` log records, but no configured alert sink saw them. This slice routes those bounded incident payloads into the existing centralized alert manager so configured callbacks, including ntfy, can surface paid-but-locked, delivery-suppressed, and revocation-miss incidents without changing checkout, unlock, revocation, or delivery state transitions.

## Intentional
- Uses the existing centralized alert manager and configured callbacks; no new alert transport, secret, or webhook is introduced.
- Structured incident logging remains the first/fallback sink when alerts are disabled.
- Alert dispatch is best-effort and bounded so slow external sinks cannot hold the Stripe webhook or delivery worker path indefinitely.

## Deferred
- #1386 follow-up: dispute-closed/manual-restore incident handling after a restore path exists.
- #1386 follow-up: scrub or omit provider error metadata before any future transport routes full incident metadata off-box.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_incidents.py -q` - 4 passed.
- `python -m pytest tests/test_alerts.py -q` - 73 passed.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 39 passed, 1 warning.
- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 12 passed.
- Delivery workflow command set - 105 passed, 1 warning.
- Stripe-paid workflow command set - 177 passed, 1 warning.
- `bash scripts/run_extracted_pipeline_checks.sh` - 3648 passed, 10 skipped, 1 warning.
- `python -m py_compile atlas_brain/api/billing.py atlas_brain/alerts/events.py atlas_brain/alerts/manager.py atlas_brain/alerts/rules.py atlas_brain/content_ops_deflection_delivery.py atlas_brain/content_ops_deflection_incidents.py` - passed.
- `git diff --check` - passed.

## Diff size
13 files, +382 / -13.
