### PR TITLE
Reviewer codebase verification rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,28 +151,35 @@ levels:
 | **BLOCKER** | Correctness, security, contract break, or CI red. Must fix before merge. | Fix or push back with rationale. |
 | **MAJOR** | Architectural / scope / pattern concern. Strong recommendation but not auto-block. | Fix in this PR if the fix is small; otherwise discuss before deferring. |
 | **NIT** | Style, naming, comment polish. Skip-worthy. | Apply if 1-line; skip otherwise. The reviewer should mark NITs as skip-worthy explicitly. |
-| **LGTM** | All gates green, no remaining concerns. | Merge. |
+| **LGTM** | All gates green, R14 verified, no remaining concerns. | Merge. |
 
 ### 2a. Reviewer's verification template
 
 The reviewer should produce something like:
 
 ```
+**Reviewed head:** `<sha from checked-out PR head>`
+
 **Verification (independent):**
 1. <claim from PR description> -- verified via <command>
 2. <invariant from Mechanism> -- confirmed at <file:line>
 3. ...
+
+**Codebase verification (R14):**
+- Changed code inspected: <files/lines>.
+- Caller/test/artifact spot-checks: <rg command, test path, generated artifact, or route checked>.
+- Not verified: <claim skipped + reason>. (Use "None" only if every verdict claim was checked.)
 
 **Plan-doc compliance:** Why / Scope / Mechanism / Files touched /
 Intentional / Deferred / Verification -- matches AGENTS.md framework.
 Slice phase is named and matches the PR's scope. Parked hardening is
 named in Deferred or explicitly marked none.
 
-**Rule results (triggered rules only, see docs/REVIEWER_RULES.md):**
+**Rule results (triggered rules plus R14, see docs/REVIEWER_RULES.md):**
 - R1 Requirements match: Pass/Fail/N-A
 - R2 Test evidence: Pass/Fail/N-A
-- R3 Security/auth ... R13 Fix-the-class: Pass/Fail/N-A
-(List only the rules the changed paths trigger; cite file:line on any Fail.)
+- R3 Security/auth ... R14 Codebase verification: Pass/Fail/N-A
+(List the rules the changed paths trigger, plus R14; cite file:line on any Fail.)
 
 **AI reconciliation:** AI findings reviewed: Y/N. All fixed or waived: Y/N.
 Waivers justified in PR body: Y/N.
@@ -609,7 +616,7 @@ example is not done.
 
 The reviewer's job is **not** "review the code" -- it is to **prove whether
 the PR satisfies its Review Contract and violates none of the rules in
-`docs/REVIEWER_RULES.md`.** Every finding cites a rule ID (R1-R13) and maps to
+`docs/REVIEWER_RULES.md`.** Every finding cites a rule ID (R1-R14) and maps to
 a verdict level (BLOCKER / MAJOR / NIT). The rule matrix and AI reconciliation
 go in the §2a template.
 
@@ -623,14 +630,18 @@ read the Review Contract, predict which files *should* change and which tests
 Don't trust the PR description's claims; reproduce them. The
 reviewer should:
 
-1. Re-run the named verification commands.
-2. Spot-check the plan's invariants at the actual file:line pointed
+1. Record the exact reviewed head SHA from the checked-out PR head.
+2. Re-run the named verification commands.
+3. Spot-check the plan's invariants at the actual file:line pointed
    to in the diff.
-3. Sweep for missed call sites with grep patterns more reliable than
+4. Sweep for missed call sites with grep patterns more reliable than
    the PR's claim (multi-line constructions, kwargs split across
    lines, etc.).
-4. Walk the rules triggered by the changed paths (per the trigger table in
+5. Walk the rules triggered by the changed paths (per the trigger table in
    `docs/REVIEWER_RULES.md`) and record Pass/Fail/N-A for each.
+6. Apply R14: every claim used in the verdict must be backed by checked-out
+   code, a caller/test/artifact spot-check, or a "not verified" note with the
+   reason. **No LGTM from the PR story alone.**
 
 ### 4a.1. AI-finding reconciliation (mandatory before LGTM)
 
@@ -675,6 +686,9 @@ Before LGTM, the reviewer confirms:
 - [ ] Every rule triggered by the changed paths (`docs/REVIEWER_RULES.md`)
       is recorded Pass/Fail/N-A, and every Fail at BLOCKER level cites
       file:line.
+- [ ] R14 is recorded Pass/Fail/N-A. The verdict names the reviewed head SHA,
+      changed code inspected, caller/test/artifact spot-checks, and any claims
+      not verified. No LGTM from PR/body/builder claims alone.
 - [ ] Every AI (Codex/Copilot) finding is fixed or explicitly waived with a
       reason in the PR body (§4a.1). No unresolved bot comments at LGTM.
 - [ ] Plan and PR body name a `Slice phase`, and the diff matches that
@@ -844,7 +858,7 @@ defines:
 
 Read `docs/REVIEWER_RULES.md` before your first review. Your job is
 not "review the code" -- it is to prove the PR satisfies its Review
-Contract and violates none of R1-R13. Cite a rule ID on every finding.
+Contract and violates none of R1-R14. Cite a rule ID on every finding.
 
 Read AUDITOR_PROMPT.md for the cross-cutting audit checks
 (canonical / integration / scope / debt). Apply both lenses.
@@ -857,19 +871,23 @@ For each PR you review:
 2. Reproduce the named verification commands from the PR body.
    Don't trust claims; re-run them. Spot-check the plan's
    invariants at the actual file:line cited in the diff.
-3. Sweep for missed call sites with grep patterns more reliable
+3. Record the reviewed head SHA and apply R14: every claim in the verdict
+   must be backed by checked-out code, a caller/test/artifact spot-check, or a
+   "not verified" note with the reason. No LGTM from PR/body/builder claims
+   alone.
+4. Sweep for missed call sites with grep patterns more reliable
    than the PR's claim (multi-line constructions, kwargs split
    across lines).
-4. Record Pass/Fail/N-A for each rule the changed paths trigger
+5. Record Pass/Fail/N-A for each rule the changed paths trigger and for R14
    (`docs/REVIEWER_RULES.md`); cite file:line on any Fail.
-5. Reconcile AI findings: do not LGTM until every Codex/Copilot
+6. Reconcile AI findings: do not LGTM until every Codex/Copilot
    finding is fixed or explicitly waived with a reason in the PR body.
-6. Confirm CI is green (extracted-checks x2 + Vercel) before
+7. Confirm CI is green (extracted-checks x2 + Vercel) before
    issuing LGTM.
-7. Mark NITs as skip-worthy explicitly when they are. The builder
+8. Mark NITs as skip-worthy explicitly when they are. The builder
    applies 1-line / unambiguous NITs; ignores style/naming/comment
    NITs unless you specifically call out "this should be fixed."
-8. Sign your review with: `_Generated by [Claude Code](
+9. Sign your review with: `_Generated by [Claude Code](
    https://claude.ai/code)_`.
 
 The package under active iteration is `extracted_content_pipeline`.

--- a/REVIEW_MISSES.md
+++ b/REVIEW_MISSES.md
@@ -37,6 +37,7 @@ the same way a builder's repeated lapse gets front-loaded into the bootstrap.
 |---|---|---|---|---|---|
 | _seed_ | _First real entry goes here. Until then this row documents the format._ | - | - | - | - |
 | 2026-06-09 | Repeated "fixed the cited example, not the class" pattern across blog-prose quality and raw-ticket clustering recall review rounds. | human/process | Review comments supplied concrete examples without making hardcoding unable to pass; builder did not self-probe with unseen same-class cases before claiming done. | R13 in `docs/REVIEWER_RULES.md` + AGENTS/bootstrap self-probe requirement for 5-10 unseen same-class cases. | reviewer + builder |
+| 2026-06-10 | Review conclusions accepted PR/story evidence instead of checked-out codebase evidence: a deep-dive issue set was pinned to a reviewer branch instead of `main`, and one repro used a transcribed function copy instead of the repository code. | human/process | Reviewer source of truth was implicit, so branch/head/codebase verification could be skipped without the verdict naming what was and was not verified. | Promoted -> R14 in `docs/REVIEWER_RULES.md` + AGENTS reviewer template/checklist/bootstrap requiring reviewed head, code/caller/test/artifact spot-checks, and "not verified" disclosure. | reviewer |
 
 ## Lifecycle (so this stays a queue, not an archive)
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -2,7 +2,7 @@
 
 > The reviewer's job is **not** to "review the code." It is to **prove whether
 > the PR satisfies its Review Contract and violates none of the rules below.**
-> Every review finding cites a rule ID (R1-R13). This pack is the checklist the
+> Every review finding cites a rule ID (R1-R14). This pack is the checklist the
 > reviewer runs; the recurring-lapse list in `docs/SESSION_BOOTSTRAP.md` is the
 > same checklist front-loaded into the builder so the repeats stop.
 
@@ -13,11 +13,15 @@ This pack sits **under** the existing verdict ladder, it does not replace it:
 | **BLOCKER** | A rule below is failed in a way that breaks correctness, security, a contract, or CI. Must fix before merge. |
 | **MAJOR** | A rule is at risk: architectural / scope / pattern concern. Fix if small; else discuss. |
 | **NIT** | Style / naming / polish. Apply only if 1-line; reviewer marks skip-worthy. |
-| **LGTM** | All triggered rules pass and all AI findings are fixed-or-waived. |
+| **LGTM** | All triggered rules pass, R14 is satisfied, and all AI findings are fixed-or-waived. |
 
 A finding is written as `Rxx (LEVEL) file:line - issue - required fix`.
 **Blockers must cite `file:line`.** A bare "LGTM" with no rule matrix and no
 independent verification is worse than no comment.
+
+R14 is universal: it applies to every review verdict, even when no changed path
+specifically triggers it. A reviewer who has not inspected the checked-out PR
+head and relevant codebase evidence cannot issue LGTM.
 
 ---
 
@@ -146,6 +150,19 @@ practical, use multiple unseen fixtures plus a short explanation of the
 generalized mechanism. Generated or unseen cases must be diverse enough to
 exercise the class, not trivial near-duplicates that satisfy the easy path.
 
+### R14 - Verify against the codebase, not the PR story
+Review verdicts must be based on the checked-out PR head and the current
+codebase, not the PR description, issue summary, builder claims, or prior
+conversation. Claims used in a verdict are verified by reading the relevant
+code, checking at least one relevant caller/test/artifact path, running or
+inspecting the relevant command output, or explicitly marking the claim "not
+verified" with a reason. **No LGTM from claims alone.**
+**Block if:** the verdict accepts a PR claim without checking the codebase; the
+review does not name the reviewed head SHA; the reviewer did not inspect the
+changed code; a shared-function or contract change lacks a caller/test/artifact
+spot-check; or skipped verification is omitted instead of listed as "not
+verified."
+
 ---
 
 ## Path-based rule triggers
@@ -166,6 +183,7 @@ these for the paths it touches:
 | `scripts/audit_*.py`, `scripts/check_*.py`, evaluators / gate predicates | R2 (failure-branch fixtures per `AGENTS.md` 3h/3i), R10 |
 | `extracted_*/` synced files | R1, R10 (manifest sync discipline) |
 | Review comments that name a defect class ("all X", "class of Y", "same failure mode") | R13 (held-out/propertied proof that the class, not only the example, is fixed) |
+| All reviewer verdicts | R14 (checked-out PR-head and codebase-backed verification) |
 
 Phase 1 of this convention is documentation + reviewer discipline. A later
 slice adds a mechanical audit that derives the required rule IDs from the diff

--- a/plans/PR-Reviewer-Codebase-Verification-Rule.md
+++ b/plans/PR-Reviewer-Codebase-Verification-Rule.md
@@ -1,0 +1,105 @@
+# PR-Reviewer-Codebase-Verification-Rule
+
+## Why this slice exists
+
+The operator called out a reviewer failure mode: a reviewer can accept the PR
+narrative without verifying the claim against the checked-out codebase. The
+existing reviewer workflow says to reproduce commands and spot-check file
+lines, but the rule pack does not make source-of-truth verification a named
+rule and the review template does not force a reviewer to disclose unverified
+claims.
+
+This workflow slice makes that explicit for every reviewer: verdicts are based
+on the current PR head plus code/caller/test/artifact evidence, not the PR
+description, issue summary, or builder claims.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Add a reviewer source-of-truth rule to `docs/REVIEWER_RULES.md`.
+2. Update `AGENTS.md` reviewer templates/checklists/bootstrap language so the
+   required review output includes checked head, codebase verification, and
+   "not verified" disclosure.
+3. Add the R14 provenance row to `REVIEW_MISSES.md` so the reviewer flywheel
+   records the originating misses.
+4. Keep this as a documentation/process contract only; no runtime behavior
+   changes.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `docs/REVIEWER_RULES.md` names a rule requiring verdicts to be based
+        on checked-out PR-head evidence, not PR/body/builder claims.
+  - [ ] `AGENTS.md` says a reviewer cannot issue LGTM from claims alone.
+  - [ ] The reviewer template requires checked head, code/caller/test/artifact
+        verification, and explicit "not verified" entries when anything is
+        skipped.
+  - [ ] The reviewer bootstrap points fresh reviewer sessions at the same rule.
+  - [ ] `REVIEW_MISSES.md` records the source-of-truth review misses promoted
+        into R14.
+- Affected surfaces: docs / workflow / reviewer contract.
+- Risk areas: stale reviewer instructions / rule-number drift / ambiguous LGTM
+  requirements.
+- Reviewer rules triggered: R1, R2, R10, R14.
+
+### Files touched
+
+- `AGENTS.md`
+- `REVIEW_MISSES.md`
+- `docs/REVIEWER_RULES.md`
+- `plans/PR-Reviewer-Codebase-Verification-Rule.md`
+
+## Mechanism
+
+Add R14 as a universal reviewer rule, then thread that rule through the
+reviewer-facing spots that actually shape behavior:
+
+- the rule-pack introduction and verdict language;
+- the AGENTS review template;
+- the reviewer independent-verification checklist;
+- the final audit checklist before LGTM;
+- the fresh-reviewer bootstrap prompt;
+- the reviewer-miss ledger row that records this as a promoted durable rule.
+
+R14 stays prose-only rather than a path glob because it applies to every
+review verdict, not only PRs touching certain files. The existing
+`scripts/audit_review_rules_triggered.py` surfaces prose-only trigger rows as
+advisory, so this preserves the current audit model.
+
+## Intentional
+
+- No new mechanical checker in this PR. This is a reviewer contract update; a
+  future checker could lint review bodies, but the immediate gap is the
+  instruction reviewers follow.
+- No changes to product code, CI workflows, or generated artifacts.
+
+## Deferred
+
+- Optional future hardening: add a review-body linter that rejects LGTM reviews
+  missing checked-head and codebase-verification sections.
+
+Parked hardening: none.
+
+## Verification
+
+- Reviewer-rule trigger audit using `scripts/audit_review_rules_triggered.py`
+  against `plans/PR-Reviewer-Codebase-Verification-Rule.md`
+  - Passed; R14 surfaces as an advisory universal reviewer-verdict rule.
+- Git whitespace check
+  - Passed.
+- R14 coverage grep across `AGENTS.md` and `docs/REVIEWER_RULES.md`
+  - Passed; both reviewer entry points include the new requirement.
+- Local PR review via `scripts/push_pr.sh`
+  - Passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 50 |
+| `REVIEW_MISSES.md` | 1 |
+| `docs/REVIEWER_RULES.md` | 22 |
+| `plans/PR-Reviewer-Codebase-Verification-Rule.md` | 105 |
+| **Total** | **178** |


### PR DESCRIPTION
Plan: plans/PR-Reviewer-Codebase-Verification-Rule.md
Slice phase: Workflow/process

This adds a universal reviewer source-of-truth rule: review verdicts must be based on the checked-out PR head and codebase evidence, not the PR description, issue summary, builder claims, or prior conversation. The reviewer template now requires the reviewed head SHA, code/caller/test/artifact spot-checks, and explicit "not verified" entries before LGTM.

## Intentional
- Documentation/process contract only; no runtime checker in this slice.
- R14 is a universal reviewer rule, not a path glob, so the existing trigger audit surfaces it as advisory rather than trying to enforce it from changed files.

## Deferred
- Optional future hardening: add a review-body linter that rejects LGTM reviews missing checked-head and codebase-verification sections.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed Codex P2 "Replace stale pending verification with the executed command": the committed plan now records the local PR review via `scripts/push_pr.sh` as passed instead of pending.
- Addressed reviewer NIT: `REVIEW_MISSES.md` now records the source-of-truth review misses promoted into R14.

## Verification
- `python scripts/audit_review_rules_triggered.py --plan plans/PR-Reviewer-Codebase-Verification-Rule.md` - passed.
- `python scripts/sync_pr_plan.py plans/PR-Reviewer-Codebase-Verification-Rule.md origin/main --check` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `rg "Reviewed head|Codebase verification|R14|No LGTM from" AGENTS.md docs/REVIEWER_RULES.md` - passed.
- `bash scripts/push_pr.sh /tmp/atlas-pr-reviewer-codebase-verification-rule.md --force-with-lease origin HEAD` - passed.

## Diff size
4 files, +160 / -18.
