### PR TITLE
Deflection proven-answer gate

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -1248,9 +1248,27 @@ _RESOLUTION_NON_VERB_LEADS = frozenset({
     "what", "when", "where", "which", "while", "who", "why", "with", "you",
     "your",
 })
+# The object of an imperative is an article/possessive-introduced noun phrase or
+# an imperative preposition. Demonstratives/pronouns (this/that/it/...) are
+# excluded: they are clause subjects, so "<adverb> this is a known issue" must
+# not parse as "<verb> <object>".
 _RESOLUTION_INSTRUCTION_OBJECT_RE = re.compile(
-    r"^(?:the|your|a|an|this|that|these|those|its|their|it|them|all|each|any|"
-    r"on|off|into|to|from|in|under|via|by|both)\b",
+    r"^(?:the|your|a|an|its|their|to|into|onto|on|off|from)\b",
+    re.IGNORECASE,
+)
+# Linking verbs never lead an imperative; a sentence opening with one is a
+# question or declarative ("Is the account active?"), not a step.
+_RESOLUTION_COPULA_LEADS = frozenset({
+    "is", "are", "was", "were", "be", "been", "being", "am",
+    "seem", "seems", "seemed", "look", "looks", "looked",
+    "remain", "remains", "remained", "appear", "appears", "appeared",
+    "become", "becomes", "became",
+})
+# "<article> <noun ...> is/are ..." is a declarative subject + copula, not an
+# instruction object ("the issue is annoying", "the export is a known limit").
+_RESOLUTION_OBJECT_DECLARATIVE_RE = re.compile(
+    r"^(?:the|your|a|an|its|their)\s+[a-z'-]+(?:\s+[a-z'-]+){0,2}\s+"
+    r"(?:is|are|was|were|be|been|seems?|looks?|remains?|appears?|becomes?)\b",
     re.IGNORECASE,
 )
 _RESOLUTION_LEAD_WORD_RE = re.compile(r"([a-z][a-z'-]*)", re.IGNORECASE)
@@ -1314,7 +1332,7 @@ def _resolution_text_looks_instructional(text: str) -> bool:
         if not lead_match:
             continue
         lead = lead_match.group(1).lower()
-        if lead in _RESOLUTION_NON_VERB_LEADS:
+        if lead in _RESOLUTION_NON_VERB_LEADS or lead in _RESOLUTION_COPULA_LEADS:
             continue
         # Stem the lead so past-tense / gerund action verbs ("Enabled the SSO",
         # "Configured ...", "Updating ...") still register as instructions.
@@ -1327,7 +1345,11 @@ def _resolution_text_looks_instructional(text: str) -> bool:
         if first_person:
             continue
         rest = remainder[lead_match.end():].lstrip()
-        if _RESOLUTION_INSTRUCTION_OBJECT_RE.match(rest):
+        # The object must be a genuine instruction object, not a clause subject
+        # that a copula turns into a declarative ("Honestly the issue is ...").
+        if _RESOLUTION_INSTRUCTION_OBJECT_RE.match(rest) and not (
+            _RESOLUTION_OBJECT_DECLARATIVE_RE.match(rest)
+        ):
             return True
     return False
 

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -1226,7 +1226,11 @@ def _resolution_text(*rows: Mapping[str, Any], question_text: str = "") -> str:
 # list. This recognizes unknown verbs (schedule, pin, narrow, forward, ...) by
 # the "<verb> the/your/a <noun>" imperative shape, numbered steps, or a UI
 # navigation path -- the enumerated lists could never keep up (four rounds).
-_RESOLUTION_SENTENCE_SPLIT_RE = re.compile(r"[.!?\n]+")
+# Split on sentence terminators but KEEP them attached (lookbehind), so a
+# trailing "?" survives and an interrogative sentence ("Did the lights change?")
+# can be told apart from a step. The lead word and object shapes are anchored to
+# the start of each sentence, so a retained terminator does not affect them.
+_RESOLUTION_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+|\n+")
 _RESOLUTION_STEP_STRUCTURE_RE = re.compile(r"(?m)^\s*(?:step\s*)?\d+[.):]\s+\S")
 _RESOLUTION_UI_PATH_RE = re.compile(
     r"\b[a-z][\w-]*\s+then\s+[a-z][\w-]*\b", re.IGNORECASE
@@ -1276,6 +1280,25 @@ _RESOLUTION_LEAD_WORD_RE = re.compile(r"([a-z][a-z'-]*)", re.IGNORECASE)
 _RESOLUTION_FIRST_PERSON_LEAD_RE = re.compile(
     r"^(?:i|we)(?:\s+(?:have|had|then|just|already|also))?\s+", re.IGNORECASE
 )
+# Contact-channel redirection: directing the requester to reach a human over a
+# private channel ("send us a DM", "message us", "shoot me a private message")
+# is a hand-off, not a self-serve resolution. This is the imperative-shaped
+# sibling of the disposition reject (a "Please DM us" reply passes the
+# instruction-shape test but answers nothing), surfaced by running the gate over
+# real support replies. Narrow on purpose -- it matches "<verb> us/me" and the
+# "DM/PM/private message" redirect nouns, not legitimate steps that merely
+# contain "send"/"message" ("Send the report to your team", "Message the channel
+# owner"). Applied per sentence, so a genuine step followed by a "...then DM us"
+# fallback still publishes on the real step.
+_RESOLUTION_CONTACT_REDIRECT_RE = re.compile(
+    r"\b(?:send|shoot|drop|message|dm|pm|ping)\s+(?:us|me)\b"
+    r"|\b(?:dm|pm|message|ping|contact)\s+us\b"
+    r"|\bsend\s+(?:us|me)\s+a\s+(?:dm\b|pm\b|message\b|private\s+message|direct\s+message)"
+    r"|\b(?:private|direct)\s+message\s+(?:us|me)\b"
+    r"|\breach\s+out\s+to\s+us\b"
+    r"|\bprivate\s+message\b",
+    re.IGNORECASE,
+)
 
 
 def _resolution_text_is_publishable(value: Any, *, question_text: str) -> bool:
@@ -1321,6 +1344,11 @@ def _resolution_text_looks_instructional(text: str) -> bool:
         stripped = sentence.strip()
         if not stripped:
             continue
+        # A question is not a step. An agent reply that ends in "?" ("Did the
+        # lights change on the router?") is a diagnostic prompt back to the
+        # requester, not a resolution they can act on.
+        if stripped.endswith("?"):
+            continue
         if _RESOLUTION_DISPOSITION_ONLY_RE.search(stripped):
             continue
         prefix = _RESOLUTION_INSTRUCTION_PREFIX_RE.match(stripped)
@@ -1328,6 +1356,13 @@ def _resolution_text_looks_instructional(text: str) -> bool:
         first_person = _RESOLUTION_FIRST_PERSON_LEAD_RE.match(remainder)
         if first_person:
             remainder = remainder[first_person.end():]
+        # A contact redirect only disqualifies the sentence when it is the lead
+        # clause ("Send us a DM ...", "Have your friend message us"). A redirect
+        # trailing a real step ("Reset the cache, then DM us if it persists")
+        # leaves the step intact, so check only up to the first clause break.
+        lead_clause = re.split(r"[,;]", remainder, maxsplit=1)[0]
+        if _RESOLUTION_CONTACT_REDIRECT_RE.search(lead_clause):
+            continue
         lead_match = _RESOLUTION_LEAD_WORD_RE.match(remainder)
         if not lead_match:
             continue

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -1220,29 +1220,141 @@ def _resolution_text(*rows: Mapping[str, Any], question_text: str = "") -> str:
     return ""
 
 
+# Imperative-shape detection for the publishable gate (#1466 Option 1). A
+# resolution is publishable when it survives the reject filters AND looks like
+# an instruction, rather than when it contains a token from a fixed action-term
+# list. This recognizes unknown verbs (schedule, pin, narrow, forward, ...) by
+# the "<verb> the/your/a <noun>" imperative shape, numbered steps, or a UI
+# navigation path -- the enumerated lists could never keep up (four rounds).
+_RESOLUTION_SENTENCE_SPLIT_RE = re.compile(r"[.!?\n]+")
+_RESOLUTION_STEP_STRUCTURE_RE = re.compile(r"(?m)^\s*(?:step\s*)?\d+[.):]\s+\S")
+_RESOLUTION_UI_PATH_RE = re.compile(
+    r"\b[a-z][\w-]*\s+then\s+[a-z][\w-]*\b", re.IGNORECASE
+)
+# A leading clause that precedes the real instruction ("To fix this, reset ...").
+_RESOLUTION_INSTRUCTION_PREFIX_RE = re.compile(
+    r"^(?:please\s+|kindly\s+|first[,]?\s+|then[,]?\s+|next[,]?\s+|now[,]?\s+"
+    r"|to\s+[a-z]+\s+(?:this|it|that|the\s+(?:issue|problem|error))\s*[,:]\s*)+",
+    re.IGNORECASE,
+)
+# Sentence-lead tokens that are not imperative verbs, so a leading "<word> the"
+# match (e.g. "About the export") is not mistaken for an instruction.
+_RESOLUTION_NON_VERB_LEADS = frozenset({
+    "about", "after", "also", "an", "and", "any", "as", "because", "before",
+    "but", "for", "he", "her", "here", "his", "how", "however", "i", "in",
+    "into", "it", "its", "my", "no", "not", "once", "or", "our", "per", "she",
+    "since", "so", "that", "the", "their", "them", "then", "there", "these",
+    "they", "this", "those", "thanks", "thank", "to", "unfortunately", "we",
+    "what", "when", "where", "which", "while", "who", "why", "with", "you",
+    "your",
+})
+_RESOLUTION_INSTRUCTION_OBJECT_RE = re.compile(
+    r"^(?:the|your|a|an|this|that|these|those|its|their|it|them|all|each|any|"
+    r"on|off|into|to|from|in|under|via|by|both)\b",
+    re.IGNORECASE,
+)
+_RESOLUTION_LEAD_WORD_RE = re.compile(r"([a-z][a-z'-]*)", re.IGNORECASE)
+# A first-person subject preceding the action ("I enabled ...", "We reset ...").
+_RESOLUTION_FIRST_PERSON_LEAD_RE = re.compile(
+    r"^(?:i|we)(?:\s+(?:have|had|then|just|already|also))?\s+", re.IGNORECASE
+)
+
+
 def _resolution_text_is_publishable(value: Any, *, question_text: str) -> bool:
     text = _compact(support_ticket_plain_text(value))
     if not text:
         return False
+    # Reject filters (honesty floor -- kept verbatim from #1456).
     if _RESOLUTION_CLOSURE_BOILERPLATE_RE.search(text):
         return False
     if _RESOLUTION_INTERNAL_NOTE_RE.search(text):
         return False
-
     resolution_tokens = _resolution_signal_tokens(text)
     if len(resolution_tokens) < 3:
         return False
-    if resolution_tokens.isdisjoint(_RESOLUTION_ACTION_TERMS):
-        return False
     if _resolution_text_is_disposition_only(text, resolution_tokens):
         return False
+    # Positive gate: structural instruction shape, not list membership.
+    if not _resolution_text_looks_instructional(text):
+        return False
+    # Action-term membership and question-topic overlap are demoted (#1466
+    # Option 1) from hard rejects to advisory signals: computed here for a
+    # future confidence surface, but they never block a structurally-valid,
+    # non-boilerplate instruction.
+    _resolution_advisory_signals(resolution_tokens, question_text)
+    return True
+
+
+def _resolution_text_looks_instructional(text: str) -> bool:
+    """True when the resolution reads like a step a user can follow.
+
+    Recognizes numbered/step structure, a UI navigation path ("Settings then
+    Phone"), or any sentence that opens with an imperative verb -- known
+    (`_RESOLUTION_ACTION_TERMS`) or by the "<verb> the/your/a <noun>" shape for
+    verbs not in the list. Disposition status sentences ("Replied to the
+    customer ...") never count, even though they open with a verb.
+    """
+
+    if _RESOLUTION_STEP_STRUCTURE_RE.search(text):
+        return True
+    if _RESOLUTION_UI_PATH_RE.search(text):
+        return True
+    for sentence in _RESOLUTION_SENTENCE_SPLIT_RE.split(text):
+        stripped = sentence.strip()
+        if not stripped:
+            continue
+        if _RESOLUTION_DISPOSITION_ONLY_RE.search(stripped):
+            continue
+        prefix = _RESOLUTION_INSTRUCTION_PREFIX_RE.match(stripped)
+        remainder = stripped[prefix.end():] if prefix else stripped
+        first_person = _RESOLUTION_FIRST_PERSON_LEAD_RE.match(remainder)
+        if first_person:
+            remainder = remainder[first_person.end():]
+        lead_match = _RESOLUTION_LEAD_WORD_RE.match(remainder)
+        if not lead_match:
+            continue
+        lead = lead_match.group(1).lower()
+        if lead in _RESOLUTION_NON_VERB_LEADS:
+            continue
+        # Stem the lead so past-tense / gerund action verbs ("Enabled the SSO",
+        # "Configured ...", "Updating ...") still register as instructions.
+        if _resolution_signal_token(lead) in _RESOLUTION_ACTION_TERMS:
+            return True
+        # The generic "<verb> the/your <noun>" shape qualifies unknown verbs
+        # ("Schedule the sync", "Pin the view") only in imperative position. A
+        # first-person subject makes it narration ("We received your request",
+        # "We closed your ticket"), so it must use a known action verb instead.
+        if first_person:
+            continue
+        rest = remainder[lead_match.end():].lstrip()
+        if _RESOLUTION_INSTRUCTION_OBJECT_RE.match(rest):
+            return True
+    return False
+
+
+def _resolution_advisory_signals(
+    resolution_tokens: set[str], question_text: str
+) -> dict[str, bool]:
+    """Demoted confidence signals (#1466 Option 1): computed, never gating.
+
+    The action-term-membership and question-topic-overlap checks were hard
+    rejects through four enumeration rounds and over-rejected real answers.
+    They are retained here as advisory diagnostics so the maps stay live for a
+    future confidence surface; they do not influence publishability.
+    """
 
     question_tokens = _resolution_signal_tokens(question_text)
-    if question_tokens and _resolution_overlap_tokens(resolution_tokens).isdisjoint(
-        _resolution_overlap_tokens(question_tokens)
-    ):
-        return False
-    return True
+    return {
+        "has_known_action_term": not resolution_tokens.isdisjoint(
+            _RESOLUTION_ACTION_TERMS
+        ),
+        "topic_aligned": (
+            not question_tokens
+            or not _resolution_overlap_tokens(resolution_tokens).isdisjoint(
+                _resolution_overlap_tokens(question_tokens)
+            )
+        ),
+    }
 
 
 def _resolution_signal_tokens(value: Any) -> set[str]:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -1229,15 +1229,22 @@ def _resolution_text(*rows: Mapping[str, Any], question_text: str = "") -> str:
 # Split on sentence terminators but KEEP them attached (lookbehind), so a
 # trailing "?" survives and an interrogative sentence ("Did the lights change?")
 # can be told apart from a step. The lead word and object shapes are anchored to
-# the start of each sentence, so a retained terminator does not affect them.
-_RESOLUTION_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+|\n+")
-_RESOLUTION_STEP_STRUCTURE_RE = re.compile(r"(?m)^\s*(?:step\s*)?\d+[.):]\s+\S")
+# the start of each sentence, so a retained terminator does not affect them. The
+# `(?<![0-9].)` guard keeps a list-number period ("1. Open ...") from splitting
+# the number off its step, so the per-sentence reject filters still apply to the
+# whole numbered sentence (a numbered question is rejected, not accepted).
+_RESOLUTION_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])(?<![0-9].)\s+|\n+")
 _RESOLUTION_UI_PATH_RE = re.compile(
     r"\b[a-z][\w-]*\s+then\s+[a-z][\w-]*\b", re.IGNORECASE
 )
 # A leading clause that precedes the real instruction ("To fix this, reset ...").
