### PR TITLE
Add maturity_sweep advisory CI check (structural brittleness triage)

### DIFF
--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - ".github/workflows/maturity_sweep_advisory.yml"
       - "scripts/maturity_sweep.py"
+      - "tests/test_maturity_sweep.py"
       - "extracted_content_pipeline/**"
       - "tests/test_extracted_*.py"
       - "tests/test_content_ops_*.py"
@@ -39,7 +40,17 @@ jobs:
         with:
           python-version: "3.11"
 
-      # stdlib-only tool -- no dependency install needed.
+      - name: Install pytest
+        run: python -m pip install --quiet pytest
+
+      # Tool correctness gates (AGENTS.md 3i failure-branch fixtures: they
+      # prove the detectors fire, and pin the dead-detector matcher bug).
+      # --noconftest: the repo-level tests/conftest.py imports pytest_asyncio
+      # and app dependencies; these tests are self-contained stdlib by design.
+      - name: Sweep unit tests (blocking)
+        run: python -m pytest tests/test_maturity_sweep.py --noconftest -q
+
+      # The sweep itself is stdlib-only.
       - name: Maturity sweep (advisory, non-blocking)
         continue-on-error: true
         run: |

--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -1,0 +1,51 @@
+name: Maturity Sweep (advisory)
+
+# Advisory brittleness triage -- NOT a gate. Ranks files in the content-ops
+# lane by structural-fragility signals (untested modules, happy-path-only
+# tests, swallowed exceptions, unguarded input) and prints a worst-first
+# agenda for an adversarial pass. It never fails the build: it surfaces
+# suspects, judgment stays with the reviewer.
+#
+# It catches STRUCTURAL brittleness only. Semantic / contract / logic bugs
+# (over-broad matchers, fail-open fields, asymmetric token handling) are NOT
+# in scope here -- those are caught by adversarial review + the live
+# AI-reconciliation gate. A green sweep is NOT a production-hardening stamp.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/maturity_sweep_advisory.yml"
+      - "scripts/maturity_sweep.py"
+      - "extracted_content_pipeline/**"
+      - "tests/test_extracted_*.py"
+      - "tests/test_content_ops_*.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/maturity_sweep_advisory.yml"
+      - "scripts/maturity_sweep.py"
+      - "extracted_content_pipeline/**"
+
+jobs:
+  maturity-sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # stdlib-only tool -- no dependency install needed.
+      - name: Maturity sweep (advisory, non-blocking)
+        continue-on-error: true
+        run: |
+          echo "Advisory brittleness triage for the content-ops lane."
+          echo "NOT a gate -- it surfaces suspect files for an adversarial pass."
+          echo "Structural signals only; semantic/contract bugs are caught by review + the reconciliation gate."
+          echo "A green sweep is not a production-hardening stamp."
+          echo
+          python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --top 25

--- a/plans/PR-Maturity-Sweep-Advisory-CI.md
+++ b/plans/PR-Maturity-Sweep-Advisory-CI.md
@@ -28,12 +28,22 @@ Slice phase: workflow/process
    `extracted_content_pipeline` with `--tests-root tests`, top 25, non-blocking
    (`continue-on-error` + no `--min-score`). Triggers on PRs touching the
    lane / tool / its tests.
+3. (Review round) Fix the per-module test matcher so the test-quality
+   detectors fire on this repo's naming: segment-boundary containment over
+   test-file stems (handles test_extracted_ and test_content_ops_ prefixes,
+   unions multiple test files per module) replaces the exact-stem match that
+   left the deflection lane's own modules with zero quality signal.
+4. (Review round) Add `tests/test_maturity_sweep.py` -- AGENTS.md 3i
+   failure-branch fixtures that prove each detector fires (and pin the
+   dead-detector matcher bug: the repo-style-naming test fails on the old
+   matcher), run as a blocking step in the workflow.
 
 ### Files touched
 
 - `.github/workflows/maturity_sweep_advisory.yml`
 - `plans/PR-Maturity-Sweep-Advisory-CI.md`
 - `scripts/maturity_sweep.py`
+- `tests/test_maturity_sweep.py`
 
 ### Review Contract
 - Acceptance: the sweep runs in CI on lane PRs, prints a worst-first agenda,
@@ -76,11 +86,6 @@ is a safety net.
   install in CI.
 
 ## Deferred
