### PR TITLE
Content-Ops Claim Evidence Fixture Loader

### DIFF
--- a/docs/content_ops_claim_evidence_benchmark_fixtures.md
+++ b/docs/content_ops_claim_evidence_benchmark_fixtures.md
@@ -2,8 +2,9 @@
 
 Issue #1435 benchmarks `verify_claim_evidence` before any model-filled
 structured-judgment slot can enter the verifier rubric. The benchmark input is a
-decoded list of labeled claim/evidence triples. The future runner may load this
-from JSON or JSONL, but the package contract starts after parsing.
+list of labeled claim/evidence triples. The package loader accepts raw JSON
+array text or JSONL object streams and then applies the same decoded row
+contract.
 
 ## Row Shape
 
@@ -43,6 +44,33 @@ The final #1435 benchmark set targets 40 rows:
 Seed sets do not need to hit these counts. The validator supports seed mode for
 early 5 to 10 real registry triples and final mode for the completed benchmark.
 
+## Fixture Text Formats
+
+JSON fixture text is one array of row objects:
+
+```json
+[
+  {
+    "triple_id": "real-001",
+    "claim_id": "claim-churn-001",
+    "evidence_quote": "Customers reduced manual escalation work by 31% after rollout.",
+    "source_id": "case-study-acme-q4",
+    "expected_supports": true,
+    "difficulty": "easy"
+  }
+]
+```
+
+JSONL fixture text is one row object per non-empty line:
+
+```jsonl
+{"triple_id":"real-001","claim_id":"claim-churn-001","evidence_quote":"Customers reduced manual escalation work by 31% after rollout.","source_id":"case-study-acme-q4","expected_supports":true,"difficulty":"easy"}
+{"triple_id":"hard-001","claim_id":"claim-integration-002","evidence_quote":"The platform exports CSV files for CRM import.","source_id":"docs-export","expected_supports":false,"difficulty":"hard"}
+```
+
+JSONL lines must be objects. Arrays belong in JSON fixture text, not JSONL, so
+line numbers remain unambiguous when the loader reports malformed input.
+
 ## Hard Cases
 
 Hard rows should feel like realistic B2B SaaS marketing copy and include cases
@@ -58,4 +86,4 @@ where keyword overlap is not enough:
 
 This fixture does not include model responses, prompts, provider settings,
 tokens, customer draft content, or verifier/MCP wiring. The future runner owns
-file loading, provider execution, and result artifacts.
+file-path loading, provider execution, and result artifacts.

--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -8,6 +8,7 @@ structured witness responses against the reliability thresholds from issue
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from itertools import combinations
 from typing import Mapping, Sequence
@@ -20,6 +21,9 @@ CONFIDENCE_COUNTS_MIN = 4
 FINAL_EASY_SUPPORTS_TARGET = 15
 FINAL_EASY_NOT_SUPPORTS_TARGET = 15
 FINAL_HARD_TARGET = 10
+FIXTURE_FORMAT_JSON = "json"
+FIXTURE_FORMAT_JSONL = "jsonl"
+VALID_FIXTURE_FORMATS = frozenset({FIXTURE_FORMAT_JSON, FIXTURE_FORMAT_JSONL})
 
 
 def _required_text(data: Mapping[str, object], key: str) -> str | None:
