### PR TITLE
Content-Ops Claim Evidence Result Artifact

### DIFF
--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence as RuntimeSequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from itertools import combinations
 from typing import Callable, Mapping, Sequence
 
@@ -390,6 +390,33 @@ class BenchmarkVerdict:
 
 
 @dataclass(frozen=True)
+class ClaimEvidenceResultArtifact:
+    """Machine-readable reliability-gate benchmark result."""
+
+    thresholds: BenchmarkThresholds
+    model_scores: tuple[ModelScore, ...]
+    agreement_matrix: tuple[PairwiseAgreement, ...]
+    stability_scores: tuple[StabilityScore, ...]
+    failure_cases: tuple[Mapping[str, object], ...]
+    verdict: BenchmarkVerdict
+    errors: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors and self.verdict.passed
+
+    @property
+    def go_no_go(self) -> str:
+        return "go" if self.ok else "no_go"
+
+    def as_mapping(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["go_no_go"] = self.go_no_go
+        payload["ok"] = self.ok
+        return payload
+
+
+@dataclass(frozen=True)
 class BenchmarkFixture:
     """Decoded operator-labeled benchmark fixture rows."""
 
@@ -683,6 +710,184 @@ def evaluate_thresholds(
     return BenchmarkVerdict(passed=not reasons, failure_reasons=tuple(reasons))
 
 
+def build_claim_evidence_result_artifact(
+    triples: Sequence[ClaimEvidenceTriple],
+    model_runs: Sequence[ClaimEvidenceModelRun],
+    *,
+    stability_runs_by_model_id: (
+        Mapping[str, Sequence[ClaimEvidenceModelRun]] | None
+    ) = None,
+    thresholds: BenchmarkThresholds = DEFAULT_THRESHOLDS,
+) -> ClaimEvidenceResultArtifact:
+    """Assemble completed model runs into a benchmark decision artifact."""
+
+    active_thresholds = (
+        thresholds if isinstance(thresholds, BenchmarkThresholds) else DEFAULT_THRESHOLDS
+    )
+    errors: list[str] = []
+    if not isinstance(thresholds, BenchmarkThresholds):
+        errors.append("thresholds must be BenchmarkThresholds")
+
+    typed_triples: tuple[ClaimEvidenceTriple, ...] = ()
+    if not _usable_sequence(triples):
+        errors.append("triples must be a non-empty sequence")
+    elif all(isinstance(triple, ClaimEvidenceTriple) for triple in triples):
+        typed_triples = tuple(triples)
+    else:
+        errors.append("triples must contain ClaimEvidenceTriple")
+
+    typed_runs: tuple[ClaimEvidenceModelRun, ...] = ()
+    if not _usable_sequence(model_runs):
+        errors.append("model_runs must be a non-empty sequence")
+    elif all(isinstance(run, ClaimEvidenceModelRun) for run in model_runs):
+        typed_runs = tuple(sorted(model_runs, key=lambda run: run.model_id))
+    else:
+        errors.append("model_runs must contain ClaimEvidenceModelRun")
+
+    triple_ids = {triple.triple_id for triple in typed_triples}
+    seen_models: set[str] = set()
+    for run in typed_runs:
+        if not run.model_id.strip():
+            errors.append("model_id missing")
+        elif run.model_id in seen_models:
+            errors.append(f"model_id duplicated: {run.model_id}")
+        else:
+            seen_models.add(run.model_id)
+        if run.errors:
+            errors.append(f"{run.model_id}: run errors: {'; '.join(run.errors)}")
+        _validate_artifact_rows(run, triple_ids, errors)
+
+    stability_runs = (
+        {} if stability_runs_by_model_id is None else stability_runs_by_model_id
+    )
+    stability_response_maps: dict[
+        str, tuple[Mapping[str, ClaimEvidenceResponse], ...]
+    ] = {}
+    if not isinstance(stability_runs, Mapping):
+        errors.append("stability_runs_by_model_id must be a mapping")
+    else:
+        stability_response_maps = _validated_stability_response_maps(
+            stability_runs,
+            seen_models,
+            triple_ids,
+            errors,
+        )
+
+    if errors:
+        return _failed_result_artifact(active_thresholds, errors)
+
+    model_responses = {
+        run.model_id: run.responses_by_triple_id for run in typed_runs
+    }
+    model_scores = tuple(
+        score_model(run.model_id, typed_triples, model_responses[run.model_id])
+        for run in typed_runs
+    )
+    agreements = pairwise_agreements(typed_triples, model_responses)
+    stability_scores = tuple(
+        intra_model_stability(
+            model_id,
+            typed_triples,
+            stability_response_maps.get(model_id, ()),
+        )
+        for model_id in sorted(model_responses)
+    )
+    verdict = evaluate_thresholds(
+        model_scores,
+        agreements,
+        stability_scores,
+        active_thresholds,
+    )
+    return ClaimEvidenceResultArtifact(
+        thresholds=active_thresholds,
+        model_scores=model_scores,
+        agreement_matrix=agreements,
+        stability_scores=stability_scores,
+        failure_cases=_claim_evidence_failure_cases(typed_triples, typed_runs),
+        verdict=verdict,
+        errors=(),
+    )
+
+
+def _usable_sequence(value: object) -> bool:
+    return (
+        isinstance(value, RuntimeSequence)
+        and not isinstance(value, (str, bytes))
+        and bool(value)
+    )
+
+
+def _validate_artifact_rows(
+    run: ClaimEvidenceModelRun,
+    triple_ids: set[str],
+    errors: list[str],
+) -> None:
+    seen_rows: set[str] = set()
+    for index, row in enumerate(run.rows, start=1):
+        if not isinstance(row, ClaimEvidenceRunRow):
+            errors.append(f"{run.model_id} row {index}: must be ClaimEvidenceRunRow")
+            continue
+        if row.triple_id in seen_rows:
+            errors.append(f"{run.model_id}: duplicate row triple_id: {row.triple_id}")
+            continue
+        seen_rows.add(row.triple_id)
+        if row.triple_id not in triple_ids:
+            errors.append(f"{run.model_id}: unknown row triple_id: {row.triple_id}")
+
+
+def _validated_stability_response_maps(
+    stability_runs: Mapping[object, object],
+    model_ids: set[str],
+    triple_ids: set[str],
+    errors: list[str],
+) -> dict[str, tuple[Mapping[str, ClaimEvidenceResponse], ...]]:
+    normalized: dict[str, object] = {}
+    for raw_model_id, raw_runs in stability_runs.items():
+        if not isinstance(raw_model_id, str) or not raw_model_id.strip():
+            errors.append("stability model_id missing")
+            continue
+        model_id = raw_model_id.strip()
+        if model_id not in model_ids:
+            errors.append(f"stability model_id not in model runs: {model_id}")
+            continue
+        if model_id in normalized:
+            errors.append(f"stability model_id duplicated: {model_id}")
+            continue
+        normalized[model_id] = raw_runs
+
+    response_maps: dict[str, tuple[Mapping[str, ClaimEvidenceResponse], ...]] = {}
+    for model_id in sorted(model_ids):
+        raw_runs = normalized.get(model_id, ())
+        if not isinstance(raw_runs, RuntimeSequence) or isinstance(
+            raw_runs, (str, bytes)
+        ):
+            errors.append(f"stability runs for {model_id} must be a sequence")
+            continue
+        run_maps: list[Mapping[str, ClaimEvidenceResponse]] = []
+        for index, run in enumerate(raw_runs, start=1):
+            if not isinstance(run, ClaimEvidenceModelRun):
+                errors.append(
+                    f"stability run {index} for {model_id}: "
+                    "must be ClaimEvidenceModelRun"
+                )
+                continue
+            if run.model_id != model_id:
+                errors.append(
+                    f"stability run {index} for {model_id}: "
+                    f"model_id mismatch: {run.model_id}"
+                )
+                continue
+            if run.errors:
+                errors.append(
+                    f"stability run {index} for {model_id}: "
+                    f"run errors: {'; '.join(run.errors)}"
+                )
+            _validate_artifact_rows(run, triple_ids, errors)
+            run_maps.append(run.responses_by_triple_id)
+        response_maps[model_id] = tuple(run_maps)
+    return response_maps
+
+
 def _require_agreement_coverage(
     reasons: list[str],
     model_scores: Sequence[ModelScore],
@@ -762,3 +967,86 @@ def _require_metric(
         return
     if value < minimum:
         reasons.append(f"{owner}: {metric} {value:.3f} below {minimum:.3f}")
+
+
+def _claim_evidence_failure_cases(
+    triples: Sequence[ClaimEvidenceTriple],
+    model_runs: Sequence[ClaimEvidenceModelRun],
+) -> tuple[Mapping[str, object], ...]:
+    failures: list[Mapping[str, object]] = []
+    for run in model_runs:
+        rows_by_id = {row.triple_id: row for row in run.rows}
+        for triple in triples:
+            row = rows_by_id.get(triple.triple_id)
+            if row is None:
+                failures.append(
+                    _failure_case(run.model_id, triple, "missing_response", None, ())
+                )
+                continue
+            if row.response is None or row.errors:
+                failures.append(
+                    _failure_case(
+                        run.model_id,
+                        triple,
+                        "malformed_response",
+                        row.response,
+                        row.errors,
+                    )
+                )
+                continue
+            if row.response.supports != triple.expected_supports:
+                failures.append(
+                    _failure_case(
+                        run.model_id,
+                        triple,
+                        "incorrect_support",
+                        row.response,
+                        (),
+                    )
+                )
+                continue
+            if row.response.confidence < CONFIDENCE_COUNTS_MIN:
+                failures.append(
+                    _failure_case(
+                        run.model_id,
+                        triple,
+                        "low_confidence",
+                        row.response,
+                        (),
+                    )
+                )
+    return tuple(failures)
+
+
+def _failure_case(
+    model_id: str,
+    triple: ClaimEvidenceTriple,
+    failure: str,
+    response: ClaimEvidenceResponse | None,
+    row_errors: tuple[str, ...],
+) -> Mapping[str, object]:
+    return {
+        "model_id": model_id,
+        "triple_id": triple.triple_id,
+        "failure": failure,
+        "expected_supports": triple.expected_supports,
+        "actual_supports": response.supports if response is not None else None,
+        "confidence": response.confidence if response is not None else None,
+        "response_reason": response.reason if response is not None else "",
+        "row_errors": row_errors,
+    }
+
+
+def _failed_result_artifact(
+    thresholds: BenchmarkThresholds,
+    errors: Sequence[str],
+) -> ClaimEvidenceResultArtifact:
+    return ClaimEvidenceResultArtifact(
+        thresholds=thresholds,
+        model_scores=(),
+        agreement_matrix=(),
+        stability_scores=(),
+        failure_cases=(),
+        verdict=BenchmarkVerdict(False, tuple(errors)),
+        errors=tuple(errors),
+    )

--- a/plans/PR-Content-Ops-Claim-Evidence-Result-Artifact.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Result-Artifact.md
@@ -1,0 +1,125 @@
+# PR-Content-Ops-Claim-Evidence-Result-Artifact
+
+## Why this slice exists
+
+#1475 added the injected-provider runner harness for #1435, so benchmark rows
+can now be collected without live provider code in the extracted package. The
+next missing deterministic step is the issue's promised output shape: a
+machine-readable benchmark artifact that combines completed model runs into
+model scores, agreement data, stability data, failure cases, and an explicit
+go/no-go decision.
+
+This PR stays below provider and MCP wiring. It makes benchmark results
+reviewable once operator-labeled triples and model-run rows exist, but it does
+not call providers, read files, write artifacts, or add the structured slot to
+the verifier.
+
+Diff-budget note: this is expected to exceed the 400 LOC soft cap because the
+artifact builder is a detector/gate surface. The failure-branch tests for
+malformed inputs and false-green result rows need to ship with the artifact
+contract rather than in a separate test-only follow-up.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a deterministic artifact assembler to the existing claim/evidence
+   benchmark module.
+2. Convert completed `ClaimEvidenceModelRun` values into model scores,
+   pairwise agreement rows, stability rows, failure-case rows, threshold
+   verdict, and go/no-go status.
+3. Fail closed on malformed artifact inputs such as duplicate model ids,
+   unknown row triple ids, duplicate row triple ids, non-run values, and
+   malformed stability reruns.
+4. Add focused tests for passing output, failure-case output, and malformed
+   artifact inputs.
+5. Keep concrete provider adapters, live model execution, file output, verifier
+   inclusion, MCP tools, database behavior, and live-client behavior out of
+   scope.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Completed model runs produce deterministic model scores, agreement
+        matrix rows, stability rows, threshold verdict, and go/no-go status.
+  - [ ] Failure cases identify malformed/missing responses, incorrect support
+        judgments, and low-confidence responses without raising.
+  - [ ] The artifact exposes a JSON-compatible mapping for downstream writeup
+        and operator review slices.
+  - [ ] Duplicate model ids, duplicate row triple ids, unknown row triple ids,
+        invalid run values, non-mapping stability input, bad stability rerun
+        values, unknown stability model ids, mismatched stability run model ids,
+        and stability run errors fail closed.
+  - [ ] Threshold evaluation remains the single verdict source; the artifact
+        does not invent a second scoring policy.
+  - [ ] No provider adapter, live prompt execution, file writing, verifier
+        rubric inclusion, MCP exposure, database change, or live-client
+        behavior is introduced.
+- Affected surfaces: extracted benchmark helper, focused benchmark tests, and
+  plan.
+- Risk areas: benchmark false-green, result-contract drift, incomplete
+  stability coverage, malformed model output, future writeup compatibility.
+- Reviewer rules triggered: R1, R2, R5, R6, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `plans/PR-Content-Ops-Claim-Evidence-Result-Artifact.md`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+
+## Mechanism
+
+The benchmark module gains immutable result-artifact and failure-case values.
+The artifact assembler accepts existing benchmark triples, completed primary
+model runs, optional stability run groups, and the existing threshold object.
+It validates the decoded inputs, builds response maps from successful runner
+rows, reuses the existing scoring, agreement, stability, and threshold helpers,
+then exposes the result through a JSON-compatible mapping.
+
+Malformed row output remains data: row errors become failure cases and missing
+scoreable responses. Malformed artifact structure is different: duplicate model
+ids, duplicate row ids, unknown triple ids, bad run values, non-mapping
+stability input, and malformed stability reruns produce a failed no-go artifact
+so incomplete or ambiguous benchmark data cannot pass silently.
+
+## Intentional
+
+- The artifact assembler stays in the existing benchmark module because it is
+  still the package-owned reliability gate, not host-layer provider wiring.
+- The go/no-go status is derived only from `BenchmarkVerdict.passed`. The
+  artifact does not add policy beyond the already-merged thresholds.
+- The artifact returns mappings but does not write JSON files. File output and
+  operator-facing reports belong in a later CLI/writeup slice.
+- Hardening scan: no parked `HARDENING.md` entries touch this ownership lane or
+  these files.
+
+## Deferred
+
+- Concrete provider adapters and live prompt execution.
+- Batch CLI for fixture-file model runs.
+- File output, markdown writeup, and operator-facing result report.
+- Batch fixture directories and operator labeling workflow.
+- Verifier rubric inclusion and MCP exposure only after benchmark results pass.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_extracted_content_claim_evidence_benchmark.py - 45 passed.
+- python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py - passed.
+- git diff --check - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - 3734 passed, 10 skipped.
+- bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/content_ops_claim_evidence_result_artifact_pr_body.md - passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_result_artifact_pr_body.md - passed.
+
+## Estimated diff size
+
+Estimated: 3 files, about +635 / -1. This is over the normal 400 LOC target for
+the reason named in Why this slice exists.
+
+| Total | 635 |

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -8,12 +8,15 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     EASY,
     HARD,
     BenchmarkThresholds,
+    ClaimEvidenceModelRun,
     ClaimEvidenceResponse,
+    ClaimEvidenceRunRow,
     ClaimEvidenceTriple,
     ModelScore,
     PairwiseAgreement,
     StabilityScore,
     build_claim_evidence_prompt_contract,
+    build_claim_evidence_result_artifact,
     claim_evidence_response_json_schema,
     evaluate_thresholds,
     intra_model_stability,
@@ -47,6 +50,39 @@ def _response(supports: bool, confidence: int = 5) -> ClaimEvidenceResponse:
 
 def _passing_score(model_id: str) -> ModelScore:
     return ModelScore(model_id, 1.0, 0.8, 0.95, 30, 10, 40, (), ())
+
+
+def _run_row(
+    model_id: str,
+    triple_id: str,
+    response: ClaimEvidenceResponse | None,
+    errors: tuple[str, ...] = (),
+) -> ClaimEvidenceRunRow:
+    return ClaimEvidenceRunRow(
+        model_id=model_id,
+        triple_id=triple_id,
+        contract_version="verify_claim_evidence.v1",
+        response=response,
+        errors=errors,
+    )
+
+
+def _model_run(
+    model_id: str,
+    responses: dict[str, ClaimEvidenceResponse],
+    *,
+    rows: tuple[ClaimEvidenceRunRow, ...] = (),
+    errors: tuple[str, ...] = (),
+) -> ClaimEvidenceModelRun:
+    return ClaimEvidenceModelRun(
+        model_id=model_id,
+        rows=tuple(
+            _run_row(model_id, triple_id, response)
+            for triple_id, response in responses.items()
+        )
+        + rows,
+        errors=errors,
+    )
 
 
 def test_triple_decoder_accepts_valid_decoded_input() -> None:
@@ -540,6 +576,190 @@ def test_runner_fails_closed_on_invalid_harness_inputs() -> None:
     assert run.errors == ("row 1: triple must be ClaimEvidenceTriple",)
     assert [row.triple_id for row in run.rows] == ["valid"]
     assert run.responses_by_triple_id == {"valid": _response(True, 5)}
+
+
+def test_result_artifact_builds_go_payload_from_completed_runs() -> None:
+    triples = (
+        _triple("easy", True, EASY),
+        _triple("hard", False, HARD),
+    )
+    claude_run = _model_run(
+        "claude",
+        {"easy": _response(True, 5), "hard": _response(False, 4)},
+    )
+    gpt_run = _model_run(
+        "gpt",
+        {"easy": _response(True, 5), "hard": _response(False, 4)},
+    )
+
+    artifact = build_claim_evidence_result_artifact(
+        triples,
+        (gpt_run, claude_run),
+        stability_runs_by_model_id={
+            "gpt": (gpt_run, gpt_run),
+            "claude": (claude_run, claude_run),
+        },
+        thresholds=BenchmarkThresholds(
+            easy_accuracy_min=1.0,
+            hard_accuracy_min=1.0,
+            inter_model_agreement_min=1.0,
+            intra_model_stability_min=1.0,
+            high_confidence_accuracy_min=0.90,
+        ),
+    )
+
+    assert artifact.ok is True
+    assert artifact.go_no_go == "go"
+    assert [score.model_id for score in artifact.model_scores] == ["claude", "gpt"]
+    assert artifact.agreement_matrix == (PairwiseAgreement("claude", "gpt", 1.0, 2),)
+    assert artifact.failure_cases == ()
+
+    payload = artifact.as_mapping()
+    assert payload["go_no_go"] == "go"
+    assert payload["verdict"] == {"passed": True, "failure_reasons": ()}
+    assert payload["model_scores"][0]["easy_accuracy"] == 1.0
+    assert payload["agreement_matrix"][0]["agreement"] == 1.0
+    assert payload["stability_scores"][0]["stability"] == 1.0
+
+
+def test_result_artifact_records_failure_cases_without_raising() -> None:
+    triples = (
+        _triple("wrong", True, EASY),
+        _triple("missing", False, HARD),
+        _triple("malformed", True, EASY),
+        _triple("low", True, EASY),
+    )
+    run = _model_run(
+        "gpt",
+        {
+            "wrong": _response(False, 5),
+            "low": _response(True, 2),
+        },
+        rows=(
+            _run_row("gpt", "malformed", None, ("reason missing",)),
+        ),
+    )
+
+    artifact = build_claim_evidence_result_artifact(triples, (run,))
+
+    assert artifact.go_no_go == "no_go"
+    assert artifact.errors == ()
+    assert [case["failure"] for case in artifact.failure_cases] == [
+        "incorrect_support",
+        "missing_response",
+        "malformed_response",
+        "low_confidence",
+    ]
+    assert artifact.failure_cases[0]["actual_supports"] is False
+    assert artifact.failure_cases[1]["actual_supports"] is None
+    assert artifact.failure_cases[2]["row_errors"] == ("reason missing",)
+    assert artifact.failure_cases[3]["confidence"] == 2
+    assert artifact.as_mapping()["failure_cases"][2]["row_errors"] == (
+        "reason missing",
+    )
+
+
+def test_result_artifact_fails_closed_on_malformed_primary_inputs() -> None:
+    known = _triple("known", True, EASY)
+    good_row = _run_row("gpt", "known", _response(True))
+    run_with_bad_rows = ClaimEvidenceModelRun(
+        "gpt",
+        (
+            _run_row("gpt", "unknown", _response(True)),
+            good_row,
+            good_row,
+        ),
+        ("setup failed",),
+    )
+    duplicate_model = ClaimEvidenceModelRun("gpt", (), ())
+    missing_model_id = ClaimEvidenceModelRun(" ", (), ())
+    bad_row_type = ClaimEvidenceModelRun("rows", ("bad-row",), ())
+
+    empty = build_claim_evidence_result_artifact(None, None)
+
+    assert empty.errors == (
+        "triples must be a non-empty sequence",
+        "model_runs must be a non-empty sequence",
+    )
+
+    bad_types = build_claim_evidence_result_artifact(
+        (known, {"not": "a triple"}),
+        ({"not": "a run"},),
+    )
+
+    assert bad_types.errors == (
+        "triples must contain ClaimEvidenceTriple",
+        "model_runs must contain ClaimEvidenceModelRun",
+    )
+
+    artifact = build_claim_evidence_result_artifact(
+        (known,),
+        (
+            run_with_bad_rows,
+            duplicate_model,
+            missing_model_id,
+            bad_row_type,
+        ),
+        thresholds="not-thresholds",
+    )
+
+    assert artifact.model_scores == ()
+    assert artifact.failure_cases == ()
+    for expected in (
+        "gpt: run errors: setup failed",
+        "gpt: unknown row triple_id: unknown",
+        "gpt: duplicate row triple_id: known",
+        "model_id duplicated: gpt",
+        "model_id missing",
+        "rows row 1: must be ClaimEvidenceRunRow",
+        "thresholds must be BenchmarkThresholds",
+    ):
+        assert expected in artifact.errors
+
+    bad_stability = build_claim_evidence_result_artifact(
+        (known,),
+        (_model_run("gpt", {"known": _response(True)}),),
+        stability_runs_by_model_id=[],
+    )
+
+    assert bad_stability.errors == ("stability_runs_by_model_id must be a mapping",)
+
+
+def test_result_artifact_rejects_malformed_stability_reruns() -> None:
+    known = _triple("known", True, EASY)
+    gpt_run = _model_run("gpt", {"known": _response(True)})
+    bad_rows = ClaimEvidenceModelRun(
+        "gpt",
+        (_run_row("gpt", "unknown", _response(True)),),
+        ("rerun setup failed",),
+    )
+
+    artifact = build_claim_evidence_result_artifact(
+        (known,),
+        (gpt_run,),
+        stability_runs_by_model_id={
+            "": (),
+            "other": (),
+            "gpt": (
+                "bad rerun",
+                ClaimEvidenceModelRun("other", (), ()),
+                bad_rows,
+            ),
+        },
+    )
+
+    assert artifact.ok is False
+    assert artifact.go_no_go == "no_go"
+    assert artifact.model_scores == ()
+    for expected in (
+        "stability model_id missing",
+        "stability model_id not in model runs: other",
+        "stability run 1 for gpt: must be ClaimEvidenceModelRun",
+        "stability run 2 for gpt: model_id mismatch: other",
+        "stability run 3 for gpt: run errors: rerun setup failed",
+        "gpt: unknown row triple_id: unknown",
+    ):
+        assert expected in artifact.errors
 
 
 def test_model_score_counts_easy_hard_and_high_confidence_accuracy() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Result-Artifact.md
Slice phase: Functional validation

This PR adds the deterministic result artifact for the #1435 `verify_claim_evidence` reliability gate. It converts completed injected-provider model runs into model scores, agreement rows, stability rows, failure-case rows, the existing threshold verdict, and an explicit go/no-go status. It keeps concrete provider adapters, live prompt execution, file output, verifier inclusion, MCP tools, database behavior, and live-client behavior out of scope.

## Intentional
- The artifact assembler stays in the existing benchmark module because this is still the package-owned reliability gate, not host-layer provider wiring.
- The go/no-go status is derived only from `BenchmarkVerdict.passed`; the artifact does not add policy beyond the merged thresholds.
- The artifact returns a JSON-compatible mapping but does not write files. File output and operator-facing reports belong in a later CLI/writeup slice.
- The diff is over the normal 400 LOC target because this artifact is a detector/gate surface and its failure-branch tests need to land with the contract.

## Deferred
- Concrete provider adapters and live prompt execution.
- Batch CLI for fixture-file model runs.
- File output, markdown writeup, and operator-facing result report.
- Batch fixture directories and operator labeling workflow.
- Verifier rubric inclusion and MCP exposure only after benchmark results pass.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_content_claim_evidence_benchmark.py - 45 passed.
- python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py - passed.
- git diff --check - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/run_extracted_pipeline_checks.sh - 3734 passed, 10 skipped.
- bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/content_ops_claim_evidence_result_artifact_pr_body.md - passed.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_result_artifact_pr_body.md - passed.

## AI reconciliation
- All fixed or waived: yes.
- Fixed reviewer BLOCKER / Codex P1: stability reruns are now validated before scoring. Bad rerun values, unknown stability model ids, mismatched stability run model ids, stability run errors, and unknown stability row ids fail the artifact closed instead of being filtered into a false-green `go`.

## Diff size
3 files, +635 / -1.
