### PR TITLE
Deflection semantic merge provenance

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -276,6 +276,7 @@ def deflection_report_summary(faq_result: TicketFAQMarkdownResult) -> dict[str, 
         "top_question": _text(items[0].get("question")) if items else "",
         "top_opportunity_score": _int(items[0].get("opportunity_score")) if items else 0,
     }
+    summary.update(_semantic_merge_summary(items))
     summary.update(_outcome_diagnostics_summary(items))
     source_date_window = _complete_source_date_window({}, items)
     if source_date_window:
@@ -312,6 +313,7 @@ def render_deflection_report(
         lines.extend(["**Source file:**", "", _md(source_label), ""])
     lines.extend(_help_desk_seo_targeting_section(items))
     lines.extend(_ranked_opportunity_section(items))
+    lines.extend(_semantic_match_provenance_section(items))
     lines.extend(_outcome_diagnostics_section(items, resolved_summary))
     lines.extend(_drafted_answer_section(proven))
     lines.extend(_no_proven_answer_section(needs_review))
@@ -447,6 +449,43 @@ def _ranked_opportunity_section(items: Sequence[Mapping[str, Any]]) -> list[str]
     return [*lines, ""]
 
 
+def _semantic_match_provenance_section(
+    items: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    rows: list[str] = []
+    for item in items:
+        question = _text(item.get("question"))
+        for edge in _semantic_merge_records(item):
+            pair = (
+                f"{edge['left_source_id']} <-> {edge['right_source_id']}"
+            )
+            rows.append(
+                "| "
+                f"{_cell(question)} | "
+                f"{_cell(pair)} | "
+                f"{_cell(_format_ratio(edge.get('cosine')))} | "
+                f"{_cell(_format_margin_pair(edge))} | "
+                f"{_cell(_format_ratio(edge.get('token_jaccard')))} |"
+            )
+    if not rows:
+        return []
+    return [
+        "## Semantic Match Provenance",
+        "",
+        (
+            "These repeated-question groups include source pairs that were joined "
+            "by the embedding booster after lexical overlap alone did not reach "
+            "the repeat threshold. Treat them as auditable grouping evidence, "
+            "not as a savings guarantee."
+        ),
+        "",
+        "| Customer question | Source pair | Cosine | MNN margins | Token overlap |",
+        "|---|---|---:|---:|---:|",
+        *rows,
+        "",
+    ]
+
+
 def _outcome_diagnostics_section(
     items: Sequence[Mapping[str, Any]],
     summary: Mapping[str, Any],
@@ -497,6 +536,56 @@ def _outcome_diagnostics_section(
             f"{_cell(_outcome_guidance(diagnostics))} |"
         )
     return [*lines, ""]
+
+
+def _semantic_merge_summary(
+    items: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    edge_count = 0
+    question_count = 0
+    source_ids: set[str] = set()
+    for item in items:
+        records = _semantic_merge_records(item)
+        if not records:
+            continue
+        question_count += 1
+        edge_count += len(records)
+        for record in records:
+            source_ids.add(record["left_source_id"])
+            source_ids.add(record["right_source_id"])
+    if edge_count == 0:
+        return {}
+    return {
+        "semantic_merge_present": True,
+        "semantic_merge_count": edge_count,
+        "semantic_merge_question_count": question_count,
+        "semantic_merge_source_count": len(source_ids),
+    }
+
+
+def _semantic_merge_records(
+    item: Mapping[str, Any],
+) -> tuple[dict[str, Any], ...]:
+    raw = item.get("semantic_merge_provenance")
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
+        return ()
+    records: list[dict[str, Any]] = []
+    for value in raw:
+        if not isinstance(value, Mapping):
+            continue
+        left = _text(value.get("left_source_id"))
+        right = _text(value.get("right_source_id"))
+        if not left or not right:
+            continue
+        records.append({
+            "left_source_id": left,
+            "right_source_id": right,
+            "cosine": _float(value.get("cosine")),
+            "left_margin": _float(value.get("left_margin")),
+            "right_margin": _float(value.get("right_margin")),
+            "token_jaccard": _float(value.get("token_jaccard")),
+        })
+    return tuple(records)
 
 
 def _drafted_answer_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
@@ -976,6 +1065,17 @@ def _format_money(value: float | int) -> str:
     return f"${rounded:,}"
 
 
+def _format_ratio(value: Any) -> str:
+    return f"{_float(value):.4f}"
+
+
+def _format_margin_pair(edge: Mapping[str, Any]) -> str:
+    return (
+        f"{_format_ratio(edge.get('left_margin'))} / "
+        f"{_format_ratio(edge.get('right_margin'))}"
+    )
+
+
 def _count(value: int) -> str:
     return f"{value:,}"
 
@@ -1021,6 +1121,19 @@ def _int(value: Any) -> int:
         return int(value)
     except (TypeError, ValueError):
         return 0
+
+
+def _float(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
 
 
 def _positive_limit(value: Any) -> int:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -720,6 +720,7 @@ def build_ticket_faq_markdown(
             group_key = (topic, evidence_group_key or f"topic:{_compact_key(topic)}")
             source_date = _source_date(evidence) or _source_date(opportunity)
             groups[group_key].append({
+                "_semantic_row_id": f"row:{opportunity_index}:evidence:{evidence_index}",
                 "text": text,
                 "source_id": source_id or "unknown",
                 "source_key": source_key,
@@ -766,7 +767,14 @@ def build_ticket_faq_markdown(
     # untouched.
     subclustered_groups: dict[tuple[str, str], list[dict[str, str]]] = {}
     excluded_singleton_keys: set[str] = set()
+    semantic_merge_records: list[dict[str, Any]] = []
     non_repeat_question_count = 0
+
+    def record_semantic_merge(record: Mapping[str, Any]) -> None:
+        semantic_merge_records.append(dict(record))
+        if embedding_merge_recorder is not None:
+            embedding_merge_recorder(record)
+
     for (topic, scope), rows in groups.items():
         if not scope.startswith("topic:"):
             subclustered_groups[(topic, scope)] = rows
@@ -775,7 +783,7 @@ def build_ticket_faq_markdown(
             _question_subclusters(
                 rows,
                 embedding_port=embedding_port,
-                embedding_merge_recorder=embedding_merge_recorder,
+                embedding_merge_recorder=record_semantic_merge,
             )
         ):
             cluster_keys = _row_source_keys(cluster_rows)
@@ -834,6 +842,12 @@ def build_ticket_faq_markdown(
         )
         for topic, rows in selected_groups
     )
+    if semantic_merge_records:
+        items = _items_with_semantic_merge_provenance(
+            items,
+            selected_groups,
+            semantic_merge_records,
+        )
     return TicketFAQMarkdownResult(
         markdown=_render(title=title, items=items, source_count=len(opportunities), ticket_source_count=len(source_keys)),
         items=items,
@@ -849,6 +863,59 @@ def build_ticket_faq_markdown(
         ),
         warnings=tuple(warnings),
     )
+
+
+def _items_with_semantic_merge_provenance(
+    items: Sequence[dict[str, Any]],
+    selected_groups: Sequence[tuple[str, Sequence[Mapping[str, str]]]],
+    semantic_merge_records: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    out = [dict(item) for item in items]
+    for record in semantic_merge_records:
+        provenance = _semantic_merge_provenance(record)
+        if not provenance:
+            continue
+        left_row_id = _clean(record.get("left_row_id"))
+        right_row_id = _clean(record.get("right_row_id"))
+        if not left_row_id or not right_row_id:
+            continue
+        for item, (_topic, rows) in zip(out, selected_groups):
+            row_ids = {
+                _clean(row.get("_semantic_row_id"))
+                for row in rows
+                if _clean(row.get("_semantic_row_id"))
+            }
+            if left_row_id not in row_ids or right_row_id not in row_ids:
+                continue
+            existing = list(item.get("semantic_merge_provenance") or ())
+            existing.append(provenance)
+            item["semantic_merge_provenance"] = tuple(existing)
+            item["semantic_merge_count"] = len(existing)
+            break
+    return tuple(out)
+
+
+def _semantic_merge_provenance(record: Mapping[str, Any]) -> dict[str, Any]:
+    left = _clean(record.get("left_source_id"))
+    right = _clean(record.get("right_source_id"))
+    if not left or not right:
+        return {}
+    return {
+        "left_source_id": left,
+        "right_source_id": right,
+        "cosine": _rounded_float(record.get("cosine")),
+        "left_margin": _rounded_float(record.get("left_margin")),
+        "right_margin": _rounded_float(record.get("right_margin")),
+        "token_jaccard": _rounded_float(record.get("token_jaccard")),
+    }
+
+
+def _rounded_float(value: Any) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return 0.0
+    if not math.isfinite(float(value)):
+        return 0.0
+    return round(float(value), 4)
 
 
 def _normalize_max_items(max_items: int | None) -> int | None:
@@ -1082,6 +1149,8 @@ def _apply_embedding_booster(
                 embedding_merge_recorder({
                     "left_index": left,
                     "right_index": right,
+                    "left_row_id": _semantic_merge_row_id(rows[left], left),
+                    "right_row_id": _semantic_merge_row_id(rows[right], right),
                     "left_source_id": _embedding_merge_source_id(rows[left]),
                     "right_source_id": _embedding_merge_source_id(rows[right]),
                     "left_text": texts[left],
@@ -1101,6 +1170,10 @@ def _embedding_merge_source_id(row: Mapping[str, str]) -> str:
     if source_id and source_id.lower() != "unknown":
         return source_id
     return str(row.get("source_key") or "").strip()
+
+
+def _semantic_merge_row_id(row: Mapping[str, str], index: int) -> str:
+    return str(row.get("_semantic_row_id") or f"row-index:{index}").strip()
 
 
 def _topic(

--- a/plans/PR-Deflection-Semantic-Merge-Provenance.md
+++ b/plans/PR-Deflection-Semantic-Merge-Provenance.md
@@ -1,0 +1,115 @@
+# PR-Deflection-Semantic-Merge-Provenance
+
+## Why this slice exists
+
+#1547 completed the mxbai validation arc by proving the accepted semantic merge
+edges are coherent on the live CFPB sample. The remaining #1504 follow-up is
+buyer-facing semantic merge provenance: if the paid report uses an embedding
+edge to count two low-lexical-overlap tickets as one repeated question, the
+unlocked report should say that the grouping was supported by semantic matching
+and show inspectable, bounded evidence.
+
+This is the next vertical slice before any production flag decision because it
+keeps the booster auditable when enabled. It does not flip
+`ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED`, tune thresholds, or add a new
+model path.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Vertical slice
+
+1. Attach sanitized semantic-merge provenance from accepted embedding booster
+   edges to the FAQ item that contains both originating row ids.
+2. Add compact paid-report Markdown that summarizes semantic edges by question
+   with source ids, cosine, margins, and token-overlap context.
+3. Add summary counts so CLI/result consumers can tell whether semantic matching
+   contributed without parsing Markdown.
+4. Keep free snapshot projection locked: no semantic merge source ids, snippets,
+   or paid provenance leak into the pre-payment snapshot.
+5. Leave the route flag default, thresholds, and host model wiring unchanged.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Semantic-Merge-Provenance.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Only edges accepted by the existing embedding booster are recorded; no
+        new clustering heuristic is introduced.
+  - [ ] Provenance is attached only to rendered FAQ items whose originating row
+        ids contain both sides of the accepted edge, so duplicate source-id
+        pairs across multiple questions cannot misattribute provenance.
+  - [ ] Paid report output exposes compact semantic matching evidence without
+        requiring raw JSON artifacts.
+  - [ ] Free snapshot output continues to omit source ids, snippets, and
+        semantic merge details.
+  - [ ] Production defaults, thresholds, route flags, and host mxbai wiring stay
+        unchanged.
+- Affected surfaces: extracted FAQ item metadata, deflection paid-report summary
+  and Markdown, free snapshot projection tests.
+- Risk areas: misleading provenance, private text leakage, accidental behavior
+  change in no-embedding callers, schema drift for decoded input.
+- Reviewer rules triggered: R1, R2, R5, R10, R11, R12, R14.
+
+## Mechanism
+
+Keep the existing recorder callback as the source of truth. During FAQ build,
+assign each normalized evidence row an internal semantic row id, collect accepted
+semantic edges locally, and, after selected groups become FAQ items, attach each
+edge to the item whose selected rows contain both edge row ids. The attached
+item payload is sanitized to source ids plus scores/margins and token Jaccard;
+it must not carry the raw left/right text snippets or internal row ids from the
+recorder.
+
+The report summary derives aggregate semantic-match counts from item metadata.
+The paid Markdown gets a small provenance section after ranked opportunities.
+The free snapshot projection remains unchanged except for a regression test
+proving the semantic metadata is absent from its encoded payload.
+
+## Intentional
+
+- This PR adds provenance only for semantic edges that survive into rendered FAQ
+  items. Edges accepted inside an overflow group are still item-level provenance
+  for that overflow item; edges for excluded singletons do not render because
+  they did not contribute to a paid repeated-question item.
+- Raw `left_text` and `right_text` stay internal to validation callers from
+  #1547. The buyer-facing report uses source ids and numeric diagnostics so the
+  same path is safer for private support-ticket uploads.
+- No production flag flip. The report surface can describe semantic matching
+  when a caller enables the existing flag, but this slice does not change when
+  the booster runs.
+
+## Deferred
+
+- Operator decision for enabling
+  `ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED`.
+- Any threshold/margin tuning if future private-ticket validation finds bad
+  semantic matches.
+- UI-specific styling for semantic provenance in atlas-portfolio or
+  atlas-intel-ui; this PR lands the extracted report contract first.
+
+Parked hardening: none.
+
+## Verification
+
+- Review-fix regression and semantic provenance spot checks -- 3 passed.
+- Focused FAQ Markdown/report test files -- 295 passed.
+- Extracted pipeline checks -- 4136 passed, 10 skipped, 1 warning.
+- Local PR review bundle with planned PR body -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 113 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 75 |
+| `plans/PR-Deflection-Semantic-Merge-Provenance.md` | 115 |
+| `tests/test_content_ops_deflection_report.py` | 45 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 47 |
+| **Total** | **395** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -468,6 +468,51 @@ def test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions() -> 
     assert "ticket-sso-1" not in encoded
 
 
+def test_deflection_report_surfaces_paid_semantic_merge_provenance() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=2,
+        ticket_source_count=2,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "How do I request a refund?",
+                "weighted_frequency": 2,
+                "ticket_count": 2,
+                "source_ids": ("refund-a", "refund-b"),
+                "answer_evidence_status": "draft_needs_review",
+                "semantic_merge_provenance": (
+                    {
+                        "left_source_id": "refund-a",
+                        "right_source_id": "refund-b",
+                        "cosine": 0.9912,
+                        "left_margin": 0.1222,
+                        "right_margin": 0.1333,
+                        "token_jaccard": 0.0,
+                    },
+                ),
+            },
+        ),
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    snapshot = build_deflection_snapshot(artifact).as_dict()
+    encoded_snapshot = json.dumps(snapshot, sort_keys=True)
+
+    assert artifact.summary["semantic_merge_present"] is True
+    assert artifact.summary["semantic_merge_count"] == 1
+    assert artifact.summary["semantic_merge_question_count"] == 1
+    assert artifact.summary["semantic_merge_source_count"] == 2
+    assert "## Semantic Match Provenance" in artifact.markdown
+    assert "refund-a <-> refund-b" in artifact.markdown
+    assert "0.9912" in artifact.markdown
+    assert "0.1222 / 0.1333" in artifact.markdown
+    assert "semantic_merge_provenance" not in encoded_snapshot
+    assert "semantic_merge_count" not in encoded_snapshot
+    assert "refund-a" not in encoded_snapshot
+    assert "refund-b" not in encoded_snapshot
+
+
 def test_deflection_snapshot_exposes_complete_source_date_window() -> None:
     result = build_ticket_faq_markdown(
         [

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2218,6 +2218,16 @@ def test_embedding_booster_records_only_accepted_semantic_pairs() -> None:
 
     assert len(result.items) == 1
     assert result.items[0]["source_ids"] == ("refund-a", "refund-b")
+    assert result.items[0]["semantic_merge_count"] == 1
+    item_provenance = result.items[0]["semantic_merge_provenance"][0]
+    assert item_provenance["left_source_id"] == "refund-a"
+    assert item_provenance["right_source_id"] == "refund-b"
+    assert item_provenance["cosine"] > 0.99
+    assert item_provenance["left_margin"] > 0.9
+    assert item_provenance["right_margin"] > 0.9
+    assert item_provenance["token_jaccard"] == 0.0
+    assert "left_text" not in item_provenance
+    assert "right_text" not in item_provenance
     assert len(semantic_merges) == 1
     merge = semantic_merges[0]
     assert merge["left_source_id"] == "refund-a"
@@ -2259,6 +2269,43 @@ def test_embedding_booster_records_source_key_when_source_id_is_unknown() -> Non
     assert len(semantic_merges) == 1
     assert semantic_merges[0]["left_source_id"] == "row:1"
     assert semantic_merges[0]["right_source_id"] == "row:2"
+    assert result.items[0]["semantic_merge_provenance"][0]["left_source_id"] == "row:1"
+    assert result.items[0]["semantic_merge_provenance"][0]["right_source_id"] == "row:2"
+
+
+def test_embedding_booster_provenance_uses_row_identity_not_source_pair() -> None:
+    rows = [
+        {
+            "source_id": source_id,
+            "source_type": "support_ticket",
+            "support_ticket_cluster": cluster,
+            "text": text,
+        }
+        for source_id, cluster, text in (
+            ("s1", "export help", "How do I export my report?"),
+            ("s2", "export help", "How do I export my report?"),
+            ("s1", "refund help", "How do I get my money back?"),
+            ("s2", "refund help", "What is the process for a refund?"),
+        )
+    ]
+
+    result = build_ticket_faq_markdown(
+        rows,
+        max_items=0,
+        embedding_port=_StubEmbeddingPort({
+            "How do I get my money back?": (1.0, 0.0),
+            "What is the process for a refund?": (0.99, 0.01),
+        }),
+    )
+
+    by_topic = {item["topic"]: item for item in result.items}
+
+    assert by_topic["export help"]["source_ids"] == ("s1", "s2")
+    assert by_topic["refund help"]["source_ids"] == ("s1", "s2")
+    assert "semantic_merge_provenance" not in by_topic["export help"]
+    assert by_topic["refund help"]["semantic_merge_count"] == 1
+    assert by_topic["refund help"]["semantic_merge_provenance"][0]["left_source_id"] == "s1"
+    assert by_topic["refund help"]["semantic_merge_provenance"][0]["right_source_id"] == "s2"
 
 
 def test_embedding_booster_skips_malformed_vectors_without_merging() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Semantic-Merge-Provenance.md
Slice phase: Vertical slice
Reviewer rules triggered: R1, R2, R5, R10, R11, R12, R14.

This PR takes the next #1504 slice after the mxbai merge-quality proof: when the embedding booster contributes semantic edges to rendered FAQ items, the unlocked paid report now exposes compact semantic-match provenance without changing thresholds, route flags, host model wiring, or production defaults.

## Intentional

- Semantic provenance attaches only to rendered FAQ items whose originating row ids contain both sides of an accepted embedding edge; duplicate source-id pairs across multiple questions do not misattribute provenance.
- Paid report output uses source ids and numeric diagnostics only; raw recorder text snippets stay out of buyer-facing item metadata and Markdown.
- The free snapshot remains locked and does not expose source ids, semantic merge details, or paid provenance.
- No production flag flip in this PR.

## Deferred

- Operator decision for enabling `ATLAS_CONTENT_OPS_FAQ_EMBEDDING_BOOSTER_ENABLED`.
- Threshold or margin tuning if future private-ticket validation finds bad semantic matches.
- UI-specific styling in atlas-portfolio or atlas-intel-ui after the extracted report contract lands.

## Parked hardening

- None.

## Verification

- Review-fix regression and semantic provenance spot checks -- 3 passed.
- Focused FAQ Markdown/report test files -- 295 passed.
- Extracted pipeline checks -- 4136 passed, 10 skipped, 1 warning.
- Local PR review bundle with planned PR body -- passed.

## AI reconciliation

- Codex/owner provenance misattribution blocker fixed: semantic edge attachment now keys on the originating row ids captured from the accepted booster edge, with a duplicate source-pair regression proving the edge lands on the actual merged question.
- Buyer-surface raw score wording noted as a non-blocking product decision; this update leaves the current table unchanged.
- All findings fixed or waived: yes.

## Diff size

5 files, +394 / -1