### PR TITLE
Deflection Zendesk credential flow

### DIFF
--- a/plans/PR-Deflection-Zendesk-Credential-Flow.md
+++ b/plans/PR-Deflection-Zendesk-Credential-Flow.md
@@ -1,0 +1,144 @@
+# PR-Deflection-Zendesk-Credential-Flow
+
+## Why this slice exists
+
+#1527 added the hosted, tenant-scoped Zendesk full-thread export route and
+explicitly deferred the portfolio UI flow that starts from stored Zendesk
+credentials. The product can already upload a saved Zendesk JSON export through
+private Blob, but a buyer with configured Zendesk credentials still has to leave
+the intake page, export by hand, and upload the JSON file. This slice closes the
+next vertical handoff: the portfolio intake can start a server-side Zendesk API
+export, persist the returned artifact privately, and reuse the existing
+full-thread submit path without exposing Zendesk API tokens, ATLAS service
+tokens, private Blob tokens, or the exported ticket artifact to browser-visible
+payloads. The first review also caught that the route itself cannot stay
+public: this slice now gates the stored-credential export with a narrow
+operator-entered route access token before any ATLAS/Zendesk/Blob work starts.
+This is over the 400 LOC soft cap because the slice is intentionally vertical
+across the portfolio server proxy, the no-file UI mode, and the enrolled shell
+tests that prove browser secrecy, fail-closed export handling, private Blob
+persistence, and submit reuse in one reviewable contract.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Add a portfolio server proxy that calls the #1527 ATLAS hosted Zendesk
+   export route with the server-side ATLAS token, validates the full-thread
+   artifact envelope, writes the artifact to private Vercel Blob, then reuses
+   the existing `submitPrivateBlob` full-thread path.
+2. Add a "Zendesk API" intake mode to the portfolio upload page. CSV and saved
+   Zendesk JSON upload modes remain unchanged. The API mode requires a route
+   access token entered by the operator; it is not a public unauthenticated
+   export trigger.
+3. Add CI-facing tests for proxy request shape, fail-closed export/Blob/submit
+   errors, sanitized responses, UI markers, and unchanged CSV/JSON upload
+   behavior through the existing enrolled shell test.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] CSV remains the default upload mode and still requires CSV inspection
+        before private Blob upload.
+  - [ ] Saved Zendesk JSON upload mode remains unchanged and still submits
+        `importer_mode="full_thread"` through private Blob.
+  - [ ] Zendesk API mode does not require a browser file upload and calls only
+        a portfolio server endpoint after the operator provides the route
+        access token; the browser never receives ATLAS tokens, Zendesk
+        credentials, Blob tokens, private Blob URLs, or the exported artifact.
+  - [ ] The server proxy rejects missing or incorrect route access tokens before
+        any ATLAS export, Blob write, or submit attempt.
+  - [ ] The server proxy calls `/api/v1/content-ops/zendesk-export/full-thread`
+        with the server-side bearer token and no caller-supplied account id.
+  - [ ] Export failures, malformed export envelopes, Blob write failures, and
+        submit failures fail closed with static public error codes and no token
+        or raw upstream body leakage.
+  - [ ] The exported artifact is written as private JSON Blob and then submitted
+        via the existing full-thread `submitPrivateBlob` helper so importer and
+        cleanup behavior stay centralized.
+- Affected surfaces: portfolio FAQ deflection intake page, portfolio
+  deflection API proxy, enrolled portfolio shell test.
+- Risk areas: browser-visible ticket data, cross-tenant account spoofing,
+  private Blob path confusion, duplicate submit helper logic, stale frontend CI
+  enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R9, R10, R12, R14.
+
+### Files touched
+
+- `plans/PR-Deflection-Zendesk-Credential-Flow.md`
+- `portfolio-ui/api/content-ops/deflection/zendesk-export-submit.js`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+
+## Mechanism
+
+The upload page gets a third `uploadMode`, `zendesk_api`. In that mode the file
+input is replaced with a credential-backed source panel plus a route access
+token password field, and the submit button calls a new portfolio endpoint
+instead of `uploadBlob`. Company/contact fields remain required; support
+platform is pinned to Zendesk.
+
+The new portfolio endpoint reads a small JSON request (`company_name`,
+`contact_email`, `limit`, optional `start_time`). It builds config only from
+server env via the existing `atlas-report.js` helpers and requires
+`Authorization: Bearer <ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN>` before
+checking account headers or invoking ATLAS. After that route gate passes, it
+calls the ATLAS export route with `Authorization: Bearer <server token>`,
+validates that the response has `importer_mode="full_thread"`,
+`support_platform="zendesk"`, and an artifact with a `tickets` array, then
+writes `artifact` to private Vercel Blob as JSON.
+After the private write succeeds, it calls the existing `submitPrivateBlob`
+helper with `importer_mode="full_thread"` and the returned pathname. That helper
+continues to own Blob readback, ATLAS multipart submit, and best-effort cleanup.
+
+Public errors from this endpoint are static codes such as
+`zendesk_export_unavailable`, `zendesk_export_contract_violation`,
+`zendesk_export_blob_unavailable`, or the existing submit error. The endpoint
+does not echo upstream response bodies, exception text, Authorization headers,
+Blob tokens, or Zendesk credentials.
+
+## Intentional
+
+- No new backend route in this PR. #1527 already shipped the tenant-scoped
+  ATLAS export route; this slice wires the portfolio product surface to it.
+- No browser-visible exported artifact. The existing saved-JSON upload path is
+  still available for manual exports, but credential-backed export keeps the
+  fetched ticket artifact server-side.
+- Browser-visible route access token, not service credentials. The operator
+  supplies a narrow gate token for this public page; the server-side ATLAS
+  token, Zendesk tenant credentials, and private Blob token are never embedded
+  in the page or response.
+- No new npm script. The existing enrolled `test:deflection-upload-shell`
+  should cover the new UI/proxy branches to avoid another frontend CI enrollment
+  gap.
+
+## Deferred
+
+- Browser-automated live smoke against the operator's Zendesk trial credentials
+  after this endpoint is deployed.
+- Optional export progress/polling UX if live Zendesk exports are too slow for
+  a single request.
+- Production provisioning of `ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN`
+  alongside the existing portfolio server env.
+
+Parked hardening: none.
+
+## Verification
+
+- `cd portfolio-ui && npm run test:deflection-upload-shell` -- 37 passed.
+- `cd portfolio-ui && npm run test:deflection-result` -- 19 passed.
+- `cd portfolio-ui && npm run test:deflection-atlas-proxy` -- 18 passed.
+- `cd portfolio-ui && npm run build` -- passed; Vite emitted the existing
+  sitemap-env and large-chunk warnings.
+- `scripts/run_extracted_pipeline_checks.sh` via bash -- 4063 passed, 10 skipped,
+  1 existing torch/pynvml warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Zendesk-Credential-Flow.md` | 144 |
+| `portfolio-ui/api/content-ops/deflection/zendesk-export-submit.js` | 354 |
+| `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` | 523 |
+| `portfolio-ui/src/pages/FaqDeflectionUpload.tsx` | 247 |
+| **Total** | **1268** |

--- a/portfolio-ui/api/content-ops/deflection/zendesk-export-submit.js
+++ b/portfolio-ui/api/content-ops/deflection/zendesk-export-submit.js
@@ -1,0 +1,354 @@
+import { timingSafeEqual } from "node:crypto";
+import { atlasUrl, clean, configFromEnv } from "./atlas-report.js";
+import {
+  BLOB_UPLOAD_PATH_PREFIX,
+  FULL_THREAD_IMPORTER_MODE,
+  submitPrivateBlob,
+} from "./submit.js";
+
+const ZENDESK_EXPORT_PATH = "/api/v1/content-ops/zendesk-export/full-thread";
+const DEFAULT_ZENDESK_EXPORT_LIMIT = 50;
+const MAX_ZENDESK_EXPORT_LIMIT = 1000;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_EXPORT_ERROR_REASONS = new Set([
+  "invalid_zendesk_export_submit",
+  "zendesk_credentials_missing",
+  "zendesk_credentials_unavailable",
+  "zendesk_export_artifact_invalid",
+  "zendesk_export_blob_contract_violation",
+  "zendesk_export_blob_unavailable",
+  "zendesk_export_contract_violation",
+  "zendesk_export_failed",
+  "zendesk_export_invalid_json",
+  "zendesk_export_request_failed",
+  "zendesk_export_unavailable",
+]);
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+function json(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(JSON.stringify(payload));
+}
+
+function header(req, name) {
+  const lower = name.toLowerCase();
+  return clean(req.headers?.[lower]) || clean(req.headers?.[name]);
+}
+
+function zendeskCredentialFlowConfig(env = process.env) {
+  const config = configFromEnv(env);
+  const blobToken = clean(env.BLOB_READ_WRITE_TOKEN);
+  const accessToken = clean(env.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN);
+  const errors = [];
+  if (!config.baseUrl) errors.push("atlas_base_url_missing");
+  if (!config.token) errors.push("atlas_token_missing");
+  if (!config.accountId || !UUID_RE.test(config.accountId)) {
+    errors.push("atlas_account_missing");
+  }
+  if (!blobToken) errors.push("blob_token_missing");
+  if (!accessToken) errors.push("zendesk_export_access_token_missing");
+  return { config, blobToken, accessToken, errors };
+}
+
+async function readJsonBody(req) {
+  if (req.body && typeof req.body === "object" && !Buffer.isBuffer(req.body)) return req.body;
+  if (typeof req.body === "string") return JSON.parse(req.body);
+  if (Buffer.isBuffer(req.body)) return JSON.parse(req.body.toString("utf8"));
+  const chunks = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+function positiveInt(value, fallback, max = MAX_ZENDESK_EXPORT_LIMIT) {
+  const raw = clean(value);
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > max) return null;
+  return parsed;
+}
+
+function nonNegativeInt(value, fallback = 0) {
+  const raw = clean(value);
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+function normalizePublicPayload(payload) {
+  const companyName = clean(payload?.company_name);
+  const contactEmail = clean(payload?.contact_email);
+  const limit = positiveInt(payload?.limit, DEFAULT_ZENDESK_EXPORT_LIMIT);
+  const startTime = nonNegativeInt(payload?.start_time, 0);
+  const errors = [];
+  if (!companyName) errors.push("company_name_required");
+  if (!contactEmail) errors.push("contact_email_required");
+  if (limit === null) errors.push("invalid_limit");
+  if (startTime === null) errors.push("invalid_start_time");
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    companyName,
+    contactEmail,
+    limit,
+    startTime,
+  };
+}
+
+function safeExportErrorReason(payload) {
+  const reason = clean(payload?.detail?.reason) || clean(payload?.reason) || clean(payload?.error);
+  return SAFE_EXPORT_ERROR_REASONS.has(reason) ? reason : "zendesk_export_failed";
+}
+
+function safeSecretEqual(left, right) {
+  const leftBuffer = Buffer.from(clean(left));
+  const rightBuffer = Buffer.from(clean(right));
+  if (leftBuffer.length === 0 || leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function requestBearerToken(req) {
+  const authorization = header(req, "authorization");
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return clean(match?.[1]);
+}
+
+function authorizeZendeskCredentialFlow(req, accessToken) {
+  return safeSecretEqual(requestBearerToken(req), accessToken);
+}
+
+function validateZendeskExportPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  if (
+    payload.importer_mode !== FULL_THREAD_IMPORTER_MODE ||
+    payload.support_platform !== "zendesk" ||
+    !payload.artifact ||
+    typeof payload.artifact !== "object" ||
+    Array.isArray(payload.artifact) ||
+    !Array.isArray(payload.artifact.tickets)
+  ) {
+    return null;
+  }
+  return payload.artifact;
+}
+
+async function exportZendeskArtifact({
+  config,
+  limit,
+  startTime,
+  fetchImpl = fetch,
+}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+  let response;
+  try {
+    response = await fetchImpl(atlasUrl(config.baseUrl, ZENDESK_EXPORT_PATH), {
+      method: "POST",
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${config.token}`,
+      },
+      body: JSON.stringify({ limit, start_time: startTime }),
+      signal: controller.signal,
+    });
+  } catch {
+    return { ok: false, statusCode: 502, error: "zendesk_export_unavailable" };
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const text = await response.text();
+  let payload = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      return { ok: false, statusCode: 502, error: "zendesk_export_invalid_json" };
+    }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      statusCode: response.status >= 400 && response.status < 500 ? response.status : 502,
+      error: safeExportErrorReason(payload),
+      atlas_status: response.status,
+    };
+  }
+  const artifact = validateZendeskExportPayload(payload);
+  if (!artifact) {
+    return { ok: false, statusCode: 502, error: "zendesk_export_contract_violation" };
+  }
+  return { ok: true, artifact };
+}
+
+async function putPrivateJsonArtifact(pathname, body, options) {
+  const { put } = await import("@vercel/blob");
+  return put(pathname, body, options);
+}
+
+function exportBlobPathname(nowMs = Date.now()) {
+  return `${BLOB_UPLOAD_PATH_PREFIX}${nowMs}-zendesk-api-export.json`;
+}
+
+async function persistZendeskArtifact({
+  artifact,
+  blobToken,
+  putBlobImpl = putPrivateJsonArtifact,
+  nowMs = Date.now(),
+}) {
+  const pathname = exportBlobPathname(nowMs);
+  const body = Buffer.from(JSON.stringify(artifact), "utf8");
+  try {
+    const result = await putBlobImpl(pathname, body, {
+      access: "private",
+      addRandomSuffix: true,
+      contentType: "application/json",
+      token: blobToken,
+    });
+    const resultPathname = clean(result?.pathname);
+    if (!resultPathname) {
+      return { ok: false, statusCode: 502, error: "zendesk_export_blob_contract_violation" };
+    }
+    return { ok: true, pathname: resultPathname };
+  } catch {
+    return { ok: false, statusCode: 502, error: "zendesk_export_blob_unavailable" };
+  }
+}
+
+async function submitZendeskCredentialFlow({
+  config,
+  blobToken,
+  payload,
+  fetchImpl = fetch,
+  putBlobImpl = putPrivateJsonArtifact,
+  getBlobImpl,
+  deleteBlobImpl,
+  eventLogger = console.warn,
+  nowMs = Date.now(),
+}) {
+  const publicPayload = normalizePublicPayload(payload);
+  if (!publicPayload.ok) {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "invalid_zendesk_export_submit",
+      details: publicPayload.errors,
+    };
+  }
+
+  const exported = await exportZendeskArtifact({
+    config,
+    limit: publicPayload.limit,
+    startTime: publicPayload.startTime,
+    fetchImpl,
+  });
+  if (!exported.ok) return exported;
+
+  const persisted = await persistZendeskArtifact({
+    artifact: exported.artifact,
+    blobToken,
+    putBlobImpl,
+    nowMs,
+  });
+  if (!persisted.ok) return persisted;
+
+  return submitPrivateBlob({
+    config,
+    blobToken,
+    payload: {
+      blob_pathname: persisted.pathname,
+      importer_mode: FULL_THREAD_IMPORTER_MODE,
+      support_platform: "zendesk",
+      company_name: publicPayload.companyName,
+      contact_email: publicPayload.contactEmail,
+      limit: String(publicPayload.limit),
+    },
+    fetchImpl,
+    getBlobImpl,
+    deleteBlobImpl,
+    eventLogger,
+  });
+}
+
+export {
+  DEFAULT_ZENDESK_EXPORT_LIMIT,
+  MAX_ZENDESK_EXPORT_LIMIT,
+  ZENDESK_EXPORT_PATH,
+  exportBlobPathname,
+  exportZendeskArtifact,
+  authorizeZendeskCredentialFlow,
+  normalizePublicPayload,
+  persistZendeskArtifact,
+  submitZendeskCredentialFlow,
+  validateZendeskExportPayload,
+  zendeskCredentialFlowConfig,
+};
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    json(res, 405, { ok: false, error: "method_not_allowed" });
+    return;
+  }
+
+  const contentType = header(req, "content-type");
+  if (!contentType.includes("application/json")) {
+    json(res, 415, { ok: false, error: "zendesk_export_json_required" });
+    return;
+  }
+
+  const { config, blobToken, accessToken, errors } = zendeskCredentialFlowConfig();
+  if (errors.length > 0) {
+    json(res, 503, { ok: false, error: "zendesk_export_not_configured" });
+    return;
+  }
+
+  if (!authorizeZendeskCredentialFlow(req, accessToken)) {
+    json(res, 401, { ok: false, error: "zendesk_export_auth_required" });
+    return;
+  }
+
+  const requestedAccountId = header(req, "x-atlas-account-id");
+  if (
+    requestedAccountId &&
+    (!UUID_RE.test(requestedAccountId) || requestedAccountId !== config.accountId)
+  ) {
+    json(res, 400, { ok: false, error: "invalid_account_id" });
+    return;
+  }
+
+  let payload;
+  try {
+    payload = await readJsonBody(req);
+  } catch {
+    json(res, 400, { ok: false, error: "invalid_zendesk_export_submit" });
+    return;
+  }
+
+  const result = await submitZendeskCredentialFlow({
+    config,
+    blobToken,
+    payload,
+  });
+  if (!result.ok) {
+    json(res, result.statusCode, {
+      ok: false,
+      error: result.error,
+      atlas_status: result.atlas_status,
+      details: result.details,
+    });
+    return;
+  }
+  json(res, 200, result.payload);
+}

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -12,6 +12,10 @@ import submitHandler, {
   readPrivateCsvBlob,
   submitPrivateBlob,
 } from "../api/content-ops/deflection/submit.js";
