### PR TITLE
Content-Ops claim evidence provider runner

### DIFF
--- a/extracted_content_pipeline/claim_evidence_benchmark.py
+++ b/extracted_content_pipeline/claim_evidence_benchmark.py
@@ -173,6 +173,78 @@ ClaimEvidenceProvider = Callable[
 ]
 
 
+@dataclass(frozen=True)
+class ClaimEvidencePromptPacket:
+    """One exported prompt/schema packet ready for provider execution."""
+
+    model_id: str
+    triple_id: str
+    contract_version: str
+    prompt: str
+    response_schema: Mapping[str, object]
+
+    @classmethod
+    def from_mapping(
+        cls, data: object
+    ) -> tuple["ClaimEvidencePromptPacket | None", tuple[str, ...]]:
+        if not isinstance(data, Mapping):
+            return None, ("packet must be an object",)
+
+        errors: list[str] = []
+        model_id = _required_text(data, "model_id")
+        triple_id = _required_text(data, "triple_id")
+        contract_version = _required_text(data, "contract_version")
+        prompt = _required_text(data, "prompt")
+        response_schema = data.get("response_schema")
+
+        for key, value in (
+            ("model_id", model_id),
+            ("triple_id", triple_id),
+            ("contract_version", contract_version),
+            ("prompt", prompt),
+        ):
+            if value is None:
+                errors.append(f"{key} missing")
+        if contract_version != VERIFY_CLAIM_EVIDENCE_CONTRACT_VERSION:
+            errors.append(f"unsupported contract_version: {contract_version or ''}")
+        if not isinstance(response_schema, Mapping):
+            errors.append("response_schema must be an object")
+        elif dict(response_schema) != claim_evidence_response_json_schema():
+            errors.append(
+                "response_schema does not match the canonical claim/evidence schema"
+            )
+        if errors:
+            return None, tuple(errors)
+
+        return (
+            cls(
+                model_id=model_id or "",
+                triple_id=triple_id or "",
+                contract_version=contract_version or "",
+                prompt=prompt or "",
+                response_schema=dict(response_schema or {}),
+            ),
+            (),
+        )
+
+
+ClaimEvidencePromptPacketProvider = Callable[
+    [ClaimEvidencePromptPacket, str, str], object
+]
+
+
+@dataclass(frozen=True)
+class ClaimEvidencePromptPacketRun:
+    """Returned response rows produced by a prompt-packet provider run."""
+
+    rows: tuple[Mapping[str, object], ...]
+    errors: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
 def claim_evidence_response_json_schema() -> dict[str, object]:
     """Return the strict JSON Schema for structured witness responses."""
 
@@ -343,6 +415,116 @@ def run_claim_evidence_provider(
         tuple(rows),
         tuple(run_errors),
     )
