### PR TITLE
Content-Ops Claim Evidence Runner Harness

### DIFF
--- a/docs/content_ops_claim_evidence_benchmark_fixtures.md
+++ b/docs/content_ops_claim_evidence_benchmark_fixtures.md
@@ -124,6 +124,25 @@ Field rules:
 
 Extra response fields are not part of the contract.
 
+## Runner Harness
+
+The benchmark runner harness is intentionally provider-injected. It renders the
+prompt/schema contract for each valid fixture row, calls a supplied provider
+boundary, and decodes the returned response through the same structured-response
+validator documented above.
+
+Runner output is a per-model in-memory result:
+
+- valid rows expose decoded responses keyed by `triple_id` for the existing
+  scorer;
+- malformed provider responses are recorded as row errors and excluded from the
+  response map;
+- provider exceptions are recorded by exception class name and do not stop later
+  rows from running.
+
+The harness does not choose models, read credentials, call network providers,
+write benchmark result files, or expose verifier/MCP behavior.
+
 ## Hard Cases
 
 Hard rows should feel like realistic B2B SaaS marketing copy and include cases

--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -9,9 +9,10 @@ structured witness responses against the reliability thresholds from issue
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence as RuntimeSequence
 from dataclasses import dataclass
 from itertools import combinations
-from typing import Mapping, Sequence
+from typing import Callable, Mapping, Sequence
 
 
 EASY = "easy"
@@ -25,6 +26,7 @@ FIXTURE_FORMAT_JSON = "json"
 FIXTURE_FORMAT_JSONL = "jsonl"
 VALID_FIXTURE_FORMATS = frozenset({FIXTURE_FORMAT_JSON, FIXTURE_FORMAT_JSONL})
 VERIFY_CLAIM_EVIDENCE_CONTRACT_VERSION = "verify_claim_evidence.v1"
+CLAIM_EVIDENCE_RESPONSE_FIELDS = frozenset({"supports", "confidence", "reason"})
 
 
 def _required_text(data: Mapping[str, object], key: str) -> str | None:
@@ -128,6 +130,11 @@ class ClaimEvidenceResponse:
             return None, ("response must be an object",)
 
         errors: list[str] = []
+        unexpected_fields = sorted(
+            str(key) for key in data.keys() if key not in CLAIM_EVIDENCE_RESPONSE_FIELDS
+        )
+        if unexpected_fields:
+            errors.append(f"unexpected fields: {', '.join(unexpected_fields)}")
         supports = _required_bool(data, "supports")
         confidence = _required_confidence(data, "confidence")
         reason = _required_text(data, "reason")
@@ -157,6 +164,11 @@ class ClaimEvidencePromptContract:
     contract_version: str
     prompt: str
     response_schema: Mapping[str, object]
+
+
+ClaimEvidenceProvider = Callable[
+    [str, ClaimEvidenceTriple, ClaimEvidencePromptContract], object
+]
 
 
 def claim_evidence_response_json_schema() -> dict[str, object]:
@@ -220,6 +232,114 @@ def build_claim_evidence_prompt_contract(
         contract_version=VERIFY_CLAIM_EVIDENCE_CONTRACT_VERSION,
         prompt=prompt,
         response_schema=claim_evidence_response_json_schema(),
+    )
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceRunRow:
+    """One provider response attempt for one benchmark triple."""
+
+    model_id: str
+    triple_id: str
+    contract_version: str
+    response: ClaimEvidenceResponse | None
+    errors: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.response is not None and not self.errors
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceModelRun:
+    """Decoded provider run for one model across benchmark triples."""
+
+    model_id: str
+    rows: tuple[ClaimEvidenceRunRow, ...]
+    errors: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors and all(row.ok for row in self.rows)
+
+    @property
+    def responses_by_triple_id(self) -> dict[str, ClaimEvidenceResponse]:
+        return {
+            row.triple_id: row.response
+            for row in self.rows
+            if row.response is not None and not row.errors
+        }
+
+
+def run_claim_evidence_provider(
+    model_id: object,
+    triples: Sequence[object],
+    provider: object,
+) -> ClaimEvidenceModelRun:
+    """Run the prompt/schema contract through an injected provider boundary."""
+
+    normalized_model_id = (
+        model_id.strip() if isinstance(model_id, str) and model_id.strip() else None
+    )
+    if normalized_model_id is None:
+        return ClaimEvidenceModelRun("", (), ("model_id missing",))
+    if not callable(provider):
+        return ClaimEvidenceModelRun(
+            normalized_model_id,
+            (),
+            ("provider must be callable",),
+        )
+    if not isinstance(triples, RuntimeSequence) or isinstance(triples, (str, bytes)):
+        return ClaimEvidenceModelRun(
+            normalized_model_id,
+            (),
+            ("triples must be a sequence",),
+        )
+    if not triples:
+        return ClaimEvidenceModelRun(
+            normalized_model_id,
+            (),
+            ("triples missing",),
+        )
+
+    run_errors: list[str] = []
+    rows: list[ClaimEvidenceRunRow] = []
+    typed_provider = provider
+    for index, triple in enumerate(triples, start=1):
+        if not isinstance(triple, ClaimEvidenceTriple):
+            run_errors.append(f"row {index}: triple must be ClaimEvidenceTriple")
+            continue
+
+        contract = build_claim_evidence_prompt_contract(triple)
+        try:
+            raw_response = typed_provider(normalized_model_id, triple, contract)
+        except Exception as error:
+            rows.append(
+                ClaimEvidenceRunRow(
+                    model_id=normalized_model_id,
+                    triple_id=triple.triple_id,
+                    contract_version=contract.contract_version,
+                    response=None,
+                    errors=(f"provider error: {error.__class__.__name__}",),
+                )
+            )
+            continue
+
+        response, response_errors = ClaimEvidenceResponse.from_mapping(raw_response)
+        rows.append(
+            ClaimEvidenceRunRow(
+                model_id=normalized_model_id,
+                triple_id=triple.triple_id,
+                contract_version=contract.contract_version,
+                response=response,
+                errors=response_errors,
+            )
+        )
+
+    return ClaimEvidenceModelRun(
+        normalized_model_id,
+        tuple(rows),
+        tuple(run_errors),
     )
 
 

