### PR TITLE
Deflection Zendesk full-thread proof

### DIFF
--- a/docs/extraction/validation/deflection_zendesk_full_thread_proof_2026-06-13.md
+++ b/docs/extraction/validation/deflection_zendesk_full_thread_proof_2026-06-13.md
@@ -1,0 +1,58 @@
+# Deflection Zendesk Full-Thread Proof
+
+Date: 2026-06-13
+
+Issue: #1419
+
+## What Ran
+
+This validation proves the Zendesk full-thread import shape can drive the paid
+FAQ deflection report's publishable-answer lane. The source fixture is a
+captured Zendesk trial API artifact shaped as `tickets + comments`:
+
+- ticket description and public requester comments become customer wording;
+- public agent replies become resolution evidence;
+- `public=false` internal notes are excluded;
+- Zendesk `status` and `satisfaction_rating` remain diagnostics.
+
+CI proof:
+
+```bash
+pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q
+```
+
+## Proof Artifacts
+
+- Source fixture:
+  `tests/fixtures/zendesk_full_thread_seed_sample.json`
+- Generated summary sample:
+  `docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/summary.json`
+- Generated report excerpt:
+  `docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/report_excerpt.md`
+
+## Result
+
+| Metric | Value |
+|---|---:|
+| Source rows | 4 |
+| Ranked questions | 1 |
+| Publishable answers drafted from proven resolutions | 1 |
+| Questions still needing approved resolutions | 0 |
+| Resolution evidence present | true |
+| Resolution evidence count | 1 |
+
+The generated paid artifact contains the public refund-answer resolution:
+
+> We confirmed the duplicate billing event and refunded the extra charge.
+
+The paid artifact does not contain the private internal note, the boilerplate
+auto-ack, or the reopened customer's "still broken" follow-up as publishable
+copy. Status and CSAT are still present in the input-provider metadata, but do
+not create extra publishable answers by themselves.
+
+## Launch Implication
+
+This closes the deterministic #1419 proof gap for the Zendesk full-thread
+path: an API-shaped Zendesk export with public agent replies can unlock
+publishable help-center copy, while private notes and diagnostics do not leak
+into customer-facing answers.

--- a/docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/report_excerpt.md
+++ b/docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/report_excerpt.md
@@ -1,0 +1,16 @@
+## Publishable Help-Center Copy From Proven Resolutions
+
+### 1. How do I get the duplicate charge refunded?
+
+To resolve this, we confirmed the duplicate billing event and refunded the
+extra charge. Then refunds normally appear on the original payment method in
+5-10 business days.
+
+**Draft answer steps:**
+
+1. We confirmed the duplicate billing event and refunded the extra charge.
+2. Refunds normally appear on the original payment method in 5-10 business days.
+3. If it still does not work, contact support and include the cited ticket details.
+
+**Evidence backing:** Backed by 1 resolved ticket (2). Full source IDs are in
+the Evidence Appendix.

--- a/docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/summary.json
@@ -1,0 +1,22 @@
+{
+  "drafted_answer_count": 1,
+  "generated": 1,
+  "no_proven_answer_count": 0,
+  "non_repeat_question_count": 3,
+  "non_repeat_ticket_count": 3,
+  "output_checks": {
+    "condensed": true,
+    "has_action_items": true,
+    "resolution_evidence_scoped": true,
+    "uses_user_vocabulary": true
+  },
+  "source_count": 4,
+  "source_date_end": "2026-06-13",
+  "source_date_start": "2026-06-13",
+  "source_window_days": 1,
+  "support_ticket_resolution_evidence_count": 1,
+  "support_ticket_resolution_evidence_present": true,
+  "ticket_source_count": 4,
+  "top_opportunity_score": 1,
+  "top_question": "How do I get the duplicate charge refunded?"
+}

