### PR TITLE
CI hygiene: refresh two stale test expectations (red on main)

### DIFF
--- a/.github/workflows/atlas_migrations_runner_checks.yml
+++ b/.github/workflows/atlas_migrations_runner_checks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install runtime dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install asyncpg pytest pytest-asyncio
+          python -m pip install asyncpg pytest pytest-asyncio pydantic pydantic-settings
 
       # No database service: test_migrations_runner.py uses a fake migration pool
       # and pure-Path prefix checks. A real-DB apply check for the deflection

--- a/.github/workflows/atlas_migrations_runner_checks.yml
+++ b/.github/workflows/atlas_migrations_runner_checks.yml
@@ -1,0 +1,45 @@
+name: Atlas Migrations Runner Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_migrations_runner_checks.yml"
+      - "atlas_brain/storage/migrations/**"
+      - "tests/test_migrations_runner.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_migrations_runner_checks.yml"
+      - "atlas_brain/storage/migrations/**"
+      - "tests/test_migrations_runner.py"
+
+jobs:
+  atlas-migrations-runner-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install asyncpg pytest pytest-asyncio
+
+      # No database service: test_migrations_runner.py uses a fake migration pool
+      # and pure-Path prefix checks. A real-DB apply check for the deflection
+      # migrations (328/332/336) lives on the #1462 reconciliation slice, where a
+      # fresh DB can apply that chain without the migration set's out-of-band
+      # product_metadata dependency (referenced by 076+ but never created by a
+      # migration, so a full fresh apply is not viable here).
+      - name: Run migrations runner tests
+        run: |
+          python -m pytest \
+            tests/test_migrations_runner.py \
+            -q

