### PR TITLE
Add semantic diff advisor (advisory matching/contract-edge CI check)

### DIFF
--- a/.github/workflows/semantic_diff_advisor.yml
+++ b/.github/workflows/semantic_diff_advisor.yml
@@ -1,0 +1,55 @@
+name: Semantic Diff Advisor (advisory)
+
+# Advisory matching/contract-edge pattern detector -- NOT a gate. When a PR
+# widens a recognition set, changes a matcher, touches a normalizer beside
+# term sets, or adds a defaulting idiom in projection context, this prints
+# the standing adversarial question for that pattern. It raises questions;
+# it never decides the change is wrong. Judgment stays with the builder
+# self-check, the reviewer, and the live AI-reconciliation gate.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/semantic_diff_advisor.yml"
+      - "scripts/semantic_diff_advisor.py"
+      - "tests/test_semantic_diff_advisor.py"
+      - "extracted_content_pipeline/**"
+      - "portfolio-ui/api/**"
+      - "portfolio-ui/src/**"
+      - "atlas_brain/_content_ops_*.py"
+
+jobs:
+  semantic-diff-advisor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for merge-base)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pytest
+        run: python -m pip install --quiet pytest
+
+      # Tool correctness gates (these are the advisor's own unit tests,
+      # including replays of the four real BLOCKER classes).
+      - name: Advisor unit tests (blocking)
+        run: python -m pytest tests/test_semantic_diff_advisor.py -q
+
+      - name: Fetch base ref
+        run: git fetch --no-tags origin "${{ github.base_ref || 'main' }}"
+
+      # Tool FINDINGS advise (non-blocking by design: no --strict, and
+      # continue-on-error as a safety net).
+      - name: Semantic diff advisor (advisory, non-blocking)
+        continue-on-error: true
+        run: |
+          echo "Advisory pattern detector: emits the standing adversarial"
+          echo "question when a matching/contract edge changes. Questions,"
+          echo "not verdicts -- a quiet run is NOT a correctness stamp."
+          echo
+          python scripts/semantic_diff_advisor.py --base "origin/${{ github.base_ref || 'main' }}"

--- a/.github/workflows/semantic_diff_advisor.yml
+++ b/.github/workflows/semantic_diff_advisor.yml
@@ -37,8 +37,10 @@ jobs:
 
       # Tool correctness gates (these are the advisor's own unit tests,
       # including replays of the four real BLOCKER classes).
+      # --noconftest: the repo-level tests/conftest.py imports pytest_asyncio
+      # and app dependencies; this test is self-contained stdlib by design.
       - name: Advisor unit tests (blocking)
-        run: python -m pytest tests/test_semantic_diff_advisor.py -q
+        run: python -m pytest tests/test_semantic_diff_advisor.py --noconftest -q
 
       - name: Fetch base ref
         run: git fetch --no-tags origin "${{ github.base_ref || 'main' }}"

--- a/plans/PR-Semantic-Diff-Advisor-CI.md
+++ b/plans/PR-Semantic-Diff-Advisor-CI.md
@@ -97,9 +97,9 @@ with the standing adversarial question for its pattern.
 - Parked hardening: none.
 
 ## Verification
-- Unit tests: 8 passed (replays of #1446, #1439, #1466, #1453 fire with the
+- Unit tests: 10 passed (replays of #1446, #1439, #1466, #1453 fire with the
   expected finding names and details; unrelated-change and unchanged-file
-  controls stay quiet; test-path filter pinned).
+  controls stay quiet; test-path filter pinned; new-module set firing + threshold pinned).
 - Real-diff replay against the four actual BLOCKER heads:
   #1446 head fires RECOGNITION_SET_WIDENED naming first_response on the exact
   set; #1439 head fires on the auth folds; #1466 head fires
