### PR TITLE
Content-Ops claim evidence artifact bundle

### DIFF
--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -416,17 +416,44 @@ class ClaimEvidenceResultArtifact:
         return payload
 
 
+@dataclass(frozen=True)
+class ClaimEvidenceResultFile:
+    """One deterministic operator-facing benchmark result file."""
+
+    path: str
+    content_type: str
+    content: str
+
+
+def claim_evidence_result_artifact_files(
+    artifact: object,
+) -> tuple[ClaimEvidenceResultFile, ...]:
+    """Return stable JSON + Markdown result files for an existing artifact."""
+
+    typed_artifact = _coerce_result_artifact(artifact)
+    json_payload = json.dumps(
+        typed_artifact.as_mapping(),
+        indent=2,
+        sort_keys=True,
+    )
+    return (
+        ClaimEvidenceResultFile(
+            path="claim_evidence_result.json",
+            content_type="application/json",
+            content=json_payload + "\n",
+        ),
+        ClaimEvidenceResultFile(
+            path="claim_evidence_result.md",
+            content_type="text/markdown",
+            content=render_claim_evidence_result_markdown(typed_artifact),
+        ),
+    )
+
+
 def render_claim_evidence_result_markdown(artifact: object) -> str:
     """Render a benchmark result artifact as an operator-facing Markdown report."""
 
