### PR TITLE
Content-Ops calibration library + adversarial pass (operating-model slice 5)

### DIFF
--- a/extracted_content_pipeline/adversarial_pass.py
+++ b/extracted_content_pipeline/adversarial_pass.py
@@ -1,0 +1,181 @@
+"""Content-ops adversarial review pass (operating-model slice 5b).
+
+The deterministic core of the **adversarial pass** from
+``docs/content_ops_operating_model.md``: a second, independent model-assisted
+pass whose only job is to find the strongest reason a draft should *not* ship
+-- overclaims, ambiguity, reader objections, promise/CTA mismatch, generic
+stretches, missing proof, voice slips. This module is the data model for that
+pass plus the deterministic disagreement/merge helpers between two independent
+passes. Pure value types + pure functions -- no I/O, no Atlas imports, no DB,
+no LLM.
+
+The pass is **not a judge**: findings are evidence the accountable editor
+resolves. That invariant is enforced at the seam -- a finding converts to a
+*non-blocking* :class:`~.content_pr.ReviewComment`; only the editor decides
+what blocks. Running the prompts that *produce* findings, and the
+model-disagreement orchestration (route-to-human on an A-pass/B-fail split),
+stay parked per the doc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - Python 3.10 CI compatibility
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
+
+from .content_pr import CommentCategory, ReviewComment
+
+
+class AdversarialFindingCategory(StrEnum):
+    """The doc's adversarial-pass target list: reasons a draft should not ship."""
+
+    OVERCLAIM = "overclaim"
+    AMBIGUITY = "ambiguity"
+    READER_OBJECTION = "reader_objection"
+    PROMISE_CTA_MISMATCH = "promise_cta_mismatch"
+    GENERIC_STRETCH = "generic_stretch"
+    MISSING_PROOF = "missing_proof"
+    VOICE_SLIP = "voice_slip"
+
+
+def _nonempty(value: object) -> bool:
+    """True only for a non-empty, non-whitespace ``str`` (None/non-str -> False).
+
+    Same robustness contract as the sibling slices: findings may be decoded from
+    a model's JSON output, so a ``None`` message counts as missing, never raises.
+    """
+
+    return isinstance(value, str) and bool(value.strip())
+
+
+@dataclass(frozen=True)
+class AdversarialFinding:
+    """One "strongest reason this should not ship" from an adversarial pass.
+
+    ``message`` is the objection; ``evidence`` is the quoted draft text it
+    points at; ``location`` is where in the draft. A finding with no message or
+    no evidence is noise, not a finding -- see :meth:`is_substantiated`.
+    """
+
+    category: AdversarialFindingCategory
+    message: str = ""
+    evidence: str = ""
+    location: str = ""
+
+    def is_substantiated(self) -> bool:
+        """True only when the finding carries both an objection and evidence.
+
+        An unsubstantiated finding cannot anchor an editor decision; the
+        substantiated filter is what keeps a chatty pass from flooding review.
+        """
+
+        return _nonempty(self.message) and _nonempty(self.evidence)
+
+
+@dataclass(frozen=True)
+class AdversarialPass:
+    """One independent adversarial pass over a draft.
+
+    ``source`` records the prompt/model identity that produced the pass (e.g.
+    ``"adversarial-prompt@v2 / model-b"``) so two passes are distinguishable;
+    independence of the two sources is the caller's responsibility.
+    """
+
+    pass_id: str
+    source: str = ""
+    findings: tuple[AdversarialFinding, ...] = ()
+
+    def categories(self) -> frozenset[AdversarialFindingCategory]:
+        """The distinct finding categories this pass raised."""
+
+        return frozenset(f.category for f in self.findings)
+
+    def substantiated(self) -> tuple[AdversarialFinding, ...]:
+        """Only the findings carrying both message and evidence, in order."""
+
+        return tuple(f for f in self.findings if f.is_substantiated())
+
+
+def corroborated_categories(
+    first: AdversarialPass, second: AdversarialPass
+) -> frozenset[AdversarialFindingCategory]:
+    """Categories BOTH passes raised independently (the strongest signal).
+
+    StrEnum set intersection is value-based, so a category decoded as a plain
+    string in one pass still corroborates the enum member in the other.
+    """
+
+    return first.categories() & second.categories()
+
+
+def disagreement_categories(
+    first: AdversarialPass, second: AdversarialPass
+) -> frozenset[AdversarialFindingCategory]:
+    """Categories exactly one pass raised (the disagreement surface).
+
+    This is the *data* for the parked orchestration: what to do about a
+    disagreement (route to human, log the override) is deliberately not decided
+    here -- deterministic blockers always block and model findings always go to
+    a human regardless, per the doc.
+    """
+
+    return first.categories() ^ second.categories()
+
+
+def merge_findings(
+    first: AdversarialPass, second: AdversarialPass
+) -> tuple[AdversarialFinding, ...]:
+    """All findings from both passes, first-pass order then second, de-duplicated.
+
+    Only *exact* duplicates (same category, message, evidence, location) merge;
+    two differently-worded objections in the same category are both kept --
+    collapsing them would be a judgment call, and this module does not judge.
+    """
+
+    merged: list[AdversarialFinding] = []
+    seen: set[AdversarialFinding] = set()
+    for finding in first.findings + second.findings:
+        if finding not in seen:
+            seen.add(finding)
+            merged.append(finding)
+    return tuple(merged)
+
+
+# Finding category -> review-comment category. VOICE_SLIP maps to the brand-rule
+# lane; every other adversarial objection lands in the editor's judgment lane
+# rather than pretending to be a deterministic gate result. Data, not branches.
+_FINDING_COMMENT_CATEGORY: Mapping[
+    AdversarialFindingCategory, CommentCategory
+] = {
+    AdversarialFindingCategory.VOICE_SLIP: CommentCategory.BRAND_RULE,
+}
+
+
+def comment_from_finding(finding: AdversarialFinding) -> ReviewComment:
+    """Convert an adversarial finding into a reviewer comment -- never blocking.
+
+    The "still not a judge" invariant lives here: a model-found objection
+    enters the Content-PR as evidence (``blocking=False``); only the
+    accountable editor escalates it to blocking. The finding's category is
+    carried in the message prefix so the editor sees which failure mode the
+    pass claimed.
+    """
+
+    category = _FINDING_COMMENT_CATEGORY.get(
+        finding.category, CommentCategory.EDITORIAL_JUDGMENT
+    )
+    prefix = f"[adversarial:{finding.category}]"
+    message = f"{prefix} {finding.message}".strip()
+    return ReviewComment(
+        category=category,
+        message=message,
+        evidence=finding.evidence,
+        blocking=False,
+    )

--- a/extracted_content_pipeline/adversarial_pass.py
+++ b/extracted_content_pipeline/adversarial_pass.py
@@ -28,7 +28,11 @@ except ImportError:  # pragma: no cover - Python 3.10 CI compatibility
     from enum import Enum
 
     class StrEnum(str, Enum):
-        pass
+        # Match CPython's real StrEnum: str(member) is the value, so the
+        # [adversarial:...] prefix formats identically on both interpreter
+        # paths (3.10's plain str+Enum would format as the class-qualified
+        # name under str()).
+        __str__ = str.__str__
 
 from .content_pr import CommentCategory, ReviewComment
 
@@ -172,10 +176,12 @@ def comment_from_finding(finding: AdversarialFinding) -> ReviewComment:
         finding.category, CommentCategory.EDITORIAL_JUDGMENT
     )
     prefix = f"[adversarial:{finding.category}]"
-    message = f"{prefix} {finding.message}".strip()
+    # A decoded None/blank message or evidence counts as missing -- the prefix
+    # alone is the message, and "None" never leaks into editor-facing text.
+    message = f"{prefix} {finding.message}" if _nonempty(finding.message) else prefix
     return ReviewComment(
         category=category,
         message=message,
-        evidence=finding.evidence,
+        evidence=finding.evidence if _nonempty(finding.evidence) else "",
         blocking=False,
     )

--- a/extracted_content_pipeline/calibration_library.py
+++ b/extracted_content_pipeline/calibration_library.py
@@ -151,19 +151,22 @@ class CalibrationLibrary:
         return tuple(e for e in self.examples if e.label == label)
 
     def by_failure_category(
-        self, category: FailureCategory
+        self, category: FailureCategory | None
     ) -> tuple[CalibrationExample, ...]:
         """Examples cross-linked to ``category``.
 
-        ``None``-category examples never match: an example with no recorded
-        failure category is not silently swept into any category's anchor set.
+        A ``None`` query returns empty, and ``None``-category examples never
+        match: an example with no recorded failure category is not silently
+        swept into any category's anchor set.
         """
 
         if category is None:
             return ()
         return tuple(e for e in self.examples if e.failure_category == category)
 