-- Per-module `HAPPY_PATH_TESTS` / `NO_RAISES_TESTS` matching is under-reported
-  because Atlas tests are named test_extracted_&lt;module&gt; while the tool
-  matches test_&lt;module&gt;; `NO_TEST_FILE` is already correct via the
-  "mentioned anywhere" fallback. Tightening the stem match (handle the
-  `extracted_` prefix) is a follow-up.
 - Broadening scope beyond `extracted_content_pipeline` (e.g. `atlas_brain`
   content-ops surfaces) -- follow-up.
 - Promoting to a regression-gate (fail only when a changed file's score
@@ -96,16 +101,28 @@ is a safety net.
 - Tested deflection files no longer show a false `NO_TEST_FILE`
   (`faq_deflection_report`, `support_ticket_input_package` -> `NO_TEST_FILE`
   absent).
+- Detector liveness, measured: with the old exact-stem matcher,
+  HAPPY_PATH_TESTS fired on 11 files and NO_RAISES_TESTS on 12 (plain
+  test_module naming only) and on ZERO of the deflection lane's four key
+  modules; with the segment-containment matcher they fire on 37 and 50
+  files respectively, and the deflection modules are now either flagged
+  (support_ticket_input_package -> NO_RAISES_TESTS) or verifiably quiet
+  because their matched suites are failure-rich (ticket_faq_markdown: 131
+  tests, 35 negative-named, 9 raises).
+- 8 unit tests pass (`tests/test_maturity_sweep.py`, --noconftest); the
+  repo-style-naming fixture fails against the old matcher (dead-detector
+  pin, verified by mutating a copy back to exact-stem matching).
 - Running `scripts/check_ascii_python.sh` passes (`scripts/maturity_sweep.py`
   is ASCII).
 - Workflow is non-blocking by construction: no `--min-score`, plus
-  `continue-on-error: true`.
+  `continue-on-error: true`; the unit-test step is blocking.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/maturity_sweep_advisory.yml` | 51 |
-| `plans/PR-Maturity-Sweep-Advisory-CI.md` | 111 |
-| `scripts/maturity_sweep.py` | 467 |
-| **Total** | **629** |
+| `.github/workflows/maturity_sweep_advisory.yml` | 62 |
+| `plans/PR-Maturity-Sweep-Advisory-CI.md` | 128 |
+| `scripts/maturity_sweep.py` | 473 |
+| `tests/test_maturity_sweep.py` | 125 |
+| **Total** | **788** |

--- a/plans/PR-Maturity-Sweep-Advisory-CI.md
+++ b/plans/PR-Maturity-Sweep-Advisory-CI.md
@@ -1,0 +1,111 @@
+# PR-Maturity-Sweep-Advisory-CI
+
+## Why this slice exists
+
+Adds a brittleness-triage tool (`maturity_sweep`) to CI as an **advisory,
+non-blocking** check. It ranks content-ops files by structural-fragility
+signals (untested modules, happy-path-only tests, swallowed exceptions,
+unguarded input) and prints a worst-first agenda for an adversarial pass --
+systematizing the triage step the lane's review already relies on.
+
+It is explicitly **not** a production-hardening gate. It catches *structural*
+brittleness only; semantic / contract / logic bugs (over-broad matchers,
+fail-open fields, asymmetric token handling -- the actual recent BLOCKERs)
+remain the job of adversarial review + the live AI-reconciliation gate. Wired
+advisory-first per the operator decision, to avoid false-positive blocking and
+to avoid a green-sweep-equals-hardened false signal.
+
+## Scope (this PR)
+
+Ownership lane: review-workflow
+Slice phase: workflow/process
+
+1. Add `scripts/maturity_sweep.py` -- a stdlib-only AST brittleness scorer
+   (operator-provided), plus a small `--tests-root` flag so it can index tests
+   from a separate directory (the repo `tests/` dir lives outside the swept
+   lane).
+2. Add `.github/workflows/maturity_sweep_advisory.yml` -- runs the sweep on
+   `extracted_content_pipeline` with `--tests-root tests`, top 25, non-blocking
+   (`continue-on-error` + no `--min-score`). Triggers on PRs touching the
+   lane / tool / its tests.
+
+### Files touched
+
+- `.github/workflows/maturity_sweep_advisory.yml`
+- `plans/PR-Maturity-Sweep-Advisory-CI.md`
+- `scripts/maturity_sweep.py`
+
+### Review Contract
+- Acceptance: the sweep runs in CI on lane PRs, prints a worst-first agenda,
+  and never fails the build. Test correlation uses `tests/` (no false
+  `NO_TEST_FILE` on files actually tested there). ASCII-clean. stdlib-only
+  (no dependency install).
+- Affected surfaces: CI only -- a new advisory workflow + a new script. No
+  runtime or product code is touched.
+- Risk areas: a noisy or blocking gate (mitigated: advisory; no `--min-score`;
+  `continue-on-error`); a false "hardening" signal (mitigated: explicit banner
+  in the workflow + this plan).
+- Reviewer rules triggered: R8 (determinism -- the tool is deterministic
+  static analysis). R2 test-evidence is N/A (tooling, not product logic).
+
+## Mechanism
+
+`maturity_sweep` walks a lane for Python source files, AST-parses each, and scores
+structural smells (`SWALLOWED_EXCEPT`, `BARE_EXCEPT`, `UNGUARDED_INPUT` on
+boundary calls, `UNGUARDED_INDEX`, `ASSERT_AS_VALIDATION`, `MUTABLE_DEFAULT`,
+`WEAK_CONTRACT`, `HEURISTIC_COMMENT`) plus test-coverage smells
+(`NO_TEST_FILE`, `HAPPY_PATH_TESTS`, `NO_RAISES_TESTS`), with per-code caps so
+one noisy category cannot dominate, sorted worst-first. The new `--tests-root`
+points test indexing at the repo `tests/` dir so coverage signals are computed
+against the real tests (which live outside the lane). Without `--min-score`
+the tool exits 0, so the CI step is advisory by construction; `continue-on-error`
+is a safety net.
+
+## Intentional
+- Advisory, not gating. A hard `--min-score` gate would block on false
+  positives (legit `except ...: return` guards flagged as `SWALLOWED_EXCEPT`;
+  safe `x[0]` as `UNGUARDED_INDEX`) and on the large pre-existing debt.
+  Operator chose advisory-first.
+- Scoped to `extracted_content_pipeline` (the active lane), not repo-wide: a
+  repo-root scan hits ~53k vendored Python files and is too slow/noisy for CI.
+- The workflow banner states plainly that a green sweep is not a hardening
+  stamp and that semantic bugs are out of scope -- to head off the
+  green-CI-equals-good misread.
+- The tool is committed near-verbatim (operator-provided); the only logic
+  delta is the ~6-line `--tests-root` wiring. stdlib-only, so no requirements
+  install in CI.
+
+## Deferred
+- Per-module `HAPPY_PATH_TESTS` / `NO_RAISES_TESTS` matching is under-reported
+  because Atlas tests are named test_extracted_&lt;module&gt; while the tool
+  matches test_&lt;module&gt;; `NO_TEST_FILE` is already correct via the
+  "mentioned anywhere" fallback. Tightening the stem match (handle the
+  `extracted_` prefix) is a follow-up.
+- Broadening scope beyond `extracted_content_pipeline` (e.g. `atlas_brain`
+  content-ops surfaces) -- follow-up.
+- Promoting to a regression-gate (fail only when a changed file's score
+  increases vs main, ignoring pre-existing debt) once a baseline exists --
+  follow-up.
+- Reducing `SWALLOWED_EXCEPT` false positives (distinguish legit early-return
+  guards) -- follow-up.
+- Parked hardening: none.
+
+## Verification
+- `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --top 25`
+  runs in ~8s, exits 0, prints a worst-first agenda.
+- Tested deflection files no longer show a false `NO_TEST_FILE`
+  (`faq_deflection_report`, `support_ticket_input_package` -> `NO_TEST_FILE`
+  absent).
+- Running `scripts/check_ascii_python.sh` passes (`scripts/maturity_sweep.py`
+  is ASCII).
+- Workflow is non-blocking by construction: no `--min-score`, plus
+  `continue-on-error: true`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/maturity_sweep_advisory.yml` | 51 |
+| `plans/PR-Maturity-Sweep-Advisory-CI.md` | 111 |
+| `scripts/maturity_sweep.py` | 467 |
+| **Total** | **629** |

--- a/scripts/maturity_sweep.py
+++ b/scripts/maturity_sweep.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""
+maturity_sweep.py - rank files by how likely they are to be brittle,
+happy-path code that will not survive production.
+
+The point of this tool is what it does NOT do. It never reads a diff, a PR
+description, a plan doc, or commit intent. It looks only at the intrinsic
+properties of each file and its tests. A reviewer that never sees the dev's
+framing cannot drift into it. The output is an agenda for an adversarial
+pass, ordered worst-first.
+
+It does not decide a file is bad. It decides a file is suspect and tells you
+exactly where to aim. Judgment stays with you (or a fresh reviewer session).
+
+stdlib only, Python 3.9+.
+
+Usage:
+    python maturity_sweep.py path/to/lane
+    python maturity_sweep.py path/to/lane --top 15
+    python maturity_sweep.py path/to/lane --json > sweep.json
+    python maturity_sweep.py path/to/lane --min-score 8   # CI gate
+"""
+
+import argparse
+import ast
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Tunable config. Bend these to your pipeline. For the Deflection Report lane
+# the ingestion/clustering files are the ones you care about, so the boundary
+# set below leans toward CSV/file/encoding entry points.
+# ---------------------------------------------------------------------------
+
+WEIGHTS = {
+    "NO_TEST_FILE": 6,          # module has functions/classes and no test touches it
+    "SWALLOWED_EXCEPT": 5,      # except: pass / return None / return [] - silent degradation
+    "HAPPY_PATH_TESTS": 4,      # tests exist but almost none exercise failure
+    "UNGUARDED_INPUT": 4,       # touches external input, no try, no raise in the function
+    "BARE_EXCEPT": 4,           # except: with no type
+    "NO_RAISES_TESTS": 3,       # test file never asserts that anything raises
+    "ASSERT_AS_VALIDATION": 3,  # assert used as a guard in non-test code (vanishes under -O)
+    "UNGUARDED_INDEX": 2,       # x[0] / split()[n] with no length check in the function
+    "MUTABLE_DEFAULT": 2,       # def f(x=[])
+    "HEURISTIC_COMMENT": 1,     # TODO/HACK/probably/best effort/brittle...
+    "WEAK_CONTRACT": 1,         # public def with zero type annotations
+    "PARSE_ERROR": 8,           # file does not parse
+}
+
+# Per-code caps so one noisy category cannot dominate a file's score.
+CAPS = {
+    "ASSERT_AS_VALIDATION": 3,
+    "UNGUARDED_INDEX": 3,
+    "HEURISTIC_COMMENT": 4,
+    "WEAK_CONTRACT": 3,
+    "MUTABLE_DEFAULT": 2,
+}
+
+# Calls that strongly indicate reading external / untrusted input. Kept tight
+# on purpose - get/post/parse/decode are too common to be signal.
+BOUNDARY_NAMES = {
+    "open", "loads", "load", "reader", "DictReader",
+    "read_csv", "read_excel", "strptime", "fromisoformat",
+    "urlopen", "recv",
+}
+
+HEURISTIC_RE = re.compile(
+    r"\b(todo|fixme|hack|xxx|for now|temporary|temp\b|best[ -]?effort|"
+    r"good enough|probably|hopefully|assume|guess|kludge|workaround|"
+    r"brittle|fragile|happy path|naive|quick fix)\b",
+    re.IGNORECASE,
+)
+
+# test-name fragments that indicate the test is trying to break something
+NEGATIVE_TEST_HINTS = (
+    "invalid", "malformed", "empty", "missing", "bad", "error", "fail",
+    "raises", "none", "null", "corrupt", "edge", "boundary", "duplicate",
+    "garbage", "unicode", "encoding", "oversize", "too_", "partial",
+    "truncat", "blank", "whitespace", "nan", "negative", "overflow",
+)
+
+SKIP_DIRS = {
+    "__pycache__", ".venv", "venv", "env", "node_modules", ".git",
+    "build", "dist", ".mypy_cache", ".pytest_cache", "migrations",
+}
+
+TEST_NAME_RE = re.compile(r"(^test_.+\.py$)|(.+_test\.py$)")
+
+
+@dataclass
+class Finding:
+    code: str
+    lineno: int
+    detail: str
+    weight: int = 0
+
+    def __post_init__(self):
+        self.weight = WEIGHTS.get(self.code, 0)
+
+
+@dataclass
+class FileResult:
+    path: str
+    score: int = 0
+    findings: list = field(default_factory=list)
+    counts: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# AST analysis
+# ---------------------------------------------------------------------------
+
+class Analyzer(ast.NodeVisitor):
+    """Collects findings from a single module. Tracks whether we are inside a
+    try block and whether the enclosing function ever raises, so that touching
+    external input without either guard can be flagged."""
+
+    def __init__(self, is_test):
+        self.is_test = is_test
+        self.findings = []
+        self.try_depth = 0
+        self.func_has_raise = []  # stack, one bool per enclosing function
+
+    def add(self, code, lineno, detail):
+        self.findings.append(Finding(code, lineno, detail))
+
+    # -- functions -----------------------------------------------------------
+    def visit_FunctionDef(self, node):
+        self._check_mutable_defaults(node)
+        self._check_contract(node)
+        has_raise = any(isinstance(n, ast.Raise) for n in ast.walk(node))
+        self.func_has_raise.append(has_raise)
+        saved = self.try_depth
+        self.try_depth = 0
+        self.generic_visit(node)
+        self.try_depth = saved
+        self.func_has_raise.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def _check_mutable_defaults(self, node):
+        defaults = list(node.args.defaults) + list(node.args.kw_defaults)
+        for d in defaults:
+            if isinstance(d, (ast.List, ast.Dict, ast.Set)):
+                self.add("MUTABLE_DEFAULT", node.lineno,
+                         "mutable default argument in %s" % node.name)
+                break
+            if isinstance(d, ast.Call) and isinstance(d.func, ast.Name) \
+                    and d.func.id in ("list", "dict", "set"):
+                self.add("MUTABLE_DEFAULT", node.lineno,
+                         "mutable default argument in %s" % node.name)
+                break
+
+    def _check_contract(self, node):
+        if node.name.startswith("_") or self.is_test:
+            return
+        annotated = node.returns is not None or any(
+            a.annotation is not None for a in node.args.args
+        )
+        if not annotated and (node.args.args or node.returns is None):
+            # only flag if it takes args or is a real public entry point
+            if node.args.args:
+                self.add("WEAK_CONTRACT", node.lineno,
+                         "public def %s has no type annotations" % node.name)
+
+    # -- try / except --------------------------------------------------------
+    def visit_Try(self, node):
+        self.try_depth += 1
+        for n in node.body:
+            self.visit(n)
+        self.try_depth -= 1
+        for h in node.handlers:
+            self.visit(h)
+        for n in node.orelse + node.finalbody:
+            self.visit(n)
+
+    def visit_ExceptHandler(self, node):
+        if node.type is None:
+            self.add("BARE_EXCEPT", node.lineno, "bare except")
+        if self._is_swallowed(node.body):
+            self.add("SWALLOWED_EXCEPT", node.lineno,
+                     "exception swallowed (no re-raise, no handling)")
+        self.generic_visit(node)
+
+    @staticmethod
+    def _is_swallowed(body):
+        if len(body) != 1:
+            return False
+        stmt = body[0]
+        if isinstance(stmt, (ast.Pass, ast.Continue)):
+            return True
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant) \
+                and stmt.value.value is Ellipsis:
+            return True
+        if isinstance(stmt, ast.Return):
+            v = stmt.value
+            if v is None:
+                return True
+            if isinstance(v, ast.Constant) and v.value in (None, "", 0, False):
+                return True
+            if isinstance(v, (ast.List, ast.Dict, ast.Set, ast.Tuple)) and not getattr(v, "elts", None) \
+                    and not getattr(v, "keys", None):
+                return True
+        return False
+
+    # -- assert as validation ------------------------------------------------
+    def visit_Assert(self, node):
+        if not self.is_test:
+            self.add("ASSERT_AS_VALIDATION", node.lineno,
+                     "assert used as a guard (removed under python -O)")
+        self.generic_visit(node)
+
+    # -- boundary calls ------------------------------------------------------
+    def visit_Call(self, node):
+        name = self._call_name(node.func)
+        if name in BOUNDARY_NAMES:
+            in_try = self.try_depth > 0
+            enclosing_raises = bool(self.func_has_raise) and self.func_has_raise[-1]
+            if not in_try and not enclosing_raises:
+                self.add("UNGUARDED_INPUT", node.lineno,
+                         "reads external input via %s() with no try and no raise"
+                         % name)
+        self.generic_visit(node)
+
+    @staticmethod
+    def _call_name(func):
+        if isinstance(func, ast.Name):
+            return func.id
+        if isinstance(func, ast.Attribute):
+            return func.attr
+        return None
+
+    # -- unguarded indexing (heuristic, low weight) --------------------------
+    def visit_Subscript(self, node):
+        idx = node.slice
+        const_int = isinstance(idx, ast.Constant) and isinstance(idx.value, int)
+        on_split = isinstance(node.value, ast.Call) and \
+            self._call_name(node.value.func) == "split"
+        if const_int or on_split:
+            self.add("UNGUARDED_INDEX", node.lineno,
+                     "fixed-index access; verify the sequence can be shorter")
+        self.generic_visit(node)
+
+
+# ---------------------------------------------------------------------------
+# test scoring
+# ---------------------------------------------------------------------------
+
+def index_tests(root):
+    """Return (test_sources, all_test_text). test_sources maps a test-file stem
+    to its source; all_test_text is every test file concatenated, for the
+    'is this module mentioned anywhere in tests' check."""
+    sources = {}
+    blobs = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn.endswith(".py") and (TEST_NAME_RE.match(fn) or "test" in Path(dirpath).name.lower()):
+                p = Path(dirpath) / fn
+                src = read_text(p)
+                sources[p.stem] = src
+                blobs.append(src)
+    return sources, "\n".join(blobs)
+
+
+def score_tests(module_stem, test_sources, all_test_text):
+    """Returns a list of findings about test coverage quality for one module."""
+    findings = []
+    candidate_stems = {"test_%s" % module_stem, "%s_test" % module_stem,
+                       "test_%s" % module_stem.lower()}
+    src = None
+    for stem in candidate_stems:
+        if stem in test_sources:
+            src = test_sources[stem]
+            break
+
+    mentioned = re.search(r"\b%s\b" % re.escape(module_stem), all_test_text)
+
+    if src is None:
+        if not mentioned:
+            findings.append(Finding("NO_TEST_FILE", 0,
+                                    "no test file and module not referenced by any test"))
+        return findings
+
+    test_defs = re.findall(r"def\s+(test_\w+)", src)
+    total = len(test_defs)
+    if total == 0:
+        return findings
+
+    negatives = sum(
+        1 for name in test_defs
+        if any(h in name.lower() for h in NEGATIVE_TEST_HINTS)
+    )
+    raises = bool(re.search(r"pytest\.raises|assertRaises|with raises", src))
+
+    ratio = negatives / total
+    if ratio < 0.15:
+        findings.append(Finding("HAPPY_PATH_TESTS", 0,
+                                "%d tests, %d exercise failure paths (%.0f%%)"
+                                % (total, negatives, ratio * 100)))
+    if not raises and total >= 3:
+        findings.append(Finding("NO_RAISES_TESTS", 0,
+                                "no test asserts that anything raises"))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# driving
+# ---------------------------------------------------------------------------
+
+def read_text(path):
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="latin-1", errors="replace")
+    except OSError:
+        return ""
+
+
+def scan_comments(source):
+    out = []
+    for i, line in enumerate(source.splitlines(), start=1):
+        m = HEURISTIC_RE.search(line)
+        if m:
+            out.append(Finding("HEURISTIC_COMMENT", i,
+                               "language of a known shortcut: '%s'" % m.group(0).strip()))
+    return out
+
+
+def is_test_path(path):
+    if TEST_NAME_RE.match(path.name):
+        return True
+    return any(part.lower() in ("tests", "test") for part in path.parts)
+
+
+def looks_substantive(tree):
+    """True if the module defines functions or classes worth testing."""
+    return any(isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+               for n in tree.body)
+
+
+def apply_caps(findings):
+    """Sum weights with per-code caps so one category cannot bury the rest."""
+    seen = {}
+    total = 0
+    counts = {}
+    for f in findings:
+        counts[f.code] = counts.get(f.code, 0) + 1
+        cap = CAPS.get(f.code)
+        if cap is not None:
+            used = seen.get(f.code, 0)
+            if used >= cap:
+                continue
+            seen[f.code] = used + 1
+        total += f.weight
+    return total, counts
+
+
+def analyze_file(path, test_sources, all_test_text):
+    source = read_text(path)
+    result = FileResult(path=str(path))
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as e:
+        result.findings.append(Finding("PARSE_ERROR", e.lineno or 0,
+                                       "does not parse: %s" % e.msg))
+        result.score, result.counts = apply_caps(result.findings)
+        return result
+
+    analyzer = Analyzer(is_test=False)
+    analyzer.visit(tree)
+    result.findings.extend(analyzer.findings)
+    result.findings.extend(scan_comments(source))
+
+    if looks_substantive(tree) and path.stem != "__init__":
+        result.findings.extend(score_tests(path.stem, test_sources, all_test_text))
+
+    result.score, result.counts = apply_caps(result.findings)
+    return result
+
+
+def sweep(root, tests_root=None):
+    root = Path(root)
+    # Tests may live outside the swept lane (e.g. a repo-level tests/ dir).
+    # Index them from tests_root when given so coverage signals are real.
+    test_sources, all_test_text = index_tests(Path(tests_root) if tests_root else root)
+    results = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if not fn.endswith(".py"):
+                continue
+            path = Path(dirpath) / fn
+            if is_test_path(path):
+                continue
+            results.append(analyze_file(path, test_sources, all_test_text))
+    results.sort(key=lambda r: r.score, reverse=True)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# reporting
+# ---------------------------------------------------------------------------
+
+def print_report(results, top, min_score):
+    flagged = [r for r in results if r.score > 0]
+    print("maturity sweep: %d files scanned, %d flagged\n" % (len(results), len(flagged)))
+    print("score  file")
+    print("-----  ----")
+    for r in flagged[:top]:
+        print("%5d  %s" % (r.score, r.path))
+
+    print("\nworst offenders, with where to aim:\n")
+    for r in flagged[:min(top, 8)]:
+        print("[%d] %s" % (r.score, r.path))
+        summary = ", ".join("%s x%d" % (c, n) for c, n in
+                            sorted(r.counts.items(), key=lambda kv: -WEIGHTS.get(kv[0], 0)))
+        print("     %s" % summary)
+        ranked = sorted(r.findings, key=lambda f: -f.weight)
+        for f in ranked[:6]:
+            loc = ("L%d" % f.lineno) if f.lineno else "file"
+            print("     %-5s %s" % (loc, f.detail))
+        print()
+
+    if min_score is not None:
+        over = [r for r in results if r.score >= min_score]
+        if over:
+            print("GATE FAILED: %d file(s) at or above min-score %d" % (len(over), min_score))
+            return 1
+        print("gate passed: nothing at or above min-score %d" % min_score)
+    return 0
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Rank files by production-fragility.")
+    ap.add_argument("path", help="directory to sweep (point at the lane)")
+    ap.add_argument("--tests-root", default=None,
+                    help="directory to index tests from (default: the swept path); "
+                         "point at the repo tests dir when source and tests are separate")
+    ap.add_argument("--top", type=int, default=20, help="how many to list")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    ap.add_argument("--min-score", type=int, default=None,
+                    help="exit nonzero if any file scores at/above this (CI gate)")
+    args = ap.parse_args(argv)
+
+    results = sweep(args.path, args.tests_root)
+
+    if args.json:
+        payload = [
+            {"path": r.path, "score": r.score, "counts": r.counts,
+             "findings": [asdict(f) for f in r.findings]}
+            for r in results if r.score > 0
+        ]
+        print(json.dumps(payload, indent=2))
+        if args.min_score is not None:
+            return 1 if any(r.score >= args.min_score for r in results) else 0
+        return 0
+
+    return print_report(results, args.top, args.min_score)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/maturity_sweep.py
+++ b/scripts/maturity_sweep.py
@@ -267,16 +267,22 @@ def index_tests(root):
     return sources, "\n".join(blobs)
 
 
+def matching_test_sources(module_stem, test_sources):
+    """All test sources whose file stem contains the module stem as a
+    _-delimited segment run. Handles prefixed conventions like
+    test_extracted_<module> and test_content_ops_<module>, and unions the
+    multiple test files a module commonly has. The previous exact-stem-only
+    match left HAPPY_PATH_TESTS/NO_RAISES_TESTS dark for prefix-named tests."""
+    seg_re = re.compile(r"(^|_)%s(_|$)" % re.escape(module_stem.lower()))
+    return [src for stem, src in sorted(test_sources.items())
+            if seg_re.search(stem.lower())]
+
+
 def score_tests(module_stem, test_sources, all_test_text):
     """Returns a list of findings about test coverage quality for one module."""
     findings = []
-    candidate_stems = {"test_%s" % module_stem, "%s_test" % module_stem,
-                       "test_%s" % module_stem.lower()}
-    src = None
-    for stem in candidate_stems:
-        if stem in test_sources:
-            src = test_sources[stem]
-            break
+    matched = matching_test_sources(module_stem, test_sources)
+    src = "\n".join(matched) if matched else None
 
     mentioned = re.search(r"\b%s\b" % re.escape(module_stem), all_test_text)
 

--- a/tests/test_maturity_sweep.py
+++ b/tests/test_maturity_sweep.py
@@ -1,0 +1,125 @@
+"""Failure-branch tests for scripts/maturity_sweep.py (AGENTS.md section 3i).
+
+The point of these fixtures is to prove the detectors FIRE, not just that the
+tool runs. The repo-style-naming case pins the dead-detector bug found in
+review: with the original exact-stem matcher, tests named
+test_extracted_<module>.py never matched, so HAPPY_PATH_TESTS and
+NO_RAISES_TESTS could not fire at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "maturity_sweep.py"
+
+SPEC = importlib.util.spec_from_file_location("maturity_sweep", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+MOD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MOD)
+
+
+def codes(findings):
+    return {f.code for f in findings}
+
+
+HAPPY_ONLY_TESTS = (
+    "def test_returns_rows():\n    assert build() == []\n\n"
+    "def test_counts_rows():\n    assert count() == 0\n\n"
+    "def test_formats_output():\n    assert fmt() == ''\n"
+)
+
+FAILURE_RICH_TESTS = (
+    "import pytest\n\n"
+    "def test_rejects_invalid_rows():\n"
+    "    with pytest.raises(ValueError):\n        build(None)\n\n"
+    "def test_missing_field_marks_invalid():\n    assert not ok({})\n\n"
+    "def test_malformed_csv_fails_loud():\n"
+    "    with pytest.raises(ValueError):\n        parse('x')\n"
+)
+
+
+def test_happy_path_detectors_fire_for_repo_style_test_naming() -> None:
+    # Dead-detector pin: test_extracted_<module> naming must match the module.
+    findings = MOD.score_tests(
+        "support_widget_pipeline",
+        {"test_extracted_support_widget_pipeline": HAPPY_ONLY_TESTS},
+        all_test_text=HAPPY_ONLY_TESTS,
+    )
+    assert "HAPPY_PATH_TESTS" in codes(findings)
+    assert "NO_RAISES_TESTS" in codes(findings)
+
+
+def test_content_ops_prefix_and_multiple_test_files_union() -> None:
+    findings = MOD.score_tests(
+        "faq_widget_report",
+        {
+            "test_content_ops_faq_widget_report": HAPPY_ONLY_TESTS,
+            "test_extracted_faq_widget_report": FAILURE_RICH_TESTS,
+        },
+        all_test_text=HAPPY_ONLY_TESTS + FAILURE_RICH_TESTS,
+    )
+    # The union has 6 tests, 3 of them negative (50%) and raises present:
+    # neither quality finding should fire.
+    assert codes(findings) == set()
+
+
+def test_quality_detectors_quiet_on_failure_rich_tests() -> None:
+    findings = MOD.score_tests(
+        "ingest_module",
+        {"test_ingest_module": FAILURE_RICH_TESTS},
+        all_test_text=FAILURE_RICH_TESTS,
+    )
+    assert "HAPPY_PATH_TESTS" not in codes(findings)
+    assert "NO_RAISES_TESTS" not in codes(findings)
+
+
+def test_no_test_file_fires_when_module_is_unreferenced() -> None:
+    findings = MOD.score_tests("orphan_module", {}, all_test_text="")
+    assert codes(findings) == {"NO_TEST_FILE"}
+
+
+def test_mentioned_anywhere_fallback_suppresses_no_test_file() -> None:
+    findings = MOD.score_tests(
+        "helper_module", {},
+        all_test_text="from pkg import helper_module\n",
+    )
+    assert codes(findings) == set()
+
+
+def test_unrelated_test_stems_do_not_match() -> None:
+    # 'report' must not match test_extracted_reporting (segment boundary).
+    assert MOD.matching_test_sources(
+        "report", {"test_extracted_reporting": HAPPY_ONLY_TESTS}) == []
+    assert MOD.matching_test_sources(
+        "report", {"test_extracted_report_builder": HAPPY_ONLY_TESTS}) != []
+
+
+def _analyze(source):
+    analyzer = MOD.Analyzer(is_test=False)
+    analyzer.visit(ast.parse(source))
+    return analyzer.findings
+
+
+def test_swallowed_except_detector_fires() -> None:
+    findings = _analyze(
+        "def f():\n"
+        "    try:\n        risky()\n"
+        "    except Exception:\n        pass\n"
+    )
+    assert "SWALLOWED_EXCEPT" in {f.code for f in findings}
+
+
+def test_unguarded_boundary_input_detector_fires_and_guarded_is_quiet() -> None:
+    unguarded = _analyze("def f(p):\n    return open(p).read()\n")
+    assert "UNGUARDED_INPUT" in {f.code for f in unguarded}
+    guarded = _analyze(
+        "def f(p):\n"
+        "    try:\n        return open(p).read()\n"
+        "    except OSError:\n        raise ValueError(p)\n"
+    )
+    assert "UNGUARDED_INPUT" not in {f.code for f in guarded}


### PR DESCRIPTION
Plan: plans/PR-Maturity-Sweep-Advisory-CI.md
Slice phase: workflow/process

Adds `maturity_sweep` to CI as an **advisory, non-blocking** check: it ranks content-ops files by structural-fragility signals (untested modules, happy-path-only tests, swallowed exceptions, unguarded input) and prints a worst-first agenda for an adversarial pass. It systematizes the triage step the lane's review already relies on.

It is **not** a production-hardening gate. It catches *structural* brittleness only; semantic/contract/logic bugs (over-broad matchers, fail-open fields, asymmetric token handling -- the actual recent BLOCKERs) stay with adversarial review + the live AI-reconciliation gate. The workflow banner says this in plain text so a green sweep is never misread as "hardened."

## Intentional
- Advisory, not gating (operator decision): no `--min-score` + `continue-on-error`. Avoids false-positive blocking (legit `except: return` guards, safe `x[0]`) and the green-sweep-equals-hardened misread.
- Scoped to `extracted_content_pipeline` (the active lane), not repo-wide -- a repo-root scan hits ~53k vendored `.py` and is too slow/noisy for CI.
- Added `--tests-root` so tests are indexed from `/tests` (which lives outside the lane); without it every tested file was a false `NO_TEST`.
- Tool is operator-provided, committed near-verbatim; stdlib-only, so no dependency install in CI.

## Deferred
- Tighten the per-module test-file match for the `test_extracted_<module>` prefix (so `HAPPY_PATH_TESTS`/`NO_RAISES_TESTS` fire; `NO_TEST_FILE` is already correct via the mentioned-anywhere fallback).
- Broaden scope beyond `extracted_content_pipeline`; promote to a regression-gate (fail only on a changed file's score increase) once a baseline exists; reduce `SWALLOWED_EXCEPT` false positives.

## Parked hardening
- None.

## Verification
- `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --top 25` runs ~8s, exit 0, prints the agenda.
- Tested deflection files no longer show a false `NO_TEST_FILE` (`faq_deflection_report`, `support_ticket_input_package`).
- `bash scripts/check_ascii_python.sh` passes; workflow YAML parses; `--min-score` gate hook intact for future promotion.

## Diff size
3 new files, ~625 LOC -- almost all the operator-provided tool (~467 lines); hand-written delta is the ~6-line `--tests-root` wiring + the ~51-line workflow.

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes.
- Fixed Codex P2 (no failure-branch tests for the detector): added `tests/test_maturity_sweep.py` (AGENTS.md 3i) -- 8 fixtures proving each detector fires and stays quiet appropriately, run as a blocking workflow step. The repo-style-naming fixture fails against the old matcher, exactly the dead-detector catch Codex predicted.
- Fixed the reviewer's verified finding (dark detectors): replaced the exact-stem test matcher with segment-boundary containment (unions multiple test files per module). Measured: HAPPY_PATH_TESTS 11 -> 37 files, NO_RAISES_TESTS 12 -> 50; the deflection lane's four key modules went from zero quality signal to flagged (support_ticket_input_package -> NO_RAISES_TESTS) or verifiably quiet (failure-rich suites, e.g. ticket_faq_markdown: 131 tests / 35 negative-named / 9 raises). Note the measured correction to both prior claims: the old matcher was not globally dark (plain test_module names did match); it was dark specifically for the prefixed naming the active lane uses.
