### PR TITLE
Deflection representative question labels

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,26 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-06-13
+
+### Customer-wording FAQ headings can publish raw PII
+- File/location: `extracted_content_pipeline/ticket_faq_markdown.py` customer-wording question extraction path.
+- Description: The representative-label path now renders only known-safe documentation/glossary terms, but the pre-existing customer-wording path can still promote raw row text containing PII into published FAQ question headings.
+- Why it matters: Deflection FAQ output is buyer-facing/publishable; names, emails, account numbers, or similar customer identifiers in headings are a privacy exposure.
+- Effort: M
+- Category: security
+- Owner/session: Codex deflection/clustering
+- Found during: PR-Deflection-Representative-Question-Labels review
+
+### Safe-vocabulary representative label collisions render duplicate FAQ headings
+- File/location: `extracted_content_pipeline/ticket_faq_markdown.py` representative source-policy label fallback.
+- Description: Distinct topic-degraded subclusters that resolve to the same safe documentation/glossary label can still render as separate FAQ items with identical headings. This preserves evidence and count truthfully, but leaves duplicate-looking entries.
+- Why it matters: The report can still look bloated even when grouping is correct; a future slice should disambiguate colliding safe labels or emit a diagnostic.
+- Effort: S
+- Category: polish
+- Owner/session: Codex deflection/clustering
+- Found during: PR-Deflection-Representative-Question-Labels review
+
 ## 2026-06-07
 
 ### Landing-page variants pass audits but are not meaningfully distinct

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -146,6 +146,12 @@ _PASSTHROUGH_KEYS = (
     "faq_source_ticket_ids",
     "faq_answer_evidence_status",
 )
