### PR TITLE
Deflection safe label disambiguation

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -41,15 +41,6 @@ register under `docs/technical-debt/`.
 - Owner/session: Codex deflection/clustering
 - Found during: PR-Deflection-Repeat-Metric-Alignment
 
-### Safe-vocabulary representative label collisions render duplicate FAQ headings
-- File/location: `extracted_content_pipeline/ticket_faq_markdown.py` representative source-policy label fallback.
-- Description: Distinct topic-degraded subclusters that resolve to the same safe documentation/glossary label can still render as separate FAQ items with identical headings. This preserves evidence and count truthfully, but leaves duplicate-looking entries.
-- Why it matters: The report can still look bloated even when grouping is correct; a future slice should disambiguate colliding safe labels or emit a diagnostic.
-- Effort: S
-- Category: polish
-- Owner/session: Codex deflection/clustering
-- Found during: PR-Deflection-Representative-Question-Labels review
-
 ## 2026-06-07
 
 ### Landing-page variants pass audits but are not meaningfully distinct

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -613,7 +613,10 @@ class TicketFAQMarkdownService:
         )
         result = replace(
             result,
-            warnings=tuple(warning.as_dict() for warning in normalized.warnings),
+            warnings=(
+                *(warning.as_dict() for warning in normalized.warnings),
+                *result.warnings,
+            ),
         )
         if self._ticket_faqs is None or not result.items:
             return result
