### PR TITLE
Stale-base push guard

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -61,4 +61,4 @@ jobs:
       - name: PR-review tooling unit tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio
-          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py -q
+          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py -q

--- a/plans/PR-Stale-Base-Push-Guard.md
+++ b/plans/PR-Stale-Base-Push-Guard.md
@@ -1,0 +1,120 @@
+# PR-Stale-Base-Push-Guard
+
+## Why this slice exists
+
+#1474 exposed the recurring stale-base failure mode at its worst: the branch
+local review used a stale `origin/main`, so the drift audit saw zero base
+changes locally while GitHub review showed the PR would have reverted three
+merged PRs. The review was caught before merge, but the workflow still relies on
+the builder remembering to fetch/rebase before every push.
+
+This slice moves that reminder into the push wrapper. Before `push_pr.sh` hands
+control to the local-review hook or pushes a branch, it refreshes the default
+remote base so the existing drift audit compares against the real current
+`origin/main`.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Update `scripts/push_pr.sh` to refresh `origin/main` before the wrapper or
+   managed pre-push hook runs local PR review.
+2. Keep dry-run mode side-effect free while making the planned fetch visible in
+   dry-run output.
+3. Add tests proving the fetch happens before review/push and a failed fetch
+   aborts before any push.
+4. Enroll `tests/test_push_pr_wrapper.py` in the pre-push audit workflow's
+   explicit PR-review tooling pytest list.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `push_pr.sh` refreshes `origin/main` before local PR review runs in both
+        wrapper-review and managed-hook paths.
+  - [ ] Dry-run mode does not fetch but prints the planned base refresh.
+  - [ ] A fetch failure exits non-zero before `git push`.
+  - [ ] Existing no-`--no-verify`, missing-body, and single-review behavior is
+        preserved.
+  - [ ] The push-wrapper test file runs in CI through
+        `.github/workflows/pre_push_audit.yml`.
+- Affected surfaces: PR push wrapper, pre-push audit workflow test list, and
+  their tests.
+- Risk areas: accidentally duplicating local review again, doing network work in
+  dry-run, bypassing hooks, or hiding fetch failures.
+- Reviewer rules triggered: R2, R10, R14.
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `plans/PR-Stale-Base-Push-Guard.md`
+- `scripts/push_pr.sh`
+- `tests/test_pre_push_audit_workflow.py`
+- `tests/test_push_pr_wrapper.py`
+
+## Mechanism
+
+`push_pr.sh` already centralizes Atlas PR pushes and chooses between:
+
+- wrapper-run `local_pr_review.sh`, when no managed hook will run it; and
+- hook-run `local_pr_review.sh`, when the managed pre-push hook is installed.
+
+This PR adds a small base-refresh step before either path:
+
+```bash
+git fetch --quiet origin main
+```
+
+The fetch updates the local `origin/main` ref before the drift audit computes
+`git merge-base HEAD origin/main`. If another PR landed since the builder last
+fetched, the existing `audit_pr_session_drift.py` check can now see the base
+changes and block stale diffs before the branch is pushed.
+
+Dry-run mode only prints the planned fetch and exits without network I/O. A real
+fetch failure is fatal; pushing with stale base information is exactly the
+failure this slice exists to prevent.
+
+The existing pre-push audit workflow runs a hand-maintained pytest file list for
+PR-review tooling. This PR adds `tests/test_push_pr_wrapper.py` to that list and
+adds a workflow test asserting the file stays enrolled.
+
+## Intentional
+
+- This does not auto-rebase. Rebasing can create conflicts and rewrite history;
+  the safe automated behavior is to refresh the base and let the existing drift
+  audit fail with a concrete reason.
+- This lives in `push_pr.sh`, not `local_pr_review.sh`, so ad hoc local reviews
+  stay offline-capable. The pre-push path is the place where stale remote state
+  can turn into a dangerous pushed PR.
+- The default is hard-coded to `origin/main` because Atlas PRs target main and
+  the existing local review bundle defaults to that same base.
+
+## Deferred
+
+- A stronger future guard could make `local_pr_review.sh` itself optionally
+  fetch when invoked directly, but that would change offline/advisory review
+  behavior. This slice closes the actual push/open failure path.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_push_pr_wrapper.py` passed, 9 tests.
+- `python -m pytest tests/test_push_pr_wrapper.py tests/test_local_pr_review.py -q` passed, 18 tests.
+- `python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py -q` passed, 92 tests.
+- `python scripts/sync_pr_plan.py plans/PR-Stale-Base-Push-Guard.md origin/main --check` passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Stale-Base-Push-Guard.md` passed.
+- `python scripts/audit_review_rules_triggered.py --plan plans/PR-Stale-Base-Push-Guard.md` passed.
+- `git diff --check origin/main...HEAD` passed.
+- `bash scripts/push_pr.sh /tmp/atlas-pr-stale-base-push-guard.md -u origin HEAD` passed; the wrapper printed `Refreshing origin/main before local PR review...`, then the managed pre-push hook ran `local_pr_review.sh` once and passed with `base changed files since branch point: 0`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pre_push_audit.yml` | 2 |
+| `plans/PR-Stale-Base-Push-Guard.md` | 120 |
+| `scripts/push_pr.sh` | 11 |
+| `tests/test_pre_push_audit_workflow.py` | 6 |
+| `tests/test_push_pr_wrapper.py` | 151 |
+| **Total** | **290** |

--- a/scripts/push_pr.sh
+++ b/scripts/push_pr.sh
@@ -26,6 +26,14 @@ has_managed_pre_push_hook() {
     [ -x "$hook_path" ] && grep -q "ATLAS_LOCAL_PR_REVIEW_HOOK" "$hook_path"
 }
 
+refresh_base_ref() {
+    echo "Refreshing origin/main before local PR review..."
+    if ! git fetch --quiet origin main; then
+        echo "push_pr.sh: failed to refresh origin/main; fetch/rebase before pushing" >&2
+        exit 1
+    fi
+}
+
 if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     usage
     exit 2
@@ -57,6 +65,7 @@ if has_managed_pre_push_hook && [ "${ATLAS_SKIP_LOCAL_PR_REVIEW:-}" != "1" ]; th
 fi
 
 if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
+    echo "DRY RUN: git fetch --quiet origin main"
     if [ "$run_wrapper_review" -eq 1 ]; then
         echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file bash scripts/local_pr_review.sh --current-pr-body-file $body_file"
     else
@@ -65,6 +74,8 @@ if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
     echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file git push $*"
     exit 0
 fi
+
+refresh_base_ref
 
 if [ "$run_wrapper_review" -eq 1 ]; then
     echo "Running local PR review with PR body: $body_file"

--- a/tests/test_pre_push_audit_workflow.py
+++ b/tests/test_pre_push_audit_workflow.py
@@ -21,3 +21,9 @@ def test_pre_push_audit_workflow_keeps_push_to_main_without_pr_body() -> None:
 
     assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in text
     assert "else\n            bash scripts/local_pr_review.sh\n          fi" in text
+
+
+def test_pre_push_audit_workflow_enrolls_push_pr_wrapper_tests() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "tests/test_push_pr_wrapper.py" in text

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -25,6 +25,7 @@ def test_push_pr_dry_run_without_managed_hook_runs_wrapper_review(tmp_path: Path
     )
 
     assert result.returncode == 0
+    assert "DRY RUN: git fetch --quiet origin main" in result.stdout
     assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
     assert f"--current-pr-body-file {body}" in result.stdout
     assert "git push -u origin HEAD" in result.stdout
@@ -48,6 +49,7 @@ def test_push_pr_dry_run_with_managed_hook_uses_hook_as_single_review_runner(
     )
 
     assert result.returncode == 0
+    assert "DRY RUN: git fetch --quiet origin main" in result.stdout
     assert "managed pre-push hook will run local PR review once" in result.stdout
     assert "bash scripts/local_pr_review.sh" not in result.stdout
     assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
@@ -74,6 +76,7 @@ def test_push_pr_dry_run_with_skip_env_keeps_wrapper_review(tmp_path: Path) -> N
     )
 
     assert result.returncode == 0
+    assert "DRY RUN: git fetch --quiet origin main" in result.stdout
     assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
     assert f"--current-pr-body-file {body}" in result.stdout
     assert "managed pre-push hook will run local PR review once" not in result.stdout
@@ -97,9 +100,107 @@ def test_push_pr_dry_run_with_non_executable_managed_hook_keeps_wrapper_review(
     )
 
     assert result.returncode == 0
+    assert "DRY RUN: git fetch --quiet origin main" in result.stdout
     assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
     assert f"--current-pr-body-file {body}" in result.stdout
     assert "managed pre-push hook will run local PR review once" not in result.stdout
+
+
+def test_push_pr_refreshes_base_before_wrapper_review_and_push(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert lines.index("git fetch --quiet origin main") < lines.index(
+        f"local-review --current-pr-body-file {body}"
+    )
+    assert lines.index(f"local-review --current-pr-body-file {body}") < lines.index(
+        "git push -u origin HEAD"
+    )
+
+
+def test_push_pr_refreshes_base_before_managed_hook_push(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    _write_local_review(repo)
+    _write_managed_hook(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert lines.index("git fetch --quiet origin main") < lines.index(
+        "git push -u origin HEAD"
+    )
+    assert not any(line.startswith("local-review ") for line in lines)
+
+
+def test_push_pr_fetch_failure_aborts_before_review_or_push(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "FAKE_GIT_FETCH_FAIL": "1",
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "failed to refresh origin/main" in result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert "git fetch --quiet origin main" in lines
+    assert "git push -u origin HEAD" not in lines
+    assert not any(line.startswith("local-review ") for line in lines)
 
 
 def test_push_pr_rejects_no_verify(tmp_path: Path) -> None:
@@ -148,6 +249,17 @@ def _write_body(repo: Path) -> Path:
     return body
 
 
+def _write_local_review(repo: Path) -> None:
+    review = repo / "scripts" / "local_pr_review.sh"
+    review.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf 'local-review %s\\n' \"$*\" >> \"$ORDER_LOG\"\n",
+        encoding="utf-8",
+    )
+    review.chmod(0o755)
+
+
 def _write_managed_hook(repo: Path, *, executable: bool = True) -> None:
     hook = repo / ".git" / "hooks" / "pre-push"
     hook.write_text(
@@ -156,3 +268,42 @@ def _write_managed_hook(repo: Path, *, executable: bool = True) -> None:
     )
     if executable:
         hook.chmod(0o755)
+
+
+def _write_fake_git(repo: Path, order_log: Path) -> Path:
+    fake_bin = repo / "fake-bin"
+    fake_bin.mkdir()
+    git = fake_bin / "git"
+    git.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "case \"${1:-}\" in\n"
+        "  rev-parse)\n"
+        "    if [ \"${2:-}\" = \"--show-toplevel\" ]; then\n"
+        "      printf '%s\\n' \"$FAKE_GIT_TOPLEVEL\"\n"
+        "      exit 0\n"
+        "    fi\n"
+        "    if [ \"${2:-}\" = \"--git-path\" ]; then\n"
+        "      printf '%s/.git/%s\\n' \"$FAKE_GIT_TOPLEVEL\" \"${3:-}\"\n"
+        "      exit 0\n"
+        "    fi\n"
+        "    ;;\n"
+        "  fetch)\n"
+        "    printf 'git %s\\n' \"$*\" >> \"$FAKE_GIT_LOG\"\n"
+        "    if [ \"${FAKE_GIT_FETCH_FAIL:-}\" = \"1\" ]; then\n"
+        "      exit 42\n"
+        "    fi\n"
+        "    exit 0\n"
+        "    ;;\n"
+        "  push)\n"
+        "    printf 'git %s\\n' \"$*\" >> \"$FAKE_GIT_LOG\"\n"
+        "    exit 0\n"
+        "    ;;\n"
+        "esac\n"
+        "printf 'unexpected git invocation: %s\\n' \"$*\" >&2\n"
+        "exit 99\n",
+        encoding="utf-8",
+    )
+    git.chmod(0o755)
+    order_log.write_text("", encoding="utf-8")
+    return fake_bin


### PR DESCRIPTION
Plan: plans/PR-Stale-Base-Push-Guard.md
Slice phase: Workflow/process

Adds a push-time stale-base guard to `scripts/push_pr.sh`: before the wrapper or managed pre-push hook runs local PR review, the wrapper refreshes `origin/main` with `git fetch --quiet origin main`. This closes the #1474 failure mode where local review used a stale `origin/main` and could not see newly merged PRs that the branch would have reverted.

## Intentional
- Fetch only; do not auto-rebase. Rebase can conflict or rewrite history, so the safe automated behavior is to refresh base state and let the existing drift audit fail if the branch is stale.
- Keep `local_pr_review.sh` offline-capable for direct/advisory runs. The push wrapper is the path where stale remote state becomes a dangerous pushed PR.
- Default to `origin/main`, matching Atlas PR target and the existing local-review default base.

## Deferred
- Optional direct `local_pr_review.sh` fetch mode, if needed later.

## Parked hardening
- None.

## Verification
- `pytest tests/test_push_pr_wrapper.py` - passed, 9 tests.
- `python -m pytest tests/test_push_pr_wrapper.py tests/test_local_pr_review.py -q` - passed, 18 tests.
- `python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py -q` - passed, 92 tests.
- `python scripts/sync_pr_plan.py plans/PR-Stale-Base-Push-Guard.md origin/main --check` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Stale-Base-Push-Guard.md` - passed.
- `python scripts/audit_review_rules_triggered.py --plan plans/PR-Stale-Base-Push-Guard.md` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `bash scripts/push_pr.sh /tmp/atlas-pr-stale-base-push-guard.md -u origin HEAD` - passed; the wrapper printed `Refreshing origin/main before local PR review...`, then the managed pre-push hook ran `local_pr_review.sh` once and passed with `base changed files since branch point: 0`.

## AI reconciliation
All fixed or waived: Yes.
- Fixed Codex P2 "Enroll push wrapper tests in CI": `tests/test_push_pr_wrapper.py` is now enrolled in `.github/workflows/pre_push_audit.yml`'s explicit PR-review tooling pytest list, and `tests/test_pre_push_audit_workflow.py` asserts that enrollment.

## Diff size
5 files, +289 / -1.