### PR TITLE
Deflection dispute restore hardening

### DIFF
--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -934,10 +934,54 @@ async def _handle_content_ops_deflection_report_dispute_closed(
         return
 
     store = PostgresDeflectionReportArtifactStore(pool=pool)
+    record = await store.get_artifact_record(
+        account_id=account_id_text,
+        request_id=request_id,
+    )
+    if record is None:
+        await emit_deflection_paid_funnel_incident_alert(
+            logger,
+            incident_type="paid_report_restore_missed_report",
+            severity="error",
+            account_id=account_id_text,
+            request_id=request_id,
+            event_type=event_type,
+            payment_reference=payment_reference or "",
+            stripe_object_id=_stripe_text(obj, "id") or "<missing>",
+        )
+        logger.error(
+            "Deflection report dispute restore missed report: "
+            "event_type=%s account=%s request=%s payment_reference=%s object=%s",
+            event_type,
+            account_id_text,
+            request_id,
+            payment_reference or "<missing>",
+            _stripe_text(obj, "id") or "<missing>",
+        )
+        return
+
+    restore_reference = payment_reference
+    if (
+        record.payment_reference
+        and payment_reference
+        and record.payment_reference != payment_reference
+    ):
+        restore_reference = None
+        logger.warning(
+            "Deflection report dispute restore preserved newer payment reference: "
+            "event_type=%s account=%s request=%s restored_reference=%s existing_reference=%s object=%s",
+            event_type,
+            account_id_text,
+            request_id,
+            payment_reference,
+            record.payment_reference,
+            _stripe_text(obj, "id") or "<missing>",
+        )
+
     restored = await store.mark_paid(
         account_id=account_id_text,
         request_id=request_id,
-        payment_reference=payment_reference,
+        payment_reference=restore_reference,
     )
     if not restored:
         await emit_deflection_paid_funnel_incident_alert(
@@ -965,7 +1009,7 @@ async def _handle_content_ops_deflection_report_dispute_closed(
         pool,
         account_id=account_id_text,
         request_id=request_id,
-        payment_reference=payment_reference,
+        payment_reference=restore_reference,
     )
     logger.warning(
         "Deflection report access restored after Stripe dispute win: "

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -436,6 +436,14 @@ async def stripe_webhook(request: Request):
             event_type=event_type,
         )
 
+    elif event_type == "charge.dispute.closed":
+        await _handle_content_ops_deflection_report_dispute_closed(
+            pool,
+            stripe,
+            obj,
+            event_type=event_type,
+        )
+
     elif event_type == "invoice.paid":
         account_id = await _handle_invoice_paid(pool, obj)
 
@@ -866,6 +874,108 @@ async def _cancel_content_ops_deflection_report_delivery(
         account_id,
         request_id,
         f"payment_revoked:{event_type}",
+    )
+
+
+async def _handle_content_ops_deflection_report_dispute_closed(
+    pool: Any,
+    stripe_module: Any,
+    obj: Any,
+    *,
+    event_type: str,
+) -> None:
+    """Restore a deflection report after Stripe closes a dispute as won."""
+
+    dispute_status = _stripe_text(obj, "status").lower()
+    if dispute_status != "won":
+        logger.info(
+            "Deflection report dispute closed without restore: "
+            "event_type=%s object=%s status=%s",
+            event_type,
+            _stripe_text(obj, "id") or "<missing>",
+            dispute_status or "<missing>",
+        )
+        return
+
+    meta, payment_reference = _content_ops_deflection_revocation_metadata(
+        stripe_module,
+        obj,
+    )
+    if meta.get("source") != "content_ops_deflection_report":
+        logger.info(
+            "Deflection report dispute restore could not be mapped: "
+            "event_type=%s object=%s payment_intent=%s",
+            event_type,
+            _stripe_text(obj, "id") or "<missing>",
+            _payment_intent_from_payment_event(obj) or "<missing>",
+        )
+        return
+
+    account_id_text = _clean_metadata(meta.get("account_id"))
+    request_id = _clean_metadata(meta.get("request_id"))
+    if not account_id_text or not request_id:
+        logger.error(
+            "Deflection report dispute restore missing account_id/request_id: "
+            "event_type=%s object=%s",
+            event_type,
+            _stripe_text(obj, "id") or "<missing>",
+        )
+        return
+    try:
+        _uuid.UUID(account_id_text)
+    except ValueError:
+        logger.error(
+            "Deflection report dispute restore has invalid account_id: "
+            "event_type=%s account=%s object=%s",
+            event_type,
+            account_id_text,
+            _stripe_text(obj, "id") or "<missing>",
+        )
+        return
+
+    store = PostgresDeflectionReportArtifactStore(pool=pool)
+    restored = await store.mark_paid(
+        account_id=account_id_text,
+        request_id=request_id,
+        payment_reference=payment_reference,
+    )
+    if not restored:
+        await emit_deflection_paid_funnel_incident_alert(
+            logger,
+            incident_type="paid_report_restore_missed_report",
+            severity="error",
+            account_id=account_id_text,
+            request_id=request_id,
+            event_type=event_type,
+            payment_reference=payment_reference or "",
+            stripe_object_id=_stripe_text(obj, "id") or "<missing>",
+        )
+        logger.error(
+            "Deflection report dispute restore missed report: "
+            "event_type=%s account=%s request=%s payment_reference=%s object=%s",
+            event_type,
+            account_id_text,
+            request_id,
+            payment_reference or "<missing>",
+            _stripe_text(obj, "id") or "<missing>",
+        )
+        return
+
+    delivery_result = await _queue_content_ops_deflection_report_delivery(
+        pool,
+        account_id=account_id_text,
+        request_id=request_id,
+        payment_reference=payment_reference,
+    )
+    logger.warning(
+        "Deflection report access restored after Stripe dispute win: "
+        "event_type=%s account=%s request=%s payment_reference=%s object=%s delivery=%s",
+        event_type,
+        account_id_text,
+        request_id,
+        payment_reference or "<missing>",
+        _stripe_text(obj, "id") or "<missing>",
+        delivery_result,
     )
 
 

--- a/plans/PR-Deflection-Dispute-Restore-Hardening.md
+++ b/plans/PR-Deflection-Dispute-Restore-Hardening.md
@@ -8,6 +8,10 @@ hardening item is the restore side of that lifecycle: if a disputed payment is
 closed as won, the report should become paid again and eligible for delivery
 without an operator hand-edit.
 
+Diff budget note: the PR exceeds 400 LOC after the AI reconciliation fix
+because the stale-reference guard needs a same-class regression that proves the
+full old-dispute-win -> newer-refund sequence, not just a one-line assertion.
+
 ## Scope (this PR)
 Ownership lane: go-live-deflection-cleanup
 Slice phase: Production hardening
@@ -29,6 +33,8 @@ Slice phase: Production hardening
   - [ ] A won-dispute restore that maps to no report emits
         `paid_report_restore_missed_report` without leaking customer email,
         raw ticket text, evidence, or report content.
+  - [ ] A stale older dispute-win restore preserves a newer stored
+        `payment_reference` so later newer-payment refunds can still relock.
   - [ ] Existing full-refund/dispute-created revocation behavior remains
         unchanged, including full-refund-only revocation and pending/sending
         delivery cancellation.
@@ -49,9 +55,11 @@ Slice phase: Production hardening
 The webhook router adds a `charge.dispute.closed` branch for the deflection
 paid-report flow. A new handler checks the dispute status first; only `won`
 continues to the same Stripe payment-event metadata mapping used by the
-revocation handler. After account/request validation, the handler calls the
-existing `PostgresDeflectionReportArtifactStore.mark_paid(...)` inverse and
-then `_queue_content_ops_deflection_report_delivery(...)`, which already
+revocation handler. After account/request validation, the handler reads the
+current report row. If the row already has a different `payment_reference`, the
+restore passes `None` into `mark_paid(...)` and delivery requeueing so the
+existing reference is preserved by the current `COALESCE` semantics. Otherwise
+the restored Checkout Session reference is kept. The delivery upsert already
 preserves delivered/sending rows and moves revoked/failed/pending rows back to
 `pending`.
 
@@ -69,6 +77,8 @@ PII-safe incident envelope style under a new incident type.
   already model the restore transition.
 - Only `status="won"` restores access. Stripe closed statuses such as `lost`
   and `warning_closed` do not restore access.
+- AI reconciliation finding fixed: stale older dispute-win restores no longer
+  overwrite a newer stored payment reference.
 
 ## Deferred
 
@@ -80,9 +90,9 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` -- 42 passed, 1 warning.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` -- 43 passed, 1 warning.
 - `python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 1 passed, 1 warning.
-- `python -m pytest tests/test_alerts.py tests/test_atlas_billing_stripe_hardening.py tests/test_b2b_vendor_briefing.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_content_ops_deflection_incidents.py tests/test_mcp_content_ops_deflection_readonly.py -q` -- 180 passed, 1 warning.
+- `python -m pytest tests/test_alerts.py tests/test_atlas_billing_stripe_hardening.py tests/test_b2b_vendor_briefing.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_content_ops_deflection_incidents.py tests/test_mcp_content_ops_deflection_readonly.py -q` -- 181 passed, 1 warning.
 - Python syntax compile over changed Python files and `git diff --check` -- passed.
 - Push-wrapper local review -- passed.
 
@@ -90,7 +100,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/api/billing.py` | 110 |
-| `plans/PR-Deflection-Dispute-Restore-Hardening.md` | 96 |
-| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 193 |
-| **Total** | **399** |
+| `atlas_brain/api/billing.py` | 154 |
+| `plans/PR-Deflection-Dispute-Restore-Hardening.md` | 106 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 310 |
+| **Total** | **570** |

--- a/plans/PR-Deflection-Dispute-Restore-Hardening.md
+++ b/plans/PR-Deflection-Dispute-Restore-Hardening.md
@@ -1,0 +1,96 @@
+# PR-Deflection-Dispute-Restore-Hardening
+
+## Why this slice exists
+
+#1386 closed the main pay -> refund/dispute -> relock gap in prior slices, then
+routed paid-funnel incidents into the alert sink. The remaining in-lane
+hardening item is the restore side of that lifecycle: if a disputed payment is
+closed as won, the report should become paid again and eligible for delivery
+without an operator hand-edit.
+
+## Scope (this PR)
+Ownership lane: go-live-deflection-cleanup
+Slice phase: Production hardening
+
+1. Route `charge.dispute.closed` for content-ops deflection payments.
+2. Restore paid access and requeue delivery only when Stripe marks the closed
+   dispute `won`.
+3. Leave `lost`, `warning_closed`, missing/unmapped metadata, and non-deflection
+   dispute-close events observed but non-mutating.
+4. Emit a bounded paid-funnel incident if a won-dispute restore maps to a
+   missing report.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] `charge.dispute.closed` with `status="won"` and deflection metadata
+        marks the report paid again and queues delivery.
+  - [ ] `charge.dispute.closed` with a non-`won` status does not restore access
+        or queue delivery.
+  - [ ] A won-dispute restore that maps to no report emits
+        `paid_report_restore_missed_report` without leaking customer email,
+        raw ticket text, evidence, or report content.
+  - [ ] Existing full-refund/dispute-created revocation behavior remains
+        unchanged, including full-refund-only revocation and pending/sending
+        delivery cancellation.
+- Affected surfaces: Stripe webhook, paid report state, delivery queue,
+  observability, CI-enrolled Python tests.
+- Risk areas: payment authorization, webhook idempotency, delivery retry safety,
+  report access restoration.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R12.
+
+### Files touched
+
+- `atlas_brain/api/billing.py`
+- `plans/PR-Deflection-Dispute-Restore-Hardening.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+The webhook router adds a `charge.dispute.closed` branch for the deflection
+paid-report flow. A new handler checks the dispute status first; only `won`
+continues to the same Stripe payment-event metadata mapping used by the
+revocation handler. After account/request validation, the handler calls the
+existing `PostgresDeflectionReportArtifactStore.mark_paid(...)` inverse and
+then `_queue_content_ops_deflection_report_delivery(...)`, which already
+preserves delivered/sending rows and moves revoked/failed/pending rows back to
+`pending`.
+
+Non-won statuses are logged and audited through the existing `billing_events`
+insert, but do not change report state. Missing reports emit the existing
+PII-safe incident envelope style under a new incident type.
+
+## Intentional
+
+- No new Stripe object retrieval by Charge ID. The current deflection checkout
+  metadata path is Checkout Session lookup by `payment_intent` or direct
+  metadata; this slice keeps that bounded lookup surface rather than adding a
+  broader Charge retrieve path.
+- No schema change. `mark_paid`, `mark_unpaid`, and delivery upsert semantics
+  already model the restore transition.
+- Only `status="won"` restores access. Stripe closed statuses such as `lost`
+  and `warning_closed` do not restore access.
+
+## Deferred
+
+- PaymentIntent/Charge metadata copy in atlas-portfolio remains a separate
+  hardening option so future dispute objects are self-describing even when
+  Checkout Session lookup is unavailable.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` -- 42 passed, 1 warning.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 1 passed, 1 warning.
+- `python -m pytest tests/test_alerts.py tests/test_atlas_billing_stripe_hardening.py tests/test_b2b_vendor_briefing.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_content_ops_deflection_incidents.py tests/test_mcp_content_ops_deflection_readonly.py -q` -- 180 passed, 1 warning.
+- Python syntax compile over changed Python files and `git diff --check` -- passed.
+- Push-wrapper local review -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/billing.py` | 110 |
+| `plans/PR-Deflection-Dispute-Restore-Hardening.md` | 96 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 193 |
+| **Total** | **399** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -152,6 +152,7 @@ def _payment_event_object(
     refunded: bool | None = None,
     amount_refunded: int | None = None,
     amount_captured: int | None = None,
+    status: str | None = None,
 ) -> SimpleNamespace:
     payload = {
         "id": object_id,
@@ -164,6 +165,8 @@ def _payment_event_object(
         payload["amount_refunded"] = amount_refunded
     if amount_captured is not None:
         payload["amount_captured"] = amount_captured
+    if status is not None:
+        payload["status"] = status
     return SimpleNamespace(
         id=object_id,
         payment_intent=payment_intent,
@@ -171,6 +174,7 @@ def _payment_event_object(
         refunded=refunded,
         amount_refunded=amount_refunded,
         amount_captured=amount_captured,
+        status=status,
         to_dict=lambda: dict(payload),
     )
 
@@ -1016,6 +1020,195 @@ async def test_stripe_webhook_dispute_relocks_paid_deflection_report_from_direct
     assert "SET paid = false" in update_calls[0][0]
     assert pool.report_rows[(account_id, "req-123")]["paid"] is False
     assert pool.delivery_rows == {}
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_won_dispute_restores_paid_deflection_report(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    account_id = str(uuid.uuid4())
+    checkout_session = _session(
+        account_id=account_id,
+        session_id="cs_test_deflection_dispute_won",
+    )
+    dispute = _payment_event_object(
+        object_id="du_test_deflection_won",
+        payment_intent="pi_test_dispute_won",
+        status="won",
+    )
+    event = SimpleNamespace(
+        id="evt_deflection_dispute_won",
+        type="charge.dispute.closed",
+        data=SimpleNamespace(object=dispute),
+    )
+    fake_stripe, session_list = _stripe_module_for_event(
+        event,
+        checkout_sessions=[checkout_session],
+    )
+    pool = _Pool()
+    pool.add_report(
+        account_id=account_id,
+        paid=False,
+        payment_reference="cs_test_deflection_dispute_won",
+    )
+    pool.delivery_rows[(account_id, "req-123")] = {
+        "account_id": account_id,
+        "request_id": "req-123",
+        "payment_reference": "cs_test_deflection_dispute_won",
+        "delivery_status": "revoked",
+        "delivery_error": "payment_revoked:charge.dispute.created",
+    }
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+    )
+
+    assert response == {"status": "ok"}
+    assert session_list.calls == [
+        {"payment_intent": "pi_test_dispute_won", "limit": 1, "timeout": 10}
+    ]
+    update_calls = [
+        call
+        for call in pool.execute_calls
+        if "UPDATE content_ops_deflection_reports" in call[0]
+    ]
+    delivery_calls = [
+        call
+        for call in pool.execute_calls
+        if "INSERT INTO content_ops_deflection_report_deliveries" in call[0]
+    ]
+    billing_event_calls = [
+        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
+    ]
+    assert update_calls[0][1] == (
+        account_id,
+        "req-123",
+        "cs_test_deflection_dispute_won",
+    )
+    assert "SET paid = true" in update_calls[0][0]
+    assert delivery_calls[0][1] == (
+        account_id,
+        "req-123",
+        "cs_test_deflection_dispute_won",
+    )
+    assert billing_event_calls[0][1][1] == "evt_deflection_dispute_won"
+    assert billing_event_calls[0][1][2] == "charge.dispute.closed"
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
+    assert pool.delivery_rows[(account_id, "req-123")]["delivery_status"] == "pending"
+    assert "access restored after Stripe dispute win" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_non_won_dispute_close_does_not_restore_report(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="atlas.api.billing")
+    account_id = str(uuid.uuid4())
+    checkout_session = _session(account_id=account_id)
+    dispute = _payment_event_object(
+        object_id="du_test_deflection_lost",
+        payment_intent="pi_test_dispute_lost",
+        status="lost",
+    )
+    event = SimpleNamespace(
+        id="evt_deflection_dispute_lost",
+        type="charge.dispute.closed",
+        data=SimpleNamespace(object=dispute),
+    )
+    fake_stripe, session_list = _stripe_module_for_event(
+        event,
+        checkout_sessions=[checkout_session],
+    )
+    pool = _Pool()
+    pool.add_report(
+        account_id=account_id,
+        paid=False,
+        payment_reference="cs_test_deflection",
+    )
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+    )
+
+    assert response == {"status": "ok"}
+    assert session_list.calls == []
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
+    assert [
+        call for call in pool.execute_calls if "UPDATE content_ops_deflection_reports" in call[0]
+    ] == []
+    assert [
+        call
+        for call in pool.execute_calls
+        if "INSERT INTO content_ops_deflection_report_deliveries" in call[0]
+    ] == []
+    billing_event_calls = [
+        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
+    ]
+    assert billing_event_calls[0][1][1] == "evt_deflection_dispute_lost"
+    assert billing_event_calls[0][1][2] == "charge.dispute.closed"
+    assert "dispute closed without restore" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_won_dispute_restore_miss_emits_paid_funnel_incident(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR, logger="atlas.api.billing")
+    account_id = str(uuid.uuid4())
+    checkout_session = _session(
+        account_id=account_id,
+        session_id="cs_test_missing_report_dispute_won",
+    )
+    dispute = _payment_event_object(
+        object_id="du_test_missing_report_won",
+        payment_intent="pi_missing_report_won",
+        status="won",
+    )
+    event = SimpleNamespace(
+        id="evt_deflection_dispute_won_missing_report",
+        type="charge.dispute.closed",
+        data=SimpleNamespace(object=dispute),
+    )
+    fake_stripe, _session_list = _stripe_module_for_event(
+        event,
+        checkout_sessions=[checkout_session],
+    )
+    pool = _Pool()
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+    )
+
+    assert response == {"status": "ok"}
+    assert [
+        call
+        for call in pool.execute_calls
+        if "INSERT INTO content_ops_deflection_report_deliveries" in call[0]
+    ] == []
+    payloads = _incident_payloads(caplog)
+    assert payloads == [
+        {
+            "account_id": account_id,
+            "event_type": "charge.dispute.closed",
+            "incident_type": "paid_report_restore_missed_report",
+            "payment_reference": "cs_test_missing_report_dispute_won",
+            "request_id": "req-123",
+            "severity": "error",
+            "stripe_object_id": "du_test_missing_report_won",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -67,7 +67,8 @@ class _Pool:
                 return "UPDATE 1"
             if row is not None:
                 row["paid"] = True
-                row["payment_reference"] = payment_reference
+                if payment_reference is not None:
+                    row["payment_reference"] = payment_reference
             return self.update_result
         if "UPDATE content_ops_deflection_report_deliveries" in query:
             account_id, request_id, delivery_error = args
@@ -78,10 +79,15 @@ class _Pool:
             return "UPDATE 1"
         if "INSERT INTO content_ops_deflection_report_deliveries" in query:
             account_id, request_id, payment_reference = args
+            existing = self.delivery_rows.get((str(account_id), str(request_id)))
             self.delivery_rows[(str(account_id), str(request_id))] = {
                 "account_id": account_id,
                 "request_id": request_id,
-                "payment_reference": payment_reference,
+                "payment_reference": (
+                    payment_reference
+                    if payment_reference is not None
+                    else (existing or {}).get("payment_reference")
+                ),
                 "delivery_status": "pending",
             }
             return "INSERT 0 1"
@@ -1100,6 +1106,113 @@ async def test_stripe_webhook_won_dispute_restores_paid_deflection_report(
     assert pool.report_rows[(account_id, "req-123")]["paid"] is True
     assert pool.delivery_rows[(account_id, "req-123")]["delivery_status"] == "pending"
     assert "access restored after Stripe dispute win" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_stale_won_dispute_preserves_newer_payment_reference(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="atlas.api.billing")
+    account_id = str(uuid.uuid4())
+    older_session = _session(
+        account_id=account_id,
+        session_id="cs_test_older_disputed_payment",
+    )
+    older_dispute = _payment_event_object(
+        object_id="du_test_older_payment_won",
+        payment_intent="pi_test_older_payment",
+        status="won",
+    )
+    older_won_event = SimpleNamespace(
+        id="evt_deflection_older_dispute_won",
+        type="charge.dispute.closed",
+        data=SimpleNamespace(object=older_dispute),
+    )
+    newer_session = _session(
+        account_id=account_id,
+        session_id="cs_test_newer_payment",
+    )
+    newer_refund = _payment_event_object(
+        object_id="ch_test_newer_payment_refund",
+        payment_intent="pi_test_newer_payment",
+        refunded=True,
+        amount_refunded=150000,
+        amount_captured=150000,
+    )
+    newer_refund_event = SimpleNamespace(
+        id="evt_deflection_newer_payment_refund",
+        type="charge.refunded",
+        data=SimpleNamespace(object=newer_refund),
+    )
+    pool = _Pool()
+    pool.add_report(
+        account_id=account_id,
+        paid=False,
+        payment_reference="cs_test_newer_payment",
+    )
+    pool.delivery_rows[(account_id, "req-123")] = {
+        "account_id": account_id,
+        "request_id": "req-123",
+        "payment_reference": "cs_test_newer_payment",
+        "delivery_status": "revoked",
+        "delivery_error": "payment_revoked:charge.dispute.created",
+    }
+
+    older_stripe, older_session_list = _stripe_module_for_event(
+        older_won_event,
+        checkout_sessions=[older_session],
+    )
+    assert await _run_stripe_webhook(
+        monkeypatch,
+        event=older_won_event,
+        pool=pool,
+        stripe_module=older_stripe,
+    ) == {"status": "ok"}
+
+    assert older_session_list.calls == [
+        {"payment_intent": "pi_test_older_payment", "limit": 1, "timeout": 10}
+    ]
+    restore_updates = [
+        call
+        for call in pool.execute_calls
+        if "UPDATE content_ops_deflection_reports" in call[0]
+    ]
+    restore_delivery_calls = [
+        call
+        for call in pool.execute_calls
+        if "INSERT INTO content_ops_deflection_report_deliveries" in call[0]
+    ]
+    assert restore_updates[0][1] == (account_id, "req-123", None)
+    assert restore_delivery_calls[0][1] == (account_id, "req-123", None)
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
+    assert pool.report_rows[(account_id, "req-123")]["payment_reference"] == (
+        "cs_test_newer_payment"
+    )
+    assert pool.delivery_rows[(account_id, "req-123")]["payment_reference"] == (
+        "cs_test_newer_payment"
+    )
+    assert "preserved newer payment reference" in caplog.text
+
+    newer_stripe, newer_session_list = _stripe_module_for_event(
+        newer_refund_event,
+        checkout_sessions=[newer_session],
+    )
+    assert await _run_stripe_webhook(
+        monkeypatch,
+        event=newer_refund_event,
+        pool=pool,
+        stripe_module=newer_stripe,
+    ) == {"status": "ok"}
+
+    assert newer_session_list.calls == [
+        {"payment_intent": "pi_test_newer_payment", "limit": 1, "timeout": 10}
+    ]
+    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
+    assert pool.report_rows[(account_id, "req-123")]["payment_reference"] == (
+        "cs_test_newer_payment"
+    )
+    assert pool.delivery_rows[(account_id, "req-123")]["delivery_status"] == "revoked"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Dispute-Restore-Hardening.md
Slice phase: Production hardening

This #1386 slice closes the restore side of the refund/dispute lifecycle: when Stripe closes a content-ops deflection dispute as won, the paid report is marked paid again and delivery is requeued through the existing paid-report delivery queue. Non-won closed disputes remain observed but non-mutating.

## Intentional
- No new Stripe Charge lookup; this keeps the current Checkout Session lookup by `payment_intent` or direct metadata path.
- No schema change; existing `mark_paid` and delivery upsert semantics already model restore.
- Only `status="won"` restores access; `lost` and `warning_closed` remain non-mutating.

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes.
- Fixed chatgpt-codex-connector stale-reference finding: a late older dispute-win restore now preserves a newer stored `payment_reference`, and regression coverage proves a later newer-payment refund still relocks access.

## Deferred
- PaymentIntent/Charge metadata copy in atlas-portfolio remains a separate hardening option so future dispute objects are self-describing even when Checkout Session lookup is unavailable.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` -- 43 passed, 1 warning.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 1 passed, 1 warning.
- `python -m pytest tests/test_alerts.py tests/test_atlas_billing_stripe_hardening.py tests/test_b2b_vendor_briefing.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_content_ops_deflection_incidents.py tests/test_mcp_content_ops_deflection_readonly.py -q` -- 181 passed, 1 warning.
- Python syntax compile over changed Python files and `git diff --check` -- passed.
- Push-wrapper local review -- passed.

## Diff size
3 files, +570 / -0. Over 400 LOC because the AI reconciliation fix includes a same-class stale-reference regression for the full old-dispute-win -> newer-refund sequence.