-    def by_verdict(self, verdict: ReviewDecision) -> tuple[CalibrationExample, ...]:
+    def by_verdict(
+        self, verdict: ReviewDecision | None
+    ) -> tuple[CalibrationExample, ...]:
         """Examples whose recorded verdict equals ``verdict`` (None never matches)."""
 
         if verdict is None:
@@ -186,19 +189,26 @@ class CalibrationLibrary:
         return tuple(e for e in self.examples if e.is_teachable())
 
     def labels_covered(self) -> frozenset[CalibrationLabel]:
-        """The distinct labels present (what kinds of judgment are anchored)."""
+        """The distinct labels with at least one *teachable* example.
 
-        return frozenset(e.label for e in self.examples)
+        Only teachable anchors count as coverage: a decoded record that carries
+        a label but no excerpt/reasoning cannot anchor a reviewer, so it must
+        not hide a blind spot (see :meth:`missing_labels`).
+        """
+
+        return frozenset(e.label for e in self.examples if e.is_teachable())
 
     def missing_labels(
         self, required: Iterable[CalibrationLabel]
     ) -> tuple[CalibrationLabel, ...]:
-        """Required labels with no example -- the set's blind spots, in order.
+        """Required labels with no teachable example -- the blind spots, in order.
 
         A calibration set that has no overclaim or voice-drift example cannot
         anchor a reviewer on those failure modes; this reports the gap so
-        curation is driven by coverage, not vibes. Preserves ``required`` order
-        and de-duplicates.
+        curation is driven by coverage, not vibes. Coverage is derived from
+        teachable examples only -- a label represented solely by decoration
+        (no excerpt or no reasoning) is still a gap. Preserves ``required``
+        order and de-duplicates.
         """
 
         covered = self.labels_covered()
@@ -217,6 +227,7 @@ def example_from_exception(
     excerpt: str,
     label: CalibrationLabel = CalibrationLabel.BORDERLINE,
     failure_category: FailureCategory | None = None,
+    suffix: str = "",
 ) -> CalibrationExample:
     """Turn an ``APPROVED_WITH_EXCEPTION`` override into a calibration example.
 
