### PR TITLE
Deflection billing: 2xx + reconciliation row for permanent paid-but-missing (#1462)

### DIFF
--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -1,6 +1,7 @@
 """Stripe billing endpoints: checkout, portal, status, webhook."""
 
 import logging
+import time
 import uuid as _uuid
 from collections.abc import Mapping, Sequence
 from hashlib import sha256
@@ -12,6 +13,7 @@ from pydantic import BaseModel
 from ..auth.dependencies import AuthUser, require_auth
 from ..config import settings
 from ..content_ops_deflection_incidents import emit_deflection_paid_funnel_incident_alert
+from ..content_ops_deflection_reconciliation import record_paid_report_missing
 from ..storage.database import get_db_pool
 from extracted_content_pipeline.deflection_report_access import (
     PostgresDeflectionReportArtifactStore,
@@ -406,6 +408,7 @@ async def stripe_webhook(request: Request):
                     obj,
                     meta,
                     event_type=event_type,
+                    event_created=getattr(event, "created", None),
                 )
         else:
             account_id = await _handle_checkout_completed(pool, obj)
@@ -421,6 +424,7 @@ async def stripe_webhook(request: Request):
                     obj,
                     meta,
                     event_type=event_type,
+                    event_created=getattr(event, "created", None),
                 )
 
     elif event_type == "checkout.session.async_payment_failed":
@@ -620,12 +624,28 @@ async def _handle_vendor_checkout_completed(pool, session, meta: dict) -> None:
         logger.exception("Failed to send vendor checkout confirmation email")
 
 
+def _event_age_seconds(event_created: int | None) -> int | None:
+    """Seconds since a Stripe event was created, or None if unknown.
+
+    Used to tell a transient write-ordering race (recent event -> retry) from a
+    permanent paid-but-missing report (aged event -> reconcile). #1462.
+    """
+
+    if not event_created:
+        return None
+    try:
+        return max(0, int(time.time()) - int(event_created))
+    except (TypeError, ValueError):
+        return None
+
+
 async def _handle_content_ops_deflection_report_checkout_completed(
     pool: Any,
     session: Any,
     meta: Mapping[str, Any],
     *,
     event_type: str = "checkout.session.completed",
+    event_created: int | None = None,
 ) -> None:
     """Handle one-time deflection report checkout completion."""
 
@@ -682,6 +702,53 @@ async def _handle_content_ops_deflection_report_checkout_completed(
         payment_reference=session_id or None,
     )
     if not marked:
