### PR TITLE
Deflection CSV encoding admission

### DIFF
--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -25,6 +25,7 @@ _CSV_UTF16_NUL_SIDE_RATIO = 0.30
 _CSV_REPLACEMENT_WARNING_RATIO = 0.01
 _CSV_UTF8_RECOVERY_REPLACEMENT_RATIO = 0.05
 _CSV_UTF8_MOJIBAKE_MARKERS = ("\u00c3", "\u00c2", "\u00e2\u20ac", "\u00e2\u201a")
+_CSV_SUSPICIOUS_LEGACY_FALLBACK_CHARS = ("\u00ff", "\u00fe")
 _CSV_BOM_ENCODINGS = (
     (b"\xff\xfe\x00\x00", "utf-32"),
     (b"\x00\x00\xfe\xff", "utf-32"),
@@ -429,7 +430,10 @@ def _decode_utf8_error_csv_bytes(
             encoding="utf-8-sig",
             warn_on_any_replacement=True,
         )
-    return legacy_text, legacy_warnings
+    return legacy_text, legacy_warnings + _legacy_fallback_corruption_warnings(
+        legacy_text,
+        recovered_text,
+    )
 
 
 def _decode_inferred_utf16_csv_bytes(
@@ -505,6 +509,32 @@ def _replacement_ratio(text: str) -> float:
 
 def _utf8_mojibake_score(text: str) -> int:
     return sum(text.count(marker) for marker in _CSV_UTF8_MOJIBAKE_MARKERS)
+
+
+def _legacy_fallback_corruption_warnings(
+    legacy_text: str,
+    recovered_text: str,
+) -> tuple[CampaignOpportunityWarning, ...]:
+    if not recovered_text.count("\ufffd"):
+        return ()
+    if _utf8_mojibake_score(legacy_text):
+        return ()
+    suspicious_count = sum(
+        legacy_text.count(char) for char in _CSV_SUSPICIOUS_LEGACY_FALLBACK_CHARS
+    )
+    if not suspicious_count:
+        return ()
+    return (
+        CampaignOpportunityWarning(
+            code="csv_encoding_ambiguous",
+            field="encoding",
+            message=(
+                "CSV failed strict UTF-8 decoding and legacy fallback produced "
+                f"{suspicious_count} suspicious character(s); verify the source "
+                "encoding before relying on these rows."
+            ),
+        ),
+    )
 
 
 def _csv_decode_warnings(

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -20,6 +20,18 @@ from .campaign_ports import TenantScope
 CustomerDataFormat = Literal["auto", "json", "csv"]
 _CSV_DETECT_DELIMITERS = ",;\t|"
 _CSV_SNIFFER_SAMPLE_CHARS = 65_536
+_CSV_NUL_REDECODE_RATIO = 0.10
+_CSV_UTF16_NUL_SIDE_RATIO = 0.30
+_CSV_REPLACEMENT_WARNING_RATIO = 0.01
+_CSV_UTF8_RECOVERY_REPLACEMENT_RATIO = 0.05
+_CSV_UTF8_MOJIBAKE_MARKERS = ("\u00c3", "\u00c2", "\u00e2\u20ac", "\u00e2\u201a")
+_CSV_BOM_ENCODINGS = (
+    (b"\xff\xfe\x00\x00", "utf-32"),
+    (b"\x00\x00\xfe\xff", "utf-32"),
+    (b"\xef\xbb\xbf", "utf-8-sig"),
+    (b"\xff\xfe", "utf-16"),
+    (b"\xfe\xff", "utf-16"),
+)
 _CSV_HEADER_HINTS = frozenset({
     "account",
     "account_name",
@@ -267,7 +279,7 @@ def _load_csv_dict_rows(
     value_coercer: Callable[[Any], Any] | None = None,
 ) -> tuple[list[dict[str, Any]], tuple[CampaignOpportunityWarning, ...]]:
     rows: list[dict[str, Any]] = []
-    text = _read_csv_text(path)
+    text, decode_warnings = _read_csv_text(path)
     if not text.strip():
         raise ValueError("CSV customer data must include a header row.")
     reader = csv.reader(StringIO(text), dialect=_detect_csv_dialect(text))
@@ -275,7 +287,10 @@ def _load_csv_dict_rows(
     header_index = _csv_header_index(raw_rows)
     if header_index is None:
         raise ValueError("CSV customer data must include a header row.")
-    load_warnings = _leading_rows_skipped_warnings(raw_rows, header_index)
+    load_warnings = decode_warnings + _leading_rows_skipped_warnings(
+        raw_rows,
+        header_index,
+    )
     header_width = len(raw_rows[header_index])
     header_fields = tuple(
         (index, str(field or "").strip())
@@ -360,12 +375,144 @@ def _normalize_csv_header_cell(value: str) -> str:
     return value.strip().lower().replace("-", "_").replace(" ", "_")
 
 
-def _read_csv_text(path: Path) -> str:
+def _read_csv_text(
+    path: Path,
+) -> tuple[str, tuple[CampaignOpportunityWarning, ...]]:
     data = path.read_bytes()
+    if not data:
+        return "", ()
+    for bom, encoding in _CSV_BOM_ENCODINGS:
+        if data.startswith(bom):
+            return _decode_csv_bytes(data, encoding=encoding)
     try:
-        return data.decode("utf-8-sig")
+        text = data.decode("utf-8-sig")
     except UnicodeDecodeError:
-        return data.decode("cp1252", errors="replace")
+        return _decode_utf8_error_csv_bytes(data)
+    inferred = _utf16_encoding_from_nul_pattern(data, text)
+    if inferred:
+        decoded, warnings = _decode_csv_bytes(data, encoding=inferred)
+        return decoded, warnings + (
+            CampaignOpportunityWarning(
+                code="csv_encoding_inferred",
+                field="encoding",
+                message=(
+                    "CSV contained UTF-16-style NUL bytes without a BOM; "
+                    f"decoded as {inferred}."
+                ),
+            ),
+        )
+    if _nul_ratio(text) >= _CSV_NUL_REDECODE_RATIO:
+        raise ValueError(
+            "CSV customer data decoded to NUL-heavy text; check the file encoding."
+        )
+    return text, _csv_decode_warnings(text, encoding="utf-8-sig")
+
+
+def _decode_legacy_csv_bytes(
+    data: bytes,
+) -> tuple[str, tuple[CampaignOpportunityWarning, ...]]:
+    for encoding in ("cp1252", "latin-1"):
+        try:
+            return _decode_csv_bytes(data, encoding=encoding)
+        except UnicodeDecodeError:
+            continue
+    raise ValueError(
+        "CSV customer data could not be decoded as UTF-8, UTF-16, UTF-32, "
+        "CP1252, or Latin-1."
+    )
+
+
+def _decode_utf8_error_csv_bytes(
+    data: bytes,
+) -> tuple[str, tuple[CampaignOpportunityWarning, ...]]:
+    legacy_text, legacy_warnings = _decode_legacy_csv_bytes(data)
+    recovered_text = data.decode("utf-8-sig", errors="replace")
+    if (
+        _replacement_ratio(recovered_text) <= _CSV_UTF8_RECOVERY_REPLACEMENT_RATIO
+        and _looks_like_utf8_mojibake(legacy_text)
+    ):
+        return recovered_text, _csv_decode_warnings(
+            recovered_text,
+            encoding="utf-8-sig",
+        )
+    return legacy_text, legacy_warnings
+
+
+def _decode_csv_bytes(
+    data: bytes,
+    *,
+    encoding: str,
+) -> tuple[str, tuple[CampaignOpportunityWarning, ...]]:
+    text = data.decode(encoding)
+    if _nul_ratio(text) >= _CSV_NUL_REDECODE_RATIO:
+        raise ValueError(
+            f"CSV customer data decoded as {encoding} but remained NUL-heavy; "
+            "check the file encoding."
+        )
+    return text, _csv_decode_warnings(text, encoding=encoding)
+
+
+def _utf16_encoding_from_nul_pattern(data: bytes, text: str) -> str | None:
+    if _nul_ratio(text) < _CSV_NUL_REDECODE_RATIO:
+        return None
+    sample = data[:_CSV_SNIFFER_SAMPLE_CHARS]
+    even = sample[0::2]
+    odd = sample[1::2]
+    if not even or not odd:
+        return None
+    even_nul_ratio = even.count(0) / len(even)
+    odd_nul_ratio = odd.count(0) / len(odd)
+    if (
+        odd_nul_ratio >= _CSV_UTF16_NUL_SIDE_RATIO
+        and even_nul_ratio < _CSV_NUL_REDECODE_RATIO
+    ):
+        return "utf-16-le"
+    if (
+        even_nul_ratio >= _CSV_UTF16_NUL_SIDE_RATIO
+        and odd_nul_ratio < _CSV_NUL_REDECODE_RATIO
+    ):
+        return "utf-16-be"
+    return None
+
+
+def _nul_ratio(text: str) -> float:
+    if not text:
+        return 0.0
+    return text.count("\x00") / len(text)
+
+
+def _replacement_ratio(text: str) -> float:
+    if not text:
+        return 0.0
+    return text.count("\ufffd") / len(text)
+
+
+def _looks_like_utf8_mojibake(text: str) -> bool:
+    return any(marker in text for marker in _CSV_UTF8_MOJIBAKE_MARKERS)
+
+
+def _csv_decode_warnings(
+    text: str,
+    *,
+    encoding: str,
+) -> tuple[CampaignOpportunityWarning, ...]:
+    replacement_count = text.count("\ufffd")
+    if not replacement_count:
+        return ()
+    ratio = _replacement_ratio(text)
+    if ratio < _CSV_REPLACEMENT_WARNING_RATIO:
+        return ()
+    return (
+        CampaignOpportunityWarning(
+            code="csv_replacement_characters",
+            field="encoding",
+            message=(
+                f"CSV decoded as {encoding} but contains {replacement_count} "
+                f"Unicode replacement character(s) ({ratio:.1%}); export "
+                "the source again with UTF-8 or UTF-16 encoding."
+            ),
+        ),
+    )
 
 
 def _detect_csv_dialect(text: str) -> csv.Dialect:

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -390,17 +390,7 @@ def _read_csv_text(
         return _decode_utf8_error_csv_bytes(data)
     inferred = _utf16_encoding_from_nul_pattern(data, text)
     if inferred:
-        decoded, warnings = _decode_csv_bytes(data, encoding=inferred)
-        return decoded, warnings + (
-            CampaignOpportunityWarning(
-                code="csv_encoding_inferred",
-                field="encoding",
-                message=(
-                    "CSV contained UTF-16-style NUL bytes without a BOM; "
-                    f"decoded as {inferred}."
-                ),
-            ),
-        )
+        return _decode_inferred_utf16_csv_bytes(data, encoding=inferred)
     if _nul_ratio(text) >= _CSV_NUL_REDECODE_RATIO:
         raise ValueError(
             "CSV customer data decoded to NUL-heavy text; check the file encoding."
@@ -425,17 +415,39 @@ def _decode_legacy_csv_bytes(
 def _decode_utf8_error_csv_bytes(
     data: bytes,
 ) -> tuple[str, tuple[CampaignOpportunityWarning, ...]]:
+    inferred = _utf16_encoding_from_nul_bytes(data)
+    if inferred:
+        return _decode_inferred_utf16_csv_bytes(data, encoding=inferred)
     legacy_text, legacy_warnings = _decode_legacy_csv_bytes(data)
     recovered_text = data.decode("utf-8-sig", errors="replace")
     if (
         _replacement_ratio(recovered_text) <= _CSV_UTF8_RECOVERY_REPLACEMENT_RATIO
-        and _looks_like_utf8_mojibake(legacy_text)
+        and _utf8_mojibake_score(legacy_text) > recovered_text.count("\ufffd")
     ):
         return recovered_text, _csv_decode_warnings(
             recovered_text,
             encoding="utf-8-sig",
+            warn_on_any_replacement=True,
         )
     return legacy_text, legacy_warnings
+
+
+def _decode_inferred_utf16_csv_bytes(
+    data: bytes,
+    *,
+    encoding: str,
+) -> tuple[str, tuple[CampaignOpportunityWarning, ...]]:
+    decoded, warnings = _decode_csv_bytes(data, encoding=encoding)
+    return decoded, warnings + (
+        CampaignOpportunityWarning(
+            code="csv_encoding_inferred",
+            field="encoding",
+            message=(
+                "CSV contained UTF-16-style NUL bytes without a BOM; "
+                f"decoded as {encoding}."
+            ),
+        ),
+    )
 
 
 def _decode_csv_bytes(
@@ -455,6 +467,10 @@ def _decode_csv_bytes(
 def _utf16_encoding_from_nul_pattern(data: bytes, text: str) -> str | None:
     if _nul_ratio(text) < _CSV_NUL_REDECODE_RATIO:
         return None
+    return _utf16_encoding_from_nul_bytes(data)
+
+
+def _utf16_encoding_from_nul_bytes(data: bytes) -> str | None:
     sample = data[:_CSV_SNIFFER_SAMPLE_CHARS]
     even = sample[0::2]
     odd = sample[1::2]
@@ -487,20 +503,21 @@ def _replacement_ratio(text: str) -> float:
     return text.count("\ufffd") / len(text)
 
 
-def _looks_like_utf8_mojibake(text: str) -> bool:
-    return any(marker in text for marker in _CSV_UTF8_MOJIBAKE_MARKERS)
+def _utf8_mojibake_score(text: str) -> int:
+    return sum(text.count(marker) for marker in _CSV_UTF8_MOJIBAKE_MARKERS)
 
 
 def _csv_decode_warnings(
     text: str,
     *,
     encoding: str,
+    warn_on_any_replacement: bool = False,
 ) -> tuple[CampaignOpportunityWarning, ...]:
     replacement_count = text.count("\ufffd")
     if not replacement_count:
         return ()
     ratio = _replacement_ratio(text)
-    if ratio < _CSV_REPLACEMENT_WARNING_RATIO:
+    if ratio < _CSV_REPLACEMENT_WARNING_RATIO and not warn_on_any_replacement:
         return ()
     return (
         CampaignOpportunityWarning(

--- a/plans/PR-Deflection-Csv-Encoding-Admission.md
+++ b/plans/PR-Deflection-Csv-Encoding-Admission.md
@@ -1,0 +1,77 @@
+# PR-Deflection-Csv-Encoding-Admission
+
+## Why this slice exists
+
+Issue #1455 is a P0 launch-readiness parser gap: support-ticket CSV ingestion falls back from UTF-8 to CP1252 with `errors="replace"`, so common help-desk exports can silently become mojibake instead of producing trustworthy rows or a visible ingestion warning. The deflection paid funnel now routes CSV uploads through the shared `_load_csv_dict_rows` loader, so hardening that one boundary protects both standalone source loading and `/deflection-reports/submit`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Harden the shared CSV text decoder so UTF-16/UTF-32 BOM exports decode explicitly, UTF-8 remains strict, CP1252/Latin-1 smart-text exports decode without replacement, and high Unicode replacement-character ratios surface a load warning instead of passing as clean input.
+2. Prove the same decoder is used by the deflection submit upload path with byte-level fixtures, not only direct file-loader tests.
+
+### Review Contract
+
+- Acceptance criteria:
+  - UTF-16 BOM CSV input parses into correct support-ticket rows.
+  - CP1252/Latin-1 support-ticket CSV input with smart punctuation/accented text parses into correct Unicode text without `errors="replace"` mojibake.
+  - A CSV containing a high ratio of Unicode replacement characters returns a visible `CampaignOpportunityWarning`.
+  - The deflection submit upload loader accepts UTF-16 BOM bytes through the real temp-file path and returns the decoded rows.
+  - Existing delimiter/header behavior is unchanged.
+- Affected surfaces:
+  - `extracted_content_pipeline/campaign_customer_data.py`
+  - `tests/test_extracted_campaign_source_adapters.py`
+  - `tests/test_extracted_content_deflection_submit.py`
+- Risk areas:
+  - Reintroducing silent replacement decoding.
+  - Warning on normal CP1252/Latin-1 exports and making clean uploads look suspect.
+  - Breaking existing semicolon/BOM and multiline CSV parsing.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `plans/PR-Deflection-Csv-Encoding-Admission.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+`_read_csv_text` becomes a decoder boundary that returns `(text, warnings)`. It first honors explicit BOMs, then tries strict UTF-8, with a NUL-pattern check for UTF-16 files missing a BOM. If UTF-8 fails it compares strict CP1252/Latin-1 fallback with a warning-surfaced UTF-8 recovery; when the legacy fallback clearly looks like UTF-8 mojibake, it preserves the UTF-8 text and emits a replacement-character warning instead of silently mojibaking the whole file. After decoding, the helper counts Unicode replacement characters and emits a warning when the ratio is high. The existing `_load_csv_dict_rows` parser appends those decode warnings to the existing leading-row warnings before returning rows.
+
+## Intentional
+
+- This slice does not add full charset-normalizer/chardet dependency behavior. BOM/strict UTF-8/CP1252/Latin-1 covers the launch-critical help-desk export cases without introducing probabilistic detection into the extracted package.
+- Clean CP1252/Latin-1 fallback does not warn. Those are common Windows export shapes; a warning is reserved for suspicious decoded content such as high replacement-character ratios.
+- `errors="replace"` is used only in the explicit warned UTF-8 recovery branch for mostly-UTF-8 corrupt files. It is no longer the silent CP1252 fallback.
+- Delimiter voting is deferred to #1459; this PR keeps the existing dialect detector behavior unless bytes could not be decoded safely.
+
+## Deferred
+
+- #1459 remains the deterministic delimiter-vote/reject branch.
+- #1457 remains the header/body-column admission report and is currently claimed by another developer.
+- Full charset confidence reporting can be added later if product wants a visible encoding diagnostic for every clean upload.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile` on `extracted_content_pipeline/campaign_customer_data.py`, `tests/test_extracted_campaign_source_adapters.py`, and `tests/test_extracted_content_deflection_submit.py` -- passed.
+- `pytest tests/test_extracted_campaign_source_adapters.py -q -k "utf16 or legacy or replacement or utf8 or semicolon or multiline"` -- 7 passed, 69 deselected.
+- `pytest tests/test_extracted_content_deflection_submit.py -q -k "utf16 or bom or embedded_quotes or metadata_header"` -- 4 passed, 50 deselected.
+- `pytest tests/test_extracted_campaign_source_adapters.py -q` -- 76 passed.
+- `pytest tests/test_extracted_content_deflection_submit.py -q` -- 54 passed.
+- `bash` + `scripts/check_ascii_python.sh` -- passed.
+- `bash` + `scripts/run_extracted_pipeline_checks.sh` -- 4121 passed, 10 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_customer_data.py` | 157 |
+| `plans/PR-Deflection-Csv-Encoding-Admission.md` | 77 |
+| `tests/test_extracted_campaign_source_adapters.py` | 109 |
+| `tests/test_extracted_content_deflection_submit.py` | 21 |
+| **Total** | **364** |

--- a/plans/PR-Deflection-Csv-Encoding-Admission.md
+++ b/plans/PR-Deflection-Csv-Encoding-Admission.md
@@ -4,6 +4,8 @@
 
 Issue #1455 is a P0 launch-readiness parser gap: support-ticket CSV ingestion falls back from UTF-8 to CP1252 with `errors="replace"`, so common help-desk exports can silently become mojibake instead of producing trustworthy rows or a visible ingestion warning. The deflection paid funnel now routes CSV uploads through the shared `_load_csv_dict_rows` loader, so hardening that one boundary protects both standalone source loading and `/deflection-reports/submit`.
 
+Diff budget note: post-review boundary coverage pushed the plan estimate over the 400 LOC soft cap. The overage is the focused decoder/test surface for the same byte-admission boundary: BOM-less UTF-16 inference, clean legacy marker text, and warned UTF-8 recovery are coupled tightly enough that splitting them would leave #1455 partially fixed.
+
 ## Scope (this PR)
 
 Ownership lane: content-ops/deflection-launch-readiness
@@ -39,7 +41,7 @@ Slice phase: Vertical slice
 
 ## Mechanism
 
-`_read_csv_text` becomes a decoder boundary that returns `(text, warnings)`. It first honors explicit BOMs, then tries strict UTF-8, with a NUL-pattern check for UTF-16 files missing a BOM. If UTF-8 fails it compares strict CP1252/Latin-1 fallback with a warning-surfaced UTF-8 recovery; when the legacy fallback clearly looks like UTF-8 mojibake, it preserves the UTF-8 text and emits a replacement-character warning instead of silently mojibaking the whole file. After decoding, the helper counts Unicode replacement characters and emits a warning when the ratio is high. The existing `_load_csv_dict_rows` parser appends those decode warnings to the existing leading-row warnings before returning rows.
+`_read_csv_text` becomes a decoder boundary that returns `(text, warnings)`. It first honors explicit BOMs, then tries strict UTF-8, with a NUL-pattern check for UTF-16 files missing a BOM. If UTF-8 fails, the error path now runs the same raw-byte NUL inference before trying legacy encodings, so BOM-less UTF-16 with non-ASCII text is still admitted. It then compares strict CP1252/Latin-1 fallback with a warning-surfaced UTF-8 recovery; the recovery is selected only when mojibake evidence in the legacy decode outnumbers the replacements the recovery would insert, preserving clean legacy exports that contain legitimate U+00C3/U+00C2 text. Any selected UTF-8 recovery that inserts replacement characters emits a warning, even below the high-ratio threshold used for literal replacement characters already present in valid UTF-8 input. The existing `_load_csv_dict_rows` parser appends those decode warnings to the existing leading-row warnings before returning rows.
 
 ## Intentional
 
@@ -59,19 +61,19 @@ Parked hardening: none.
 ## Verification
 
 - `python -m py_compile` on `extracted_content_pipeline/campaign_customer_data.py`, `tests/test_extracted_campaign_source_adapters.py`, and `tests/test_extracted_content_deflection_submit.py` -- passed.
-- `pytest tests/test_extracted_campaign_source_adapters.py -q -k "utf16 or legacy or replacement or utf8 or semicolon or multiline"` -- 7 passed, 69 deselected.
+- `pytest tests/test_extracted_campaign_source_adapters.py -q -k "utf16 or legacy or marker or replacement or utf8 or semicolon or multiline"` -- 11 passed, 69 deselected.
 - `pytest tests/test_extracted_content_deflection_submit.py -q -k "utf16 or bom or embedded_quotes or metadata_header"` -- 4 passed, 50 deselected.
-- `pytest tests/test_extracted_campaign_source_adapters.py -q` -- 76 passed.
+- `pytest tests/test_extracted_campaign_source_adapters.py -q` -- 80 passed.
 - `pytest tests/test_extracted_content_deflection_submit.py -q` -- 54 passed.
 - `bash` + `scripts/check_ascii_python.sh` -- passed.
-- `bash` + `scripts/run_extracted_pipeline_checks.sh` -- 4121 passed, 10 skipped, 1 warning.
+- `bash` + `scripts/run_extracted_pipeline_checks.sh` -- 4125 passed, 10 skipped, 1 warning.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/campaign_customer_data.py` | 157 |
-| `plans/PR-Deflection-Csv-Encoding-Admission.md` | 77 |
-| `tests/test_extracted_campaign_source_adapters.py` | 109 |
+| `extracted_content_pipeline/campaign_customer_data.py` | 174 |
+| `plans/PR-Deflection-Csv-Encoding-Admission.md` | 79 |
+| `tests/test_extracted_campaign_source_adapters.py` | 169 |
 | `tests/test_extracted_content_deflection_submit.py` | 21 |
-| **Total** | **364** |
+| **Total** | **443** |

--- a/plans/PR-Deflection-Csv-Encoding-Admission.md
+++ b/plans/PR-Deflection-Csv-Encoding-Admission.md
@@ -4,7 +4,7 @@
 
 Issue #1455 is a P0 launch-readiness parser gap: support-ticket CSV ingestion falls back from UTF-8 to CP1252 with `errors="replace"`, so common help-desk exports can silently become mojibake instead of producing trustworthy rows or a visible ingestion warning. The deflection paid funnel now routes CSV uploads through the shared `_load_csv_dict_rows` loader, so hardening that one boundary protects both standalone source loading and `/deflection-reports/submit`.
 
-Diff budget note: post-review boundary coverage pushed the plan estimate over the 400 LOC soft cap. The overage is the focused decoder/test surface for the same byte-admission boundary: BOM-less UTF-16 inference, clean legacy marker text, and warned UTF-8 recovery are coupled tightly enough that splitting them would leave #1455 partially fixed.
+Diff budget note: post-review boundary coverage pushed the plan estimate over the 400 LOC soft cap. The overage is the focused decoder/test surface for the same byte-admission boundary: BOM-less UTF-16 inference, clean legacy marker text, warned UTF-8 recovery, and the ASCII-plus-one-corrupt-byte legacy fallback warning are coupled tightly enough that splitting them would leave #1455 partially fixed.
 
 ## Scope (this PR)
 
@@ -41,7 +41,7 @@ Slice phase: Vertical slice
 
 ## Mechanism
 
-`_read_csv_text` becomes a decoder boundary that returns `(text, warnings)`. It first honors explicit BOMs, then tries strict UTF-8, with a NUL-pattern check for UTF-16 files missing a BOM. If UTF-8 fails, the error path now runs the same raw-byte NUL inference before trying legacy encodings, so BOM-less UTF-16 with non-ASCII text is still admitted. It then compares strict CP1252/Latin-1 fallback with a warning-surfaced UTF-8 recovery; the recovery is selected only when mojibake evidence in the legacy decode outnumbers the replacements the recovery would insert, preserving clean legacy exports that contain legitimate U+00C3/U+00C2 text. Any selected UTF-8 recovery that inserts replacement characters emits a warning, even below the high-ratio threshold used for literal replacement characters already present in valid UTF-8 input. The existing `_load_csv_dict_rows` parser appends those decode warnings to the existing leading-row warnings before returning rows.
+`_read_csv_text` becomes a decoder boundary that returns `(text, warnings)`. It first honors explicit BOMs, then tries strict UTF-8, with a NUL-pattern check for UTF-16 files missing a BOM. If UTF-8 fails, the error path now runs the same raw-byte NUL inference before trying legacy encodings, so BOM-less UTF-16 with non-ASCII text is still admitted. It then compares strict CP1252/Latin-1 fallback with a warning-surfaced UTF-8 recovery; the recovery is selected only when mojibake evidence in the legacy decode outnumbers the replacements the recovery would insert, preserving clean legacy exports that contain legitimate U+00C3/U+00C2 text. Any selected UTF-8 recovery that inserts replacement characters emits a warning, even below the high-ratio threshold used for literal replacement characters already present in valid UTF-8 input. If recovery is not selected but the legacy fallback contains suspicious U+00FF/U+00FE artifacts after a strict UTF-8 failure, the loader returns the legacy-decoded text with a `csv_encoding_ambiguous` warning instead of silently treating that corrupt byte as clean CP1252. The existing `_load_csv_dict_rows` parser appends those decode warnings to the existing leading-row warnings before returning rows.
 
 ## Intentional
 
@@ -55,25 +55,27 @@ Slice phase: Vertical slice
 - #1459 remains the deterministic delimiter-vote/reject branch.
 - #1457 remains the header/body-column admission report and is currently claimed by another developer.
 - Full charset confidence reporting can be added later if product wants a visible encoding diagnostic for every clean upload.
+- Clean UTF-8 bytes that are semantically double-encoded mojibake can still decode without warning; that is a separate content-quality heuristic, not this byte-admission slice.
+- Sub-10% NUL contamination that does not satisfy UTF-16 side-pattern inference is still deferred; a future suspicious-NUL warning band can close that without changing this launch-critical admission path.
 
 Parked hardening: none.
 
 ## Verification
 
 - `python -m py_compile` on `extracted_content_pipeline/campaign_customer_data.py`, `tests/test_extracted_campaign_source_adapters.py`, and `tests/test_extracted_content_deflection_submit.py` -- passed.
-- `pytest tests/test_extracted_campaign_source_adapters.py -q -k "utf16 or legacy or marker or replacement or utf8 or semicolon or multiline"` -- 11 passed, 69 deselected.
+- `pytest tests/test_extracted_campaign_source_adapters.py -q -k "utf16 or legacy or marker or replacement or utf8 or corrupt or semicolon or multiline"` -- 12 passed, 69 deselected.
 - `pytest tests/test_extracted_content_deflection_submit.py -q -k "utf16 or bom or embedded_quotes or metadata_header"` -- 4 passed, 50 deselected.
-- `pytest tests/test_extracted_campaign_source_adapters.py -q` -- 80 passed.
+- `pytest tests/test_extracted_campaign_source_adapters.py -q` -- 81 passed.
 - `pytest tests/test_extracted_content_deflection_submit.py -q` -- 54 passed.
 - `bash` + `scripts/check_ascii_python.sh` -- passed.
-- `bash` + `scripts/run_extracted_pipeline_checks.sh` -- 4125 passed, 10 skipped, 1 warning.
+- `bash` + `scripts/run_extracted_pipeline_checks.sh` -- 4127 passed, 10 skipped, 1 warning.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/campaign_customer_data.py` | 174 |
-| `plans/PR-Deflection-Csv-Encoding-Admission.md` | 79 |
-| `tests/test_extracted_campaign_source_adapters.py` | 169 |
+| `extracted_content_pipeline/campaign_customer_data.py` | 204 |
+| `plans/PR-Deflection-Csv-Encoding-Admission.md` | 81 |
+| `tests/test_extracted_campaign_source_adapters.py` | 197 |
 | `tests/test_extracted_content_deflection_submit.py` | 21 |
-| **Total** | **443** |
+| **Total** | **503** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -11,6 +11,7 @@ from extracted_content_pipeline import campaign_source_adapters as adapters
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
     load_source_rows_from_file,
+    load_source_rows_with_warnings_from_file,
     parse_default_fields,
     parse_default_fields_with_booking_url_or_exit,
     parse_default_fields_or_exit,
@@ -265,6 +266,114 @@ def test_load_source_rows_preserves_quoted_commas_and_multiline_text(
         "subject": "Export help",
         "message": "How do I export, then download\nthe attribution report?",
     }]
+
+
+def test_load_source_rows_from_utf16_bom_csv_decodes_support_ticket_export(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_utf16.csv"
+    path.write_bytes(
+        (
+            "ticket_id,subject,message\n"
+            "ticket-1,Export help,How do I export attribution reports?\n"
+        ).encode("utf-16")
+    )
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+
+    assert warnings == ()
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": "How do I export attribution reports?",
+    }]
+
+
+@pytest.mark.parametrize(
+    ("encoding", "message"),
+    (
+        ("cp1252", "Customer can\u2019t export reports."),
+        ("latin-1", "Le caf\u00e9 export failed."),
+    ),
+)
+def test_load_source_rows_from_legacy_csv_decodes_clean_text_without_warning(
+    tmp_path: Path,
+    encoding: str,
+    message: str,
+) -> None:
+    path = tmp_path / f"support_tickets_{encoding}.csv"
+    path.write_bytes((
+        "ticket_id,subject,message\n"
+        f"ticket-1,Export help,{message}\n"
+    ).encode(encoding))
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+
+    assert warnings == ()
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": message,
+    }]
+
+
+def test_load_source_rows_warns_on_high_replacement_character_ratio(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_corrupt.csv"
+    corrupt_text = "\ufffd" * 16
+    path.write_bytes((
+        "ticket_id,subject,message\n"
+        f"ticket-1,Corrupt export,{corrupt_text}\n"
+    ).encode("utf-8"))
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Corrupt export",
+        "message": corrupt_text,
+    }]
+    assert [warning.code for warning in warnings] == ["csv_replacement_characters"]
+    assert warnings[0].field == "encoding"
+    assert "Unicode replacement character" in warnings[0].message
+
+
+def test_load_source_rows_prefers_warned_utf8_recovery_over_cp1252_mojibake(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_truncated_utf8.csv"
+    message = "Café export failed — cannot save"
+    path.write_bytes(
+        (
+            "ticket_id,subject,message\n"
+            f"ticket-1,Export help,{message}"
+        ).encode("utf-8")
+        + b"\xff\n"
+    )
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": f"{message}\ufffd",
+    }]
+    assert [warning.code for warning in warnings] == ["csv_replacement_characters"]
+    assert "CafÃ" not in rows[0]["message"]
+    assert "â" not in rows[0]["message"]
 
 
 def test_source_row_maps_provider_complaint_narrative_aliases() -> None:

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -292,6 +292,32 @@ def test_load_source_rows_from_utf16_bom_csv_decodes_support_ticket_export(
     }]
 
 
+@pytest.mark.parametrize("encoding", ("utf-16-le", "utf-16-be"))
+def test_load_source_rows_infers_bomless_utf16_after_utf8_failure(
+    tmp_path: Path,
+    encoding: str,
+) -> None:
+    path = tmp_path / f"support_tickets_{encoding}.csv"
+    message = "Le caf\u00e9 export failed."
+    path.write_bytes((
+        "ticket_id,subject,message\n"
+        f"ticket-1,Export help,{message}\n"
+    ).encode(encoding))
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": message,
+    }]
+    assert [warning.code for warning in warnings] == ["csv_encoding_inferred"]
+    assert encoding in warnings[0].message
+
+
 @pytest.mark.parametrize(
     ("encoding", "message"),
     (
@@ -323,6 +349,37 @@ def test_load_source_rows_from_legacy_csv_decodes_clean_text_without_warning(
     }]
 
 
+@pytest.mark.parametrize(
+    "message",
+    (
+        "\u00c3lvaro can\u2019t export reports.",
+        "\u00c2ngela can\u2019t export reports.",
+    ),
+)
+def test_load_source_rows_prefers_clean_cp1252_marker_text_over_utf8_recovery(
+    tmp_path: Path,
+    message: str,
+) -> None:
+    path = tmp_path / "support_tickets_cp1252_marker.csv"
+    path.write_bytes((
+        "ticket_id,subject,message\n"
+        f"ticket-1,Export help,{message}\n"
+    ).encode("cp1252"))
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+
+    assert warnings == ()
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": message,
+    }]
+    assert "\ufffd" not in rows[0]["message"]
+
+
 def test_load_source_rows_warns_on_high_replacement_character_ratio(
     tmp_path: Path,
 ) -> None:
@@ -352,7 +409,10 @@ def test_load_source_rows_prefers_warned_utf8_recovery_over_cp1252_mojibake(
     tmp_path: Path,
 ) -> None:
     path = tmp_path / "support_tickets_truncated_utf8.csv"
-    message = "Café export failed — cannot save"
+    message = (
+        "Caf\u00e9 export failed \u2014 cannot save "
+        + "the monthly attribution report " * 20
+    )
     path.write_bytes(
         (
             "ticket_id,subject,message\n"

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -436,6 +436,34 @@ def test_load_source_rows_prefers_warned_utf8_recovery_over_cp1252_mojibake(
     assert "â" not in rows[0]["message"]
 
 
+def test_load_source_rows_warns_on_ascii_utf8_corrupt_byte_legacy_fallback(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_ascii_corrupt_utf8.csv"
+    message = "Cannot export the monthly attribution report at all today"
+    path.write_bytes(
+        (
+            "ticket_id,subject,message\n"
+            f"ticket-1,Export help,{message}"
+        ).encode("utf-8")
+        + b"\xff\n"
+    )
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": f"{message}\u00ff",
+    }]
+    assert [warning.code for warning in warnings] == ["csv_encoding_ambiguous"]
+    assert warnings[0].field == "encoding"
+    assert "failed strict UTF-8" in warnings[0].message
+
+
 def test_source_row_maps_provider_complaint_narrative_aliases() -> None:
     opportunity, warnings = source_row_to_campaign_opportunity({
         "Complaint ID": "3182593",

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -151,6 +151,27 @@ async def test_deflection_submit_upload_parses_bom_semicolon_csv() -> None:
 
 
 @pytest.mark.asyncio
+async def test_deflection_submit_upload_parses_utf16_bom_csv() -> None:
+    data = (
+        "ticket_id,subject,message\n"
+        "ticket-1,Export help,How do I export attribution reports?\n"
+    ).encode("utf-16")
+
+    rows, byte_count, load_warnings = await api_module._load_deflection_submit_upload_rows(
+        _Upload(data),
+        max_bytes=2048,
+    )
+
+    assert byte_count == len(data)
+    assert load_warnings == ()
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": "How do I export attribution reports?",
+    }]
+
+
+@pytest.mark.asyncio
 async def test_deflection_submit_upload_parses_embedded_quotes_and_newlines() -> None:
     data = _csv_dict_bytes([
         {


### PR DESCRIPTION
Plan: plans/PR-Deflection-Csv-Encoding-Admission.md
Slice phase: Vertical slice

Issue #1455 is a P0 launch-readiness parser gap: support-ticket CSV ingestion could fall back from UTF-8 to CP1252 with silent replacement mojibake. This hardens the shared CSV decode boundary used by both source loading and `/deflection-reports/submit`: explicit BOM handling for UTF-16/UTF-32, strict UTF-8 first, clean CP1252/Latin-1 fallback, warning-surfaced UTF-8 recovery when legacy fallback has stronger mojibake evidence than the recovery would lose, and an ambiguity warning for ASCII-plus-corrupt-byte legacy fallback. Closes #1455.

## Intentional
- No charset-normalizer/chardet dependency in this slice; deterministic BOM/strict UTF-8/CP1252/Latin-1 covers the launch-critical export shapes.
- Clean CP1252/Latin-1 fallback does not warn; suspicious replacement-character content does.
- `errors="replace"` is used only in the explicit warned UTF-8 recovery branch, never as a silent fallback.
- Delimiter voting stays deferred to #1459.

## Deferred
- #1459 remains the deterministic delimiter-vote/reject branch.
- #1457 remains the header/body-column admission report and is currently claimed by another developer.
- Full charset confidence reporting can be added later if needed.
- Clean UTF-8 bytes that are semantically double-encoded mojibake can still decode without warning; that is a separate content-quality heuristic, not this byte-admission slice.
- Sub-10% NUL contamination that does not satisfy UTF-16 side-pattern inference is still deferred; a future suspicious-NUL warning band can close it.

## Parked hardening
- None.

## Verification
- `python -m py_compile` on `extracted_content_pipeline/campaign_customer_data.py`, `tests/test_extracted_campaign_source_adapters.py`, and `tests/test_extracted_content_deflection_submit.py` -- passed.
- `pytest tests/test_extracted_campaign_source_adapters.py -q -k "utf16 or legacy or marker or replacement or utf8 or corrupt or semicolon or multiline"` -- 12 passed, 69 deselected.
- `pytest tests/test_extracted_content_deflection_submit.py -q -k "utf16 or bom or embedded_quotes or metadata_header"` -- 4 passed, 50 deselected.
- `pytest tests/test_extracted_campaign_source_adapters.py -q` -- 81 passed.
- `pytest tests/test_extracted_content_deflection_submit.py -q` -- 54 passed.
- `bash` + `scripts/check_ascii_python.sh` -- passed.
- `bash` + `scripts/run_extracted_pipeline_checks.sh` -- 4127 passed, 10 skipped, 1 warning.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed Codex P2: BOM-less UTF-16 NUL inference now runs after strict UTF-8 decode failures.
- Fixed Codex P2: clean CP1252 marker text such as U+00C3/U+00C2 names is preferred over lossy UTF-8 recovery unless mojibake evidence outnumbers inserted replacements.
- Fixed Codex P2: UTF-8 recovery emits `csv_replacement_characters` whenever it inserts replacement characters.
- Fixed reviewer MAJOR: ASCII UTF-8 with one corrupt 0xFF byte now returns a visible `csv_encoding_ambiguous` warning instead of silently treating U+00FF as clean legacy text.
- Waived: none.

## Diff size
4 files, +498 / -5
