### PR TITLE
Deflection mxbai merge spot-check

### DIFF
--- a/docs/extraction/validation/deflection_mxbai_merge_spotcheck_2026-06-14.md
+++ b/docs/extraction/validation/deflection_mxbai_merge_spotcheck_2026-06-14.md
@@ -1,0 +1,60 @@
+# Deflection Mxbai Merge Spot-Check
+
+Date: 2026-06-14
+
+Issue: #1504
+
+## What Ran
+
+This validation reran the live CFPB fees sample with the pinned local mxbai
+embedding path and the semantic-edge recorder enabled by this slice.
+
+```bash
+python scripts/smoke_content_ops_cfpb_faq_markdown.py \
+  --search-term fees \
+  --limit 1000 \
+  --max-rows-scanned 5000 \
+  --max-items 20 \
+  --support-contact "https://support.example.com" \
+  --compare-embedding-booster \
+  --output-source-rows tmp/cfpb_mxbai_merge_spotcheck/cfpb_sources_1000.jsonl \
+  --output-markdown tmp/cfpb_mxbai_merge_spotcheck/cfpb_faq_1000_boosted.md \
+  --json > tmp/cfpb_mxbai_merge_spotcheck/summary_raw.json
+```
+
+## Proof Artifact
+
+- Sanitized summary:
+  `docs/extraction/validation/fixtures/deflection_mxbai_merge_spotcheck_20260614/summary.json`
+- Excluded raw working files:
+  `tmp/cfpb_mxbai_merge_spotcheck/cfpb_sources_1000.jsonl`,
+  `tmp/cfpb_mxbai_merge_spotcheck/cfpb_faq_1000_boosted.md`, and
+  `tmp/cfpb_mxbai_merge_spotcheck/summary_raw.json`
+
+## Result
+
+| Metric | Value |
+|---|---:|
+| Exit status | 0 |
+| Live CFPB source rows | 1,000 |
+| Embedding probe calls | 14 |
+| Embedding valid batches | 14 |
+| Accepted semantic merge edges | 9 |
+| Non-repeat ticket delta | -18 |
+| Spot-checked plausible same-issue edges | 9 |
+| Spot-checked unclear edges | 0 |
+| Spot-checked likely false merges | 0 |
+
+The accepted semantic edges are the same mutual-nearest-neighbor pairs the
+booster unioned. All 9 edges looked like plausible same-issue merges in this
+sample, including mortgage servicing transfer, health-related card-payment
+hardship, travel booking disputes, rental scam recovery, payday loan wording,
+negative-balance charges, credit-card fraud disputes, recurring checking fees,
+and rent-payment transfer loss.
+
+## Launch Implication
+
+This removes the review's immediate merge-quality blocker for the 18-ticket
+lift observed in #1544. It still does not flip
+`ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED`: the operator still owns the
+ROI decision for enabling a small CFPB lift with a local CPU mxbai dependency.

