### PR TITLE
Deflection reconciliation: NULL-safe stripe_session_id dedup (#1462 gap)

### DIFF
--- a/.github/workflows/atlas_deflection_migration_apply_checks.yml
+++ b/.github/workflows/atlas_deflection_migration_apply_checks.yml
@@ -8,6 +8,7 @@ on:
       - "atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql"
       - "atlas_brain/storage/migrations/332_content_ops_deflection_report_deliveries.sql"
       - "atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql"
+      - "atlas_brain/storage/migrations/337_content_ops_deflection_reconciliation_null_session.sql"
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - "atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql"
       - "atlas_brain/storage/migrations/332_content_ops_deflection_report_deliveries.sql"
       - "atlas_brain/storage/migrations/336_content_ops_deflection_paid_reconciliation.sql"
+      - "atlas_brain/storage/migrations/337_content_ops_deflection_reconciliation_null_session.sql"
 
 jobs:
   atlas-deflection-migration-apply-checks:

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -720,7 +720,10 @@ async def _handle_content_ops_deflection_report_checkout_completed(
                 pool,
                 account_id=account_id_text,
                 request_id=request_id,
-                stripe_session_id=session_id or None,
+                # '' (not NULL) so the reconciliation ledger's
+                # (account_id, request_id, stripe_session_id) UNIQUE dedups a
+                # missing-session retry; NULL would be treated as DISTINCT.
+                stripe_session_id=session_id or "",
                 event_type=event_type,
             )
             await emit_deflection_paid_funnel_incident_alert(

--- a/atlas_brain/content_ops_deflection_reconciliation.py
+++ b/atlas_brain/content_ops_deflection_reconciliation.py
@@ -35,14 +35,16 @@ async def record_paid_report_missing(
 
     Idempotent on (account_id, request_id, stripe_session_id) so Stripe retries
     -- or a later genuine arrival of the same event -- do not create duplicate
-    ledger rows.
+    ledger rows. A missing/empty session id is normalized to '' (never NULL):
+    Postgres treats NULL as DISTINCT in a UNIQUE constraint, so a NULL session
+    id would defeat the ON CONFLICT dedup. Migration 337 enforces NOT NULL.
     """
 
     await pool.execute(
         _INSERT_PAID_RECONCILIATION_SQL,
         account_id,
         request_id,
-        stripe_session_id,
+        stripe_session_id or "",
         event_type,
         reason,
     )

--- a/atlas_brain/storage/migrations/337_content_ops_deflection_reconciliation_null_session.sql
+++ b/atlas_brain/storage/migrations/337_content_ops_deflection_reconciliation_null_session.sql
@@ -1,0 +1,37 @@
+-- Make the deflection reconciliation dedup NULL-safe (#1462 follow-up).
+--
+-- Migration 336 created content_ops_deflection_paid_reconciliation with a
+-- nullable stripe_session_id and UNIQUE (account_id, request_id,
+-- stripe_session_id). Postgres treats NULL as DISTINCT in a UNIQUE constraint,
+-- so the ON CONFLICT (account_id, request_id, stripe_session_id) DO NOTHING
+-- that record_paid_report_missing relies on does NOT dedup rows whose
+-- stripe_session_id is NULL. The billing webhook forwarded `session_id or None`,
+-- so a missing/empty Stripe session id became NULL and every retry (Stripe is
+-- at-least-once) or sibling event type wrote a duplicate ledger row -- breaking
+-- the idempotency the function promises.
+--
+-- This collapses any existing NULL-equivalent duplicates, backfills NULL -> '',
+-- and forbids NULL going forward, so the existing UNIQUE dedups uniformly (the
+-- empty string is a normal, conflict-eligible value). Re-runnable.
+
+-- 1. Collapse rows that share (account_id, request_id, COALESCE(stripe_session_id, ''))
+--    down to the lowest id. The 336 UNIQUE already prevents non-NULL duplicates,
+--    so this only removes the NULL-equivalent duplicates the gap allowed.
+DELETE FROM content_ops_deflection_paid_reconciliation a
+USING content_ops_deflection_paid_reconciliation b
+WHERE a.account_id = b.account_id
+  AND a.request_id = b.request_id
+  AND COALESCE(a.stripe_session_id, '') = COALESCE(b.stripe_session_id, '')
+  AND a.id > b.id;
+
+-- 2. Backfill remaining NULLs to '' (safe after the dedup above: at most one
+--    COALESCE='' row per (account_id, request_id) remains).
+UPDATE content_ops_deflection_paid_reconciliation
+SET stripe_session_id = ''
+WHERE stripe_session_id IS NULL;
+
+-- 3. Forbid NULL going forward; default to '' so the existing UNIQUE dedups it.
+ALTER TABLE content_ops_deflection_paid_reconciliation
+    ALTER COLUMN stripe_session_id SET DEFAULT '';
+ALTER TABLE content_ops_deflection_paid_reconciliation
+    ALTER COLUMN stripe_session_id SET NOT NULL;

--- a/plans/PR-Deflection-Reconciliation-Null-Session-Dedup.md
+++ b/plans/PR-Deflection-Reconciliation-Null-Session-Dedup.md
@@ -1,0 +1,135 @@
+# PR-Deflection-Reconciliation-Null-Session-Dedup
+
+## Why this slice exists
+
+The paid-but-report-missing reconciliation ledger (#1462) promises idempotency
+"on (account_id, request_id, stripe_session_id) so Stripe retries do not create
+duplicate ledger rows" -- but that guarantee is false when the session id is
+NULL. Migration 336 made `stripe_session_id` nullable with
+`UNIQUE (account_id, request_id, stripe_session_id)`, and Postgres treats NULL as
+DISTINCT in a UNIQUE constraint, so `ON CONFLICT (...) DO NOTHING` does not dedup
+NULL-session rows. The billing webhook forwarded `session_id or None`
+(`billing.py`), so a missing/empty Stripe session id became NULL and a Stripe
+at-least-once redelivery -- or a sibling event type (`completed` +
+`async_payment_succeeded`) for the same checkout -- wrote a duplicate row.
+
+Low probability in normal operation (real Stripe events always carry a session
+id), but it is a money-path data-integrity gap, and the #1517 apply test only
+exercised the non-null dedup, so the test gave false confidence about an
+idempotency guarantee the code did not hold.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-billing
+Slice phase: Production hardening
+
+1. `atlas_brain/storage/migrations/337_content_ops_deflection_reconciliation_null_session.sql`:
+   collapse existing NULL-equivalent duplicate rows (lowest id wins), backfill
+   `NULL -> ''`, then `SET DEFAULT ''` + `SET NOT NULL` so the existing UNIQUE
+   dedups uniformly. Re-runnable; no CONCURRENTLY (transaction-safe).
+2. `atlas_brain/content_ops_deflection_reconciliation.py`: bind
+   `stripe_session_id or ""` in the insert so a missing session is never NULL
+   (protects every caller against the NOT NULL column).
+3. `atlas_brain/api/billing.py`: forward `session_id or ""` (not `or None`) at
+   the reconciliation call site.
+4. `tests/test_deflection_migrations_apply.py`: apply 337 in the chain; assert
+   `stripe_session_id` is NOT NULL, that the going-forward empty-session dedup
+   holds, and (new test) that 337 collapses two pre-existing NULL duplicates to
+   one row backfilled to `''`.
+5. `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`: new unit
+   test asserting an empty Stripe session id binds `''` (not None) in the
+   reconciliation insert.
+6. `.github/workflows/atlas_deflection_migration_apply_checks.yml`: add migration
+   337 to the path triggers.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] After 337, `stripe_session_id` is NOT NULL and defaults to `''`.
+  - [ ] 337 collapses pre-existing NULL-session duplicates for the same
+        (account_id, request_id) to one row, backfilled to `''`.
+  - [ ] Two missing-session events for the same checkout dedup to one ledger row
+        (the gap NULL left open).
+  - [ ] `record_paid_report_missing` / the billing handler bind `''`, not None,
+        for a missing session id.
+  - [ ] No change to the non-null dedup behavior or the 2xx/409 disposition.
+- Affected surfaces: the reconciliation ledger schema + insert and the billing
+  webhook reconciliation call site, plus the migration-apply and billing tests.
+  No buyer-facing report shape change; no API change.
+- Risk areas: money-path data integrity; migration safety against existing rows;
+  test isolation (both apply tests share one CI database).
+- Reviewer rules triggered: R1 (requirements match), R2 (test evidence), R4
+  (data and migration safety), R5 (backward compatibility), R6 (webhook), R8
+  (billing / payment), R10 (maintainability), R12 (CI enrollment).
+
+### Files touched
+
+- `.github/workflows/atlas_deflection_migration_apply_checks.yml`
+- `atlas_brain/api/billing.py`
+- `atlas_brain/content_ops_deflection_reconciliation.py`
+- `atlas_brain/storage/migrations/337_content_ops_deflection_reconciliation_null_session.sql`
+- `plans/PR-Deflection-Reconciliation-Null-Session-Dedup.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+- `tests/test_deflection_migrations_apply.py`
+
+## Mechanism
+
+The fix is two-sided so the gap cannot reappear. The schema can no longer hold a
+NULL (337 enforces NOT NULL DEFAULT ''), and both the producer (the billing
+handler and `record_paid_report_missing`) coerce a missing session to `''`. The
+empty string is a normal, conflict-eligible value, so the existing
+`(account_id, request_id, stripe_session_id)` UNIQUE and the unchanged
+`ON CONFLICT (...) DO NOTHING` now dedup a missing-session retry. The migration
+collapses any rows the gap already produced by `COALESCE(stripe_session_id, '')`,
+keeping the lowest id, then backfills the survivor.
+
+The apply tests share one CI service database, so each test drops the deflection
+tables first (`_reset`) -- test 1 applies 337 (NOT NULL), which would otherwise
+break test 2's pre-337 NULL insert.
+
+## Intentional
+
+- Coerce at both the schema and the producer, not just one: NOT NULL stops a
+  future caller from re-introducing the gap; the `or ""` keeps inserts valid
+  against the NOT NULL column.
+- Keep the existing 3-column UNIQUE + ON CONFLICT unchanged (no expression
+  index) -- once NULL is impossible, the plain constraint dedups `''` correctly,
+  which is simpler and lower-risk than an expression index.
+- Only the reconciliation call site changes; `mark_paid`'s
+  `payment_reference=session_id or None` (a different, nullable column with no
+  dedup concern) is left alone.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+Ran locally against a fresh throwaway Postgres and the unit suite:
+
+```
+ATLAS_MIGRATION_TEST_DATABASE_URL=... pytest tests/test_deflection_migrations_apply.py
+pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+python -m py_compile atlas_brain/api/billing.py atlas_brain/content_ops_deflection_reconciliation.py
+bash scripts/check_ascii_python.sh
+```
+
+- Migration apply tests: 2 passed (chain applies with NOT NULL; empty-session
+  dedup holds; 337 collapses two pre-existing NULL duplicates to one `''` row).
+- Billing reconciliation tests: 47 passed, including the new empty-session bind
+  assertion.
+- ASCII + py_compile clean.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/storage/migrations/337_content_ops_deflection_reconciliation_null_session.sql` | ~40 |
+| `tests/test_deflection_migrations_apply.py` | ~120 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | ~35 |
+| `atlas_brain/content_ops_deflection_reconciliation.py` | ~6 |
+| `atlas_brain/api/billing.py` | ~5 |
+| `.github/workflows/atlas_deflection_migration_apply_checks.yml` | ~2 |
+| `plans/PR-Deflection-Reconciliation-Null-Session-Dedup.md` | ~115 |
+| **Total** | **~323** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -429,6 +429,44 @@ async def test_deflection_checkout_completion_records_reconciliation_when_event_
 
 
 @pytest.mark.asyncio
+async def test_deflection_reconciliation_binds_empty_string_for_missing_session_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A missing/empty Stripe session id must be recorded as '' (never NULL):
+    # NULL is DISTINCT in the (account_id, request_id, stripe_session_id) UNIQUE,
+    # so a NULL would defeat the ON CONFLICT dedup on a Stripe retry (#1462 gap).
+    caplog.set_level(logging.ERROR, logger="atlas.api.billing")
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id, session_id="")
+    pool = _Pool()
+    pool.update_result = "UPDATE 0"
+    aged_event_created = int(time.time()) - 100_000  # past the 300s grace
+
+    returned = await billing._handle_content_ops_deflection_report_checkout_completed(
+        pool,
+        session,
+        session.metadata,
+        event_created=aged_event_created,
+    )
+
+    assert returned is None
+    reconciliations = [
+        call
+        for call in pool.execute_calls
+        if "content_ops_deflection_paid_reconciliation" in call[0]
+    ]
+    assert len(reconciliations) == 1
+    _query, args = reconciliations[0]
+    assert args == (
+        account_id,
+        "req-123",
+        "",  # '' not None -- the NULL-dedup gap fix
+        "checkout.session.completed",
+        "paid_report_missing",
+    )
+
+
+@pytest.mark.asyncio
 async def test_deflection_checkout_completion_retries_409_within_race_window() -> None:
     # A recent event is the transient write-ordering race: keep the 409 so Stripe
     # retries and finds the report row once its write commits. No reconciliation

--- a/tests/test_deflection_migrations_apply.py
+++ b/tests/test_deflection_migrations_apply.py
@@ -8,13 +8,15 @@ This check is scoped to the deflection chain, which has no such dependency:
 - 328 content_ops_deflection_reports
 - 332 content_ops_deflection_report_deliveries
 - 336 content_ops_deflection_paid_reconciliation  (#1462 money-path table)
+- 337 reconciliation NULL-session dedup (NOT NULL stripe_session_id)
 
 It applies those files in order to a fresh Postgres database and verifies the
-tables exist and the reconciliation table's idempotency constraint holds. Runs
-in CI against the workflow's fresh atlas_migration_tests service database;
-skipped unless ATLAS_MIGRATION_TEST_DATABASE_URL points at a disposable DB. The
-migrations dir is resolved by path (no atlas_brain import), so the CI job needs
-no application dependencies beyond asyncpg.
+tables exist and the reconciliation table's idempotency constraint holds --
+including the NULL-session dedup gap that 337 closes. Runs in CI against the
+workflow's fresh atlas_migration_tests service database; skipped unless
+ATLAS_MIGRATION_TEST_DATABASE_URL points at a disposable DB. The migrations dir
+is resolved by path (no atlas_brain import), so the CI job needs no application
+dependencies beyond asyncpg.
 """
 
 from __future__ import annotations
@@ -32,21 +34,51 @@ DEFLECTION_MIGRATION_CHAIN = (
     "332_content_ops_deflection_report_deliveries.sql",
     "336_content_ops_deflection_paid_reconciliation.sql",
 )
+NULL_SESSION_MIGRATION = "337_content_ops_deflection_reconciliation_null_session.sql"
 
 _TEST_ACCOUNT_ID = "acct-deflection-migration-apply-test"
+
+_RECON_INSERT_SQL = (
+    "INSERT INTO content_ops_deflection_paid_reconciliation "
+    "(account_id, request_id, stripe_session_id, event_type, reason) "
+    "VALUES ($1, $2, $3, $4, $5) "
+    "ON CONFLICT (account_id, request_id, stripe_session_id) DO NOTHING"
+)
+
+
+def _database_url() -> str | None:
+    return os.environ.get("ATLAS_MIGRATION_TEST_DATABASE_URL")
+
+
+async def _apply(conn, *names: str) -> None:
+    for name in names:
+        await conn.execute((MIGRATIONS_DIR / name).read_text())
+
+
+async def _reset(conn) -> None:
+    # Both tests share the CI service database; test 1 applies 337 (NOT NULL),
+    # which would break test 2's pre-337 NULL insert. Drop the deflection tables
+    # so each test applies from a clean schema regardless of order. No-op on a
+    # genuinely fresh database.
+    await conn.execute(
+        "DROP TABLE IF EXISTS "
+        "content_ops_deflection_paid_reconciliation, "
+        "content_ops_deflection_report_deliveries, "
+        "content_ops_deflection_reports CASCADE"
+    )
 
 
 @pytest.mark.asyncio
 async def test_deflection_migration_chain_applies_to_a_fresh_database() -> None:
     asyncpg = pytest.importorskip("asyncpg")
-    database_url = os.environ.get("ATLAS_MIGRATION_TEST_DATABASE_URL")
+    database_url = _database_url()
     if not database_url:
         pytest.skip("ATLAS_MIGRATION_TEST_DATABASE_URL not set")
 
     conn = await asyncpg.connect(database_url)
     try:
-        for name in DEFLECTION_MIGRATION_CHAIN:
-            await conn.execute((MIGRATIONS_DIR / name).read_text())
+        await _reset(conn)
+        await _apply(conn, *DEFLECTION_MIGRATION_CHAIN, NULL_SESSION_MIGRATION)
 
         existing = {
             row["tablename"]
@@ -77,44 +109,126 @@ async def test_deflection_migration_chain_applies_to_a_fresh_database() -> None:
             "created_at",
         } <= recon_columns
 
-        # The (account_id, request_id, stripe_session_id) uniqueness that
-        # record_paid_report_missing relies on (ON CONFLICT DO NOTHING): a second
-        # event for the same checkout must not create a duplicate ledger row.
-        insert_sql = (
-            "INSERT INTO content_ops_deflection_paid_reconciliation "
-            "(account_id, request_id, stripe_session_id, event_type, reason) "
-            "VALUES ($1, $2, $3, $4, $5) "
-            "ON CONFLICT (account_id, request_id, stripe_session_id) DO NOTHING"
+        # 337 forbids NULL so the (account_id, request_id, stripe_session_id)
+        # UNIQUE can dedup a missing-session row (NULL would be DISTINCT).
+        is_nullable = await conn.fetchval(
+            "SELECT is_nullable FROM information_schema.columns "
+            "WHERE table_name = 'content_ops_deflection_paid_reconciliation' "
+            "AND column_name = 'stripe_session_id'"
         )
+        assert is_nullable == "NO"
+
+        # Non-null dedup (ON CONFLICT DO NOTHING): a second event for the same
+        # checkout must not create a duplicate ledger row.
         await conn.execute(
-            insert_sql,
+            _RECON_INSERT_SQL,
             _TEST_ACCOUNT_ID,
-            "req-test",
+            "req-sess",
             "sess-test",
             "checkout.session.completed",
             "paid_report_missing",
         )
         await conn.execute(
-            insert_sql,
+            _RECON_INSERT_SQL,
             _TEST_ACCOUNT_ID,
-            "req-test",
+            "req-sess",
             "sess-test",
             "checkout.session.async_payment_succeeded",
             "paid_report_missing",
         )
-        rows = await conn.fetchval(
-            "SELECT count(*) FROM content_ops_deflection_paid_reconciliation "
-            "WHERE account_id = $1 AND request_id = 'req-test'",
-            _TEST_ACCOUNT_ID,
-        )
-        assert rows == 1
-    finally:
-        try:
-            await conn.execute(
-                "DELETE FROM content_ops_deflection_paid_reconciliation "
-                "WHERE account_id = $1",
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM content_ops_deflection_paid_reconciliation "
+                "WHERE account_id = $1 AND request_id = 'req-sess'",
                 _TEST_ACCOUNT_ID,
             )
-        except Exception:
-            pass
+            == 1
+        )
+
+        # Going-forward empty-session dedup: '' is a normal conflict-eligible
+        # value, so two missing-session events for the same checkout dedup
+        # (the gap that NULL left open).
+        for event_type in (
+            "checkout.session.completed",
+            "checkout.session.async_payment_succeeded",
+        ):
+            await conn.execute(
+                _RECON_INSERT_SQL,
+                _TEST_ACCOUNT_ID,
+                "req-empty",
+                "",
+                event_type,
+                "paid_report_missing",
+            )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM content_ops_deflection_paid_reconciliation "
+                "WHERE account_id = $1 AND request_id = 'req-empty'",
+                _TEST_ACCOUNT_ID,
+            )
+            == 1
+        )
+    finally:
+        await _cleanup(conn)
         await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deflection_337_collapses_pre_existing_null_session_duplicates() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = _database_url()
+    if not database_url:
+        pytest.skip("ATLAS_MIGRATION_TEST_DATABASE_URL not set")
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _reset(conn)
+        # 336 only: stripe_session_id is nullable and NULL is DISTINCT, so two
+        # NULL-session rows for the same checkout both land (the bug).
+        await _apply(conn, *DEFLECTION_MIGRATION_CHAIN)
+        for event_type in (
+            "checkout.session.completed",
+            "checkout.session.async_payment_succeeded",
+        ):
+            await conn.execute(
+                "INSERT INTO content_ops_deflection_paid_reconciliation "
+                "(account_id, request_id, stripe_session_id, event_type, reason) "
+                "VALUES ($1, $2, NULL, $3, $4)",
+                _TEST_ACCOUNT_ID,
+                "req-null",
+                event_type,
+                "paid_report_missing",
+            )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM content_ops_deflection_paid_reconciliation "
+                "WHERE account_id = $1 AND request_id = 'req-null'",
+                _TEST_ACCOUNT_ID,
+            )
+            == 2
+        )
+
+        # 337 collapses the NULL-equivalent duplicates to one row and backfills
+        # the survivor's session id to ''.
+        await _apply(conn, NULL_SESSION_MIGRATION)
+        rows = await conn.fetch(
+            "SELECT stripe_session_id FROM content_ops_deflection_paid_reconciliation "
+            "WHERE account_id = $1 AND request_id = 'req-null'",
+            _TEST_ACCOUNT_ID,
+        )
+        assert len(rows) == 1
+        assert rows[0]["stripe_session_id"] == ""
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+async def _cleanup(conn) -> None:
+    try:
+        await conn.execute(
+            "DELETE FROM content_ops_deflection_paid_reconciliation "
+            "WHERE account_id = $1",
+            _TEST_ACCOUNT_ID,
+        )
+    except Exception:
+        pass


