### PR TITLE
Deflection delivery idempotency: dedupe report email on re-claim (#1461)

### DIFF
--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -164,6 +164,19 @@ def deflection_report_result_url(
     )
 
 
+def _delivery_idempotency_key(account_id: str, request_id: str) -> str:
+    """Deterministic Resend idempotency key for a paid report delivery (#1461).
+
+    Derived purely from (account_id, request_id) so a re-claimed 'sending' row
+    recomputes the identical key. Resend dedupes identical keys server-side for
+    24h, and the claim re-tries after DELIVERY_CLAIM_STALE_AFTER (15 minutes) --
+    well inside that window -- so a crash between send and mark cannot produce a
+    second email on re-claim.
+    """
+
+    return f"deflection-report:{account_id}:{request_id}"
+
+
 def _send_request(
     *,
     account_id: str,
@@ -176,6 +189,7 @@ def _send_request(
     has_attachment = bool(attachments)
     return SendRequest(
         campaign_id=f"content_ops_deflection_report:{account_id}:{request_id}",
+        idempotency_key=_delivery_idempotency_key(account_id, request_id),
         to_email=email,
         from_email=_required_text(config.from_email, "from_email"),
         reply_to=_clean(config.reply_to) or None,

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -9,7 +9,11 @@ from typing import Any, Literal, Mapping, Protocol
 from urllib.parse import quote
 
 from .content_ops_deflection_incidents import emit_deflection_paid_funnel_incident_alert
-from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
+from extracted_content_pipeline.campaign_ports import (
+    IdempotentReplayConflict,
+    SendRequest,
+    SendResult,
+)
 from extracted_content_pipeline.storage._jsonb_helpers import decode_jsonb_field
 
 
@@ -117,6 +121,25 @@ async def send_pending_deflection_report_deliveries(
                     config=config,
                 )
             )
+        except IdempotentReplayConflict:
+            # The original send already went out for this idempotency key (the
+            # provider rejected the retried payload). Mark delivered, not failed
+            # -- no second email is sent. Re-rendered PDF attachments differ
+            # byte-for-byte on re-claim, so this is the normal re-claim path.
+            await _emit_delivery_incident(
+                "paid_report_delivery_idempotent_replay",
+                account_id=account_id,
+                request_id=request_id,
+                severity="info",
+            )
+            await _mark_delivered(
+                pool,
+                account_id,
+                request_id,
+                _provider_message_id("resend", "idempotent-replay"),
+            )
+            sent += 1
+            continue
         except Exception as exc:
             error = _bounded_error(exc)
             await _emit_delivery_incident(

--- a/extracted_content_pipeline/campaign_ports.py
+++ b/extracted_content_pipeline/campaign_ports.py
@@ -154,6 +154,25 @@ class SendResult:
     raw: Any | None = None
 
 
+class IdempotentReplayConflict(Exception):
+    """A retried send reused an idempotency key with a different payload.
+
+    The provider (Resend: HTTP 409 ``invalid_idempotent_request``) rejects the
+    retry because an email was already accepted for this key with a different
+    body. It is positive proof the original send succeeded, so callers should
+    treat it as delivered (idempotent replay), NOT as a send failure -- the
+    second email never goes out.
+    """
+
+    def __init__(self, idempotency_key: str = "") -> None:
+        self.idempotency_key = idempotency_key
+        super().__init__(
+            f"idempotent replay conflict for key {idempotency_key!r}"
+            if idempotency_key
+            else "idempotent replay conflict"
+        )
+
+
 @dataclass(frozen=True)
 class WebhookEvent:
     provider: str

--- a/extracted_content_pipeline/campaign_ports.py
+++ b/extracted_content_pipeline/campaign_ports.py
@@ -140,6 +140,11 @@ class SendRequest:
     tags: Sequence[Mapping[str, str]] = field(default_factory=tuple)
     attachments: Sequence[Mapping[str, str]] = field(default_factory=tuple)
     metadata: JsonDict = field(default_factory=dict)
+    # Optional provider idempotency key. When set, an idempotency-capable sender
+    # (e.g. Resend) forwards it so a retried send with the same key is deduped
+    # server-side rather than producing a duplicate email. Backward-compatible:
+    # senders that do not support idempotency ignore it.
+    idempotency_key: str | None = None
 
 
 @dataclass(frozen=True)

--- a/extracted_content_pipeline/campaign_sender.py
+++ b/extracted_content_pipeline/campaign_sender.py
@@ -79,6 +79,11 @@ class ResendCampaignSender:
             "Authorization": f"Bearer {self._config.api_key}",
             "Content-Type": "application/json",
         }
+        # Resend dedupes identical Idempotency-Key values server-side for 24h,
+        # so a retried send (e.g. a re-claimed delivery row) does not produce a
+        # second email.
+        if request.idempotency_key:
+            headers["Idempotency-Key"] = request.idempotency_key
         if self._http_client is not None:
             response = await self._http_client.post(
                 self._config.api_url,

--- a/extracted_content_pipeline/campaign_sender.py
+++ b/extracted_content_pipeline/campaign_sender.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping
 
 import httpx
 
-from .campaign_ports import SendRequest, SendResult
+from .campaign_ports import IdempotentReplayConflict, SendRequest, SendResult
 
 
 RESEND_API_URL = "https://api.resend.com/emails"
@@ -33,6 +33,27 @@ def normalize_tags(tags: Any) -> list[dict[str, str]]:
             continue
         normalized.append({"name": name, "value": sanitize_tag_value(value)})
     return normalized
+
+
+def _is_idempotency_conflict(response: Any) -> bool:
+    """True when a Resend 409 body is the idempotency-key payload mismatch.
+
+    Matches Resend's documented ``invalid_idempotent_request`` error so only an
+    idempotency conflict (not any other 409) is treated as an idempotent replay.
+    """
+
+    try:
+        body = response.json()
+    except Exception:
+        return False
+    if isinstance(body, Mapping):
+        name = str(body.get("name") or body.get("error") or "")
+        message = str(body.get("message") or "")
+        return (
+            "invalid_idempotent_request" in name
+            or "invalid_idempotent_request" in message
+        )
+    return "invalid_idempotent_request" in str(body)
 
 
 @dataclass(frozen=True)
@@ -97,6 +118,15 @@ class ResendCampaignSender:
                     json=payload,
                     headers=headers,
                 )
+        # Resend returns 409 invalid_idempotent_request when this key was already
+        # used with a different payload -- positive proof the original email was
+        # accepted. Surface it as an idempotent replay (delivered), not a generic
+        # HTTP failure, so a re-claimed delivery whose attachment re-renders to
+        # different bytes is not mismarked as failed.
+        if getattr(response, "status_code", 200) == 409 and _is_idempotency_conflict(
+            response
+        ):
+            raise IdempotentReplayConflict(request.idempotency_key or "")
         response.raise_for_status()
         data = response.json()
         return SendResult(provider="resend", message_id=str(data["id"]), raw=data)

--- a/plans/PR-Deflection-Delivery-Idempotency.md
+++ b/plans/PR-Deflection-Delivery-Idempotency.md
@@ -34,7 +34,9 @@ Slice phase: Production hardening
 Out of scope: the billing 409 retry-storm (#1462, separate slice); any schema /
 migration change; the SES sender.
 
-- Reviewer rules triggered: R1, R2, R10.
+- Reviewer rules triggered: R1, R2, R6, R8, R10. (R6 error-handling/observability
+  and R8 concurrency/idempotency: this is a retry/idempotency slice that changes
+  how a provider conflict is handled on the delivery path.)
 
 ### Files touched
 
@@ -124,10 +126,13 @@ Parked hardening: none.
   (the two Resend Idempotency-Key HTTP-header forwarding tests + the 409
   `invalid_idempotent_request` -> `IdempotentReplayConflict` test and the
   non-idempotency-409 still-raises test), and
-  `tests/test_send_content_ops_deflection_report_deliveries.py`.
+  `tests/test_send_content_ops_deflection_report_deliveries.py`, plus an end-to-end
+  regression using the real `ResendCampaignSender` + a payload-aware fake HTTP
+  client + the real render->link-only fallback (same key, different body ->
+  delivered, not failed).
 - ASCII gate `scripts/check_ascii_python.sh` -- passed.
 - Python compile check for the touched modules -- passed.
-- Full gauntlet `scripts/run_extracted_pipeline_checks.sh` -- 3909 passed,
+- Full gauntlet `scripts/run_extracted_pipeline_checks.sh` -- 3910 passed,
   10 skipped, 0 failed; existing torch/pynvml warning.
 - Standalone audit `scripts/audit_extracted_standalone.py` (with --fail-on-debt)
   -- 0 import findings.

--- a/plans/PR-Deflection-Delivery-Idempotency.md
+++ b/plans/PR-Deflection-Delivery-Idempotency.md
@@ -1,0 +1,116 @@
+# PR: Deflection delivery idempotency (ATLAS #1461)
+
+## Why this slice exists
+
+ATLAS #1461 is a P1 money-path bug. In `content_ops_deflection_delivery.py` the
+send loop calls `await sender.send(...)` (`:110`) and only afterwards calls
+`_mark_delivered` (`:132`). A crash or DB blip between those two leaves the row
+`delivery_status = 'sending'`. The claim SQL re-claims `'sending'` rows older
+than `DELIVERY_CLAIM_STALE_AFTER = "15 minutes"` (`:422`), and the pre-send
+`_confirm_delivery_still_sendable` check passes (the row is still `'sending'` +
+`paid`), so the worker **sends the report email a second time** to a paying
+customer. The stored `provider_message_id` does not help: in the crash case it
+was never written.
+
+This blocks the #1440 live run: we should not invite a real paid run while a
+single crash window double-emails the buyer.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-delivery
+Slice phase: Production hardening
+
+1. Add an optional, backward-compatible `idempotency_key` field to the shared
+   `SendRequest` port.
+2. Have the Resend sender forward it as the Resend `Idempotency-Key` HTTP
+   request header (Resend dedupes identical keys server-side for 24h).
+3. Have the deflection delivery path set a **deterministic** key derived purely
+   from `(account_id, request_id)`, so a re-claimed `'sending'` row recomputes
+   the identical key and Resend dedupes the resend.
+4. A regression test that simulates a crash between `send()` and
+   `_mark_delivered`, re-claims, and asserts the resend carries the same key and
+   no second email is emitted.
+
+Out of scope: the billing 409 retry-storm (#1462, separate slice); any schema /
+migration change; the SES sender.
+
+- Reviewer rules triggered: R1, R2, R10.
+
+### Files touched
+
+- `plans/PR-Deflection-Delivery-Idempotency.md`
+- `extracted_content_pipeline/campaign_ports.py`
+- `extracted_content_pipeline/campaign_sender.py`
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_extracted_campaign_sender.py`
+
+## Mechanism
+
+The key is a pure function of identifiers already on the row:
+`deflection-report:{account_id}:{request_id}`. Because the claim re-tries after
+15 minutes -- far inside Resend's 24h idempotency window -- the recomputed key
+on re-claim matches the original send, and Resend returns the original email
+instead of sending a new one. No new column is needed: the key is recomputed,
+not stored.
+
+- `extracted_content_pipeline/campaign_ports.py` (owned): `SendRequest` gains
+  `idempotency_key: str | None = None` as a trailing optional field
+  (backward-compatible -- existing positional/keyword construction unaffected).
+- `extracted_content_pipeline/campaign_sender.py` (owned):
+  `ResendCampaignSender.send` adds `headers["Idempotency-Key"] =
+  request.idempotency_key` to the HTTP request headers when the key is set. The
+  SES sender ignores it (SES has no native idempotency header, and it is not on
+  the deflection path).
+- `atlas_brain/content_ops_deflection_delivery.py`: a `_delivery_idempotency_key`
+  helper, used by `_send_request`.
+
+## Intentional
+
+- The key is deterministic and recomputed, not persisted -- no migration, and
+  re-claim is guaranteed to reproduce it.
+- Resend-only. The deflection delivery sender is `create_campaign_sender(
+  "resend", ...)`, so the native Resend `Idempotency-Key` is the correct,
+  simplest mechanism. The `idempotency_key` field is provider-agnostic; if a
+  non-Resend sender is ever wired into deflection delivery, the same key is the
+  right primitive and a provider-appropriate dedupe (e.g. a Sent-mailbox lookup
+  for an API without idempotency) would be added then.
+- This relies on Resend honoring the key within 24h. The 15-minute claim window
+  keeps the resend well inside that window; the dependency is documented rather
+  than belt-and-suspendered with a second DB-level dedupe, to keep the slice
+  small and avoid a schema change.
+
+## Deferred
+
+- #1462 (billing 409 -> Stripe retry storm) is the next money-path slice.
+- A DB-level idempotency ledger (provider-independent, survives a >24h stall)
+  is a future hardening if delivery ever needs a claim window longer than the
+  provider idempotency TTL.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused pytest passed over `tests/test_atlas_content_ops_deflection_delivery.py`
+  (incl. the new crash/re-claim no-double-send test),
+  `tests/test_extracted_campaign_sender.py` (the two Resend Idempotency-Key
+  HTTP-header forwarding tests), and
+  `tests/test_send_content_ops_deflection_report_deliveries.py`.
+- ASCII gate `scripts/check_ascii_python.sh` -- passed.
+- Python compile check for the three touched modules -- passed.
+- Full gauntlet `scripts/run_extracted_pipeline_checks.sh` -- 3906 passed,
+  10 skipped, 0 failed; existing torch/pynvml warning.
+- Standalone audit `scripts/audit_extracted_standalone.py` (with --fail-on-debt)
+  -- 0 import findings.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_ports.py` | 5 |
+| `extracted_content_pipeline/campaign_sender.py` | 5 |
+| `atlas_brain/content_ops_deflection_delivery.py` | 14 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 65 |
+| `tests/test_extracted_campaign_sender.py` | 26 |
+| `plans/PR-Deflection-Delivery-Idempotency.md` | 97 |
+| **Total** | **212** |

--- a/plans/PR-Deflection-Delivery-Idempotency.md
+++ b/plans/PR-Deflection-Delivery-Idempotency.md
@@ -65,10 +65,37 @@ not stored.
 - `atlas_brain/content_ops_deflection_delivery.py`: a `_delivery_idempotency_key`
   helper, used by `_send_request`.
 
+### Idempotent-replay conflict (Codex #1511 review)
+
+Resend returns `409 invalid_idempotent_request` when the same key is reused with
+a *different* payload. The paid report carries a generated PDF attachment, and
+the real PDF renderer stamps a per-call creation timestamp / file id, so the
+re-claim re-renders to different bytes -> the retry would be a 409, which the
+delivery loop's generic `except` would mark `failed` (a false send-failure
+incident) even though the original email already went out. To close that:
+
+- `campaign_ports.IdempotentReplayConflict` -- a typed exception meaning "an
+  email was already accepted for this key" (delivered, not failed).
+- `ResendCampaignSender.send` detects the documented `invalid_idempotent_request`
+  409 body and raises `IdempotentReplayConflict` instead of a generic HTTP error
+  (other 409s still raise normally via `raise_for_status`).
+- The delivery loop catches it before the generic failure branch, emits an
+  `info` `paid_report_delivery_idempotent_replay` incident, and marks the row
+  `delivered` (`provider_message_id = resend:idempotent-replay`).
+
+This makes the fix robust to *any* payload drift, not only the PDF timestamp.
+
 ## Intentional
 
 - The key is deterministic and recomputed, not persisted -- no migration, and
   re-claim is guaranteed to reproduce it.
+- A re-claim that re-renders a byte-different PDF is treated as delivered via the
+  `IdempotentReplayConflict` path above, not failed. Chosen over forcing a
+  byte-deterministic PDF render because it is contained to the delivery
+  path/sender and robust to all payload drift; the sentinel
+  `resend:idempotent-replay` id costs nothing here because the deflection
+  delivery's `provider_message_id` is write-only (no webhook/bounce correlation
+  reads it, unlike the campaign flow).
 - Resend-only. The deflection delivery sender is `create_campaign_sender(
   "resend", ...)`, so the native Resend `Idempotency-Key` is the correct,
   simplest mechanism. The `idempotency_key` field is provider-agnostic; if a
@@ -92,13 +119,15 @@ Parked hardening: none.
 ## Verification
 
 - Focused pytest passed over `tests/test_atlas_content_ops_deflection_delivery.py`
-  (incl. the new crash/re-claim no-double-send test),
-  `tests/test_extracted_campaign_sender.py` (the two Resend Idempotency-Key
-  HTTP-header forwarding tests), and
+  (the crash/re-claim no-double-send test + the idempotent-replay-conflict
+  marks-delivered-not-failed test), `tests/test_extracted_campaign_sender.py`
+  (the two Resend Idempotency-Key HTTP-header forwarding tests + the 409
+  `invalid_idempotent_request` -> `IdempotentReplayConflict` test and the
+  non-idempotency-409 still-raises test), and
   `tests/test_send_content_ops_deflection_report_deliveries.py`.
 - ASCII gate `scripts/check_ascii_python.sh` -- passed.
-- Python compile check for the three touched modules -- passed.
-- Full gauntlet `scripts/run_extracted_pipeline_checks.sh` -- 3906 passed,
+- Python compile check for the touched modules -- passed.
+- Full gauntlet `scripts/run_extracted_pipeline_checks.sh` -- 3909 passed,
   10 skipped, 0 failed; existing torch/pynvml warning.
 - Standalone audit `scripts/audit_extracted_standalone.py` (with --fail-on-debt)
   -- 0 import findings.
@@ -107,10 +136,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/campaign_ports.py` | 5 |
-| `extracted_content_pipeline/campaign_sender.py` | 5 |
-| `atlas_brain/content_ops_deflection_delivery.py` | 14 |
-| `tests/test_atlas_content_ops_deflection_delivery.py` | 65 |
-| `tests/test_extracted_campaign_sender.py` | 26 |
-| `plans/PR-Deflection-Delivery-Idempotency.md` | 97 |
-| **Total** | **212** |
+| `extracted_content_pipeline/campaign_ports.py` | 24 |
+| `extracted_content_pipeline/campaign_sender.py` | 36 |
+| `atlas_brain/content_ops_deflection_delivery.py` | 38 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 97 |
+| `tests/test_extracted_campaign_sender.py` | 62 |
+| `plans/PR-Deflection-Delivery-Idempotency.md` | 152 |
+| **Total** | **~409** |

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -15,7 +15,11 @@ from atlas_brain.content_ops_deflection_delivery import (
     send_pending_deflection_report_deliveries,
 )
 from atlas_brain.content_ops_deflection_incidents import INCIDENT_LOG_MARKER
-from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
+from extracted_content_pipeline.campaign_ports import (
+    IdempotentReplayConflict,
+    SendRequest,
+    SendResult,
+)
 
 
 def _incident_payloads(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
@@ -342,6 +346,33 @@ async def test_delivery_worker_does_not_double_send_on_reclaim_after_crash(
         == "deflection-report:acct-123:content-ops-abc123"
     )
     assert len(sender.delivered) == 1  # still one unique email -- no duplicate
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_marks_idempotent_replay_delivered_not_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # On re-claim the PDF re-renders to different bytes, so Resend rejects the
+    # retry with 409 invalid_idempotent_request -> IdempotentReplayConflict. The
+    # original email already went out, so the row must be delivered (not failed,
+    # which would fire a false send-failure incident).
+    class _ConflictSender:
+        async def send(self, request: SendRequest) -> SendResult:
+            raise IdempotentReplayConflict(request.idempotency_key or "")
+
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-fake-bytes")
+    pool = _Pool([_row()])
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool, sender=_ConflictSender(), config=_config()
+    )
+
+    assert summary.sent == 1
+    assert summary.failed == 0
+    update_query, update_args = pool.execute_calls[0]
+    assert "delivery_status = 'delivered'" in update_query
+    assert "delivery_status = 'sending'" in update_query
+    assert update_args == ("acct-123", "content-ops-abc123", "resend:idempotent-replay")
 
 
 @pytest.mark.asyncio

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -376,6 +376,81 @@ async def test_delivery_worker_marks_idempotent_replay_delivered_not_failed(
 
 
 @pytest.mark.asyncio
+async def test_reclaim_changing_attachment_payload_marks_delivered_via_real_resend_sender(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # End-to-end regression for the R8 BLOCKER (real ResendCampaignSender + the
+    # real render->link-only fallback transition): first send carries the PDF
+    # attachment; on re-claim the render fails so the email is link-only -- a
+    # DIFFERENT payload under the SAME idempotency key. A Resend-like client
+    # returns 409 invalid_idempotent_request for that mismatch, and the delivery
+    # path must mark the row delivered (idempotent replay), not failed.
+    from extracted_content_pipeline.campaign_sender import (
+        ResendCampaignSender,
+        ResendSenderConfig,
+    )
+
+    class _Resp:
+        def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+            self._payload = payload
+            self.status_code = status_code
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"http {self.status_code}")
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+    class _IdempotentResendHTTP:
+        """Records the first body per key; a different body on the same key 409s."""
+
+        def __init__(self) -> None:
+            self.seen: dict[str, Any] = {}
+            self.posts: list[dict[str, Any]] = []
+
+        async def post(self, url: str, *, json: Any, headers: Any) -> _Resp:
+            key = headers.get("Idempotency-Key")
+            self.posts.append({"key": key, "json": json})
+            if key and key in self.seen and self.seen[key] != json:
+                return _Resp(
+                    {"name": "invalid_idempotent_request", "message": "different payload"},
+                    status_code=409,
+                )
+            self.seen.setdefault(key, json)
+            return _Resp({"id": f"email-{len(self.seen)}"})
+
+    http = _IdempotentResendHTTP()
+    sender = ResendCampaignSender(ResendSenderConfig(api_key="re_key"), http_client=http)
+
+    render_calls = {"n": 0}
+
+    def _renderer(_artifact: Any) -> bytes:
+        render_calls["n"] += 1
+        if render_calls["n"] == 1:
+            return b"%PDF-first-render"
+        raise RuntimeError("render failed on reclaim")
+
+    _install_fake_pdf_renderer(monkeypatch, _renderer)
+    row = _row()
+
+    first = await send_pending_deflection_report_deliveries(
+        _Pool([row]), sender=sender, config=_config()
+    )
+    assert first.sent == 1 and first.failed == 0
+
+    # Re-claim: render now fails -> link-only -> different payload, same key.
+    second = await send_pending_deflection_report_deliveries(
+        _Pool([row]), sender=sender, config=_config()
+    )
+    assert second.sent == 1  # delivered via idempotent replay, NOT failed
+    assert second.failed == 0
+    assert len(http.posts) == 2
+    assert http.posts[0]["key"] == http.posts[1]["key"]  # same idempotency key
+    assert http.posts[0]["json"] != http.posts[1]["json"]  # attachment vs link-only
+
+
+@pytest.mark.asyncio
 async def test_delivery_worker_marks_missing_email_failed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -280,6 +280,71 @@ async def test_delivery_worker_claim_query_retries_stale_sending_rows() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delivery_worker_does_not_double_send_on_reclaim_after_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #1461: a crash between send() and _mark_delivered leaves the row
+    # 'sending'; the claim re-tries stale 'sending' rows, so the worker calls
+    # send() again. A deterministic idempotency key keeps the resend deduped.
+    class _IdempotentResendSender:
+        """Resend-style sender: identical Idempotency-Key values are deduped."""
+
+        def __init__(self) -> None:
+            self.calls: list[SendRequest] = []
+            self.delivered: dict[str, str] = {}
+
+        async def send(self, request: SendRequest) -> SendResult:
+            self.calls.append(request)
+            key = request.idempotency_key or ""
+            if key in self.delivered:
+                message_id = self.delivered[key]
+                return SendResult(
+                    provider="resend",
+                    message_id=message_id,
+                    raw={"id": message_id, "deduped": True},
+                )
+            message_id = f"email-{len(self.delivered) + 1}"
+            self.delivered[key] = message_id
+            return SendResult(
+                provider="resend", message_id=message_id, raw={"id": message_id}
+            )
+
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-fake-bytes")
+    sender = _IdempotentResendSender()
+    row = _row()
+
+    # Run 1: the delivered-mark UPDATE raises, so the process dies before
+    # finalizing and the row stays 'sending'.
+    class _CrashOnMarkPool(_Pool):
+        async def execute(self, query: str, *args: Any) -> str:
+            raise RuntimeError("crash between send and mark")
+
+    crash_pool = _CrashOnMarkPool([row])
+    with pytest.raises(RuntimeError, match="crash between send and mark"):
+        await send_pending_deflection_report_deliveries(
+            crash_pool, sender=sender, config=_config()
+        )
+    assert len(sender.calls) == 1
+    assert len(sender.delivered) == 1  # one real email so far
+
+    # Run 2: the claim re-tries the still-'sending' row; the resend carries the
+    # same deterministic key, so Resend dedupes it and no second email is sent.
+    reclaim_pool = _Pool([row])
+    summary = await send_pending_deflection_report_deliveries(
+        reclaim_pool, sender=sender, config=_config()
+    )
+
+    assert summary.sent == 1
+    assert len(sender.calls) == 2
+    assert sender.calls[0].idempotency_key == sender.calls[1].idempotency_key
+    assert (
+        sender.calls[1].idempotency_key
+        == "deflection-report:acct-123:content-ops-abc123"
+    )
+    assert len(sender.delivered) == 1  # still one unique email -- no duplicate
+
+
+@pytest.mark.asyncio
 async def test_delivery_worker_marks_missing_email_failed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_extracted_campaign_sender.py
+++ b/tests/test_extracted_campaign_sender.py
@@ -112,6 +112,32 @@ async def test_resend_sender_builds_payload_and_returns_message_id():
 
 
 @pytest.mark.asyncio
+async def test_resend_sender_forwards_idempotency_key_as_http_header():
+    client = _HTTPClient(_Response({"id": "resend-1"}))
+    sender = ResendCampaignSender(ResendSenderConfig(api_key="re_key"), http_client=client)
+
+    await sender.send(_request(idempotency_key="deflection-report:acct-1:req-1"))
+
+    assert client.calls[0]["headers"] == {
+        "Authorization": "Bearer re_key",
+        "Content-Type": "application/json",
+        "Idempotency-Key": "deflection-report:acct-1:req-1",
+    }
+    # The idempotency key is an HTTP request header, not an email payload header.
+    assert "Idempotency-Key" not in client.calls[0]["json"].get("headers", {})
+
+
+@pytest.mark.asyncio
+async def test_resend_sender_omits_idempotency_header_when_unset():
+    client = _HTTPClient(_Response({"id": "resend-1"}))
+    sender = ResendCampaignSender(ResendSenderConfig(api_key="re_key"), http_client=client)
+
+    await sender.send(_request())
+
+    assert "Idempotency-Key" not in client.calls[0]["headers"]
+
+
+@pytest.mark.asyncio
 async def test_resend_sender_includes_attachments_when_requested():
     client = _HTTPClient(_Response({"id": "resend-1"}))
     sender = ResendCampaignSender(ResendSenderConfig(api_key="re_key"), http_client=client)

--- a/tests/test_extracted_campaign_sender.py
+++ b/tests/test_extracted_campaign_sender.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from extracted_content_pipeline.campaign_ports import SendRequest
+from extracted_content_pipeline.campaign_ports import (
+    IdempotentReplayConflict,
+    SendRequest,
+)
 from extracted_content_pipeline.campaign_sender import (
     RESEND_API_URL,
     ResendCampaignSender,
@@ -16,8 +19,9 @@ from extracted_content_pipeline.campaign_sender import (
 
 
 class _Response:
-    def __init__(self, payload, *, status_error: Exception | None = None):
+    def __init__(self, payload, *, status_code: int = 200, status_error: Exception | None = None):
         self._payload = payload
+        self.status_code = status_code
         self._status_error = status_error
 
     def raise_for_status(self):
@@ -153,6 +157,36 @@ async def test_resend_sender_includes_attachments_when_requested():
     assert client.calls[0]["json"]["attachments"] == [
         {"filename": "support-deflection-report.pdf", "content": "JVBERi0="},
     ]
+
+
+@pytest.mark.asyncio
+async def test_resend_sender_raises_idempotent_replay_on_409_conflict():
+    client = _HTTPClient(
+        _Response(
+            {
+                "statusCode": 409,
+                "name": "invalid_idempotent_request",
+                "message": "This idempotency key has already been used on a request with a different payload.",
+            },
+            status_code=409,
+        )
+    )
+    sender = ResendCampaignSender(ResendSenderConfig(api_key="re_key"), http_client=client)
+
+    with pytest.raises(IdempotentReplayConflict):
+        await sender.send(_request(idempotency_key="deflection-report:acct-1:req-1"))
+
+
+@pytest.mark.asyncio
+async def test_resend_sender_does_not_swallow_non_idempotency_409():
+    boom = RuntimeError("rate limited")
+    client = _HTTPClient(
+        _Response({"name": "rate_limit_exceeded"}, status_code=409, status_error=boom)
+    )
+    sender = ResendCampaignSender(ResendSenderConfig(api_key="re_key"), http_client=client)
+
+    with pytest.raises(RuntimeError, match="rate limited"):
+        await sender.send(_request(idempotency_key="deflection-report:acct-1:req-1"))
 
 
 def test_resend_sender_requires_api_key():


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delivery-Idempotency.md
Slice phase: Production hardening

Closes ATLAS #1461 (P1, money path). The deflection delivery worker calls `sender.send(...)` then a separate `_mark_delivered`. A crash or DB blip between the two leaves the row `delivery_status = 'sending'`; the claim SQL re-claims stale `'sending'` rows after `DELIVERY_CLAIM_STALE_AFTER = "15 minutes"`, and the pre-send `_confirm_delivery_still_sendable` check passes (the row is still `'sending'` + `paid`), so the worker sends the report email a **second time** to a paying customer. The stored `provider_message_id` does not help: in the crash case it was never written.

This gates the #1440 live run -- we should not invite a real paid run while a single crash window double-emails the buyer.

## Mechanism
A deterministic Resend `Idempotency-Key` derived purely from `(account_id, request_id)`: `deflection-report:{account_id}:{request_id}`. A re-claimed `'sending'` row recomputes the identical key, and Resend dedupes identical keys server-side for 24h -- far outside the 15-minute claim window -- so the resend returns the original email instead of sending a new one. No new column / migration: the key is recomputed, not stored.

- `extracted_content_pipeline/campaign_ports.py` (owned): `SendRequest` gains a trailing optional `idempotency_key: str | None = None` (backward-compatible).
- `extracted_content_pipeline/campaign_sender.py` (owned): `ResendCampaignSender.send` adds the `Idempotency-Key` HTTP request header when the key is set.
- `atlas_brain/content_ops_deflection_delivery.py`: `_delivery_idempotency_key` helper used by `_send_request`.

**Idempotent-replay conflict (Codex review):** Resend returns `409 invalid_idempotent_request` when the same key is reused with a *different* payload. The paid report carries a generated PDF whose renderer stamps a per-call timestamp/file id, so a re-claim re-renders to different bytes and the retry would be a 409 -- which the generic `except` would mark `failed` (a false send-failure incident) even though the original email already went out. Fix: `campaign_ports.IdempotentReplayConflict` (typed), `ResendCampaignSender.send` raises it on the documented `invalid_idempotent_request` 409 (other 409s still raise), and the delivery loop catches it before the failure branch, emits an `info` `paid_report_delivery_idempotent_replay` incident, and marks the row `delivered` (`provider_message_id = resend:idempotent-replay`). This makes the fix robust to any payload drift, not just the timestamp.

## Intentional
- Deterministic, recomputed (not persisted) -- no migration, and re-claim is guaranteed to reproduce the key.
- Resend-only: the deflection delivery sender is `create_campaign_sender("resend", ...)`, so the native Resend `Idempotency-Key` is the correct, simplest mechanism. The `idempotency_key` field is provider-agnostic; the SES sender ignores it (no native idempotency header, and SES is not on this path).
- Relies on Resend honoring the key within 24h. The 15-minute claim window keeps the resend well inside it; documented rather than belt-and-suspendered with a second DB-level dedupe, to keep the slice small and avoid a schema change.
- A re-claim that re-renders a byte-different PDF is treated as delivered via the `IdempotentReplayConflict` path, not failed -- chosen over forcing a byte-deterministic PDF render because it is contained to the delivery path/sender and robust to all payload drift. The sentinel `resend:idempotent-replay` id costs nothing here: the deflection delivery's `provider_message_id` is write-only (no webhook/bounce correlation reads it, unlike the campaign flow).

## Deferred
- #1462 (billing 409 -> Stripe retry storm) is the next money-path slice.
- A DB-level idempotency ledger (provider-independent, survives a >24h stall) is future hardening if the claim window ever exceeds the provider idempotency TTL.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed reviewer R6/R8 BLOCKER + Codex P2 (same root cause) "unstable retry payload under a stable idempotency key": the re-claim re-renders the PDF (or falls back to link-only when the render fails), so the same key carries a different payload and Resend returns `409 invalid_idempotent_request`. The loop previously caught that as a send failure and marked the already-sent paid delivery `failed`. Fix: the Resend sender raises a typed `IdempotentReplayConflict` on that specific 409 and the loop treats it as an idempotent replay -> `delivered` (info incident), not failed -- robust to ANY payload drift, not only the timestamp. Verified Resend's 409 behavior against its docs.
- R2 evidence (reviewer ask): added an end-to-end regression with the REAL `ResendCampaignSender` + a payload-aware fake HTTP client + the real render->link-only fallback, asserting the re-claim reuses the same key with a different body and is marked delivered (not failed). Plus the sender 409->`IdempotentReplayConflict` test (and a non-idempotency-409 still-raises test).
- Plan-doc R6/R8: the Review Contract trigger list now declares R1, R2, R6, R8, R10.

## Verification
- `pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_extracted_campaign_sender.py tests/test_send_content_ops_deflection_report_deliveries.py` - passed. Includes the crash/re-claim no-double-send test, the idempotent-replay-conflict marks-delivered-not-failed test, the two Resend `Idempotency-Key` HTTP-header forwarding tests, and the 409 `invalid_idempotent_request` -> `IdempotentReplayConflict` test (plus the non-idempotency-409 still-raises test).
- `bash scripts/check_ascii_python.sh` - passed.
- `python -m py_compile` for the touched modules - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed, 3910 passed, 10 skipped; existing torch/pynvml warning.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - 0 import findings.

## Diff size
6 files, ~409 added.