### PR TITLE
Deflection embedding host adapter

### DIFF
--- a/.github/workflows/atlas_content_ops_input_provider_checks.yml
+++ b/.github/workflows/atlas_content_ops_input_provider_checks.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
+      - "atlas_brain/api/__init__.py"
+      - "atlas_brain/config.py"
+      - "atlas_brain/_content_ops_infrastructure.py"
       - "atlas_brain/_content_ops_input_provider.py"
       - "atlas_brain/_content_ops_services.py"
+      - "atlas_brain/services/embedding/sentence_transformer.py"
       - "tests/test_atlas_content_ops_input_provider.py"
+      - "tests/test_atlas_content_ops_infrastructure.py"
       - "tests/test_atlas_content_ops_review_input_provider.py"
       - "tests/test_atlas_content_ops_execution_services.py"
       - "tests/test_support_ticket_provider_landing_blog_execute.py"
@@ -15,9 +20,14 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
+      - "atlas_brain/api/__init__.py"
+      - "atlas_brain/config.py"
+      - "atlas_brain/_content_ops_infrastructure.py"
       - "atlas_brain/_content_ops_input_provider.py"
       - "atlas_brain/_content_ops_services.py"
+      - "atlas_brain/services/embedding/sentence_transformer.py"
       - "tests/test_atlas_content_ops_input_provider.py"
+      - "tests/test_atlas_content_ops_infrastructure.py"
       - "tests/test_atlas_content_ops_review_input_provider.py"
       - "tests/test_atlas_content_ops_execution_services.py"
       - "tests/test_support_ticket_provider_landing_blog_execute.py"
@@ -45,6 +55,7 @@ jobs:
         run: |
           python -m pytest \
             tests/test_atlas_content_ops_input_provider.py \
+            tests/test_atlas_content_ops_infrastructure.py \
             tests/test_atlas_content_ops_review_input_provider.py \
             tests/test_atlas_content_ops_execution_services.py \
             tests/test_support_ticket_provider_landing_blog_execute.py \

--- a/atlas_brain/_content_ops_infrastructure.py
+++ b/atlas_brain/_content_ops_infrastructure.py
@@ -31,7 +31,7 @@ contract.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +42,12 @@ from extracted_content_pipeline.campaign_ports import (
     SkillStore,
 )
 from extracted_content_pipeline.campaign_llm_client import PipelineLLMClient
+from extracted_content_pipeline.embedding_port import EmbeddingPort
+
+
+CONTENT_OPS_FAQ_EMBEDDING_MODEL = "mixedbread-ai/mxbai-embed-large-v1"
+CONTENT_OPS_FAQ_EMBEDDING_REVISION = "b33106f585b9ce46904ad7443a3b52b7a63e231c"
+CONTENT_OPS_FAQ_EMBEDDING_DEVICE = "cpu"
 
 
 class _HostLLMClient:
@@ -154,6 +160,56 @@ class _HostSkillStore:
         return content
 
 