+
+
+def run_claim_evidence_prompt_packets(
+    packets: Sequence[object],
+    provider: object,
+    *,
+    stability_run_count: object = 0,
+) -> ClaimEvidencePromptPacketRun:
+    """Run exported prompt packets through an injected provider boundary."""
+
+    if not callable(provider):
+        return ClaimEvidencePromptPacketRun((), ("provider must be callable",))
+    if not isinstance(packets, RuntimeSequence) or isinstance(packets, (str, bytes)):
+        return ClaimEvidencePromptPacketRun((), ("packets must be a sequence",))
+    if not packets:
+        return ClaimEvidencePromptPacketRun((), ("packets missing",))
+    if (
+        not isinstance(stability_run_count, int)
+        or isinstance(stability_run_count, bool)
+        or stability_run_count < 0
+    ):
+        return ClaimEvidencePromptPacketRun(
+            (),
+            ("stability_run_count must be a non-negative integer",),
+        )
+
+    decoded_packets: list[ClaimEvidencePromptPacket] = []
+    errors: list[str] = []
+    seen: set[tuple[str, str, str]] = set()
+    for index, packet_data in enumerate(packets, start=1):
+        packet, packet_errors = ClaimEvidencePromptPacket.from_mapping(packet_data)
+        if packet_errors:
+            errors.extend(f"packet row {index}: {error}" for error in packet_errors)
+            continue
+        if packet is None:
+            errors.append(f"packet row {index}: packet missing")
+            continue
+        key = (packet.model_id, packet.triple_id, packet.contract_version)
+        if key in seen:
+            errors.append(
+                "packet row "
+                f"{index}: duplicate packet key: "
+                f"{packet.model_id}/{packet.triple_id}/{packet.contract_version}"
+            )
+            continue
+        seen.add(key)
+        decoded_packets.append(packet)
+    if errors:
+        return ClaimEvidencePromptPacketRun((), tuple(errors))
+
+    rows: list[Mapping[str, object]] = []
+    for packet in decoded_packets:
+        row, row_error = _run_claim_evidence_prompt_packet(
+            packet,
+            provider,
+            run_type="main",
+            run_id="",
+        )
+        if row_error:
+            errors.append(row_error)
+        elif row is not None:
+            rows.append(row)
+    for rerun_index in range(1, stability_run_count + 1):
+        run_id = f"rerun-{rerun_index}"
+        for packet in decoded_packets:
+            row, row_error = _run_claim_evidence_prompt_packet(
+                packet,
+                provider,
+                run_type="stability",
+                run_id=run_id,
+            )
+            if row_error:
+                errors.append(row_error)
+            elif row is not None:
+                rows.append(row)
+
+    if errors:
+        return ClaimEvidencePromptPacketRun((), tuple(errors))
+    return ClaimEvidencePromptPacketRun(tuple(rows), ())
+
+
+def _run_claim_evidence_prompt_packet(
+    packet: ClaimEvidencePromptPacket,
+    provider: ClaimEvidencePromptPacketProvider,
+    *,
+    run_type: str,
+    run_id: str,
+) -> tuple[dict[str, object] | None, str | None]:
+    label = f"{run_type} {packet.model_id}/{packet.triple_id}"
+    try:
+        raw_response = provider(packet, run_type, run_id)
+    except Exception as error:
+        return None, f"{label}: provider error: {error.__class__.__name__}"
+
+    response, response_errors = ClaimEvidenceResponse.from_mapping(raw_response)
+    if response_errors:
+        return None, f"{label}: response {'; '.join(response_errors)}"
+    if response is None:
+        return None, f"{label}: response missing"
+
+    row: dict[str, object] = {
+        "model_id": packet.model_id,
+        "triple_id": packet.triple_id,
+        "contract_version": packet.contract_version,
+        "response": asdict(response),
+    }
+    if run_type == "stability":
+        row["run_type"] = "stability"
+        row["run_id"] = run_id
+    return row, None
 
 
 @dataclass(frozen=True)

