### PR TITLE
Deflection repeat-volume preview

### DIFF
--- a/plans/PR-Deflection-Repeat-Volume-Preview.md
+++ b/plans/PR-Deflection-Repeat-Volume-Preview.md
@@ -1,0 +1,119 @@
+# PR-Deflection-Repeat-Volume-Preview
+
+## Why this slice exists
+
+#1450 made the public FAQ-deflection upload run ATLAS inspect before private
+Blob submit, and #1419's publishable-answer proof already landed through
+#1424, #1430/#1444, and #1441. The remaining in-lane preview gap is from
+#1440 Ask 2: a low-repeat-volume export can produce a technically valid but
+thin report, so the pre-payment surfaces should show repeat-ticket volume and
+warn when the export is light before the customer reaches the $1,500 checkout.
+
+This is a follow-on to the deflection/clustering raw-data lane. It renders an
+already-produced snapshot metric; it does not touch CSV parsing, report
+generation, PDF/email delivery, Stripe, or the separate full-50k delivery
+proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Functional validation
+
+1. Project `snapshot.summary.repeat_ticket_count` through the existing
+   portfolio snapshot projection.
+2. Render the repeat-volume signal on the hosted locked result page next to
+   the existing resolution-evidence lane.
+3. Render the same signal on the React fallback result page for local/client
+   snapshot continuity.
+4. Keep the warning soft: light exports are not blocked because they can still
+   be useful as gap-list diagnostics.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] The portfolio snapshot proxy preserves `repeat_ticket_count` as a safe
+        summary metric and still strips paid artifact fields.
+  - [ ] Missing or non-finite `repeat_ticket_count` fails closed instead of
+        synthesizing `0` and showing a false light-volume warning.
+  - [ ] The hosted locked result page renders `repeat_ticket_count` from the
+        snapshot summary before checkout, including a low-volume warning when
+        it is small.
+  - [ ] The React fallback result page renders the same repeat-volume cue from
+        session-storage snapshots.
+  - [ ] Existing resolution-evidence diagnostics and private-Blob submit
+        gating remain unchanged.
+- Affected surfaces: portfolio result proxy, portfolio result page, React
+  fallback result page, CI-enrolled portfolio tests.
+- Risk areas: API backcompat, PII/source leakage, frontend state coverage, CI
+  enrollment.
+- Reviewer rules triggered: R1, R2, R5, R9, R10, R12.
+
+### Files touched
+
+- `plans/PR-Deflection-Repeat-Volume-Preview.md`
+- `portfolio-ui/api/content-ops/deflection/atlas-report.js`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+- `portfolio-ui/src/pages/FaqDeflectionResult.tsx`
+
+## Mechanism
+
+`faq_deflection_report.build_deflection_snapshot()` already includes
+`summary.repeat_ticket_count`. The portfolio `atlas-report.js` projection
+currently drops that safe summary metric, and the hosted result page renders
+only questions, evidence-backed answers, and needs-proof counts.
+
+This slice carries `repeat_ticket_count` through the existing safe snapshot
+projection and renders a `Repeat-ticket volume` card before the Checkout CTA.
+Counts under 10 get a soft "light on repeat volume" warning; higher counts get
+the ready-state copy. The React fallback result page gets the same metric and
+copy so local/client snapshot rendering stays aligned with the hosted API
+route. Because the metric informs payment self-selection, both the hosted
+projection and the React fallback parser require a finite value and reject
+malformed snapshots instead of defaulting missing values to zero.
+
+## Intentional
+
+- This is a soft warning, not a hard gate. Low-volume uploads can still produce
+  useful diagnostics, and blocking them would be a product-policy decision
+  outside this narrow slice.
+- The threshold is presentation-only. No new `ATLAS_*` config is introduced
+  because no backend behavior changes.
+- The slice uses the existing snapshot summary. It does not call an LLM/Ollama
+  route, add a second clustering implementation, or recompute report quality in
+  the browser.
+- The full-50k intake -> snapshot -> email -> pay -> report-email proof from
+  #1440 remains outside this session's lane.
+
+## Deferred
+
+- #1440 full-50k delivery proof remains with the delivery/payment lane.
+- Operator-supplied production exports can tune the warning copy/threshold once
+  enough live examples exist.
+- Upload-inspect repeat-cluster diagnostics remain deferred; this slice uses
+  the locked result-page snapshot because that is the pre-checkout surface.
+- Closing stale tracker issues #1384/#1419 is operator/reviewer housekeeping,
+  not part of this code slice.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm --prefix portfolio-ui run test:deflection-result` - passed, 19 checks.
+- `npm --prefix portfolio-ui run test:deflection-atlas-proxy` - passed, 18 checks.
+- `npm --prefix portfolio-ui ci` - passed; reports existing npm audit findings
+  (1 moderate, 2 high), not changed in this slice.
+- `npm --prefix portfolio-ui run build` - passed; Vite reports existing
+  large-chunk and missing-sitemap-env warnings.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Repeat-Volume-Preview.md` | 119 |
+| `portfolio-ui/api/content-ops/deflection/atlas-report.js` | 3 |
+| `portfolio-ui/api/content-ops/deflection/result-page.js` | 39 |
+| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 24 |
+| `portfolio-ui/scripts/faq-deflection-result-page.test.mjs` | 27 |
+| `portfolio-ui/src/pages/FaqDeflectionResult.tsx` | 47 |
+| **Total** | **259** |

