### PR TITLE
Content-Ops: remove dead deflection snapshot teaser + clustering compat shim

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_checkout_contract.md
+++ b/docs/frontend/content_ops_faq_deflection_checkout_contract.md
@@ -34,19 +34,15 @@ type GatedDeflectionExecuteResult = {
 };
 ```
 
-Render `snapshot` on the free page. The only answer body available before
-payment is `snapshot.teaser.full_answer`, when present. Teaser previews are
-body-withheld (`body_withheld: true`) and exist only to show answer structure.
-Do not derive other answer text, evidence, source IDs, or Markdown from this
-object.
+Render `snapshot` on the free page. The snapshot contains no answer bodies;
+all answer text, evidence, source IDs, and Markdown stay behind paid unlock.
+Do not derive any of them from this object.
 
 For Support Tax or FOMO copy, use only raw measured count fields:
-`snapshot.summary.repeat_ticket_count`, visible
-`snapshot.top_questions[].ticket_count`, and locked
-`snapshot.locked_questions[].ticket_count`. `weighted_frequency` is a ranking
+`snapshot.summary.repeat_ticket_count` and visible
+`snapshot.top_questions[].ticket_count`. `weighted_frequency` is a ranking
 score, not a customer-specific ticket count; do not use it for spend
-calculations or projections. `locked_questions` intentionally exposes only
-rank and ticket count, with question text withheld until paid unlock.
+calculations or projections.
 
 For period-normalized Support Tax copy, use
 `snapshot.summary.source_date_start`, `snapshot.summary.source_date_end`, and
@@ -106,11 +102,6 @@ Responses:
 
 - `200`: `DeflectionSnapshot`
 - `404`: no report exists for this `request_id` in the authenticated account
-
-The snapshot teaser is bounded and fail-closed: at most one full scoped
-resolution-backed answer plus configured body-withheld previews. When no item
-has scoped resolution evidence, `teaser.full_answer` is `null` and previews are
-empty.
 
 The authenticated ATLAS scope supplies `account_id`; do not put `account_id` in
 the path or query string.

--- a/docs/frontend/content_ops_faq_deflection_snapshot_example.json
+++ b/docs/frontend/content_ops_faq_deflection_snapshot_example.json
@@ -1,5 +1,4 @@
 {
-  "locked_questions": [],
   "summary": {
     "drafted_answer_count": 1,
     "generated": 2,
@@ -10,22 +9,6 @@
     "source_window_days": 15,
     "support_ticket_resolution_evidence_count": 1,
     "support_ticket_resolution_evidence_present": true
-  },
-  "teaser": {
-    "full_answer": {
-      "answer": "To resolve this, open Analytics, choose Attribution, then click Download report.",
-      "answer_evidence_status": "resolution_evidence",
-      "question": "How do I export attribution reports?",
-      "rank": 1,
-      "resolution_evidence_scope": "scoped",
-      "source_count": 2,
-      "steps": [
-        "Open Analytics, choose Attribution, then click Download report.",
-        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-      ],
-      "weighted_frequency": 2
-    },
-    "previews": []
   },
   "top_questions": [
     {

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -91,8 +91,6 @@ type DeflectionSnapshot = {
     source_window_days?: number; // inclusive day count, only when coverage is complete
   };
   top_questions: DeflectionSnapshotQuestion[];
-  locked_questions: DeflectionSnapshotLockedQuestion[];
-  teaser: DeflectionSnapshotTeaser;
 };
 
 type DeflectionSnapshotQuestion = {
@@ -102,53 +100,16 @@ type DeflectionSnapshotQuestion = {
   weighted_frequency: number;
   customer_wording: string;
 };
-
-type DeflectionSnapshotLockedQuestion = {
-  rank: number;
-  ticket_count: number;
-};
-
-type DeflectionSnapshotTeaser = {
-  full_answer: DeflectionSnapshotFullAnswer | null;
-  previews: DeflectionSnapshotAnswerPreview[];
-};
-
-type DeflectionSnapshotFullAnswer = {
-  rank: number;
-  question: string;
-  answer: string;
-  steps: string[];
-  answer_evidence_status: "resolution_evidence";
-  resolution_evidence_scope: "scoped";
-  weighted_frequency: number;
-  source_count: number;
-};
-
-type DeflectionSnapshotAnswerPreview = {
-  rank: number;
-  question: string;
-  answer_evidence_status: "resolution_evidence";
-  resolution_evidence_scope: "scoped";
-  weighted_frequency: number;
-  step_count: number;
-  source_count: number;
-  body_withheld: true;
-};
 ```
 
 This shape intentionally excludes paid deliverable fields:
 
 - no `markdown`
 - no `faq_result`
-- no answer text or `steps` outside `teaser.full_answer`
+- no answer text or `steps`
 - no `evidence_quotes`
 - no `source_ids`
 - no vocabulary term mappings
-- no locked question text; `locked_questions` contains only rank and raw
-  ticket count
-
-The teaser is fail-closed: only scoped `resolution_evidence` FAQ items are
-eligible. Preview entries never include answer body text.
 
 `ticket_count` and `summary.repeat_ticket_count` are raw measured counts from
 the report items/source rows. `weighted_frequency` is ranking metadata only and