--- a/docs/extraction/validation/fixtures/deflection_mxbai_merge_spotcheck_20260614/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_mxbai_merge_spotcheck_20260614/summary.json
@@ -1,0 +1,37 @@
+{
+  "artifact": "deflection_mxbai_merge_spotcheck",
+  "run_timestamp_utc": "2026-06-14T04:23:00Z",
+  "issue": "#1504",
+  "source": "cfpb",
+  "ok": true,
+  "source_rows": 1000,
+  "probe": {"calls": 14, "valid_batches": 14},
+  "delta": {
+    "non_repeat_ticket_count": -18,
+    "non_repeat_question_count": -18,
+    "changed_top_question": false
+  },
+  "semantic_merge_count": 9,
+  "spot_check_summary": {
+    "plausible_same_issue": 9,
+    "unclear": 0,
+    "likely_false_merge": 0,
+    "production_enablement": "still requires operator decision; this artifact only checks the accepted semantic edges"
+  },
+  "raw_outputs_excluded_from_git": [
+    "tmp/cfpb_mxbai_merge_spotcheck/cfpb_sources_1000.jsonl",
+    "tmp/cfpb_mxbai_merge_spotcheck/cfpb_faq_1000_boosted.md",
+    "tmp/cfpb_mxbai_merge_spotcheck/summary_raw.json"
+  ],
+  "semantic_merges": [
+    {"left_source_id": "cfpb:6712260", "right_source_id": "cfpb:6747999", "cosine": 0.837934, "left_margin": 0.065296, "right_margin": 0.099356, "token_jaccard": 0.192308, "left_text": "I applied and was granted a forbearance with XXXX mortgage. During my forebearance period, XXXX sold my loan and the new serviced became LoanCare.", "right_text": "XXXX mortgage sold our loan to LoanCare ( XXXX ). We applied and were approved for HAF of {$16000.00}.", "spot_check": "plausible_same_issue", "reason": "mortgage servicing transfer and LoanCare hardship/payment handling"},
+    {"left_source_id": "cfpb:6731679", "right_source_id": "cfpb:6744117", "cosine": 0.782258, "left_margin": 0.080118, "right_margin": 0.078388, "token_jaccard": 0.0, "left_text": "I became very ill and fell behind my payments for my Discover card.", "right_text": "My health has taken a toll with my work. I have been trying to pay.", "spot_check": "plausible_same_issue", "reason": "illness-driven credit-card payment hardship"},
+    {"left_source_id": "cfpb:6683723", "right_source_id": "cfpb:6689662", "cosine": 0.840901, "left_margin": 0.110398, "right_margin": 0.121482, "token_jaccard": 0.190476, "left_text": "I used my Capital One credit card to purchase flights from the travel website.", "right_text": "I made a reservation through the credit card travel website for my vacation.", "spot_check": "plausible_same_issue", "reason": "credit-card travel booking/reservation dispute"},
+    {"left_source_id": "cfpb:6689331", "right_source_id": "cfpb:6743811", "cosine": 0.79392, "left_margin": 0.063752, "right_margin": 0.06021, "token_jaccard": 0.173913, "left_text": "What should I do if I was the victim of a rental scam and my bank is refusing to restore funds?", "right_text": "My financial institution is refusing to dispute, stop payment, or reclaim lost funds from this rental scam.", "spot_check": "plausible_same_issue", "reason": "rental scam funds recovery dispute"},
+    {"left_source_id": "cfpb:6697380", "right_source_id": "cfpb:6723781", "cosine": 0.825534, "left_margin": 0.086971, "right_margin": 0.12956, "token_jaccard": 0.222222, "left_text": "What should I do if I got a payday advance from this company?", "right_text": "What should I do if I received a pay day loan?", "spot_check": "plausible_same_issue", "reason": "payday advance/payday loan same wording variant"},
+    {"left_source_id": "cfpb:6694745", "right_source_id": "cfpb:6711208", "cosine": 0.835961, "left_margin": 0.073402, "right_margin": 0.074742, "token_jaccard": 0.105263, "left_text": "Excess charges to my account without disclosure or explanation; account balance reflects a negative balance.", "right_text": "Saying my checking account is negative through email and unknown charges to my account.", "spot_check": "plausible_same_issue", "reason": "unexpected account charges causing negative balance"},
+    {"left_source_id": "cfpb:6694318", "right_source_id": "cfpb:6728972", "cosine": 0.807645, "left_margin": 0.065503, "right_margin": 0.091091, "token_jaccard": 0.217391, "left_text": "A credit-card charge was disputed with the card company and fraud department.", "right_text": "Fraud charges on a Citi credit card were disputed with Citi Bank.", "spot_check": "plausible_same_issue", "reason": "credit-card fraud charge dispute"},
+    {"left_source_id": "cfpb:6714720", "right_source_id": "cfpb:6729093", "cosine": 0.822259, "left_margin": 0.064367, "right_margin": 0.066319, "token_jaccard": 0.24, "left_text": "Bank of America started charging a monthly fee after years without the fee.", "right_text": "Fifth Third bank started charging my checking account a monthly service fee after years with no fee.", "spot_check": "plausible_same_issue", "reason": "unexpected recurring checking-account service fee"},
+    {"left_source_id": "cfpb:6720397", "right_source_id": "cfpb:6751504", "cosine": 0.820663, "left_margin": 0.068151, "right_margin": 0.082779, "token_jaccard": 0.130435, "left_text": "I sent my rent to my landlord and later realized it was cashed unexpectedly.", "right_text": "I sent money via Cash App for rent and a service fee to the rental company.", "spot_check": "plausible_same_issue", "reason": "rent payment transfer/rental-company payment loss"}
+  ]
+}

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -654,6 +654,7 @@ def build_ticket_faq_markdown(
     representative_taxonomy_terms: Sequence[str] = (),
     vocabulary_gap_rules: Sequence[Sequence[str]] = (),
     embedding_port: EmbeddingPort | None = None,
+    embedding_merge_recorder: Callable[[Mapping[str, Any]], None] | None = None,
 ) -> TicketFAQMarkdownResult:
     """Render an extractive FAQ from normalized source-row opportunities."""
 
