### PR TITLE
Content-Ops claim evidence artifact writer

### DIFF
--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -1,9 +1,9 @@
 """Deterministic benchmark scoring for claim/evidence support checks.
 
-This module is intentionally pure. It does not call a model, read the claim
-registry, or expose an MCP tool. It only scores labeled benchmark triples and
-structured witness responses against the reliability thresholds from issue
-#1435.
+This module does not call a model, read the claim registry, or expose an MCP
+tool. It scores labeled benchmark triples and structured witness responses
+against the reliability thresholds from issue #1435. The only file I/O is the
+explicit operator artifact writer for already-built result artifacts.
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ import json
 from collections.abc import Sequence as RuntimeSequence
 from dataclasses import asdict, dataclass
 from itertools import combinations
+from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
 
@@ -425,6 +426,29 @@ class ClaimEvidenceResultFile:
     content: str
 
 
+@dataclass(frozen=True)
+class ClaimEvidenceWrittenResultFile:
+    """Metadata for one benchmark result file written to disk."""
+
+    path: str
+    content_type: str
+    output_path: str
+    bytes_written: int
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceResultWrite:
+    """Result of writing operator-facing benchmark artifact files."""
+
+    output_dir: str
+    files: tuple[ClaimEvidenceWrittenResultFile, ...]
+    errors: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
 def claim_evidence_result_artifact_files(
     artifact: object,
 ) -> tuple[ClaimEvidenceResultFile, ...]:
@@ -448,6 +472,66 @@ def claim_evidence_result_artifact_files(
             content=render_claim_evidence_result_markdown(typed_artifact),
         ),
     )
+
+
+def write_claim_evidence_result_artifact_files(
+    artifact: object,
+    output_dir: object,
+) -> ClaimEvidenceResultWrite:
+    """Write the JSON + Markdown result bundle into an operator directory."""
+
+    if not isinstance(output_dir, (str, Path)):
+        return _failed_result_write("", ("output_dir must be a path",))
+
+    target_dir = Path(output_dir)
+    if target_dir.exists() and not target_dir.is_dir():
+        return _failed_result_write(
+            str(target_dir),
+            (f"output_dir is not a directory: {target_dir}",),
+        )
+
+    files = claim_evidence_result_artifact_files(artifact)
+    path_errors = _result_file_path_errors(files)
+    if path_errors:
+        return _failed_result_write(str(target_dir), path_errors)
+
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        return _failed_result_write(
+            str(target_dir),
+            (f"output_dir could not be created: {target_dir}: {error.strerror or error}",),
+        )
+
+    written: list[ClaimEvidenceWrittenResultFile] = []
+    for file in files:
+        output_path = target_dir / file.path
+        if output_path.is_symlink():
+            return ClaimEvidenceResultWrite(
+                output_dir=str(target_dir),
+                files=tuple(written),
+                errors=(f"result file path is a symlink: {output_path}",),
+            )
+        try:
+            output_path.write_text(file.content, encoding="utf-8")
+        except OSError as error:
+            return ClaimEvidenceResultWrite(
+                output_dir=str(target_dir),
+                files=tuple(written),
+                errors=(
+                    f"result file could not be written: "
+                    f"{output_path}: {error.strerror or error}",
+                ),
+            )
+        written.append(
+            ClaimEvidenceWrittenResultFile(
+                path=file.path,
+                content_type=file.content_type,
+                output_path=str(output_path),
+                bytes_written=len(file.content.encode("utf-8")),
+            )
+        )
+    return ClaimEvidenceResultWrite(str(target_dir), tuple(written), ())
 
 
 def render_claim_evidence_result_markdown(artifact: object) -> str:
@@ -572,6 +656,32 @@ def _coerce_result_artifact(artifact: object) -> ClaimEvidenceResultArtifact:
     return _failed_result_artifact(
         DEFAULT_THRESHOLDS,
         ("artifact must be ClaimEvidenceResultArtifact",),
+    )
+
+
+def _result_file_path_errors(
+    files: Sequence[ClaimEvidenceResultFile],
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    for file in files:
+        path = Path(file.path)
+        if (
+            path.is_absolute()
+            or path.name != file.path
+            or file.path in ("", ".", "..")
+        ):
+            errors.append(f"result file path must be a relative filename: {file.path}")
+    return tuple(errors)
+
+
+def _failed_result_write(
+    output_dir: str,
+    errors: Sequence[str],
+) -> ClaimEvidenceResultWrite:
+    return ClaimEvidenceResultWrite(
+        output_dir=output_dir,
+        files=(),
+        errors=tuple(errors),
     )
 
 

--- a/plans/PR-Content-Ops-Claim-Evidence-Artifact-Writer.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Artifact-Writer.md
@@ -1,0 +1,111 @@
+# PR-Content-Ops-Claim-Evidence-Artifact-Writer
+
+## Why this slice exists
+
+Issue #1435 now has a deterministic benchmark result artifact, Markdown
+renderer, and package-owned JSON/Markdown bundle. The next operator handoff gap
+is writing that bundle into an artifact directory without letting a future CLI
+or transport layer reinvent filenames, content types, or failure presentation.
+This slice lands the narrow write boundary over an already-built artifact so the
+later live-run CLI can focus on provider execution and orchestration.
+
+This slice exceeds the normal 400 LOC target after review because PR #1508
+surfaced a MAJOR symlink-follow defect at the write boundary. The added scope is
+limited to rejecting symlinked result paths and pinning the defect class with
+multiple same-class probes.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Functional validation
+
+1. Add a deterministic artifact-directory writer for the existing
+   claim/evidence JSON + Markdown bundle.
+2. Return a small write result with success state, written file metadata, and
+   errors.
+3. Create the output directory when needed and reject an output path that is an
+   existing file.
+4. Preserve the existing fail-closed artifact behavior: malformed artifact input
+   still writes a no-go JSON/Markdown bundle.
+5. Leave artifact JSON parsing, provider adapters, live prompt execution, and
+   batch model-run CLI orchestration out of this slice.
+
+### Files touched
+
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `plans/PR-Content-Ops-Claim-Evidence-Artifact-Writer.md`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+
+### Review Contract
+
+Acceptance criteria:
+- A valid result artifact writes the stable JSON and Markdown bundle into the
+  requested output directory.
+- The returned write result identifies both written files, content types, and
+  byte counts.
+- Missing directories are created.
+- An existing non-directory output path fails closed with no write attempt.
+- Malformed artifact input writes no-go JSON and Markdown using the same
+  fail-closed artifact error as the bundle helper.
+
+Affected surfaces: extracted benchmark helper and focused unit tests.
+
+Risk areas: accidental file writes outside the requested directory, false-green
+artifact presentation, and future CLI compatibility.
+
+Reviewer rules triggered: R1, R2, R6, R10, R14.
+
+## Mechanism
+
+The benchmark module gains immutable write-result value types and a helper that
+calls `claim_evidence_result_artifact_files`, creates the requested output
+directory, writes each fixed bundle entry with UTF-8 encoding, and returns
+metadata for the files it wrote. It does not accept caller-controlled filenames;
+the only file names are the two package-owned bundle names from #1506.
+
+Invalid output-directory input or an existing file at the output path returns a
+failed result with an error string. A malformed artifact object is not an output
+path error: it follows the already-established fail-closed artifact path and
+writes no-go JSON/Markdown so operators can inspect the failure.
+
+## Intentional
+
+- This introduces file I/O only at the explicit artifact-writer boundary. The
+  benchmark runner, scorer, renderer, and bundle helper remain deterministic and
+  provider-free.
+- No CLI is added yet. The helper gives the next CLI slice one package-owned
+  write primitive instead of duplicating write behavior in a script.
+- The writer reports relative bundle names and concrete file-system paths; it
+  does not make an opinionated archive layout beyond the requested directory.
+- Symlink rejection uses an explicit pre-write path check. A kernel-level
+  no-follow write is deferred until this helper becomes a concurrent automation
+  boundary.
+
+## Deferred
+
+- CLI wrapper that loads/constructs benchmark artifacts and calls this writer.
+- Artifact JSON parsing back into result dataclasses.
+- Concrete provider adapters and live prompt execution.
+- Batch model-run CLI for fixture-file model runs.
+- Verifier rubric inclusion and MCP exposure only if benchmark thresholds pass.
+- Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_extracted_content_claim_evidence_benchmark.py: 59 passed.
+- bash scripts/validate_extracted_content_pipeline.sh: passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline: passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt: Atlas runtime import findings: 0.
+- bash scripts/check_ascii_python.sh: passed.
+- bash scripts/run_extracted_pipeline_checks.sh: 3903 passed, 10 skipped.
+- git diff --check: passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_artifact_writer_pr_body.md: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/claim_evidence_benchmark.py` | 118 |
+| `plans/PR-Content-Ops-Claim-Evidence-Artifact-Writer.md` | 111 |
+| `tests/test_extracted_content_claim_evidence_benchmark.py` | 223 |
+| **Total** | **452** |

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from extracted_content_pipeline.claim_evidence_benchmark import (
     EASY,
@@ -10,6 +11,7 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     BenchmarkThresholds,
     ClaimEvidenceModelRun,
     ClaimEvidenceResponse,
+    ClaimEvidenceResultFile,
     ClaimEvidenceRunRow,
     ClaimEvidenceTriple,
     ModelScore,
@@ -27,6 +29,8 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     run_claim_evidence_provider,
     score_model,
     validate_claim_evidence_fixture,
+    write_claim_evidence_result_artifact_files,
+    _result_file_path_errors,
 )
 
 
@@ -988,6 +992,225 @@ def test_result_artifact_files_fail_closed_on_malformed_input() -> None:
     ]
     assert "- Go/no-go: NO_GO" in files[1].content
     assert "artifact must be ClaimEvidenceResultArtifact" in files[1].content
+
+
+def test_result_artifact_writer_writes_bundle_to_directory(tmp_path) -> None:
+    triples = (
+        _triple("easy", True, EASY),
+        _triple("hard", False, HARD),
+    )
+    claude_run = _model_run(
+        "claude",
+        {"easy": _response(True, 5), "hard": _response(False, 4)},
+    )
+    gpt_run = _model_run(
+        "gpt",
+        {"easy": _response(True, 5), "hard": _response(False, 4)},
+    )
+    artifact = build_claim_evidence_result_artifact(
+        triples,
+        (gpt_run, claude_run),
+        stability_runs_by_model_id={
+            "gpt": (gpt_run, gpt_run),
+            "claude": (claude_run, claude_run),
+        },
+        thresholds=BenchmarkThresholds(
+            easy_accuracy_min=1.0,
+            hard_accuracy_min=1.0,
+            inter_model_agreement_min=1.0,
+            intra_model_stability_min=1.0,
+            high_confidence_accuracy_min=0.90,
+        ),
+    )
+    output_dir = tmp_path / "claim-evidence-result"
+
+    result = write_claim_evidence_result_artifact_files(artifact, output_dir)
+
+    assert result.ok is True
+    assert result.output_dir == str(output_dir)
+    assert [file.path for file in result.files] == [
+        "claim_evidence_result.json",
+        "claim_evidence_result.md",
+    ]
+    json_path = output_dir / "claim_evidence_result.json"
+    markdown_path = output_dir / "claim_evidence_result.md"
+    assert json_path.exists()
+    assert markdown_path.exists()
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["go_no_go"] == "go"
+    assert payload["ok"] is True
+    assert markdown_path.read_text(encoding="utf-8") == (
+        render_claim_evidence_result_markdown(artifact)
+    )
+    assert result.files[0].content_type == "application/json"
+    assert result.files[0].bytes_written == len(
+        json_path.read_text(encoding="utf-8").encode("utf-8")
+    )
+
+
+def test_result_artifact_writer_creates_missing_parent_directories(tmp_path) -> None:
+    output_dir = tmp_path / "nested" / "claim-evidence"
+
+    result = write_claim_evidence_result_artifact_files(
+        {"not": "an artifact"},
+        output_dir,
+    )
+
+    assert result.ok is True
+    assert output_dir.is_dir()
+    payload = json.loads(
+        (output_dir / "claim_evidence_result.json").read_text(encoding="utf-8")
+    )
+    assert payload["go_no_go"] == "no_go"
+    assert payload["errors"] == ["artifact must be ClaimEvidenceResultArtifact"]
+    assert "artifact must be ClaimEvidenceResultArtifact" in (
+        output_dir / "claim_evidence_result.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_result_artifact_writer_rejects_file_output_path(tmp_path) -> None:
+    output_path = tmp_path / "result-file"
+    output_path.write_text("already a file", encoding="utf-8")
+
+    result = write_claim_evidence_result_artifact_files(
+        {"not": "an artifact"},
+        output_path,
+    )
+
+    assert result.ok is False
+    assert result.files == ()
+    assert result.errors == (f"output_dir is not a directory: {output_path}",)
+    assert output_path.read_text(encoding="utf-8") == "already a file"
+
+
+def test_result_artifact_writer_rejects_non_path_output_dir() -> None:
+    result = write_claim_evidence_result_artifact_files(
+        {"not": "an artifact"},
+        None,
+    )
+
+    assert result.ok is False
+    assert result.output_dir == ""
+    assert result.files == ()
+    assert result.errors == ("output_dir must be a path",)
+
+
+def test_result_artifact_writer_reports_directory_creation_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    output_dir = tmp_path / "blocked"
+    original_mkdir = Path.mkdir
+
+    def fail_mkdir(self, *args, **kwargs):
+        if self == output_dir:
+            raise PermissionError("permission denied")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fail_mkdir)
+
+    result = write_claim_evidence_result_artifact_files(
+        {"not": "an artifact"},
+        output_dir,
+    )
+
+    assert result.ok is False
+    assert result.files == ()
+    assert result.errors == (
+        f"output_dir could not be created: {output_dir}: permission denied",
+    )
+    assert output_dir.exists() is False
+
+
+def test_result_artifact_writer_reports_file_write_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    output_dir = tmp_path / "claim-evidence"
+    original_write_text = Path.write_text
+
+    def fail_markdown_write(self, data, *args, **kwargs):
+        if self.name == "claim_evidence_result.md":
+            raise PermissionError("permission denied")
+        return original_write_text(self, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_markdown_write)
+
+    result = write_claim_evidence_result_artifact_files(
+        {"not": "an artifact"},
+        output_dir,
+    )
+
+    assert result.ok is False
+    assert [file.path for file in result.files] == ["claim_evidence_result.json"]
+    assert result.errors == (
+        f"result file could not be written: "
+        f"{output_dir / 'claim_evidence_result.md'}: permission denied",
+    )
+    assert (output_dir / "claim_evidence_result.json").exists()
+    assert (output_dir / "claim_evidence_result.md").exists() is False
+
+
+def test_result_artifact_writer_rejects_symlinked_bundle_paths(tmp_path) -> None:
+    cases = (
+        ("claim_evidence_result.json", "existing-file"),
+        ("claim_evidence_result.md", "existing-file"),
+        ("claim_evidence_result.json", "missing-file"),
+        ("claim_evidence_result.md", "missing-file"),
+        ("claim_evidence_result.json", "directory"),
+        ("claim_evidence_result.md", "directory"),
+    )
+
+    for index, (bundle_name, target_kind) in enumerate(cases):
+        output_dir = tmp_path / f"case-{index}" / "artifact-dir"
+        output_dir.mkdir(parents=True)
+        target = tmp_path / f"case-{index}" / "external-target"
+        if target_kind == "existing-file":
+            target.write_text("PROTECTED-CONTENT", encoding="utf-8")
+            expected_target_text = "PROTECTED-CONTENT"
+        elif target_kind == "directory":
+            target.mkdir()
+            expected_target_text = None
+        else:
+            expected_target_text = None
+        (output_dir / bundle_name).symlink_to(
+            target,
+            target_is_directory=target_kind == "directory",
+        )
+
+        result = write_claim_evidence_result_artifact_files(
+            {"not": "an artifact"},
+            output_dir,
+        )
+
+        assert result.ok is False
+        assert result.errors == (
+            f"result file path is a symlink: {output_dir / bundle_name}",
+        )
+        if bundle_name == "claim_evidence_result.json":
+            assert result.files == ()
+        else:
+            assert [file.path for file in result.files] == ["claim_evidence_result.json"]
+        if expected_target_text is not None:
+            assert target.read_text(encoding="utf-8") == expected_target_text
+        elif target_kind == "missing-file":
+            assert target.exists() is False
+        else:
+            assert target.is_dir()
+
+
+def test_result_file_path_errors_rejects_pseudo_parent_filename() -> None:
+    errors = _result_file_path_errors(
+        (
+            ClaimEvidenceResultFile(
+                path="..",
+                content_type="application/json",
+                content="{}",
+            ),
+        )
+    )
+
+    assert errors == ("result file path must be a relative filename: ..",)
 
 
 def test_model_score_counts_easy_hard_and_high_confidence_accuracy() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Artifact-Writer.md
Slice phase: Functional validation

Adds the deterministic artifact-directory writer for the #1435 claim/evidence benchmark result bundle. The existing package-owned JSON/Markdown artifact can now be written into an operator directory with fixed filenames, content metadata, fail-closed malformed-artifact output, and explicit I/O error reporting.

## Intentional
- File I/O is limited to the explicit artifact-writer boundary; benchmark scoring, rendering, and bundle construction remain deterministic and provider-free.
- No CLI, provider adapter, live prompt execution, verifier rubric inclusion, or MCP exposure is added in this slice.
- The writer owns only the two fixed bundle filenames and the requested output directory; it does not introduce an archive layout.
- PR #1508 review MAJOR on symlink-follow is addressed inline by rejecting symlinked result paths and pinning the defect class with six same-class probes.

## Deferred
- CLI wrapper that loads or constructs benchmark artifacts and calls this writer.
- Artifact JSON parsing back into result dataclasses.
- Concrete provider adapters and live prompt execution.
- Batch model-run CLI for fixture-file model runs.
- Verifier rubric inclusion and MCP exposure only if benchmark thresholds pass.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_content_claim_evidence_benchmark.py: 59 passed.
- bash scripts/validate_extracted_content_pipeline.sh: passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline: passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt: Atlas runtime import findings: 0.
- bash scripts/check_ascii_python.sh: passed.
- bash scripts/run_extracted_pipeline_checks.sh: 3903 passed, 10 skipped.
- git diff --check: passed.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_artifact_writer_pr_body.md: passed.

## Diff size
3 files, +448 / -4.