+import zendeskExportSubmitHandler, {
+  ZENDESK_EXPORT_PATH,
+  submitZendeskCredentialFlow,
+} from "../api/content-ops/deflection/zendesk-export-submit.js";
 import inspectHandler, {
   INSPECT_PATH,
   MAX_INSPECT_MULTIPART_BYTES,
@@ -39,6 +43,10 @@ const appSource = await readFile(resolve(root, "src/App.tsx"), "utf8");
 const servicesSource = await readFile(resolve(root, "src/pages/Services.tsx"), "utf8");
 const uploadSource = await readFile(resolve(root, "src/pages/FaqDeflectionUpload.tsx"), "utf8");
 const submitSource = await readFile(resolve(root, "api/content-ops/deflection/submit.js"), "utf8");
+const zendeskExportSubmitSource = await readFile(
+  resolve(root, "api/content-ops/deflection/zendesk-export-submit.js"),
+  "utf8",
+);
 const inspectSource = await readFile(resolve(root, "api/content-ops/deflection/inspect.js"), "utf8");
 const submitSmokeSource = await readFile(
   resolve(root, "scripts/faq-deflection-submit-live-smoke.mjs"),
@@ -55,6 +63,7 @@ const ENV = {
   ATLAS_API_BASE_URL: "https://atlas.example.com",
   ATLAS_B2B_JWT: "secret-service-token",
   ATLAS_ACCOUNT_ID: ACCOUNT_ID,
+  ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN: "operator-export-access-token",
   BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_token",
 };
 const READY_INSPECT_PAYLOAD = {
@@ -208,7 +217,11 @@ await test("upload shell exposes live submit markers and avoids browser credenti
     "data-atlas-deflection-submit",
     "data-atlas-deflection-inspect-endpoint",
     "data-atlas-deflection-upload-endpoint",
+    "data-atlas-deflection-zendesk-export-submit-endpoint",
     "data-atlas-deflection-upload-progress",
+    "data-atlas-deflection-zendesk-api-source",
+    "data-atlas-deflection-zendesk-export-access-token",
+    "data-atlas-deflection-zendesk-export-progress",
     "data-atlas-deflection-inspect-preview",
     "data-atlas-deflection-export-guidance",
     "data-atlas-deflection-retry",
@@ -239,6 +252,21 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.match(uploadSource, /publishable answers require uploaded resolution\s+evidence/);
   assert.match(uploadSource, /value: "zendesk_full_thread"/);
   assert.match(uploadSource, /Zendesk JSON/);
+  assert.match(uploadSource, /value: "zendesk_api"/);
+  assert.match(uploadSource, /Zendesk API/);
+  assert.match(uploadSource, /ZENDESK_EXPORT_SUBMIT_ENDPOINT = "\/api\/content-ops\/deflection\/zendesk-export-submit"/);
+  assert.match(uploadSource, /fetch\(ZENDESK_EXPORT_SUBMIT_ENDPOINT/);
+  assert.match(uploadSource, /Authorization": `Bearer \$\{zendeskExportAccessToken\.trim\(\)\}`/);
+  assert.match(uploadSource, /setSubmit\(\{ status: "exporting" \}\)/);
+  assert.match(uploadSource, /The browser receives only the locked report path/);
+  assert.match(uploadSource, /ticket artifacts stay server-side/);
+  assert.match(zendeskExportSubmitSource, /ZENDESK_EXPORT_PATH = "\/api\/v1\/content-ops\/zendesk-export\/full-thread"/);
+  assert.match(zendeskExportSubmitSource, /ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN/);
+  assert.match(zendeskExportSubmitSource, /zendesk_export_auth_required/);
+  assert.match(zendeskExportSubmitSource, /bodyParser: false/);
+  assert.match(zendeskExportSubmitSource, /submitPrivateBlob/);
+  assert.match(zendeskExportSubmitSource, /access: "private"/);
+  assert.match(zendeskExportSubmitSource, /addRandomSuffix: true/);
   assert.match(uploadSource, /public requester comments[\s\S]*public agent replies/);
   assert.match(uploadSource, /Private notes are dropped during import/);
   assert.match(uploadSource, /ATLAS validates the thread shape during submit/);
@@ -279,7 +307,7 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.match(uploadSource, /JSON\.stringify/);
   assert.doesNotMatch(uploadSource, /X-Atlas-Account-Id|account_id/);
   assert.doesNotMatch(uploadSource, /ATLAS_B2B_JWT|ATLAS_API_BASE_URL|ATLAS_TOKEN/);
-  assert.doesNotMatch(uploadSource, /Authorization/);
+  assert.doesNotMatch(uploadSource, /BLOB_READ_WRITE_TOKEN|ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN/);
   assert.doesNotMatch(uploadSource, /\/paid\b/);
 });
 
@@ -1009,6 +1037,499 @@ await test("private blob submit forwards Zendesk full-thread JSON without CSV in
       options: { token: ENV.BLOB_READ_WRITE_TOKEN },
     },
   ]);
+});
+
+await test("Zendesk credential flow exports server-side, stores private JSON, then submits", async () => {
+  const calls = [];
+  const putCalls = [];
+  const deleteCalls = [];
+  const artifact = {
+    tickets: [
+      {
+        ticket: { id: 123, status: "solved", satisfaction_rating: { score: "good" } },
+        comments: [
+          { id: 1, public: true, author_role: "end_user", body: "How do I export reports?" },
+          { id: 2, public: true, author_role: "agent", body: "Open Reports, then Export." },
+        ],
+      },
+    ],
+  };
+  let storedBody = null;
+  const result = await submitZendeskCredentialFlow({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      account_id: "3b2b950d-f64b-4852-bc30-f92a34cdf169",
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+      start_time: "0",
+    },
+    nowMs: 123456,
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      if (url.endsWith(ZENDESK_EXPORT_PATH)) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({
+              importer_mode: FULL_THREAD_IMPORTER_MODE,
+              support_platform: "zendesk",
+              ticket_count: 1,
+              limit: 1000,
+              start_time: 0,
+              artifact,
+            });
+          },
+        };
+      }
+      assert.equal(url.endsWith(SUBMIT_PATH), true);
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ request_id: "content-ops-zendeskapi123" });
+        },
+      };
+    },
+    putBlobImpl: async (pathname, body, options) => {
+      putCalls.push({ pathname, body, options });
+      storedBody = body;
+      return {
+        pathname: `${BLOB_UPLOAD_PATH_PREFIX}123456-zendesk-api-export-random.json`,
+        url: `https://blob.example.com/private/zendesk-api-export.json?token=${ENV.BLOB_READ_WRITE_TOKEN}`,
+      };
+    },
+    getBlobImpl: async (pathname, options) => {
+      assert.equal(pathname, `${BLOB_UPLOAD_PATH_PREFIX}123456-zendesk-api-export-random.json`);
+      assert.deepEqual(options, {
+        access: "private",
+        token: ENV.BLOB_READ_WRITE_TOKEN,
+        useCache: false,
+      });
+      return {
+        statusCode: 200,
+        stream: new Blob([storedBody], { type: "application/json" }).stream(),
+        blob: {
+          size: storedBody.length,
+          contentType: "application/json",
+        },
+      };
+    },
+    deleteBlobImpl: async (pathname, options) => {
+      deleteCalls.push({ pathname, options });
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.payload.result_path.includes("content-ops-zendeskapi123"), true);
+  const resultJson = JSON.stringify(result);
+  assert.equal(resultJson.includes("tickets"), false);
+  assert.equal(resultJson.includes("https://blob.example.com/private"), false);
+  assert.equal(resultJson.includes(ENV.BLOB_READ_WRITE_TOKEN), false);
+  assert.equal(resultJson.includes(ENV.ATLAS_B2B_JWT), false);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${ZENDESK_EXPORT_PATH}`);
+  assert.equal(calls[0].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
+  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
+  assert.deepEqual(JSON.parse(calls[0].options.body), { limit: 1000, start_time: 0 });
+  assert.equal(calls[0].options.body.includes("account_id"), false);
+  assert.equal(calls[0].options.body.includes(ENV.BLOB_READ_WRITE_TOKEN), false);
+  assert.equal(putCalls.length, 1);
+  assert.equal(putCalls[0].pathname, `${BLOB_UPLOAD_PATH_PREFIX}123456-zendesk-api-export.json`);
+  assert.deepEqual(putCalls[0].options, {
+    access: "private",
+    addRandomSuffix: true,
+    contentType: "application/json",
+    token: ENV.BLOB_READ_WRITE_TOKEN,
+  });
+  assert.equal(putCalls[0].body.toString("utf8"), JSON.stringify(artifact));
+  assert.equal(calls[1].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);
+  assert.equal(calls[1].options.body.get("support_platform"), "zendesk");
+  assert.equal(calls[1].options.body.get("importer_mode"), FULL_THREAD_IMPORTER_MODE);
+  assert.equal(await calls[1].options.body.get("json_file").text(), JSON.stringify(artifact));
+  assert.deepEqual(deleteCalls, [
+    {
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}123456-zendesk-api-export-random.json`,
+      options: { token: ENV.BLOB_READ_WRITE_TOKEN },
+    },
+  ]);
+});
+
+await test("Zendesk credential flow fails closed when private Blob write fails", async () => {
+  const calls = [];
+  const artifact = {
+    tickets: [
+      {
+        ticket: { id: 123, status: "solved" },
+        comments: [{ id: 1, public: true, author_role: "agent", body: "Use Reports." }],
+      },
+    ],
+  };
+
+  const result = await submitZendeskCredentialFlow({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      if (url.endsWith(ZENDESK_EXPORT_PATH)) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({
+              importer_mode: FULL_THREAD_IMPORTER_MODE,
+              support_platform: "zendesk",
+              artifact,
+            });
+          },
+        };
+      }
+      throw new Error("must not submit after failed Blob write");
+    },
+    putBlobImpl: async () => {
+      throw new Error(`blob failed with ${ENV.BLOB_READ_WRITE_TOKEN}`);
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    statusCode: 502,
+    error: "zendesk_export_blob_unavailable",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${ZENDESK_EXPORT_PATH}`);
+  assert.equal(JSON.stringify(result).includes(ENV.BLOB_READ_WRITE_TOKEN), false);
+  assert.equal(JSON.stringify(result).includes("tickets"), false);
+});
+
+await test("Zendesk credential flow fails closed on malformed Blob write envelope", async () => {
+  const result = await submitZendeskCredentialFlow({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    fetchImpl: async (url) => {
+      assert.equal(url.endsWith(ZENDESK_EXPORT_PATH), true);
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({
+            importer_mode: FULL_THREAD_IMPORTER_MODE,
+            support_platform: "zendesk",
+            artifact: { tickets: [{ ticket: { id: 123 }, comments: [] }] },
+          });
+        },
+      };
+    },
+    putBlobImpl: async () => ({ url: "https://blob.example.com/private/no-pathname.json" }),
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    statusCode: 502,
+    error: "zendesk_export_blob_contract_violation",
+  });
+  assert.equal(JSON.stringify(result).includes("https://blob.example.com/private"), false);
+});
+
+await test("Zendesk credential flow preserves submit failure after export and Blob success", async () => {
+  const calls = [];
+  const deleteCalls = [];
+  let storedBody = null;
+  const result = await submitZendeskCredentialFlow({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    nowMs: 222,
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      if (url.endsWith(ZENDESK_EXPORT_PATH)) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({
+              importer_mode: FULL_THREAD_IMPORTER_MODE,
+              support_platform: "zendesk",
+              artifact: { tickets: [{ ticket: { id: 123 }, comments: [] }] },
+            });
+          },
+        };
+      }
+      assert.equal(url.endsWith(SUBMIT_PATH), true);
+      return {
+        ok: false,
+        status: 503,
+        async text() {
+          return JSON.stringify({
+            error: "upstream failed",
+            detail: ENV.ATLAS_B2B_JWT,
+          });
+        },
+      };
+    },
+    putBlobImpl: async (_pathname, body) => {
+      storedBody = body;
+      return { pathname: `${BLOB_UPLOAD_PATH_PREFIX}222-zendesk-api-export-random.json` };
+    },
+    getBlobImpl: async (pathname, options) => {
+      assert.equal(pathname, `${BLOB_UPLOAD_PATH_PREFIX}222-zendesk-api-export-random.json`);
+      assert.deepEqual(options, {
+        access: "private",
+        token: ENV.BLOB_READ_WRITE_TOKEN,
+        useCache: false,
+      });
+      return {
+        statusCode: 200,
+        stream: new Blob([storedBody], { type: "application/json" }).stream(),
+        blob: {
+          size: storedBody.length,
+          contentType: "application/json",
+        },
+      };
+    },
+    deleteBlobImpl: async (pathname, options) => {
+      deleteCalls.push({ pathname, options });
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    statusCode: 502,
+    error: "atlas_submit_failed",
+    atlas_status: 503,
+  });
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${ZENDESK_EXPORT_PATH}`);
+  assert.equal(calls[1].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);
+  assert.deepEqual(deleteCalls, [
+    {
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}222-zendesk-api-export-random.json`,
+      options: { token: ENV.BLOB_READ_WRITE_TOKEN },
+    },
+  ]);
+  assert.equal(JSON.stringify(result).includes(ENV.ATLAS_B2B_JWT), false);
+  assert.equal(JSON.stringify(result).includes("tickets"), false);
+});
+
+await test("Zendesk credential flow fails closed on malformed export envelope", async () => {
+  let putCalled = false;
+  const result = await submitZendeskCredentialFlow({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({
+          importer_mode: FULL_THREAD_IMPORTER_MODE,
+          support_platform: "zendesk",
+          artifact: { ticket: [] },
+        });
+      },
+    }),
+    putBlobImpl: async () => {
+      putCalled = true;
+      throw new Error("must not persist malformed export");
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    statusCode: 502,
+    error: "zendesk_export_contract_violation",
+  });
+  assert.equal(putCalled, false);
+});
+
+await test("Zendesk credential flow reports missing credentials without leaking upstream body", async () => {
+  let putCalled = false;
+  const result = await submitZendeskCredentialFlow({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    fetchImpl: async () => ({
+      ok: false,
+      status: 404,
+      async text() {
+        return JSON.stringify({
+          detail: {
+            reason: "zendesk_credentials_missing",
+            message: `missing ${ENV.ATLAS_B2B_JWT}`,
+          },
+        });
+      },
+    }),
+    putBlobImpl: async () => {
+      putCalled = true;
+      throw new Error("must not persist failed export");
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    statusCode: 404,
+    error: "zendesk_credentials_missing",
+    atlas_status: 404,
+  });
+  assert.equal(JSON.stringify(result).includes(ENV.ATLAS_B2B_JWT), false);
+  assert.equal(putCalled, false);
+});
+
+await test("Zendesk credential flow endpoint gates method, content type, and access token", async () => {
+  const previousFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    throw new Error("must not call ATLAS before route auth passes");
+  };
+  try {
+    const methodRes = mockResponse();
+    await zendeskExportSubmitHandler(
+      request({
+        method: "GET",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN}`,
+        },
+        body: Buffer.from("{}"),
+      }),
+      methodRes,
+    );
+    assert.equal(methodRes.statusCode, 405);
+    assert.deepEqual(JSON.parse(methodRes.body), { ok: false, error: "method_not_allowed" });
+
+    const contentTypeRes = mockResponse();
+    await zendeskExportSubmitHandler(
+      request({
+        headers: {
+          "content-type": "text/plain",
+          authorization: `Bearer ${ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN}`,
+        },
+        body: Buffer.from("{}"),
+      }),
+      contentTypeRes,
+    );
+    assert.equal(contentTypeRes.statusCode, 415);
+    assert.deepEqual(JSON.parse(contentTypeRes.body), {
+      ok: false,
+      error: "zendesk_export_json_required",
+    });
+
+    const authRes = mockResponse();
+    await withEnv(ENV, async () => {
+      await zendeskExportSubmitHandler(
+        request({
+          headers: { "content-type": "application/json" },
+          body: Buffer.from(JSON.stringify({
+            company_name: "Acme Co.",
+            contact_email: "lead@acme.example",
+          })),
+        }),
+        authRes,
+      );
+    });
+    assert.equal(authRes.statusCode, 401);
+    assert.deepEqual(JSON.parse(authRes.body), {
+      ok: false,
+      error: "zendesk_export_auth_required",
+    });
+    assert.equal(authRes.body.includes(ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN), false);
+    assert.equal(authRes.body.includes(ENV.ATLAS_B2B_JWT), false);
+    assert.equal(fetchCalled, false);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+await test("Zendesk credential flow endpoint rejects account spoofing before ATLAS", async () => {
+  const previousFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async (url, options) => {
+    fetchCalled = true;
+    throw new Error(`must not call ATLAS: ${url} ${options?.method}`);
+  };
+  const res = mockResponse();
+  try {
+    await withEnv(ENV, async () => {
+      await zendeskExportSubmitHandler(
+        request({
+          headers: {
+            "content-type": "application/json",
+            "authorization": `Bearer ${ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN}`,
+            "x-atlas-account-id": "3b2b950d-f64b-4852-bc30-f92a34cdf169",
+          },
+          body: Buffer.from(JSON.stringify({
+            company_name: "Acme Co.",
+            contact_email: "lead@acme.example",
+          })),
+        }),
+        res,
+      );
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(fetchCalled, false);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.headers["Cache-Control"], "no-store");
+  assert.deepEqual(JSON.parse(res.body), { ok: false, error: "invalid_account_id" });
+  assert.equal(res.body.includes(ENV.ATLAS_B2B_JWT), false);
 });
 
 await test("private blob submit blocks not-ready inspect before report submit", async () => {

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeft,
   CheckCircle2,
   FileSpreadsheet,
+  KeyRound,
   Loader2,
   RotateCcw,
   Send,
@@ -16,6 +17,7 @@ import { SeoHead } from "@/components/seo/SeoHead";
 const SUBMIT_ENDPOINT = "/api/content-ops/deflection/submit";
 const INSPECT_ENDPOINT = "/api/content-ops/deflection/inspect";
 const BLOB_UPLOAD_ENDPOINT = "/api/content-ops/deflection/upload";
+const ZENDESK_EXPORT_SUBMIT_ENDPOINT = "/api/content-ops/deflection/zendesk-export-submit";
 const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
 const MAX_CSV_BYTES = 50 * 1024 * 1024;
 const FULL_THREAD_IMPORTER_MODE = "full_thread";
@@ -36,6 +38,11 @@ const UPLOAD_MODES = [
     label: "Zendesk JSON",
     description: "Import ticket metadata plus public comment threads.",
   },
+  {
+    value: "zendesk_api",
+    label: "Zendesk API",
+    description: "Use stored tenant credentials to fetch public ticket threads.",
+  },
 ] as const;
 
 type UploadMode = (typeof UPLOAD_MODES)[number]["value"];
@@ -48,6 +55,7 @@ type UploadState =
 type SubmitState =
   | { status: "idle" }
   | { status: "inspecting" }
+  | { status: "exporting" }
   | { status: "uploading"; percentage: number }
   | { status: "submitting" }
   | { status: "error"; message: string };
@@ -172,14 +180,25 @@ async function inspectDeflectionCsv(file: File): Promise<InspectDiagnostics> {
 export default function FaqDeflectionUpload() {
   const [companyName, setCompanyName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
+  const [zendeskExportAccessToken, setZendeskExportAccessToken] = useState("");
   const [supportPlatform, setSupportPlatform] = useState<string>(SUPPORT_PLATFORMS[0].value);
   const [uploadMode, setUploadMode] = useState<UploadMode>("csv");
   const [upload, setUpload] = useState<UploadState>({ status: "empty" });
   const [inspect, setInspect] = useState<InspectState>({ status: "idle" });
   const [submit, setSubmit] = useState<SubmitState>({ status: "idle" });
   const isFullThreadUpload = uploadMode === "zendesk_full_thread";
-  const uploadLabel = isFullThreadUpload ? "Zendesk full-thread JSON" : "Support-ticket CSV";
-  const uploadFormat = isFullThreadUpload ? "Zendesk JSON" : "CSV";
+  const isZendeskApi = uploadMode === "zendesk_api";
+  const isZendeskSource = isFullThreadUpload || isZendeskApi;
+  const uploadLabel = isZendeskApi
+    ? "Stored Zendesk credentials"
+    : isFullThreadUpload
+      ? "Zendesk full-thread JSON"
+      : "Support-ticket CSV";
+  const uploadFormat = isZendeskApi
+    ? "Zendesk API export"
+    : isFullThreadUpload
+      ? "Zendesk JSON"
+      : "CSV";
 
   const fieldsReady = useMemo(
     () =>
@@ -187,19 +206,63 @@ export default function FaqDeflectionUpload() {
         companyName.trim() &&
           contactEmail.trim() &&
           supportPlatform &&
-          upload.status === "ready",
+          (!isZendeskApi || zendeskExportAccessToken.trim()) &&
+          (isZendeskApi || upload.status === "ready"),
       ),
-    [companyName, contactEmail, supportPlatform, upload.status],
+    [companyName, contactEmail, isZendeskApi, supportPlatform, upload.status, zendeskExportAccessToken],
   );
   const canSubmit =
     fieldsReady &&
     submit.status !== "inspecting" &&
+    submit.status !== "exporting" &&
     submit.status !== "uploading" &&
     submit.status !== "submitting";
   const isRetry = submit.status === "error";
 
   const startSubmit = async () => {
-    if (upload.status !== "ready" || !fieldsReady) return;
+    if (!fieldsReady) return;
+
+    if (isZendeskApi) {
+      try {
+        setInspect({ status: "idle" });
+        setSubmit({ status: "exporting" });
+        const response = await fetch(ZENDESK_EXPORT_SUBMIT_ENDPOINT, {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${zendeskExportAccessToken.trim()}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            company_name: companyName.trim(),
+            contact_email: contactEmail.trim(),
+            limit: "1000",
+            start_time: "0",
+          }),
+        });
+        const payload = (await response.json().catch(() => null)) as {
+          result_path?: unknown;
+          error?: unknown;
+        } | null;
+        if (!response.ok || !payload || typeof payload.result_path !== "string") {
+          const message =
+            payload && typeof payload.error === "string"
+              ? payload.error
+              : "Zendesk export submit could not be started.";
+          setSubmit({ status: "error", message });
+          return;
+        }
+        window.location.assign(payload.result_path);
+      } catch (error) {
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : "Zendesk export submit could not be completed.";
+        setSubmit({ status: "error", message });
+      }
+      return;
+    }
+
+    if (upload.status !== "ready") return;
 
     let phase: "inspect" | "upload" = isFullThreadUpload ? "upload" : "inspect";
     try {
@@ -293,6 +356,7 @@ export default function FaqDeflectionUpload() {
         data-atlas-deflection-submit-endpoint={SUBMIT_ENDPOINT}
         data-atlas-deflection-inspect-endpoint={INSPECT_ENDPOINT}
         data-atlas-deflection-upload-endpoint={BLOB_UPLOAD_ENDPOINT}
+        data-atlas-deflection-zendesk-export-submit-endpoint={ZENDESK_EXPORT_SUBMIT_ENDPOINT}
       >
         <Link
           to="/services"
@@ -354,7 +418,7 @@ export default function FaqDeflectionUpload() {
                       setUpload({ status: "empty" });
                       setInspect({ status: "idle" });
                       setSubmit({ status: "idle" });
-                      if (mode.value === "zendesk_full_thread") {
+                      if (mode.value !== "csv") {
                         setSupportPlatform("zendesk");
                       }
                     }}
@@ -398,7 +462,7 @@ export default function FaqDeflectionUpload() {
                   className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 text-sm text-white outline-none transition focus:border-primary-400 disabled:cursor-not-allowed disabled:text-surface-200/55"
                   data-atlas-deflection-support-platform
                   value={supportPlatform}
-                  disabled={isFullThreadUpload}
+                  disabled={isZendeskSource}
                   onChange={(event) => {
                     setSupportPlatform(event.target.value);
                     setInspect({ status: "idle" });
@@ -421,55 +485,108 @@ export default function FaqDeflectionUpload() {
               </div>
             </div>
 
-            <label className="mt-6 block rounded-lg border border-dashed border-surface-600 bg-surface-900/55 p-5 transition focus-within:border-primary-400">
-              <span className="flex items-center gap-3 text-sm font-medium text-surface-100">
-                <Upload size={18} className="text-primary-300" />
-                {uploadLabel}
-              </span>
-              <input
-                key={uploadMode}
-                className="mt-4 block w-full cursor-pointer rounded-lg border border-surface-700 bg-surface-900 text-sm text-surface-100 file:mr-4 file:border-0 file:bg-primary-500 file:px-4 file:py-3 file:text-sm file:font-semibold file:text-surface-900"
-                data-atlas-deflection-csv-file
-                data-atlas-deflection-upload-file
-                type="file"
-                accept={isFullThreadUpload ? ".json,application/json" : ".csv,text/csv"}
-                onChange={(event) => {
-                  setUpload(fileState(event.target.files?.[0], uploadMode));
-                  setInspect({ status: "idle" });
-                }}
-              />
+            {isZendeskApi ? (
               <div
-                className="mt-4 space-y-2 text-xs leading-5 text-surface-200/70"
-                data-atlas-deflection-export-guidance
+                className="mt-6 rounded-lg border border-surface-700 bg-surface-900/55 p-5"
+                data-atlas-deflection-zendesk-api-source
               >
-                <p className="font-semibold text-surface-100">
-                  {isFullThreadUpload
-                    ? "Best input: Zendesk ticket JSON with public requester comments, public agent replies, status, and satisfaction fields."
-                    : "Best input: full ticket threads with customer questions plus agent replies, resolution text, or resolved ticket notes."}
-                </p>
-                <p>
-                  {isFullThreadUpload
-                    ? "Private notes are dropped during import. ATLAS validates the thread shape during submit before the locked report is created."
-                    : "Question-only exports still work for clustering and a gap list, but publishable answers require uploaded resolution evidence."}
-                </p>
+                <span className="flex items-center gap-3 text-sm font-medium text-surface-100">
+                  <KeyRound size={18} className="text-primary-300" />
+                  {uploadLabel}
+                </span>
+                <div
+                  className="mt-4 space-y-2 text-xs leading-5 text-surface-200/70"
+                  data-atlas-deflection-export-guidance
+                >
+                  <p className="font-semibold text-surface-100">
+                    ATLAS exports Zendesk tickets server-side using the stored
+                    tenant credentials for this workspace.
+                  </p>
+                  <p>
+                    The browser receives only the locked report path. Exported
+                    ticket threads are written to private Blob and submitted as
+                    full-thread Zendesk JSON without exposing the artifact.
+                  </p>
+                </div>
+                <label className="mt-4 block">
+                  <span className="text-sm font-medium text-surface-100">
+                    Export access token
+                  </span>
+                  <input
+                    className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-950 px-3 py-3 text-sm text-white outline-none transition focus:border-primary-400"
+                    data-atlas-deflection-zendesk-export-access-token
+                    type="password"
+                    value={zendeskExportAccessToken}
+                    onChange={(event) => setZendeskExportAccessToken(event.target.value)}
+                    autoComplete="off"
+                    placeholder="Paste route access token"
+                  />
+                </label>
+                <div className="mt-4 rounded-md border border-primary-500/30 bg-primary-500/10 px-4 py-3">
+                  <p className="text-sm font-semibold text-primary-100">
+                    🛡️ 100% Deterministic Engine
+                  </p>
+                  <p className="mt-2 text-xs leading-5 text-primary-100/80">
+                    This tool does not use LLMs or generative AI to analyze your
+                    logs. We use deterministic clustering to sort your data.
+                  </p>
+                </div>
+                <span className="mt-3 block text-xs text-surface-200/60">
+                  Up to 1,000 tickets per export. Credentials, service tokens,
+                  private Blob tokens, and ticket artifacts stay server-side.
+                </span>
               </div>
-              <div className="mt-4 rounded-md border border-primary-500/30 bg-primary-500/10 px-4 py-3">
-                <p className="text-sm font-semibold text-primary-100">
-                  🛡️ 100% Deterministic Engine
-                </p>
-                <p className="mt-2 text-xs leading-5 text-primary-100/80">
-                  This tool does not use LLMs or generative AI to analyze your
-                  logs. We use deterministic clustering to sort your data.
-                </p>
-              </div>
-              <span className="mt-3 block text-xs text-surface-200/60">
-                Up to 50 MB. {isFullThreadUpload ? "JSON import" : "CSV inspection"} and
-                private storage both run server-side; service tokens never reach the browser.
-              </span>
-            </label>
+            ) : (
+              <label className="mt-6 block rounded-lg border border-dashed border-surface-600 bg-surface-900/55 p-5 transition focus-within:border-primary-400">
+                <span className="flex items-center gap-3 text-sm font-medium text-surface-100">
+                  <Upload size={18} className="text-primary-300" />
+                  {uploadLabel}
+                </span>
+                <input
+                  key={uploadMode}
+                  className="mt-4 block w-full cursor-pointer rounded-lg border border-surface-700 bg-surface-900 text-sm text-surface-100 file:mr-4 file:border-0 file:bg-primary-500 file:px-4 file:py-3 file:text-sm file:font-semibold file:text-surface-900"
+                  data-atlas-deflection-csv-file
+                  data-atlas-deflection-upload-file
+                  type="file"
+                  accept={isFullThreadUpload ? ".json,application/json" : ".csv,text/csv"}
+                  onChange={(event) => {
+                    setUpload(fileState(event.target.files?.[0], uploadMode));
+                    setInspect({ status: "idle" });
+                  }}
+                />
+                <div
+                  className="mt-4 space-y-2 text-xs leading-5 text-surface-200/70"
+                  data-atlas-deflection-export-guidance
+                >
+                  <p className="font-semibold text-surface-100">
+                    {isFullThreadUpload
+                      ? "Best input: Zendesk ticket JSON with public requester comments, public agent replies, status, and satisfaction fields."
+                      : "Best input: full ticket threads with customer questions plus agent replies, resolution text, or resolved ticket notes."}
+                  </p>
+                  <p>
+                    {isFullThreadUpload
+                      ? "Private notes are dropped during import. ATLAS validates the thread shape during submit before the locked report is created."
+                      : "Question-only exports still work for clustering and a gap list, but publishable answers require uploaded resolution evidence."}
+                  </p>
+                </div>
+                <div className="mt-4 rounded-md border border-primary-500/30 bg-primary-500/10 px-4 py-3">
+                  <p className="text-sm font-semibold text-primary-100">
+                    🛡️ 100% Deterministic Engine
+                  </p>
+                  <p className="mt-2 text-xs leading-5 text-primary-100/80">
+                    This tool does not use LLMs or generative AI to analyze your
+                    logs. We use deterministic clustering to sort your data.
+                  </p>
+                </div>
+                <span className="mt-3 block text-xs text-surface-200/60">
+                  Up to 50 MB. {isFullThreadUpload ? "JSON import" : "CSV inspection"} and
+                  private storage both run server-side; service tokens never reach the browser.
+                </span>
+              </label>
+            )}
 
             <div className="mt-5 min-h-12">
-              {upload.status === "ready" && (
+              {!isZendeskApi && upload.status === "ready" && (
                 <div className="flex items-start gap-3 rounded-lg border border-primary-500/30 bg-primary-500/10 p-4 text-sm text-primary-100">
                   <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-primary-300" />
                   <p>
@@ -477,7 +594,7 @@ export default function FaqDeflectionUpload() {
                   </p>
                 </div>
               )}
-              {upload.status === "invalid" && (
+              {!isZendeskApi && upload.status === "invalid" && (
                 <div className="flex items-start gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100">
                   <AlertTriangle className="mt-0.5 h-5 w-5 flex-none text-amber-300" />
                   <p>{upload.message}</p>
@@ -505,6 +622,15 @@ export default function FaqDeflectionUpload() {
                       style={{ width: `${submit.percentage}%` }}
                     />
                   </div>
+                </div>
+              )}
+              {submit.status === "exporting" && (
+                <div
+                  className="flex items-start gap-3 rounded-lg border border-primary-500/30 bg-primary-500/10 p-4 text-sm text-primary-100"
+                  data-atlas-deflection-zendesk-export-progress
+                >
+                  <Loader2 className="mt-0.5 h-5 w-5 flex-none animate-spin text-primary-300" />
+                  <p>Exporting Zendesk tickets with stored workspace credentials.</p>
                 </div>
               )}
               {inspect.status === "checking" && (
@@ -594,6 +720,11 @@ export default function FaqDeflectionUpload() {
                   <Loader2 className="h-4 w-4 animate-spin" />
                   Checking CSV
                 </>
+              ) : submit.status === "exporting" ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Exporting Zendesk
+                </>
               ) : submit.status === "uploading" ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -618,8 +749,10 @@ export default function FaqDeflectionUpload() {
             </button>
             {submit.status === "error" && (
               <p className="mt-3 text-xs leading-5 text-amber-200" data-atlas-deflection-retry>
-                {submit.message} Retry keeps the selected {uploadFormat} and starts a new
-                private upload.
+                {submit.message}{" "}
+                {isZendeskApi
+                  ? "Retry starts a new server-side Zendesk export."
+                  : `Retry keeps the selected ${uploadFormat} and starts a new private upload.`}
               </p>
             )}
           </form>
@@ -642,12 +775,14 @@ export default function FaqDeflectionUpload() {
               <div>
                 <dt className="text-surface-200/60">Submit mode</dt>
                 <dd className="mt-1 font-mono text-xs text-surface-100">
-                  private_blob_persistence
+                  {isZendeskApi ? "zendesk_api_export" : "private_blob_persistence"}
                 </dd>
               </div>
             </dl>
             <p className="mt-5 text-sm leading-6 text-surface-200/70">
-              {isFullThreadUpload
+              {isZendeskApi
+                ? "ATLAS exports from stored Zendesk credentials server-side, stores the artifact privately, then sends the browser to the locked result page for snapshot hydration and Checkout."
+                : isFullThreadUpload
                 ? "ATLAS reads the private Zendesk JSON server-side, imports public thread evidence, then sends the browser to the locked result page for snapshot hydration and Checkout."
                 : "ATLAS checks the CSV first, stores it privately after validation, then sends the browser to the locked result page for snapshot hydration and Checkout."}
             </p>


### PR DESCRIPTION
Plan: plans/PR-Deflection-Zendesk-Credential-Flow.md
Slice phase: Vertical slice

#1527 shipped the hosted tenant-scoped Zendesk export route. This slice wires the portfolio intake to that route: the browser can choose Zendesk API mode, enter a narrow route access token, and the portfolio server calls ATLAS with server-side credentials, persists the returned full-thread artifact to private Blob, and reuses the existing full-thread submit helper without exposing Zendesk credentials, ATLAS service tokens, Blob tokens, private Blob URLs, or exported ticket artifacts to browser-visible payloads.

## Intentional
- No new backend route; #1527 already owns the tenant-scoped ATLAS export boundary.
- The exported Zendesk artifact stays server-side. Manual saved-JSON upload remains available for hand-saved exports.
- The browser-visible token is only a route access gate for this public portfolio endpoint; ATLAS, Zendesk, and Blob service credentials remain server-side.
- No new npm script; the existing enrolled `test:deflection-upload-shell` covers the new UI/proxy branches.

## Deferred
- Browser-automated live smoke against the operator's Zendesk trial credentials after deployment.
- Optional export progress/polling UX if live Zendesk exports are too slow for one request.
- Production provisioning of `ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN` alongside the existing portfolio server env.

## Parked hardening
- None.

## AI reconciliation
- Codex P1 `Require auth before running stored Zendesk export`: fixed by requiring `Authorization: Bearer <ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN>` before account checks, ATLAS export, Blob writes, or submit. All fixed or waived: yes.
- Reviewer MAJOR test gaps: fixed with enrolled shell-test coverage for Blob write failure, malformed Blob write envelope, success-response secrecy, and export-success/Blob-success/submit-failure through `submitZendeskCredentialFlow`. All fixed or waived: yes.

## Verification
- `cd portfolio-ui && npm run test:deflection-upload-shell` -- 37 passed.
- `cd portfolio-ui && npm run test:deflection-result` -- 19 passed.
- `cd portfolio-ui && npm run test:deflection-atlas-proxy` -- 18 passed.
- `cd portfolio-ui && npm run build` -- passed; existing sitemap-env and large-chunk warnings only.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4063 passed, 10 skipped, 1 existing torch/pynvml warning.
- `python scripts/sync_pr_plan.py --check plans/PR-Deflection-Zendesk-Credential-Flow.md` -- passed.

## Diff size
4 files, +1211 / -57