-    typed_artifact = (
-        artifact
-        if isinstance(artifact, ClaimEvidenceResultArtifact)
-        else _failed_result_artifact(
-            DEFAULT_THRESHOLDS,
-            ("artifact must be ClaimEvidenceResultArtifact",),
-        )
-    )
+    typed_artifact = _coerce_result_artifact(artifact)
     lines = [
         "# Claim Evidence Benchmark Result",
         "",
@@ -537,6 +564,15 @@ def render_claim_evidence_result_markdown(artifact: object) -> str:
     lines.extend(("", "## Failure Cases", ""))
     lines.extend(_failure_case_table(typed_artifact.failure_cases))
     return "\n".join(lines).rstrip() + "\n"
+
+
+def _coerce_result_artifact(artifact: object) -> ClaimEvidenceResultArtifact:
+    if isinstance(artifact, ClaimEvidenceResultArtifact):
+        return artifact
+    return _failed_result_artifact(
+        DEFAULT_THRESHOLDS,
+        ("artifact must be ClaimEvidenceResultArtifact",),
+    )
 
 
 @dataclass(frozen=True)

--- a/plans/PR-Content-Ops-Claim-Evidence-Artifact-Bundle.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Artifact-Bundle.md
@@ -1,0 +1,105 @@
+# PR-Content-Ops-Claim-Evidence-Artifact-Bundle
+
+## Why this slice exists
+
+Issue #1435 still needs operator-facing benchmark artifacts before the
+`verify_claim_evidence` structured-witness slot can be considered for verifier
+inclusion. Prior slices built the scorer/evaluator, fixture contract, fixture
+loader, validation CLI, prompt/schema contract, injected-provider runner,
+machine-readable result artifact, and Markdown writeup. The next deterministic
+gap is packaging an already-built result artifact into stable JSON and Markdown
+file contents so a later CLI/live-run slice can write exactly those files
+without inventing presentation logic at the transport boundary.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a deterministic file-bundle value type for claim/evidence benchmark
+   result artifacts.
+2. Add a pure bundler that returns stable JSON and Markdown entries from an
+   existing result artifact.
+3. Fail closed on malformed bundler input by returning no-go JSON and Markdown
+   that carry the artifact error.
+4. Leave disk writing, provider adapters, live prompt execution, and model-run
+   CLI orchestration out of this slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Claim-Evidence-Artifact-Bundle.md`
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+
+### Review Contract
+
+Acceptance criteria:
+- The bundler returns exactly two stable entries: JSON result payload and
+  Markdown writeup.
+- The JSON entry is deterministic, newline-terminated, and parseable back into
+  the existing artifact fields including `go_no_go` and `ok`.
+- The Markdown entry matches the existing operator-facing renderer.
+- Malformed bundler input does not raise; it returns no-go JSON and Markdown
+  with the same attributable artifact error.
+
+Affected surfaces: extracted benchmark helper and focused unit tests.
+
+Risk areas: false-green presentation, future CLI/file-output compatibility,
+and accidental live/provider scope creep.
+
+Reviewer rules triggered: R1, R2, R10, R14.
+
+## Mechanism
+
+The benchmark module already has a machine-readable result artifact and a
+Markdown renderer. This slice adds a tiny file-entry dataclass plus a pure
+bundler that normalizes malformed input through the same failed-artifact path as
+the renderer, then emits:
+
+- JSON entry named claim_evidence_result.json with sorted, indented JSON from the artifact
+  payload.
+- Markdown entry named claim_evidence_result.md with the existing writeup.
+
+The function returns content, names, and content types only. A later CLI can
+write these entries to an operator artifact directory without duplicating
+serialization or Markdown decisions.
+
+## Intentional
+
+- No filesystem writes in this PR. Keeping the extracted benchmark module pure
+  preserves the current no-I/O contract and gives the future CLI a narrow helper
+  to call.
+- No provider adapters or live model execution. The reliability gate still must
+  be run and evaluated before verifier/MCP inclusion.
+- The JSON payload uses the existing artifact mapping rather than a new schema.
+  This avoids a second artifact contract for the same data.
+
+## Deferred
+
+- Disk-writing CLI and operator artifact directory handling.
+- Concrete provider adapters and live prompt execution.
+- Batch model-run CLI for fixture-file model runs.
+- Verifier rubric inclusion and MCP exposure only if benchmark thresholds pass.
+- Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_extracted_content_claim_evidence_benchmark.py -- 51 passed.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
+- bash scripts/check_ascii_python.sh -- passed.
+- bash scripts/run_extracted_pipeline_checks.sh -- 3895 passed, 10 skipped.
+- git diff --check -- passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_artifact_bundle_pr_body.md -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-Claim-Evidence-Artifact-Bundle.md` | 105 |
+| `extracted_content_pipeline/claim_evidence_benchmark.py` | 52 |
+| `tests/test_extracted_content_claim_evidence_benchmark.py` | 63 |
+| **Total** | **220** |
+
+Under the 400 LOC target.

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -17,6 +17,7 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     StabilityScore,
     build_claim_evidence_prompt_contract,
     build_claim_evidence_result_artifact,
+    claim_evidence_result_artifact_files,
     claim_evidence_response_json_schema,
     evaluate_thresholds,
     intra_model_stability,
@@ -925,6 +926,68 @@ def test_result_writeup_fails_closed_on_malformed_renderer_input() -> None:
     assert "artifact must be ClaimEvidenceResultArtifact" in markdown
     assert "No model scores." in markdown
     assert "No failure cases." in markdown
+
+
+def test_result_artifact_files_bundle_json_and_markdown_outputs() -> None:
+    triples = (
+        _triple("easy", True, EASY),
+        _triple("hard", False, HARD),
+    )
+    claude_run = _model_run(
+        "claude",
+        {"easy": _response(True, 5), "hard": _response(False, 4)},
+    )
+    gpt_run = _model_run(
+        "gpt",
+        {"easy": _response(True, 5), "hard": _response(False, 4)},
+    )
+    artifact = build_claim_evidence_result_artifact(
+        triples,
+        (gpt_run, claude_run),
+        stability_runs_by_model_id={
+            "gpt": (gpt_run, gpt_run),
+            "claude": (claude_run, claude_run),
+        },
+        thresholds=BenchmarkThresholds(
+            easy_accuracy_min=1.0,
+            hard_accuracy_min=1.0,
+            inter_model_agreement_min=1.0,
+            intra_model_stability_min=1.0,
+            high_confidence_accuracy_min=0.90,
+        ),
+    )
+
+    files = claim_evidence_result_artifact_files(artifact)
+
+    assert [file.path for file in files] == [
+        "claim_evidence_result.json",
+        "claim_evidence_result.md",
+    ]
+    assert [file.content_type for file in files] == [
+        "application/json",
+        "text/markdown",
+    ]
+    assert files[0].content.endswith("\n")
+    payload = json.loads(files[0].content)
+    assert payload["go_no_go"] == "go"
+    assert payload["ok"] is True
+    assert payload["model_scores"][0]["model_id"] == "claude"
+    assert files[1].content == render_claim_evidence_result_markdown(artifact)
+    assert "- Go/no-go: GO" in files[1].content
+
+
+def test_result_artifact_files_fail_closed_on_malformed_input() -> None:
+    files = claim_evidence_result_artifact_files({"not": "an artifact"})
+
+    payload = json.loads(files[0].content)
+    assert payload["go_no_go"] == "no_go"
+    assert payload["ok"] is False
+    assert payload["errors"] == ["artifact must be ClaimEvidenceResultArtifact"]
+    assert payload["verdict"]["failure_reasons"] == [
+        "artifact must be ClaimEvidenceResultArtifact"
+    ]
+    assert "- Go/no-go: NO_GO" in files[1].content
+    assert "artifact must be ClaimEvidenceResultArtifact" in files[1].content
 
 
 def test_model_score_counts_easy_hard_and_high_confidence_accuracy() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Artifact-Bundle.md
Slice phase: Functional validation

This PR closes the next deterministic #1435 delivery gap by packaging an already-built claim/evidence benchmark result artifact into stable JSON and Markdown file entries. It does not write files or call providers; it gives the future operator CLI/live-run slice a single package-owned serialization contract to use.

## Intentional
- No filesystem writes in this PR; the extracted benchmark module stays pure.
- No provider adapters, live prompt execution, model-run CLI, verifier rubric inclusion, or MCP exposure.
- The JSON payload uses the existing artifact mapping rather than creating a second artifact schema.

## Deferred
- Disk-writing CLI and operator artifact directory handling.
- Concrete provider adapters and live prompt execution.
- Batch model-run CLI for fixture-file model runs.
- Verifier rubric inclusion and MCP exposure only if benchmark thresholds pass.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_claim_evidence_benchmark.py` -- 51 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 3895 passed, 10 skipped.
- `git diff --check` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_artifact_bundle_pr_body.md` -- passed.

## Diff size
3 files, about +220 LOC.