@@ -833,17 +836,25 @@ def build_ticket_faq_markdown(
     else:
         selected_groups = tuple(sorted_groups)
 
-    items = tuple(
-        _item(
-            topic,
+    item_records = tuple(
+        (
             rows,
-            max_evidence_per_item=max_evidence_per_item,
-            support_contact=support_contact,
-            documentation_terms=resolved_documentation_terms,
-            vocabulary_gap_rules=resolved_vocabulary_gap_rules,
+            _item(
+                topic,
+                rows,
+                max_evidence_per_item=max_evidence_per_item,
+                support_contact=support_contact,
+                documentation_terms=resolved_documentation_terms,
+                vocabulary_gap_rules=resolved_vocabulary_gap_rules,
+            ),
         )
         for topic, rows in selected_groups
     )
+    items, disambiguation_warnings = _disambiguate_source_policy_question_collisions(
+        item_records,
+        documentation_terms=resolved_documentation_terms,
+    )
+    warnings.extend(disambiguation_warnings)
     return TicketFAQMarkdownResult(
         markdown=_render(title=title, items=items, source_count=len(opportunities), ticket_source_count=len(source_keys)),
         items=items,
@@ -2301,6 +2312,135 @@ def _safe_vocabulary_representative_label(
         key=lambda token: (-repeated_tokens[token], safe_tokens[token][0], token),
     )[:5]
     return " ".join(safe_tokens[token][1] for token in tokens)
+
+
+def _disambiguate_source_policy_question_collisions(
+    item_records: Sequence[tuple[Sequence[Mapping[str, str]], Mapping[str, Any]]],
+    *,
+    documentation_terms: Sequence[str],
+) -> tuple[tuple[dict[str, Any], ...], tuple[dict[str, Any], ...]]:
+    items = [dict(item) for _rows, item in item_records]
+    indexes_by_question: dict[str, list[int]] = defaultdict(list)
+    for index, item in enumerate(items):
+        if item.get("question_source") != "source_policy":
+            continue
+        question = _clean(item.get("question"))
+        if question:
+            indexes_by_question[question].append(index)
+
+    warnings: list[dict[str, Any]] = []
+    for question, indexes in indexes_by_question.items():
+        if len(indexes) < 2:
+            continue
+        suffixes: list[str] = []
+        seen_suffixes: set[str] = set()
+        for index in indexes:
+            rows = item_records[index][0]
+            suffix = _source_policy_disambiguation_suffix(
+                question,
+                rows,
+                documentation_terms=documentation_terms,
+            )
+            if not suffix or suffix in seen_suffixes:
+                suffixes = []
+                break
+            suffixes.append(suffix)
+            seen_suffixes.add(suffix)
+        if len(suffixes) != len(indexes):
+            warnings.append(_duplicate_source_policy_question_warning(question, items, indexes))
+            continue
+        disambiguated_questions = tuple(
+            _disambiguated_question(question, suffix) for suffix in suffixes
+        )
+        if not all(disambiguated_questions):
+            warnings.append(_duplicate_source_policy_question_warning(question, items, indexes))
+            continue
+        for index, disambiguated in zip(indexes, disambiguated_questions):
+            items[index]["question"] = disambiguated
+            items[index]["answer"] = _answer_for_disambiguated_question(
+                items[index],
+                disambiguated,
+            )
+    return (tuple(items), tuple(warnings))
+
+
+def _answer_for_disambiguated_question(
+    item: Mapping[str, Any],
+    question: str,
+) -> str:
+    if item.get("answer_evidence_status") == "resolution_evidence":
+        return str(item.get("answer") or "")
+    return _answer_summary(
+        question=question,
+        source_count=len(_list(item.get("source_ids"))),
+        answer_evidence_status=str(item.get("answer_evidence_status") or ""),
+    )
+
+
+def _source_policy_disambiguation_suffix(
+    question: str,
+    rows: Sequence[Mapping[str, str]],
+    *,
+    documentation_terms: Sequence[str],
+) -> str:
+    safe_tokens = _safe_representative_tokens(
+        (
+            *documentation_terms,
+            *(
+                _clean(row.get("safe_label_context"))
+                for row in rows
+                if _clean(row.get("safe_label_context"))
+            ),
+        )
+    )
+    if not safe_tokens:
+        return ""
+    question_tokens = support_ticket_tokens(question)
+    token_counts: dict[str, int] = {}
+    for row in rows:
+        for token in _question_gist_tokens(str(row.get("text") or "")):
+            if (
+                token not in safe_tokens
+                or token in question_tokens
+                or _REDACTION_TOKEN_RE.fullmatch(token)
+            ):
+                continue
+            token_counts[token] = token_counts.get(token, 0) + 1
+    if not token_counts:
+        return ""
+    tokens = sorted(
+        token_counts,
+        key=lambda token: (-token_counts[token], safe_tokens[token][0], token),
+    )[:3]
+    return " ".join(safe_tokens[token][1] for token in tokens)
+
+
+def _disambiguated_question(question: str, suffix: str) -> str:
+    stem = _clean(question).rstrip("?.!,;: ")
+    suffix_text = _clean(suffix).lower()
+    if not stem or not suffix_text:
+        return ""
+    disambiguated = _normalize_question_text(f"{stem} - {suffix_text}")
+    return disambiguated if _usable_question(disambiguated) else ""
+
+
+def _duplicate_source_policy_question_warning(
+    question: str,
+    items: Sequence[Mapping[str, Any]],
+    indexes: Sequence[int],
+) -> dict[str, Any]:
+    source_ids: list[str] = []
+    for index in indexes:
+        source_ids.extend(str(source_id) for source_id in _list(items[index].get("source_ids")))
+    return {
+        "code": "duplicate_source_policy_questions",
+        "message": (
+            "Some source-policy FAQ headings remain duplicated because no safe "
+            "controlled-vocabulary disambiguator was available."
+        ),
+        "question": question,
+        "source_ids": source_ids,
+    }
 
 
 def _safe_representative_tokens(

--- a/plans/PR-Deflection-Safe-Label-Disambiguation.md
+++ b/plans/PR-Deflection-Safe-Label-Disambiguation.md
@@ -1,0 +1,130 @@
+# PR-Deflection-Safe-Label-Disambiguation
+
+## Why this slice exists
+
+`HARDENING.md` still tracks `Safe-vocabulary representative label collisions
+render duplicate FAQ headings`.
+
+The upstream grouping is now correct: distinct topic-degraded support-ticket
+subclusters stay separate, and the renderer only emits controlled-vocabulary
+representative labels. The remaining defect is presentation-level label
+collision. Two truthful groups can choose the same safe representative heading,
+which makes the paid report look bloated even though the evidence groups should
+not be merged.
+
+Root cause: selected FAQ items do not have a collision-resolution pass after
+question-label resolution. A downstream symptom fix would merge same-heading
+groups or suppress one item, but that would undo the count/evidence truth fixed
+by the prior slices. This slice fixes the root at the renderer boundary by
+disambiguating colliding safe source-policy headings while preserving groups.
+
+The final diff is over the 400 LOC target because review found two dependent
+surface gaps in this same path: disambiguated draft answers must reference the
+new heading, and service-generated drafts must preserve renderer warnings.
+Splitting either fix would knowingly ship an inconsistent or silent
+duplicate-heading path.
+
+## Scope (this PR)
+
+Ownership lane: deflection/clustering
+Slice phase: Production hardening
+
+1. Add a deterministic post-label disambiguation pass for selected
+   source-policy FAQ items whose rendered questions collide.
+2. Use only already-safe representative vocabulary from each item's evidence
+   group as the disambiguator; never publish raw source titles or raw ticket
+   text.
+3. Preserve grouping, item count, source IDs, evidence quotes, and sort order.
+4. Emit a diagnostic warning when duplicate source-policy headings remain
+   because no safe per-group disambiguator exists.
+5. Remove the closed safe-vocabulary collision item from `HARDENING.md`.
+
+### Files touched
+
+- `HARDENING.md`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Safe-Label-Disambiguation.md`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Distinct topic-degraded support-ticket subclusters that initially
+        resolve to the same safe source-policy question render distinct buyer
+        headings when each group has an additional safe distinguishing token.
+  - [ ] Disambiguation does not merge, drop, or reorder FAQ items.
+  - [ ] Disambiguation does not change customer-wording questions.
+  - [ ] Disambiguation does not publish raw source titles, raw evidence text,
+        emails, phone-shaped values, redaction artifacts, or identifier-context
+        long numbers.
+  - [ ] If a collision cannot be safely disambiguated, the report emits a
+        warning diagnostic and leaves the truthful duplicate headings intact.
+- Affected surfaces: ticket FAQ Markdown question labels and warning diagnostics.
+- Risk areas: buyer-facing report shape, privacy boundary, grouping truth,
+  deterministic ordering, and support-ticket evidence accounting.
+- Reviewer rules triggered: R1, R2, R3, R10, R13, R14.
+
+## Mechanism
+
+After selected groups become FAQ item dictionaries, the renderer groups only
+`source_policy` items by normalized question text. Singleton labels pass through.
+
+For a duplicate source-policy question, the renderer looks for safe
+controlled-vocabulary tokens that appeared in that item's evidence group but do
+not already appear in the question. If every item in the collision set gets a
+distinct safe suffix, the heading becomes a deterministic variant such as
+`What should I do about billing issue - invoice refund?`. The suffix comes from
+documentation or structured taxonomy vocabulary already admitted by the
+representative-label gate, not from raw ticket text. Draft answers are refreshed
+when the heading changes so downstream JSON/search consumers see one question.
+
+If any item in the collision set cannot receive a safe unique suffix, the
+renderer leaves every item unchanged and adds a warning with the duplicate
+question and affected source IDs. The service path merges those renderer
+warnings with source-normalization warnings before returning or saving drafts.
+
+## Intentional
+
+- **No group merge.** Duplicate-looking headings are a label collision, not
+  proof that the evidence groups are the same customer question.
+- **No raw-text fallback.** A heading stays duplicate if the only available
+  distinguishing text is unsafe customer/source text.
+- **No customer-wording rewrite.** Customer wording already passed the
+  buyer-facing privacy gate and should not be altered by a source-policy label
+  disambiguator.
+- **No embedding-booster work.** The operator stopped further embedding-booster
+  buildout unless a new explicit enablement/calibration decision is made.
+
+## Deferred
+
+- Broader report/UI copy for explaining warning diagnostics if unresolved
+  duplicate labels remain visible in a live paid-funnel artifact.
+
+Parked hardening: none expected; this slice should close the
+`Safe-vocabulary representative label collisions render duplicate FAQ headings`
+entry.
+
+## Verification
+
+- Command passed: python -m py_compile for the touched Python files.
+- Command passed: pytest focused duplicate-label, privacy, and
+  representative-label regressions -- 13 passed.
+- Command passed: pytest review-fix regressions -- 4 passed.
+- Command passed: pytest tests/test_extracted_ticket_faq_markdown.py -q -- 265 passed.
+- Command passed: bash scripts/check_ascii_python.sh.
+- Command passed: git diff --check.
+- Command passed: bash scripts/validate_extracted_content_pipeline.sh.
+- Command passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline.
+- Command passed: python scripts/audit_extracted_standalone.py --fail-on-debt.
+- Command passed: bash scripts/run_extracted_pipeline_checks.sh -- 4152 passed, 10 skipped, 1 warning.
+- Pending before push: bash scripts/local_pr_review.sh with the PR body file.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `HARDENING.md` | 9 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 156 |
+| `plans/PR-Deflection-Safe-Label-Disambiguation.md` | 130 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 196 |
+| **Total** | **491** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2111,6 +2111,141 @@ def test_build_ticket_faq_markdown_uses_repeated_gist_tokens_for_representative_
     assert result.items[0]["question"] == "What should I do about export timeout?"
 
 
+def test_build_ticket_faq_markdown_disambiguates_colliding_safe_source_policy_labels() -> None:
+    common = "workspace connector dashboard export billing"
+    refund = "invoice refund ledger credit memo adjustment dispute"
+    reboot = "device reboot loop firmware crash restart kernel"
+    rows = [
+        {
+            "source_type": "support_ticket",
+            "support_ticket_cluster": "technical support",
+            "source_title": "technical support",
+            "text": f"{common} {extra}",
+            "source_id": f"{prefix}-{index}",
+        }
+        for prefix, extra in (("refund", refund), ("reboot", reboot))
+        for index in range(2)
+    ]
+
+    result = build_ticket_faq_markdown(
+        rows,
+        max_items=0,
+        documentation_terms=(common, refund, reboot),
+    )
+
+    assert [
+        (item["question"], item["source_ids"])
+        for item in result.items
+    ] == [
+        (
+            "What should I do about workspace connector dashboard export billing - invoice refund ledger?",
+            ("refund-0", "refund-1"),
+        ),
+        (
+            "What should I do about workspace connector dashboard export billing - device reboot loop?",
+            ("reboot-0", "reboot-1"),
+        ),
+    ]
+    assert result.items[0]["question"] in result.items[0]["answer"]
+    assert result.items[1]["question"] in result.items[1]["answer"]
+    assert not result.items[0]["answer"].endswith(
+        "What should I do about workspace connector dashboard export billing?"
+    )
+    assert result.warnings == ()
+
+
+def test_build_ticket_faq_markdown_does_not_disambiguate_customer_wording_questions() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "text": "How do I update the workspace billing contact?",
+                "source_id": "ticket-1",
+                "resolution_text": "Send the billing admin update form.",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "text": "How do I update the workspace billing contact?",
+                "source_id": "ticket-2",
+                "resolution_text": "Escalate the request to workspace finance.",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert [item["question_source"] for item in result.items] == [
+        "customer_wording",
+        "customer_wording",
+    ]
+    assert [item["question"] for item in result.items] == [
+        "How do I update the workspace billing contact?",
+        "How do I update the workspace billing contact?",
+    ]
+    assert result.warnings == ()
+
+
+def test_build_ticket_faq_markdown_warns_when_duplicate_source_policy_labels_remain() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Case for jane.doe@example.com",
+                "text": "workspace connector dashboard export billing jane doe",
+                "source_id": "ticket-1a",
+                "resolution_text": "Resolve from refund queue.",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Case for jane.doe@example.com",
+                "text": "workspace connector dashboard export billing jane doe",
+                "source_id": "ticket-1b",
+                "resolution_text": "Resolve from refund queue.",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Case for jane.doe@example.com",
+                "text": "workspace connector dashboard export billing jane doe",
+                "source_id": "ticket-2a",
+                "resolution_text": "Resolve from reboot queue.",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": "Case for jane.doe@example.com",
+                "text": "workspace connector dashboard export billing jane doe",
+                "source_id": "ticket-2b",
+                "resolution_text": "Resolve from reboot queue.",
+            },
+        ],
+        max_items=0,
+        documentation_terms=("workspace connector dashboard export billing",),
+    )
+
+    assert [item["question"] for item in result.items] == [
+        "What should I do about workspace connector dashboard export billing?",
+        "What should I do about workspace connector dashboard export billing?",
+    ]
+    assert [item["source_ids"] for item in result.items] == [
+        ("ticket-1a", "ticket-1b"),
+        ("ticket-2a", "ticket-2b"),
+    ]
+    assert result.warnings == ({
+        "code": "duplicate_source_policy_questions",
+        "message": (
+            "Some source-policy FAQ headings remain duplicated because no safe "
+            "controlled-vocabulary disambiguator was available."
+        ),
+        "question": "What should I do about workspace connector dashboard export billing?",
+        "source_ids": ["ticket-1a", "ticket-1b", "ticket-2a", "ticket-2b"],
+    },)
+    assert "jane.doe@example.com" not in result.markdown
+
+
 def test_safe_vocabulary_representative_label_rejects_single_occurrence_tokens() -> None:
     assert _safe_vocabulary_representative_label(
         "technical support",
@@ -2689,8 +2824,8 @@ def test_build_ticket_faq_markdown_does_not_merge_resolution_backed_same_label()
 
     assert result.as_dict()["generated"] == 2
     assert [item["question"] for item in result.items] == [
-        "What should I do about technical support?",
-        "What should I do about technical support?",
+        "What should I do about technical support - device reboot loop?",
+        "What should I do about technical support - export timeout?",
     ]
     assert {
         item["answer_evidence_status"] for item in result.items
@@ -3749,6 +3884,63 @@ async def test_ticket_faq_service_exposes_source_normalization_warnings() -> Non
 
     assert result.as_dict()["generated"] == 1
     assert result.as_dict()["warnings"][0]["code"] == "missing_source_text"
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_preserves_renderer_duplicate_heading_warning() -> None:
+    service = TicketFAQMarkdownService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "support_tickets": [
+                {
+                    "ticket_id": "ticket-1a",
+                    "subject": "Case for jane.doe@example.com",
+                    "message": "workspace connector dashboard export billing jane doe",
+                    "pain_category": "reporting friction",
+                    "resolution_text": "Resolve from refund queue.",
+                },
+                {
+                    "ticket_id": "ticket-1b",
+                    "subject": "Case for jane.doe@example.com",
+                    "message": "workspace connector dashboard export billing jane doe",
+                    "pain_category": "reporting friction",
+                    "resolution_text": "Resolve from refund queue.",
+                },
+                {
+                    "ticket_id": "ticket-2a",
+                    "subject": "Case for jane.doe@example.com",
+                    "message": "workspace connector dashboard export billing jane doe",
+                    "pain_category": "reporting friction",
+                    "resolution_text": "Resolve from reboot queue.",
+                },
+                {
+                    "ticket_id": "ticket-2b",
+                    "subject": "Case for jane.doe@example.com",
+                    "message": "workspace connector dashboard export billing jane doe",
+                    "pain_category": "reporting friction",
+                    "resolution_text": "Resolve from reboot queue.",
+                },
+            ]
+        },
+        max_items=0,
+        documentation_terms=("workspace connector dashboard export billing",),
+    )
+
+    warning_codes = [warning["code"] for warning in result.as_dict()["warnings"]]
+    assert "missing_company_name" in warning_codes
+    assert "duplicate_source_policy_questions" in warning_codes
+    assert result.as_dict()["warnings"][-1] == {
+        "code": "duplicate_source_policy_questions",
+        "message": (
+            "Some source-policy FAQ headings remain duplicated because no safe "
+            "controlled-vocabulary disambiguator was available."
+        ),
+        "question": "What should I do about reporting friction?",
+        "source_ids": ["ticket-1a", "ticket-1b", "ticket-2a", "ticket-2b"],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Safe-Label-Disambiguation.md
Slice phase: Production hardening
Reviewer rules triggered: R1, R2, R3, R10, R13, R14.

This closes the parked safe-vocabulary representative-label collision item: distinct truthful FAQ groups can now get deterministic safe suffixes when their source-policy questions collide, without merging groups or publishing raw ticket text. The review update also refreshes draft answers after disambiguation and preserves renderer warnings through the service path.

## Intentional
- No group merge; duplicate-looking headings are label collisions, not proof the evidence groups are the same.
- No raw-text fallback; unresolved duplicates remain duplicated with a diagnostic if only unsafe text could distinguish them.
- No customer-wording rewrite; the disambiguator only touches source-policy questions.
- No embedding-booster work.

## Deferred
- Broader report/UI copy for explaining warning diagnostics if unresolved duplicate labels remain visible in a live paid-funnel artifact.

## Parked hardening
- None expected; this PR removes `Safe-vocabulary representative label collisions render duplicate FAQ headings` from `HARDENING.md`.

## Verification
- python -m py_compile for the touched Python files.
- pytest focused duplicate-label, privacy, and representative-label regressions -- 13 passed.
- pytest review-fix regressions -- 4 passed.
- pytest tests/test_extracted_ticket_faq_markdown.py -q -- 265 passed.
- bash scripts/check_ascii_python.sh.
- git diff --check.
- bash scripts/validate_extracted_content_pipeline.sh.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline.
- python scripts/audit_extracted_standalone.py --fail-on-debt.
- bash scripts/run_extracted_pipeline_checks.sh -- 4152 passed, 10 skipped, 1 warning.

## AI reconciliation
- AI findings reviewed: Codex P2 `Refresh the answer after disambiguating` and Codex P2 `Preserve duplicate-heading warnings in the service path`.
- Fixed: draft answers are recomputed after source-policy heading disambiguation.
- Fixed: service-generated results merge source-normalization warnings with renderer warnings before returning or saving drafts.
- All fixed or waived: yes.

## Diff size
4 files, +472 / -19