+# A list-number prefix ("1.", "2)", "step 3:") is stripped here too, so a
+# numbered step is evaluated by the same lead/object logic as any other sentence
+# -- the numbering is not a standalone "this is a step" signal that could bypass
+# the question/declarative/redirect rejects (round-7 review BLOCKER).
 _RESOLUTION_INSTRUCTION_PREFIX_RE = re.compile(
     r"^(?:please\s+|kindly\s+|first[,]?\s+|then[,]?\s+|next[,]?\s+|now[,]?\s+"
+    r"|(?:step\s+)?\d+[.):]\s+"
     r"|to\s+[a-z]+\s+(?:this|it|that|the\s+(?:issue|problem|error))\s*[,:]\s*)+",
     re.IGNORECASE,
 )
@@ -1329,17 +1336,16 @@ def _resolution_text_is_publishable(value: Any, *, question_text: str) -> bool:
 def _resolution_text_looks_instructional(text: str) -> bool:
     """True when the resolution reads like a step a user can follow.
 
-    Recognizes numbered/step structure, a UI navigation path ("Settings then
-    Phone"), or any sentence that opens with an imperative verb -- known
-    (`_RESOLUTION_ACTION_TERMS`) or by the "<verb> the/your/a <noun>" shape for
-    verbs not in the list. Disposition status sentences ("Replied to the
-    customer ...") never count, even though they open with a verb.
+    Every positive signal -- a UI navigation path ("Settings then Phone"), a
+    known action verb, or the "<verb> the/your/a <noun>" imperative shape for
+    verbs not in the list -- is evaluated per sentence and only AFTER that
+    sentence clears the question / disposition / contact-redirect /
+    declarative-lead rejects. A numbered/UI-path/declarative diagnostic ("1. Did
+    the lights change?", "The issue is in Billing then Plan ...") therefore can
+    no longer short-circuit those rejects (round-7 review BLOCKER); list numbers
+    are stripped as a prefix, not treated as a standalone "this is a step" flag.
     """
 
-    if _RESOLUTION_STEP_STRUCTURE_RE.search(text):
-        return True
-    if _RESOLUTION_UI_PATH_RE.search(text):
-        return True
     for sentence in _RESOLUTION_SENTENCE_SPLIT_RE.split(text):
         stripped = sentence.strip()
         if not stripped:
@@ -1369,6 +1375,13 @@ def _resolution_text_looks_instructional(text: str) -> bool:
         lead = lead_match.group(1).lower()
         if lead in _RESOLUTION_NON_VERB_LEADS or lead in _RESOLUTION_COPULA_LEADS:
             continue
+        # A UI navigation path ("Settings then Phone") is a step -- but only now
+        # that the sentence has cleared the question / disposition / redirect /
+        # non-verb-lead rejects above, so a declarative ("The issue is in Billing
+        # then Plan") or question ("Did Settings then Phone show ...?") cannot
+        # qualify through the path shape.
+        if _RESOLUTION_UI_PATH_RE.search(remainder):
+            return True
         # Stem the lead so past-tense / gerund action verbs ("Enabled the SSO",
         # "Configured ...", "Updating ...") still register as instructions.
         if _resolution_signal_token(lead) in _RESOLUTION_ACTION_TERMS:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -225,6 +225,154 @@ _RESOLUTION_TEXT_KEYS = (
     "staff_reply",
     "answer_text",
 )
