### PR TITLE
Real-DB apply check for the deflection migration chain (328/332/336)

### DIFF
--- a/.github/workflows/atlas_deflection_migration_apply_checks.yml
+++ b/.github/workflows/atlas_deflection_migration_apply_checks.yml
@@ -1,0 +1,59 @@
+name: Atlas Deflection Migration Apply Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_deflection_migration_apply_checks.yml"
+      - "tests/test_deflection_migrations_apply.py"
+      - "atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql"
+      - "atlas_brain/storage/migrations/332_content_ops_deflection_report_deliveries.sql"
+      - "atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_deflection_migration_apply_checks.yml"
+      - "tests/test_deflection_migrations_apply.py"
+      - "atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql"
+      - "atlas_brain/storage/migrations/332_content_ops_deflection_report_deliveries.sql"
+      - "atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql"
+
+jobs:
+  atlas-deflection-migration-apply-checks:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas_migration_tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas -d atlas_migration_tests"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install asyncpg pytest pytest-asyncio
+
+      - name: Apply the deflection migration chain to a fresh database
+        run: |
+          python -m pytest \
+            tests/test_deflection_migrations_apply.py \
+            -q

--- a/plans/PR-Deflection-Migration-Apply-Check.md
+++ b/plans/PR-Deflection-Migration-Apply-Check.md
@@ -34,7 +34,25 @@ Out of scope: making the full migration set fresh-appliable (the missing
 `product_metadata` migration) -- separate migration-debt issue; any production
 code change.
 
-- Reviewer rules triggered: R2, R4, R12.
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The deflection chain (328 -> 332 -> 336) applies in order to a fresh Postgres.
+  - [ ] All three `content_ops_deflection*` tables exist after apply.
+  - [ ] `content_ops_deflection_paid_reconciliation` has its expected columns.
+  - [ ] A second insert on `(account_id, request_id, stripe_session_id)` dedupes
+        (the `ON CONFLICT DO NOTHING` guarantee `record_paid_report_missing` relies on).
+  - [ ] The test skips cleanly when `ATLAS_MIGRATION_TEST_DATABASE_URL` is unset, so
+        local unit runs are unaffected.
+- Affected surfaces: one env-guarded test (`tests/test_deflection_migrations_apply.py`)
+  and one CI workflow (`.github/workflows/atlas_deflection_migration_apply_checks.yml`,
+  Postgres service).
+  No production code path changes.
+- Risk areas: CI-only behavior; the test must skip without the env var; the job stays
+  dependency-light (asyncpg only, resolves the migrations dir by path with no
+  `atlas_brain` import).
+- Reviewer rules triggered: R2 (failure-branch / fixtures), R4, R12 (CI runs the
+  enrolled test).
 
 ### Files touched
 

