### PR TITLE
Reviewer R14 review body linter

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -28,10 +28,32 @@ jobs:
         run: |
           git remote set-head origin --auto || git remote set-head origin main
 
+      - name: Write current PR body
+        if: github.event_name == 'pull_request'
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          body = event.get("pull_request", {}).get("body") or ""
+          Path(os.environ["RUNNER_TEMP"], "current-pr-body.md").write_text(
+              body,
+              encoding="utf-8",
+          )
+          PY
+
       - name: Run local PR review bundle
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash scripts/local_pr_review.sh
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            bash scripts/local_pr_review.sh --current-pr-body-file "$RUNNER_TEMP/current-pr-body.md"
+          else
+            bash scripts/local_pr_review.sh
+          fi
 
       # Unit-cover the PR-review tooling itself (including the plans-archive
       # advisory). This workflow runs the bundle above, so its fixtures belong
@@ -39,4 +61,4 @@ jobs:
       - name: PR-review tooling unit tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio
-          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py -q
+          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py -q

--- a/plans/PR-Reviewer-R14-Review-Body-Linter.md
+++ b/plans/PR-Reviewer-R14-Review-Body-Linter.md
@@ -1,0 +1,147 @@
+# PR-Reviewer-R14-Review-Body-Linter
+
+## Why this slice exists
+
+#1468 added R14: reviewers cannot LGTM from a PR story alone, and must record
+the reviewed head SHA, changed code inspected, caller/test/artifact
+spot-checks, and "not verified" disclosure. That PR intentionally deferred
+mechanical enforcement.
+
+This slice adds the first local enforcement tool: a review-body linter that
+fails LGTM review text when the R14 evidence sections are missing or
+placeholder-only. It turns the rule from a pure instruction into a reusable
+checker a reviewer can run before posting an LGTM.
+
+Diff budget note: this is slightly over the 400 LOC soft cap because the
+checker and its failure-branch fixtures need to land together for the rule to
+be trustworthy.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Add `scripts/check_review_body_r14.py`, a stdlib-only CLI that reads a
+   review body from a file or stdin and validates R14 evidence for LGTM
+   verdicts.
+2. Add focused fixture tests for valid LGTM text, non-LGTM bypass behavior, and
+   each missing/placeholder failure branch.
+3. Accept bounded reviewer label variants that preserve the same R14 evidence
+   contract (`at HEAD` qualifiers and `Spot-checks:` shorthand), while reporting
+   exact expected labels on failures.
+4. Wire the pre-push audit workflow to pass the live pull-request body into the
+   existing local review bundle, so CI enforces the same body contract the local
+   `push_pr.sh` wrapper enforces.
+5. Keep R14 review-body enforcement local/ad hoc in this slice; do not wire it
+   to live GitHub review APIs yet.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] LGTM review text fails if it omits the reviewed head SHA.
+  - [ ] LGTM review text fails if it omits the `Codebase verification (R14)`
+        section.
+  - [ ] LGTM review text fails if changed-code, caller/test/artifact, or
+        `Not verified` evidence lines are missing or placeholder-only.
+  - [ ] LGTM review text accepts bounded evidence-label variants (`Changed code
+        inspected at HEAD:`, `Caller/test/artifact spot-checks at HEAD:`, and
+        `Spot-checks:`) without accepting placeholder evidence.
+  - [ ] Missing-evidence errors name the exact expected label forms.
+  - [ ] CI `pre-push-audit` passes the pull-request body to
+        `local_pr_review.sh --current-pr-body-file` for PR events, while
+        push-to-main keeps the no-body invocation.
+  - [ ] LGTM review text fails if the R14 rule result is absent or non-passing.
+  - [ ] Non-LGTM review text is allowed unless the caller explicitly passes
+        `--verdict lgtm`.
+  - [ ] Tests cover every detection branch and false-positive bypass path.
+- Affected surfaces: local reviewer workflow script and tests only.
+- Risk areas: false-positive LGTM detection / placeholder text passing as
+  evidence / future live-review integration expecting a stable CLI contract.
+- Reviewer rules triggered: R2, R10, R14.
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `plans/PR-Reviewer-R14-Review-Body-Linter.md`
+- `scripts/check_review_body_r14.py`
+- `tests/test_check_review_body_r14.py`
+- `tests/test_pre_push_audit_workflow.py`
+
+## Mechanism
+
+`check_review_body_r14.py` parses Markdown text and determines whether R14 is
+required by explicit `--verdict lgtm` or auto-detected LGTM verdict language.
+When R14 is required, it checks:
+
+- a `Reviewed head:` line with a hex commit-like value;
+- a `Codebase verification (R14)` section;
+- non-placeholder `Changed code inspected`, `Caller/test/artifact
+  spot-checks`, and `Not verified` lines inside that section;
+- a passing R14 rule-results mention. `R14 Fail`, `R14 N/A`, and
+  `R14 Not applicable` fail in LGTM mode.
+
+For reviewer ergonomics, the changed-code and spot-check labels accept the
+bounded `at HEAD` qualifier, and the spot-check line also accepts `Spot-checks:`
+as a shorthand. `Not verified:` remains exact because it is a specific
+disclosure field. Missing-evidence errors name the accepted labels so a reviewer
+can fix a label mismatch without guessing.
+
+The checker reports all missing evidence in one run and exits non-zero on
+failure. It reads stdin when the path is `-`, matching common reviewer tooling
+flows.
+
+The GitHub Actions pre-push audit writes `github.event.pull_request.body` from
+the event payload to a runner-temp body file and invokes
+`local_pr_review.sh --current-pr-body-file` for pull-request events. Push events
+continue to run the existing no-body command because there is no current PR body
+to validate.
+
+## Intentional
+
+- No GitHub API integration in this PR. This is the local review-body contract
+  checker; live review enforcement can come later once the body shape is proven.
+- Auto-detection is conservative: it looks for verdict-style LGTM language
+  rather than every incidental "LGTM" mention in discussion prose. Callers that
+  know the verdict can force enforcement with `--verdict lgtm`.
+- The checker validates that required evidence is present and non-placeholder;
+  it does not judge whether the evidence is substantively correct. R14 remains a
+  reviewer judgment rule.
+
+## Deferred
+
+- Wire the linter into a future live-review workflow that reads submitted LGTM
+  reviews from GitHub and fails when R14 evidence is missing.
+- Optionally add an AGENTS.md one-liner once the command is adopted by the
+  reviewer session.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused pytest for `tests/test_check_review_body_r14.py`
+  - Passed, 19 tests.
+- Focused pytest for the linter plus workflow wiring tests
+  (`tests/test_check_review_body_r14.py` and
+  `tests/test_pre_push_audit_workflow.py`)
+  - Passed, 21 tests.
+- PR-review tooling unit-test list from `.github/workflows/pre_push_audit.yml`
+  - Passed, 63 tests.
+- Py-compile for `scripts/check_review_body_r14.py` and
+  `tests/test_check_review_body_r14.py`
+  - Passed.
+- CLI stdin smoke for `scripts/check_review_body_r14.py`
+  - Passed; forced-LGTM input with R14 evidence exits 0.
+- Plan sync check for `plans/PR-Reviewer-R14-Review-Body-Linter.md`
+  - Passed.
+- Pending before push: local PR review via `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pre_push_audit.yml` | 26 |
+| `plans/PR-Reviewer-R14-Review-Body-Linter.md` | 147 |
+| `scripts/check_review_body_r14.py` | 202 |
+| `tests/test_check_review_body_r14.py` | 195 |
+| `tests/test_pre_push_audit_workflow.py` | 23 |
+| **Total** | **593** |

