### PR TITLE
Deflection Zendesk tenant export route

### DIFF
--- a/.github/workflows/atlas_content_ops_generated_assets_checks.yml
+++ b/.github/workflows/atlas_content_ops_generated_assets_checks.yml
@@ -7,12 +7,15 @@ on:
       - "atlas_brain/_content_ops_brand_voice_profiles.py"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/api/content_ops_brand_voice_profiles.py"
+      - "atlas_brain/api/content_ops_zendesk_export.py"
       - "atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql"
       - "extracted_content_pipeline/api/control_surfaces.py"
       - "extracted_content_pipeline/api/generated_assets.py"
       - "tests/test_atlas_content_ops_generated_assets_api.py"
       - "tests/test_content_ops_brand_voice_profiles.py"
       - "tests/test_content_ops_brand_voice_profiles_api.py"
+      - "tests/test_content_ops_zendesk_credentials.py"
+      - "tests/test_content_ops_zendesk_export_api.py"
   push:
     branches:
       - main
@@ -21,12 +24,15 @@ on:
       - "atlas_brain/_content_ops_brand_voice_profiles.py"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/api/content_ops_brand_voice_profiles.py"
+      - "atlas_brain/api/content_ops_zendesk_export.py"
       - "atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql"
       - "extracted_content_pipeline/api/control_surfaces.py"
       - "extracted_content_pipeline/api/generated_assets.py"
       - "tests/test_atlas_content_ops_generated_assets_api.py"
       - "tests/test_content_ops_brand_voice_profiles.py"
       - "tests/test_content_ops_brand_voice_profiles_api.py"
+      - "tests/test_content_ops_zendesk_credentials.py"
+      - "tests/test_content_ops_zendesk_export_api.py"
 
 jobs:
   atlas-content-ops-generated-assets-checks:
@@ -53,4 +59,6 @@ jobs:
             tests/test_atlas_content_ops_generated_assets_api.py \
             tests/test_content_ops_brand_voice_profiles.py \
             tests/test_content_ops_brand_voice_profiles_api.py \
+            tests/test_content_ops_zendesk_credentials.py \
+            tests/test_content_ops_zendesk_export_api.py \
             -q

--- a/atlas_brain/_content_ops_zendesk_credentials.py
+++ b/atlas_brain/_content_ops_zendesk_credentials.py
@@ -33,6 +33,10 @@ class ContentOpsZendeskCredentialRecord:
     revoked_at: Optional[datetime]
 
 