@@ -114,8 +114,8 @@ with the standing adversarial question for its pattern.
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/semantic_diff_advisor.yml` | 55 |
+| `.github/workflows/semantic_diff_advisor.yml` | 57 |
 | `plans/PR-Semantic-Diff-Advisor-CI.md` | 121 |
-| `scripts/semantic_diff_advisor.py` | 378 |
-| `tests/test_semantic_diff_advisor.py` | 153 |
-| **Total** | **707** |
+| `scripts/semantic_diff_advisor.py` | 381 |
+| `tests/test_semantic_diff_advisor.py` | 175 |
+| **Total** | **734** |

--- a/plans/PR-Semantic-Diff-Advisor-CI.md
+++ b/plans/PR-Semantic-Diff-Advisor-CI.md
@@ -1,0 +1,121 @@
+# PR-Semantic-Diff-Advisor-CI
+
+## Why this slice exists
+
+Four recent BLOCKERs were one class: a recognition surface changed and the
+boundary case slipped -- #1439 (over-broad auth fold), #1446 (generic
+first_response key captured auto-acks as resolutions), #1453 (fail-open
+default on a new contract field), #1466 (stemmer/term-set asymmetry). The
+defect itself needs judgment, but the TRIGGER is mechanical: each bug arrived
+via one of four detectable diff patterns. This slice mechanizes the trigger --
+an advisory CI check that detects those patterns in a PR diff and prints the
+standing adversarial question for each -- so the question fires pre-push at
+the builder instead of costing a red reconciliation-gate round-trip.
+
+Companion to the structural sweep (PR #1470) and the invariant-test pack
+steered to the deflection lane (issue #1471). This is the judgment-trigger
+layer; it raises questions, never verdicts.
+
+## Scope (this PR)
+
+Ownership lane: review-workflow
+Slice phase: workflow/process
+
+1. Add `scripts/semantic_diff_advisor.py` -- stdlib-only detector. Pure
+   detection functions take old/new source pairs; a thin git layer feeds them
+   from the PR diff (merge-base vs HEAD). Advisory: exit 0 unless a future
+   --strict flag is passed.
+2. Add `tests/test_semantic_diff_advisor.py` -- unit tests whose fixtures are
+   minimized replays of the four real BLOCKERs, plus quiet-control cases.
+3. Add `.github/workflows/semantic_diff_advisor.yml` -- runs the unit tests
+   (blocking: tool correctness gates) then the advisor against the PR base
+   (non-blocking: tool findings advise).
+
+### Files touched
+
+- `.github/workflows/semantic_diff_advisor.yml`
+- `plans/PR-Semantic-Diff-Advisor-CI.md`
+- `scripts/semantic_diff_advisor.py`
+- `tests/test_semantic_diff_advisor.py`
+
+### Review Contract
+- Acceptance: the advisor fires on replays of all four real BLOCKER diffs and
+  stays quiet on a copy-only control; unit tests pass and run in the
+  workflow; the advisory step cannot fail the build; ASCII-clean; stdlib-only.
+- Affected surfaces: CI only. No runtime or product code.
+- Risk areas: noise (mitigated: high-precision AST membership diffing for the
+  main detector, test paths excluded, new-set threshold of 3 members, quiet
+  controls in tests); a quiet-run-equals-correct misread (mitigated: banner
+  states questions-not-verdicts and quiet is not a stamp).
+- Reviewer rules triggered: R8 (deterministic static analysis, no LLM). R13
+  context: the tool exists to force class-level questions, not example fixes.
+
+## Mechanism
+
+Detection is pure (old source, new source) -> findings, so tests need no git.
+Four detectors:
+
+1. RECOGNITION_SET_WIDENED / RECOGNITION_SET_ADDED -- parse both sources,
+   collect module-level constants that are collections of string literals
+   (set, tuple, list, dict keys, or set/frozenset/tuple calls wrapping one),
+   and diff membership per constant name. Added members are listed in the
+   finding. New sets fire only at 3+ members to cut noise.
+2. MATCHER_CHANGED -- module-level compiled-regex constants whose pattern
+   source changed between the two parses.
+3. NORMALIZER_TERMSET_COUPLING -- a module-level function whose name matches
+   token, stem, normal, fold, or signal changed (or was added) in a module
+   that holds string-collection constants.
+4. DEFAULTED_CONTRACT_FIELD -- line-diff (difflib opcodes) finds added lines
+   carrying a defaulting idiom (nullish-coalesce to zero or empty, get with a
+   zero/empty default, or-zero) within 60 lines below a projection, parse,
+   validate, snapshot, or payload function context. Works on Python and JS.
+
+The git layer resolves merge-base vs HEAD, skips test paths and non-Python,
+non-JS files, and feeds worktree content as the new side. Each finding prints
+with the standing adversarial question for its pattern.
+
+## Intentional
+- Advisory, not gating: the questions need judgment; a hard gate would block
+  legitimate widenings. Same posture as the structural sweep (#1470).
+- The unit-test step IS blocking -- the tool's own correctness gates; only
+  its findings advise.
+- Test paths are excluded from detection: tests legitimately add string
+  fixtures and would drown the signal.
+- JS/TS files get only the line-based defaulting detector (no JS parser in
+  stdlib); the AST detectors are Python-only. The #1453 class was a JS bug
+  and the line-based detector catches it at the exact flagged line.
+- PR-trigger only (no push trigger): the tool is a diff inspector; there is
+  no meaningful base on a push to main.
+
+## Deferred
+- A --strict promotion path (fail when patterns are found without a matching
+  negative-fixture diff) once noise is measured in practice.
+- PR-comment output (posting the questions as a sticky comment) instead of
+  job-log output.
+- Extending matcher-change detection to f-string regex patterns (currently
+  compared by unparsed expression source).
+- Parked hardening: none.
+
+## Verification
+- Unit tests: 8 passed (replays of #1446, #1439, #1466, #1453 fire with the
+  expected finding names and details; unrelated-change and unchanged-file
+  controls stay quiet; test-path filter pinned).
+- Real-diff replay against the four actual BLOCKER heads:
+  #1446 head fires RECOGNITION_SET_WIDENED naming first_response on the exact
+  set; #1439 head fires on the auth folds; #1466 head fires
+  NORMALIZER_TERMSET_COUPLING on the stemmer; #1453 head fires
+  DEFAULTED_CONTRACT_FIELD at the exact line the bot flagged (L102).
+  Copy-only control (#1441 head) yields zero findings.
+- Advisory by construction: exit 0 without --strict; workflow adds
+  continue-on-error on the advisory step; the unit-test step is blocking.
+- ASCII-clean; stdlib-only (workflow installs pytest only).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/semantic_diff_advisor.yml` | 55 |
+| `plans/PR-Semantic-Diff-Advisor-CI.md` | 121 |
+| `scripts/semantic_diff_advisor.py` | 378 |
+| `tests/test_semantic_diff_advisor.py` | 153 |
+| **Total** | **707** |

