### PR TITLE
Deflection delimiter vote reject

### DIFF
--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -20,6 +20,8 @@ from .campaign_ports import TenantScope
 CustomerDataFormat = Literal["auto", "json", "csv"]
 _CSV_DETECT_DELIMITERS = ",;\t|"
 _CSV_SNIFFER_SAMPLE_CHARS = 65_536
+_CSV_DELIMITER_SAMPLE_LINES = 100
+_CSV_DELIMITER_MIN_CONSISTENCY = 0.90
 _CSV_NUL_REDECODE_RATIO = 0.10
 _CSV_UTF16_NUL_SIDE_RATIO = 0.30
 _CSV_REPLACEMENT_WARNING_RATIO = 0.01
@@ -92,6 +94,31 @@ class CampaignOpportunityWarning:
         if self.field:
             data["field"] = self.field
         return data
+
+
+@dataclass(frozen=True)
+class _CsvDelimiterCandidate:
+    delimiter: str
+    header_index: int | None
+    header_width: int
+    data_rows: int
+    consistent_rows: int
+    first_offending_row: int | None
+
+    @property
+    def consistency(self) -> float:
+        if not self.data_rows:
+            return 1.0
+        return self.consistent_rows / self.data_rows
+
+    @property
+    def valid(self) -> bool:
+        return (
+            self.header_index is not None
+            and self.header_width >= 1
+            and (self.data_rows > 0 or self.header_index == 0)
+            and self.consistency >= _CSV_DELIMITER_MIN_CONSISTENCY
+        )
 
 
 @dataclass(frozen=True)
