### PR TITLE
Deflection date-window: carry date-column signal out-of-band (no row marker)

### DIFF
--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -261,6 +261,7 @@ def build_support_ticket_input_package(
             "code": "source_material_empty",
             "message": "No support-ticket source rows were provided.",
         })
+    source_date_signal_count = 0
     for index, row in enumerate(raw_rows[:max_rows], start=1):
         if not isinstance(row, Mapping):
             warnings.append({
@@ -272,6 +273,14 @@ def build_support_ticket_input_package(
         normalized = _normalize_ticket_row(row, row_index=index)
         if normalized:
             normalized_rows.append(normalized)
+            # Carry the date-column-present signal out-of-band rather than
+            # stamping a marker onto the shared row dict (which would ride
+            # through clustering and every normalized_rows consumer). A row
+            # has the signal when the raw upload carried a date column, even
+            # if that cell was blank -- _has_any_key supersets a parseable
+            # created_at, so this reproduces the old marker exactly.
+            if _has_any_key(row, _DATE_KEYS):
+                source_date_signal_count += 1
             continue
         warnings.append({
             "code": "ticket_row_missing_text",
@@ -306,7 +315,9 @@ def build_support_ticket_input_package(
             "row_count": cluster_diagnostics["token_set_row_count"],
             "max_token_set_rows": cluster_diagnostics["max_token_set_rows"],
         })
-    date_diagnostics = _source_date_diagnostics(normalized_rows)
+    date_diagnostics = _source_date_diagnostics(
+        normalized_rows, source_date_signal_count=source_date_signal_count
+    )
     has_valid_date_window = (
         bool(normalized_rows) and date_diagnostics["missing_count"] == 0
     )
@@ -463,8 +474,6 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
         value = row.get(key)
         if value not in (None, "", [], {}):
             normalized[key] = value
-    if _has_any_key(row, _DATE_KEYS):
-        normalized["_date_source_present"] = True
     for key, keys in (
         ("created_at", _DATE_KEYS),
         ("source_url", _URL_KEYS),
@@ -728,16 +737,22 @@ def _all_rows_have_dates(rows: Sequence[Mapping[str, Any]]) -> bool:
     return bool(rows) and _source_date_diagnostics(rows)["missing_count"] == 0
 
 
-def _source_date_diagnostics(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+def _source_date_diagnostics(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    source_date_signal_count: int | None = None,
+) -> dict[str, Any]:
+    # The date-column-present signal is supplied out-of-band (computed during
+    # row normalization) so it never has to ride on the row dicts. When it is
+    # omitted, fall back to the created_at value alone; that under-counts
+    # blank-date-column rows, which only matters for source_date_signal_count
+    # (the warning trigger), not for the missing_count window gate.
     dated_count = 0
-    source_date_signal_count = 0
+    fallback_signal_count = 0
     missing_source_ids: list[str] = []
     for index, row in enumerate(rows, start=1):
-        has_date_signal = bool(row.get("_date_source_present")) or _clean(
-            row.get("created_at")
-        ) != ""
-        if has_date_signal:
-            source_date_signal_count += 1
+        if source_date_signal_count is None and _clean(row.get("created_at")) != "":
+            fallback_signal_count += 1
         if parse_support_ticket_source_date(row.get("created_at")) is not None:
             dated_count += 1
             continue
@@ -747,7 +762,11 @@ def _source_date_diagnostics(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any
         "included_count": len(rows),
         "dated_count": dated_count,
         "missing_count": len(rows) - dated_count,
-        "source_date_signal_count": source_date_signal_count,
+        "source_date_signal_count": (
+            source_date_signal_count
+            if source_date_signal_count is not None
+            else fallback_signal_count
+        ),
         "example_source_ids": missing_source_ids[:5],
     }
 

--- a/plans/PR-Deflection-Date-Marker-Out-Of-Band.md
+++ b/plans/PR-Deflection-Date-Marker-Out-Of-Band.md
@@ -1,0 +1,108 @@
+# PR-Deflection-Date-Marker-Out-Of-Band
+
+## Why this slice exists
+
+Follow-up to the #1519 reviewer NIT. `build_support_ticket_input_package`
+stamped an internal `_date_source_present` marker onto each normalized row dict
+to record "this upload row carried a date column (even if the cell was blank)" --
+a signal a parseable created_at alone cannot capture. That marker then rode
+through clustering and every normalized_rows consumer, and was stripped only at
+the single source_material egress (`_public_ticket_row`); only that egress was
+guarded by a test. A future whole-row echo of a normalized row could leak the
+marker. This slice carries the signal out-of-band so no internal marker rides on
+the shared row dicts.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Production hardening
+
+1. `extracted_content_pipeline/support_ticket_input_package.py`: compute a
+   source-date-signal count in the normalization loop of
+   `build_support_ticket_input_package` (one increment per appended row where
+   `_has_any_key` matches the date keys), instead of stamping the marker.
+2. Remove the marker stamp from `_normalize_ticket_row`.
+3. `_source_date_diagnostics` gains an out-of-band keyword count; when omitted it
+   falls back to a created_at-only signal count (the only other caller,
+   `_all_rows_have_dates`, reads only the missing count).
+4. Pass the count at the single live call site.
+5. `tests/test_extracted_support_ticket_input_package.py`: add a regression test
+   asserting the blank-date-column warning still fires and no `_`-prefixed marker
+   rides on the exported source rows.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] No `_date_source_present` (or any `_`-prefixed marker) appears on the
+        exported source rows.
+  - [ ] A blank date-column upload still disables the dated window and emits
+        `support_ticket_date_window_disabled` (behavior preserved).
+  - [ ] A no-date-column upload still emits no date-window warning.
+  - [ ] The out-of-band count equals the pre-change marker-based count
+        (clustering is count/order-preserving, so the pre-cluster loop count ==
+        the old post-cluster marker count).
+  - [ ] Existing input-package + FAQ-markdown suites stay green.
+- Affected surfaces: `build_support_ticket_input_package` normalization loop and
+  `_source_date_diagnostics` internals, plus their test. No report
+  snapshot/teaser/ladder/pricing shape change; no DB; no public API change.
+- Risk areas: behavior preservation of the date-window warning trigger;
+  determinism; the `_all_rows_have_dates` fallback path.
+- Reviewer rules triggered: R1 (extracted_* change), R2 (failure-branch /
+  fixtures), R10 (maintainability).
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `plans/PR-Deflection-Date-Marker-Out-Of-Band.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+
+## Mechanism
+
+The marker was exactly `_has_any_key` over the date keys on the raw row. The
+created_at field is set only from a non-empty date-key value, so a parseable
+created_at always implies the date key is present -- the marker supersets a
+non-empty created_at, and the old `has_date_signal = marker OR created_at` equals
+the marker. Computing the same key check per appended row in the normalization
+loop reproduces the marker count exactly. `assign_support_ticket_clusters_with_diagnostics`
+emits one copied row per input row in order (no filter, no reorder), so the count
+is identical whether computed before or after clustering. The count is then handed
+to `_source_date_diagnostics` out-of-band; the marker is gone from the row dicts
+entirely.
+
+## Intentional
+
+- Out-of-band integer, not a parallel per-row structure: the signal is
+  upload-level (a count), and clustering is count/order-preserving, so a single
+  accumulator suffices and survives clustering without any row carrying state.
+- `_source_date_diagnostics` keeps an optional keyword count with a created_at-only
+  fallback so it stays callable standalone; the `_all_rows_have_dates` path is
+  unchanged (it reads only the missing count).
+- No touch to `_all_rows_have_dates` (pre-existing, uncalled) -- out of scope.
+
+## Deferred
+
+- Removing the dead `_all_rows_have_dates` helper -- separate cleanup slice.
+
+Parked hardening: none.
+
+## Verification
+
+Ran locally -- 285 passed (incl. the new
+test_support_ticket_date_signal_is_carried_out_of_band_not_on_rows); py_compile,
+ASCII, and the extracted CI mirror all clean:
+
+```
+pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py
+python -m py_compile extracted_content_pipeline/support_ticket_input_package.py tests/test_extracted_support_ticket_input_package.py
+bash scripts/check_ascii_python.sh
+bash scripts/run_extracted_pipeline_checks.sh
+```
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_input_package.py` | ~30 |
+| `tests/test_extracted_support_ticket_input_package.py` | ~25 |
+| `plans/PR-Deflection-Date-Marker-Out-Of-Band.md` | ~90 |
+| **Total** | **~145** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -941,6 +941,32 @@ def test_support_ticket_input_package_warns_when_date_column_is_blank() -> None:
     )
 
 
+def test_support_ticket_date_signal_is_carried_out_of_band_not_on_rows() -> None:
+    # #1519 follow-up: the date-column-present signal used to be stamped onto
+    # the shared row dict (_date_source_present) and stripped only at the
+    # source_material egress. It is now computed during normalization and
+    # handed to _source_date_diagnostics out-of-band. Behavior is preserved
+    # (a blank date column still disables the window and warns), and no
+    # internal marker rides on the exported rows.
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Login email change",
+            "message": "How do I change my email address?",
+            "created_at": "",
+        }
+    ])
+
+    assert package.inputs["has_dated_window"] is False
+    assert any(
+        warning["code"] == "support_ticket_date_window_disabled"
+        for warning in package.warnings
+    )
+    for row in package.inputs["source_material"]:
+        assert "_date_source_present" not in row
+        assert not any(str(key).startswith("_") for key in row)
+
+
 def test_support_ticket_input_package_omits_window_filter_without_parseable_row_dates() -> None:
     package = build_support_ticket_input_package([
         {


### PR DESCRIPTION
Plan: plans/PR-Deflection-Date-Marker-Out-Of-Band.md
Slice phase: Production hardening

Follow-up to the #1519 reviewer NIT. `build_support_ticket_input_package` stamped an internal `_date_source_present` marker onto each normalized row dict to record "this upload row carried a date column, even if the cell was blank" -- a signal a parseable created_at cannot capture. The marker then rode through clustering and every normalized_rows consumer, and was stripped only at the single source_material egress (`_public_ticket_row`); only that egress was guarded by a test, so a future whole-row echo could leak it. This carries the signal out-of-band so no internal marker rides on the shared rows.

## Mechanism
The marker was exactly the date-key presence check on the raw row. created_at is set only from a non-empty date value, so a parseable created_at always implies the date key is present -- the marker supersets created_at, and the old `marker OR created_at` equals the marker. Computing the same check per appended row in the normalization loop reproduces the count exactly. `assign_support_ticket_clusters_with_diagnostics` emits one copied row per input row in order (no filter, no reorder), so the pre-cluster count equals the old post-cluster marker count. The count is handed to `_source_date_diagnostics` out-of-band; the marker is removed entirely.

## Intentional
- Out-of-band integer, not a parallel per-row structure: the signal is upload-level and clustering is count/order-preserving, so a single accumulator survives clustering with no row carrying state.
- `_source_date_diagnostics` keeps an optional keyword count plus a created_at-only fallback so it stays callable standalone; the `_all_rows_have_dates` path (reads only the missing count) is unchanged.

## Deferred
- Removing the dead, uncalled `_all_rows_have_dates` helper -- separate cleanup slice.

## Parked hardening
None.

## AI reconciliation
All fixed or waived: Yes. No automated-review findings at PR open; will reconcile any Codex/reviewer threads on the first review pass.

## Verification
- `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_ticket_faq_markdown.py` -> 285 passed (incl. the new no-leak test).
- `bash scripts/run_extracted_pipeline_checks.sh` (full extracted CI mirror) -> 4020 passed, 10 skipped.
- `python -m py_compile` on the changed module + test -> OK; `bash scripts/check_ascii_python.sh` -> pass.
- plan-shape / plan-files-touched / plan-code-consistency -> green.

## Diff size
~30 LOC module + ~25 LOC test + ~90 LOC plan = ~145 LOC.