+_STRUCTURED_CONTEXT_KEYS = (
+    ("product", ("product", "product_name")),
+    ("sub_product", ("sub_product", "sub_product_name")),
+    ("issue", ("issue", "issue_type")),
+    ("sub_issue", ("sub_issue", "sub_issue_type")),
+)
 _DATE_KEYS = (
     "created_at",
     "created_time",
@@ -472,6 +478,10 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
         normalized["measured_outcome"] = _clip_text(measured_outcome, max_chars=500)
     for key in _PASSTHROUGH_KEYS:
         value = row.get(key)
+        if value not in (None, "", [], {}):
+            normalized[key] = value
+    for key, keys in _STRUCTURED_CONTEXT_KEYS:
+        value = _first_value(row, keys)
         if value not in (None, "", [], {}):
             normalized[key] = value
     for key, keys in (

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -50,6 +50,21 @@ _SPEAKER_LABEL_RE = re.compile(
 )
 _CUSTOMER_SPEAKERS = {"customer", "user", "requester", "client"}
 _SUPPORTED_QUESTION_SOURCES = {"customer_wording", "source_policy"}
+_REPRESENTATIVE_EMAIL_RE = re.compile(r"\b\S+@\S+\b")
+_REPRESENTATIVE_LONG_NUMBER_RE = re.compile(r"\b\d{4,}\b")
+_REPRESENTATIVE_LABEL_SOURCE_TYPES = {
+    "ticket",
+    "support_ticket",
+    "case",
+    "chat",
+    "chat_transcript",
+    "conversation",
+    "transcript",
+    "sales_call",
+    "meeting",
+    "sales_objection",
+    "objection",
+}
 _GENERIC_QUESTION_TEXTS = {
     "help?",
     "need help?",
@@ -170,10 +185,52 @@ _DATE_KEYS = (
 )
 _SOURCE_CONTEXT_KEYS = (
     "product",
+    "product_name",
     "category",
     "sub_product",
+    "sub_product_name",
     "issue",
     "sub_issue",
+    "sub_issue_type",
+)
+_REPRESENTATIVE_SAFE_CONTEXT_KEYS = (
+    "product",
+    "product_name",
+    "sub_product",
+    "sub_product_name",
+    "issue",
+    "issue_type",
+    "sub_issue",
+    "sub_issue_type",
+)
+_REPRESENTATIVE_TAXONOMY_TERMS = (
+    "Advertising",
+    "Attempts to collect debt not owed",
+    "Checking or savings account",
+    "Closing an account",
+    "Communication tactics",
+    "Credit card or prepaid card",
+    "Credit reporting, credit repair services, or other personal consumer reports",
+    "Customer service",
+    "Debt collection",
+    "Fees or interest",
+    "Getting a credit card",
+    "Improper use of your report",
+    "Managing an account",
+    "Managing the loan or lease",
+    "Money transfer, virtual currency, or money service",
+    "Mortgage",
+    "Opening an account",
+    "Other service problem",
+    "Other transaction problem",
+    "Struggling to pay mortgage",
+    "Trouble during payment process",
+    "Vehicle loan or lease",
+    "Wire transfer problem",
+)
+_REPRESENTATIVE_TAXONOMY_KEYS = frozenset(
+    _KEY_SEPARATOR_RE.sub("", term.strip().lower())
+    for term in _REPRESENTATIVE_TAXONOMY_TERMS
 )
 _DOCUMENTATION_SOURCE_TYPES = {
     "article",
@@ -645,6 +702,14 @@ def build_ticket_faq_markdown(
                 "source_title": support_ticket_plain_text(
                     evidence.get("source_title") or opportunity.get("source_title")
                 ),
+                "support_ticket_cluster": support_ticket_plain_text(
+                    evidence.get("support_ticket_cluster")
+                    or opportunity.get("support_ticket_cluster")
+                ),
+                "safe_label_context": _representative_safe_context_text(
+                    opportunity,
+                    evidence,
+                ),
                 "source_date": source_date.isoformat() if source_date is not None else "",
                 "evidence_group_key": evidence_group_key,
                 "results_count": _first_present(evidence, opportunity, key="results_count"),
@@ -981,9 +1046,23 @@ def _intent_topic(
 
 
 def _source_context_text(*rows: Mapping[str, Any]) -> str:
+    return _context_text(_SOURCE_CONTEXT_KEYS, *rows)
+
+
+def _representative_safe_context_text(*rows: Mapping[str, Any]) -> str:
     values: list[str] = []
     for row in rows:
-        for key in _SOURCE_CONTEXT_KEYS:
+        for key in _REPRESENTATIVE_SAFE_CONTEXT_KEYS:
+            text = _compact(_field_value(row, key))
+            if text and _compact_key(text) in _REPRESENTATIVE_TAXONOMY_KEYS:
+                values.append(text)
+    return " ".join(values)
+
+
+def _context_text(keys: Sequence[str], *rows: Mapping[str, Any]) -> str:
+    values: list[str] = []
+    for row in rows:
+        for key in keys:
             text = _compact(_field_value(row, key))
             if text:
                 values.append(text)
@@ -1023,15 +1102,13 @@ def _item(
         snippets,
         " / ".join(_clean(row.get("source_title")) for row in display_rows if _clean(row.get("source_title"))),
     ))
+    question, question_source, question_row = _resolve_question_label(
+        topic,
+        rows,
+        max_evidence_per_item=max_evidence_per_item,
+        documentation_terms=documentation_terms,
+    )
     has_mixed_evidence_scopes = _has_mixed_evidence_scopes(rows)
-    if has_mixed_evidence_scopes:
-        question, question_source, question_row = (
-            _MIXED_EVIDENCE_REVIEW_QUESTION,
-            "source_policy",
-            None,
-        )
-    else:
-        question, question_source, question_row = _question(topic, display_rows)
     summary_rows = _rows_with_question_source_first(display_rows, question_row)
     summary = _summary(
         topic=topic,
@@ -1854,15 +1931,126 @@ def _first_present(*rows: Mapping[str, Any], key: str) -> Any:
 def _question(
     topic: str,
     rows: Sequence[Mapping[str, str]],
+    documentation_terms: Sequence[str],
 ) -> tuple[str, str, Mapping[str, str] | None]:
     for row in rows:
         text = _question_text(row.get("text", ""))
         if text:
             return (text, "customer_wording", row)
+    representative_question = _representative_source_question(
+        topic,
+        rows,
+        documentation_terms=documentation_terms,
+    )
+    if representative_question:
+        return (representative_question, "source_policy", None)
     policy_question = _policy_question(topic)
     if policy_question:
         return (policy_question, "source_policy", None)
     return (f"What are customers asking about {topic}?", "topic_fallback", None)
+
+
+def _representative_source_question(
+    topic: str,
+    rows: Sequence[Mapping[str, str]],
+    *,
+    documentation_terms: Sequence[str],
+) -> str:
+    if not any(_clean(row.get("support_ticket_cluster")) for row in rows):
+        return ""
+    if not any(
+        _source_type_key(row.get("source_type")) in _REPRESENTATIVE_LABEL_SOURCE_TYPES
+        for row in rows
+    ):
+        return ""
+    label = _safe_vocabulary_representative_label(
+        topic,
+        rows,
+        documentation_terms=documentation_terms,
+    )
+    if not label:
+        return ""
+    question = _normalize_question_text(f"What should I do about {label.lower()}")
+    return question if _usable_question(question) else ""
+
+
+def _safe_vocabulary_representative_label(
+    topic: str,
+    rows: Sequence[Mapping[str, str]],
+    *,
+    documentation_terms: Sequence[str],
+) -> str:
+    safe_tokens = _safe_representative_tokens(
+        (
+            *documentation_terms,
+            *(
+                _clean(row.get("safe_label_context"))
+                for row in rows
+                if _clean(row.get("safe_label_context"))
+            ),
+        )
+    )
+    if not safe_tokens:
+        return ""
+    topic_tokens = support_ticket_tokens(topic)
+    token_counts: dict[str, int] = {}
+    for row in rows:
+        text = str(row.get("text") or "")
+        for token in _question_gist_tokens(text):
+            if (
+                token not in safe_tokens
+                or token in topic_tokens
+                or _REDACTION_TOKEN_RE.fullmatch(token)
+            ):
+                continue
+            token_counts[token] = token_counts.get(token, 0) + 1
+    repeated_tokens = {
+        token: count
+        for token, count in token_counts.items()
+        if count >= 2
+    }
+    if len(repeated_tokens) < 2:
+        return ""
+    tokens = sorted(
+        repeated_tokens,
+        key=lambda token: (-repeated_tokens[token], safe_tokens[token][0], token),
+    )[:5]
+    return " ".join(safe_tokens[token][1] for token in tokens)
+
+
+def _safe_representative_tokens(
+    documentation_terms: Sequence[str],
+) -> dict[str, tuple[int, str]]:
+    ordered: dict[str, tuple[int, str]] = {}
+    for term in documentation_terms:
+        if _has_representative_label_pii(term):
+            continue
+        for token, display in _ordered_support_ticket_tokens(term):
+            if _REDACTION_TOKEN_RE.fullmatch(token):
+                continue
+            ordered.setdefault(token, (len(ordered), display))
+    return ordered
+
+
+def _ordered_support_ticket_tokens(value: Any) -> tuple[tuple[str, str], ...]:
+    tokens = support_ticket_tokens(value)
+    ordered: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for raw in re.findall(r"[a-z0-9]+", support_ticket_plain_text(value).lower()):
+        folded = support_ticket_tokens(raw)
+        for token in sorted(folded):
+            if token in tokens and token not in seen:
+                ordered.append((token, raw))
+                seen.add(token)
+    return tuple(ordered)
+
+
+def _has_representative_label_pii(value: Any) -> bool:
+    text = support_ticket_plain_text(value)
+    return bool(
+        _REPRESENTATIVE_EMAIL_RE.search(text)
+        or _REPRESENTATIVE_LONG_NUMBER_RE.search(text)
+    )
 
 
 def _rows_with_question_source_first(
@@ -2147,6 +2335,23 @@ def _term_mapping_impact_line(mapping: Mapping[str, Any]) -> str:
     if opportunity_score:
         parts.append(f"mapping score {opportunity_score}")
     return f"({'; '.join(parts)}.)"
+
+
+def _resolve_question_label(
+    topic: str,
+    rows: Sequence[Mapping[str, str]],
+    *,
+    max_evidence_per_item: int,
+    documentation_terms: Sequence[str],
+) -> tuple[str, str, Mapping[str, str] | None]:
+    if _has_mixed_evidence_scopes(rows):
+        return (
+            _MIXED_EVIDENCE_REVIEW_QUESTION,
+            "source_policy",
+            None,
+        )
+    display_rows = rows[:max_evidence_per_item]
+    return _question(topic, display_rows, documentation_terms)
 
 
 def _summary(

--- a/plans/PR-Deflection-Question-Label-Merge.md
+++ b/plans/PR-Deflection-Question-Label-Merge.md
@@ -1,0 +1,183 @@
+# PR-Deflection-Representative-Question-Labels
+
+## Why this slice exists
+
+The paid-funnel deflection run on June 13, 2026 showed the report shape can
+still balloon when many generated FAQ items render the same generic question
+label. The local archive7 run artifact available under
+`tmp/deflection_live_run/` has 11,923 uploaded ticket rows, 3,566 generated
+items, and 980 distinct rendered question labels. The UI snapshot captured in
+`results-snapshot.yml` shows a related hosted result with a 3,427-question
+headline. Both artifacts point at the same product defect: topic-degraded
+support-ticket subclusters can remain distinct, but still render buyer-facing
+labels like "What should I do about technical support?"
+
+The first implementation attempted to merge same-label topic-degraded groups.
+Review rejected that approach. `#1460` deliberately splits those rows because
+they are genuinely different repeated issues; collapsing them again lowers the
+buyer-facing question count and can hide over-cap evidence. The defect is the
+fallback label, not the grouping. This re-scoped slice fixes the root cause by
+deriving a representative source-policy label from the subcluster's own
+support-ticket content when no extractable customer question is available.
+
+This remains complementary to #1515. The hybrid clustering RFC improves recall
+inside question subclustering; it does not change how a kept subcluster is
+labeled after the split.
+
+The diff is over the 400 LOC target because the reviewed PR was re-scoped after
+operator feedback and then received a privacy BLOCKER review. Keeping the
+correction in one update lets the open PR replace the rejected merge approach,
+add the root-cause representative-label path, handle the PII/coherence findings,
+rewrite the affected regression tests, and record the hardening/reconciliation
+trail against one corrected contract.
+The final privacy review chose the zero-residual path for this new
+representative label code: no customer-authored free text is allowed to become a
+published representative heading.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Production hardening
+
+1. `extracted_content_pipeline/ticket_faq_markdown.py`: preserve the existing
+   topic-degraded subcluster grouping and remove the rejected same-label merge
+   pass.
+2. Carry the provided support-ticket cluster onto normalized evidence rows so
+   the fallback can distinguish the reviewed topic-degraded path from older
+   source-policy fallback paths.
+3. When no customer wording can be extracted for a clustered support-ticket
+   subcluster, derive a deterministic representative source-policy question
+   only from known-safe documentation/glossary tokens or structured
+   product/issue tokens that match the known taxonomy allowlist and also appear
+   in the subcluster evidence.
+4. Keep email/long-number filtering as defense-in-depth for safe vocabulary
+   inputs, and require representative labels to have at least two repeated safe
+   tokens before rendering.
+5. Add focused tests proving distinct topic-degraded repeated issues render
+   distinct labels, identical repeated content stays one subcluster, cap order
+   remains insertion-stable, resolution-backed groups remain separate, PII-shaped
+   labels fall back safely, clean-looking source titles do not bypass the safe
+   vocabulary, allowlisted structured issue fields work without an explicit
+   glossary, unlisted structured issue fields fall back generically, and
+   low-signal repeated evidence tokens do not become headings.
+6. Record the operator/Codex review reconciliation in the PR body so the live
+   reconciliation gate can verify the open automated-review finding is handled.
+
+### Files touched
+
+- `HARDENING.md`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Question-Label-Merge.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] No same-label merge pass remains in the ticket FAQ renderer.
+  - [ ] Topic-degraded rows render distinct source-policy questions when their
+        evidence intersects known-safe documentation/glossary terms or known
+        product/issue taxonomy terms.
+  - [ ] Identical repeated topic-degraded content still renders as one
+        subcluster with one item and all source IDs preserved.
+  - [ ] Existing non-clustered policy fallback paths remain unchanged.
+  - [ ] Tied topic-degraded subclusters preserve creation order through the
+        `max_items` cap and overflow condensation.
+  - [ ] Representative fallback never emits raw source title or raw evidence
+        free text.
+  - [ ] Representative fallback requires at least two repeated known-safe tokens
+        before rendering; otherwise it falls back to the generic topic question.
+  - [ ] Safe-vocabulary inputs containing email addresses or long numeric
+        identifiers are ignored as defense-in-depth.
+  - [ ] Support-ticket upload normalization preserves structured product/issue
+        taxonomy fields, and the renderer validates those fields against the
+        known taxonomy allowlist before using them as representative labels.
+  - [ ] Resolution-backed same-label groups remain separate and keep
+        `answer_evidence_status = resolution_evidence`.
+- Affected surfaces: ticket FAQ Markdown grouping/rendering internals and
+  focused deflection FAQ tests.
+- Risk areas: buyer-facing report shape, drafted-answer preservation,
+  deterministic ordering, golden report stability, and fallback-label precision.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+## Mechanism
+
+Normalized evidence rows now retain `support_ticket_cluster`. The grouping
+pipeline still builds `subclustered_groups` exactly once: resolution-scoped
+groups pass through, and topic-degraded groups are split by question similarity.
+There is no post-subcluster label merge.
+
+The shared question resolver still prefers extractable customer wording for the
+existing path. If no customer wording is usable and the rows came from the
+clustered support-ticket path, the representative fallback builds a safe token
+vocabulary from `documentation_terms` plus structured product/issue taxonomy
+fields carried through support-ticket upload normalization. Structured fields
+contribute only when they match the known taxonomy allowlist; uploads without a
+matching taxonomy fall back to the generic topic question on this path. The
+resolver also ignores any safe vocabulary term that contains an email address or
+long numeric identifier. It then treats row text only as a signal: tokens must
+appear in the subcluster evidence, repeat at least twice, and also exist in that
+safe vocabulary before they can render in the heading.
+
+The emitted label uses the safe documentation/glossary or structured taxonomy
+display token, not the raw row token. Raw support-ticket `source_title` remains
+excluded from the vocabulary. If no safe distinct label can be formed, the
+resolver falls back to the generic topic policy question. Non-clustered rows
+keep the existing topic policy fallback.
+
+This fixes the duplicate-label presentation defect for supplied-glossary or
+known-taxonomy uploads without changing which subclusters exist, lowering the
+count by collapse, or reordering groups. Uploads without a matching safe
+vocabulary keep the generic topic fallback by design.
+
+## Intentional
+
+- **No merge pass.** The operator decision rejected symptom-level collapse; this
+  slice removes that code instead of trying to warn around it.
+- **`source_policy` remains the source bucket.** Representative labels are
+  derived from source metadata/content, not extracted customer questions, so no
+  result-contract enum is added.
+- **Cluster marker required.** The representative fallback is gated on retained
+  `support_ticket_cluster` data so older complaint/search/source-policy cases do
+  not drift.
+- **Representative labels are controlled-vocabulary only.** The new
+  representative source-policy path does not render raw `source_title` or raw
+  evidence text; row text can only select repeated known-safe documentation
+  tokens or allowlisted structured product/issue taxonomy tokens.
+- **Resolution-backed groups stay separate.** This slice does not merge or
+  otherwise combine evidence scopes.
+
+## Deferred
+
+- #1515's hybrid lexical/embedding recall booster.
+- Hosted paid-funnel re-baseline after representative labels land.
+- UI/report wording changes around the new label shape.
+- Broader representative-label tuning for non-clustered fallback paths.
+- Parked hardening: `Customer-wording FAQ headings can publish raw PII` and
+  `Safe-vocabulary representative label collisions render duplicate FAQ headings`.
+
+## Verification
+
+- Command passed: python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py extracted_content_pipeline/support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py.
+- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py -q -- 298 passed.
+- Command passed: pytest tests/test_content_ops_deflection_resolution_live_proof.py::test_resolution_live_proof_regenerates_from_committed_csv -q -- 1 passed.
+- Command passed: bash scripts/validate_extracted_content_pipeline.sh.
+- Command passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline.
+- Command passed: python scripts/audit_extracted_standalone.py --fail-on-debt.
+- Command passed: bash scripts/check_ascii_python.sh.
+- Command passed: bash scripts/run_extracted_pipeline_checks.sh -- 4041 passed, 10 skipped, 1 warning.
+- Command passed: git diff --check.
+- Planned before push: bash scripts/local_pr_review.sh --current-pr-body-file tmp/deflection_question_label_merge_pr_body.md.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `HARDENING.md` | 20 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 10 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 223 |
+| `plans/PR-Deflection-Question-Label-Merge.md` | 183 |
+| `tests/test_extracted_support_ticket_input_package.py` | 4 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 438 |
+| **Total** | **878** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -43,6 +43,8 @@ def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
             "Subject": "How do I change my login email?",
             "Description": "I cannot find where to update the email on my account.",
             "Pain Category": "profile updates",
+            "Product": "Account settings",
+            "Issue": "Email profile updates",
             "Created At": "2026-05-01",
         },
         {
@@ -113,6 +115,8 @@ def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
         "company_name": "Acme Logistics",
         "vendor_name": "HelpDeskPro",
         "pain_category": "profile updates",
+        "product": "Account settings",
+        "issue": "Email profile updates",
         "created_at": "2026-05-01",
         "support_ticket_cluster": "profile updates",
         "support_ticket_cluster_key": "explicit:profile-updates",

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -24,6 +24,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (
     _resolution_advisory_signals,
     _resolution_signal_tokens,
     _resolution_text_is_publishable,
+    _safe_vocabulary_representative_label,
     _source_date_span,
     build_ticket_faq_markdown,
     normalize_intent_rules,
@@ -828,7 +829,8 @@ def test_build_ticket_faq_markdown_counts_resolution_sources_not_unique_texts() 
                     "resolution_text": "Send the reset email from Account Settings.",
                 }],
             },
-        ]
+        ],
+        documentation_terms=("Export issue",),
     )
 
     item = result.items[0]
@@ -871,7 +873,8 @@ def test_build_ticket_faq_markdown_keeps_distinct_questions_from_sharing_resolut
                     ),
                 }],
             },