--- a/portfolio-ui/api/content-ops/deflection/atlas-report.js
+++ b/portfolio-ui/api/content-ops/deflection/atlas-report.js
@@ -99,6 +99,7 @@ function projectSnapshot(snapshot) {
   if (errors.length > 0) return { ok: false, errors };
 
   const generated = finiteNumber(snapshot.summary.generated);
+  const repeatTicketCount = finiteNumber(snapshot.summary.repeat_ticket_count);
   const draftedAnswerCount = finiteNumber(snapshot.summary.drafted_answer_count);
   const noProvenAnswerCount = finiteNumber(snapshot.summary.no_proven_answer_count);
   const resolutionEvidencePresent = snapshot.summary.support_ticket_resolution_evidence_present;
@@ -107,6 +108,7 @@ function projectSnapshot(snapshot) {
   );
   if (
     generated === null ||
+    repeatTicketCount === null ||
     draftedAnswerCount === null ||
     noProvenAnswerCount === null ||
     typeof resolutionEvidencePresent !== "boolean" ||
@@ -142,6 +144,7 @@ function projectSnapshot(snapshot) {
     snapshot: {
       summary: {
         generated,
+        repeat_ticket_count: repeatTicketCount,
         drafted_answer_count: draftedAnswerCount,
         no_proven_answer_count: noProvenAnswerCount,
         support_ticket_resolution_evidence_present: resolutionEvidencePresent,

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -3,6 +3,7 @@ import { CHECKOUT_SOURCE, resultPath } from "./checkout.js";
 
 const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LIGHT_REPEAT_TICKET_THRESHOLD = 10;
 
 function clean(value) {
   if (Array.isArray(value)) return clean(value[0]);
@@ -90,6 +91,26 @@ function renderResolutionEvidenceDiagnostic(summary) {
           </div>`;
 }
 
+function renderRepeatVolumeDiagnostic(summary) {
+  const count = finiteCount(summary.repeat_ticket_count);
+  const light = count < LIGHT_REPEAT_TICKET_THRESHOLD;
+  const label = count > 0 ? `${formatNumber(count)} repeat-ticket hits` : "No repeated clusters yet";
+  const copy = light
+    ? "This export is light on repeat volume. Review the free snapshot before paying for the full report."
+    : "This export has enough repeated ticket volume for a substantial paid report preview.";
+  return `<div
+            class="repeat-volume ${light ? "light" : "ready"}"
+            data-atlas-deflection-repeat-volume
+            data-repeat-volume-light="${light ? "true" : "false"}"
+          >
+            <div>
+              <span>Repeat-ticket volume</span>
+              <strong>${escapeHtml(label)}</strong>
+            </div>
+            <p>${escapeHtml(copy)}</p>
+          </div>`;
+}
+
 function renderSnapshot(report) {
   if (!report || !report.ok || !report.snapshot) {
     return `<section class="snapshot" aria-labelledby="snapshot-title">
@@ -105,9 +126,11 @@ function renderSnapshot(report) {
           <h2 id="snapshot-title">Free snapshot</h2>
           <div class="metrics">
             <div><span>Questions found</span><strong>${escapeHtml(formatNumber(summary.generated))}</strong></div>
+            <div><span>Repeat-ticket hits</span><strong>${escapeHtml(formatNumber(finiteCount(summary.repeat_ticket_count)))}</strong></div>
             <div><span>Evidence-backed answers</span><strong>${escapeHtml(formatNumber(summary.drafted_answer_count))}</strong></div>
             <div><span>Needs support proof</span><strong>${escapeHtml(formatNumber(summary.no_proven_answer_count))}</strong></div>
           </div>
+          ${renderRepeatVolumeDiagnostic(summary)}
           ${renderResolutionEvidenceDiagnostic(summary)}
           <h2>Help-desk SEO targeting list</h2>
           <p class="muted">Use actual customer phrases from the uploaded tickets for help-center titles, internal-search synonyms, and FAQ wording. No keyword volume, ranking, or traffic promise is implied.</p>
@@ -239,16 +262,19 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     button { width: 100%; border: 0; border-radius: 8px; background: #22c55e; color: #020617; padding: 13px 16px; font-weight: 800; cursor: pointer; }
     button:disabled { background: #1e293b; color: rgba(226, 232, 240, .55); cursor: not-allowed; }
     .snapshot { margin-top: 32px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(15, 23, 42, .42); padding: 24px; }
-    .metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin: 18px 0 24px; }
+    .metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin: 18px 0 24px; }
     .metrics div { border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; padding: 14px; background: rgba(2, 6, 23, .35); }
     .metrics span { display: block; color: rgba(226, 232, 240, .66); font-size: 13px; }
     .metrics strong { display: block; margin-top: 8px; font-size: 28px; }
-    .resolution-evidence { display: flex; gap: 18px; justify-content: space-between; align-items: flex-start; margin: 0 0 24px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; padding: 16px; background: rgba(2, 6, 23, .35); }
-    .resolution-evidence span { display: block; color: rgba(226, 232, 240, .66); font-size: 13px; }
-    .resolution-evidence strong { display: block; margin-top: 6px; font-size: 18px; }
-    .resolution-evidence p { max-width: 560px; margin: 0; color: rgba(226, 232, 240, .75); line-height: 1.55; }
+    .resolution-evidence, .repeat-volume { display: flex; gap: 18px; justify-content: space-between; align-items: flex-start; margin: 0 0 24px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; padding: 16px; background: rgba(2, 6, 23, .35); }
+    .repeat-volume { margin-bottom: 12px; }
+    .resolution-evidence span, .repeat-volume span { display: block; color: rgba(226, 232, 240, .66); font-size: 13px; }
+    .resolution-evidence strong, .repeat-volume strong { display: block; margin-top: 6px; font-size: 18px; }
+    .resolution-evidence p, .repeat-volume p { max-width: 560px; margin: 0; color: rgba(226, 232, 240, .75); line-height: 1.55; }
     .resolution-evidence.present strong { color: #86efac; }
     .resolution-evidence.absent strong { color: #fde68a; }
+    .repeat-volume.ready strong { color: #86efac; }
+    .repeat-volume.light strong { color: #fde68a; }
     .customer-wording-card { margin: 18px 0 24px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(2, 6, 23, .35); padding: 18px; }
     .customer-wording-header { display: flex; gap: 10px; align-items: baseline; justify-content: space-between; }
     .customer-wording-header p { margin: 0; font-weight: 700; }
@@ -264,7 +290,8 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     .notice { margin-top: 20px; border-radius: 8px; padding: 14px 16px; color: #fde68a; background: rgba(251, 191, 36, .1); border: 1px solid rgba(251, 191, 36, .28); }
     .success { color: #bbf7d0; background: rgba(34, 197, 94, .1); border-color: rgba(34, 197, 94, .28); }
     .muted { color: rgba(226, 232, 240, .68); line-height: 1.65; }
-    @media (max-width: 820px) { .grid, .metrics, .customer-wording-list { grid-template-columns: 1fr; } .shell { padding-top: 32px; } .customer-wording-header, .resolution-evidence { align-items: flex-start; flex-direction: column; } }
+    @media (max-width: 920px) { .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    @media (max-width: 820px) { .grid, .metrics, .customer-wording-list { grid-template-columns: 1fr; } .shell { padding-top: 32px; } .customer-wording-header, .resolution-evidence, .repeat-volume { align-items: flex-start; flex-direction: column; } }
   </style>
 </head>
 <body>

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -20,6 +20,7 @@ const ENV = {
 const SNAPSHOT = {
   summary: {
     generated: 3,
+    repeat_ticket_count: 12,
     drafted_answer_count: 2,
     no_proven_answer_count: 1,
     support_ticket_resolution_evidence_present: true,
@@ -204,11 +205,34 @@ await test("snapshot projection only returns known safe fields", async () => {
   ]);
 });
 
+await test("proxy rejects snapshots that omit repeat-ticket counts", async () => {
+  const { repeat_ticket_count: _repeatTicketCount, ...summaryWithoutRepeatCount } =
+    SNAPSHOT.summary;
+  const missingRepeatCount = {
+    ...SNAPSHOT,
+    summary: summaryWithoutRepeatCount,
+  };
+  const result = await loadDeflectionReport({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    env: ENV,
+    fetchImpl: mockFetch([response(missingRepeatCount, 200)]).fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 502);
+  assert.equal(result.error, "atlas_snapshot_contract_violation");
+  assert.deepEqual(result.details, [
+    "snapshot.summary metrics must include finite counts and resolution evidence",
+  ]);
+});
+
 await test("proxy rejects snapshots that omit resolution evidence diagnostics", async () => {
   const missingResolutionEvidence = {
     ...SNAPSHOT,
     summary: {
       generated: 3,
+      repeat_ticket_count: 12,
       drafted_answer_count: 2,
       no_proven_answer_count: 1,
     },

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -95,6 +95,7 @@ await test("result page exposes validation markers and checkout metadata", () =>
   }
   for (const source of [pageSource, resultPageSource]) {
     assert.match(source, /data-atlas-deflection-resolution-evidence/);
+    assert.match(source, /data-atlas-deflection-repeat-volume/);
   }
   assert.match(pageSource, /content_ops_deflection_report/);
   assert.match(html, /content_ops_deflection_report/);
@@ -122,6 +123,19 @@ await test("snapshot guard names paid report fields that must not render pre-pay
     assert.match(pageSource, new RegExp(`"${forbidden}"`));
   }
   assert.match(pageSource, /collectForbiddenKeys/);
+});
+
+await test("React fallback rejects snapshots that omit repeat-ticket counts", () => {
+  const compactPageSource = pageSource.replace(/\s+/g, " ");
+  assert.match(
+    compactPageSource,
+    /const repeatTicketCount = finiteNumber\(value\.summary\.repeat_ticket_count\);/,
+  );
+  assert.match(compactPageSource, /repeatTicketCount === null \|\| draftedAnswerCount === null/);
+  assert.doesNotMatch(
+    pageSource,
+    /finiteNumber\(value\.summary\.repeat_ticket_count\)\s*\?\?\s*0/,
+  );
 });
 
 await test("real snapshot page groups bounded customer wording examples", () => {
@@ -154,6 +168,7 @@ await test("real snapshot page groups bounded customer wording examples", () => 
       snapshot: {
         summary: {
           generated: 6,
+          repeat_ticket_count: 12,
           drafted_answer_count: 2,
           no_proven_answer_count: 4,
           support_ticket_resolution_evidence_present: true,
@@ -166,6 +181,11 @@ await test("real snapshot page groups bounded customer wording examples", () => 
   });
   assert.match(html, /Help-desk SEO targeting list/);
   assert.match(html, /data-atlas-deflection-resolution-evidence/);
+  assert.match(html, /data-atlas-deflection-repeat-volume/);
+  assert.match(html, /data-repeat-volume-light="false"/);
+  assert.match(html, /Repeat-ticket volume/);
+  assert.match(html, /12 repeat-ticket hits/);
+  assert.match(html, /substantial paid report preview/);
   assert.match(html, /data-resolution-evidence-present="true"/);
   assert.match(html, /Resolution evidence/);
   assert.match(html, /Present/);
@@ -195,6 +215,7 @@ await test("real snapshot page groups bounded customer wording examples", () => 
       snapshot: {
         summary: {
           generated: 0,
+          repeat_ticket_count: 0,
           drafted_answer_count: 0,
           no_proven_answer_count: 0,
           support_ticket_resolution_evidence_present: false,
@@ -219,6 +240,7 @@ await test("hosted result page flags absent resolution evidence as gap list only
       snapshot: {
         summary: {
           generated: 2,
+          repeat_ticket_count: 3,
           drafted_answer_count: 0,
           no_proven_answer_count: 2,
           support_ticket_resolution_evidence_present: false,
@@ -238,6 +260,10 @@ await test("hosted result page flags absent resolution evidence as gap list only
   });
 
   assert.match(html, /data-atlas-deflection-resolution-evidence/);
+  assert.match(html, /data-atlas-deflection-repeat-volume/);
+  assert.match(html, /data-repeat-volume-light="true"/);
+  assert.match(html, /3 repeat-ticket hits/);
+  assert.match(html, /light on repeat volume/);
   assert.match(html, /data-resolution-evidence-present="false"/);
   assert.match(html, /Resolution evidence/);
   assert.match(html, /Absent/);
@@ -290,6 +316,7 @@ await test("hosted result page loads report with configured account when URL omi
             ? {
                 summary: {
                   generated: 1,
+                  repeat_ticket_count: 1,
                   drafted_answer_count: 0,
                   no_proven_answer_count: 1,
                   support_ticket_resolution_evidence_present: false,

--- a/portfolio-ui/src/pages/FaqDeflectionResult.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionResult.tsx
@@ -13,6 +13,7 @@ import { SeoHead } from "@/components/seo/SeoHead";
 const SNAPSHOT_STORAGE_PREFIX = "atlas:deflection:snapshot:";
 const CHECKOUT_ENDPOINT = "/api/content-ops/deflection/checkout";
 const CHECKOUT_SOURCE = "content_ops_deflection_report";
+const LIGHT_REPEAT_TICKET_THRESHOLD = 10;
 const FORBIDDEN_SNAPSHOT_KEYS = new Set([
   "answer",
   "answers",
@@ -30,6 +31,7 @@ const FORBIDDEN_SNAPSHOT_KEYS = new Set([
 type DeflectionSnapshot = {
   summary: {
     generated: number;
+    repeat_ticket_count: number;
     drafted_answer_count: number;
     no_proven_answer_count: number;
     support_ticket_resolution_evidence_present: boolean;
@@ -87,6 +89,7 @@ function parseSnapshot(value: unknown): SnapshotState {
   }
 
   const generated = finiteNumber(value.summary.generated);
+  const repeatTicketCount = finiteNumber(value.summary.repeat_ticket_count);
   const draftedAnswerCount = finiteNumber(value.summary.drafted_answer_count);
   const noProvenAnswerCount = finiteNumber(value.summary.no_proven_answer_count);
   const resolutionEvidencePresent = value.summary.support_ticket_resolution_evidence_present;
@@ -95,6 +98,7 @@ function parseSnapshot(value: unknown): SnapshotState {
   );
   if (
     generated === null ||
+    repeatTicketCount === null ||
     draftedAnswerCount === null ||
     noProvenAnswerCount === null ||
     typeof resolutionEvidencePresent !== "boolean" ||
@@ -133,6 +137,7 @@ function parseSnapshot(value: unknown): SnapshotState {
     snapshot: {
       summary: {
         generated,
+        repeat_ticket_count: repeatTicketCount,
         drafted_answer_count: draftedAnswerCount,
         no_proven_answer_count: noProvenAnswerCount,
         support_ticket_resolution_evidence_present: resolutionEvidencePresent,
@@ -175,6 +180,7 @@ export default function FaqDeflectionResult() {
     const { summary } = snapshotState.snapshot;
     return [
       { label: "Questions found", value: summary.generated },
+      { label: "Repeat-ticket hits", value: summary.repeat_ticket_count },
       { label: "Evidence-backed answers", value: summary.drafted_answer_count },
       { label: "Needs support proof", value: summary.no_proven_answer_count },
     ];
@@ -199,6 +205,19 @@ export default function FaqDeflectionResult() {
       copy: present
         ? `${formatCount(count)} resolved ticket rows can support publishable answer drafting.`
         : "This export supports a gap list only; publishable answers need agent replies or resolved ticket notes.",
+    };
+  }, [snapshotState]);
+
+  const repeatVolume = useMemo(() => {
+    if (snapshotState.status !== "available") return null;
+    const count = snapshotState.snapshot.summary.repeat_ticket_count;
+    const light = count < LIGHT_REPEAT_TICKET_THRESHOLD;
+    return {
+      light,
+      label: count > 0 ? `${formatCount(count)} repeat-ticket hits` : "No repeated clusters yet",
+      copy: light
+        ? "This export is light on repeat volume. Review the free snapshot before paying for the full report."
+        : "This export has enough repeated ticket volume for a substantial paid report preview.",
     };
   }, [snapshotState]);
 
@@ -280,7 +299,7 @@ export default function FaqDeflectionResult() {
               </div>
             )}
 
-            <div className="mt-8 grid gap-4 sm:grid-cols-3">
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {metricCards.length > 0 ? (
                 metricCards.map((metric) => (
                   <div
@@ -294,7 +313,7 @@ export default function FaqDeflectionResult() {
                   </div>
                 ))
               ) : (
-                <div className="sm:col-span-3 rounded-lg border border-surface-700/60 bg-surface-800/40 p-5">
+                <div className="sm:col-span-2 lg:col-span-4 rounded-lg border border-surface-700/60 bg-surface-800/40 p-5">
                   <p className="text-sm font-semibold text-white">Snapshot not loaded</p>
                   <p className="mt-2 text-sm leading-6 text-surface-200/75">
                     This page has not received the free snapshot from the submit
@@ -304,6 +323,30 @@ export default function FaqDeflectionResult() {
                 </div>
               )}
             </div>
+
+            {repeatVolume && (
+              <div
+                className="mt-4 flex flex-col gap-3 rounded-lg border border-surface-700/60 bg-surface-800/40 p-5 sm:flex-row sm:items-start sm:justify-between"
+                data-atlas-deflection-repeat-volume
+                data-repeat-volume-light={repeatVolume.light ? "true" : "false"}
+              >
+                <div>
+                  <p className="text-sm text-surface-200/70">Repeat-ticket volume</p>
+                  <p
+                    className={
+                      repeatVolume.light
+                        ? "mt-2 text-lg font-semibold text-amber-200"
+                        : "mt-2 text-lg font-semibold text-primary-300"
+                    }
+                  >
+                    {repeatVolume.label}
+                  </p>
+                </div>
+                <p className="max-w-xl text-sm leading-6 text-surface-200/75">
+                  {repeatVolume.copy}
+                </p>
+              </div>
+            )}
 
             {resolutionEvidence && (
               <div


### PR DESCRIPTION
Plan: plans/PR-Deflection-Repeat-Volume-Preview.md
Slice phase: Functional validation

#1440 Ask 2 called out that low-repeat-volume exports can produce a thin but valid report. This slice carries the existing `repeat_ticket_count` snapshot summary through the portfolio projection and renders a soft repeat-volume cue on the locked result page before Checkout.

## Intentional
- Soft warning only: low-volume uploads can still produce useful gap-list diagnostics, so this does not block checkout.
- Presentation-only threshold: no new `ATLAS_*` config because backend behavior is unchanged.
- Uses the existing snapshot summary; no LLM/Ollama route, new clustering implementation, or browser-side quality recomputation.
- The full-50k intake -> snapshot -> email -> pay -> report-email proof from #1440 remains outside this session's lane.

## Deferred
- #1440 full-50k delivery proof remains with the delivery/payment lane.
- Operator-supplied production exports can tune the warning copy/threshold once enough live examples exist.
- Upload-inspect repeat-cluster diagnostics remain deferred; this slice uses the locked result-page snapshot because that is the pre-checkout surface.
- Closing stale tracker issues #1384/#1419 is operator/reviewer housekeeping, not part of this code slice.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed Codex P2 "Reject missing repeat-ticket counts": `repeat_ticket_count` now fails closed in both the hosted snapshot projection and React fallback parser instead of defaulting a missing value to `0`; added missing-field regression coverage in both test layers.

## Verification
- `npm --prefix portfolio-ui run test:deflection-result` - passed, 19 checks.
- `npm --prefix portfolio-ui run test:deflection-atlas-proxy` - passed, 18 checks.
- `npm --prefix portfolio-ui ci` - passed; reports existing npm audit findings (1 moderate, 2 high), not changed in this slice.
- `npm --prefix portfolio-ui run build` - passed; Vite reports existing large-chunk and missing-sitemap-env warnings.
- `bash scripts/push_pr.sh /tmp/atlas-pr-deflection-repeat-volume-preview.md --force-with-lease origin HEAD` - passed; local PR review passed.

## Diff size
6 files, +251 / -8.
