### PR TITLE
Content-Ops Claim Evidence Prompt Schema

### DIFF
--- a/docs/content_ops_claim_evidence_benchmark_fixtures.md
+++ b/docs/content_ops_claim_evidence_benchmark_fixtures.md
@@ -14,6 +14,7 @@ Each row is an object with these fields:
 {
   "triple_id": "real-001",
   "claim_id": "claim-churn-001",
+  "claim_text": "Customers reduced manual escalation work by 31% after rollout.",
   "evidence_quote": "Customers reduced manual escalation work by 31% after rollout.",
   "source_id": "case-study-acme-q4",
   "expected_supports": true,
@@ -24,7 +25,9 @@ Each row is an object with these fields:
 Field rules:
 
 - `triple_id`: unique non-empty string for this benchmark row.
-- `claim_id`: non-empty string that identifies the claim under test.
+- `claim_id`: non-empty identifier for traceability, deduplication, or registry
+  linkage.
+- `claim_text`: non-empty claim statement the model judges against the evidence.
 - `evidence_quote`: non-empty quote or excerpt the model will judge.
 - `source_id`: non-empty source identifier for traceability.
 - `expected_supports`: operator label; `true` means the evidence supports the
@@ -53,6 +56,7 @@ JSON fixture text is one array of row objects:
   {
     "triple_id": "real-001",
     "claim_id": "claim-churn-001",
+    "claim_text": "Customers reduced manual escalation work by 31% after rollout.",
     "evidence_quote": "Customers reduced manual escalation work by 31% after rollout.",
     "source_id": "case-study-acme-q4",
     "expected_supports": true,
@@ -64,8 +68,8 @@ JSON fixture text is one array of row objects:
 JSONL fixture text is one row object per non-empty line:
 
 ```jsonl
-{"triple_id":"real-001","claim_id":"claim-churn-001","evidence_quote":"Customers reduced manual escalation work by 31% after rollout.","source_id":"case-study-acme-q4","expected_supports":true,"difficulty":"easy"}
-{"triple_id":"hard-001","claim_id":"claim-integration-002","evidence_quote":"The platform exports CSV files for CRM import.","source_id":"docs-export","expected_supports":false,"difficulty":"hard"}
+{"triple_id":"real-001","claim_id":"claim-churn-001","claim_text":"Customers reduced manual escalation work by 31% after rollout.","evidence_quote":"Customers reduced manual escalation work by 31% after rollout.","source_id":"case-study-acme-q4","expected_supports":true,"difficulty":"easy"}
+{"triple_id":"hard-001","claim_id":"claim-integration-002","claim_text":"The platform syncs Salesforce opportunities natively.","evidence_quote":"The platform exports CSV files for CRM import.","source_id":"docs-export","expected_supports":false,"difficulty":"hard"}
 ```
 
 JSONL lines must be objects. Arrays belong in JSON fixture text, not JSONL, so
@@ -86,6 +90,40 @@ The command prints a JSON envelope with `ok`, `errors`, `triple_count`,
 zero only when the fixture is valid. It does not call models, write benchmark
 results, or expose verifier/MCP behavior.
 
+## Prompt And Response Contract
+
+The structured-witness contract is versioned as `verify_claim_evidence.v1`.
+For each benchmark row, the future provider runner will render a prompt with:
+
+- the claim text;
+- the claim id for traceability;
+- the evidence quote;
+- the source id;
+- the difficulty bucket.
+
+The prompt asks the witness to decide whether the evidence quote supports the
+claim under test. It explicitly tells the witness not to decide whether the
+claim is generally true and not to use outside knowledge.
+
+Responses must match this strict JSON shape:
+
+```json
+{
+  "supports": true,
+  "confidence": 4,
+  "reason": "The quote directly states the measured outcome."
+}
+```
+
+Field rules:
+
+- `supports`: boolean support judgment.
+- `confidence`: integer from 1 through 5. Downstream scoring only credits high
+  confidence responses.
+- `reason`: non-empty, non-whitespace rationale grounded in the evidence quote.
+
+Extra response fields are not part of the contract.
+
 ## Hard Cases
 
 Hard rows should feel like realistic B2B SaaS marketing copy and include cases
@@ -99,6 +137,6 @@ where keyword overlap is not enough:
 
 ## Out Of Scope
 
-This fixture does not include model responses, prompts, provider settings,
-tokens, customer draft content, or verifier/MCP wiring. The future runner owns
-file-path loading, provider execution, and result artifacts.
+This fixture does not include model responses, provider settings, tokens,
+customer draft content, or verifier/MCP wiring. The future runner owns provider
+execution and result artifacts.

--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -24,6 +24,7 @@ FINAL_HARD_TARGET = 10
 FIXTURE_FORMAT_JSON = "json"
 FIXTURE_FORMAT_JSONL = "jsonl"
 VALID_FIXTURE_FORMATS = frozenset({FIXTURE_FORMAT_JSON, FIXTURE_FORMAT_JSONL})
+VERIFY_CLAIM_EVIDENCE_CONTRACT_VERSION = "verify_claim_evidence.v1"
 
 
 def _required_text(data: Mapping[str, object], key: str) -> str | None:
@@ -59,6 +60,7 @@ class ClaimEvidenceTriple:
 
     triple_id: str
     claim_id: str
+    claim_text: str
     evidence_quote: str
     source_id: str
     expected_supports: bool
@@ -74,6 +76,7 @@ class ClaimEvidenceTriple:
         errors: list[str] = []
         triple_id = _required_text(data, "triple_id")
         claim_id = _required_text(data, "claim_id")
+        claim_text = _required_text(data, "claim_text")
         evidence_quote = _required_text(data, "evidence_quote")
         source_id = _required_text(data, "source_id")
         expected_supports = _required_bool(data, "expected_supports")
@@ -82,6 +85,7 @@ class ClaimEvidenceTriple:
         for key, value in (
             ("triple_id", triple_id),
             ("claim_id", claim_id),
+            ("claim_text", claim_text),
             ("evidence_quote", evidence_quote),
             ("source_id", source_id),
         ):
@@ -98,6 +102,7 @@ class ClaimEvidenceTriple:
             cls(
                 triple_id=triple_id or "",
                 claim_id=claim_id or "",
+                claim_text=claim_text or "",
                 evidence_quote=evidence_quote or "",
                 source_id=source_id or "",
                 expected_supports=bool(expected_supports),
@@ -143,6 +148,79 @@ class ClaimEvidenceResponse:
             ),
             (),
         )
+
+
+@dataclass(frozen=True)
+class ClaimEvidencePromptContract:
+    """Provider-neutral prompt and response schema for one witness call."""
+
+    contract_version: str
+    prompt: str
+    response_schema: Mapping[str, object]
+
+
+def claim_evidence_response_json_schema() -> dict[str, object]:
+    """Return the strict JSON Schema for structured witness responses."""
+
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["supports", "confidence", "reason"],
+        "properties": {
+            "supports": {
+                "type": "boolean",
+                "description": (
+                    "True only when the provided evidence quote supports the "
+                    "claim under test."
+                ),
+            },
+            "confidence": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+                "description": (
+                    "Confidence in the support judgment. Use 4 or 5 only for "
+                    "clear support or clear non-support."
+                ),
+            },
+            "reason": {
+                "type": "string",
+                "pattern": "\\S",
+                "description": (
+                    "Short rationale grounded only in the evidence quote."
+                ),
+            },
+        },
+    }
+
+
+def build_claim_evidence_prompt_contract(
+    triple: ClaimEvidenceTriple,
+) -> ClaimEvidencePromptContract:
+    """Build the deterministic prompt/schema contract for one benchmark triple."""
+
+    prompt = "\n".join(
+        (
+            f"Contract: {VERIFY_CLAIM_EVIDENCE_CONTRACT_VERSION}",
+            "Task: decide whether the evidence quote supports the claim under test.",
+            "Judge support only from the provided evidence quote.",
+            "Do not decide whether the claim is true in general.",
+            "Do not use outside knowledge or infer facts not present in the quote.",
+            "Return only JSON that matches the response schema.",
+            "",
+            f"Claim: {triple.claim_text}",
+            f"Claim id: {triple.claim_id}",
+            f"Source id: {triple.source_id}",
+            f"Difficulty bucket: {triple.difficulty}",
+            "Evidence quote:",
+            triple.evidence_quote,
+        )
+    )
+    return ClaimEvidencePromptContract(
+        contract_version=VERIFY_CLAIM_EVIDENCE_CONTRACT_VERSION,
+        prompt=prompt,
+        response_schema=claim_evidence_response_json_schema(),
+    )
 
 
 @dataclass(frozen=True)

