### PR TITLE
Content-Ops Claim Evidence Strictness Guard

### DIFF
--- a/plans/PR-Content-Ops-Claim-Evidence-Strictness-Guard.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Strictness-Guard.md
@@ -1,0 +1,76 @@
+# PR-Content-Ops-Claim-Evidence-Strictness-Guard
+
+## Why this slice exists
+
+Reviews across #1469, #1475, and #1477 surfaced the same drift class:
+the contract advertised strictness while the validator accepted a looser shape.
+#1484 carried this as a deferred follow-up. Before moving toward live provider
+adapters or batch model-run CLI, this PR pins the response-schema strictness
+claims to decoder behavior in one guard test.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Robust testing
+
+1. Add a consolidated regression test for the `verify_claim_evidence.v1`
+   response schema claims.
+2. Prove required fields, boolean support, integer confidence bounds, string
+   non-whitespace reason, and no-extra-fields are all enforced by the decoded
+   response validator.
+3. Keep production code, provider adapters, live prompt execution, model-run
+   CLI, file writing, verifier rubric inclusion, MCP tools, DB, and live-client
+   behavior out of scope.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Each response-schema rejection claim has a matching decoder failure
+        assertion in one guard test.
+  - [ ] The guard covers lookalikes that caused prior drift: boolean confidence,
+        non-string/whitespace reason, and extra provider fields.
+  - [ ] No production behavior changes are introduced.
+- Affected surfaces: focused benchmark tests and plan.
+- Risk areas: false-green contract strictness, schema/decoder drift, test
+  coverage brittleness.
+- Reviewer rules triggered: R1, R2, R10, R12.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Claim-Evidence-Strictness-Guard.md`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+
+## Mechanism
+
+The benchmark test suite gains one table-driven guard. It reads the response
+schema fields and then feeds same-class rejected values through
+`ClaimEvidenceResponse.from_mapping`, asserting the specific decoder errors.
+The existing per-case tests stay in place; this guard is the class-level net.
+
+## Intentional
+
+- This is test-only because the strict decoder behavior already exists.
+- The guard lives in the existing benchmark test module so no CI enrollment
+  change is needed.
+- Hardening scan: no parked `HARDENING.md` entries touch this ownership lane or
+  these files.
+
+## Deferred
+
+- Provider adapters, live prompt execution, model-run CLI, and file output.
+- Verifier rubric inclusion and MCP exposure only after benchmark results pass.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused benchmark pytest - 49 passed.
+- Python compile check and diff whitespace check - passed.
+- Full extracted pipeline wrapper - 3872 passed, 10 skipped.
+- Body-aware local PR review - passed.
+
+## Estimated diff size
+
+Estimated: 2 files, about +152 / -0. Below the 400 LOC target.
+
+| Total | 152 |

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -407,6 +407,82 @@ def test_response_json_schema_matches_decoder_contract() -> None:
     assert response == ClaimEvidenceResponse(True, 4, "quote states it")
 
 
+def test_response_schema_rejection_claims_are_enforced_by_decoder() -> None:
+    schema = claim_evidence_response_json_schema()
+
+    assert schema["required"] == ["supports", "confidence", "reason"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["supports"]["type"] == "boolean"
+    assert schema["properties"]["confidence"]["type"] == "integer"
+    assert schema["properties"]["confidence"]["minimum"] == 1
+    assert schema["properties"]["confidence"]["maximum"] == 5
+    assert schema["properties"]["reason"]["type"] == "string"
+    assert schema["properties"]["reason"]["pattern"] == "\\S"
+
+    cases = (
+        (
+            "missing supports",
+            {"confidence": 4, "reason": "quote states it"},
+            ("supports missing",),
+        ),
+        (
+            "non-boolean supports",
+            {"supports": "true", "confidence": 4, "reason": "quote states it"},
+            ("supports missing",),
+        ),
+        (
+            "missing confidence",
+            {"supports": True, "reason": "quote states it"},
+            ("confidence must be an integer from 1 to 5",),
+        ),
+        (
+            "boolean confidence",
+            {"supports": True, "confidence": True, "reason": "quote states it"},
+            ("confidence must be an integer from 1 to 5",),
+        ),
+        (
+            "below-min confidence",
+            {"supports": True, "confidence": 0, "reason": "quote states it"},
+            ("confidence must be an integer from 1 to 5",),
+        ),
+        (
+            "above-max confidence",
+            {"supports": True, "confidence": 6, "reason": "quote states it"},
+            ("confidence must be an integer from 1 to 5",),
+        ),
+        (
+            "missing reason",
+            {"supports": True, "confidence": 4},
+            ("reason missing",),
+        ),
+        (
+            "whitespace reason",
+            {"supports": True, "confidence": 4, "reason": "  \t"},
+            ("reason missing",),
+        ),
+        (
+            "non-string reason",
+            {"supports": True, "confidence": 4, "reason": 123},
+            ("reason missing",),
+        ),
+        (
+            "extra field",
+            {
+                "supports": True,
+                "confidence": 4,
+                "reason": "quote states it",
+                "extra": "not in schema",
+            },
+            ("unexpected fields: extra",),
+        ),
+    )
+    for _label, raw_response, expected_errors in cases:
+        response, errors = ClaimEvidenceResponse.from_mapping(raw_response)
+
+        assert response is None
+        assert errors == expected_errors
+
+
 def test_response_json_schema_rejects_whitespace_reason_like_decoder() -> None:
     schema = claim_evidence_response_json_schema()
     whitespace_reason = {"supports": True, "confidence": 4, "reason": "   "}


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Strictness-Guard.md
Slice phase: Robust testing

This PR adds the deferred class-level strictness guard for the #1435 `verify_claim_evidence` response contract. It proves the schema's rejection claims are enforced by `ClaimEvidenceResponse.from_mapping` for required fields, boolean support, integer confidence bounds, string non-whitespace reason, and no-extra-fields. It is test-only and does not change production behavior, provider wiring, file output, verifier/MCP exposure, DB behavior, or live clients.

## Intentional
- This is test-only because the strict decoder behavior already exists.
- The guard lives in the existing benchmark test module so no CI enrollment change is needed.
- It is a class-level net over the same drift class surfaced in #1469/#1475/#1477.

## Deferred
- Provider adapters, live prompt execution, model-run CLI, and file output.
- Verifier rubric inclusion and MCP exposure only after benchmark results pass.

## Parked hardening
- None.

## Verification
- Focused benchmark pytest - 49 passed.
- Python compile check and diff whitespace check - passed.
- Full extracted pipeline wrapper - 3872 passed, 10 skipped.
- Body-aware local PR review - passed.

## Diff size
2 files, +152 / -0.