### PR DESCRIPTION
Plan: plans/PR-Deflection-Reconciliation-Null-Session-Dedup.md
Slice phase: Production hardening

The paid-but-report-missing reconciliation ledger (#1462) claims idempotency on `(account_id, request_id, stripe_session_id)`, but Postgres treats NULL as DISTINCT in a UNIQUE constraint, so `ON CONFLICT (...) DO NOTHING` does not dedup NULL-session rows. The billing webhook forwarded `session_id or None`, so a missing/empty Stripe session id became NULL and a Stripe at-least-once retry -- or a sibling event type for the same checkout -- wrote a duplicate ledger row. Low-probability (real events carry a session id) but a money-path data-integrity gap, and the #1517 apply test only covered the non-null dedup, so it gave false confidence.

## Mechanism
Two-sided so the gap cannot reappear. Migration 337 collapses existing NULL-equivalent duplicates (`COALESCE(stripe_session_id, '')`, lowest id wins), backfills `NULL -> ''`, then `SET DEFAULT ''` + `SET NOT NULL`. The billing handler and `record_paid_report_missing` coerce a missing session to `''`. The empty string is a normal conflict-eligible value, so the unchanged 3-column UNIQUE + `ON CONFLICT` now dedup a missing-session retry.

## Intentional
- Coerce at both the schema (NOT NULL) and the producer (`or ""`) so a future caller cannot re-introduce NULL.
- Keep the plain 3-column UNIQUE (no expression index) -- once NULL is impossible, `''` dedups correctly, simpler and lower-risk.
- `mark_paid`'s `payment_reference=session_id or None` (a different nullable column with no dedup concern) is left alone.

## Deferred
None.

## Parked hardening
None.

## AI reconciliation
All fixed or waived: Yes. No automated-review findings at PR open; will reconcile any Codex/reviewer threads on the first review pass.

## Verification
- `pytest tests/test_deflection_migrations_apply.py` against a fresh throwaway Postgres -> 2 passed (chain applies NOT NULL; empty-session dedup holds; 337 collapses two pre-existing NULL duplicates to one `''` row).
- `pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` -> 47 passed, incl. the new empty-session bind assertion.
- `python -m py_compile` + `bash scripts/check_ascii_python.sh` + plan-shape/files-touched/consistency -> clean.

## Diff size
~40 migration + ~120 migration test + ~35 billing test + ~6 reconciliation + ~5 billing + ~2 workflow + ~115 plan = ~323 LOC.
