### PR TITLE
Deflection embedding booster core

### DIFF
--- a/extracted_content_pipeline/embedding_port.py
+++ b/extracted_content_pipeline/embedding_port.py
@@ -1,0 +1,45 @@
+"""Model-free embedding port contract for extracted content helpers."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Protocol
+
+
+class EmbeddingPort(Protocol):
+    def embed_texts(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
+        """Return one vector per input text, preserving order."""
+
+
+def cosine_similarity(
+    left: Sequence[float],
+    right: Sequence[float],
+) -> float | None:
+    """Return cosine similarity, or None for malformed/non-comparable vectors."""
+
+    if (
+        not isinstance(left, Sequence)
+        or not isinstance(right, Sequence)
+        or isinstance(left, (str, bytes, bytearray))
+        or isinstance(right, (str, bytes, bytearray))
+        or len(left) != len(right)
+        or len(left) == 0
+    ):
+        return None
+    try:
+        left_values = tuple(float(value) for value in left)
+        right_values = tuple(float(value) for value in right)
+    except (TypeError, ValueError):
+        return None
+    if not all(math.isfinite(value) for value in left_values + right_values):
+        return None
+    left_norm = math.sqrt(sum(value * value for value in left_values))
+    right_norm = math.sqrt(sum(value * value for value in right_values))
+    if left_norm == 0 or right_norm == 0:
+        return None
+    result = sum(
+        left_value * right_value
+        for left_value, right_value in zip(left_values, right_values, strict=True)
+    ) / (left_norm * right_norm)
+    return result if math.isfinite(result) else None

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -328,6 +328,9 @@
       "target": "extracted_content_pipeline/ticket_faq_markdown.py"
     },
     {
+      "target": "extracted_content_pipeline/embedding_port.py"
+    },
+    {
       "target": "extracted_content_pipeline/faq_deflection_report.py"
     },
     {

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -15,6 +15,7 @@ from .campaign_source_adapters import (
     source_material_to_source_rows,
     source_rows_to_campaign_opportunities,
 )
+from .embedding_port import EmbeddingPort, cosine_similarity
 from .support_ticket_clustering import (
     support_ticket_plain_text,
     support_ticket_tokens,
@@ -456,6 +457,7 @@ class TicketFAQMarkdownConfig:
     documentation_terms: tuple[str, ...] = ()
     representative_taxonomy_terms: tuple[str, ...] = ()
     vocabulary_gap_rules: tuple[tuple[str, ...], ...] = ()
+    embedding_port: EmbeddingPort | None = None
 
 
 class TicketFAQMarkdownService:
@@ -488,6 +490,7 @@ class TicketFAQMarkdownService:
         documentation_terms: Sequence[str] | None = None,
         representative_taxonomy_terms: Sequence[str] | None = None,
         vocabulary_gap_rules: Sequence[Sequence[str]] | None = None,
+        embedding_port: EmbeddingPort | None = None,
         **kwargs: Any,
     ) -> TicketFAQMarkdownResult:
         del kwargs
@@ -547,6 +550,11 @@ class TicketFAQMarkdownService:
             if vocabulary_gap_rules is not None
             else self.config.vocabulary_gap_rules
         )
+        resolved_embedding_port = (
+            embedding_port
+            if embedding_port is not None
+            else self.config.embedding_port
+        )
         title_text = title or self.config.title
         result = build_ticket_faq_markdown(
             normalized.opportunities,
@@ -561,6 +569,7 @@ class TicketFAQMarkdownService:
             documentation_terms=resolved_documentation_terms,
             representative_taxonomy_terms=resolved_representative_taxonomy_terms,
             vocabulary_gap_rules=resolved_vocabulary_gap_rules,
+            embedding_port=resolved_embedding_port,
         )
         result = replace(
             result,
@@ -614,6 +623,7 @@ def build_ticket_faq_markdown(
     documentation_terms: Sequence[str] = (),
     representative_taxonomy_terms: Sequence[str] = (),
     vocabulary_gap_rules: Sequence[Sequence[str]] = (),
+    embedding_port: EmbeddingPort | None = None,
 ) -> TicketFAQMarkdownResult:
     """Render an extractive FAQ from normalized source-row opportunities."""
 
@@ -719,7 +729,9 @@ def build_ticket_faq_markdown(
         if not scope.startswith("topic:"):
             subclustered_groups[(topic, scope)] = rows
             continue
-        for cluster_index, cluster_rows in enumerate(_question_subclusters(rows)):
+        for cluster_index, cluster_rows in enumerate(
+            _question_subclusters(rows, embedding_port=embedding_port)
+        ):
             cluster_keys = _row_source_keys(cluster_rows)
             if len(cluster_keys) < 2:
                 excluded_singleton_keys.update(cluster_keys)
@@ -830,14 +842,19 @@ def _evidence_rows(opportunity: Mapping[str, Any]) -> tuple[Mapping[str, Any], .
 
 _SUBCLUSTER_JACCARD_THRESHOLD = 1 / 3
 _SUBCLUSTER_GIST_TOKEN_LIMIT = 30
+_EMBEDDING_MNN_COSINE_FLOOR = 0.78
+_EMBEDDING_MNN_MARGIN = 0.05
+
+
+def _question_gist_text(text: str) -> str:
+    question = _question_text(text)
+    return question if question else " ".join(text.split()[: _SUBCLUSTER_GIST_TOKEN_LIMIT])
 
 
 def _question_gist_tokens(text: str) -> frozenset[str]:
     """Tokens of the row's question sentence, or its opening gist."""
 
