### PR TITLE
Deflection ingestion: recognize Status + CSAT columns

### DIFF
--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -322,6 +322,7 @@ def build_support_ticket_input_package(
     measured_outcome_examples = _measured_outcome_examples(normalized_rows)
     ticket_status_summary = _ticket_status_summary(normalized_rows)
     ticket_status_present_count = sum(ticket_status_summary.values())
+    csat_present_count = _csat_present_count(normalized_rows)
     csat_scores = _csat_scores(normalized_rows)
     resolved_secondary_keywords = tuple(secondary_keywords or (
         "customer support FAQ",
@@ -393,7 +394,8 @@ def build_support_ticket_input_package(
         "ticket_status_present": ticket_status_present_count > 0,
         "ticket_status_present_count": ticket_status_present_count,
         "ticket_status_summary": ticket_status_summary,
-        "csat_present": len(csat_scores) > 0,
+        "csat_present": csat_present_count > 0,
+        "csat_present_count": csat_present_count,
         "csat_score_count": len(csat_scores),
         "csat_score_average": (
             round(sum(csat_scores) / len(csat_scores), 2) if csat_scores else None
@@ -671,6 +673,12 @@ def _ticket_status_summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
         if state:
             counts[state] = counts.get(state, 0) + 1
     return counts
+
+
+def _csat_present_count(rows: Sequence[Mapping[str, Any]]) -> int:
+    # Presence reflects any raw CSAT value (textual good/bad included), not just
+    # numeric scores -- a textual-only export must not read as absent.
+    return sum(1 for row in rows if _clean(row.get("csat")))
 
 
 def _csat_scores(rows: Sequence[Mapping[str, Any]]) -> list[float]:

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -166,6 +166,66 @@ _CONTACT_EMAIL_KEYS = (
     "customer_email",
 )
 _PAIN_KEYS = ("pain_category", "category", "intent", "topic")
+_STATUS_KEYS = (
+    "ticket_status",
+    "issue_status",
+    "case_status",
+    "status",
+    "ticket_state",
+    "state",
+)
+_CSAT_KEYS = (
+    "csat",
+    "csat_score",
+    "satisfaction_score",
+    "satisfaction_rating",
+    "customer_satisfaction_rating",
+    "customer_satisfaction_score",
+    "customer_satisfaction",
+    "satisfaction",
+    "rating",
+)
+# Canonical lifecycle buckets. Values are compared after `_key()` normalization
+# (lowercase, alphanumerics only), so "In Progress" -> "inprogress". Unknown
+# vocabulary maps to "other" so nothing is silently relabeled resolved/open.
+_REOPENED_STATUS_VALUES = frozenset({"reopened", "reopen"})
+_RESOLVED_STATUS_VALUES = frozenset({
+    "resolved",
+    "closed",
+    "done",
+    "solved",
+    "complete",
+    "completed",
+    "fixed",
+    "resolvedundermonitoring",
+})
+_CANCELLED_STATUS_VALUES = frozenset({
+    "cancelled",
+    "canceled",
+    "rejected",
+    "withdrawn",
+    "void",
+})
+_OPEN_STATUS_VALUES = frozenset({
+    "open",
+    "new",
+    "todo",
+    "inprogress",
+    "pending",
+    "pendingcustomerapproval",
+    "pendingdeployment",
+    "waiting",
+    "onhold",
+    "hold",
+    "underreview",
+    "inreview",
+    "validation",
+    "monitoring",
+    "testingmonitoring",
+    "deployment",
+    "investigating",
+    "active",
+})
 
 
 def build_support_ticket_input_package(
@@ -260,6 +320,9 @@ def build_support_ticket_input_package(
     resolution_evidence_examples = _resolution_evidence_examples(normalized_rows)
     measured_outcome_count = _measured_outcome_count(normalized_rows)
     measured_outcome_examples = _measured_outcome_examples(normalized_rows)
+    ticket_status_summary = _ticket_status_summary(normalized_rows)
+    ticket_status_present_count = sum(ticket_status_summary.values())
+    csat_scores = _csat_scores(normalized_rows)
     resolved_secondary_keywords = tuple(secondary_keywords or (
         "customer support FAQ",
         "repeat support questions",
@@ -327,6 +390,14 @@ def build_support_ticket_input_package(
         "measured_outcome_count": measured_outcome_count,
         "top_ticket_clusters": top_ticket_clusters,
         "cluster_quality": support_ticket_cluster_quality(normalized_rows),
+        "ticket_status_present": ticket_status_present_count > 0,
+        "ticket_status_present_count": ticket_status_present_count,
+        "ticket_status_summary": ticket_status_summary,
+        "csat_present": len(csat_scores) > 0,
+        "csat_score_count": len(csat_scores),
+        "csat_score_average": (
+            round(sum(csat_scores) / len(csat_scores), 2) if csat_scores else None
+        ),
     }
     if cluster_diagnostics["cluster_preview_skipped"]:
         metadata["cluster_preview_skipped"] = True
@@ -389,6 +460,19 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
         value = _first_value(row, keys)
         if value not in (None, "", [], {}):
             normalized[key] = value
+    status_raw = _first_text(row, _STATUS_KEYS)
+    if status_raw:
+        normalized["ticket_status"] = status_raw
+        state = _normalize_status_state(status_raw)
+        if state:
+            normalized["ticket_status_state"] = state
+    csat_value = _first_value(row, _CSAT_KEYS)
+    csat_raw = _evidence_text(csat_value)
+    if csat_raw:
+        normalized["csat"] = csat_raw
+        csat_score = _parse_csat_score(csat_value)
+        if csat_score is not None:
+            normalized["csat_score"] = csat_score
     return normalized
 
 
@@ -549,6 +633,55 @@ def _measured_outcome_examples(
         if len(examples) >= limit:
             return examples
     return examples
+
+
+def _normalize_status_state(value: Any) -> str:
+    key = _key(value)
+    if not key:
+        return ""
+    if key in _REOPENED_STATUS_VALUES:
+        return "reopened"
+    if key in _RESOLVED_STATUS_VALUES:
+        return "resolved"
+    if key in _CANCELLED_STATUS_VALUES:
+        return "cancelled"
+    if key in _OPEN_STATUS_VALUES:
+        return "open"
+    return "other"
+
+
+def _parse_csat_score(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = _clean(value)
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _ticket_status_summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        state = _clean(row.get("ticket_status_state"))
+        if state:
+            counts[state] = counts.get(state, 0) + 1
+    return counts
+
+
+def _csat_scores(rows: Sequence[Mapping[str, Any]]) -> list[float]:
+    scores: list[float] = []
+    for row in rows:
+        score = row.get("csat_score")
+        if isinstance(score, bool):
+            continue
+        if isinstance(score, (int, float)):
+            scores.append(float(score))
+    return scores
 
 
 def _evidence_text(value: Any) -> str:

--- a/plans/PR-Deflection-Status-CSAT-Ingestion.md
+++ b/plans/PR-Deflection-Status-CSAT-Ingestion.md
@@ -1,0 +1,108 @@
+# PR-Deflection-Status-CSAT-Ingestion
+
+## Why this slice exists
+
+Discussion #1507 (deflection import-shape + dataset reconnaissance) established that a
+real helpdesk export carries two structured outcome signals the deflection pipeline
+currently throws away: **ticket status** (resolved vs abandoned / reopened) and
+**customer-satisfaction rating**. Verified against the code: ingestion recognizes only
+resolution *text* (`_RESOLUTION_TEXT_KEYS`); there is no `_STATUS_KEYS` / `_CSAT_KEYS`,
+so a Zendesk `Ticket Status` / `Customer Satisfaction Rating` column (or Mendeley
+`issue_status`) is dropped at the door. Both #1419 (prove + gate the publishable-answer
+lane) and #1466 (proven-answer gate) need these signals: status separates the Tier-2
+"answer-gap" backlog from resolved tickets, and `reopened` / low CSAT are the behavioral
+"answered but not actually resolved" signals that are stronger and cheaper than scraping
+reply text for instruction-shape.
+
+This slice does the narrow, deterministic ingestion half: **recognize, normalize, and
+expose** status and CSAT. It deliberately does **not** change the proven/gap
+classification or any buyer-facing report output -- that consumption is #1419's product
+decision and is out of scope here (per the no-product-shape-changes rule).
+
+## Scope (this PR)
+
+Ownership lane: deflection/ingestion
+Slice phase: Production hardening
+
+1. `extracted_content_pipeline/support_ticket_input_package.py`: add `_STATUS_KEYS` and
+   `_CSAT_KEYS`; normalize status into a canonical state bucket (resolved / open /
+   reopened / cancelled / other) and parse numeric CSAT; attach both (raw + normalized)
+   onto each normalized row; surface aggregate status/CSAT summaries in package metadata.
+2. Tests in the already-CI-enrolled `tests/test_extracted_support_ticket_input_package.py`
+   proving recognition across header aliases, status bucketization, numeric-CSAT parsing,
+   metadata summary correctness, and that absent columns leave the package unchanged.
+
+### Review Contract
+- Acceptance criteria: a row carrying `status` / `ticket_status` / `issue_status` / `state`
+  gets `ticket_status` (raw) + `ticket_status_state` (canonical bucket); a row carrying a
+  satisfaction column gets `csat` (raw) + `csat_score` (numeric when parseable); package
+  metadata reports `ticket_status_present(_count)`, `ticket_status_summary` (per-bucket
+  counts), `csat_present`, `csat_score_count`, `csat_score_average`; rows without these
+  columns are byte-for-byte unchanged and produce no new warnings.
+- Affected surfaces: one ingestion module + its unit test. No report output, no DB, no
+  network, no generation-input change.
+- Risk areas: status vocabulary misclassification (mitigated: unknown values map to
+  "other", nothing is silently relabeled) and accidental product-behavior change
+  (mitigated: proven/gap logic untouched; new data is additive passthrough + metadata).
+- Reviewer rules triggered: R1 (requirements match -- `extracted_*` change), R2
+  (failure-branch fixtures: absent / empty / non-numeric CSAT), R10 (maintainability),
+  R12 (test runs in CI -- existing enrolled file).
+
+### Files touched
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `plans/PR-Deflection-Status-CSAT-Ingestion.md`
+
+## Mechanism
+
+`_STATUS_KEYS` and `_CSAT_KEYS` are matched through the existing `_first_value` /
+`_key` machinery, so header aliases differing only in case / spaces / underscores
+(`Ticket Status`, `ticket_status`, `issue_status`) resolve to the same key. Status text
+is normalized by `_normalize_status_state` against four fixed value sets into one of
+`resolved` / `open` / `reopened` / `cancelled` / `other`; unknown vocabulary returns
+`other` so nothing is mislabeled. `reopened` is its own bucket because it is the churn
+signal #1419/#1466 care about. CSAT is parsed by `_parse_csat_score`, which returns a
+float only for numeric values (textual labels like Zendesk good/bad keep their raw value
+but no score, because the negative-threshold decision belongs to #1419, not ingestion).
+Per-row attachment is additive passthrough; aggregate summaries (`_ticket_status_summary`,
+numeric-score list) are computed once and placed in `metadata` only -- generation inputs
+are untouched.
+
+## Intentional
+- Deterministic only; no LLM/model dependency (matches the deflection positioning).
+- Normalize-and-expose, not consume: the proven/gap split, churn-risk flagging, and any
+  report-surface change are explicitly deferred to #1419 so the buyer-facing shape does
+  not move in an ingestion slice.
+- Unknown status vocabulary -> `other` (never silently coerced to resolved/open).
+- CSAT negative-threshold is NOT decided here (a 1-2-is-bad rule assumes a 5-point scale;
+  Zendesk CSAT is good/bad). Ingestion exposes raw + numeric; the product rule is #1419's.
+- Aggregates live in `metadata` (diagnostics/preview), not `inputs` (generation), to keep
+  the generation path byte-stable for rows without these columns.
+
+## Deferred
+- Consuming `ticket_status_state` / `reopened` / `csat_score` in the proven-vs-gap
+  classification and the Tier-2 churn-risk lane (#1419).
+- Demoting #1466's text gate to "one of three signals" in the proof logic (#1466).
+- Resolution-disposition codes (`Won't Do` / `Duplicate` / `Cannot Reproduce`) as a
+  distinct "resolved-on-paper-only" class -- a follow-up key set.
+- Metrics-only vs full-mode importer branching and preview self-diagnosis (#1507 contract).
+
+Parked hardening: none.
+
+## Verification
+- `tests/test_extracted_support_ticket_input_package.py`: alias recognition, status
+  bucketization (closed->resolved, reopened->reopened, unknown->other), numeric-CSAT
+  parse + non-numeric -> no score, metadata summary counts/average, and an unchanged-row
+  control case.
+- `scripts/check_ascii_python.sh` clean.
+- Targeted: `pytest tests/test_extracted_support_ticket_input_package.py -q`.
+
+## Estimated diff size
+| Area | Est LOC |
+|---|---:|
+| Plan | ~115 |
+| Ingestion module | ~100 |
+| Tests | ~90 |
+| Total | ~305 |
+
+Within the 400 soft cap.

--- a/plans/PR-Deflection-Status-CSAT-Ingestion.md
+++ b/plans/PR-Deflection-Status-CSAT-Ingestion.md
@@ -37,8 +37,9 @@ Slice phase: Production hardening
   gets `ticket_status` (raw) + `ticket_status_state` (canonical bucket); a row carrying a
   satisfaction column gets `csat` (raw) + `csat_score` (numeric when parseable); package
   metadata reports `ticket_status_present(_count)`, `ticket_status_summary` (per-bucket
-  counts), `csat_present`, `csat_score_count`, `csat_score_average`; rows without these
-  columns are byte-for-byte unchanged and produce no new warnings.
+  counts), `csat_present(_count)` (from raw `csat`, so textual good/bad reads as present),
+  `csat_score_count`, `csat_score_average` (numeric-only); rows without these columns are
+  byte-for-byte unchanged and produce no new warnings.
 - Affected surfaces: one ingestion module + its unit test. No report output, no DB, no
   network, no generation-input change.
 - Risk areas: status vocabulary misclassification (mitigated: unknown values map to

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1174,6 +1174,7 @@ def test_support_ticket_input_package_recognizes_status_and_csat_columns() -> No
     assert package.metadata["ticket_status_present_count"] == 2
     assert package.metadata["ticket_status_summary"] == {"resolved": 1, "open": 1}
     assert package.metadata["csat_present"] is True
+    assert package.metadata["csat_present_count"] == 2
     assert package.metadata["csat_score_count"] == 2
     assert package.metadata["csat_score_average"] == 3.5
 
@@ -1234,8 +1235,38 @@ def test_support_ticket_csat_parses_numeric_only_and_averages_numeric() -> None:
     assert rows[2]["csat_score"] == 2.0
 
     assert package.metadata["csat_present"] is True
+    assert package.metadata["csat_present_count"] == 3
     assert package.metadata["csat_score_count"] == 2
     assert package.metadata["csat_score_average"] == 3.0
+
+
+def test_support_ticket_input_package_marks_textual_csat_present_without_score() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "zd-1",
+            "subject": "How do I reset my password?",
+            "description": "I cannot reset my password from the login screen.",
+            "Customer Satisfaction Rating": "good",
+        },
+        {
+            "ticket_id": "zd-2",
+            "subject": "Billing question",
+            "description": "Why was I charged twice this month?",
+            "satisfaction_rating": "bad",
+        },
+    ])
+
+    rows = package.inputs["source_material"]
+    assert rows[0]["csat"] == "good"
+    assert "csat_score" not in rows[0]
+    assert rows[1]["csat"] == "bad"
+    assert "csat_score" not in rows[1]
+
+    # all-textual CSAT must read as PRESENT even though no numeric score exists
+    assert package.metadata["csat_present"] is True
+    assert package.metadata["csat_present_count"] == 2
+    assert package.metadata["csat_score_count"] == 0
+    assert package.metadata["csat_score_average"] is None
 
 
 def test_support_ticket_input_package_without_status_or_csat_is_unchanged() -> None:
@@ -1256,5 +1287,6 @@ def test_support_ticket_input_package_without_status_or_csat_is_unchanged() -> N
     assert package.metadata["ticket_status_present_count"] == 0
     assert package.metadata["ticket_status_summary"] == {}
     assert package.metadata["csat_present"] is False
+    assert package.metadata["csat_present_count"] == 0
     assert package.metadata["csat_score_count"] == 0
     assert package.metadata["csat_score_average"] is None

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1142,3 +1142,119 @@ def test_support_ticket_input_package_rejects_invalid_window_and_row_limit() -> 
         assert str(exc) == "max_rows must be at least 1"
     else:
         raise AssertionError("expected max_rows validation error")
+
+
+def test_support_ticket_input_package_recognizes_status_and_csat_columns() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "Ticket ID": "zd-1",
+            "Subject": "How do I reset my password?",
+            "Description": "I cannot reset my password from the login screen.",
+            "Ticket Status": "Closed",
+            "Customer Satisfaction Rating": "5",
+        },
+        {
+            "ticket_id": "zd-2",
+            "subject": "Billing question",
+            "description": "Why was I charged twice this month?",
+            "status": "Open",
+            "satisfaction_score": 2,
+        },
+    ])
+
+    rows = package.inputs["source_material"]
+    assert rows[0]["ticket_status"] == "Closed"
+    assert rows[0]["ticket_status_state"] == "resolved"
+    assert rows[0]["csat"] == "5"
+    assert rows[0]["csat_score"] == 5.0
+    assert rows[1]["ticket_status_state"] == "open"
+    assert rows[1]["csat_score"] == 2.0
+
+    assert package.metadata["ticket_status_present"] is True
+    assert package.metadata["ticket_status_present_count"] == 2
+    assert package.metadata["ticket_status_summary"] == {"resolved": 1, "open": 1}
+    assert package.metadata["csat_present"] is True
+    assert package.metadata["csat_score_count"] == 2
+    assert package.metadata["csat_score_average"] == 3.5
+
+
+def test_support_ticket_status_normalizes_to_canonical_buckets() -> None:
+    statuses = {
+        "done": "resolved",
+        "Solved": "resolved",
+        "In Progress": "open",
+        "Pending Customer Approval": "open",
+        "reopened": "reopened",
+        "Cancelled": "cancelled",
+        "Escalated": "other",
+    }
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": f"t-{index}",
+            "description": f"How do I handle scenario {index} for my account export?",
+            "issue_status": raw,
+        }
+        for index, raw in enumerate(statuses, start=1)
+    ])
+
+    got = {
+        row["ticket_status"]: row["ticket_status_state"]
+        for row in package.inputs["source_material"]
+    }
+    assert got == statuses
+    # the reopened bucket is the churn signal #1419/#1466 consume; keep it distinct
+    assert package.metadata["ticket_status_summary"]["reopened"] == 1
+
+
+def test_support_ticket_csat_parses_numeric_only_and_averages_numeric() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "t-1",
+            "description": "How do I export the dashboard before renewal?",
+            "csat": "4",
+        },
+        {
+            "ticket_id": "t-2",
+            "description": "Where do I update my billing contact details?",
+            "csat": "good",
+        },
+        {
+            "ticket_id": "t-3",
+            "description": "Why did my report fail to generate overnight?",
+            "satisfaction_rating": 2,
+        },
+    ])
+
+    rows = package.inputs["source_material"]
+    assert rows[0]["csat"] == "4"
+    assert rows[0]["csat_score"] == 4.0
+    # textual ratings are kept raw but yield no numeric score (threshold is #1419's call)
+    assert rows[1]["csat"] == "good"
+    assert "csat_score" not in rows[1]
+    assert rows[2]["csat_score"] == 2.0
+
+    assert package.metadata["csat_present"] is True
+    assert package.metadata["csat_score_count"] == 2
+    assert package.metadata["csat_score_average"] == 3.0
+
+
+def test_support_ticket_input_package_without_status_or_csat_is_unchanged() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "t-1",
+            "subject": "How do I reset my password?",
+            "description": "I cannot reset my password from the login screen.",
+        },
+    ])
+
+    row = package.inputs["source_material"][0]
+    assert "ticket_status" not in row
+    assert "ticket_status_state" not in row
+    assert "csat" not in row
+    assert "csat_score" not in row
+    assert package.metadata["ticket_status_present"] is False
+    assert package.metadata["ticket_status_present_count"] == 0
+    assert package.metadata["ticket_status_summary"] == {}
+    assert package.metadata["csat_present"] is False
+    assert package.metadata["csat_score_count"] == 0
+    assert package.metadata["csat_score_average"] is None


