### PR TITLE
Deflection full volume smoke gates

### DIFF
--- a/plans/PR-Deflection-Full-Volume-Smoke-Gates.md
+++ b/plans/PR-Deflection-Full-Volume-Smoke-Gates.md
@@ -1,0 +1,67 @@
+# PR-Deflection-Full-Volume-Smoke-Gates
+## Why this slice exists
+#1440 needs a real-condition proof using a near-50 MB raw CFPB CSV through hosted
+submit. #1452 made the route accept that file, but the reusable smoke still lets
+a 3-row fixture pass a full-volume proof command.
+
+Root cause: the harness validates handoff shape but not real-volume evidence.
+The upstream fix is hosted submit smoke gates for uploaded bytes, rows,
+generated questions, repeat-ticket volume, and visible top questions.
+## Scope (this PR)
+Ownership lane: deflection-full-50k-e2e-proof
+Slice phase: Functional validation
+
+1. Add optional minimum-volume gates to the hosted submit handoff smoke.
+2. Gate on existing submit metadata and free snapshot summary only.
+3. Prove low-volume payloads fail under gates while no-gate fixtures remain valid.
+### Review Contract
+- Acceptance criteria:
+  - Callers can require uploaded bytes, row counts, generated questions, repeat
+    tickets, and top questions.
+  - Missing or below-threshold metrics fail closed with a specific gate error.
+  - Existing no-gate behavior stays compatible and summaries stay redacted.
+- Affected surfaces: hosted deflection submit smoke and its CI-enrolled tests.
+- Risk areas: skipped metrics, broken fixture behavior, or CI wording implying
+  live email/payment proof.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+### Files touched
+
+- `plans/PR-Deflection-Full-Volume-Smoke-Gates.md`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+
+## Mechanism
+The smoke already captures submit metadata and validates the free snapshot. This
+slice adds parser options and a deterministic validator reading only existing
+scalar fields: uploaded/blob bytes, rows, generated count, repeat-ticket count,
+and top-question count.
+
+Missing, non-numeric, or below-threshold values fail closed. Configured gates
+that cannot run because submit/envelope validation failed are marked skipped
+with `ok: false`, so the summary cannot imply the gates passed.
+
+## Intentional
+- No live email, PDF, Stripe, or hosted payment run in CI; this PR only makes
+  hosted submit enforce full-volume evidence.
+- No new orchestration script. The existing submit smoke is the upstream proof
+  boundary for raw upload -> snapshot -> locked artifact.
+- No generator or clustering behavior change.
+
+## Deferred
+- After deployment, run #1440 live with the near-50 MB CFPB CSV: submit raw CSV,
+  confirm snapshot/email/PDF, complete payment, drain delivery, and confirm the
+  full report email/PDF.
+Parked hardening: none.
+## Verification
+- Passed: python -m pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q (37 passed).
+- Passed: python -m py_compile scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_submit_handoff.py
+- Passed: bash scripts/check_ascii_python.sh
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (4182 passed, 10 skipped, 1 warning).
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Full-Volume-Smoke-Gates.md` | 64 |
+| `scripts/smoke_content_ops_deflection_submit_handoff.py` | 128 |
+| `tests/test_smoke_content_ops_deflection_submit_handoff.py` | 200 |
+| **Total** | **392** |

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -101,6 +101,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--company-name", default=_env("ATLAS_DEFLECTION_COMPANY_NAME"))
     parser.add_argument("--contact-email", default=_env("ATLAS_DEFLECTION_CONTACT_EMAIL"))
     parser.add_argument("--limit", type=int)
+    parser.add_argument("--min-uploaded-bytes", type=int, default=0)
+    parser.add_argument("--min-source-row-count", type=int, default=0)
+    parser.add_argument("--min-submitted-row-count", type=int, default=0)
+    parser.add_argument("--min-generated-questions", type=int, default=0)
+    parser.add_argument("--min-repeat-ticket-count", type=int, default=0)
+    parser.add_argument("--min-top-question-count", type=int, default=0)
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--submit-path", default=SUBMIT_PATH)
     parser.add_argument("--snapshot-path-template", default=SNAPSHOT_PATH_TEMPLATE)
@@ -152,6 +158,16 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         int(args.limit) <= 0 or int(args.limit) > SUBMIT_ROW_LIMIT_MAX
     ):
         errors.append(f"--limit must be between 1 and {SUBMIT_ROW_LIMIT_MAX}")
+    for attr, label in (
+        ("min_uploaded_bytes", "--min-uploaded-bytes"),
+        ("min_source_row_count", "--min-source-row-count"),
+        ("min_submitted_row_count", "--min-submitted-row-count"),
+        ("min_generated_questions", "--min-generated-questions"),
+        ("min_repeat_ticket_count", "--min-repeat-ticket-count"),
+        ("min_top_question_count", "--min-top-question-count"),
+    ):
+        if int(getattr(args, attr)) < 0:
+            errors.append(f"{label} must be zero or greater")
     if not math.isfinite(float(args.timeout)) or float(args.timeout) <= 0:
         errors.append("--timeout must be a positive finite number")
     for attr, label in (
@@ -576,6 +592,107 @@ def _status_summary(response: HttpJsonResponse) -> dict[str, Any]:
     }
 
 
+def _configured_volume_gates(args: argparse.Namespace) -> dict[str, int]:
+    return {
+        "uploaded_bytes": int(args.min_uploaded_bytes),
+        "source_row_count": int(args.min_source_row_count),
+        "submitted_row_count": int(args.min_submitted_row_count),
+        "generated_questions": int(args.min_generated_questions),
+        "repeat_ticket_count": int(args.min_repeat_ticket_count),
+        "top_question_count": int(args.min_top_question_count),
+    }
+
+
+def _strict_count(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _volume_gate_actuals(
+    *,
+    submit_mode: str,
+    diagnostics: Mapping[str, Any],
+    snapshot: Mapping[str, Any] | None,
+) -> dict[str, int | None]:
+    metadata = diagnostics.get("metadata")
+    if not isinstance(metadata, Mapping):
+        metadata = {}
+    summary = snapshot.get("summary") if isinstance(snapshot, Mapping) else None
+    if not isinstance(summary, Mapping):
+        summary = {}
+    top_questions = snapshot.get("top_questions") if isinstance(snapshot, Mapping) else None
+    byte_key = "uploaded_bytes" if submit_mode == "multipart" else "blob_bytes"
+    return {
+        "uploaded_bytes": _strict_count(metadata.get(byte_key)),
+        "source_row_count": _strict_count(metadata.get("source_row_count")),
+        "submitted_row_count": _strict_count(metadata.get("submitted_row_count")),
+        "generated_questions": _strict_count(summary.get("generated")),
+        "repeat_ticket_count": _strict_count(summary.get("repeat_ticket_count")),
+        "top_question_count": (
+            len(top_questions)
+            if isinstance(top_questions, Sequence)
+            and not isinstance(top_questions, (str, bytes, bytearray))
+            else None
+        ),
+    }
+
+
+def _volume_gate_errors(
+    args: argparse.Namespace,
+    *,
+    submit_mode: str,
+    diagnostics: Mapping[str, Any],
+    snapshot: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], list[str]]:
+    expected = _configured_volume_gates(args)
+    actual = _volume_gate_actuals(
+        submit_mode=submit_mode,
+        diagnostics=diagnostics,
+        snapshot=snapshot,
+    )
+    errors: list[str] = []
+    for gate, minimum in expected.items():
+        if minimum <= 0:
+            continue
+        value = actual.get(gate)
+        if value is None:
+            errors.append(f"volume gate {gate} expected >= {minimum}, got missing")
+        elif value < minimum:
+            errors.append(f"volume gate {gate} expected >= {minimum}, got {value}")
+    configured = {key: value for key, value in expected.items() if value > 0}
+    return {
+        "configured": configured,
+        "actual": actual,
+        "ok": not errors,
+        "errors": errors,
+    }, errors
+
+
+def _skipped_volume_gates(
+    args: argparse.Namespace,
+    *,
+    reason: str,
+) -> dict[str, Any]:
+    configured = {
+        key: value
+        for key, value in _configured_volume_gates(args).items()
+        if value > 0
+    }
+    if not configured:
+        return {"configured": {}, "actual": {}, "ok": True, "errors": []}
+    return {
+        "configured": configured,
+        "actual": {},
+        "ok": False,
+        "skipped": True,
+        "not_run_reason": reason,
+        "errors": [],
+    }
+
+
 def _preflight_summary(
     args: argparse.Namespace,
     errors: Sequence[str],
@@ -591,6 +708,7 @@ def _preflight_summary(
         "submit_mode": _submit_mode(args),
         "csv_file_size": _csv_file_size(args),
         "blob_host": _redacted_blob_host(_clean(args.blob_url)),
+        "volume_gates": _skipped_volume_gates(args, reason=reason),
         "submit": {"ok": False, "skipped": True, "not_run_reason": reason},
         "snapshot": {"ok": False, "skipped": True, "not_run_reason": reason},
         "artifact": {"ok": False, "skipped": True, "not_run_reason": reason},
@@ -641,6 +759,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     request_id = ""
     submit_snapshot: Mapping[str, Any] | None = None
     diagnostics: dict[str, Any] = {}
+    volume_gates = _skipped_volume_gates(args, reason="submit_failed")
     submit_errors.extend(
         _stale_multipart_submit_route_errors(submit_response, submit_mode=submit_mode)
     )
@@ -652,6 +771,14 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             submit_mode=submit_mode,
         )
         submit_errors.extend(envelope_errors)
+        if not envelope_errors:
+            volume_gates, volume_gate_errors = _volume_gate_errors(
+                args,
+                submit_mode=submit_mode,
+                diagnostics=diagnostics,
+                snapshot=submit_snapshot,
+            )
+            errors.extend(volume_gate_errors)
     errors.extend(submit_errors)
     snapshot_summary: dict[str, Any] = {
         "ok": False,
@@ -712,6 +839,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "submit_mode": submit_mode,
         "csv_file_size": _csv_file_size(args),
         "blob_host": _redacted_blob_host(_clean(args.blob_url)),
+        "volume_gates": volume_gates,
         "submit": {
             **_status_summary(submit_response),
             "ok": not submit_errors,

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -207,6 +207,12 @@ def _fake_open(sequence: list[tuple[int, Any]], calls: list[dict[str, Any]]):
     return _open
 
 
+def _patch_open(monkeypatch, sequence: list[tuple[int, Any]]) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(smoke, "_open_http_request", _fake_open(sequence, calls))
+    return calls
+
+
 def test_validate_args_fails_closed_for_missing_and_unsafe_inputs() -> None:
     args = smoke._build_parser().parse_args([
         "--base-url",
@@ -244,6 +250,23 @@ def test_validate_args_fails_closed_for_missing_and_unsafe_inputs() -> None:
         "--submit-path must start with /",
         "--snapshot-path-template must include {request_id}",
     ]
+
+
+def test_validate_args_rejects_negative_volume_gates(tmp_path) -> None:
+    flags = (
+        "--min-uploaded-bytes",
+        "--min-source-row-count",
+        "--min-submitted-row-count",
+        "--min-generated-questions",
+        "--min-repeat-ticket-count",
+        "--min-top-question-count",
+    )
+    args = smoke._build_parser().parse_args([
+        *_base_args(tmp_path),
+        *(item for flag in flags for item in (flag, "-1")),
+    ])
+
+    assert smoke._validate_args(args) == [f"{flag} must be zero or greater" for flag in flags]
 
 
 def test_validate_args_fails_closed_for_missing_csv_file(tmp_path) -> None:
@@ -606,6 +629,183 @@ def test_run_sends_explicit_large_submit_limit_when_requested(monkeypatch, tmp_p
     assert summary["ok"] is True
     assert calls[0]["body"]["limit"] == 25000
     assert summary["submit"]["diagnostics"]["metadata"]["max_source_material_rows"] == 25000
+
+
+def _full_volume_snapshot() -> dict[str, Any]:
+    return {
+        **SNAPSHOT,
+        "summary": {
+            **SNAPSHOT["summary"],
+            "generated": 37,
+            "repeat_ticket_count": 35386,
+        },
+        "top_questions": [
+            {
+                **SNAPSHOT["top_questions"][0],
+                "rank": index,
+                "ticket_count": 1000 - index,
+            }
+            for index in range(1, 6)
+        ],
+    }
+
+
+def test_run_passes_configured_full_volume_gates(monkeypatch, tmp_path):
+    snapshot = _full_volume_snapshot()
+    metadata = {
+        "source": "portfolio_deflection_submit",
+        "source_row_count": 35386,
+        "submitted_row_count": 35386,
+        "truncated_row_count": 0,
+        "max_source_material_rows": 35386,
+        "blob_bytes": 52363054,
+        "support_platform": "zendesk",
+    }
+    _patch_open(
+        monkeypatch,
+        [
+            (200, _submit_payload(snapshot=snapshot, metadata=metadata)),
+            (200, snapshot),
+            (403, {"detail": "payment_required"}),
+        ],
+    )
+    flags = (
+        "--min-uploaded-bytes",
+        "50000000",
+        "--min-source-row-count",
+        "30000",
+        "--min-submitted-row-count",
+        "30000",
+        "--min-generated-questions",
+        "30",
+        "--min-repeat-ticket-count",
+        "30000",
+        "--min-top-question-count",
+        "5",
+    )
+    summary = smoke.run(smoke._build_parser().parse_args([*_base_args(tmp_path), *flags]))
+
+    assert summary["ok"] is True
+    assert summary["volume_gates"]["ok"] is True
+    assert summary["volume_gates"]["actual"] == {
+        "uploaded_bytes": 52363054,
+        "source_row_count": 35386,
+        "submitted_row_count": 35386,
+        "generated_questions": 37,
+        "repeat_ticket_count": 35386,
+        "top_question_count": 5,
+    }
+    serialized = json.dumps(summary)
+    assert "token-secret" not in serialized
+    assert "signed-secret" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("flag", "gate", "minimum", "actual"),
+    [
+        ("--min-uploaded-bytes", "uploaded_bytes", "201", 200),
+        ("--min-source-row-count", "source_row_count", "4", 3),
+        ("--min-submitted-row-count", "submitted_row_count", "4", 3),
+        ("--min-generated-questions", "generated_questions", "3", 2),
+        ("--min-repeat-ticket-count", "repeat_ticket_count", "5", 4),
+        ("--min-top-question-count", "top_question_count", "2", 1),
+    ],
+)
+def test_run_fails_each_configured_volume_gate_when_tiny_fixture_passes_shape(
+    monkeypatch,
+    tmp_path,
+    flag: str,
+    gate: str,
+    minimum: str,
+    actual: int,
+):
+    calls = _patch_open(
+        monkeypatch,
+        [
+            (200, _submit_payload()),
+            (200, SNAPSHOT),
+            (403, {"detail": "payment_required"}),
+        ],
+    )
+    summary = smoke.run(
+        smoke._build_parser().parse_args([*_base_args(tmp_path), flag, minimum])
+    )
+
+    assert summary["ok"] is False
+    assert summary["volume_gates"]["ok"] is False
+    assert summary["volume_gates"]["errors"] == [
+        f"volume gate {gate} expected >= {minimum}, got {actual}"
+    ]
+    assert summary["errors"] == summary["volume_gates"]["errors"]
+    assert len(calls) == 3
+
+
+def test_run_fails_volume_gate_when_metric_is_missing(monkeypatch, tmp_path):
+    snapshot = {
+        **SNAPSHOT,
+        "summary": {
+            "generated": 2,
+            "drafted_answer_count": 1,
+            "no_proven_answer_count": 1,
+        },
+    }
+    _patch_open(
+        monkeypatch,
+        [
+            (200, _submit_payload(snapshot=snapshot)),
+            (200, snapshot),
+            (403, {"detail": "payment_required"}),
+        ],
+    )
+    summary = smoke.run(
+        smoke._build_parser().parse_args([
+            *_base_args(tmp_path),
+            "--min-repeat-ticket-count",
+            "1",
+        ])
+    )
+
+    assert summary["ok"] is False
+    assert summary["volume_gates"]["errors"] == [
+        "volume gate repeat_ticket_count expected >= 1, got missing"
+    ]
+
+
+def test_run_marks_configured_volume_gates_skipped_when_envelope_fails(
+    monkeypatch,
+    tmp_path,
+):
+    payload = _submit_payload(metadata={
+        "source": "portfolio_deflection_submit",
+        "source_row_count": 3,
+        "submitted_row_count": 3,
+        "truncated_row_count": 0,
+        "max_source_material_rows": 1000,
+        "support_platform": "zendesk",
+    })
+    calls = _patch_open(monkeypatch, [(200, payload)])
+    summary = smoke.run(
+        smoke._build_parser().parse_args([
+            *_base_args(tmp_path),
+            "--min-generated-questions",
+            "1",
+        ])
+    )
+
+    assert summary["ok"] is False
+    assert summary["volume_gates"] == {
+        "configured": {"generated_questions": 1},
+        "actual": {},
+        "ok": False,
+        "skipped": True,
+        "not_run_reason": "submit_failed",
+        "errors": [],
+    }
+    assert (
+        "input_provider.metadata.blob_bytes must be a positive integer "
+        "for json_blob_url submit"
+    ) in summary["errors"]
+    assert len(calls) == 1
 
 
 def test_run_fails_with_stale_multipart_submit_route_diagnostic(monkeypatch, tmp_path):


### PR DESCRIPTION
Plan: plans/PR-Deflection-Full-Volume-Smoke-Gates.md
Slice phase: Functional validation

#1440 needs the hosted deflection submit proof to reject tiny smoke fixtures when the operator is proving a real full-volume raw CSV. This adds optional minimum-volume gates to the existing submit handoff smoke, using only existing submit metadata and free snapshot fields.

## Intentional
- No live email, PDF, Stripe, or hosted payment run in CI.
- No new orchestration script; the existing raw upload -> snapshot -> locked artifact smoke is the upstream proof boundary.
- No generator or clustering behavior change.

## Deferred
- Run the #1440 live hosted proof after deployment: submit the near-50 MB CFPB CSV, confirm snapshot/email/PDF, complete payment, drain delivery, and confirm the full report email/PDF.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed Codex P2 / owner MINOR: configured volume gates that cannot run after a
  submit-envelope failure now report `ok: false`, `skipped: true`, and
  `not_run_reason`, with a regression covering the bad-envelope path.

## Verification
- `python -m pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q` (37 passed)
- `python -m py_compile scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_submit_handoff.py`
- `bash scripts/check_ascii_python.sh`
- `bash scripts/run_extracted_pipeline_checks.sh` (4182 passed, 10 skipped, 1 warning)

## Diff size
3 files, +395 / -0.