--- a/scripts/semantic_diff_advisor.py
+++ b/scripts/semantic_diff_advisor.py
@@ -204,7 +204,10 @@ def detect_python(old_src, new_src, path):
                 findings.append(Finding(
                     path, "RECOGNITION_SET_WIDENED", name, lineno,
                     "added: " + ", ".join(sorted(added)[:12])))
-        elif old_tree is not None and len(members) >= MIN_NEW_SET_MEMBERS:
+        elif len(members) >= MIN_NEW_SET_MEMBERS:
+            # Fires for brand-new modules too (old_src empty): a new file
+            # introducing a recognition set is exactly when the
+            # both-direction-fixtures question applies.
             findings.append(Finding(
                 path, "RECOGNITION_SET_ADDED", name, lineno,
                 "%d members" % len(members)))

--- a/scripts/semantic_diff_advisor.py
+++ b/scripts/semantic_diff_advisor.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+semantic_diff_advisor.py - advisory diff-pattern detector for matching/contract
+edge risks.
+
+Four recent review BLOCKERs shared one shape: a recognition surface changed and
+the boundary case slipped (over-broad fold #1439, generic key over-capture
+#1446, fail-open contract field #1453, stemmer/term-set asymmetry #1466). The
+defect itself needs judgment, but the TRIGGER is mechanical. This tool detects
+the trigger patterns in a diff and emits the matching adversarial question.
+
+It never decides the change is wrong. It is advisory: exit code is 0 unless
+--strict is passed. Judgment stays with the builder self-check, the reviewer,
+and the live AI-reconciliation gate.
+
+stdlib only, Python 3.9+.
+
+Usage:
+    python scripts/semantic_diff_advisor.py --base origin/main
+    python scripts/semantic_diff_advisor.py --base origin/main --json
+"""
+
+import argparse
+import ast
+import difflib
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+PY_EXTS = {".py"}
+JS_EXTS = {".js", ".jsx", ".ts", ".tsx", ".mjs"}
+
+# Patterns -> the standing adversarial question each one should trigger.
+QUESTIONS = {
+    "RECOGNITION_SET_WIDENED": (
+        "A recognition set gained members. Probe the GENERIC ones: does any "
+        "added entry over-capture (SLA/metadata columns, auto-acks, API-auth "
+        "vs user-login)? Ship a negative fixture per new entry. "
+        "(class: #1446 first_response, #1439 auth fold)"
+    ),
+    "RECOGNITION_SET_ADDED": (
+        "A new recognition set was introduced. Every member needs "
+        "both-direction coverage: a fixture that should match and a boundary "
+        "fixture that must NOT. (class: #1446/#1439)"
+    ),
+    "MATCHER_CHANGED": (
+        "A compiled matcher changed. Probe BOTH directions: what does it now "
+        "match that it should not, and what does it no longer match that it "
+        "should? (class: #1432/#1437 HTML strip over/under-detection)"
+    ),
+    "DEFAULTED_CONTRACT_FIELD": (
+        "A defaulting idiom appeared in projection/validation context. Do the "
+        "sibling fields fail closed? A missing field must invalidate, not "
+        "render a default. Add a field-deletion test. (class: #1453 fail-open)"
+    ),
+    "NORMALIZER_TERMSET_COUPLING": (
+        "A normalizer changed in a module holding term sets. Every term's "
+        "inflections must be recognized by the REAL matching path -- add or "
+        "refresh the inflection-coverage invariant test. Checking that terms "
+        "are fixed points is NOT enough; check recognition of inflected "
+        "forms. (class: #1466 stemmer asymmetry)"
+    ),
+}
+
+NORMALIZER_NAME_RE = re.compile(r"(token|stem|normal|fold|signal)", re.IGNORECASE)
+
+# Defaulting idioms that make a new contract field fail open.
+DEFAULT_IDIOM_RE = re.compile(
+    r"(\?\?\s*(0|\"\"|''|null|\[\])"
+    r"|\.get\([^()]*,\s*(0|\"\"|'')\)"
+    r"|\bor\s+(0|\"\"|''))"
+)
+# Function context that marks projection / validation code.
+CONTRACT_CTX_RE = re.compile(
+    r"\b(?:function\s+\w*(?:project|parse|validate)\w*"
+    r"|def\s+\w*(?:project|parse|validate|snapshot|payload)\w*"
+    r"|(?:project|parse)\w*(?:Snapshot|Payload|Inspect)\w*)",
+    re.IGNORECASE,
+)
+CONTEXT_WINDOW_LINES = 60
+MIN_NEW_SET_MEMBERS = 3
+
+
+@dataclass
+class Finding:
+    path: str
+    code: str
+    name: str
+    lineno: int
+    detail: str
+
+
+# ---------------------------------------------------------------------------
+# AST extraction (Python sources)
+# ---------------------------------------------------------------------------
+
+def _string_elts(node):
+    """Return frozenset of string members if node is a literal collection of
+    strings (set/tuple/list, dict of string keys, or set()/frozenset()/tuple()
+    wrapping one). None when it is anything else."""
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+            and node.func.id in ("set", "frozenset", "tuple", "list") and node.args:
+        return _string_elts(node.args[0])
+    if isinstance(node, (ast.Set, ast.Tuple, ast.List)):
+        vals = []
+        for e in node.elts:
+            if isinstance(e, ast.Constant) and isinstance(e.value, str):
+                vals.append(e.value)
+            else:
+                return None
+        return frozenset(vals)
+    if isinstance(node, ast.Dict):
+        keys = []
+        for k in node.keys:
+            if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                keys.append(k.value)
+            else:
+                return None
+        return frozenset(keys)
+    return None
+
+
+def string_collections(tree):
+    """name -> (members, lineno) for module-level constants that are
+    collections of string literals."""
+    out = {}
+    for node in tree.body:
+        target = None
+        value = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                and isinstance(node.targets[0], ast.Name):
+            target, value = node.targets[0].id, node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) \
+                and node.value is not None:
+            target, value = node.target.id, node.value
+        if target is None:
+            continue
+        members = _string_elts(value)
+        if members is not None and members:
+            out[target] = (members, node.lineno)
+    return out
+
+
+def regex_constants(tree):
+    """name -> (pattern_source, lineno) for module-level NAME = re.compile(...)."""
+    out = {}
+    for node in tree.body:
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)):
+            continue
+        v = node.value
+        if isinstance(v, ast.Call) and isinstance(v.func, ast.Attribute) \
+                and v.func.attr == "compile" \
+                and isinstance(v.func.value, ast.Name) and v.func.value.id == "re":
+            try:
+                pattern = ast.unparse(v.args[0]) if v.args else ""
+            except Exception:
+                pattern = ""
+            out[node.targets[0].id] = (pattern, node.lineno)
+    return out
+
+
+def normalizer_funcs(tree):
+    """name -> unparsed body for module-level functions whose name suggests
+    token/stem/normalize/fold work."""
+    out = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) \
+                and NORMALIZER_NAME_RE.search(node.name):
+            try:
+                out[node.name] = ast.unparse(node)
+            except Exception:
+                out[node.name] = node.name
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Detectors (pure: old/new source in, findings out)
+# ---------------------------------------------------------------------------
+
+def detect_python(old_src, new_src, path):
+    findings = []
+    try:
+        new_tree = ast.parse(new_src)
+    except SyntaxError:
+        return findings
+    old_tree = None
+    if old_src:
+        try:
+            old_tree = ast.parse(old_src)
+        except SyntaxError:
+            old_tree = None
+
+    new_sets = string_collections(new_tree)
+    old_sets = string_collections(old_tree) if old_tree else {}
+
+    for name, (members, lineno) in sorted(new_sets.items()):
+        if name in old_sets:
+            added = members - old_sets[name][0]
+            if added:
+                findings.append(Finding(
+                    path, "RECOGNITION_SET_WIDENED", name, lineno,
+                    "added: " + ", ".join(sorted(added)[:12])))
+        elif old_tree is not None and len(members) >= MIN_NEW_SET_MEMBERS:
+            findings.append(Finding(
+                path, "RECOGNITION_SET_ADDED", name, lineno,
+                "%d members" % len(members)))
+
+    new_res = regex_constants(new_tree)
+    old_res = regex_constants(old_tree) if old_tree else {}
+    for name, (pattern, lineno) in sorted(new_res.items()):
+        if name in old_res and old_res[name][0] != pattern:
+            findings.append(Finding(
+                path, "MATCHER_CHANGED", name, lineno, "pattern changed"))
+
+    new_fns = normalizer_funcs(new_tree)
+    old_fns = normalizer_funcs(old_tree) if old_tree else {}
+    changed = sorted(n for n, body in new_fns.items() if old_fns.get(n) != body)
+    if changed and new_sets:
+        findings.append(Finding(
+            path, "NORMALIZER_TERMSET_COUPLING", ", ".join(changed[:3]), 0,
+            "term sets in module: " + ", ".join(sorted(new_sets)[:4])))
+
+    findings.extend(detect_default_idiom(old_src, new_src, path))
+    return findings
+
+
+def detect_default_idiom(old_src, new_src, path):
+    """Added lines with a defaulting idiom near projection/validation context.
+    Works on any language (line-based)."""
+    findings = []
+    old_lines = (old_src or "").splitlines()
+    new_lines = (new_src or "").splitlines()
+    matcher = difflib.SequenceMatcher(a=old_lines, b=new_lines, autojunk=False)
+    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+        if tag not in ("insert", "replace"):
+            continue
+        for j in range(j1, j2):
+            line = new_lines[j]
+            if not DEFAULT_IDIOM_RE.search(line):
+                continue
+            lo = max(0, j - CONTEXT_WINDOW_LINES)
+            context = "\n".join(new_lines[lo:j + 1])
+            if CONTRACT_CTX_RE.search(context):
+                findings.append(Finding(
+                    path, "DEFAULTED_CONTRACT_FIELD", "", j + 1,
+                    line.strip()[:100]))
+    return findings
+
+
+def detect(old_src, new_src, path):
+    ext = Path(path).suffix.lower()
+    if ext in PY_EXTS:
+        return detect_python(old_src, new_src, path)
+    if ext in JS_EXTS:
+        return detect_default_idiom(old_src, new_src, path)
+    return []
+
+
+def is_test_path(path):
+    p = Path(path)
+    name = p.name.lower()
+    if name.startswith("test_") or name.endswith("_test.py"):
+        return True
+    if ".test." in name or ".spec." in name:
+        return True
+    return any(part.lower() in ("tests", "test") for part in p.parts)
+
+
+# ---------------------------------------------------------------------------
+# Git layer
+# ---------------------------------------------------------------------------
+
+def _git(*args):
+    proc = subprocess.run(["git", *args], capture_output=True, text=True)
+    return proc.returncode, proc.stdout
+
+
+def merge_base(base):
+    code, out = _git("merge-base", base, "HEAD")
+    return out.strip() if code == 0 else None
+
+
+def changed_paths(mb):
+    code, out = _git("diff", "--name-only", mb, "HEAD")
+    if code != 0:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def file_at(rev, path):
+    code, out = _git("show", "%s:%s" % (rev, path))
+    return out if code == 0 else ""
+
+
+def read_worktree(path):
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def sweep_diff(base):
+    mb = merge_base(base)
+    if mb is None:
+        print("semantic-diff-advisor: cannot resolve merge-base for %r; "
+              "skipping (advisory)." % base)
+        return []
+    findings = []
+    for path in changed_paths(mb):
+        ext = Path(path).suffix.lower()
+        if ext not in PY_EXTS | JS_EXTS:
+            continue
+        if is_test_path(path):
+            continue
+        new_src = read_worktree(path)
+        if not new_src:
+            continue  # deleted file
+        old_src = file_at(mb, path)
+        findings.extend(detect(old_src, new_src, path))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def print_report(findings):
+    if not findings:
+        print("semantic-diff-advisor: no matching/contract-edge patterns "
+              "detected in this diff.")
+        return
+    print("semantic-diff-advisor: %d pattern(s) detected. These are "
+          "QUESTIONS, not verdicts.\n" % len(findings))
+    by_path = {}
+    for f in findings:
+        by_path.setdefault(f.path, []).append(f)
+    asked = set()
+    for path in sorted(by_path):
+        print(path)
+        for f in by_path[path]:
+            loc = "L%d" % f.lineno if f.lineno else "file"
+            label = (" %s" % f.name) if f.name else ""
+            print("  [%s]%s %s -- %s" % (f.code, label, loc, f.detail))
+        print()
+    print("ask yourself, per pattern:")
+    for f in findings:
+        if f.code in asked:
+            continue
+        asked.add(f.code)
+        print("- %s: %s" % (f.code, QUESTIONS[f.code]))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Advisory matching/contract-edge pattern detector for a diff.")
+    ap.add_argument("--base", default="origin/main",
+                    help="base ref to diff against (default: origin/main)")
+    ap.add_argument("--json", action="store_true", help="emit JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 when patterns are found (default: advisory, exit 0)")
+    args = ap.parse_args(argv)
+
+    findings = sweep_diff(args.base)
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], indent=2))
+    else:
+        print_report(findings)
+    if args.strict and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_semantic_diff_advisor.py
+++ b/tests/test_semantic_diff_advisor.py
@@ -119,6 +119,28 @@ def test_matcher_changed_fires_on_a_regex_pattern_change() -> None:
     assert changed[0].name == "_HTML_SIGNAL_RE"
 
 
+def test_recognition_set_added_fires_for_a_brand_new_module() -> None:
+    # Codex P2 on this PR: a brand-new file (old source empty) introducing a
+    # recognition set must still raise the both-direction-fixtures question.
+    new = (
+        '_NEW_PROVIDER_KEYS = (\n'
+        '    "agent_reply",\n'
+        '    "admin_reply",\n'
+        '    "staff_reply",\n'
+        ')\n'
+    )
+    findings = MOD.detect_python("", new, "pkg/brand_new_module.py")
+    added = [f for f in findings if f.code == "RECOGNITION_SET_ADDED"]
+    assert len(added) == 1
+    assert added[0].name == "_NEW_PROVIDER_KEYS"
+
+
+def test_recognition_set_added_respects_min_member_threshold() -> None:
+    new = '_SMALL = ("a", "b")\n'
+    findings = MOD.detect_python("", new, "pkg/brand_new_small.py")
+    assert [f for f in findings if f.code == "RECOGNITION_SET_ADDED"] == []
+
+
 def test_quiet_on_unrelated_changes() -> None:
     old = (
         'def helper(value):\n'

--- a/tests/test_semantic_diff_advisor.py
+++ b/tests/test_semantic_diff_advisor.py
@@ -1,0 +1,153 @@
+"""Unit tests for scripts/semantic_diff_advisor.py.
+
+Each detector test replays one of the four real review BLOCKERs (minimized)
+that motivated the tool: #1446 (recognition set widened by a generic key),
+#1439 (fold map widened), #1466 (normalizer changed beside term sets),
+#1453 (fail-open default on a contract field). A control case asserts the
+advisor stays quiet on an unrelated change.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "semantic_diff_advisor.py"
+
+SPEC = importlib.util.spec_from_file_location("semantic_diff_advisor", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+MOD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MOD)
+
+
+def codes(findings):
+    return {f.code for f in findings}
+
+
+def test_recognition_set_widened_fires_on_the_1446_replay() -> None:
+    old = (
+        '_RESOLUTION_TEXT_KEYS = (\n'
+        '    "resolution_text",\n'
+        '    "agent_reply",\n'
+        ')\n'
+    )
+    new = (
+        '_RESOLUTION_TEXT_KEYS = (\n'
+        '    "resolution_text",\n'
+        '    "agent_reply",\n'
+        '    "first_response",\n'
+        '    "last_response",\n'
+        ')\n'
+    )
+    findings = MOD.detect_python(old, new, "pkg/support_ticket_input_package.py")
+    widened = [f for f in findings if f.code == "RECOGNITION_SET_WIDENED"]
+    assert len(widened) == 1
+    assert widened[0].name == "_RESOLUTION_TEXT_KEYS"
+    assert "first_response" in widened[0].detail
+    assert "last_response" in widened[0].detail
+
+
+def test_fold_map_widened_fires_on_the_1439_replay() -> None:
+    old = (
+        '_TOKEN_FOLDS = {\n'
+        '    "billed": "billing",\n'
+        '}\n'
+    )
+    new = (
+        '_TOKEN_FOLDS = {\n'
+        '    "billed": "billing",\n'
+        '    "auth": "login",\n'
+        '    "authentication": "login",\n'
+        '}\n'
+    )
+    findings = MOD.detect_python(old, new, "pkg/support_ticket_clustering.py")
+    widened = [f for f in findings if f.code == "RECOGNITION_SET_WIDENED"]
+    assert len(widened) == 1
+    assert widened[0].name == "_TOKEN_FOLDS"
+    assert "auth" in widened[0].detail
+
+
+def test_normalizer_termset_coupling_fires_on_the_1466_replay() -> None:
+    old = (
+        '_RESOLUTION_ACTION_TERMS = {"enable", "reset", "update"}\n'
+        'def _resolution_signal_token(token):\n'
+        '    return token\n'
+    )
+    new = (
+        '_RESOLUTION_ACTION_TERMS = {"enable", "reset", "update"}\n'
+        'def _resolution_signal_token(token):\n'
+        '    if len(token) > 4 and token.endswith("ed"):\n'
+        '        return token[:-2]\n'
+        '    return token\n'
+    )
+    findings = MOD.detect_python(old, new, "pkg/ticket_faq_markdown.py")
+    coupled = [f for f in findings if f.code == "NORMALIZER_TERMSET_COUPLING"]
+    assert len(coupled) == 1
+    assert "_resolution_signal_token" in coupled[0].name
+    assert "_RESOLUTION_ACTION_TERMS" in coupled[0].detail
+
+
+def test_defaulted_contract_field_fires_on_the_1453_replay() -> None:
+    old = (
+        'function projectSnapshot(snapshot) {\n'
+        '  const generated = finiteNumber(snapshot.summary.generated);\n'
+        '  return { generated };\n'
+        '}\n'
+    )
+    new = (
+        'function projectSnapshot(snapshot) {\n'
+        '  const generated = finiteNumber(snapshot.summary.generated);\n'
+        '  const repeatTicketCount = finiteNumber(snapshot.summary.repeat_ticket_count) ?? 0;\n'
+        '  return { generated, repeat_ticket_count: repeatTicketCount };\n'
+        '}\n'
+    )
+    findings = MOD.detect(old, new, "portfolio-ui/api/content-ops/deflection/atlas-report.js")
+    defaulted = [f for f in findings if f.code == "DEFAULTED_CONTRACT_FIELD"]
+    assert len(defaulted) == 1
+    assert "?? 0" in defaulted[0].detail
+
+
+def test_matcher_changed_fires_on_a_regex_pattern_change() -> None:
+    old = '_HTML_SIGNAL_RE = re.compile(r"</?(?:p|div)\\b")\n'
+    new = '_HTML_SIGNAL_RE = re.compile(r"</?(?:a|b|p|div)\\b")\n'
+    findings = MOD.detect_python("import re\n" + old, "import re\n" + new,
+                                 "pkg/support_ticket_clustering.py")
+    changed = [f for f in findings if f.code == "MATCHER_CHANGED"]
+    assert len(changed) == 1
+    assert changed[0].name == "_HTML_SIGNAL_RE"
+
+
+def test_quiet_on_unrelated_changes() -> None:
+    old = (
+        'def helper(value):\n'
+        '    return value + 1\n'
+    )
+    new = (
+        'def helper(value):\n'
+        '    return value + 2\n'
+    )
+    assert MOD.detect_python(old, new, "pkg/anything.py") == []
+
+
+def test_quiet_when_set_unchanged_and_defaults_preexisting() -> None:
+    src = (
+        '_KEYS = ("a", "b", "c")\n'
+        'function = None\n'
+    )
+    assert MOD.detect_python(src, src, "pkg/static.py") == []
+    js = (
+        'function parsePayload(x) {\n'
+        '  const n = x.count ?? 0;\n'
+        '  return n;\n'
+        '}\n'
+    )
+    # unchanged file: the defaulting idiom is pre-existing, not added
+    assert MOD.detect(js, js, "ui/api/thing.js") == []
+
+
+def test_test_paths_are_excluded_by_the_path_filter() -> None:
+    assert MOD.is_test_path("tests/test_extracted_support_ticket_input_package.py")
+    assert MOD.is_test_path("portfolio-ui/scripts/faq-deflection-result-page.test.mjs")
+    assert not MOD.is_test_path("extracted_content_pipeline/support_ticket_clustering.py")


### PR DESCRIPTION
Plan: plans/PR-Semantic-Diff-Advisor-CI.md
Slice phase: workflow/process

Advisory CI check that mechanizes the **trigger** for the recurring matching/contract-edge BLOCKER class. Four recent BLOCKERs (#1439 over-broad auth fold, #1446 generic first_response key, #1453 fail-open `?? 0`, #1466 stemmer/term-set asymmetry) all arrived via four detectable diff patterns; this tool detects those patterns in a PR diff and prints the standing adversarial question for each, so the question fires pre-push instead of costing a red reconciliation-gate round-trip. Questions, not verdicts -- a quiet run is NOT a correctness stamp. Companion to the structural sweep (#1470) and the deflection invariant-test pack (#1471).

## Intentional
- Advisory by construction (exit 0 without `--strict`) + `continue-on-error`; the tool's own unit tests ARE blocking in the same workflow.
- High-precision core: AST membership diffing of module-level string-collection constants; test paths excluded; new-set threshold of 3 members.
- JS/TS files get the line-based defaulting detector only (no stdlib JS parser); the #1453 class was a JS bug and is caught at the exact flagged line.
- PR-trigger only: a diff inspector has no meaningful base on a push to main.

## Deferred
- `--strict` promotion path once noise is measured; PR-comment (sticky) output; f-string regex pattern comparison.

## Parked hardening
- None.

## Verification
- **Unit tests (8 passed)** -- the fixtures are minimized replays of the four real BLOCKERs, plus quiet controls (unrelated change, unchanged file, test-path filter).
- **Real-diff replay against the four actual BLOCKER heads:** #1446 fires RECOGNITION_SET_WIDENED naming `first_response` on the exact set; #1439 fires on the `auth` folds; #1466 fires NORMALIZER_TERMSET_COUPLING on `_resolution_signal_token`; #1453 fires DEFAULTED_CONTRACT_FIELD at the exact line the bot flagged (L102). Copy-only control (#1441) yields zero findings.
- Advisory exit 0 verified; ASCII clean; workflow YAML parses; stdlib-only (CI installs pytest only).

## Diff size
4 new files, ~707 LOC (script 378, tests 153, workflow 55, plan ~121).

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes.
- Fixed Codex P1 (workflow pytest fails on conftest pytest_asyncio import): run the advisor unit tests with --noconftest instead of installing the asyncio stack -- the test file is self-contained stdlib by design; verified green in both modes locally.
- Fixed Codex P2 (RECOGNITION_SET_ADDED suppressed for brand-new modules): dropped the old-tree guard so a new file introducing a recognition set fires the question; pinned with a new-module test plus a min-member-threshold test (10 tests total).