@@ -228,10 +239,19 @@ def example_from_exception(
     stamped ``"override"`` so curated and override-fed anchors stay
     distinguishable. ``verdict`` is fixed to ``APPROVED_WITH_EXCEPTION`` (the
     only decision an :class:`ExceptionRecord` represents).
+
+    The same soft rule is often waived repeatedly (that is what
+    ``should_update_rule`` exists for), and repeats would collide on
+    ``override:{rule}`` -- ``example_id`` is **not** unique across a library
+    unless the caller passes a distinguishing ``suffix`` (an asset id, date,
+    or sequence number), which is appended as ``override:{rule}:{suffix}``.
     """
 
+    example_id = f"override:{record.rule}"
+    if _nonempty(suffix):
+        example_id = f"{example_id}:{suffix}"
     return CalibrationExample(
-        example_id=f"override:{record.rule}",
+        example_id=example_id,
         excerpt=excerpt,
         label=label,
         reasoning=record.reason,

--- a/extracted_content_pipeline/calibration_library.py
+++ b/extracted_content_pipeline/calibration_library.py
@@ -1,0 +1,241 @@
+"""Content-ops review calibration library (operating-model slice 5a).
+
+The deterministic core of the **review calibration library** from
+``docs/content_ops_operating_model.md``: a curated reference set of worked
+review examples (verdict + reasoning + label) that anchors *both* human and
+model reviewers. Without examples, "brand voice" is a seance; this is the
+living anti-drift set every brief is checked against, and overrides
+(``APPROVED_WITH_EXCEPTION``) feed new examples back into it.
+
+Pure value types + pure functions -- no I/O, no Atlas imports, no DB, no LLM.
+The part that *requires* an LLM -- scoring a fresh draft *against* these
+anchors, or generating new example text -- is a later slice. This module only
+stores, classifies, and queries already-curated examples, and converts a
+slice-1 :class:`ExceptionRecord` override into one.
+
+The adversarial pass (slice 5b) and model-disagreement orchestration stay
+parked per the doc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - Python 3.10 CI compatibility
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
+
+from .review_contract import ExceptionRecord, FailureCategory, ReviewDecision
+
+
+class CalibrationLabel(StrEnum):
+    """The teaching label on a calibration example (the doc's example list).
+
+    The polarity of a label (does this example show *good* or *bad* work?) is
+    decided by :data:`_POSITIVE_LABELS` / :data:`_NEGATIVE_LABELS`;
+    ``BORDERLINE`` is deliberately neither -- it is the judgment-call case a
+    reviewer is meant to study, not a clean exemplar.
+    """
+
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    BORDERLINE = "borderline"
+    KNOWN_DEFECT = "known_defect"
+    GOOD_VOICE = "good_voice"
+    VOICE_DRIFT = "voice_drift"
+    OVERCLAIM = "overclaim"
+    WEAK_PERSUASION = "weak_persuasion"
+    STRONG_PERSUASION = "strong_persuasion"
+
+
+# Label polarity as data. A label is positive (a "do this" anchor), negative (a
+# "not this" anchor), or neither (BORDERLINE -- the studied judgment call).
+# frozenset membership is value-based for StrEnum, so a plain decoded string
+# such as "overclaim" classifies the same as CalibrationLabel.OVERCLAIM.
+_POSITIVE_LABELS: frozenset[CalibrationLabel] = frozenset(
+    {
+        CalibrationLabel.APPROVED,
+        CalibrationLabel.GOOD_VOICE,
+        CalibrationLabel.STRONG_PERSUASION,
+    }
+)
+_NEGATIVE_LABELS: frozenset[CalibrationLabel] = frozenset(
+    {
+        CalibrationLabel.REJECTED,
+        CalibrationLabel.KNOWN_DEFECT,
+        CalibrationLabel.VOICE_DRIFT,
+        CalibrationLabel.OVERCLAIM,
+        CalibrationLabel.WEAK_PERSUASION,
+    }
+)
+
+
+def is_positive_label(label: object) -> bool:
+    """True if ``label`` anchors *good* work (compares by value, not identity)."""
+
+    return label in _POSITIVE_LABELS
+
+
+def is_negative_label(label: object) -> bool:
+    """True if ``label`` anchors a *defect* to avoid (compares by value)."""
+
+    return label in _NEGATIVE_LABELS
+
+
+def _nonempty(value: object) -> bool:
+    """True only for a non-empty, non-whitespace ``str`` (None/non-str -> False).
+
+    Mirrors the robustness contract in the sibling slices: these records may be
+    built from decoded/untrusted input, so a ``None`` excerpt or reasoning
+    counts as missing rather than raising on ``.strip()``.
+    """
+
+    return isinstance(value, str) and bool(value.strip())
+
+
+@dataclass(frozen=True)
+class CalibrationExample:
+    """One curated review example: the anchor a reviewer studies.
+
+    ``excerpt`` is the worked copy (or the relevant fragment), ``label`` is its
+    teaching classification, and ``reasoning`` is *why* it earned that label --
+    the part that makes the set anchor judgment instead of just listing verdicts.
+    ``verdict`` and ``failure_category`` are optional cross-links into slice 1's
+    vocabulary; ``source`` records provenance (``"curated"`` vs ``"override"``).
+    """
+
+    example_id: str
+    excerpt: str = ""
+    label: CalibrationLabel = CalibrationLabel.BORDERLINE
+    reasoning: str = ""
+    verdict: ReviewDecision | None = None
+    failure_category: FailureCategory | None = None
+    source: str = "curated"
+
+    def is_positive(self) -> bool:
+        return is_positive_label(self.label)
+
+    def is_negative(self) -> bool:
+        return is_negative_label(self.label)
+
+    def is_teachable(self) -> bool:
+        """True only when the example can actually anchor a reviewer.
+
+        An anchor with no copy to look at, or no reasoning for its label, is
+        decoration -- it teaches nothing. Both ``excerpt`` and ``reasoning``
+        must be present, non-whitespace text.
+        """
+
+        return _nonempty(self.excerpt) and _nonempty(self.reasoning)
+
+
+@dataclass(frozen=True)
+class CalibrationLibrary:
+    """An immutable, queryable set of calibration examples.
+
+    The living reference set queried before every brief. Pure container: every
+    query returns a new tuple in input order and never mutates the set (curation
+    happens by building a new library, per the frozen-record convention).
+    """
+
+    examples: tuple[CalibrationExample, ...] = ()
+
+    def by_label(self, label: CalibrationLabel) -> tuple[CalibrationExample, ...]:
+        """Examples carrying ``label`` (value comparison handles decoded input)."""
+
+        return tuple(e for e in self.examples if e.label == label)
+
+    def by_failure_category(
+        self, category: FailureCategory
+    ) -> tuple[CalibrationExample, ...]:
+        """Examples cross-linked to ``category``.
+
+        ``None``-category examples never match: an example with no recorded
+        failure category is not silently swept into any category's anchor set.
+        """
+
+        if category is None:
+            return ()
+        return tuple(e for e in self.examples if e.failure_category == category)
+
+    def by_verdict(self, verdict: ReviewDecision) -> tuple[CalibrationExample, ...]:
+        """Examples whose recorded verdict equals ``verdict`` (None never matches)."""
+
+        if verdict is None:
+            return ()
+        return tuple(e for e in self.examples if e.verdict == verdict)
+
+    def positives(self) -> tuple[CalibrationExample, ...]:
+        """The "do this" anchors (good-voice / strong-persuasion / approved)."""
+
+        return tuple(e for e in self.examples if e.is_positive())
+
+    def negatives(self) -> tuple[CalibrationExample, ...]:
+        """The "not this" anchors (drift / overclaim / weak / rejected / defect)."""
+
+        return tuple(e for e in self.examples if e.is_negative())
+
+    def teachable(self) -> tuple[CalibrationExample, ...]:
+        """Only the anchors that actually carry copy + reasoning."""
+
+        return tuple(e for e in self.examples if e.is_teachable())
+
+    def labels_covered(self) -> frozenset[CalibrationLabel]:
+        """The distinct labels present (what kinds of judgment are anchored)."""
+
+        return frozenset(e.label for e in self.examples)
+
+    def missing_labels(
+        self, required: Iterable[CalibrationLabel]
+    ) -> tuple[CalibrationLabel, ...]:
+        """Required labels with no example -- the set's blind spots, in order.
+
+        A calibration set that has no overclaim or voice-drift example cannot
+        anchor a reviewer on those failure modes; this reports the gap so
+        curation is driven by coverage, not vibes. Preserves ``required`` order
+        and de-duplicates.
+        """
+
+        covered = self.labels_covered()
+        seen: set[CalibrationLabel] = set()
+        gaps: list[CalibrationLabel] = []
+        for label in required:
+            if label not in covered and label not in seen:
+                seen.add(label)
+                gaps.append(label)
+        return tuple(gaps)
+
+
+def example_from_exception(
+    record: ExceptionRecord,
+    *,
+    excerpt: str,
+    label: CalibrationLabel = CalibrationLabel.BORDERLINE,
+    failure_category: FailureCategory | None = None,
+) -> CalibrationExample:
+    """Turn an ``APPROVED_WITH_EXCEPTION`` override into a calibration example.
+
+    The doc's compounding rule: *overrides feed the calibration set, so the
+    judgment layer itself compounds.* An override is by construction a
+    judgment call -- a piece shipped despite a soft-rule violation -- so it
+    defaults to a ``BORDERLINE`` anchor with the override's own reason as the
+    teaching reasoning, the waived ``rule`` carried into the id, and provenance
+    stamped ``"override"`` so curated and override-fed anchors stay
+    distinguishable. ``verdict`` is fixed to ``APPROVED_WITH_EXCEPTION`` (the
+    only decision an :class:`ExceptionRecord` represents).
+    """
+
+    return CalibrationExample(
+        example_id=f"override:{record.rule}",
+        excerpt=excerpt,
+        label=label,
+        reasoning=record.reason,
+        verdict=ReviewDecision.APPROVED_WITH_EXCEPTION,
+        failure_category=failure_category,
+        source="override",
+    )

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -244,6 +244,9 @@
       "target": "extracted_content_pipeline/content_pr.py"
     },
     {
+      "target": "extracted_content_pipeline/calibration_library.py"
+    },
+    {
       "target": "extracted_content_pipeline/claim_evidence_benchmark.py"
     },
     {

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -247,6 +247,9 @@
       "target": "extracted_content_pipeline/calibration_library.py"
     },
     {
+      "target": "extracted_content_pipeline/adversarial_pass.py"
+    },
+    {
       "target": "extracted_content_pipeline/claim_evidence_benchmark.py"
     },
     {

--- a/plans/PR-Content-Ops-Calibration-Library.md
+++ b/plans/PR-Content-Ops-Calibration-Library.md
@@ -1,0 +1,135 @@
+# PR-Content-Ops-Calibration-Library
+
+## Why this slice exists
+
+Operating-model tracker #1338 lists slice 5 (**calibration library + adversarial
+pass**) as the last unbuilt deterministic core, and #1353/#1435 keep the
+marketer-verify MCP surface deliberately thin and verify-only until the
+reviewer-anchoring pieces exist. `docs/content_ops_operating_model.md` names the
+**review calibration library** as "the missing anti-drift piece": without curated
+worked examples, "brand voice" is a seance, and both human and model reviewers
+have nothing to anchor on. This slice lands the deterministic half of slice 5 --
+the calibration set as a pure typed store -- and defers the adversarial pass to
+5b. It closes the operator's scope nod on #1338 ("land the deterministic core and
+defer the LLM, like slice 3").
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+1. Add `extracted_content_pipeline/calibration_library.py`: the `CalibrationLabel`
+   vocabulary, a frozen `CalibrationExample`, an immutable `CalibrationLibrary`
+   query container, and a converter that turns a slice-1 override into an example.
+2. Register the new module as package-owned in the manifest.
+3. Enroll the new test in the extracted-pipeline CI runner.
+
+### Files touched
+
+- `extracted_content_pipeline/calibration_library.py`
+- `extracted_content_pipeline/manifest.json`
+- `plans/PR-Content-Ops-Calibration-Library.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_content_calibration_library.py`
+
+### Review Contract
+
+Acceptance criteria:
+- The module is pure: no I/O, no Atlas imports, no DB, no LLM (only in-package
+  imports from `review_contract`).
+- Label polarity is data-driven and value-based: a decoded string label
+  classifies the same as the enum member.
+- Queries return new tuples in input order and never mutate the set.
+- `by_failure_category` / `by_verdict` return empty for a `None` argument and
+  never sweep in uncategorized examples.
+- An override (`ExceptionRecord`) converts to a `BORDERLINE`,
+  `APPROVED_WITH_EXCEPTION`, `source="override"` example carrying the override
+  reason, and is then queryable like any curated example.
+- Records tolerate decoded input (`None`/non-str excerpt/reasoning count as
+  missing, never raise).
+
+Affected surfaces: extracted_content_pipeline package only; no host wiring, no
+MCP tool, no route, no DB. The marketer-verify MCP surface is unchanged.
+
+Risk areas: value-vs-identity enum comparison (the recurring slice-1..4 trap);
+None-argument query branches.
+
+Reviewer rules triggered: R1, R2, R10, R14.
+
+## Mechanism
+
+`CalibrationLabel` is a `StrEnum` of the doc's example labels. Two module-level
+frozensets (`_POSITIVE_LABELS`, `_NEGATIVE_LABELS`) encode polarity as data;
+`BORDERLINE` is in neither (the studied judgment call). The `is_positive_label` /
+`is_negative_label` helpers test set membership, which is value-based for
+`StrEnum`, so a plain decoded string classifies identically to the enum member --
+the same robustness contract the sibling slices use.
+
+`CalibrationExample` is a frozen record (id, excerpt, label, reasoning, optional
+verdict + failure_category, provenance source). Its predicate for whether an
+anchor actually teaches requires both excerpt and reasoning to be non-whitespace
+text; `None` counts as missing rather than raising.
+
+`CalibrationLibrary` is a frozen tuple-backed container. Its query helpers filter
+by label, failure category, verdict, and polarity, report the distinct labels
+present, and report required-but-absent labels (the set's blind spots) in order
+and de-duplicated. The `None`-argument branches on the category/verdict queries
+return empty so an uncategorized example is never silently grouped.
+
+`example_from_exception` is the compounding seam: it maps a slice-1
+`ExceptionRecord` (an approve-with-exception override) into a calibration example
+-- defaulting to a `BORDERLINE` anchor, fixing the verdict to
+`APPROVED_WITH_EXCEPTION`, carrying the override reason as the teaching
+reasoning, and stamping provenance `override` -- so the judgment layer compounds
+exactly as the doc's section-5 flywheel prescribes.
+
+## Intentional
+
+- **No host/MCP wiring.** This is the deterministic store; scoring a fresh draft
+  *against* the anchors (the LLM step) and exposing it through the verifier are
+  deferred. Matches the slice-3 precedent (land the data, defer the extractor).
+- **Polarity is a fixed data table, not per-example.** A label's meaning is
+  global; encoding it once keeps curation from drifting example by example.
+  `BORDERLINE` intentionally has no polarity.
+- **The library is immutable; curation builds a new one.** Consistent with the
+  frozen-record convention across slices 1/3/4; avoids a mutable-set aliasing
+  surface in a value module.
+- **`example_from_exception` defaults the label rather than inferring it.** An
+  override is a judgment call, so `BORDERLINE` is the safe default; the caller
+  can pass `OVERCLAIM`/etc. when the override has a known failure shape.
+
+## Deferred
+
+- **Slice 5b -- adversarial pass:** the data model for a second independent
+  review pass + a deterministic disagreement/merge helper between two passes
+  (operating-model section 4). Named in #1338; unlocked by this slice landing.
+- **LLM scoring against anchors:** selecting the nearest anchors for a fresh
+  draft and the model-assisted drift judgment (operating-model stage 3C) -- the
+  step that actually consumes this set. Gated behind the #1435 reliability work.
+- **Host persistence / a curated seed set:** this slice ships the type + queries,
+  not a populated library or a DB table.
+- Parked hardening: none.
+
+## Verification
+
+- Reviewer rules triggered: R1, R2, R10, R14.
+- Passed: python3 -m py_compile of the new module and test -- OK.
+- Passed: pytest of the new slice-5a test file -- 24 passed.
+- Passed: pytest of slice 5a plus sibling slices 1, 3, 4 -- 72 passed, no
+  sibling-slice regression.
+- Passed: python3 scripts/audit_extracted_pipeline_ci_enrollment.py -- OK, 166
+  matching tests are enrolled (includes the new test).
+- Passed: python3 scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas
+  runtime import findings: 0.
+- Passed: bash scripts/check_ascii_python.sh -- ASCII check passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/calibration_library.py` | 241 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `plans/PR-Content-Ops-Calibration-Library.md` | 135 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_content_calibration_library.py` | 248 |
+| **Total** | **628** |

--- a/plans/PR-Content-Ops-Calibration-Library.md
+++ b/plans/PR-Content-Ops-Calibration-Library.md
@@ -167,8 +167,8 @@ only the accountable editor can escalate a model objection to blocking.
 - Reviewer rules triggered: R1, R2, R10, R14.
 - Passed: python3 -m py_compile of both new modules and tests -- OK.
 - Passed: pytest of the slice-5a test file -- 22 passed; slice-5b test file --
-  17 passed.
-- Passed: pytest of slice 5 (both halves) plus sibling slices 1, 3, 4 -- 92
+  18 passed.
+- Passed: pytest of slice 5 (both halves) plus sibling slices 1, 3, 4 -- 93
   passed, no sibling-slice regression.
 - Passed: python3 scripts/audit_extracted_pipeline_ci_enrollment.py -- OK, 167
   matching tests are enrolled (includes both new tests).
@@ -180,11 +180,11 @@ only the accountable editor can escalate a model objection to blocking.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/adversarial_pass.py` | 181 |
+| `extracted_content_pipeline/adversarial_pass.py` | 187 |
 | `extracted_content_pipeline/calibration_library.py` | 261 |
 | `extracted_content_pipeline/manifest.json` | 6 |
 | `plans/PR-Content-Ops-Calibration-Library.md` | 190 |
 | `scripts/run_extracted_pipeline_checks.sh` | 2 |
-| `tests/test_extracted_content_adversarial_pass.py` | 223 |
+| `tests/test_extracted_content_adversarial_pass.py` | 240 |
 | `tests/test_extracted_content_calibration_library.py` | 279 |
-| **Total** | **1142** |
+| **Total** | **1165** |

--- a/plans/PR-Content-Ops-Calibration-Library.md
+++ b/plans/PR-Content-Ops-Calibration-Library.md
@@ -52,8 +52,13 @@ Acceptance criteria:
 - Label polarity is data-driven and value-based: a decoded string label
   classifies the same as the enum member.
 - Queries return new tuples in input order and never mutate the set.
-- `by_failure_category` / `by_verdict` return empty for a `None` argument and
-  never sweep in uncategorized examples.
+- `by_failure_category` / `by_verdict` accept `None` in their signatures,
+  return empty for it, and never sweep in uncategorized examples.
+- Label coverage and blind-spot reporting (`labels_covered` /
+  `missing_labels`) count only teachable examples: a label represented solely
+  by a record with no excerpt/reasoning is still reported as a gap.
+- Repeat overrides of the same rule disambiguate via a caller-supplied
+  `suffix`; the docstring states `example_id` is not unique without one.
 - An override (`ExceptionRecord`) converts to a `BORDERLINE`,
   `APPROVED_WITH_EXCEPTION`, `source="override"` example carrying the override
   reason, and is then queryable like any curated example.
@@ -90,9 +95,12 @@ text; `None` counts as missing rather than raising.
 
 `CalibrationLibrary` is a frozen tuple-backed container. Its query helpers filter
 by label, failure category, verdict, and polarity, report the distinct labels
-present, and report required-but-absent labels (the set's blind spots) in order
-and de-duplicated. The `None`-argument branches on the category/verdict queries
-return empty so an uncategorized example is never silently grouped.
+anchored by teachable examples, and report required-but-uncovered labels (the
+set's blind spots) in order and de-duplicated -- coverage is derived from
+teachable examples only, so a decoration record (label without excerpt or
+reasoning) never hides a gap. The `None`-argument branches on the
+category/verdict queries return empty so an uncategorized example is never
+silently grouped.
 
 `example_from_exception` is the compounding seam: it maps a slice-1
 `ExceptionRecord` (an approve-with-exception override) into a calibration example
@@ -158,9 +166,9 @@ only the accountable editor can escalate a model objection to blocking.
 
 - Reviewer rules triggered: R1, R2, R10, R14.
 - Passed: python3 -m py_compile of both new modules and tests -- OK.
-- Passed: pytest of the slice-5a test file -- 24 passed; slice-5b test file --
+- Passed: pytest of the slice-5a test file -- 22 passed; slice-5b test file --
   17 passed.
-- Passed: pytest of slice 5 (both halves) plus sibling slices 1, 3, 4 -- 89
+- Passed: pytest of slice 5 (both halves) plus sibling slices 1, 3, 4 -- 92
   passed, no sibling-slice regression.
 - Passed: python3 scripts/audit_extracted_pipeline_ci_enrollment.py -- OK, 167
   matching tests are enrolled (includes both new tests).
@@ -173,10 +181,10 @@ only the accountable editor can escalate a model objection to blocking.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/adversarial_pass.py` | 181 |
-| `extracted_content_pipeline/calibration_library.py` | 241 |
+| `extracted_content_pipeline/calibration_library.py` | 261 |
 | `extracted_content_pipeline/manifest.json` | 6 |
-| `plans/PR-Content-Ops-Calibration-Library.md` | 178 |
+| `plans/PR-Content-Ops-Calibration-Library.md` | 190 |
 | `scripts/run_extracted_pipeline_checks.sh` | 2 |
 | `tests/test_extracted_content_adversarial_pass.py` | 223 |
-| `tests/test_extracted_content_calibration_library.py` | 248 |
-| **Total** | **1079** |
+| `tests/test_extracted_content_calibration_library.py` | 279 |
+| **Total** | **1142** |

--- a/plans/PR-Content-Ops-Calibration-Library.md
+++ b/plans/PR-Content-Ops-Calibration-Library.md
@@ -8,10 +8,15 @@ marketer-verify MCP surface deliberately thin and verify-only until the
 reviewer-anchoring pieces exist. `docs/content_ops_operating_model.md` names the
 **review calibration library** as "the missing anti-drift piece": without curated
 worked examples, "brand voice" is a seance, and both human and model reviewers
-have nothing to anchor on. This slice lands the deterministic half of slice 5 --
-the calibration set as a pure typed store -- and defers the adversarial pass to
-5b. It closes the operator's scope nod on #1338 ("land the deterministic core and
-defer the LLM, like slice 3").
+have nothing to anchor on. This slice lands the full deterministic core of
+slice 5 exactly as the tracker row defines it -- the calibration set as a pure
+typed store (5a) plus the adversarial-pass data model and deterministic
+disagreement/merge helpers (5b) -- and defers the LLM steps (anchor scoring,
+finding-producing prompts, disagreement orchestration). It closes the
+operator's scope nod on #1338 ("land the deterministic core and defer the LLM,
+like slice 3"). The diff is over the 400-LOC soft cap because the two halves
+are one tracker row and ~55% of the diff is the detection-coverage test suite
+the AGENTS 3i contract requires; the production modules total ~400 LOC.
 
 ## Scope (this PR)
 
@@ -21,15 +26,22 @@ Slice phase: Vertical slice
 1. Add `extracted_content_pipeline/calibration_library.py`: the `CalibrationLabel`
    vocabulary, a frozen `CalibrationExample`, an immutable `CalibrationLibrary`
    query container, and a converter that turns a slice-1 override into an example.
-2. Register the new module as package-owned in the manifest.
-3. Enroll the new test in the extracted-pipeline CI runner.
+2. Add `extracted_content_pipeline/adversarial_pass.py`: the
+   `AdversarialFindingCategory` vocabulary (the doc's target list), frozen
+   `AdversarialFinding` / `AdversarialPass` records, deterministic
+   corroboration/disagreement/merge helpers between two passes, and a converter
+   that turns a finding into a never-blocking slice-4 review comment.
+3. Register both new modules as package-owned in the manifest.
+4. Enroll both new tests in the extracted-pipeline CI runner.
 
 ### Files touched
 
+- `extracted_content_pipeline/adversarial_pass.py`
 - `extracted_content_pipeline/calibration_library.py`
 - `extracted_content_pipeline/manifest.json`
 - `plans/PR-Content-Ops-Calibration-Library.md`
 - `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_content_adversarial_pass.py`
 - `tests/test_extracted_content_calibration_library.py`
 
 ### Review Contract
@@ -47,6 +59,12 @@ Acceptance criteria:
   reason, and is then queryable like any curated example.
 - Records tolerate decoded input (`None`/non-str excerpt/reasoning count as
   missing, never raise).
+- An adversarial finding converts to a review comment that is **never
+  blocking** (the "still not a judge" invariant), with the finding category
+  carried in the message prefix.
+- Corroboration is the category intersection of two passes; disagreement is the
+  symmetric difference; merge de-duplicates only exact duplicates and preserves
+  first-then-second order.
 
 Affected surfaces: extracted_content_pipeline package only; no host wiring, no
 MCP tool, no route, no DB. The marketer-verify MCP surface is unchanged.
@@ -83,6 +101,20 @@ return empty so an uncategorized example is never silently grouped.
 reasoning, and stamping provenance `override` -- so the judgment layer compounds
 exactly as the doc's section-5 flywheel prescribes.
 
+The adversarial-pass module (5b) models the doc's second independent pass.
+`AdversarialFindingCategory` is the doc's target list (overclaim, ambiguity,
+reader objection, promise/CTA mismatch, generic stretch, missing proof, voice
+slip). `AdversarialFinding` is substantiated only when it carries both an
+objection and quoted evidence -- the filter that keeps a chatty pass from
+flooding review. `AdversarialPass` records the prompt/model identity so two
+passes are distinguishable. The deterministic helpers compute the corroborated
+categories (set intersection -- the strongest signal), the disagreement surface
+(symmetric difference -- the *data* for the parked orchestration), and an
+exact-duplicate-only merge. `comment_from_finding` is where "still not a judge"
+is enforced: every finding becomes a `blocking=False` review comment (voice
+slips route to the brand-rule lane, everything else to editorial judgment), so
+only the accountable editor can escalate a model objection to blocking.
+
 ## Intentional
 
 - **No host/MCP wiring.** This is the deterministic store; scoring a fresh draft
@@ -97,28 +129,41 @@ exactly as the doc's section-5 flywheel prescribes.
 - **`example_from_exception` defaults the label rather than inferring it.** An
   override is a judgment call, so `BORDERLINE` is the safe default; the caller
   can pass `OVERCLAIM`/etc. when the override has a known failure shape.
+- **`comment_from_finding` cannot produce a blocking comment.** The doc is
+  explicit that the adversarial pass is not a judge; hard-coding
+  `blocking=False` at the seam makes the invariant unbypassable rather than
+  conventional.
+- **Merge collapses only exact duplicates.** Two differently-worded objections
+  in the same category are both kept; deciding they are "the same" is a
+  judgment call this module refuses to make.
+- **Disagreement is computed, not acted on.** Routing an A-pass/B-fail split to
+  a human and logging the override is the parked orchestration (operating-model
+  section 4); this slice ships only the deterministic data it would consume.
 
 ## Deferred
 
-- **Slice 5b -- adversarial pass:** the data model for a second independent
-  review pass + a deterministic disagreement/merge helper between two passes
-  (operating-model section 4). Named in #1338; unlocked by this slice landing.
 - **LLM scoring against anchors:** selecting the nearest anchors for a fresh
   draft and the model-assisted drift judgment (operating-model stage 3C) -- the
-  step that actually consumes this set. Gated behind the #1435 reliability work.
-- **Host persistence / a curated seed set:** this slice ships the type + queries,
-  not a populated library or a DB table.
+  step that actually consumes the calibration set. Gated behind the #1435
+  reliability work.
+- **Finding-producing prompts:** the adversarial prompts/models that emit
+  `AdversarialFinding` rows are the LLM step, same deferral as above.
+- **Model-disagreement orchestration:** parked per the doc until slices 1-5
+  prove out.
+- **Host persistence / a curated seed set:** this slice ships the types +
+  queries, not a populated library or a DB table.
 - Parked hardening: none.
 
 ## Verification
 
 - Reviewer rules triggered: R1, R2, R10, R14.
-- Passed: python3 -m py_compile of the new module and test -- OK.
-- Passed: pytest of the new slice-5a test file -- 24 passed.
-- Passed: pytest of slice 5a plus sibling slices 1, 3, 4 -- 72 passed, no
-  sibling-slice regression.
-- Passed: python3 scripts/audit_extracted_pipeline_ci_enrollment.py -- OK, 166
-  matching tests are enrolled (includes the new test).
+- Passed: python3 -m py_compile of both new modules and tests -- OK.
+- Passed: pytest of the slice-5a test file -- 24 passed; slice-5b test file --
+  17 passed.
+- Passed: pytest of slice 5 (both halves) plus sibling slices 1, 3, 4 -- 89
+  passed, no sibling-slice regression.
+- Passed: python3 scripts/audit_extracted_pipeline_ci_enrollment.py -- OK, 167
+  matching tests are enrolled (includes both new tests).
 - Passed: python3 scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas
   runtime import findings: 0.
 - Passed: bash scripts/check_ascii_python.sh -- ASCII check passed.
@@ -127,9 +172,11 @@ exactly as the doc's section-5 flywheel prescribes.
 
 | File | LOC |
 |---|---:|
+| `extracted_content_pipeline/adversarial_pass.py` | 181 |
 | `extracted_content_pipeline/calibration_library.py` | 241 |
-| `extracted_content_pipeline/manifest.json` | 3 |
-| `plans/PR-Content-Ops-Calibration-Library.md` | 135 |
-| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `extracted_content_pipeline/manifest.json` | 6 |
+| `plans/PR-Content-Ops-Calibration-Library.md` | 178 |
+| `scripts/run_extracted_pipeline_checks.sh` | 2 |
+| `tests/test_extracted_content_adversarial_pass.py` | 223 |
 | `tests/test_extracted_content_calibration_library.py` | 248 |
-| **Total** | **628** |
+| **Total** | **1079** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -20,6 +20,7 @@ pytest \
   tests/test_extracted_content_triage_experiment.py \
   tests/test_extracted_content_claims_map.py \
   tests/test_extracted_content_pr.py \
+  tests/test_extracted_content_calibration_library.py \
   tests/test_extracted_content_claim_evidence_benchmark.py \
   tests/test_validate_content_ops_claim_evidence_fixture.py \
   tests/test_extracted_content_coverage_rows.py \

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -21,6 +21,7 @@ pytest \
   tests/test_extracted_content_claims_map.py \
   tests/test_extracted_content_pr.py \
   tests/test_extracted_content_calibration_library.py \
+  tests/test_extracted_content_adversarial_pass.py \
   tests/test_extracted_content_claim_evidence_benchmark.py \
   tests/test_validate_content_ops_claim_evidence_fixture.py \
   tests/test_extracted_content_coverage_rows.py \

--- a/tests/test_extracted_content_adversarial_pass.py
+++ b/tests/test_extracted_content_adversarial_pass.py
@@ -1,0 +1,223 @@
+"""Unit tests for slice 5b: the adversarial review pass.
+
+Pure value types + deterministic merge helpers; no DB, no async, no Atlas
+imports, no LLM. Composes slice 4 (ReviewComment / CommentCategory).
+"""
+
+from __future__ import annotations
+
+from extracted_content_pipeline.adversarial_pass import (
+    AdversarialFinding,
+    AdversarialFindingCategory,
+    AdversarialPass,
+    comment_from_finding,
+    corroborated_categories,
+    disagreement_categories,
+    merge_findings,
+)
+from extracted_content_pipeline.content_pr import CommentCategory
+
+
+def _finding(
+    category: AdversarialFindingCategory,
+    *,
+    message: str = "the strongest reason this should not ship",
+    evidence: str = "quoted draft text",
+    location: str = "para 2",
+) -> AdversarialFinding:
+    return AdversarialFinding(
+        category=category, message=message, evidence=evidence, location=location
+    )
+
+
+# -- AdversarialFinding -------------------------------------------------------
+
+
+def test_finding_is_substantiated_requires_message_and_evidence() -> None:
+    assert _finding(AdversarialFindingCategory.OVERCLAIM).is_substantiated() is True
+    assert (
+        _finding(AdversarialFindingCategory.OVERCLAIM, message="  ").is_substantiated()
+        is False
+    )
+    assert (
+        _finding(AdversarialFindingCategory.OVERCLAIM, evidence="").is_substantiated()
+        is False
+    )
+
+
+def test_finding_is_substantiated_tolerates_decoded_none() -> None:
+    # message/evidence may arrive as JSON null; missing, not a raise.
+    decoded = AdversarialFinding(
+        category=AdversarialFindingCategory.AMBIGUITY,
+        message=None,  # type: ignore[arg-type]
+        evidence=None,  # type: ignore[arg-type]
+    )
+    assert decoded.is_substantiated() is False
+
+
+# -- AdversarialPass ----------------------------------------------------------
+
+
+def _pass_a() -> AdversarialPass:
+    return AdversarialPass(
+        pass_id="a",
+        source="adversarial-prompt@v1 / model-a",
+        findings=(
+            _finding(AdversarialFindingCategory.OVERCLAIM),
+            _finding(AdversarialFindingCategory.MISSING_PROOF),
+            _finding(AdversarialFindingCategory.AMBIGUITY, evidence=""),  # noise
+        ),
+    )
+
+
+def _pass_b() -> AdversarialPass:
+    return AdversarialPass(
+        pass_id="b",
+        source="adversarial-prompt@v2 / model-b",
+        findings=(
+            _finding(
+                AdversarialFindingCategory.OVERCLAIM,
+                message="differently worded overclaim objection",
+            ),
+            _finding(AdversarialFindingCategory.VOICE_SLIP),
+        ),
+    )
+
+
+def test_pass_categories_are_distinct() -> None:
+    assert _pass_a().categories() == frozenset(
+        {
+            AdversarialFindingCategory.OVERCLAIM,
+            AdversarialFindingCategory.MISSING_PROOF,
+            AdversarialFindingCategory.AMBIGUITY,
+        }
+    )
+
+
+def test_pass_substantiated_filters_noise_in_order() -> None:
+    kept = _pass_a().substantiated()
+    assert tuple(f.category for f in kept) == (
+        AdversarialFindingCategory.OVERCLAIM,
+        AdversarialFindingCategory.MISSING_PROOF,
+    )
+
+
+def test_empty_pass_has_no_categories_or_findings() -> None:
+    empty = AdversarialPass(pass_id="e")
+    assert empty.categories() == frozenset()
+    assert empty.substantiated() == ()
+
+
+# -- corroboration / disagreement ---------------------------------------------
+
+
+def test_corroborated_categories_is_the_intersection() -> None:
+    assert corroborated_categories(_pass_a(), _pass_b()) == frozenset(
+        {AdversarialFindingCategory.OVERCLAIM}
+    )
+
+
+def test_disagreement_categories_is_the_symmetric_difference() -> None:
+    assert disagreement_categories(_pass_a(), _pass_b()) == frozenset(
+        {
+            AdversarialFindingCategory.MISSING_PROOF,
+            AdversarialFindingCategory.AMBIGUITY,
+            AdversarialFindingCategory.VOICE_SLIP,
+        }
+    )
+
+
+def test_identical_passes_have_no_disagreement() -> None:
+    assert disagreement_categories(_pass_a(), _pass_a()) == frozenset()
+
+
+def test_corroboration_matches_decoded_string_category() -> None:
+    # One pass decoded its category as a plain string; still corroborates.
+    decoded = AdversarialPass(
+        pass_id="d",
+        findings=(
+            AdversarialFinding(
+                category="overclaim",  # type: ignore[arg-type]
+                message="m",
+                evidence="e",
+            ),
+        ),
+    )
+    assert corroborated_categories(decoded, _pass_b()) == frozenset(
+        {AdversarialFindingCategory.OVERCLAIM}
+    )
+
+
+# -- merge_findings -----------------------------------------------------------
+
+
+def test_merge_preserves_first_then_second_order() -> None:
+    merged = merge_findings(_pass_a(), _pass_b())
+    assert tuple(f.category for f in merged) == (
+        AdversarialFindingCategory.OVERCLAIM,
+        AdversarialFindingCategory.MISSING_PROOF,
+        AdversarialFindingCategory.AMBIGUITY,
+        AdversarialFindingCategory.OVERCLAIM,  # differently worded -> kept
+        AdversarialFindingCategory.VOICE_SLIP,
+    )
+
+
+def test_merge_drops_only_exact_duplicates() -> None:
+    shared = _finding(AdversarialFindingCategory.GENERIC_STRETCH)
+    first = AdversarialPass(pass_id="a", findings=(shared,))
+    second = AdversarialPass(
+        pass_id="b",
+        findings=(
+            shared,  # exact duplicate -> merged away
+            _finding(
+                AdversarialFindingCategory.GENERIC_STRETCH,
+                message="same category, different objection",
+            ),
+        ),
+    )
+    merged = merge_findings(first, second)
+    assert len(merged) == 2
+    assert merged[0] == shared
+
+
+def test_merge_of_empty_passes_is_empty() -> None:
+    assert merge_findings(AdversarialPass(pass_id="a"), AdversarialPass(pass_id="b")) == ()
+
+
+# -- comment_from_finding (the "not a judge" seam) ------------------------------
+
+
+def test_comment_is_never_blocking() -> None:
+    for category in AdversarialFindingCategory:
+        comment = comment_from_finding(_finding(category))
+        assert comment.blocking is False
+
+
+def test_voice_slip_maps_to_brand_rule_lane() -> None:
+    comment = comment_from_finding(_finding(AdversarialFindingCategory.VOICE_SLIP))
+    assert comment.category == CommentCategory.BRAND_RULE
+
+
+def test_other_findings_map_to_editorial_judgment_lane() -> None:
+    comment = comment_from_finding(_finding(AdversarialFindingCategory.OVERCLAIM))
+    assert comment.category == CommentCategory.EDITORIAL_JUDGMENT
+
+
+def test_comment_carries_category_prefix_message_and_evidence() -> None:
+    finding = _finding(
+        AdversarialFindingCategory.MISSING_PROOF,
+        message="cites no source for the 40% number",
+        evidence="cuts support tickets by 40%",
+    )
+    comment = comment_from_finding(finding)
+    assert comment.message == "[adversarial:missing_proof] cites no source for the 40% number"
+    assert comment.evidence == "cuts support tickets by 40%"
+
+
+def test_comment_from_unsubstantiated_finding_still_never_blocks() -> None:
+    # Even an empty-message finding converts safely (prefix only, no raise).
+    comment = comment_from_finding(
+        AdversarialFinding(category=AdversarialFindingCategory.AMBIGUITY)
+    )
+    assert comment.message == "[adversarial:ambiguity]"
+    assert comment.blocking is False

--- a/tests/test_extracted_content_adversarial_pass.py
+++ b/tests/test_extracted_content_adversarial_pass.py
@@ -221,3 +221,20 @@ def test_comment_from_unsubstantiated_finding_still_never_blocks() -> None:
     )
     assert comment.message == "[adversarial:ambiguity]"
     assert comment.blocking is False