--- a/plans/PR-CI-Hygiene-Stale-Test-Expectations.md
+++ b/plans/PR-CI-Hygiene-Stale-Test-Expectations.md
@@ -1,0 +1,89 @@
+# PR: CI hygiene -- refresh two stale test expectations
+
+## Why this slice exists
+
+Two tests are red on `origin/main` because their pinned expectations were not
+updated when earlier work merged. They are unrelated to each other and to any
+in-flight feature; the failures pre-date this branch (verified by checking them
+out on `origin/main`). The deflection-paid-flow one is what makes the
+`atlas-content-ops-deflection-stripe-paid-checks` CI lane red on any PR that
+touches the deflection billing surface (e.g. #1462), so it blocks unrelated
+merges. This slice refreshes the expectations to match the already-merged,
+already-reviewed behavior. No production code changes.
+
+## Scope (this PR)
+
+Ownership lane: testing/ci-hygiene
+Slice phase: Robust testing
+
+1. `test_repo_migration_prefix_collisions_are_only_historical_exceptions`: add
+   the accepted historical prefix collisions 281/282/283/298 (parallel-session
+   b2b migrations that already shipped on main with the same numeric prefix) to
+   the allowlist, so the test again catches only NEW collisions.
+2. `test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks`:
+   refresh the expected snapshot summary to the current counts produced by the
+   merged measured-repetition (#1486: repeat vs non-repeat split) and
+   proven-answer gate (#1466: stricter resolution evidence).
+
+Out of scope: any production behavior change; the underlying migration-numbering
+convention (the collisions are accepted as historical, not renumbered).
+
+- Reviewer rules triggered: R1, R2.
+
+### Files touched
+
+- `.github/workflows/atlas_migrations_runner_checks.yml`
+- `plans/PR-CI-Hygiene-Stale-Test-Expectations.md`
+- `tests/test_atlas_billing_content_ops_deflection_paid_flow.py`
+- `tests/test_migrations_runner.py`
+
+## Mechanism
+
+Both changes are assertion/fixture updates only.
+
+- The collision allowlist gains four entries with the exact sorted file pairs
+  `_find_duplicate_migration_prefixes` returns for prefixes 281/282/283/298.
+- The paid-flow test's two summary checks (the pre-payment gated snapshot and
+  the post-payment unlocked summary) move from the pre-#1486/#1466 counts
+  (`generated=3`, `no_proven_answer_count=2`, `repeat_ticket_count=4`) to the
+  current ones (`generated=1`, `no_proven_answer_count=0`, `repeat_ticket_count=2`,
+  `non_repeat_ticket_count=2`). The markdown section assertions are unchanged --
+  the "No Proven Answer Yet" section still renders for this fixture.
+
+## Intentional
+
+- The migration collisions are accepted as historical (already on main), so the
+  allowlist is extended rather than the migrations renumbered. The test still
+  fails on any genuinely new collision.
+- The paid-flow expectations are updated to match merged/reviewed behavior, not
+  to assert a new behavior; this is fixture drift, not a product change.
+
+## Deferred
+
+- A scoped real-DB apply test for the deflection migration chain (328/332/336)
+  -> the #1462 reconciliation slice.
+- Making the full migration set fresh-appliable (the missing `product_metadata`
+  migration) -> separate migration-debt issue; out of scope here.
+
+Parked hardening: none.
+
+## Verification
+
+- `tests/test_migrations_runner.py` -- passed (incl. the refreshed collision
+  allowlist test).
+- `tests/test_atlas_billing_content_ops_deflection_paid_flow.py` -- passed
+  (the refreshed gated + unlocked summary counts).
+- Both files failed identically on `origin/main` before this change (verified by
+  checkout/stash); they pass after.
+- Non-ASCII scan of the two test files -- clean.
+- `python -m py_compile` for the two test files -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_migrations_runner_checks.yml` | 45 |
+| `plans/PR-CI-Hygiene-Stale-Test-Expectations.md` | 89 |
+| `tests/test_atlas_billing_content_ops_deflection_paid_flow.py` | 11 |
+| `tests/test_migrations_runner.py` | 20 |
+| **Total** | **165** |

--- a/tests/test_atlas_billing_content_ops_deflection_paid_flow.py
+++ b/tests/test_atlas_billing_content_ops_deflection_paid_flow.py
@@ -193,11 +193,14 @@ async def test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks(
             "reason": "payment_required",
         },
     }
+    # Summary reflects merged measured-repetition (#1486: repeat vs non-repeat
+    # split) and the proven-answer gate (#1466: stricter resolution evidence).
     assert gated_result["snapshot"]["summary"] == {
-        "generated": 3,
+        "generated": 1,
         "drafted_answer_count": 1,
-        "no_proven_answer_count": 2,
-        "repeat_ticket_count": 4,
+        "no_proven_answer_count": 0,
+        "repeat_ticket_count": 2,
+        "non_repeat_ticket_count": 2,
         "support_ticket_resolution_evidence_count": 1,
         "support_ticket_resolution_evidence_present": True,
     }
@@ -256,7 +259,7 @@ async def test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks(
 
     unlocked = await artifact_route.endpoint(request_id=request_id)
     assert unlocked["summary"]["drafted_answer_count"] == 1
-    assert unlocked["summary"]["no_proven_answer_count"] == 2
+    assert unlocked["summary"]["no_proven_answer_count"] == 0
     assert "## Support Tax Confirmation" in unlocked["markdown"]
     assert "## Publishable Help-Center Copy From Proven Resolutions" in unlocked["markdown"]
     assert "## No Proven Answer Yet" in unlocked["markdown"]

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -90,6 +90,10 @@ def test_repo_migration_prefix_collisions_are_only_historical_exceptions():
 
     duplicates = _find_duplicate_migration_prefixes(sorted(MIGRATIONS_DIR.glob("*.sql")))
 
+    # Accepted historical prefix collisions: each pair already shipped on main
+    # with the same numeric prefix (parallel-session migrations that landed
+    # together). The allowlist documents them so this test still catches a NEW
+    # collision; 281/282/283/298 were added after the allowlist was last updated.
     assert duplicates == {
         76: [
             "076_consumer_analytics_views.sql",
@@ -98,5 +102,21 @@ def test_repo_migration_prefix_collisions_are_only_historical_exceptions():
         230: [
             "230_b2b_reasoning_synthesis.sql",
             "230_scrape_target_checkpoints.sql",
+        ],
+        281: [
+            "281_b2b_report_subscription_filter_payload.sql",
+            "281_b2b_watchlist_alert_reopen_count.sql",
+        ],
+        282: [
+            "282_b2b_enrichment_stage_runs.sql",
+            "282_b2b_materialization_run_id.sql",
+        ],
+        283: [
+            "283_b2b_enrichment_stage_runs_work_fingerprint.sql",
+            "283_b2b_report_subscription_delivery_blocked_freshness.sql",
+        ],
+        298: [
+            "298_b2b_review_vendor_mentions_drop_duplicate_rows.sql",
+            "298_b2b_watchlist_preview_alert_policy.sql",
         ],
     }


### PR DESCRIPTION
Plan: plans/PR-CI-Hygiene-Stale-Test-Expectations.md
Slice phase: Robust testing

Two tests are red on `origin/main` because their pinned expectations were not refreshed when earlier work merged. The failures pre-date this branch (verified by checkout). The deflection-paid-flow one makes the `atlas-content-ops-deflection-stripe-paid-checks` CI lane red on any PR touching the deflection billing surface (e.g. #1462), blocking unrelated merges. Test-only; no production code changes.

## Mechanism
- `test_repo_migration_prefix_collisions_are_only_historical_exceptions`: add the accepted historical prefix collisions 281/282/283/298 (parallel-session b2b migrations already on main with the same numeric prefix) to the allowlist, so the test again catches only NEW collisions.
- `test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks`: refresh the gated (pre-payment) and unlocked (post-payment) snapshot summary counts to the merged measured-repetition (#1486: repeat vs non-repeat split) and proven-answer gate (#1466: stricter resolution evidence) behavior -- `generated` 3->1, `no_proven_answer_count` 2->0, `repeat_ticket_count` 4->2, `+non_repeat_ticket_count` 2. The markdown section assertions are unchanged (the "No Proven Answer Yet" section still renders for this fixture).
- Touching `tests/test_migrations_runner.py` (imports `atlas_brain.*`) triggers the CI-enrollment audit, so this adds a lean no-DB `.github/workflows/atlas_migrations_runner_checks.yml` (the runner tests use a fake pool + Path prefix checks).

## Finding (no-fix here)
A full real-DB `run_migrations` fresh apply is **not viable**: migration `076_consumer_analytics_views.sql` (and 092/123/138/154) reference a `product_metadata` table that **no migration creates** (the app creates it out-of-band), so a fresh apply fails at 076. Verified against a throwaway Postgres database. Hence the lean no-DB workflow here; a scoped real-DB apply of the deflection chain (328/332/336) is deferred to #1462.

## Intentional
- Migration collisions are accepted as historical (already on main), so the allowlist is extended rather than the migrations renumbered; the test still fails on any genuinely new collision.
- The paid-flow expectations are updated to match merged/reviewed behavior (fixture drift), not to assert a new behavior.

## Deferred
- None.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed Codex P1 "Install package dependencies before running migration tests": the new workflow imported `atlas_brain.storage.migrations` (-> storage/__init__ -> .config) but installed only `asyncpg pytest pytest-asyncio`, so CI failed with `ModuleNotFoundError: pydantic`. Added `pydantic pydantic-settings`; an import-chain scan confirms those + asyncpg are the only external deps, so the explicit list is sufficient without the full requirements.txt.

## Verification
- `tests/test_migrations_runner.py` - passed (incl. the refreshed collision allowlist test).
- `tests/test_atlas_billing_content_ops_deflection_paid_flow.py` - passed (refreshed gated + unlocked summary counts).
- Both files failed identically on `origin/main` before this change (verified by checkout); pass after.
- Non-ASCII scan of the two test files - clean.
- `python -m py_compile` for the two test files - passed.

## Diff size
4 files, ~161 (incl. the lean migrations-runner workflow).