--- a/scripts/check_review_body_r14.py
+++ b/scripts/check_review_body_r14.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Validate R14 evidence in reviewer LGTM bodies.
+
+R14 requires reviewer verdicts to be backed by the checked-out codebase, not
+the PR story. This checker owns the review-body shape that is mechanically
+checkable before a reviewer posts LGTM: reviewed head, codebase-verification
+evidence, not-verified disclosure, and an R14 rule result.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+REVIEWED_HEAD_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?\*{0,2}Reviewed head\*{0,2}\s*:\*{0,2}\s*`?([0-9a-f]{7,40})`?\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+CODEBASE_SECTION_RE = re.compile(
+    r"^\s*(?:#{1,6}\s+|(?:[-*]\s*)?\*\*)?Codebase verification\s*\(R14\)\s*:?\*?\*?\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+HEADING_RE = re.compile(r"^\s*(#{1,6})\s+\S")
+BOLD_HEADING_RE = re.compile(r"^\s*\*\*[^*\n]+:\*\*\s*$")
+LABEL_RE_TEMPLATE = r"^[ \t]*(?:[-*][ \t]*)?{label}[ \t]*:[ \t]*(?P<value>.*)$"
+LABEL_AT_HEAD_RE_TEMPLATE = (
+    r"^[ \t]*(?:[-*][ \t]*)?{label}(?:[ \t]+at[ \t]+HEAD)?"
+    r"[ \t]*:[ \t]*(?P<value>.*)$"
+)
+R14_RULE_PASS_RE = re.compile(
+    r"\bR14\b[^\n]*\bPass\b",
+    re.IGNORECASE,
+)
+R14_RULE_NON_PASS_RE = re.compile(
+    r"\bR14\b[^\n]*(?:\bFail\b|N[-/ ]?A|Not applicable)\b",
+    re.IGNORECASE,
+)
+AUTO_LGTM_RE = re.compile(
+    r"^\s*(?:#{1,6}\s*)?(?:\*\*)?(?:Verdict\s*:\s*)?LGTM(?:[.,!?:]|\s*$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+PLACEHOLDER_RE = re.compile(
+    r"^\s*(?:|todo|tbd|n/?a|none|not checked|not verified|<[^>]+>|\.\.\.)\s*$",
+    re.IGNORECASE,
+)
+CHANGED_CODE_LABELS = ("Changed code inspected",)
+SPOT_CHECK_LABELS = ("Caller/test/artifact spot-checks", "Spot-checks")
+NOT_VERIFIED_LABELS = ("Not verified",)
+
+
+def requires_r14(body: str, verdict: str) -> bool:
+    """Return whether this review body must satisfy R14 evidence checks."""
+    normalized = verdict.lower()
+    if normalized == "lgtm":
+        return True
+    if normalized in {"non-lgtm", "non_lgtm", "not-lgtm", "not_lgtm"}:
+        return False
+    return AUTO_LGTM_RE.search(body) is not None
+
+
+def extract_codebase_section(body: str) -> str | None:
+    """Return the Codebase verification (R14) section body, if present."""
+    lines = body.splitlines()
+    start: int | None = None
+    for idx, line in enumerate(lines):
+        if CODEBASE_SECTION_RE.match(line):
+            start = idx
+            break
+    if start is None:
+        return None
+
+    collected: list[str] = []
+    for line in lines[start + 1:]:
+        if HEADING_RE.match(line) or BOLD_HEADING_RE.match(line):
+            break
+        collected.append(line)
+    return "\n".join(collected)
+
+
+def _label_value(
+    section: str,
+    labels: Sequence[str],
+    *,
+    allow_at_head: bool = False,
+) -> str | None:
+    template = LABEL_AT_HEAD_RE_TEMPLATE if allow_at_head else LABEL_RE_TEMPLATE
+    for label in labels:
+        pattern = re.compile(
+            template.format(label=re.escape(label)),
+            re.IGNORECASE | re.MULTILINE,
+        )
+        match = pattern.search(section)
+        if match:
+            return match.group("value").strip()
+    return None
+
+
+def _expected_label_text(labels: Sequence[str], *, allow_at_head: bool = False) -> str:
+    expected: list[str] = []
+    for label in labels:
+        expected.append(f"{label}:")
+        if allow_at_head:
+            expected.append(f"{label} at HEAD:")
+    return " or ".join(f"'{label}'" for label in expected)
+
+
+def _has_evidence_value(value: str | None, *, allow_none: bool = False) -> bool:
+    if value is None:
+        return False
+    if allow_none and value.strip().lower() == "none":
+        return True
+    return PLACEHOLDER_RE.match(value) is None
+
+
+def r14_errors(body: str, verdict: str = "auto") -> list[str]:
+    """Return R14 evidence errors for a review body."""
+    if not requires_r14(body, verdict):
+        return []
+
+    errors: list[str] = []
+    if not REVIEWED_HEAD_RE.search(body):
+        errors.append("missing reviewed head SHA")
+
+    section = extract_codebase_section(body)
+    if section is None:
+        errors.append("missing Codebase verification (R14) section")
+    else:
+        changed = _label_value(section, CHANGED_CODE_LABELS, allow_at_head=True)
+        if not _has_evidence_value(changed):
+            errors.append(
+                "missing non-placeholder changed-code evidence "
+                f"(expected {_expected_label_text(CHANGED_CODE_LABELS, allow_at_head=True)})"
+            )
+
+        spot_checks = _label_value(section, SPOT_CHECK_LABELS, allow_at_head=True)
+        if not _has_evidence_value(spot_checks):
+            errors.append(
+                "missing non-placeholder caller/test/artifact spot-checks "
+                f"(expected {_expected_label_text(SPOT_CHECK_LABELS, allow_at_head=True)})"
+            )
+
+        not_verified = _label_value(section, NOT_VERIFIED_LABELS)
+        if not _has_evidence_value(not_verified, allow_none=True):
+            errors.append(
+                "missing not-verified disclosure "
+                f"(expected {_expected_label_text(NOT_VERIFIED_LABELS)})"
+            )
+
+    if R14_RULE_NON_PASS_RE.search(body):
+        errors.append("R14 rule result must pass for LGTM")
+    elif not R14_RULE_PASS_RE.search(body):
+        errors.append("missing passing R14 rule result")
+
+    return errors
+
+
+def _read_body(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate R14 evidence in reviewer LGTM bodies."
+    )
+    parser.add_argument("body_file", help="review body file, or '-' for stdin")
+    parser.add_argument(
+        "--verdict",
+        choices=("auto", "lgtm", "non-lgtm"),
+        default="auto",
+        help="force whether R14 is required; auto detects final LGTM wording",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        body = _read_body(args.body_file)
+    except OSError as exc:
+        print(f"review body R14 audit: cannot read {args.body_file}: {exc}", file=sys.stderr)
+        return 2
+
+    errors = r14_errors(body, verdict=args.verdict)
+    print("review body R14 audit")
+    print(f"body file: {args.body_file}")
+    print(f"verdict mode: {args.verdict}")
+    print("-" * 60)
+    if errors:
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+    if requires_r14(body, args.verdict):
+        print("OK: R14 LGTM evidence is present.")
+    else:
+        print("OK: R14 evidence not required for this non-LGTM review body.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_review_body_r14.py
+++ b/tests/test_check_review_body_r14.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_review_body_r14.py"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location("check_review_body_r14", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+VALID_LGTM = """**LGTM. All review items resolved; CI green.**
+
+**Reviewed head:** `55ead4e25651b4f7dfe953e923b338dc46191510`
+
+**Codebase verification (R14):**
+- Changed code inspected: `docs/REVIEWER_RULES.md:153`, `AGENTS.md:161`.
+- Caller/test/artifact spot-checks: `rg "Codebase verification" AGENTS.md`.
+- Not verified: None.
+
+**Rule results:** R1 Pass, R10 Pass, R14 Pass.
+"""
+
+
+def test_valid_lgtm_body_passes():
+    checker = load_checker()
+    assert checker.r14_errors(VALID_LGTM) == []
+
+
+def test_at_head_label_qualifiers_pass():
+    checker = load_checker()
+    body = VALID_LGTM.replace(
+        "- Changed code inspected:",
+        "- Changed code inspected at HEAD:",
+    ).replace(
+        "- Caller/test/artifact spot-checks:",
+        "- Caller/test/artifact spot-checks at HEAD:",
+    )
+    assert checker.r14_errors(body) == []
+
+
+def test_spot_checks_shorthand_label_passes():
+    checker = load_checker()
+    body = VALID_LGTM.replace(
+        "- Caller/test/artifact spot-checks:",
+        "- Spot-checks:",
+    )
+    assert checker.r14_errors(body) == []
+
+
+def test_forced_lgtm_body_passes_without_auto_lgtm_phrase():
+    checker = load_checker()
+    body = VALID_LGTM.replace("**LGTM. All review items resolved; CI green.**", "Ready.")
+    assert checker.r14_errors(body, verdict="lgtm") == []
+
+
+def test_non_lgtm_body_does_not_require_r14():
+    checker = load_checker()
+    body = "BLOCKER - missing tests. No LGTM until fixed.\n"
+    assert checker.r14_errors(body) == []
+
+
+def test_explicit_non_lgtm_bypasses_incidental_lgtm_word():
+    checker = load_checker()
+    body = "LGTM on the idea, but not mergeable yet.\n"
+    assert checker.r14_errors(body, verdict="non-lgtm") == []
+
+
+def test_missing_reviewed_head_fails():
+    checker = load_checker()
+    body = VALID_LGTM.replace(
+        "**Reviewed head:** `55ead4e25651b4f7dfe953e923b338dc46191510`\n\n",
+        "",
+    )
+    errors = checker.r14_errors(body)
+    assert "missing reviewed head SHA" in errors
+
+
+def test_placeholder_reviewed_head_fails():
+    checker = load_checker()
+    body = VALID_LGTM.replace("55ead4e25651b4f7dfe953e923b338dc46191510", "<sha>")
+    errors = checker.r14_errors(body)
+    assert "missing reviewed head SHA" in errors
+
+
+def test_missing_codebase_section_fails():
+    checker = load_checker()
+    body = VALID_LGTM.replace("**Codebase verification (R14):**", "**Verification:**")
+    errors = checker.r14_errors(body)
+    assert "missing Codebase verification (R14) section" in errors
+
+
+def test_missing_changed_code_evidence_fails():
+    checker = load_checker()
+    body = VALID_LGTM.replace(
+        "- Changed code inspected: `docs/REVIEWER_RULES.md:153`, `AGENTS.md:161`.",
+        "- Changed code inspected: TODO",
+    )
+    errors = checker.r14_errors(body)
+    assert (
+        "missing non-placeholder changed-code evidence "
+        "(expected 'Changed code inspected:' or 'Changed code inspected at HEAD:')"
+    ) in errors
+
+
+def test_missing_spot_check_fails():
+    checker = load_checker()
+    body = VALID_LGTM.replace(
+        '- Caller/test/artifact spot-checks: `rg "Codebase verification" AGENTS.md`.',
+        "- Caller/test/artifact spot-checks: None",
+    )
+    errors = checker.r14_errors(body)
+    assert (
+        "missing non-placeholder caller/test/artifact spot-checks "
+        "(expected 'Caller/test/artifact spot-checks:' or "
+        "'Caller/test/artifact spot-checks at HEAD:' or 'Spot-checks:' or "
+        "'Spot-checks at HEAD:')"
+    ) in errors
+
+
+def test_missing_label_error_names_expected_changed_code_label():
+    checker = load_checker()
+    body = VALID_LGTM.replace(
+        "- Changed code inspected: `docs/REVIEWER_RULES.md:153`, `AGENTS.md:161`.",
+        "- Changed code checked: `docs/REVIEWER_RULES.md:153`, `AGENTS.md:161`.",
+    )
+    errors = checker.r14_errors(body)
+    assert any("expected 'Changed code inspected:'" in error for error in errors)
+
+
+def test_missing_label_error_names_expected_spot_check_labels():
+    checker = load_checker()
+    body = VALID_LGTM.replace(
+        '- Caller/test/artifact spot-checks: `rg "Codebase verification" AGENTS.md`.',
+        '- Verification commands: `rg "Codebase verification" AGENTS.md`.',
+    )
+    errors = checker.r14_errors(body)
+    assert any("expected 'Caller/test/artifact spot-checks:'" in error for error in errors)
+    assert any("'Spot-checks:'" in error for error in errors)
+
+
+def test_missing_not_verified_disclosure_fails():
+    checker = load_checker()
+    body = VALID_LGTM.replace("- Not verified: None.", "- Not verified: ")
+    errors = checker.r14_errors(body)
+    assert "missing not-verified disclosure (expected 'Not verified:')" in errors
+
+
+def test_not_verified_none_is_allowed():
+    checker = load_checker()
+    body = VALID_LGTM.replace("- Not verified: None.", "- Not verified: None")
+    assert checker.r14_errors(body) == []
+
+
+def test_missing_r14_rule_result_fails():
+    checker = load_checker()
+    body = VALID_LGTM.replace("R1 Pass, R10 Pass, R14 Pass", "R1 Pass, R10 Pass")
+    errors = checker.r14_errors(body)
+    assert "missing passing R14 rule result" in errors
+
+
+def test_non_pass_r14_rule_result_fails():
+    checker = load_checker()
+    for status in ("Fail", "N/A", "Not applicable"):
+        body = VALID_LGTM.replace("R14 Pass", f"R14 {status}")
+        errors = checker.r14_errors(body)
+        assert "R14 rule result must pass for LGTM" in errors
+
+
+def test_cli_exit_codes(tmp_path: Path):
+    checker = load_checker()
+
+    ok = tmp_path / "ok.md"
+    ok.write_text(VALID_LGTM, encoding="utf-8")
+    assert checker.main([str(ok)]) == 0
+
+    bad = tmp_path / "bad.md"
+    bad.write_text("LGTM.\n", encoding="utf-8")
+    assert checker.main([str(bad)]) == 1
+
+    missing = tmp_path / "missing.md"
+    assert checker.main([str(missing)]) == 2
+
+
+def test_cli_forced_lgtm_catches_non_lgtm_shape(tmp_path: Path):
+    checker = load_checker()
+    body = tmp_path / "body.md"
+    body.write_text("Looks good after discussion, but no explicit LGTM marker.\n", encoding="utf-8")
+    assert checker.main([str(body), "--verdict", "lgtm"]) == 1

--- a/tests/test_pre_push_audit_workflow.py
+++ b/tests/test_pre_push_audit_workflow.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "pre_push_audit.yml"
+
+
+def test_pre_push_audit_workflow_passes_pr_body_to_local_review() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Write current PR body" in text
+    assert "github.event_name == 'pull_request'" in text
+    assert 'Path(os.environ["RUNNER_TEMP"], "current-pr-body.md")' in text
+    assert 'EVENT_NAME: ${{ github.event_name }}' in text
+    assert 'bash scripts/local_pr_review.sh --current-pr-body-file "$RUNNER_TEMP/current-pr-body.md"' in text
+
+
+def test_pre_push_audit_workflow_keeps_push_to_main_without_pr_body() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in text
+    assert "else\n            bash scripts/local_pr_review.sh\n          fi" in text


### PR DESCRIPTION
Plan: plans/PR-Reviewer-R14-Review-Body-Linter.md
Slice phase: Workflow/process

Adds a local R14 review-body linter for reviewer LGTM text. The checker reads a review body from a file or stdin, detects LGTM verdicts, and fails when the body lacks a reviewed head SHA, `Codebase verification (R14)`, changed-code evidence, caller/test/artifact spot-checks, `Not verified` disclosure, or an R14 rule result. The pre-push audit workflow now passes the pull-request body into `local_pr_review.sh` for PR events so CI enforces the same body contract as the local `push_pr.sh` wrapper.

## Intentional
- Local/ad hoc checker only; no GitHub API live-review integration in this slice.
- Auto-detection is conservative; callers can force enforcement with `--verdict lgtm`.
- The checker validates evidence shape, not the substantive correctness of the reviewer's judgment.
- CI wiring is limited to providing PR-body context to the existing pre-push audit; push-to-main keeps the no-body invocation.

## Deferred
- Wire the linter into a future live-review workflow that reads submitted LGTM reviews from GitHub.
- Optionally add an AGENTS.md one-liner once the command is adopted by the reviewer session.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed Codex P2 "Reject failing R14 results for LGTM": LGTM-mode now accepts only a passing R14 rule result, and the regression test covers `R14 Fail`, `R14 N/A`, and `R14 Not applicable`.
- Fixed reviewer NIT "exact-label strictness": the linter now accepts bounded `at HEAD` label qualifiers plus the `Spot-checks:` shorthand, while missing-evidence errors name the exact expected labels.

## Verification
- `pytest tests/test_check_review_body_r14.py` - passed, 19 tests.
- `pytest tests/test_check_review_body_r14.py tests/test_pre_push_audit_workflow.py` - passed, 21 tests.
- `python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py -q` - passed, 63 tests.
- `python -m py_compile scripts/check_review_body_r14.py tests/test_check_review_body_r14.py tests/test_pre_push_audit_workflow.py` - passed.
- `python scripts/check_review_body_r14.py - --verdict lgtm` - passed via stdin smoke.
- `python scripts/audit_review_rules_triggered.py --plan plans/PR-Reviewer-R14-Review-Body-Linter.md` - passed.
- `python scripts/sync_pr_plan.py plans/PR-Reviewer-R14-Review-Body-Linter.md origin/main --check` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `bash scripts/push_pr.sh /tmp/atlas-pr-reviewer-r14-review-body-linter.md --force-with-lease origin HEAD` - passed.

## Diff size
5 files, +591 / -2.
