### PR TITLE
Deflection Zendesk full-thread importer

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -88,6 +88,9 @@ from ..reasoning_policy import (
 from ..reasoning_signals import reasoning_validation_blocked_reason
 from ..ticket_faq_input_contract import ticket_faq_input_contracts
 from ..support_ticket_input_package import build_support_ticket_input_package
+from ..support_ticket_zendesk_thread import (
+    load_zendesk_full_thread_rows_from_json_bytes,
+)
 
 ExecutionServicesProvider = Callable[
     [],
@@ -152,6 +155,7 @@ _DEFLECTION_SUBMIT_PLATFORMS = frozenset({
     "help_scout",
     "other",
 })
+_DEFLECTION_SUBMIT_IMPORTER_MODES = frozenset({"csv", "full_thread"})
 _UPLOAD_FILE_FORMATS = ("auto", "json", "jsonl", "csv")
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _MAX_FALSIFICATION_RULES = 20
@@ -630,6 +634,7 @@ if BaseModel is not None:
         company_name: str = Field(..., min_length=1, max_length=200)
         contact_email: str = Field(..., min_length=3, max_length=320)
         limit: int | None = Field(default=None, ge=1, le=_MAX_DEFLECTION_SUBMIT_ROWS)
+        importer_mode: str = Field(default="csv", min_length=1, max_length=40)
 
         @field_validator("support_platform")
         @classmethod
@@ -640,6 +645,14 @@ if BaseModel is not None:
                     "support_platform must be one of: zendesk, intercom, "
                     "help_scout, other"
                 )
+            return text
+
+        @field_validator("importer_mode")
+        @classmethod
+        def _validate_importer_mode(cls, value: Any) -> str:
+            text = (_clean(value) or "csv").lower().replace("-", "_")
+            if text not in _DEFLECTION_SUBMIT_IMPORTER_MODES:
+                raise ValueError("importer_mode must be one of: csv, full_thread")
             return text
 
         @field_validator("company_name", "contact_email")
@@ -1234,11 +1247,21 @@ def create_content_ops_control_surface_router(
             max_bytes=_MAX_DEFLECTION_SUBMIT_BLOB_BYTES,
         )
         if not rows:
+            importer_mode = _clean(data.get("importer_mode")) or "csv"
             raise HTTPException(
                 status_code=400,
                 detail={
-                    "reason": "deflection_submit_empty_csv",
-                    "message": "Submitted CSV did not contain support-ticket rows.",
+                    "reason": (
+                        "deflection_submit_empty_full_thread"
+                        if importer_mode == "full_thread"
+                        else "deflection_submit_empty_csv"
+                    ),
+                    "message": (
+                        "Submitted Zendesk full-thread JSON did not contain "
+                        "support-ticket rows."
+                        if importer_mode == "full_thread"
+                        else "Submitted CSV did not contain support-ticket rows."
+                    ),
                 },
             )
         loaded_row_count = len(rows)
@@ -1266,11 +1289,18 @@ def create_content_ops_control_surface_router(
         )
         included_row_count = int(package.metadata.get("included_row_count") or 0)
         if included_row_count <= 0:
+            source_label = (
+                "Zendesk full-thread JSON"
+                if _clean(data.get("importer_mode")) == "full_thread"
+                else "Blob CSV"
+            )
             raise HTTPException(
                 status_code=400,
                 detail={
                     "reason": "deflection_submit_no_usable_rows",
-                    "message": "Blob CSV did not include usable support-ticket wording.",
+                    "message": (
+                        f"{source_label} did not include usable support-ticket wording."
+                    ),
                     "source_row_count": raw_row_count,
                     "max_source_material_rows": max_rows,
                 },
@@ -1302,6 +1332,7 @@ def create_content_ops_control_surface_router(
             package=package.as_dict(),
             support_platform=data["support_platform"],
             byte_count_key=byte_count_key,
+            importer_mode=_clean(data.get("importer_mode")) or "csv",
         )
 
     return router
@@ -1327,6 +1358,11 @@ async def _load_deflection_submit_rows_from_request(
             if csv_file is None:
                 raise HTTPException(status_code=422, detail="csv_file is required")
             data = _deflection_submit_form_to_mapping(form)
+            if data.get("importer_mode") == "full_thread":
+                raise HTTPException(
+                    status_code=422,
+                    detail="importer_mode=full_thread requires JSON blob_url submit",
+                )
             rows, byte_count, load_warnings = await _load_deflection_submit_upload_rows(
                 csv_file,
                 max_bytes=max_bytes,
@@ -1344,6 +1380,7 @@ async def _load_deflection_submit_rows_from_request(
         rows, byte_count, load_warnings = await _load_deflection_submit_blob_rows(
             data["blob_url"],
             max_bytes=max_bytes,
+            importer_mode=data.get("importer_mode") or "csv",
         )
         return data, rows, byte_count, "blob_bytes", load_warnings
 
@@ -1351,6 +1388,7 @@ async def _load_deflection_submit_rows_from_request(
     rows, byte_count, load_warnings = await _load_deflection_submit_blob_rows(
         data["blob_url"],
         max_bytes=max_bytes,
+        importer_mode=data.get("importer_mode") or "csv",
     )
     return data, rows, byte_count, "blob_bytes", load_warnings
 
@@ -1404,6 +1442,9 @@ def _deflection_submit_form_to_mapping(form: Any) -> dict[str, Any]:
     limit = form.get("limit") if hasattr(form, "get") else None
     if _clean(limit):
         data["limit"] = limit
+    importer_mode = form.get("importer_mode") if hasattr(form, "get") else None
+    if _clean(importer_mode):
+        data["importer_mode"] = importer_mode
     return _deflection_submit_fields_to_mapping(data)
 
 
@@ -1479,11 +1520,13 @@ async def _load_deflection_submit_blob_rows(
     blob_url: str,
     *,
     max_bytes: int,
+    importer_mode: str = "csv",
 ) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
     return await asyncio.to_thread(
         _load_deflection_submit_blob_rows_sync,
         blob_url,
         max_bytes,
+        importer_mode,
     )
 
 
@@ -1521,17 +1564,38 @@ async def _load_deflection_submit_upload_rows(
 def _load_deflection_submit_blob_rows_sync(
     blob_url: str,
     max_bytes: int,
+    importer_mode: str = "csv",
 ) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
     data = _read_bounded_https_blob(blob_url, max_bytes=max_bytes)
     if not data:
+        detail = (
+            "Zendesk full-thread JSON is empty."
+            if importer_mode == "full_thread"
+            else "Blob CSV is empty."
+        )
         raise HTTPException(
             status_code=400,
-            detail="Blob CSV is empty.",
+            detail=detail,
         )
+    if importer_mode == "full_thread":
+        return _parse_deflection_submit_zendesk_thread_bytes(data)
     return _parse_deflection_submit_csv_bytes(
         data,
         parse_error_detail="Blob CSV could not be parsed.",
     )
+
+
+def _parse_deflection_submit_zendesk_thread_bytes(
+    data: bytes,
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    try:
+        result = load_zendesk_full_thread_rows_from_json_bytes(data)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Zendesk full-thread JSON could not be parsed.",
+        ) from exc
+    return result.rows, len(data), result.warnings
 
 
 def _parse_deflection_submit_csv_bytes(
@@ -1937,6 +2001,7 @@ def _with_deflection_submit_diagnostics(
     support_platform: str,
     byte_count_key: str = "blob_bytes",
     csv_load_warnings: Sequence[Mapping[str, Any]] = (),
+    importer_mode: str = "csv",
 ) -> dict[str, Any]:
     out = dict(response)
     existing = out.get("input_provider")
@@ -1959,6 +2024,27 @@ def _with_deflection_submit_diagnostics(
             )
             if key in package_metadata
         })
+        if package_metadata.get("ticket_status_present"):
+            metadata.update({
+                key: package_metadata[key]
+                for key in (
+                    "ticket_status_present",
+                    "ticket_status_present_count",
+                    "ticket_status_summary",
+                )
+                if key in package_metadata
+            })
+        if package_metadata.get("csat_present"):
+            metadata.update({
+                key: package_metadata[key]
+                for key in (
+                    "csat_present",
+                    "csat_present_count",
+                    "csat_score_count",
+                    "csat_score_average",
+                )
+                if key in package_metadata
+            })
     truncated_row_count = max(0, source_row_count - submitted_row_count)
     metadata.update({
         "source": "portfolio_deflection_submit",
@@ -1969,6 +2055,8 @@ def _with_deflection_submit_diagnostics(
         byte_count_key: byte_count,
         "support_platform": support_platform,
     })
+    if importer_mode != "csv":
+        metadata["importer_mode"] = importer_mode
     if language_filtered_row_count:
         metadata["loaded_source_row_count"] = loaded_row_count
         metadata["language_filtered_row_count"] = language_filtered_row_count

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -322,6 +322,9 @@
       "target": "extracted_content_pipeline/support_ticket_dates.py"
     },
     {
+      "target": "extracted_content_pipeline/support_ticket_zendesk_thread.py"
+    },
+    {
       "target": "extracted_content_pipeline/ticket_faq_markdown.py"
     },
     {

--- a/extracted_content_pipeline/support_ticket_zendesk_thread.py
+++ b/extracted_content_pipeline/support_ticket_zendesk_thread.py
@@ -12,14 +12,24 @@ from .support_ticket_clustering import support_ticket_plain_text
 
 
 _WHITESPACE_RE = re.compile(r"\s+")
-_AUTO_ACK_RE = re.compile(
-    r"\b("
-    r"a member of (the )?support team will get back to you|"
-    r"we (received|got) your (ticket|request)|"
-    r"thanks? for (contacting|reaching out)|"
-    r"we'?ll get back to you"
-    r")\b",
-    re.IGNORECASE,
+_AUTO_ACK_PATTERNS = (
+    re.compile(
+        r"^a member of (the )?support team will get back to you"
+        r"(?: within [^.]+)?[.!]?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^we (received|got) your (ticket|request)"
+        r"(?: and (will|we'?ll) get back to you(?: soon| within [^.]+)?)?[.!]?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^(thanks?|thank you) for (contacting|reaching out)"
+        r"(?: to support)?[.!;]?"
+        r"(?: we (received|got) your (ticket|request)[.!]?)?"
+        r"(?: we'?ll get back to you(?: soon| within [^.]+)?[.!]?)?$",
+        re.IGNORECASE,
+    ),
 )
 _UNRATED_ZENDESK_SCORES = frozenset({"unoffered", "offered"})
 
@@ -110,7 +120,6 @@ def _row_from_entry(
     customer_parts: list[str] = []
     resolution_parts: list[str] = []
     warnings: list[dict[str, Any]] = []
-    _append_unique(customer_parts, _plain(ticket.get("description")))
     comments = entry.get("comments")
     if comments in (None, "", [], {}):
         comments = ()
@@ -126,6 +135,14 @@ def _row_from_entry(
             "message": "Ignored Zendesk comments because they were not a list.",
         })
         comments = ()
+    private_comment_keys = {
+        _text_key(_comment_text(comment))
+        for comment in comments
+        if isinstance(comment, Mapping) and comment.get("public") is False
+    }
+    description = _plain(ticket.get("description"))
+    if description and _text_key(description) not in private_comment_keys:
+        _append_unique(customer_parts, description)
     for comment in comments:
         if not isinstance(comment, Mapping):
             warnings.append({
@@ -203,11 +220,16 @@ def _append_unique(parts: list[str], value: str) -> None:
 
 
 def _looks_like_auto_ack(value: str) -> bool:
-    return bool(_AUTO_ACK_RE.search(_plain(value)))
+    text = _plain(value)
+    return any(pattern.fullmatch(text) for pattern in _AUTO_ACK_PATTERNS)
 
 
 def _plain(value: Any) -> str:
     return _WHITESPACE_RE.sub(" ", support_ticket_plain_text(_clean(value))).strip()
+
+
+def _text_key(value: Any) -> str:
+    return _plain(value).lower()
 
 
 def _id_text(value: Any) -> str:

--- a/extracted_content_pipeline/support_ticket_zendesk_thread.py
+++ b/extracted_content_pipeline/support_ticket_zendesk_thread.py
@@ -1,0 +1,225 @@
+"""Zendesk full-thread export normalization for support-ticket deflection."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .support_ticket_clustering import support_ticket_plain_text
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_AUTO_ACK_RE = re.compile(
+    r"\b("
+    r"a member of (the )?support team will get back to you|"
+    r"we (received|got) your (ticket|request)|"
+    r"thanks? for (contacting|reaching out)|"
+    r"we'?ll get back to you"
+    r")\b",
+    re.IGNORECASE,
+)
+_UNRATED_ZENDESK_SCORES = frozenset({"unoffered", "offered"})
+
+
+@dataclass(frozen=True)
+class ZendeskThreadImportResult:
+    rows: list[dict[str, Any]]
+    warnings: tuple[dict[str, Any], ...] = ()
+
+
+def load_zendesk_full_thread_rows_from_json_bytes(
+    data: bytes,
+) -> ZendeskThreadImportResult:
+    """Parse Zendesk thread JSON bytes into support-ticket rows."""
+
+    try:
+        artifact = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Zendesk full-thread JSON could not be parsed.") from exc
+    return rows_from_zendesk_full_thread(artifact)
+
+
+def rows_from_zendesk_full_thread(artifact: Any) -> ZendeskThreadImportResult:
+    """Normalize Zendesk `{ticket, comments}` records into flat ticket rows."""
+
+    ticket_entries = _ticket_entries(artifact)
+    rows: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    if ticket_entries is None:
+        return ZendeskThreadImportResult(
+            rows=[],
+            warnings=({
+                "code": "zendesk_thread_invalid_shape",
+                "message": "Zendesk full-thread artifact must be an object or list.",
+            },),
+        )
+    if not ticket_entries:
+        return ZendeskThreadImportResult(
+            rows=[],
+            warnings=({
+                "code": "zendesk_thread_empty",
+                "message": "Zendesk full-thread artifact did not include tickets.",
+            },),
+        )
+    for index, entry in enumerate(ticket_entries, start=1):
+        normalized = _row_from_entry(entry, row_index=index)
+        if normalized is None:
+            warnings.append({
+                "code": "zendesk_thread_ticket_missing",
+                "row_index": index,
+                "message": "Skipped Zendesk thread row because ticket was missing.",
+            })
+            continue
+        row, row_warnings = normalized
+        rows.append(row)
+        warnings.extend(row_warnings)
+    return ZendeskThreadImportResult(rows=rows, warnings=tuple(warnings))
+
+
+def _ticket_entries(artifact: Any) -> Sequence[Any] | None:
+    if isinstance(artifact, Mapping):
+        tickets = artifact.get("tickets")
+        if isinstance(tickets, Sequence) and not isinstance(
+            tickets, (str, bytes, bytearray)
+        ):
+            return tickets
+        return (artifact,)
+    if isinstance(artifact, Sequence) and not isinstance(
+        artifact, (str, bytes, bytearray)
+    ):
+        return artifact
+    return None
+
+
+def _row_from_entry(
+    entry: Any,
+    *,
+    row_index: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+    if not isinstance(entry, Mapping):
+        return None
+    ticket = entry.get("ticket") if isinstance(entry.get("ticket"), Mapping) else entry
+    if not isinstance(ticket, Mapping):
+        return None
+    requester_id = _id_text(ticket.get("requester_id"))
+    ticket_id = _clean(ticket.get("id")) or f"zendesk-ticket-{row_index}"
+    subject = _plain(ticket.get("subject") or ticket.get("raw_subject"))
+    customer_parts: list[str] = []
+    resolution_parts: list[str] = []
+    warnings: list[dict[str, Any]] = []
+    _append_unique(customer_parts, _plain(ticket.get("description")))
+    comments = entry.get("comments")
+    if comments in (None, "", [], {}):
+        comments = ()
+    if isinstance(comments, Mapping):
+        comments = (comments,)
+    if not isinstance(comments, Sequence) or isinstance(
+        comments, (str, bytes, bytearray)
+    ):
+        warnings.append({
+            "code": "zendesk_thread_comments_invalid",
+            "row_index": row_index,
+            "source_id": ticket_id,
+            "message": "Ignored Zendesk comments because they were not a list.",
+        })
+        comments = ()
+    for comment in comments:
+        if not isinstance(comment, Mapping):
+            warnings.append({
+                "code": "zendesk_thread_comment_not_object",
+                "row_index": row_index,
+                "source_id": ticket_id,
+                "message": "Ignored Zendesk comment because it was not an object.",
+            })
+            continue
+        if comment.get("public") is False:
+            continue
+        text = _comment_text(comment)
+        if not text:
+            continue
+        author_id = _id_text(comment.get("author_id"))
+        if requester_id and author_id == requester_id:
+            _append_unique(customer_parts, text)
+            continue
+        if _looks_like_auto_ack(text):
+            continue
+        _append_unique(resolution_parts, text)
+    if not (subject or customer_parts or resolution_parts):
+        return None
+
+    row: dict[str, Any] = {
+        "ticket_id": ticket_id,
+        "source_id": ticket_id,
+        "source_type": "support_ticket",
+    }
+    if subject:
+        row["subject"] = subject
+    if customer_parts:
+        row["description"] = "\n".join(customer_parts)
+    if resolution_parts:
+        row["resolution_text"] = "\n".join(resolution_parts)
+    for source_key, target_key in (
+        ("status", "ticket_status"),
+        ("created_at", "created_at"),
+        ("url", "source_url"),
+    ):
+        value = _clean(ticket.get(source_key))
+        if value:
+            row[target_key] = value
+    csat = _satisfaction_rating(ticket.get("satisfaction_rating"))
+    if csat:
+        row["satisfaction_rating"] = csat
+    return row, warnings
+
+
+def _comment_text(comment: Mapping[str, Any]) -> str:
+    for key in ("plain_body", "body", "html_body"):
+        text = _plain(comment.get(key))
+        if text:
+            return text
+    return ""
+
+
+def _satisfaction_rating(value: Any) -> str:
+    if isinstance(value, Mapping):
+        value = value.get("score")
+    text = _clean(value)
+    if not text or text.lower() in _UNRATED_ZENDESK_SCORES:
+        return ""
+    return text
+
+
+def _append_unique(parts: list[str], value: str) -> None:
+    text = _plain(value)
+    if not text:
+        return
+    key = text.lower()
+    if any(existing.lower() == key for existing in parts):
+        return
+    parts.append(text)
+
+
+def _looks_like_auto_ack(value: str) -> bool:
+    return bool(_AUTO_ACK_RE.search(_plain(value)))
+
+
+def _plain(value: Any) -> str:
+    return _WHITESPACE_RE.sub(" ", support_ticket_plain_text(_clean(value))).strip()
+
+
+def _id_text(value: Any) -> str:
+    return _clean(value)
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "ZendeskThreadImportResult",
+    "load_zendesk_full_thread_rows_from_json_bytes",
+    "rows_from_zendesk_full_thread",
+]

--- a/plans/PR-Deflection-Zendesk-Full-Thread-Importer.md
+++ b/plans/PR-Deflection-Zendesk-Full-Thread-Importer.md
@@ -90,8 +90,9 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_deflection_submit.py -q` - passed, 98 tests.
-- Local full-artifact proof against `/home/juan-canfield/Downloads/zendesk_trial_full_thread_seed_20260613_with_csat.json` - passed: 49 rows, 0 warnings, status summary `{'resolved': 29, 'open': 20}`, CSAT `24 good / 5 bad`, no private-note leak, no auto-ack leak.
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_suppress_private_first_description tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_keep_substantive_agent_reply_after_boilerplate tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_preserve_public_roles_and_drop_private_notes tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` - passed, 4 tests.
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_deflection_submit.py -q` - passed, 100 tests.
+- Local full-artifact proof against `/home/juan-canfield/Downloads/zendesk_trial_full_thread_seed_20260613_with_csat.json` - passed: 49 rows, 0 warnings, resolution evidence count 38, status summary `{'resolved': 29, 'open': 20}`, CSAT `24 good / 5 bad`, no private-note leak, no auto-ack leak.
 - `scripts/validate_extracted_content_pipeline.sh` via bash - passed.
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
 - `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
@@ -105,9 +106,9 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/api/control_surfaces.py` | 96 |
 | `extracted_content_pipeline/manifest.json` | 3 |
-| `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 225 |
-| `plans/PR-Deflection-Zendesk-Full-Thread-Importer.md` | 113 |
+| `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 247 |
+| `plans/PR-Deflection-Zendesk-Full-Thread-Importer.md` | 114 |
 | `tests/fixtures/zendesk_full_thread_seed_sample.json` | 133 |
 | `tests/test_extracted_content_deflection_submit.py` | 112 |
-| `tests/test_extracted_support_ticket_input_package.py` | 101 |
-| **Total** | **783** |
+| `tests/test_extracted_support_ticket_input_package.py` | 182 |
+| **Total** | **887** |

--- a/plans/PR-Deflection-Zendesk-Full-Thread-Importer.md
+++ b/plans/PR-Deflection-Zendesk-Full-Thread-Importer.md
@@ -1,0 +1,113 @@
+# PR-Deflection-Zendesk-Full-Thread-Importer
+
+## Why this slice exists
+
+The deflection report can ingest flat CSV rows, but a real Zendesk export/API
+thread is shaped as `{ticket, comments}`. For launch-readiness we need to prove
+that full-ticket conversation history can feed the existing deflection package:
+customer wording from requester/public comments, public agent replies as answer
+evidence, private notes dropped before ingestion, and Zendesk status/CSAT
+feeding the #1510 metadata.
+
+This is over the 400 LOC soft cap because the safe vertical slice needs all
+three pieces together: runtime mode routing, a provider-shape normalizer, and
+private-note/auto-ack/CSAT failure-path tests plus a compact real-shape fixture.
+Splitting the tests or fixture out would leave the importer mergeable without
+the evidence that it does not leak private notes or count auto-acks as answers.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Add a Zendesk full-thread JSON importer behind `importer_mode="full_thread"`
+   on the existing deflection submit blob path. Omitted mode stays CSV.
+2. Normalize Zendesk `{ticket, comments}` records into existing support-ticket
+   rows; reuse `build_support_ticket_input_package` downstream.
+3. Add CI-facing tests for role/public/private mapping, auto-ack rejection,
+   malformed-shape handling, API routing, and default CSV compatibility.
+4. Add local full-artifact proof against the generated Zendesk trial export.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Default deflection submit behavior remains CSV when `importer_mode` is
+        omitted.
+  - [ ] `importer_mode="full_thread"` parses Zendesk JSON blob bytes into rows
+        with customer wording, public-agent `resolution_text`, status, and CSAT.
+  - [ ] `public=false` comments never appear in row text, resolution evidence,
+        package examples, or submit diagnostics.
+  - [ ] Generic public auto-ack replies do not count as resolution evidence.
+  - [ ] Bad mode and malformed JSON fail closed with clear 422/400 responses.
+- Affected surfaces: extracted package importer, deflection submit API,
+  extracted-checks tests.
+- Risk areas: private-note leakage, false resolution evidence, API
+  compatibility, CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/support_ticket_zendesk_thread.py`
+- `plans/PR-Deflection-Zendesk-Full-Thread-Importer.md`
+- `tests/fixtures/zendesk_full_thread_seed_sample.json`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+
+## Mechanism
+
+`extracted_content_pipeline/support_ticket_zendesk_thread.py` exposes a small
+normalizer that accepts decoded JSON mappings/lists or JSON bytes and returns
+rows plus warnings. The submit API chooses CSV vs full-thread parsing after the
+existing bounded blob fetch, using `importer_mode` from the validated payload.
+
+The normalizer uses `ticket.requester_id` to split comments: public comments
+from the requester become customer wording; public comments from other authors
+become `resolution_text` unless they match generic auto-ack wording; private
+comments are skipped. Zendesk `satisfaction_rating.score` is copied only for
+real ratings (`good`/`bad` or numeric-like values), so `unoffered` does not
+inflate CSAT presence.
+
+## Intentional
+
+- No Zendesk API fetch or credential handling in this slice; the runtime input
+  is an already-exported JSON blob.
+- Multipart/browser upload remains CSV-only for now. Full-thread mode is wired
+  to JSON `blob_url` submit first so the backend contract can land without a
+  portfolio UI upload-type change.
+- The importer emits ordinary support-ticket rows rather than adding a new
+  downstream package contract; status, CSAT, clustering, truncation, and
+  resolution diagnostics stay owned by `build_support_ticket_input_package`.
+
+## Deferred
+
+- Portfolio UI JSON/Zendesk upload UX and copy.
+- Direct Zendesk API export/import using tenant-scoped credentials.
+- Full 49-ticket generated artifact is local proof, not a checked-in fixture;
+  CI uses a compact real-shape sample fixture.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_deflection_submit.py -q` - passed, 98 tests.
+- Local full-artifact proof against `/home/juan-canfield/Downloads/zendesk_trial_full_thread_seed_20260613_with_csat.json` - passed: 49 rows, 0 warnings, status summary `{'resolved': 29, 'open': 20}`, CSAT `24 good / 5 bad`, no private-note leak, no auto-ack leak.
+- `scripts/validate_extracted_content_pipeline.sh` via bash - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `scripts/check_ascii_python.sh` via bash - passed.
+- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed.
+- `scripts/run_extracted_pipeline_checks.sh` via bash - passed: `extracted_reasoning_core` 295 passed; `extracted_content_pipeline` 4008 passed, 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 96 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 225 |
+| `plans/PR-Deflection-Zendesk-Full-Thread-Importer.md` | 113 |
+| `tests/fixtures/zendesk_full_thread_seed_sample.json` | 133 |
+| `tests/test_extracted_content_deflection_submit.py` | 112 |
+| `tests/test_extracted_support_ticket_input_package.py` | 101 |
+| **Total** | **783** |

--- a/plans/PR-Deflection-Zendesk-Full-Thread-Importer.md
+++ b/plans/PR-Deflection-Zendesk-Full-Thread-Importer.md
@@ -92,7 +92,11 @@ Parked hardening: none.
 
 - `python -m pytest tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_suppress_private_first_description tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_keep_substantive_agent_reply_after_boilerplate tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_preserve_public_roles_and_drop_private_notes tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` - passed, 4 tests.
 - `python -m pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_deflection_submit.py -q` - passed, 100 tests.
-- Local full-artifact proof against `/home/juan-canfield/Downloads/zendesk_trial_full_thread_seed_20260613_with_csat.json` - passed: 49 rows, 0 warnings, resolution evidence count 38, status summary `{'resolved': 29, 'open': 20}`, CSAT `24 good / 5 bad`, no private-note leak, no auto-ack leak.
+- Local full-artifact proof against the generated 49-ticket Zendesk trial
+  artifact kept outside the repo - passed: 49 rows, 0 warnings, resolution
+  evidence count 38, status summary `{'resolved': 29, 'open': 20}`, CSAT
+  `24 good / 5 bad`, no private-note leak, no auto-ack leak. CI uses the
+  checked-in compact real-shape fixture.
 - `scripts/validate_extracted_content_pipeline.sh` via bash - passed.
 - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
 - `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
@@ -107,8 +111,8 @@ Parked hardening: none.
 | `extracted_content_pipeline/api/control_surfaces.py` | 96 |
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 247 |
-| `plans/PR-Deflection-Zendesk-Full-Thread-Importer.md` | 114 |
+| `plans/PR-Deflection-Zendesk-Full-Thread-Importer.md` | 118 |
 | `tests/fixtures/zendesk_full_thread_seed_sample.json` | 133 |
 | `tests/test_extracted_content_deflection_submit.py` | 112 |
 | `tests/test_extracted_support_ticket_input_package.py` | 182 |
-| **Total** | **887** |
+| **Total** | **891** |

--- a/tests/fixtures/zendesk_full_thread_seed_sample.json
+++ b/tests/fixtures/zendesk_full_thread_seed_sample.json
@@ -1,0 +1,133 @@
+{
+  "source": "zendesk_trial_api",
+  "subdomain": "finetunelab",
+  "run_tag": "atlas_seed_20260613",
+  "ticket_count": 4,
+  "tickets": [
+    {
+      "ticket": {
+        "id": 2,
+        "url": "https://finetunelab.zendesk.com/api/v2/tickets/2.json",
+        "subject": "[Atlas seed 01] Billing question: duplicate charge",
+        "description": "I was billed twice for this month. How do I get the duplicate charge refunded?",
+        "status": "solved",
+        "created_at": "2026-06-13T19:23:41Z",
+        "requester_id": 52571758969619,
+        "satisfaction_rating": {
+          "score": "good",
+          "comment": "Atlas CSAT seed: answer resolved the issue."
+        }
+      },
+      "comments": [
+        {
+          "id": 52571745316755,
+          "author_id": 52571758969619,
+          "public": true,
+          "plain_body": "I was billed twice for this month. How do I get the duplicate charge refunded?"
+        },
+        {
+          "id": 52571759051539,
+          "author_id": 52571125400467,
+          "public": true,
+          "plain_body": "We confirmed the duplicate billing event and refunded the extra charge. Refunds normally appear on the original payment method in 5-10 business days."
+        }
+      ]
+    },
+    {
+      "ticket": {
+        "id": 28,
+        "url": "https://finetunelab.zendesk.com/api/v2/tickets/28.json",
+        "subject": "[Atlas seed 27] Unanswered product question",
+        "description": "Do you support invoices in euros for EU subsidiaries?",
+        "status": "open",
+        "created_at": "2026-06-13T19:25:11Z",
+        "requester_id": 52571747469587,
+        "satisfaction_rating": {
+          "score": "unoffered"
+        }
+      },
+      "comments": [
+        {
+          "id": 52571747469587,
+          "author_id": 52571747469587,
+          "public": true,
+          "plain_body": "Do you support invoices in euros for EU subsidiaries?"
+        },
+        {
+          "id": 52571747469588,
+          "author_id": -1,
+          "public": true,
+          "plain_body": "A member of the support team will get back to you within the next 48 hours."
+        }
+      ]
+    },
+    {
+      "ticket": {
+        "id": 34,
+        "url": "https://finetunelab.zendesk.com/api/v2/tickets/34.json",
+        "subject": "[Atlas seed 33] Private note must not become answer",
+        "description": "The account export button is missing for my workspace. What permission do I need?",
+        "status": "open",
+        "created_at": "2026-06-13T19:25:35Z",
+        "requester_id": 52571730514067,
+        "satisfaction_rating": {
+          "score": "unoffered"
+        }
+      },
+      "comments": [
+        {
+          "id": 52571730514067,
+          "author_id": 52571730514067,
+          "public": true,
+          "plain_body": "The account export button is missing for my workspace. What permission do I need?"
+        },
+        {
+          "id": 52571730514068,
+          "author_id": 52571125400467,
+          "public": false,
+          "plain_body": "Internal note: explain the real workaround to the account owner only. This must not become customer-facing FAQ wording."
+        }
+      ]
+    },
+    {
+      "ticket": {
+        "id": 41,
+        "url": "https://finetunelab.zendesk.com/api/v2/tickets/41.json",
+        "subject": "[Atlas seed 40] Answered but reopened risk signal",
+        "description": "I followed the refund steps but the credit still has not posted after two weeks.",
+        "status": "open",
+        "created_at": "2026-06-13T19:26:22Z",
+        "requester_id": 52571778008595,
+        "satisfaction_rating": {
+          "score": "unoffered"
+        }
+      },
+      "comments": [
+        {
+          "id": 52571778008595,
+          "author_id": 52571778008595,
+          "public": true,
+          "plain_body": "I followed the refund steps but the credit still has not posted after two weeks."
+        },
+        {
+          "id": 52571778008596,
+          "author_id": 52571125400467,
+          "public": true,
+          "plain_body": "We sent the standard resolution steps and marked this as solved. Please reply if the issue continues."
+        },
+        {
+          "id": 52571778008597,
+          "author_id": 52571778008595,
+          "public": true,
+          "plain_body": "This is still broken after trying the steps. Please reopen this ticket; the answer did not resolve it."
+        },
+        {
+          "id": 52571778008598,
+          "author_id": -1,
+          "public": true,
+          "plain_body": "A member of the support team will get back to you within the next 48 hours."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import http.client
+import json
 from io import StringIO
 from pathlib import Path
 import socket
@@ -31,6 +32,7 @@ PROVIDER_FIXTURE_DIR = (
     / "examples"
     / "support_ticket_provider_exports"
 )
+ZENDESK_THREAD_SAMPLE = ROOT / "tests/fixtures/zendesk_full_thread_seed_sample.json"
 
 
 def _route(router: Any, path: str, method: str) -> Any:
@@ -332,6 +334,56 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     ) == {"request_id": payload["request_id"], "paid": True}
     artifact_payload = await artifact.endpoint(request_id=payload["request_id"])
     assert "lead@acme.example" not in str(artifact_payload)
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_accepts_zendesk_full_thread_blob(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    artifact_data = ZENDESK_THREAD_SAMPLE.read_bytes()
+    calls = _install_blob(monkeypatch, artifact_data)
+    store = InMemoryDeflectionReportArtifactStore()
+    router = _router(store)
+
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    payload = await submit.endpoint({
+        "blob_url": "https://portfolio.example/blob/zendesk-thread.json",
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+        "importer_mode": "full_thread",
+    })
+
+    assert calls == [(
+        "https://portfolio.example/blob/zendesk-thread.json",
+        "93.184.216.34",
+        api_module._DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS,
+    )]
+    assert payload["status"] == "completed"
+    metadata = payload["input_provider"]["metadata"]
+    assert metadata["source_row_count"] == 4
+    assert metadata["submitted_row_count"] == 4
+    assert metadata["included_row_count"] == 4
+    assert metadata["blob_bytes"] == len(artifact_data)
+    assert metadata["importer_mode"] == "full_thread"
+    assert metadata["support_platform"] == "zendesk"
+    assert metadata["support_ticket_resolution_evidence_present"] is True
+    assert metadata["support_ticket_resolution_evidence_count"] == 2
+    assert metadata["ticket_status_present"] is True
+    assert metadata["ticket_status_present_count"] == 4
+    assert metadata["ticket_status_summary"] == {"resolved": 1, "open": 3}
+    assert metadata["csat_present"] is True
+    assert metadata["csat_present_count"] == 1
+    assert metadata["csat_score_count"] == 0
+    assert metadata["csat_score_average"] is None
+    assert payload["input_provider"]["warnings"] == []
+    assert "Internal note" not in json.dumps(payload)
+    assert "A member of the support team will get back to you" not in json.dumps(payload)
+    assert payload["steps"][0]["result"]["full_report"] == {
+        "status": "locked",
+        "reason": "payment_required",
+    }
 
 
 @pytest.mark.asyncio
@@ -795,6 +847,26 @@ async def test_deflection_submit_rejects_multipart_without_csv_file() -> None:
 
 
 @pytest.mark.asyncio
+async def test_deflection_submit_rejects_full_thread_multipart_upload() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(_FormRequest({
+            "csv_file": _Upload(b"ticket_id,subject,message\n1,Question,How?\n"),
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+            "importer_mode": "full_thread",
+        }))
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == (
+        "importer_mode=full_thread requires JSON blob_url submit"
+    )
+
+
+@pytest.mark.asyncio
 async def test_deflection_submit_rejects_oversize_uploaded_csv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -867,6 +939,24 @@ async def test_deflection_submit_rejects_non_https_blob_url() -> None:
 
 
 @pytest.mark.asyncio
+async def test_deflection_submit_rejects_unknown_importer_mode() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "https://portfolio.example/blob/tickets.csv",
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+            "importer_mode": "xml",
+        })
+
+    assert exc.value.status_code == 422
+    assert "importer_mode must be one of: csv, full_thread" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_deflection_submit_rejects_blob_url_with_invalid_port() -> None:
     router = _router(InMemoryDeflectionReportArtifactStore())
     submit = _route(router, "/ops/deflection-reports/submit", "POST")
@@ -906,6 +996,28 @@ async def test_deflection_submit_rejects_oversize_blob(
         "reason": "deflection_submit_blob_too_large",
         "max_file_bytes": 10,
     }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_malformed_full_thread_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    _install_blob(monkeypatch, b"{not-json")
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "https://portfolio.example/blob/zendesk-thread.json",
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+            "importer_mode": "full_thread",
+        })
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Zendesk full-thread JSON could not be parsed."
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1420,6 +1420,87 @@ def test_zendesk_full_thread_rows_preserve_public_roles_and_drop_private_notes()
     assert "A member of the support team will get back to you" not in str(by_id["41"])
 
 
+def test_zendesk_full_thread_rows_suppress_private_first_description() -> None:
+    result = rows_from_zendesk_full_thread({
+        "tickets": [{
+            "ticket": {
+                "id": "zd-private-first",
+                "subject": "Internal migration workaround",
+                "description": (
+                    "Internal note: explain the real workaround only to the owner."
+                ),
+                "requester_id": "requester-1",
+            },
+            "comments": [
+                {
+                    "author_id": "agent-1",
+                    "public": False,
+                    "plain_body": (
+                        "Internal note: explain the real workaround only to the owner."
+                    ),
+                },
+                {
+                    "author_id": "requester-1",
+                    "public": True,
+                    "plain_body": "What permission do I need for account exports?",
+                },
+            ],
+        }],
+    })
+
+    assert result.warnings == ()
+    assert result.rows == [{
+        "ticket_id": "zd-private-first",
+        "source_id": "zd-private-first",
+        "source_type": "support_ticket",
+        "subject": "Internal migration workaround",
+        "description": "What permission do I need for account exports?",
+    }]
+    package = build_support_ticket_input_package(result.rows)
+    assert "Internal note" not in json.dumps(package.as_dict())
+    assert package.inputs["faq_questions"] == [
+        "What permission do I need for account exports?"
+    ]
+
+
+def test_zendesk_full_thread_rows_keep_substantive_agent_reply_after_boilerplate() -> None:
+    result = rows_from_zendesk_full_thread({
+        "tickets": [{
+            "ticket": {
+                "id": "zd-boilerplate-answer",
+                "subject": "How do I export invoices?",
+                "description": "Where do invoice exports live?",
+                "requester_id": "requester-1",
+            },
+            "comments": [
+                {
+                    "author_id": "agent-1",
+                    "public": True,
+                    "plain_body": (
+                        "Thanks for reaching out. Open Billing > Invoices, "
+                        "then choose Export CSV."
+                    ),
+                },
+                {
+                    "author_id": "agent-1",
+                    "public": True,
+                    "plain_body": (
+                        "A member of the support team will get back to you within "
+                        "the next 48 hours."
+                    ),
+                },
+            ],
+        }],
+    })
+
+    assert result.warnings == ()
+    row = result.rows[0]
+    assert row["resolution_text"] == (
+        "Thanks for reaching out. Open Billing > Invoices, then choose Export CSV."
+    )
+    assert "A member of the support team" not in str(row)
+
+
 def test_zendesk_full_thread_rows_feed_status_csat_and_resolution_package() -> None:
     result = load_zendesk_full_thread_rows_from_json_bytes(
         ZENDESK_THREAD_SAMPLE.read_bytes()

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from extracted_content_pipeline.content_ops_input_provider import (
@@ -21,6 +24,14 @@ from extracted_content_pipeline.support_ticket_input_package import (
     DEFAULT_FAQ_REPORT_CTA_LABEL,
     build_support_ticket_input_package,
 )
+from extracted_content_pipeline.support_ticket_zendesk_thread import (
+    load_zendesk_full_thread_rows_from_json_bytes,
+    rows_from_zendesk_full_thread,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ZENDESK_THREAD_SAMPLE = ROOT / "tests/fixtures/zendesk_full_thread_seed_sample.json"
 
 
 def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
@@ -1377,3 +1388,93 @@ def test_support_ticket_input_package_without_status_or_csat_is_unchanged() -> N
     assert package.metadata["csat_present_count"] == 0
     assert package.metadata["csat_score_count"] == 0
     assert package.metadata["csat_score_average"] is None
+
+
+def test_zendesk_full_thread_rows_preserve_public_roles_and_drop_private_notes() -> None:
+    result = load_zendesk_full_thread_rows_from_json_bytes(
+        ZENDESK_THREAD_SAMPLE.read_bytes()
+    )
+
+    assert result.warnings == ()
+    by_id = {row["ticket_id"]: row for row in result.rows}
+    assert by_id["2"]["description"] == (
+        "I was billed twice for this month. How do I get the duplicate charge refunded?"
+    )
+    assert by_id["2"]["resolution_text"] == (
+        "We confirmed the duplicate billing event and refunded the extra charge. "
+        "Refunds normally appear on the original payment method in 5-10 business days."
+    )
+    assert by_id["2"]["ticket_status"] == "solved"
+    assert by_id["2"]["satisfaction_rating"] == "good"
+
+    assert "resolution_text" not in by_id["28"]
+    assert "A member of the support team will get back to you" not in str(by_id["28"])
+    assert "resolution_text" not in by_id["34"]
+    assert "Internal note" not in str(result.rows)
+
+    assert by_id["41"]["resolution_text"] == (
+        "We sent the standard resolution steps and marked this as solved. "
+        "Please reply if the issue continues."
+    )
+    assert "This is still broken after trying the steps" in by_id["41"]["description"]
+    assert "A member of the support team will get back to you" not in str(by_id["41"])
+
+
+def test_zendesk_full_thread_rows_feed_status_csat_and_resolution_package() -> None:
+    result = load_zendesk_full_thread_rows_from_json_bytes(
+        ZENDESK_THREAD_SAMPLE.read_bytes()
+    )
+    package = build_support_ticket_input_package(result.rows)
+
+    assert package.inputs["source_row_count"] == 4
+    assert package.inputs["included_ticket_row_count"] == 4
+    assert package.inputs["support_ticket_resolution_evidence_present"] is True
+    assert package.inputs["support_ticket_resolution_evidence_count"] == 2
+    assert package.metadata["ticket_status_present"] is True
+    assert package.metadata["ticket_status_present_count"] == 4
+    assert package.metadata["ticket_status_summary"] == {"resolved": 1, "open": 3}
+    assert package.metadata["csat_present"] is True
+    assert package.metadata["csat_present_count"] == 1
+    assert package.metadata["csat_score_count"] == 0
+    assert package.metadata["csat_score_average"] is None
+    assert "Internal note" not in json.dumps(package.as_dict())
+    assert "A member of the support team will get back to you" not in json.dumps(
+        package.as_dict()
+    )
+
+
+def test_zendesk_full_thread_rows_warn_on_malformed_entries() -> None:
+    result = rows_from_zendesk_full_thread({
+        "tickets": [
+            {"comments": []},
+            {
+                "ticket": {
+                    "id": "zd-valid",
+                    "subject": "How do I export data?",
+                    "description": "Where do I download the export?",
+                },
+                "comments": "not-a-list",
+            },
+        ],
+    })
+
+    assert result.rows == [{
+        "ticket_id": "zd-valid",
+        "source_id": "zd-valid",
+        "source_type": "support_ticket",
+        "subject": "How do I export data?",
+        "description": "Where do I download the export?",
+    }]
+    assert result.warnings == (
+        {
+            "code": "zendesk_thread_ticket_missing",
+            "row_index": 1,
+            "message": "Skipped Zendesk thread row because ticket was missing.",
+        },
+        {
+            "code": "zendesk_thread_comments_invalid",
+            "row_index": 2,
+            "source_id": "zd-valid",
+            "message": "Ignored Zendesk comments because they were not a list.",
+        },
+    )


### PR DESCRIPTION
Plan: plans/PR-Deflection-Zendesk-Full-Thread-Importer.md
Slice phase: Vertical slice

Adds `importer_mode="full_thread"` to the existing deflection submit blob path so Zendesk `{ticket, comments}` JSON exports can feed the report without changing the default CSV flow. The importer maps requester/public comments to customer wording, public agent replies to `resolution_text`, drops private notes before packaging, and carries Zendesk status/CSAT into the existing #1510 support-ticket metadata.

## Intentional
- No Zendesk API credential fetch in this slice; runtime input is an already-exported JSON blob.
- Multipart/browser upload remains CSV-only until the portfolio UI adds JSON upload UX.
- The importer emits ordinary support-ticket rows; downstream package/report contracts stay unchanged.

## Deferred
- Portfolio UI JSON/Zendesk upload UX and copy.
- Direct Zendesk API export/import using tenant-scoped credentials.
- Full 49-ticket generated artifact remains local proof; CI uses a compact real-shape sample fixture.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_suppress_private_first_description tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_keep_substantive_agent_reply_after_boilerplate tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_preserve_public_roles_and_drop_private_notes tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` - passed, 4 tests.
- `python -m pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_deflection_submit.py -q` - passed, 100 tests.
- Local full-artifact proof against the generated 49-ticket Zendesk trial artifact kept outside the repo - passed: 49 rows, 0 warnings, resolution evidence count 38, status summary `{'resolved': 29, 'open': 20}`, CSAT `24 good / 5 bad`, no private-note leak, no auto-ack leak. CI uses the checked-in compact real-shape fixture.
- `scripts/validate_extracted_content_pipeline.sh` via bash - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `scripts/check_ascii_python.sh` via bash - passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed.
- `scripts/run_extracted_pipeline_checks.sh` via bash - passed: `extracted_reasoning_core` 295 passed; `extracted_content_pipeline` 4008 passed, 10 skipped.

## AI reconciliation
All fixed or waived: Yes.
- Codex P1 private first-comment leak: fixed in `a25f34fdd` by suppressing `ticket.description` when it matches a `public=false` comment; covered by `test_zendesk_full_thread_rows_suppress_private_first_description`.
- Codex P2 boilerplate-prefixed answer drop: fixed in `a25f34fdd` by matching only whole-message auto-ack patterns; covered by `test_zendesk_full_thread_rows_keep_substantive_agent_reply_after_boilerplate`.

## Diff size
7 files, +887 / -4.
