### PR TITLE
Deflection CSV legacy fallback warning

### DIFF
--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -28,7 +28,7 @@ _CSV_UTF16_NUL_SIDE_RATIO = 0.30
 _CSV_REPLACEMENT_WARNING_RATIO = 0.01
 _CSV_UTF8_RECOVERY_REPLACEMENT_RATIO = 0.05
 _CSV_UTF8_MOJIBAKE_MARKERS = ("\u00c3", "\u00c2", "\u00e2\u20ac", "\u00e2\u201a")
-_CSV_SUSPICIOUS_LEGACY_FALLBACK_CHARS = ("\u00ff", "\u00fe")
+_CSV_IMPLAUSIBLE_LEGACY_FALLBACK_CHARS = ("\u00ff", "\u00fe")
 _CSV_BOM_ENCODINGS = (
     (b"\xff\xfe\x00\x00", "utf-32"),
     (b"\x00\x00\xfe\xff", "utf-32"),
@@ -566,26 +566,50 @@ def _legacy_fallback_corruption_warnings(
     legacy_text: str,
     recovered_text: str,
 ) -> tuple[CampaignOpportunityWarning, ...]:
-    if not recovered_text.count("\ufffd"):
+    artifact_count = _legacy_fallback_implausible_artifact_count(
+        legacy_text,
+        recovered_text,
+    )
+    if not artifact_count:
         return ()
     if _utf8_mojibake_score(legacy_text):
-        return ()
-    suspicious_count = sum(
-        legacy_text.count(char) for char in _CSV_SUSPICIOUS_LEGACY_FALLBACK_CHARS
-    )
-    if not suspicious_count:
         return ()
     return (
         CampaignOpportunityWarning(
             code="csv_encoding_ambiguous",
             field="encoding",
             message=(
-                "CSV failed strict UTF-8 decoding and legacy fallback produced "
-                f"{suspicious_count} suspicious character(s); verify the source "
-                "encoding before relying on these rows."
+                "CSV failed strict UTF-8 decoding; legacy fallback decoded the "
+                "bytes, but UTF-8 recovery would contain "
+                f"{artifact_count} replacement character(s). Verify the "
+                "source encoding before relying on these rows."
             ),
         ),
     )
+
+
+def _legacy_fallback_implausible_artifact_count(
+    legacy_text: str,
+    recovered_text: str,
+) -> int:
+    count = 0
+    for index, char in enumerate(recovered_text):
+        if char != "\ufffd":
+            continue
+        legacy_char = legacy_text[index] if index < len(legacy_text) else ""
+        if not _is_implausible_legacy_fallback_char(legacy_char):
+            continue
+        count += 1
+    return count
+
+
+def _is_implausible_legacy_fallback_char(char: str) -> bool:
+    if not char:
+        return False
+    if char in _CSV_IMPLAUSIBLE_LEGACY_FALLBACK_CHARS:
+        return True
+    codepoint = ord(char)
+    return 0x80 <= codepoint <= 0x9F
 
 
 def _csv_decode_warnings(

--- a/plans/PR-Deflection-Csv-Legacy-Fallback-Warning.md
+++ b/plans/PR-Deflection-Csv-Legacy-Fallback-Warning.md
@@ -1,0 +1,111 @@
+# PR-Deflection-Csv-Legacy-Fallback-Warning
+
+## Why this slice exists
+
+Issue #1551 is the next parser/encoding launch-readiness follow-up after #1545.
+The #1545 legacy-fallback warning fixed the reviewer's exact `0xFF`/`0xFE`
+corrupt-byte repro, but left the defect class open for other strict-UTF-8
+failures that decode through CP1252/Latin-1 with implausible fallback
+artifacts.
+
+Root cause: the warning predicate is keyed to the output characters from the
+cited repro (`U+00FF`/`U+00FE`) rather than the upstream condition that makes
+the import suspicious: strict UTF-8 failed, UTF-8 recovery would put a
+replacement character where the fallback produced an implausible character for
+clean support-ticket text, and the legacy fallback does not show double-encoding
+mojibake evidence. The review corrected an important overreach:
+common CP1252 bytes such as accented letters, euro signs, and copyright signs
+are byte-identical to arbitrary corrupt bytes at this layer, so they cannot be
+deterministically separated without a charset detector. The most-upstream safe
+fix in this slice is therefore the shared CSV decoder boundary with a narrow
+implausible-artifact predicate, not a route-specific warning or a broad
+"replacement at boundary" rule.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Replace the two-character legacy-fallback suspicion allowlist with a narrow
+   predicate for implausible fallback artifacts.
+2. Keep clean CP1252/Latin-1 support-ticket exports warning-free.
+3. Add sibling implausible-byte fixtures and common-CP1252 rejection fixtures so
+   the fix cannot pass only the original `0xFF`/`0xFE` examples or over-warn
+   normal legacy exports.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `plans/PR-Deflection-Csv-Legacy-Fallback-Warning.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - ASCII UTF-8 CSV content with one implausible byte from the
+    CP1252-undefined/C1-control set, at field end or mid-field, returns parsed
+    rows plus `csv_encoding_ambiguous`.
+  - The existing `0xFF` corrupt-byte warning remains covered.
+  - Clean CP1252/Latin-1 exports, including marker-looking legitimate text and
+    common field-ending characters such as accented letters, euro signs, and
+    copyright signs, keep `warnings == ()`.
+  - The warning predicate is expressed as the decoder class condition plus an
+    implausible fallback artifact guard, not a broad boundary replacement rule.
+- Affected surfaces:
+  - Shared CSV decoding for campaign/deflection source loading.
+  - Support-ticket upload warning propagation through existing callers.
+- Risk areas:
+  - Over-warning legitimate legacy encodings.
+  - Under-warning silent mojibake for sibling corrupt bytes.
+  - Reintroducing a cited-example-only character allowlist.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+## Mechanism
+
+`_decode_utf8_error_csv_bytes` already has both views of the failed decode: the
+legacy fallback text and a UTF-8 recovery string with replacement characters.
+This slice changes `_legacy_fallback_corruption_warnings` to warn when recovery
+contains replacement characters, the matching legacy fallback character is
+implausible in clean text (`U+00FF`, `U+00FE`, or a C1 control from the Latin-1
+fallback after CP1252 rejects an undefined byte), and the legacy fallback has no
+mojibake marker score. Common CP1252 characters are intentionally not warning
+signals because the decoder cannot distinguish a legitimate trailing CP1252 byte
+from an arbitrary corrupt byte without a charset detector.
+
+## Intentional
+
+- No blanket "legacy fallback happened" warning. Clean CP1252/Latin-1 exports
+  are supported input and remain warning-free.
+- No broad boundary replacement warning. The review proved that it false-positives
+  on normal CP1252 text.
+- No blanket "replacement exists in UTF-8 recovery" warning. That would over-warn
+  legitimate CP1252/Latin-1 words such as `cafe` with an accented byte or
+  smart-quote contractions.
+- No charset detector dependency. That remains the full answer for ambiguous
+  common bytes, but it is outside this narrow hardening slice.
+- No route-specific handling. `/deflection-reports/submit` already consumes this
+  shared loader, so the decoder boundary is the correct upstream fix point.
+
+## Deferred
+
+- None.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: python -m py_compile for the touched Python module and test file.
+- Passed: focused legacy/corrupt CSV pytest selection (29 passed, 77 deselected).
+- Passed: extracted campaign customer data tests (10 passed).
+- Passed: extracted campaign source adapter tests (106 passed).
+- Passed: bash scripts/check_ascii_python.sh.
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (4168 passed, 10 skipped).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_customer_data.py` | 44 |
+| `plans/PR-Deflection-Csv-Legacy-Fallback-Warning.md` | 111 |
+| `tests/test_extracted_campaign_source_adapters.py` | 83 |
+| **Total** | **238** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -554,8 +554,12 @@ def test_load_source_rows_prefers_warned_utf8_recovery_over_cp1252_mojibake(
     assert "â" not in rows[0]["message"]
 
 
-def test_load_source_rows_warns_on_ascii_utf8_corrupt_byte_legacy_fallback(
+@pytest.mark.parametrize("corrupt_byte", (0x81, 0x8D, 0x8F, 0x90, 0x9D, 0xFE, 0xFF))
+@pytest.mark.parametrize("suffix", (b"\n", b"cd\n"))
+def test_load_source_rows_warns_on_implausible_legacy_fallback_artifacts(
     tmp_path: Path,
+    corrupt_byte: int,
+    suffix: bytes,
 ) -> None:
     path = tmp_path / "support_tickets_ascii_corrupt_utf8.csv"
     message = "Cannot export the monthly attribution report at all today"
@@ -564,22 +568,95 @@ def test_load_source_rows_warns_on_ascii_utf8_corrupt_byte_legacy_fallback(
             "ticket_id,subject,message\n"
             f"ticket-1,Export help,{message}"
         ).encode("utf-8")
-        + b"\xff\n"
+        + bytes([corrupt_byte])
+        + suffix
     )
 
     rows, warnings = load_source_rows_with_warnings_from_file(
         path,
         file_format="csv",
     )
+    try:
+        legacy_char = bytes([corrupt_byte]).decode("cp1252")
+    except UnicodeDecodeError:
+        legacy_char = bytes([corrupt_byte]).decode("latin-1")
 
     assert rows == [{
         "ticket_id": "ticket-1",
         "subject": "Export help",
-        "message": f"{message}\u00ff",
+        "message": f"{message}{legacy_char}{suffix.decode('ascii').strip()}",
     }]
     assert [warning.code for warning in warnings] == ["csv_encoding_ambiguous"]
     assert warnings[0].field == "encoding"
     assert "failed strict UTF-8" in warnings[0].message
+
+
+@pytest.mark.parametrize(
+    ("prefix", "corrupt_byte", "suffix"),
+    (
+        ("oops", 0x81, "cd"),
+        ("aa", 0x90, "bb"),
+    ),
+)
+def test_load_source_rows_warns_on_mid_field_implausible_fallback_artifacts(
+    tmp_path: Path,
+    prefix: str,
+    corrupt_byte: int,
+    suffix: str,
+) -> None:
+    path = tmp_path / "support_tickets_mid_field_corrupt_utf8.csv"
+    path.write_bytes(
+        b"ticket_id,subject,message\n"
+        + f"ticket-1,Export help,{prefix}".encode("utf-8")
+        + bytes([corrupt_byte])
+        + f"{suffix}\n".encode("utf-8")
+    )
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+    legacy_char = bytes([corrupt_byte]).decode("latin-1")
+
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": f"{prefix}{legacy_char}{suffix}",
+    }]
+    assert [warning.code for warning in warnings] == ["csv_encoding_ambiguous"]
+
+
+@pytest.mark.parametrize(
+    "message",
+    (
+        "Le caf\u00e9",
+        "5\u20ac",
+        "(c)\u00a9",
+        "caf\u00e9,done",
+        "Se\u00f1or \u00fcber",
+    ),
+)
+def test_load_source_rows_does_not_warn_on_clean_cp1252_field_endings(
+    tmp_path: Path,
+    message: str,
+) -> None:
+    path = tmp_path / "support_tickets_cp1252_clean_field_endings.csv"
+    path.write_bytes((
+        "ticket_id,subject,message\n"
+        f'ticket-1,Export help,"{message}"\n'
+    ).encode("cp1252"))
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="csv",
+    )
+
+    assert warnings == ()
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": message,
+    }]
 
 
 def test_source_row_maps_provider_complaint_narrative_aliases() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Csv-Legacy-Fallback-Warning.md
