### PR TITLE
Deflection stream submit uploads

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -144,6 +144,7 @@ _MAX_INGESTION_FILE_BYTES = 25 * 1024 * 1024
 _MAX_DEFLECTION_SUBMIT_BLOB_BYTES = 50 * 1024 * 1024
 _MAX_DEFLECTION_SUBMIT_ROWS = _MAX_DEFLECTION_SUBMIT_BLOB_BYTES
 _MAX_DEFLECTION_SUBMIT_MULTIPART_OVERHEAD_BYTES = 1024 * 1024
+_DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES = 1024 * 1024
 _MAX_INGESTION_SAMPLE_LIMIT = 25
 _DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS = 15
 _DEFLECTION_SUBMIT_OUTPUTS = ("faq_deflection_report",)
@@ -1551,30 +1552,71 @@ async def _load_deflection_submit_upload_rows(
     *,
     max_bytes: int,
 ) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    temp_path: Path | None = None
     try:
-        data = await csv_file.read(max_bytes + 1)
-    except OSError as exc:
-        raise HTTPException(
-            status_code=400,
-            detail="Uploaded CSV could not be read.",
-        ) from exc
-    if len(data) > max_bytes:
-        raise HTTPException(
-            status_code=413,
-            detail={
-                "reason": "deflection_submit_csv_too_large",
-                "max_file_bytes": max_bytes,
-            },
+        with tempfile.NamedTemporaryFile(
+            prefix="content-ops-deflection-submit-",
+            suffix=".csv",
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            byte_count = await _copy_deflection_submit_upload_to_tempfile(
+                csv_file,
+                handle,
+                max_bytes=max_bytes,
+            )
+        if byte_count == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Uploaded CSV is empty.",
+            )
+        return _parse_deflection_submit_csv_file(
+            temp_path,
+            byte_count=byte_count,
+            parse_error_detail="Uploaded CSV could not be parsed.",
         )
-    if not data:
-        raise HTTPException(
-            status_code=400,
-            detail="Uploaded CSV is empty.",
-        )
-    return _parse_deflection_submit_csv_bytes(
-        data,
-        parse_error_detail="Uploaded CSV could not be parsed.",
-    )
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("Content Ops deflection submit temp cleanup failed")
+
+
+async def _copy_deflection_submit_upload_to_tempfile(
+    csv_file: Any,
+    handle: Any,
+    *,
+    max_bytes: int,
+) -> int:
+    byte_count = 0
+    while True:
+        try:
+            chunk = await csv_file.read(_DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES)
+        except OSError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Uploaded CSV could not be read.",
+            ) from exc
+        if not chunk:
+            return byte_count
+        next_byte_count = byte_count + len(chunk)
+        if next_byte_count > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail={
+                    "reason": "deflection_submit_csv_too_large",
+                    "max_file_bytes": max_bytes,
+                },
+            )
+        try:
+            handle.write(chunk)
+        except OSError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Uploaded CSV could not be staged.",
+            ) from exc
+        byte_count = next_byte_count
 
 
 async def _load_deflection_submit_json_upload_rows(
@@ -1656,18 +1698,10 @@ def _parse_deflection_submit_csv_bytes(
         ) as handle:
             temp_path = Path(handle.name)
             handle.write(data)
-        try:
-            rows, load_warnings = load_source_rows_with_warnings_from_file(
-                temp_path,
-                file_format="csv",
-            )
-        except (OSError, UnicodeDecodeError, ValueError) as exc:
-            raise HTTPException(
-                status_code=400,
-                detail=parse_error_detail,
-            ) from exc
-        return rows, len(data), tuple(
-            warning.as_dict() for warning in load_warnings
+        return _parse_deflection_submit_csv_file(
+            temp_path,
+            byte_count=len(data),
+            parse_error_detail=parse_error_detail,
         )
     finally:
         if temp_path is not None:
@@ -1675,6 +1709,25 @@ def _parse_deflection_submit_csv_bytes(
                 temp_path.unlink(missing_ok=True)
             except OSError:
                 logger.warning("Content Ops deflection submit temp cleanup failed")
+
+
+def _parse_deflection_submit_csv_file(
+    temp_path: Path,
+    *,
+    byte_count: int,
+    parse_error_detail: str,
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    try:
+        rows, load_warnings = load_source_rows_with_warnings_from_file(
+            temp_path,
+            file_format="csv",
+        )
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=parse_error_detail,
+        ) from exc
+    return rows, byte_count, tuple(warning.as_dict() for warning in load_warnings)
 
 
 def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:

--- a/plans/PR-Deflection-Stream-Upload-Tempfile.md
+++ b/plans/PR-Deflection-Stream-Upload-Tempfile.md
@@ -1,0 +1,106 @@
+# PR-Deflection-Stream-Upload-Tempfile
+
+## Why this slice exists
+
+Issue #1458 flags the deflection submit multipart path as a launch-readiness
+memory risk: the uploaded CSV is read into one full `bytes` object before being
+written back to a temporary file for parsing. That creates an avoidable full-file
+copy at the upload boundary, before the existing parser and row caps can help.
+This vertical slice fixes the most-upstream safe boundary in scope: multipart CSV
+uploads are copied directly to a bounded temp file in chunks, while the existing
+CSV parser, diagnostics, and blob path remain unchanged.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Stream multipart CSV uploads for `/content-ops/deflection/submit` into a
+   bounded temporary file instead of reading the whole upload into one `bytes`
+   object.
+2. Add upload-boundary regression coverage proving the helper uses chunked reads,
+   preserves the current parser output, and still fails closed when the stream
+   crosses the byte limit.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Multipart CSV submit no longer calls `read(max_bytes + 1)` on the upload
+    object.
+  - Oversize multipart CSV uploads still return the existing 413
+    `deflection_submit_csv_too_large` envelope.
+  - Existing CSV parsing behavior, load warnings, and byte-count diagnostics are
+    preserved for successful uploads.
+- Affected surfaces: `extracted_content_pipeline/api/control_surfaces.py`,
+  `tests/test_extracted_content_deflection_submit.py`.
+- Risk areas: temp-file cleanup, byte-count accounting, async upload fakes in
+  tests, and preserving parser warning behavior.
+- Reviewer rules triggered: R1, R2, R8, R9, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Stream-Upload-Tempfile.md`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+The deflection submit upload loader stops calling a full-limit upload read.
+Instead it opens the existing submit temp file up front, then reads the
+multipart upload in fixed-size chunks, writes each chunk to disk, and counts
+bytes as it goes. If the count crosses `max_bytes`, it raises the same
+`413 deflection_submit_csv_too_large` envelope as today. Empty uploads and
+parser failures keep their existing behavior.
+
+After the bounded copy succeeds, the helper parses that temp file through the
+same `load_source_rows_with_warnings_from_file(..., file_format="csv")` path used
+today, so delimiter/BOM/warning behavior stays centralized.
+
+## Intentional
+
+- This PR leaves the blob URL path unchanged. Blob fetches are the same root
+  shape, but lower priority: they are bounded at 50MB and sourced from the
+  app-controlled Vercel Blob path rather than direct browser multipart upload.
+- This PR does not rewrite `load_source_rows_with_warnings_from_file()` into a
+  streaming row iterator. The parser still returns a row list; this slice removes
+  the avoidable full-upload `bytes` copy before parsing.
+- The full-thread JSON upload path is unchanged because its shape is a separate
+  importer mode and would need its own JSON streaming design.
+
+## Deferred
+
+- Follow-up hardening for #1458: stream rows out of the CSV parser instead of
+  accumulating every parsed row before package construction, if live-volume
+  profiling still shows memory pressure after this upload-boundary fix.
+- Same-root deferred follow-up: stream the blob URL path into a bounded temp file
+  instead of fetching the full blob into memory before parsing.
+- Follow-up hardening: consider a streaming bounded JSON temp-file copy for
+  `importer_mode=full_thread` if full-thread artifacts approach the submit byte
+  limit in live trials.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py
+- python -m pytest tests/test_extracted_content_deflection_submit.py -q (56 passed)
+- bash scripts/check_ascii_python.sh
+- bash scripts/validate_extracted_content_pipeline.sh
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+- python scripts/audit_extracted_standalone.py --fail-on-debt
+- bash scripts/run_extracted_pipeline_checks.sh (reasoning core: 295 passed;
+  content pipeline: 4185 passed, 10 skipped)
+- python -m pytest tests/test_atlas_content_ops_generated_assets_api.py
+  tests/test_content_ops_brand_voice_profiles.py
+  tests/test_content_ops_brand_voice_profiles_api.py
+  tests/test_content_ops_zendesk_credentials.py
+  tests/test_content_ops_zendesk_export_api.py -q (62 passed)
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 121 |
+| `plans/PR-Deflection-Stream-Upload-Tempfile.md` | 106 |
+| `tests/test_extracted_content_deflection_submit.py` | 64 |
+| **Total** | **291** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import http.client
 import json
+import tempfile
 from io import StringIO
 from pathlib import Path
 import socket
@@ -64,10 +65,20 @@ class _BlobResponse:
 class _Upload:
     def __init__(self, data: bytes, *, filename: str = "tickets.csv") -> None:
         self._data = data
+        self._offset = 0
         self.filename = filename
+        self.read_sizes: list[int] = []
 
-    async def read(self, _size: int) -> bytes:
-        return self._data
+    async def read(self, size: int) -> bytes:
+        self.read_sizes.append(size)
+        if self._offset >= len(self._data):
+            return b""
+        if size < 0:
+            size = len(self._data) - self._offset
+        end = min(len(self._data), self._offset + size)
+        chunk = self._data[self._offset:end]
+        self._offset = end
+        return chunk
 
 
 class _FormRequest:
@@ -100,6 +111,55 @@ def _csv_dict_bytes(rows: list[dict[str, str]]) -> bytes:
     writer.writeheader()
     writer.writerows(rows)
     return out.getvalue().encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_upload_copy_streams_chunks_not_whole_limit() -> None:
+    data = b"a" * (api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES + 17)
+    upload = _Upload(data)
+
+    with tempfile.NamedTemporaryFile() as handle:
+        byte_count = await api_module._copy_deflection_submit_upload_to_tempfile(
+            upload,
+            handle,
+            max_bytes=len(data) + 1024,
+        )
+        handle.flush()
+        handle.seek(0)
+        staged = handle.read()
+
+    assert byte_count == len(data)
+    assert staged == data
+    assert upload.read_sizes
+    assert all(
+        size == api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES
+        for size in upload.read_sizes
+    )
+    assert len(data) + 1025 not in upload.read_sizes
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_upload_copy_rejects_oversize_mid_stream() -> None:
+    data = b"a" * (api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES + 2)
+    upload = _Upload(data)
+
+    with tempfile.NamedTemporaryFile() as handle:
+        with pytest.raises(api_module.HTTPException) as exc_info:
+            await api_module._copy_deflection_submit_upload_to_tempfile(
+                upload,
+                handle,
+                max_bytes=api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES + 1,
+            )
+
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.detail == {
+        "reason": "deflection_submit_csv_too_large",
+        "max_file_bytes": api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES + 1,
+    }
+    assert upload.read_sizes == [
+        api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES,
+        api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES,
+    ]
 
 
 def _install_blob(


### PR DESCRIPTION
Plan: plans/PR-Deflection-Stream-Upload-Tempfile.md
Slice phase: Vertical slice
Refs #1458

Issue #1458 flags the deflection submit multipart path as a launch-readiness memory risk: the uploaded CSV was read into one full `bytes` object before being written back to a temporary file for parsing. This slice fixes the upload boundary by streaming multipart CSV uploads into a bounded temp file in chunks, preserving the existing parser, diagnostics, and blob path behavior.

## Intentional
- Blob URL fetches are the same root shape, but remain deferred here because they are bounded at 50MB and sourced from the app-controlled Vercel Blob path rather than direct browser multipart upload.
- The CSV parser still returns a row list; this PR removes the avoidable full-upload bytes copy before parsing rather than rewriting the parser into an iterator.
- Full-thread JSON uploads are unchanged because that importer mode needs its own streaming JSON design.

## Deferred
- Stream rows out of the CSV parser if live-volume profiling still shows memory pressure after this upload-boundary fix.
- Same-root follow-up: stream the blob URL path into a bounded temp file instead of fetching the full blob into memory before parsing.
- Consider streaming bounded JSON temp-file staging for `importer_mode=full_thread` if full-thread artifacts approach the submit byte limit.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py`
- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` (56 passed)
- `bash scripts/check_ascii_python.sh`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/run_extracted_pipeline_checks.sh` (reasoning core: 295 passed; content pipeline: 4185 passed, 10 skipped)
- `python -m pytest tests/test_atlas_content_ops_generated_assets_api.py tests/test_content_ops_brand_voice_profiles.py tests/test_content_ops_brand_voice_profiles_api.py tests/test_content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_export_api.py -q` (62 passed)

## Diff size
3 files, +255 / -36