+_RESOLUTION_ACTION_TERMS = {
+    "add",
+    "approve",
+    "ask",
+    "change",
+    "check",
+    "choose",
+    "clear",
+    "click",
+    "compare",
+    "configure",
+    "confirm",
+    "connect",
+    "contact",
+    "create",
+    "deploy",
+    "disable",
+    "download",
+    "enable",
+    "export",
+    "grant",
+    "import",
+    "map",
+    "open",
+    "paste",
+    "refresh",
+    "remove",
+    "rerun",
+    "reset",
+    "review",
+    "revoke",
+    "run",
+    "save",
+    "select",
+    "send",
+    "set",
+    "start",
+    "update",
+    "verify",
+}
+_RESOLUTION_TOPIC_STOPWORDS = {
+    "about",
+    "after",
+    "and",
+    "are",
+    "can",
+    "cannot",
+    "could",
+    "customer",
+    "does",
+    "for",
+    "from",
+    "help",
+    "how",
+    "into",
+    "issue",
+    "need",
+    "not",
+    "please",
+    "request",
+    "support",
+    "that",
+    "the",
+    "then",
+    "this",
+    "ticket",
+    "user",
+    "what",
+    "when",
+    "where",
+    "why",
+    "with",
+}
+_RESOLUTION_CLOSURE_BOILERPLATE_RE = re.compile(
+    r"\b(?:customer|user|requester|client)\s+"
+    r"(?:did not|didn't|does not|doesn't)\s+respond\b"
+    r"|\bno response from (?:the )?(?:customer|user|requester|client)\b"
+    r"|\bclosed due to no response\b"
+    r"|\bclosing due to no response\b"
+    r"|\bclosing this out\b"
+    r"|\bthanks[,. ]+(?:closing|closed)\b",
+    re.IGNORECASE,
+)
+_RESOLUTION_INTERNAL_NOTE_RE = re.compile(
+    r"\b(?:assigned|escalated|routed)\s+to\s+(?:t[0-9]+|tier\s*[0-9]+|l[0-9]+)\b"
+    r"|\bpolicy\s+\d+(?:\.\d+)+\b"
+    r"|\binternal\s+(?:note|only)\b",
+    re.IGNORECASE,
+)
+_RESOLUTION_DISPOSITION_ONLY_ACTION_TERMS = {
+    "ask",
+    "check",
+    "confirm",
+    "contact",
+    "review",
+    "send",
+    "start",
+    "update",
+}
+_RESOLUTION_DISPOSITION_ONLY_RE = re.compile(
+    r"\b(?:replied|responded)\s+to\s+(?:the\s+)?(?:customer|client|user|requester)\b"
+    r"|\b(?:sent|provided)\s+(?:the\s+)?(?:customer|client|user|requester)\s+"
+    r"(?:an?\s+)?(?:update|reply|response)\b"
+    r"|\b(?:sent|provided)\s+(?:an?\s+)?(?:update|reply|response)\s+"
+    r"to\s+(?:the\s+)?(?:customer|client|user|requester)\b"
+    r"|\b(?:customer|client|user|requester)\s+(?:was\s+)?"
+    r"(?:updated|notified|informed)\b",
+    re.IGNORECASE,
+)
+_RESOLUTION_TOPIC_EQUIVALENCE_GROUPS = (
+    frozenset({
+        "auth",
+        "authentication",
+        "code",
+        "credential",
+        "login",
+        "log",
+        "password",
+        "reset",
+        "sign",
+    }),
+    frozenset({
+        "bill",
+        "billing",
+        "charge",
+        "invoice",
+        "payment",
+        "receipt",
+        "statement",
+    }),
+    frozenset({
+        "connect",
+        "connection",
+        "integration",
+        "sync",
+    }),
+    frozenset({
+        "cancel",
+        "cancellation",
+        "renewal",
+        "subscription",
+    }),
+)
+_RESOLUTION_TOPIC_EQUIVALENCE: dict[str, frozenset[str]] = {
+    token: group
+    for group in _RESOLUTION_TOPIC_EQUIVALENCE_GROUPS
+    for token in group
+}
 _VOCABULARY_GAP_RULES = (
     ("export", "download", "download report", "report download"),
     ("dashboard", "analytics", "reporting", "reports"),
@@ -469,7 +617,22 @@ def build_ticket_faq_markdown(
             seen.add(key)
             source_keys.add(source_key)
             topic = _topic(opportunity, evidence, intent_rules=intent_rules)
-            resolution_text = _resolution_text(evidence, opportunity)
+            resolution_context = " / ".join(
+                value
+                for value in (
+                    text,
+                    topic,
+                    _clean(evidence.get("source_title") or opportunity.get("source_title")),
+                    _clean(evidence.get("pain_category") or opportunity.get("pain_category")),
+                    _clean(evidence.get("tags") or opportunity.get("tags")),
+                )
+                if value
+            )
+            resolution_text = _resolution_text(
+                evidence,
+                opportunity,
+                question_text=resolution_context,
+            )
             evidence_group_key = _evidence_group_key(resolution_text)
             group_key = (topic, evidence_group_key or f"topic:{_compact_key(topic)}")
             source_date = _source_date(evidence) or _source_date(opportunity)
@@ -1048,13 +1211,90 @@ def _source_weight(*rows: Mapping[str, Any]) -> int:
     return source_row_weight(*rows)
 
 
-def _resolution_text(*rows: Mapping[str, Any]) -> str:
+def _resolution_text(*rows: Mapping[str, Any], question_text: str = "") -> str:
     for row in rows:
         for key in _RESOLUTION_TEXT_KEYS:
             text = support_ticket_plain_text(_field_value(row, key))
-            if text:
+            if text and _resolution_text_is_publishable(text, question_text=question_text):
                 return text
     return ""
+
+
+def _resolution_text_is_publishable(value: Any, *, question_text: str) -> bool:
+    text = _compact(support_ticket_plain_text(value))
+    if not text:
+        return False
+    if _RESOLUTION_CLOSURE_BOILERPLATE_RE.search(text):
+        return False
+    if _RESOLUTION_INTERNAL_NOTE_RE.search(text):
+        return False
+
+    resolution_tokens = _resolution_signal_tokens(text)
+    if len(resolution_tokens) < 3:
+        return False
+    if resolution_tokens.isdisjoint(_RESOLUTION_ACTION_TERMS):
+        return False
+    if _resolution_text_is_disposition_only(text, resolution_tokens):
+        return False
+
+    question_tokens = _resolution_signal_tokens(question_text)
+    if question_tokens and _resolution_overlap_tokens(resolution_tokens).isdisjoint(
+        _resolution_overlap_tokens(question_tokens)
+    ):
+        return False
+    return True
+
+
+def _resolution_signal_tokens(value: Any) -> set[str]:
+    return {
+        _resolution_signal_token(token)
+        for token in re.findall(r"[a-z0-9]+", _compact(value).lower())
+        if len(token) > 2 and token not in _RESOLUTION_TOPIC_STOPWORDS
+    }
+
+
+def _resolution_text_is_disposition_only(text: str, resolution_tokens: set[str]) -> bool:
+    action_tokens = resolution_tokens & _RESOLUTION_ACTION_TERMS
+    return bool(
+        action_tokens
+        and action_tokens <= _RESOLUTION_DISPOSITION_ONLY_ACTION_TERMS
+        and _RESOLUTION_DISPOSITION_ONLY_RE.search(text)
+    )
+
+
+def _resolution_overlap_tokens(tokens: set[str]) -> set[str]:
+    expanded = set(tokens)
+    for token in tokens:
+        expanded.update(_RESOLUTION_TOPIC_EQUIVALENCE.get(token, ()))
+    return expanded
+
+
+def _resolution_signal_token(token: str) -> str:
+    if len(token) > 4 and token.endswith("ies"):
+        return f"{token[:-3]}y"
+    if len(token) > 5 and token.endswith("ing"):
+        base = token[:-3]
+        if base in _RESOLUTION_ACTION_TERMS:
+            return base
+        if f"{base}e" in _RESOLUTION_ACTION_TERMS:
+            return f"{base}e"
+        if len(base) > 3 and base[-1:] == base[-2:-1] and base[:-1] in _RESOLUTION_ACTION_TERMS:
+            return base[:-1]
+        return base
+    if len(token) > 4 and token.endswith("ed"):
+        base = token[:-2]
+        if base in _RESOLUTION_ACTION_TERMS:
+            return base
+        if f"{base}e" in _RESOLUTION_ACTION_TERMS:
+            return f"{base}e"
+        if base.endswith("i") and f"{base[:-1]}y" in _RESOLUTION_ACTION_TERMS:
+            return f"{base[:-1]}y"
+        if len(base) > 3 and base[-1:] == base[-2:-1] and base[:-1] in _RESOLUTION_ACTION_TERMS:
+            return base[:-1]
+        return base
+    if len(token) > 3 and token.endswith("s") and not token.endswith("ss"):
+        return token[:-1]
+    return token
 
 
 def _resolution_texts(rows: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:

--- a/plans/PR-Deflection-Proven-Answer-Gate.md
+++ b/plans/PR-Deflection-Proven-Answer-Gate.md
@@ -122,6 +122,19 @@ converge. The predicate now is:
    - **Answer-is-a-question**: the sentence splitter now retains terminators, so
      a sentence ending in "?" ("Did the lights change on the router?") -- a
      diagnostic prompt back to the requester -- is skipped, not parsed as a step.
+8. **Structural recognizers moved behind the per-sentence rejects** (round-7
+   re-review BLOCKER fix). The numbered-step and UI-path recognizers previously
+   `return True` over the whole text *before* the per-sentence loop, so a
+   numbered or UI-path diagnostic question/declarative bypassed the
+   question/disposition/redirect/declarative rejects ("1. Did the lights
+   change?", "Did Settings then Phone show the toggle?", "The issue is in
+   Billing then Plan ..." all published). Now: the list-number prefix
+   ("1.", "2)", "step 3:") is stripped as a sentence prefix and the UI-path
+   check runs *inside* the loop after the rejects and after the non-verb/copula
+   lead check. A numbered sentence is evaluated by the same lead/object logic as
+   any other (numbering is no longer a standalone "this is a step" signal); the
+   splitter gained a `(?<![0-9].)` guard so a list-number period keeps its step
+   on one sentence. Real UI-path / numbered instructions still publish.
 
 The action-term-membership and question-topic-overlap checks are **demoted, not
 deleted**, to advisory signals (`_resolution_advisory_signals`): the maps stay
@@ -180,14 +193,16 @@ Parked hardening: none.
 ## Verification
 
 - Option-1 inversion (operator decision): held-out probe of
-  `_resolution_text_is_publishable` -- 20/20 realistic answers publish
+  `_resolution_text_is_publishable` -- 21/21 realistic answers publish
   (varied verbs incl. schedule/pin/narrow/forward/assign/rename/archive/submit/
   cancel + symptom/fix synonym pairs login-SSO/crash-cache/charged-refund +
   past-tense/first-person + numbered steps + "to fix this," preamble + round-7
-  redirect/question guards: real "send"/"message" steps and step-then-fallback
-  still publish), 19/19 honesty-floor non-answers rejected (incl. round-7
-  contact-redirect + non-copula question), 0 misses either direction. The corpus
-  is pinned into the test file (`_HELD_OUT_PUBLISHABLE` / `_HELD_OUT_REJECTED`).
+  redirect/question guards + a real UI-path instruction: real "send"/"message"
+  steps and step-then-fallback still publish), 22/22 honesty-floor non-answers
+  rejected (incl. round-7 contact-redirect + non-copula question + the round-7
+  re-review's UI-path question, numbered question, and UI-path declarative), 0
+  misses either direction. The corpus is pinned into the test file
+  (`_HELD_OUT_PUBLISHABLE` / `_HELD_OUT_REJECTED`).
 - Round-7 real-corpus calibration: ran the gate over 400 real Twitter brand
   replies (reject-side) and 400 real Ubuntu QA responses (recall-side). The two
   new disqualifiers drop Twitter publish 15% -> 10% (the DM/clarifying-question
@@ -195,11 +210,11 @@ Parked hardening: none.
 - `drafted_answer_count` does not regress: the resolution-bearing live-proof,
   saas-demo, and macro-writeback fixtures keep their drafted counts;
   measured-repetition merged-state language-filter test stays green.
-- Full extracted gauntlet (`scripts/run_extracted_pipeline_checks.sh`) -- 3952
+- Full extracted gauntlet (`scripts/run_extracted_pipeline_checks.sh`) -- 3956
   passed, 10 skipped, 0 failed (inversion + measured-repetition reconciliation
-  + round-7 redirect/question disqualifiers).
+  + round-7 redirect/question disqualifiers + structural-recognizer bypass fix).
 - Focused pytest for `tests/test_extracted_ticket_faq_markdown.py`.
-  - Passed, 219 tests.
+  - Passed, 223 tests.
 - Downstream pytest targets in `tests/test_content_ops_deflection_resolution_live_proof.py`,
   `tests/test_extracted_ticket_faq_macro_writeback.py`,
   `tests/test_extracted_ticket_faq_output_ingestion.py`, and
@@ -217,7 +232,7 @@ Parked hardening: none.
   and `tests/test_extracted_ticket_faq_markdown.py`
   - Passed.
 - `./scripts/run_extracted_pipeline_checks.sh`
-  - Passed, 3952 passed, 10 skipped; existing torch/pynvml warning.
+  - Passed, 3956 passed, 10 skipped; existing torch/pynvml warning.
 
 ## Estimated diff size
 

--- a/plans/PR-Deflection-Proven-Answer-Gate.md
+++ b/plans/PR-Deflection-Proven-Answer-Gate.md
@@ -31,8 +31,9 @@ Slice phase: Production hardening
    copy, or steps in `ticket_faq_markdown.py`.
 2. Reject closure/disposition boilerplate, disposition-only agent update notes,
    and narrow internal-note patterns.
-3. Require a minimal actionable/on-topic signal for a resolution to count as
-   publishable answer evidence.
+3. Require structural instruction-shape (not action-term/topic-overlap list
+   membership) for a resolution to count as publishable answer evidence
+   (operator decision #1466 Option 1).
 4. Add failure-first fixtures proving boilerplate/internal notes and
    disposition-only agent updates stay `draft_needs_review`, plus positive
    fixtures proving real step-wise resolution evidence still gates, including
@@ -51,12 +52,15 @@ Slice phase: Production hardening
   - [ ] A genuine step-wise, on-topic resolution still gates as
         `resolution_evidence`, including "start the return" style portal
         instructions.
-  - [ ] Common support synonym pairs used by real tickets, such as
-        login/password reset, receipt/invoice, connect/integration sync, and
-        renewal/cancel, do not get dropped by a raw lexical-overlap check.
-  - [ ] Off-topic near-misses still fail closed; synonym expansion must not let
-        billing steps answer login questions or password resets answer receipt
-        questions.
+  - [ ] Realistic answers across varied verbs (incl. verbs absent from any
+        list -- schedule/pin/narrow/forward/assign/rename/...) and symptom/fix
+        synonym pairs (login/SSO, crash/cache, charged-twice/refund) PUBLISH;
+        list membership is no longer required.
+  - [ ] Question-topic overlap is demoted to an advisory `topic_aligned`
+        signal (computed, surfaced for a future confidence layer) and no
+        longer hard-rejects an off-topic-but-genuine instruction. (Operator
+        Option 1: list-widening did not converge; the honesty floor is the
+        reject filters, not topic membership.)
   - [ ] The filter is deterministic and lives in the extracted package; no
         LLM/Ollama/local model path is introduced.
 - Affected surfaces: deflection FAQ markdown/report item construction and its
@@ -77,32 +81,42 @@ Slice phase: Production hardening
 The resolution-text normalizer is the earliest point where raw evidence/opportunity
 fields are normalized into the row-level `resolution_text` used by grouping,
 answer status, answer copy, and resolution source counts. This slice adds a
-deterministic publishability predicate there:
+deterministic publishability predicate there.
+
+**The gate is reject-known-bad + structural instruction-shape, not
+require-membership (operator decision, #1466 Option 1).** Four earlier rounds
+gated on membership in enumerated lists (action terms, disposition set,
+topic-equivalence map); held-out probes showed those lists still rejected the
+majority of realistic publishable answers and per-example list-widening did not
+converge. The predicate now is:
 
 1. compact the candidate text;
-2. reject narrow closure/disposition boilerplate;
-3. reject narrow internal-note patterns such as tier escalations and numbered
-   internal policy references;
-4. reject disposition-only customer-update notes when the only action signal is
-   weak status/review/check/send/update/start wording, including
-   `sent an update to the customer` and `provided an update to the requester`;
-5. require enough actionable/on-topic signal before returning the text, using
-   the ticket text plus existing topic/source-title/pain-category/tag context
-   so legitimate invoice/receipt wording is not lost.
-6. normalize action verbs symmetrically enough that e-ending past-tense agent
-   notes such as "enabled", "configured", and "updated" still match the
-   publishable-action gate.
-7. recognize concrete "start" instructions as customer-facing actions while
-   still rejecting started/reviewed/sent-update disposition notes.
-8. expand only the final topic-overlap token sets through a narrow support
-   synonym map. The action-token and disposition-only checks still use the raw
-   normalized tokens, so synonym support cannot manufacture action evidence or
-   bypass the weak-status guard.
+2. reject narrow closure/disposition boilerplate (`_RESOLUTION_CLOSURE_BOILERPLATE_RE`);
+3. reject narrow internal-note patterns -- tier escalations, numbered internal
+   policy references (`_RESOLUTION_INTERNAL_NOTE_RE`);
+4. require minimum substance (`len(resolution_tokens) >= 3`);
+5. reject disposition-only customer-update notes via the kept two-factor
+   `_resolution_text_is_disposition_only` (weak status verbs + disposition
+   regex), e.g. `sent an update to the customer`;
+6. **positive gate -- the text must look like an instruction**
+   (`_resolution_text_looks_instructional`): numbered/step structure, a UI
+   navigation path ("Settings then Phone"), or a sentence that opens with an
+   imperative verb. The verb may be a known action term (stemmed, so past-tense
+   "enabled"/"configured"/"updated" register) OR an unknown verb in the
+   "<verb> the/your/a <noun>" imperative shape (so "schedule", "pin", "narrow",
+   "forward", "assign", "rename", "archive", "submit", "cancel", ... publish
+   without ever being listed). Disposition sentences are disqualified
+   per-sentence, and a first-person subject ("We received your request") must
+   use a known action verb -- the generic object shape is imperative-position
+   only -- so narration is not mistaken for an instruction.
 
-If a candidate fails, the normalizer returns an empty string. That keeps
-the bogus text out of `evidence_group_key`, collected resolution texts,
-`resolution_source_count`, resolution-evidence scope calculation, generated
-steps, and paid answer summaries.
+The action-term-membership and question-topic-overlap checks are **demoted, not
+deleted**, to advisory signals (`_resolution_advisory_signals`): the maps stay
+live for a future confidence surface but never block a structurally-valid,
+non-boilerplate instruction. If a candidate fails, the normalizer returns an
+empty string, keeping bogus text out of `evidence_group_key`, collected
+resolution texts, `resolution_source_count`, resolution-evidence scope, steps,
+and paid answer summaries.
 
 ## Intentional
 
@@ -117,10 +131,14 @@ steps, and paid answer summaries.
   customer-update/reply wording. It does not reject concrete step-wise account
   fixes such as opening invoices and updating a payment method, or concrete
   return-flow instructions such as starting a return in a portal.
-- The synonym map is intentionally small and support-domain-specific. It covers
-  recurring help-desk wording pairs that still point at the same customer task,
-  and tests include off-topic near-misses to keep the expansion from becoming a
-  broad topical bypass.
+- Topic alignment is deliberately NOT a gate (operator Option 1). The
+  action-term and topic-equivalence maps are kept and computed as advisory
+  signals (`_resolution_advisory_signals.topic_aligned` /
+  `has_known_action_term`) for a future confidence surface, but an off-topic
+  yet genuine instruction publishes. The tradeoff is conscious: four rounds of
+  topic/verb list-widening still over-rejected real answers, so the honesty
+  floor is the reject filters (boilerplate / internal-note / disposition-only /
+  sub-3-token), not membership.
 - This does not solve the separate #1460 fixed-bucket over-merge issue.
 
 ## Deferred
@@ -133,8 +151,20 @@ Parked hardening: none.
 
 ## Verification
 
+- Option-1 inversion (operator decision): held-out probe of
+  `_resolution_text_is_publishable` -- 16/16 realistic answers publish
+  (varied verbs incl. schedule/pin/narrow/forward/assign/rename/archive/submit/
+  cancel + symptom/fix synonym pairs login-SSO/crash-cache/charged-refund +
+  past-tense/first-person + numbered steps + "to fix this," preamble), 10/10
+  honesty-floor non-answers rejected, 0 misses either direction. The corpus is
+  pinned into the test file (`_HELD_OUT_PUBLISHABLE` / `_HELD_OUT_REJECTED`).
+- `drafted_answer_count` does not regress: the resolution-bearing live-proof,
+  saas-demo, and macro-writeback fixtures keep their drafted counts;
+  measured-repetition merged-state language-filter test stays green.
+- Full extracted gauntlet (`scripts/run_extracted_pipeline_checks.sh`) -- 3939
+  passed, 10 skipped, 0 failed (inversion + measured-repetition reconciliation).
 - Focused pytest for `tests/test_extracted_ticket_faq_markdown.py`.
-  - Passed, 177 tests.
+  - Passed, 206 tests.
 - Downstream pytest targets in `tests/test_content_ops_deflection_resolution_live_proof.py`,
   `tests/test_extracted_ticket_faq_macro_writeback.py`,
   `tests/test_extracted_ticket_faq_output_ingestion.py`, and
@@ -158,8 +188,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/ticket_faq_markdown.py` | 246 |
-| `plans/PR-Deflection-Proven-Answer-Gate.md` | 165 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 358 |
+| `plans/PR-Deflection-Proven-Answer-Gate.md` | 195 |
 | `tests/test_build_deflection_messy_csv_fixtures.py` | 11 |
-| `tests/test_extracted_ticket_faq_markdown.py` | 343 |
-| **Total** | **765** |
+| `tests/test_extracted_ticket_faq_markdown.py` | 450 |
+| **Total** | **1014** |

--- a/plans/PR-Deflection-Proven-Answer-Gate.md
+++ b/plans/PR-Deflection-Proven-Answer-Gate.md
@@ -109,6 +109,19 @@ converge. The predicate now is:
    per-sentence, and a first-person subject ("We received your request") must
    use a known action verb -- the generic object shape is imperative-position
    only -- so narration is not mistaken for an instruction.
+7. **Two structural per-sentence disqualifiers** added in round 7 after running
+   the gate over real support replies (Twitter brand replies + Ubuntu QA):
+   - **Contact-channel redirection** (`_RESOLUTION_CONTACT_REDIRECT_RE`): a
+     hand-off to a human over a private channel ("send us a DM", "message us",
+     "shoot me a private message") is imperative-shaped but answers nothing --
+     the disposition reject's imperative-phrased sibling. Narrow on purpose
+     (matches "<verb> us/me" and the DM/PM/private-message redirect nouns, not
+     legitimate steps that merely contain "send"/"message"), and checked against
+     the sentence's lead clause only, so a real step with a trailing redirect
+     fallback ("Reset the cache, then DM us") still publishes on the step.
+   - **Answer-is-a-question**: the sentence splitter now retains terminators, so
+     a sentence ending in "?" ("Did the lights change on the router?") -- a
+     diagnostic prompt back to the requester -- is skipped, not parsed as a step.
 
 The action-term-membership and question-topic-overlap checks are **demoted, not
 deleted**, to advisory signals (`_resolution_advisory_signals`): the maps stay
@@ -140,31 +153,53 @@ and paid answer summaries.
   floor is the reject filters (boilerplate / internal-note / disposition-only /
   sub-3-token), not membership.
 - This does not solve the separate #1460 fixed-bucket over-merge issue.
+- The contact-redirect disqualifier is deliberately conservative: it fires on
+  the lead clause, so a redirect leading a sentence rejects even if a real step
+  trails it ("DM us, then reset"). Under-publishing a real answer is the safe
+  direction for a proven-answer gate; the common shape (step first, redirect
+  fallback) is preserved.
 
 ## Deferred
 
 - #1460 remains the broader within-intent clustering/subcluster fix.
 - A future robust-testing slice can add a larger resolution-quality corpus and
   calibrate thresholds against real help-desk exports.
+- A separate over-accept class observed in the real-corpus run -- interjection /
+  adjective sentence leads ("Guac on!", "Love the aesthetic", "Glad to know")
+  parsing as "<verb> <object>" -- is out of scope here. It is Twitter-pleasantry
+  noise that does not appear in real Zendesk `resolution_notes`; chasing it risks
+  over-fitting. Left for the same future calibration slice.
+- The structured-outcome factor (read `status` / `reopens` /
+  `satisfaction_score`; gate `proven` on answer-AND-outcome) and a shape-aware
+  importer (Zendesk full-export vs metrics-only CSV) -- per discussion #1507 --
+  are the larger honesty win and a separate slice. This slice hardens only the
+  answer-text factor.
 
 Parked hardening: none.
 
 ## Verification
 
 - Option-1 inversion (operator decision): held-out probe of
-  `_resolution_text_is_publishable` -- 16/16 realistic answers publish
+  `_resolution_text_is_publishable` -- 20/20 realistic answers publish
   (varied verbs incl. schedule/pin/narrow/forward/assign/rename/archive/submit/
   cancel + symptom/fix synonym pairs login-SSO/crash-cache/charged-refund +
-  past-tense/first-person + numbered steps + "to fix this," preamble), 10/10
-  honesty-floor non-answers rejected, 0 misses either direction. The corpus is
-  pinned into the test file (`_HELD_OUT_PUBLISHABLE` / `_HELD_OUT_REJECTED`).
+  past-tense/first-person + numbered steps + "to fix this," preamble + round-7
+  redirect/question guards: real "send"/"message" steps and step-then-fallback
+  still publish), 19/19 honesty-floor non-answers rejected (incl. round-7
+  contact-redirect + non-copula question), 0 misses either direction. The corpus
+  is pinned into the test file (`_HELD_OUT_PUBLISHABLE` / `_HELD_OUT_REJECTED`).
+- Round-7 real-corpus calibration: ran the gate over 400 real Twitter brand
+  replies (reject-side) and 400 real Ubuntu QA responses (recall-side). The two
+  new disqualifiers drop Twitter publish 15% -> 10% (the DM/clarifying-question
+  false positives) while Ubuntu real-instruction publish holds 9% -> 8%.
 - `drafted_answer_count` does not regress: the resolution-bearing live-proof,
   saas-demo, and macro-writeback fixtures keep their drafted counts;
   measured-repetition merged-state language-filter test stays green.
-- Full extracted gauntlet (`scripts/run_extracted_pipeline_checks.sh`) -- 3939
-  passed, 10 skipped, 0 failed (inversion + measured-repetition reconciliation).
+- Full extracted gauntlet (`scripts/run_extracted_pipeline_checks.sh`) -- 3952
+  passed, 10 skipped, 0 failed (inversion + measured-repetition reconciliation
+  + round-7 redirect/question disqualifiers).
 - Focused pytest for `tests/test_extracted_ticket_faq_markdown.py`.
-  - Passed, 206 tests.
+  - Passed, 219 tests.
 - Downstream pytest targets in `tests/test_content_ops_deflection_resolution_live_proof.py`,
   `tests/test_extracted_ticket_faq_macro_writeback.py`,
   `tests/test_extracted_ticket_faq_output_ingestion.py`, and
@@ -182,14 +217,14 @@ Parked hardening: none.
   and `tests/test_extracted_ticket_faq_markdown.py`
   - Passed.
 - `./scripts/run_extracted_pipeline_checks.sh`
-  - Passed, 3881 passed, 10 skipped; existing torch/pynvml warning.
+  - Passed, 3952 passed, 10 skipped; existing torch/pynvml warning.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/ticket_faq_markdown.py` | 380 |
-| `plans/PR-Deflection-Proven-Answer-Gate.md` | 195 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 417 |
+| `plans/PR-Deflection-Proven-Answer-Gate.md` | 237 |
 | `tests/test_build_deflection_messy_csv_fixtures.py` | 11 |
-| `tests/test_extracted_ticket_faq_markdown.py` | 457 |
-| **Total** | **1043** |
+| `tests/test_extracted_ticket_faq_markdown.py` | 475 |
+| **Total** | **1140** |

--- a/plans/PR-Deflection-Proven-Answer-Gate.md
+++ b/plans/PR-Deflection-Proven-Answer-Gate.md
@@ -1,0 +1,163 @@
+# PR-Deflection-Proven-Answer-Gate
+
+## Why this slice exists
+
+#1456 is a P0 launch-readiness issue: the paid deflection report currently
+marks any non-empty `resolution_text` as `resolution_evidence`. That means
+closure boilerplate such as "Customer did not respond, closing this out" or
+internal notes such as "Escalated to T2 / refunded per policy 4.2" can become
+paid, teaser-eligible, customer-facing answers.
+
+This slice hardens the proven-answer gate before the #1440 real full-volume
+paid run. It keeps the deterministic/no-LLM deflection lane intact and avoids
+the open #1452 parser/full-volume submit PR.
+
+Diff budget note: this PR is over the 400 LOC soft cap after the review-blocker
+fixes because the gate, symmetric verb normalization, disposition-only note
+filter, concrete-start action support, narrow synonym overlap support, and
+failure-first fixtures need to land together. Splitting the past-tense
+normalization, disposition-only rejection, valid "start the return"
+restoration, or login/password-style synonym support from the gate would
+knowingly leave either real support resolutions under-included or generic agent
+status updates over-included.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Filter support-ticket resolution candidates before they can populate
+   `resolution_text`, `evidence_group_key`, `resolution_evidence`, answer
+   copy, or steps in `ticket_faq_markdown.py`.
+2. Reject closure/disposition boilerplate, disposition-only agent update notes,
+   and narrow internal-note patterns.
+3. Require a minimal actionable/on-topic signal for a resolution to count as
+   publishable answer evidence.
+4. Add failure-first fixtures proving boilerplate/internal notes and
+   disposition-only agent updates stay `draft_needs_review`, plus positive
+   fixtures proving real step-wise resolution evidence still gates, including
+   past-tense agent language, concrete account-review steps, and common
+   support synonym pairs such as login/password reset and receipt/invoice.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Closure boilerplate does not produce `resolution_evidence`, resolution
+        source counts, customer-facing steps, or leaked answer copy.
+  - [ ] Internal operational notes do not produce `resolution_evidence` or
+        leak internal policy/escalation details into paid answers.
+  - [ ] Disposition-only agent status updates such as reviewed/replied or
+        checked/sent-update notes do not produce `resolution_evidence`,
+        including phrasing where the update/reply appears before the recipient.
+  - [ ] A genuine step-wise, on-topic resolution still gates as
+        `resolution_evidence`, including "start the return" style portal
+        instructions.
+  - [ ] Common support synonym pairs used by real tickets, such as
+        login/password reset, receipt/invoice, connect/integration sync, and
+        renewal/cancel, do not get dropped by a raw lexical-overlap check.
+  - [ ] Off-topic near-misses still fail closed; synonym expansion must not let
+        billing steps answer login questions or password resets answer receipt
+        questions.
+  - [ ] The filter is deterministic and lives in the extracted package; no
+        LLM/Ollama/local model path is introduced.
+- Affected surfaces: deflection FAQ markdown/report item construction and its
+  extracted-checks test suite.
+- Risk areas: over-filtering short legitimate resolutions, under-filtering
+  generic closure text, grouping drift via bogus `evidence_group_key`.
+- Reviewer rules triggered: R1, R2, R9, R10, R13.
+
+### Files touched
+
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Proven-Answer-Gate.md`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+## Mechanism
+
+The resolution-text normalizer is the earliest point where raw evidence/opportunity
+fields are normalized into the row-level `resolution_text` used by grouping,
+answer status, answer copy, and resolution source counts. This slice adds a
+deterministic publishability predicate there:
+
+1. compact the candidate text;
+2. reject narrow closure/disposition boilerplate;
+3. reject narrow internal-note patterns such as tier escalations and numbered
+   internal policy references;
+4. reject disposition-only customer-update notes when the only action signal is
+   weak status/review/check/send/update/start wording, including
+   `sent an update to the customer` and `provided an update to the requester`;
+5. require enough actionable/on-topic signal before returning the text, using
+   the ticket text plus existing topic/source-title/pain-category/tag context
+   so legitimate invoice/receipt wording is not lost.
+6. normalize action verbs symmetrically enough that e-ending past-tense agent
+   notes such as "enabled", "configured", and "updated" still match the
+   publishable-action gate.
+7. recognize concrete "start" instructions as customer-facing actions while
+   still rejecting started/reviewed/sent-update disposition notes.
+8. expand only the final topic-overlap token sets through a narrow support
+   synonym map. The action-token and disposition-only checks still use the raw
+   normalized tokens, so synonym support cannot manufacture action evidence or
+   bypass the weak-status guard.
+
+If a candidate fails, the normalizer returns an empty string. That keeps
+the bogus text out of `evidence_group_key`, collected resolution texts,
+`resolution_source_count`, resolution-evidence scope calculation, generated
+steps, and paid answer summaries.
+
+## Intentional
+
+- No LLM judge in this slice. The launch blocker is that obvious non-answer
+  text is currently trusted as proven evidence; a deterministic fail-closed
+  filter closes that immediate risk without adding cost or model dependency.
+- The internal-note matcher stays narrow. It rejects concrete operational
+  patterns named in #1456 but avoids broad words such as "policy" or
+  "escalation" by themselves, because those can appear in legitimate
+  customer-facing instructions.
+- The disposition-only guard is constrained to weak action-token sets plus
+  customer-update/reply wording. It does not reject concrete step-wise account
+  fixes such as opening invoices and updating a payment method, or concrete
+  return-flow instructions such as starting a return in a portal.
+- The synonym map is intentionally small and support-domain-specific. It covers
+  recurring help-desk wording pairs that still point at the same customer task,
+  and tests include off-topic near-misses to keep the expansion from becoming a
+  broad topical bypass.
+- This does not solve the separate #1460 fixed-bucket over-merge issue.
+
+## Deferred
+
+- #1460 remains the broader within-intent clustering/subcluster fix.
+- A future robust-testing slice can add a larger resolution-quality corpus and
+  calibrate thresholds against real help-desk exports.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused pytest for `tests/test_extracted_ticket_faq_markdown.py`.
+  - Passed, 177 tests.
+- Downstream pytest targets in `tests/test_content_ops_deflection_resolution_live_proof.py`,
+  `tests/test_extracted_ticket_faq_macro_writeback.py`,
+  `tests/test_extracted_ticket_faq_output_ingestion.py`, and
+  `tests/test_extracted_content_ops_live_execute_harness.py`
+  - Passed, 4 tests.
+- `./scripts/validate_extracted_content_pipeline.sh`
+  - Passed.
+- `./extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - Passed.
+- `./scripts/audit_extracted_standalone.py --fail-on-debt`
+  - Passed.
+- `./scripts/check_ascii_python.sh`
+  - Passed.
+- Python compile check for `extracted_content_pipeline/ticket_faq_markdown.py`
+  and `tests/test_extracted_ticket_faq_markdown.py`
+  - Passed.
+- `./scripts/run_extracted_pipeline_checks.sh`
+  - Passed, 3881 passed, 10 skipped; existing torch/pynvml warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 246 |
+| `plans/PR-Deflection-Proven-Answer-Gate.md` | 163 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 311 |
+| **Total** | **720** |

--- a/plans/PR-Deflection-Proven-Answer-Gate.md
+++ b/plans/PR-Deflection-Proven-Answer-Gate.md
@@ -188,8 +188,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/ticket_faq_markdown.py` | 358 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 380 |
 | `plans/PR-Deflection-Proven-Answer-Gate.md` | 195 |
 | `tests/test_build_deflection_messy_csv_fixtures.py` | 11 |
-| `tests/test_extracted_ticket_faq_markdown.py` | 450 |
-| **Total** | **1014** |
+| `tests/test_extracted_ticket_faq_markdown.py` | 457 |
+| **Total** | **1043** |

--- a/plans/PR-Deflection-Proven-Answer-Gate.md
+++ b/plans/PR-Deflection-Proven-Answer-Gate.md
@@ -69,6 +69,7 @@ Slice phase: Production hardening
 
 - `extracted_content_pipeline/ticket_faq_markdown.py`
 - `plans/PR-Deflection-Proven-Answer-Gate.md`
+- `tests/test_build_deflection_messy_csv_fixtures.py`
 - `tests/test_extracted_ticket_faq_markdown.py`
 
 ## Mechanism
@@ -158,6 +159,7 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/ticket_faq_markdown.py` | 246 |
-| `plans/PR-Deflection-Proven-Answer-Gate.md` | 163 |
-| `tests/test_extracted_ticket_faq_markdown.py` | 311 |
-| **Total** | **720** |
+| `plans/PR-Deflection-Proven-Answer-Gate.md` | 165 |
+| `tests/test_build_deflection_messy_csv_fixtures.py` | 11 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 343 |
+| **Total** | **765** |

--- a/tests/test_build_deflection_messy_csv_fixtures.py
+++ b/tests/test_build_deflection_messy_csv_fixtures.py
@@ -32,10 +32,15 @@ def _write_source_rows(tmp_path: Path) -> Path:
             "company_response": "Closed with explanation",
         },
         {
+            # Shares cfpb:1's question gist so the first four rows contain a
+            # genuine 2-ticket repeat. Under measured repetition (#1486) plus
+            # the stricter proven-answer gate (#1466) these disposition-only
+            # resolutions are rejected, so without a real repeat every row
+            # would be a non-repeat singleton and the report would be empty.
             "source_id": "cfpb:2",
-            "source_title": "Credit card - Billing dispute",
-            "text": "My payment was applied to the wrong balance.",
-            "pain_category": "Billing dispute",
+            "source_title": "Checking account - Managing an account",
+            "text": "The bank charged a fee when I closed the account.",
+            "pain_category": "Managing an account",
             "company_response": "Closed with non-monetary relief",
         },
         {

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -21,6 +21,9 @@ from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
     _output_checks,
+    _resolution_advisory_signals,
+    _resolution_signal_tokens,
+    _resolution_text_is_publishable,
     build_ticket_faq_markdown,
     normalize_intent_rules,
     weighted_source_volume_by_group,
@@ -453,10 +456,15 @@ def test_build_ticket_faq_markdown_keeps_synonymous_resolution_topics(
         ),
     ),
 )
-def test_build_ticket_faq_markdown_rejects_off_topic_synonym_near_misses(
+def test_build_ticket_faq_markdown_publishes_off_topic_instruction_overlap_demoted(
     question_text: str,
     resolution_text: str,
 ) -> None:
+    # #1466 Option 1: question-topic overlap is demoted from a hard reject to an
+    # advisory signal. An off-topic-but-genuine instruction now PUBLISHES (it
+    # passes the reject filters + instruction-shape gate); the advisory
+    # `topic_aligned` signal still reports the mismatch for a future confidence
+    # surface, but it no longer blocks publication.
     result = build_ticket_faq_markdown(
         [{
             "source_type": "support_ticket",
@@ -479,11 +487,26 @@ def test_build_ticket_faq_markdown_rejects_off_topic_synonym_near_misses(
     )
 
     item = result.items[0]
-    assert item["answer_evidence_status"] == "draft_needs_review"
-    assert item["resolution_evidence_scope"] == "not_applicable"
-    assert item["resolution_source_count"] == 0
-    assert item["steps"][0].startswith("Review the cited ticket evidence")
-    assert resolution_text not in result.markdown
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    advisory = _resolution_advisory_signals(
+        _resolution_signal_tokens(resolution_text), question_text
+    )
+    assert advisory["topic_aligned"] is False
+
+
+def test_resolution_advisory_topic_aligned_distinguishes_on_and_off_topic() -> None:
+    # The demoted overlap signal still computes correctly: on-topic resolutions
+    # align, off-topic ones do not (kept for a future confidence surface).
+    on_topic = _resolution_advisory_signals(
+        _resolution_signal_tokens("Reset the password and confirm the new login."),
+        "I cannot log in to my account.",
+    )
+    off_topic = _resolution_advisory_signals(
+        _resolution_signal_tokens("Open Billing and download the invoice PDF."),
+        "I cannot log in to my account.",
+    )
+    assert on_topic["topic_aligned"] is True
+    assert off_topic["topic_aligned"] is False
 
 
 def test_build_ticket_faq_markdown_keeps_past_tense_action_resolution() -> None:
@@ -5196,3 +5219,87 @@ def test_ticket_faq_cli_rejects_as_of_date_without_window(tmp_path: Path) -> Non
 
     assert completed.returncode == 1
     assert "--as-of-date requires --window-days" in completed.stderr
+
+
+# --- Held-out publishability corpus for the #1466 Option 1 inversion ---------
+# Pinned per the operator decision: the gate must publish realistic answers
+# across varied verbs and symptom/fix synonym pairs (not just the four cited
+# examples), and keep the honesty-floor reject classes rejected. These are
+# probed directly against _resolution_text_is_publishable so a regression in
+# the gate fails here, not only in an end-to-end assertion.
+
+_HELD_OUT_PUBLISHABLE = (
+    # varied imperative verbs, including verbs absent from the action-term list
+    ("Why is my sync slow?", "Schedule the sync to run during off-peak hours."),
+    ("How do I keep my view?", "Pin the saved view to your dashboard so it loads first."),
+    ("I never got the email", "Check the spam folder for the confirmation email and mark it not spam."),
+    ("My export times out", "Narrow the export window to under 90 days and retry the export."),
+    ("Wrong team got my ticket", "Forward the ticket to the billing queue from the actions menu."),
+    ("Who owns this case?", "Assign the case to yourself, then add an internal label."),
+    ("Change workspace name", "Rename the workspace under Settings then General."),
+    ("Too many old threads", "Archive the old thread and start a fresh conversation."),
+    ("Form will not submit", "Submit the form again after clearing the browser cache."),
+    ("Stop my plan", "Cancel the subscription from Billing then Plan before the renewal date."),
+    # symptom/fix synonym pairs (topic overlap demoted -> still publishable)
+    ("I cannot log in", "Reset the SSO certificate and re-enable single sign-on for the org."),
+    ("App keeps crashing", "Clear the cache and restart the app to stop the crash."),
+    ("I was charged twice", "Open Billing, find the duplicate charge, and request a refund."),
+    # past-tense / first-person action narration
+    ("How do I update MFA settings?", "I enabled MFA and configured the authenticator, then updated the settings."),
+    # numbered steps
+    ("Sensor offline", "1. Open Settings. 2. Tap Devices. 3. Re-pair the sensor."),
+    # "to fix this," instruction preamble
+    ("Stuck on payment", "To fix this, clear the saved card and add it again under Billing."),
+)
+
+_HELD_OUT_REJECTED = (
+    ("anything", "Customer did not respond, closing this out."),
+    ("anything", "Sent an update to the customer."),
+    ("anything", "Replied to the requester with the latest status details."),
+    ("anything", "Provided the customer an update on the timeline."),
+    ("anything", "Escalated to T2 for further review."),
+    ("anything", "Refunded per policy 4.2."),
+    ("anything", "Thank you for contacting support. We received your request."),
+    ("anything", "We have closed your ticket as resolved."),
+    ("anything", "Done."),
+    ("Why was I charged?", "The bank charged a fee after I closed the account."),
+)
+
+
+@pytest.mark.parametrize(("question_text", "resolution_text"), _HELD_OUT_PUBLISHABLE)
+def test_resolution_gate_publishes_held_out_real_answers(
+    question_text: str, resolution_text: str
+) -> None:
+    assert _resolution_text_is_publishable(
+        resolution_text, question_text=question_text
+    ) is True
+
+
+@pytest.mark.parametrize(("question_text", "resolution_text"), _HELD_OUT_REJECTED)
+def test_resolution_gate_rejects_held_out_non_answers(
+    question_text: str, resolution_text: str
+) -> None:
+    assert _resolution_text_is_publishable(
+        resolution_text, question_text=question_text
+    ) is False
+
+
+def test_resolution_gate_drafts_held_out_answers_end_to_end() -> None:
+    # drafted_answer_count must not regress: a repeated question whose two
+    # tickets carry a held-out publishable instruction surfaces as a drafted
+    # (resolution_evidence) answer through the full builder.
+    question = "How do I rotate my API key?"
+    answer = "Open Settings then Developers, revoke the old key, and create a new one."
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "API key rotation",
+            "evidence": [
+                {"text": question, "source_id": "held-1", "source_type": "support_ticket", "resolution_text": answer},
+                {"text": question, "source_id": "held-2", "source_type": "support_ticket", "resolution_text": answer},
+            ],
+        }]
+    )
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -5257,6 +5257,9 @@ _HELD_OUT_PUBLISHABLE = (
     ("Where do I send it?", "Send the report to your team from the Export menu."),
     ("App errors out", "Reset the cache, then DM us if the error persists."),
     ("Service is down", "Check the logs. Did it work? If not, restart the service."),
+    # A real UI-path instruction must still publish after the structural
+    # recognizers were moved behind the per-sentence rejects (round-7 BLOCKER).
+    ("Disable airplane mode", "Go to Settings then Phone and toggle airplane mode off."),
 )
 
 _HELD_OUT_REJECTED = (
@@ -5288,6 +5291,12 @@ _HELD_OUT_REJECTED = (
     # step they can follow (a non-copula interrogative, complementing the
     # existing "Is the account still active?" copula case above).
     ("Internet keeps dropping", "Did the lights change on the router when this happened?"),
+    # Structural recognizers must not bypass the per-sentence rejects (round-7
+    # BLOCKER): a UI-path or numbered diagnostic question, and a UI-path
+    # declarative, are non-answers even though they carry a step-like shape.
+    ("Phone carrier", "Did Settings then Phone show the carrier toggle?"),
+    ("Router lights", "1. Did the lights change on the router?"),
+    ("Billing location", "The issue is in Billing then Plan and not your account."),
 )
 
 

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -269,12 +269,20 @@ def test_build_ticket_faq_markdown_rejects_closure_boilerplate_as_resolution() -
         [{
             "source_type": "support_ticket",
             "source_title": "Export issue",
-            "evidence": [{
-                "text": "How do I export billing reports?",
-                "source_id": "ticket-closure-1",
-                "source_type": "support_ticket",
-                "resolution_text": "Customer did not respond, closing this out.",
-            }],
+            "evidence": [
+                {
+                    "text": "How do I export billing reports?",
+                    "source_id": "ticket-closure-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": "Customer did not respond, closing this out.",
+                },
+                {
+                    "text": "How do I export billing reports?",
+                    "source_id": "ticket-closure-2",
+                    "source_type": "support_ticket",
+                    "resolution_text": "Customer did not respond, closing this out.",
+                },
+            ],
         }]
     )
 
@@ -291,12 +299,20 @@ def test_build_ticket_faq_markdown_rejects_internal_notes_as_resolution() -> Non
         [{
             "source_type": "support_ticket",
             "source_title": "Refund issue",
-            "evidence": [{
-                "text": "How do I get a refund for a duplicate charge?",
-                "source_id": "ticket-internal-1",
-                "source_type": "support_ticket",
-                "resolution_text": "Refunded per policy 4.2. Escalated to T2 for review.",
-            }],
+            "evidence": [
+                {
+                    "text": "How do I get a refund for a duplicate charge?",
+                    "source_id": "ticket-internal-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": "Refunded per policy 4.2. Escalated to T2 for review.",
+                },
+                {
+                    "text": "How do I get a refund for a duplicate charge?",
+                    "source_id": "ticket-internal-2",
+                    "source_type": "support_ticket",
+                    "resolution_text": "Refunded per policy 4.2. Escalated to T2 for review.",
+                },
+            ],
         }]
     )
 
@@ -445,12 +461,20 @@ def test_build_ticket_faq_markdown_rejects_off_topic_synonym_near_misses(
         [{
             "source_type": "support_ticket",
             "source_title": "Off-topic support wording",
-            "evidence": [{
-                "text": question_text,
-                "source_id": "ticket-off-topic-synonym-1",
-                "source_type": "support_ticket",
-                "resolution_text": resolution_text,
-            }],
+            "evidence": [
+                {
+                    "text": question_text,
+                    "source_id": "ticket-off-topic-synonym-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": resolution_text,
+                },
+                {
+                    "text": question_text,
+                    "source_id": "ticket-off-topic-synonym-2",
+                    "source_type": "support_ticket",
+                    "resolution_text": resolution_text,
+                },
+            ],
         }]
     )
 
@@ -505,12 +529,20 @@ def test_build_ticket_faq_markdown_rejects_disposition_only_agent_updates(
         [{
             "source_type": "support_ticket",
             "source_title": "Billing account",
-            "evidence": [{
-                "text": "How do I update the billing account?",
-                "source_id": "ticket-disposition-1",
-                "source_type": "support_ticket",
-                "resolution_text": resolution_text,
-            }],
+            "evidence": [
+                {
+                    "text": "How do I update the billing account?",
+                    "source_id": "ticket-disposition-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": resolution_text,
+                },
+                {
+                    "text": "How do I update the billing account?",
+                    "source_id": "ticket-disposition-2",
+                    "source_type": "support_ticket",
+                    "resolution_text": resolution_text,
+                },
+            ],
         }]
     )
 

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -5263,6 +5263,13 @@ _HELD_OUT_REJECTED = (
     ("anything", "We have closed your ticket as resolved."),
     ("anything", "Done."),
     ("Why was I charged?", "The bank charged a fee after I closed the account."),
+    # Declarative status / opinion commentary must NOT publish as a step (the
+    # inversion's over-accept flip-side: the imperative object-shape must not
+    # match a clause subject + copula). Round-6 review MAJOR.
+    ("anything", "Honestly this is a known issue and pretty annoying for everyone."),
+    ("anything", "That is the expected behavior for the free tier."),
+    ("anything", "Unfortunately the issue is a duplicate of an existing bug."),
+    ("anything", "Is the account still active on your end?"),
 )
 
 

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -264,6 +264,317 @@ def test_build_ticket_faq_markdown_uses_resolution_evidence_for_steps() -> None:
     assert "support@example.com" in result.markdown
 
 
+def test_build_ticket_faq_markdown_rejects_closure_boilerplate_as_resolution() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Export issue",
+            "evidence": [{
+                "text": "How do I export billing reports?",
+                "source_id": "ticket-closure-1",
+                "source_type": "support_ticket",
+                "resolution_text": "Customer did not respond, closing this out.",
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_evidence_scope"] == "not_applicable"
+    assert item["resolution_source_count"] == 0
+    assert item["steps"][0].startswith("Review the cited ticket evidence")
+    assert "closing this out" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_rejects_internal_notes_as_resolution() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Refund issue",
+            "evidence": [{
+                "text": "How do I get a refund for a duplicate charge?",
+                "source_id": "ticket-internal-1",
+                "source_type": "support_ticket",
+                "resolution_text": "Refunded per policy 4.2. Escalated to T2 for review.",
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_evidence_scope"] == "not_applicable"
+    assert item["resolution_source_count"] == 0
+    assert "policy 4.2" not in result.markdown
+    assert "Escalated to T2" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_keeps_legitimate_policy_resolution() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Refund issue",
+            "evidence": [{
+                "text": "How do I request a refund under the billing policy?",
+                "source_id": "ticket-policy-1",
+                "source_type": "support_ticket",
+                "resolution_text": (
+                    "Open Billing, choose Refunds, then review the refund policy "
+                    "before submitting the request."
+                ),
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == (
+        "Open Billing, choose Refunds, then review the refund policy before "
+        "submitting the request."
+    )
+
+
+def test_build_ticket_faq_markdown_uses_row_context_for_resolution_topic_match() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Receipt export",
+            "pain_category": "billing export",
+            "tags": "billing,invoices,resolved",
+            "evidence": [{
+                "text": "Can finance export subscription receipts without admin access?",
+                "source_id": "ticket-context-1",
+                "source_type": "support_ticket",
+                "resolution_text": (
+                    "Open Billing then Invoices, filter by the quarter, and "
+                    "download the PDF from the invoice row."
+                ),
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == (
+        "Open Billing then Invoices, filter by the quarter, and download the "
+        "PDF from the invoice row."
+    )
+
+
+@pytest.mark.parametrize(
+    ("question_text", "resolution_text", "expected_step"),
+    (
+        (
+            "I cannot log in to my account.",
+            "Reset the password and send a temporary code.",
+            "Reset the password and send a temporary code.",
+        ),
+        (
+            "How do I sign in after lockout?",
+            "Reset the password and send a backup code.",
+            "Reset the password and send a backup code.",
+        ),
+        (
+            "Why does authentication fail on mobile?",
+            "Clear saved credentials and reset the password.",
+            "Clear saved credentials and reset the password.",
+        ),
+        (
+            "How do I get receipts for finance?",
+            "Open Billing, choose Invoices, and download the PDF.",
+            "Open Billing, choose Invoices, and download the PDF.",
+        ),
+        (
+            "Can I connect Salesforce?",
+            "Open Integrations and refresh the sync.",
+            "Open Integrations and refresh the sync.",
+        ),
+        (
+            "How do I stop renewal?",
+            "Open Billing and cancel the subscription.",
+            "Open Billing and cancel the subscription.",
+        ),
+    ),
+)
+def test_build_ticket_faq_markdown_keeps_synonymous_resolution_topics(
+    question_text: str,
+    resolution_text: str,
+    expected_step: str,
+) -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Synonymous support wording",
+            "evidence": [{
+                "text": question_text,
+                "source_id": "ticket-synonym-1",
+                "source_type": "support_ticket",
+                "resolution_text": resolution_text,
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == expected_step
+
+
+@pytest.mark.parametrize(
+    ("question_text", "resolution_text"),
+    (
+        (
+            "I cannot log in to my account.",
+            "Open Billing and download the invoice PDF.",
+        ),
+        (
+            "How do I get receipts for finance?",
+            "Reset the password and send a temporary code.",
+        ),
+    ),
+)
+def test_build_ticket_faq_markdown_rejects_off_topic_synonym_near_misses(
+    question_text: str,
+    resolution_text: str,
+) -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Off-topic support wording",
+            "evidence": [{
+                "text": question_text,
+                "source_id": "ticket-off-topic-synonym-1",
+                "source_type": "support_ticket",
+                "resolution_text": resolution_text,
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_evidence_scope"] == "not_applicable"
+    assert item["resolution_source_count"] == 0
+    assert item["steps"][0].startswith("Review the cited ticket evidence")
+    assert resolution_text not in result.markdown
+
+
+def test_build_ticket_faq_markdown_keeps_past_tense_action_resolution() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "MFA settings",
+            "evidence": [{
+                "text": "How do I update MFA settings?",
+                "source_id": "ticket-past-tense-1",
+                "source_type": "support_ticket",
+                "resolution_text": (
+                    "I enabled MFA and configured the authenticator, then "
+                    "updated the settings."
+                ),
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == (
+        "I enabled MFA and configured the authenticator, then updated the settings."
+    )
+
+
+@pytest.mark.parametrize(
+    "resolution_text",
+    (
+        "Reviewed the billing account and replied to the customer.",
+        "Checked the account and sent the customer an update.",
+        "Reviewed the billing account and sent an update to the customer.",
+        "Checked the account and provided an update to the requester.",
+        "Started reviewing the billing account and sent an update to the customer.",
+    ),
+)
+def test_build_ticket_faq_markdown_rejects_disposition_only_agent_updates(
+    resolution_text: str,
+) -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Billing account",
+            "evidence": [{
+                "text": "How do I update the billing account?",
+                "source_id": "ticket-disposition-1",
+                "source_type": "support_ticket",
+                "resolution_text": resolution_text,
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_evidence_scope"] == "not_applicable"
+    assert item["resolution_source_count"] == 0
+    assert item["steps"][0].startswith("Review the cited ticket evidence")
+    assert resolution_text not in result.markdown
+
+
+def test_build_ticket_faq_markdown_keeps_concrete_step_after_account_review() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Billing account",
+            "evidence": [{
+                "text": "How do I update the billing account?",
+                "source_id": "ticket-concrete-review-1",
+                "source_type": "support_ticket",
+                "resolution_text": (
+                    "Checked the billing account, opened Invoices, and updated "
+                    "the payment method."
+                ),
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == (
+        "Checked the billing account, opened Invoices, and updated the payment method."
+    )
+
+
+def test_build_ticket_faq_markdown_keeps_concrete_started_return_step() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Product return",
+            "evidence": [{
+                "text": "How do I return a recent purchase from your store?",
+                "source_id": "ticket-return-1",
+                "source_type": "support_ticket",
+                "resolution_text": (
+                    "Items should be returned within 30 days in their original "
+                    "condition. Start the return in the online returns portal."
+                ),
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == (
+        "Items should be returned within 30 days in their original condition."
+    )
+    assert item["steps"][1] == "Start the return in the online returns portal."
+
+
 def test_build_ticket_faq_markdown_rejects_generic_response_metadata_as_resolution() -> None:
     result = build_ticket_faq_markdown(
         [{

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -5250,6 +5250,13 @@ _HELD_OUT_PUBLISHABLE = (
     ("Sensor offline", "1. Open Settings. 2. Tap Devices. 3. Re-pair the sensor."),
     # "to fix this," instruction preamble
     ("Stuck on payment", "To fix this, clear the saved card and add it again under Billing."),
+    # Guards for the contact-redirect / question reject classes (#1466 round 7):
+    # real steps that merely contain "send"/"message", or a trailing redirect or
+    # question after a genuine step, must still publish on the step.
+    ("Cannot reach owner", "Message the channel owner to request access."),
+    ("Where do I send it?", "Send the report to your team from the Export menu."),
+    ("App errors out", "Reset the cache, then DM us if the error persists."),
+    ("Service is down", "Check the logs. Did it work? If not, restart the service."),
 )
 
 _HELD_OUT_REJECTED = (
@@ -5270,6 +5277,17 @@ _HELD_OUT_REJECTED = (
     ("anything", "That is the expected behavior for the free tier."),
     ("anything", "Unfortunately the issue is a duplicate of an existing bug."),
     ("anything", "Is the account still active on your end?"),
+    # Contact-channel redirection: a hand-off to a human over a private channel
+    # is imperative-shaped but answers nothing. Surfaced running the gate over
+    # real support replies (Twitter brand replies), round 7.
+    ("My account is locked", "Please send me a private message so we can help."),
+    ("I need help", "Have your friend message us."),
+    ("Where is my order?", "Send us a Direct Message with your order number."),
+    ("Login broken", "DM us your account email and we'll investigate."),
+    # Answer-is-a-question: a diagnostic prompt back to the requester is not a
+    # step they can follow (a non-copula interrogative, complementing the
+    # existing "Is the account still active?" copula case above).
+    ("Internet keeps dropping", "Did the lights change on the router when this happened?"),
 )
 
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-Proven-Answer-Gate.md
Slice phase: Production hardening

#1456 is a P0 launch-readiness issue: paid deflection reports trusted any non-empty `resolution_text` as proven answer evidence. This hardens the gate so closure boilerplate, disposition-only agent updates, and narrow internal-note patterns cannot become `resolution_evidence`, customer-facing steps, or paid answer copy.

The gate is **reject-known-bad + structural instruction-shape** (operator Option 1), not membership in enumerated action-term/topic lists -- four rounds of list-widening still over-rejected real answers. Round 7 adds two structural reject classes surfaced by running the gate over real support replies (not just hand-written probes).

Diff budget note: this is over the 400 LOC soft cap because the gate, verb normalization, disposition-only note filter, structural instruction-shape, and failure-first fixtures need to land together.

## Intentional
- Deterministic gate only; no LLM/Ollama/local model dependency.
- The internal-note matcher stays narrow: concrete tier escalation / numbered policy / internal-note patterns are rejected, but generic words such as "policy" are not rejected by themselves.
- The disposition-only guard is constrained to weak action-token sets plus customer-update/reply wording, so concrete step-wise account fixes and concrete return-flow portal instructions still pass.
- Topic alignment is deliberately NOT a gate (Option 1): the action-term and topic-equivalence maps are kept and computed as advisory signals (`_resolution_advisory_signals`) for a future confidence surface, but an off-topic yet genuine instruction publishes. The honesty floor is the reject filters, not membership.
- Round 7 -- two structural per-sentence disqualifiers, both surfaced by running the gate over real support replies (400 Twitter brand replies + 400 Ubuntu QA responses):
  - **Contact-channel redirection** (`_RESOLUTION_CONTACT_REDIRECT_RE`): "send us a DM", "message us", "shoot me a private message" -- a hand-off to a human, the imperative-shaped sibling of the disposition reject. Narrow (matches "<verb> us/me" + DM/PM/private-message nouns, not legit "send"/"message" steps) and checked on the lead clause only, so a real step with a trailing redirect fallback ("Reset the cache, then DM us") still publishes.
  - **Answer-is-a-question**: the sentence splitter now retains terminators, so a sentence ending in "?" ("Did the lights change on the router?") -- a diagnostic prompt back to the requester -- is skipped, not parsed as a step.
  - The contact-redirect disqualifier is deliberately conservative (lead-clause only): a redirect leading a sentence rejects even if a real step trails it. Under-publishing a real answer is the safe direction for a proven-answer gate.
- Round-7 re-review BLOCKER fix: the numbered-step and UI-path recognizers previously `return True` over the whole text *before* the per-sentence loop, so a numbered/UI-path diagnostic question or declarative bypassed the question/disposition/redirect/declarative rejects. They are now evaluated *inside* the loop after those rejects -- the list-number prefix is stripped as a sentence prefix (numbering is no longer a standalone "this is a step" signal) and the UI-path check runs after the non-verb/copula lead check. Real UI-path / numbered instructions still publish. Verified the reviewer's probes now reject: `Did Settings then Phone show the carrier toggle?`, `1. Did the lights change on the router?`, `The issue is in Billing then Plan and not your account.`
- This does not solve the separate #1460 fixed-bucket over-merge issue.

## Deferred
- #1460 remains the broader within-intent clustering/subcluster fix.
- A future robust-testing slice can add a larger resolution-quality corpus and calibrate thresholds against real help-desk exports.
- A separate over-accept class observed in the real-corpus run -- interjection / adjective sentence leads ("Guac on!", "Love the aesthetic", "Glad to know") parsing as "<verb> <object>" -- is out of scope: it is Twitter-pleasantry noise that does not appear in real Zendesk `resolution_notes`, and chasing it risks over-fitting. Left for the same future calibration slice.
- The structured-outcome factor (read `status` / `reopens` / `satisfaction_score`; gate `proven` on answer-AND-outcome) and a shape-aware importer (Zendesk full-export vs metrics-only CSV) -- per discussion #1507 -- are the larger honesty win and a separate slice. This slice hardens only the answer-text factor.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed round-7 re-review BLOCKER (reviewer) "structural recognizers bypass the per-sentence rejects": numbered-step / UI-path recognizers no longer short-circuit before the question/disposition/redirect/declarative rejects; the reviewer's three probes now reject and a real UI-path instruction still publishes (regression fixtures pinned).
- Fixed round-6 MAJOR (reviewer) "copula/declarative over-accept": a sentence opening with a linking verb, or "<article> <noun> is/are ..." declarative subject + copula, no longer parses as an imperative ("Honestly this is a known issue", "That is the expected behavior").
- Fixed Codex P2 "Preserve past-tense action verbs for the gate": regular `-ed`/`-ing` forms normalize back to known action terms (`enabled`/`configured`/`updated`).
- Fixed Codex P1 "Reject disposition-only agent updates": weak reviewed/checked/sent/replied status notes fail closed, including `sent an update to the customer` orderings; concrete account-review and return-portal step fixtures remain publishable.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py` - passed, 223 tests (incl. round-7 redirect/question fixtures and the round-7 re-review UI-path/numbered-question/UI-path-declarative fixtures).
- Held-out probe of `_resolution_text_is_publishable`: 21/21 realistic answers publish, 22/22 honesty-floor non-answers reject, 0 misses either direction. Pinned in `_HELD_OUT_PUBLISHABLE` / `_HELD_OUT_REJECTED`.
- Round-7 real-corpus calibration: gate run over 400 real Twitter brand replies + 400 real Ubuntu QA responses -- the two new disqualifiers drop Twitter publish 15% -> 10% (DM/clarifying-question false positives) while Ubuntu real-instruction publish holds 9% -> 8%.
- `pytest tests/test_content_ops_deflection_resolution_live_proof.py::test_resolution_live_proof_regenerates_from_committed_csv tests/test_extracted_ticket_faq_macro_writeback.py::test_macro_writeback_preview_uses_real_faq_generator_resolution_steps tests/test_extracted_ticket_faq_output_ingestion.py::test_source_material_to_source_rows_accepts_ticket_faq_result_dict tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n` - passed, 4 tests.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed, 3956 passed, 10 skipped; existing torch/pynvml warning.

## Diff size
4 files, ~1140 added (cumulative vs main); round-7 delta +92 added across gate / tests / plan.