+        age = _event_age_seconds(event_created)
+        grace = int(
+            getattr(
+                settings.saas_auth,
+                "stripe_content_ops_deflection_report_reconcile_grace_seconds",
+                300,
+            )
+            or 300
+        )
+        if age is not None and age > grace:
+            # Aged past the write-ordering race window: the report row will not
+            # appear on retry, so this is a permanent paid-but-missing case.
+            # Record it for manual reconciliation and return 2xx so Stripe stops
+            # retrying a non-2xx for hours (#1462).
+            await record_paid_report_missing(
+                pool,
+                account_id=account_id_text,
+                request_id=request_id,
+                stripe_session_id=session_id or None,
+                event_type=event_type,
+            )
+            await emit_deflection_paid_funnel_incident_alert(
+                logger,
+                incident_type="paid_report_missing_after_payment",
+                severity="error",
+                account_id=account_id_text,
+                request_id=request_id,
+                event_type=event_type,
+                stripe_session_id=session_id,
+                disposition="reconciled",
+                event_age_seconds=age,
+            )
+            logger.error(
+                "Deflection report checkout completed but report was not found "
+                "(permanent, recorded for reconciliation): account=%s request=%s "
+                "session=%s age=%ss",
+                account_id_text,
+                request_id,
+                session_id,
+                age,
+            )
+            return
+        # Within the race window (or unknown event age): 409 so Stripe retries
+        # and finds the report row once its write commits. Real Stripe events
+        # always carry `created`, so a genuinely permanent miss ages past the
+        # window above; only the transient race (or a malformed/timestampless
+        # event) lands here.
         await emit_deflection_paid_funnel_incident_alert(
             logger,
             incident_type="paid_report_missing_after_payment",

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -120,6 +120,7 @@ class SaaSAuthConfig(BaseSettings):
     )
     stripe_content_ops_deflection_report_reconcile_grace_seconds: int = Field(
         default=300,
+        ge=1,
         description=(
             "Grace window in seconds after a paid Stripe deflection-checkout event "
             "before a missing report row is treated as permanent rather than a "

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -118,6 +118,17 @@ class SaaSAuthConfig(BaseSettings):
         default="usd",
         description="Stripe Checkout currency for the one-time Content Ops FAQ deflection report",
     )
+    stripe_content_ops_deflection_report_reconcile_grace_seconds: int = Field(
+        default=300,
+        description=(
+            "Grace window in seconds after a paid Stripe deflection-checkout event "
+            "before a missing report row is treated as permanent rather than a "
+            "transient write-ordering race. Within the window the webhook returns "
+            "409 so Stripe retries; once the event has aged past it, the webhook "
+            "returns 2xx and records a paid-but-missing reconciliation row instead "
+            "of retrying into the void (#1462)"
+        ),
+    )
 
     # LLM Gateway plan tiers (PR-D2). Stripe products are created
     # operationally; the price IDs land here when ready, _init_price_map()

--- a/atlas_brain/content_ops_deflection_reconciliation.py
+++ b/atlas_brain/content_ops_deflection_reconciliation.py
@@ -1,0 +1,48 @@
+"""Paid-but-report-missing reconciliation ledger writes (#1462).
+
+When a Stripe deflection checkout completes (paid) but no report row exists and
+the event has aged past the write-ordering race window, the billing webhook
+returns 2xx (to stop Stripe retrying a non-2xx for hours) and records the
+paid-but-undelivered case here so it is surfaced for manual reconciliation
+rather than retried into the void.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("atlas.content_ops_deflection_reconciliation")
+
+_INSERT_PAID_RECONCILIATION_SQL = """
+INSERT INTO content_ops_deflection_paid_reconciliation
+    (account_id, request_id, stripe_session_id, event_type, reason)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (account_id, request_id, stripe_session_id) DO NOTHING
+"""
+
+
+async def record_paid_report_missing(
+    pool: Any,
+    *,
+    account_id: str,
+    request_id: str,
+    stripe_session_id: str | None,
+    event_type: str,
+    reason: str = "paid_report_missing",
+) -> None:
+    """Record a paid Stripe deflection checkout that has no report row.
+
+    Idempotent on (account_id, request_id, stripe_session_id) so Stripe retries
+    -- or a later genuine arrival of the same event -- do not create duplicate
+    ledger rows.
+    """
+
+    await pool.execute(
+        _INSERT_PAID_RECONCILIATION_SQL,
+        account_id,
+        request_id,
+        stripe_session_id,
+        event_type,
+        reason,
+    )

--- a/atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql
+++ b/atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql
@@ -1,0 +1,22 @@
+-- Paid-but-report-missing reconciliation ledger (#1462).
+--
+-- When a Stripe deflection checkout completes (paid) but no report row exists
+-- and the event has aged past the write-ordering race window, the webhook
+-- returns 2xx -- to stop Stripe retrying a non-2xx for hours -- and records the
+-- paid-but-undelivered case here for manual reconciliation, instead of letting
+-- the buyer's payment retry into the void. account_id is TEXT to match
+-- content_ops_deflection_reports (migration 328).
+
+CREATE TABLE IF NOT EXISTS content_ops_deflection_paid_reconciliation (
+    id                BIGSERIAL PRIMARY KEY,
+    account_id        TEXT NOT NULL,
+    request_id        TEXT NOT NULL,
+    stripe_session_id TEXT,
+    event_type        TEXT NOT NULL,
+    reason            TEXT NOT NULL DEFAULT 'paid_report_missing',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (account_id, request_id, stripe_session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_ops_deflection_paid_reconciliation_created
+    ON content_ops_deflection_paid_reconciliation (created_at DESC);

--- a/plans/PR-Deflection-Billing-Reconciliation.md
+++ b/plans/PR-Deflection-Billing-Reconciliation.md
@@ -1,0 +1,134 @@
+# PR: Deflection billing reconciliation (ATLAS #1462)
+
+## Why this slice exists
+
+ATLAS #1462 is a P1 money-path bug. In `billing.py`, the deflection checkout
+webhook handler raises `HTTPException(409)` whenever `mark_paid` finds no report
+row. Stripe retries non-2xx webhook responses for hours, so:
+
+- For the **permanent** case (the report row never existed), the buyer paid but
+  is never marked/delivered; after retries exhaust, the payment is lost into the
+  void with only a transient log line.
+- Only the **transient write-ordering race** (the report row write lagging the
+  webhook) actually benefits from the retry.
+
+This blocks the #1440 live run alongside #1461: a real paid run should not be
+able to land a paid-but-undelivered report that silently disappears.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-billing
+Slice phase: Production hardening
+
+1. Discriminate the permanent paid-but-missing case from the transient race by
+   **event age** (`event.created` vs now, grace window from config).
+2. Permanent (event aged past the window): return **2xx** (stop the retry
+   storm) + record a durable reconciliation row + emit the existing
+   `paid_report_missing_after_payment` alert.
+3. Race (recent event, or unknown event age): keep the **409** so Stripe retries
+   and finds the report row once its write commits.
+4. Add a `content_ops_deflection_paid_reconciliation` table + a small atlas_brain
+   write helper + failure-first tests for both branches.
+
+Out of scope: #1461 (delivery idempotency, separate merged slice); any
+buyer-facing surface change; the pre-existing migration-prefix-collision test
+failure (281/282/283/298) which is unrelated to this slice.
+
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R11, R12. (R3/R8
+  billing + idempotency money path; R4 new migration/table; R5 webhook handler
+  return-contract change; R6 error-handling/observability; R11/R12 new config
+  field.)
+
+### Files touched
+
+- `plans/PR-Deflection-Billing-Reconciliation.md`
+- `atlas_brain/api/billing.py`
+- `atlas_brain/config.py`
+- `atlas_brain/content_ops_deflection_reconciliation.py`
+- `atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+`_handle_content_ops_deflection_report_checkout_completed` gains an
+`event_created` parameter (passed from both webhook dispatch sites as
+`event.created`). `_event_age_seconds(event_created)` returns the seconds since
+the Stripe event was created, or `None` if unknown.
+
+In the `if not marked:` branch:
+
+- **Aged past grace** (`age is not None and age > grace`,
+  `grace = settings.saas_auth.stripe_content_ops_deflection_report_reconcile_grace_seconds`,
+  default 300): the report row will not appear on retry, so this is permanent.
+  `record_paid_report_missing(...)` inserts a row into
+  `content_ops_deflection_paid_reconciliation` (idempotent via
+  `ON CONFLICT (account_id, request_id, stripe_session_id) DO NOTHING`), the
+  alert fires with `disposition="reconciled"`, and the handler **returns** (2xx).
+- **Within grace, or unknown age**: the existing alert fires and the handler
+  raises `409` (unchanged), so Stripe retries the genuine race. Real Stripe
+  events always carry `created`, so a genuinely permanent miss ages past the
+  window; only the transient race (or a malformed/timestampless event, e.g. a
+  hand-built test session) lands in the 409 branch.
+
+The reconciliation table is atlas_brain-only (migration 336), matching the
+existing deflection report/delivery tables (migrations 328/332); the write
+helper lives in atlas_brain (`content_ops_deflection_reconciliation.py`) rather
+than the extracted store, since the billing webhook is host-only.
+
+## Intentional
+
+- `account_id` is `TEXT` to match `content_ops_deflection_reports` (328), not a
+  uuid column.
+- Unknown event age conservatively keeps the 409 (retry) rather than recording
+  a reconciliation row. This preserves the prior behavior for timestampless
+  sessions and never converts a possible race into a permanent record; the
+  permanent path requires a real, aged event timestamp.
+- The reconciliation row is durable and queryable (operator-actionable), per the
+  operator decision over an alert/log-only record.
+- The race-branch alert is byte-identical to the prior behavior, so existing
+  incident-payload assertions are unaffected; the permanent branch adds
+  `disposition`/`event_age_seconds` to its alert.
+
+## Deferred
+
+- A sweeper/operator surface that lists and clears
+  `content_ops_deflection_paid_reconciliation` rows (this slice only writes the
+  ledger; reading/clearing is a follow-up).
+- The pre-existing migration-prefix-collision test failure
+  (`test_repo_migration_prefix_collisions_are_only_historical_exceptions`,
+  collisions at 281/282/283/298) is unrelated to this slice and is red on
+  `origin/main` independently; not touched here.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused pytest over `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  -- passed, 45 tests (incl. the new aged->reconcile-2xx test and the
+  recent->409-race test; the existing missing-report tests still 409 because
+  they pass no `event_created`).
+- Focused pytest over the three deflection-billing test files
+  `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`,
+  `tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py`, and
+  `tests/test_content_ops_deflection_incidents.py` -- passed, 58 tests.
+- `python -c "from atlas_brain.config import settings; ..."` -- the new
+  `stripe_content_ops_deflection_report_reconcile_grace_seconds` field loads
+  (default 300).
+- Migration 336 is the next free atlas_brain prefix and is collision-free
+  (`_find_duplicate_migration_prefixes` does not list 336). The migration-prefix
+  collision test fails identically on `origin/main` without this change
+  (verified by stashing) -- pre-existing, unrelated.
+- Non-ASCII scan of the touched atlas_brain files + migration -- clean.
+- `python -m py_compile` for the touched modules -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/billing.py` | 60 |
+| `atlas_brain/config.py` | 12 |
+| `atlas_brain/content_ops_deflection_reconciliation.py` | 50 |
+| `atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql` | 23 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 75 |
+| `plans/PR-Deflection-Billing-Reconciliation.md` | 130 |
+| **Total** | **~350** |

--- a/plans/PR-Deflection-Billing-Reconciliation.md
+++ b/plans/PR-Deflection-Billing-Reconciliation.md
@@ -83,6 +83,10 @@ than the extracted store, since the billing webhook is host-only.
   a reconciliation row. This preserves the prior behavior for timestampless
   sessions and never converts a possible race into a permanent record; the
   permanent path requires a real, aged event timestamp.
+- The grace config is validated `ge=1` (fail-closed): a non-positive value would
+  make a fresh event (`age == 0`) satisfy `age > grace` and record a genuine
+  write-ordering race as permanent (2xx), bypassing the retry. With `ge=1` such
+  a value cannot load (review R11/R8 + Codex). A regression asserts -1/0 raise.
 - The reconciliation row is durable and queryable (operator-actionable), per the
   operator decision over an alert/log-only record.
 - The race-branch alert is byte-identical to the prior behavior, so existing
@@ -94,19 +98,23 @@ than the extracted store, since the billing webhook is host-only.
 - A sweeper/operator surface that lists and clears
   `content_ops_deflection_paid_reconciliation` rows (this slice only writes the
   ledger; reading/clearing is a follow-up).
-- The pre-existing migration-prefix-collision test failure
-  (`test_repo_migration_prefix_collisions_are_only_historical_exceptions`,
-  collisions at 281/282/283/298) is unrelated to this slice and is red on
-  `origin/main` independently; not touched here.
+- Two pre-existing CI-red test failures are red on `origin/main` independently
+  of this slice (verified by stashing) and are handled in a separate CI-hygiene
+  follow-up PR, not here: `test_repo_migration_prefix_collisions_are_only_historical_exceptions`
+  (collisions at 281/282/283/298 missing from its allowlist) and
+  `test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks` (its
+  expected snapshot summary predates the merged #1486 measured-repetition /
+  #1466 proven-answer-gate counts). The latter is what makes the
+  `atlas-content-ops-deflection-stripe-paid-checks` lane red on this PR.
 
 Parked hardening: none.
 
 ## Verification
 
 - Focused pytest over `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
-  -- passed, 45 tests (incl. the new aged->reconcile-2xx test and the
-  recent->409-race test; the existing missing-report tests still 409 because
-  they pass no `event_created`).
+  -- passed, 46 tests (incl. the aged->reconcile-2xx test, the recent->409-race
+  test, and the config-rejects-non-positive-grace test; the existing
+  missing-report tests still 409 because they pass no `event_created`).
 - Focused pytest over the three deflection-billing test files
   `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`,
   `tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py`, and

--- a/plans/PR-Deflection-Billing-Reconciliation.md
+++ b/plans/PR-Deflection-Billing-Reconciliation.md
@@ -41,11 +41,11 @@ failure (281/282/283/298) which is unrelated to this slice.
 
 ### Files touched
 
-- `plans/PR-Deflection-Billing-Reconciliation.md`
 - `atlas_brain/api/billing.py`
 - `atlas_brain/config.py`
 - `atlas_brain/content_ops_deflection_reconciliation.py`
 - `atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql`
+- `plans/PR-Deflection-Billing-Reconciliation.md`
 - `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
 
 ## Mechanism
@@ -98,14 +98,9 @@ than the extracted store, since the billing webhook is host-only.
 - A sweeper/operator surface that lists and clears
   `content_ops_deflection_paid_reconciliation` rows (this slice only writes the
   ledger; reading/clearing is a follow-up).
-- Two pre-existing CI-red test failures are red on `origin/main` independently
-  of this slice (verified by stashing) and are handled in a separate CI-hygiene
-  follow-up PR, not here: `test_repo_migration_prefix_collisions_are_only_historical_exceptions`
-  (collisions at 281/282/283/298 missing from its allowlist) and
-  `test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks` (its
-  expected snapshot summary predates the merged #1486 measured-repetition /
-  #1466 proven-answer-gate counts). The latter is what makes the
-  `atlas-content-ops-deflection-stripe-paid-checks` lane red on this PR.
+- The earlier unrelated CI-red paid-flow and migration-prefix expectation drift
+  was handled in #1516; this branch is rebased on that fix so the
+  `atlas-content-ops-deflection-stripe-paid-checks` lane can validate this slice.
 
 Parked hardening: none.
 
@@ -118,14 +113,16 @@ Parked hardening: none.
 - Focused pytest over the three deflection-billing test files
   `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`,
   `tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py`, and
-  `tests/test_content_ops_deflection_incidents.py` -- passed, 58 tests.
+  `tests/test_content_ops_deflection_incidents.py` -- passed, 59 tests.
+- Full `atlas-content-ops-deflection-stripe-paid-checks` pytest list -- passed,
+  184 tests after rebasing on #1516.
 - `python -c "from atlas_brain.config import settings; ..."` -- the new
   `stripe_content_ops_deflection_report_reconcile_grace_seconds` field loads
   (default 300).
 - Migration 336 is the next free atlas_brain prefix and is collision-free
-  (`_find_duplicate_migration_prefixes` does not list 336). The migration-prefix
-  collision test fails identically on `origin/main` without this change
-  (verified by stashing) -- pre-existing, unrelated.
+  (`_find_duplicate_migration_prefixes` does not list 336). The historical
+  migration-prefix allowlist drift was handled in #1516; 336 remains outside the
+  historical collision set.
 - Non-ASCII scan of the touched atlas_brain files + migration -- clean.
 - `python -m py_compile` for the touched modules -- passed.
 
@@ -133,10 +130,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/api/billing.py` | 60 |
+| `atlas_brain/api/billing.py` | 67 |
 | `atlas_brain/config.py` | 12 |
-| `atlas_brain/content_ops_deflection_reconciliation.py` | 50 |
-| `atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql` | 23 |
-| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 75 |
-| `plans/PR-Deflection-Billing-Reconciliation.md` | 130 |
-| **Total** | **~350** |
+| `atlas_brain/content_ops_deflection_reconciliation.py` | 48 |
+| `atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql` | 22 |
+| `plans/PR-Deflection-Billing-Reconciliation.md` | 139 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 88 |
+| **Total** | **376** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -454,6 +454,23 @@ async def test_deflection_checkout_completion_retries_409_within_race_window() -
     ] == []
 
 
+def test_reconcile_grace_config_rejects_non_positive_values() -> None:
+    # #1462 R11/R8: a negative/zero grace would make a fresh event (age 0)
+    # satisfy `age > grace`, recording a genuine write-ordering race as a
+    # permanent reconciliation (2xx) and bypassing the retry this slice exists
+    # to preserve. The money-path config must fail closed for non-positive values
+    # so a bad value cannot even load.
+    from pydantic import ValidationError
+
+    from atlas_brain.config import SaaSAuthConfig
+
+    for bad in (-1, 0):
+        with pytest.raises(ValidationError):
+            SaaSAuthConfig(
+                stripe_content_ops_deflection_report_reconcile_grace_seconds=bad
+            )
+
+
 @pytest.mark.asyncio
 async def test_deflection_checkout_completion_emits_incident_for_terms_mismatch(
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import time
 import uuid
 from types import SimpleNamespace
 from typing import Any
@@ -381,6 +382,76 @@ async def test_deflection_checkout_completion_emits_incident_when_report_missing
             "stripe_session_id": "cs_test_deflection",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_deflection_checkout_completion_records_reconciliation_when_event_aged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # #1462: an event aged past the race window with no report row is a permanent
+    # paid-but-missing case -> record a reconciliation row and return 2xx (stop
+    # the Stripe retry storm), instead of 409-retrying into the void.
+    caplog.set_level(logging.ERROR, logger="atlas.api.billing")
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    pool = _Pool()
+    pool.update_result = "UPDATE 0"
+    aged_event_created = int(time.time()) - 100_000  # well past the 300s grace
+
+    returned = await billing._handle_content_ops_deflection_report_checkout_completed(
+        pool,
+        session,
+        session.metadata,
+        event_created=aged_event_created,
+    )
+
+    assert returned is None  # 2xx, no HTTPException
+    reconciliations = [
+        call
+        for call in pool.execute_calls
+        if "content_ops_deflection_paid_reconciliation" in call[0]
+    ]
+    assert len(reconciliations) == 1
+    query, args = reconciliations[0]
+    assert "INSERT INTO content_ops_deflection_paid_reconciliation" in query
+    assert "ON CONFLICT" in query
+    assert args == (
+        account_id,
+        "req-123",
+        "cs_test_deflection",
+        "checkout.session.completed",
+        "paid_report_missing",
+    )
+    payloads = _incident_payloads(caplog)
+    assert len(payloads) == 1
+    assert payloads[0]["incident_type"] == "paid_report_missing_after_payment"
+    assert payloads[0]["disposition"] == "reconciled"
+
+
+@pytest.mark.asyncio
+async def test_deflection_checkout_completion_retries_409_within_race_window() -> None:
+    # A recent event is the transient write-ordering race: keep the 409 so Stripe
+    # retries and finds the report row once its write commits. No reconciliation
+    # row is written for the race case.
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    pool = _Pool()
+    pool.update_result = "UPDATE 0"
+
+    with pytest.raises(billing.HTTPException) as exc:
+        await billing._handle_content_ops_deflection_report_checkout_completed(
+            pool,
+            session,
+            session.metadata,
+            event_created=int(time.time()),
+        )
+
+    assert exc.value.status_code == 409
+    assert [
+        call
+        for call in pool.execute_calls
+        if "content_ops_deflection_paid_reconciliation" in call[0]
+    ] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Billing-Reconciliation.md
Slice phase: Production hardening

Closes ATLAS #1462 (P1, money path). The deflection checkout webhook handler raised `HTTPException(409)` whenever `mark_paid` found no report row. Stripe retries non-2xx webhook responses for hours, so the **permanent** case (the report row never existed) = the buyer paid but is never marked/delivered, lost into the void after retries exhaust; only the transient write-ordering **race** (the report row write lagging the webhook) benefits from the retry.

This gates the #1440 live run alongside the merged #1461: a real paid run must not be able to land a paid-but-undelivered report that silently disappears.

## Mechanism
`_handle_content_ops_deflection_report_checkout_completed` gains an `event_created` parameter (passed from both webhook dispatch sites as `event.created`). `_event_age_seconds(event_created)` returns seconds since the Stripe event, or `None` if unknown.

In the `if not marked:` branch:
- **Aged past grace** (`age > settings.saas_auth.stripe_content_ops_deflection_report_reconcile_grace_seconds`, default 300s): permanent. Insert a durable `content_ops_deflection_paid_reconciliation` row (idempotent via `ON CONFLICT (account_id, request_id, stripe_session_id) DO NOTHING`), emit the existing `paid_report_missing_after_payment` alert with `disposition="reconciled"`, and **return 2xx** -- Stripe stops retrying.
- **Within grace, or unknown age**: keep the **409** so Stripe retries the genuine race and finds the report row once its write commits. Real Stripe events always carry `created`, so a permanent miss ages past the window; only the race (or a timestampless/test session) lands here -- existing 409 tests are unchanged.

New: migration 336 (atlas_brain, `account_id TEXT` to match reports/328), an atlas_brain write helper `content_ops_deflection_reconciliation.record_paid_report_missing`, and a config grace field validated `ge=1`.

## Intentional
- Unknown event age conservatively keeps the 409 (retry), never converting a possible race into a permanent record; the permanent path requires a real, aged event timestamp.
- The reconciliation row is durable/queryable (operator-actionable), per the operator decision over an alert/log-only record.
- The race-branch alert is byte-identical to prior behavior (existing incident-payload assertions unaffected); the permanent branch adds `disposition`/`event_age_seconds`.
- The write helper lives in atlas_brain (not the extracted store): the Stripe webhook is host-only, and the table is atlas_brain-only (matching reports/328 + deliveries/332).
- The grace config fails closed with `ge=1`, so non-positive values cannot load and cannot turn a fresh race into permanent 2xx reconciliation.

## Deferred
- An operator surface to list/clear `content_ops_deflection_paid_reconciliation` rows (this slice only writes the ledger).
- The earlier unrelated paid-flow and migration-prefix expectation drift was handled in #1516; this branch is rebased on that fix.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed reviewer R11/R8 BLOCKER + Codex P2 "validate the reconciliation grace window": `stripe_content_ops_deflection_report_reconcile_grace_seconds` is `Field(default=300, ge=1, ...)`, so non-positive values cannot load. Added `test_reconcile_grace_config_rejects_non_positive_values` for -1 and 0.
- R12 paid-flow lane: fixed by rebasing on #1516, which refreshed the stale paid-flow snapshot expectations and migration-prefix allowlist.

## Verification
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` -> 46 passed.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py tests/test_content_ops_deflection_incidents.py -q` -> 59 passed.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py::test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks -q` -> 1 passed after rebasing on #1516.
- Full `atlas-content-ops-deflection-stripe-paid-checks` pytest list locally -> 184 passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Billing-Reconciliation.md --check` -> plan already in sync.
- `git diff --check origin/main...HEAD` -> clean.

## Diff size
6 files, +376 / -0.