-        ]
+        ],
+        documentation_terms=("Export issue",),
     )
 
     by_question = {item["question"]: item for item in result.items}
@@ -1697,11 +1700,12 @@ def test_build_ticket_faq_markdown_derives_question_from_complaint_narrative() -
     assert "contact support at https://example.com/support" in result.markdown
 
 
-def test_build_ticket_faq_markdown_uses_source_policy_question_when_customer_wording_is_missing() -> None:
+def test_build_ticket_faq_markdown_uses_representative_label_when_customer_wording_is_missing() -> None:
     result = build_ticket_faq_markdown(
         [
             {
                 "source_type": "support_ticket",
+                "support_ticket_cluster": "reporting friction",
                 "source_title": "Export issue",
                 "evidence": [{
                     "text": "The dashboard export button disappears for analysts.",
@@ -1711,6 +1715,7 @@ def test_build_ticket_faq_markdown_uses_source_policy_question_when_customer_wor
             },
             {
                 "source_type": "support_ticket",
+                "support_ticket_cluster": "reporting friction",
                 "source_title": "Export issue",
                 "evidence": [{
                     "text": "The dashboard export button disappears for our analysts.",
@@ -1718,13 +1723,436 @@ def test_build_ticket_faq_markdown_uses_source_policy_question_when_customer_wor
                     "source_type": "support_ticket",
                 }],
             },
-        ]
+        ],
+        documentation_terms=("Dashboard export",),
     )
 
     assert result.items[0]["topic"] == "reporting friction"
-    assert result.items[0]["question"] == "What should I do about reporting friction?"
+    assert result.items[0]["question"] == "What should I do about dashboard export?"
     assert result.items[0]["question_source"] == "source_policy"
     assert result.output_checks["uses_user_vocabulary"] is True
+
+
+def test_build_ticket_faq_markdown_uses_safe_terms_instead_of_pii_source_title() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Reset password for Sarah Chen",
+                "text": "Reset password for Sarah Chen blocks support.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Reset password for Sarah Chen",
+                "text": "Reset password for Sarah Chen blocks support.",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+        documentation_terms=("Reset password",),
+    )
+
+    assert result.items[0]["question"] == "What should I do about reset password?"
+    assert "sarah" not in result.items[0]["question"].lower()
+    assert "chen" not in result.items[0]["question"].lower()
+
+
+def test_build_ticket_faq_markdown_ignores_clean_source_title_without_safe_vocabulary() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Billing portal outage",
+                "text": "The support case is still blocked for our team.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Billing portal outage",
+                "text": "The support case is still blocked for our admins.",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == "What should I do about technical support?"
+    assert "billing" not in result.items[0]["question"].lower()
+    assert "portal" not in result.items[0]["question"].lower()
+
+
+def test_build_ticket_faq_markdown_ignores_unlisted_structured_issue_vocabulary_without_documentation_terms() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Customer subject A",
+                "product": "Support operations",
+                "issue": "Device reboot loop",
+                "text": "The device reboot loop blocks support agents.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Customer subject B",
+                "product": "Support operations",
+                "issue": "Device reboot loop",
+                "text": "Device reboot loop still blocks admins.",
+                "source_id": "ticket-2",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Customer subject C",
+                "product": "Analytics",
+                "issue": "Export timeout",
+                "text": "The analytics export timeout blocks analysts.",
+                "source_id": "ticket-3",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Customer subject D",
+                "product": "Analytics",
+                "issue": "Export timeout",
+                "text": "Analytics export timeout still blocks managers.",
+                "source_id": "ticket-4",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert [item["question"] for item in result.items] == [
+        "What should I do about technical support?",
+        "What should I do about technical support?",
+    ]
+    assert all(item["question_source"] == "source_policy" for item in result.items)
+    assert "customer subject" not in " ".join(item["question"].lower() for item in result.items)
+    assert "device reboot" not in " ".join(item["question"].lower() for item in result.items)
+
+
+def test_build_ticket_faq_markdown_uses_known_taxonomy_without_documentation_terms() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Customer subject A",
+                "product": "Debt collection",
+                "issue": "Communication tactics",
+                "text": "Debt collection communication tactics keep blocking customers.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Customer subject B",
+                "product": "Debt collection",
+                "issue": "Communication tactics",
+                "text": "The communication tactics in debt collection still block customers.",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == "What should I do about debt collection communication tactics?"
+    assert result.items[0]["question_source"] == "source_policy"
+    assert "customer subject" not in result.items[0]["question"].lower()
+
+
+def test_build_ticket_faq_markdown_uses_safe_terms_instead_of_pii_gist_tokens() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "technical support",
+                "text": "Duplicate fee for jane.doe@acme.com account 4829103 remains open.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "technical support",
+                "text": "Duplicate fee for jane.doe@acme.com account 4829103 remains open.",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+        documentation_terms=("Duplicate fee",),
+    )
+
+    assert result.items[0]["question"] == "What should I do about duplicate fee?"
+    assert "4829103" not in result.items[0]["question"]
+    assert "acme" not in result.items[0]["question"].lower()
+
+
+def test_build_ticket_faq_markdown_uses_repeated_gist_tokens_for_representative_label() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "technical support",
+                "text": "The export timeout blocks agents.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "technical support",
+                "text": "The export timeout blocks admins.",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+        documentation_terms=("Export timeout",),
+    )
+
+    assert result.items[0]["question"] == "What should I do about export timeout?"
+
+
+def test_safe_vocabulary_representative_label_rejects_single_occurrence_tokens() -> None:
+    assert _safe_vocabulary_representative_label(
+        "technical support",
+        [
+            {
+                "text": "Asdf baz blarg blocks agents.",
+            },
+            {
+                "text": "Frobnicate quux zorb blocks admins.",
+            },
+        ],
+        documentation_terms=("Asdf baz", "Frobnicate quux"),
+    ) == ""
+
+
+@pytest.mark.parametrize(
+    "unsafe_documentation_term",
+    (
+        "Reset password for jane.doe@acme.com",
+        "Reset password for account 4829103",
+    ),
+)
+def test_build_ticket_faq_markdown_ignores_unsafe_documentation_terms(
+    unsafe_documentation_term: str,
+) -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "technical support",
+                "text": "Reset password blocks agents.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "technical support",
+                "text": "Reset password blocks admins.",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+        documentation_terms=(unsafe_documentation_term,),
+    )
+
+    assert result.items[0]["question"] == "What should I do about technical support?"
+    assert "reset" not in result.items[0]["question"].lower()
+    assert "4829103" not in result.items[0]["question"]
+    assert "@" not in result.items[0]["question"]
+
+
+def test_build_ticket_faq_markdown_labels_topic_degraded_subclusters_without_merging() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Device reboot loop",
+                "text": "The device reboot loop blocks support agents.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Device restart loop",
+                "text": "The device reboot loop blocks support agents.",
+                "source_id": "ticket-2",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Export timeout",
+                "text": "The analytics export timeout blocks support agents.",
+                "source_id": "ticket-3",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Analytics export timeout",
+                "text": "The analytics export timeout blocks support agents.",
+                "source_id": "ticket-4",
+            },
+        ],
+        max_items=0,
+        documentation_terms=("Device reboot loop", "Analytics export timeout"),
+    )
+
+    assert result.as_dict()["generated"] == 2
+    assert [
+        (item["question"], item["source_ids"], item["ticket_count"])
+        for item in result.items
+    ] == [
+        ("What should I do about device reboot loop?", ("ticket-1", "ticket-2"), 2),
+        ("What should I do about analytics export timeout?", ("ticket-3", "ticket-4"), 2),
+    ]
+    assert {item["question_source"] for item in result.items} == {"source_policy"}
+    assert {item["answer_evidence_status"] for item in result.items} == {"draft_needs_review"}
+
+
+def test_build_ticket_faq_markdown_keeps_identical_topic_degraded_content_together() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Device reboot loop",
+                "text": "The device reboot loop blocks support agents.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Device restart loop",
+                "text": "The device reboot loop blocks support agents.",
+                "source_id": "ticket-2",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Device reboot loop",
+                "text": "The device reboot loop blocks support agents.",
+                "source_id": "ticket-3",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Device restart loop",
+                "text": "The device reboot loop blocks support agents.",
+                "source_id": "ticket-4",
+            },
+        ],
+        max_items=0,
+        documentation_terms=("Device reboot loop",),
+    )
+
+    assert result.as_dict()["generated"] == 1
+    assert result.items[0]["question"] == "What should I do about device reboot loop?"
+    assert result.items[0]["source_ids"] == ("ticket-1", "ticket-2", "ticket-3", "ticket-4")
+    assert result.items[0]["ticket_count"] == 4
+
+
+def test_build_ticket_faq_markdown_preserves_topic_degraded_creation_order_under_cap() -> None:
+    labels = [
+        "Alpha connector freeze",
+        "Bravo invoice failure",
+        "Charlie webhook delay",
+        "Delta profile lock",
+        "Echo export timeout",
+        "Foxtrot seat limit",
+        "Golf billing retry",
+        "Hotel invite bounce",
+        "India report blank",
+        "Juliet sync pause",
+        "Kilo audit stall",
+    ]
+    opportunities = [
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "technical support",
+            "source_title": label,
+            "text": f"{label} blocks the account team.",
+            "source_id": f"ticket-{index}-{suffix}",
+        }
+        for index, label in enumerate(labels)
+        for suffix in ("a", "b")
+    ]
+
+    result = build_ticket_faq_markdown(
+        opportunities,
+        max_items=5,
+        documentation_terms=tuple(labels),
+    )
+
+    assert [item["question"] for item in result.items[:4]] == [
+        "What should I do about alpha connector freeze?",
+        "What should I do about bravo invoice failure?",
+        "What should I do about charlie webhook delay?",
+        "What should I do about delta profile lock?",
+    ]
+    assert result.items[-1]["topic"] == "other support issues"
+    assert result.items[-1]["source_ids"] == tuple(
+        f"ticket-{index}-{suffix}"
+        for index in range(4, 11)
+        for suffix in ("a", "b")
+    )
+
+
+def test_build_ticket_faq_markdown_does_not_merge_resolution_backed_same_label() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Device reboot loop",
+                "evidence": [{
+                    "text": "The device reboot loop blocks support agents.",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": (
+                        "Open Settings then Firmware, choose version 4.1, "
+                        "and restart the device."
+                    ),
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Export timeout",
+                "evidence": [{
+                    "text": "The analytics export timeout blocks support agents.",
+                    "source_id": "ticket-2",
+                    "source_type": "support_ticket",
+                    "resolution_text": (
+                        "Open Settings then Exports, increase the timeout, "
+                        "and retry the job."
+                    ),
+                }],
+            },
+        ],
+        max_items=0,
+        documentation_terms=("Device reboot loop", "Export timeout"),
+    )
+
+    assert result.as_dict()["generated"] == 2
+    assert [item["question"] for item in result.items] == [
+        "What should I do about technical support?",
+        "What should I do about technical support?",
+    ]
+    assert {
+        item["answer_evidence_status"] for item in result.items
+    } == {"resolution_evidence"}
+    assert all(item["source_ids"] in {("ticket-1",), ("ticket-2",)} for item in result.items)
 
 
 def test_build_ticket_faq_markdown_uses_source_policy_when_customer_question_is_too_long() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Question-Label-Merge.md
