### PR TITLE
Deflection customer wording PII headings

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -41,15 +41,6 @@ register under `docs/technical-debt/`.
 - Owner/session: Codex deflection/clustering
 - Found during: PR-Deflection-Repeat-Metric-Alignment
 
-### Customer-wording FAQ headings can publish raw PII
-- File/location: `extracted_content_pipeline/ticket_faq_markdown.py` customer-wording question extraction path.
-- Description: The representative-label path now renders only known-safe documentation/glossary terms, but the pre-existing customer-wording path can still promote raw row text containing PII into published FAQ question headings.
-- Why it matters: Deflection FAQ output is buyer-facing/publishable; names, emails, account numbers, or similar customer identifiers in headings are a privacy exposure.
-- Effort: M
-- Category: security
-- Owner/session: Codex deflection/clustering
-- Found during: PR-Deflection-Representative-Question-Labels review
-
 ### Safe-vocabulary representative label collisions render duplicate FAQ headings
 - File/location: `extracted_content_pipeline/ticket_faq_markdown.py` representative source-policy label fallback.
 - Description: Distinct topic-degraded subclusters that resolve to the same safe documentation/glossary label can still render as separate FAQ items with identical headings. This preserves evidence and count truthfully, but leaves duplicate-looking entries.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -57,6 +57,16 @@ _CUSTOMER_SPEAKERS = {"customer", "user", "requester", "client"}
 _SUPPORTED_QUESTION_SOURCES = {"customer_wording", "source_policy"}
 _REPRESENTATIVE_EMAIL_RE = re.compile(r"\b\S+@\S+\b")
 _REPRESENTATIVE_LONG_NUMBER_RE = re.compile(r"\b\d{4,}\b")