--- a/plans/PR-Content-Ops-Claim-Evidence-Provider-Runner.md
+++ b/plans/PR-Content-Ops-Claim-Evidence-Provider-Runner.md
@@ -1,0 +1,119 @@
+# PR-Content-Ops-Claim-Evidence-Provider-Runner
+
+## Why this slice exists
+
+#1435 now has the manual benchmark path from labeled fixture through prompt
+packets, returned response import, and result artifacts. The next remaining gap
+is provider execution: concrete Claude/GPT adapters should be thin wrappers
+around a deterministic runner seam, not places where coverage, stability, or
+row-shape rules are reinvented.
+
+This slice lands that seam without credentials or network calls. It takes the
+already-exported prompt packets and an injected provider boundary, produces the
+same returned response rows consumed by the #1530 importer, and can request
+main plus stability reruns with deterministic run ids.
+
+The estimate is slightly above the 400 LOC target because this is a new
+package-level runner plus same-slice negative fixtures for each detector branch.
+Splitting the tests would leave the provider seam without CI-proven failure
+detection.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Vertical slice
+
+1. Add a package-owned provider runner that executes prompt packets through an
+   injected provider boundary and emits returned response rows in the existing
+   importer contract.
+2. Support a main run plus optional stability reruns per model with stable
+   run-id labels.
+3. Fail closed on malformed packet rows, duplicate packet identities, invalid
+   response payloads, provider exceptions, invalid stability counts, and missing
+   provider results without calling live models.
+4. Add focused tests and enroll them in extracted checks.
+
+### Files touched
+
+- `extracted_content_pipeline/claim_evidence_benchmark.py`
+- `plans/PR-Content-Ops-Claim-Evidence-Provider-Runner.md`
+- `tests/test_extracted_content_claim_evidence_benchmark.py`
+
+### Review Contract
+
+Acceptance criteria:
+
+- A valid prompt-packet set plus injected provider responses produces returned
+  response rows accepted by the existing response importer.
+- Stability reruns are explicitly labeled and do not overwrite main rows.
+- Provider exceptions and malformed provider responses become row errors and no
+  silent successful response is emitted.
+- The runner remains deterministic and package-owned: no Atlas imports, no DB,
+  no credentials, no HTTP, no MCP, and no verifier rubric inclusion.
+- New or changed tests are enrolled in the extracted pipeline checks.
+
+Affected surfaces:
+
+- Package-owned claim/evidence benchmark module and focused tests.
+
+Risk areas:
+
+- Prompt-packet row validation must match the exporter/importer identity shape.
+- Stability row labeling must remain deterministic.
+- Provider errors must fail closed without stopping later rows.
+- CI enrollment for any new test coverage.
+
+Reviewer rules triggered: R1, R2, R10, R12, R14
+
+## Mechanism
+
+The runner adds a small data contract around the existing prompt packet shape:
+
+1. Decode prompt packet mappings into typed packet records that preserve
+   model id, triple id, contract version, prompt, and response schema.
+2. Call an injected provider with each packet for the main run, then repeat for
+   each requested stability run.
+3. Decode each provider return through the existing strict claim/evidence
+   response contract.
+4. Emit row mappings with the same fields the prompt-response importer expects:
+   model id, triple id, contract version, response, and optional stability
+   run metadata.
+
+The future live-provider PR should only adapt API clients to this provider
+boundary. It should not change benchmark scoring, artifact generation, or MCP
+verifier behavior.
+
+## Intentional
+
+- No OpenAI/Anthropic SDK usage in this slice. That keeps credentials, network
+  behavior, rate limits, and model-specific JSON-mode quirks out until the
+  deterministic orchestration seam is reviewed.
+- No CLI in this slice. The provider runner is package-owned core; a later CLI
+  can bind it to concrete provider configuration without duplicating row rules.
+- No verifier/MCP inclusion. The issue still requires real benchmark results and
+  threshold admission before a structured-witness slot enters the verifier.
+
+## Deferred
+
+- Concrete Claude/GPT provider adapters and credential loading.
+- Batch CLI that binds provider adapters to fixture/prompt-packet files and
+  writes returned response rows.
+- Real benchmark go/no-go writeup from the final operator-labeled set.
+- Verifier rubric inclusion and MCP exposure, only after #1435 thresholds pass.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused claim/evidence benchmark tests: 70 passed.
+- Full extracted pipeline wrapper: 4093 passed, 10 skipped.
+- Body-aware local PR review: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/claim_evidence_benchmark.py` | 182 |
+| `plans/PR-Content-Ops-Claim-Evidence-Provider-Runner.md` | 119 |
+| `tests/test_extracted_content_claim_evidence_benchmark.py` | 189 |
+| **Total** | **490** |

--- a/tests/test_extracted_content_claim_evidence_benchmark.py
+++ b/tests/test_extracted_content_claim_evidence_benchmark.py
@@ -10,6 +10,7 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     HARD,
     BenchmarkThresholds,
     ClaimEvidenceModelRun,
+    ClaimEvidencePromptPacket,
     ClaimEvidenceResponse,
     ClaimEvidenceResultFile,
     ClaimEvidenceRunRow,
@@ -29,6 +30,7 @@ from extracted_content_pipeline.claim_evidence_benchmark import (
     pairwise_agreements,
     render_claim_evidence_result_markdown,
     run_claim_evidence_provider,
+    run_claim_evidence_prompt_packets,
     score_model,
     validate_claim_evidence_fixture,
     write_claim_evidence_result_artifact_files,
@@ -54,6 +56,26 @@ def _response(supports: bool, confidence: int = 5) -> ClaimEvidenceResponse:
         confidence=confidence,
         reason="quote directly supports the claim",
     )
+
+
+def _packet(
+    model_id: str = "gpt",
+    triple_id: str = "easy",
+    *,
+    contract_version: str = "verify_claim_evidence.v1",
+    response_schema: object | None = None,
+) -> dict[str, object]:
+    return {
+        "model_id": model_id,
+        "triple_id": triple_id,
+        "contract_version": contract_version,
+        "prompt": f"Prompt for {triple_id}",
+        "response_schema": (
+            claim_evidence_response_json_schema()
+            if response_schema is None
+            else response_schema
+        ),
+    }
 
 
 def _passing_score(model_id: str) -> ModelScore:
@@ -690,6 +712,173 @@ def test_runner_fails_closed_on_invalid_harness_inputs() -> None:
     assert run.errors == ("row 1: triple must be ClaimEvidenceTriple",)
     assert [row.triple_id for row in run.rows] == ["valid"]
     assert run.responses_by_triple_id == {"valid": _response(True, 5)}
+
+
+def test_prompt_packet_runner_emits_importer_compatible_rows() -> None:
+    packets = (
+        _packet("claude", "easy"),
+        _packet("gpt", "hard"),
+    )
+    calls = []
+
+    def provider(packet, run_type, run_id):
+        calls.append((packet, run_type, run_id))
+        return {
+            "supports": packet.triple_id == "easy",
+            "confidence": 5,
+            "reason": "quote directly supports the judgment",
+        }
+
+    run = run_claim_evidence_prompt_packets(packets, provider)
+
+    assert run.ok is True
+    assert run.errors == ()
+    assert run.rows == (
+        {
+            "model_id": "claude",
+            "triple_id": "easy",
+            "contract_version": "verify_claim_evidence.v1",
+            "response": {
+                "supports": True,
+                "confidence": 5,
+                "reason": "quote directly supports the judgment",
+            },
+        },
+        {
+            "model_id": "gpt",
+            "triple_id": "hard",
+            "contract_version": "verify_claim_evidence.v1",
+            "response": {
+                "supports": False,
+                "confidence": 5,
+                "reason": "quote directly supports the judgment",
+            },
+        },
+    )
+    assert [(call[1], call[2]) for call in calls] == [("main", ""), ("main", "")]
+    assert isinstance(calls[0][0], ClaimEvidencePromptPacket)
+    assert calls[0][0].prompt == "Prompt for easy"
+
+
+def test_prompt_packet_runner_emits_deterministic_stability_rows() -> None:
+    packets = (_packet("gpt", "easy"),)
+
+    def provider(packet, run_type, run_id):
+        return {
+            "supports": True,
+            "confidence": 4,
+            "reason": f"{run_type} {run_id or 'main'}",
+        }
+
+    run = run_claim_evidence_prompt_packets(
+        packets,
+        provider,
+        stability_run_count=2,
+    )
+
+    assert run.ok is True
+    assert [row.get("run_type", "main") for row in run.rows] == [
+        "main",
+        "stability",
+        "stability",
+    ]
+    assert [row.get("run_id", "") for row in run.rows] == [
+        "",
+        "rerun-1",
+        "rerun-2",
+    ]
+    assert [row["response"]["reason"] for row in run.rows] == [
+        "main main",
+        "stability rerun-1",
+        "stability rerun-2",
+    ]
+
+
+def test_prompt_packet_runner_rejects_bad_packets_before_provider_calls() -> None:
+    calls = []
+
+    def provider(packet, run_type, run_id):
+        calls.append(packet)
+        return {"supports": True, "confidence": 5, "reason": "unused"}
+
+    run = run_claim_evidence_prompt_packets(
+        (
+            _packet("gpt", "easy"),
+            _packet("gpt", "easy"),
+            _packet("claude", "bad-version", contract_version="v0"),
+            _packet("claude", "empty-schema", response_schema={}),
+            _packet(
+                "sonnet",
+                "mutated-schema",
+                response_schema={
+                    **claim_evidence_response_json_schema(),
+                    "required": ["supports", "confidence"],
+                },
+            ),
+            {"model_id": "sonnet", "triple_id": "missing-schema", "prompt": "Prompt"},
+        ),
+        provider,
+    )
+
+    assert run.ok is False
+    assert run.rows == ()
+    assert run.errors == (
+        "packet row 2: duplicate packet key: gpt/easy/verify_claim_evidence.v1",
+        "packet row 3: unsupported contract_version: v0",
+        "packet row 4: response_schema does not match the canonical claim/evidence schema",
+        "packet row 5: response_schema does not match the canonical claim/evidence schema",
+        "packet row 6: contract_version missing",
+        "packet row 6: unsupported contract_version: ",
+        "packet row 6: response_schema must be an object",
+    )
+    assert calls == []
+
+
+def test_prompt_packet_runner_records_response_and_provider_failures() -> None:
+    packets = (
+        _packet("gpt", "missing-reason"),
+        _packet("gpt", "raises"),
+    )
+
+    def provider(packet, run_type, run_id):
+        if packet.triple_id == "raises":
+            raise RuntimeError("vendor timeout with sensitive details")
+        return {"supports": True, "confidence": 5, "reason": " "}
+
+    run = run_claim_evidence_prompt_packets(packets, provider)
+
+    assert run.ok is False
+    assert run.rows == ()
+    assert run.errors == (
+        "main gpt/missing-reason: response reason missing",
+        "main gpt/raises: provider error: RuntimeError",
+    )
+    assert "sensitive" not in " ".join(run.errors)
+
+
+def test_prompt_packet_runner_fails_closed_on_invalid_inputs() -> None:
+    def provider(packet, run_type, run_id):
+        return {"supports": True, "confidence": 5, "reason": "ok"}
+
+    assert run_claim_evidence_prompt_packets((), None).errors == (
+        "provider must be callable",
+    )
+    assert run_claim_evidence_prompt_packets(None, provider).errors == (
+        "packets must be a sequence",
+    )
+    assert run_claim_evidence_prompt_packets((), provider).errors == (
+        "packets missing",
+    )
+    assert run_claim_evidence_prompt_packets(
+        (_packet(),),
+        provider,
+        stability_run_count=True,
+    ).errors == ("stability_run_count must be a non-negative integer",)
+    assert run_claim_evidence_prompt_packets(
+        (_packet(),),
+        provider,
+        stability_run_count=-1,
+    ).errors == ("stability_run_count must be a non-negative integer",)
 
 
 def test_result_artifact_builds_go_payload_from_completed_runs() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Claim-Evidence-Provider-Runner.md
Slice phase: Vertical slice

Adds the deterministic provider-runner seam for #1435 so exported claim/evidence prompt packets can be executed through an injected provider boundary and converted into the returned-response rows already consumed by the importer, without adding live SDKs, credentials, HTTP, MCP, or verifier behavior.

## Intentional
- No OpenAI/Anthropic SDK usage in this slice; concrete providers stay thin wrappers around this package-owned seam in a follow-up.
- No CLI in this slice; this lands the deterministic core before binding files, credentials, and operator flags.
- No verifier/MCP inclusion; #1435 still requires real benchmark results and threshold admission first.

## Deferred
- Concrete Claude/GPT provider adapters and credential loading.
- Batch CLI that binds provider adapters to fixture/prompt-packet files and writes returned response rows.
- Real benchmark go/no-go writeup from the final operator-labeled set.
- Verifier rubric inclusion and MCP exposure, only after #1435 thresholds pass.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_claim_evidence_benchmark.py -q` -- 70 passed.
- `python scripts/sync_pr_plan.py plans/PR-Content-Ops-Claim-Evidence-Provider-Runner.md && python scripts/sync_pr_plan.py plans/PR-Content-Ops-Claim-Evidence-Provider-Runner.md --check && bash scripts/run_extracted_pipeline_checks.sh` -- 4093 passed, 10 skipped.
- `ATLAS_CURRENT_PR_BODY_FILE=tmp/content_ops_claim_evidence_provider_runner_pr_body.md bash scripts/local_pr_review.sh --current-pr-body-file tmp/content_ops_claim_evidence_provider_runner_pr_body.md` -- passed.

## AI reconciliation
- All fixed or waived: Yes.
- Codex P2 schema-validation finding fixed: prompt packets now require `response_schema` to match `claim_evidence_response_json_schema()` before provider calls; regression coverage asserts empty and mutated schemas fail closed and the provider is not called.

## Diff size
3 files, +490 / -0
