### PR TITLE
Deflection inspect preview gate

### DIFF
--- a/plans/PR-Deflection-Inspect-Preview-Gate.md
+++ b/plans/PR-Deflection-Inspect-Preview-Gate.md
@@ -1,0 +1,121 @@
+# PR-Deflection-Inspect-Preview-Gate
+
+## Why this slice exists
+
+#1384's remaining ATLAS-side launch gap is the pre-payment inspect gate. CSV
+parser hardening, HTML normalization, and provider-shaped fixtures are merged,
+but the public FAQ deflection upload still goes straight from browser -> private
+Blob -> submit/report generation. A bad or ticket-index-only CSV can therefore
+reach the locked-report path before the buyer sees the existing ingestion
+diagnostics.
+
+This slice gates the public portfolio submit flow with the existing ATLAS
+`/content-ops/ingestion/files/inspect` contract before private Blob upload and
+report generation. It does not invent a new parser or LLM path.
+
+The diff is over the 400 LOC soft cap because the gate is indivisible at this
+layer: the server proxy, browser block, submit-route enforcement, and
+CI-facing negative tests must land together or the public page either exposes an
+unauthenticated client call, shows diagnostics without enforcement, leaves the
+submit API bypassable, or enforces a gate with no failure-branch coverage.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Functional validation
+
+1. Add a portfolio server route that forwards browser multipart inspect requests
+   to ATLAS with server-side auth, byte limits, and fail-closed response
+   projection.
+2. Run inspect from `FaqDeflectionUpload` before private Blob upload; block
+   normal report creation when inspect fails or returns `ok: false`.
+3. Re-inspect the private Blob server-side in the submit route before forwarding
+   to ATLAS report generation so direct submit API calls cannot bypass the gate.
+4. Show bounded diagnostics in the upload page: ticket/source count, source
+   type counts, warning/missing-field counts, and sample preview.
+5. Extend the enrolled portfolio upload shell test for success and failure
+   paths. No new test script or workflow enrollment is needed.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The browser never receives ATLAS URL/token/account credentials.
+  - [ ] The inspect route forwards multipart bytes to ATLAS with auth and caps
+        upload size before forwarding.
+  - [ ] Malformed ATLAS inspect envelopes fail closed.
+  - [ ] `ok: false` inspect diagnostics block browser Blob upload and direct
+        private-Blob report submit.
+  - [ ] `ok: true` diagnostics allow the existing private Blob submit path.
+  - [ ] UI copy calls this a pre-flight/preview, not a paid-report result.
+- Affected surfaces: portfolio deflection API route, public upload page, enrolled
+  portfolio upload shell test.
+- Risk areas: secret leakage, double-upload ergonomics, malformed upstream
+  envelope handling, false-green source tests.
+- Reviewer rules triggered: R1, R2, R3, R5, R9, R10, R12, R13.
+
+### Files touched
+
+- `plans/PR-Deflection-Inspect-Preview-Gate.md`
+- `portfolio-ui/api/content-ops/deflection/inspect.js`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+
+## Mechanism
+
+`FaqDeflectionUpload` builds a `FormData` payload with the selected CSV and
+deflection defaults (`source_rows=true`, `source=ticket-csv-upload`,
+`target_mode=faq_deflection_report`, `file_format=csv`, small sample limit).
+It posts that payload to `/api/content-ops/deflection/inspect`.
+
+The new portfolio route disables body parsing, reads the raw multipart request
+with a strict byte cap, and forwards the same body to ATLAS
+`/api/v1/content-ops/ingestion/files/inspect` using `ATLAS_B2B_JWT` from the
+server environment. It projects only bounded diagnostics back to the browser.
+
+If browser inspect fails, is malformed, or returns `ok: false`, the UI renders
+the diagnostics/error and does not start private Blob upload. If browser inspect
+succeeds, the private Blob upload runs.
+
+The submit route does not trust that browser state. After reading the private
+Blob, it builds its own ATLAS inspect `FormData` from the stored CSV, requires
+`ok: true`, and only then forwards to `/api/v1/content-ops/deflection-reports/submit`.
+A direct API caller with only a `blob_pathname` therefore cannot bypass the
+pre-payment gate.
+
+## Intentional
+
+- This is a validation gate, not a replacement for the paid result page.
+- The normal UI path inspects before Blob upload, then the submit route
+  re-inspects the private Blob. That duplicate deterministic inspect is
+  intentional because the submit API must not trust React state.
+- The route projects diagnostics instead of returning the full upstream payload
+  so source material and raw emails do not leak into the browser by accident.
+
+## Deferred
+
+- Richer provider-specific remediation copy can be added after this gate lands.
+- True operator-supplied sanitized provider exports remain a stronger #1384 proof
+  when supplied.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm ci` (portfolio-ui dependencies installed for local build)
+- `npm run build` (passes; Vite reports existing sitemap/chunk-size warnings)
+- `npm run test:deflection-upload-shell` (25/25 ok)
+- `npm run test:deflection-result` (18/18 ok)
+- `npm run test:deflection-atlas-proxy` (17/17 ok)
+- `git diff --check`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Inspect-Preview-Gate.md` | 121 |
+| `portfolio-ui/api/content-ops/deflection/inspect.js` | 224 |
+| `portfolio-ui/api/content-ops/deflection/submit.js` | 39 |
+| `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` | 365 |
+| `portfolio-ui/src/pages/FaqDeflectionUpload.tsx` | 214 |
+| **Total** | **963** |

