### PR TITLE
Add light Spark routing enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,9 +232,10 @@ Update the map:
 - after merging a PR;
 - before handing back to the operator.
 
-The map must name the current lane, current task, owned active PR
-number/title/branch/plan/head SHA when one exists, PRs this session may
-touch, PRs this session must not touch, and the last safe action.
+The map must name the current lane, current task, Spark/subagent routing used
+or considered, owned active PR number/title/branch/plan/head SHA when one
+exists, PRs this session may touch, PRs this session must not touch, and the
+last safe action.
 
 Before inspecting comments, pushing updates, closing, or merging any
 PR, the builder must verify all of the following:

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -15,7 +15,7 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >
 > 1. **Read first, in order:** `AGENTS.md` (the multi-session PR contract), `CLAUDE.md`, `CANONICAL.md`, `INTEGRATION_MAP.md`, `BUILD_SPEC.md`, `CONTEXT.md`. Then run `git log --oneline -20` and `gh pr list --state open` to see where things actually stand. Do not infer state from this prompt — those sources are truth.
 >
-> 2. **Session ownership map:** read `SESSION_STATE.local.md` if it exists. If it does not exist, create it from `docs/SESSION_STATE_TEMPLATE.md` before any PR action. Fill in your assigned lane, current task, owned active PR (or `none`), open PRs that are explicitly **not yours**, current worktree, and last safe action. A PR that is not listed as owned in this file is not yours.
+> 2. **Session ownership map:** read `SESSION_STATE.local.md` if it exists. If it does not exist, create it from `docs/SESSION_STATE_TEMPLATE.md` before any PR action. Fill in your assigned lane, current task, Spark/subagent routing used or considered, owned active PR (or `none`), open PRs that are explicitly **not yours**, current worktree, and last safe action. A PR that is not listed as owned in this file is not yours.
 >
 > 3. **Your current lane:** [ONE line — e.g. "Content-Ops macro-writeback" or "deflection/Stripe monetization". If unsure, read CONTEXT.md + open PRs to find the active slice.] Stay in this lane. **Do not close, merge, or modify PRs outside your current task** — if a PR looks abandoned, ask the operator; don't close it. If an open PR is in the same lane but is not marked owned in `SESSION_STATE.local.md`, treat it as someone else's PR.
 >

--- a/docs/SESSION_STATE_TEMPLATE.md
+++ b/docs/SESSION_STATE_TEMPLATE.md
@@ -14,6 +14,7 @@ Last updated: YYYY-MM-DD HH:MM TZ
 Session role: builder
 Operator-assigned lane: <one sentence>
 Current task: <one sentence>
+Spark/subagent routing: used <what/why> | considered <why main/direct was better> | not applicable
 
 ## Owned Active PR
 

--- a/plans/PR-Spark-Routing-Light-Enforcement.md
+++ b/plans/PR-Spark-Routing-Light-Enforcement.md
@@ -1,0 +1,91 @@
+# PR-Spark-Routing-Light-Enforcement
+
+## Why this slice exists
+
+#1543 codified Spark as the preferred lightweight scout for bounded read-only
+work, but the policy still depends on memory. The operator wants light
+enforcement, not a hard CI gate. This slice makes the routing decision visible
+in the mandatory local session-state handoff so future sessions record whether
+Spark or another subagent was used, considered, or not applicable.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Add a `Spark/subagent routing` field to the session-state template.
+2. Update the builder workflow and fresh-session bootstrap to require filling
+   that field when maintaining the session map.
+3. Keep enforcement lightweight: no new scripts, CI gates, or local-review
+   blockers.
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/SESSION_BOOTSTRAP.md`
+- `docs/SESSION_STATE_TEMPLATE.md`
+- `plans/PR-Spark-Routing-Light-Enforcement.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- The session-state template has a visible Spark/subagent routing field.
+- `AGENTS.md` says the session map must record Spark/subagent routing used or
+  considered.
+- The fresh-session bootstrap tells new sessions to fill in the routing field.
+- The slice does not add hard enforcement through CI, local-review scripts, or
+  PR mutation gates.
+
+Affected surfaces:
+
+- Atlas workflow/process documentation and local session-state template only.
+
+Risk areas:
+
+- Wording must not imply subagents can own judgment, edits, Git/GitHub
+  mutations, or final synthesis.
+- The field should support "not applicable" so tiny direct tasks do not produce
+  noisy process churn.
+
+Reviewer rules triggered: R1, R12, R14
+
+## Mechanism
+
+The mandatory local session map gets a single new top-level line:
+`Spark/subagent routing: used ... | considered ... | not applicable`.
+`AGENTS.md` and the fresh-session bootstrap both name that field in the list of
+session-state data builders must maintain. This creates lightweight
+accountability in the handoff state without adding a mechanical gate.
+
+## Intentional
+
+- No new checker or CI gate. A subjective "should Spark have been used" audit
+  would be noisy as a hard blocker.
+- No changes to the PR body contract. The routing note belongs in local session
+  state, not every PR description.
+- The field allows "not applicable" for small direct commands and edit-target
+  reads where main should work directly.
+
+## Deferred
+
+- A script-backed checker remains deferred unless repeated misses show that the
+  session-state field is insufficient.
+
+Parked hardening: none.
+
+## Verification
+
+- Doc diff inspection: passed.
+- `python scripts/sync_pr_plan.py plans/PR-Spark-Routing-Light-Enforcement.md --check`: passed.
+- Body-aware local PR review: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 7 |
+| `docs/SESSION_BOOTSTRAP.md` | 2 |
+| `docs/SESSION_STATE_TEMPLATE.md` | 1 |
+| `plans/PR-Spark-Routing-Light-Enforcement.md` | 91 |
+| **Total** | **101** |


### PR DESCRIPTION
Plan: plans/PR-Spark-Routing-Light-Enforcement.md
Slice phase: Workflow/process

Adds light enforcement for the Spark routing policy by making the Spark/subagent routing decision part of the mandatory local session-state handoff, without adding CI gates or local-review blockers.

## Intentional
- No new checker or CI gate; the enforcement is visible handoff accountability.
- No PR body contract change; the routing note belongs in `SESSION_STATE.local.md`.
- The field supports `not applicable` so small direct tasks and edit-target reads stay lightweight.

## Deferred
- Script-backed enforcement remains deferred unless repeated misses show the session-state field is insufficient.

## Parked hardening
- None.

## Verification
- Doc diff inspection: passed.
- `python scripts/sync_pr_plan.py plans/PR-Spark-Routing-Light-Enforcement.md --check` -- passed.
- `bash scripts/push_pr.sh tmp/spark_routing_light_enforcement_pr_body.md -u origin HEAD` -- body-aware local PR review passed.

## Diff size
4 files, +97 / -4
