### PR TITLE
Deflection statement customer wording smoke

### DIFF
--- a/plans/PR-Deflection-Statement-Customer-Wording-Smoke.md
+++ b/plans/PR-Deflection-Statement-Customer-Wording-Smoke.md
@@ -1,0 +1,96 @@
+# PR-Deflection-Statement-Customer-Wording-Smoke
+
+## Why this slice exists
+
+Issue #1478 found that the hosted deflection submit smoke fails on real
+statement-shaped exports such as CFPB because it requires every
+`snapshot.top_questions[*].customer_wording` value to be non-empty. The product
+snapshot contract already permits empty customer wording when a top question is
+generated from `source_policy` / fallback wording rather than a customer-shaped
+question. The smoke should catch real contract breaks without rejecting valid
+statement-shaped exports before launch validation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Update the deflection submit smoke snapshot validator so blank
+   `customer_wording` is allowed for the current real snapshot shape that omits
+   `question_source`, and for explicit non-customer generated sources
+   (`source_policy` or `topic_fallback`).
+2. Add validator tests for both directions: generated/missing-source snapshots
+   may omit customer wording, while explicit customer-wording or unknown-source
+   questions must still provide customer wording.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Statement-shaped snapshots with `question_source: source_policy` and empty
+    `customer_wording` pass the smoke validator.
+  - `topic_fallback` receives the same allowance for defensive compatibility
+    with the label resolver.
+  - The current real snapshot shape, which omits `question_source`, can carry
+    empty `customer_wording` without failing the smoke.
+  - `question_source: customer_wording` or unknown source still fails
+    when `customer_wording` is empty.
+  - The smoke still rejects forbidden answer/evidence/source-id leaks.
+- Affected surfaces:
+  - `scripts/smoke_content_ops_deflection_submit_handoff.py`
+  - `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+- Risk areas:
+  - Weakening the smoke so it stops detecting missing customer wording for
+    explicitly customer-wording-sourced questions.
+  - One-sided coverage that only pins the CFPB/source-policy case and misses
+    missing-real-shape or unknown-source regressions.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+### Files touched
+
+- `plans/PR-Deflection-Statement-Customer-Wording-Smoke.md`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+
+## Mechanism
+
+The smoke validator keeps the existing rank/question/count/frequency checks. If
+`customer_wording` is blank, it fails only when the snapshot explicitly provides
+a `question_source` outside the generated-source allowlist. This accepts the
+current real free snapshot shape, which does not expose `question_source`, and
+still rejects explicit customer-wording or unknown-source items with blank
+wording.
+
+## Intentional
+
+- This is a smoke-contract fix, not a paid report-generation or free-snapshot
+  shape change. The earlier review-fix option of exposing `question_source` in
+  the free snapshot was rejected because that is a buyer-facing product-shape
+  decision.
+- Missing `question_source` with blank wording is intentionally allowed because
+  that is the current real emitted snapshot shape. Explicit customer-wording or
+  unknown source values remain fail-closed.
+
+## Deferred
+
+- Buyer-visible copy for statement-shaped exports remains under the broader
+  #1419/#1386 product-positioning work; this PR only fixes the smoke's contract
+  enforcement.
+- Existing ticket FAQ label/privacy hardening entries in `HARDENING.md` remain
+  parked for their own slices.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q` -- 27 passed.
+- `bash` + `scripts/run_extracted_pipeline_checks.sh` -- 4112 passed,
+  10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Statement-Customer-Wording-Smoke.md` | 96 |
+| `scripts/smoke_content_ops_deflection_submit_handoff.py` | 16 |
+| `tests/test_smoke_content_ops_deflection_submit_handoff.py` | 57 |
+| **Total** | **169** |

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -47,6 +47,10 @@ FORBIDDEN_SNAPSHOT_KEYS = frozenset({
     "steps",
     "term_mappings",
 })
+OPTIONAL_CUSTOMER_WORDING_QUESTION_SOURCES = frozenset({
+    "source_policy",
+    "topic_fallback",
+})
 
 try:
     from dotenv import load_dotenv
@@ -435,8 +439,16 @@ def _validate_snapshot(snapshot: Any, *, label: str) -> list[str]:
                 errors.append(f"{label}.top_questions[{index}].rank must be an integer")
             if not _clean(item.get("question")):
                 errors.append(f"{label}.top_questions[{index}].question must be non-empty")
-            if not _clean(item.get("customer_wording")):
-                errors.append(f"{label}.top_questions[{index}].customer_wording must be non-empty")
+            question_source = _clean(item.get("question_source"))
+            if (
+                not _clean(item.get("customer_wording"))
+                and question_source
+                and question_source not in OPTIONAL_CUSTOMER_WORDING_QUESTION_SOURCES
+            ):
+                errors.append(
+                    f"{label}.top_questions[{index}].customer_wording must be non-empty "
+                    "for customer-wording questions"
+                )
             if not isinstance(item.get("weighted_frequency"), (int, float)):
                 errors.append(
                     f"{label}.top_questions[{index}].weighted_frequency must be numeric"

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -306,6 +306,63 @@ def test_validate_submit_envelope_accepts_locked_gated_result() -> None:
     assert diagnostics["metadata"]["source_row_count"] == 3
 
 
+def test_validate_submit_envelope_accepts_generated_questions_without_customer_wording() -> None:
+    snapshot = {
+        **SNAPSHOT,
+        "top_questions": [
+            {
+                **SNAPSHOT["top_questions"][0],
+                "question_source": "source_policy",
+                "customer_wording": "",
+            },
+            {
+                **SNAPSHOT["top_questions"][0],
+                "rank": 2,
+                "question": "What are customers asking about exports?",
+                "question_source": "topic_fallback",
+                "customer_wording": "",
+            },
+            {
+                **SNAPSHOT["top_questions"][0],
+                "rank": 3,
+                "question": "What should I do about export reporting?",
+                "customer_wording": "",
+            },
+        ],
+    }
+
+    _request_id, _snapshot, _diagnostics, errors = smoke._validate_submit_envelope(
+        _submit_payload(snapshot=snapshot)
+    )
+
+    assert errors == []
+
+
+@pytest.mark.parametrize("question_source", ["customer_wording", "internal_taxonomy"])
+def test_validate_submit_envelope_requires_customer_wording_for_customer_sources(
+    question_source: str,
+) -> None:
+    top_question = {
+        **SNAPSHOT["top_questions"][0],
+        "customer_wording": "",
+        "question_source": question_source,
+    }
+    snapshot = {
+        **SNAPSHOT,
+        "top_questions": [top_question],
+    }
+
+    _request_id, _snapshot, _diagnostics, errors = smoke._validate_submit_envelope(
+        _submit_payload(snapshot=snapshot)
+    )
+
+    assert any(
+        "snapshot.top_questions[0].customer_wording must be non-empty "
+        "for customer-wording questions" in error
+        for error in errors
+    )
+
+
 def test_validate_submit_envelope_requires_json_blob_byte_counter() -> None:
     payload = _submit_payload(metadata={
         "source": "portfolio_deflection_submit",


### PR DESCRIPTION
Plan: plans/PR-Deflection-Statement-Customer-Wording-Smoke.md
Slice phase: Vertical slice

Issue #1478 found that the hosted deflection submit smoke fails on real statement-shaped exports because it requires every `snapshot.top_questions[*].customer_wording` value to be non-empty. The product snapshot contract already permits empty customer wording when a top question is generated from `source_policy` / fallback wording rather than a customer-shaped question, so this aligns the smoke with the current real emitted snapshot shape while keeping explicit customer-wording/unknown-source snapshots fail-closed.

## Intentional
- This is a smoke-contract fix, not a paid report-generation or free-snapshot shape change.
- Blank customer wording is allowed for `source_policy`, `topic_fallback`, and the current missing-source snapshot shape; explicit customer-wording and unknown-source questions still fail.
- The current real free snapshot omits `question_source`; missing-source blank wording is intentionally allowed so statement-shaped exports do not fail the hosted smoke.

## Deferred
- Buyer-visible statement-export copy remains under #1419/#1386 product-positioning work.
- Existing ticket FAQ label/privacy hardening entries in `HARDENING.md` remain parked for their own slices.

## Parked hardening
- None.

## Verification
- `pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q` -- 27 passed.
- `bash` + `scripts/run_extracted_pipeline_checks.sh` -- 4112 passed, 10 skipped.

## Diff size
3 files, +167 / -2
