### PR TITLE
Deflection outcome risk diagnostics

### DIFF
--- a/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md
+++ b/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md
@@ -36,6 +36,22 @@ Use these source-backed phrases as help-center headings, internal-search synonym
 | 3 | Where do I upload the new SSO certificate before it expires? | 3 | $41 | 3 | no proven answer yet | 3 source tickets |
 | 4 | Why did the CRM integration pause after the field mapping changed? | 2 | $27 | 2 | no proven answer yet | 2 source tickets |
 
+## Resolution Outcome Diagnostics
+
+These status and CSAT signals flag answers that may need review. They do not prove a publishable answer; only uploaded resolution evidence can do that.
+
+- Tickets with outcome diagnostics: 12
+- Tickets with reopened or negative-CSAT risk: 0
+- Reopened tickets: 0
+- Negative CSAT tickets: 0
+
+| Customer question | Status mix | Reopened | Negative CSAT | Guidance |
+|---|---|---:|---:|---|
+| How do I export attribution reports before our board meeting? | resolved: 4 | 0 | 0 | Outcome context only; use resolution evidence to decide publishability. |
+| Where can I download invoices for last quarter? | resolved: 3 | 0 | 0 | Outcome context only; use resolution evidence to decide publishability. |
+| Where do I upload the new SSO certificate before it expires? | resolved: 3 | 0 | 0 | Outcome context only; use resolution evidence to decide publishability. |
+| Why did the CRM integration pause after the field mapping changed? | resolved: 2 | 0 | 0 | Outcome context only; use resolution evidence to decide publishability. |
+
 ## Publishable Help-Center Copy From Proven Resolutions
 
 ### 1. How do I export attribution reports before our board meeting?

--- a/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/result.json
+++ b/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/result.json
@@ -94,17 +94,23 @@
   "source_count": 12,
   "status": "ok",
   "summary": {
+    "csat_present_count": 0,
     "drafted_answer_count": 2,
     "generated": 4,
+    "negative_csat_ticket_count": 0,
     "no_proven_answer_count": 2,
     "non_repeat_question_count": 0,
     "non_repeat_ticket_count": 0,
+    "outcome_diagnostic_ticket_count": 12,
+    "outcome_diagnostics_present": true,
+    "outcome_risk_ticket_count": 0,
     "output_checks": {
       "condensed": true,
       "has_action_items": true,
       "resolution_evidence_scoped": true,
       "uses_user_vocabulary": true
     },
+    "reopened_ticket_count": 0,
     "source_count": 12,
     "source_date_end": "2026-05-08",
     "source_date_start": "2026-05-02",
@@ -112,6 +118,9 @@
     "support_ticket_resolution_evidence_count": 2,
     "support_ticket_resolution_evidence_present": true,
     "ticket_source_count": 12,
+    "ticket_status_summary": {
+      "resolved": 12
+    },
     "top_opportunity_score": 12,
     "top_question": "How do I export attribution reports before our board meeting?"
   },

--- a/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/summary.json
@@ -1,15 +1,21 @@
 {
+  "csat_present_count": 0,
   "drafted_answer_count": 2,
   "generated": 4,
+  "negative_csat_ticket_count": 0,
   "no_proven_answer_count": 2,
   "non_repeat_question_count": 0,
   "non_repeat_ticket_count": 0,
+  "outcome_diagnostic_ticket_count": 12,
+  "outcome_diagnostics_present": true,
+  "outcome_risk_ticket_count": 0,
   "output_checks": {
     "condensed": true,
     "has_action_items": true,
     "resolution_evidence_scoped": true,
     "uses_user_vocabulary": true
   },
+  "reopened_ticket_count": 0,
   "source_count": 12,
   "source_date_end": "2026-05-08",
   "source_date_start": "2026-05-02",
@@ -17,6 +23,9 @@
   "support_ticket_resolution_evidence_count": 2,
   "support_ticket_resolution_evidence_present": true,
   "ticket_source_count": 12,
+  "ticket_status_summary": {
+    "resolved": 12
+  },
   "top_opportunity_score": 12,
   "top_question": "How do I export attribution reports before our board meeting?"
 }

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -276,6 +276,7 @@ def deflection_report_summary(faq_result: TicketFAQMarkdownResult) -> dict[str, 
         "top_question": _text(items[0].get("question")) if items else "",
         "top_opportunity_score": _int(items[0].get("opportunity_score")) if items else 0,
     }
