### PR TITLE
Deflection Zendesk upload handoff

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1354,15 +1354,31 @@ async def _load_deflection_submit_rows_from_request(
                     status_code=400,
                     detail="Multipart deflection submit body could not be parsed.",
                 ) from exc
+            data = _deflection_submit_form_to_mapping(form)
+            if data.get("importer_mode") == "full_thread":
+                csv_file = form.get("csv_file") if hasattr(form, "get") else None
+                if csv_file is not None:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="csv_file is not accepted with importer_mode=full_thread",
+                    )
+                json_file = form.get("json_file") if hasattr(form, "get") else None
+                if json_file is None:
+                    raise HTTPException(status_code=422, detail="json_file is required")
+                rows, byte_count, load_warnings = await _load_deflection_submit_json_upload_rows(
+                    json_file,
+                    max_bytes=max_bytes,
+                )
+                return data, rows, byte_count, "uploaded_bytes", load_warnings
+            json_file = form.get("json_file") if hasattr(form, "get") else None
+            if json_file is not None:
+                raise HTTPException(
+                    status_code=422,
+                    detail="json_file requires importer_mode=full_thread",
+                )
             csv_file = form.get("csv_file") if hasattr(form, "get") else None
             if csv_file is None:
                 raise HTTPException(status_code=422, detail="csv_file is required")