@@ -283,11 +310,13 @@ def _load_csv_dict_rows(
     text, decode_warnings = _read_csv_text(path)
     if not text.strip():
         raise ValueError("CSV customer data must include a header row.")
-    reader = csv.reader(StringIO(text), dialect=_detect_csv_dialect(text))
+    delimiter = _select_csv_delimiter(text).delimiter
+    reader = csv.reader(StringIO(text), dialect=_csv_delimiter_dialect(delimiter))
     raw_rows = list(reader)
     header_index = _csv_header_index(raw_rows)
     if header_index is None:
         raise ValueError("CSV customer data must include a header row.")
+    _validate_csv_column_consistency(raw_rows, header_index, delimiter=delimiter)
     load_warnings = decode_warnings + _leading_rows_skipped_warnings(
         raw_rows,
         header_index,
@@ -562,29 +591,148 @@ def _csv_decode_warnings(
     )
 
 
-def _detect_csv_dialect(text: str) -> csv.Dialect:
-    sample = text[:_CSV_SNIFFER_SAMPLE_CHARS]
-    try:
-        return _harden_csv_dialect(csv.Sniffer().sniff(
-            sample,
-            delimiters=_CSV_DETECT_DELIMITERS,
-        ))
-    except csv.Error:
-        return csv.excel
+def _select_csv_delimiter(text: str) -> _CsvDelimiterCandidate:
+    candidates = tuple(
+        _score_csv_delimiter(text, delimiter=delimiter)
+        for delimiter in _CSV_DETECT_DELIMITERS
+    )
+    valid = [candidate for candidate in candidates if candidate.valid]
+    if valid:
+        return max(valid, key=_csv_delimiter_candidate_key)
+    _raise_csv_delimiter_error(max(candidates, key=_csv_delimiter_candidate_key))
 
 
-def _harden_csv_dialect(dialect: csv.Dialect) -> type[csv.Dialect]:
-    class HardenedDialect(csv.Dialect):
-        delimiter = dialect.delimiter
-        quotechar = dialect.quotechar or '"'
-        escapechar = dialect.escapechar
-        doublequote = True
-        skipinitialspace = dialect.skipinitialspace
-        lineterminator = dialect.lineterminator
-        quoting = dialect.quoting
-        strict = False
+def _score_csv_delimiter(text: str, *, delimiter: str) -> _CsvDelimiterCandidate:
+    reader = csv.reader(
+        StringIO(_csv_delimiter_sample_text(text)),
+        dialect=_csv_delimiter_dialect(delimiter),
+    )
+    rows = list(reader)
+    header_index = _csv_header_index(rows)
+    return _csv_delimiter_candidate(rows, header_index, delimiter=delimiter)
 
-    return HardenedDialect
+
+def _csv_delimiter_candidate(
+    rows: Sequence[Sequence[Any]],
+    header_index: int | None,
+    *,
+    delimiter: str,
+) -> _CsvDelimiterCandidate:
+    header_width = len(rows[header_index]) if header_index is not None else 0
+    data_rows = 0
+    consistent_rows = 0
+    first_offending_row: int | None = None
+    if header_index is not None and header_width:
+        for row_number, row in enumerate(rows[header_index + 1:], start=header_index + 2):
+            if not any(str(value or "").strip() for value in row):
+                continue
+            data_rows += 1
+            if _csv_row_matches_delimiter(row, header_width, delimiter=delimiter):
+                consistent_rows += 1
+            elif first_offending_row is None:
+                first_offending_row = row_number
+    return _CsvDelimiterCandidate(
+        delimiter=delimiter,
+        header_index=header_index,
+        header_width=header_width,
+        data_rows=data_rows,
+        consistent_rows=consistent_rows,
+        first_offending_row=first_offending_row,
+    )
+
+
+def _csv_delimiter_candidate_key(
+    candidate: _CsvDelimiterCandidate,
+) -> tuple[bool, bool, float, int, int, int]:
+    return (
+        candidate.header_index is not None,
+        candidate.data_rows > 0,
+        candidate.consistency,
+        candidate.header_width,
+        candidate.consistent_rows,
+        -_CSV_DETECT_DELIMITERS.index(candidate.delimiter),
+    )
+
+
+def _csv_row_matches_delimiter(
+    row: Sequence[Any],
+    header_width: int,
+    *,
+    delimiter: str,
+) -> bool:
+    if len(row) == header_width:
+        return True
+    if len(row) > header_width:
+        return True
+    return not _csv_short_row_uses_competing_delimiter(row, delimiter=delimiter)
+
+
+def _csv_short_row_uses_competing_delimiter(
+    row: Sequence[Any],
+    *,
+    delimiter: str,
+) -> bool:
+    if len(row) != 1:
+        return False
+    text = str(row[0] or "")
+    return any(
+        candidate != delimiter and candidate in text
+        for candidate in _CSV_DETECT_DELIMITERS
+    )
+
+
+def _csv_delimiter_sample_text(text: str) -> str:
+    return "\n".join(text.splitlines()[:_CSV_DELIMITER_SAMPLE_LINES])
+
+
+def _csv_delimiter_dialect(delimiter: str) -> type[csv.Dialect]:
+    return type(
+        "CandidateDialect",
+        (csv.Dialect,),
+        {
+            "delimiter": delimiter,
+            "quotechar": '"',
+            "escapechar": None,
+            "doublequote": True,
+            "skipinitialspace": False,
+            "lineterminator": "\n",
+            "quoting": csv.QUOTE_MINIMAL,
+            "strict": False,
+        },
+    )
+
+
+def _validate_csv_column_consistency(
+    rows: Sequence[Sequence[Any]],
+    header_index: int,
+    *,
+    delimiter: str,
+) -> None:
+    candidate = _csv_delimiter_candidate(rows, header_index, delimiter=delimiter)
+    if candidate.valid:
+        return
+    _raise_csv_delimiter_error(candidate)
+
+
+def _raise_csv_delimiter_error(candidate: _CsvDelimiterCandidate) -> None:
+    delimiter_name = {
+        ",": "comma",
+        ";": "semicolon",
+        "\t": "tab",
+        "|": "pipe",
+    }.get(candidate.delimiter, repr(candidate.delimiter))
+    row_hint = (
+        f"; first inconsistent row {candidate.first_offending_row}"
+        if candidate.first_offending_row is not None
+        else ""
+    )
+    raise ValueError(
+        "CSV customer data has inconsistent column counts under the best "
+        f"delimiter candidate ({delimiter_name}); "
+        f"{candidate.consistent_rows}/{candidate.data_rows} data row(s) "
+        f"matched the {candidate.header_width}-column header{row_hint}. "
+        "Check the delimiter and header row."
+    )
 
 
 def _coerce_csv_value(value: Any) -> Any:

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -663,7 +663,10 @@ def _csv_delimiter_candidate(
             if not any(str(value or "").strip() for value in row):
                 continue
             data_rows += 1
-            collapsed = _csv_short_row_uses_competing_delimiter(row, delimiter=delimiter)
+            collapsed = (
+                header_width >= 2
+                and _csv_short_row_uses_competing_delimiter(row, delimiter=delimiter)
+            )
             if collapsed and first_collapsed_row is None:
                 first_collapsed_row = row_number
             if len(row) == header_width:

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -19,6 +19,7 @@ from .campaign_ports import TenantScope
 
 CustomerDataFormat = Literal["auto", "json", "csv"]
 _CSV_DETECT_DELIMITERS = ",;\t|"
+_CSV_DETECT_QUOTECHARS = ('"', "'")
 _CSV_SNIFFER_SAMPLE_CHARS = 65_536
 _CSV_DELIMITER_SAMPLE_LINES = 100
 _CSV_DELIMITER_MIN_CONSISTENCY = 0.90
@@ -99,11 +100,14 @@ class CampaignOpportunityWarning:
 @dataclass(frozen=True)
 class _CsvDelimiterCandidate:
     delimiter: str
+    quotechar: str
     header_index: int | None
     header_width: int
     data_rows: int
     consistent_rows: int
+    exact_width_rows: int
     first_offending_row: int | None
+    first_collapsed_row: int | None
 
     @property
     def consistency(self) -> float:
@@ -112,11 +116,18 @@ class _CsvDelimiterCandidate:
         return self.consistent_rows / self.data_rows
 
     @property
+    def exactness(self) -> float:
+        if not self.data_rows:
+            return 1.0
+        return self.exact_width_rows / self.data_rows
+
+    @property
     def valid(self) -> bool:
         return (
             self.header_index is not None
             and self.header_width >= 1
             and (self.data_rows > 0 or self.header_index == 0)
+            and self.first_collapsed_row is None
             and self.consistency >= _CSV_DELIMITER_MIN_CONSISTENCY
         )
 
@@ -310,13 +321,24 @@ def _load_csv_dict_rows(
     text, decode_warnings = _read_csv_text(path)
     if not text.strip():
         raise ValueError("CSV customer data must include a header row.")
-    delimiter = _select_csv_delimiter(text).delimiter
-    reader = csv.reader(StringIO(text), dialect=_csv_delimiter_dialect(delimiter))
+    candidate = _select_csv_delimiter(text)
+    reader = csv.reader(
+        StringIO(text),
+        dialect=_csv_delimiter_dialect(
+            candidate.delimiter,
+            quotechar=candidate.quotechar,
+        ),
+    )
     raw_rows = list(reader)
     header_index = _csv_header_index(raw_rows)
     if header_index is None:
         raise ValueError("CSV customer data must include a header row.")
-    _validate_csv_column_consistency(raw_rows, header_index, delimiter=delimiter)
+    _validate_csv_column_consistency(
+        raw_rows,
+        header_index,
+        delimiter=candidate.delimiter,
+        quotechar=candidate.quotechar,
+    )
     load_warnings = decode_warnings + _leading_rows_skipped_warnings(
         raw_rows,
         header_index,
@@ -593,8 +615,9 @@ def _csv_decode_warnings(
 
 def _select_csv_delimiter(text: str) -> _CsvDelimiterCandidate:
     candidates = tuple(
-        _score_csv_delimiter(text, delimiter=delimiter)
+        _score_csv_delimiter(text, delimiter=delimiter, quotechar=quotechar)
         for delimiter in _CSV_DETECT_DELIMITERS
+        for quotechar in _CSV_DETECT_QUOTECHARS
     )
     valid = [candidate for candidate in candidates if candidate.valid]
     if valid:
@@ -602,14 +625,24 @@ def _select_csv_delimiter(text: str) -> _CsvDelimiterCandidate:
     _raise_csv_delimiter_error(max(candidates, key=_csv_delimiter_candidate_key))
 
 
-def _score_csv_delimiter(text: str, *, delimiter: str) -> _CsvDelimiterCandidate:
+def _score_csv_delimiter(
+    text: str,
+    *,
+    delimiter: str,
+    quotechar: str,
+) -> _CsvDelimiterCandidate:
     reader = csv.reader(
         StringIO(_csv_delimiter_sample_text(text)),
-        dialect=_csv_delimiter_dialect(delimiter),
+        dialect=_csv_delimiter_dialect(delimiter, quotechar=quotechar),
     )
     rows = list(reader)
     header_index = _csv_header_index(rows)
-    return _csv_delimiter_candidate(rows, header_index, delimiter=delimiter)
+    return _csv_delimiter_candidate(
+        rows,
+        header_index,
+        delimiter=delimiter,
+        quotechar=quotechar,
+    )
 
 
 def _csv_delimiter_candidate(
@@ -617,40 +650,55 @@ def _csv_delimiter_candidate(
     header_index: int | None,
     *,
     delimiter: str,
+    quotechar: str,
 ) -> _CsvDelimiterCandidate:
     header_width = len(rows[header_index]) if header_index is not None else 0
     data_rows = 0
     consistent_rows = 0
+    exact_width_rows = 0
     first_offending_row: int | None = None
+    first_collapsed_row: int | None = None
     if header_index is not None and header_width:
         for row_number, row in enumerate(rows[header_index + 1:], start=header_index + 2):
             if not any(str(value or "").strip() for value in row):
                 continue
             data_rows += 1
+            collapsed = _csv_short_row_uses_competing_delimiter(row, delimiter=delimiter)
+            if collapsed and first_collapsed_row is None:
+                first_collapsed_row = row_number
+            if len(row) == header_width:
+                exact_width_rows += 1
             if _csv_row_matches_delimiter(row, header_width, delimiter=delimiter):
                 consistent_rows += 1
             elif first_offending_row is None:
                 first_offending_row = row_number
     return _CsvDelimiterCandidate(
         delimiter=delimiter,
+        quotechar=quotechar,
         header_index=header_index,
         header_width=header_width,
         data_rows=data_rows,
         consistent_rows=consistent_rows,
+        exact_width_rows=exact_width_rows,
         first_offending_row=first_offending_row,
+        first_collapsed_row=first_collapsed_row,
     )
 
 
 def _csv_delimiter_candidate_key(
     candidate: _CsvDelimiterCandidate,
-) -> tuple[bool, bool, float, int, int, int]:
+) -> tuple[bool, bool, bool, float, float, int, int, int, int]:
     return (
         candidate.header_index is not None,
         candidate.data_rows > 0,
+        candidate.first_collapsed_row is None,
         candidate.consistency,
+        candidate.exactness,
+        candidate.exact_width_rows,
         candidate.header_width,
         candidate.consistent_rows,
         -_CSV_DETECT_DELIMITERS.index(candidate.delimiter),
+        -_CSV_DETECT_QUOTECHARS.index(candidate.quotechar),
     )
 
 
@@ -685,13 +733,17 @@ def _csv_delimiter_sample_text(text: str) -> str:
     return "\n".join(text.splitlines()[:_CSV_DELIMITER_SAMPLE_LINES])
 
 
-def _csv_delimiter_dialect(delimiter: str) -> type[csv.Dialect]:
+def _csv_delimiter_dialect(
+    delimiter: str,
+    *,
+    quotechar: str,
+) -> type[csv.Dialect]:
     return type(
         "CandidateDialect",
         (csv.Dialect,),
         {
             "delimiter": delimiter,
-            "quotechar": '"',
+            "quotechar": quotechar,
             "escapechar": None,
             "doublequote": True,
             "skipinitialspace": False,
@@ -707,8 +759,14 @@ def _validate_csv_column_consistency(
     header_index: int,
     *,
     delimiter: str,
+    quotechar: str,
 ) -> None:
-    candidate = _csv_delimiter_candidate(rows, header_index, delimiter=delimiter)
+    candidate = _csv_delimiter_candidate(
+        rows,
+        header_index,
+        delimiter=delimiter,
+        quotechar=quotechar,
+    )
     if candidate.valid:
         return
     _raise_csv_delimiter_error(candidate)
@@ -722,7 +780,9 @@ def _raise_csv_delimiter_error(candidate: _CsvDelimiterCandidate) -> None:
         "|": "pipe",
     }.get(candidate.delimiter, repr(candidate.delimiter))
     row_hint = (
-        f"; first inconsistent row {candidate.first_offending_row}"
+        f"; first collapsed mixed-delimiter row {candidate.first_collapsed_row}"
+        if candidate.first_collapsed_row is not None
+        else f"; first inconsistent row {candidate.first_offending_row}"
         if candidate.first_offending_row is not None
         else ""
     )

--- a/plans/PR-Deflection-Delimiter-Vote-Reject.md
+++ b/plans/PR-Deflection-Delimiter-Vote-Reject.md
@@ -6,6 +6,8 @@ Issue #1459 is the next launch-readiness parser gap after #1455: the unified CSV
 
 Root cause: the CSV loader modeled delimiter detection as an opaque Sniffer choice rather than an explicit candidate contract, so it could not distinguish true delimiter evidence from free-text delimiter characters or report collapse. The review follow-up found the first implementation still treated a collapsed competing-delimiter row as a soft ratio miss, and modeled delimiter without quotechar, which was a symptom fix rather than the full parser contract. This PR fixes the root by making delimiter, quotechar, row-width fit, and collapsed-row detection part of one deterministic candidate model.
 
+Review follow-up root cause: a collapsed competing-delimiter row only exists when the expected table shape has multiple columns. The first hard-reject treated every single-cell row with delimiter-like text as collapse, which falsely rejected valid single-column `message` exports. The fix keeps the hard reject at the parser-candidate layer, but scopes it to `header_width >= 2`.
+
 Diff-size note: the review fix brings the slice above the 400 LOC soft cap because the root fix needs parser-state changes plus two regression fixtures: the >=90% collapsed-row boundary and single-quote quotechar preservation. Splitting those would leave one reviewed regression unprotected on the same import path.
 
 ## Scope (this PR)
@@ -24,6 +26,7 @@ Slice phase: Vertical slice
   - A semicolon-delimited support-ticket CSV still parses correctly through `load_source_rows_from_file`.
   - A malformed mixed-delimiter CSV fails with a clear delimiter/column-consistency error instead of returning one-column or misaligned rows.
   - A >=90% mostly-consistent CSV still fails if one row collapses into a competing-delimiter one-cell row.
+  - A valid single-column `message` CSV whose free-text data contains `;` or `,` still parses as one column.
   - Single-quote-quoted CSV fields with embedded commas continue to parse through the shared import path.
   - Campaign CSV loading continues to support semicolon exports through the same shared loader.
 - Affected surfaces:
@@ -64,23 +67,23 @@ Parked hardening: none.
 ## Verification
 
 - python -m py_compile extracted_content_pipeline/campaign_customer_data.py tests/test_extracted_campaign_source_adapters.py (pass)
-- pytest tests/test_extracted_campaign_source_adapters.py -q -k "delimiter or quote or multiline or semicolon" (6 passed, 79 deselected)
+- pytest tests/test_extracted_campaign_source_adapters.py -q -k "delimiter or quote or multiline or semicolon or single_column" (7 passed, 79 deselected)
 - pytest tests/test_build_deflection_messy_csv_fixtures.py -q -k "ragged_short_rows or ragged_extra_cells" (2 passed, 9 deselected)
 - pytest tests/test_smoke_content_ops_support_ticket_package.py -q -k "no_rows_survive" (1 passed, 17 deselected)
-- pytest tests/test_extracted_campaign_source_adapters.py -q (85 passed)
+- pytest tests/test_extracted_campaign_source_adapters.py -q (86 passed)
 - pytest tests/test_extracted_campaign_customer_data.py -q (10 passed)
 - pytest tests/test_build_deflection_messy_csv_fixtures.py -q (11 passed)
 - pytest tests/test_smoke_content_ops_support_ticket_package.py -q (18 passed)
 - pytest tests/test_extracted_content_deflection_submit.py -q -k "embedded_quotes_and_newlines" (1 passed, 53 deselected)
 - pytest tests/test_extracted_content_deflection_submit.py -q (54 passed)
 - bash scripts/check_ascii_python.sh (pass)
-- bash scripts/run_extracted_pipeline_checks.sh (4138 passed, 10 skipped, 1 warning)
+- bash scripts/run_extracted_pipeline_checks.sh (4139 passed, 10 skipped, 1 warning)
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/campaign_customer_data.py` | 256 |
-| `plans/PR-Deflection-Delimiter-Vote-Reject.md` | 86 |
-| `tests/test_extracted_campaign_source_adapters.py` | 99 |
-| **Total** | **441** |
+| `extracted_content_pipeline/campaign_customer_data.py` | 259 |
+| `plans/PR-Deflection-Delimiter-Vote-Reject.md` | 89 |
+| `tests/test_extracted_campaign_source_adapters.py` | 118 |
+| **Total** | **466** |

--- a/plans/PR-Deflection-Delimiter-Vote-Reject.md
+++ b/plans/PR-Deflection-Delimiter-Vote-Reject.md
@@ -4,13 +4,17 @@
 
 Issue #1459 is the next launch-readiness parser gap after #1455: the unified CSV loader must choose common help-desk delimiters deterministically and fail loud when no delimiter produces a consistent table. Current `main` already routes campaign and deflection source CSVs through `_load_csv_dict_rows`, but delimiter choice is still delegated to `csv.Sniffer` without a reported/reject branch, so a long free-text support-ticket body can still make delimiter behavior hard to reason about.
 
+Root cause: the CSV loader modeled delimiter detection as an opaque Sniffer choice rather than an explicit candidate contract, so it could not distinguish true delimiter evidence from free-text delimiter characters or report collapse. The review follow-up found the first implementation still treated a collapsed competing-delimiter row as a soft ratio miss, and modeled delimiter without quotechar, which was a symptom fix rather than the full parser contract. This PR fixes the root by making delimiter, quotechar, row-width fit, and collapsed-row detection part of one deterministic candidate model.
+
+Diff-size note: the review fix brings the slice above the 400 LOC soft cap because the root fix needs parser-state changes plus two regression fixtures: the >=90% collapsed-row boundary and single-quote quotechar preservation. Splitting those would leave one reviewed regression unprotected on the same import path.
+
 ## Scope (this PR)
 
 Ownership lane: content-ops/deflection-launch-readiness
 Slice phase: Vertical slice
 
 1. Replace the `csv.Sniffer` delimiter selection inside the shared `_load_csv_dict_rows` path with deterministic bounded delimiter voting over the parsed sample.
-2. Reject CSVs whose non-empty data rows cannot reach a >=90% delimiter-consistency threshold under the chosen delimiter, with the first offending line named in the error.
+2. Reject CSVs whose non-empty data rows cannot reach a >=90% delimiter-consistency threshold under the chosen delimiter, with the first offending line named in the error; hard-reject any collapsed competing-delimiter row regardless of the ratio.
 3. Prove that semicolon/tab text inside quoted support-ticket bodies does not override comma headers, and that genuinely inconsistent delimiter shapes fail before producing collapsed rows.
 
 ### Review Contract
@@ -19,6 +23,8 @@ Slice phase: Vertical slice
   - A comma-delimited support-ticket CSV whose quoted body contains semicolons and tabs still parses as comma-delimited rows.
   - A semicolon-delimited support-ticket CSV still parses correctly through `load_source_rows_from_file`.
   - A malformed mixed-delimiter CSV fails with a clear delimiter/column-consistency error instead of returning one-column or misaligned rows.
+  - A >=90% mostly-consistent CSV still fails if one row collapses into a competing-delimiter one-cell row.
+  - Single-quote-quoted CSV fields with embedded commas continue to parse through the shared import path.
   - Campaign CSV loading continues to support semicolon exports through the same shared loader.
 - Affected surfaces:
   - `extracted_content_pipeline/campaign_customer_data.py`
@@ -29,6 +35,7 @@ Slice phase: Vertical slice
   - Rejecting valid sparse rows that have fewer cells than the header.
   - Treating a later mixed-delimiter data row as a fallback header candidate.
   - Reintroducing nondeterministic or hard-to-debug delimiter behavior.
+  - Regressing quotechar support that `csv.Sniffer` previously inferred.
 - Reviewer rules triggered: R1, R2, R10, R13, R14.
 
 ### Files touched
@@ -39,7 +46,7 @@ Slice phase: Vertical slice
 
 ## Mechanism
 
-The loader parses the same bounded text sample against `,`, `;`, tab, and `|` using hardened CSV dialects. For each delimiter it scores non-empty rows by expected header width and delimiter consistency, ignoring blank rows and keeping quoted fields intact through Python's CSV parser. The best candidate wins only if it has a plausible header and at least 90% of non-empty data rows are consistent with the chosen delimiter. Short ragged rows remain allowed unless a one-cell row still contains a competing delimiter, which is the mixed-delimiter collapse case; extra cells keep the existing "more cells than the header" failure. If no candidate reaches the threshold, `_load_csv_dict_rows` raises `ValueError` with the selected/rejected delimiter context and the first offending row number. The rest of row cleaning stays unchanged.
+The loader parses the same bounded text sample against `,`, `;`, tab, and `|`, crossed with double-quote and single-quote dialects. For each candidate it scores non-empty rows by expected header width, exact-width fit, delimiter consistency, and hard collapsed-row detection, ignoring blank rows and keeping quoted fields intact through Python's CSV parser. The best candidate wins only if it has a plausible header, at least 90% of non-empty data rows are consistent with the chosen delimiter/quotechar, and no one-cell data row still contains a competing delimiter. Short ragged rows remain allowed unless a one-cell row still contains a competing delimiter, which is the mixed-delimiter collapse case; extra cells keep the existing "more cells than the header" failure unless another quotechar candidate parses them exactly. If no candidate reaches the threshold, `_load_csv_dict_rows` raises `ValueError` with the selected/rejected delimiter context and the first offending row number. The rest of row cleaning stays unchanged.
 
 ## Intentional
 
@@ -57,21 +64,23 @@ Parked hardening: none.
 ## Verification
 
 - python -m py_compile extracted_content_pipeline/campaign_customer_data.py tests/test_extracted_campaign_source_adapters.py (pass)
-- pytest tests/test_extracted_campaign_source_adapters.py -q -k "delimiter or multiline or semicolon" (4 passed, 79 deselected)
+- pytest tests/test_extracted_campaign_source_adapters.py -q -k "delimiter or quote or multiline or semicolon" (6 passed, 79 deselected)
 - pytest tests/test_build_deflection_messy_csv_fixtures.py -q -k "ragged_short_rows or ragged_extra_cells" (2 passed, 9 deselected)
 - pytest tests/test_smoke_content_ops_support_ticket_package.py -q -k "no_rows_survive" (1 passed, 17 deselected)
-- pytest tests/test_extracted_campaign_source_adapters.py -q (83 passed)
+- pytest tests/test_extracted_campaign_source_adapters.py -q (85 passed)
 - pytest tests/test_extracted_campaign_customer_data.py -q (10 passed)
 - pytest tests/test_build_deflection_messy_csv_fixtures.py -q (11 passed)
 - pytest tests/test_smoke_content_ops_support_ticket_package.py -q (18 passed)
+- pytest tests/test_extracted_content_deflection_submit.py -q -k "embedded_quotes_and_newlines" (1 passed, 53 deselected)
+- pytest tests/test_extracted_content_deflection_submit.py -q (54 passed)
 - bash scripts/check_ascii_python.sh (pass)
-- bash scripts/run_extracted_pipeline_checks.sh (4136 passed, 10 skipped, 1 warning)
+- bash scripts/run_extracted_pipeline_checks.sh (4138 passed, 10 skipped, 1 warning)
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/campaign_customer_data.py` | 196 |
-| `plans/PR-Deflection-Delimiter-Vote-Reject.md` | 77 |
-| `tests/test_extracted_campaign_source_adapters.py` | 54 |
-| **Total** | **327** |
+| `extracted_content_pipeline/campaign_customer_data.py` | 256 |
+| `plans/PR-Deflection-Delimiter-Vote-Reject.md` | 86 |
+| `tests/test_extracted_campaign_source_adapters.py` | 99 |
+| **Total** | **441** |

--- a/plans/PR-Deflection-Delimiter-Vote-Reject.md
+++ b/plans/PR-Deflection-Delimiter-Vote-Reject.md
@@ -1,0 +1,77 @@
+# PR-Deflection-Delimiter-Vote-Reject
+
+## Why this slice exists
+
+Issue #1459 is the next launch-readiness parser gap after #1455: the unified CSV loader must choose common help-desk delimiters deterministically and fail loud when no delimiter produces a consistent table. Current `main` already routes campaign and deflection source CSVs through `_load_csv_dict_rows`, but delimiter choice is still delegated to `csv.Sniffer` without a reported/reject branch, so a long free-text support-ticket body can still make delimiter behavior hard to reason about.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Replace the `csv.Sniffer` delimiter selection inside the shared `_load_csv_dict_rows` path with deterministic bounded delimiter voting over the parsed sample.
+2. Reject CSVs whose non-empty data rows cannot reach a >=90% delimiter-consistency threshold under the chosen delimiter, with the first offending line named in the error.
+3. Prove that semicolon/tab text inside quoted support-ticket bodies does not override comma headers, and that genuinely inconsistent delimiter shapes fail before producing collapsed rows.
+
+### Review Contract
+
+- Acceptance criteria:
+  - A comma-delimited support-ticket CSV whose quoted body contains semicolons and tabs still parses as comma-delimited rows.
+  - A semicolon-delimited support-ticket CSV still parses correctly through `load_source_rows_from_file`.
+  - A malformed mixed-delimiter CSV fails with a clear delimiter/column-consistency error instead of returning one-column or misaligned rows.
+  - Campaign CSV loading continues to support semicolon exports through the same shared loader.
+- Affected surfaces:
+  - `extracted_content_pipeline/campaign_customer_data.py`
+  - `tests/test_extracted_campaign_source_adapters.py`
+  - `tests/test_extracted_campaign_customer_data.py`
+- Risk areas:
+  - Breaking quoted multiline CSV rows.
+  - Rejecting valid sparse rows that have fewer cells than the header.
+  - Treating a later mixed-delimiter data row as a fallback header candidate.
+  - Reintroducing nondeterministic or hard-to-debug delimiter behavior.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `plans/PR-Deflection-Delimiter-Vote-Reject.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+
+## Mechanism
+
+The loader parses the same bounded text sample against `,`, `;`, tab, and `|` using hardened CSV dialects. For each delimiter it scores non-empty rows by expected header width and delimiter consistency, ignoring blank rows and keeping quoted fields intact through Python's CSV parser. The best candidate wins only if it has a plausible header and at least 90% of non-empty data rows are consistent with the chosen delimiter. Short ragged rows remain allowed unless a one-cell row still contains a competing delimiter, which is the mixed-delimiter collapse case; extra cells keep the existing "more cells than the header" failure. If no candidate reaches the threshold, `_load_csv_dict_rows` raises `ValueError` with the selected/rejected delimiter context and the first offending row number. The rest of row cleaning stays unchanged.
+
+## Intentional
+
+- This does not add caller-supplied delimiter hints in this slice; there is no current upload UI/control surface for one, and the launch blocker is silent autodetection/collapse.
+- This does not build the full unmapped-column report from #1457; that issue is claimed by another developer and should remain separate.
+- The reject branch is row-shape based rather than semantic. Header/body role mapping remains the job of the existing source-row adapter and the #1457 follow-up.
+
+## Deferred
+
+- #1457 remains the header/body-column admission report and Zendesk column mapping fix, currently claimed by another developer.
+- Caller-supplied delimiter overrides can be added later if the paid-tier UI exposes an explicit advanced import control.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m py_compile extracted_content_pipeline/campaign_customer_data.py tests/test_extracted_campaign_source_adapters.py (pass)
+- pytest tests/test_extracted_campaign_source_adapters.py -q -k "delimiter or multiline or semicolon" (4 passed, 79 deselected)
+- pytest tests/test_build_deflection_messy_csv_fixtures.py -q -k "ragged_short_rows or ragged_extra_cells" (2 passed, 9 deselected)
+- pytest tests/test_smoke_content_ops_support_ticket_package.py -q -k "no_rows_survive" (1 passed, 17 deselected)
+- pytest tests/test_extracted_campaign_source_adapters.py -q (83 passed)
+- pytest tests/test_extracted_campaign_customer_data.py -q (10 passed)
+- pytest tests/test_build_deflection_messy_csv_fixtures.py -q (11 passed)
+- pytest tests/test_smoke_content_ops_support_ticket_package.py -q (18 passed)
+- bash scripts/check_ascii_python.sh (pass)
+- bash scripts/run_extracted_pipeline_checks.sh (4136 passed, 10 skipped, 1 warning)
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_customer_data.py` | 196 |
+| `plans/PR-Deflection-Delimiter-Vote-Reject.md` | 77 |
+| `tests/test_extracted_campaign_source_adapters.py` | 54 |
+| **Total** | **327** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -246,6 +246,60 @@ def test_load_source_rows_from_semicolon_csv_detects_support_ticket_export(
     }]
 
 
+def test_load_source_rows_keeps_comma_delimiter_when_body_has_tabs_semicolons(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets.csv"
+    path.write_text(
+        "\n".join([
+            "ticket_id,subject,message",
+            (
+                'ticket-1,Export help,"Clicked reports; exports; analytics\t'
+                'but the download still fails"'
+            ),
+            (
+                'ticket-2,Billing help,"Invoice tab\tshows paid; portal says due"'
+            ),
+        ]),
+        encoding="utf-8",
+    )
+
+    rows = load_source_rows_from_file(path, file_format="csv")
+
+    assert rows == [
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Export help",
+            "message": (
+                "Clicked reports; exports; analytics\t"
+                "but the download still fails"
+            ),
+        },
+        {
+            "ticket_id": "ticket-2",
+            "subject": "Billing help",
+            "message": "Invoice tab\tshows paid; portal says due",
+        },
+    ]
+
+
+def test_load_source_rows_rejects_inconsistent_mixed_delimiters(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_mixed_delimiters.csv"
+    path.write_text(
+        "\n".join([
+            "ticket_id,subject,message",
+            "ticket-1,Export help,How do I export reports?",
+            "ticket-2;Billing help;Invoice portal is wrong",
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="inconsistent column counts"):
+        load_source_rows_from_file(path, file_format="csv")
+
+
 def test_load_source_rows_preserves_quoted_commas_and_multiline_text(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -300,6 +300,51 @@ def test_load_source_rows_rejects_inconsistent_mixed_delimiters(
         load_source_rows_from_file(path, file_format="csv")
 
 
+def test_load_source_rows_rejects_collapsed_mixed_delimiter_at_threshold(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_mixed_delimiters.csv"
+    lines = ["ticket_id,subject,message"]
+    lines.extend(
+        f"ticket-{index},Export help,How do I export report {index}?"
+        for index in range(1, 10)
+    )
+    lines.append("ticket-bad;Billing help;Invoice portal is wrong")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="first collapsed mixed-delimiter row 11"):
+        load_source_rows_from_file(path, file_format="csv")
+
+
+def test_load_source_rows_preserves_single_quote_quoted_commas(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_single_quote.csv"
+    path.write_text(
+        "\n".join([
+            "ticket_id,subject,message",
+            "ticket-1,Export help,'How do I export, then download?'",
+            "ticket-2,Billing help,'Invoice portal says paid, then due'",
+        ]),
+        encoding="utf-8",
+    )
+
+    rows = load_source_rows_from_file(path, file_format="csv")
+
+    assert rows == [
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Export help",
+            "message": "How do I export, then download?",
+        },
+        {
+            "ticket_id": "ticket-2",
+            "subject": "Billing help",
+            "message": "Invoice portal says paid, then due",
+        },
+    ]
+
+
 def test_load_source_rows_preserves_quoted_commas_and_multiline_text(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -316,6 +316,25 @@ def test_load_source_rows_rejects_collapsed_mixed_delimiter_at_threshold(
         load_source_rows_from_file(path, file_format="csv")
 
 
+def test_load_source_rows_allows_single_column_message_with_delimiters(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_ticket_messages.csv"
+    path.write_text(
+        "\n".join([
+            "message",
+            "I tried A; then B failed, and setup still loops",
+        ]),
+        encoding="utf-8",
+    )
+
+    rows = load_source_rows_from_file(path, file_format="csv")
+
+    assert rows == [{
+        "message": "I tried A; then B failed, and setup still loops",
+    }]
+
+
 def test_load_source_rows_preserves_single_quote_quoted_commas(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delimiter-Vote-Reject.md
Slice phase: Vertical slice

Issue #1459 is the next launch-readiness parser gap after #1455: the unified CSV loader must choose common help-desk delimiters deterministically and fail loud when no delimiter produces a consistent table. This replaces `csv.Sniffer` in the shared CSV path with deterministic delimiter/quotechar candidate voting, keeps quoted support-ticket body delimiters from overriding the real header delimiter, and rejects mixed-delimiter collapse before rows silently turn partial.

Root cause: the loader previously treated delimiter detection as an opaque Sniffer result, not an explicit parser contract. The review caught that the first deterministic pass still handled collapse as a soft ratio miss and modeled delimiter without quotechar. This update fixes the root by scoring delimiter, quotechar, exact row-width fit, consistency, and collapsed-row detection in one candidate model.

## Intentional
- This does not add caller-supplied delimiter hints in this slice; there is no current upload UI/control surface for one, and the launch blocker is silent autodetection/collapse.
- This does not build the full unmapped-column report from #1457; that issue is claimed by another developer and should remain separate.
- The reject branch is row-shape based rather than semantic. Header/body role mapping remains the job of the existing source-row adapter and the #1457 follow-up.
- The slice is above the 400 LOC soft cap because both review findings are regressions on the same shared import path; splitting would leave one parser contract hole unprotected.

## Deferred
- #1457 remains the header/body-column admission report and Zendesk column mapping fix, currently claimed by another developer.
- Caller-supplied delimiter overrides can be added later if the paid-tier UI exposes an explicit advanced import control.

## Parked hardening
- None.

## Review feedback addressed
- P1/BLOCKER: collapsed competing-delimiter rows are now hard-rejected even when the file remains >=90% consistent; regression test covers the 9/10 boundary.
- P2/MAJOR: single-quote quoted CSV fields with embedded commas parse again through quotechar-aware candidate scoring.
- Re-review MAJOR: single-column `message` CSVs with free-text delimiters now remain valid; collapsed-row hard rejection applies only when the expected header shape has multiple columns.

## Verification
- `python -m py_compile extracted_content_pipeline/campaign_customer_data.py tests/test_extracted_campaign_source_adapters.py` (pass)
- `pytest tests/test_extracted_campaign_source_adapters.py -q -k "delimiter or quote or multiline or semicolon or single_column"` (7 passed, 79 deselected)
- `pytest tests/test_build_deflection_messy_csv_fixtures.py -q -k "ragged_short_rows or ragged_extra_cells"` (2 passed, 9 deselected)
- `pytest tests/test_smoke_content_ops_support_ticket_package.py -q -k "no_rows_survive"` (1 passed, 17 deselected)
- `pytest tests/test_extracted_campaign_source_adapters.py -q` (86 passed)
- `pytest tests/test_extracted_campaign_customer_data.py -q` (10 passed)
- `pytest tests/test_build_deflection_messy_csv_fixtures.py -q` (11 passed)
- `pytest tests/test_smoke_content_ops_support_ticket_package.py -q` (18 passed)
- `pytest tests/test_extracted_content_deflection_submit.py -q -k "embedded_quotes_and_newlines"` (1 passed, 53 deselected)
- `pytest tests/test_extracted_content_deflection_submit.py -q` (54 passed)
- `bash scripts/check_ascii_python.sh` (pass)
- `bash scripts/run_extracted_pipeline_checks.sh` (4139 passed, 10 skipped, 1 warning)

## Diff size
3 files, +442 / -24

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: Codex P1 collapsed mixed-delimiter row, Codex P2 single-quote quotechar regression, and human re-review single-column false-positive regression.