--- a/plans/PR-Deflection-Migration-Apply-Check.md
+++ b/plans/PR-Deflection-Migration-Apply-Check.md
@@ -1,0 +1,97 @@
+# PR: Deflection migration apply check (real DB)
+
+## Why this slice exists
+
+The #1462 reconciliation slice added migration `336_content_ops_deflection_paid_reconciliation.sql`
+and the handler relies on its `ON CONFLICT (account_id, request_id, stripe_session_id)`
+idempotency. Nothing exercised that DDL against a real database: the
+migrations-runner CI lane is no-DB (fake pool + Path checks), and a repo-wide
+`run_migrations` fresh apply is not viable -- migration 076 references a
+`product_metadata` table that no migration creates (the app creates it
+out-of-band), so a full fresh apply fails at 076.
+
+This slice adds the operator-approved real-DB check, scoped to the deflection
+chain (which has no `product_metadata` dependency): apply 328 -> 332 -> 336 to a
+fresh Postgres and verify the tables and the reconciliation table's idempotency
+constraint. It is the deferred follow-up from the #1462 review.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-billing
+Slice phase: Robust testing
+
+1. Add `tests/test_deflection_migrations_apply.py`: env-guarded
+   (`ATLAS_MIGRATION_TEST_DATABASE_URL`), applies the three deflection migration
+   files in order to a fresh database, asserts the three tables exist, asserts
+   `content_ops_deflection_paid_reconciliation` has its expected columns, and
+   proves the `(account_id, request_id, stripe_session_id)` uniqueness dedupes a
+   second insert (the `record_paid_report_missing` ON CONFLICT guarantee).
+2. Add `.github/workflows/atlas_deflection_migration_apply_checks.yml`: a
+   Postgres service (fresh `atlas_migration_tests` DB) + the env var so the test
+   runs against a real database in CI.
+
+Out of scope: making the full migration set fresh-appliable (the missing
+`product_metadata` migration) -- separate migration-debt issue; any production
+code change.
+
+- Reviewer rules triggered: R2, R4, R12.
+
+### Files touched
+
+- `.github/workflows/atlas_deflection_migration_apply_checks.yml`
+- `plans/PR-Deflection-Migration-Apply-Check.md`
+- `tests/test_deflection_migrations_apply.py`
+
+## Mechanism
+
+The test resolves the migrations directory by path
+(`Path(__file__).resolve().parents[1] / "atlas_brain" / "storage" / "migrations"`)
+rather than importing `atlas_brain`, so the CI job needs no application
+dependencies beyond `asyncpg` (no `pydantic`/`pydantic-settings`). It executes
+each chain file's SQL with `conn.execute` (autocommit), then queries `pg_tables`
+/ `information_schema.columns` and performs a two-insert ON CONFLICT dedupe
+check, cleaning up its test rows in `finally`. Without the env var it skips, so
+local unit runs are unaffected.
+
+The chain (328 reports, 332 deliveries, 336 reconciliation) is standalone --
+neither 328 nor 332 has foreign keys to other tables, so the three files apply
+to an empty database in order.
+
+## Intentional
+
+- Scoped to the deflection chain, not `run_migrations` over the full set, which
+  fails at 076 (`product_metadata`) -- a pre-existing, out-of-scope migration-set
+  property.
+- Path-based migrations-dir resolution keeps the CI job dependency-light and
+  avoids the `atlas_brain` import chain (the pydantic gap that bit the
+  migrations-runner workflow).
+- The dedupe assertion targets the #1462 money-path guarantee specifically (the
+  reconciliation ledger must not double-record a retried checkout event).
+
+## Deferred
+
+- Making the full migration set fresh-appliable (add a `product_metadata`
+  migration / fix 076 ordering) -> separate migration-debt issue.
+
+Parked hardening: none.
+
+## Verification
+
+- Ran `tests/test_deflection_migrations_apply.py` against a fresh throwaway
+  Postgres database (chain applied; tables + reconciliation columns asserted;
+  ON CONFLICT dedupe verified) -- passed.
+- Confirmed the test skips cleanly when `ATLAS_MIGRATION_TEST_DATABASE_URL` is
+  unset (local unit runs unaffected).
+- Verified the chain (328/332/336) applies to a fresh database with no missing
+  dependencies.
+- Non-ASCII scan of the new test + workflow -- clean.
+- Python compile check for `tests/test_deflection_migrations_apply.py` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_deflection_migration_apply_checks.yml` | 59 |
+| `plans/PR-Deflection-Migration-Apply-Check.md` | 97 |
+| `tests/test_deflection_migrations_apply.py` | 120 |
+| **Total** | **276** |

--- a/tests/test_deflection_migrations_apply.py
+++ b/tests/test_deflection_migrations_apply.py
@@ -1,0 +1,120 @@
+"""Real-database apply check for the deflection migration chain (#1462 follow-up).
+
+The full migration set is not cleanly fresh-appliable (migration 076 references
+a `product_metadata` table that no migration creates -- the app creates it
+out-of-band), so a repo-wide `run_migrations` against a fresh database fails.
+This check is scoped to the deflection chain, which has no such dependency:
+
+- 328 content_ops_deflection_reports
+- 332 content_ops_deflection_report_deliveries
+- 336 content_ops_deflection_paid_reconciliation  (#1462 money-path table)
+
+It applies those files in order to a fresh Postgres database and verifies the
+tables exist and the reconciliation table's idempotency constraint holds. Runs
+in CI against the workflow's fresh atlas_migration_tests service database;
+skipped unless ATLAS_MIGRATION_TEST_DATABASE_URL points at a disposable DB. The
+migrations dir is resolved by path (no atlas_brain import), so the CI job needs
+no application dependencies beyond asyncpg.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = ROOT / "atlas_brain" / "storage" / "migrations"
+
+DEFLECTION_MIGRATION_CHAIN = (
+    "328_content_ops_deflection_reports.sql",
+    "332_content_ops_deflection_report_deliveries.sql",
+    "336_content_ops_deflection_paid_reconciliation.sql",
+)
+
+_TEST_ACCOUNT_ID = "acct-deflection-migration-apply-test"
+
+
+@pytest.mark.asyncio
+async def test_deflection_migration_chain_applies_to_a_fresh_database() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_MIGRATION_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_MIGRATION_TEST_DATABASE_URL not set")
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        for name in DEFLECTION_MIGRATION_CHAIN:
+            await conn.execute((MIGRATIONS_DIR / name).read_text())
+
+        existing = {
+            row["tablename"]
+            for row in await conn.fetch(
+                "SELECT tablename FROM pg_tables WHERE schemaname = 'public' "
+                "AND tablename LIKE 'content_ops_deflection%'"
+            )
+        }
+        assert {
+            "content_ops_deflection_reports",
+            "content_ops_deflection_report_deliveries",
+            "content_ops_deflection_paid_reconciliation",
+        } <= existing
+
+        recon_columns = {
+            row["column_name"]
+            for row in await conn.fetch(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'content_ops_deflection_paid_reconciliation'"
+            )
+        }
+        assert {
+            "account_id",
+            "request_id",
+            "stripe_session_id",
+            "event_type",
+            "reason",
+            "created_at",
+        } <= recon_columns
+
+        # The (account_id, request_id, stripe_session_id) uniqueness that
+        # record_paid_report_missing relies on (ON CONFLICT DO NOTHING): a second
+        # event for the same checkout must not create a duplicate ledger row.
+        insert_sql = (
+            "INSERT INTO content_ops_deflection_paid_reconciliation "
+            "(account_id, request_id, stripe_session_id, event_type, reason) "
+            "VALUES ($1, $2, $3, $4, $5) "
+            "ON CONFLICT (account_id, request_id, stripe_session_id) DO NOTHING"
+        )
+        await conn.execute(
+            insert_sql,
+            _TEST_ACCOUNT_ID,
+            "req-test",
+            "sess-test",
+            "checkout.session.completed",
+            "paid_report_missing",
+        )
+        await conn.execute(
+            insert_sql,
+            _TEST_ACCOUNT_ID,
+            "req-test",
+            "sess-test",
+            "checkout.session.async_payment_succeeded",
+            "paid_report_missing",
+        )
+        rows = await conn.fetchval(
+            "SELECT count(*) FROM content_ops_deflection_paid_reconciliation "
+            "WHERE account_id = $1 AND request_id = 'req-test'",
+            _TEST_ACCOUNT_ID,
+        )
+        assert rows == 1
+    finally:
+        try:
+            await conn.execute(
+                "DELETE FROM content_ops_deflection_paid_reconciliation "
+                "WHERE account_id = $1",
+                _TEST_ACCOUNT_ID,
+            )
+        except Exception:
+            pass
+        await conn.close()


### PR DESCRIPTION
Plan: plans/PR-Deflection-Migration-Apply-Check.md
Slice phase: Robust testing

Follow-up from the #1462 review (deferred real-DB check). The #1462 reconciliation table (migration `336`) and its `ON CONFLICT (account_id, request_id, stripe_session_id)` idempotency were never exercised against a real database: the migrations-runner CI lane is no-DB, and a repo-wide `run_migrations` fresh apply is not viable -- migration `076` references a `product_metadata` table that no migration creates (the app creates it out-of-band), so a full fresh apply fails at 076. This adds the operator-approved real-DB check, scoped to the deflection chain (no `product_metadata` dependency).

## Mechanism
- `tests/test_deflection_migrations_apply.py`: env-guarded (`ATLAS_MIGRATION_TEST_DATABASE_URL`); applies `328` -> `332` -> `336` in order to a fresh DB, asserts the three `content_ops_deflection*` tables exist, asserts the reconciliation table's columns, and proves the `(account_id, request_id, stripe_session_id)` uniqueness dedupes a second insert (the `record_paid_report_missing` ON CONFLICT guarantee). Resolves the migrations dir by `Path` (no `atlas_brain` import), so the CI job needs only `asyncpg`. Cleans up its test rows in `finally`.
- `.github/workflows/atlas_deflection_migration_apply_checks.yml`: a Postgres service (fresh `atlas_migration_tests` DB) + `ATLAS_MIGRATION_TEST_DATABASE_URL` so the test runs against a real DB in CI.

## Intentional
- Scoped to the deflection chain, not `run_migrations` over the full set (which fails at 076 -- a pre-existing, out-of-scope migration-set property).
- Path-based migrations-dir resolution keeps the CI job dependency-light and avoids the `atlas_brain` import chain (the pydantic gap that bit the migrations-runner workflow).
- The dedupe assertion targets the #1462 money-path guarantee specifically.

## Deferred
- Making the full migration set fresh-appliable (the missing `product_metadata` migration) -> separate migration-debt issue.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes. No automated-review findings at PR open; will reconcile any Codex/reviewer threads on the first review pass.

## Verification
- Ran `tests/test_deflection_migrations_apply.py` against a fresh throwaway Postgres (chain applied; tables + reconciliation columns asserted; ON CONFLICT dedupe verified) - passed.
- Confirmed the test skips cleanly when `ATLAS_MIGRATION_TEST_DATABASE_URL` is unset.
- Verified the chain (328/332/336) applies to a fresh database with no missing dependencies.
- Non-ASCII scan of the new test + workflow - clean.
- Python compile check for the new test - passed.

## Diff size
3 files, ~276.