@@ -257,6 +261,68 @@ def validate_claim_evidence_fixture(
         errors.extend(_final_shape_errors(fixture))
         fixture = BenchmarkFixture(fixture.triples, tuple(errors))
     return fixture
+
+
+def load_claim_evidence_fixture_text(
+    text: object,
+    *,
+    source_format: object = FIXTURE_FORMAT_JSON,
+    require_final_shape: bool = False,
+) -> BenchmarkFixture:
+    """Load raw fixture text into the decoded benchmark fixture contract."""
+
+    if not isinstance(text, str):
+        return BenchmarkFixture((), ("fixture text must be a string",))
+    if not isinstance(source_format, str):
+        return BenchmarkFixture((), ("fixture format must be json or jsonl",))
+
+    normalized_format = source_format.strip().lower()
+    if normalized_format not in VALID_FIXTURE_FORMATS:
+        return BenchmarkFixture((), ("fixture format must be json or jsonl",))
+
+    if normalized_format == FIXTURE_FORMAT_JSON:
+        rows, errors = _decode_json_fixture_text(text)
+    else:
+        rows, errors = _decode_jsonl_fixture_text(text)
+    if errors:
+        return BenchmarkFixture((), errors)
+    return validate_claim_evidence_fixture(
+        rows,
+        require_final_shape=require_final_shape,
+    )
+
+
+def _decode_json_fixture_text(text: str) -> tuple[list[object], tuple[str, ...]]:
+    try:
+        decoded = json.loads(text)
+    except json.JSONDecodeError as error:
+        return [], (f"json fixture is malformed: {error.msg}",)
+    if not isinstance(decoded, list):
+        return [], ("json fixture must decode to a list of objects",)
+    return decoded, ()
+
+
+def _decode_jsonl_fixture_text(text: str) -> tuple[list[object], tuple[str, ...]]:
+    rows: list[object] = []
+    errors: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            decoded = json.loads(stripped)
+        except json.JSONDecodeError as error:
+            errors.append(
+                f"line {line_number}: jsonl fixture is malformed: {error.msg}"
+            )
+            continue
+        if not isinstance(decoded, Mapping):
+            errors.append(f"line {line_number}: jsonl fixture line must be an object")
+            continue
+        rows.append(decoded)
+    if errors:
+        return [], tuple(errors)
+    return rows, ()
 
 
 def _final_shape_errors(fixture: BenchmarkFixture) -> tuple[str, ...]:

--- a/plans/PR-Content-Ops-Claim-Evidence-Fixture-Loader.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Fixture-Loader.md
@@ -1,0 +1,112 @@
+# PR-Content-Ops-Claim-Evidence-Fixture-Loader
+
+## Why this slice exists
+
+#1448 made the operator-labeled benchmark fixture contract explicit after
+#1443 landed the deterministic scorer. The remaining practical gap before a
+runner can be useful is getting raw fixture text into that decoded contract
+without each caller inventing its own parser behavior.
+
+This PR lands only the deterministic loading boundary for issue #1435. It
+parses JSON array text and JSONL object streams into decoded rows, delegates to
+the existing fixture validator, and reports malformed input without raising.
+It still does not read files, call models, prompt providers, write result
+artifacts, alter verifier behavior, or expose MCP transport.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a pure fixture-text loader to the benchmark core for JSON and JSONL
+   payloads.
+2. Thread loader results through the existing fixture validator so seed and
+   final-shape validation behave exactly like decoded input validation.
+3. Document the accepted JSON and JSONL fixture formats for the operator.
+4. Add focused tests for malformed text, unsupported formats, JSONL row
+   indexing, and final-shape delegation.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Non-string fixture text is reported invalid without raising.
+  - [ ] Unsupported fixture formats are reported invalid without raising.
+  - [ ] JSON array text validates through the existing decoded fixture
+        contract.
+  - [ ] JSON text that is not an array reports a loader-level error before
+        decoded fixture validation.
+  - [ ] JSONL text parses one object per non-empty line and reports malformed
+        line numbers.
+  - [ ] JSONL arrays are rejected so line/object semantics stay unambiguous.
+  - [ ] Final-shape validation remains delegated to the existing fixture
+        validator.
+  - [ ] No file I/O, model/provider runner, prompt/schema capture, result
+        artifact, verifier rubric wiring, MCP tool, database, or live-client
+        behavior is introduced.
+- Affected surfaces: extracted benchmark validation core, tests, and docs.
+- Risk areas: benchmark false-green, malformed operator input, schema
+  tolerance.
+- Reviewer rules triggered: R1, R2, R5, R10.
+
+### Files touched
+
+- `docs/content_ops_claim_evidence_benchmark_fixtures.md`
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `plans/PR-Content-Ops-Claim-Evidence-Fixture-Loader.md`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+
+## Mechanism
+
+The loader accepts raw text plus a format name. For JSON, it decodes one JSON
+array and passes the resulting list into the existing fixture validator. For
+JSONL, it decodes each non-empty line as one object, preserves line numbers in
+parse errors, rejects per-line arrays, and then passes the list of decoded
+objects into the same fixture validator.
+
+The result type mirrors the existing fixture result shape: valid triples plus
+explicit errors. When parsing fails, the result has no triples and only
+loader-level errors. When parsing succeeds, validator errors are returned
+unchanged so callers see the same row-contract messages regardless of whether
+they started from decoded rows or text.
+
+## Intentional
+
+- No filesystem loader lands here. The future runner owns source paths,
+  storage, and operator workflow; this slice stays at the raw-text boundary.
+- Format names are explicit rather than inferred from file extensions because
+  this package should not know about filenames.
+- JSONL rejects arrays on a line even though JSON can parse them. The benchmark
+  fixture contract is one object per JSONL line, and accepting arrays there
+  would make row numbering ambiguous.
+
+## Deferred
+
+- File-path loading and CLI/operator handoff.
+- Provider/model runner and prompt/schema capture.
+- Results table, inter-model agreement matrix, failure-case list, and go/no-go
+  writeup.
+- Verifier rubric inclusion and MCP exposure only after benchmark results pass.
+- Parked hardening: none.
+
+## Verification
+
+Local verification:
+
+- pytest tests/test_extracted_content_claim_evidence_benchmark.py - 30 passed.
+- python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - 3690 passed, 10 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_fixture_loader_pr_body.md - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/content_ops_claim_evidence_benchmark_fixtures.md` | 34 |
+| `extracted_content_pipeline/claim_evidence_benchmark.py` | 66 |
+| `plans/PR-Content-Ops-Claim-Evidence-Fixture-Loader.md` | 112 |
+| `tests/test_extracted_content_claim_evidence_benchmark.py` | 99 |
+| **Total** | **311** |

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from extracted_content_pipeline.claim_evidence_benchmark import (
     EASY,
     HARD,
@@ -13,6 +15,7 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     StabilityScore,
     evaluate_thresholds,
     intra_model_stability,
+    load_claim_evidence_fixture_text,
     pairwise_agreements,
     score_model,
     validate_claim_evidence_fixture,
@@ -170,6 +173,102 @@ def test_fixture_validator_reports_final_shape_shortfalls() -> None:
         "final fixture requires 15 easy support rows; got 1",
         "final fixture requires 15 easy non-support rows; got 0",
         "final fixture requires 10 hard rows; got 1",
+    )
+
+
+def test_fixture_loader_rejects_non_string_text_without_raising() -> None:
+    fixture = load_claim_evidence_fixture_text(None)
+
+    assert fixture.triples == ()
+    assert fixture.errors == ("fixture text must be a string",)
+
+
+def test_fixture_loader_rejects_unsupported_format_without_raising() -> None:
+    for source_format in (None, "csv"):
+        fixture = load_claim_evidence_fixture_text("[]", source_format=source_format)
+
+        assert fixture.triples == ()
+        assert fixture.errors == ("fixture format must be json or jsonl",)
+
+
+def test_fixture_loader_accepts_json_array_text() -> None:
+    fixture = load_claim_evidence_fixture_text(
+        json.dumps([_triple("json-1", True, EASY).__dict__])
+    )
+
+    assert fixture.ok is True
+    assert [triple.triple_id for triple in fixture.triples] == ["json-1"]
+
+
+def test_fixture_loader_rejects_json_malformed_text() -> None:
+    fixture = load_claim_evidence_fixture_text("[")
+
+    assert fixture.triples == ()
+    assert fixture.errors == ("json fixture is malformed: Expecting value",)
+
+
+def test_fixture_loader_rejects_json_non_array_text_before_validation() -> None:
+    fixture = load_claim_evidence_fixture_text(json.dumps({"triple_id": "one"}))
+
+    assert fixture.triples == ()
+    assert fixture.errors == ("json fixture must decode to a list of objects",)
+
+
+def test_fixture_loader_accepts_jsonl_object_lines() -> None:
+    text = "\n".join(
+        [
+            json.dumps(_triple("jsonl-1", True, EASY).__dict__),
+            "",
+            json.dumps(_triple("jsonl-2", False, HARD).__dict__),
+        ]
+    )
+
+    fixture = load_claim_evidence_fixture_text(text, source_format="jsonl")
+
+    assert fixture.ok is True
+    assert [triple.triple_id for triple in fixture.triples] == [
+        "jsonl-1",
+        "jsonl-2",
+    ]
+
+
+def test_fixture_loader_reports_jsonl_malformed_line_numbers() -> None:
+    text = "\n".join(
+        [
+            json.dumps(_triple("jsonl-1", True, EASY).__dict__),
+            "{",
+        ]
+    )
+
+    fixture = load_claim_evidence_fixture_text(text, source_format="jsonl")
+
+    assert fixture.triples == ()
+    assert fixture.errors == (
+        "line 2: jsonl fixture is malformed: "
+        "Expecting property name enclosed in double quotes",
+    )
+
+
+def test_fixture_loader_rejects_jsonl_array_lines() -> None:
+    fixture = load_claim_evidence_fixture_text(
+        json.dumps([_triple("jsonl-array", True, EASY).__dict__]),
+        source_format="jsonl",
+    )
+
+    assert fixture.triples == ()
+    assert fixture.errors == ("line 1: jsonl fixture line must be an object",)
+
+
+def test_fixture_loader_delegates_final_shape_validation() -> None:
+    fixture = load_claim_evidence_fixture_text(
+        json.dumps([_triple("easy-yes", True, EASY).__dict__]),
+        require_final_shape=True,
+    )
+
+    assert fixture.errors == (
+        "final fixture requires 15 easy support rows; got 1",
+        "final fixture requires 15 easy non-support rows; got 0",
+        "final fixture requires 10 hard rows; got 0",
     )
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Fixture-Loader.md
Slice phase: Functional validation

This PR lands the deterministic loading boundary for #1435 fixture data: raw JSON array text or JSONL object streams decode into the already-merged claim/evidence fixture validator, with malformed input reported without raising. It does not add file I/O, model/provider execution, prompt/schema capture, result artifacts, verifier rubric wiring, MCP transport, database changes, or live-client behavior.

## Intentional
- No filesystem loader lands here; the future runner owns source paths, storage, and operator workflow.
- Format names are explicit rather than inferred from file extensions because this package should not know about filenames.
- JSONL rejects arrays on a line so each non-empty line remains one fixture row with unambiguous error line numbers.

## Deferred
- File-path loading and CLI/operator handoff.
- Provider/model runner and prompt/schema capture.
- Results table, inter-model agreement matrix, failure-case list, and go/no-go writeup.
- Verifier rubric inclusion and MCP exposure only after benchmark results pass.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_content_claim_evidence_benchmark.py - 30 passed.
- python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/run_extracted_pipeline_checks.sh - 3690 passed, 10 skipped.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_fixture_loader_pr_body.md - passed.

## Diff size
4 files, +308 / -3
