### PR TITLE
Content-Ops Claim Evidence Result Writeup

### DIFF
--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -416,6 +416,129 @@ class ClaimEvidenceResultArtifact:
         return payload
 
 
+def render_claim_evidence_result_markdown(artifact: object) -> str:
+    """Render a benchmark result artifact as an operator-facing Markdown report."""
+
+    typed_artifact = (
+        artifact
+        if isinstance(artifact, ClaimEvidenceResultArtifact)
+        else _failed_result_artifact(
+            DEFAULT_THRESHOLDS,
+            ("artifact must be ClaimEvidenceResultArtifact",),
+        )
+    )
+    lines = [
+        "# Claim Evidence Benchmark Result",
+        "",
+        "## Decision",
+        "",
+        f"- Go/no-go: {typed_artifact.go_no_go.upper()}",
+        f"- Artifact ok: {_yes_no(typed_artifact.ok)}",
+        f"- Verdict passed: {_yes_no(typed_artifact.verdict.passed)}",
+        "",
+        "## Thresholds",
+        "",
+    ]
+    lines.extend(
+        _markdown_table(
+            ("Metric", "Threshold"),
+            (
+                (
+                    "Easy accuracy",
+                    f">= {_format_percent(typed_artifact.thresholds.easy_accuracy_min)}",
+                ),
+                (
+                    "Hard accuracy",
+                    f">= {_format_percent(typed_artifact.thresholds.hard_accuracy_min)}",
+                ),
+                (
+                    "Inter-model agreement",
+                    (
+                        ">= "
+                        f"{_format_percent(typed_artifact.thresholds.inter_model_agreement_min)}"
+                    ),
+                ),
+                (
+                    "Intra-model stability",
+                    (
+                        ">= "
+                        f"{_format_percent(typed_artifact.thresholds.intra_model_stability_min)}"
+                    ),
+                ),
+                (
+                    "High-confidence accuracy",
+                    (
+                        "> "
+                        f"{_format_percent(typed_artifact.thresholds.high_confidence_accuracy_min)}"
+                    ),
+                ),
+            ),
+        )
+    )
+    lines.extend(("", "## Model Scores", ""))
+    lines.extend(
+        _markdown_table(
+            (
+                "Model",
+                "Easy",
+                "Hard",
+                "High confidence",
+                "Missing responses",
+                "Low confidence",
+            ),
+            tuple(
+                (
+                    score.model_id,
+                    _format_percent(score.easy_accuracy),
+                    _format_percent(score.hard_accuracy),
+                    _format_percent(score.high_confidence_accuracy),
+                    _comma_list(score.missing_response_ids),
+                    _comma_list(score.low_confidence_response_ids),
+                )
+                for score in typed_artifact.model_scores
+            ),
+            empty_label="No model scores.",
+        )
+    )
+    lines.extend(("", "## Inter-Model Agreement", ""))
+    lines.extend(
+        _markdown_table(
+            ("Pair", "Agreement", "Total"),
+            tuple(
+                (
+                    f"{row.left_model_id} / {row.right_model_id}",
+                    _format_percent(row.agreement),
+                    row.total,
+                )
+                for row in typed_artifact.agreement_matrix
+            ),
+            empty_label="No agreement rows.",
+        )
+    )
+    lines.extend(("", "## Intra-Model Stability", ""))
+    lines.extend(
+        _markdown_table(
+            ("Model", "Stability", "Total"),
+            tuple(
+                (
+                    row.model_id,
+                    _format_percent(row.stability),
+                    row.total,
+                )
+                for row in typed_artifact.stability_scores
+            ),
+            empty_label="No stability rows.",
+        )
+    )
+    lines.extend(("", "## Verdict Failures", ""))
+    lines.extend(_markdown_bullets(typed_artifact.verdict.failure_reasons))
+    lines.extend(("", "## Artifact Errors", ""))
+    lines.extend(_markdown_bullets(typed_artifact.errors))
+    lines.extend(("", "## Failure Cases", ""))
+    lines.extend(_failure_case_table(typed_artifact.failure_cases))
+    return "\n".join(lines).rstrip() + "\n"
+
+
 @dataclass(frozen=True)
 class BenchmarkFixture:
     """Decoded operator-labeled benchmark fixture rows."""
