### PR TITLE
Content-Ops: claim-registry admin write surface

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -10,6 +10,9 @@ on:
       - "atlas_brain/_content_ops_calibration_library.py"
       - "atlas_brain/api/content_ops_calibration_library.py"
       - "atlas_brain/storage/migrations/335_content_ops_calibration_library.sql"
+      - "atlas_brain/_content_ops_claim_registry.py"
+      - "atlas_brain/api/content_ops_claim_registry.py"
+      - "atlas_brain/storage/migrations/334_content_ops_claim_registry.sql"
       - "extracted_content_pipeline/campaign_ports.py"
       - "extracted_content_pipeline/claims_map.py"
       - "extracted_content_pipeline/content_pr.py"
@@ -23,6 +26,7 @@ on:
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_content_ops_calibration_library.py"
       - "tests/test_content_ops_calibration_library_api.py"
+      - "tests/test_content_ops_claim_registry_api.py"
       - "tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py"
       - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
       - "tests/test_check_content_ops_marketer_verify_dual_client_rollout.py"
@@ -40,6 +44,9 @@ on:
       - "atlas_brain/_content_ops_calibration_library.py"
       - "atlas_brain/api/content_ops_calibration_library.py"
       - "atlas_brain/storage/migrations/335_content_ops_calibration_library.sql"
+      - "atlas_brain/_content_ops_claim_registry.py"
+      - "atlas_brain/api/content_ops_claim_registry.py"
+      - "atlas_brain/storage/migrations/334_content_ops_claim_registry.sql"
       - "extracted_content_pipeline/campaign_ports.py"
       - "extracted_content_pipeline/claims_map.py"
       - "extracted_content_pipeline/content_pr.py"
@@ -53,6 +60,7 @@ on:
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_content_ops_calibration_library.py"
       - "tests/test_content_ops_calibration_library_api.py"
+      - "tests/test_content_ops_claim_registry_api.py"
       - "tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py"
       - "tests/test_check_content_ops_marketer_verify_oauth_e2e.py"
       - "tests/test_check_content_ops_marketer_verify_dual_client_rollout.py"
@@ -85,6 +93,7 @@ jobs:
             tests/test_atlas_content_ops_review_workflow.py \
             tests/test_content_ops_calibration_library.py \
             tests/test_content_ops_calibration_library_api.py \
+            tests/test_content_ops_claim_registry_api.py \
             tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py \
             tests/test_check_content_ops_marketer_verify_dual_client_rollout.py \
             tests/test_check_content_ops_marketer_verify_oauth_e2e.py \

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -196,6 +196,9 @@ try:
     from .content_ops_calibration_library import (
         create_content_ops_calibration_library_router,
     )
+    from .content_ops_claim_registry import (
+        create_content_ops_claim_registry_router,
+    )
     from ..auth.dependencies import AuthUser
     from ..config import settings
     from ..storage.database import get_db_pool
@@ -319,6 +322,11 @@ try:
         auth_dependency=_capture_content_ops_auth_user,
     )
     router.include_router(calibration_library_router)
+    claim_registry_router = create_content_ops_claim_registry_router(
+        pool_provider=get_db_pool,
+        auth_dependency=_capture_content_ops_auth_user,
+    )
+    router.include_router(claim_registry_router)
     public_landing_page_router = create_public_landing_page_router(
         pool_provider=get_db_pool,
     )