Slice phase: Production hardening

This slice fixes duplicate generic deflection FAQ labels for supplied-glossary or allowlisted-taxonomy uploads at the source: topic-degraded support-ticket subclusters keep their existing grouping, but no-customer-wording fallbacks now render deterministic representative source-policy labels only from known-safe documentation/glossary terms or allowlisted structured product/issue taxonomy terms that repeat in the subcluster evidence. Uploads without a matching safe vocabulary keep the generic topic fallback by design.

## Intentional
- The rejected same-label merge pass is removed rather than warned around.
- Representative labels stay under `source_policy`; no result-contract enum is added.
- The fallback is gated on retained `support_ticket_cluster` data so older non-clustered policy paths do not drift.
- Representative labels never render raw source titles or raw evidence text; row text can only select repeated known-safe documentation tokens or allowlisted structured product/issue taxonomy tokens.
- Resolution-backed groups stay separate and keep their evidence scope.

## Deferred
- Hybrid lexical/embedding recall booster from #1515.
- Hosted paid-funnel re-baseline and UI/report wording changes.
- Broader representative-label tuning for non-clustered fallback paths.

## Parked hardening
- `Customer-wording FAQ headings can publish raw PII`.
- `Safe-vocabulary representative label collisions render duplicate FAQ headings`.