--- a/plans/PR-Content-Ops-Claim-Evidence-Runner-Harness.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Runner-Harness.md
@@ -1,0 +1,94 @@
+# PR-Content-Ops-Claim-Evidence-Runner-Harness
+
+## Why this slice exists
+
+#1469 captured the prompt and JSON Schema contract for the #1435 slot. The
+benchmark still needs a provider-boundary runner that renders the prompt,
+decodes the structured response, and preserves per-row failures. This PR lands
+that seam with fake-provider tests only: no credentials, network calls, result
+artifacts, verifier wiring, or MCP behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a deterministic runner harness to the existing benchmark module.
+2. Render the merged prompt/schema contract and call an injected provider.
+3. Decode provider responses through the merged response validator.
+4. Preserve provider exceptions and malformed responses as per-row errors.
+5. Add fake-provider tests for success, malformed output, exceptions, and
+   invalid harness input.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Provider is called once per valid triple with model id, triple, prompt,
+        contract version, and response schema.
+  - [ ] Successful responses become a `triple_id` response map.
+  - [ ] Missing model id, empty/non-sequence triples, non-callable provider,
+        non-triple inputs, malformed responses, and provider exceptions fail
+        closed without stopping later triples.
+  - [ ] No live provider adapter, credential lookup, network call, result file,
+        verifier/MCP wiring, database, or live-client behavior is introduced.
+- Affected surfaces: extracted benchmark helper, focused benchmark tests, docs,
+  and plan.
+- Risk areas: benchmark false-green, provider-contract drift, malformed output,
+  future result-artifact compatibility, CI enrollment.
+- Reviewer rules triggered: R1, R2, R5, R6, R10, R12.
+
+### Files touched
+
+- `docs/content_ops_claim_evidence_benchmark_fixtures.md`
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `plans/PR-Content-Ops-Claim-Evidence-Runner-Harness.md`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+
+## Mechanism
+
+The benchmark module gains immutable per-row and per-model run results. The
+runner accepts a model id, existing `ClaimEvidenceTriple` objects, and an
+injected provider callable. For each valid triple, it builds the #1469
+prompt/schema contract, calls the provider, decodes the returned mapping with
+the response decoder, and records row errors instead of raising. The decoder
+also enforces the schema's strict response field set so extra provider fields
+cannot enter the scoreable response map.
+
+## Intentional
+
+- The provider is injected, not a concrete OpenAI, Anthropic, OpenRouter, or
+  MCP client. Credential and retry policy decisions belong in a later slice.
+- The runner records per-row errors but does not score or write artifacts.
+- The runner catches provider exceptions by class name only. It does not log or
+  persist provider messages here, which avoids accidentally storing prompt,
+  token, or vendor diagnostics in this pure package layer.
+- The harness stays in the existing benchmark module because this is still the
+  package-owned deterministic reliability gate, not host-layer provider wiring.
+
+## Deferred
+
+Concrete provider adapters, live model execution, batch CLI, result artifact,
+scoring table, agreement matrix, failure list, go/no-go writeup, batch fixture
+directories, operator labeling workflow, verifier rubric inclusion, and MCP
+exposure all remain deferred until benchmark results justify them.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_extracted_content_claim_evidence_benchmark.py - 41 passed.
+- python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py - passed.
+- git diff --check - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - 3708 passed, 10 skipped.
+- bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/content_ops_claim_evidence_runner_harness_pr_body.md - passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_runner_harness_pr_body.md - passed.
+
+## Estimated diff size
+
+Estimated: 4 files, about +398 / -1 after review fixes.
+
+| Total | 399 |

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -19,6 +19,7 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     intra_model_stability,
     load_claim_evidence_fixture_text,
     pairwise_agreements,