--- a/atlas_brain/api/content_ops_claim_registry.py
+++ b/atlas_brain/api/content_ops_claim_registry.py
@@ -1,0 +1,257 @@
+"""Tenant-scoped admin CRUD for the Content Ops claim registry.
+
+The marketer verify MCP surface is deliberately verify-only, so curation of a
+tenant's approved-wording claim registry lives here as an authenticated admin
+API, mirroring the calibration-library and brand-voice-profiles admin pattern.
+The verify flow reads these rows server-side via
+``ContentOpsClaimRegistryRepository``.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from inspect import isawaitable
+from typing import Any, Awaitable, Callable
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .._content_ops_claim_registry import (
+    ContentOpsClaimRegistryRecord,
+    archive_registry_claim,
+    create_registry_claim,
+    expire_registry_claim,
+    list_registry_claim_records,
+    update_registry_claim,
+)
+from ..auth.dependencies import AuthUser
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+AuthDependency = Callable[..., AuthUser | Awaitable[AuthUser]]
+
+
+class UpsertClaimRegistryRequest(BaseModel):
+    registry_id: str = Field(..., min_length=1, max_length=160)
+    approved_wording: str = Field(..., min_length=1, max_length=4000)
+    risk_tier: str | None = Field(default=None, max_length=40)
+    expires_on: str | None = Field(default=None, max_length=40)
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class ExpireClaimRegistryRequest(BaseModel):
+    expires_on: str | None = Field(default=None, max_length=40)
+
+
+class ClaimRegistryView(BaseModel):
+    id: str
+    account_id: str
+    registry_id: str
+    approved_wording: str
+    risk_tier: str | None = None
+    expires_on: str | None = None
+    metadata: dict[str, object]
+    created_at: str
+    updated_at: str
+    archived_at: str | None = None
+
+
+def _default_pool_provider() -> Any:
+    from ..storage.database import get_db_pool
+
+    return get_db_pool()
+
+
+def create_content_ops_claim_registry_router(
+    *,
+    pool_provider: PoolProvider = _default_pool_provider,
+    auth_dependency: AuthDependency,
+) -> APIRouter:
+    """Build the tenant-scoped claim-registry admin router."""
+
+    router = APIRouter(
+        prefix="/content-ops/claim-registry",
+        tags=["content-ops"],
+    )
+
+    @router.get("", response_model=list[ClaimRegistryView])
+    async def list_claims(
+        user: AuthUser = Depends(auth_dependency),
+    ) -> list[ClaimRegistryView]:
+        account_id = _account_uuid(user)
+        pool = await _resolve_ready_pool(pool_provider)
+        records = await list_registry_claim_records(pool, account_id=account_id)
+        return [_record_to_view(record) for record in records]
+
+    @router.post("", response_model=ClaimRegistryView, status_code=201)
+    async def add_claim(
+        body: UpsertClaimRegistryRequest,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> ClaimRegistryView:
+        _require_claim_registry_admin(user)
+        account_id = _account_uuid(user)
+        pool = await _resolve_ready_pool(pool_provider)
+        try:
+            record = await create_registry_claim(
+                pool, account_id=account_id, payload=body.model_dump()
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:  # noqa: BLE001 - translate DB unique conflict
+            if exc.__class__.__name__ == "UniqueViolationError":
+                raise HTTPException(
+                    status_code=409,
+                    detail="A claim with this registry id already exists",
+                )
+            raise
+        return _record_to_view(record)
+
+    @router.put("/{row_id}", response_model=ClaimRegistryView)
+    async def update_claim(
+        row_id: str,
+        body: UpsertClaimRegistryRequest,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> ClaimRegistryView:
+        _require_claim_registry_admin(user)
+        account_id = _account_uuid(user)
+        pool = await _resolve_ready_pool(pool_provider)
+        try:
+            record = await update_registry_claim(
+                pool,
+                account_id=account_id,
+                claim_id=_row_uuid(row_id),
+                payload=body.model_dump(),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:  # noqa: BLE001 - translate DB unique conflict
+            if exc.__class__.__name__ == "UniqueViolationError":
+                raise HTTPException(
+                    status_code=409,
+                    detail="A claim with this registry id already exists",
+                )
+            raise
+        if record is None:
+            raise HTTPException(status_code=404, detail="Claim not found")
+        return _record_to_view(record)
+
+    @router.post("/{row_id}/expire", response_model=ClaimRegistryView)
+    async def expire_claim(
+        row_id: str,
+        body: ExpireClaimRegistryRequest | None = None,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> ClaimRegistryView:
+        _require_claim_registry_admin(user)
+        account_id = _account_uuid(user)
+        pool = await _resolve_ready_pool(pool_provider)
+        try:
+            record = await expire_registry_claim(
+                pool,
+                account_id=account_id,
+                claim_id=_row_uuid(row_id),
+                expires_on=_optional_expiration(body),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        if record is None:
+            raise HTTPException(status_code=404, detail="Claim not found")
+        return _record_to_view(record)
+
+    @router.delete("/{row_id}", status_code=204)
+    async def delete_claim(
+        row_id: str,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> None:
+        _require_claim_registry_admin(user)
+        account_id = _account_uuid(user)
+        pool = await _resolve_ready_pool(pool_provider)
+        archived = await archive_registry_claim(
+            pool, account_id=account_id, claim_id=_row_uuid(row_id)
+        )
+        if not archived:
+            raise HTTPException(status_code=404, detail="Claim not found")
+
+    return router
+
+
+async def _resolve_ready_pool(pool_provider: PoolProvider) -> Any:
+    pool = pool_provider()
+    if isawaitable(pool):
+        pool = await pool
+    return pool
+
+
+def _account_uuid(user: AuthUser) -> _uuid.UUID:
+    try:
+        return _uuid.UUID(str(user.account_id))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid tenant scope")
+
+
+def _row_uuid(row_id: str) -> _uuid.UUID:
+    try:
+        return _uuid.UUID(str(row_id))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=404, detail="Claim not found")
+
+
+def _optional_expiration(body: ExpireClaimRegistryRequest | None):
+    """Parse an optional expiration date string from the request body.
+
+    A missing body or blank value defers to the repo default (today). A
+    malformed date string is a 400 rather than a silent fallthrough.
+    """
+
+    from datetime import date
+
+    raw = getattr(body, "expires_on", None) if body is not None else None
+    if raw is None:
+        return None
+    cleaned = str(raw).strip()
+    if not cleaned:
+        return None
+    try:
+        return date.fromisoformat(cleaned)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid expiration date")
+
+
+def _require_claim_registry_admin(user: AuthUser) -> None:
+    role = str(getattr(user, "role", "") or "").strip().lower()
+    if bool(getattr(user, "is_admin", False)) or role in {"owner", "admin"}:
+        return
+    raise HTTPException(status_code=403, detail="Admin access required")
+
+
+def _record_to_view(record: ContentOpsClaimRegistryRecord) -> ClaimRegistryView:
+    return ClaimRegistryView(
+        id=str(record.id),
+        account_id=str(record.account_id),
+        registry_id=record.registry_id,
+        approved_wording=record.approved_wording,
+        risk_tier=_risk_tier_str(record.risk_tier),
+        expires_on=_fmt_date(record.expires_on),
+        metadata=dict(record.metadata),
+        created_at=_fmt_time(record.created_at) or "",
+        updated_at=_fmt_time(record.updated_at) or "",
+        archived_at=_fmt_time(record.archived_at),
+    )
+
+
+def _risk_tier_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return getattr(value, "value", None) or str(value)
+
+
+def _fmt_date(value: Any) -> str | None:
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    return isoformat() if callable(isoformat) else str(value)
+
+
+def _fmt_time(value: Any) -> str | None:
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    return isoformat() if callable(isoformat) else str(value)

--- a/plans/PR-Content-Ops-Claim-Registry-Admin-Write.md
+++ b/plans/PR-Content-Ops-Claim-Registry-Admin-Write.md
@@ -111,13 +111,17 @@ alongside the other content-ops admin routers with
 ## Verification
 
 - Reviewer rules triggered: R1, R2, R5, R14.
-- Passed: pytest tests/test_content_ops_claim_registry_api.py -- 14 passed
-  (list, create-201, create-403/400/409, update-200/404, expire-200/404 +
-  default + invalid-date-400, archive-204/404, 401 on bad tenant scope).
+- Passed: pytest tests/test_content_ops_claim_registry_api.py -- 18 passed
+  (list, create-201/403/400/409, update-200/403/404/409, expire-200/403/404 +
+  default + invalid-date-400, archive-204/403/404, 401 on bad tenant scope).
 - Passed: bash scripts/check_ascii_python.sh -- ASCII check passed.
+- Passed: bash scripts/run_extracted_pipeline_checks.sh -- 3890 passed,
+  10 skipped.
 - The new test is enrolled in
   `.github/workflows/atlas_content_ops_review_workflow_checks.yml` (path filter +
   pytest run step), alongside the calibration API test.
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file
+  tmp/content_ops_claim_registry_admin_write_pr_body.md.
 
 ## Estimated diff size
 
@@ -126,7 +130,7 @@ alongside the other content-ops admin routers with
 | `.github/workflows/atlas_content_ops_review_workflow_checks.yml` | 9 |
 | `atlas_brain/api/__init__.py` | 8 |
 | `atlas_brain/api/content_ops_claim_registry.py` | 257 |
-| `plans/PR-Content-Ops-Claim-Registry-Admin-Write.md` | 130 |
+| `plans/PR-Content-Ops-Claim-Registry-Admin-Write.md` | 136 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_content_ops_claim_registry_api.py` | 240 |
-| **Total** | **645** |
+| `tests/test_content_ops_claim_registry_api.py` | 285 |
+| **Total** | **696** |

--- a/plans/PR-Content-Ops-Claim-Registry-Admin-Write.md
+++ b/plans/PR-Content-Ops-Claim-Registry-Admin-Write.md
@@ -1,0 +1,132 @@
+# PR-Content-Ops-Claim-Registry-Admin-Write
+
+## Why this slice exists
+
+The calibration-library admin surface (#1496) explicitly deferred "the claim
+registry's parallel admin write surface" as a follow-up. Today the claim
+registry has a table (migration `334`) and a full repository CRUD
+(`create/update/expire/archive/list_registry_claim_records` in
+`atlas_brain/_content_ops_claim_registry.py`), but **no HTTP write path** -- a
+tenant's approved-wording rows can only be written by hand in the database. This
+slice closes that gap with a tenant-scoped, admin-gated FastAPI router, mirroring
+the calibration-library and brand-voice-profiles admin pattern. The marketer
+verify MCP surface is deliberately verify-only, so curation lives as an
+authenticated API. No migration and no repo changes are needed -- this slice is
+purely the router, its registration, and tests.
+
+The ~640 LOC total is over the 400 soft cap, but the net new logic is small: the
+two largest files (router + router test) mirror the already-reviewed
+calibration-library slice (#1496) almost verbatim, differing only in the
+registry's extra fields and the expire endpoint. Splitting transport from its
+test would ship an untested router, so they land together.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. `atlas_brain/api/content_ops_claim_registry.py`: a tenant-scoped admin router
+   (list / create / update / expire / archive) with the shared admin gate and
+   account-UUID scoping, mirroring the calibration-library router.
+2. Register the router in the api aggregator with the same
+   `_capture_content_ops_auth_user` auth dependency.
+3. Enroll the new router test in the content-ops review-workflow CI workflow.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+- `atlas_brain/api/__init__.py`
+- `atlas_brain/api/content_ops_claim_registry.py`
+- `plans/PR-Content-Ops-Claim-Registry-Admin-Write.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_content_ops_claim_registry_api.py`
+
+### Review Contract
+
+Acceptance criteria:
+- All routes are tenant-scoped by `account_id`; create/update/expire/archive
+  require an admin/owner role (403 otherwise); list requires only auth.
+- Create validates the payload via the existing repo `_validated_claim`
+  (required registry_id + approved_wording, known risk tier) -> `ValueError` ->
+  HTTP 400 before any DB write.
+- Update/expire/archive of a missing or cross-tenant row returns 404; a
+  registry-id unique conflict on create/update returns 409.
+- The expire endpoint accepts an optional `expires_on`; a malformed date is 400,
+  a missing one defers to the repo default (today).
+- An invalid tenant scope returns 401; an invalid path id returns 404.
+- No change to the verify MCP surface, the reader, the review logic, the
+  repository, or the migration.
+
+Affected surfaces: a new admin API router + its registration + the CI
+enrollment. Pure addition.
+
+Risk areas: tenant scoping in every route; the admin gate; the DB
+unique-violation -> 409 translation (matched by class name to avoid a hard
+asyncpg import); the optional-date parse on expire.
+
+Reviewer rules triggered: R1, R2, R5, R14.
+
+## Mechanism
+
+The router factory `create_content_ops_claim_registry_router` takes a
+`pool_provider` + `auth_dependency` (the same pattern as the calibration and
+brand-voice routers), exposes `GET/POST/PUT/DELETE
+/content-ops/claim-registry` plus a registry-specific
+`POST /content-ops/claim-registry/{row_id}/expire`, gates writes through
+`_require_claim_registry_admin`, scopes by `_account_uuid(user)`, and maps repo
+records to a `ClaimRegistryView`. It delegates to the existing repo functions
+(note the repo param is `claim_id`, not `example_row_id`). A `ValueError`
+becomes 400, a missing row 404, and a DB `UniqueViolationError` (matched by
+class name) becomes 409. It is registered in `atlas_brain/api/__init__.py`
+alongside the other content-ops admin routers with
+`_capture_content_ops_auth_user`.
+
+## Intentional
+
+- **Expire endpoint included.** Unlike the calibration template, the claim
+  registry repo already supports `expire_registry_claim`, and expiry is a
+  first-class claim mutation (a claim's approved wording can lapse without being
+  archived), so the admin surface exposes it. Optional `expires_on`; blank/absent
+  defers to the repo default.
+- **Admin API, not an MCP tool.** The marketer verify MCP is verify-only by
+  contract; curation is a separate authenticated surface, following the
+  established brand-voice/calibration admin pattern.
+- **Unique-violation matched by class name.** Avoids a hard `asyncpg` import in
+  the router (kept out of the lightweight import path) while still translating
+  the conflict to 409.
+- **The router test loads the module by file path** (importlib), like the
+  calibration and brand-voice API tests, to bypass the heavy
+  `atlas_brain.api.__init__` chain (asyncpg/numpy) so it runs without a full
+  runtime install.
+- **No repo or migration change.** Both already exist (migration `334`, repo
+  CRUD). This slice is the missing transport only.
+
+## Deferred
+
+- A claim-registry admin UI screen (deferred per operator: the calibration UI
+  ships first; the claim-registry UI is a later follow-up).
+- A seed/import path for bulk claim curation.
+- Parked hardening: none new this slice.
+
+## Verification
+
+- Reviewer rules triggered: R1, R2, R5, R14.
+- Passed: pytest tests/test_content_ops_claim_registry_api.py -- 14 passed
+  (list, create-201, create-403/400/409, update-200/404, expire-200/404 +
+  default + invalid-date-400, archive-204/404, 401 on bad tenant scope).
+- Passed: bash scripts/check_ascii_python.sh -- ASCII check passed.
+- The new test is enrolled in
+  `.github/workflows/atlas_content_ops_review_workflow_checks.yml` (path filter +
+  pytest run step), alongside the calibration API test.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_review_workflow_checks.yml` | 9 |
+| `atlas_brain/api/__init__.py` | 8 |
+| `atlas_brain/api/content_ops_claim_registry.py` | 257 |
+| `plans/PR-Content-Ops-Claim-Registry-Admin-Write.md` | 130 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_content_ops_claim_registry_api.py` | 240 |
+| **Total** | **645** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -127,6 +127,7 @@ pytest \
   tests/test_content_ops_claim_registry.py \
   tests/test_content_ops_calibration_library.py \
   tests/test_content_ops_calibration_library_api.py \
+  tests/test_content_ops_claim_registry_api.py \
   tests/test_atlas_content_ops_generated_assets_api.py \
   tests/test_atlas_content_ops_import_admission.py \
   tests/test_atlas_content_ops_input_provider.py \

--- a/tests/test_content_ops_claim_registry_api.py
+++ b/tests/test_content_ops_claim_registry_api.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+import importlib.util
+from pathlib import Path
+import sys
+import uuid
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from atlas_brain.auth.dependencies import AuthUser
+
+
+# Load the router module by file path to bypass the heavy atlas_brain.api
+# package __init__ (which pulls in asyncpg/numpy via the storage chain).
+API_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain"
+    / "api"
+    / "content_ops_claim_registry.py"
+)
+api = None
+
+
+def setup_module() -> None:
+    global api
+    spec = importlib.util.spec_from_file_location(
+        "atlas_brain.api.content_ops_claim_registry_for_test",
+        API_MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    api = module
+
+
+ACCOUNT_ID = uuid.uuid4()
+
+
+class _Pool:
+    def __init__(self, *, fetchrow_result=None, fetch_rows=None) -> None:
+        self.fetchrow_result = fetchrow_result
+        self.fetch_rows = list(fetch_rows or [])
+        self.fetchrow_calls: list[tuple] = []
+        self.fetch_calls: list[tuple] = []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append(args)
+        return self.fetchrow_result
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append(args)
+        return self.fetch_rows
+
+
+def _row(**overrides):
+    row = {
+        "id": uuid.uuid4(),
+        "account_id": ACCOUNT_ID,
+        "registry_id": "uptime-claim",
+        "approved_wording": "99.9% uptime SLA, credited monthly",
+        "risk_tier": "high",
+        "expires_on": date(2026, 12, 31),
+        "metadata": "{}",
+        "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "updated_at": datetime(2026, 1, 2, tzinfo=timezone.utc),
+        "archived_at": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _user(account_id=ACCOUNT_ID, *, role: str = "owner") -> AuthUser:
+    return AuthUser(
+        user_id="33333333-3333-3333-3333-333333333333",
+        account_id=str(account_id),
+        plan="b2b_growth",
+        plan_status="active",
+        role=role,
+        product="b2b_challenger",
+    )
+
+
+def _client(*, pool=None, user: AuthUser | None = None) -> TestClient:
+    app = fastapi.FastAPI()
+
+    def pool_provider():
+        return pool if pool is not None else _Pool()
+
+    def auth_dependency():
+        return user or _user()
+
+    app.include_router(
+        api.create_content_ops_claim_registry_router(
+            pool_provider=pool_provider,
+            auth_dependency=auth_dependency,
+        )
+    )
+    return TestClient(app)
+
+
+_VALID_BODY = {
+    "registry_id": "uptime-claim",
+    "approved_wording": "99.9% uptime SLA, credited monthly",
+    "risk_tier": "high",
+}
+
+
+def test_list_returns_tenant_claims() -> None:
+    pool = _Pool(fetch_rows=[_row()])
+    resp = _client(pool=pool).get("/content-ops/claim-registry")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["registry_id"] == "uptime-claim"
+    assert body[0]["risk_tier"] == "high"
+    assert body[0]["expires_on"] == "2026-12-31"
+    assert pool.fetch_calls[0] == (ACCOUNT_ID,)
+
+
+def test_create_requires_admin_role() -> None:
+    resp = _client(user=_user(role="member")).post(
+        "/content-ops/claim-registry", json=_VALID_BODY
+    )
+    assert resp.status_code == 403
+
+
+def test_create_inserts_and_returns_view() -> None:
+    pool = _Pool(fetchrow_result=_row())
+    resp = _client(pool=pool).post("/content-ops/claim-registry", json=_VALID_BODY)
+    assert resp.status_code == 201
+    assert resp.json()["registry_id"] == "uptime-claim"
+    # account scoping: first insert arg is the tenant account id.
+    assert pool.fetchrow_calls[0][0] == ACCOUNT_ID
+
+
+def test_create_rejects_blank_registry_id() -> None:
+    pool = _Pool(fetchrow_result=_row())
+    body = dict(_VALID_BODY, registry_id="   ")
+    resp = _client(pool=pool).post("/content-ops/claim-registry", json=body)
+    assert resp.status_code == 400
+    assert pool.fetchrow_calls == []  # never reached the DB
+
+
+def test_create_translates_unique_violation_to_409() -> None:
+    class UniqueViolationError(Exception):  # matches asyncpg's class name
+        pass
+
+    class _ConflictPool(_Pool):
+        async def fetchrow(self, query, *args):
+            raise UniqueViolationError()
+
+    resp = _client(pool=_ConflictPool()).post(
+        "/content-ops/claim-registry", json=_VALID_BODY
+    )
+    assert resp.status_code == 409
+
+
+def test_update_missing_row_is_404() -> None:
+    pool = _Pool(fetchrow_result=None)
+    resp = _client(pool=pool).put(
+        f"/content-ops/claim-registry/{uuid.uuid4()}", json=_VALID_BODY
+    )
+    assert resp.status_code == 404
+
+
+def test_update_returns_view_for_existing_row() -> None:
+    pool = _Pool(fetchrow_result=_row())
+    resp = _client(pool=pool).put(
+        f"/content-ops/claim-registry/{uuid.uuid4()}", json=_VALID_BODY
+    )
+    assert resp.status_code == 200
+    assert resp.json()["registry_id"] == "uptime-claim"
+
+
+def test_expire_returns_view_for_existing_row() -> None:
+    pool = _Pool(fetchrow_result=_row(expires_on=date(2026, 6, 12)))
+    resp = _client(pool=pool).post(
+        f"/content-ops/claim-registry/{uuid.uuid4()}/expire",
+        json={"expires_on": "2026-06-12"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["expires_on"] == "2026-06-12"
+    # the requested expiration is forwarded to the repo as a real date.
+    assert pool.fetchrow_calls[0][2] == date(2026, 6, 12)
+
+
+def test_expire_without_body_defers_to_repo_default() -> None:
+    pool = _Pool(fetchrow_result=_row())
+    resp = _client(pool=pool).post(
+        f"/content-ops/claim-registry/{uuid.uuid4()}/expire"
+    )
+    assert resp.status_code == 200
+    # No explicit date -> router forwards None and the repo applies its
+    # own default (today). The forwarded value is a real date, not a string.
+    assert isinstance(pool.fetchrow_calls[0][2], date)
+
+
+def test_expire_rejects_invalid_date() -> None:
+    pool = _Pool(fetchrow_result=_row())
+    resp = _client(pool=pool).post(
+        f"/content-ops/claim-registry/{uuid.uuid4()}/expire",
+        json={"expires_on": "not-a-date"},
+    )
+    assert resp.status_code == 400
+    assert pool.fetchrow_calls == []
+
+
+def test_expire_missing_row_is_404() -> None:
+    pool = _Pool(fetchrow_result=None)
+    resp = _client(pool=pool).post(
+        f"/content-ops/claim-registry/{uuid.uuid4()}/expire"
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_archives_and_returns_204() -> None:
+    pool = _Pool(fetchrow_result={"id": uuid.uuid4()})
+    resp = _client(pool=pool).delete(
+        f"/content-ops/claim-registry/{uuid.uuid4()}"
+    )
+    assert resp.status_code == 204
+
+
+def test_delete_missing_row_is_404() -> None:
+    pool = _Pool(fetchrow_result=None)
+    resp = _client(pool=pool).delete(
+        f"/content-ops/claim-registry/{uuid.uuid4()}"
+    )
+    assert resp.status_code == 404
+
+
+def test_invalid_tenant_scope_is_401() -> None:
+    resp = _client(user=_user(account_id="not-a-uuid")).get(
+        "/content-ops/claim-registry"
+    )
+    assert resp.status_code == 401

--- a/tests/test_content_ops_claim_registry_api.py
+++ b/tests/test_content_ops_claim_registry_api.py
@@ -122,10 +122,12 @@ def test_list_returns_tenant_claims() -> None:
 
 
 def test_create_requires_admin_role() -> None:
-    resp = _client(user=_user(role="member")).post(
+    pool = _Pool(fetchrow_result=_row())
+    resp = _client(pool=pool, user=_user(role="member")).post(
         "/content-ops/claim-registry", json=_VALID_BODY
     )
     assert resp.status_code == 403
+    assert pool.fetchrow_calls == []
 
 
 def test_create_inserts_and_returns_view() -> None:
@@ -167,6 +169,15 @@ def test_update_missing_row_is_404() -> None:
     assert resp.status_code == 404
 
 
+def test_update_requires_admin_role_before_repo_call() -> None:
+    pool = _Pool(fetchrow_result=_row())
+    resp = _client(pool=pool, user=_user(role="member")).put(
+        f"/content-ops/claim-registry/{uuid.uuid4()}", json=_VALID_BODY
+    )
+    assert resp.status_code == 403
+    assert pool.fetchrow_calls == []
+
+
 def test_update_returns_view_for_existing_row() -> None:
     pool = _Pool(fetchrow_result=_row())
     resp = _client(pool=pool).put(
@@ -174,6 +185,20 @@ def test_update_returns_view_for_existing_row() -> None:
     )
     assert resp.status_code == 200
     assert resp.json()["registry_id"] == "uptime-claim"
+
+
+def test_update_translates_unique_violation_to_409() -> None:
+    class UniqueViolationError(Exception):  # matches asyncpg's class name
+        pass
+
+    class _ConflictPool(_Pool):
+        async def fetchrow(self, query, *args):
+            raise UniqueViolationError()
+
+    resp = _client(pool=_ConflictPool()).put(
+        f"/content-ops/claim-registry/{uuid.uuid4()}", json=_VALID_BODY
+    )
+    assert resp.status_code == 409
 
 
 def test_expire_returns_view_for_existing_row() -> None:
@@ -188,14 +213,25 @@ def test_expire_returns_view_for_existing_row() -> None:
     assert pool.fetchrow_calls[0][2] == date(2026, 6, 12)
 
 
+def test_expire_requires_admin_role_before_repo_call() -> None:
+    pool = _Pool(fetchrow_result=_row())
+    resp = _client(pool=pool, user=_user(role="member")).post(
+        f"/content-ops/claim-registry/{uuid.uuid4()}/expire",
+        json={"expires_on": "2026-06-12"},
+    )
+    assert resp.status_code == 403
+    assert pool.fetchrow_calls == []
+
+
 def test_expire_without_body_defers_to_repo_default() -> None:
     pool = _Pool(fetchrow_result=_row())
     resp = _client(pool=pool).post(
         f"/content-ops/claim-registry/{uuid.uuid4()}/expire"
     )
     assert resp.status_code == 200
-    # No explicit date -> router forwards None and the repo applies its
-    # own default (today). The forwarded value is a real date, not a string.
+    # The router forwards expires_on=None to the repo when no date is given;
+    # the repo resolves that to today() before the DB call, so the value seen
+    # at the fetchrow (DB) boundary is always a real date, never None or a str.
     assert isinstance(pool.fetchrow_calls[0][2], date)
 
 
@@ -223,6 +259,15 @@ def test_delete_archives_and_returns_204() -> None:
         f"/content-ops/claim-registry/{uuid.uuid4()}"
     )
     assert resp.status_code == 204
+
+
+def test_delete_requires_admin_role_before_repo_call() -> None:
+    pool = _Pool(fetchrow_result={"id": uuid.uuid4()})
+    resp = _client(pool=pool, user=_user(role="member")).delete(
+        f"/content-ops/claim-registry/{uuid.uuid4()}"
+    )
+    assert resp.status_code == 403
+    assert pool.fetchrow_calls == []
 
 
 def test_delete_missing_row_is_404() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Registry-Admin-Write.md
Slice phase: Functional validation

The calibration-library admin surface (#1496) explicitly deferred "the claim registry's parallel admin write surface" as a follow-up. The claim registry has a table (migration `334`) and full repository CRUD (`create/update/expire/archive/list_registry_claim_records`), but no HTTP write path -- approved-wording rows could only be written by hand in the database. This slice adds a tenant-scoped, admin-gated FastAPI router, mirroring the calibration-library and brand-voice-profiles admin pattern. The marketer verify MCP surface is verify-only by contract, so curation lives as an authenticated API. No migration and no repo changes -- purely the router, its registration, and tests.

## Intentional
- **Expire endpoint included.** Unlike the calibration template, the repo already supports `expire_registry_claim` and expiry is a first-class claim mutation (approved wording can lapse without being archived), so the admin surface exposes `POST /content-ops/claim-registry/{row_id}/expire`. Optional `expires_on`; blank/absent defers to the repo default (today); a malformed date is 400.
- **Admin API, not an MCP tool.** The verify MCP is verify-only by contract; curation is a separate authenticated surface, following the brand-voice/calibration pattern.
- **Unique-violation matched by class name** to avoid a hard `asyncpg` import in the lightweight router path while still translating the conflict to 409.
- **The router test loads the module by file path** (importlib), like the calibration/brand-voice API tests, to bypass the heavy `atlas_brain.api.__init__` chain.
- **No repo or migration change** -- both already exist; this is the missing transport only.

## Deferred
- A claim-registry admin UI screen (the calibration UI ships first per operator).
- A seed/import path for bulk claim curation.

## Parked hardening
- None.

## Verification
- pytest tests/test_content_ops_claim_registry_api.py -- 18 passed (list, create-201/403/400/409, update-200/403/404/409, expire-200/403/404 + default + invalid-date-400, archive-204/403/404, 401 on bad tenant scope).
- bash scripts/check_ascii_python.sh -- passed.
- bash scripts/run_extracted_pipeline_checks.sh -- 3890 passed, 10 skipped.
- New test enrolled in `.github/workflows/atlas_content_ops_review_workflow_checks.yml` (path filter + run step) and `scripts/run_extracted_pipeline_checks.sh`.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_registry_admin_write_pr_body.md -- green.

Reviewer rules triggered: R1, R2, R5, R14.

## Diff size
6 files, +696 LOC (router + router test mirror the reviewed #1496 calibration slice; net new logic is small). Over the 400 soft cap, justified in the plan.

https://claude.ai/code/session_01Ud6BQdNvpRNXH9KwAkjGE2
