### PR TITLE
Codify Spark subagent routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -736,6 +736,7 @@ If neither, route by shape:
 
 | Shape | Where | Why |
 |---|---|---|
+| Bounded read-only scouting/checking with a small known surface and no edits planned | Spark subagent (if available), else `Explore` | Lightweight retrieval/checking without pulling raw context into main |
 | Read-only, >400 lines, no edits planned | `Explore` subagent | Pure retrieval; summary lands in main context, raw file does not |
 | Reading 3+ files just to orient | `Explore` subagent | Width without depth -- the subagent's strength |
 | "Find every caller of X" / "where is Y defined" | `grep`/`find` via Bash | Regex match, no LLM needed |
@@ -756,12 +757,21 @@ refresh (three `Explore` agents in parallel mapped churn signals,
 extracted packages, and planned products); without it the same work
 would have cost N round-trips of main-context overhead.
 
-### 5c. The Kimi worker model relationship
+### 5c. Spark and lightweight worker relationships
+
+Spark is the preferred lightweight subagent for bounded read-only scouting and
+checking when it is available: known files, narrow searches, review-thread
+summaries, plan-vs-diff checks, backlog scans, and other retrieval tasks where
+the answer can be a compact list of facts. Do not use Spark for edit-target
+reads that need exact file context in main, architectural decisions,
+root-cause calls, review verdicts, Git/GitHub mutations, or final user-facing
+synthesis. If Spark is unavailable, or the task needs broader multi-file
+orientation, use `Explore`.
 
 If a `claude-coworker-model`-style worker LLM is installed locally
 (Kimi / DeepSeek / Ollama via OpenRouter), it slots in as a
 **cheaper** retrieval channel for cases where an `Explore`
-subagent is overkill -- one big file, no reasoning needed, no other
+or Spark subagent is overkill -- one big file, no reasoning needed, no other
 files to cross-reference. The decision table above is unchanged;
 just add a row:
 
@@ -769,8 +779,8 @@ just add a row:
 |---|---|---|
 | Deep retrieval of one large file, no cross-refs | Worker LLM (if installed), else `Explore` | Worker is cheapest; `Explore` is the in-tree fallback |
 
-The worker never replaces `Explore` for multi-file orientation or
-the main session for judgment.
+The worker never replaces Spark or `Explore` for multi-file orientation, and no
+worker replaces the main session for judgment.
 
 ### 5d. Routing anti-patterns
 

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -55,6 +55,7 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 > 6. **Context discipline (keeps the session from compacting mid-work):**
 >    - After opening or updating a PR, **stop** — do not poll CI or wait for review (AGENTS.md §3c). Report the PR URL + the local checks you already ran, then hand back to the operator; resume only on the operator's signal.
 >    - During iteration, read **targeted ranges** of large files (e.g. `control_surfaces.py` is ~1.4k lines), not whole files; and run the **single relevant test file**, not the full suite. Run the full `run_extracted_pipeline_checks.sh` gauntlet **once**, right before pushing — not on every change.
+>    - For bounded read-only scouting/checking, prefer a lightweight Spark subagent when available; keep judgment, edit-target reads, Git/GitHub mutations, and final synthesis in main.
 >    - Before pushing, use `scripts/push_pr.sh` as the single local-review entry
 >      point. Do **not** run `local_pr_review.sh` manually and then immediately
 >      run `push_pr.sh`; the wrapper/hook path is responsible for exactly one

--- a/plans/PR-Spark-Subagent-Routing-Docs.md
+++ b/plans/PR-Spark-Subagent-Routing-Docs.md
@@ -1,0 +1,88 @@
+# PR-Spark-Subagent-Routing-Docs
+
+## Why this slice exists
+
+The operator wants lightweight Spark subagents used automatically for bounded
+read-only scouting when that can reduce main-session context usage. The current
+workflow already says lookup belongs in subagents, but it predates the Spark
+preference and still names the older Explore/Kimi shapes. This slice codifies
+the new default without changing the core safety boundary: main owns judgment,
+edits, Git/GitHub mutations, and final synthesis.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Update the within-session agent routing contract so Spark is the preferred
+   lightweight read-only scout for narrow checks when available.
+2. Add a fresh-session bootstrap reminder so restarted sessions apply the same
+   Spark default without the operator having to ask.
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/SESSION_BOOTSTRAP.md`
+- `plans/PR-Spark-Subagent-Routing-Docs.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- The docs distinguish Spark read-only scouting from main-session judgment and
+  mutation work.
+- The docs preserve the existing boundaries: main reads files it will edit,
+  `rg`/Bash owns exact lookups, main owns review verdicts and final answers.
+- Fresh-session bootstrap includes a concise reminder to use Spark for bounded
+  read-only scouting.
+
+Affected surfaces:
+
+- Atlas builder/reviewer workflow documentation only.
+
+Risk areas:
+
+- Over-broad wording could imply Spark may make merge/review/code decisions.
+- Naming Spark too narrowly could fail to preserve Explore as the wider
+  orientation fallback.
+
+Reviewer rules triggered: R1, R12, R14
+
+## Mechanism
+
+`AGENTS.md` section 5 gets an explicit Spark row in the routing table and a
+short subsection that defines Spark as the preferred lightweight read-only scout.
+The existing worker-model subsection remains as the cheaper single-file fallback
+language. `docs/SESSION_BOOTSTRAP.md` gets a one-bullet reminder under context
+discipline so fresh sessions inherit the same policy.
+
+## Intentional
+
+- No code or tool wrapper changes. The goal is to codify routing policy, not to
+  hardwire model selection in scripts.
+- Spark is framed as "if available" so sessions without that subagent surface
+  can fall back to Explore or direct reads.
+- Judgment, GitHub mutations, exact edit-target reads, and final synthesis stay
+  in main.
+
+## Deferred
+
+- No automated enforcement for subagent choice. The routing decision remains an
+  operating-model rule, not a mechanical gate.
+
+Parked hardening: none.
+
+## Verification
+
+- Doc diff inspection: passed.
+- `python scripts/sync_pr_plan.py plans/PR-Spark-Subagent-Routing-Docs.md --check`: passed.
+- Body-aware local PR review: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 18 |
+| `docs/SESSION_BOOTSTRAP.md` | 1 |
+| `plans/PR-Spark-Subagent-Routing-Docs.md` | 88 |
+| **Total** | **107** |


### PR DESCRIPTION
Plan: plans/PR-Spark-Subagent-Routing-Docs.md
Slice phase: Workflow/process

Codifies the operator preference that Spark should be the default lightweight subagent for bounded read-only scouting/checking when available, while keeping judgment, edit-target reads, Git/GitHub mutations, and final synthesis in the main session.

## Intentional
- No code or tool wrapper changes; this is workflow policy only.
- Spark is documented as "if available" with Explore/direct-read fallbacks.
- Main session still owns judgment, review verdicts, exact edit-target reads, GitHub mutations, and final user-facing synthesis.

## Deferred
- No automated enforcement for subagent choice. The routing decision remains an operating-model rule.

## Parked hardening
- None.

## Verification
- Doc diff inspection: passed.
- `python scripts/sync_pr_plan.py plans/PR-Spark-Subagent-Routing-Docs.md --check` -- passed.
- `bash scripts/push_pr.sh tmp/spark_subagent_routing_docs_pr_body.md -u origin HEAD` -- body-aware local PR review passed.

## Diff size
3 files, +103 / -4