+    summary.update(_outcome_diagnostics_summary(items))
     source_date_window = _complete_source_date_window({}, items)
     if source_date_window:
         summary.update(source_date_window)
@@ -311,6 +312,7 @@ def render_deflection_report(
         lines.extend(["**Source file:**", "", _md(source_label), ""])
     lines.extend(_help_desk_seo_targeting_section(items))
     lines.extend(_ranked_opportunity_section(items))
+    lines.extend(_outcome_diagnostics_section(items, resolved_summary))
     lines.extend(_drafted_answer_section(proven))
     lines.extend(_no_proven_answer_section(needs_review))
     lines.extend(_vocabulary_gap_section(items))
@@ -445,6 +447,58 @@ def _ranked_opportunity_section(items: Sequence[Mapping[str, Any]]) -> list[str]
     return [*lines, ""]
 
 
+def _outcome_diagnostics_section(
+    items: Sequence[Mapping[str, Any]],
+    summary: Mapping[str, Any],
+) -> list[str]:
+    diagnostic_items = [
+        item for item in items
+        if _item_outcome_diagnostics(item)
+    ]
+    if not diagnostic_items:
+        return []
+    lines = [
+        "## Resolution Outcome Diagnostics",
+        "",
+        (
+            "These status and CSAT signals flag answers that may need review. "
+            "They do not prove a publishable answer; only uploaded resolution "
+            "evidence can do that."
+        ),
+        "",
+        (
+            f"- Tickets with outcome diagnostics: "
+            f"{_count(_int(summary.get('outcome_diagnostic_ticket_count')))}"
+        ),
+        (
+            f"- Tickets with reopened or negative-CSAT risk: "
+            f"{_count(_int(summary.get('outcome_risk_ticket_count')))}"
+        ),
+        (
+            f"- Reopened tickets: "
+            f"{_count(_int(summary.get('reopened_ticket_count')))}"
+        ),
+        (
+            f"- Negative CSAT tickets: "
+            f"{_count(_int(summary.get('negative_csat_ticket_count')))}"
+        ),
+        "",
+        "| Customer question | Status mix | Reopened | Negative CSAT | Guidance |",
+        "|---|---|---:|---:|---|",
+    ]
+    for item in diagnostic_items:
+        diagnostics = _item_outcome_diagnostics(item)
+        lines.append(
+            "| "
+            f"{_cell(item.get('question'))} | "
+            f"{_cell(_status_mix_label(diagnostics))} | "
+            f"{_int(diagnostics.get('reopened_ticket_count'))} | "
+            f"{_int(diagnostics.get('negative_csat_ticket_count'))} | "
+            f"{_cell(_outcome_guidance(diagnostics))} |"
+        )
+    return [*lines, ""]
+
+
 def _drafted_answer_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
     lines = ["## Publishable Help-Center Copy From Proven Resolutions", ""]
     if not items:
@@ -567,6 +621,68 @@ def _status_label(item: Mapping[str, Any]) -> str:
 
 def _item(value: Mapping[str, Any]) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _item_outcome_diagnostics(item: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = item.get("outcome_diagnostics")
+    return value if isinstance(value, Mapping) else {}
+
+
+def _outcome_diagnostics_summary(
+    items: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    status_summary: dict[str, int] = {}
+    diagnostic_count = 0
+    risk_count = 0
+    reopened_count = 0
+    negative_csat_count = 0
+    csat_present_count = 0
+    for item in items:
+        diagnostics = _item_outcome_diagnostics(item)
+        if not diagnostics:
+            continue
+        diagnostic_count += _int(diagnostics.get("diagnostic_ticket_count"))
+        risk_count += _int(diagnostics.get("outcome_risk_ticket_count"))
+        reopened_count += _int(diagnostics.get("reopened_ticket_count"))
+        negative_csat_count += _int(diagnostics.get("negative_csat_ticket_count"))
+        csat_present_count += _int(diagnostics.get("csat_present_count"))
+        raw_summary = diagnostics.get("ticket_status_summary")
+        if isinstance(raw_summary, Mapping):
+            for status, count in raw_summary.items():
+                key = _text(status)
+                if key:
+                    status_summary[key] = status_summary.get(key, 0) + _int(count)
+    if diagnostic_count == 0:
+        return {}
+    return {
+        "outcome_diagnostics_present": True,
+        "outcome_diagnostic_ticket_count": diagnostic_count,
+        "outcome_risk_ticket_count": risk_count,
+        "reopened_ticket_count": reopened_count,
+        "negative_csat_ticket_count": negative_csat_count,
+        "csat_present_count": csat_present_count,
+        "ticket_status_summary": dict(sorted(status_summary.items())),
+    }
+
+
+def _status_mix_label(diagnostics: Mapping[str, Any]) -> str:
+    raw_summary = diagnostics.get("ticket_status_summary")
+    if not isinstance(raw_summary, Mapping) or not raw_summary:
+        return "No status supplied"
+    parts = [
+        f"{_text(status)}: {_count(_int(count))}"
+        for status, count in sorted(raw_summary.items())
+        if _text(status) and _int(count) > 0
+    ]
+    return ", ".join(parts) or "No status supplied"
+
+
+def _outcome_guidance(diagnostics: Mapping[str, Any]) -> str:
+    if _int(diagnostics.get("reopened_ticket_count")):
+        return "Review the answer before publishing because at least one ticket reopened."
+    if _int(diagnostics.get("negative_csat_ticket_count")):
+        return "Review the answer before publishing because CSAT was negative."
+    return "Outcome context only; use resolution evidence to decide publishability."
 
 
 def _artifact_summary(

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -21,6 +21,10 @@ from .support_ticket_clustering import (
     support_ticket_tokens,
 )
 from .support_ticket_dates import parse_support_ticket_source_date
+from .support_ticket_input_package import (
+    _normalize_status_state as _normalize_ticket_status_state,
+    _parse_csat_score as _parse_ticket_csat_score,
+)
 from .ticket_faq_ports import TicketFAQDraft, TicketFAQRepository
 
 
@@ -412,6 +416,32 @@ _VOCABULARY_GAP_RULES = (
     ("connect", "connection", "integration", "sync"),
     ("cancel", "cancellation", "renewal"),
 )
+_NEGATIVE_TEXTUAL_CSAT = frozenset({
+    "bad",
+    "negative",
+    "poor",
+    "unhappy",
+    "unsatisfied",
+    "dissatisfied",
+})
+_OUTCOME_STATUS_KEYS = (
+    "ticket_status",
+    "issue_status",
+    "case_status",
+    "status",
+    "ticket_state",
+    "state",
+)
+_OUTCOME_CSAT_KEYS = (
+    "csat",
+    "satisfaction_score",
+    "satisfaction_rating",
+    "customer_satisfaction_rating",
+    "customer_satisfaction_score",
+    "customer_satisfaction",
+    "satisfaction",
+    "rating",
+)
 @dataclass(frozen=True)
 class TicketFAQMarkdownResult:
     """FAQ Markdown plus metadata useful for CLI summaries and tests."""
@@ -713,6 +743,17 @@ def build_ticket_faq_markdown(
                 "zero_result": _first_present(evidence, opportunity, key="zero_result"),
                 "source_weight": _source_weight(evidence, opportunity),
                 "resolution_text": resolution_text,
+                "ticket_status_state": _first_present(
+                    evidence, opportunity, key="ticket_status_state"
+                ),
+                "ticket_status": _first_available(
+                    evidence,
+                    opportunity,
+                    keys=_OUTCOME_STATUS_KEYS,
+                ),
+                "csat": _first_present(evidence, opportunity, key="csat"),
+                "csat_score": _first_present(evidence, opportunity, key="csat_score"),
+                "csat_raw": _first_available(evidence, opportunity, keys=_OUTCOME_CSAT_KEYS),
             })
 
     # #1460: topic-degraded groups (scope "topic:*") measure bucket
@@ -1249,6 +1290,9 @@ def _item(
         "displayed_evidence_count": len(display_rows),
         "ticket_count": len(source_ids),
     }
+    outcome_diagnostics = _outcome_diagnostics(rows)
+    if outcome_diagnostics:
+        item["outcome_diagnostics"] = outcome_diagnostics
     source_date_span = _source_date_span(rows)
     if source_date_span is not None:
         item["source_date_span"] = source_date_span
@@ -1290,6 +1334,110 @@ def _opportunity_score(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[st
         "failure_risk_signals": failure_risk_signals,
         "opportunity_score": frequency * (1 + failure_risk_score),
     }
+
+
+def _outcome_diagnostics(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    tickets: dict[str, dict[str, Any]] = {}
+    for index, row in enumerate(rows, start=1):
+        source_key = _clean(row.get("source_key") or row.get("source_id")) or f"row:{index}"
+        ticket = tickets.setdefault(source_key, {
+            "status": "",
+            "csat_present": False,
+            "csat_score": None,
+            "negative_csat": False,
+        })
+        status = _outcome_status(row)
+        if status:
+            ticket["status"] = _stronger_outcome_status(
+                _clean(ticket.get("status")),
+                status,
+            )
+        csat_text, csat_score = _outcome_csat(row)
+        if csat_text or csat_score is not None:
+            ticket["csat_present"] = True
+        if csat_score is not None and ticket.get("csat_score") is None:
+            ticket["csat_score"] = csat_score
+        if _negative_csat(csat_text, csat_score):
+            ticket["negative_csat"] = True
+
+    status_summary: dict[str, int] = {}
+    csat_scores: list[float] = []
+    diagnostic_keys: set[str] = set()
+    risk_keys: set[str] = set()
+    reopened_count = 0
+    csat_present_count = 0
+    negative_csat_count = 0
+    for source_key, ticket in tickets.items():
+        status = _clean(ticket.get("status")).lower()
+        if status:
+            diagnostic_keys.add(source_key)
+            status_summary[status] = status_summary.get(status, 0) + 1
+            if status == "reopened":
+                reopened_count += 1
+                risk_keys.add(source_key)
+        csat_score = ticket.get("csat_score")
+        if ticket.get("csat_present"):
+            diagnostic_keys.add(source_key)
+            csat_present_count += 1
+        if isinstance(csat_score, (int, float)):
+            csat_scores.append(csat_score)
+        if ticket.get("negative_csat"):
+            negative_csat_count += 1
+            risk_keys.add(source_key)
+    if not diagnostic_keys:
+        return {}
+    out: dict[str, Any] = {
+        "diagnostic_ticket_count": len(diagnostic_keys),
+        "outcome_risk_ticket_count": len(risk_keys),
+    }
+    if status_summary:
+        out["ticket_status_summary"] = dict(sorted(status_summary.items()))
+    if reopened_count:
+        out["reopened_ticket_count"] = reopened_count
+    if csat_present_count:
+        out["csat_present_count"] = csat_present_count
+    if negative_csat_count:
+        out["negative_csat_ticket_count"] = negative_csat_count
+    if csat_scores:
+        out["csat_score_average"] = round(sum(csat_scores) / len(csat_scores), 2)
+    return out
+
+
+def _outcome_status(row: Mapping[str, Any]) -> str:
+    state = _clean(row.get("ticket_status_state")).lower()
+    if state:
+        return state
+    raw_status = _first_available(row, keys=_OUTCOME_STATUS_KEYS)
+    return _normalize_ticket_status_state(raw_status)
+
+
+def _stronger_outcome_status(current: str, candidate: str) -> str:
+    priority = {
+        "reopened": 5,
+        "open": 4,
+        "other": 3,
+        "cancelled": 2,
+        "resolved": 1,
+    }
+    if priority.get(candidate, 0) > priority.get(current, 0):
+        return candidate
+    return current
+
+
+def _outcome_csat(row: Mapping[str, Any]) -> tuple[str, float | None]:
+    raw_text = _first_available(row, keys=("csat_raw", *_OUTCOME_CSAT_KEYS))
+    raw_score = _first_present(row, key="csat_score")
+    score = _parse_ticket_csat_score(raw_score)
+    if score is None:
+        score = _parse_ticket_csat_score(raw_text)
+    text = _clean(raw_text if raw_text not in (None, "", [], {}) else raw_score).lower()
+    return text, score
+
+
+def _negative_csat(csat_text: str, csat_score: float | None) -> bool:
+    if csat_score is not None:
+        return csat_score <= 2
+    return csat_text in _NEGATIVE_TEXTUAL_CSAT
 
 
 def _distinct_source_keys(rows: Sequence[Mapping[str, str]]) -> tuple[str, ...]:
@@ -1999,6 +2147,14 @@ def _integer_or_none(value: Any) -> int | None:
 def _first_present(*rows: Mapping[str, Any], key: str) -> Any:
     for row in rows:
         value = row.get(key)
+        if value not in (None, "", [], {}):
+            return value
+    return ""
+
+
+def _first_available(*rows: Mapping[str, Any], keys: Sequence[str]) -> Any:
+    for key in keys:
+        value = _first_present(*rows, key=key)
         if value not in (None, "", [], {}):
             return value
     return ""

--- a/plans/PR-Deflection-Outcome-Risk-Diagnostics.md
+++ b/plans/PR-Deflection-Outcome-Risk-Diagnostics.md
@@ -1,0 +1,160 @@
+# PR-Deflection-Outcome-Risk-Diagnostics
+
+## Why this slice exists
+
+Issue #1419/#1507 deliberately separated ingestion from product consumption:
+#1510 normalized ticket status / reopened / CSAT fields, and #1535 proved the
+Zendesk full-thread path can draft publishable answers from public agent
+resolution evidence. The remaining vertical gap is buyer-visible consumption
+of the status/CSAT/reopen signals. Today those fields sit in normalized rows and
+input-provider metadata, but the paid report does not tell the buyer which
+questions were "resolved on paper" but still risky because tickets reopened or
+CSAT was negative.
+
+This slice adds the thinnest paid-report diagnostic lane for that signal
+without weakening the proven-answer gate: status/CSAT/reopen can flag outcome
+risk, but they still cannot create `resolution_evidence` or publishable answer
+copy by themselves.
+
+The synced diff estimate is above 400 LOC because it includes this plan doc
+and the review-fix probes. The item diagnostics, report rendering, raw-alias
+normalization, and negative gate tests are one indivisible vertical slice.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Carry per-question outcome diagnostics from normalized support-ticket rows
+   into FAQ items: status summary, reopened count, CSAT-present count, negative
+   CSAT count, and numeric CSAT average when available.
+2. Normalize direct raw-row status/CSAT aliases (`ticket_status`, `status`,
+   `satisfaction_rating`, etc.) through the same semantics as the input package.
+3. Count diagnostic totals by distinct source ticket, not evidence row, so one
+   ticket with multiple snippets cannot inflate reopened/CSAT counts.
+4. Aggregate those diagnostics into the paid report summary.
+5. Render a paid-report "Resolution Outcome Diagnostics" section that explains
+   the signal as review guidance, not answer proof.
+6. Add focused extracted tests covering positive diagnostics, textual Zendesk
+   `bad` CSAT, numeric low CSAT, direct raw aliases, duplicate evidence rows,
+   and the negative case where diagnostics alone do not turn a
+   draft-needs-review item into `resolution_evidence`.
+7. Regenerate the committed resolution-evidence proof artifacts so the live
+   proof fixture reflects the new paid-report diagnostics section.
+
+### Review Contract
+
+Acceptance criteria:
+- Rows with `ticket_status_state="reopened"` or negative CSAT surface as
+  outcome-risk diagnostics in FAQ items, report summary, and paid Markdown.
+- Textual Zendesk CSAT (`bad`) and numeric low CSAT (`<=2`) both count as
+  negative; positive textual/numeric CSAT does not.
+- Direct report rows with raw `ticket_status`/`status` and textual/numeric CSAT
+  aliases produce the same outcome diagnostics as input-package-normalized rows.
+- Duplicate evidence rows with the same `source_id` count as one ticket for
+  diagnostic totals, risk totals, status mix, reopened count, and CSAT count.
+- The diagnostic lane explicitly says these signals do not prove a publishable
+  answer.
+- A no-resolution item with only status/CSAT diagnostics remains
+  `answer_evidence_status == "draft_needs_review"` and appears in the
+  no-proven-answer section, not the publishable-answer section.
+- The free snapshot does not expose new answer text/evidence; this PR only
+  changes paid report item/summary/Markdown details.
+
+Affected surfaces:
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `tests/test_content_ops_deflection_report.py`
+
+Risk areas:
+- Accidentally treating status/CSAT/reopen as resolution evidence.
+- Over-capturing CSAT: textual `good` or numeric `4/5` must not become a
+  negative signal.
+- Row-vs-ticket counting drift when one support ticket contributes multiple
+  evidence snippets.
+- Direct CSV/script path drift from the input-package normalized path.
+- Adding paid-report summary fields that drift from item-level counts.
+- Changing the free snapshot contract.
+
+Reviewer rules triggered: R1, R2, R10, R14.
+
+### Files touched
+
+- `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md`
+- `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/result.json`
+- `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/summary.json`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Outcome-Risk-Diagnostics.md`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+`build_ticket_faq_markdown(...)` already groups support-ticket evidence into
+per-question FAQ items. This PR adds a small deterministic helper that inspects
+those grouped rows for fields #1510 already emits:
+
+- `ticket_status_state`
+- `csat`
+- `csat_score`
+
+For the direct report path, the helper also preserves raw status/CSAT aliases
+from the opportunity row and normalizes them with the same status/CSAT helpers
+used by `support_ticket_input_package.py`.
+
+The helper first collapses diagnostics by `source_key`/`source_id`, then
+aggregates counts. That keeps ticket-level numbers coherent when a single
+ticket contributes multiple evidence snippets.
+
+When at least one status/CSAT field is present, the helper attaches an
+`outcome_diagnostics` dict to the item. The dict is diagnostic only; it is not
+consulted by the answer-evidence gate.
+
+`deflection_report_summary(...)` then aggregates item diagnostics into compact
+counts, and `render_deflection_report(...)` inserts a paid-only section between
+ranked opportunities and publishable answers. The section is skipped when no
+diagnostics are present.
+
+## Intentional
+
+- This PR does not invent a universal CSAT scale. Numeric `<=2` is treated as
+  negative because it is the common 1-5 low-score band; textual Zendesk `bad`
+  is treated as negative; textual `good` only counts as CSAT-present.
+- Open/pending status is displayed as context, but the risk counts focus on
+  reopened and negative CSAT. Open tickets may be unresolved rather than
+  failed resolutions.
+- Raw direct-row status/CSAT aliases reuse the input-package normalizers rather
+  than maintaining a second set of semantics in the report path.
+- The section is paid-report only. The pre-payment snapshot stays focused on
+  safe counts and locked questions.
+
+## Deferred
+
+- Tier-2 churn-risk scoring and buyer prioritization remain follow-up product
+  work. This PR only surfaces the raw diagnostics in the paid report.
+- Live Zendesk operator export rerun is still outside CI; this PR uses
+  deterministic fixture-level tests.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_content_ops_deflection_report.py -q` — 41 passed.
+- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py -q` — 302 passed.
+- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py -q` — 343 passed.
+- `pytest tests/test_content_ops_deflection_resolution_live_proof.py -q` — 3 passed.
+- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py tests/test_content_ops_deflection_resolution_live_proof.py -q` — 355 passed after rebasing onto #1536.
+- bash `scripts/run_extracted_pipeline_checks.sh` — 4101 passed, 10 skipped after rebasing onto #1536.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md` | 16 |
+| `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/result.json` | 9 |
+| `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/summary.json` | 9 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 116 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 156 |
+| `plans/PR-Deflection-Outcome-Risk-Diagnostics.md` | 160 |
+| `tests/test_content_ops_deflection_report.py` | 236 |
+| **Total** | **702** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -15,6 +15,9 @@ from extracted_content_pipeline.deflection_report_access import (
     InMemoryDeflectionReportArtifactStore,
     PostgresDeflectionReportArtifactStore,
 )
+from extracted_content_pipeline.support_ticket_input_package import (
+    build_support_ticket_input_package,
+)
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownResult,
     build_ticket_faq_markdown,
@@ -531,6 +534,239 @@ def test_deflection_snapshot_omits_date_window_when_source_dates_are_partial() -
     assert "source_date_start" not in snapshot["summary"]
     assert "source_date_end" not in snapshot["summary"]
     assert "source_window_days" not in snapshot["summary"]
+
+
+def test_deflection_report_surfaces_outcome_risk_diagnostics() -> None:
+    package = build_support_ticket_input_package(
+        [
+            {
+                "source_id": "zd-refund-1",
+                "source_type": "support_ticket",
+                "source_title": "Duplicate charge refund",
+                "description": "How do I get a duplicate charge refunded?",
+                "resolution_text": (
+                    "Open Billing > Payments, select the duplicate charge, "
+                    "choose Refund, enter the customer note, and confirm the refund."
+                ),
+                "ticket_status": "resolved",
+                "csat": "good",
+            },
+            {
+                "source_id": "zd-refund-2",
+                "source_type": "support_ticket",
+                "source_title": "Duplicate charge reopened",
+                "description": "How do I get a duplicate charge refunded?",
+                "resolution_text": (
+                    "Open Billing > Payments, select the duplicate charge, "
+                    "choose Refund, enter the customer note, and confirm the refund."
+                ),
+                "ticket_status": "reopened",
+                "csat": "bad",
+            },
+            {
+                "source_id": "zd-refund-3",
+                "source_type": "support_ticket",
+                "source_title": "Duplicate charge low CSAT",
+                "description": "How do I get a duplicate charge refunded?",
+                "resolution_text": (
+                    "Open Billing > Payments, select the duplicate charge, "
+                    "choose Refund, enter the customer note, and confirm the refund."
+                ),
+                "ticket_status": "resolved",
+                "csat": "2",
+            },
+        ],
+    )
+    result = build_ticket_faq_markdown(
+        package.inputs["source_material"],
+        max_items=1,
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    item = artifact.faq_result.items[0]
+    diagnostics = item["outcome_diagnostics"]
+    snapshot = build_deflection_snapshot(artifact).as_dict()
+    encoded_snapshot = json.dumps(snapshot, sort_keys=True)
+
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert diagnostics == {
+        "csat_present_count": 3,
+        "csat_score_average": 2.0,
+        "diagnostic_ticket_count": 3,
+        "negative_csat_ticket_count": 2,
+        "outcome_risk_ticket_count": 2,
+        "reopened_ticket_count": 1,
+        "ticket_status_summary": {"reopened": 1, "resolved": 2},
+    }
+    assert artifact.summary["outcome_diagnostics_present"] is True
+    assert artifact.summary["outcome_diagnostic_ticket_count"] == 3
+    assert artifact.summary["outcome_risk_ticket_count"] == 2
+    assert artifact.summary["reopened_ticket_count"] == 1
+    assert artifact.summary["negative_csat_ticket_count"] == 2
+    assert artifact.summary["csat_present_count"] == 3
+    assert artifact.summary["ticket_status_summary"] == {
+        "reopened": 1,
+        "resolved": 2,
+    }
+    assert "## Resolution Outcome Diagnostics" in artifact.markdown
+    assert "They do not prove a publishable answer" in artifact.markdown
+    assert "Tickets with reopened or negative-CSAT risk: 2" in artifact.markdown
+    assert "reopened: 1, resolved: 2" in artifact.markdown
+    assert "Review the answer before publishing because at least one ticket reopened." in (
+        artifact.markdown
+    )
+    assert "outcome" not in encoded_snapshot
+    assert "csat" not in encoded_snapshot.lower()
+
+
+def test_outcome_diagnostics_do_not_create_publishable_answers_without_resolution() -> None:
+    package = build_support_ticket_input_package(
+        [
+            {
+                "source_id": "zd-export-1",
+                "source_type": "support_ticket",
+                "source_title": "Export permission reopened",
+                "description": "What permission do I need for account exports?",
+                "ticket_status": "reopened",
+                "csat": "bad",
+            },
+            {
+                "source_id": "zd-export-2",
+                "source_type": "support_ticket",
+                "source_title": "Export permission low CSAT",
+                "description": "What permission do I need for account exports?",
+                "ticket_status": "resolved",
+                "csat": "1",
+            },
+        ],
+    )
+    result = build_ticket_faq_markdown(
+        package.inputs["source_material"],
+        max_items=1,
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    item = artifact.faq_result.items[0]
+    drafted = artifact.markdown.split(
+        "## Publishable Help-Center Copy From Proven Resolutions",
+        1,
+    )[1].split("## No Proven Answer Yet", 1)[0]
+    no_proven = artifact.markdown.split("## No Proven Answer Yet", 1)[1].split(
+        "## Vocabulary Gaps",
+        1,
+    )[0]
+
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["outcome_diagnostics"]["outcome_risk_ticket_count"] == 2
+    assert artifact.summary["drafted_answer_count"] == 0
+    assert artifact.summary["no_proven_answer_count"] == 1
+    assert "What permission do I need for account exports?" not in drafted
+    assert "What permission do I need for account exports?" in no_proven
+    assert "No verified support resolution was present" in no_proven
+    assert "## Resolution Outcome Diagnostics" in artifact.markdown
+    assert "They do not prove a publishable answer" in artifact.markdown
+
+
+def test_outcome_diagnostics_count_duplicate_evidence_by_source_ticket() -> None:
+    resolution_text = (
+        "Open Billing > Payments, select the duplicate charge, choose Refund, "
+        "enter the customer note, and confirm the refund."
+    )
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_id": "zd-duplicate-1",
+                "source_type": "support_ticket",
+                "source_title": "Duplicate charge thread",
+                "support_ticket_cluster": "duplicate charge refund",
+                "evidence": [
+                    {
+                        "source_id": "zd-duplicate-1",
+                        "source_type": "support_ticket",
+                        "source_title": "Duplicate charge thread",
+                        "text": "How do I get the duplicate charge refunded?",
+                        "resolution_text": resolution_text,
+                        "ticket_status_state": "reopened",
+                        "csat": "bad",
+                        "csat_score": 1,
+                    },
+                    {
+                        "source_id": "zd-duplicate-1",
+                        "source_type": "support_ticket",
+                        "source_title": "Duplicate charge thread",
+                        "text": "The same duplicate charge still needs a refund.",
+                        "resolution_text": resolution_text,
+                        "ticket_status_state": "reopened",
+                        "csat": "bad",
+                        "csat_score": 1,
+                    },
+                ],
+            },
+        ],
+        max_items=1,
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    diagnostics = artifact.faq_result.items[0]["outcome_diagnostics"]
+
+    assert diagnostics == {
+        "csat_present_count": 1,
+        "csat_score_average": 1.0,
+        "diagnostic_ticket_count": 1,
+        "negative_csat_ticket_count": 1,
+        "outcome_risk_ticket_count": 1,
+        "reopened_ticket_count": 1,
+        "ticket_status_summary": {"reopened": 1},
+    }
+    assert artifact.summary["outcome_diagnostic_ticket_count"] == 1
+    assert artifact.summary["reopened_ticket_count"] == 1
+    assert artifact.summary["negative_csat_ticket_count"] == 1
+    assert "Tickets with outcome diagnostics: 1" in artifact.markdown
+    assert "Reopened tickets: 1" in artifact.markdown
+
+
+def test_outcome_diagnostics_normalize_direct_raw_status_and_csat() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_id": "direct-1",
+                "source_type": "support_ticket",
+                "source_title": "Refund reopened",
+                "text": "How do I get a duplicate charge refunded?",
+                "support_ticket_cluster": "duplicate charge refund",
+                "ticket_status": "reopened",
+                "csat": "bad",
+            },
+            {
+                "source_id": "direct-2",
+                "source_type": "support_ticket",
+                "source_title": "Refund resolved",
+                "text": "How do I get a duplicate charge refunded?",
+                "support_ticket_cluster": "duplicate charge refund",
+                "status": "Closed",
+                "satisfaction_rating": "3",
+            },
+        ],
+        max_items=1,
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    diagnostics = artifact.faq_result.items[0]["outcome_diagnostics"]
+
+    assert artifact.faq_result.items[0]["answer_evidence_status"] == "draft_needs_review"
+    assert diagnostics == {
+        "csat_present_count": 2,
+        "csat_score_average": 3.0,
+        "diagnostic_ticket_count": 2,
+        "negative_csat_ticket_count": 1,
+        "outcome_risk_ticket_count": 1,
+        "reopened_ticket_count": 1,
+        "ticket_status_summary": {"reopened": 1, "resolved": 1},
+    }
+    assert artifact.summary["outcome_diagnostic_ticket_count"] == 2
+    assert artifact.summary["outcome_risk_ticket_count"] == 1
+    assert "Tickets with reopened or negative-CSAT risk: 1" in artifact.markdown
+    assert "reopened: 1, resolved: 1" in artifact.markdown
 
 
 def test_deflection_snapshot_omits_contradictory_summary_date_window() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Outcome-Risk-Diagnostics.md
Slice phase: Vertical slice

This closes the paid-report consumption gap for the #1510 status/CSAT/reopen fields: the report now surfaces "resolved on paper but risky" diagnostics from status, reopened tickets, and negative CSAT without treating those signals as proof of a publishable answer.

## Intentional
- Outcome diagnostics are diagnostic only; they do not influence the `resolution_evidence` gate.
- The section is paid-report only, so the free snapshot stays limited to locked safe counts/questions.
- Numeric CSAT `<=2` and textual Zendesk `bad` count as negative; textual `good` is CSAT-present but not negative.
- Direct raw-row status/CSAT aliases reuse the input-package normalizers instead of maintaining separate semantics.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed Codex `Normalize raw ticket statuses before diagnostics`: direct report rows now preserve raw status/CSAT aliases and normalize them before building outcome diagnostics.
- Fixed Codex `Count outcome totals by source ticket`: outcome diagnostics now collapse by `source_id`/`source_key` before counting status, reopened, CSAT-present, negative CSAT, and CSAT score average.
- Waived: none.

## Deferred
- Tier-2 churn-risk scoring and buyer prioritization remain follow-up product work.
- Live Zendesk operator export rerun remains outside CI for this slice.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_deflection_report.py -q` — 41 passed.
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py -q` — 302 passed.
- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py -q` — 343 passed.
- `pytest tests/test_content_ops_deflection_resolution_live_proof.py -q` — 3 passed.
- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py tests/test_content_ops_deflection_resolution_live_proof.py -q` — 355 passed after rebasing onto #1536.
- bash `scripts/run_extracted_pipeline_checks.sh` — 4101 passed, 10 skipped after rebasing onto #1536.

## Diff size
7 files, synced estimate 702 LOC. This includes the plan doc and regenerated proof artifacts for the paid-report diagnostics section.
