### PR TITLE
Deflection paid unlock diagnostics

### DIFF
--- a/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
@@ -219,6 +219,12 @@ deflection metadata, and then confirms the artifact route returns the full paid
 report. The event id and Checkout session id are generated when omitted, so a
 fresh run does not reuse Stripe webhook idempotency keys.
 
+If the webhook result records status `400` with `error_detail` equal to
+`Invalid signature`, treat that as deployed Stripe signing-secret drift. Do not
+bypass verification or retry with guessed secrets. Align the deployed
+`ATLAS_SAAS_STRIPE_WEBHOOK_SECRET` with the secret used by the smoke, or rotate
+the deployed value to include the new secret, then rerun this smoke.
+
 To also prove the deployed duplicate-event guard, add `--replay-webhook`. That
 posts the same signed event a second time and requires the webhook response to
 return `{"status": "already_processed"}` before the final paid artifact fetch.

--- a/plans/PR-Deflection-Paid-Unlock-Diagnostics.md
+++ b/plans/PR-Deflection-Paid-Unlock-Diagnostics.md
@@ -1,0 +1,108 @@
+# PR-Deflection-Paid-Unlock-Diagnostics
+
+## Why this slice exists
+
+#1557 proved the hosted full-volume ATLAS intake and snapshot path for #1440,
+but the paid-unlock proof stopped at a Stripe webhook `400`. A manual probe
+showed the deployed endpoint returned `Invalid signature`, which means the
+hosted webhook secret and the operator-provided signing secret are not aligned.
+
+The root cause is not weak webhook handling: ATLAS must keep rejecting bad
+Stripe signatures. The correct upstream fix for this slice is to make the paid
+unlock smoke artifact preserve safe server failure details, so future live runs
+identify configuration drift without a second manual probe and without exposing
+tokens, webhook secrets, signed payloads, paid report Markdown, PDFs, or email
+bodies.
+
+## Scope (this PR)
+
+Ownership lane: deflection-full-50k-e2e-proof
+Slice phase: Functional validation
+
+1. Add redacted HTTP error details to the paid-unlock smoke result artifact
+   when hosted webhook or artifact checks fail.
+2. Keep successful smoke artifacts backward-compatible: status fields remain
+   unchanged, and no secret-bearing request values are emitted.
+3. Document the `Invalid signature` interpretation in the #1440 handoff
+   runbook as a deployed Stripe signing-secret alignment blocker, not as a
+   reason to bypass verification.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A hosted webhook failure with JSON `detail` is recorded in the smoke
+        result artifact as a short safe diagnostic.
+  - [ ] Reflected secret-like values in error details are redacted before being
+        written to disk or printed in JSON mode.
+  - [ ] Existing happy-path and replay paid-unlock smoke behavior stays
+        unchanged.
+  - [ ] The runbook names `Invalid signature` as a deployment/config alignment
+        issue and keeps the signed-webhook trust boundary intact.
+- Affected surfaces: scripts, validation docs, payment smoke artifacts.
+- Risk areas: security, observability, backcompat, CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R14.
+
+### Files touched
+
+- `docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md`
+- `plans/PR-Deflection-Paid-Unlock-Diagnostics.md`
+- `scripts/smoke_content_ops_deflection_stripe_paid_unlock.py`
+- `tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py`
+
+## Mechanism
+
+The smoke already reads HTTP error bodies as JSON when a hosted endpoint returns
+an error. This slice adds a small result-summary helper that includes the HTTP
+status and, only when present, a redacted scalar `detail` value from the JSON
+error envelope. The expected pre-webhook artifact lock remains status-only, so
+successful smoke artifacts do not gain an `error_detail` field for the normal
+`payment_required` response.
+
+Redaction happens before the artifact is assembled. It masks common Atlas and
+Stripe secret prefixes and bearer-token shapes, then truncates the diagnostic
+to a short bounded string. The smoke still fails when the webhook status is not
+`200`; it only records why the server rejected the call.
+
+## Intentional
+
+- No change to `atlas_brain/api/billing.py`: accepting the mismatched local
+  signing secret would weaken Stripe webhook verification. The live blocker is
+  deployment/config alignment, not a webhook-code bug.
+- No raw response body capture: the server currently returns safe JSON detail,
+  but recording arbitrary response text would create unnecessary leakage risk.
+- No new CI enrollment is needed because the existing smoke test file is
+  already listed in `scripts/run_extracted_pipeline_checks.sh` and the
+  extracted-checks workflow path filters.
+- The cross-layer caller hint for the result payload helper is name-only. The
+  referenced scripts define their own local helpers; they do not import or call
+  the paid-unlock smoke helper changed here.
+- AI reconciliation: fixed the Codex P2 by suppressing `error_detail` for the
+  expected pre-webhook locked artifact response while preserving detail for
+  unexpected webhook/artifact failures.
+
+## Deferred
+
+- Live #1440 paid unlock and email/PDF delivery remain blocked until the
+  deployed Stripe webhook signing secret matches the secret used by the smoke
+  or the deployed secret is rotated to include it.
+- The portfolio result-page `404` and repeat-volume gate calibration remain
+  separate #1440 blockers and are not changed here.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py - 10 passed.
+- Command: python -m py_compile scripts/smoke_content_ops_deflection_stripe_paid_unlock.py - passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh - 4183 passed, 10 skipped, 1 existing torch warning.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_paid_unlock_diagnostics.md - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md` | 6 |
+| `plans/PR-Deflection-Paid-Unlock-Diagnostics.md` | 108 |
+| `scripts/smoke_content_ops_deflection_stripe_paid_unlock.py` | 50 |
+| `tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py` | 49 |
+| **Total** | **213** |

--- a/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -9,6 +9,7 @@ import hmac
 import json
 import math
 import os
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,6 +28,14 @@ WEBHOOK_PATH = "/webhooks/stripe"
 ARTIFACT_PATH_TEMPLATE = "/api/v1/content-ops/deflection-reports/{request_id}/artifact"
 DEFAULT_AMOUNT_CENTS = 150000
 DEFAULT_CURRENCY = "usd"
+MAX_ERROR_DETAIL_CHARS = 300
+SECRET_TOKEN_PATTERNS = (
+    re.compile(r"\bwhsec_[A-Za-z0-9_=-]+"),
+    re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9_=-]+"),
+    re.compile(r"\brk_(?:live|test)_[A-Za-z0-9_=-]+"),
+    re.compile(r"\bATLAS_[A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|KEY)[A-Z0-9_]*=[^\s,;]+"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE),
+)
 
 try:
     from dotenv import load_dotenv
@@ -241,6 +250,36 @@ def _artifact_errors(artifact: Any) -> list[str]:
     return errors
 
 
+def _redact_error_detail(value: Any) -> str:
+    detail = _clean(value)
+    for pattern in SECRET_TOKEN_PATTERNS:
+        detail = pattern.sub("[redacted]", detail)
+    if len(detail) > MAX_ERROR_DETAIL_CHARS:
+        detail = f"{detail[:MAX_ERROR_DETAIL_CHARS]}..."
+    return detail
+
+
+def _safe_error_detail(result: HttpResult | None) -> str:
+    if result is None or not isinstance(result.payload, Mapping):
+        return ""
+    detail = result.payload.get("detail")
+    if detail is None or isinstance(detail, (Mapping, Sequence)) and not isinstance(detail, str):
+        return ""
+    return _redact_error_detail(detail)
+
+
+def _http_summary(
+    result: HttpResult | None,
+    *,
+    include_error_detail: bool = True,
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {"status": result.status if result else None}
+    detail = _safe_error_detail(result) if include_error_detail else ""
+    if include_error_detail and detail:
+        summary["error_detail"] = detail
+    return summary
+
+
 def _generated_id(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex}"
 
@@ -270,17 +309,20 @@ def _result_payload(
             "token_present": bool(_clean(args.token)),
             "webhook_secret_present": bool(_clean(args.webhook_secret)),
         },
-        "before_artifact": {"status": before_artifact.status if before_artifact else None},
-        "webhook": {"status": webhook.status if webhook else None},
+        "before_artifact": _http_summary(
+            before_artifact,
+            include_error_detail=before_artifact is not None and before_artifact.status != 403,
+        ),
+        "webhook": _http_summary(webhook),
         "replay_webhook": {
-            "status": replay_webhook.status if replay_webhook else None,
+            **_http_summary(replay_webhook),
             "payload_status": (
                 replay_webhook.payload.get("status")
                 if replay_webhook and isinstance(replay_webhook.payload, Mapping)
                 else None
             ),
         },
-        "after_artifact": {"status": after_artifact.status if after_artifact else None},
+        "after_artifact": _http_summary(after_artifact),
     }
 
 

--- a/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -174,7 +174,7 @@ def test_main_posts_signed_webhook_and_unlocks_artifact(monkeypatch, tmp_path, c
     payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
     assert printed == payload
     assert payload["ok"] is True
-    assert payload["before_artifact"]["status"] == 403
+    assert payload["before_artifact"] == {"status": 403}
     assert payload["webhook"]["status"] == 200
     assert payload["after_artifact"]["status"] == 200
 
@@ -233,6 +233,7 @@ def test_main_replays_signed_webhook_and_requires_idempotent_response(
     payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
     assert printed == payload
     assert payload["ok"] is True
+    assert payload["before_artifact"] == {"status": 403}
     assert payload["webhook"] == {"status": 200}
     assert payload["replay_webhook"] == {
         "status": 200,
@@ -309,7 +310,53 @@ def test_main_reports_webhook_failure_without_fetching_unlocked_artifact(monkeyp
     assert code == 1
     assert calls == ["GET", "POST"]
     assert payload["errors"] == ["stripe webhook status must be 200, got 409"]
+    assert payload["webhook"] == {
+        "status": 409,
+        "error_detail": "Deflection report not found",
+    }
     assert payload["after_artifact"]["status"] is None
+
+
+def test_main_redacts_reflected_secret_values_from_error_detail(monkeypatch, tmp_path) -> None:
+    secret_values = {
+        "whsec_reflectedsecret",
+        "sk_live_reflectedsecret",
+        "Bearer reflected-token",
+        "ATLAS_SAAS_STRIPE_WEBHOOK_SECRET=reflectedsecret",
+    }
+
+    def _open(request, *, timeout):
+        if request.get_method() == "GET":
+            raise _http_error(request.full_url, 403, {"detail": "payment_required"})
+        raise _http_error(
+            request.full_url,
+            400,
+            {
+                "detail": (
+                    "Invalid signature for whsec_reflectedsecret using "
+                    "sk_live_reflectedsecret and Bearer reflected-token; "
+                    "ATLAS_SAAS_STRIPE_WEBHOOK_SECRET=reflectedsecret"
+                )
+            },
+        )
+
+    monkeypatch.setattr(smoke, "_open_http_request", _open)
+
+    code = smoke.main(_base_args(tmp_path))
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    serialized = json.dumps(payload)
+
+    assert code == 1
+    assert payload["webhook"] == {
+        "status": 400,
+        "error_detail": (
+            "Invalid signature for [redacted] using [redacted] and [redacted]; "
+            "[redacted]"
+        ),
+    }
+    assert payload["before_artifact"] == {"status": 403}
+    for value in secret_values:
+        assert value not in serialized
 
 
 def test_main_rejects_unlocked_artifact_without_paid_report_fields(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Paid-Unlock-Diagnostics.md
Slice phase: Functional validation

#1557 proved the hosted full-volume ATLAS intake and snapshot path for #1440, but paid unlock stopped at a Stripe webhook `400`. This PR makes the paid-unlock smoke preserve safe, redacted server failure details so signature/config drift is visible in the artifact without weakening Stripe webhook verification or requiring a second manual probe.

## Intentional
- Keep Stripe signature verification unchanged; mismatched secrets still fail closed.
- Do not capture raw response bodies or secret-bearing request values.
- No new CI enrollment is needed because the existing smoke test file is already enrolled in the extracted checks.
- The cross-layer caller hint for the result payload helper is name-only; other scripts define their own local helpers and do not import this smoke helper.
- AI reconciliation: fixed the Codex P2 by suppressing `error_detail` for the expected pre-webhook locked artifact response while preserving detail for unexpected webhook/artifact failures.

## AI reconciliation
- [chatgpt-codex-connector] Preserve the success artifact shape: fixed by keeping the expected pre-webhook 403 lock response status-only while still recording redacted detail for unexpected webhook/artifact failures.

All findings fixed or waived: yes.

## Deferred
- Live #1440 paid unlock and email/PDF delivery remain blocked until the deployed Stripe webhook signing secret matches the secret used by the smoke or the deployed secret is rotated to include it.
- The portfolio result-page `404` and repeat-volume gate calibration remain separate #1440 blockers.

## Parked hardening
- None.

## Verification
- Command: pytest tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py - 10 passed.
- Command: python -m py_compile scripts/smoke_content_ops_deflection_stripe_paid_unlock.py - passed.
- Command: bash scripts/run_extracted_pipeline_checks.sh - 4183 passed, 10 skipped, 1 existing torch warning.
- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_paid_unlock_diagnostics.md - passed.

## Diff size
4 files, +208 / -5