--- a/plans/PR-Deflection-Zendesk-Full-Thread-Proof.md
+++ b/plans/PR-Deflection-Zendesk-Full-Thread-Proof.md
@@ -1,0 +1,129 @@
+# PR-Deflection-Zendesk-Full-Thread-Proof
+
+## Why this slice exists
+
+Issue #1419 still needs the publishable-answer lane proven on a real
+resolution-bearing Zendesk full-thread export. The CSV/intake path can already
+surface gap-list diagnostics, and #1532 wired per-tenant Zendesk credentials,
+but the launch gate still needs a deterministic proof that the API-shaped
+`tickets + comments` export can flow through submit -> paid artifact and
+produce at least one publishable FAQ answer without leaking private notes.
+
+This is a vertical proof slice, not a new importer: the Zendesk full-thread
+normalizer, full-thread submit mode, and paid-report artifact path already
+exist. This PR pins their combined behavior with the seeded Zendesk trial JSON
+fixture from #1507/#1419.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Extend the existing full-thread deflection-submit test so the Zendesk
+   API-shaped JSON fixture is unlocked through the paid artifact route, not
+   only accepted as metadata.
+2. Assert the launch-critical proof points: `drafted_answer_count > 0`,
+   `resolution_evidence` answer status, refund-answer copy present, private
+   note text absent, auto-ack text absent, and unresolved/reopen-style public
+   text does not become publishable copy merely because status/CSAT/reopen
+   diagnostics exist.
+3. Add a compact validation note pointing reviewers/operators at the source
+   fixture and generated proof values.
+
+### Review Contract
+
+Acceptance criteria:
+- The seeded Zendesk full-thread fixture reaches the paid report artifact path
+  and produces a summary with at least one drafted answer backed by
+  `resolution_evidence`.
+- The generated artifact contains the public refund-answer resolution from the
+  agent reply.
+- Internal/private note text and boilerplate auto-ack text are absent from the
+  free payload, paid artifact, and markdown/report strings asserted by the
+  test.
+- Status and CSAT metadata remain exposed as diagnostics, but do not create
+  extra publishable answers by themselves.
+- No live Zendesk API call runs in CI; the proof uses the committed
+  `tests/fixtures/zendesk_full_thread_seed_sample.json` producer-shaped
+  artifact.
+
+Affected surfaces:
+- `tests/test_extracted_content_deflection_submit.py`
+- `docs/extraction/validation/deflection_zendesk_full_thread_proof_2026-06-13.md`
+
+Risk areas:
+- Accidentally asserting only package metadata while leaving the paid report
+  artifact unproved.
+- Leaking private/internal notes into customer-facing strings.
+- Treating diagnostics such as open status or CSAT as answer evidence.
+- Adding a new test without enrolling it in the extracted-checks suite.
+
+Reviewer rules triggered: R1, R2, R12, R14.
+
+### Files touched
+
+- `docs/extraction/validation/deflection_zendesk_full_thread_proof_2026-06-13.md`
+- `docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/report_excerpt.md`
+- `docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/summary.json`
+- `plans/PR-Deflection-Zendesk-Full-Thread-Proof.md`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+The existing `test_deflection_submit_accepts_zendesk_full_thread_blob` already
+submits the Zendesk seed JSON through the control-surface route and checks the
+normalized package metadata. This PR extends that same enrolled route test:
+
+1. Submit the API-shaped Zendesk full-thread blob with
+   `importer_mode="full_thread"`.
+2. Confirm the locked/free response still hides the full report.
+3. Mark the request paid through the existing paid route.
+4. Fetch the artifact route and assert the summary/markdown prove the
+   publishable-answer lane while excluding private notes and boilerplate.
+
+The validation doc records the same fixture, run target, and headline generated
+values for the operator/reviewer. The test is added to an existing test file
+already listed in `scripts/run_extracted_pipeline_checks.sh`, so no new CI
+enrollment step is needed.
+
+## Intentional
+
+- No live Zendesk API call in this PR. The trial API shape was already captured
+  as `tests/fixtures/zendesk_full_thread_seed_sample.json`; CI must stay
+  deterministic and token-free.
+- No new CLI/importer mode. The route and importer are already merged; this
+  slice proves the existing full-thread path rather than expanding product
+  surface.
+- The fixture has one publishable answer and several non-repeat/unresolved
+  tickets. That is enough for the vertical proof because #1419's remaining
+  launch gate is "can a full-thread export produce publishable answers at all?"
+  while preserving private-note safety.
+
+## Deferred
+
+- Reopen/CSAT product scoring remains deferred to the product-decision follow-up
+  already called out in #1419/#1510. This slice only proves those fields remain
+  diagnostics and do not create answer evidence on their own.
+- Live operator run against a fresh Zendesk trial/export remains outside CI;
+  this PR pins the committed producer-shaped artifact so the regression guard
+  is stable.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` - 1 passed.
+- `pytest tests/test_extracted_content_deflection_submit.py -q` - 53 passed.
+- `pytest tests/test_extracted_support_ticket_input_package.py -q` - 61 passed.
+- `scripts/run_extracted_pipeline_checks.sh` via bash - extracted reasoning core 295 passed; extracted content pipeline 4080 passed, 10 skipped; all checks completed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/deflection_zendesk_full_thread_proof_2026-06-13.md` | 58 |
+| `docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/report_excerpt.md` | 16 |
+| `docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/summary.json` | 22 |
+| `plans/PR-Deflection-Zendesk-Full-Thread-Proof.md` | 129 |
+| `tests/test_extracted_content_deflection_submit.py` | 40 |
+| **Total** | **265** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -380,10 +380,48 @@ async def test_deflection_submit_accepts_zendesk_full_thread_blob(
     assert payload["input_provider"]["warnings"] == []
     assert "Internal note" not in json.dumps(payload)
     assert "A member of the support team will get back to you" not in json.dumps(payload)
-    assert payload["steps"][0]["result"]["full_report"] == {
+    gated_result = payload["steps"][0]["result"]
+    assert gated_result["full_report"] == {
         "status": "locked",
         "reason": "payment_required",
     }
+    assert "markdown" not in str(gated_result)
+
+    artifact = _route(router, "/ops/deflection-reports/{request_id}/artifact", "GET")
+    with pytest.raises(api_module.HTTPException) as locked:
+        await artifact.endpoint(request_id=payload["request_id"])
+    assert locked.value.status_code == 403
+
+    paid = _route(router, "/ops/deflection-reports/{request_id}/paid", "POST")
+    assert await paid.endpoint(
+        payload=api_module.DeflectionReportPaidModel(
+            payment_reference="checkout-session:zendesk-full-thread"
+        ),
+        request_id=payload["request_id"],
+    ) == {"request_id": payload["request_id"], "paid": True}
+
+    artifact_payload = await artifact.endpoint(request_id=payload["request_id"])
+    summary = artifact_payload["summary"]
+    assert summary["drafted_answer_count"] == 1
+    assert summary["support_ticket_resolution_evidence_present"] is True
+    assert summary["support_ticket_resolution_evidence_count"] == 1
+    assert summary["no_proven_answer_count"] == 0
+    assert artifact_payload["faq_result"]["items"][0]["answer_evidence_status"] == (
+        "resolution_evidence"
+    )
+    assert list(artifact_payload["faq_result"]["items"][0]["source_ids"]) == ["2"]
+    assert "duplicate billing event and refunded the extra charge" in (
+        artifact_payload["markdown"]
+    )
+    assert "Internal note" not in json.dumps(artifact_payload)
+    assert "A member of the support team will get back to you" not in json.dumps(
+        artifact_payload
+    )
+    assert "We sent the standard resolution steps" not in artifact_payload["markdown"]
+    assert "This is still broken after trying the steps" not in artifact_payload[
+        "markdown"
+    ]
+    assert "lead@acme.example" not in json.dumps(artifact_payload)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Zendesk-Full-Thread-Proof.md
Slice phase: Vertical slice

Issue #1419 still needed deterministic proof that a Zendesk full-thread export can drive the paid report's publishable-answer lane. This PR extends the existing enrolled submit-route test so the committed Zendesk API-shaped seed JSON goes through submit, stays locked before payment, unlocks through the paid artifact route, and proves one `resolution_evidence` answer while keeping private notes, auto-acks, and reopen-style unresolved text out of customer-facing copy.

## Intentional
- No live Zendesk API call in CI; this uses `tests/fixtures/zendesk_full_thread_seed_sample.json`.
- No new importer or CLI mode; this proves the merged full-thread submit and paid artifact path.
- The fixture proves the vertical launch gate with one publishable answer while preserving private-note safety.

## Deferred
- Reopen/CSAT product scoring remains in the #1419/#1510 follow-up; this PR only proves those fields stay diagnostics and do not create answer evidence by themselves.
- Fresh live operator export remains outside deterministic CI.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` - 1 passed.
- `pytest tests/test_extracted_content_deflection_submit.py -q` - 53 passed.
- `pytest tests/test_extracted_support_ticket_input_package.py -q` - 61 passed.
- `scripts/run_extracted_pipeline_checks.sh` via bash - extracted reasoning core 295 passed; extracted content pipeline 4080 passed, 10 skipped; all checks completed.

## Proof artifacts
- Source fixture: `tests/fixtures/zendesk_full_thread_seed_sample.json`
- Proof note: `docs/extraction/validation/deflection_zendesk_full_thread_proof_2026-06-13.md`
- Generated summary: `docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/summary.json`
- Generated report excerpt: `docs/extraction/validation/fixtures/deflection_zendesk_full_thread_proof_20260613/report_excerpt.md`

## Diff size
5 files, +264 / -1
