### PR TITLE
Deflection full-volume submit limit

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -139,10 +139,13 @@ _MAX_INGESTION_ROWS = 1000
 _MAX_FILE_INGESTION_ROWS = 10000
 _MAX_INGESTION_FILE_BYTES = 25 * 1024 * 1024
 _MAX_DEFLECTION_SUBMIT_BLOB_BYTES = 50 * 1024 * 1024
+_MAX_DEFLECTION_SUBMIT_ROWS = _MAX_DEFLECTION_SUBMIT_BLOB_BYTES
 _MAX_DEFLECTION_SUBMIT_MULTIPART_OVERHEAD_BYTES = 1024 * 1024
 _MAX_INGESTION_SAMPLE_LIMIT = 25
 _DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS = 15
 _DEFLECTION_SUBMIT_OUTPUTS = ("faq_deflection_report",)
+_DEFLECTION_SUBMIT_INTERNAL_TOKEN_KEY = "_deflection_submit_internal_token"
+_DEFLECTION_SUBMIT_INTERNAL_TOKEN = object()
 _DEFLECTION_SUBMIT_PLATFORMS = frozenset({
     "zendesk",
     "intercom",
@@ -626,7 +629,7 @@ if BaseModel is not None:
         support_platform: str = Field(..., min_length=1, max_length=80)
         company_name: str = Field(..., min_length=1, max_length=200)
         contact_email: str = Field(..., min_length=3, max_length=320)
-        limit: int = Field(_MAX_INGESTION_ROWS, ge=1, le=_MAX_INGESTION_ROWS)
+        limit: int | None = Field(default=None, ge=1, le=_MAX_DEFLECTION_SUBMIT_ROWS)
 
         @field_validator("support_platform")
         @classmethod
@@ -1083,6 +1086,10 @@ def create_content_ops_control_surface_router(
         payload: ContentOpsRequestModel = Body(...),
     ) -> dict[str, Any]:
         payload_mapping = _payload_to_mapping(payload, exclude_unset=input_provider is not None)
+        internal_deflection_submit = (
+            payload_mapping.pop(_DEFLECTION_SUBMIT_INTERNAL_TOKEN_KEY, None)
+            is _DEFLECTION_SUBMIT_INTERNAL_TOKEN
+        )
         if not await execute_gate.acquire():
             raise HTTPException(
                 status_code=429,
@@ -1108,10 +1115,11 @@ def create_content_ops_control_surface_router(
                 brand_voice_profile_provider=brand_voice_profile_provider,
                 scope=scope,
             )
-            _enforce_faq_execute_source_material_limit(
-                payload_mapping,
-                max_rows=resolved_config.faq_execute_max_source_material_rows,
-            )
+            if not internal_deflection_submit:
+                _enforce_faq_execute_source_material_limit(
+                    payload_mapping,
+                    max_rows=resolved_config.faq_execute_max_source_material_rows,
+                )
             budget_evaluation = await _evaluate_account_usage_budget(
                 payload_mapping,
                 usage_pool_provider=usage_pool_provider,
@@ -1219,10 +1227,6 @@ def create_content_ops_control_surface_router(
             request,
             max_bytes=_MAX_DEFLECTION_SUBMIT_BLOB_BYTES,
         )
-        max_rows = min(
-            int(data.get("limit") or _MAX_INGESTION_ROWS),
-            resolved_config.faq_execute_max_source_material_rows,
-        )
         if not rows:
             raise HTTPException(
                 status_code=400,
@@ -1231,7 +1235,20 @@ def create_content_ops_control_surface_router(
                     "message": "Submitted CSV did not contain support-ticket rows.",
                 },
             )
+        loaded_row_count = len(rows)
+        rows, language_filtered_row_count = _deflection_submit_english_rows(rows)
+        if not rows:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "reason": "deflection_submit_no_english_rows",
+                    "message": "Submitted CSV did not contain English support-ticket rows.",
+                    "source_row_count": loaded_row_count,
+                    "language_filtered_row_count": language_filtered_row_count,
+                },
+            )
         raw_row_count = len(rows)
+        max_rows = _deflection_submit_max_rows(data.get("limit"), raw_row_count)
         submitted_rows = _deflection_submit_rows_with_defaults(data, rows)[:max_rows]
         title = _deflection_submit_title(data)
         package = build_support_ticket_input_package(
@@ -1261,8 +1278,9 @@ def create_content_ops_control_surface_router(
             "support_platform": data["support_platform"],
         })
         result = await execute_generation({
+            _DEFLECTION_SUBMIT_INTERNAL_TOKEN_KEY: _DEFLECTION_SUBMIT_INTERNAL_TOKEN,
             "outputs": list(_DEFLECTION_SUBMIT_OUTPUTS),
-            "limit": max_rows,
+            "limit": 1,
             "require_quality_gates": False,
             "inputs": execute_inputs,
         })
@@ -1270,8 +1288,10 @@ def create_content_ops_control_surface_router(
             result,
             byte_count=byte_count,
             max_rows=max_rows,
+            loaded_row_count=loaded_row_count,
             source_row_count=raw_row_count,
             submitted_row_count=len(submitted_rows),
+            language_filtered_row_count=language_filtered_row_count,
             package=package.as_dict(),
             support_platform=data["support_platform"],
             byte_count_key=byte_count_key,
@@ -1378,6 +1398,14 @@ def _deflection_submit_form_to_mapping(form: Any) -> dict[str, Any]:
     if _clean(limit):
         data["limit"] = limit
     return _deflection_submit_fields_to_mapping(data)
+
+
+def _deflection_submit_max_rows(limit: Any, raw_row_count: int) -> int:
+    if raw_row_count <= 0:
+        return 0
+    if limit is None:
+        return raw_row_count
+    return min(int(limit), raw_row_count)
 
 
 async def _inspect_uploaded_ingestion_file(
@@ -1772,6 +1800,35 @@ def _deflection_submit_rows_with_defaults(
     ]
 
 
+def _deflection_submit_english_rows(rows: Sequence[Any]) -> tuple[list[Any], int]:
+    if not any(_deflection_submit_language(row) for row in rows):
+        return list(rows), 0
+    out: list[Any] = []
+    filtered = 0
+    for row in rows:
+        language = _deflection_submit_language(row)
+        if language and not _is_english_language(language):
+            filtered += 1
+            continue
+        out.append(row)
+    return out, filtered
+
+
+def _deflection_submit_language(row: Any) -> str:
+    if not isinstance(row, Mapping):
+        return ""
+    for key in ("language", "lang", "locale"):
+        value = _clean(row.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _is_english_language(value: str) -> bool:
+    normalized = value.strip().lower().replace("_", "-")
+    return normalized in {"en", "eng", "english"} or normalized.startswith("en-")
+
+
 def _deflection_submit_title(data: Mapping[str, Any]) -> str:
     return f"{data['company_name']} Support Deflection Report"
 
@@ -1852,8 +1909,10 @@ def _with_deflection_submit_diagnostics(
     *,
     byte_count: int,
     max_rows: int,
+    loaded_row_count: int,
     source_row_count: int,
     submitted_row_count: int,
+    language_filtered_row_count: int,
     package: Mapping[str, Any],
     support_platform: str,
     byte_count_key: str = "blob_bytes",
@@ -1887,11 +1946,23 @@ def _with_deflection_submit_diagnostics(
         byte_count_key: byte_count,
         "support_platform": support_platform,
     })
+    if language_filtered_row_count:
+        metadata["loaded_source_row_count"] = loaded_row_count
+        metadata["language_filtered_row_count"] = language_filtered_row_count
     warnings = [
         dict(warning)
         for warning in diagnostics.get("warnings") or ()
         if isinstance(warning, Mapping)
     ]
+    if language_filtered_row_count:
+        warnings.append({
+            "code": "deflection_submit_non_english_rows_filtered",
+            "message": (
+                f"Skipped {language_filtered_row_count} non-English support-ticket rows."
+            ),
+            "row_count": loaded_row_count,
+            "filtered_row_count": language_filtered_row_count,
+        })
     if truncated_row_count:
         warnings.append({
             "code": "deflection_submit_rows_truncated",
@@ -3147,6 +3218,12 @@ def _clean_sequence(value: Any) -> tuple[str, ...]:
 
 
 def _payload_to_mapping(payload: Any, *, exclude_unset: bool = False) -> dict[str, Any]:
+    if (
+        isinstance(payload, Mapping)
+        and payload.get(_DEFLECTION_SUBMIT_INTERNAL_TOKEN_KEY)
+        is _DEFLECTION_SUBMIT_INTERNAL_TOKEN
+    ):
+        return _internal_deflection_submit_payload_to_mapping(payload)
     if BaseModel is not None and isinstance(payload, ContentOpsRequestModel):
         return payload.model_dump(exclude_unset=exclude_unset)
     try:
@@ -3155,6 +3232,27 @@ def _payload_to_mapping(payload: Any, *, exclude_unset: bool = False) -> dict[st
         )
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
+
+
+def _internal_deflection_submit_payload_to_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        request = request_from_mapping({
+            "target_mode": payload.get("target_mode") or "vendor_retention",
+            "outputs": payload.get("outputs") or _DEFLECTION_SUBMIT_OUTPUTS,
+            "limit": payload.get("limit") or 1,
+            "inputs": payload.get("inputs") if isinstance(payload.get("inputs"), Mapping) else {},
+            "require_quality_gates": bool(payload.get("require_quality_gates", True)),
+        })
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return {
+        _DEFLECTION_SUBMIT_INTERNAL_TOKEN_KEY: _DEFLECTION_SUBMIT_INTERNAL_TOKEN,
+        "target_mode": request.target_mode,
+        "outputs": list(request.outputs),
+        "limit": request.limit,
+        "inputs": dict(request.inputs),
+        "require_quality_gates": request.require_quality_gates,
+    }
 
 
 def _ingestion_payload_to_mapping(payload: Any) -> dict[str, Any]:

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -45,7 +45,7 @@ from ..campaign_ports import TenantScope
 from ..brand_voice import BrandVoiceProfile, brand_voice_profile_from_mapping
 from ..campaign_postgres_import import import_campaign_opportunities
 from ..campaign_source_adapters import source_material_to_source_rows
-from ..campaign_source_adapters import load_source_rows_from_file
+from ..campaign_source_adapters import load_source_rows_with_warnings_from_file
 from ..content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
@@ -1223,7 +1223,13 @@ def create_content_ops_control_surface_router(
     async def submit_deflection_report(
         request: Request,
     ) -> dict[str, Any]:
-        data, rows, byte_count, byte_count_key = await _load_deflection_submit_rows_from_request(
+        (
+            data,
+            rows,
+            byte_count,
+            byte_count_key,
+            csv_load_warnings,
+        ) = await _load_deflection_submit_rows_from_request(
             request,
             max_bytes=_MAX_DEFLECTION_SUBMIT_BLOB_BYTES,
         )
@@ -1292,6 +1298,7 @@ def create_content_ops_control_surface_router(
             source_row_count=raw_row_count,
             submitted_row_count=len(submitted_rows),
             language_filtered_row_count=language_filtered_row_count,
+            csv_load_warnings=csv_load_warnings,
             package=package.as_dict(),
             support_platform=data["support_platform"],
             byte_count_key=byte_count_key,
@@ -1304,7 +1311,7 @@ async def _load_deflection_submit_rows_from_request(
     request: Any,
     *,
     max_bytes: int,
-) -> tuple[dict[str, Any], list[Any], int, str]:
+) -> tuple[dict[str, Any], list[Any], int, str, tuple[dict[str, Any], ...]]:
     if _is_deflection_submit_http_request(request):
         content_type = _request_content_type(request)
         if "multipart/form-data" in content_type:
@@ -1320,11 +1327,11 @@ async def _load_deflection_submit_rows_from_request(
             if csv_file is None:
                 raise HTTPException(status_code=422, detail="csv_file is required")
             data = _deflection_submit_form_to_mapping(form)
-            rows, byte_count = await _load_deflection_submit_upload_rows(
+            rows, byte_count, load_warnings = await _load_deflection_submit_upload_rows(
                 csv_file,
                 max_bytes=max_bytes,
             )
-            return data, rows, byte_count, "uploaded_bytes"
+            return data, rows, byte_count, "uploaded_bytes", load_warnings
 
         try:
             payload = await request.json()
@@ -1334,18 +1341,18 @@ async def _load_deflection_submit_rows_from_request(
                 detail="JSON deflection submit body could not be parsed.",
             ) from exc
         data = _deflection_submit_payload_to_mapping(payload)
-        rows, byte_count = await _load_deflection_submit_blob_rows(
+        rows, byte_count, load_warnings = await _load_deflection_submit_blob_rows(
             data["blob_url"],
             max_bytes=max_bytes,
         )
-        return data, rows, byte_count, "blob_bytes"
+        return data, rows, byte_count, "blob_bytes", load_warnings
 
     data = _deflection_submit_payload_to_mapping(request)
-    rows, byte_count = await _load_deflection_submit_blob_rows(
+    rows, byte_count, load_warnings = await _load_deflection_submit_blob_rows(
         data["blob_url"],
         max_bytes=max_bytes,
     )
-    return data, rows, byte_count, "blob_bytes"
+    return data, rows, byte_count, "blob_bytes", load_warnings
 
 
 def _is_deflection_submit_http_request(value: Any) -> bool:
@@ -1472,7 +1479,7 @@ async def _load_deflection_submit_blob_rows(
     blob_url: str,
     *,
     max_bytes: int,
-) -> tuple[list[Any], int]:
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
     return await asyncio.to_thread(
         _load_deflection_submit_blob_rows_sync,
         blob_url,
@@ -1484,7 +1491,7 @@ async def _load_deflection_submit_upload_rows(
     csv_file: Any,
     *,
     max_bytes: int,
-) -> tuple[list[Any], int]:
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
     try:
         data = await csv_file.read(max_bytes + 1)
     except OSError as exc:
@@ -1514,7 +1521,7 @@ async def _load_deflection_submit_upload_rows(
 def _load_deflection_submit_blob_rows_sync(
     blob_url: str,
     max_bytes: int,
-) -> tuple[list[Any], int]:
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
     data = _read_bounded_https_blob(blob_url, max_bytes=max_bytes)
     if not data:
         raise HTTPException(
@@ -1531,7 +1538,7 @@ def _parse_deflection_submit_csv_bytes(
     data: bytes,
     *,
     parse_error_detail: str,
-) -> tuple[list[Any], int]:
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
     temp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -1542,13 +1549,18 @@ def _parse_deflection_submit_csv_bytes(
             temp_path = Path(handle.name)
             handle.write(data)
         try:
-            rows = load_source_rows_from_file(temp_path, file_format="csv")
+            rows, load_warnings = load_source_rows_with_warnings_from_file(
+                temp_path,
+                file_format="csv",
+            )
         except (OSError, UnicodeDecodeError, ValueError) as exc:
             raise HTTPException(
                 status_code=400,
                 detail=parse_error_detail,
             ) from exc
-        return rows, len(data)
+        return rows, len(data), tuple(
+            warning.as_dict() for warning in load_warnings
+        )
     finally:
         if temp_path is not None:
             try:
@@ -1826,7 +1838,15 @@ def _deflection_submit_language(row: Any) -> str:
 
 def _is_english_language(value: str) -> bool:
     normalized = value.strip().lower().replace("_", "-")
-    return normalized in {"en", "eng", "english"} or normalized.startswith("en-")
+    # Provider exports may use display forms such as "English (US)" or
+    # "English (United Kingdom)"; the parenthetical region is not a
+    # language signal, so strip it before matching.
+    normalized = normalized.split("(", 1)[0].strip()
+    return (
+        normalized in {"en", "eng", "english"}
+        or normalized.startswith("en-")
+        or normalized.startswith("english")
+    )
 
 
 def _deflection_submit_title(data: Mapping[str, Any]) -> str:
@@ -1916,6 +1936,7 @@ def _with_deflection_submit_diagnostics(
     package: Mapping[str, Any],
     support_platform: str,
     byte_count_key: str = "blob_bytes",
+    csv_load_warnings: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
     out = dict(response)
     existing = out.get("input_provider")
@@ -1954,6 +1975,11 @@ def _with_deflection_submit_diagnostics(
         for warning in diagnostics.get("warnings") or ()
         if isinstance(warning, Mapping)
     ]
+    warnings.extend(
+        dict(warning)
+        for warning in csv_load_warnings
+        if isinstance(warning, Mapping)
+    )
     if language_filtered_row_count:
         warnings.append({
             "code": "deflection_submit_non_english_rows_filtered",

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -20,6 +20,44 @@ from .campaign_ports import TenantScope
 CustomerDataFormat = Literal["auto", "json", "csv"]
 _CSV_DETECT_DELIMITERS = ",;\t|"
 _CSV_SNIFFER_SAMPLE_CHARS = 65_536
+_CSV_HEADER_HINTS = frozenset({
+    "account",
+    "account_name",
+    "answer",
+    "body",
+    "case_id",
+    "category",
+    "company",
+    "company_name",
+    "contact_email",
+    "conversation_id",
+    "conversation_title",
+    "created_at",
+    "customer_message",
+    "description",
+    "email",
+    "id",
+    "initial_message",
+    "language",
+    "message",
+    "opportunity_id",
+    "pain_category",
+    "queue",
+    "requester_comment",
+    "resolution",
+    "resolution_text",
+    "source_id",
+    "subject",
+    "summary",
+    "ticket_number",
+    "ticket_id",
+    "ticket_subject",
+    "title",
+    "topic",
+    "user_email",
+    "vendor",
+    "vendor_name",
+})
 
 
 @dataclass(frozen=True)
@@ -229,27 +267,30 @@ def _load_csv_dict_rows(
     text = _read_csv_text(path)
     if not text.strip():
         raise ValueError("CSV customer data must include a header row.")
-    reader = csv.DictReader(
-        StringIO(text),
-        dialect=_detect_csv_dialect(text),
-    )
-    fieldnames = tuple(
-        str(field).strip()
-        for field in (reader.fieldnames or ())
+    reader = csv.reader(StringIO(text), dialect=_detect_csv_dialect(text))
+    raw_rows = list(reader)
+    header_index = _csv_header_index(raw_rows)
+    if header_index is None:
+        raise ValueError("CSV customer data must include a header row.")
+    header_width = len(raw_rows[header_index])
+    header_fields = tuple(
+        (index, str(field or "").strip())
+        for index, field in enumerate(raw_rows[header_index])
         if field is not None and str(field).strip()
     )
-    if not fieldnames:
+    if not header_fields:
         raise ValueError("CSV customer data must include a header row.")
-    for row_index, row in enumerate(reader, start=2):
-        if row.get(None):
+    for row_index, values in enumerate(raw_rows[header_index + 1:], start=header_index + 2):
+        if not any(str(value or "").strip() for value in values):
+            continue
+        if len(values) > header_width:
             raise ValueError(
                 f"CSV row {row_index} has more cells than the header; "
                 "check the delimiter and header row."
             )
         cleaned: dict[str, Any] = {}
-        for key, value in row.items():
-            if key is None:
-                continue
+        for value_index, key in header_fields:
+            value = values[value_index] if value_index < len(values) else ""
             cleaned_key = str(key).strip()
             if not cleaned_key:
                 continue
@@ -258,6 +299,27 @@ def _load_csv_dict_rows(
                 cleaned[cleaned_key] = cleaned_value
         rows.append(cleaned)
     return rows
+
+
+def _csv_header_index(rows: Sequence[Sequence[Any]]) -> int | None:
+    fallback: int | None = None
+    for index, row in enumerate(rows):
+        cells = [str(cell or "").strip() for cell in row]
+        nonempty = [cell for cell in cells if cell]
+        if not nonempty:
+            continue
+        normalized = {_normalize_csv_header_cell(cell) for cell in nonempty}
+        if normalized.intersection(_CSV_HEADER_HINTS):
+            return index
+        if len(nonempty) < 2:
+            continue
+        if fallback is None:
+            fallback = index
+    return fallback
+
+
+def _normalize_csv_header_cell(value: str) -> str:
+    return value.strip().lower().replace("-", "_").replace(" ", "_")
 
 
 def _read_csv_text(path: Path) -> str:
@@ -271,9 +333,26 @@ def _read_csv_text(path: Path) -> str:
 def _detect_csv_dialect(text: str) -> csv.Dialect:
     sample = text[:_CSV_SNIFFER_SAMPLE_CHARS]
     try:
-        return csv.Sniffer().sniff(sample, delimiters=_CSV_DETECT_DELIMITERS)
+        return _harden_csv_dialect(csv.Sniffer().sniff(
+            sample,
+            delimiters=_CSV_DETECT_DELIMITERS,
+        ))
     except csv.Error:
         return csv.excel
+
+
+def _harden_csv_dialect(dialect: csv.Dialect) -> type[csv.Dialect]:
+    class HardenedDialect(csv.Dialect):
+        delimiter = dialect.delimiter
+        quotechar = dialect.quotechar or '"'
+        escapechar = dialect.escapechar
+        doublequote = True
+        skipinitialspace = dialect.skipinitialspace
+        lineterminator = dialect.lineterminator
+        quoting = dialect.quoting
+        strict = False
+
+    return HardenedDialect
 
 
 def _coerce_csv_value(value: Any) -> Any:

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -125,14 +125,15 @@ def load_campaign_opportunities_from_file(
 
     source = Path(path)
     resolved_format = _resolve_format(source, file_format)
+    load_warnings: tuple[CampaignOpportunityWarning, ...] = ()
     if resolved_format == "csv":
-        rows = _load_csv_rows(source)
+        rows, load_warnings = _load_csv_rows(source)
     else:
         rows = _load_json_rows(source)
     result = normalize_campaign_opportunity_rows(rows, target_mode=target_mode)
     return CampaignOpportunityLoadResult(
         opportunities=result.opportunities,
-        warnings=result.warnings,
+        warnings=load_warnings + result.warnings,
         source=str(source),
     )
 
@@ -254,7 +255,9 @@ def _load_json_rows(path: Path) -> list[Any]:
     return [dict(data)]
 
 
-def _load_csv_rows(path: Path) -> list[dict[str, Any]]:
+def _load_csv_rows(
+    path: Path,
+) -> tuple[list[dict[str, Any]], tuple[CampaignOpportunityWarning, ...]]:
     return _load_csv_dict_rows(path, value_coercer=_coerce_csv_value)
 
 
@@ -262,7 +265,7 @@ def _load_csv_dict_rows(
     path: Path,
     *,
     value_coercer: Callable[[Any], Any] | None = None,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], tuple[CampaignOpportunityWarning, ...]]:
     rows: list[dict[str, Any]] = []
     text = _read_csv_text(path)
     if not text.strip():
@@ -272,6 +275,7 @@ def _load_csv_dict_rows(
     header_index = _csv_header_index(raw_rows)
     if header_index is None:
         raise ValueError("CSV customer data must include a header row.")
+    load_warnings = _leading_rows_skipped_warnings(raw_rows, header_index)
     header_width = len(raw_rows[header_index])
     header_fields = tuple(
         (index, str(field or "").strip())
@@ -298,7 +302,41 @@ def _load_csv_dict_rows(
             if cleaned_value not in (None, ""):
                 cleaned[cleaned_key] = cleaned_value
         rows.append(cleaned)
-    return rows
+    return rows, load_warnings
+
+
+def _leading_rows_skipped_warnings(
+    raw_rows: Sequence[Sequence[Any]],
+    header_index: int,
+) -> tuple[CampaignOpportunityWarning, ...]:
+    skipped: list[tuple[int, Sequence[Any]]] = []
+    for index, row in enumerate(raw_rows[:header_index]):
+        if any(str(cell or "").strip() for cell in row):
+            skipped.append((index + 1, row))
+    if not skipped:
+        return ()
+    first_row_number, first_row = skipped[0]
+    preview = _csv_row_preview(first_row)
+    return (
+        CampaignOpportunityWarning(
+            code="csv_leading_rows_skipped",
+            message=(
+                f"Skipped {len(skipped)} leading row(s) before the CSV header "
+                f"on row {header_index + 1}; "
+                f"first skipped row {first_row_number}: {preview}"
+            ),
+            row_index=first_row_number,
+        ),
+    )
+
+
+def _csv_row_preview(row: Sequence[Any], *, max_chars: int = 80) -> str:
+    text = ", ".join(
+        str(cell).strip() for cell in row if str(cell or "").strip()
+    )
+    if len(text) > max_chars:
+        return text[: max_chars - 3] + "..."
+    return text
 
 
 def _csv_header_index(rows: Sequence[Sequence[Any]]) -> int | None:

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -366,7 +366,7 @@ def load_source_campaign_opportunities_from_file(
     """Load review/transcript/document rows as campaign opportunities."""
 
     source = Path(path)
-    rows = _load_source_rows(source, file_format=file_format)
+    rows, load_warnings = _load_source_rows(source, file_format=file_format)
     result = source_rows_to_campaign_opportunities(
         rows,
         target_mode=target_mode,
@@ -375,7 +375,7 @@ def load_source_campaign_opportunities_from_file(
     )
     return CampaignOpportunityLoadResult(
         opportunities=result.opportunities,
-        warnings=result.warnings,
+        warnings=load_warnings + result.warnings,
         source=str(source),
     )
 
@@ -386,6 +386,20 @@ def load_source_rows_from_file(
     file_format: SourceDataFormat = "auto",
 ) -> list[Any]:
     """Load source rows from a CSV, JSON, or JSONL file without opportunity mapping."""
+
+    rows, _warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format=file_format,
+    )
+    return rows
+
+
+def load_source_rows_with_warnings_from_file(
+    path: str | Path,
+    *,
+    file_format: SourceDataFormat = "auto",
+) -> tuple[list[Any], tuple[CampaignOpportunityWarning, ...]]:
+    """Load source rows plus non-fatal load warnings (e.g. skipped prologue rows)."""
 
     return _load_source_rows(Path(path), file_format=file_format)
 
@@ -614,7 +628,11 @@ def source_row_to_campaign_opportunity(
     return normalize_campaign_opportunity(opportunity), tuple(warnings)
 
 
-def _load_source_rows(path: Path, *, file_format: SourceDataFormat) -> list[Any]:
+def _load_source_rows(
+    path: Path,
+    *,
+    file_format: SourceDataFormat,
+) -> tuple[list[Any], tuple[CampaignOpportunityWarning, ...]]:
     resolved_format = _resolve_format(path, file_format)
     if resolved_format == "csv":
         return _load_source_csv_rows(path)
@@ -624,13 +642,13 @@ def _load_source_rows(path: Path, *, file_format: SourceDataFormat) -> list[Any]
             text = line.strip()
             if text:
                 rows.append(json.loads(text))
-        return rows
+        return rows, ()
     data = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(data, list):
-        return list(data)
+        return list(data), ()
     if not isinstance(data, Mapping):
         raise ValueError("Source JSON must be an object or array")
-    return _source_rows_from_bundle(data)
+    return _source_rows_from_bundle(data), ()
 
 
 def _source_rows_from_bundle(
@@ -697,7 +715,9 @@ def _is_safe_parent_value(value: Any) -> bool:
     return False
 
 
-def _load_source_csv_rows(path: Path) -> list[dict[str, Any]]:
+def _load_source_csv_rows(
+    path: Path,
+) -> tuple[list[dict[str, Any]], tuple[CampaignOpportunityWarning, ...]]:
     return _load_csv_dict_rows(path)
 
 
@@ -902,6 +922,7 @@ __all__ = [
     "SourceDataFormat",
     "load_source_campaign_opportunities_from_file",
     "load_source_rows_from_file",
+    "load_source_rows_with_warnings_from_file",
     "parse_default_fields",
     "parse_default_fields_with_booking_url_or_exit",
     "parse_default_fields_or_exit",

--- a/plans/PR-Deflection-Full-Volume-Submit-Limit.md
+++ b/plans/PR-Deflection-Full-Volume-Submit-Limit.md
@@ -1,0 +1,184 @@
+# PR-Deflection-Full-Volume-Submit-Limit
+
+## Why this slice exists
+
+#1440 needs a real full-volume deflection funnel proof using a messy CFPB export,
+not the tiny golden upload. The local 50k CFPB JSONL is 106 MB, so the operator
+asked to cut the file to the existing 50 MB upload guard instead of treating the
+byte cap as a blocker. That still leaves a correctness problem: the hosted
+deflection submit route and smoke script clamp the execution to 1000 rows, so a
+near-50 MB real upload would silently test only the first 1000 rows.
+
+This slice removes that deflection-submit row clamp while preserving the 50 MB
+upload guard, so #1440 can run a deterministic real-export sample through the
+hosted intake, snapshot, snapshot email/PDF, payment, and full report
+email/PDF path. The CFPB prep also exposed a parser brittleness class: valid
+messy CSV with embedded quotes can fail before any report is built. This slice
+therefore hardens the submit CSV parser enough to ingest messy high-volume CSV
+without turning #1440 into a hand-sanitized-file exercise.
+
+This PR exceeds the 400 LOC soft cap because the row-cap change and CSV
+hardening now ship together with failure-first fixtures for embedded quotes,
+provider prologue rows, support-export headers, missing optional fields,
+mixed-language filtering, and all-non-English fail-closed behavior. Splitting
+after #1452 was already open would leave the high-volume proof still dependent
+on hand-sanitized CSV.
+
+## Scope (this PR)
+
+Ownership lane: deflection-full-50k-e2e-proof
+Slice phase: Functional validation
+
+1. Allow the deflection submit route to use every parsed support-ticket row
+   from a CSV/blob that already passed the 50 MB submit guard unless the caller
+   explicitly supplies a smaller limit.
+2. Keep the general `/execute` FAQ source-material guard unchanged for non-submit
+   paths.
+3. Update the hosted submit smoke so a near-50 MB real export can omit the
+   legacy 1000-row default or explicitly request more than 1000 rows while the
+   smoke still validates the reported diagnostics.
+4. Add focused regression coverage proving large deflection submit payloads are
+   not truncated at 1000 rows while explicit smaller limits still truncate.
+5. Harden CSV dialect parsing so valid CSV with embedded quotes/newlines does
+   not fail because `csv.Sniffer()` guessed non-standard quote behavior.
+6. When a submit CSV includes a language column, keep English rows and skip
+   non-English rows before packaging so the internal Hugging Face proof remains
+   an English report-quality test, not a multilingual clustering test.
+7. Keep provider metadata/prologue rows accepted only when a plausible support
+   export header follows, and keep malformed/ragged rows fail-loud.
+8. Keep existing provider full-thread fixtures usable by recognizing common
+   support export headers such as Intercom conversation fields.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Deflection submit defaults to all rows parsed from the accepted upload,
+        not `_MAX_INGESTION_ROWS`.
+  - [ ] Explicit smaller `limit` values still reduce submitted rows and report
+        truncation diagnostics.
+  - [ ] The 50 MB upload/blob guard remains in place.
+  - [ ] Non-submit FAQ `/execute` row-limit behavior remains unchanged.
+  - [ ] The hosted smoke preflight accepts no explicit limit by default and can
+        accept a limit suitable for the near-50 MB #1440 CFPB sample.
+  - [ ] Valid messy CSV with embedded quotes/newlines parses without requiring
+        hand-normalized quote replacement.
+  - [ ] Provider title/prologue rows before a plausible header parse; malformed
+        extra-cell rows still fail loudly.
+  - [ ] Hugging Face-shaped rows (`subject`, `body`, `answer`, `language`) can
+        be submitted with missing IDs/categories, use `answer` as resolution
+        evidence, and filter non-English rows.
+- Affected surfaces: API, file upload validation, hosted smoke script, tests.
+- Risk areas: performance, backward compatibility, file-upload abuse, diagnostic
+  truthfulness.
+- Reviewer rules triggered: R1, R2, R3, R5, R7, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `plans/PR-Deflection-Full-Volume-Submit-Limit.md`
+- `scripts/build_deflection_messy_csv_fixtures.py`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_build_deflection_messy_csv_fixtures.py`
+- `tests/test_extracted_campaign_customer_data.py`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+
+## Mechanism
+
+Introduce a deflection-submit-specific row ceiling derived from the submit byte
+guard for explicit limit validation, and use the parsed file size as the real
+per-upload row cap. The submit route chooses `raw_row_count` as the default max
+so accepted uploads run at their full parsed size; an explicit lower limit
+continues to slice the rows and flow through the existing
+`build_support_ticket_input_package` truncation metadata.
+
+CSV dialect detection still uses `csv.Sniffer()` for delimiter support, but the
+returned dialect is projected into a hardened dialect that preserves delimiter
+choice while forcing standard doubled-quote handling. That keeps semicolon/tab
+fixtures working while preventing valid quoted text from becoming false
+"more cells than header" failures.
+
+CSV header detection now skips provider title/prologue rows only when a later
+row has known support-export header signals. Single-column known headers such
+as `ticket_id` remain valid CSV headers so the support-ticket package can report
+the real no-usable-wording failure instead of a parser-level header failure.
+
+The submit route applies an English-only filter only when row metadata includes
+a language marker. Rows without a language marker continue through the existing
+path. Filtered non-English counts are reported in submit diagnostics instead of
+being treated as row-limit truncation.
+
+The generic `/execute` validator continues to use `_MAX_INGESTION_ROWS`, so
+large inline `source_material` payloads outside the portfolio submit handoff do
+not become unbounded request bodies.
+
+## Intentional
+
+- The 50 MB upload/blob guard stays intact. #1440 will cut the real CFPB export
+  to fit that guard rather than raising request body size for this slice.
+- This does not make the generic `/execute` endpoint accept 50k inline rows.
+  The live funnel uses the submit route, and broadening `/execute` would widen a
+  public API surface unnecessarily.
+- The explicit limit ceiling is tied to the 50 MB byte guard. The real effective
+  row cap is the number of rows parsed from the accepted file; the #1440 sample
+  currently fits 34,914 rows under that guard.
+- The limit is a row-count safety ceiling, not a display cap. The report builder
+  remains responsible for deterministic clustering and ranked-question output.
+- This does not add translation or multilingual clustering. Mixed-language
+  uploads with a language marker are reduced to English rows for this proof
+  lane.
+- Existing fail-loud fixture labels are updated only where the behavior is now
+  intentionally accepted production input. Ragged extra-cell rows stay fail-loud.
+
+## Deferred
+
+- The actual #1440 live run remains after this PR deploys: submit the generated
+  near-50 MB CFPB CSV sample to hosted intake, confirm snapshot email/PDF,
+  complete payment, and confirm full report email/PDF to
+  `canfieldjuan24@gmail.com`.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: pytest tests/test_extracted_content_deflection_submit.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_support_ticket_input_package.py
+  - 235 passed, 1 skipped.
+- Passed: pytest tests/test_extracted_campaign_customer_data.py tests/test_build_deflection_messy_csv_fixtures.py tests/test_smoke_content_ops_support_ticket_package.py
+  - 39 passed.
+- Passed after rebase: pytest tests/test_extracted_content_deflection_submit.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_support_ticket_input_package.py tests/test_extracted_campaign_customer_data.py tests/test_build_deflection_messy_csv_fixtures.py tests/test_smoke_content_ops_support_ticket_package.py
+  - 274 passed, 1 skipped.
+- Passed: python scripts/build_content_ops_deflection_report.py tmp/deflection_full_50k_e2e_20260609/cfpb_real_upload_under_50mb.csv --source-format csv --title "CFPB Real Export Deflection Report" --faq-title "CFPB Real Export FAQ Deflection Report" --default-field company_name=CFPB --default-field contact_email=canfieldjuan24@gmail.com --default-field vendor_name=CFPB --output tmp/deflection_full_50k_e2e_20260609/report_build/report.md --summary-output tmp/deflection_full_50k_e2e_20260609/report_build/summary.json --result-output tmp/deflection_full_50k_e2e_20260609/report_build/result.json --require-output-checks
+  - Passed on 35,386-row / 52,363,054-byte CFPB sample generated with standard
+    CSV quoting and embedded source quotes preserved; generated 37 ranked
+    questions, 35,386 ticket sources, 0 proven answers, output checks all true.
+- Passed: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed.
+- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed.
+- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed.
+- Passed: bash scripts/check_ascii_python.sh
+  - Passed.
+- Passed: python -m py_compile extracted_content_pipeline/api/control_surfaces.py extracted_content_pipeline/campaign_customer_data.py scripts/build_deflection_messy_csv_fixtures.py scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_extracted_content_deflection_submit.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_extracted_support_ticket_input_package.py tests/test_extracted_campaign_customer_data.py tests/test_build_deflection_messy_csv_fixtures.py tests/test_smoke_content_ops_support_ticket_package.py
+  - Passed.
+- Passed: git diff --check
+  - Passed.
+- Pending before push:
+  - python scripts/sync_pr_plan.py plans/PR-Deflection-Full-Volume-Submit-Limit.md --check
+  - bash scripts/local_pr_review.sh
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 118 |
+| `extracted_content_pipeline/campaign_customer_data.py` | 107 |
+| `plans/PR-Deflection-Full-Volume-Submit-Limit.md` | 184 |
+| `scripts/build_deflection_messy_csv_fixtures.py` | 4 |
+| `scripts/smoke_content_ops_deflection_submit_handoff.py` | 21 |
+| `tests/test_build_deflection_messy_csv_fixtures.py` | 3 |
+| `tests/test_extracted_campaign_customer_data.py` | 9 |
+| `tests/test_extracted_content_deflection_submit.py` | 187 |
+| `tests/test_smoke_content_ops_deflection_submit_handoff.py` | 42 |
+| **Total** | **675** |

--- a/plans/PR-Deflection-Full-Volume-Submit-Limit.md
+++ b/plans/PR-Deflection-Full-Volume-Submit-Limit.md
@@ -76,6 +76,7 @@ Slice phase: Functional validation
 
 - `extracted_content_pipeline/api/control_surfaces.py`
 - `extracted_content_pipeline/campaign_customer_data.py`
+- `extracted_content_pipeline/campaign_source_adapters.py`
 - `plans/PR-Deflection-Full-Volume-Submit-Limit.md`
 - `scripts/build_deflection_messy_csv_fixtures.py`
 - `scripts/smoke_content_ops_deflection_submit_handoff.py`
@@ -107,7 +108,19 @@ the real no-usable-wording failure instead of a parser-level header failure.
 The submit route applies an English-only filter only when row metadata includes
 a language marker. Rows without a language marker continue through the existing
 path. Filtered non-English counts are reported in submit diagnostics instead of
-being treated as row-limit truncation.
+being treated as row-limit truncation. The English matcher accepts locale codes
+(`en`, `en-US`, `en_GB`, `eng`) and human display forms such as
+`English (United Kingdom)` by stripping a trailing parenthetical region before
+matching.
+
+Per the review-closeout and the #1467 admission-contract direction, a skipped
+provider prologue row is no longer silent: `_load_csv_dict_rows` returns a
+`csv_leading_rows_skipped` warning naming the skipped row(s), the campaign
+opportunity loaders merge it into their existing warnings channel, and the
+funnel path exposes it through the new
+`load_source_rows_with_warnings_from_file` adapter so the submit response
+surfaces it in `input_provider.warnings` alongside the existing non-English
+filter and truncation warnings.
 
 The generic `/execute` validator continues to use `_MAX_INGESTION_ROWS`, so
 large inline `source_material` payloads outside the portfolio submit handoff do
@@ -164,6 +177,16 @@ Parked hardening: none.
   - Passed.
 - Passed: git diff --check
   - Passed.
+- Review closeout (display-form language match + prologue-skip warning):
+  - Passed: pytest tests/test_extracted_content_deflection_submit.py
+    tests/test_extracted_campaign_customer_data.py
+    tests/test_extracted_campaign_source_adapters.py
+    tests/test_build_deflection_messy_csv_fixtures.py
+    tests/test_smoke_content_ops_support_ticket_package.py
+    - 153 passed.
+  - Passed: bash scripts/run_extracted_pipeline_checks.sh
+    - 3712 passed, 10 skipped.
+  - Passed: bash scripts/check_ascii_python.sh
 - Pending before push:
   - python scripts/sync_pr_plan.py plans/PR-Deflection-Full-Volume-Submit-Limit.md --check
   - bash scripts/local_pr_review.sh
@@ -172,13 +195,14 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/api/control_surfaces.py` | 118 |
-| `extracted_content_pipeline/campaign_customer_data.py` | 107 |
-| `plans/PR-Deflection-Full-Volume-Submit-Limit.md` | 184 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 174 |
+| `extracted_content_pipeline/campaign_customer_data.py` | 155 |
+| `extracted_content_pipeline/campaign_source_adapters.py` | 35 |
+| `plans/PR-Deflection-Full-Volume-Submit-Limit.md` | 208 |
 | `scripts/build_deflection_messy_csv_fixtures.py` | 4 |
 | `scripts/smoke_content_ops_deflection_submit_handoff.py` | 21 |
 | `tests/test_build_deflection_messy_csv_fixtures.py` | 3 |
-| `tests/test_extracted_campaign_customer_data.py` | 9 |
-| `tests/test_extracted_content_deflection_submit.py` | 187 |
+| `tests/test_extracted_campaign_customer_data.py` | 13 |
+| `tests/test_extracted_content_deflection_submit.py` | 266 |
 | `tests/test_smoke_content_ops_deflection_submit_handoff.py` | 42 |
-| **Total** | **675** |
+| **Total** | **921** |

--- a/scripts/build_deflection_messy_csv_fixtures.py
+++ b/scripts/build_deflection_messy_csv_fixtures.py
@@ -201,8 +201,8 @@ def _write_leading_metadata_case(output_dir: Path, rows: Sequence[Mapping[str, s
     return {
         "name": path.name,
         "path": path.name,
-        "expected": "fail_loud",
-        "notes": "Title row before header should not silently parse as support data.",
+        "expected": "parsed",
+        "notes": "Provider title row before a plausible header should be skipped.",
     }
 
 

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -31,6 +31,7 @@ DEFAULT_CSV_FILE = (
 LOCAL_BASE_URL_HOSTS = frozenset({"localhost", "0.0.0.0", "::1"})
 SUPPORT_PLATFORMS = frozenset({"zendesk", "intercom", "help_scout", "other"})
 CSV_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
+SUBMIT_ROW_LIMIT_MAX = CSV_UPLOAD_MAX_BYTES
 SUBMIT_PATH = "/api/v1/content-ops/deflection-reports/submit"
 SNAPSHOT_PATH_TEMPLATE = "/api/v1/content-ops/deflection-reports/{request_id}/snapshot"
 ARTIFACT_PATH_TEMPLATE = "/api/v1/content-ops/deflection-reports/{request_id}/artifact"
@@ -95,7 +96,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--support-platform", default=_env("ATLAS_DEFLECTION_SUPPORT_PLATFORM") or "zendesk")
     parser.add_argument("--company-name", default=_env("ATLAS_DEFLECTION_COMPANY_NAME"))
     parser.add_argument("--contact-email", default=_env("ATLAS_DEFLECTION_CONTACT_EMAIL"))
-    parser.add_argument("--limit", type=int, default=1000)
+    parser.add_argument("--limit", type=int)
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--submit-path", default=SUBMIT_PATH)
     parser.add_argument("--snapshot-path-template", default=SNAPSHOT_PATH_TEMPLATE)
@@ -143,8 +144,10 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("ATLAS_DEFLECTION_COMPANY_NAME or --company-name is required")
     if not _clean(args.contact_email):
         errors.append("ATLAS_DEFLECTION_CONTACT_EMAIL or --contact-email is required")
-    if int(args.limit) <= 0 or int(args.limit) > 1000:
-        errors.append("--limit must be between 1 and 1000")
+    if args.limit is not None and (
+        int(args.limit) <= 0 or int(args.limit) > SUBMIT_ROW_LIMIT_MAX
+    ):
+        errors.append(f"--limit must be between 1 and {SUBMIT_ROW_LIMIT_MAX}")
     if not math.isfinite(float(args.timeout)) or float(args.timeout) <= 0:
         errors.append("--timeout must be a positive finite number")
     for attr, label in (
@@ -244,22 +247,26 @@ def _redacted_blob_host(blob_url: str) -> str:
 
 
 def _submit_body(args: argparse.Namespace) -> dict[str, Any]:
-    return {
+    body: dict[str, Any] = {
         "blob_url": _clean(args.blob_url),
         "support_platform": _clean(args.support_platform),
         "company_name": _clean(args.company_name),
         "contact_email": _clean(args.contact_email),
-        "limit": int(args.limit),
     }
+    if args.limit is not None:
+        body["limit"] = int(args.limit)
+    return body
 
 
 def _submit_fields(args: argparse.Namespace) -> dict[str, str]:
-    return {
+    fields = {
         "support_platform": _clean(args.support_platform),
         "company_name": _clean(args.company_name),
         "contact_email": _clean(args.contact_email),
-        "limit": str(int(args.limit)),
     }
+    if args.limit is not None:
+        fields["limit"] = str(int(args.limit))
+    return fields
 
 
 def _open_http_request(request: urllib.request.Request, *, timeout: float) -> Any:

--- a/tests/test_build_deflection_messy_csv_fixtures.py
+++ b/tests/test_build_deflection_messy_csv_fixtures.py
@@ -91,6 +91,7 @@ def test_build_deflection_messy_csv_fixtures_writes_manifest_and_cases(tmp_path:
         ("cp1252_semicolon.csv", 4),
         ("tab_delimited.csv", 4),
         ("html_bodies.csv", 4),
+        ("leading_metadata_row.csv", 3),
         ("quoted_multiline.csv", 3),
         ("ragged_short_rows.csv", 1),
     ],
@@ -126,7 +127,7 @@ def test_generated_html_case_produces_non_empty_deflection_report_items(tmp_path
     assert "Needs review & policy check." in result.markdown
 
 
-@pytest.mark.parametrize("filename", ["leading_metadata_row.csv", "ragged_extra_cells.csv"])
+@pytest.mark.parametrize("filename", ["ragged_extra_cells.csv"])
 def test_generated_bad_messy_csv_cases_fail_loud(tmp_path: Path, filename: str) -> None:
     output_dir = _build_fixtures(tmp_path)
 

--- a/tests/test_extracted_campaign_customer_data.py
+++ b/tests/test_extracted_campaign_customer_data.py
@@ -136,7 +136,7 @@ def test_load_campaign_opportunities_from_semicolon_csv_detects_delimiter(
     assert loaded.opportunities[0]["vendor_name"] == "HubSpot"
 
 
-def test_load_campaign_opportunities_from_csv_fails_on_leading_metadata_row(
+def test_load_campaign_opportunities_from_csv_skips_leading_metadata_row(
     tmp_path: Path,
 ) -> None:
     path = tmp_path / "opportunities.csv"
@@ -149,8 +149,11 @@ def test_load_campaign_opportunities_from_csv_fails_on_leading_metadata_row(
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="more cells than the header"):
-        load_campaign_opportunities_from_file(path)
+    loaded = load_campaign_opportunities_from_file(path)
+
+    assert loaded.warnings == ()
+    assert loaded.opportunities[0]["target_id"] == "opp-1"
+    assert loaded.opportunities[0]["company_name"] == "Acme"
 
 
 def test_normalize_campaign_opportunity_rows_skips_non_object_rows() -> None:

--- a/tests/test_extracted_campaign_customer_data.py
+++ b/tests/test_extracted_campaign_customer_data.py
@@ -151,7 +151,11 @@ def test_load_campaign_opportunities_from_csv_skips_leading_metadata_row(
 
     loaded = load_campaign_opportunities_from_file(path)
 
-    assert loaded.warnings == ()
+    assert len(loaded.warnings) == 1
+    skip_warning = loaded.warnings[0]
+    assert skip_warning.code == "csv_leading_rows_skipped"
+    assert skip_warning.row_index == 1
+    assert "Zendesk ticket export" in skip_warning.message
     assert loaded.opportunities[0]["target_id"] == "opp-1"
     assert loaded.opportunities[0]["company_name"] == "Acme"
 

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import csv
 import http.client
+from io import StringIO
 from pathlib import Path
 import socket
 import urllib.error
@@ -86,6 +88,18 @@ def _csv_bytes(rows: list[str]) -> bytes:
     return ("\n".join(rows) + "\n").encode("utf-8")
 
 
+def _csv_dict_bytes(rows: list[dict[str, str]]) -> bytes:
+    out = StringIO()
+    writer = csv.DictWriter(
+        out,
+        fieldnames=tuple(rows[0]),
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    return out.getvalue().encode("utf-8")
+
+
 def _install_blob(
     monkeypatch: pytest.MonkeyPatch,
     data: bytes,
@@ -134,21 +148,55 @@ async def test_deflection_submit_upload_parses_bom_semicolon_csv() -> None:
 
 
 @pytest.mark.asyncio
-async def test_deflection_submit_upload_fails_loud_on_metadata_header() -> None:
+async def test_deflection_submit_upload_parses_embedded_quotes_and_newlines() -> None:
+    data = _csv_dict_bytes([
+        {
+            "ticket_id": "ticket-quoted-1",
+            "subject": 'Need help with "classes"',
+            "message": (
+                'The portal says "classes" are missing.\n'
+                "I already tried the setup wizard."
+            ),
+            "answer": 'Open Settings, choose "Classes", then select Sync.',
+        },
+    ])
+
+    rows, byte_count = await api_module._load_deflection_submit_upload_rows(
+        _Upload(data),
+        max_bytes=2048,
+    )
+
+    assert byte_count == len(data)
+    assert rows == [{
+        "ticket_id": "ticket-quoted-1",
+        "subject": 'Need help with "classes"',
+        "message": (
+            'The portal says "classes" are missing.\n'
+            "I already tried the setup wizard."
+        ),
+        "answer": 'Open Settings, choose "Classes", then select Sync.',
+    }]
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_upload_skips_provider_metadata_header() -> None:
     data = _csv_bytes([
         "Zendesk ticket export",
         "ticket_id,subject,message",
         "ticket-1,Export help,How do I export attribution reports?",
     ])
 
-    with pytest.raises(api_module.HTTPException) as excinfo:
-        await api_module._load_deflection_submit_upload_rows(
-            _Upload(data),
-            max_bytes=1024,
-        )
+    rows, byte_count = await api_module._load_deflection_submit_upload_rows(
+        _Upload(data),
+        max_bytes=1024,
+    )
 
-    assert excinfo.value.status_code == 400
-    assert excinfo.value.detail == "Uploaded CSV could not be parsed."
+    assert byte_count == len(data)
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": "How do I export attribution reports?",
+    }]
 
 
 def _router(
@@ -347,6 +395,127 @@ async def test_deflection_submit_accepts_multipart_csv_bytes() -> None:
 
     snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
     assert await snapshot.endpoint(request_id=payload["request_id"]) == gated_result["snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_defaults_to_all_rows_that_fit_upload_guard() -> None:
+    row_count = api_module._MAX_INGESTION_ROWS + 5
+    csv_data = _csv_bytes([
+        "ticket_id,subject,message,resolution_text,pain_category",
+        *(
+            (
+                f"ticket-export-{index},Export reports,"
+                f"How do I export report batch {index}?,"
+                "Open Analytics and click Download report.,exports"
+            )
+            for index in range(row_count)
+        ),
+    ])
+    store = InMemoryDeflectionReportArtifactStore()
+    router = _router(store)
+
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    request = _FormRequest({
+        "csv_file": _Upload(csv_data),
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+    })
+    payload = await submit.endpoint(request)
+
+    metadata = payload["input_provider"]["metadata"]
+    assert metadata["source_row_count"] == row_count
+    assert metadata["submitted_row_count"] == row_count
+    assert metadata["included_row_count"] == row_count
+    assert metadata["truncated_row_count"] == 0
+    assert metadata["max_source_material_rows"] == row_count
+    assert payload["input_provider"]["warnings"] == []
+    assert payload["steps"][0]["result"]["full_report"] == {
+        "status": "locked",
+        "reason": "payment_required",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_filters_non_english_huggingface_shaped_rows() -> None:
+    csv_data = _csv_dict_bytes([
+        {
+            "subject": "Instructions for Returning Products",
+            "body": "How do I return a recent purchase from your store?",
+            "answer": (
+                "Items should be returned within 30 days in their original "
+                "condition. Start the return in the online returns portal."
+            ),
+            "language": "en",
+            "queue": "Returns and Exchanges",
+        },
+        {
+            "subject": "Synchronisationsproblem",
+            "body": "Ich erfahre Schwierigkeiten bei der Synchronisation.",
+            "answer": "Bitte senden Sie aktuelle Fehlerprotokolle.",
+            "language": "de",
+            "queue": "Technical Support",
+        },
+    ])
+    store = InMemoryDeflectionReportArtifactStore()
+    router = _router(store)
+
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    request = _FormRequest({
+        "csv_file": _Upload(csv_data),
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+    })
+    payload = await submit.endpoint(request)
+
+    metadata = payload["input_provider"]["metadata"]
+    assert metadata["loaded_source_row_count"] == 2
+    assert metadata["source_row_count"] == 1
+    assert metadata["submitted_row_count"] == 1
+    assert metadata["included_row_count"] == 1
+    assert metadata["language_filtered_row_count"] == 1
+    assert metadata["support_ticket_resolution_evidence_count"] == 1
+    assert payload["input_provider"]["warnings"] == [{
+        "code": "deflection_submit_non_english_rows_filtered",
+        "message": "Skipped 1 non-English support-ticket rows.",
+        "row_count": 2,
+        "filtered_row_count": 1,
+    }]
+    snapshot = payload["steps"][0]["result"]["snapshot"]
+    assert snapshot["summary"]["support_ticket_resolution_evidence_count"] == 1
+    assert snapshot["summary"]["drafted_answer_count"] == 1
+    assert "Synchronisationsproblem" not in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_all_non_english_language_marked_rows() -> None:
+    csv_data = _csv_dict_bytes([
+        {
+            "subject": "Synchronisationsproblem",
+            "body": "Ich erfahre Schwierigkeiten bei der Synchronisation.",
+            "answer": "Bitte senden Sie aktuelle Fehlerprotokolle.",
+            "language": "de",
+        },
+    ])
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(_FormRequest({
+            "csv_file": _Upload(csv_data),
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        }))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "reason": "deflection_submit_no_english_rows",
+        "message": "Submitted CSV did not contain English support-ticket rows.",
+        "source_row_count": 1,
+        "language_filtered_row_count": 1,
+    }
 
 
 @pytest.mark.asyncio
@@ -650,7 +819,7 @@ async def test_deflection_submit_rejects_csv_without_usable_ticket_text(
         "reason": "deflection_submit_no_usable_rows",
         "message": "Blob CSV did not include usable support-ticket wording.",
         "source_row_count": 1,
-        "max_source_material_rows": 1000,
+        "max_source_material_rows": 1,
     }
 
 

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -134,12 +134,13 @@ async def test_deflection_submit_upload_parses_bom_semicolon_csv() -> None:
         "ticket-1;Export help;How do I export attribution reports?\n"
     ).encode("utf-8")
 
-    rows, byte_count = await api_module._load_deflection_submit_upload_rows(
+    rows, byte_count, load_warnings = await api_module._load_deflection_submit_upload_rows(
         _Upload(data),
         max_bytes=1024,
     )
 
     assert byte_count == len(data)
+    assert load_warnings == ()
     assert rows == [{
         "ticket_id": "ticket-1",
         "subject": "Export help",
@@ -161,12 +162,13 @@ async def test_deflection_submit_upload_parses_embedded_quotes_and_newlines() ->
         },
     ])
 
-    rows, byte_count = await api_module._load_deflection_submit_upload_rows(
+    rows, byte_count, load_warnings = await api_module._load_deflection_submit_upload_rows(
         _Upload(data),
         max_bytes=2048,
     )
 
     assert byte_count == len(data)
+    assert load_warnings == ()
     assert rows == [{
         "ticket_id": "ticket-quoted-1",
         "subject": 'Need help with "classes"',
@@ -186,12 +188,16 @@ async def test_deflection_submit_upload_skips_provider_metadata_header() -> None
         "ticket-1,Export help,How do I export attribution reports?",
     ])
 
-    rows, byte_count = await api_module._load_deflection_submit_upload_rows(
+    rows, byte_count, load_warnings = await api_module._load_deflection_submit_upload_rows(
         _Upload(data),
         max_bytes=1024,
     )
 
     assert byte_count == len(data)
+    assert len(load_warnings) == 1
+    assert load_warnings[0]["code"] == "csv_leading_rows_skipped"
+    assert load_warnings[0]["row_index"] == 1
+    assert "Zendesk ticket export" in load_warnings[0]["message"]
     assert rows == [{
         "ticket_id": "ticket-1",
         "subject": "Export help",
@@ -516,6 +522,77 @@ async def test_deflection_submit_rejects_all_non_english_language_marked_rows() 
         "source_row_count": 1,
         "language_filtered_row_count": 1,
     }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_surfaces_skipped_prologue_row_warning() -> None:
+    csv_data = _csv_bytes([
+        "Zendesk ticket export",
+        "ticket_id,subject,message,resolution_text",
+        (
+            "ticket-1,Export attribution,"
+            "How do I export attribution reports?,"
+            "Open Analytics and click Download report."
+        ),
+        (
+            "ticket-2,Report download,"
+            "Where is the report download for attribution exports?,"
+            "Open Analytics and click Download report."
+        ),
+    ])
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    request = _FormRequest({
+        "csv_file": _Upload(csv_data),
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+    })
+
+    payload = await submit.endpoint(request)
+
+    metadata = payload["input_provider"]["metadata"]
+    assert metadata["source_row_count"] == 2
+    assert metadata["submitted_row_count"] == 2
+    warnings = payload["input_provider"]["warnings"]
+    assert len(warnings) == 1
+    assert warnings[0]["code"] == "csv_leading_rows_skipped"
+    assert warnings[0]["row_index"] == 1
+    assert "Zendesk ticket export" in warnings[0]["message"]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "en",
+        "EN",
+        "eng",
+        "English",
+        "en-US",
+        "en_GB",
+        "English (US)",
+        "English (United Kingdom)",
+        "english(us)",
+        "en (US)",
+    ],
+)
+def test_is_english_language_accepts_common_and_display_forms(value: str) -> None:
+    assert api_module._is_english_language(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "de",
+        "German",
+        "Deutsch (Deutschland)",
+        "es-MX",
+        "fr_FR",
+        "(US)",
+    ],
+)
+def test_is_english_language_rejects_non_english_forms(value: str) -> None:
+    assert api_module._is_english_language(value) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -222,7 +222,7 @@ def test_validate_args_fails_closed_for_missing_and_unsafe_inputs() -> None:
         "--contact-email",
         "",
         "--limit",
-        "1001",
+        str(smoke.SUBMIT_ROW_LIMIT_MAX + 1),
         "--timeout",
         "0",
         "--submit-path",
@@ -239,7 +239,7 @@ def test_validate_args_fails_closed_for_missing_and_unsafe_inputs() -> None:
         "--support-platform must be one of: help_scout, intercom, other, zendesk",
         "ATLAS_DEFLECTION_COMPANY_NAME or --company-name is required",
         "ATLAS_DEFLECTION_CONTACT_EMAIL or --contact-email is required",
-        "--limit must be between 1 and 1000",
+        f"--limit must be between 1 and {smoke.SUBMIT_ROW_LIMIT_MAX}",
         "--timeout must be a positive finite number",
         "--submit-path must start with /",
         "--snapshot-path-template must include {request_id}",
@@ -458,6 +458,7 @@ def test_run_success_posts_submit_and_probes_snapshot_and_locked_artifact(monkey
     assert calls[0]["url"] == "https://atlas.example.com/api/v1/content-ops/deflection-reports/submit"
     assert calls[0]["body"]["blob_url"] == "https://blob.example.com/tickets.csv?sig=signed-secret"
     assert calls[0]["body"]["support_platform"] == "zendesk"
+    assert "limit" not in calls[0]["body"]
     assert calls[1]["url"].endswith("/content-ops-123/snapshot")
     assert calls[2]["url"].endswith("/content-ops-123/artifact")
     serialized = json.dumps(summary)
@@ -506,11 +507,48 @@ def test_run_success_posts_multipart_csv_and_probes_locked_artifact(monkeypatch,
     assert 'name="csv_file"; filename="tickets.csv"' in calls[0]["body_text"]
     assert "How do I export reports?" in calls[0]["body_text"]
     assert 'name="support_platform"' in calls[0]["body_text"]
+    assert 'name="limit"' not in calls[0]["body_text"]
     assert "blob_url" not in calls[0]["body_text"]
     assert summary["submit"]["diagnostics"]["metadata"]["uploaded_bytes"] == csv_file.stat().st_size
     serialized = json.dumps(summary)
     assert "token-secret" not in serialized
     assert "How do I export reports?" not in serialized
+
+
+def test_run_sends_explicit_large_submit_limit_when_requested(monkeypatch, tmp_path):
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        smoke,
+        "_open_http_request",
+        _fake_open(
+            [
+                (
+                    200,
+                    _submit_payload(
+                        metadata={
+                            "source": "portfolio_deflection_submit",
+                            "source_row_count": 25000,
+                            "submitted_row_count": 25000,
+                            "truncated_row_count": 0,
+                            "max_source_material_rows": 25000,
+                            "blob_bytes": 200,
+                            "support_platform": "zendesk",
+                        }
+                    ),
+                ),
+                (200, SNAPSHOT),
+                (403, {"detail": "payment_required"}),
+            ],
+            calls,
+        ),
+    )
+    args = smoke._build_parser().parse_args([*_base_args(tmp_path), "--limit", "25000"])
+
+    summary = smoke.run(args)
+
+    assert summary["ok"] is True
+    assert calls[0]["body"]["limit"] == 25000
+    assert summary["submit"]["diagnostics"]["metadata"]["max_source_material_rows"] == 25000
 
 
 def test_run_fails_with_stale_multipart_submit_route_diagnostic(monkeypatch, tmp_path):


### PR DESCRIPTION
Plan: plans/PR-Deflection-Full-Volume-Submit-Limit.md
Slice phase: Functional validation

#1440 needs the real CFPB upload proof to exercise every row that fits under the existing 50 MB submit guard. The submit path still had a legacy 1000-row default/clamp, and the CSV loader could reject or corrupt valid messy provider CSV before any report was built. This removes the silent truncation for portfolio deflection submit, hardens messy CSV parsing, skips provider prologue rows only when a plausible support-export header follows, filters language-marked uploads to English rows for this proof lane, and keeps the generic `/execute` FAQ row guard plus the 50 MB upload/blob guard intact.

## Intentional
- The explicit submit limit ceiling is tied to the 50 MB byte guard; the effective default cap is the parsed row count for that accepted file.
- The internal submit bypass uses an identity token and is stripped before downstream execution, so external `/execute` requests still use the existing public validation and row guard.
- The #1440 sample leaves `resolution_text` empty because CFPB company response status text is not proven help-desk answer evidence.
- Provider title/prologue rows are accepted only when followed by a plausible header; ragged extra-cell CSV remains fail-loud.
- This does not add translation or multilingual clustering; rows with a language marker are reduced to English rows.

## Deferred
- The live #1440 hosted run remains after this deploy: submit the generated 35,386-row CFPB sample, confirm snapshot email/PDF, complete payment, and confirm the full report email/PDF to `canfieldjuan24@gmail.com`.
- P0 production hardening for clustering scale, encoding detection, and proven-answer validation remains in #1454, #1455, and #1456.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_content_deflection_submit.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_support_ticket_input_package.py
  - 235 passed, 1 skipped.
- pytest tests/test_extracted_content_deflection_submit.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_support_ticket_input_package.py tests/test_extracted_campaign_customer_data.py tests/test_build_deflection_messy_csv_fixtures.py tests/test_smoke_content_ops_support_ticket_package.py
  - 274 passed, 1 skipped.
- python scripts/build_content_ops_deflection_report.py tmp/deflection_full_50k_e2e_20260609/cfpb_real_upload_under_50mb.csv --source-format csv --title "CFPB Real Export Deflection Report" --faq-title "CFPB Real Export FAQ Deflection Report" --default-field company_name=CFPB --default-field contact_email=canfieldjuan24@gmail.com --default-field vendor_name=CFPB --output tmp/deflection_full_50k_e2e_20260609/report_build/report.md --summary-output tmp/deflection_full_50k_e2e_20260609/report_build/summary.json --result-output tmp/deflection_full_50k_e2e_20260609/report_build/result.json --require-output-checks
  - Passed on 35,386-row / 52,363,054-byte CFPB sample generated with standard CSV quoting and embedded source quotes preserved; generated 37 ranked questions, 35,386 ticket sources, 0 proven answers, output checks all true.
- bash scripts/validate_extracted_content_pipeline.sh
  - Passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
  - Passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt
  - Passed.
- bash scripts/check_ascii_python.sh
  - Passed.
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py extracted_content_pipeline/campaign_customer_data.py scripts/build_deflection_messy_csv_fixtures.py scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_extracted_content_deflection_submit.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_extracted_support_ticket_input_package.py tests/test_extracted_campaign_customer_data.py tests/test_build_deflection_messy_csv_fixtures.py tests/test_smoke_content_ops_support_ticket_package.py
  - Passed.
- git diff --check
  - Passed.
- python scripts/sync_pr_plan.py plans/PR-Deflection-Full-Volume-Submit-Limit.md --check
  - Passed.

## Diff size
9 files, estimated 675 LOC. This is over the soft cap because the row-cap fix now includes parser hardening plus failure-first fixtures for embedded quotes, provider prologues/support-export headers, missing optional fields, mixed-language filtering, and all-non-English fail-closed behavior.