@@ -272,9 +233,8 @@ type TicketFAQSearchResponse = {
 - Use `items` for ranked cards or sections, and `markdown` for the full report.
 - For `faq_deflection_report`, render top-level `markdown` as the deliverable.
   Use `summary` for proof badges and `faq_result` for drill-down cards.
-- For unpaid deflection results, render only `DeflectionSnapshot.summary`,
-  `DeflectionSnapshot.top_questions`, `DeflectionSnapshot.locked_questions`,
-  and `DeflectionSnapshot.teaser`. Do not infer answer text, evidence, or
+- For unpaid deflection results, render only `DeflectionSnapshot.summary` and
+  `DeflectionSnapshot.top_questions`. Do not infer answer text, evidence, or
   source IDs from the snapshot.
 - Show `source_count`, `ticket_source_count`, and `output_checks` as proof badges.
 - Show `answer_evidence_status` near steps. `draft_needs_review` means the

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -70,7 +70,6 @@ from ..control_surfaces import (
 from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
 from ..faq_deflection_report import (
     DEFAULT_DEFLECTION_SNAPSHOT_TOP_N,
-    DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT,
     build_deflection_snapshot,
 )
 from ..landing_page_input_contract import landing_page_seo_geo_aeo_input_contracts
@@ -355,9 +354,6 @@ class ContentOpsControlSurfaceApiConfig:
     execute_max_concurrency: int = 8
     faq_execute_max_source_material_rows: int = _MAX_INGESTION_ROWS
     deflection_snapshot_top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N
-    deflection_snapshot_teaser_preview_count: int = (
-        DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT
-    )
     deflection_checkout_amount_cents: int = 150000
     deflection_checkout_allowed_amount_cents: str = ""
     deflection_checkout_currency: str = "usd"
@@ -411,10 +407,6 @@ class ContentOpsControlSurfaceApiConfig:
             )
         if self.deflection_snapshot_top_n <= 0:
             raise ValueError("deflection_snapshot_top_n must be positive")
-        if self.deflection_snapshot_teaser_preview_count < 0:
-            raise ValueError(
-                "deflection_snapshot_teaser_preview_count must be non-negative"
-            )
         if self.deflection_checkout_amount_cents < 0:
             raise ValueError("deflection_checkout_amount_cents cannot be negative")
         if self.ingestion_import_max_concurrency <= 0:
@@ -1192,9 +1184,6 @@ def create_content_ops_control_surface_router(
                 scope=scope,
                 request_id=request_id,
                 top_n=resolved_config.deflection_snapshot_top_n,
-                teaser_preview_count=(
-                    resolved_config.deflection_snapshot_teaser_preview_count
-                ),
                 preview_summary_metadata=_deflection_resolution_preview_summary(
                     payload_mapping
                 ),
@@ -2772,7 +2761,6 @@ async def _gate_deflection_report_artifacts(
     scope: TenantScope | None,
     request_id: str,
     top_n: int,
-    teaser_preview_count: int,
     preview_summary_metadata: Mapping[str, Any] | None = None,
     delivery_email: str | None = None,
 ) -> dict[str, Any]:
@@ -2798,7 +2786,6 @@ async def _gate_deflection_report_artifacts(
             snapshot = build_deflection_snapshot(
                 artifact,
                 top_n=top_n,
-                teaser_preview_count=teaser_preview_count,
             ).as_dict()
             if preview_summary_metadata:
                 snapshot_summary = dict(snapshot.get("summary") or {})

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -12,10 +12,8 @@ from .ticket_faq_markdown import TicketFAQMarkdownResult, TicketFAQMarkdownServi
 
 
 _RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
-_RESOLUTION_EVIDENCE_SCOPE_SCOPED = "scoped"
 _DRAFT_NEEDS_REVIEW_STATUS = "draft_needs_review"
 DEFAULT_DEFLECTION_SNAPSHOT_TOP_N = 5
-DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT = 3
 _UNCAPPED_REPORT_MAX_ITEMS = 0
 _ASSISTED_CONTACT_COST = 13.50
 _ASSISTED_CONTACT_COST_LABEL = "$13.50"
@@ -28,28 +26,11 @@ class DeflectionSnapshot:
 
     summary: dict[str, Any]
     top_questions: tuple[dict[str, Any], ...]
-    locked_questions: tuple[dict[str, int], ...]
-    teaser: dict[str, Any]
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "summary": dict(self.summary),
             "top_questions": [dict(question) for question in self.top_questions],
-            "locked_questions": [
-                dict(question) for question in self.locked_questions
-            ],
-            "teaser": {
-                "full_answer": (
-                    dict(self.teaser["full_answer"])
-                    if isinstance(self.teaser.get("full_answer"), Mapping)
-                    else None
-                ),
-                "previews": [
-                    dict(preview)
-                    for preview in self.teaser.get("previews", ())
-                    if isinstance(preview, Mapping)
-                ],
-            },
         }
 
 
@@ -147,7 +128,6 @@ def build_deflection_snapshot(
     artifact: DeflectionReportArtifact | Mapping[str, Any],
     *,
     top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N,
-    teaser_preview_count: int = DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT,
 ) -> DeflectionSnapshot:
     """Project a report into the free snapshot shape.
 
@@ -157,8 +137,6 @@ def build_deflection_snapshot(
 
     if top_n <= 0:
         raise ValueError("top_n must be positive")
-    if teaser_preview_count < 0:
-        raise ValueError("teaser_preview_count must be non-negative")
     summary = _artifact_summary(artifact)
     items = _artifact_items(artifact)
     snapshot_summary: dict[str, Any] = {
@@ -188,21 +166,9 @@ def build_deflection_snapshot(
             ),
             "customer_wording": _snapshot_customer_wording(item, question),
         })
-    teaser = _snapshot_teaser(items, preview_count=teaser_preview_count)
-    teaser_full_rank = _teaser_full_answer_rank(teaser)
-    locked_questions = tuple(
-        {
-            "rank": rank,
-            "ticket_count": _ticket_count(item),
-        }
-        for rank, item in enumerate(items[top_n:], start=top_n + 1)
-        if rank != teaser_full_rank
-    )
     return DeflectionSnapshot(
         summary=snapshot_summary,
         top_questions=tuple(top_questions),
-        locked_questions=locked_questions,
-        teaser=teaser,
     )
 
 
@@ -598,78 +564,6 @@ def _snapshot_customer_wording(item: Mapping[str, Any], question: str) -> str:
     return ""
 
 
-def _snapshot_teaser(
-    items: Sequence[Mapping[str, Any]],
-    *,
-    preview_count: int,
-) -> dict[str, Any]:
-    eligible = tuple(
-        (rank, item)
-        for rank, item in enumerate(items, start=1)
-        if _is_teaser_eligible(item)
-    )
-    if not eligible:
-        return {"full_answer": None, "previews": []}
-    full_rank, full_item = _select_full_teaser_item(eligible)
-    previews = [
-        _teaser_preview(rank, item)
-        for rank, item in eligible
-        if rank != full_rank
-    ][:preview_count]
-    return {
-        "full_answer": _teaser_full_answer(full_rank, full_item),
-        "previews": previews,
-    }
-
-
-def _teaser_full_answer_rank(teaser: Mapping[str, Any]) -> int | None:
-    full_answer = teaser.get("full_answer")
-    if not isinstance(full_answer, Mapping):
-        return None
-    rank = _int(full_answer.get("rank"))
-    return rank if rank > 0 else None
-
-
-def _is_teaser_eligible(item: Mapping[str, Any]) -> bool:
-    return (
-        _text(item.get("answer_evidence_status")) == _RESOLUTION_EVIDENCE_STATUS
-        and _text(item.get("resolution_evidence_scope")) == _RESOLUTION_EVIDENCE_SCOPE_SCOPED
-        and bool(_text(item.get("answer")))
-    )
-
-
-def _select_full_teaser_item(
-    eligible: Sequence[tuple[int, Mapping[str, Any]]],
-) -> tuple[int, Mapping[str, Any]]:
-    return eligible[0]
-
-
-def _teaser_full_answer(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
-    return {
-        "rank": rank,
-        "question": _text(item.get("question")),
-        "answer": _text(item.get("answer")),
-        "steps": _texts(item.get("steps")),
-        "answer_evidence_status": _RESOLUTION_EVIDENCE_STATUS,
-        "resolution_evidence_scope": _RESOLUTION_EVIDENCE_SCOPE_SCOPED,
-        "weighted_frequency": _int(item.get("weighted_frequency") or item.get("frequency")),
-        "source_count": _source_count(item),
-    }
-
-
-def _teaser_preview(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
-    return {
-        "rank": rank,
-        "question": _text(item.get("question")),
-        "answer_evidence_status": _RESOLUTION_EVIDENCE_STATUS,
-        "resolution_evidence_scope": _RESOLUTION_EVIDENCE_SCOPE_SCOPED,
-        "weighted_frequency": _int(item.get("weighted_frequency") or item.get("frequency")),
-        "step_count": len(_texts(item.get("steps"))),
-        "source_count": _source_count(item),
-        "body_withheld": True,
-    }
-
-
 def _source_count(item: Mapping[str, Any]) -> int:
     source_count = len(_texts(item.get("source_ids")))
     return source_count or _int(item.get("ticket_count"))
@@ -890,7 +784,6 @@ def _md(value: Any) -> str:
 
 __all__ = [
     "DEFAULT_DEFLECTION_SNAPSHOT_TOP_N",
-    "DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT",
     "DeflectionSnapshot",
     "DeflectionReportArtifact",
     "FAQDeflectionReportService",

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -397,20 +397,6 @@ def support_ticket_cluster_hint(row: Mapping[str, Any]) -> SupportTicketClusterH
     )
 
 
-def assign_support_ticket_clusters(
-    rows: Sequence[Mapping[str, Any]],
-    *,
-    max_token_set_rows: int | None = None,
-) -> tuple[dict[str, Any], ...]:
-    """Return rows annotated with stable deterministic support-ticket clusters."""
-
-    annotated, _diagnostics = assign_support_ticket_clusters_with_diagnostics(
-        rows,
-        max_token_set_rows=max_token_set_rows,
-    )
-    return annotated
-
-
 def assign_support_ticket_clusters_with_diagnostics(
     rows: Sequence[Mapping[str, Any]],
     *,
@@ -530,7 +516,8 @@ def support_ticket_cluster_quality(rows: Sequence[Mapping[str, Any]]) -> dict[st
 def _ensure_clustered(rows: Sequence[Mapping[str, Any]]) -> tuple[dict[str, Any], ...]:
     if any(support_ticket_plain_text(row.get("support_ticket_cluster")) for row in rows):
         return tuple(dict(row) for row in rows)
-    return assign_support_ticket_clusters(rows)
+    annotated, _diagnostics = assign_support_ticket_clusters_with_diagnostics(rows)
+    return annotated
 
 
 def _bucket_for_hint(
@@ -684,7 +671,6 @@ def _compact_key(value: Any) -> str:
 __all__ = [
     "MAX_TOKEN_SET_CLUSTER_ROWS",
     "SupportTicketClusterHint",
-    "assign_support_ticket_clusters",
     "assign_support_ticket_clusters_with_diagnostics",
     "support_ticket_cluster_hint",
     "support_ticket_cluster_quality",

--- a/plans/PR-Deflection-Dead-Code-Removal.md
+++ b/plans/PR-Deflection-Dead-Code-Removal.md
@@ -141,10 +141,10 @@ deleted delegate did.
 - `pytest tests/test_mcp_content_ops_deflection_readonly.py -q` - 13 passed (MCP boundary unaffected).
 - `pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_content_ops_deflection_resolution_live_proof.py tests/test_content_ops_faq_deflection_live_upload_fixture.py tests/test_smoke_content_ops_support_ticket_package.py -q` - 154 passed.
 - `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_deflection_submit.py tests/test_extracted_support_ticket_input_package.py -q` - all passed.
-- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- bash `scripts/validate_extracted_content_pipeline.sh` - passed.
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - clean.
 - `python scripts/audit_extracted_standalone.py --fail-on-debt` - 0 findings.
-- `bash scripts/check_ascii_python.sh` - passed.
+- bash `scripts/check_ascii_python.sh` - passed.
 - `ruff check` over all touched Python files - clean.
 - `git grep` residue sweep for `teaser`/`locked_questions`/`assign_support_ticket_clusters`
   across py/ts/js/json/md - only negative-assertion test lines and unrelated

--- a/plans/PR-Deflection-Dead-Code-Removal.md
+++ b/plans/PR-Deflection-Dead-Code-Removal.md
@@ -1,0 +1,132 @@
+# PR-Deflection-Dead-Code-Removal
+
+## Why this slice exists
+
+The 2026-06 deflection-lane dead-code audit (issues #1500, #1501, #1502)
+confirmed two zero-consumer subsystems with grep-proven evidence at commit
+7dd668c:
+
+1. `assign_support_ticket_clusters` in
+   `extracted_content_pipeline/support_ticket_clustering.py` was kept as a
+   backward-compat delegate when PR-Deflection-Cluster-Preview-Skip introduced
+   `assign_support_ticket_clusters_with_diagnostics`. Its only callers were
+   one signature-pinning test and an internal `_ensure_clustered` call; no
+   production module, script, or MCP surface imports it.
+
+2. The snapshot `teaser` + `locked_questions` subsystem in
+   `extracted_content_pipeline/faq_deflection_report.py` was built across
+   three slices (PR-Deflection-Snapshot-Teaser, PR-Deflection-Teaser-Top-Answer,
+   PR-Deflection-Teaser-Locked-Dedupe) for a portfolio rendering that every
+   slice deferred and that never landed: `git log -S 'teaser' -- portfolio-ui/`
+   returns no commits, the portfolio proxy `projectSnapshot()` strips both keys
+   fail-closed before any browser sees them, and the readonly MCP server uses a
+   separate projection. The producer ran on every snapshot for nothing, and the
+   teaser was the only path that exposed a full answer body pre-payment.
+
+Keeping either would preserve misleading API surface, a documented contract no
+client honors, and tests pinning behavior with zero consumers. Operator decided
+remove-fully over render (the paid-report reframe already moved teaser/FOMO
+copy into the report itself).
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Dead-code removal (audit follow-through)
+
+1. Remove the `assign_support_ticket_clusters` delegate and its `__all__`
+   entry; `_ensure_clustered` calls the diagnostics entry point directly.
+2. Remove `DeflectionSnapshot.teaser` / `DeflectionSnapshot.locked_questions`,
+   the `_snapshot_teaser` / `_teaser_*` / `_is_teaser_eligible` /
+   `_select_full_teaser_item` helper cluster, the now-orphaned
+   `_RESOLUTION_EVIDENCE_SCOPE_SCOPED` constant, and
+   `DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT`.
+3. Remove the `deflection_snapshot_teaser_preview_count` config field, its
+   validation branch, and the threading through
+   `_gate_deflection_report_artifacts` in
+   `extracted_content_pipeline/api/control_surfaces.py`.
+4. Update the frontend contract docs and checked-in snapshot example so the
+   documented shape matches the producer exactly: `summary` + `top_questions`
+   only, no answer bodies before paid unlock.
+5. Retarget or delete the pinning tests; add
+   `test_deflection_snapshot_never_exposes_answer_bodies` to pin the
+   strengthened privacy invariant (snapshot contains zero answer bodies).
+6. Drop stale `locked_questions` fixture keys from the paid-postgres smoke
+   script and submit-handoff test fixture.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/support_ticket_clustering.py`
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `docs/frontend/content_ops_faq_deflection_checkout_contract.md`
+- `docs/frontend/content_ops_faq_deflection_snapshot_example.json`
+- `scripts/smoke_content_ops_deflection_paid_postgres.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_ops_live_execute_harness.py`
+- `tests/test_extracted_support_ticket_clustering_scale.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+- `plans/PR-Deflection-Dead-Code-Removal.md`
+
+## Mechanism
+
+`build_deflection_snapshot` drops the `teaser_preview_count` parameter and the
+teaser/locked construction; `DeflectionSnapshot.as_dict()` serializes only
+`summary` and `top_questions`. The snapshot privacy posture strictly tightens:
+the teaser full answer was the single pre-payment answer-body exposure, so
+after this slice no answer text, steps, evidence, or source IDs exist anywhere
+in the snapshot payload. Tests that asserted the intentional teaser leak now
+assert its absence (`"Open Analytics" not in gated_payload`, visible answer
+count 0). `_ensure_clustered` keeps identical behavior by unpacking the
+diagnostics tuple and discarding the diagnostics dict, exactly what the
+deleted delegate did.
+
+## Intentional
+
+- No API versioning shim for the removed snapshot keys: the only production
+  consumer (portfolio proxy) already projects them away, so no shipped client
+  observes the change. Stored historical snapshots in
+  `content_ops_deflection_reports.snapshot` JSONB may still contain the old
+  keys; readers tolerate extra keys, and no read path selects them.
+- `deflection_snapshot_content_opportunities` (MCP projection) is untouched;
+  it never read the removed keys.
+- The unrelated "teaser" marketing copy in `docs/report_catalog.md` and the
+  digest skills is out of scope (different product surface).
+- The companion stale-deferral docs cleanup flagged in #1500 (1,000-row
+  fixture text in an archived plan) stays archived untouched; archives are
+  historical records.
+
+## Deferred
+
+- If a free-tier conversion teaser is ever wanted again, it should be designed
+  against the paid-report-reframe surface, not restored from this code; the
+  removed shape is recoverable from git history and issue #1502.
+- Backfill/normalization of historical snapshot JSONB rows (removing stale
+  `teaser`/`locked_questions` keys) is unnecessary for correctness and left
+  out.
+
+## Verification
+
+- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_support_ticket_clustering_scale.py -q` - 38 passed.
+- `pytest tests/test_content_ops_faq_report_contract_docs.py tests/test_smoke_content_ops_deflection_submit_handoff.py -q` - 29 passed.
+- `pytest tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_live_execute_harness.py -q` - 155 passed, 1 skipped.
+- `pytest tests/test_mcp_content_ops_deflection_readonly.py -q` - 13 passed (MCP boundary unaffected).
+- `pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_content_ops_deflection_resolution_live_proof.py tests/test_content_ops_faq_deflection_live_upload_fixture.py tests/test_smoke_content_ops_support_ticket_package.py -q` - 154 passed.
+- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_deflection_submit.py tests/test_extracted_support_ticket_input_package.py -q` - all passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - clean.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - 0 findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `ruff check` over all touched Python files - clean.
+- `git grep` residue sweep for `teaser`/`locked_questions`/`assign_support_ticket_clusters`
+  across py/ts/js/json/md - only negative-assertion test lines and unrelated
+  marketing copy remain.
+
+## Estimated diff size
+
+~520 changed lines, overwhelmingly deletions (35 insertions / 481 deletions
+before the plan doc). Over the 400 LOC soft cap because the slice is a pure
+removal of an audited dead subsystem plus its pinning tests; splitting it
+would leave the package importing deleted symbols between PRs.

--- a/plans/PR-Deflection-Dead-Code-Removal.md
+++ b/plans/PR-Deflection-Dead-Code-Removal.md
@@ -53,6 +53,32 @@ Slice phase: Dead-code removal (audit follow-through)
 6. Drop stale `locked_questions` fixture keys from the paid-postgres smoke
    script and submit-handoff test fixture.
 
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `assign_support_ticket_clusters` no longer exists anywhere in the
+        package, `__all__`, or tests; `_ensure_clustered` produces identical
+        annotations via the diagnostics entry point.
+  - [ ] `DeflectionSnapshot.as_dict()` serializes exactly `summary` and
+        `top_questions`; no `teaser`, `locked_questions`, or answer-body text
+        appears in any snapshot payload, gated execute result, or checked-in
+        example.
+  - [ ] `ContentOpsControlSurfaceApiConfig` no longer accepts or validates
+        `deflection_snapshot_teaser_preview_count`; no caller threads a
+        teaser count.
+  - [ ] Contract docs and `content_ops_faq_deflection_snapshot_example.json`
+        match the producer shape byte-for-byte under the contract-docs test.
+  - [ ] No production behavior changes outside the deflection snapshot
+        projection; the readonly MCP server suite passes unchanged.
+- Affected surfaces: content-ops API response shape (unpaid snapshot),
+  extracted-package public symbols, frontend contract docs, tests, one smoke
+  script. No DB, auth, or scheduler changes.
+- Risk areas: backcompat (removed public symbols and snapshot keys; mitigated
+  by grep-proven zero consumers in #1501/#1502), stale stored snapshot JSONB
+  rows still carrying old keys (no read path selects them).
+- Reviewer rules triggered: R1, R2, R5, R10 (extracted-package + API-surface
+  path triggers), R14.
+
 ### Files touched
 
 - `extracted_content_pipeline/faq_deflection_report.py`

--- a/scripts/smoke_content_ops_deflection_paid_postgres.py
+++ b/scripts/smoke_content_ops_deflection_paid_postgres.py
@@ -274,7 +274,6 @@ def _smoke_payload(request_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
                 "customer_wording": "How do I export attribution reports?",
             }
         ],
-        "locked_questions": [],
     }
     artifact = {
         "markdown": "# Smoke FAQ Deflection Report\n\nOpen Analytics and export.",

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -352,13 +352,6 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
                 "customer_wording": "How do I export attribution reports?",
             }
         ],
-        "locked_questions": [
-            {
-                "rank": 2,
-                "ticket_count": 1,
-            }
-        ],
-        "teaser": {"full_answer": None, "previews": []},
     }
     assert "Open Analytics" not in encoded
     assert "ticket-export-1" not in encoded
@@ -404,7 +397,7 @@ def test_deflection_snapshot_marks_question_only_exports_absent_resolution_evide
     assert snapshot["summary"]["no_proven_answer_count"] == 2
 
 
-def test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions() -> None:
+def test_deflection_snapshot_counts_are_raw_and_rows_beyond_top_n_are_omitted() -> None:
     result = TicketFAQMarkdownResult(
         markdown="# FAQ",
         source_count=10,
@@ -448,10 +441,7 @@ def test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions() -> 
             "customer_wording": "",
         }
     ]
-    assert snapshot["locked_questions"] == [
-        {"rank": 2, "ticket_count": 2},
-        {"rank": 3, "ticket_count": 0},
-    ]
+    assert "locked_questions" not in snapshot
     assert "Can I enable SSO?" not in encoded
     assert "Weighted score is not a ticket count" not in encoded
     assert "ticket-sso-1" not in encoded
@@ -551,187 +541,32 @@ def test_deflection_snapshot_omits_contradictory_summary_date_window() -> None:
     assert "source_window_days" not in snapshot["summary"]
 
 
-def test_deflection_snapshot_includes_bounded_fail_closed_teaser() -> None:
-    result = TicketFAQMarkdownResult(
-        markdown="# FAQ",
-        source_count=6,
-        ticket_source_count=6,
-        output_checks={"condensed": True},
-        items=(
-            _scoped_answer_item(1, "How do I export reports?", "Locked top answer one"),
-            _scoped_answer_item(2, "How do I update billing?", "Locked top answer two"),
-            _scoped_answer_item(3, "How do I enable SSO?", "Locked top answer three"),
-            _scoped_answer_item(
-                4,
-                "How do we rotate API tokens?",
-                "Create the replacement token, deploy it, then revoke the old token.",
-                step="Create the replacement token before revoking the old one.",
-            ),
-            {
-                **_scoped_answer_item(
-                    5,
-                    "Why is the dashboard stale?",
-                    "Mismatched answer must stay locked.",
-                ),
-                "resolution_evidence_scope": "scope_mismatch",
-            },
-            _scoped_answer_item(6, "How do I add a teammate?", "Tail answer locked"),
-        ),
-    )
-
-    snapshot = build_deflection_snapshot(
-        build_deflection_report_artifact(result),
-        top_n=3,
-        teaser_preview_count=2,
-    ).as_dict()
-    encoded = json.dumps(snapshot, sort_keys=True)
-
-    assert snapshot["summary"]["generated"] == 6
-    assert len(snapshot["top_questions"]) == 3
-    assert snapshot["teaser"]["full_answer"] == {
-        "rank": 1,
-        "question": "How do I export reports?",
-        "answer": "Locked top answer one",
-        "steps": ["Step for How do I export reports?"],
-        "answer_evidence_status": "resolution_evidence",
-        "resolution_evidence_scope": "scoped",
-        "weighted_frequency": 1,
-        "source_count": 1,
-    }
-    assert [preview["rank"] for preview in snapshot["teaser"]["previews"]] == [2, 3]
-    for preview in snapshot["teaser"]["previews"]:
-        assert preview["body_withheld"] is True
-        assert preview["answer_evidence_status"] == "resolution_evidence"
-        assert preview["resolution_evidence_scope"] == "scoped"
-        assert "answer" not in preview
-        assert "steps" not in preview
-
-    assert "Locked top answer one" in encoded
-    assert "Locked top answer two" not in encoded
-    assert "Locked top answer three" not in encoded
-    assert "Mismatched answer must stay locked" not in encoded
-    assert "Tail answer locked" not in encoded
-    assert "ticket-" not in encoded
-    assert "evidence_quotes" not in encoded
-    assert "source_ids" not in encoded
-
-
-def test_deflection_snapshot_teaser_falls_through_to_next_eligible_rank() -> None:
+def test_deflection_snapshot_never_exposes_answer_bodies() -> None:
     result = TicketFAQMarkdownResult(
         markdown="# FAQ",
         source_count=3,
         ticket_source_count=3,
         output_checks={"condensed": True},
         items=(
-            {
-                **_scoped_answer_item(
-                    1,
-                    "How do I export reports?",
-                    "Blocked top answer must not leak.",
-                ),
-                "answer_evidence_status": "draft_needs_review",
-            },
-            _scoped_answer_item(2, "How do I update billing?", "Second answer"),
-            _scoped_answer_item(3, "How do I enable SSO?", "Third answer"),
+            _scoped_answer_item(1, "How do I export reports?", "Top answer body"),
+            _scoped_answer_item(2, "How do I update billing?", "Second answer body"),
+            _scoped_answer_item(3, "How do I enable SSO?", "Third answer body"),
         ),
     )
 
     snapshot = build_deflection_snapshot(
         build_deflection_report_artifact(result),
         top_n=2,
-        teaser_preview_count=1,
     ).as_dict()
     encoded = json.dumps(snapshot, sort_keys=True)
 
-    assert snapshot["teaser"]["full_answer"] == {
-        "rank": 2,
-        "question": "How do I update billing?",
-        "answer": "Second answer",
-        "steps": ["Step for How do I update billing?"],
-        "answer_evidence_status": "resolution_evidence",
-        "resolution_evidence_scope": "scoped",
-        "weighted_frequency": 2,
-        "source_count": 1,
-    }
-    assert [preview["rank"] for preview in snapshot["teaser"]["previews"]] == [3]
-    assert "Blocked top answer must not leak" not in encoded
-    assert "Third answer" not in encoded
-
-
-def test_deflection_snapshot_omits_full_teaser_rank_from_locked_rows() -> None:
-    result = TicketFAQMarkdownResult(
-        markdown="# FAQ",
-        source_count=4,
-        ticket_source_count=4,
-        output_checks={"condensed": True},
-        items=(
-            {
-                **_scoped_answer_item(
-                    1,
-                    "How do I export reports?",
-                    "Blocked top answer must not leak.",
-                ),
-                "answer_evidence_status": "draft_needs_review",
-            },
-            {
-                **_scoped_answer_item(
-                    2,
-                    "How do I update billing?",
-                    "Blocked second answer must not leak.",
-                ),
-                "answer_evidence_status": "draft_needs_review",
-            },
-            _scoped_answer_item(3, "How do I enable SSO?", "Third answer"),
-            _scoped_answer_item(4, "How do I rotate tokens?", "Fourth answer"),
-        ),
-    )
-
-    snapshot = build_deflection_snapshot(
-        build_deflection_report_artifact(result),
-        top_n=1,
-        teaser_preview_count=1,
-    ).as_dict()
-    encoded = json.dumps(snapshot, sort_keys=True)
-
-    assert snapshot["teaser"]["full_answer"]["rank"] == 3
-    assert snapshot["locked_questions"] == [
-        {"rank": 2, "ticket_count": 1},
-        {"rank": 4, "ticket_count": 1},
-    ]
-    assert "Third answer" in encoded
-    assert "Blocked top answer must not leak" not in encoded
-    assert "Blocked second answer must not leak" not in encoded
-    assert "Fourth answer" not in encoded
-
-
-def test_deflection_snapshot_teaser_empty_when_no_scoped_resolution_evidence() -> None:
-    result = TicketFAQMarkdownResult(
-        markdown="# FAQ",
-        source_count=2,
-        ticket_source_count=2,
-        output_checks={"condensed": True},
-        items=(
-            {
-                **_scoped_answer_item(1, "How do I export reports?", "Locked answer"),
-                "resolution_evidence_scope": "scope_mismatch",
-            },
-            {
-                "question": "Scoped status without answer body stays hidden",
-                "weighted_frequency": 1,
-                "answer": "",
-                "answer_evidence_status": "resolution_evidence",
-                "resolution_evidence_scope": "scoped",
-                "source_ids": ("ticket-2",),
-            },
-        ),
-    )
-
-    snapshot = build_deflection_snapshot(build_deflection_report_artifact(result)).as_dict()
-    encoded = json.dumps(snapshot, sort_keys=True)
-
-    assert snapshot["teaser"] == {"full_answer": None, "previews": []}
-    assert "Locked answer" not in encoded
-    assert "ticket-1" not in encoded
+    assert set(snapshot) == {"summary", "top_questions"}
+    assert "Top answer body" not in encoded
+    assert "Second answer body" not in encoded
+    assert "Third answer body" not in encoded
+    assert "ticket-" not in encoded
+    assert "evidence_quotes" not in encoded
+    assert "source_ids" not in encoded
 
 
 def test_deflection_snapshot_rejects_non_positive_top_n() -> None:
@@ -745,22 +580,6 @@ def test_deflection_snapshot_rejects_non_positive_top_n() -> None:
 
     with pytest.raises(ValueError, match="top_n must be positive"):
         build_deflection_snapshot(build_deflection_report_artifact(result), top_n=0)
-
-
-def test_deflection_snapshot_rejects_negative_teaser_preview_count() -> None:
-    result = TicketFAQMarkdownResult(
-        markdown="# FAQ",
-        source_count=0,
-        ticket_source_count=0,
-        output_checks={},
-        items=(),
-    )
-
-    with pytest.raises(ValueError, match="teaser_preview_count must be non-negative"):
-        build_deflection_snapshot(
-            build_deflection_report_artifact(result),
-            teaser_preview_count=-1,
-        )
 
 
 def _scoped_answer_item(

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -197,8 +197,6 @@ def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() ->
     assert set(payload) == {
         "summary",
         "top_questions",
-        "locked_questions",
-        "teaser",
     }
     assert set(payload["summary"]) == {
         "generated",
@@ -219,37 +217,9 @@ def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() ->
             "weighted_frequency",
             "customer_wording",
         }
-    for question in payload["locked_questions"]:
-        assert set(question) == {"rank", "ticket_count"}
-    assert set(payload["teaser"]) == {"full_answer", "previews"}
-    if payload["teaser"]["full_answer"] is not None:
-        assert set(payload["teaser"]["full_answer"]) == {
-            "rank",
-            "question",
-            "answer",
-            "steps",
-            "answer_evidence_status",
-            "resolution_evidence_scope",
-            "weighted_frequency",
-            "source_count",
-        }
-        assert (
-            payload["teaser"]["full_answer"]["answer_evidence_status"]
-            == "resolution_evidence"
-        )
-        assert payload["teaser"]["full_answer"]["resolution_evidence_scope"] == "scoped"
-    for preview in payload["teaser"]["previews"]:
-        assert set(preview) == {
-            "rank",
-            "question",
-            "answer_evidence_status",
-            "resolution_evidence_scope",
-            "weighted_frequency",
-            "step_count",
-            "source_count",
-            "body_withheld",
-        }
-        assert preview["body_withheld"] is True
+    assert '"answer"' not in encoded
+    assert "teaser" not in encoded
+    assert "locked_questions" not in encoded
     assert "markdown" not in encoded
     assert "faq_result" not in encoded
     assert "source_ids" not in encoded
@@ -280,8 +250,7 @@ def test_content_ops_faq_deflection_checkout_contract_pins_paid_handoff() -> Non
         "account_id: string;",
         "request_id: string;",
         "GET /content-ops/deflection-reports/{request_id}/snapshot",
-        "snapshot.teaser.full_answer",
-        "body_withheld: true",
+        "The snapshot contains no answer bodies",
         "GET /content-ops/deflection-reports/{request_id}/artifact",
         "csv_file: File;",
         "do not expose raw support-ticket CSVs through a",

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -2788,10 +2788,9 @@ async def test_execute_generation_route_returns_snapshot_for_unpaid_deflection_r
     assert result["snapshot"]["summary"]["repeat_ticket_count"] == 2
     assert result["snapshot"]["top_questions"][0]["rank"] == 1
     assert result["snapshot"]["top_questions"][0]["ticket_count"] == 1
-    assert result["snapshot"]["locked_questions"] == []
-    assert result["snapshot"]["teaser"]["full_answer"]["answer"] == (
-        "To resolve this, open Analytics and download the report."
-    )
+    assert "locked_questions" not in result["snapshot"]
+    assert "teaser" not in result["snapshot"]
+    assert "To resolve this, open Analytics and download the report." not in encoded
     assert "markdown" not in result
     assert "faq_result" not in result
     assert "ticket-export-1" not in encoded
@@ -4406,14 +4405,6 @@ def test_content_ops_config_rejects_invalid_faq_execute_row_limit():
 def test_content_ops_config_rejects_invalid_ingestion_import_concurrency():
     with pytest.raises(ValueError, match="ingestion_import_max_concurrency must be positive"):
         ContentOpsControlSurfaceApiConfig(ingestion_import_max_concurrency=0)
-
-
-def test_content_ops_config_rejects_negative_deflection_teaser_preview_count():
-    with pytest.raises(
-        ValueError,
-        match="deflection_snapshot_teaser_preview_count must be non-negative",
-    ):
-        ContentOpsControlSurfaceApiConfig(deflection_snapshot_teaser_preview_count=-1)
 
 
 def test_content_ops_config_rejects_invalid_falsification_rules_shape():

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -810,7 +810,7 @@ async def test_live_execute_route_returns_faq_deflection_report_artifact() -> No
     assert "markdown" not in step["result"]
     assert "faq_result" not in step["result"]
     gated_payload = json.dumps(step["result"], sort_keys=True)
-    assert "Open Analytics" in gated_payload
+    assert "Open Analytics" not in gated_payload
     assert "ticket-export-1" not in gated_payload
     assert "evidence_quotes" not in gated_payload
 
@@ -936,7 +936,6 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(
             deflection_snapshot_top_n=2,
-            deflection_snapshot_teaser_preview_count=1,
         ),
         execution_services_provider=lambda: ContentOpsExecutionServices(
             faq_deflection_report=FAQDeflectionReportService(),
@@ -1028,20 +1027,8 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
     }
     assert len(snapshot["top_questions"]) == 2
     assert [question["ticket_count"] for question in snapshot["top_questions"]] == [1, 1]
-    assert snapshot["locked_questions"] == [
-        {"rank": 3, "ticket_count": 1},
-        {"rank": 4, "ticket_count": 1},
-    ]
-    assert snapshot["teaser"]["full_answer"]["answer_evidence_status"] == (
-        "resolution_evidence"
-    )
-    assert snapshot["teaser"]["full_answer"]["resolution_evidence_scope"] == "scoped"
-    assert snapshot["teaser"]["full_answer"]["rank"] == 1
-    assert len(snapshot["teaser"]["previews"]) == 1
-    assert snapshot["teaser"]["previews"][0]["rank"] == 2
-    assert snapshot["teaser"]["previews"][0]["body_withheld"] is True
-    assert "answer" not in snapshot["teaser"]["previews"][0]
-    assert "steps" not in snapshot["teaser"]["previews"][0]
+    assert "locked_questions" not in snapshot
+    assert "teaser" not in snapshot
     snapshot_payload = json.dumps(snapshot, sort_keys=True)
     visible_answer_count = sum(
         answer in snapshot_payload
@@ -1052,7 +1039,7 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
             "Create the replacement token",
         )
     )
-    assert visible_answer_count == 1
+    assert visible_answer_count == 0
     assert "resolution_text" not in snapshot_payload
     assert "ticket-token-1" not in snapshot_payload
     assert "source_ids" not in snapshot_payload

--- a/tests/test_extracted_support_ticket_clustering_scale.py
+++ b/tests/test_extracted_support_ticket_clustering_scale.py
@@ -14,7 +14,6 @@ import pytest
 from extracted_content_pipeline import support_ticket_clustering as clustering
 from extracted_content_pipeline.support_ticket_clustering import (
     MAX_TOKEN_SET_CLUSTER_ROWS,
-    assign_support_ticket_clusters,
     assign_support_ticket_clusters_with_diagnostics,
     support_ticket_cluster_quality,
 )
@@ -76,15 +75,6 @@ def test_token_set_rows_above_threshold_skip_preview_but_keep_rows() -> None:
     quality = support_ticket_cluster_quality(annotated)
     assert quality["uncategorized_row_count"] == 4
     assert quality["clustered_row_count"] == 1
-
-
-def test_assign_support_ticket_clusters_keeps_plain_signature() -> None:
-    rows = [_token_set_row(index) for index in range(4)]
-
-    annotated = assign_support_ticket_clusters(rows, max_token_set_rows=3)
-
-    assert len(annotated) == 4
-    assert all("support_ticket_cluster" not in row for row in annotated)
 
 
 def test_package_surfaces_cluster_preview_skip_warning(

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -35,7 +35,6 @@ SNAPSHOT = {
             "customer_wording": "How do I export reports?",
         }
     ],
-    "locked_questions": [{"rank": 2, "ticket_count": 1}],
 }
 
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-Dead-Code-Removal.md
Slice phase: Dead-code removal (audit follow-through)

The 2026-06 deflection-lane dead-code audit (#1500) confirmed two zero-consumer subsystems at commit 7dd668c: the `assign_support_ticket_clusters` compat delegate (#1501, only caller was its own signature-pinning test) and the snapshot `teaser` + `locked_questions` subsystem (#1502, built across three slices for a portfolio rendering that never landed — `git log -S 'teaser' -- portfolio-ui/` is empty, the portfolio proxy `projectSnapshot()` strips both keys fail-closed, and the readonly MCP server uses a separate projection). This slice removes both fully — producers, config knob, contract docs, example payload, and pinning tests — with no shims left behind. The snapshot privacy posture strictly tightens: the teaser was the only pre-payment answer-body exposure, so the snapshot now contains no answer text at all, pinned by the new `test_deflection_snapshot_never_exposes_answer_bodies`.

## Intentional

- No API versioning shim for the removed snapshot keys: the only production consumer (portfolio proxy) already projects them away, so no shipped client observes the change.
- Stored historical snapshot JSONB rows may carry the old keys; no read path selects them and readers tolerate extra keys, so no backfill.
- `deflection_snapshot_content_opportunities` (MCP projection) untouched; it never read the removed keys.
- Unrelated "teaser" marketing copy in `docs/report_catalog.md` and digest skills is out of scope (different product surface).

## Deferred

- If a free-tier conversion teaser is ever wanted again, design it against the paid-report-reframe surface rather than restoring this code; the removed shape is recoverable from git history and #1502.
- Backfill/normalization of historical snapshot JSONB rows is unnecessary for correctness and left out.

## Parked hardening

- None. `HARDENING.md` was scanned; no relevant active entries for this removal slice.

## Verification

- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_support_ticket_clustering_scale.py -q` — 38 passed.
- `pytest tests/test_content_ops_faq_report_contract_docs.py tests/test_smoke_content_ops_deflection_submit_handoff.py -q` — 29 passed.
- `pytest tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_live_execute_harness.py -q` — 155 passed, 1 skipped.
- `pytest tests/test_mcp_content_ops_deflection_readonly.py -q` — 13 passed (MCP boundary unaffected).
- `pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_content_ops_deflection_resolution_live_proof.py tests/test_content_ops_faq_deflection_live_upload_fixture.py tests/test_smoke_content_ops_support_ticket_package.py -q` — 154 passed.
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_deflection_submit.py tests/test_extracted_support_ticket_input_package.py -q` — all passed.
- `bash scripts/validate_extracted_content_pipeline.sh`, `forbid_atlas_reasoning_imports.py`, `audit_extracted_standalone.py --fail-on-debt`, `check_ascii_python.sh`, `ruff check` over all touched files — all clean.
- Residue sweep: `git grep` for `teaser` / `locked_questions` / `assign_support_ticket_clusters` finds only negative-assertion test lines and unrelated marketing copy.

## Diff size

14 files, +193 / -481 (35/481 in code+tests+docs, remainder is the plan doc). Over the 400 LOC soft cap because it is a pure removal of an audited dead subsystem plus its pinning tests; splitting would leave the package importing deleted symbols between PRs.

## AI reconciliation

AI findings reviewed: Yes. All fixed or waived: Yes. Waivers justified in PR body: N/A (no waivers).

- Codex P2 (`plans/PR-Deflection-Dead-Code-Removal.md` — missing `### Review Contract` block): **fixed** in ea6f6f8; thread replied and resolved.
- Copilot: reviewed all 14 files, generated no findings.

Closes #1501, closes #1502. Audit umbrella: #1500.

https://claude.ai/code/session_01M8jthoVzZ7zfNazDU63hyp