--- a/plans/PR-Content-Ops-Claim-Evidence-Prompt-Schema.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Prompt-Schema.md
@@ -1,0 +1,123 @@
+# PR-Content-Ops-Claim-Evidence-Prompt-Schema
+
+## Why this slice exists
+
+#1435 needs a provider runner eventually, but the runner should not invent the
+prompt or response contract at call time. After #1465, operators can validate
+benchmark fixtures locally; the next missing deterministic artifact is the
+structured-witness prompt and JSON Schema that every future provider run will
+use for the claim/evidence support slot.
+
+This PR captures that contract without calling any model. It keeps the
+reliability gate reproducible: the prompt text, response schema, and response
+decoder are versioned and tested before provider execution or benchmark results
+exist.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a deterministic prompt/schema helper for the `verify_claim_evidence`
+   structured-witness slot.
+2. Add the missing `claim_text` fixture field so the prompt carries the actual
+   claim statement while `claim_id` remains traceability metadata.
+3. Keep the response schema aligned with the existing decoded response
+   contract: `supports`, `confidence`, and `reason`.
+4. Add focused tests proving prompt content, schema required fields, no extra
+   response fields, and response decoder compatibility.
+5. Document the prompt/schema contract next to the fixture/operator handoff.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The fixture contract requires `claim_text` separately from `claim_id`.
+  - [ ] The prompt contract includes claim text, claim id, evidence quote,
+        source id, and difficulty from one benchmark triple.
+  - [ ] The prompt tells the witness to judge whether the evidence supports the
+        claim, not whether the claim is generally true.
+  - [ ] The JSON Schema requires `supports`, `confidence`, and `reason`.
+  - [ ] The JSON Schema rejects extra response fields.
+  - [ ] The schema bounds confidence to integer values from 1 through 5.
+  - [ ] The schema rejects whitespace-only rationale text the same way the
+        decoded response validator does.
+  - [ ] The schema stays compatible with the existing decoded response
+        validator.
+  - [ ] No provider/model runner, prompt execution, result artifact, verifier
+        rubric wiring, MCP tool, database, or live-client behavior is
+        introduced.
+- Affected surfaces: extracted benchmark helper, focused benchmark tests, docs,
+  and plan.
+- Risk areas: benchmark false-green, schema drift, future provider-contract
+  incompatibility, CI enrollment.
+- Reviewer rules triggered: R1, R2, R5, R10, R12.
+
+### Files touched
+
+- `docs/content_ops_claim_evidence_benchmark_fixtures.md`
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `plans/PR-Content-Ops-Claim-Evidence-Prompt-Schema.md`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+- `tests/test_validate_content_ops_claim_evidence_fixture.py`
+
+## Mechanism
+
+The benchmark module gains a pure prompt/schema contract object with a stable
+contract version, a JSON Schema mapping, and a rendered prompt string for a
+single `ClaimEvidenceTriple`.
+
+The prompt is intentionally narrow: it passes only the triple fields the
+benchmark owns and instructs the witness to decide support from the provided
+evidence quote alone. The schema is intentionally strict: only `supports`,
+`confidence`, and `reason` are allowed, `confidence` is bounded to the same
+1 through 5 range accepted by the existing response decoder, and `reason`
+requires non-whitespace text.
+
+Focused tests assert the prompt includes the right triple fields and guardrail
+language, then validate the schema shape against the decoded response contract.
+
+## Intentional
+
+- The prompt/schema helper lives in the existing benchmark module instead of a
+  provider-runner module. The runner is still deferred, and keeping the contract
+  adjacent to the scorer prevents a second source of truth.
+- The schema remains provider-neutral JSON Schema rather than OpenAI-,
+  Anthropic-, or FastMCP-specific metadata. Provider adapters can wrap it later.
+- The prompt does not include ground-truth labels or benchmark thresholds. Those
+  remain scorer inputs, not witness inputs.
+- `claim_text` is added to the unmerged fixture contract instead of overloading
+  `claim_id`. That makes existing draft examples update, but preserves
+  traceability semantics before any real benchmark fixture is published.
+
+## Deferred
+
+- Provider/model runner and prompt execution.
+- Result artifact, scoring table, agreement matrix, failure-case list, and
+  go/no-go writeup.
+- Batch fixture directories and operator labeling workflow.
+- Verifier rubric inclusion and MCP exposure only after benchmark results pass.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_extracted_content_claim_evidence_benchmark.py tests/test_validate_content_ops_claim_evidence_fixture.py - 41 passed.
+- python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py tests/test_validate_content_ops_claim_evidence_fixture.py - passed.
+- git diff --check - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - 3701 passed, 10 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_prompt_schema_pr_body.md - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/content_ops_claim_evidence_benchmark_fixtures.md` | 50 |
+| `extracted_content_pipeline/claim_evidence_benchmark.py` | 78 |
+| `plans/PR-Content-Ops-Claim-Evidence-Prompt-Schema.md` | 123 |
+| `tests/test_extracted_content_claim_evidence_benchmark.py` | 80 |
+| `tests/test_validate_content_ops_claim_evidence_fixture.py` | 1 |
+| **Total** | **332** |

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -13,6 +13,8 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     ModelScore,
     PairwiseAgreement,
     StabilityScore,
+    build_claim_evidence_prompt_contract,
+    claim_evidence_response_json_schema,
     evaluate_thresholds,
     intra_model_stability,
     load_claim_evidence_fixture_text,
@@ -26,6 +28,7 @@ def _triple(triple_id: str, expected: bool, difficulty: str) -> ClaimEvidenceTri
     return ClaimEvidenceTriple(
         triple_id=triple_id,
         claim_id=f"claim-{triple_id}",
+        claim_text=f"Claim statement {triple_id}",
         evidence_quote=f"evidence {triple_id}",
         source_id=f"source-{triple_id}",
         expected_supports=expected,
@@ -50,6 +53,7 @@ def test_triple_decoder_accepts_valid_decoded_input() -> None:
         {
             "triple_id": "t1",
             "claim_id": "c1",
+            "claim_text": "The product integrates with Salesforce.",
             "evidence_quote": "The product integrates with Salesforce.",
             "source_id": "s1",
             "expected_supports": True,
@@ -60,6 +64,7 @@ def test_triple_decoder_accepts_valid_decoded_input() -> None:
     assert errors == ()
     assert triple is not None
     assert triple.triple_id == "t1"
+    assert triple.claim_text == "The product integrates with Salesforce."
     assert triple.expected_supports is True
 
 
@@ -68,6 +73,7 @@ def test_triple_decoder_reports_missing_and_wrong_typed_fields() -> None:
         {
             "triple_id": None,
             "claim_id": 10,
+            "claim_text": " ",
             "evidence_quote": "",
             "source_id": "s1",
             "expected_supports": "yes",
@@ -79,6 +85,7 @@ def test_triple_decoder_reports_missing_and_wrong_typed_fields() -> None:
     assert errors == (
         "triple_id missing",
         "claim_id missing",
+        "claim_text missing",
         "evidence_quote missing",
         "expected_supports missing",
         "difficulty must be easy or hard",
@@ -106,6 +113,7 @@ def test_fixture_validator_prefixes_row_decoder_errors() -> None:
             {
                 "triple_id": "t1",
                 "claim_id": "",
+                "claim_text": "",
                 "evidence_quote": "source quote",
                 "source_id": "s1",
                 "expected_supports": None,
@@ -117,6 +125,7 @@ def test_fixture_validator_prefixes_row_decoder_errors() -> None:
     assert fixture.triples == ()
     assert fixture.errors == (
         "row 1: claim_id missing",
+        "row 1: claim_text missing",
         "row 1: expected_supports missing",
         "row 1: difficulty must be easy or hard",
     )
@@ -296,6 +305,77 @@ def test_response_decoder_reports_missing_and_wrong_typed_fields() -> None:
         "confidence must be an integer from 1 to 5",
         "reason missing",
     )
+
+
+def test_prompt_contract_renders_required_triple_fields_and_guardrails() -> None:
+    contract = build_claim_evidence_prompt_contract(
+        ClaimEvidenceTriple(
+            triple_id="hard-001",
+            claim_id="claim-escalation-001",
+            claim_text="Customers reduced escalations by 31 percent.",
+            evidence_quote="Escalation volume fell 31% after rollout.",
+            source_id="case-study-acme",
+            expected_supports=True,
+            difficulty=HARD,
+        )
+    )
+
+    assert contract.contract_version == "verify_claim_evidence.v1"
+    assert "Claim: Customers reduced escalations by 31 percent." in contract.prompt
+    assert "Claim id: claim-escalation-001" in contract.prompt
+    assert "Source id: case-study-acme" in contract.prompt
+    assert "Difficulty bucket: hard" in contract.prompt
+    assert "Escalation volume fell 31% after rollout." in contract.prompt
+    assert "supports the claim under test" in contract.prompt
+    assert "Do not decide whether the claim is true in general." in contract.prompt
+    assert "Do not use outside knowledge" in contract.prompt
+
+
+def test_response_json_schema_matches_decoder_contract() -> None:
+    schema = claim_evidence_response_json_schema()
+
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == ["supports", "confidence", "reason"]
+    assert schema["properties"]["supports"]["type"] == "boolean"
+    assert schema["properties"]["confidence"]["type"] == "integer"
+    assert schema["properties"]["confidence"]["minimum"] == 1
+    assert schema["properties"]["confidence"]["maximum"] == 5
+    assert schema["properties"]["reason"]["type"] == "string"
+    assert schema["properties"]["reason"]["pattern"] == "\\S"
+
+    response, errors = ClaimEvidenceResponse.from_mapping(
+        {"supports": True, "confidence": 4, "reason": "quote states it"}
+    )
+
+    assert errors == ()
+    assert response == ClaimEvidenceResponse(True, 4, "quote states it")
+
+
+def test_response_json_schema_rejects_whitespace_reason_like_decoder() -> None:
+    schema = claim_evidence_response_json_schema()
+    whitespace_reason = {"supports": True, "confidence": 4, "reason": "   "}
+
+    assert schema["properties"]["reason"]["pattern"] == "\\S"
+    assert not any(
+        character.strip() for character in str(whitespace_reason["reason"])
+    )
+
+    response, errors = ClaimEvidenceResponse.from_mapping(whitespace_reason)
+
+    assert response is None
+    assert errors == ("reason missing",)
+
+
+def test_response_json_schema_returns_fresh_mapping() -> None:
+    schema = claim_evidence_response_json_schema()
+    schema["required"] = []
+
+    assert claim_evidence_response_json_schema()["required"] == [
+        "supports",
+        "confidence",
+        "reason",
+    ]
 
 
 def test_model_score_counts_easy_hard_and_high_confidence_accuracy() -> None:

--- a/tests/test_validate_content_ops_claim_evidence_fixture.py
+++ b/tests/test_validate_content_ops_claim_evidence_fixture.py
@@ -31,6 +31,7 @@ def _row(
     return {
         "triple_id": triple_id,
         "claim_id": f"claim-{triple_id}",
+        "claim_text": f"Claim statement {triple_id}",
         "evidence_quote": f"evidence {triple_id}",
         "source_id": f"source-{triple_id}",
         "expected_supports": expected,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Prompt-Schema.md
Slice phase: Functional validation

This PR captures the deterministic prompt and JSON Schema contract for the #1435 `verify_claim_evidence` structured-witness slot. It keeps the benchmark path provider-neutral and reproducible before any model runner exists: one helper renders the prompt from a fixture triple, and the strict response schema stays aligned with the existing decoded response validator.

## Intentional
- The prompt/schema helper lives in the existing benchmark module instead of a provider-runner module. The runner is still deferred, and keeping the contract adjacent to the scorer avoids a second source of truth.
- The schema remains provider-neutral JSON Schema rather than OpenAI-, Anthropic-, or FastMCP-specific metadata. Provider adapters can wrap it later.
- The prompt does not include ground-truth labels or benchmark thresholds. Those remain scorer inputs, not witness inputs.
- `claim_text` is added to the unmerged fixture contract instead of overloading `claim_id`. That preserves traceability semantics before any real benchmark fixture is published.

## Deferred
- Provider/model runner and prompt execution.
- Result artifact, scoring table, agreement matrix, failure-case list, and go/no-go writeup.
- Batch fixture directories and operator labeling workflow.
- Verifier rubric inclusion and MCP exposure only after benchmark results pass.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_content_claim_evidence_benchmark.py tests/test_validate_content_ops_claim_evidence_fixture.py - 41 passed.
- python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py tests/test_validate_content_ops_claim_evidence_fixture.py - passed.
- git diff --check - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/run_extracted_pipeline_checks.sh - 3701 passed, 10 skipped.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_prompt_schema_pr_body.md - passed.

## AI reconciliation
- All fixed or waived: yes.
- Fixed reviewer BLOCKER / Codex P1: added `claim_text` to the fixture contract and prompt so the witness receives the actual claim statement while `claim_id` remains traceability metadata.
- Fixed reviewer MAJOR / Codex P2: replaced `reason` `minLength: 1` with a non-whitespace schema pattern aligned with the decoded response validator.

## Diff size
5 files, +326 / -6.