@@ -1035,6 +1158,106 @@ def _failure_case(
         "response_reason": response.reason if response is not None else "",
         "row_errors": row_errors,
     }
+
+
+def _format_percent(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _comma_list(values: Sequence[object]) -> str:
+    if not values:
+        return "none"
+    return ", ".join(str(value) for value in values)
+
+
+def _markdown_cell(value: object) -> str:
+    text = str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def _markdown_table(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[object]],
+    *,
+    empty_label: str | None = None,
+) -> list[str]:
+    lines = [
+        "| " + " | ".join(_markdown_cell(header) for header in headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    if not rows and empty_label is not None:
+        lines.append(
+            "| "
+            + _markdown_cell(empty_label)
+            + " | "
+            + " | ".join("" for _ in headers[1:])
+            + " |"
+        )
+        return lines
+    for row in rows:
+        lines.append("| " + " | ".join(_markdown_cell(value) for value in row) + " |")
+    return lines
+
+
+def _markdown_bullets(values: Sequence[object]) -> list[str]:
+    if not values:
+        return ["- None."]
+    return [f"- {_markdown_cell(value)}" for value in values]
+
+
+def _failure_case_table(
+    failure_cases: Sequence[Mapping[str, object]],
+) -> list[str]:
+    return _markdown_table(
+        (
+            "Model",
+            "Triple",
+            "Failure",
+            "Expected",
+            "Actual",
+            "Confidence",
+            "Row errors",
+        ),
+        tuple(
+            (
+                failure.get("model_id", ""),
+                failure.get("triple_id", ""),
+                failure.get("failure", ""),
+                failure.get("expected_supports", ""),
+                _markdown_optional_bool_text(failure.get("actual_supports")),
+                _markdown_optional_text(failure.get("confidence")),
+                _comma_list(_tuple_or_empty(failure.get("row_errors"))),
+            )
+            for failure in failure_cases
+        ),
+        empty_label="No failure cases.",
+    )
+
+
+def _tuple_or_empty(value: object) -> tuple[object, ...]:
+    if isinstance(value, tuple):
+        return value
+    if isinstance(value, list):
+        return tuple(value)
+    return ()
+
+
+def _markdown_optional_bool_text(value: object) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return "n/a"
+
+
+def _markdown_optional_text(value: object) -> str:
+    if value is None:
+        return "n/a"
+    return str(value)
 
 
 def _failed_result_artifact(

--- a/plans/PR-Content-Ops-Claim-Evidence-Result-Writeup.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Result-Writeup.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-Claim-Evidence-Result-Writeup
+
+## Why this slice exists
+
+#1477 merged the deterministic result artifact for #1435. The remaining issue
+deliverable is the operator-facing writeup: a readable benchmark summary before
+any verifier/MCP inclusion.
+
+This PR renders an already-built artifact into deterministic Markdown so later
+CLI/live-run slices can reuse the same presentation rules.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a pure Markdown renderer for `ClaimEvidenceResultArtifact`.
+2. Include go/no-go, thresholds, model score table, inter-model
+   agreement rows, stability rows, verdict failure reasons, artifact errors,
+   and failure-case list.
+3. Render malformed input as a no-go writeup with a visible artifact error.
+4. Add focused tests for passing, no-go, and malformed renderer input.
+5. Keep provider adapters, live prompt execution, model-run CLI,
+   file writing, verifier rubric inclusion, MCP tools, database behavior, and
+   live-client behavior out of scope.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Passing artifacts render go/no-go, thresholds, model scores, agreement,
+        and stability sections.
+  - [ ] No-go artifacts render verdict reasons, artifact errors, and failure
+        cases without raising.
+  - [ ] Non-artifact input renders a failed no-go writeup with an attributable
+        error.
+  - [ ] The renderer only presents artifact/threshold fields and does not add
+        scoring policy.
+  - [ ] No provider, file writing, verifier/MCP, DB, or live-client behavior is
+        introduced.
+- Affected surfaces: extracted benchmark helper, focused tests, and plan.
+- Risk areas: false-green presentation, malformed artifact output, future
+  writeup compatibility.
+- Reviewer rules triggered: R1, R2, R5, R6, R10, R12.
+
+### Files touched
+
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `plans/PR-Content-Ops-Claim-Evidence-Result-Writeup.md`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+
+## Mechanism
+
+The benchmark module gains a renderer that accepts an artifact and returns
+Markdown. It formats percentages, renders empty tables explicitly, and lists
+artifact/verdict errors before failure cases. Malformed input becomes a failed
+artifact-shaped report instead of an exception.
+
+## Intentional
+
+- The renderer stays in the existing benchmark module as artifact presentation,
+  not host-layer wiring.
+- The renderer does not parse JSON or write files.
+- The go/no-go text derives from the artifact status only; this PR does not add
+  new threshold policy or constrained-go logic.
+- Hardening scan: no parked `HARDENING.md` entries touch this ownership lane or
+  these files.
+
+## Deferred
+
+- Provider adapters, live prompt execution, model-run CLI, and file output.
+- Verifier rubric inclusion and MCP exposure only after benchmark results pass.
+- Follow-up drift-class guard for schema/decoder/artifact strictness claims.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused benchmark pytest - 48 passed; Python compile check - passed; diff whitespace check - passed.
+- Extracted guardrails passed: manifest validation, Atlas reasoning import guard, standalone audit, and ASCII Python check.
+- Full extracted pipeline wrapper - 3744 passed, 10 skipped.
+- Body-aware local PR review - passed.
+
+## Estimated diff size
+
+Estimated: 3 files, about +399 / -0. Below the 400 LOC target.
+
+| Total | 399 |

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -22,6 +22,7 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     intra_model_stability,
     load_claim_evidence_fixture_text,
     pairwise_agreements,
+    render_claim_evidence_result_markdown,
     run_claim_evidence_provider,
     score_model,
     validate_claim_evidence_fixture,
@@ -760,6 +761,94 @@ def test_result_artifact_rejects_malformed_stability_reruns() -> None:
         "gpt: unknown row triple_id: unknown",
     ):
         assert expected in artifact.errors
+
+
+def test_result_writeup_renders_passing_artifact_sections() -> None:
+    triples = (
+        _triple("easy", True, EASY),
+        _triple("hard", False, HARD),
+    )
+    claude_run = _model_run(
+        "claude",
+        {"easy": _response(True, 5), "hard": _response(False, 4)},
+    )
+    gpt_run = _model_run(
+        "gpt",
+        {"easy": _response(True, 5), "hard": _response(False, 4)},
+    )
+    artifact = build_claim_evidence_result_artifact(
+        triples,
+        (gpt_run, claude_run),
+        stability_runs_by_model_id={
+            "gpt": (gpt_run, gpt_run),
+            "claude": (claude_run, claude_run),
+        },
+        thresholds=BenchmarkThresholds(
+            easy_accuracy_min=1.0,
+            hard_accuracy_min=1.0,
+            inter_model_agreement_min=1.0,
+            intra_model_stability_min=1.0,
+            high_confidence_accuracy_min=0.90,
+        ),
+    )
+
+    markdown = render_claim_evidence_result_markdown(artifact)
+
+    assert markdown.startswith("# Claim Evidence Benchmark Result\n")
+    assert "- Go/no-go: GO" in markdown
+    assert "- Artifact ok: yes" in markdown
+    assert "| Easy accuracy | >= 100.0% |" in markdown
+    assert "| High-confidence accuracy | > 90.0% |" in markdown
+    assert "| claude | 100.0% | 100.0% | 100.0% | none | none |" in markdown
+    assert "| claude / gpt | 100.0% | 2 |" in markdown
+    assert "| claude | 100.0% | 2 |" in markdown
+    assert "## Verdict Failures\n\n- None." in markdown
+    assert "No failure cases." in markdown
+
+
+def test_result_writeup_renders_no_go_failure_cases_without_raising() -> None:
+    triples = (
+        _triple("wrong", True, EASY),
+        _triple("missing", False, HARD),
+        _triple("malformed", True, EASY),
+        _triple("low", True, EASY),
+    )
+    run = _model_run(
+        "gpt",
+        {
+            "wrong": _response(False, 5),
+            "low": _response(True, 2),
+        },
+        rows=(
+            _run_row("gpt", "malformed", None, ("reason missing",)),
+        ),
+    )
+    artifact = build_claim_evidence_result_artifact(triples, (run,))
+
+    markdown = render_claim_evidence_result_markdown(artifact)
+
+    assert "- Go/no-go: NO_GO" in markdown
+    assert "- Artifact ok: no" in markdown
+    assert "gpt: missing responses" in markdown
+    assert "| gpt | wrong | incorrect_support | True | false | 5 | none |" in markdown
+    assert "| gpt | missing | missing_response | False | n/a | n/a | none |" in markdown
+    assert (
+        "| gpt | malformed | malformed_response | True | n/a | n/a | "
+        "reason missing |"
+    ) in markdown
+    assert "| gpt | low | low_confidence | True | true | 2 | none |" in markdown
+    assert "## Artifact Errors\n\n- None." in markdown
+
+
+def test_result_writeup_fails_closed_on_malformed_renderer_input() -> None:
+    markdown = render_claim_evidence_result_markdown({"not": "an artifact"})
+
+    assert "- Go/no-go: NO_GO" in markdown
+    assert "- Artifact ok: no" in markdown
+    assert "- Verdict passed: no" in markdown
+    assert "artifact must be ClaimEvidenceResultArtifact" in markdown
+    assert "No model scores." in markdown
+    assert "No failure cases." in markdown
 
 
 def test_model_score_counts_easy_hard_and_high_confidence_accuracy() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Result-Writeup.md
Slice phase: Functional validation

This PR adds the deterministic operator-facing Markdown writeup for the #1435 `verify_claim_evidence` reliability gate. It renders an existing `ClaimEvidenceResultArtifact` into go/no-go, thresholds, model score, inter-model agreement, stability, verdict failure, artifact error, and failure-case sections. It does not call providers, parse or write files, alter verifier behavior, expose MCP tools, change database behavior, or affect live clients.

## Intentional
- The renderer stays in the existing benchmark module as artifact presentation, not host-layer wiring.
- The renderer does not parse JSON or write files.
- The go/no-go text derives from the artifact status only; this PR does not add new threshold policy or constrained-go logic.
- The diff stays under the 400 LOC target.

## Deferred
- Provider adapters, live prompt execution, model-run CLI, and file output.
- Verifier rubric inclusion and MCP exposure only after benchmark results pass.
- Follow-up drift-class guard for schema/decoder/artifact strictness claims.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_claim_evidence_benchmark.py -q` - 48 passed; `python -m py_compile extracted_content_pipeline/claim_evidence_benchmark.py tests/test_extracted_content_claim_evidence_benchmark.py` - passed; `git diff --check` - passed.
- Extracted guardrails passed: `bash scripts/validate_extracted_content_pipeline.sh`; `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`; `python scripts/audit_extracted_standalone.py --fail-on-debt`; `bash scripts/check_ascii_python.sh`.
- `bash scripts/run_extracted_pipeline_checks.sh` - 3744 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_result_writeup_pr_body.md` - passed.

## Diff size
3 files, +399 / -0.