Slice phase: Production hardening

Issue #1551 follows up #1545's CSV legacy-fallback warning. The old predicate warned only for the original cited output characters (`U+00FF`/`U+00FE`), leaving other implausible strict-UTF-8 failures that decode through CP1252/Latin-1 without any ambiguity warning. This fixes the shared CSV decoder boundary with a narrow predicate: strict UTF-8 failed, UTF-8 recovery would place a replacement character where the legacy fallback produced an implausible clean-ticket character, and the legacy fallback has no mojibake marker evidence. Common CP1252 characters remain silent because this layer cannot deterministically separate a legitimate accented/currency byte from an arbitrary corrupt byte without charset detection.

## Intentional
- No blanket "legacy fallback happened" warning; clean CP1252/Latin-1 exports remain warning-free.
- No broad boundary replacement warning; the predicate stays narrow to avoid false positives on normal accented names, prices, and copyright text.
- No charset detector dependency in this slice.
- No route-specific handling; deflection submit already consumes the shared source loader.

## Deferred
- None.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed Codex P2 and owner BLOCKER: narrowed the warning predicate so clean CP1252 field endings stay silent, while implausible fallback artifacts still warn.
- Fixed follow-up mid-field under-warn: removed the leftover boundary restriction and added `oops\\x81cd` / `aa\\x90bb` probes.
- Added rejection fixtures for clean CP1252 field endings and sibling fixtures for CP1252-undefined/C1-control bytes.

## Verification
- `python -m py_compile extracted_content_pipeline/campaign_customer_data.py tests/test_extracted_campaign_source_adapters.py`
- `pytest tests/test_extracted_campaign_source_adapters.py -q -k "legacy or marker or corrupt or utf8 or replacement or cp1252 or mid_field"` (29 passed, 77 deselected)
- `pytest tests/test_extracted_campaign_customer_data.py -q` (10 passed)
- `pytest tests/test_extracted_campaign_source_adapters.py -q` (106 passed)
- `bash scripts/check_ascii_python.sh`
- `bash scripts/run_extracted_pipeline_checks.sh` (4168 passed, 10 skipped)

## Diff size
3 files, +191 / -13.