## AI reconciliation
- All fixed or waived: Yes.
- Codex P2 / reviewer BLOCKER on insertion-order drift from `sorted(groups)`: fixed by removing the same-label merge pass entirely; no dict rebuild or label-based scope rewrite remains.
- Reviewer product-shape finding on silent collapse of distinct topic-degraded issues: fixed by deriving distinct representative labels from each kept subcluster instead of collapsing groups.
- Reviewer warning request for merge diagnostics: fixed by eliminating the merge path, so there is no hidden collapse to diagnose.
- Reviewer BLOCKER on PII leaking through representative source labels: fixed by removing raw `source_title` and raw row text from the representative label vocabulary; the path can emit only known-safe documentation/glossary tokens selected by repeated evidence tokens.
- Reviewer MAJOR on low-signal gist labels: fixed by requiring at least two repeated known-safe tokens before rendering a representative heading.
- Reviewer MAJOR on same-label representative collisions: deferred to parked hardening because it preserves count/evidence truth and does not reintroduce data loss or the PII blocker.
- Operator zero-residual privacy decision: fixed by removing raw `source_title` and raw row text as label vocabulary; representative labels now emit only known-safe documentation/glossary or structured product/issue tokens selected by repeated evidence tokens.
- Production inertness finding: fixed by preserving structured product/issue taxonomy fields through support-ticket upload normalization and adding allowlisted taxonomy matches to the representative safe vocabulary when no external glossary is supplied; uploads without a matching taxonomy fall back generic on this path.

## Verification
- Command passed: python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py extracted_content_pipeline/support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py.
- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py -q -- 298 passed.
- Command passed: pytest tests/test_content_ops_deflection_resolution_live_proof.py::test_resolution_live_proof_regenerates_from_committed_csv -q -- 1 passed.
- Command passed: bash scripts/validate_extracted_content_pipeline.sh.
- Command passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline.
- Command passed: python scripts/audit_extracted_standalone.py --fail-on-debt.
- Command passed: bash scripts/check_ascii_python.sh.
- Command passed: bash scripts/run_extracted_pipeline_checks.sh -- 4041 passed, 10 skipped, 1 warning.
- Command passed: git diff --check.

## Diff size
6 files, +864 / -14
