### PR TITLE
Content-Ops support-ticket date-window diagnostics

### DIFF
--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -319,6 +319,9 @@
       "target": "extracted_content_pipeline/support_ticket_clustering.py"
     },
     {
+      "target": "extracted_content_pipeline/support_ticket_dates.py"
+    },
+    {
       "target": "extracted_content_pipeline/ticket_faq_markdown.py"
     },
     {

--- a/extracted_content_pipeline/support_ticket_dates.py
+++ b/extracted_content_pipeline/support_ticket_dates.py
@@ -1,0 +1,50 @@
+"""Date parsing helpers for support-ticket source rows."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+_US_DATE_FORMATS = (
+    "%m/%d/%Y",
+    "%m/%d/%y",
+    "%m-%d-%Y",
+    "%m-%d-%y",
+)
+
+
+def parse_support_ticket_source_date(value: Any) -> date | None:
+    """Parse source dates from support-ticket exports.
+
+    Existing ISO-style inputs stay accepted. Common US SaaS CSV export dates are
+    accepted explicitly; natural-language and locale-ambiguous text is not.
+    """
+
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = _clean(value)
+    if not text:
+        return None
+    normalized = text.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized).date()
+    except ValueError:
+        pass
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        pass
+    for fmt in _US_DATE_FORMATS:
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _clean(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
-from datetime import date, datetime
+from datetime import date
 from typing import Any
 
 from .campaign_source_adapters import source_material_to_source_rows
@@ -26,6 +26,7 @@ from .support_ticket_context_contract import (
     UPLOADED_SUPPORT_TICKETS_SOURCE_PERIOD,
     support_ticket_topic_filter,
 )
+from .support_ticket_dates import parse_support_ticket_source_date
 
 
 DEFAULT_SUPPORT_TICKET_OUTPUTS: tuple[str, ...] = (
@@ -305,7 +306,16 @@ def build_support_ticket_input_package(
             "row_count": cluster_diagnostics["token_set_row_count"],
             "max_token_set_rows": cluster_diagnostics["max_token_set_rows"],
         })
-    has_valid_date_window = _all_rows_have_dates(normalized_rows)
+    date_diagnostics = _source_date_diagnostics(normalized_rows)
+    has_valid_date_window = (
+        bool(normalized_rows) and date_diagnostics["missing_count"] == 0
+    )
+    if (
+        normalized_rows
+        and not has_valid_date_window
+        and date_diagnostics["source_date_signal_count"] > 0
+    ):
+        warnings.append(_date_window_disabled_warning(date_diagnostics))
     source_period = (
         f"Last {window_days} days of support tickets"
         if has_valid_date_window
@@ -335,8 +345,10 @@ def build_support_ticket_input_package(
         "Can our team review the answers first?",
     ))
 
+    source_material_rows = [_public_ticket_row(row) for row in normalized_rows]
+
     inputs = {
-        "source_material": normalized_rows,
+        "source_material": source_material_rows,
         "faq_source_types": faq_source_types,
         "faq_title": campaign_name,
         "topic": SUPPORT_TICKET_DEFAULT_TOPIC,
@@ -451,6 +463,8 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
         value = row.get(key)
         if value not in (None, "", [], {}):
             normalized[key] = value
+    if _has_any_key(row, _DATE_KEYS):
+        normalized["_date_source_present"] = True
     for key, keys in (
         ("created_at", _DATE_KEYS),
         ("source_url", _URL_KEYS),
@@ -711,29 +725,56 @@ def _clip_text(value: str, *, max_chars: int) -> str:
 
 
 def _all_rows_have_dates(rows: Sequence[Mapping[str, Any]]) -> bool:
-    return bool(rows) and all(
-        _parse_ticket_source_date(row.get("created_at")) is not None
-        for row in rows
-    )
+    return bool(rows) and _source_date_diagnostics(rows)["missing_count"] == 0
+
+
+def _source_date_diagnostics(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    dated_count = 0
+    source_date_signal_count = 0
+    missing_source_ids: list[str] = []
+    for index, row in enumerate(rows, start=1):
+        has_date_signal = bool(row.get("_date_source_present")) or _clean(
+            row.get("created_at")
+        ) != ""
+        if has_date_signal:
+            source_date_signal_count += 1
+        if parse_support_ticket_source_date(row.get("created_at")) is not None:
+            dated_count += 1
+            continue
+        source_id = _clean(row.get("source_id")) or f"row-{index}"
+        missing_source_ids.append(source_id)
+    return {
+        "included_count": len(rows),
+        "dated_count": dated_count,
+        "missing_count": len(rows) - dated_count,
+        "source_date_signal_count": source_date_signal_count,
+        "example_source_ids": missing_source_ids[:5],
+    }
+
+
+def _public_ticket_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in row.items() if not str(key).startswith("_")}
+
+
+def _date_window_disabled_warning(diagnostics: Mapping[str, Any]) -> dict[str, Any]:
+    included_count = int(diagnostics.get("included_count") or 0)
+    missing_count = int(diagnostics.get("missing_count") or 0)
+    return {
+        "code": "support_ticket_date_window_disabled",
+        "message": (
+            "Disabled the dated support-ticket source window because "
+            f"{missing_count} of {included_count} included ticket rows did not "
+            "include a parseable source date."
+        ),
+        "included_row_count": included_count,
+        "dated_row_count": int(diagnostics.get("dated_count") or 0),
+        "missing_or_unparseable_date_count": missing_count,
+        "example_source_ids": list(diagnostics.get("example_source_ids") or ()),
+    }
 
 
 def _parse_ticket_source_date(value: Any) -> date | None:
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    text = _clean(value)
-    if not text:
-        return None
-    normalized = text.replace("Z", "+00:00")
-    try:
-        return datetime.fromisoformat(normalized).date()
-    except ValueError:
-        pass
-    try:
-        return date.fromisoformat(text[:10])
-    except ValueError:
-        return None
+    return parse_support_ticket_source_date(value)
 
 
 def _first_question(value: Any) -> str:
@@ -766,6 +807,11 @@ def _first_value(row: Mapping[str, Any], keys: Sequence[str]) -> Any:
             if _key(raw_key) == normalized_key and value not in (None, "", [], {}):
                 return value
     return None
+
+
+def _has_any_key(row: Mapping[str, Any], keys: Sequence[str]) -> bool:
+    normalized_keys = {_key(key) for key in keys}
+    return any(_key(raw_key) in normalized_keys for raw_key in row)
 
 
 def _key(value: Any) -> str:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -19,6 +19,7 @@ from .support_ticket_clustering import (
     support_ticket_plain_text,
     support_ticket_tokens,
 )
+from .support_ticket_dates import parse_support_ticket_source_date
 from .ticket_faq_ports import TicketFAQDraft, TicketFAQRepository
 
 
@@ -2406,22 +2407,7 @@ def _compact_key(value: Any) -> str:
 
 
 def _parse_source_date(value: Any) -> date | None:
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    text = _clean(value)
-    if not text:
-        return None
-    normalized = text.replace("Z", "+00:00")
-    try:
-        return datetime.fromisoformat(normalized).date()
-    except ValueError:
-        pass
-    try:
-        return date.fromisoformat(text[:10])
-    except ValueError:
-        return None
+    return parse_support_ticket_source_date(value)
 
 
 def _parse_as_of_date(value: Any) -> date | None:

--- a/plans/PR-Content-Ops-Support-Ticket-Date-Window-Diagnostics.md
+++ b/plans/PR-Content-Ops-Support-Ticket-Date-Window-Diagnostics.md
@@ -1,0 +1,127 @@
+# PR-Content-Ops-Support-Ticket-Date-Window-Diagnostics
+
+## Why this slice exists
+
+Support-ticket uploads currently enter dated-window mode only when every included
+row has a parseable date. That conservative rule is correct because date-window
+copy and report annualization must not be inferred from partial evidence, but the
+parser only accepts ISO-style dates today. Common US SaaS CSV exports such as
+`05/01/2026` therefore lose dated-window positioning even when every included row
+is dated. The same ISO-ish parsing logic is also duplicated between the input
+package and FAQ/report date-span path.
+
+This slice keeps the all-rows-must-be-dated contract, accepts common US export
+formats, and adds an explicit warning when rows carry a date-field signal but
+missing or unparseable dates disable the window. The slice is 416 LOC, slightly
+over the soft cap, because the parser is shared and the warning contract needs
+focused negative, blank-date, mixed-date, and smoke-fixture coverage in the same
+PR.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add a shared support-ticket source-date parser for ISO-style dates and common
+   US export dates.
+2. Use the shared parser in support-ticket input packaging and ticket FAQ/report
+   source-date spans.
+3. Keep dated-window mode all-or-nothing for included rows.
+4. Emit a package warning when included rows carry a date-field signal but
+   missing or unparseable dates disable dated-window mode.
+5. Leave UI surfacing, live DB/app verification, and international date guessing
+   out of scope.
+
+### Files touched
+
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/support_ticket_dates.py`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Content-Ops-Support-Ticket-Date-Window-Diagnostics.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_smoke_content_ops_gate_a_live_quality.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] ISO dates/datetimes and common US export dates keep dated-window mode
+        when every included support-ticket row has one.
+  - [ ] Natural-language dates and mixed missing-date rows still disable
+        dated-window mode.
+  - [ ] Disabled dated-window mode emits a warning with included count, dated
+        count, missing/unparseable count, and example source IDs when the upload
+        has a date-field signal.
+  - [ ] Intentionally undated uploads keep the uploaded-ticket fallback without
+        adding date-window warning noise.
+  - [ ] Ticket FAQ/report source-date spans accept the same US export dates.
+  - [ ] Existing prompt/report behavior remains conservative when the window is
+        disabled.
+- Affected surfaces: extracted support-ticket package, ticket FAQ date-span
+  helper, focused tests, and extracted manifest ownership.
+- Risk areas: backcompat, false date-window claims, parser ambiguity.
+- Reviewer rules triggered: R1, R2, R5, R10, R13, R14.
+
+## Mechanism
+
+A new owned helper module exposes `parse_support_ticket_source_date`. It keeps
+the existing accepted inputs (`date`, `datetime`, ISO date strings, ISO datetimes,
+and `Z` datetimes) and adds explicit US date formats: `M/D/YYYY`, `MM/DD/YYYY`,
+`M/D/YY`, `MM/DD/YY`, plus the same month/day/year order with `-` separators.
+The helper deliberately does not parse natural-language dates or infer non-US
+locale order.
+
+`support_ticket_input_package` uses the helper to compute per-row date
+diagnostics. If every included row has a parseable date, it preserves the
+existing dated-window fields. If the upload includes a date-field signal but any
+included row is blank or unparseable, it keeps the existing uploaded-ticket
+fallback and appends a `support_ticket_date_window_disabled` warning. Rows from
+intentionally undated uploads still use the fallback without extra warning
+noise. `ticket_faq_markdown` uses the same parser for item date spans so report
+windows and package windows do not drift.
+
+## Intentional
+
+- **US export formats only.** Slash/dash month-day-year exports are common for
+  the expected operator CSVs. Day-month-year inference is deferred because it can
+  silently invert dates.
+- **All-or-nothing remains.** A partial date set still disables dated-window
+  copy and annualized report math.
+- **Warning, not blocker.** Rows remain included; the warning explains why the
+  package cannot make calendar-window claims.
+- **Shared helper module.** This avoids importing the full input-package module
+  from the FAQ renderer and keeps date parsing deterministic and package-owned.
+
+## Deferred
+
+- UI/product surfacing beyond existing package warnings.
+- International date parsing or operator-configured locale.
+- Live app/DB verification; this slice is pure package behavior.
+- Parked hardening: none.
+
+## Verification
+
+- Command passed: python -m py_compile extracted_content_pipeline/support_ticket_dates.py extracted_content_pipeline/support_ticket_input_package.py extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_gate_a_live_quality.py.
+- Command passed: pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py -- 279 passed.
+- Command passed: pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_smoke_content_ops_gate_a_live_quality.py tests/test_atlas_content_ops_input_provider.py tests/test_support_ticket_provider_landing_blog_execute.py tests/test_extracted_content_ops_live_execute_harness.py -- 370 passed, 1 warning.
+- Command passed: bash scripts/validate_extracted_content_pipeline.sh -- outside sandbox after sandbox startup failed with bwrap loopback RTM_NEWADDR.
+- Command passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- outside sandbox after the same sandbox startup failure.
+- Command passed: python scripts/audit_extracted_standalone.py --fail-on-debt -- outside sandbox after the same sandbox startup failure.
+- Command passed: bash scripts/check_ascii_python.sh -- outside sandbox after the same sandbox startup failure.
+- Command passed: git diff --check.
+- Command completed: bash scripts/run_extracted_pipeline_checks.sh -- 4009 passed, 10 skipped, 1 warning; one unrelated order-dependent failure remains in tests/test_send_content_ops_deflection_report_deliveries.py::test_validate_fails_closed_before_pool_for_missing_destination. The same test passes by itself on this branch and on detached origin/main at f44086c52, and this PR has no diff in that deflection-delivery surface.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/support_ticket_dates.py` | 50 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 92 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 18 |
+| `plans/PR-Content-Ops-Support-Ticket-Date-Window-Diagnostics.md` | 127 |
+| `tests/test_extracted_support_ticket_input_package.py` | 99 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 16 |
+| `tests/test_smoke_content_ops_gate_a_live_quality.py` | 18 |
+| **Total** | **423** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -14,6 +14,9 @@ from extracted_content_pipeline.support_ticket_clustering import (
     support_ticket_plain_text,
     support_ticket_tokens,
 )
+from extracted_content_pipeline.support_ticket_dates import (
+    parse_support_ticket_source_date,
+)
 from extracted_content_pipeline.support_ticket_input_package import (
     DEFAULT_FAQ_REPORT_CTA_LABEL,
     build_support_ticket_input_package,
@@ -113,6 +116,32 @@ def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
         "singleton_cluster_count": 2,
         "largest_cluster_count": 1,
     }
+
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    (
+        ("2026-05-01", "2026-05-01"),
+        ("2026-05-01T12:00:00Z", "2026-05-01"),
+        ("05/01/2026", "2026-05-01"),
+        ("5/1/2026", "2026-05-01"),
+        ("05/01/26", "2026-05-01"),
+        ("05-01-2026", "2026-05-01"),
+    ),
+)
+def test_support_ticket_source_date_parser_accepts_us_export_dates(
+    raw: str,
+    expected: str,
+) -> None:
+    parsed = parse_support_ticket_source_date(raw)
+
+    assert parsed is not None
+    assert parsed.isoformat() == expected
+
+
+def test_support_ticket_source_date_parser_rejects_natural_language() -> None:
+    assert parse_support_ticket_source_date("last week") is None
 
 
 def test_support_ticket_bundle_inherits_parent_fields_and_comment_text() -> None:
@@ -372,21 +401,21 @@ def test_support_ticket_input_package_accepts_common_platform_csv_shapes() -> No
             "Id": "zd-100",
             "Subject": "How do I reset MFA?",
             "Description": "I cannot get the login code on my new phone.",
-            "Created at": "2026-05-01T09:00:00Z",
+            "Created at": "05/01/2026",
             "Requester email": "maya@example.test",
         },
         {
             "Ticket ID": "fd-200",
             "Ticket Subject": "Where do I update billing?",
             "Ticket Description": "Why was I charged twice this month?",
-            "Created time": "2026-05-02 10:15:00",
+            "Created time": "5/2/2026",
             "Contact email address": "ops@example.test",
         },
         {
             "Conversation ID": "ic-300",
             "Conversation title": "Cancellation before renewal",
             "Conversation body": "How do I cancel my account before it renews?",
-            "Conversation created at": "2026-05-03",
+            "Conversation created at": "05-03-26",
             "User email": "founder@example.test",
         },
     ])
@@ -407,7 +436,7 @@ def test_support_ticket_input_package_accepts_common_platform_csv_shapes() -> No
         "text": (
             "How do I reset MFA? I cannot get the login code on my new phone."
         ),
-        "created_at": "2026-05-01T09:00:00Z",
+        "created_at": "05/01/2026",
         "contact_email": "maya@example.test",
         "support_ticket_cluster": "code login mfa new",
         "support_ticket_cluster_key": "tokens:code-login-mfa-new",
@@ -418,14 +447,14 @@ def test_support_ticket_input_package_accepts_common_platform_csv_shapes() -> No
     assert rows[1]["text"] == (
         "Where do I update billing? Why was I charged twice this month?"
     )
-    assert rows[1]["created_at"] == "2026-05-02 10:15:00"
+    assert rows[1]["created_at"] == "5/2/2026"
     assert rows[1]["contact_email"] == "ops@example.test"
     assert rows[2]["source_id"] == "ic-300"
     assert rows[2]["source_title"] == "Cancellation before renewal"
     assert rows[2]["text"] == (
         "Cancellation before renewal How do I cancel my account before it renews?"
     )
-    assert rows[2]["created_at"] == "2026-05-03"
+    assert rows[2]["created_at"] == "05-03-26"
     assert rows[2]["contact_email"] == "founder@example.test"
 
 
@@ -869,6 +898,36 @@ def test_support_ticket_input_package_omits_window_filter_without_row_dates() ->
     assert "faq_window_days" not in package.inputs
     assert package.inputs["source_period"] == "Uploaded support tickets"
     assert package.inputs["has_dated_window"] is False
+    assert package.warnings == ()
+
+
+def test_support_ticket_input_package_warns_when_date_column_is_blank() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Login email change",
+            "message": "How do I change my email address?",
+            "created_at": "",
+        }
+    ])
+
+    assert "faq_window_days" not in package.inputs
+    assert package.inputs["source_period"] == "Uploaded support tickets"
+    assert package.inputs["has_dated_window"] is False
+    assert package.warnings == (
+        {
+            "code": "support_ticket_date_window_disabled",
+            "message": (
+                "Disabled the dated support-ticket source window because "
+                "1 of 1 included ticket rows did not include a parseable "
+                "source date."
+            ),
+            "included_row_count": 1,
+            "dated_row_count": 0,
+            "missing_or_unparseable_date_count": 1,
+            "example_source_ids": ["ticket-1"],
+        },
+    )
 
 
 def test_support_ticket_input_package_omits_window_filter_without_parseable_row_dates() -> None:
@@ -884,6 +943,20 @@ def test_support_ticket_input_package_omits_window_filter_without_parseable_row_
     assert "faq_window_days" not in package.inputs
     assert package.inputs["source_period"] == "Uploaded support tickets"
     assert package.inputs["has_dated_window"] is False
+    assert package.warnings == (
+        {
+            "code": "support_ticket_date_window_disabled",
+            "message": (
+                "Disabled the dated support-ticket source window because "
+                "1 of 1 included ticket rows did not include a parseable "
+                "source date."
+            ),
+            "included_row_count": 1,
+            "dated_row_count": 0,
+            "missing_or_unparseable_date_count": 1,
+            "example_source_ids": ["ticket-1"],
+        },
+    )
 
 
 def test_support_ticket_input_package_omits_window_filter_for_mixed_date_rows() -> None:
@@ -903,6 +976,20 @@ def test_support_ticket_input_package_omits_window_filter_for_mixed_date_rows() 
 
     assert "faq_window_days" not in package.inputs
     assert package.inputs["has_dated_window"] is False
+    assert package.warnings == (
+        {
+            "code": "support_ticket_date_window_disabled",
+            "message": (
+                "Disabled the dated support-ticket source window because "
+                "1 of 2 included ticket rows did not include a parseable "
+                "source date."
+            ),
+            "included_row_count": 2,
+            "dated_row_count": 1,
+            "missing_or_unparseable_date_count": 1,
+            "example_source_ids": ["ticket-2"],
+        },
+    )
 
 
 def test_support_ticket_input_package_accepts_single_mapping_comment_thread() -> None:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -24,6 +24,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (
     _resolution_advisory_signals,
     _resolution_signal_tokens,
     _resolution_text_is_publishable,
+    _source_date_span,
     build_ticket_faq_markdown,
     normalize_intent_rules,
     weighted_source_volume_by_group,
@@ -133,6 +134,21 @@ def _run_ticket_faq_cli(path: Path, *args: str) -> subprocess.CompletedProcess[s
         capture_output=True,
         text=True,
     )
+
+
+def test_source_date_span_accepts_us_export_dates() -> None:
+    span = _source_date_span([
+        {"source_id": "ticket-1", "date": "05/01/2026"},
+        {"source_id": "ticket-2", "created_at": "5-3-26"},
+    ])
+
+    assert span == {
+        "start": "2026-05-01",
+        "end": "2026-05-03",
+        "window_days": 3,
+        "dated_source_count": 2,
+        "missing_source_count": 0,
+    }
 
 
 def test_single_ticket_with_multiple_evidence_rows_is_not_a_repeat() -> None:

--- a/tests/test_smoke_content_ops_gate_a_live_quality.py
+++ b/tests/test_smoke_content_ops_gate_a_live_quality.py
@@ -39,7 +39,25 @@ def test_messy_grounding_fixture_exercises_noisy_lopsided_ticket_shape() -> None
     assert [warning["code"] for warning in package.warnings] == [
         "ticket_row_missing_text",
         "ticket_row_missing_text",
+        "support_ticket_date_window_disabled",
     ]
+    assert package.warnings[-1] == {
+        "code": "support_ticket_date_window_disabled",
+        "message": (
+            "Disabled the dated support-ticket source window because 12 of 42 "
+            "included ticket rows did not include a parseable source date."
+        ),
+        "included_row_count": 42,
+        "dated_row_count": 30,
+        "missing_or_unparseable_date_count": 12,
+        "example_source_ids": [
+            "messy-003",
+            "messy-005",
+            "messy-006",
+            "messy-008",
+            "messy-015",
+        ],
+    }
     assert package.inputs["top_ticket_clusters"][:4] == [
         {"label": "reporting export", "count": 11},
         {"label": "dashboard freshness", "count": 7},


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Support-Ticket-Date-Window-Diagnostics.md
Slice phase: Production hardening

Support-ticket uploads keep dated-window mode only when every included row has a parseable source date. This slice preserves that conservative contract, adds a shared parser for common US SaaS CSV export dates, and emits a targeted diagnostic when a date-bearing upload falls back because some included rows are blank or unparseable.

## Intentional
- US month-day-year slash/dash export formats only; day-month-year inference stays out of scope because it can silently invert dates.
- All-or-nothing dated-window mode remains unchanged.
- The date-window-disabled signal is a warning, not a blocker; rows remain included.
- Intentionally undated uploads keep the uploaded-ticket fallback without extra date warning noise.

## Deferred
- UI/product surfacing beyond existing package warnings.
- International date parsing or operator-configured locale.
- Live app/DB verification; this slice is pure package behavior.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/support_ticket_dates.py extracted_content_pipeline/support_ticket_input_package.py extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_gate_a_live_quality.py` -- passed.
- `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py` -- 279 passed.
- `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_smoke_content_ops_gate_a_live_quality.py tests/test_atlas_content_ops_input_provider.py tests/test_support_ticket_provider_landing_blog_execute.py tests/test_extracted_content_ops_live_execute_harness.py` -- 370 passed, 1 warning.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed outside sandbox after sandbox startup failed with `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed outside sandbox after the same sandbox startup failure.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed outside sandbox after the same sandbox startup failure.
- `bash scripts/check_ascii_python.sh` -- passed outside sandbox after the same sandbox startup failure.
- `git diff --check` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4009 passed, 10 skipped, 1 warning; one unrelated order-dependent failure remains in `tests/test_send_content_ops_deflection_report_deliveries.py::test_validate_fails_closed_before_pool_for_missing_destination`. The same test passes by itself on this branch and on detached `origin/main` at `f44086c52`, and this PR has no diff in that deflection-delivery surface.

## Diff size
8 files, +378 / -45