-            data = _deflection_submit_form_to_mapping(form)
-            if data.get("importer_mode") == "full_thread":
-                raise HTTPException(
-                    status_code=422,
-                    detail="importer_mode=full_thread requires JSON blob_url submit",
-                )
             rows, byte_count, load_warnings = await _load_deflection_submit_upload_rows(
                 csv_file,
                 max_bytes=max_bytes,
@@ -1559,6 +1575,34 @@ async def _load_deflection_submit_upload_rows(
         data,
         parse_error_detail="Uploaded CSV could not be parsed.",
     )
+
+
+async def _load_deflection_submit_json_upload_rows(
+    json_file: Any,
+    *,
+    max_bytes: int,
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    try:
+        data = await json_file.read(max_bytes + 1)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Uploaded Zendesk full-thread JSON could not be read.",
+        ) from exc
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "reason": "deflection_submit_full_thread_too_large",
+                "max_file_bytes": max_bytes,
+            },
+        )
+    if not data:
+        raise HTTPException(
+            status_code=400,
+            detail="Uploaded Zendesk full-thread JSON is empty.",
+        )
+    return _parse_deflection_submit_zendesk_thread_bytes(data)
 
 
 def _load_deflection_submit_blob_rows_sync(

--- a/plans/PR-Deflection-Zendesk-Upload-Handoff.md
+++ b/plans/PR-Deflection-Zendesk-Upload-Handoff.md
@@ -1,0 +1,149 @@
+# PR-Deflection-Zendesk-Upload-Handoff
+
+## Why this slice exists
+
+PR #1520 proved the Zendesk `{ticket, comments}` full-thread importer and
+backend `importer_mode="full_thread"` contract, but deliberately left the
+browser upload UX CSV-only. That means a real Zendesk trial export still cannot
+be submitted from the portfolio intake page without hand-building a backend
+request.
+
+This slice closes that handoff: the portfolio upload page can accept either the
+existing support-ticket CSV or a Zendesk full-thread JSON export, store it in
+private Vercel Blob, and submit it through the authenticated portfolio proxy to
+ATLAS. The proxy keeps Blob private and forwards JSON bytes server-side; it does
+not expose ATLAS tokens, Blob tokens, or private Blob URLs to the browser.
+
+This may exceed the 400 LOC soft cap because the product path spans the
+portfolio upload UI, the portfolio submit/upload proxies, the ATLAS multipart
+submit parser, and CI-facing tests on both sides. Splitting the backend parser
+from the UI would leave the browser with a visible JSON mode that cannot
+complete a real report.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Add a portfolio upload mode selector for CSV vs Zendesk full-thread JSON.
+   CSV remains the default and keeps CSV inspection before private Blob upload.
+2. Allow private Blob uploads under the existing `faq-deflection/uploads/`
+   prefix for JSON Zendesk exports as well as CSV.
+3. Extend the portfolio submit proxy so JSON full-thread blobs are read
+   server-side and forwarded to ATLAS as authenticated multipart `json_file`
+   with `importer_mode="full_thread"`. CSV submit behavior remains unchanged.
+4. Extend the ATLAS deflection submit multipart parser to accept
+   `json_file` only when `importer_mode="full_thread"`; CSV mode still requires
+   `csv_file`.
+5. Add CI-facing tests for CSV unchanged behavior, JSON handoff request shape,
+   fail-closed blob/path/mode validation, and ATLAS multipart full-thread
+   parsing.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Omitted/CSV mode remains the default: CSV file validation, CSV inspect,
+        private Blob upload, proxy cleanup, and ATLAS multipart `csv_file`
+        submit still work.
+  - [ ] Zendesk JSON mode accepts JSON files, uploads them privately with an
+        allowed JSON content type, skips CSV inspect, and submits
+        `importer_mode="full_thread"` to the portfolio proxy.
+  - [ ] The portfolio proxy never exposes ATLAS credentials, Blob tokens, buyer
+        account IDs, or private Blob URLs in browser-visible payloads.
+  - [ ] JSON full-thread blobs are forwarded to ATLAS as authenticated
+        multipart `json_file` with support metadata and `limit`.
+  - [ ] Mismatched mode/path combinations fail closed: CSV mode cannot submit a
+        JSON blob, full-thread mode cannot submit a CSV blob, unsafe paths are
+        rejected before Blob/ATLAS calls, and malformed ATLAS envelopes still
+        fail closed.
+  - [ ] ATLAS multipart full-thread parsing produces the same diagnostics as
+        the #1520 blob-url importer path and rejects missing `json_file`.
+- Affected surfaces: portfolio upload page, portfolio Blob upload token route,
+  portfolio submit proxy, ATLAS deflection submit API, portfolio and extracted
+  tests.
+- Risk areas: private data leakage, mode/path confusion, skipped CSV preflight,
+  backend contract drift, frontend CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R9, R10, R12, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Zendesk-Upload-Handoff.md`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/api/content-ops/deflection/upload.js`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+The upload page gains an `uploadMode` state with two values:
+`csv` and `zendesk_full_thread`. `fileState` validates the selected file against
+that mode, and `blobPathname` preserves the corresponding CSV or JSON
+suffix under the same private Blob prefix. CSV mode keeps the existing
+inspect-before-upload path. Zendesk JSON mode skips the CSV inspect route,
+uploads the JSON privately, then includes `importer_mode: "full_thread"` in the
+portfolio submit payload.
+
+The Blob token route admits JSON pathnames/content types in addition to the
+existing CSV set, still scoped to `faq-deflection/uploads/`, still bound to the
+server-configured account, and still capped at 50 MB.
+
+The portfolio submit proxy replaces CSV-only helpers with mode-aware private
+Blob helpers. CSV mode continues to read the blob, inspect it through ATLAS, and
+forward multipart `csv_file`. Full-thread mode reads a JSON private blob,
+skips CSV inspect, and forwards multipart `json_file` plus
+`importer_mode="full_thread"` to ATLAS. Cleanup remains best-effort after the
+side-effectful submit and must not mask a successful report creation.
+
+The ATLAS submit parser accepts multipart `json_file` only when
+`importer_mode="full_thread"` and parses it through the same
+`load_zendesk_full_thread_rows_from_json_bytes` path used by #1520's blob-url
+importer. CSV mode keeps requiring `csv_file`.
+
+## Intentional
+
+- No direct Zendesk API fetch in this slice; this is still an uploaded-export
+  path. API export/import remains separate credentialed work.
+- No CSV-style preflight inspect for full-thread JSON in the browser. The
+  existing inspect route is a flat-file CSV ingestion preflight; JSON validation
+  happens in ATLAS submit parsing after the private upload, with cleanup on
+  failure.
+- The portfolio does not pass private Blob URLs to ATLAS. The proxy reads
+  private Blob bytes server-side and forwards authenticated multipart to avoid
+  exposing Blob access.
+
+## Deferred
+
+- Direct Zendesk API export/import using tenant-scoped credentials.
+- A dedicated JSON preflight diagnostics route if we need preview counts before
+  private upload for full-thread exports.
+- Live browser smoke against the operator's real Zendesk trial export.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_deflection_submit.py -q`
+  - 51 passed.
+- `cd portfolio-ui && npm run test:deflection-upload-shell`
+  - 27 passed.
+- `cd portfolio-ui && npm run test:deflection-atlas-proxy`
+  - 18 passed.
+- `cd portfolio-ui && npm run build`
+  - Passed after `npm ci` installed this worktree's local dependencies. Vite
+    emitted the existing large-chunk and sitemap-env warnings.
+- `scripts/run_extracted_pipeline_checks.sh` (via bash)
+  - 4022 passed, 10 skipped, 1 existing torch CUDA warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 52 |
+| `plans/PR-Deflection-Zendesk-Upload-Handoff.md` | 149 |
+| `portfolio-ui/api/content-ops/deflection/submit.js` | 110 |
+| `portfolio-ui/api/content-ops/deflection/upload.js` | 16 |
+| `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` | 182 |
+| `portfolio-ui/src/pages/FaqDeflectionUpload.tsx` | 162 |
+| `tests/test_extracted_content_deflection_submit.py` | 73 |
+| **Total** | **744** |

--- a/plans/PR-Deflection-Zendesk-Upload-Handoff.md
+++ b/plans/PR-Deflection-Zendesk-Upload-Handoff.md
@@ -92,7 +92,9 @@ The portfolio submit proxy replaces CSV-only helpers with mode-aware private
 Blob helpers. CSV mode continues to read the blob, inspect it through ATLAS, and
 forward multipart `csv_file`. Full-thread mode reads a JSON private blob,
 skips CSV inspect, and forwards multipart `json_file` plus
-`importer_mode="full_thread"` to ATLAS. Cleanup remains best-effort after the
+`importer_mode="full_thread"` to ATLAS. The proxy pins full-thread
+`support_platform` metadata to `zendesk` server-side because those bytes are
+always parsed as Zendesk thread exports. Cleanup remains best-effort after the
 side-effectful submit and must not mask a successful report creation.
 
 The ATLAS submit parser accepts multipart `json_file` only when
@@ -124,7 +126,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_extracted_content_deflection_submit.py -q`
-  - 51 passed.
+  - 53 passed.
 - `cd portfolio-ui && npm run test:deflection-upload-shell`
   - 27 passed.
 - `cd portfolio-ui && npm run test:deflection-atlas-proxy`
@@ -134,16 +136,19 @@ Parked hardening: none.
     emitted the existing large-chunk and sitemap-env warnings.
 - `scripts/run_extracted_pipeline_checks.sh` (via bash)
   - 4022 passed, 10 skipped, 1 existing torch CUDA warning.
+- Review-fix focused checks:
+  - `python -m pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_full_thread_multipart_json_upload tests/test_extracted_content_deflection_submit.py::test_deflection_submit_rejects_oversize_uploaded_json tests/test_extracted_content_deflection_submit.py::test_deflection_submit_rejects_empty_uploaded_json -q`
+    - 3 passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/api/control_surfaces.py` | 52 |
-| `plans/PR-Deflection-Zendesk-Upload-Handoff.md` | 149 |
-| `portfolio-ui/api/content-ops/deflection/submit.js` | 110 |
+| `plans/PR-Deflection-Zendesk-Upload-Handoff.md` | 154 |
+| `portfolio-ui/api/content-ops/deflection/submit.js` | 115 |
 | `portfolio-ui/api/content-ops/deflection/upload.js` | 16 |
-| `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` | 182 |
+| `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` | 185 |
 | `portfolio-ui/src/pages/FaqDeflectionUpload.tsx` | 162 |
-| `tests/test_extracted_content_deflection_submit.py` | 73 |
-| **Total** | **744** |
+| `tests/test_extracted_content_deflection_submit.py` | 117 |
+| **Total** | **801** |

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -8,6 +8,8 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 const SUBMIT_PATH = "/api/v1/content-ops/deflection-reports/submit";
 const MAX_BLOB_CSV_BYTES = 50 * 1024 * 1024;
 const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
+const CSV_IMPORTER_MODE = "csv";
+const FULL_THREAD_IMPORTER_MODE = "full_thread";
 
 export const config = {
   api: {
@@ -136,17 +138,31 @@ async function forwardSubmit({ config, contentType, body, fetchImpl = fetch }) {
   return { ok: true, statusCode: 200, payload: projected };
 }
 
-function validBlobPathname(value) {
+function normalizeImporterMode(value) {
+  const mode = clean(value);
+  if (!mode || mode === CSV_IMPORTER_MODE) return CSV_IMPORTER_MODE;
+  if (mode === FULL_THREAD_IMPORTER_MODE) return FULL_THREAD_IMPORTER_MODE;
+  return "";
+}
+
+function validBlobPathname(value, importerMode = CSV_IMPORTER_MODE) {
   const pathname = clean(value);
+  const mode = normalizeImporterMode(importerMode);
+  if (!mode) return "";
   if (!pathname.startsWith(BLOB_UPLOAD_PATH_PREFIX)) return "";
-  if (!pathname.toLowerCase().endsWith(".csv")) return "";
+  const lowerPathname = pathname.toLowerCase();
+  if (mode === FULL_THREAD_IMPORTER_MODE && !lowerPathname.endsWith(".json")) return "";
+  if (mode === CSV_IMPORTER_MODE && !lowerPathname.endsWith(".csv")) return "";
   if (pathname.includes("..") || pathname.includes("\\") || pathname.startsWith("/")) return "";
   return pathname;
 }
 
-function fileNameFromPathname(pathname) {
-  const name = pathname.split("/").filter(Boolean).pop() || "tickets.csv";
-  return name.toLowerCase().endsWith(".csv") ? name : "tickets.csv";
+function fileNameFromPathname(pathname, importerMode = CSV_IMPORTER_MODE) {
+  const mode = normalizeImporterMode(importerMode) || CSV_IMPORTER_MODE;
+  const fallback = mode === FULL_THREAD_IMPORTER_MODE ? "zendesk-thread.json" : "tickets.csv";
+  const extension = mode === FULL_THREAD_IMPORTER_MODE ? ".json" : ".csv";
+  const name = pathname.split("/").filter(Boolean).pop() || fallback;
+  return name.toLowerCase().endsWith(extension) ? name : fallback;
 }
 
 async function getPrivateBlob(pathname, options) {
@@ -159,14 +175,22 @@ async function deletePrivateBlob(pathname, options) {
   return del(pathname, options);
 }
 
-async function readPrivateCsvBlob({
+async function readPrivateSubmitBlob({
   pathname,
   token,
+  importerMode = CSV_IMPORTER_MODE,
   getBlobImpl = getPrivateBlob,
   maxBytes = MAX_BLOB_CSV_BYTES,
 }) {
-  const safePathname = validBlobPathname(pathname);
+  const mode = normalizeImporterMode(importerMode);
+  if (!mode) return { ok: false, statusCode: 400, error: "invalid_importer_mode" };
+  const safePathname = validBlobPathname(pathname, mode);
   if (!safePathname) return { ok: false, statusCode: 400, error: "invalid_blob_reference" };
+  const tooLargeError =
+    mode === FULL_THREAD_IMPORTER_MODE
+      ? "deflection_submit_full_thread_too_large"
+      : "deflection_submit_csv_too_large";
+  const fallbackContentType = mode === FULL_THREAD_IMPORTER_MODE ? "application/json" : "text/csv";
   try {
     const result = await getBlobImpl(safePathname, {
       access: "private",
@@ -177,31 +201,42 @@ async function readPrivateCsvBlob({
       return { ok: false, statusCode: 404, error: "private_blob_unavailable" };
     }
     if (Number.isFinite(result.blob?.size) && result.blob.size > maxBytes) {
-      return { ok: false, statusCode: 413, error: "deflection_submit_csv_too_large" };
+      return { ok: false, statusCode: 413, error: tooLargeError };
     }
     const body = await streamToBuffer(result.stream, maxBytes);
     if (!body.ok) {
-      return { ok: false, statusCode: 413, error: "deflection_submit_csv_too_large" };
+      return { ok: false, statusCode: 413, error: tooLargeError };
     }
     return {
       ok: true,
       pathname: safePathname,
       body: body.body,
-      contentType: clean(result.blob?.contentType) || "text/csv",
-      fileName: fileNameFromPathname(safePathname),
+      contentType: clean(result.blob?.contentType) || fallbackContentType,
+      fileName: fileNameFromPathname(safePathname, mode),
     };
   } catch {
     return { ok: false, statusCode: 502, error: "private_blob_unavailable" };
   }
 }
 
-async function cleanupPrivateCsvBlob({
+async function readPrivateCsvBlob(options) {
+  return readPrivateSubmitBlob({ ...options, importerMode: CSV_IMPORTER_MODE });
+}
+
+async function readPrivateJsonBlob(options) {
+  return readPrivateSubmitBlob({ ...options, importerMode: FULL_THREAD_IMPORTER_MODE });
+}
+
+async function cleanupPrivateSubmitBlob({
   pathname,
   token,
+  importerMode = CSV_IMPORTER_MODE,
   deleteBlobImpl = deletePrivateBlob,
   eventLogger = console.warn,
 }) {
-  const safePathname = validBlobPathname(pathname);
+  const mode = normalizeImporterMode(importerMode);
+  if (!mode) return { ok: false, skipped: true, error: "invalid_importer_mode" };
+  const safePathname = validBlobPathname(pathname, mode);
   if (!safePathname) return { ok: false, skipped: true, error: "invalid_blob_reference" };
   try {
     await deleteBlobImpl(safePathname, { token });
@@ -213,6 +248,14 @@ async function cleanupPrivateCsvBlob({
     }, eventLogger);
     return { ok: false, error: "private_blob_cleanup_failed" };
   }
+}
+
+async function cleanupPrivateCsvBlob(options) {
+  return cleanupPrivateSubmitBlob({ ...options, importerMode: CSV_IMPORTER_MODE });
+}
+
+async function cleanupPrivateJsonBlob(options) {
+  return cleanupPrivateSubmitBlob({ ...options, importerMode: FULL_THREAD_IMPORTER_MODE });
 }
 
 function inspectFormFromBlob(blob) {
@@ -250,35 +293,47 @@ async function submitPrivateBlob({
   deleteBlobImpl = deletePrivateBlob,
   eventLogger = console.warn,
 }) {
-  const blob = await readPrivateCsvBlob({
+  const importerMode = normalizeImporterMode(payload?.importer_mode);
+  if (!importerMode) return { ok: false, statusCode: 400, error: "invalid_importer_mode" };
+  const blob = await readPrivateSubmitBlob({
     pathname: payload?.blob_pathname,
     token: blobToken,
+    importerMode,
     getBlobImpl,
   });
   if (!blob.ok) return blob;
 
-  const inspectResult = await inspectPrivateCsvBlob({ config, blob, fetchImpl });
-  if (!inspectResult.ok) {
-    await cleanupPrivateCsvBlob({
-      pathname: blob.pathname,
-      token: blobToken,
-      deleteBlobImpl,
-      eventLogger,
-    });
-    return inspectResult;
+  if (importerMode === CSV_IMPORTER_MODE) {
+    const inspectResult = await inspectPrivateCsvBlob({ config, blob, fetchImpl });
+    if (!inspectResult.ok) {
+      await cleanupPrivateSubmitBlob({
+        pathname: blob.pathname,
+        token: blobToken,
+        importerMode,
+        deleteBlobImpl,
+        eventLogger,
+      });
+      return inspectResult;
+    }
   }
 
   const form = new FormData();
-  form.set("csv_file", new Blob([blob.body], { type: blob.contentType }), blob.fileName);
+  if (importerMode === FULL_THREAD_IMPORTER_MODE) {
+    form.set("json_file", new Blob([blob.body], { type: blob.contentType }), blob.fileName);
+    form.set("importer_mode", FULL_THREAD_IMPORTER_MODE);
+  } else {
+    form.set("csv_file", new Blob([blob.body], { type: blob.contentType }), blob.fileName);
+  }
   form.set("support_platform", clean(payload?.support_platform));
   form.set("company_name", clean(payload?.company_name));
   form.set("contact_email", clean(payload?.contact_email));
   form.set("limit", clean(payload?.limit) || "1000");
 
   const result = await forwardSubmit({ config, contentType: "", body: form, fetchImpl });
-  await cleanupPrivateCsvBlob({
+  await cleanupPrivateSubmitBlob({
     pathname: blob.pathname,
     token: blobToken,
+    importerMode,
     deleteBlobImpl,
     eventLogger,
   });
@@ -287,13 +342,18 @@ async function submitPrivateBlob({
 
 export {
   BLOB_UPLOAD_PATH_PREFIX,
+  CSV_IMPORTER_MODE,
+  FULL_THREAD_IMPORTER_MODE,
   MAX_BLOB_CSV_BYTES,
   SUBMIT_PATH,
   cleanupPrivateCsvBlob,
+  cleanupPrivateJsonBlob,
   forwardSubmit,
   inspectPrivateCsvBlob,
+  normalizeImporterMode,
   projectSubmitPayload,
   readPrivateCsvBlob,
+  readPrivateJsonBlob,
   submitPrivateBlob,
   validBlobPathname,
 };

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -324,7 +324,10 @@ async function submitPrivateBlob({
   } else {
     form.set("csv_file", new Blob([blob.body], { type: blob.contentType }), blob.fileName);
   }
-  form.set("support_platform", clean(payload?.support_platform));
+  form.set(
+    "support_platform",
+    importerMode === FULL_THREAD_IMPORTER_MODE ? "zendesk" : clean(payload?.support_platform),
+  );
   form.set("company_name", clean(payload?.company_name));
   form.set("contact_email", clean(payload?.contact_email));
   form.set("limit", clean(payload?.limit) || "1000");

--- a/portfolio-ui/api/content-ops/deflection/upload.js
+++ b/portfolio-ui/api/content-ops/deflection/upload.js
@@ -3,6 +3,8 @@ import { clean } from "./atlas-report.js";
 const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
 const MAX_BLOB_CSV_BYTES = 50 * 1024 * 1024;
 const CSV_CONTENT_TYPES = ["text/csv", "application/vnd.ms-excel", "application/csv"];
+const JSON_CONTENT_TYPES = ["application/json", "text/json"];
+const BLOB_UPLOAD_CONTENT_TYPES = [...CSV_CONTENT_TYPES, ...JSON_CONTENT_TYPES];
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function json(res, statusCode, payload) {
@@ -45,7 +47,15 @@ function uploadTokenConfig(pathname, clientPayload, env = process.env) {
   const payload = parseClientPayload(clientPayload);
   const accountId = clean(payload.account_id);
   const errors = [...config.errors];
-  if (!pathname.startsWith(BLOB_UPLOAD_PATH_PREFIX) || !pathname.toLowerCase().endsWith(".csv")) {
+  const lowerPathname = pathname.toLowerCase();
+  const hasAllowedExtension = lowerPathname.endsWith(".csv") || lowerPathname.endsWith(".json");
+  if (
+    !pathname.startsWith(BLOB_UPLOAD_PATH_PREFIX) ||
+    !hasAllowedExtension ||
+    pathname.includes("..") ||
+    pathname.includes("\\") ||
+    pathname.startsWith("/")
+  ) {
     errors.push("invalid_blob_pathname");
   }
   if (accountId && accountId !== config.accountId) {
@@ -56,7 +66,7 @@ function uploadTokenConfig(pathname, clientPayload, env = process.env) {
     ok: true,
     token: config.token,
     options: {
-      allowedContentTypes: CSV_CONTENT_TYPES,
+      allowedContentTypes: BLOB_UPLOAD_CONTENT_TYPES,
       maximumSizeInBytes: MAX_BLOB_CSV_BYTES,
       addRandomSuffix: true,
       tokenPayload: JSON.stringify({ account_id: config.accountId }),
@@ -70,8 +80,10 @@ async function handleBlobUpload(options) {
 }
 
 export {
+  BLOB_UPLOAD_CONTENT_TYPES,
   BLOB_UPLOAD_PATH_PREFIX,
   CSV_CONTENT_TYPES,
+  JSON_CONTENT_TYPES,
   MAX_BLOB_CSV_BYTES,
   handleBlobUpload,
   parseClientPayload,

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -446,6 +446,7 @@ await test("portfolio submit endpoint pins private Blob submit handling", () => 
   assert.match(submitSource, /normalizeImporterMode/);
   assert.match(submitSource, /form\.set\("json_file"/);
   assert.match(submitSource, /form\.set\("importer_mode", FULL_THREAD_IMPORTER_MODE\)/);
+  assert.match(submitSource, /importerMode === FULL_THREAD_IMPORTER_MODE \? "zendesk" : clean\(payload\?\.support_platform\)/);
   assert.match(submitSource, /inspectPrivateCsvBlob/);
   assert.match(submitSource, /deflection_inspect_not_ready/);
   assert.match(inspectSource, /bodyParser:\s*false/);
@@ -723,6 +724,7 @@ await test("private blob submit reads server-side blob and forwards ATLAS multip
   assert.equal(calls[1].options.body instanceof FormData, true);
   assert.equal(calls[1].options.body.get("support_platform"), "zendesk");
   assert.equal(calls[1].options.body.get("company_name"), "Acme Co.");
+  assert.equal(calls[1].options.body.get("limit"), "1000");
   assert.equal(await calls[1].options.body.get("csv_file").text(), csv);
   assert.deepEqual(deleteCalls, [
     {
@@ -754,7 +756,7 @@ await test("private blob submit forwards Zendesk full-thread JSON without CSV in
     payload: {
       blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}zendesk-thread.json`,
       importer_mode: FULL_THREAD_IMPORTER_MODE,
-      support_platform: "zendesk",
+      support_platform: "intercom",
       company_name: "Acme Co.",
       contact_email: "lead@acme.example",
       limit: "1000",
@@ -801,6 +803,7 @@ await test("private blob submit forwards Zendesk full-thread JSON without CSV in
   assert.equal(calls[0].options.body instanceof FormData, true);
   assert.equal(calls[0].options.body.get("support_platform"), "zendesk");
   assert.equal(calls[0].options.body.get("company_name"), "Acme Co.");
+  assert.equal(calls[0].options.body.get("limit"), "1000");
   assert.equal(calls[0].options.body.get("importer_mode"), FULL_THREAD_IMPORTER_MODE);
   assert.equal(await calls[0].options.body.get("json_file").text(), threadJson);
   assert.equal(calls[0].options.body.get("csv_file"), null);

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -4,6 +4,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import submitHandler, {
   BLOB_UPLOAD_PATH_PREFIX,
+  FULL_THREAD_IMPORTER_MODE,
   MAX_BLOB_CSV_BYTES,
   SUBMIT_PATH,
   cleanupPrivateCsvBlob,
@@ -16,7 +17,9 @@ import inspectHandler, {
   MAX_INSPECT_MULTIPART_BYTES,
 } from "../api/content-ops/deflection/inspect.js";
 import {
+  BLOB_UPLOAD_CONTENT_TYPES,
   CSV_CONTENT_TYPES,
+  JSON_CONTENT_TYPES,
   MAX_BLOB_CSV_BYTES as MAX_UPLOAD_CSV_BYTES,
   uploadTokenConfig,
 } from "../api/content-ops/deflection/upload.js";
@@ -196,6 +199,9 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   for (const marker of [
     "data-atlas-deflection-upload",
     "data-atlas-deflection-csv-file",
+    "data-atlas-deflection-upload-file",
+    "data-atlas-deflection-upload-mode",
+    "data-atlas-deflection-upload-mode-option",
     "data-atlas-deflection-company",
     "data-atlas-deflection-contact-email",
     "data-atlas-deflection-support-platform",
@@ -210,10 +216,13 @@ await test("upload shell exposes live submit markers and avoids browser credenti
     assert.match(uploadSource, new RegExp(marker));
   }
   assert.match(uploadSource, /MAX_CSV_BYTES = 50 \* 1024 \* 1024/);
+  assert.match(uploadSource, /FULL_THREAD_IMPORTER_MODE = "full_thread"/);
   assert.match(uploadSource, /@vercel\/blob\/client/);
   assert.doesNotMatch(blobUploadRouteSource, /^import .*@vercel\/blob\/client/m);
   assert.match(blobUploadRouteSource, /import\("@vercel\/blob\/client"\)/);
   assert.match(uploadSource, /access: "private"/);
+  assert.match(uploadSource, /accept=\{isFullThreadUpload \? "\.json,application\/json" : "\.csv,text\/csv"\}/);
+  assert.match(uploadSource, /contentType: isFullThreadUpload \? "application\/json" : "text\/csv"/);
   assert.match(uploadSource, /onUploadProgress/);
   assert.match(uploadSource, /boundedProgress\(event\.percentage\)/);
   assert.match(uploadSource, /role="progressbar"/);
@@ -228,13 +237,22 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.match(uploadSource, /resolution text[\s\S]*resolved ticket notes/);
   assert.match(uploadSource, /Question-only exports[\s\S]*clustering[\s\S]*gap\s+list/);
   assert.match(uploadSource, /publishable answers require uploaded resolution\s+evidence/);
+  assert.match(uploadSource, /value: "zendesk_full_thread"/);
+  assert.match(uploadSource, /Zendesk JSON/);
+  assert.match(uploadSource, /public requester comments[\s\S]*public agent replies/);
+  assert.match(uploadSource, /Private notes are dropped during import/);
+  assert.match(uploadSource, /ATLAS validates the thread shape during submit/);
   assert.doesNotMatch(uploadSource, /exact mathematical clustering/);
   assert.match(uploadSource, /Workspace routing is handled server-side/);
   assert.match(uploadSource, /Your browser never[\s\S]*receives ATLAS service tokens/);
-  assert.match(uploadSource, /CSV inspection and private storage both run\s+server-side/);
+  assert.match(uploadSource, /JSON import/);
+  assert.match(uploadSource, /CSV inspection/);
+  assert.match(uploadSource, /private storage both run server-side/);
   assert.match(uploadSource, /ATLAS checks the CSV first[\s\S]*stores it privately after validation/);
+  assert.match(uploadSource, /private Zendesk JSON server-side[\s\S]*imports public thread evidence/);
   assert.match(uploadSource, /const INSPECT_ENDPOINT = "\/api\/content-ops\/deflection\/inspect"/);
   assert.match(uploadSource, /fetch\(INSPECT_ENDPOINT/);
+  assert.match(uploadSource, /if \(!isFullThreadUpload\)/);
   assert.match(uploadSource, /source_rows", "true"/);
   assert.match(uploadSource, /target_mode", "faq_deflection_report"/);
   assert.match(uploadSource, /Checking CSV/);
@@ -248,8 +266,10 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.doesNotMatch(uploadSource, /Bound server-side to the configured report workspace/);
   assert.doesNotMatch(uploadSource, /CSV bytes are first stored in private Vercel Blob/);
   assert.match(uploadSource, /Retry upload/);
-  assert.match(uploadSource, /starts a new private upload/);
+  assert.match(uploadSource, /starts a new\s+private upload/);
   assert.match(uploadSource, /blob_pathname: blob\.pathname/);
+  assert.match(uploadSource, /support_platform: isFullThreadUpload \? "zendesk" : supportPlatform/);
+  assert.match(uploadSource, /importer_mode: FULL_THREAD_IMPORTER_MODE/);
   assert.match(uploadSource, /private_blob_persistence/);
   assert.match(uploadSource, /value: "help_scout"/);
   assert.match(uploadSource, /value: "other", label: "Freshdesk \/ other"/);
@@ -422,6 +442,10 @@ await test("portfolio submit endpoint pins private Blob submit handling", () => 
   assert.match(submitSource, /const \{ del \} = await import\("@vercel\/blob"\)/);
   assert.match(submitSource, /direct_multipart_deprecated/);
   assert.doesNotMatch(submitSource, /readRawBody|MAX_MULTIPART_OVERHEAD_BYTES/);
+  assert.match(submitSource, /FULL_THREAD_IMPORTER_MODE = "full_thread"/);
+  assert.match(submitSource, /normalizeImporterMode/);
+  assert.match(submitSource, /form\.set\("json_file"/);
+  assert.match(submitSource, /form\.set\("importer_mode", FULL_THREAD_IMPORTER_MODE\)/);
   assert.match(submitSource, /inspectPrivateCsvBlob/);
   assert.match(submitSource, /deflection_inspect_not_ready/);
   assert.match(inspectSource, /bodyParser:\s*false/);
@@ -582,11 +606,28 @@ await test("private blob upload token config fails closed on path and account bi
   assert.equal(ok.ok, true);
   assert.equal(ok.token, ENV.BLOB_READ_WRITE_TOKEN);
   assert.equal(ok.options.maximumSizeInBytes, MAX_UPLOAD_CSV_BYTES);
-  assert.deepEqual(ok.options.allowedContentTypes, CSV_CONTENT_TYPES);
+  assert.deepEqual(ok.options.allowedContentTypes, BLOB_UPLOAD_CONTENT_TYPES);
+  assert.deepEqual(BLOB_UPLOAD_CONTENT_TYPES, [...CSV_CONTENT_TYPES, ...JSON_CONTENT_TYPES]);
   assert.equal(ok.options.addRandomSuffix, true);
+
+  const jsonOk = uploadTokenConfig(
+    `${BLOB_UPLOAD_PATH_PREFIX}zendesk-thread.json`,
+    "",
+    ENV,
+  );
+  assert.equal(jsonOk.ok, true);
+  assert.deepEqual(jsonOk.options.allowedContentTypes, BLOB_UPLOAD_CONTENT_TYPES);
 
   assert.deepEqual(
     uploadTokenConfig("other/tickets.csv", JSON.stringify({ account_id: ACCOUNT_ID }), ENV),
+    { ok: false, errors: ["invalid_blob_pathname"] },
+  );
+  assert.deepEqual(
+    uploadTokenConfig(`${BLOB_UPLOAD_PATH_PREFIX}tickets.txt`, "", ENV),
+    { ok: false, errors: ["invalid_blob_pathname"] },
+  );
+  assert.deepEqual(
+    uploadTokenConfig(`${BLOB_UPLOAD_PATH_PREFIX}../tickets.csv`, "", ENV),
     { ok: false, errors: ["invalid_blob_pathname"] },
   );
   assert.deepEqual(
@@ -686,6 +727,86 @@ await test("private blob submit reads server-side blob and forwards ATLAS multip
   assert.deepEqual(deleteCalls, [
     {
       pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      options: { token: ENV.BLOB_READ_WRITE_TOKEN },
+    },
+  ]);
+});
+
+await test("private blob submit forwards Zendesk full-thread JSON without CSV inspect", async () => {
+  const calls = [];
+  const deleteCalls = [];
+  const threadJson = JSON.stringify({
+    ticket: { id: 123, status: "solved", satisfaction_rating: { score: "good" } },
+    comments: [
+      { id: 1, public: true, author_role: "end_user", body: "How do I export reports?" },
+      { id: 2, public: false, author_role: "agent", body: "Private triage note" },
+      { id: 3, public: true, author_role: "agent", body: "Open Reports, then Export." },
+    ],
+  });
+  const result = await submitPrivateBlob({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}zendesk-thread.json`,
+      importer_mode: FULL_THREAD_IMPORTER_MODE,
+      support_platform: "zendesk",
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    getBlobImpl: async (pathname, options) => {
+      assert.equal(pathname, `${BLOB_UPLOAD_PATH_PREFIX}zendesk-thread.json`);
+      assert.deepEqual(options, {
+        access: "private",
+        token: ENV.BLOB_READ_WRITE_TOKEN,
+        useCache: false,
+      });
+      return {
+        statusCode: 200,
+        stream: new Blob([threadJson], { type: "application/json" }).stream(),
+        blob: {
+          size: Buffer.byteLength(threadJson),
+          contentType: "application/json",
+        },
+      };
+    },
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      assert.equal(url.endsWith(INSPECT_PATH), false);
+      assert.equal(url.endsWith(SUBMIT_PATH), true);
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ request_id: "content-ops-json123" });
+        },
+      };
+    },
+    deleteBlobImpl: async (pathname, options) => {
+      deleteCalls.push({ pathname, options });
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.payload.result_path.includes("content-ops-json123"), true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);
+  assert.equal(calls[0].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
+  assert.equal("Content-Type" in calls[0].options.headers, false);
+  assert.equal(calls[0].options.body instanceof FormData, true);
+  assert.equal(calls[0].options.body.get("support_platform"), "zendesk");
+  assert.equal(calls[0].options.body.get("company_name"), "Acme Co.");
+  assert.equal(calls[0].options.body.get("importer_mode"), FULL_THREAD_IMPORTER_MODE);
+  assert.equal(await calls[0].options.body.get("json_file").text(), threadJson);
+  assert.equal(calls[0].options.body.get("csv_file"), null);
+  assert.deepEqual(deleteCalls, [
+    {
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}zendesk-thread.json`,
       options: { token: ENV.BLOB_READ_WRITE_TOKEN },
     },
   ]);
@@ -966,6 +1087,61 @@ await test("private blob reader rejects unsafe or oversized blob references", as
     }),
     { ok: false, statusCode: 413, error: "deflection_submit_csv_too_large" },
   );
+});
+
+await test("private blob submit fails closed on importer mode and blob extension mismatch", async () => {
+  let externalCalled = false;
+  const common = {
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    getBlobImpl: async () => {
+      externalCalled = true;
+      throw new Error("must not call blob store");
+    },
+    fetchImpl: async () => {
+      externalCalled = true;
+      throw new Error("must not call ATLAS");
+    },
+    deleteBlobImpl: async () => {
+      externalCalled = true;
+    },
+  };
+
+  assert.deepEqual(
+    await submitPrivateBlob({
+      ...common,
+      payload: {
+        blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+        importer_mode: FULL_THREAD_IMPORTER_MODE,
+      },
+    }),
+    { ok: false, statusCode: 400, error: "invalid_blob_reference" },
+  );
+  assert.deepEqual(
+    await submitPrivateBlob({
+      ...common,
+      payload: {
+        blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}zendesk-thread.json`,
+      },
+    }),
+    { ok: false, statusCode: 400, error: "invalid_blob_reference" },
+  );
+  assert.deepEqual(
+    await submitPrivateBlob({
+      ...common,
+      payload: {
+        blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}zendesk-thread.json`,
+        importer_mode: "raw_json",
+      },
+    }),
+    { ok: false, statusCode: 400, error: "invalid_importer_mode" },
+  );
+  assert.equal(externalCalled, false);
 });
 
 await test("portfolio submit forwarding times out hung ATLAS calls", async () => {

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -18,12 +18,27 @@ const INSPECT_ENDPOINT = "/api/content-ops/deflection/inspect";
 const BLOB_UPLOAD_ENDPOINT = "/api/content-ops/deflection/upload";
 const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
 const MAX_CSV_BYTES = 50 * 1024 * 1024;
+const FULL_THREAD_IMPORTER_MODE = "full_thread";
 const SUPPORT_PLATFORMS = [
   { value: "zendesk", label: "Zendesk" },
   { value: "intercom", label: "Intercom" },
   { value: "help_scout", label: "Help Scout" },
   { value: "other", label: "Freshdesk / other" },
 ] as const;
+const UPLOAD_MODES = [
+  {
+    value: "csv",
+    label: "CSV",
+    description: "Inspect mapped ticket rows before private upload.",
+  },
+  {
+    value: "zendesk_full_thread",
+    label: "Zendesk JSON",
+    description: "Import ticket metadata plus public comment threads.",
+  },
+] as const;
+
+type UploadMode = (typeof UPLOAD_MODES)[number]["value"];
 
 type UploadState =
   | { status: "empty" }
@@ -60,28 +75,34 @@ function formatBytes(bytes: number) {
   return `${bytes} bytes`;
 }
 
-function fileState(file: File | undefined): UploadState {
+function fileState(file: File | undefined, uploadMode: UploadMode): UploadState {
   if (!file) return { status: "empty" };
   const lowerName = file.name.toLowerCase();
-  if (!lowerName.endsWith(".csv")) {
-    return { status: "invalid", message: "Select a CSV export." };
+  const isFullThreadUpload = uploadMode === "zendesk_full_thread";
+  const extension = isFullThreadUpload ? ".json" : ".csv";
+  const formatLabel = isFullThreadUpload ? "Zendesk JSON export" : "CSV export";
+  if (!lowerName.endsWith(extension)) {
+    return { status: "invalid", message: `Select a ${formatLabel}.` };
   }
   if (file.size <= 0) {
-    return { status: "invalid", message: "The selected CSV is empty." };
+    return { status: "invalid", message: `The selected ${formatLabel} is empty.` };
   }
   if (file.size > MAX_CSV_BYTES) {
-    return { status: "invalid", message: "CSV exports must be 50 MB or smaller." };
+    return { status: "invalid", message: "Uploads must be 50 MB or smaller." };
   }
   return { status: "ready", file, fileName: file.name, fileSize: file.size };
 }
 
-function blobPathname(fileName: string) {
+function blobPathname(fileName: string, uploadMode: UploadMode) {
+  const isFullThreadUpload = uploadMode === "zendesk_full_thread";
+  const extension = isFullThreadUpload ? ".json" : ".csv";
+  const fallback = isFullThreadUpload ? "zendesk-thread.json" : "tickets.csv";
   const cleaned = fileName
     .toLowerCase()
     .replace(/[^a-z0-9_.-]+/g, "-")
     .replace(/^-+|-+$/g, "");
-  const csvName = cleaned.endsWith(".csv") ? cleaned : "tickets.csv";
-  return `${BLOB_UPLOAD_PATH_PREFIX}${Date.now()}-${csvName}`;
+  const uploadName = cleaned.endsWith(extension) ? cleaned : fallback;
+  return `${BLOB_UPLOAD_PATH_PREFIX}${Date.now()}-${uploadName}`;
 }
 
 function boundedProgress(percentage: number | undefined) {
@@ -152,9 +173,13 @@ export default function FaqDeflectionUpload() {
   const [companyName, setCompanyName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
   const [supportPlatform, setSupportPlatform] = useState<string>(SUPPORT_PLATFORMS[0].value);
+  const [uploadMode, setUploadMode] = useState<UploadMode>("csv");
   const [upload, setUpload] = useState<UploadState>({ status: "empty" });
   const [inspect, setInspect] = useState<InspectState>({ status: "idle" });
   const [submit, setSubmit] = useState<SubmitState>({ status: "idle" });
+  const isFullThreadUpload = uploadMode === "zendesk_full_thread";
+  const uploadLabel = isFullThreadUpload ? "Zendesk full-thread JSON" : "Support-ticket CSV";
+  const uploadFormat = isFullThreadUpload ? "Zendesk JSON" : "CSV";
 
   const fieldsReady = useMemo(
     () =>
@@ -176,26 +201,30 @@ export default function FaqDeflectionUpload() {
   const startSubmit = async () => {
     if (upload.status !== "ready" || !fieldsReady) return;
 
-    let phase: "inspect" | "upload" = "inspect";
+    let phase: "inspect" | "upload" = isFullThreadUpload ? "upload" : "inspect";
     try {
-      setSubmit({ status: "inspecting" });
-      setInspect({ status: "checking" });
-      const diagnostics = await inspectDeflectionCsv(upload.file);
-      if (!diagnostics.ok) {
-        setInspect({
-          status: "not_ready",
-          diagnostics,
-          message: inspectMessage(diagnostics),
-        });
-        setSubmit({ status: "idle" });
-        return;
+      if (!isFullThreadUpload) {
+        setSubmit({ status: "inspecting" });
+        setInspect({ status: "checking" });
+        const diagnostics = await inspectDeflectionCsv(upload.file);
+        if (!diagnostics.ok) {
+          setInspect({
+            status: "not_ready",
+            diagnostics,
+            message: inspectMessage(diagnostics),
+          });
+          setSubmit({ status: "idle" });
+          return;
+        }
+        setInspect({ status: "ready", diagnostics });
+        phase = "upload";
+      } else {
+        setInspect({ status: "idle" });
       }
-      setInspect({ status: "ready", diagnostics });
-      phase = "upload";
       setSubmit({ status: "uploading", percentage: 0 });
-      const blob = await uploadBlob(blobPathname(upload.fileName), upload.file, {
+      const blob = await uploadBlob(blobPathname(upload.fileName, uploadMode), upload.file, {
         access: "private",
-        contentType: "text/csv",
+        contentType: isFullThreadUpload ? "application/json" : "text/csv",
         handleUploadUrl: BLOB_UPLOAD_ENDPOINT,
         multipart: upload.fileSize > 4 * 1024 * 1024,
         onUploadProgress: (event) => {
@@ -214,10 +243,11 @@ export default function FaqDeflectionUpload() {
         },
         body: JSON.stringify({
           blob_pathname: blob.pathname,
-          support_platform: supportPlatform,
+          support_platform: isFullThreadUpload ? "zendesk" : supportPlatform,
           company_name: companyName.trim(),
           contact_email: contactEmail.trim(),
           limit: "1000",
+          ...(isFullThreadUpload ? { importer_mode: FULL_THREAD_IMPORTER_MODE } : {}),
         }),
       });
       const payload = (await response.json().catch(() => null)) as {
@@ -299,7 +329,46 @@ export default function FaqDeflectionUpload() {
               chatbot interpretation.
             </p>
 
-            <div className="mt-8 grid gap-5 md:grid-cols-2">
+            <div
+              className="mt-8 grid gap-3 rounded-lg border border-surface-700/70 bg-surface-900/45 p-3 sm:grid-cols-2"
+              data-atlas-deflection-upload-mode
+              role="radiogroup"
+              aria-label="Upload format"
+            >
+              {UPLOAD_MODES.map((mode) => {
+                const selected = uploadMode === mode.value;
+                return (
+                  <button
+                    key={mode.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    data-atlas-deflection-upload-mode-option={mode.value}
+                    className={`rounded-md border px-4 py-3 text-left transition ${
+                      selected
+                        ? "border-primary-400 bg-primary-500/15 text-primary-100"
+                        : "border-surface-700 bg-surface-950/60 text-surface-200 hover:border-surface-500"
+                    }`}
+                    onClick={() => {
+                      setUploadMode(mode.value);
+                      setUpload({ status: "empty" });
+                      setInspect({ status: "idle" });
+                      setSubmit({ status: "idle" });
+                      if (mode.value === "zendesk_full_thread") {
+                        setSupportPlatform("zendesk");
+                      }
+                    }}
+                  >
+                    <span className="block text-sm font-semibold">{mode.label}</span>
+                    <span className="mt-1 block text-xs leading-5 opacity-75">
+                      {mode.description}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-6 grid gap-5 md:grid-cols-2">
               <label className="block">
                 <span className="text-sm font-medium text-surface-100">Company</span>
                 <input
@@ -326,9 +395,10 @@ export default function FaqDeflectionUpload() {
               <label className="block">
                 <span className="text-sm font-medium text-surface-100">Support platform</span>
                 <select
-                  className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 text-sm text-white outline-none transition focus:border-primary-400"
+                  className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 text-sm text-white outline-none transition focus:border-primary-400 disabled:cursor-not-allowed disabled:text-surface-200/55"
                   data-atlas-deflection-support-platform
                   value={supportPlatform}
+                  disabled={isFullThreadUpload}
                   onChange={(event) => {
                     setSupportPlatform(event.target.value);
                     setInspect({ status: "idle" });
@@ -354,15 +424,17 @@ export default function FaqDeflectionUpload() {
             <label className="mt-6 block rounded-lg border border-dashed border-surface-600 bg-surface-900/55 p-5 transition focus-within:border-primary-400">
               <span className="flex items-center gap-3 text-sm font-medium text-surface-100">
                 <Upload size={18} className="text-primary-300" />
-                Support-ticket CSV
+                {uploadLabel}
               </span>
               <input
+                key={uploadMode}
                 className="mt-4 block w-full cursor-pointer rounded-lg border border-surface-700 bg-surface-900 text-sm text-surface-100 file:mr-4 file:border-0 file:bg-primary-500 file:px-4 file:py-3 file:text-sm file:font-semibold file:text-surface-900"
                 data-atlas-deflection-csv-file
+                data-atlas-deflection-upload-file
                 type="file"
-                accept=".csv,text/csv"
+                accept={isFullThreadUpload ? ".json,application/json" : ".csv,text/csv"}
                 onChange={(event) => {
-                  setUpload(fileState(event.target.files?.[0]));
+                  setUpload(fileState(event.target.files?.[0], uploadMode));
                   setInspect({ status: "idle" });
                 }}
               />
@@ -371,13 +443,14 @@ export default function FaqDeflectionUpload() {
                 data-atlas-deflection-export-guidance
               >
                 <p className="font-semibold text-surface-100">
-                  Best input: full ticket threads with customer questions plus
-                  agent replies, resolution text, or resolved ticket notes.
+                  {isFullThreadUpload
+                    ? "Best input: Zendesk ticket JSON with public requester comments, public agent replies, status, and satisfaction fields."
+                    : "Best input: full ticket threads with customer questions plus agent replies, resolution text, or resolved ticket notes."}
                 </p>
                 <p>
-                  Question-only exports still work for clustering and a gap
-                  list, but publishable answers require uploaded resolution
-                  evidence.
+                  {isFullThreadUpload
+                    ? "Private notes are dropped during import. ATLAS validates the thread shape during submit before the locked report is created."
+                    : "Question-only exports still work for clustering and a gap list, but publishable answers require uploaded resolution evidence."}
                 </p>
               </div>
               <div className="mt-4 rounded-md border border-primary-500/30 bg-primary-500/10 px-4 py-3">
@@ -390,8 +463,8 @@ export default function FaqDeflectionUpload() {
                 </p>
               </div>
               <span className="mt-3 block text-xs text-surface-200/60">
-                Up to 50 MB. CSV inspection and private storage both run
-                server-side; service tokens never reach the browser.
+                Up to 50 MB. {isFullThreadUpload ? "JSON import" : "CSV inspection"} and
+                private storage both run server-side; service tokens never reach the browser.
               </span>
             </label>
 
@@ -416,13 +489,13 @@ export default function FaqDeflectionUpload() {
                   data-atlas-deflection-upload-progress
                 >
                   <div className="flex items-center justify-between gap-3 text-xs font-medium text-primary-100">
-                    <span>Uploading CSV to private Blob</span>
+                    <span>Uploading {uploadFormat} to private Blob</span>
                     <span>{submit.percentage}%</span>
                   </div>
                   <div
                     className="mt-3 h-2 overflow-hidden rounded-full bg-surface-900"
                     role="progressbar"
-                    aria-label="CSV upload progress"
+                    aria-label={`${uploadFormat} upload progress`}
                     aria-valuemin={0}
                     aria-valuemax={100}
                     aria-valuenow={submit.percentage}
@@ -524,7 +597,7 @@ export default function FaqDeflectionUpload() {
               ) : submit.status === "uploading" ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  Uploading CSV
+                  Uploading {uploadFormat}
                 </>
               ) : submit.status === "submitting" ? (
                 <>
@@ -545,7 +618,8 @@ export default function FaqDeflectionUpload() {
             </button>
             {submit.status === "error" && (
               <p className="mt-3 text-xs leading-5 text-amber-200" data-atlas-deflection-retry>
-                {submit.message} Retry keeps the selected CSV and starts a new private upload.
+                {submit.message} Retry keeps the selected {uploadFormat} and starts a new
+                private upload.
               </p>
             )}
           </form>
@@ -573,9 +647,9 @@ export default function FaqDeflectionUpload() {
               </div>
             </dl>
             <p className="mt-5 text-sm leading-6 text-surface-200/70">
-              ATLAS checks the CSV first, stores it privately after validation,
-              then sends the browser to the locked result page for snapshot
-              hydration and Checkout.
+              {isFullThreadUpload
+                ? "ATLAS reads the private Zendesk JSON server-side, imports public thread evidence, then sends the browser to the locked result page for snapshot hydration and Checkout."
+                : "ATLAS checks the CSV first, stores it privately after validation, then sends the browser to the locked result page for snapshot hydration and Checkout."}
             </p>
           </aside>
         </div>

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -847,7 +847,42 @@ async def test_deflection_submit_rejects_multipart_without_csv_file() -> None:
 
 
 @pytest.mark.asyncio
-async def test_deflection_submit_rejects_full_thread_multipart_upload() -> None:
+async def test_deflection_submit_accepts_full_thread_multipart_json_upload() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    artifact_data = ZENDESK_THREAD_SAMPLE.read_bytes()
+    request = _FormRequest({
+        "json_file": _Upload(artifact_data, filename="zendesk-thread.json"),
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+        "importer_mode": "full_thread",
+    })
+
+    payload = await submit.endpoint(request)
+
+    assert request.form_kwargs == {"max_part_size": api_module._MAX_DEFLECTION_SUBMIT_BLOB_BYTES}
+    assert payload["status"] == "completed"
+    metadata = payload["input_provider"]["metadata"]
+    assert metadata["source_row_count"] == 4
+    assert metadata["submitted_row_count"] == 4
+    assert metadata["included_row_count"] == 4
+    assert metadata["uploaded_bytes"] == len(artifact_data)
+    assert metadata["importer_mode"] == "full_thread"
+    assert metadata["support_platform"] == "zendesk"
+    assert metadata["support_ticket_resolution_evidence_present"] is True
+    assert metadata["support_ticket_resolution_evidence_count"] == 2
+    assert metadata["ticket_status_present"] is True
+    assert metadata["ticket_status_summary"] == {"resolved": 1, "open": 3}
+    assert metadata["csat_present"] is True
+    assert metadata["csat_present_count"] == 1
+    assert metadata["csat_score_count"] == 0
+    assert metadata["csat_score_average"] is None
+    assert payload["input_provider"]["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_full_thread_multipart_csv_file() -> None:
     router = _router(InMemoryDeflectionReportArtifactStore())
     submit = _route(router, "/ops/deflection-reports/submit", "POST")
 
@@ -862,8 +897,42 @@ async def test_deflection_submit_rejects_full_thread_multipart_upload() -> None:
 
     assert exc.value.status_code == 422
     assert exc.value.detail == (
-        "importer_mode=full_thread requires JSON blob_url submit"
+        "csv_file is not accepted with importer_mode=full_thread"
     )
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_full_thread_without_json_file() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(_FormRequest({
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+            "importer_mode": "full_thread",
+        }))
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "json_file is required"
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_json_file_without_full_thread_mode() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(_FormRequest({
+            "json_file": _Upload(ZENDESK_THREAD_SAMPLE.read_bytes(), filename="zendesk.json"),
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        }))
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "json_file requires importer_mode=full_thread"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -879,6 +879,8 @@ async def test_deflection_submit_accepts_full_thread_multipart_json_upload() -> 
     assert metadata["csat_score_count"] == 0
     assert metadata["csat_score_average"] is None
     assert payload["input_provider"]["warnings"] == []
+    assert "Internal note" not in json.dumps(payload)
+    assert "A member of the support team will get back to you" not in json.dumps(payload)
 
 
 @pytest.mark.asyncio
@@ -933,6 +935,48 @@ async def test_deflection_submit_rejects_json_file_without_full_thread_mode() ->
 
     assert exc.value.status_code == 422
     assert exc.value.detail == "json_file requires importer_mode=full_thread"
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_oversize_uploaded_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api_module, "_MAX_DEFLECTION_SUBMIT_BLOB_BYTES", 10)
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(_FormRequest({
+            "json_file": _Upload(b"01234567890", filename="zendesk-thread.json"),
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+            "importer_mode": "full_thread",
+        }))
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == {
+        "reason": "deflection_submit_full_thread_too_large",
+        "max_file_bytes": 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_empty_uploaded_json() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(_FormRequest({
+            "json_file": _Upload(b"", filename="zendesk-thread.json"),
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+            "importer_mode": "full_thread",
+        }))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Uploaded Zendesk full-thread JSON is empty."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Zendesk-Upload-Handoff.md
Slice phase: Vertical slice

Adds the portfolio handoff for Zendesk full-thread JSON exports: the upload page can choose CSV or Zendesk JSON, private Blob upload now allows `.json`, the portfolio submit proxy reads private JSON server-side and forwards authenticated multipart `json_file` with `importer_mode="full_thread"`, and ATLAS accepts multipart JSON only for that full-thread mode. CSV remains the default path with CSV inspect before private upload.

## Intentional
- No direct Zendesk API fetch in this slice; this is still the uploaded-export handoff.
- Full-thread JSON skips CSV inspect because the existing inspect route is flat CSV preflight; ATLAS validates the full-thread JSON during submit parsing.
- The portfolio does not pass private Blob URLs to ATLAS. The proxy reads private Blob bytes server-side and forwards authenticated multipart to avoid exposing Blob access.
- The portfolio proxy pins full-thread `support_platform` metadata to `zendesk` server-side because those bytes are always parsed as Zendesk thread exports.

## Deferred
- Direct Zendesk API export/import using tenant-scoped credentials.
- A dedicated JSON preflight diagnostics route if preview counts are needed before private upload.
- Live browser smoke against the operator's real Zendesk trial export.

## Parked hardening
- None.

## AI reconciliation
- No automated-review findings yet.
- Human reviewer MAJOR/NITs addressed: JSON oversize test, JSON empty-body test, forwarded `limit` assertions, server-side full-thread Zendesk platform pin, and multipart private-note redaction assertion.

## Verification
- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` — 53 passed.
- `cd portfolio-ui && npm run test:deflection-upload-shell` — 27 passed.
- `cd portfolio-ui && npm run test:deflection-atlas-proxy` — 18 passed.
- `cd portfolio-ui && npm run build` — passed after `npm ci` installed this worktree's local dependencies; Vite emitted the existing large-chunk and sitemap-env warnings.
- `bash scripts/run_extracted_pipeline_checks.sh` — 4022 passed, 10 skipped, 1 existing torch CUDA warning.
- Review-fix focused check: `python -m pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_full_thread_multipart_json_upload tests/test_extracted_content_deflection_submit.py::test_deflection_submit_rejects_oversize_uploaded_json tests/test_extracted_content_deflection_submit.py::test_deflection_submit_rejects_empty_uploaded_json -q` — 3 passed.

## Diff size
7 files, +720 / -81.