--- a/portfolio-ui/api/content-ops/deflection/inspect.js
+++ b/portfolio-ui/api/content-ops/deflection/inspect.js
@@ -1,0 +1,224 @@
+import { atlasUrl, clean, configFromEnv } from "./atlas-report.js";
+
+const INSPECT_PATH = "/api/v1/content-ops/ingestion/files/inspect";
+const MAX_INSPECT_MULTIPART_BYTES = 51 * 1024 * 1024;
+const MAX_SAMPLE_COUNT = 3;
+const MAX_SAMPLE_FIELD_CHARS = 240;
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+function json(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(JSON.stringify(payload));
+}
+
+function header(req, name) {
+  const lower = name.toLowerCase();
+  return clean(req.headers?.[lower]) || clean(req.headers?.[name]);
+}
+
+function inspectConfig(env = process.env) {
+  const config = configFromEnv(env);
+  const errors = [];
+  if (!config.baseUrl) errors.push("atlas_base_url_missing");
+  if (!config.token) errors.push("atlas_token_missing");
+  return { config, errors };
+}
+
+async function readRequestBody(req, maxBytes = MAX_INSPECT_MULTIPART_BYTES) {
+  if (Buffer.isBuffer(req.body)) {
+    if (req.body.length > maxBytes) return { ok: false, statusCode: 413 };
+    return { ok: true, body: req.body };
+  }
+  if (typeof req.body === "string") {
+    const body = Buffer.from(req.body);
+    if (body.length > maxBytes) return { ok: false, statusCode: 413 };
+    return { ok: true, body };
+  }
+
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.from(chunk);
+    total += buffer.length;
+    if (total > maxBytes) return { ok: false, statusCode: 413 };
+    chunks.push(buffer);
+  }
+  return { ok: true, body: Buffer.concat(chunks) };
+}
+
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function countMap(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const projected = {};
+  for (const [key, rawValue] of Object.entries(value)) {
+    const count = finiteNumber(rawValue);
+    if (count === null) return null;
+    projected[clean(key) || "unknown"] = count;
+  }
+  return projected;
+}
+
+function sanitizeSampleValue(value) {
+  if (typeof value === "string") {
+    return value
+      .replace(EMAIL_RE, "[redacted-email]")
+      .slice(0, MAX_SAMPLE_FIELD_CHARS);
+  }
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return value;
+  }
+  return "";
+}
+
+function sanitizeSample(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const projected = {};
+  for (const [key, value] of Object.entries(row)) {
+    const cleanKey = clean(key);
+    if (!cleanKey) continue;
+    projected[cleanKey] = sanitizeSampleValue(value);
+  }
+  return projected;
+}
+
+function projectInspectPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  if (typeof payload.ok !== "boolean") return null;
+  const opportunityCount = finiteNumber(payload.opportunity_count);
+  const warningCount = finiteNumber(payload.warning_count);
+  const warningCounts = countMap(payload.warning_counts);
+  const missingFieldCounts = countMap(payload.missing_field_counts);
+  const sourceTypeCounts = countMap(payload.source_type_counts);
+  if (
+    opportunityCount === null ||
+    warningCount === null ||
+    warningCounts === null ||
+    missingFieldCounts === null ||
+    sourceTypeCounts === null ||
+    !Array.isArray(payload.samples)
+  ) {
+    return null;
+  }
+  const samples = payload.samples
+    .slice(0, MAX_SAMPLE_COUNT)
+    .map(sanitizeSample)
+    .filter(Boolean);
+  return {
+    ok: payload.ok,
+    ingestion_path: clean(payload.ingestion_path),
+    mode: clean(payload.mode),
+    opportunity_count: opportunityCount,
+    warning_count: warningCount,
+    warning_counts: warningCounts,
+    missing_field_counts: missingFieldCounts,
+    source_type_counts: sourceTypeCounts,
+    samples,
+  };
+}
+
+async function forwardInspect({ config, contentType, body, fetchImpl = fetch }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+  const headers = {
+    "Accept": "application/json",
+    "Authorization": `Bearer ${config.token}`,
+  };
+  if (contentType) headers["Content-Type"] = contentType;
+  try {
+    const response = await fetchImpl(atlasUrl(config.baseUrl, INSPECT_PATH), {
+      method: "POST",
+      headers,
+      body,
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let payload = null;
+    if (text) {
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        return { ok: false, statusCode: 502, error: "atlas_inspect_invalid_json" };
+      }
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        statusCode: response.status >= 400 && response.status < 500 ? response.status : 502,
+        error: "atlas_inspect_failed",
+        atlas_status: response.status,
+      };
+    }
+    const projected = projectInspectPayload(payload);
+    if (!projected) {
+      return { ok: false, statusCode: 502, error: "atlas_inspect_contract_violation" };
+    }
+    return { ok: true, statusCode: 200, payload: projected };
+  } catch (error) {
+    return {
+      ok: false,
+      statusCode: error?.name === "AbortError" ? 504 : 502,
+      error: "atlas_inspect_unreachable",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export {
+  INSPECT_PATH,
+  MAX_INSPECT_MULTIPART_BYTES,
+  forwardInspect,
+  inspectConfig,
+  projectInspectPayload,
+  readRequestBody,
+};
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    json(res, 405, { ok: false, error: "method_not_allowed" });
+    return;
+  }
+  const contentType = header(req, "content-type");
+  if (!contentType.includes("multipart/form-data")) {
+    json(res, 415, { ok: false, error: "multipart_required" });
+    return;
+  }
+  const { config: atlasConfig, errors } = inspectConfig();
+  if (errors.length > 0) {
+    json(res, 503, { ok: false, error: "atlas_inspect_not_configured" });
+    return;
+  }
+
+  const body = await readRequestBody(req);
+  if (!body.ok) {
+    json(res, body.statusCode, { ok: false, error: "deflection_inspect_csv_too_large" });
+    return;
+  }
+
+  const result = await forwardInspect({
+    config: atlasConfig,
+    contentType,
+    body: body.body,
+  });
+  if (!result.ok) {
+    json(res, result.statusCode, {
+      ok: false,
+      error: result.error,
+      atlas_status: result.atlas_status,
+    });
+    return;
+  }
+  json(res, 200, result.payload);
+}

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -1,6 +1,7 @@
 import { atlasUrl, clean, configFromEnv } from "./atlas-report.js";
 import { resultPath } from "./checkout.js";
 import { emitDeflectionServerEvent } from "./events.js";
+import { forwardInspect } from "./inspect.js";
 
 const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -214,6 +215,32 @@ async function cleanupPrivateCsvBlob({
   }
 }
 
+function inspectFormFromBlob(blob) {
+  const form = new FormData();
+  form.set("file", new Blob([blob.body], { type: blob.contentType }), blob.fileName);
+  form.set("source_rows", "true");
+  form.set("source", "ticket-csv-upload");
+  form.set("target_mode", "faq_deflection_report");
+  form.set("file_format", "csv");
+  form.set("sample_limit", "3");
+  form.set("include_source_material", "false");
+  return form;
+}
+
+async function inspectPrivateCsvBlob({ config, blob, fetchImpl = fetch }) {
+  const result = await forwardInspect({
+    config,
+    contentType: "",
+    body: inspectFormFromBlob(blob),
+    fetchImpl,
+  });
+  if (!result.ok) return result;
+  if (!result.payload.ok) {
+    return { ok: false, statusCode: 400, error: "deflection_inspect_not_ready" };
+  }
+  return { ok: true, payload: result.payload };
+}
+
 async function submitPrivateBlob({
   config,
   blobToken,
@@ -229,6 +256,17 @@ async function submitPrivateBlob({
     getBlobImpl,
   });
   if (!blob.ok) return blob;
+
+  const inspectResult = await inspectPrivateCsvBlob({ config, blob, fetchImpl });
+  if (!inspectResult.ok) {
+    await cleanupPrivateCsvBlob({
+      pathname: blob.pathname,
+      token: blobToken,
+      deleteBlobImpl,
+      eventLogger,
+    });
+    return inspectResult;
+  }
 
   const form = new FormData();
   form.set("csv_file", new Blob([blob.body], { type: blob.contentType }), blob.fileName);
@@ -253,6 +291,7 @@ export {
   SUBMIT_PATH,
   cleanupPrivateCsvBlob,
   forwardSubmit,
+  inspectPrivateCsvBlob,
   projectSubmitPayload,
   readPrivateCsvBlob,
   submitPrivateBlob,

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -11,6 +11,10 @@ import submitHandler, {
   readPrivateCsvBlob,
   submitPrivateBlob,
 } from "../api/content-ops/deflection/submit.js";
+import inspectHandler, {
+  INSPECT_PATH,
+  MAX_INSPECT_MULTIPART_BYTES,
+} from "../api/content-ops/deflection/inspect.js";
 import {
   CSV_CONTENT_TYPES,
   MAX_BLOB_CSV_BYTES as MAX_UPLOAD_CSV_BYTES,
@@ -32,6 +36,7 @@ const appSource = await readFile(resolve(root, "src/App.tsx"), "utf8");
 const servicesSource = await readFile(resolve(root, "src/pages/Services.tsx"), "utf8");
 const uploadSource = await readFile(resolve(root, "src/pages/FaqDeflectionUpload.tsx"), "utf8");
 const submitSource = await readFile(resolve(root, "api/content-ops/deflection/submit.js"), "utf8");
+const inspectSource = await readFile(resolve(root, "api/content-ops/deflection/inspect.js"), "utf8");
 const submitSmokeSource = await readFile(
   resolve(root, "scripts/faq-deflection-submit-live-smoke.mjs"),
   "utf8",
@@ -49,6 +54,28 @@ const ENV = {
   ATLAS_ACCOUNT_ID: ACCOUNT_ID,
   BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_token",
 };
+const READY_INSPECT_PAYLOAD = {
+  ok: true,
+  ingestion_path: "file_upload",
+  mode: "source_rows",
+  opportunity_count: 1,
+  warning_count: 0,
+  warning_counts: {},
+  missing_field_counts: {},
+  source_type_counts: { support_ticket: 1 },
+  samples: [],
+};
+const NOT_READY_INSPECT_PAYLOAD = {
+  ok: false,
+  ingestion_path: "file_upload",
+  mode: "source_rows",
+  opportunity_count: 0,
+  warning_count: 1,
+  warning_counts: { no_rows: 1 },
+  missing_field_counts: { target_id: 1 },
+  source_type_counts: {},
+  samples: [],
+};
 const MULTIPART_BODY = Buffer.from(
   [
     "--atlas",
@@ -65,6 +92,34 @@ const MULTIPART_BODY = Buffer.from(
     "lead@acme.example",
     "--atlas",
     'Content-Disposition: form-data; name="csv_file"; filename="tickets.csv"',
+    "Content-Type: text/csv",
+    "",
+    "ticket_id,message",
+    "ticket-1,How do I export reports?",
+    "--atlas--",
+    "",
+  ].join("\r\n"),
+);
+const INSPECT_MULTIPART_BODY = Buffer.from(
+  [
+    "--atlas",
+    'Content-Disposition: form-data; name="source_rows"',
+    "",
+    "true",
+    "--atlas",
+    'Content-Disposition: form-data; name="source"',
+    "",
+    "ticket-csv-upload",
+    "--atlas",
+    'Content-Disposition: form-data; name="target_mode"',
+    "",
+    "faq_deflection_report",
+    "--atlas",
+    'Content-Disposition: form-data; name="file_format"',
+    "",
+    "csv",
+    "--atlas",
+    'Content-Disposition: form-data; name="file"; filename="tickets.csv"',
     "Content-Type: text/csv",
     "",
     "ticket_id,message",
@@ -145,8 +200,10 @@ await test("upload shell exposes live submit markers and avoids browser credenti
     "data-atlas-deflection-contact-email",
     "data-atlas-deflection-support-platform",
     "data-atlas-deflection-submit",
+    "data-atlas-deflection-inspect-endpoint",
     "data-atlas-deflection-upload-endpoint",
     "data-atlas-deflection-upload-progress",
+    "data-atlas-deflection-inspect-preview",
     "data-atlas-deflection-export-guidance",
     "data-atlas-deflection-retry",
   ]) {
@@ -174,7 +231,19 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.doesNotMatch(uploadSource, /exact mathematical clustering/);
   assert.match(uploadSource, /Workspace routing is handled server-side/);
   assert.match(uploadSource, /Your browser never[\s\S]*receives ATLAS service tokens/);
-  assert.match(uploadSource, /Your CSV stays in private storage first/);
+  assert.match(uploadSource, /CSV inspection and private storage both run\s+server-side/);
+  assert.match(uploadSource, /ATLAS checks the CSV first[\s\S]*stores it privately after validation/);
+  assert.match(uploadSource, /const INSPECT_ENDPOINT = "\/api\/content-ops\/deflection\/inspect"/);
+  assert.match(uploadSource, /fetch\(INSPECT_ENDPOINT/);
+  assert.match(uploadSource, /source_rows", "true"/);
+  assert.match(uploadSource, /target_mode", "faq_deflection_report"/);
+  assert.match(uploadSource, /Checking CSV/);
+  assert.match(uploadSource, /CSV pre-flight passed/);
+  assert.match(uploadSource, /CSV needs a fuller export/);
+  assert.ok(
+    uploadSource.indexOf("await inspectDeflectionCsv") < uploadSource.indexOf("uploadBlob("),
+    "inspect must run before private Blob upload",
+  );
   assert.doesNotMatch(uploadSource, />\s*Support-ticket CSV upload\s*</);
   assert.doesNotMatch(uploadSource, /Bound server-side to the configured report workspace/);
   assert.doesNotMatch(uploadSource, /CSV bytes are first stored in private Vercel Blob/);
@@ -186,12 +255,164 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.match(uploadSource, /value: "other", label: "Freshdesk \/ other"/);
   assert.doesNotMatch(uploadSource, /value: "freshdesk"/);
   assert.doesNotMatch(uploadSource, /value: "help-scout"/);
-  assert.doesNotMatch(uploadSource, /new FormData/);
+  assert.match(uploadSource, /new FormData\(\)/);
   assert.match(uploadSource, /JSON\.stringify/);
   assert.doesNotMatch(uploadSource, /X-Atlas-Account-Id|account_id/);
   assert.doesNotMatch(uploadSource, /ATLAS_B2B_JWT|ATLAS_API_BASE_URL|ATLAS_TOKEN/);
   assert.doesNotMatch(uploadSource, /Authorization/);
   assert.doesNotMatch(uploadSource, /\/paid\b/);
+});
+
+await test("portfolio inspect endpoint forwards multipart to ATLAS and redacts preview samples", async () => {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({
+          ok: true,
+          ingestion_path: "file_upload",
+          mode: "source_rows",
+          opportunity_count: 2,
+          warning_count: 0,
+          warning_counts: {},
+          missing_field_counts: {},
+          source_type_counts: { support_ticket: 2 },
+          samples: [{
+            target_id: "ticket-1",
+            text: "Customer lead@example.com asks how to export reports.",
+          }],
+          source_material: [{
+            contact_email: "lead@example.com",
+          }],
+        });
+      },
+    };
+  };
+  const res = mockResponse();
+  try {
+    await withEnv(ENV, async () => {
+      await inspectHandler(
+        request({ body: INSPECT_MULTIPART_BODY }),
+        res,
+      );
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${INSPECT_PATH}`);
+  assert.equal(calls[0].options.method, "POST");
+  assert.equal(calls[0].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
+  assert.equal(calls[0].options.headers["Content-Type"], "multipart/form-data; boundary=atlas");
+  assert.deepEqual(calls[0].options.body, INSPECT_MULTIPART_BODY);
+  const payload = JSON.parse(res.body);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.opportunity_count, 2);
+  assert.deepEqual(payload.source_type_counts, { support_ticket: 2 });
+  assert.equal(payload.samples[0].text.includes("[redacted-email]"), true);
+  assert.equal("source_material" in payload, false);
+  assert.equal(res.body.includes(ENV.ATLAS_B2B_JWT), false);
+  assert.equal(res.body.includes("lead@example.com"), false);
+});
+
+await test("portfolio inspect endpoint returns not-ready diagnostics without failing transport", async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async text() {
+      return JSON.stringify({
+        ok: false,
+        ingestion_path: "file_upload",
+        mode: "source_rows",
+        opportunity_count: 0,
+        warning_count: 1,
+        warning_counts: { no_rows: 1 },
+        missing_field_counts: { target_id: 1 },
+        source_type_counts: {},
+        samples: [],
+      });
+    },
+  });
+  const res = mockResponse();
+  try {
+    await withEnv(ENV, async () => {
+      await inspectHandler(request({ body: INSPECT_MULTIPART_BODY }), res);
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: false,
+    ingestion_path: "file_upload",
+    mode: "source_rows",
+    opportunity_count: 0,
+    warning_count: 1,
+    warning_counts: { no_rows: 1 },
+    missing_field_counts: { target_id: 1 },
+    source_type_counts: {},
+    samples: [],
+  });
+});
+
+await test("portfolio inspect endpoint fails closed on malformed ATLAS envelope", async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async text() {
+      return JSON.stringify({ ok: true, samples: [] });
+    },
+  });
+  const res = mockResponse();
+  try {
+    await withEnv(ENV, async () => {
+      await inspectHandler(request({ body: INSPECT_MULTIPART_BODY }), res);
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(res.statusCode, 502);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: false,
+    error: "atlas_inspect_contract_violation",
+  });
+});
+
+await test("portfolio inspect endpoint caps multipart bytes before ATLAS", async () => {
+  const previousFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    throw new Error("must not call ATLAS for oversized inspect");
+  };
+  const res = mockResponse();
+  try {
+    await withEnv(ENV, async () => {
+      await inspectHandler(
+        request({ body: Buffer.alloc(MAX_INSPECT_MULTIPART_BYTES + 1) }),
+        res,
+      );
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(fetchCalled, false);
+  assert.equal(res.statusCode, 413);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: false,
+    error: "deflection_inspect_csv_too_large",
+  });
 });
 
 await test("portfolio submit endpoint pins private Blob submit handling", () => {
@@ -201,6 +422,11 @@ await test("portfolio submit endpoint pins private Blob submit handling", () => 
   assert.match(submitSource, /const \{ del \} = await import\("@vercel\/blob"\)/);
   assert.match(submitSource, /direct_multipart_deprecated/);
   assert.doesNotMatch(submitSource, /readRawBody|MAX_MULTIPART_OVERHEAD_BYTES/);
+  assert.match(submitSource, /inspectPrivateCsvBlob/);
+  assert.match(submitSource, /deflection_inspect_not_ready/);
+  assert.match(inspectSource, /bodyParser:\s*false/);
+  assert.match(inspectSource, /projectInspectPayload/);
+  assert.doesNotMatch(inspectSource, /ATLAS_B2B_JWT[^\\n]*console\\.log/);
 });
 
 await test("submit live smoke exercises the production private blob helper", async () => {
@@ -417,6 +643,16 @@ await test("private blob submit reads server-side blob and forwards ATLAS multip
     },
     fetchImpl: async (url, options) => {
       calls.push({ url, options });
+      if (url.endsWith(INSPECT_PATH)) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify(READY_INSPECT_PAYLOAD);
+          },
+        };
+      }
+      assert.equal(url.endsWith(SUBMIT_PATH), true);
       return {
         ok: true,
         status: 200,
@@ -432,14 +668,81 @@ await test("private blob submit reads server-side blob and forwards ATLAS multip
 
   assert.equal(result.ok, true);
   assert.equal(result.payload.result_path.includes("content-ops-private123"), true);
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${INSPECT_PATH}`);
   assert.equal(calls[0].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
   assert.equal("Content-Type" in calls[0].options.headers, false);
   assert.equal(calls[0].options.body instanceof FormData, true);
-  assert.equal(calls[0].options.body.get("support_platform"), "zendesk");
-  assert.equal(calls[0].options.body.get("company_name"), "Acme Co.");
-  assert.equal(await calls[0].options.body.get("csv_file").text(), csv);
+  assert.equal(calls[0].options.body.get("source_rows"), "true");
+  assert.equal(calls[0].options.body.get("target_mode"), "faq_deflection_report");
+  assert.equal(await calls[0].options.body.get("file").text(), csv);
+  assert.equal(calls[1].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);
+  assert.equal(calls[1].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
+  assert.equal("Content-Type" in calls[1].options.headers, false);
+  assert.equal(calls[1].options.body instanceof FormData, true);
+  assert.equal(calls[1].options.body.get("support_platform"), "zendesk");
+  assert.equal(calls[1].options.body.get("company_name"), "Acme Co.");
+  assert.equal(await calls[1].options.body.get("csv_file").text(), csv);
+  assert.deepEqual(deleteCalls, [
+    {
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      options: { token: ENV.BLOB_READ_WRITE_TOKEN },
+    },
+  ]);
+});
+
+await test("private blob submit blocks not-ready inspect before report submit", async () => {
+  const calls = [];
+  const deleteCalls = [];
+  const csv = "ticket_id,message\nticket-1,How do I export reports?";
+  const result = await submitPrivateBlob({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      support_platform: "zendesk",
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    getBlobImpl: async () => ({
+      statusCode: 200,
+      stream: new Blob([csv], { type: "text/csv" }).stream(),
+      blob: {
+        size: Buffer.byteLength(csv),
+        contentType: "text/csv",
+      },
+    }),
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      if (url.endsWith(SUBMIT_PATH)) {
+        throw new Error("not-ready inspect must block report submit");
+      }
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify(NOT_READY_INSPECT_PAYLOAD);
+        },
+      };
+    },
+    deleteBlobImpl: async (pathname, options) => {
+      deleteCalls.push({ pathname, options });
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    statusCode: 400,
+    error: "deflection_inspect_not_ready",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${INSPECT_PATH}`);
   assert.deepEqual(deleteCalls, [
     {
       pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
@@ -474,13 +777,24 @@ await test("private blob cleanup preserves ATLAS failure result", async () => {
         contentType: "text/csv",
       },
     }),
-    fetchImpl: async () => ({
-      ok: false,
-      status: 502,
-      async text() {
-        return JSON.stringify({ error: "upstream failed" });
-      },
-    }),
+    fetchImpl: async (url) => {
+      if (url.endsWith(INSPECT_PATH)) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify(READY_INSPECT_PAYLOAD);
+          },
+        };
+      }
+      return {
+        ok: false,
+        status: 502,
+        async text() {
+          return JSON.stringify({ error: "upstream failed" });
+        },
+      };
+    },
     deleteBlobImpl: async (pathname, options) => {
       deleteCalls.push({ pathname, options });
     },
@@ -526,13 +840,24 @@ await test("private blob cleanup failure does not mask submit success", async ()
         contentType: "text/csv",
       },
     }),
-    fetchImpl: async () => ({
-      ok: true,
-      status: 200,
-      async text() {
-        return JSON.stringify({ request_id: "content-ops-cleanup123" });
-      },
-    }),
+    fetchImpl: async (url) => {
+      if (url.endsWith(INSPECT_PATH)) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify(READY_INSPECT_PAYLOAD);
+          },
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ request_id: "content-ops-cleanup123" });
+        },
+      };
+    },
     deleteBlobImpl: async () => {
       throw new Error("delete unavailable");
     },

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -14,6 +14,7 @@ import {
 import { SeoHead } from "@/components/seo/SeoHead";
 
 const SUBMIT_ENDPOINT = "/api/content-ops/deflection/submit";
+const INSPECT_ENDPOINT = "/api/content-ops/deflection/inspect";
 const BLOB_UPLOAD_ENDPOINT = "/api/content-ops/deflection/upload";
 const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
 const MAX_CSV_BYTES = 50 * 1024 * 1024;
@@ -31,8 +32,26 @@ type UploadState =
 
 type SubmitState =
   | { status: "idle" }
+  | { status: "inspecting" }
   | { status: "uploading"; percentage: number }
   | { status: "submitting" }
+  | { status: "error"; message: string };
+
+type InspectDiagnostics = {
+  ok: boolean;
+  opportunity_count: number;
+  warning_count: number;
+  warning_counts: Record<string, number>;
+  missing_field_counts: Record<string, number>;
+  source_type_counts: Record<string, number>;
+  samples: Array<Record<string, unknown>>;
+};
+
+type InspectState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "ready"; diagnostics: InspectDiagnostics }
+  | { status: "not_ready"; diagnostics: InspectDiagnostics; message: string }
   | { status: "error"; message: string };
 
 function formatBytes(bytes: number) {
@@ -70,11 +89,71 @@ function boundedProgress(percentage: number | undefined) {
   return Math.max(0, Math.min(100, Math.round(percentage ?? 0)));
 }
 
+function countSummary(counts: Record<string, number>) {
+  const entries = Object.entries(counts).filter(([, value]) => value > 0);
+  if (entries.length === 0) return "none";
+  return entries.map(([key, value]) => `${key}: ${value}`).join(", ");
+}
+
+function inspectMessage(diagnostics: InspectDiagnostics) {
+  if (diagnostics.opportunity_count <= 0) {
+    return "ATLAS could not find usable ticket rows in this CSV. Re-export full ticket threads before creating a report.";
+  }
+  if (Object.values(diagnostics.missing_field_counts).some((value) => value > 0)) {
+    return "ATLAS found rows, but required mapped fields are missing. Check the preview before creating a report.";
+  }
+  return "ATLAS found usable rows in this CSV.";
+}
+
+async function inspectDeflectionCsv(file: File): Promise<InspectDiagnostics> {
+  const formData = new FormData();
+  formData.set("file", file);
+  formData.set("source_rows", "true");
+  formData.set("source", "ticket-csv-upload");
+  formData.set("target_mode", "faq_deflection_report");
+  formData.set("file_format", "csv");
+  formData.set("sample_limit", "3");
+  formData.set("include_source_material", "false");
+  const response = await fetch(INSPECT_ENDPOINT, { method: "POST", body: formData });
+  const payload = (await response.json().catch(() => null)) as Partial<InspectDiagnostics> & {
+    error?: unknown;
+  } | null;
+  if (!response.ok) {
+    throw new Error(
+      payload && typeof payload.error === "string"
+        ? payload.error
+        : "CSV pre-flight inspection failed.",
+    );
+  }
+  if (
+    !payload ||
+    typeof payload.ok !== "boolean" ||
+    typeof payload.opportunity_count !== "number" ||
+    typeof payload.warning_count !== "number" ||
+    !payload.warning_counts ||
+    !payload.missing_field_counts ||
+    !payload.source_type_counts ||
+    !Array.isArray(payload.samples)
+  ) {
+    throw new Error("CSV pre-flight inspection returned an invalid response.");
+  }
+  return {
+    ok: payload.ok,
+    opportunity_count: payload.opportunity_count,
+    warning_count: payload.warning_count,
+    warning_counts: payload.warning_counts,
+    missing_field_counts: payload.missing_field_counts,
+    source_type_counts: payload.source_type_counts,
+    samples: payload.samples,
+  };
+}
+
 export default function FaqDeflectionUpload() {
   const [companyName, setCompanyName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
   const [supportPlatform, setSupportPlatform] = useState<string>(SUPPORT_PLATFORMS[0].value);
   const [upload, setUpload] = useState<UploadState>({ status: "empty" });
+  const [inspect, setInspect] = useState<InspectState>({ status: "idle" });
   const [submit, setSubmit] = useState<SubmitState>({ status: "idle" });
 
   const fieldsReady = useMemo(
@@ -87,13 +166,32 @@ export default function FaqDeflectionUpload() {
       ),
     [companyName, contactEmail, supportPlatform, upload.status],
   );
-  const canSubmit = fieldsReady && submit.status !== "uploading" && submit.status !== "submitting";
+  const canSubmit =
+    fieldsReady &&
+    submit.status !== "inspecting" &&
+    submit.status !== "uploading" &&
+    submit.status !== "submitting";
   const isRetry = submit.status === "error";
 
   const startSubmit = async () => {
     if (upload.status !== "ready" || !fieldsReady) return;
 
+    let phase: "inspect" | "upload" = "inspect";
     try {
+      setSubmit({ status: "inspecting" });
+      setInspect({ status: "checking" });
+      const diagnostics = await inspectDeflectionCsv(upload.file);
+      if (!diagnostics.ok) {
+        setInspect({
+          status: "not_ready",
+          diagnostics,
+          message: inspectMessage(diagnostics),
+        });
+        setSubmit({ status: "idle" });
+        return;
+      }
+      setInspect({ status: "ready", diagnostics });
+      phase = "upload";
       setSubmit({ status: "uploading", percentage: 0 });
       const blob = await uploadBlob(blobPathname(upload.fileName), upload.file, {
         access: "private",
@@ -135,8 +233,15 @@ export default function FaqDeflectionUpload() {
         return;
       }
       window.location.assign(payload.result_path);
-    } catch {
-      setSubmit({ status: "error", message: "FAQ deflection upload could not be completed." });
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : "FAQ deflection upload could not be completed.";
+      if (phase === "inspect") {
+        setInspect({ status: "error", message });
+      }
+      setSubmit({ status: "error", message });
     }
   };
 
@@ -156,6 +261,7 @@ export default function FaqDeflectionUpload() {
         className="mx-auto max-w-6xl px-6 py-10 md:py-14"
         data-atlas-deflection-upload
         data-atlas-deflection-submit-endpoint={SUBMIT_ENDPOINT}
+        data-atlas-deflection-inspect-endpoint={INSPECT_ENDPOINT}
         data-atlas-deflection-upload-endpoint={BLOB_UPLOAD_ENDPOINT}
       >
         <Link
@@ -223,7 +329,10 @@ export default function FaqDeflectionUpload() {
                   className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 text-sm text-white outline-none transition focus:border-primary-400"
                   data-atlas-deflection-support-platform
                   value={supportPlatform}
-                  onChange={(event) => setSupportPlatform(event.target.value)}
+                  onChange={(event) => {
+                    setSupportPlatform(event.target.value);
+                    setInspect({ status: "idle" });
+                  }}
                 >
                   {SUPPORT_PLATFORMS.map((platform) => (
                     <option key={platform.value} value={platform.value}>
@@ -252,7 +361,10 @@ export default function FaqDeflectionUpload() {
                 data-atlas-deflection-csv-file
                 type="file"
                 accept=".csv,text/csv"
-                onChange={(event) => setUpload(fileState(event.target.files?.[0]))}
+                onChange={(event) => {
+                  setUpload(fileState(event.target.files?.[0]));
+                  setInspect({ status: "idle" });
+                }}
               />
               <div
                 className="mt-4 space-y-2 text-xs leading-5 text-surface-200/70"
@@ -278,9 +390,8 @@ export default function FaqDeflectionUpload() {
                 </p>
               </div>
               <span className="mt-3 block text-xs text-surface-200/60">
-                Up to 50 MB. Your CSV stays in private storage first, then
-                ATLAS reads it server-side; service tokens never reach the
-                browser.
+                Up to 50 MB. CSV inspection and private storage both run
+                server-side; service tokens never reach the browser.
               </span>
             </label>
 
@@ -323,6 +434,80 @@ export default function FaqDeflectionUpload() {
                   </div>
                 </div>
               )}
+              {inspect.status === "checking" && (
+                <div
+                  className="flex items-start gap-3 rounded-lg border border-primary-500/30 bg-primary-500/10 p-4 text-sm text-primary-100"
+                  data-atlas-deflection-inspect-preview
+                >
+                  <Loader2 className="mt-0.5 h-5 w-5 flex-none animate-spin text-primary-300" />
+                  <p>Checking CSV rows with ATLAS before private upload.</p>
+                </div>
+              )}
+              {(inspect.status === "ready" || inspect.status === "not_ready") && (
+                <div
+                  className={`rounded-lg border p-4 text-sm ${
+                    inspect.status === "ready"
+                      ? "border-primary-500/30 bg-primary-500/10 text-primary-100"
+                      : "border-amber-400/30 bg-amber-400/10 text-amber-100"
+                  }`}
+                  data-atlas-deflection-inspect-preview
+                >
+                  <div className="flex items-start gap-3">
+                    {inspect.status === "ready" ? (
+                      <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-primary-300" />
+                    ) : (
+                      <AlertTriangle className="mt-0.5 h-5 w-5 flex-none text-amber-300" />
+                    )}
+                    <div>
+                      <p className="font-semibold">
+                        {inspect.status === "ready"
+                          ? "CSV pre-flight passed"
+                          : "CSV needs a fuller export"}
+                      </p>
+                      <p className="mt-1 text-xs leading-5 opacity-80">
+                        {inspect.status === "ready"
+                          ? inspectMessage(inspect.diagnostics)
+                          : inspect.message}
+                      </p>
+                    </div>
+                  </div>
+                  <dl className="mt-3 grid gap-2 text-xs leading-5 md:grid-cols-2">
+                    <div>
+                      <dt className="font-semibold">Rows found</dt>
+                      <dd>{inspect.diagnostics.opportunity_count}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-semibold">Source types</dt>
+                      <dd>{countSummary(inspect.diagnostics.source_type_counts)}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-semibold">Warnings</dt>
+                      <dd>
+                        {inspect.diagnostics.warning_count} total;{" "}
+                        {countSummary(inspect.diagnostics.warning_counts)}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="font-semibold">Missing mapped fields</dt>
+                      <dd>{countSummary(inspect.diagnostics.missing_field_counts)}</dd>
+                    </div>
+                  </dl>
+                  {inspect.diagnostics.samples.length > 0 && (
+                    <pre className="mt-3 max-h-40 overflow-auto rounded-md bg-surface-950/70 p-3 text-[11px] leading-5 text-surface-100">
+                      {JSON.stringify(inspect.diagnostics.samples, null, 2)}
+                    </pre>
+                  )}
+                </div>
+              )}
+              {inspect.status === "error" && (
+                <div
+                  className="flex items-start gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100"
+                  data-atlas-deflection-inspect-preview
+                >
+                  <AlertTriangle className="mt-0.5 h-5 w-5 flex-none text-amber-300" />
+                  <p>{inspect.message}</p>
+                </div>
+              )}
             </div>
 
             <button
@@ -331,7 +516,12 @@ export default function FaqDeflectionUpload() {
               data-atlas-deflection-submit
               disabled={!canSubmit}
             >
-              {submit.status === "uploading" ? (
+              {submit.status === "inspecting" ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Checking CSV
+                </>
+              ) : submit.status === "uploading" ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
                   Uploading CSV
@@ -383,9 +573,9 @@ export default function FaqDeflectionUpload() {
               </div>
             </dl>
             <p className="mt-5 text-sm leading-6 text-surface-200/70">
-              ATLAS stores the CSV privately, reads it back on the server, then
-              sends the browser to the locked result page for snapshot hydration
-              and Checkout.
+              ATLAS checks the CSV first, stores it privately after validation,
+              then sends the browser to the locked result page for snapshot
+              hydration and Checkout.
             </p>
           </aside>
         </div>


### PR DESCRIPTION
Plan: plans/PR-Deflection-Inspect-Preview-Gate.md
Slice phase: Functional validation

#1384's remaining launch gap is that the public FAQ deflection upload can still go straight to private Blob submit before showing the existing ATLAS ingestion diagnostics. This adds a server-side portfolio inspect proxy, runs it before Blob upload, and re-inspects the private Blob server-side before report submit so direct API calls cannot bypass the gate.

## Intentional
- This is a validation gate, not a replacement for the paid result page.
- The normal UI path inspects before Blob upload, then the submit route re-inspects the private Blob. The duplicate deterministic inspect is intentional because the submit API cannot trust React state.
- The inspect proxy returns bounded diagnostics only, dropping full source material and redacting email-shaped sample values before the browser sees them.

## Deferred
- Richer provider-specific remediation copy can follow after the gate lands.
- Operator-supplied sanitized provider exports remain the stronger #1384 proof when available.

## Parked hardening
- None.

## AI reconciliation
- All fixed or waived: yes.
- Codex P2 "Enforce inspect before accepting submit server-side" fixed: the submit route now re-inspects the private Blob with server-side ATLAS credentials and returns `deflection_inspect_not_ready` before report submit when inspect returns `ok:false`.
- Reviewer NIT "not_ready -> no upload isn't directly tested" fixed in the enrolled upload-shell test: `private blob submit blocks not-ready inspect before report submit` asserts the report submit endpoint is never called.

## Verification
- `npm ci`
- `npm run build` (passes; Vite reports existing sitemap/chunk-size warnings)
- `npm run test:deflection-upload-shell` (25/25 ok)
- `npm run test:deflection-result` (18/18 ok)
- `npm run test:deflection-atlas-proxy` (17/17 ok)
- `git diff --check`

## Diff size
- 5 files, 963 LOC.