### PR DESCRIPTION
Plan: plans/PR-Deflection-Status-CSAT-Ingestion.md
Slice phase: Production hardening

Discussion #1507 (deflection import-shape + dataset recon) established that a real helpdesk export carries two structured outcome signals the deflection pipeline threw away -- ticket status (resolved vs abandoned / reopened) and customer satisfaction -- and #1419 and #1466 both need them. Verified in code: ingestion recognized only resolution text (`_RESOLUTION_TEXT_KEYS`); there was no `_STATUS_KEYS` / `_CSAT_KEYS`, so a Zendesk `Ticket Status` / `Customer Satisfaction Rating` column (or Mendeley `issue_status`) was dropped at the door. This slice does the narrow, deterministic ingestion half: recognize, normalize, and expose status and CSAT, without touching the proven/gap classification (that consumption is #1419's product call).

## Scope
- `extracted_content_pipeline/support_ticket_input_package.py`: add `_STATUS_KEYS` and `_CSAT_KEYS`; normalize status into a canonical bucket (resolved / open / reopened / cancelled / other) and parse numeric CSAT; attach raw + normalized per row; surface aggregate status/CSAT summaries in package metadata.
- `tests/test_extracted_support_ticket_input_package.py` (already CI-enrolled): alias recognition, status bucketization, numeric-CSAT parse, metadata summary, and an unchanged-row control.