+_CUSTOMER_HEADING_PHONE_RE = re.compile(
+    r"(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b"
+)
+_CUSTOMER_IDENTIFIER_NUMBER_RE = re.compile(
+    r"\b(?:account|acct|case|claim|confirmation|customer|id|invoice|member|"
+    r"number|order|ref|reference|ticket)\s*(?:id|number|no\.?|#)?\s*[:#-]?\s*\d{4,}\b"
+    r"|\b\d{4,}\s*(?:account|acct|case|claim|customer|invoice|member|order|ref|reference|ticket)\b",
+    re.IGNORECASE,
+)
+_PUBLISHED_TEXT_PRIVACY_PLACEHOLDER = "Customer-provided details omitted for privacy."
 _REPRESENTATIVE_LABEL_SOURCE_TYPES = {
     "ticket",
     "support_ticket",
@@ -1121,7 +1131,10 @@ def _topic(
             text = _compact(value)
             if text:
                 return text.lower()
-    return (_compact(evidence.get("source_title") or opportunity.get("source_title")) or "customer support issues").lower()
+    fallback_topic = _published_customer_text(
+        evidence.get("source_title") or opportunity.get("source_title")
+    )
+    return (fallback_topic or "customer support issues").lower()
 
 
 def _provided_support_ticket_cluster_topic(
@@ -1247,10 +1260,17 @@ def _item(
     sources = tuple(_source_label(row) for row in display_rows)
     source_keys = (row.get("source_key") or row.get("source_id", "") for row in rows)
     source_ids = tuple(dict.fromkeys(value for value in source_keys if value))
-    snippets = " / ".join(_quote(row.get("text", "")) for row in display_rows)
+    snippets = " / ".join(_published_customer_quote(row.get("text", "")) for row in display_rows)
     action_context = " / ".join((
         snippets,
-        " / ".join(_clean(row.get("source_title")) for row in display_rows if _clean(row.get("source_title"))),
+        " / ".join(
+            title
+            for title in (
+                _published_customer_text(row.get("source_title"))
+                for row in display_rows
+            )
+            if title
+        ),
     ))
     question, question_source, question_row = _resolve_question_label(
         topic,
@@ -2199,7 +2219,7 @@ def _question(
     documentation_terms: Sequence[str],
 ) -> tuple[str, str, Mapping[str, str] | None]:
     for row in rows:
-        text = _question_text(row.get("text", ""))
+        text = _publishable_customer_question_text(row.get("text", ""))
         if text:
             return (text, "customer_wording", row)
     representative_question = _representative_source_question(
@@ -2330,28 +2350,47 @@ def _rows_with_question_source_first(
 
 
 def _question_text(value: Any) -> str:
+    return _question_text_matching(value, _usable_question)
+
+
+def _publishable_customer_question_text(value: Any) -> str:
+    return _question_text_matching(
+        value,
+        _usable_customer_heading_question,
+        context_predicate=lambda text: not _has_customer_heading_pii(text),
+    )
+
+
+def _question_text_matching(
+    value: Any,
+    predicate: Callable[[str], bool],
+    *,
+    context_predicate: Callable[[str], bool] | None = None,
+) -> str:
     for text in _question_candidate_texts(value):
+        if context_predicate is not None and not context_predicate(text):
+            continue
         if "?" in text:
             prefix, remainder = text.split("?", 1)
             prefix = prefix.strip()
             sentence_parts = [part.strip() for part in re.split(r"[.!:;]+", prefix) if part.strip()]
             candidate = sentence_parts[-1] if sentence_parts else prefix
             normalized = _normalize_question_text(candidate)
-            if _usable_question(normalized):
+            if predicate(normalized):
                 return normalized
             tail = _compact(remainder)
             if tail:
-                normalized = _question_start_text(tail)
+                normalized = _question_start_text(tail, predicate=predicate)
                 if normalized:
                     return normalized
-                normalized = _first_person_issue_question_text(tail)
+                normalized = _first_person_issue_question_text(tail, predicate=predicate)
                 if normalized:
                     return normalized
             continue
-        normalized = _question_start_text(text)
+        normalized = _question_start_text(text, predicate=predicate)
         if normalized:
             return normalized
-        normalized = _first_person_issue_question_text(text)
+        normalized = _first_person_issue_question_text(text, predicate=predicate)
         if normalized:
             return normalized
     return ""
@@ -2383,17 +2422,27 @@ def _question_segment(value: str) -> str:
     return _compact(_URL_RE.sub("", value))
 
 
-def _question_start_text(text: str) -> str:
+def _question_start_text(
+    text: str,
+    *,
+    predicate: Callable[[str], bool] | None = None,
+) -> str:
+    resolved_predicate = predicate or _usable_question
     question_starts = ("how ", "what ", "where ", "when ", "why ", "can ", "could ", "do ", "does ", "is ")
     lowered = text.lower()
     if lowered.startswith(question_starts):
         normalized = _normalize_question_text(text)
-        if _usable_question(normalized):
+        if resolved_predicate(normalized):
             return normalized
     return ""
 
 
-def _first_person_issue_question_text(text: str) -> str:
+def _first_person_issue_question_text(
+    text: str,
+    *,
+    predicate: Callable[[str], bool] | None = None,
+) -> str:
+    resolved_predicate = predicate or _usable_question
     sentence = _first_sentence(text)
     lowered = sentence.lower()
     patterns = (
@@ -2418,7 +2467,7 @@ def _first_person_issue_question_text(text: str) -> str:
         if lowered.startswith(prefix):
             remainder = sentence[len(prefix):].strip()
             normalized = _normalize_question_text(f"{question_prefix}{remainder}")
-            if _usable_question(normalized):
+            if resolved_predicate(normalized):
                 return normalized
     complaint_patterns = (
         ("i was ", "What should I do if I was "),
@@ -2436,7 +2485,7 @@ def _first_person_issue_question_text(text: str) -> str:
         if lowered.startswith(prefix):
             remainder = sentence[len(prefix):].strip()
             normalized = _normalize_question_text(f"{question_prefix}{remainder}")
-            if _usable_question(normalized):
+            if resolved_predicate(normalized):
                 return normalized
     return ""
 
@@ -2454,6 +2503,38 @@ def _usable_question(value: str) -> bool:
         and lowered not in _GENERIC_QUESTION_TEXTS
         and not any(phrase in lowered for phrase in _GENERIC_QUESTION_PHRASES)
         and not _looks_malformed_question(value)
+    )
+
+
+def _usable_customer_heading_question(value: str) -> bool:
+    return _usable_question(value) and not _has_customer_heading_pii(value)
+
+
+def _has_customer_heading_pii(value: Any) -> bool:
+    return _has_published_customer_text_pii(value)
+
+
+def _published_customer_text(value: Any) -> str:
+    text = support_ticket_plain_text(value)
+    if not text or _has_published_customer_text_pii(text):
+        return ""
+    return text
+
+
+def _published_customer_quote(value: Any, *, limit: int = 220) -> str:
+    text = _published_customer_text(value)
+    if not text:
+        return _PUBLISHED_TEXT_PRIVACY_PLACEHOLDER
+    return _quote(text, limit=limit)
+
+
+def _has_published_customer_text_pii(value: Any) -> bool:
+    text = support_ticket_plain_text(value)
+    return bool(
+        _REPRESENTATIVE_EMAIL_RE.search(text)
+        or _CUSTOMER_IDENTIFIER_NUMBER_RE.search(text)
+        or _CUSTOMER_HEADING_PHONE_RE.search(text)
+        or _REDACTION_TOKEN_RE.search(text)
     )
 
 
@@ -2564,7 +2645,7 @@ def _render(
 
 def _source_label(row: Mapping[str, str]) -> str:
     source_id = _clean(row.get("source_id"))
-    title = _clean(row.get("source_title"))
+    title = _published_customer_text(row.get("source_title"))
     if source_id and title:
         return f"`{source_id}` - {title}"
     return f"`{source_id or 'unknown'}`"
@@ -2627,7 +2708,11 @@ def _summary(
     question_source: str,
 ) -> str:
     issue = _topic_label(topic)
-    example = _quote(rows[0].get("text", ""), limit=180) if rows else "the cited ticket evidence"
+    example = (
+        _published_customer_quote(rows[0].get("text", ""), limit=180)
+        if rows
+        else "the cited ticket evidence"
+    )
     if source_count > 1:
         if question_source != "customer_wording":
             return (
@@ -2812,7 +2897,7 @@ def _support_sentence(support_contact: str | None) -> str:
 
 def _evidence_quote(row: Mapping[str, str]) -> str:
     label = _source_label(row)
-    text = _quote(row.get("text", ""), limit=220)
+    text = _published_customer_quote(row.get("text", ""), limit=220)
     return f"{label}: {text}"
 
 

--- a/plans/PR-Deflection-Customer-Wording-PII-Headings.md
+++ b/plans/PR-Deflection-Customer-Wording-PII-Headings.md
@@ -1,0 +1,122 @@
+# PR-Deflection-Customer-Wording-PII-Headings
+
+## Why this slice exists
+
+The next deflection/clustering hardening target started as the parked security
+item `Customer-wording FAQ headings can publish raw PII`. Review showed heading
+admission was only one path to the real defect: raw customer-derived free text
+also reached buyer-facing output through fallback topics, evidence quotes,
+source titles, summaries, and action context.
+
+Root cause: the FAQ renderer has no shared "published customer text" boundary.
+Different render surfaces independently decide whether to emit raw uploaded
+text. A heading-only denylist fixes one symptom while leaving the true upstream
+cause in place.
+
+This fixes the root inside this renderer with one shared buyer-facing
+customer-text gate before Markdown-facing fields are built. It is not global
+ingestion redaction; other products that publish raw support-ticket text need
+their own upstream privacy issue.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Production hardening
+
+1. Add a shared published-customer-text gate for FAQ Markdown-facing fields.
+2. Block emails, phone-shaped numbers, redaction artifacts, and long numbers
+   only in identifier contexts such as account, case, order, reference, or
+   ticket.
+3. Apply the gate to customer-wording question selection, source-title topic
+   fallback, source labels, evidence quotes, summaries, and action context.
+4. Add focused tests for unsafe heading/body text, safe customer wording, safe
+   form/year numbers, and fallback stability.
+5. Remove the closed renderer PII hardening item from `HARDENING.md`.
+
+### Files touched
+
+- `HARDENING.md`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Customer-Wording-PII-Headings.md`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Customer-wording questions containing emails, identifier-context long
+        numbers, phone-shaped numbers, or redaction artifacts are not selected.
+  - [ ] Safe customer wording still renders as customer wording, including
+        non-identifier four-digit terms such as tax forms or years.
+  - [ ] Unsafe customer wording falls through to existing source-policy or
+        generic fallback rather than being rewritten.
+  - [ ] Unsafe source titles cannot become fallback topic headings.
+  - [ ] Unsafe source titles and evidence snippets do not render in buyer-facing
+        Markdown source lines.
+  - [ ] The representative-label behavior from the prior slice is unchanged.
+- Affected surfaces: ticket FAQ Markdown item question selection and focused
+  extracted-package tests.
+- Risk areas: buyer-facing FAQ headings, source-policy fallback stability,
+  customer-vocabulary retention, source-line privacy, and false positives on
+  normal account/login/year/form wording.
+- Reviewer rules triggered: R1, R2, R3, R10, R13, R14.
+
+## Mechanism
+
+The renderer now has one helper that returns customer-derived text only when it
+is safe for buyer-facing output. The question resolver uses it at candidate
+admission time and checks source context before punctuation splitting, so an
+email cannot be reduced to a clean-looking fragment. Source-title fallback
+topics, source labels, evidence quote text, summary examples, and action context
+use the same helper.
+
+The safety check blocks emails, phone-shaped numbers, redaction artifacts, and
+long numbers in identifier contexts. Generic `account`, `email`, `login`, and
+`password` wording remains allowed, as do non-identifier numbers such as `1099`
+or `2024`.
+
+If every customer-wording candidate is skipped, existing source-policy fallback
+handles the question. Unsafe evidence/source titles render as source ID plus a
+privacy placeholder.
+
+## Intentional
+
+- **No per-surface heading scrub.** This is a shared renderer boundary, not a
+  one-off post-render heading rewrite.
+- **No broad ban on customer vocabulary.** Safe terms and bare long numbers
+  without identifier context stay valid by accepted precision trade.
+- **No global ingestion redaction.** This slice owns the FAQ Markdown renderer;
+  other raw-text publishing products need separate privacy follow-up.
+- **No duplicate-label work.** That is a controlled-vocabulary collision issue,
+  not a reason to merge groups again.
+- **No metric/copy alignment work.** #1533 already landed that item.
+- **No embedding-booster work.** The operator stopped further embedding-booster
+  buildout unless a new explicit enablement/calibration decision is made.
+
+## Deferred
+
+- Safe-vocabulary representative label collision handling. Root cause: distinct
+  kept subclusters can resolve to the same controlled-vocabulary label because
+  the labeler has no disambiguation term after privacy-safe token selection.
+
+Parked hardening: `Safe-vocabulary representative label collisions render
+duplicate FAQ headings`.
+
+## Verification
+
+- Command passed: pytest targeted PII/body and nearby representative-label regressions -- 11 passed.
+- Command passed: python -m py_compile for the touched Python files.
+- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py -q -- 261 passed.
+- Command passed: bash scripts/check_ascii_python.sh.
+- Command passed: git diff --check.
+- Command passed: bash scripts/run_extracted_pipeline_checks.sh -- 4143 passed, 10 skipped, 1 warning.
+- Command passed: bash scripts/local_pr_review.sh --current-pr-body-file tmp/deflection_customer_wording_pii_headings_pr_body.md.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `HARDENING.md` | 9 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 119 |
+| `plans/PR-Deflection-Customer-Wording-PII-Headings.md` | 122 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 149 |
+| **Total** | **399** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -1771,6 +1771,155 @@ def test_build_ticket_faq_markdown_uses_safe_terms_instead_of_pii_source_title()
     assert "chen" not in result.items[0]["question"].lower()
 
 
+@pytest.mark.parametrize(
+    ("unsafe_question", "blocked_fragment"),
+    (
+        ("How do I reset the password for jane.doe@acme.com?", "jane"),
+        ("How do I reset the password for account 4829103?", "4829103"),
+        ("How do I reset the password for 555-123-4567?", "555"),
+        ("How do I reset the password for XXXXX?", "xxxxx"),
+    ),
+)
+def test_build_ticket_faq_markdown_does_not_publish_pii_customer_wording_headings(
+    unsafe_question: str,
+    blocked_fragment: str,
+) -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Password reset",
+                "text": unsafe_question,
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Password reset",
+                "text": unsafe_question,
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == "What should I do about technical support?"
+    assert result.items[0]["question_source"] == "source_policy"
+    assert blocked_fragment not in result.items[0]["question"].lower()
+    assert f"## 1. {unsafe_question}" not in result.markdown
+    assert "## 1. What should I do about technical support?" in result.markdown
+
+
+def test_build_ticket_faq_markdown_does_not_publish_pii_fallback_topic_or_body_text() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Case for jane.doe@acme.com",
+                "text": "How can jane.doe@acme.com get help?",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Case for jane.doe@acme.com",
+                "text": "How can jane.doe@acme.com get help?",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == "What should I do about customer support issues?"
+    assert result.items[0]["question_source"] == "source_policy"
+    assert result.items[0]["evidence_quotes"] == (
+        "`ticket-1`: Customer-provided details omitted for privacy.",
+        "`ticket-2`: Customer-provided details omitted for privacy.",
+    )
+    assert "jane" not in result.markdown.lower()
+    assert "acme" not in result.markdown.lower()
+    assert "Case for" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_keeps_safe_customer_wording_with_account_terms() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Account email",
+                "text": "How do I update the account email?",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Account email",
+                "text": "How do I update the account email?",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == "How do I update the account email?"
+    assert result.items[0]["question_source"] == "customer_wording"
+
+
+@pytest.mark.parametrize(
+    "safe_question",
+    (
+        "How do I download my 1099?",
+        "How do I update the 2024 pricing?",
+    ),
+)
+def test_build_ticket_faq_markdown_keeps_non_identifier_numbers_in_customer_wording(
+    safe_question: str,
+) -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Safe numeric question",
+                "text": safe_question,
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Safe numeric question",
+                "text": safe_question,
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == safe_question
+    assert result.items[0]["question_source"] == "customer_wording"
+
+
+def test_build_ticket_faq_markdown_skips_unsafe_question_then_uses_safe_customer_wording() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "text": "How do I reset the password for account 4829103?",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "text": "How do I reset the password?",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == "How do I reset the password?"
+    assert result.items[0]["question_source"] == "customer_wording"
+    assert "4829103" not in result.items[0]["question"]
+
+
 def test_build_ticket_faq_markdown_ignores_clean_source_title_without_safe_vocabulary() -> None:
     result = build_ticket_faq_markdown(
         [


### PR DESCRIPTION
Plan: plans/PR-Deflection-Customer-Wording-PII-Headings.md
Slice phase: Production hardening
Reviewer rules triggered: R1, R2, R3, R10, R13, R14.

This PR closes the parked security hardening item where customer-derived FAQ text could publish raw PII. Root cause: the FAQ renderer had no shared published-customer-text boundary, so raw uploaded text could reach buyer-facing headings, fallback topics, source labels, evidence quotes, summaries, and action context through separate paths. The fix applies one shared buyer-facing text gate across those renderer surfaces.

## Intentional

- No per-surface heading scrub; unsafe customer text is skipped or replaced before Markdown-facing fields are built.
- No broad ban on customer vocabulary; generic account/login/email wording and safe form/year numbers remain eligible when they contain no concrete identifier.
- No global ingestion redaction; this PR owns the FAQ Markdown renderer, and other raw-text publishing products need separate privacy follow-up.
- No duplicate-label work in this slice; that is a controlled-vocabulary collision/disambiguation follow-up, not a security fix.
- No metric/copy alignment work; #1533 already landed that item.
- No embedding-booster work; the operator stopped further booster buildout pending a separate enablement/calibration decision.

## Deferred

- Safe-vocabulary representative label collision handling. Root cause: distinct kept subclusters can resolve to the same controlled-vocabulary label because the labeler has no disambiguation term after privacy-safe token selection.

## Parked hardening

- `Safe-vocabulary representative label collisions render duplicate FAQ headings` remains parked as product polish.

## Verification

- Focused PII/body and nearby representative-label regressions -- 11 passed.
- `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py` -- passed.
- `pytest tests/test_extracted_ticket_faq_markdown.py -q` -- 261 passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `git diff --check` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4143 passed, 10 skipped, 1 warning.

## AI reconciliation

- Codex/owner blocker fixed: unsafe customer text is now gated across customer-wording headings, fallback source-title topics, source labels, evidence quotes, summaries, and action context.
- Codex/owner numeric over-block fixed: identifier-context long numbers are blocked, while non-identifier numbers such as 1099 and 2024 remain valid customer wording.
- All findings fixed or waived: yes.

## Diff size

4 files, +373 / -26