+def _embedding_row_to_tuple(row: Any) -> tuple[float, ...]:
+    values = row.tolist() if hasattr(row, "tolist") else row
+    return tuple(float(value) for value in values)
+
+
+class _HostEmbeddingPort:
+    """Adapter implementing the extracted FAQ embedding port over host embeddings."""
+
+    def __init__(self, host_embedding: Any) -> None:
+        self._host = host_embedding
+
+    def embed_texts(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
+        normalized = [str(text or "") for text in texts]
+        if not normalized:
+            return ()
+        embeddings = self._host.embed_batch(normalized)
+        values = embeddings.tolist() if hasattr(embeddings, "tolist") else embeddings
+        return tuple(_embedding_row_to_tuple(row) for row in values)
+
+
+_CONTENT_OPS_FAQ_EMBEDDING_PORT: EmbeddingPort | None = None
+
+
+def build_content_ops_faq_embedding_port(
+    *,
+    embedding_service_factory: Callable[..., Any] | None = None,
+) -> EmbeddingPort:
+    """Return the pinned local embedding port for FAQ question clustering."""
+
+    global _CONTENT_OPS_FAQ_EMBEDDING_PORT
+    kwargs = {
+        "model_name": CONTENT_OPS_FAQ_EMBEDDING_MODEL,
+        "device": CONTENT_OPS_FAQ_EMBEDDING_DEVICE,
+        "revision": CONTENT_OPS_FAQ_EMBEDDING_REVISION,
+        "local_files_only": True,
+    }
+    if embedding_service_factory is not None:
+        return _HostEmbeddingPort(embedding_service_factory(**kwargs))
+
+    if _CONTENT_OPS_FAQ_EMBEDDING_PORT is None:
+        from atlas_brain.services.embedding.sentence_transformer import (
+            SentenceTransformerEmbedding,
+        )
+
+        _CONTENT_OPS_FAQ_EMBEDDING_PORT = _HostEmbeddingPort(
+            SentenceTransformerEmbedding(**kwargs)
+        )
+    return _CONTENT_OPS_FAQ_EMBEDDING_PORT
+
+
 def build_content_ops_llm_client(
     *,
     llm_registry: Any = None,
@@ -259,6 +315,10 @@ def build_content_ops_skill_store(
 
 
 __all__ = [
+    "CONTENT_OPS_FAQ_EMBEDDING_DEVICE",
+    "CONTENT_OPS_FAQ_EMBEDDING_MODEL",
+    "CONTENT_OPS_FAQ_EMBEDDING_REVISION",
+    "build_content_ops_faq_embedding_port",
     "build_content_ops_llm_client",
     "build_content_ops_skill_store",
 ]

--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -80,6 +80,7 @@ from extracted_content_pipeline.content_image_provider import (
 from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
 )
+from extracted_content_pipeline.embedding_port import EmbeddingPort
 from extracted_content_pipeline.faq_deflection_report import (
     FAQDeflectionReportService,
 )
@@ -123,6 +124,7 @@ from extracted_content_pipeline.stat_card_postgres import (
     PostgresStatCardRepository,
 )
 from extracted_content_pipeline.ticket_faq_markdown import (
+    TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
 )
 from extracted_content_pipeline.ticket_faq_postgres import (
@@ -277,12 +279,25 @@ def _build_content_image_provider() -> ContentImageProvider | None:
     )
 
 
-def _build_ticket_faq_service(*, pool: Any) -> TicketFAQMarkdownService | None:
-    """Build the persisted FAQ Markdown service when a DB pool is active."""
+def _build_ticket_faq_service(
+    *,
+    pool: Any,
+    embedding_port: EmbeddingPort | None = None,
+) -> TicketFAQMarkdownService | None:
+    """Build the FAQ Markdown service when persistence or embeddings are active."""
 
-    if pool is None:
+    if pool is None and embedding_port is None:
         return None
-    return TicketFAQMarkdownService(ticket_faqs=PostgresTicketFAQRepository(pool=pool))
+    return TicketFAQMarkdownService(
+        config=(
+            TicketFAQMarkdownConfig(embedding_port=embedding_port)
+            if embedding_port is not None
+            else None
+        ),
+        ticket_faqs=(
+            PostgresTicketFAQRepository(pool=pool) if pool is not None else None
+        ),
+    )
 
 
 def _build_social_post_service(
@@ -337,6 +352,7 @@ def build_content_ops_execution_services(
     llm_factory: Callable[[], LLMClient | None] | None = None,
     skills_factory: Callable[[], SkillStore] | None = None,
     pool_factory: Callable[[], Any] | None = None,
+    faq_embedding_port_factory: Callable[[], EmbeddingPort | None] | None = None,
     enable_db_services: bool = False,
     expose_faq_markdown_output: bool = True,
 ) -> ContentOpsExecutionServices:
@@ -393,9 +409,19 @@ def build_content_ops_execution_services(
     ad_copy = _AD_COPY_SERVICE
     quote_card = _QUOTE_CARD_SERVICE
     stat_card = _STAT_CARD_SERVICE
-    faq_markdown_service = _FAQ_MARKDOWN_SERVICE
+    faq_embedding_port = (
+        faq_embedding_port_factory() if faq_embedding_port_factory is not None else None
+    )
+    faq_markdown_service = (
+        _build_ticket_faq_service(pool=None, embedding_port=faq_embedding_port)
+        or _FAQ_MARKDOWN_SERVICE
+    )
     faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
-    faq_deflection_report = _FAQ_DEFLECTION_REPORT_SERVICE
+    faq_deflection_report = (
+        FAQDeflectionReportService(faq_markdown=faq_markdown_service)
+        if faq_embedding_port is not None
+        else _FAQ_DEFLECTION_REPORT_SERVICE
+    )
     if enable_db_services:
         llm = llm_factory()
         skills = skills_factory()
@@ -445,7 +471,13 @@ def build_content_ops_execution_services(
         ad_copy = _build_ad_copy_service(pool=pool)
         quote_card = _build_quote_card_service(pool=pool)
         stat_card = _build_stat_card_service(pool=pool)
-        faq_markdown_service = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
+        faq_markdown_service = (
+            _build_ticket_faq_service(
+                pool=pool,
+                embedding_port=faq_embedding_port,
+            )
+            or _FAQ_MARKDOWN_SERVICE
+        )
         faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
         faq_deflection_report = FAQDeflectionReportService(
             faq_markdown=faq_markdown_service

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -171,6 +171,7 @@ try:
     )
     from .._content_ops_input_provider import build_content_ops_input_provider
     from .._content_ops_infrastructure import (
+        build_content_ops_faq_embedding_port,
         build_content_ops_llm_client,
         build_content_ops_skill_store,
     )
@@ -242,6 +243,11 @@ try:
         ).strip()
         return policy or None
 
+    def _build_content_ops_faq_embedding_port_if_enabled():
+        if settings.b2b_campaign.content_ops_faq_embedding_booster_enabled:
+            return build_content_ops_faq_embedding_port()
+        return None
+
     content_ops_config = ContentOpsControlSurfaceApiConfig(
         deflection_checkout_amount_cents=(
             settings.saas_auth.stripe_content_ops_deflection_report_amount_cents
@@ -263,6 +269,9 @@ try:
             build_content_ops_execution_services(
                 enable_db_services=True,
                 expose_faq_markdown_output=False,
+                faq_embedding_port_factory=(
+                    _build_content_ops_faq_embedding_port_if_enabled
+                ),
             )
         ),
         scope_provider=build_content_ops_scope,

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4807,6 +4807,14 @@ class B2BCampaignConfig(BaseSettings):
             "to exact-cache or no-store to default hosted runs."
         ),
     )
+    content_ops_faq_embedding_booster_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED"),
+        description=(
+            "Enable the hosted Content Ops FAQ embedding booster. Defaults off "
+            "until the mxbai thresholds are live-baselined."
+        ),
+    )
     content_ops_zendesk_email: str = Field(
         default="",
         validation_alias=AliasChoices(

--- a/atlas_brain/services/embedding/sentence_transformer.py
+++ b/atlas_brain/services/embedding/sentence_transformer.py
@@ -23,9 +23,13 @@ class SentenceTransformerEmbedding:
         self,
         model_name: str = "all-MiniLM-L6-v2",
         device: Optional[str] = None,
+        revision: Optional[str] = None,
+        local_files_only: bool = False,
     ):
         self.model_name = model_name
         self.device = device
+        self.revision = revision
+        self.local_files_only = bool(local_files_only)
         self._model = None
         self._dimension = 384
 
@@ -49,10 +53,13 @@ class SentenceTransformerEmbedding:
             from sentence_transformers import SentenceTransformer
 
             logger.info("Loading embedding model: %s", self.model_name)
-            self._model = SentenceTransformer(
-                self.model_name,
-                device=self.device,
-            )
+            kwargs = {
+                "device": self.device,
+                "local_files_only": self.local_files_only,
+            }
+            if self.revision is not None:
+                kwargs["revision"] = self.revision
+            self._model = SentenceTransformer(self.model_name, **kwargs)
             self._dimension = self._model.get_sentence_embedding_dimension()
             logger.info(
                 "Embedding model loaded (dim=%d, device=%s)",

--- a/plans/PR-Deflection-Embedding-Host-Adapter.md
+++ b/plans/PR-Deflection-Embedding-Host-Adapter.md
@@ -1,0 +1,162 @@
+# PR-Deflection-Embedding-Host-Adapter
+
+## Why this slice exists
+
+#1504 is now past the lexical floor and extracted booster-core slices. PR #1531
+made the documented exact-Jaccard floor literal, and PR #1536 landed the
+model-free embedding booster core behind an optional `EmbeddingPort`.
+
+The remaining vertical gap is host activation wiring: the production Content
+Ops execution route still builds FAQ/deflection services without an embedding
+port, so the booster is landed but unreachable outside extracted-package tests.
+The #1504 calibration note and the RFC plan require the host side to use the
+pinned offline `mixedbread-ai/mxbai-embed-large-v1` model rather than the older
+default MiniLM embedding service.
+
+This slice wires only that host seam. It deliberately avoids the FAQ clustering
+and report files that landed through #1538.
+
+The slice lands above the 400 LOC soft target because the host seam is only
+useful if the adapter, service-bundle injection, route gate, CI enrollment, and
+tests proving those pieces ship together.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Vertical slice
+
+1. Add a host `EmbeddingPort` adapter in
+   `atlas_brain/_content_ops_infrastructure.py` that wraps the existing
+   sentence-transformer embedding service and returns plain Python float
+   vectors.
+2. Extend the host sentence-transformer service to accept optional model
+   revision and offline-cache flags while preserving existing defaults.
+3. Add a pinned Content Ops FAQ embedding-port factory for
+   `mixedbread-ai/mxbai-embed-large-v1` at cached revision
+   `b33106f585b9ce46904ad7443a3b52b7a63e231c`, CPU device, and local-files-only
+   loading.
+4. Thread an optional FAQ embedding-port factory through the host execution
+   services bundle and inject it into FAQ Markdown and deflection-report services
+   when provided.
+5. Wire the authenticated Content Ops route to pass a default-off gated factory,
+   so the hosted deflection path can exercise the booster core only after the
+   operator enables `ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED`.
+6. Add host-side tests proving adapter conversion, pinned/offline factory
+   construction, bundle injection, hidden-FAQ report reuse, no-port default
+   behavior, and the default-off route gate.
+7. Enroll the new atlas-brain-importing infrastructure test and the source
+   files it covers in the dedicated atlas Content Ops service workflow.
+8. Guard the heavy host infrastructure test with `pytest.importorskip("torch")`
+   so torch-less extracted CI skips it during collection while the atlas
+   workflow still runs it.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Host adapter converts batch embeddings from array/list-like service
+        output into plain float vectors accepted by the extracted port.
+  - [ ] The pinned factory constructs the mxbai service with model name,
+        revision, CPU device, and local-files-only loading, without loading the
+        model during service-bundle construction.
+  - [ ] The service bundle keeps no-port behavior unchanged unless a caller
+        provides a FAQ embedding-port factory.
+  - [ ] When a factory is provided, both `faq_markdown` and
+        `faq_deflection_report` use the same configured FAQ service, including
+        when `faq_markdown` is hidden from customer-executable outputs.
+  - [ ] The authenticated Content Ops route passes a gated factory into the
+        execution-services provider, and the gate defaults off.
+  - [ ] No extracted package imports host embedding code; the MCP/execution
+        transport remains a thin service wrapper.
+- Affected surfaces: host Content Ops infrastructure, host execution-services
+  bundle, Content Ops route provider wiring, config flag, sentence-transformer
+  service construction, host tests, atlas workflow enrollment, and this plan.
+- Risk areas: accidental real-model load in tests or service construction,
+  silently falling back to MiniLM, premature production activation before live
+  mxbai calibration, and collision with open PR #1540.
+- Reviewer rules triggered: R1, R2, R5, R10, R11, R12, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_input_provider_checks.yml`
+- `atlas_brain/_content_ops_infrastructure.py`
+- `atlas_brain/_content_ops_services.py`
+- `atlas_brain/api/__init__.py`
+- `atlas_brain/config.py`
+- `atlas_brain/services/embedding/sentence_transformer.py`
+- `plans/PR-Deflection-Embedding-Host-Adapter.md`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `tests/test_atlas_content_ops_infrastructure.py`
+
+## Mechanism
+
+The extracted package already owns the pure `EmbeddingPort` protocol. The host
+adapter implements that protocol over an injected embedding service with an
+`embed_batch` method, normalizing service output into immutable Python tuples of
+floats. The adapter does not import or call the FAQ builder directly.
+
+The pinned factory lives beside the existing host LLM/skill adapters. Production
+construction uses `mixedbread-ai/mxbai-embed-large-v1`, revision
+`b33106f585b9ce46904ad7443a3b52b7a63e231c`, `device="cpu"`, and
+`local_files_only=True`. Construction remains lazy with respect to model load:
+the model loads only if FAQ clustering actually asks the port for embeddings,
+and the extracted booster still fails closed if embedding generation raises.
+
+The execution-services bundle gets a `faq_embedding_port_factory` dependency
+injection parameter. By default it is absent, preserving today’s no-port
+behavior for tests, scripts, and dependency-light callers. The authenticated
+Content Ops API route passes a gated helper that returns `None` unless
+`ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED=true`, which keeps production
+activation explicit until the mxbai live baseline is accepted.
+
+## Intentional
+
+- This PR does not change `extracted_content_pipeline/ticket_faq_markdown.py` or
+  `extracted_content_pipeline/faq_deflection_report.py`; #1538 already handled
+  the report surface, and #1536 already landed the extracted core.
+- The default service-bundle factory remains no-port unless a caller explicitly
+  passes a FAQ embedding-port factory. That keeps unit tests and standalone
+  scripts from loading mxbai accidentally while the hosted route is wired behind
+  a default-off operator flag.
+- The factory pins a local cached revision instead of resolving the floating
+  Hugging Face `main` ref at runtime. That is the determinism/offline contract
+  from #1504/#1515.
+- The hosted route gate defaults off because the mxbai thresholds still need
+  live CFPB re-baseline evidence before production activation.
+
+## Deferred
+
+- Live CFPB re-baseline after the hosted route has the embedding port wired and
+  the operator approves enabling the route flag for the live input.
+- Surfacing semantic merge provenance in the report UI/output, if product wants
+  buyer-visible explanation for embedding-driven joins.
+- Multi-row lexical component semantic expansion remains deferred from #1536
+  until a safer cluster-level criterion is proven.
+
+Parked hardening: none.
+
+## Verification
+
+- Command passed: python -m py_compile atlas_brain/config.py atlas_brain/_content_ops_infrastructure.py atlas_brain/_content_ops_services.py atlas_brain/api/__init__.py atlas_brain/services/embedding/sentence_transformer.py tests/test_atlas_content_ops_infrastructure.py tests/test_atlas_content_ops_execution_services.py.
+- Command passed: pytest tests/test_atlas_content_ops_infrastructure.py::test_host_embedding_port_converts_batch_output_to_float_vectors tests/test_atlas_content_ops_infrastructure.py::test_content_ops_faq_embedding_factory_pins_mxbai_offline_model tests/test_atlas_content_ops_infrastructure.py::test_sentence_transformer_embedding_load_uses_revision_and_offline_flags tests/test_atlas_content_ops_execution_services.py::test_faq_markdown_uses_injected_host_embedding_port tests/test_atlas_content_ops_execution_services.py::test_faq_markdown_can_be_hidden_while_deflection_report_runs tests/test_atlas_content_ops_execution_services.py::test_faq_markdown_default_bundle_keeps_no_port_behavior tests/test_atlas_content_ops_execution_services.py::test_content_ops_api_route_gates_pinned_faq_embedding_factory -q - 7 passed, 1 warning.
+- Command passed: pytest tests/test_atlas_content_ops_infrastructure.py -q - 15 passed, 1 warning.
+- Command passed: pytest tests/test_atlas_content_ops_execution_services.py -q - 33 passed.
+- Command passed: pytest tests/test_atlas_content_ops_infrastructure.py tests/test_atlas_content_ops_execution_services.py -q - 48 passed.
+- Command passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main . - OK: 178 matching tests are enrolled.
+- Command passed: bash scripts/run_extracted_pipeline_checks.sh - 4109 passed, 10 skipped, 1 warning.
+- Command passed: python scripts/sync_pr_plan.py plans/PR-Deflection-Embedding-Host-Adapter.md origin/main --check.
+- Command passed: bash scripts/push_pr.sh tmp/deflection_embedding_host_adapter_pr_body.md -u origin claude/pr-deflection-embedding-host-adapter - local PR review passed and branch pushed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_input_provider_checks.yml` | 11 |
+| `atlas_brain/_content_ops_infrastructure.py` | 62 |
+| `atlas_brain/_content_ops_services.py` | 46 |
+| `atlas_brain/api/__init__.py` | 9 |
+| `atlas_brain/config.py` | 8 |
+| `atlas_brain/services/embedding/sentence_transformer.py` | 15 |
+| `plans/PR-Deflection-Embedding-Host-Adapter.md` | 162 |
+| `tests/test_atlas_content_ops_execution_services.py` | 180 |
+| `tests/test_atlas_content_ops_infrastructure.py` | 103 |
+| **Total** | **596** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -43,6 +43,8 @@ Test inventory covers:
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -51,10 +53,13 @@ import pytest
 from atlas_brain._content_ops_services import (
     build_content_ops_execution_services,
 )
+from atlas_brain.config import B2BCampaignConfig
 from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
 from extracted_content_pipeline.content_ops_execution import (
     execute_content_ops_from_mapping,
 )
+
+_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _make_llm_stub() -> Any:
@@ -92,6 +97,18 @@ class _SocialPostLLMStub:
             ),
             model="test-model",
             usage={"input_tokens": 3, "output_tokens": 5},
+        )
+
+
+class _FAQEmbeddingPortStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    def embed_texts(self, texts):
+        self.calls.append(tuple(texts))
+        return tuple(
+            (1.0, 0.0) if "money back" in text else (0.99, 0.01)
+            for text in texts
         )
 
 
@@ -241,6 +258,49 @@ async def test_faq_markdown_persists_when_db_services_enabled() -> None:
     assert step["status"] == "completed"
     assert step["result"]["saved_ids"] == ["faq-uuid-1"]
     assert "INSERT INTO ticket_faq_markdown" in pool.fetchval_calls[0]["query"]
+
+
+@pytest.mark.asyncio
+async def test_faq_markdown_uses_injected_host_embedding_port() -> None:
+    port = _FAQEmbeddingPortStub()
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        faq_embedding_port_factory=lambda: port,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_markdown"],
+            "inputs": {
+                "source_material": [
+                    {
+                        "ticket_id": "refund-a",
+                        "source_type": "ticket",
+                        "message": "How do I get my money back?",
+                        "pain_category": "refunds",
+                    },
+                    {
+                        "ticket_id": "refund-b",
+                        "source_type": "ticket",
+                        "message": "What is the process for a refund?",
+                        "pain_category": "refunds",
+                    },
+                ]
+            },
+        },
+        services=services,
+    )
+
+    step = result["steps"][0]
+    assert step["status"] == "completed"
+    assert step["result"]["generated"] == 1
+    assert step["result"]["items"][0]["ticket_count"] == 2
+    assert port.calls == [(
+        "How do I get my money back?",
+        "What is the process for a refund?",
+    )]
 
 
 @pytest.mark.asyncio
@@ -554,12 +614,14 @@ async def test_faq_deflection_report_runs_through_host_bundle() -> None:
 @pytest.mark.asyncio
 async def test_faq_markdown_can_be_hidden_while_deflection_report_runs() -> None:
     pool = _FAQPoolStub()
+    port = _FAQEmbeddingPortStub()
     services = build_content_ops_execution_services(
         llm_factory=_no_llm,
         skills_factory=_make_skill_store_stub,
         pool_factory=lambda: pool,
         enable_db_services=True,
         expose_faq_markdown_output=False,
+        faq_embedding_port_factory=lambda: port,
     )
 
     assert services.faq_markdown is None
@@ -579,19 +641,17 @@ async def test_faq_markdown_can_be_hidden_while_deflection_report_runs() -> None
             "inputs": {
                 "deflection_report_title": "Hidden FAQ Source Report",
                 "source_material": [
-                    # #1460: a repeat partner keeps the question a billable
-                    # FAQ cluster (one-off questions are excluded).
                     {
                         "ticket_id": "ticket-1",
                         "source_type": "ticket",
-                        "message": "How do I fix failed exports?",
-                        "pain_category": "exports",
+                        "message": "How do I get my money back?",
+                        "pain_category": "refunds",
                     },
                     {
                         "ticket_id": "ticket-2",
                         "source_type": "ticket",
-                        "message": "How can I fix failed exports?",
-                        "pain_category": "exports",
+                        "message": "What is the process for a refund?",
+                        "pain_category": "refunds",
                     },
                 ],
             },
@@ -605,6 +665,114 @@ async def test_faq_markdown_can_be_hidden_while_deflection_report_runs() -> None
     assert step["status"] == "completed"
     assert step["result"]["summary"]["generated"] == 1
     assert step["result"]["markdown"].startswith("# Hidden FAQ Source Report")
+    assert port.calls == [(
+        "How do I get my money back?",
+        "What is the process for a refund?",
+    )]
+
+
+@pytest.mark.asyncio
+async def test_faq_markdown_default_bundle_keeps_no_port_behavior() -> None:
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_markdown"],
+            "inputs": {
+                "source_material": [
+                    {
+                        "ticket_id": "refund-a",
+                        "source_type": "ticket",
+                        "message": "How do I get my money back?",
+                        "pain_category": "refunds",
+                    },
+                    {
+                        "ticket_id": "refund-b",
+                        "source_type": "ticket",
+                        "message": "What is the process for a refund?",
+                        "pain_category": "refunds",
+                    },
+                ]
+            },
+        },
+        services=services,
+    )
+
+    step = result["steps"][0]
+    assert step["status"] == "completed"
+    assert step["result"]["generated"] == 0
+
+
+def test_content_ops_faq_embedding_booster_config_defaults_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(
+        "ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED",
+        raising=False,
+    )
+    config = B2BCampaignConfig(_env_file=None)
+
+    assert config.content_ops_faq_embedding_booster_enabled is False
+
+
+def test_content_ops_faq_embedding_booster_config_accepts_env_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(
+        "ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED",
+        raising=False,
+    )
+    monkeypatch.setenv("ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED", "true")
+
+    config = B2BCampaignConfig(_env_file=None)
+
+    assert config.content_ops_faq_embedding_booster_enabled is True
+
+
+def test_content_ops_api_route_gates_pinned_faq_embedding_factory() -> None:
+    """Route wiring keeps the hosted FAQ embedding booster opt-in."""
+
+    tree = ast.parse((_ROOT / "atlas_brain/api/__init__.py").read_text())
+    provider_uses_gate = False
+    helper_checks_flag = False
+    helper_calls_factory = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and (
+            node.name == "_build_content_ops_faq_embedding_port_if_enabled"
+        ):
+            for child in ast.walk(node):
+                if (
+                    isinstance(child, ast.Attribute)
+                    and child.attr == "content_ops_faq_embedding_booster_enabled"
+                ):
+                    helper_checks_flag = True
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Name)
+                    and child.func.id == "build_content_ops_faq_embedding_port"
+                ):
+                    helper_calls_factory = True
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id != "build_content_ops_execution_services":
+            continue
+        for keyword in node.keywords:
+            if (
+                keyword.arg == "faq_embedding_port_factory"
+                and isinstance(keyword.value, ast.Name)
+                and keyword.value.id == "_build_content_ops_faq_embedding_port_if_enabled"
+            ):
+                provider_uses_gate = True
+
+    assert provider_uses_gate is True
+    assert helper_checks_flag is True
+    assert helper_calls_factory is True
 
 
 def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:

--- a/tests/test_atlas_content_ops_infrastructure.py
+++ b/tests/test_atlas_content_ops_infrastructure.py
@@ -40,15 +40,26 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+import sys
 from typing import Any
 
 import pytest
 
+pytest.importorskip("torch")
+
 from atlas_brain._content_ops_infrastructure import (
+    CONTENT_OPS_FAQ_EMBEDDING_DEVICE,
+    CONTENT_OPS_FAQ_EMBEDDING_MODEL,
+    CONTENT_OPS_FAQ_EMBEDDING_REVISION,
+    _HostEmbeddingPort,
     _HostLLMClient,
     _HostSkillStore,
+    build_content_ops_faq_embedding_port,
     build_content_ops_llm_client,
     build_content_ops_skill_store,
+)
+from atlas_brain.services.embedding.sentence_transformer import (
+    SentenceTransformerEmbedding,
 )
 from extracted_content_pipeline.campaign_llm_client import PipelineLLMClient
 from extracted_content_pipeline.campaign_ports import LLMMessage
@@ -133,6 +144,98 @@ def test_host_skill_store_returns_none_for_missing_skill() -> None:
 
     store = build_content_ops_skill_store()
     assert store.get_prompt("digest/__definitely_not_a_real_skill__") is None
+
+
+def test_host_embedding_port_converts_batch_output_to_float_vectors() -> None:
+    """Host embedding service output is normalized to the extracted port shape."""
+
+    class _ArrayLike:
+        def tolist(self):
+            return [["1.0", 2], [3.5, "4.25"]]
+
+    class _FakeEmbeddingService:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        def embed_batch(self, texts: list[str]) -> _ArrayLike:
+            self.calls.append(texts)
+            return _ArrayLike()
+
+    service = _FakeEmbeddingService()
+    port = _HostEmbeddingPort(service)
+
+    assert port.embed_texts(["refund help", "password reset"]) == (
+        (1.0, 2.0),
+        (3.5, 4.25),
+    )
+    assert service.calls == [["refund help", "password reset"]]
+
+
+def test_content_ops_faq_embedding_factory_pins_mxbai_offline_model() -> None:
+    """Factory builds the mxbai service with the pinned offline contract."""
+
+    received: dict[str, Any] = {}
+
+    class _FakeEmbeddingService:
+        def __init__(self, **kwargs: Any) -> None:
+            received.update(kwargs)
+
+        def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            return [[float(len(text)), 1.0] for text in texts]
+
+    port = build_content_ops_faq_embedding_port(
+        embedding_service_factory=_FakeEmbeddingService
+    )
+
+    assert received == {
+        "model_name": CONTENT_OPS_FAQ_EMBEDDING_MODEL,
+        "device": CONTENT_OPS_FAQ_EMBEDDING_DEVICE,
+        "revision": CONTENT_OPS_FAQ_EMBEDDING_REVISION,
+        "local_files_only": True,
+    }
+    assert port.embed_texts(["a", "abcd"]) == ((1.0, 1.0), (4.0, 1.0))
+
+
+def test_sentence_transformer_embedding_load_uses_revision_and_offline_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The host embedding service passes revision/offline args to the loader."""
+
+    received: dict[str, Any] = {}
+
+    class _FakeSentenceTransformer:
+        device = "cpu"
+
+        def __init__(self, model_name: str, **kwargs: Any) -> None:
+            received["model_name"] = model_name
+            received["kwargs"] = kwargs
+
+        def get_sentence_embedding_dimension(self) -> int:
+            return 1024
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        SimpleNamespace(SentenceTransformer=_FakeSentenceTransformer),
+    )
+
+    service = SentenceTransformerEmbedding(
+        model_name="example/model",
+        device="cpu",
+        revision="abc123",
+        local_files_only=True,
+    )
+    service.load()
+
+    assert received == {
+        "model_name": "example/model",
+        "kwargs": {
+            "device": "cpu",
+            "local_files_only": True,
+            "revision": "abc123",
+        },
+    }
+    assert service.dimension == 1024
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Embedding-Host-Adapter.md
Slice phase: Vertical slice

This slice wires the hosted Content Ops deflection path to the #1504 embedding booster: a host `EmbeddingPort` adapter wraps the existing sentence-transformer service, the mxbai model is pinned to the cached offline revision, the services bundle accepts an explicit FAQ embedding-port factory, and the authenticated Content Ops route uses a default-off gate before calling that factory.

It also enrolls the new atlas-brain-importing infrastructure test and covered source files in the dedicated atlas Content Ops service workflow so the host-side proof is protected outside the extracted runner.

## Intentional
- Default service-bundle callers remain no-port unless they pass a FAQ embedding-port factory, so tests/scripts do not load mxbai accidentally.
- The authenticated hosted route is wired but defaults off behind `ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED` until the mxbai live baseline validates the thresholds.
- No changes to FAQ clustering/report internals; #1538 already handled the report surface.
- The PR is over the 400 LOC soft target because adapter, service injection, route gate, CI enrollment, and proof are one vertical seam.

## Deferred
- Live CFPB re-baseline after hosted wiring is reviewed and the operator enables the route flag for the live input.
- Semantic merge provenance surfacing.
- Multi-row lexical component semantic expansion after a safer cluster-level criterion is proven.

## Parked hardening
- None.

## AI reconciliation
- All findings fixed or waived: Yes.
- Fixed Codex R12 workflow-path finding by adding `atlas_brain/api/__init__.py`, `atlas_brain/config.py`, and `atlas_brain/services/embedding/sentence_transformer.py` to the dedicated atlas Content Ops service workflow filters.

## Verification
- Command passed: python -m py_compile atlas_brain/config.py atlas_brain/_content_ops_infrastructure.py atlas_brain/_content_ops_services.py atlas_brain/api/__init__.py atlas_brain/services/embedding/sentence_transformer.py tests/test_atlas_content_ops_infrastructure.py tests/test_atlas_content_ops_execution_services.py.
- Command passed: pytest tests/test_atlas_content_ops_infrastructure.py::test_host_embedding_port_converts_batch_output_to_float_vectors tests/test_atlas_content_ops_infrastructure.py::test_content_ops_faq_embedding_factory_pins_mxbai_offline_model tests/test_atlas_content_ops_infrastructure.py::test_sentence_transformer_embedding_load_uses_revision_and_offline_flags tests/test_atlas_content_ops_execution_services.py::test_faq_markdown_uses_injected_host_embedding_port tests/test_atlas_content_ops_execution_services.py::test_faq_markdown_can_be_hidden_while_deflection_report_runs tests/test_atlas_content_ops_execution_services.py::test_faq_markdown_default_bundle_keeps_no_port_behavior tests/test_atlas_content_ops_execution_services.py::test_content_ops_api_route_gates_pinned_faq_embedding_factory -q - 7 passed.
- Command passed: pytest tests/test_atlas_content_ops_infrastructure.py -q - 15 passed, 1 warning.
- Command passed: pytest tests/test_atlas_content_ops_execution_services.py -q - 33 passed.
- Command passed: pytest tests/test_atlas_content_ops_infrastructure.py tests/test_atlas_content_ops_execution_services.py -q - 48 passed.
- Command passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main . - OK: 178 matching tests are enrolled.
- Command passed: bash scripts/run_extracted_pipeline_checks.sh - 4109 passed, 10 skipped, 1 warning.
- Command passed: python scripts/sync_pr_plan.py plans/PR-Deflection-Embedding-Host-Adapter.md origin/main --check.
- Command passed: python scripts/audit_plan_doc_diff_size.py plans/PR-Deflection-Embedding-Host-Adapter.md origin/main - status OK.
- Command passed: bash scripts/push_pr.sh tmp/deflection_embedding_host_adapter_pr_body.md - local PR review passed and branch pushed.

## Diff size
9 files, +578 / -18