### PR TITLE
Deflection exact repeat join

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import date, datetime, timedelta
-import hashlib
+import math
 import re
 from typing import Any
 
@@ -715,14 +715,11 @@ def build_ticket_faq_markdown(
     subclustered_groups: dict[tuple[str, str], list[dict[str, str]]] = {}
     excluded_singleton_keys: set[str] = set()
     non_repeat_question_count = 0
-    token_hashes: dict[str, int] = {}
     for (topic, scope), rows in groups.items():
         if not scope.startswith("topic:"):
             subclustered_groups[(topic, scope)] = rows
             continue
-        for cluster_index, cluster_rows in enumerate(
-            _question_subclusters(rows, token_hashes=token_hashes)
-        ):
+        for cluster_index, cluster_rows in enumerate(_question_subclusters(rows)):
             cluster_keys = _row_source_keys(cluster_rows)
             if len(cluster_keys) < 2:
                 excluded_singleton_keys.update(cluster_keys)
@@ -828,33 +825,11 @@ def _evidence_rows(opportunity: Mapping[str, Any]) -> tuple[Mapping[str, Any], .
 # ticket in the bucket would render as ONE FAQ whose ticket_count measures
 # bucket membership, not question repetition. These helpers split each
 # degraded bucket into question-similarity sub-clusters with deterministic
-# MinHash-LSH banding plus exact-Jaccard verification, so only questions
-# customers actually asked more than once count as repeats.
+# prefix-filtered exact-Jaccard verification, so only questions customers
+# actually asked more than once count as repeats.
 
 _SUBCLUSTER_JACCARD_THRESHOLD = 1 / 3
 _SUBCLUSTER_GIST_TOKEN_LIMIT = 30
-_MINHASH_PRIME = (1 << 61) - 1
-# Fixed (a, b) permutation constants: 16 hashes = 4 bands x 4 rows. Literal
-# constants keep the clustering deterministic across runs and processes.
-_MINHASH_PERMUTATIONS = (
-    (1099511628211, 40503185483),
-    (216613626151, 92821459571),
-    (805306457117, 18352446323),
-    (655360001281, 73692873701),
-    (377778524351, 28419182549),
-    (982451653069, 61231040987),
-    (472882049891, 35742392227),
-    (715827883159, 50321736709),
-    (293339129747, 87178291199),
-    (846835986133, 22801763489),
-    (538216442407, 67867967773),
-    (159218691971, 44560482149),
-    (920419823369, 15485863757),
-    (368345293463, 79302361813),
-    (614741108437, 31556891543),
-    (257885161353, 96846628681),
-)
-_MINHASH_BAND_ROWS = 4
 
 
 def _question_gist_tokens(text: str) -> frozenset[str]:
@@ -868,30 +843,25 @@ def _question_gist_tokens(text: str) -> frozenset[str]:
     )
 
 
-def _minhash_signature(
-    tokens: frozenset[str],
-    token_hashes: dict[str, int],
-) -> tuple[int, ...]:
-    hashes = []
-    for token in tokens:
-        value = token_hashes.get(token)
-        if value is None:
-            value = int.from_bytes(
-                hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest(),
-                "big",
-            )
-            token_hashes[token] = value
-        hashes.append(value)
-    return tuple(
-        min(((a * value + b) % _MINHASH_PRIME) for value in hashes)
-        for a, b in _MINHASH_PERMUTATIONS
-    )
-
-
 def _jaccard(left: frozenset[str], right: frozenset[str]) -> float:
     if not left or not right:
         return 0.0
     return len(left & right) / len(left | right)
+
+
+def _jaccard_prefix_tokens(
+    tokens: frozenset[str],
+    token_counts: Mapping[str, int],
+) -> tuple[str, ...]:
+    ordered = sorted(tokens, key=lambda token: (token_counts[token], token))
+    prefix_size = len(ordered) - math.ceil(_SUBCLUSTER_JACCARD_THRESHOLD * len(ordered)) + 1
+    return tuple(ordered[:max(0, prefix_size)])
+
+
+def _jaccard_lengths_can_match(left_size: int, right_size: int) -> bool:
+    if left_size <= 0 or right_size <= 0:
+        return False
+    return min(left_size, right_size) / max(left_size, right_size) >= _SUBCLUSTER_JACCARD_THRESHOLD
 
 
 def _row_source_keys(rows: Sequence[Mapping[str, str]]) -> set[str]:
@@ -904,18 +874,20 @@ def _row_source_keys(rows: Sequence[Mapping[str, str]]) -> set[str]:
 
 def _question_subclusters(
     rows: Sequence[Mapping[str, str]],
-    *,
-    token_hashes: dict[str, int],
 ) -> list[list[Mapping[str, str]]]:
     """Split one degraded topic bucket into question-similarity clusters.
 
-    Deterministic: fixed MinHash permutations, insertion-ordered band
-    buckets, and candidate verification against each band bucket's first
-    member only (bounded work; LSH recall is approximate by design, #1460).
-    Rows with an empty gist never merge.
+    Deterministic: exact duplicate matching plus prefix-filtered candidate
+    nomination, followed by exact-Jaccard verification. Rows with an empty
+    gist never merge.
     """
 
     gists = [_question_gist_tokens(str(row.get("text") or "")) for row in rows]
+    token_counts: dict[str, int] = defaultdict(int)
+    for gist in gists:
+        for token in gist:
+            token_counts[token] += 1
+
     parent = list(range(len(rows)))
 
     def find(index: int) -> int:
@@ -930,7 +902,7 @@ def _question_subclusters(
             parent[max(root_left, root_right)] = min(root_left, root_right)
 
     exact: dict[frozenset[str], int] = {}
-    band_buckets: dict[tuple[int, tuple[int, ...]], int] = {}
+    prefix_index: dict[str, list[int]] = defaultdict(list)
     for index, gist in enumerate(gists):
         if not gist:
             continue
@@ -938,13 +910,20 @@ def _question_subclusters(
         if first_exact != index:
             union(first_exact, index)
             continue
-        signature = _minhash_signature(gist, token_hashes)
-        for band_index in range(0, len(signature), _MINHASH_BAND_ROWS):
-            band = (band_index, signature[band_index:band_index + _MINHASH_BAND_ROWS])
-            representative = band_buckets.setdefault(band, index)
-            if representative != index and find(representative) != find(index):
-                if _jaccard(gists[representative], gist) >= _SUBCLUSTER_JACCARD_THRESHOLD:
-                    union(representative, index)
+        candidates: set[int] = set()
+        prefix = _jaccard_prefix_tokens(gist, token_counts)
+        for token in prefix:
+            candidates.update(prefix_index[token])
+        for candidate in sorted(candidates):
+            if find(candidate) == find(index):
+                continue
+            candidate_gist = gists[candidate]
+            if not _jaccard_lengths_can_match(len(candidate_gist), len(gist)):
+                continue
+            if _jaccard(candidate_gist, gist) >= _SUBCLUSTER_JACCARD_THRESHOLD:
+                union(candidate, index)
+        for token in prefix:
+            prefix_index[token].append(index)
 
     clusters: dict[int, list[Mapping[str, str]]] = defaultdict(list)
     for index, row in enumerate(rows):

--- a/plans/PR-Deflection-Exact-Repeat-Join.md
+++ b/plans/PR-Deflection-Exact-Repeat-Join.md
@@ -1,0 +1,114 @@
+# PR-Deflection-Exact-Repeat-Join
+
+## Why this slice exists
+
+Issue #1504 shows the repeat-question subclustering path says it groups
+questions at exact Jaccard >= 1/3, but the shipped MinHash banding only
+nominates a small fraction of pairs at that bar and is sensitive to row order.
+Issue #1481 is the buyer-visible symptom: the deflection snapshot can present
+category membership as repeat-question volume when the generator does not
+measure question-level repetition tightly enough.
+
+This vertical slice closes the lexical half of that gap. It makes the existing
+documented lexical rule literal inside the real FAQ generation path by replacing
+the approximate LSH candidate nomination with a deterministic prefix-filtered
+exact join. The semantic embedding booster discussed in #1504 remains separate
+because it needs a host-injected model port, calibration, and auditability
+decisions.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Vertical slice
+
+1. Replace probabilistic MinHash-LSH nomination inside degraded topic buckets
+   with an exact lexical candidate join that verifies the same Jaccard >= 1/3
+   repeat-question rule already documented by the report methodology.
+2. Preserve existing exact-duplicate behavior, empty-gist singleton behavior,
+   and deterministic ordering for rendered FAQ items.
+3. Add focused regression coverage for order-insensitive clustering and
+   borderline lexical-overlap pairs that the old LSH shape could miss.
+4. Keep embeddings, model dependencies, and live CFPB re-baselining out of this
+   PR.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Reworded question gists whose exact token-set Jaccard is at least 1/3
+        merge regardless of whether they share a MinHash band.
+  - [ ] The same rows in a different input order produce the same repeat
+        clusters and ticket counts.
+  - [ ] Rows below the Jaccard threshold stay separate and continue to be
+        excluded as non-repeat tickets when singleton-only.
+  - [ ] Empty-gist rows never merge.
+  - [ ] The implementation remains deterministic and bounded by prefix-filtered
+        candidate generation rather than a naive all-pairs scan.
+- Affected surfaces: extracted FAQ Markdown generation and its tests.
+- Risk areas: repeat-count movement, performance on large degraded buckets,
+  deterministic ordering, and over-merging unrelated tickets.
+- Reviewer rules triggered: R1, R2, R7, R10, R12, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Exact-Repeat-Join.md`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+## Mechanism
+
+For each degraded topic bucket, derive the same question gist token sets used
+today. Exact duplicate token sets still union immediately. For non-identical
+gists, index each row by a rare-token-first prefix whose length follows the
+standard prefix-filter shape for thresholded Jaccard matching. A row only
+compares against earlier rows that share at least one indexed prefix token and
+pass the threshold length-ratio filter; every candidate edge is still verified
+with exact Jaccard before union.
+
+The rendered cluster ordering stays root-index based, so the first occurrence
+continues to anchor deterministic output. This removes the LSH recall gap
+without adding embeddings, external services, or nondeterministic model calls.
+
+## Intentional
+
+- This PR keeps the lexical Jaccard rule. It does not try to catch same-meaning
+  questions with near-zero token overlap; that is the embedding booster
+  discussion in #1504 and needs a separate model-port slice.
+- This PR accepts that published repeat counts can move. That movement is the
+  point: the delivered rule should match the documented lexical rule.
+- This PR avoids a naive all-pairs scan. The exact join may do more comparisons
+  than LSH, but only after prefix and length-ratio filtering.
+
+## Deferred
+
+- Embedding booster with mutual-nearest-neighbor plus margin/floor calibration
+  from #1504.
+- Live CFPB artifact re-baseline after the lexical join lands.
+- Issue #1481 copy/metric alignment for Support Tax wording once the
+  question-level counts are on the corrected lexical foundation.
+- Issue #1518 status vocabulary bug; useful but not part of repeat-question
+  clustering.
+
+Parked hardening: `Customer-wording FAQ headings can publish raw PII` and
+`Safe-vocabulary representative label collisions render duplicate FAQ headings`
+remain parked because they touch the same renderer but do not block this exact
+repeat-join slice.
+
+## Verification
+
+- Command passed: python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py.
+- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py -q - 241 passed.
+- Command passed: bash scripts/validate_extracted_content_pipeline.sh.
+- Command passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline.
+- Command passed: python scripts/audit_extracted_standalone.py --fail-on-debt.
+- Command passed: bash scripts/check_ascii_python.sh.
+- Command passed: bash scripts/run_extracted_pipeline_checks.sh - 4053 passed, 10 skipped, 1 warning.
+- Pending before push: local PR review wrapper.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 105 |
+| `plans/PR-Deflection-Exact-Repeat-Join.md` | 114 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 99 |
+| **Total** | **318** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -25,6 +25,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (
     _resolution_signal_tokens,
     _resolution_text_is_publishable,
     _safe_vocabulary_representative_label,
+    _question_subclusters,
     _source_date_span,
     build_ticket_faq_markdown,
     normalize_intent_rules,
@@ -2091,6 +2092,104 @@ def test_build_ticket_faq_markdown_keeps_identical_topic_degraded_content_togeth
     assert result.items[0]["question"] == "What should I do about device reboot loop?"
     assert result.items[0]["source_ids"] == ("ticket-1", "ticket-2", "ticket-3", "ticket-4")
     assert result.items[0]["ticket_count"] == 4
+
+
+def test_question_subclusters_exact_join_merges_threshold_pairs_without_lsh_nomination() -> None:
+    shared = tuple(f"shared{index}" for index in range(6))
+    cases = [
+        shared + tuple(f"lefta{index}" for index in range(6)),
+        shared + tuple(f"righta{index}" for index in range(6)),
+        shared + tuple(f"leftb{index}" for index in range(5)),
+        shared + tuple(f"rightb{index}" for index in range(7)),
+        tuple(f"lowshared{index}" for index in range(5))
+        + tuple(f"leftc{index}" for index in range(7)),
+        tuple(f"lowshared{index}" for index in range(5))
+        + tuple(f"rightc{index}" for index in range(7)),
+    ]
+    rows = [
+        {
+            "text": " ".join(tokens),
+            "source_key": f"ticket-{index}",
+        }
+        for index, tokens in enumerate(cases)
+    ]
+
+    clusters = _question_subclusters(rows)
+
+    assert [tuple(row["source_key"] for row in cluster) for cluster in clusters] == [
+        ("ticket-0", "ticket-1", "ticket-2", "ticket-3"),
+        ("ticket-4",),
+        ("ticket-5",),
+    ]
+
+
+def test_question_subclusters_exact_join_keeps_empty_gists_separate() -> None:
+    clusters = _question_subclusters([
+        {"text": "", "source_key": "ticket-empty-1"},
+        {"text": "", "source_key": "ticket-empty-2"},
+    ])
+
+    assert [tuple(row["source_key"] for row in cluster) for cluster in clusters] == [
+        ("ticket-empty-1",),
+        ("ticket-empty-2",),
+    ]
+
+
+def test_build_ticket_faq_markdown_subclusters_are_order_insensitive() -> None:
+    rows = [
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "technical support",
+            "source_title": "Password reset",
+            "text": "password reset email link expired account login access issue",
+            "source_id": "ticket-a",
+        },
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "technical support",
+            "source_title": "Password reset",
+            "text": "password reset email link invalid account login problem",
+            "source_id": "ticket-b",
+        },
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "technical support",
+            "source_title": "Invoice refund",
+            "text": "invoice refund credit card charge duplicate billing issue",
+            "source_id": "ticket-c",
+        },
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "technical support",
+            "source_title": "Invoice refund",
+            "text": "invoice refund credit card charge duplicate payment problem",
+            "source_id": "ticket-d",
+        },
+    ]
+
+    first = build_ticket_faq_markdown(
+        rows,
+        max_items=0,
+        documentation_terms=("Password reset", "Invoice refund"),
+    )
+    second = build_ticket_faq_markdown(
+        tuple(reversed(rows)),
+        max_items=0,
+        documentation_terms=("Password reset", "Invoice refund"),
+    )
+
+    first_clusters = sorted(
+        (tuple(sorted(item["source_ids"])), item["ticket_count"])
+        for item in first.items
+    )
+    second_clusters = sorted(
+        (tuple(sorted(item["source_ids"])), item["ticket_count"])
+        for item in second.items
+    )
+    assert first_clusters == second_clusters == [
+        (("ticket-a", "ticket-b"), 2),
+        (("ticket-c", "ticket-d"), 2),
+    ]
 
 
 def test_build_ticket_faq_markdown_preserves_topic_degraded_creation_order_under_cap() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Exact-Repeat-Join.md
Slice phase: Vertical slice

This slice takes #1504 S1: the FAQ repeat-question subclustering path now uses a deterministic prefix-filtered exact lexical join, so the delivered degraded-bucket rule matches the documented exact Jaccard >= 1/3 bar instead of depending on probabilistic MinHash-LSH nomination.

## Intentional
- Lexical-only in this PR; the embedding booster, model port, and calibration work from #1504 stay deferred.
- Published repeat counts may move because the previous delivered rule was stricter than the documented lexical rule.
- Candidate generation is prefix/length filtered, not a naive all-pairs scan.

## Deferred
- Embedding booster with mutual-nearest-neighbor plus margin/floor calibration from #1504.
- Live CFPB artifact re-baseline after the lexical join lands.
- #1481 Support Tax wording/metric alignment once the question-level counts are on the corrected lexical foundation.
- #1518 status vocabulary bug; useful but not part of repeat-question clustering.

## Parked hardening
- `Customer-wording FAQ headings can publish raw PII`.
- `Safe-vocabulary representative label collisions render duplicate FAQ headings`.

## AI reconciliation
- All fixed or waived: Yes.
- No AI findings posted yet.

## Verification
- Command passed: `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py`.
- Command passed: `pytest tests/test_extracted_ticket_faq_markdown.py -q` - 241 passed after rebase.
- Command passed: `bash scripts/validate_extracted_content_pipeline.sh`.
- Command passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`.
- Command passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`.
- Command passed: `bash scripts/check_ascii_python.sh`.
- Command passed: `bash scripts/run_extracted_pipeline_checks.sh` - 4053 passed, 10 skipped, 1 warning.

## Diff size
3 files, +255 / -63