+class ZendeskCredentialLookupError(RuntimeError):
+    """Stored Zendesk credentials could not be read or decrypted."""
+
+
 async def upsert_zendesk_credentials(
     pool,
     *,
@@ -158,7 +162,7 @@ async def lookup_zendesk_credentials(
         )
     except Exception:
         logger.exception("zendesk credential lookup failed account_id=%s", account_uuid)
-        return None
+        raise ZendeskCredentialLookupError("zendesk_credentials_unavailable")
     if row is None:
         return None
     token = decrypt_secret(bytes(row["encrypted_api_token"]), str(row["encryption_kid"]))
@@ -168,7 +172,7 @@ async def lookup_zendesk_credentials(
             account_uuid,
             row["id"],
         )
-        return None
+        raise ZendeskCredentialLookupError("zendesk_credentials_unavailable")
     credentials = ZendeskMacroCredentials(
         email=str(row["email"] or "").strip(),
         api_token=token,
@@ -181,7 +185,7 @@ async def lookup_zendesk_credentials(
             account_uuid,
             row["id"],
         )
-        return None
+        raise ZendeskCredentialLookupError("zendesk_credentials_unavailable")
     await _touch_credentials(pool, credential_id=row["id"])
     return credentials
 
@@ -255,6 +259,7 @@ async def _touch_credentials(pool, *, credential_id: _uuid.UUID) -> None:
 __all__ = [
     "ContentOpsZendeskCredentialRecord",
     "TOKEN_PREFIX_LEN",
+    "ZendeskCredentialLookupError",
     "list_zendesk_credentials",
     "lookup_zendesk_credentials",
     "revoke_zendesk_credentials",

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -190,6 +190,9 @@ try:
     from .content_ops_zendesk_credentials import (
         create_content_ops_zendesk_credentials_router,
     )
+    from .content_ops_zendesk_export import (
+        create_content_ops_zendesk_export_router,
+    )
     from .content_ops_brand_voice_profiles import (
         create_content_ops_brand_voice_profiles_router,
     )
@@ -312,6 +315,11 @@ try:
         auth_dependency=_capture_content_ops_auth_user,
     )
     router.include_router(zendesk_credentials_router)
+    zendesk_export_router = create_content_ops_zendesk_export_router(
+        pool_provider=get_db_pool,
+        auth_dependency=_capture_content_ops_auth_user,
+    )
+    router.include_router(zendesk_export_router)
     brand_voice_profiles_router = create_content_ops_brand_voice_profiles_router(
         pool_provider=get_db_pool,
         auth_dependency=_capture_content_ops_auth_user,

--- a/atlas_brain/api/content_ops_zendesk_export.py
+++ b/atlas_brain/api/content_ops_zendesk_export.py
@@ -1,0 +1,201 @@
+"""Tenant-scoped Zendesk full-thread export routes for Content Ops."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+import logging
+import uuid as _uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+import httpx
+from pydantic import BaseModel, Field
+
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZendeskMacroCredentials,
+)
+from extracted_content_pipeline.support_ticket_zendesk_export import (
+    DEFAULT_ZENDESK_EXPORT_LIMIT,
+    MAX_ZENDESK_EXPORT_LIMIT,
+    ZendeskTicketExportError,
+    export_zendesk_full_thread_artifact,
+)
+
+from .._content_ops_zendesk_credentials import lookup_zendesk_credentials
+from ..auth.dependencies import AuthUser
+
+
+logger = logging.getLogger("atlas.content_ops_zendesk_export")
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+AuthDependency = Callable[..., AuthUser | Awaitable[AuthUser]]
+CredentialLookup = Callable[..., ZendeskMacroCredentials | None | Awaitable[ZendeskMacroCredentials | None]]
+ZendeskExporter = Callable[..., Mapping[str, Any] | Awaitable[Mapping[str, Any]]]
+
+
+class ZendeskFullThreadExportRequest(BaseModel):
+    limit: int = Field(
+        default=DEFAULT_ZENDESK_EXPORT_LIMIT,
+        ge=1,
+        le=MAX_ZENDESK_EXPORT_LIMIT,
+    )
+    start_time: int = Field(default=0, ge=0)
+
+
+class ZendeskFullThreadExportResponse(BaseModel):
+    importer_mode: str
+    support_platform: str
+    ticket_count: int
+    limit: int
+    start_time: int
+    artifact: dict[str, object]
+
+
+def _default_pool_provider() -> Any:
+    from ..storage.database import get_db_pool
+
+    return get_db_pool()
+
+
+def create_content_ops_zendesk_export_router(
+    *,
+    pool_provider: PoolProvider = _default_pool_provider,
+    auth_dependency: AuthDependency,
+    credential_lookup: CredentialLookup = lookup_zendesk_credentials,
+    exporter: ZendeskExporter = export_zendesk_full_thread_artifact,
+) -> APIRouter:
+    """Create tenant-scoped Zendesk full-thread export routes."""
+
+    router = APIRouter(
+        prefix="/content-ops/zendesk-export",
+        tags=["content-ops"],
+    )
+
+    @router.post("/full-thread", response_model=ZendeskFullThreadExportResponse)
+    async def export_full_thread(
+        body: ZendeskFullThreadExportRequest,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> ZendeskFullThreadExportResponse:
+        pool = await _resolve_ready_pool(pool_provider)
+        account_id = _account_uuid(user)
+        credentials = await _lookup_credentials(
+            credential_lookup,
+            pool,
+            account_id=account_id,
+        )
+        if credentials is None:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "reason": "zendesk_credentials_missing",
+                    "message": "Zendesk credentials are not configured for this tenant.",
+                },
+            )
+
+        try:
+            artifact = await _maybe_await(exporter(
+                credentials,
+                limit=body.limit,
+                start_time=body.start_time,
+            ))
+        except ZendeskTicketExportError as exc:
+            raise _export_error_to_http(exc) from exc
+        except httpx.RequestError as exc:
+            logger.warning(
+                "zendesk export transport failed account_id=%s",
+                account_id,
+                extra={"error_type": type(exc).__name__},
+            )
+            raise HTTPException(
+                status_code=502,
+                detail={"reason": "zendesk_export_unavailable"},
+            ) from exc
+
+        artifact_dict = _artifact_mapping(artifact)
+        return ZendeskFullThreadExportResponse(
+            importer_mode="full_thread",
+            support_platform="zendesk",
+            ticket_count=_ticket_count(artifact_dict),
+            limit=body.limit,
+            start_time=body.start_time,
+            artifact=dict(artifact_dict),
+        )
+
+    return router
+
+
+async def _resolve_ready_pool(pool_provider: PoolProvider) -> Any:
+    pool = pool_provider()
+    pool = await _maybe_await(pool)
+    if pool is None or getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(status_code=503, detail="Database not ready")
+    return pool
+
+
+def _account_uuid(user: AuthUser) -> _uuid.UUID:
+    try:
+        return _uuid.UUID(str(user.account_id))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid tenant scope")
+
+
+async def _lookup_credentials(
+    credential_lookup: CredentialLookup,
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+) -> ZendeskMacroCredentials | None:
+    try:
+        return await _maybe_await(credential_lookup(pool, account_id=account_id))
+    except Exception as exc:
+        logger.exception(
+            "zendesk export credential lookup failed account_id=%s",
+            account_id,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail={"reason": "zendesk_credentials_unavailable"},
+        ) from exc
+
+
+def _export_error_to_http(exc: ZendeskTicketExportError) -> HTTPException:
+    detail: dict[str, Any] = {"reason": exc.message}
+    if exc.status_code is not None:
+        detail["zendesk_status_code"] = exc.status_code
+    status_code = 404 if exc.message == "zendesk_credentials_missing" else 502
+    return HTTPException(status_code=status_code, detail=detail)
+
+
+def _artifact_mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise HTTPException(
+            status_code=502,
+            detail={"reason": "zendesk_export_artifact_invalid"},
+        )
+    tickets = value.get("tickets")
+    if not isinstance(tickets, Sequence) or isinstance(tickets, (str, bytes, bytearray)):
+        raise HTTPException(
+            status_code=502,
+            detail={"reason": "zendesk_export_artifact_invalid"},
+        )
+    return value
+
+
+def _ticket_count(artifact: Mapping[str, Any]) -> int:
+    tickets = artifact.get("tickets")
+    if isinstance(tickets, Sequence) and not isinstance(tickets, (str, bytes, bytearray)):
+        return len(tickets)
+    return 0
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+__all__ = [
+    "ZendeskFullThreadExportRequest",
+    "ZendeskFullThreadExportResponse",
+    "create_content_ops_zendesk_export_router",
+]

--- a/plans/PR-Deflection-Zendesk-Tenant-Export-Route.md
+++ b/plans/PR-Deflection-Zendesk-Tenant-Export-Route.md
@@ -1,0 +1,121 @@
+# PR-Deflection-Zendesk-Tenant-Export-Route
+
+## Why this slice exists
+
+#1526 added the pure Zendesk API exporter that produces the full-thread
+`{tickets: [...]}` artifact, and #1520 already lets `/deflection-reports/submit`
+ingest that artifact. The remaining gap is a hosted, tenant-scoped route that
+uses stored Zendesk credentials to produce the artifact without requiring the
+operator or browser to handle API tokens. This is the next thin vertical slice
+before wiring the portfolio UI to start from stored Zendesk credentials.
+This PR is over the 400 LOC soft cap because the hosted route, API registration,
+CI enrollment, review-fix error classification, and the non-happy-path route
+tests need to ship together to avoid a token-leaking or cross-tenant false-green
+export surface.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Add a Content Ops Zendesk export router that returns the full-thread artifact
+   for the authenticated tenant.
+2. Resolve credentials only through `content_ops_zendesk_credentials` tenant
+   storage. Missing tenant credentials fail closed with no config/global
+   fallback.
+3. Register the route with the existing Content Ops auth bridge and DB pool.
+4. Add focused API tests with a mocked exporter/transport; no live Zendesk call
+   in CI.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] The route requires the existing Content Ops auth dependency and uses the
+        authenticated account id for credential lookup.
+  - [ ] A tenant without stored Zendesk credentials gets a deterministic
+        `404`/missing-credentials response and the exporter is not called.
+  - [ ] Exporter failures are mapped to sanitized HTTP errors without exposing
+        tokens, headers, or raw Zendesk payloads.
+  - [ ] Request bounds (`limit`, `start_time`) are validated before any Zendesk
+        call.
+  - [ ] Tests mock the exporter boundary and assert request shape; CI does not
+        call live Zendesk.
+- Affected surfaces: host Content Ops Zendesk export API, API router
+  registration, route-focused tests.
+- Risk areas: cross-tenant data access, unscoped credential fallback, token
+  leakage, route registration drift, live network in CI.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_generated_assets_checks.yml`
+- `atlas_brain/_content_ops_zendesk_credentials.py`
+- `atlas_brain/api/__init__.py`
+- `atlas_brain/api/content_ops_zendesk_export.py`
+- `plans/PR-Deflection-Zendesk-Tenant-Export-Route.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+- `tests/test_content_ops_zendesk_credentials.py`
+- `tests/test_content_ops_zendesk_export_api.py`
+
+## Mechanism
+
+`create_content_ops_zendesk_export_router(...)` accepts a pool provider, auth
+dependency, credential lookup function, and exporter function. The production
+router resolves the authenticated account UUID, asks tenant credential storage
+for that account's active Zendesk credentials, and calls
+`export_zendesk_full_thread_artifact(credentials, limit=..., start_time=...)`.
+
+The response is the exporter artifact plus small display-safe metadata
+(`ticket_count`, `limit`, `start_time`, `importer_mode`). The route never
+returns credentials, authorization headers, or raw transport errors. It maps
+missing stored credentials to a deterministic HTTP response and maps
+`ZendeskTicketExportError` to sanitized HTTP errors by error code. Credential
+lookup/decrypt outages raise a typed lookup error so the route returns `503`
+instead of mislabeling the outage as missing credentials, and transient
+`httpx.RequestError` failures from the exporter return a sanitized `502`.
+
+## Intentional
+
+- No portfolio UI button in this PR. This slice proves the hosted API boundary;
+  the UI can wire to it next.
+- No live Zendesk call in tests. The exporter was already covered with a mocked
+  transport in #1526; this route test mocks the exporter function to prove
+  tenant scoping and HTTP behavior.
+- No config-backed Zendesk fallback. Hosted deflection export is always
+  tenant-scoped because it can pull real customer ticket data.
+
+## Deferred
+
+- Portfolio UI flow that starts the export from stored Zendesk credentials and
+  hands the returned artifact into the existing private Blob/full-thread submit
+  path.
+- Optional guarded live trial-account smoke against the route after deployment.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_zendesk_export_api.py tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_generated_assets_api.py -q`
+  -- 37 passed, 1 existing torch/pynvml warning.
+- `bash` `scripts/run_extracted_pipeline_checks.sh` -- 4062 passed, 10 skipped,
+  1 existing torch/pynvml warning.
+- `python` `scripts/audit_extracted_pipeline_ci_enrollment.py` -- OK, 176
+  matching tests enrolled.
+- `python` `scripts/audit_review_rules_triggered.py` --plan
+  `plans/PR-Deflection-Zendesk-Tenant-Export-Route.md` origin/main
+  -- OK, plan declares every triggered rule.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_generated_assets_checks.yml` | 8 |
+| `atlas_brain/_content_ops_zendesk_credentials.py` | 11 |
+| `atlas_brain/api/__init__.py` | 8 |
+| `atlas_brain/api/content_ops_zendesk_export.py` | 201 |
+| `plans/PR-Deflection-Zendesk-Tenant-Export-Route.md` | 121 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | 18 |
+| `tests/test_content_ops_zendesk_credentials.py` | 33 |
+| `tests/test_content_ops_zendesk_export_api.py` | 343 |
+| **Total** | **744** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -142,6 +142,7 @@ pytest \
   tests/test_content_ops_brand_voice_profiles_api.py \
   tests/test_content_ops_zendesk_credentials.py \
   tests/test_content_ops_zendesk_credentials_api.py \
+  tests/test_content_ops_zendesk_export_api.py \
   tests/test_atlas_content_ops_reasoning.py \
   tests/test_atlas_content_ops_scope.py \
   tests/test_support_ticket_provider_landing_blog_execute.py \

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -379,6 +379,24 @@ def test_content_ops_zendesk_credentials_route_uses_shared_auth_and_pool() -> No
     assert "_capture_content_ops_auth_user" in dependency_names
 
 
+def test_content_ops_zendesk_export_route_uses_shared_auth_and_pool() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/zendesk-export/full-thread")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert closure["pool_provider"].__name__ == "get_db_pool"
+    assert "_capture_content_ops_auth_user" in dependency_names
+
+
 def test_content_ops_brand_voice_profiles_route_uses_shared_auth_and_pool() -> None:
     api_pkg = _fresh_api_package()
     route = _route(api_pkg, "/content-ops/brand-voice-profiles")

--- a/tests/test_content_ops_zendesk_credentials.py
+++ b/tests/test_content_ops_zendesk_credentials.py
@@ -154,19 +154,40 @@ async def test_lookup_zendesk_credentials_decrypts_tenant_row(
 
 
 @pytest.mark.asyncio
-async def test_lookup_zendesk_credentials_returns_none_on_decrypt_failure(
+async def test_lookup_zendesk_credentials_raises_on_decrypt_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pool = _Pool(fetchrow_result=_row())
     monkeypatch.setattr(service, "decrypt_secret", lambda ciphertext, kid: None)
 
-    credentials = await service.lookup_zendesk_credentials(
-        pool,
-        account_id=str(uuid.uuid4()),
-    )
+    with pytest.raises(
+        service.ZendeskCredentialLookupError,
+        match="zendesk_credentials_unavailable",
+    ):
+        await service.lookup_zendesk_credentials(
+            pool,
+            account_id=str(uuid.uuid4()),
+        )
 
-    assert credentials is None
     assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_lookup_zendesk_credentials_raises_on_fetch_failure() -> None:
+    class _FailingPool(_Pool):
+        async def fetchrow(self, query, *args):
+            raise RuntimeError("db down secret-token")
+
+    with pytest.raises(
+        service.ZendeskCredentialLookupError,
+        match="zendesk_credentials_unavailable",
+    ) as exc:
+        await service.lookup_zendesk_credentials(
+            _FailingPool(),
+            account_id=str(uuid.uuid4()),
+        )
+
+    assert "secret-token" not in str(exc.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_ops_zendesk_export_api.py
+++ b/tests/test_content_ops_zendesk_export_api.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+from typing import Any
+import uuid
+
+import httpx
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from atlas_brain.auth.dependencies import AuthUser
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZendeskMacroCredentials,
+)
+from extracted_content_pipeline.support_ticket_zendesk_export import (
+    ZendeskTicketExportError,
+)
+
+
+API_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain"
+    / "api"
+    / "content_ops_zendesk_export.py"
+)
+ACCOUNT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+api = None
+
+
+def setup_module() -> None:
+    global api
+    api = _load_api_module()
+
+
+def _load_api_module():
+    spec = importlib.util.spec_from_file_location(
+        "atlas_brain.api.content_ops_zendesk_export_for_test",
+        API_MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Pool:
+    is_initialized = True
+
+
+def _user(account_id: Any = ACCOUNT_ID) -> AuthUser:
+    return AuthUser(
+        user_id="33333333-3333-3333-3333-333333333333",
+        account_id=str(account_id),
+        plan="b2b_growth",
+        plan_status="active",
+        role="owner",
+        product="b2b_challenger",
+    )
+
+
+def _credentials() -> ZendeskMacroCredentials:
+    return ZendeskMacroCredentials(
+        email="agent@example.com",
+        api_token="secret-token",
+        subdomain="acme",
+    )
+
+
+def _client(
+    *,
+    pool: Any | None = None,
+    user: AuthUser | None = None,
+    credential_lookup: Any,
+    exporter: Any,
+) -> TestClient:
+    app = fastapi.FastAPI()
+
+    def pool_provider():
+        return pool if pool is not None else _Pool()
+
+    def auth_dependency():
+        return user or _user()
+
+    app.include_router(api.create_content_ops_zendesk_export_router(
+        pool_provider=pool_provider,
+        auth_dependency=auth_dependency,
+        credential_lookup=credential_lookup,
+        exporter=exporter,
+    ))
+    return TestClient(app)
+
+
+def test_zendesk_export_route_uses_tenant_credentials_and_returns_artifact() -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def lookup(pool, *, account_id):
+        calls.append({"kind": "lookup", "pool": pool, "account_id": account_id})
+        return _credentials()
+
+    async def exporter(credentials, *, limit, start_time):
+        calls.append({
+            "kind": "export",
+            "credentials": credentials,
+            "limit": limit,
+            "start_time": start_time,
+        })
+        return {"tickets": [{"ticket": {"id": 101}, "comments": []}]}
+
+    response = _client(
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post(
+        "/content-ops/zendesk-export/full-thread",
+        json={
+            "limit": 2,
+            "start_time": 1_700_000_000,
+            "account_id": "99999999-9999-9999-9999-999999999999",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["importer_mode"] == "full_thread"
+    assert body["support_platform"] == "zendesk"
+    assert body["ticket_count"] == 1
+    assert body["limit"] == 2
+    assert body["start_time"] == 1_700_000_000
+    assert body["artifact"] == {"tickets": [{"ticket": {"id": 101}, "comments": []}]}
+    assert calls[0]["kind"] == "lookup"
+    assert calls[0]["account_id"] == ACCOUNT_ID
+    assert calls[1]["kind"] == "export"
+    assert calls[1]["credentials"].normalized_base_url() == "https://acme.zendesk.com"
+    assert "secret-token" not in str(body)
+
+
+def test_zendesk_export_route_fails_closed_without_tenant_credentials() -> None:
+    calls: list[str] = []
+
+    async def lookup(pool, *, account_id):
+        calls.append(f"lookup:{account_id}")
+        return None
+
+    async def exporter(*args, **kwargs):
+        raise AssertionError("missing tenant credentials must not export")
+
+    response = _client(
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 1})
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["reason"] == "zendesk_credentials_missing"
+    assert calls == [f"lookup:{ACCOUNT_ID}"]
+
+
+def test_zendesk_export_route_sanitizes_export_errors() -> None:
+    async def lookup(pool, *, account_id):
+        return _credentials()
+
+    async def exporter(credentials, *, limit, start_time):
+        raise ZendeskTicketExportError(
+            "zendesk_export_request_failed",
+            status_code=429,
+        )
+
+    response = _client(
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 1})
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == {
+        "reason": "zendesk_export_request_failed",
+        "zendesk_status_code": 429,
+    }
+    assert "secret-token" not in response.text
+    assert "Authorization" not in response.text
+
+
+def test_zendesk_export_route_maps_exporter_missing_credentials_to_404() -> None:
+    async def lookup(pool, *, account_id):
+        return _credentials()
+
+    async def exporter(credentials, *, limit, start_time):
+        raise ZendeskTicketExportError("zendesk_credentials_missing")
+
+    response = _client(
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 1})
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == {"reason": "zendesk_credentials_missing"}
+
+
+def test_zendesk_export_route_sanitizes_transport_errors() -> None:
+    async def lookup(pool, *, account_id):
+        return _credentials()
+
+    async def exporter(credentials, *, limit, start_time):
+        request = httpx.Request("GET", "https://secret-token.zendesk.com/api/v2")
+        raise httpx.ConnectTimeout("timeout secret-token", request=request)
+
+    response = _client(
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 1})
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == {"reason": "zendesk_export_unavailable"}
+    assert "secret-token" not in response.text
+    assert "Authorization" not in response.text
+
+
+def test_zendesk_export_route_maps_credential_lookup_failure_to_503() -> None:
+    async def lookup(pool, *, account_id):
+        raise RuntimeError("database down secret-token")
+
+    async def exporter(*args, **kwargs):
+        raise AssertionError("credential lookup failure must stop before export")
+
+    response = _client(
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 1})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == {"reason": "zendesk_credentials_unavailable"}
+    assert "secret-token" not in response.text
+
+
+def test_zendesk_export_route_rejects_invalid_authenticated_account_id() -> None:
+    async def lookup(pool, *, account_id):
+        raise AssertionError("invalid auth scope must stop before lookup")
+
+    async def exporter(*args, **kwargs):
+        raise AssertionError("invalid auth scope must stop before export")
+
+    response = _client(
+        user=_user(account_id="not-a-uuid"),
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 1})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid tenant scope"
+
+
+def test_zendesk_export_route_validates_bounds_before_lookup() -> None:
+    calls: list[str] = []
+
+    async def lookup(pool, *, account_id):
+        calls.append("lookup")
+        return _credentials()
+
+    async def exporter(*args, **kwargs):
+        calls.append("export")
+        return {"tickets": []}
+
+    response = _client(
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 0})
+
+    assert response.status_code == 422
+    assert calls == []
+
+
+def test_zendesk_export_route_fails_closed_on_bad_export_artifact() -> None:
+    async def lookup(pool, *, account_id):
+        return _credentials()
+
+    async def exporter(credentials, *, limit, start_time):
+        return {"ticket": []}
+
+    response = _client(
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 1})
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == {"reason": "zendesk_export_artifact_invalid"}
+
+
+def test_zendesk_export_route_fails_when_database_unavailable() -> None:
+    class _UninitializedPool:
+        is_initialized = False
+
+    async def lookup(pool, *, account_id):
+        raise AssertionError("database unavailable should stop before lookup")
+
+    async def exporter(*args, **kwargs):
+        raise AssertionError("database unavailable should stop before export")
+
+    response = _client(
+        pool=_UninitializedPool(),
+        credential_lookup=lookup,
+        exporter=exporter,
+    ).post("/content-ops/zendesk-export/full-thread", json={"limit": 1})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database not ready"
+
+
+def test_zendesk_export_api_import_does_not_require_asyncpg() -> None:
+    script = textwrap.dedent("""
+import sys
+
+class BlockAsyncpg:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == 'asyncpg' or fullname.startswith('asyncpg.'):
+            raise ModuleNotFoundError("No module named 'asyncpg'")
+        return None
+
+sys.meta_path.insert(0, BlockAsyncpg())
+import importlib.util
+from pathlib import Path
+
+path = Path('atlas_brain/api/content_ops_zendesk_export.py').resolve()
+spec = importlib.util.spec_from_file_location(
+    'atlas_brain.api.content_ops_zendesk_export_block_asyncpg_test',
+    path,
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+print(module.ZendeskFullThreadExportResponse.__name__)
+""")
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ZendeskFullThreadExportResponse" in result.stdout


### PR DESCRIPTION
Plan: plans/PR-Deflection-Zendesk-Tenant-Export-Route.md
Slice phase: Vertical slice

#1526 added the pure Zendesk API exporter and #1520 already lets the deflection submit path ingest the resulting full-thread artifact. This PR adds the hosted tenant-scoped API boundary: authenticated Content Ops tenants can export Zendesk full-thread JSON from stored Zendesk credentials, with no token exposure and no config/global credential fallback.

## Intentional
- No portfolio UI button in this PR. This slice proves the hosted API boundary first.
- No live Zendesk call in tests. The route mocks the exporter boundary; #1526 covers exporter request shape with a mocked transport.
- No config-backed Zendesk fallback. Hosted ticket export always requires stored tenant credentials.
- Diff is above the 400-LOC soft cap because the hosted route, API registration, CI enrollment, and non-happy-path route tests need to ship together.

## Deferred
- Portfolio UI flow that starts from stored Zendesk credentials and hands the returned artifact into the existing private Blob/full-thread submit path.
- Optional guarded live trial-account smoke against the route after deployment.

## Parked hardening
- None.

## AI reconciliation
- All findings fixed or waived: Yes.
- Codex thread `atlas_brain/api/content_ops_zendesk_export.py:92` fixed: stored-credential lookup/decrypt failures now raise a typed lookup error and the route maps that to sanitized `503 zendesk_credentials_unavailable`; a real absent row still maps to `404 zendesk_credentials_missing`.
- Codex thread `atlas_brain/api/content_ops_zendesk_export.py:101` fixed: transient `httpx.RequestError` exporter failures now map to sanitized `502 zendesk_export_unavailable` without leaking exception text, URLs, tokens, or headers.

## Verification
- `python -m pytest tests/test_content_ops_zendesk_export_api.py tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_generated_assets_api.py -q` -- 37 passed, 1 existing torch/pynvml warning.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4062 passed, 10 skipped, 1 existing torch/pynvml warning.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Zendesk-Tenant-Export-Route.md --check` -- plan already in sync.
- `python scripts/audit_plan_code_consistency.py plans/PR-Deflection-Zendesk-Tenant-Export-Route.md` -- OK.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- OK, 176 matching tests enrolled.
- `python scripts/audit_review_rules_triggered.py --plan plans/PR-Deflection-Zendesk-Tenant-Export-Route.md origin/main` -- OK, plan declares every triggered rule.

## Diff size
9 files, +735 / -9.