## Mechanism
Keys match through the existing `_first_value` / `_key` machinery, so aliases differing only in case / spaces / underscores resolve together. `_normalize_status_state` maps status text against four fixed value sets; unknown vocabulary returns `other` so nothing is mislabeled, and `reopened` is its own bucket (the churn signal). `_parse_csat_score` returns a float only for numeric values; textual labels keep their raw value but get no score. Per-row attachment is additive passthrough; aggregates land in `metadata` only, so generation inputs are byte-stable for rows without these columns.

## Intentional
- Deterministic only; no LLM/model dependency.
- Normalize-and-expose, not consume: proven/gap classification, churn-risk flagging, and report-surface changes are deferred to #1419 so the buyer-facing shape does not move in an ingestion slice.
- Unknown status vocabulary -> `other` (never silently coerced to resolved/open).
- CSAT negative-threshold is NOT decided here (a 1-2-is-bad rule assumes a 5-point scale; Zendesk CSAT is good/bad). Ingestion exposes raw + numeric; the product rule is #1419's.

## Deferred
- Consuming `ticket_status_state` / `reopened` / `csat_score` in the proven-vs-gap split and Tier-2 churn-risk lane (#1419).
- Demoting #1466's text gate to "one of three signals" in the proof logic (#1466).
- Resolution-disposition codes (`Won't Do` / `Duplicate` / `Cannot Reproduce`) as a distinct "resolved-on-paper-only" class.
- Metrics-only vs full-mode importer branching and preview self-diagnosis (#1507 contract).

## Parked hardening
None.

## Verification
- `pytest tests/test_extracted_support_ticket_input_package.py -q` -> 46 passed (42 existing + 4 new).
- Downstream consumers (synthetic generator round-trip, faq markdown, smoke, input provider) -> 210 passed.
- `scripts/check_ascii_python.sh` -> clean.
- CI on this branch: extracted-checks, pre-push-audit, live-reconciliation, maturity-sweep, semantic-diff-advisor all green.

## Diff size
+357 LOC across module (+133), tests (+116), and the plan doc. Within the 400 soft cap.