+    run_claim_evidence_provider,
     score_model,
     validate_claim_evidence_fixture,
 )
@@ -307,6 +308,23 @@ def test_response_decoder_reports_missing_and_wrong_typed_fields() -> None:
     )
 
 
+def test_response_decoder_rejects_extra_fields_like_schema() -> None:
+    response, errors = ClaimEvidenceResponse.from_mapping(
+        {
+            "supports": True,
+            "confidence": 5,
+            "reason": "quote directly supports the claim",
+            "internal_metadata": {"model_version": "x.y.z"},
+            "leaked_chain_of_thought": "Let me think step by step.",
+        }
+    )
+
+    assert response is None
+    assert errors == (
+        "unexpected fields: internal_metadata, leaked_chain_of_thought",
+    )
+
+
 def test_prompt_contract_renders_required_triple_fields_and_guardrails() -> None:
     contract = build_claim_evidence_prompt_contract(
         ClaimEvidenceTriple(
@@ -356,6 +374,7 @@ def test_response_json_schema_rejects_whitespace_reason_like_decoder() -> None:
     schema = claim_evidence_response_json_schema()
     whitespace_reason = {"supports": True, "confidence": 4, "reason": "   "}
 
+    assert schema["additionalProperties"] is False
     assert schema["properties"]["reason"]["pattern"] == "\\S"
     assert not any(
         character.strip() for character in str(whitespace_reason["reason"])
@@ -367,6 +386,23 @@ def test_response_json_schema_rejects_whitespace_reason_like_decoder() -> None:
     assert errors == ("reason missing",)
 
 
+def test_response_json_schema_rejects_extra_fields_like_decoder() -> None:
+    schema = claim_evidence_response_json_schema()
+    response_with_extra = {
+        "supports": True,
+        "confidence": 4,
+        "reason": "quote states it",
+        "extra": "not in schema",
+    }
+
+    assert schema["additionalProperties"] is False
+
+    response, errors = ClaimEvidenceResponse.from_mapping(response_with_extra)
+
+    assert response is None
+    assert errors == ("unexpected fields: extra",)
+
+
 def test_response_json_schema_returns_fresh_mapping() -> None:
     schema = claim_evidence_response_json_schema()
     schema["required"] = []
@@ -376,6 +412,134 @@ def test_response_json_schema_returns_fresh_mapping() -> None:
         "confidence",
         "reason",
     ]
+
+
+def test_runner_calls_provider_with_prompt_contract_for_each_triple() -> None:
+    triples = (
+        _triple("a", True, EASY),
+        _triple("b", False, HARD),
+    )
+    calls = []
+
+    def provider(model_id, triple, contract):
+        calls.append((model_id, triple.triple_id, contract))
+        return {
+            "supports": triple.expected_supports,
+            "confidence": 5,
+            "reason": "quote directly supports the claim",
+        }
+
+    run = run_claim_evidence_provider(" opus ", triples, provider)
+
+    assert run.ok is True
+    assert run.errors == ()
+    assert [row.triple_id for row in run.rows] == ["a", "b"]
+    assert [call[0] for call in calls] == ["opus", "opus"]
+    assert [call[1] for call in calls] == ["a", "b"]
+    assert calls[0][2].contract_version == "verify_claim_evidence.v1"
+    assert "Claim: Claim statement a" in calls[0][2].prompt
+    assert calls[0][2].response_schema["required"] == [
+        "supports",
+        "confidence",
+        "reason",
+    ]
+    assert run.responses_by_triple_id == {
+        "a": _response(True, 5),
+        "b": _response(False, 5),
+    }
+
+
+def test_runner_records_malformed_response_without_scoring_it() -> None:
+    def provider(model_id, triple, contract):
+        return {"supports": True, "confidence": 4, "reason": "   "}
+
+    run = run_claim_evidence_provider("gpt", (_triple("bad", True, EASY),), provider)
+
+    assert run.ok is False
+    assert run.errors == ()
+    assert len(run.rows) == 1
+    assert run.rows[0].response is None
+    assert run.rows[0].errors == ("reason missing",)
+    assert run.responses_by_triple_id == {}
+
+
+def test_runner_records_extra_field_response_without_scoring_it() -> None:
+    def provider(model_id, triple, contract):
+        return {
+            "supports": True,
+            "confidence": 4,
+            "reason": "quote directly supports the claim",
+            "extra": "provider drift",
+        }
+
+    run = run_claim_evidence_provider("gpt", (_triple("extra", True, EASY),), provider)
+
+    assert run.ok is False
+    assert run.errors == ()
+    assert run.rows[0].response is None
+    assert run.rows[0].errors == ("unexpected fields: extra",)
+    assert run.responses_by_triple_id == {}
+
+
+def test_runner_records_provider_exception_and_continues_later_triples() -> None:
+    triples = (
+        _triple("raises", True, EASY),
+        _triple("after", False, HARD),
+    )
+
+    def provider(model_id, triple, contract):
+        if triple.triple_id == "raises":
+            raise RuntimeError("vendor timeout with sensitive details")
+        return {"supports": False, "confidence": 4, "reason": "quote does not say it"}
+
+    run = run_claim_evidence_provider("sonnet", triples, provider)
+
+    assert run.ok is False
+    assert run.errors == ()
+    assert [row.triple_id for row in run.rows] == ["raises", "after"]
+    assert run.rows[0].errors == ("provider error: RuntimeError",)
+    assert "sensitive" not in run.rows[0].errors[0]
+    assert run.rows[1].ok is True
+    assert run.responses_by_triple_id == {
+        "after": ClaimEvidenceResponse(
+            supports=False,
+            confidence=4,
+            reason="quote does not say it",
+        )
+    }
+
+
+def test_runner_fails_closed_on_invalid_harness_inputs() -> None:
+    def provider(model_id, triple, contract):
+        return {
+            "supports": True,
+            "confidence": 5,
+            "reason": "quote directly supports the claim",
+        }
+
+    assert run_claim_evidence_provider(None, (), provider).errors == (
+        "model_id missing",
+    )
+    assert run_claim_evidence_provider("model", (), None).errors == (
+        "provider must be callable",
+    )
+    assert run_claim_evidence_provider("model", None, provider).errors == (
+        "triples must be a sequence",
+    )
+    assert run_claim_evidence_provider("model", (), provider).errors == (
+        "triples missing",
+    )
+
+    run = run_claim_evidence_provider(
+        "model",
+        ({"triple_id": "decoded"}, _triple("valid", True, EASY)),
+        provider,
+    )
+
+    assert run.ok is False
+    assert run.errors == ("row 1: triple must be ClaimEvidenceTriple",)
+    assert [row.triple_id for row in run.rows] == ["valid"]
+    assert run.responses_by_triple_id == {"valid": _response(True, 5)}
 
 
 def test_model_score_counts_easy_hard_and_high_confidence_accuracy() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Runner-Harness.md
Slice phase: Functional validation

This PR adds the deterministic runner harness for the #1435 `verify_claim_evidence` reliability gate. It renders the merged prompt/schema contract for each benchmark triple, calls an injected provider boundary, decodes structured responses through the existing validator, and records malformed provider output or provider exceptions as data instead of raising. It keeps live model adapters, credentials, result artifacts, verifier rubric wiring, MCP tools, database behavior, and live-client behavior out of scope.

## Intentional
- The provider is injected, not a concrete OpenAI, Anthropic, OpenRouter, or MCP client.
- The runner records per-row errors but does not score or write result artifacts.
- Provider exceptions are recorded by class name only; provider messages are not persisted in this pure package layer.
- The harness stays in the existing benchmark module because this is still the package-owned reliability gate, not host-layer provider wiring.

## Deferred
- Concrete provider adapters and any live model execution.
- Batch CLI for running provider models over fixture files.
- Result artifact, scoring table, agreement matrix, failure-case list, and go/no-go writeup.
- Batch fixture directories and operator labeling workflow.
- Verifier rubric inclusion and MCP exposure only after benchmark results pass.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_content_claim_evidence_benchmark.py - 41 passed.
- python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py - passed.
- git diff --check - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/run_extracted_pipeline_checks.sh - 3708 passed, 10 skipped.
- bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/content_ops_claim_evidence_runner_harness_pr_body.md - passed.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_runner_harness_pr_body.md - passed.

## AI reconciliation
- All fixed or waived: yes.
- Fixed reviewer BLOCKER: rebased onto current `origin/main` so #1470 and #1473 are no longer missing from the branch.
- Fixed reviewer MAJOR / Codex P2: `ClaimEvidenceResponse.from_mapping` now rejects response fields outside the strict schema set, and runner tests prove extra-field provider drift stays out of `responses_by_triple_id`.

## Diff size
4 files, +398 / -1.