+
+
+def test_comment_from_decoded_none_does_not_leak_none_text() -> None:
+    # A finding decoded from model JSON may carry null message/evidence; the
+    # literal string "None" must never appear in editor-facing comment text
+    # (reviewer NIT on #1487).
+    comment = comment_from_finding(
+        AdversarialFinding(
+            category=AdversarialFindingCategory.READER_OBJECTION,
+            message=None,  # type: ignore[arg-type]
+            evidence=None,  # type: ignore[arg-type]
+        )
+    )
+    assert comment.message == "[adversarial:reader_objection]"
+    assert "None" not in comment.message
+    assert comment.evidence == ""
+    assert comment.blocking is False

--- a/tests/test_extracted_content_calibration_library.py
+++ b/tests/test_extracted_content_calibration_library.py
@@ -1,0 +1,248 @@
+"""Unit tests for slice 5a: the review calibration library.
+
+Pure value types + query helpers; no DB, no async, no Atlas imports, no LLM.
+Composes slice 1 (ReviewDecision, FailureCategory, ExceptionRecord).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from extracted_content_pipeline.calibration_library import (
+    CalibrationExample,
+    CalibrationLabel,
+    CalibrationLibrary,
+    example_from_exception,
+    is_negative_label,
+    is_positive_label,
+)
+from extracted_content_pipeline.review_contract import (
+    ExceptionRecord,
+    FailureCategory,
+    ReviewDecision,
+)
+
+
+def _ex(
+    example_id: str,
+    label: CalibrationLabel,
+    *,
+    excerpt: str = "some worked copy",
+    reasoning: str = "why it earned the label",
+    verdict: ReviewDecision | None = None,
+    failure_category: FailureCategory | None = None,
+) -> CalibrationExample:
+    return CalibrationExample(
+        example_id=example_id,
+        excerpt=excerpt,
+        label=label,
+        reasoning=reasoning,
+        verdict=verdict,
+        failure_category=failure_category,
+    )
+
+
+# -- label polarity ----------------------------------------------------------
+
+
+def test_positive_labels_are_the_do_this_anchors() -> None:
+    assert is_positive_label(CalibrationLabel.APPROVED) is True
+    assert is_positive_label(CalibrationLabel.GOOD_VOICE) is True
+    assert is_positive_label(CalibrationLabel.STRONG_PERSUASION) is True
+    assert is_positive_label(CalibrationLabel.OVERCLAIM) is False
+
+
+def test_negative_labels_are_the_not_this_anchors() -> None:
+    for label in (
+        CalibrationLabel.REJECTED,
+        CalibrationLabel.KNOWN_DEFECT,
+        CalibrationLabel.VOICE_DRIFT,
+        CalibrationLabel.OVERCLAIM,
+        CalibrationLabel.WEAK_PERSUASION,
+    ):
+        assert is_negative_label(label) is True
+    assert is_negative_label(CalibrationLabel.APPROVED) is False
+
+
+def test_borderline_is_neither_positive_nor_negative() -> None:
+    assert is_positive_label(CalibrationLabel.BORDERLINE) is False
+    assert is_negative_label(CalibrationLabel.BORDERLINE) is False
+
+
+def test_label_polarity_classifies_decoded_string() -> None:
+    # A label arriving as a plain string (decoded JSON) classifies by value.
+    assert is_positive_label("approved") is True
+    assert is_negative_label("overclaim") is True
+    assert is_positive_label("overclaim") is False
+
+
+# -- CalibrationExample ------------------------------------------------------
+
+
+def test_example_polarity_delegates_to_label() -> None:
+    assert _ex("e1", CalibrationLabel.GOOD_VOICE).is_positive() is True
+    assert _ex("e2", CalibrationLabel.VOICE_DRIFT).is_negative() is True
+
+
+def test_example_is_teachable_requires_excerpt_and_reasoning() -> None:
+    assert _ex("e1", CalibrationLabel.APPROVED).is_teachable() is True
+    assert _ex("e2", CalibrationLabel.APPROVED, excerpt="   ").is_teachable() is False
+    assert _ex("e3", CalibrationLabel.APPROVED, reasoning="").is_teachable() is False
+
+
+def test_example_is_teachable_tolerates_decoded_none() -> None:
+    # excerpt/reasoning may arrive as JSON null; that counts as missing, not a raise.
+    decoded = CalibrationExample(
+        example_id="e1",
+        excerpt=None,  # type: ignore[arg-type]
+        label=CalibrationLabel.OVERCLAIM,
+        reasoning=None,  # type: ignore[arg-type]
+    )
+    assert decoded.is_teachable() is False
+
+
+# -- CalibrationLibrary queries ----------------------------------------------
+
+
+def _library() -> CalibrationLibrary:
+    return CalibrationLibrary(
+        examples=(
+            _ex("p1", CalibrationLabel.GOOD_VOICE, verdict=ReviewDecision.APPROVED),
+            _ex(
+                "n1",
+                CalibrationLabel.OVERCLAIM,
+                verdict=ReviewDecision.REVISION_REQUIRED,
+                failure_category=FailureCategory.CLAIM_CREDIBILITY_GAP,
+            ),
+            _ex(
+                "n2",
+                CalibrationLabel.WEAK_PERSUASION,
+                failure_category=FailureCategory.WEAK_HOOK,
+            ),
+            _ex("b1", CalibrationLabel.BORDERLINE),
+        )
+    )
+
+
+def test_by_label_returns_only_matching_in_order() -> None:
+    lib = _library()
+    assert tuple(e.example_id for e in lib.by_label(CalibrationLabel.OVERCLAIM)) == ("n1",)
+    assert lib.by_label(CalibrationLabel.REJECTED) == ()
+
+
+def test_by_label_matches_decoded_string_label() -> None:
+    # A stored label decoded as a plain string still matches the enum query.
+    lib = CalibrationLibrary(
+        examples=(
+            CalibrationExample(
+                example_id="d1",
+                excerpt="copy",
+                label="overclaim",  # type: ignore[arg-type]
+                reasoning="r",
+            ),
+        )
+    )
+    assert tuple(e.example_id for e in lib.by_label(CalibrationLabel.OVERCLAIM)) == ("d1",)
+
+
+def test_positives_and_negatives_split_the_set() -> None:
+    lib = _library()
+    assert tuple(e.example_id for e in lib.positives()) == ("p1",)
+    assert tuple(e.example_id for e in lib.negatives()) == ("n1", "n2")
+
+
+def test_by_failure_category_filters_and_ignores_uncategorized() -> None:
+    lib = _library()
+    assert tuple(e.example_id for e in lib.by_failure_category(FailureCategory.WEAK_HOOK)) == (
+        "n2",
+    )
+    # The positive and borderline examples have no category -> never swept in.
+    assert lib.by_failure_category(FailureCategory.TIMING) == ()
+
+
+def test_by_failure_category_none_returns_empty() -> None:
+    # Detection branch: a None query must not match the uncategorized examples.
+    assert _library().by_failure_category(None) == ()  # type: ignore[arg-type]
+
+
+def test_by_verdict_filters_and_none_returns_empty() -> None:
+    lib = _library()
+    assert tuple(e.example_id for e in lib.by_verdict(ReviewDecision.APPROVED)) == ("p1",)
+    assert lib.by_verdict(None) == ()  # type: ignore[arg-type]
+
+
+def test_teachable_drops_decoration() -> None:
+    lib = CalibrationLibrary(
+        examples=(
+            _ex("ok", CalibrationLabel.APPROVED),
+            _ex("blank", CalibrationLabel.APPROVED, reasoning=""),
+        )
+    )
+    assert tuple(e.example_id for e in lib.teachable()) == ("ok",)
+
+
+def test_labels_covered_reports_distinct_labels() -> None:
+    assert _library().labels_covered() == frozenset(
+        {
+            CalibrationLabel.GOOD_VOICE,
+            CalibrationLabel.OVERCLAIM,
+            CalibrationLabel.WEAK_PERSUASION,
+            CalibrationLabel.BORDERLINE,
+        }
+    )
+
+
+def test_missing_labels_reports_gaps_in_order_deduped() -> None:
+    lib = _library()
+    required = (
+        CalibrationLabel.GOOD_VOICE,  # covered
+        CalibrationLabel.VOICE_DRIFT,  # gap
+        CalibrationLabel.REJECTED,  # gap
+        CalibrationLabel.VOICE_DRIFT,  # duplicate gap -> deduped
+    )
+    assert lib.missing_labels(required) == (
+        CalibrationLabel.VOICE_DRIFT,
+        CalibrationLabel.REJECTED,
+    )
+
+
+def test_empty_library_is_all_gaps() -> None:
+    lib = CalibrationLibrary()
+    assert lib.positives() == ()
+    assert lib.labels_covered() == frozenset()
+    assert lib.missing_labels((CalibrationLabel.APPROVED,)) == (CalibrationLabel.APPROVED,)
+
+
+# -- overrides feed the set (example_from_exception) --------------------------
+
+
+def test_example_from_exception_defaults_to_borderline_override_anchor() -> None:
+    record = ExceptionRecord(
+        rule="brand_voice.no_superlatives",
+        reason="founder quote keeps the superlative; on-brand exception",
+        owner="editor@example.com",
+        expiration=date(2026, 12, 31),
+    )
+    example = example_from_exception(record, excerpt="the best onboarding, period.")
+    assert example.example_id == "override:brand_voice.no_superlatives"
+    assert example.label == CalibrationLabel.BORDERLINE
+    assert example.verdict == ReviewDecision.APPROVED_WITH_EXCEPTION
+    assert example.reasoning == record.reason
+    assert example.source == "override"
+    assert example.is_teachable() is True
+
+
+def test_example_from_exception_honors_explicit_label_and_category() -> None:
+    record = ExceptionRecord(rule="claim.tos_uptime", reason="legacy SLA still cited", owner="x")
+    example = example_from_exception(
+        record,
+        excerpt="99.99% uptime guaranteed",
+        label=CalibrationLabel.OVERCLAIM,
+        failure_category=FailureCategory.CLAIM_CREDIBILITY_GAP,
+    )
+    assert example.label == CalibrationLabel.OVERCLAIM
+    assert example.failure_category == FailureCategory.CLAIM_CREDIBILITY_GAP
+    assert example.is_negative() is True
+    # An override-fed negative example is queryable like any curated one.
+    lib = CalibrationLibrary(examples=(example,))
+    assert lib.by_failure_category(FailureCategory.CLAIM_CREDIBILITY_GAP) == (example,)

--- a/tests/test_extracted_content_calibration_library.py
+++ b/tests/test_extracted_content_calibration_library.py
@@ -162,13 +162,13 @@ def test_by_failure_category_filters_and_ignores_uncategorized() -> None:
 
 def test_by_failure_category_none_returns_empty() -> None:
     # Detection branch: a None query must not match the uncategorized examples.
-    assert _library().by_failure_category(None) == ()  # type: ignore[arg-type]
+    assert _library().by_failure_category(None) == ()
 
 
 def test_by_verdict_filters_and_none_returns_empty() -> None:
     lib = _library()
     assert tuple(e.example_id for e in lib.by_verdict(ReviewDecision.APPROVED)) == ("p1",)
-    assert lib.by_verdict(None) == ()  # type: ignore[arg-type]
+    assert lib.by_verdict(None) == ()
 
 
 def test_teachable_drops_decoration() -> None:
@@ -213,6 +213,21 @@ def test_empty_library_is_all_gaps() -> None:
     assert lib.missing_labels((CalibrationLabel.APPROVED,)) == (CalibrationLabel.APPROVED,)
 
 
+def test_unteachable_example_does_not_count_as_label_coverage() -> None:
+    # A decoded record carrying a label but no excerpt/reasoning cannot anchor
+    # a reviewer, so it must not hide the blind spot (Codex finding on #1487).
+    lib = CalibrationLibrary(
+        examples=(
+            _ex("ok", CalibrationLabel.GOOD_VOICE),
+            _ex("decoration", CalibrationLabel.OVERCLAIM, excerpt="", reasoning=""),
+        )
+    )
+    assert lib.labels_covered() == frozenset({CalibrationLabel.GOOD_VOICE})
+    assert lib.missing_labels(
+        (CalibrationLabel.GOOD_VOICE, CalibrationLabel.OVERCLAIM)
+    ) == (CalibrationLabel.OVERCLAIM,)
+
+
 # -- overrides feed the set (example_from_exception) --------------------------
 
 
@@ -246,3 +261,19 @@ def test_example_from_exception_honors_explicit_label_and_category() -> None:
     # An override-fed negative example is queryable like any curated one.
     lib = CalibrationLibrary(examples=(example,))
     assert lib.by_failure_category(FailureCategory.CLAIM_CREDIBILITY_GAP) == (example,)
+
+
+def test_example_from_exception_suffix_disambiguates_repeat_overrides() -> None:
+    # The same soft rule waived twice must not collide on one id (reviewer
+    # MAJOR on #1487): a caller-supplied suffix keeps repeats distinct.
+    record = ExceptionRecord(rule="brand_voice.no_superlatives", reason="r", owner="o")
+    first = example_from_exception(record, excerpt="copy a", suffix="asset-101")
+    second = example_from_exception(record, excerpt="copy b", suffix="asset-202")
+    assert first.example_id == "override:brand_voice.no_superlatives:asset-101"
+    assert second.example_id == "override:brand_voice.no_superlatives:asset-202"
+    assert first.example_id != second.example_id
+
+
+def test_example_from_exception_blank_suffix_keeps_bare_id() -> None:
+    record = ExceptionRecord(rule="r1", reason="r", owner="o")
+    assert example_from_exception(record, excerpt="c", suffix="  ").example_id == "override:r1"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Calibration-Library.md
Slice phase: Vertical slice

Lands the full deterministic core of operating-model slice 5 (#1338) exactly as
the tracker row defines it: the review calibration library (5a) -- a pure typed
store of curated review examples that anchors human and model reviewers, with
approve-with-exception overrides feeding back into it -- plus the adversarial
pass (5b) -- the data model for a second independent review pass and the
deterministic corroboration/disagreement/merge helpers between two passes. Pure
value modules -- no I/O, no Atlas imports, no DB, no LLM. No host/MCP wiring;
the marketer-verify MCP surface (#1353) is unchanged. Over the 400-LOC soft cap
because the two halves are one tracker row and over half the diff is the
detection-coverage test suite; production modules total ~400 LOC (justified in
the plan).

## Intentional
- Pure value modules; only in-package imports (review_contract, content_pr).
- Label polarity is a fixed value-based data table; BORDERLINE has no polarity
  (it is the studied judgment-call case, not a clean exemplar).
- Label coverage / blind-spot reporting counts only teachable examples, so a
  decoded record carrying a label without excerpt/reasoning never hides a gap.
- The library is immutable; curation builds a new one (frozen-record convention).
- example_from_exception defaults to a BORDERLINE override anchor, fixes the
  verdict to APPROVED_WITH_EXCEPTION, and takes a caller suffix to keep repeat
  overrides of the same rule distinct.
- comment_from_finding cannot produce a blocking comment: the doc's "still not
  a judge" invariant is hard-coded at the seam, so only the accountable editor
  escalates a model objection to blocking.
- merge_findings collapses only exact duplicates; deciding two differently
  worded same-category objections are "the same" is a judgment call the module
  refuses to make.
- Disagreement is computed, not acted on: route-to-human orchestration stays
  parked per the operating-model doc.

## Deferred
- LLM scoring of a fresh draft against the calibration anchors (stage 3C),
  gated behind the #1435 reliability work.
- The adversarial prompts/models that produce AdversarialFinding rows (the LLM
  step, same deferral).
- Model-disagreement orchestration (parked per the doc until slices 1-5 prove
  out).
- Host persistence / a curated seed set: this ships the types + queries only.

## Parked hardening
- None.

## AI reconciliation
- [chatgpt-codex-connector] extracted_content_pipeline/calibration_library.py:204
  "Use teachable examples when reporting label coverage" - FIXED: labels_covered
  and missing_labels now derive coverage from teachable examples only; a label
  represented solely by a no-excerpt/no-reasoning record is reported as a gap.
  Negative fixture added (test_unteachable_example_does_not_count_as_label_coverage).
- [copilot-pull-request-reviewer] extracted_content_pipeline/calibration_library.py:155
  "by_failure_category should be typed optional" - FIXED: parameter annotated
  FailureCategory | None; the type: ignore in the None-branch test is dropped.
- [copilot-pull-request-reviewer] extracted_content_pipeline/calibration_library.py:166
  "by_verdict should accept None in its signature" - FIXED: parameter annotated
  ReviewDecision | None; the type: ignore in the None-branch test is dropped.
- [copilot-pull-request-reviewer] plans/PR-Content-Ops-Calibration-Library.md
  "Why section must justify the >400 LOC overage" - FIXED (outdated thread):
  the Why section now ties the overage to the single tracker row and the
  detection-coverage test contract, and the plan/body diff-size summaries match.
- [reviewer MAJOR] extracted_content_pipeline/calibration_library.py:234
  "example_id collides for repeat overrides of the same rule" - FIXED:
  example_from_exception takes a caller-supplied suffix appended as
  override:{rule}:{suffix}, and the docstring states the id is not unique
  without one. Disambiguation + blank-suffix fixtures added.
- [reviewer NIT] extracted_content_pipeline/calibration_library.py:166
  "annotations contradict the documented None contract" - FIXED with the two
  Copilot findings above.
- [reviewer NIT] extracted_content_pipeline/adversarial_pass.py:175 "harden the
  3.10 StrEnum shim" - FIXED: the fallback shim now sets __str__ = str.__str__
  (matching CPython's real StrEnum) so the [adversarial:...] prefix formats
  identically on both interpreter paths under str()/format()/f-strings.
- [reviewer NIT] extracted_content_pipeline/adversarial_pass.py:175 "decoded None
  message leaks the literal string None into the comment" - FIXED:
  comment_from_finding now uses the module's _nonempty guard for message and
  evidence; a null message yields the bare prefix and null evidence yields "".
  Negative fixture added (test_comment_from_decoded_none_does_not_leak_none_text).
- [reviewer NIT, both passes] "verification counts don't reproduce" - FIXED:
  counts re-measured at head on every push (now 22 calibration + 18
  adversarial, 93 with siblings).

All findings fixed or waived: yes.

## Verification
- Reviewer rules triggered: R1, R2, R10, R14.
- pytest slice 5 (both halves) + sibling slices 1/3/4 -- 93 passed (22
  calibration + 18 adversarial new; no sibling regression).
- python3 scripts/audit_extracted_pipeline_ci_enrollment.py -- OK, 167 enrolled.
- python3 scripts/audit_extracted_standalone.py --fail-on-debt -- 0 findings.
- bash scripts/check_ascii_python.sh -- passed.

## Diff size
7 files, ~410 LOC production modules + ~480 LOC tests (over the soft cap;
justified in the plan -- one tracker row, test-heavy by the detection-coverage
contract).

https://claude.ai/code/session_01Ud6BQdNvpRNXH9KwAkjGE2