-    question = _question_text(text)
-    source = question if question else " ".join(text.split()[: _SUBCLUSTER_GIST_TOKEN_LIMIT])
-    tokens = support_ticket_tokens(source)
+    tokens = support_ticket_tokens(_question_gist_text(text))
     return frozenset(
         token for token in tokens if not _REDACTION_TOKEN_RE.fullmatch(token)
     )
@@ -874,6 +891,8 @@ def _row_source_keys(rows: Sequence[Mapping[str, str]]) -> set[str]:
 
 def _question_subclusters(
     rows: Sequence[Mapping[str, str]],
+    *,
+    embedding_port: EmbeddingPort | None = None,
 ) -> list[list[Mapping[str, str]]]:
     """Split one degraded topic bucket into question-similarity clusters.
 
@@ -925,10 +944,89 @@ def _question_subclusters(
         for token in prefix:
             prefix_index[token].append(index)
 
+    _apply_embedding_booster(
+        rows,
+        gists=gists,
+        find=find,
+        union=union,
+        embedding_port=embedding_port,
+    )
+
     clusters: dict[int, list[Mapping[str, str]]] = defaultdict(list)
     for index, row in enumerate(rows):
         clusters[find(index)].append(row)
     return [clusters[root] for root in sorted(clusters)]
+
+
+def _apply_embedding_booster(
+    rows: Sequence[Mapping[str, str]],
+    *,
+    gists: Sequence[frozenset[str]],
+    find: Callable[[int], int],
+    union: Callable[[int, int], None],
+    embedding_port: EmbeddingPort | None,
+) -> None:
+    if embedding_port is None or len(rows) < 2:
+        return
+    texts = [
+        _question_gist_text(str(row.get("text") or "")).strip()
+        for row in rows
+    ]
+    component_sizes: dict[int, int] = defaultdict(int)
+    for index in range(len(rows)):
+        component_sizes[find(index)] += 1
+    active_indexes = [
+        index
+        for index, text in enumerate(texts)
+        if text and gists[index] and component_sizes[find(index)] == 1
+    ]
+    if len(active_indexes) < 2:
+        return
+    try:
+        embedded = embedding_port.embed_texts([texts[index] for index in active_indexes])
+    except Exception:
+        return
+    if (
+        not isinstance(embedded, Sequence)
+        or isinstance(embedded, (str, bytes, bytearray))
+        or len(embedded) != len(active_indexes)
+    ):
+        return
+    vectors: dict[int, Sequence[float]] = {
+        index: embedded[position]
+        for position, index in enumerate(active_indexes)
+    }
+    best_by_index: dict[int, tuple[int, float, float]] = {}
+    for index in active_indexes:
+        scored: list[tuple[float, int]] = []
+        for candidate in active_indexes:
+            if candidate == index or find(candidate) == find(index):
+                continue
+            score = cosine_similarity(vectors[index], vectors[candidate])
+            if score is None:
+                continue
+            scored.append((score, candidate))
+        if not scored:
+            continue
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        best_score, best_index = scored[0]
+        runner_up = scored[1][0] if len(scored) > 1 else -1.0
+        best_by_index[index] = (best_index, best_score, runner_up)
+    pairs: set[tuple[int, int]] = set()
+    for index, (candidate, score, runner_up) in best_by_index.items():
+        candidate_best = best_by_index.get(candidate)
+        if candidate_best is None or candidate_best[0] != index:
+            continue
+        if score < _EMBEDDING_MNN_COSINE_FLOOR:
+            continue
+        if score - runner_up < _EMBEDDING_MNN_MARGIN:
+            continue
+        if candidate_best[1] - candidate_best[2] < _EMBEDDING_MNN_MARGIN:
+            continue
+        pairs.add(tuple(sorted((index, candidate))))
+    for left, right in sorted(pairs):
+        if find(left) != find(right):
+            union(left, right)
 
 
 def _topic(

--- a/plans/PR-Deflection-Embedding-Booster-Core.md
+++ b/plans/PR-Deflection-Embedding-Booster-Core.md
@@ -1,0 +1,127 @@
+# PR-Deflection-Embedding-Booster-Core
+
+## Why this slice exists
+
+#1504 closed the lexical mismatch with #1531: the repeat-question rule now
+matches the documented exact Jaccard floor. The remaining gap is semantic
+recall: two tickets can ask the same thing with near-zero shared tokens, so the
+exact lexical floor still fragments the reworded long tail.
+
+#1515 approved the hybrid direction: keep the exact lexical floor, then add an
+embedding recall booster through a host-injected port so the extracted package
+stays model-free. The later #1504 calibration note replaced a flat cosine
+threshold with mutual nearest neighbor, a margin, and a loose cosine floor.
+This slice lands that deterministic extracted core only.
+
+The first review found three safety holes in that core: non-finite vectors
+could return `nan` and bypass both gates, margin was enforced from only one side
+of a mutual-nearest pair, and a non-singleton lexical component could amplify
+embedding-only unions into a hub-and-spoke collapse. Those are core acceptance
+criteria for this slice, so the fixes and regressions stay here even though the
+review update pushes the PR above the soft 400 LOC target.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Vertical slice
+
+1. Add a model-free embedding port contract and cosine helper owned by
+   `extracted_content_pipeline`.
+2. Thread an optional embedding port through the FAQ Markdown config, service,
+   builder, and sub-clustering path.
+3. Add a deterministic embedding booster that only considers pairs left
+   unmerged by the lexical floor, limits semantic edges to singleton lexical
+   components, and merges mutual-nearest-neighbor pairs only when both rows
+   clear the margin plus loose-floor thresholds.
+4. Prove default behavior is unchanged when no port is injected.
+5. Prove a deterministic stub port merges a same-meaning no-token-overlap pair
+   through the full `build_ticket_faq_markdown` path.
+6. Prove non-finite vectors, one-sided-margin ambiguity, and lexical-hub
+   amplification fail closed.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] No embedding port keeps the existing lexical floor behavior and output
+        shape unchanged.
+  - [ ] A deterministic stub embedding port can merge two no-token-overlap
+        rewordings in the full FAQ Markdown builder.
+  - [ ] The booster only runs after lexical clustering and cannot merge pairs
+        unless they are singleton lexical components, mutual nearest
+        neighbors, both meet the configured margin, and meet the loose cosine
+        floor.
+  - [ ] Empty, malformed, or non-finite embedding vectors fail closed by
+        skipping the semantic merge instead of raising or merging.
+  - [ ] Non-singleton lexical components cannot create hub-and-spoke semantic
+        fan-out through the embedding booster.
+  - [ ] The extracted package remains model-free: no `atlas_brain`,
+        `sentence_transformers`, network, DB, or host imports.
+- Affected surfaces: FAQ clustering internals, embedding port contract,
+  focused tests, and package manifest.
+- Risk areas: accidental default output drift, opaque semantic over-merging,
+  malformed injected vectors, and extracted package boundary violations.
+- Reviewer rules triggered: R1, R2, R9, R10, R12, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/embedding_port.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Embedding-Booster-Core.md`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+## Mechanism
+
+The lexical floor remains the first pass and keeps the published floor
+guarantee. The optional port receives one text per singleton lexical component,
+returns vectors, and the core computes exact finite cosine values in process.
+Each row chooses its best not-yet-merged singleton neighbor; only reciprocal best
+matches above the loose floor and both rows' margins merge. Iteration order and
+tie-breaking are stable, non-finite vectors return no score, and no host model
+is loaded by default.
+
+## Intentional
+
+- This PR does not import or configure the live mxbai model. The extracted core
+  must stay model-free; host adapter wiring belongs in the next slice.
+- This PR uses mutual-nearest-neighbor plus margin and loose floor, not a flat
+  cosine threshold, because #1504 measured that flat thresholds do not transfer
+  across real corpora.
+- This PR keeps the existing lexical floor as the default and first pass. The
+  booster can only add recall when a caller explicitly injects a port.
+- This PR limits embedding edges to singleton lexical components. That is a
+  conservative over-merge guard: it preserves the no-token-overlap recall path
+  while deferring multi-row lexical component expansion until a later slice can
+  prove a safer cluster-level criterion.
+
+## Deferred
+
+- Host adapter and service wiring for the pinned/offline mxbai model.
+- Live CFPB re-baseline after host wiring is available and operator-approved.
+- #1518 status vocabulary fix remains in the deflection backlog, but it is a
+  status-normalization lane item rather than this clustering slice.
+
+Parked hardening: none.
+
+## Verification
+
+- Command passed: python -m py_compile extracted_content_pipeline/embedding_port.py extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py.
+- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_merges_no_overlap_reworded_repeat_in_builder tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_skips_malformed_vectors_without_merging tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_skips_non_finite_vectors_without_merging tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_requires_both_mutual_neighbor_margins tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_ignores_non_singleton_lexical_components tests/test_extracted_ticket_faq_markdown.py::test_cosine_similarity_rejects_malformed_vectors tests/test_extracted_ticket_faq_markdown.py::test_ticket_faq_service_config_threads_embedding_port -q - 9 passed.
+- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py -q - 250 passed.
+- Command passed: bash scripts/validate_extracted_content_pipeline.sh.
+- Command passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline.
+- Command passed: python scripts/audit_extracted_standalone.py --fail-on-debt.
+- Command passed: bash scripts/check_ascii_python.sh.
+- Command passed: bash scripts/run_extracted_pipeline_checks.sh - 4089 passed, 10 skipped, 1 warning.
+- Pending before push: plan sync and local PR review.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/embedding_port.py` | 45 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 106 |
+| `plans/PR-Deflection-Embedding-Booster-Core.md` | 127 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 224 |
+| **Total** | **505** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 from html.parser import HTMLParser
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -14,6 +15,7 @@ from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.embedding_port import cosine_similarity
 from extracted_content_pipeline.support_ticket_input_package import (
     build_support_ticket_input_package,
 )
@@ -41,6 +43,14 @@ FAQ_CUSTOM_RULES = ROOT / "extracted_content_pipeline/examples/faq_custom_rules.
 FAQ_DOCUMENTATION_TERMS = (
     ROOT / "extracted_content_pipeline/examples/faq_documentation_terms.txt"
 )
+
+
+class _StubEmbeddingPort:
+    def __init__(self, vectors: dict[str, tuple[float, ...]]) -> None:
+        self.vectors = vectors
+
+    def embed_texts(self, texts):
+        return [self.vectors.get(text, ()) for text in texts]
 
 
 class _RenderedFAQHTML(HTMLParser):
@@ -2135,6 +2145,181 @@ def test_question_subclusters_exact_join_keeps_empty_gists_separate() -> None:
     ]
 
 
+def test_embedding_booster_merges_no_overlap_reworded_repeat_in_builder() -> None:
+    rows = [
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "billing help",
+            "source_title": "Refund",
+            "text": "How do I get my money back?",
+            "source_id": "refund-a",
+        },
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "billing help",
+            "source_title": "Refund",
+            "text": "What is the process for a refund?",
+            "source_id": "refund-b",
+        },
+    ]
+
+    without_port = build_ticket_faq_markdown(rows, max_items=0)
+    explicit_no_port = build_ticket_faq_markdown(rows, max_items=0, embedding_port=None)
+    with_port = build_ticket_faq_markdown(
+        rows,
+        max_items=0,
+        embedding_port=_StubEmbeddingPort({
+            "How do I get my money back?": (1.0, 0.0),
+            "What is the process for a refund?": (0.99, 0.01),
+        }),
+    )
+
+    assert explicit_no_port.as_dict() == without_port.as_dict()
+    assert without_port.items == ()
+    assert without_port.non_repeat_ticket_count == 2
+    assert len(with_port.items) == 1
+    assert with_port.items[0]["ticket_count"] == 2
+    assert with_port.items[0]["source_ids"] == ("refund-a", "refund-b")
+
+
+def test_embedding_booster_skips_malformed_vectors_without_merging() -> None:
+    rows = [
+        {
+            "text": "How do I get my money back?",
+            "source_key": "refund-a",
+        },
+        {
+            "text": "What is the process for a refund?",
+            "source_key": "refund-b",
+        },
+    ]
+
+    clusters = _question_subclusters(
+        rows,
+        embedding_port=_StubEmbeddingPort({
+            "How do I get my money back?": (1.0, 0.0),
+            "What is the process for a refund?": (),
+        }),
+    )
+
+    assert [tuple(row["source_key"] for row in cluster) for cluster in clusters] == [
+        ("refund-a",),
+        ("refund-b",),
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad_vector",
+    [
+        (math.nan, 1.0),
+        (math.inf, 1.0),
+        (-math.inf, 1.0),
+    ],
+)
+def test_embedding_booster_skips_non_finite_vectors_without_merging(
+    bad_vector: tuple[float, float],
+) -> None:
+    rows = [
+        {"text": "How can I reset my password?", "source_key": "password"},
+        {"text": "Where do I update my billing address?", "source_key": "billing"},
+    ]
+
+    clusters = _question_subclusters(
+        rows,
+        embedding_port=_StubEmbeddingPort({
+            "How can I reset my password?": bad_vector,
+            "Where do I update my billing address?": (1.0, 1.0),
+        }),
+    )
+
+    assert [tuple(row["source_key"] for row in cluster) for cluster in clusters] == [
+        ("password",),
+        ("billing",),
+    ]
+
+
+def test_embedding_booster_requires_both_mutual_neighbor_margins() -> None:
+    rows = [
+        {"text": "How do I get my money back?", "source_key": "refund"},
+        {"text": "Where do I update my billing address?", "source_key": "billing"},
+        {"text": "How do I export account reports?", "source_key": "exports"},
+    ]
+
+    clusters = _question_subclusters(
+        rows,
+        embedding_port=_StubEmbeddingPort({
+            "How do I get my money back?": (1.0, 0.0),
+            "Where do I update my billing address?": (0.9, 0.4358898943540673),
+            "How do I export account reports?": (0.5680837372370346, 0.8229707573703964),
+        }),
+    )
+
+    assert [tuple(row["source_key"] for row in cluster) for cluster in clusters] == [
+        ("refund",),
+        ("billing",),
+        ("exports",),
+    ]
+
+
+def test_embedding_booster_ignores_non_singleton_lexical_components() -> None:
+    rows = [
+        {
+            "text": "password reset email link expired login access one",
+            "source_key": "hub-a",
+        },
+        {
+            "text": "password reset email link expired login access two",
+            "source_key": "hub-b",
+        },
+        {
+            "text": "password reset email link expired login access three",
+            "source_key": "hub-c",
+        },
+        {
+            "text": "billing address update payment invoice",
+            "source_key": "spoke-billing",
+        },
+        {
+            "text": "dashboard chart loading analytics view",
+            "source_key": "spoke-dashboard",
+        },
+        {
+            "text": "export csv report download file",
+            "source_key": "spoke-export",
+        },
+    ]
+
+    clusters = _question_subclusters(
+        rows,
+        embedding_port=_StubEmbeddingPort({
+            rows[0]["text"]: (1.0, 0.0, 0.0),
+            rows[1]["text"]: (0.0, 1.0, 0.0),
+            rows[2]["text"]: (0.0, 0.0, 1.0),
+            rows[3]["text"]: (0.99, 0.01, 0.0),
+            rows[4]["text"]: (0.0, 0.99, 0.01),
+            rows[5]["text"]: (0.01, 0.0, 0.99),
+        }),
+    )
+
+    assert [tuple(row["source_key"] for row in cluster) for cluster in clusters] == [
+        ("hub-a", "hub-b", "hub-c"),
+        ("spoke-billing",),
+        ("spoke-dashboard",),
+        ("spoke-export",),
+    ]
+
+
+def test_cosine_similarity_rejects_malformed_vectors() -> None:
+    assert cosine_similarity((1.0, 0.0), (0.5, 0.5)) == pytest.approx(0.70710678)
+    assert cosine_similarity((1.0,), (1.0, 0.0)) is None
+    assert cosine_similarity((0.0, 0.0), (1.0, 0.0)) is None
+    assert cosine_similarity("bad", (1.0, 0.0)) is None
+    assert cosine_similarity((object(),), (1.0,)) is None
+    assert cosine_similarity((math.nan, 1.0), (1.0, 1.0)) is None
+    assert cosine_similarity((math.inf, 1.0), (1.0, 1.0)) is None
+    assert cosine_similarity((-math.inf, 1.0), (1.0, 1.0)) is None
+
+
 def test_build_ticket_faq_markdown_subclusters_are_order_insensitive() -> None:
     rows = [
         {
@@ -3159,6 +3344,45 @@ async def test_ticket_faq_service_generates_from_inline_source_material() -> Non
     assert result.as_dict()["generated"] == 1
     assert "How do I change my email address?" in result.markdown
     assert "`ticket-1` - Login email change" in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_config_threads_embedding_port() -> None:
+    service = TicketFAQMarkdownService(
+        TicketFAQMarkdownConfig(
+            embedding_port=_StubEmbeddingPort({
+                "How do I get my money back?": (1.0, 0.0),
+                "What is the process for a refund?": (0.99, 0.01),
+            })
+        )
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "support_tickets": [
+                {
+                    "ticket_id": "refund-a",
+                    "subject": "Refund request",
+                    "source_type": "ticket",
+                    "message": "How do I get my money back?",
+                    "pain_category": "billing",
+                },
+                {
+                    "ticket_id": "refund-b",
+                    "subject": "Refund request",
+                    "source_type": "ticket",
+                    "message": "What is the process for a refund?",
+                    "pain_category": "billing",
+                },
+            ]
+        },
+        max_items=0,
+    )
+
+    assert len(result.items) == 1
+    assert result.items[0]["source_ids"] == ("refund-a", "refund-b")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Embedding-Booster-Core.md
Slice phase: Vertical slice

This slice lands the model-free #1504 embedding-booster core behind an optional extracted-package port: the lexical floor remains the default first pass, and callers can inject deterministic embeddings to recover no-token-overlap reworded repeats through mutual-nearest-neighbor, margin, and loose-floor checks.

Review update: this head also closes the first review's over-merge holes by rejecting non-finite embedding values, requiring both sides of a mutual-nearest pair to clear the margin, and limiting semantic edges to singleton lexical components so lexical hubs cannot fan out into unrelated spokes.

## Intentional
- No live mxbai import or host adapter in this PR; extracted stays model-free.
- No report or snapshot shape change; this proves clustering behavior before surfacing semantic provenance.
- No flat cosine threshold; the booster follows the relative criterion from the #1504 calibration note.
- Singleton-only semantic edges are a conservative over-merge guard for this core slice; multi-row lexical component expansion needs a future cluster-level criterion.

## Deferred
- Host adapter and service wiring for the pinned/offline mxbai model.
- Live CFPB re-baseline after host wiring is available and operator-approved.
- #1518 status vocabulary fix remains in the deflection backlog but is a separate status-normalization lane item.
- Multi-row lexical component semantic expansion after a safer cluster-level criterion is proven.

## Parked hardening
- None.

## AI reconciliation
- All fixed or waived: Yes.
- Codex `embedding_port.py` non-finite vector finding: fixed by finite input/result validation plus cosine and booster regressions.
- Codex `ticket_faq_markdown.py` one-sided margin finding: fixed by requiring both mutual-nearest rows to clear the configured margin plus a one-sided-margin regression.
- Human review hub-and-spoke finding: fixed by limiting embedding edges to singleton lexical components plus a lexical-hub regression.

## Verification
- Command passed: python -m py_compile extracted_content_pipeline/embedding_port.py extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py.
- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_merges_no_overlap_reworded_repeat_in_builder tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_skips_malformed_vectors_without_merging tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_skips_non_finite_vectors_without_merging tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_requires_both_mutual_neighbor_margins tests/test_extracted_ticket_faq_markdown.py::test_embedding_booster_ignores_non_singleton_lexical_components tests/test_extracted_ticket_faq_markdown.py::test_cosine_similarity_rejects_malformed_vectors tests/test_extracted_ticket_faq_markdown.py::test_ticket_faq_service_config_threads_embedding_port -q - 9 passed.
- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py -q - 250 passed.
- Command passed: bash scripts/validate_extracted_content_pipeline.sh.
- Command passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline.
- Command passed: python scripts/audit_extracted_standalone.py --fail-on-debt.
- Command passed: bash scripts/check_ascii_python.sh.
- Command passed: bash scripts/run_extracted_pipeline_checks.sh - 4089 passed, 10 skipped, 1 warning.

## Diff size
5 files, +501 / -4