@@ -771,7 +772,11 @@ def build_ticket_faq_markdown(
             subclustered_groups[(topic, scope)] = rows
             continue
         for cluster_index, cluster_rows in enumerate(
-            _question_subclusters(rows, embedding_port=embedding_port)
+            _question_subclusters(
+                rows,
+                embedding_port=embedding_port,
+                embedding_merge_recorder=embedding_merge_recorder,
+            )
         ):
             cluster_keys = _row_source_keys(cluster_rows)
             if len(cluster_keys) < 2:
@@ -934,6 +939,7 @@ def _question_subclusters(
     rows: Sequence[Mapping[str, str]],
     *,
     embedding_port: EmbeddingPort | None = None,
+    embedding_merge_recorder: Callable[[Mapping[str, Any]], None] | None = None,
 ) -> list[list[Mapping[str, str]]]:
     """Split one degraded topic bucket into question-similarity clusters.
 
@@ -991,6 +997,7 @@ def _question_subclusters(
         find=find,
         union=union,
         embedding_port=embedding_port,
+        embedding_merge_recorder=embedding_merge_recorder,
     )
 
     clusters: dict[int, list[Mapping[str, str]]] = defaultdict(list)
@@ -1006,6 +1013,7 @@ def _apply_embedding_booster(
     find: Callable[[int], int],
     union: Callable[[int, int], None],
     embedding_port: EmbeddingPort | None,
+    embedding_merge_recorder: Callable[[Mapping[str, Any]], None] | None,
 ) -> None:
     if embedding_port is None or len(rows) < 2:
         return
@@ -1067,7 +1075,32 @@ def _apply_embedding_booster(
         pairs.add(tuple(sorted((index, candidate))))
     for left, right in sorted(pairs):
         if find(left) != find(right):
+            if embedding_merge_recorder is not None:
+                left_best, left_score, left_runner_up = best_by_index[left]
+                right_best, right_score, right_runner_up = best_by_index[right]
+                score = left_score if left_best == right else right_score
+                embedding_merge_recorder({
+                    "left_index": left,
+                    "right_index": right,
+                    "left_source_id": _embedding_merge_source_id(rows[left]),
+                    "right_source_id": _embedding_merge_source_id(rows[right]),
+                    "left_text": texts[left],
+                    "right_text": texts[right],
+                    "cosine": score,
+                    "left_runner_up": left_runner_up,
+                    "right_runner_up": right_runner_up,
+                    "left_margin": left_score - left_runner_up,
+                    "right_margin": right_score - right_runner_up,
+                    "token_jaccard": _jaccard(gists[left], gists[right]),
+                })
             union(left, right)
+
+
+def _embedding_merge_source_id(row: Mapping[str, str]) -> str:
+    source_id = str(row.get("source_id") or "").strip()
+    if source_id and source_id.lower() != "unknown":
+        return source_id
+    return str(row.get("source_key") or "").strip()
 
 
 def _topic(

--- a/plans/PR-Deflection-Mxbai-Merge-Spotcheck.md
+++ b/plans/PR-Deflection-Mxbai-Merge-Spotcheck.md
@@ -1,0 +1,114 @@
+# PR-Deflection-Mxbai-Merge-Spotcheck
+
+## Why this slice exists
+
+#1544 proved the pinned local mxbai path runs on live CFPB data and has a
+bounded effect, but the review left one launch-readiness question open before
+any route flag flip: the 18 semantic merges need a spot-check. The committed
+#1544 artifact records counts and probe batches, not the exact accepted semantic
+edges, so an operator cannot inspect whether those merges are semantically
+correct without rerunning local raw output.
+
+This slice adds reviewable semantic-edge telemetry to the existing CFPB compare
+harness and commits a sanitized live spot-check artifact. It does not enable the
+production flag, change thresholds, or change FAQ output.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Functional validation
+
+1. Add an optional recorder callback to the existing embedding-booster pair
+   selection so accepted mutual-nearest-neighbor edges can be inspected.
+2. Surface recorded edges in the CFPB compare smoke payload under the embedding
+   comparison, with source ids, question gist text, cosine score, runner-up
+   margins, and token Jaccard.
+3. Add focused deterministic tests proving the recorder captures accepted edges,
+   omits failed embedding paths, and does not change FAQ output.
+4. Run the live CFPB fees sample again and commit a sanitized spot-check summary
+   for the accepted semantic merge edges.
+5. Leave raw CFPB JSONL rows and full generated Markdown under `tmp/` only.
+
+### Files touched
+
+- `docs/extraction/validation/deflection_mxbai_merge_spotcheck_2026-06-14.md`
+- `docs/extraction/validation/fixtures/deflection_mxbai_merge_spotcheck_20260614/summary.json`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Mxbai-Merge-Spotcheck.md`
+- `scripts/smoke_content_ops_cfpb_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_smoke_content_ops_cfpb_faq_markdown.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Semantic merge recorder data comes from the same accepted MNN pairs that
+        are unioned by the booster; no separate clustering heuristic.
+  - [ ] The CFPB compare payload exposes enough edge data to spot-check merge
+        quality without committing raw complaint narratives.
+  - [ ] Failure/invalid embedding paths do not report accepted semantic edges.
+  - [ ] FAQ Markdown output, thresholds, route flags, and production defaults
+        remain unchanged.
+- Affected surfaces: extracted FAQ private clustering helper, CFPB compare
+  smoke harness, focused tests, validation docs/artifacts.
+- Risk areas: misleading provenance, accidental raw-data leak, API drift from
+  optional recorder plumbing.
+- Reviewer rules triggered: R1, R2, R5, R10, R11, R12, R14.
+
+## Mechanism
+
+Thread an optional `embedding_merge_recorder` callback through
+`build_ticket_faq_markdown` into the private question sub-clustering path. The
+recorder is invoked only after the existing MNN floor and two-sided margin gates
+accept a pair, immediately before the existing union operation. The callback
+receives row indexes, source ids, question gist text, cosine score, each side's
+runner-up score, each side's margin, and token Jaccard.
+
+The CFPB compare smoke passes a local recorder only for the boosted run and adds
+the recorded edges to `embedding_comparison`. The committed validation artifact
+summarizes those edges; raw source rows and full Markdown stay outside git.
+
+## Intentional
+
+- No route flag flip. This slice creates the spot-check evidence needed before
+  an operator decides whether the 1.8% CFPB lift is worth enabling.
+- No threshold or margin tuning. If the spot-check exposes bad merges, that
+  becomes a separate scoped follow-up.
+- The recorder is optional and inert by default, so existing callers keep the
+  same output shape unless they explicitly request edge telemetry.
+- The committed artifact may include short question gists and source ids because
+  those are the inspection surface; full complaint narratives and raw JSONL rows
+  are not committed.
+- The recorder emits customer-text snippets to its explicit caller. It is for
+  validation/inspection surfaces only and must not be wired into private-ticket
+  logs or committed artifacts without redaction.
+
+## Deferred
+
+- Production enablement decision for `ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED`.
+- Threshold/margin changes if the spot-check finds incorrect semantic merges.
+- Buyer-facing semantic merge provenance in the final report UI.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused FAQ Markdown and CFPB smoke test files -- 260 passed.
+- Live CFPB compare command with semantic edge telemetry -- passed, exit 0;
+  recorded 9 accepted semantic merge edges matching the -18 non-repeat ticket
+  delta.
+- Extracted pipeline checks -- 4118 passed, 10 skipped, 1 warning.
+- Local PR review bundle with planned PR body -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/deflection_mxbai_merge_spotcheck_2026-06-14.md` | 60 |
+| `docs/extraction/validation/fixtures/deflection_mxbai_merge_spotcheck_20260614/summary.json` | 37 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 35 |
+| `plans/PR-Deflection-Mxbai-Merge-Spotcheck.md` | 114 |
+| `scripts/smoke_content_ops_cfpb_faq_markdown.py` | 35 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 79 |
+| `tests/test_smoke_content_ops_cfpb_faq_markdown.py` | 14 |
+| **Total** | **374** |

--- a/scripts/smoke_content_ops_cfpb_faq_markdown.py
+++ b/scripts/smoke_content_ops_cfpb_faq_markdown.py
@@ -142,6 +142,7 @@ def run_cfpb_faq_markdown_smoke(
                         f"embedding booster unavailable: {type(exc).__name__}: {exc}"
                     )
                 else:
+                    semantic_merges: list[Mapping[str, Any]] = []
                     boosted_result = build_ticket_faq_markdown(
                         loaded.opportunities,
                         title=str(args.title),
@@ -149,6 +150,7 @@ def run_cfpb_faq_markdown_smoke(
                         max_evidence_per_item=int(args.max_evidence_per_item),
                         support_contact=args.support_contact,
                         embedding_port=embedding_port,
+                        embedding_merge_recorder=semantic_merges.append,
                     )
                     embedding_comparison["probe"] = {
                         "calls": embedding_port.calls,
@@ -171,6 +173,9 @@ def run_cfpb_faq_markdown_smoke(
                                 baseline=baseline_result,
                                 boosted=boosted_result,
                             )
+                        )
+                        embedding_comparison["semantic_merges"] = (
+                            _semantic_merge_payload(semantic_merges)
                         )
             faq = result.as_dict()
             failed = _failed_output_checks(result.output_checks)
@@ -276,6 +281,36 @@ def _embedding_comparison_payload(*, baseline: Any, boosted: Any) -> dict[str, A
             ],
         },
     }
+
+
+def _semantic_merge_payload(merges: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "left_source_id": str(merge.get("left_source_id") or ""),
+            "right_source_id": str(merge.get("right_source_id") or ""),
+            "left_text": _short_text(merge.get("left_text")),
+            "right_text": _short_text(merge.get("right_text")),
+            "cosine": _round_score(merge.get("cosine")),
+            "left_margin": _round_score(merge.get("left_margin")),
+            "right_margin": _round_score(merge.get("right_margin")),
+            "left_runner_up": _round_score(merge.get("left_runner_up")),
+            "right_runner_up": _round_score(merge.get("right_runner_up")),
+            "token_jaccard": _round_score(merge.get("token_jaccard")),
+        }
+        for merge in merges
+    ]
+
+
+def _round_score(value: Any) -> float:
+    try:
+        return round(float(value), 6)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _short_text(value: Any, *, limit: int = 220) -> str:
+    text = " ".join(str(value or "").split())
+    return text if len(text) <= limit else f"{text[: limit - 3].rstrip()}..."
 
 
 def _faq_summary(result: Any) -> dict[str, Any]:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2182,6 +2182,85 @@ def test_embedding_booster_merges_no_overlap_reworded_repeat_in_builder() -> Non
     assert with_port.items[0]["source_ids"] == ("refund-a", "refund-b")
 
 
+def test_embedding_booster_records_only_accepted_semantic_pairs() -> None:
+    rows = [
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "billing help",
+            "text": "How do I get my money back?",
+            "source_id": "refund-a",
+        },
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "billing help",
+            "text": "What is the process for a refund?",
+            "source_id": "refund-b",
+        },
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "billing help",
+            "text": "Where can I update my billing address?",
+            "source_id": "billing-address",
+        },
+    ]
+    semantic_merges = []
+
+    result = build_ticket_faq_markdown(
+        rows,
+        max_items=0,
+        embedding_port=_StubEmbeddingPort({
+            "How do I get my money back?": (1.0, 0.0),
+            "What is the process for a refund?": (0.99, 0.01),
+            "Where can I update my billing address?": (0.0, 1.0),
+        }),
+        embedding_merge_recorder=semantic_merges.append,
+    )
+
+    assert len(result.items) == 1
+    assert result.items[0]["source_ids"] == ("refund-a", "refund-b")
+    assert len(semantic_merges) == 1
+    merge = semantic_merges[0]
+    assert merge["left_source_id"] == "refund-a"
+    assert merge["right_source_id"] == "refund-b"
+    assert merge["left_text"] == "How do I get my money back?"
+    assert merge["right_text"] == "What is the process for a refund?"
+    assert merge["cosine"] > 0.99
+    assert merge["left_margin"] > 0.9
+    assert merge["right_margin"] > 0.9
+    assert merge["token_jaccard"] < (1 / 3)
+
+
+def test_embedding_booster_records_source_key_when_source_id_is_unknown() -> None:
+    rows = [
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "billing help",
+            "text": "How do I get my money back?",
+        },
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "billing help",
+            "text": "What is the process for a refund?",
+        },
+    ]
+    semantic_merges = []
+
+    result = build_ticket_faq_markdown(
+        rows,
+        max_items=0,
+        embedding_port=_StubEmbeddingPort({
+            "How do I get my money back?": (1.0, 0.0),
+            "What is the process for a refund?": (0.99, 0.01),
+        }),
+        embedding_merge_recorder=semantic_merges.append,
+    )
+
+    assert len(result.items) == 1
+    assert len(semantic_merges) == 1
+    assert semantic_merges[0]["left_source_id"] == "row:1"
+    assert semantic_merges[0]["right_source_id"] == "row:2"
+
+
 def test_embedding_booster_skips_malformed_vectors_without_merging() -> None:
     rows = [
         {

--- a/tests/test_smoke_content_ops_cfpb_faq_markdown.py
+++ b/tests/test_smoke_content_ops_cfpb_faq_markdown.py
@@ -232,6 +232,20 @@ def test_cfpb_faq_smoke_compares_embedding_booster(
     assert comparison["delta"]["added_questions"] == [
         "How do I get my money back after an overdraft charge?"
     ]
+    assert comparison["semantic_merges"] == [
+        {
+            "left_source_id": "cfpb:1",
+            "right_source_id": "cfpb:2",
+            "left_text": "How do I get my money back after an overdraft charge?",
+            "right_text": "What is the process for a refund on an overdraft fee?",
+            "cosine": 0.999949,
+            "left_margin": 1.999949,
+            "right_margin": 1.999949,
+            "left_runner_up": -1.0,
+            "right_runner_up": -1.0,
+            "token_jaccard": 0.142857,
+        }
+    ]
     assert payload["errors"] == []
 
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-Mxbai-Merge-Spotcheck.md
Slice phase: Functional validation
Reviewer rules triggered: R1, R2, R5, R10, R11, R12, R14.

This PR closes the #1544 review follow-up before any embedding-booster flag flip: it records the exact semantic merge edges accepted by the existing mxbai MNN booster and commits a sanitized live CFPB spot-check artifact. It does not change thresholds, FAQ output, route flags, or production defaults.

## Intentional

- The recorder is optional and inert unless a caller asks for merge-edge telemetry.
- The CFPB compare smoke exposes short question-gist snippets and source ids for inspection, but raw CFPB JSONL rows and full generated Markdown stay in `tmp/`.
- The artifact spot-checks the 9 accepted semantic edges from the live 1,000-row sample; the production enablement decision remains deferred to the operator.

## Deferred

- Production enablement decision for `ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED`.
- Threshold or margin changes if future spot-checks find incorrect semantic merges.
- Buyer-facing semantic merge provenance in the final report UI.

## Parked hardening

- None.

## Verification

- Focused FAQ Markdown and CFPB smoke test files -- 260 passed.
- Live CFPB compare command with semantic edge telemetry -- passed, exit 0; recorded 9 accepted semantic merge edges matching the -18 non-repeat ticket delta.
- Extracted pipeline checks -- 4118 passed, 10 skipped, 1 warning.

## AI reconciliation

- Codex source-id sentinel finding fixed: recorder provenance now treats `source_id == "unknown"` as missing and falls back to `source_key`, with a regression test for rows without explicit source ids.
- Codex private-text note waived for this validation artifact: the recorder intentionally returns short question-gist text to its explicit caller, and the plan records that private-ticket logs or committed artifacts must redact it before reuse.
- All findings fixed or waived: yes.

## Diff size

7 files, +373 / -1