### PR TITLE
Deflection stream blob CSV submits

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1652,23 +1652,94 @@ def _load_deflection_submit_blob_rows_sync(
     max_bytes: int,
     importer_mode: str = "csv",
 ) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
-    data = _read_bounded_https_blob(blob_url, max_bytes=max_bytes)
-    if not data:
-        detail = (
-            "Zendesk full-thread JSON is empty."
-            if importer_mode == "full_thread"
-            else "Blob CSV is empty."
+    if importer_mode == "full_thread":
+        data = _read_bounded_https_blob(blob_url, max_bytes=max_bytes)
+        if not data:
+            raise HTTPException(
+                status_code=400,
+                detail="Zendesk full-thread JSON is empty.",
+            )
+        return _parse_deflection_submit_zendesk_thread_bytes(data)
+    return _load_deflection_submit_csv_blob_rows_sync(blob_url, max_bytes=max_bytes)
+
+
+def _load_deflection_submit_csv_blob_rows_sync(
+    blob_url: str,
+    *,
+    max_bytes: int,
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="content-ops-deflection-submit-",
+            suffix=".csv",
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            byte_count = _copy_bounded_https_blob_to_tempfile(
+                blob_url,
+                handle,
+                max_bytes=max_bytes,
+            )
+        if byte_count == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Blob CSV is empty.",
+            )
+        return _parse_deflection_submit_csv_file(
+            temp_path,
+            byte_count=byte_count,
+            parse_error_detail="Blob CSV could not be parsed.",
         )
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("Content Ops deflection submit temp cleanup failed")
+
+
+def _copy_bounded_https_blob_to_tempfile(
+    blob_url: str,
+    handle: Any,
+    *,
+    max_bytes: int,
+) -> int:
+    response: Any | None = None
+    byte_count = 0
+    try:
+        response = _open_validated_https_blob_response(blob_url)
+        while True:
+            chunk = response.read(_DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES)
+            if not chunk:
+                return byte_count
+            next_byte_count = byte_count + len(chunk)
+            if next_byte_count > max_bytes:
+                raise HTTPException(
+                    status_code=413,
+                    detail={
+                        "reason": "deflection_submit_blob_too_large",
+                        "max_file_bytes": max_bytes,
+                    },
+                )
+            try:
+                handle.write(chunk)
+            except OSError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Blob CSV could not be staged.",
+                ) from exc
+            byte_count = next_byte_count
+    except HTTPException:
+        raise
+    except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
         raise HTTPException(
             status_code=400,
-            detail=detail,
-        )
-    if importer_mode == "full_thread":
-        return _parse_deflection_submit_zendesk_thread_bytes(data)
-    return _parse_deflection_submit_csv_bytes(
-        data,
-        parse_error_detail="Blob CSV could not be parsed.",
-    )
+            detail="Blob URL could not be fetched.",
+        ) from exc
+    finally:
+        if response is not None:
+            _close_https_blob_response(response)
 
 
 def _parse_deflection_submit_zendesk_thread_bytes(
@@ -1682,33 +1753,6 @@ def _parse_deflection_submit_zendesk_thread_bytes(
             detail="Zendesk full-thread JSON could not be parsed.",
         ) from exc
     return result.rows, len(data), result.warnings
-
-
-def _parse_deflection_submit_csv_bytes(
-    data: bytes,
-    *,
-    parse_error_detail: str,
-) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
-    temp_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            prefix="content-ops-deflection-submit-",
-            suffix=".csv",
-            delete=False,
-        ) as handle:
-            temp_path = Path(handle.name)
-            handle.write(data)
-        return _parse_deflection_submit_csv_file(
-            temp_path,
-            byte_count=len(data),
-            parse_error_detail=parse_error_detail,
-        )
-    finally:
-        if temp_path is not None:
-            try:
-                temp_path.unlink(missing_ok=True)
-            except OSError:
-                logger.warning("Content Ops deflection submit temp cleanup failed")
 
 
 def _parse_deflection_submit_csv_file(
@@ -1731,6 +1775,32 @@ def _parse_deflection_submit_csv_file(
 
 
 def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
+    response: Any | None = None
+    try:
+        response = _open_validated_https_blob_response(blob_url)
+        data = response.read(max_bytes + 1)
+    except HTTPException:
+        raise
+    except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Blob URL could not be fetched.",
+        ) from exc
+    finally:
+        if response is not None:
+            _close_https_blob_response(response)
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "reason": "deflection_submit_blob_too_large",
+                "max_file_bytes": max_bytes,
+            },
+        )
+    return data
+
+
+def _open_validated_https_blob_response(blob_url: str) -> Any:
     target = _validate_https_blob_fetch_target(blob_url)
     response: Any | None = None
     try:
@@ -1749,7 +1819,7 @@ def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
                 status_code=400,
                 detail="Blob URL could not be fetched.",
             )
-        data = response.read(max_bytes + 1)
+        return response
     except urllib.error.HTTPError as exc:
         if 300 <= int(getattr(exc, "code", 0) or 0) < 400:
             raise HTTPException(
@@ -1760,23 +1830,15 @@ def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
             status_code=400,
             detail="Blob URL could not be fetched.",
         ) from exc
+    except HTTPException:
+        if response is not None:
+            _close_https_blob_response(response)
+        raise
     except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
         raise HTTPException(
             status_code=400,
             detail="Blob URL could not be fetched.",
         ) from exc
-    finally:
-        if response is not None:
-            _close_https_blob_response(response)
-    if len(data) > max_bytes:
-        raise HTTPException(
-            status_code=413,
-            detail={
-                "reason": "deflection_submit_blob_too_large",
-                "max_file_bytes": max_bytes,
-            },
-        )
-    return data
 
 
 @dataclass(frozen=True)

--- a/plans/PR-Deflection-Blob-Upload-Tempfile.md
+++ b/plans/PR-Deflection-Blob-Upload-Tempfile.md
@@ -1,0 +1,111 @@
+# PR-Deflection-Blob-Upload-Tempfile
+
+## Why this slice exists
+
+PR-Deflection-Stream-Upload-Tempfile closed the direct multipart upload memory
+risk from #1458, but its review called out the same root still present in the
+blob URL CSV path: `_read_bounded_https_blob(...)` returns one full `bytes`
+object, then `_parse_deflection_submit_csv_bytes(...)` writes those bytes back
+to a temp file for the CSV parser. That is the same avoidable full-file copy one
+hop later in the submit flow. This slice drains that deferred same-root item for
+CSV blobs by streaming the fetched response into the bounded temp file that the
+parser already consumes.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Stream `importer_mode=csv` blob URL responses into a bounded temp file
+   instead of materializing the full blob as `bytes` before CSV parsing.
+2. Preserve the existing blob URL security gates: HTTPS-only validation, DNS
+   fail-closed checks, no redirects, non-2xx rejection, timeout, byte cap, and
+   response close behavior.
+3. Add regression coverage proving the CSV blob path reads in chunks, rejects
+   oversize blobs before writing the over-limit chunk, closes responses, and
+   still parses through the existing CSV loader.
+4. Leave full-thread JSON blob parsing unchanged because
+   `load_zendesk_full_thread_rows_from_json_bytes(...)` currently requires a
+   byte payload and needs a separate JSON streaming design.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `importer_mode=csv` blob fetches no longer call `response.read(max_bytes + 1)`.
+  - Oversize CSV blobs still return the existing 413
+    `deflection_submit_blob_too_large` envelope.
+  - CSV blob parsing still reports the same byte count and load-warning shape.
+  - Redirect/non-success/malformed fetch handling and response cleanup remain
+    fail-closed.
+- Affected surfaces: `extracted_content_pipeline/api/control_surfaces.py`,
+  `tests/test_extracted_content_deflection_submit.py`.
+- Risk areas: response cleanup, partial temp-file cleanup, byte-count
+  accounting, preserving full-thread JSON behavior, and broadening the SSRF
+  fetch surface by accident.
+- Reviewer rules triggered: R1, R2, R8, R9, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Blob-Upload-Tempfile.md`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+The blob loader keeps the existing async-to-thread boundary. Inside the sync
+CSV path it opens the HTTP response through the same validated target helper,
+checks redirect/status exactly as before, then copies `response.read(CHUNK)` into
+a named temp file while counting bytes. If the next chunk would cross
+`max_bytes`, it raises the existing 413 envelope before writing that chunk. After
+a successful non-empty copy, it parses the temp file through
+`_parse_deflection_submit_csv_file(...)`, preserving delimiter/BOM/warning
+behavior from the shared CSV loader.
+
+The existing `_read_bounded_https_blob(...)` stays for full-thread JSON and
+other byte-oriented callers. Shared fetch status/error/cleanup behavior is kept
+small and local so the security surface does not fork.
+
+## Intentional
+
+- This PR does not stream full-thread JSON blobs. The full-thread importer is
+  already intentionally byte-oriented through
+  `load_zendesk_full_thread_rows_from_json_bytes(...)`; changing that safely is a
+  separate parser-design slice.
+- This PR does not rewrite `load_source_rows_with_warnings_from_file()` into a
+  streaming row iterator. It removes the extra blob `bytes` materialization while
+  keeping the existing parser contract.
+- The direct multipart upload helper remains unchanged; #1556 already moved
+  that path to chunked temp-file staging.
+
+## Deferred
+
+- Follow-up hardening for #1458: stream rows out of the CSV parser instead of
+  accumulating every parsed row before package construction, if live-volume
+  profiling still shows memory pressure after the upload/blob-boundary fixes.
+- Full-thread JSON follow-up: design a bounded streaming JSON artifact parser if
+  full-thread exports approach the submit byte limit in live trials.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m py_compile extracted_content_pipeline/api/control_surfaces.py
+  tests/test_extracted_content_deflection_submit.py
+- python -m pytest tests/test_extracted_content_deflection_submit.py -q
+  (58 passed)
+- bash scripts/check_ascii_python.sh
+- bash scripts/validate_extracted_content_pipeline.sh
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline
+- python scripts/audit_extracted_standalone.py --fail-on-debt
+- bash scripts/run_extracted_pipeline_checks.sh (reasoning core: 295 passed;
+  content pipeline: 4187 passed, 10 skipped)
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 156 |
+| `plans/PR-Deflection-Blob-Upload-Tempfile.md` | 111 |
+| `tests/test_extracted_content_deflection_submit.py` | 86 |
+| **Total** | **353** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -46,11 +46,21 @@ def _route(router: Any, path: str, method: str) -> Any:
 class _BlobResponse:
     def __init__(self, data: bytes, *, status: int = 200) -> None:
         self._data = data
+        self._offset = 0
         self.status = status
         self.closed = False
+        self.read_sizes: list[int] = []
 
-    def read(self, _size: int) -> bytes:
-        return self._data
+    def read(self, size: int) -> bytes:
+        self.read_sizes.append(size)
+        if self._offset >= len(self._data):
+            return b""
+        if size < 0:
+            size = len(self._data) - self._offset
+        end = min(len(self._data), self._offset + size)
+        chunk = self._data[self._offset:end]
+        self._offset = end
+        return chunk
 
     def close(self) -> None:
         self.closed = True
@@ -187,6 +197,78 @@ def _install_public_dns(monkeypatch: pytest.MonkeyPatch) -> None:
         )]
 
     monkeypatch.setattr(api_module.socket, "getaddrinfo", _getaddrinfo)
+
+
+def test_deflection_submit_blob_csv_streams_response_to_tempfile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    message = "How do I export reports? " * 4000
+    data = _csv_bytes(
+        ["ticket_id,message"]
+        + [f"ticket-{index},{message}" for index in range(12)]
+    )
+    response = _BlobResponse(data)
+
+    monkeypatch.setattr(
+        api_module,
+        "_open_https_blob_request",
+        lambda _target, *, timeout: response,
+    )
+
+    rows, byte_count, load_warnings = api_module._load_deflection_submit_blob_rows_sync(
+        "https://portfolio.example/blob/tickets.csv",
+        max_bytes=len(data) + 1024,
+        importer_mode="csv",
+    )
+
+    assert byte_count == len(data)
+    assert load_warnings == ()
+    assert rows[0]["ticket_id"] == "ticket-0"
+    assert response.closed
+    assert response.read_sizes
+    assert all(
+        size == api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES
+        for size in response.read_sizes
+    )
+    assert len(data) + 1025 not in response.read_sizes
+
+
+def test_copy_bounded_https_blob_rejects_oversize_before_writing_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    data = b"a" * (api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES + 2)
+    response = _BlobResponse(data)
+
+    monkeypatch.setattr(
+        api_module,
+        "_open_https_blob_request",
+        lambda _target, *, timeout: response,
+    )
+
+    with tempfile.NamedTemporaryFile() as handle:
+        with pytest.raises(api_module.HTTPException) as exc_info:
+            api_module._copy_bounded_https_blob_to_tempfile(
+                "https://portfolio.example/blob/tickets.csv",
+                handle,
+                max_bytes=api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES + 1,
+            )
+        handle.flush()
+        handle.seek(0)
+        staged = handle.read()
+
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.detail == {
+        "reason": "deflection_submit_blob_too_large",
+        "max_file_bytes": api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES + 1,
+    }
+    assert staged == b"a" * api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES
+    assert response.closed
+    assert response.read_sizes == [
+        api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES,
+        api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES,
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Blob-Upload-Tempfile.md
Slice phase: Production hardening
Refs #1458

PR-Deflection-Stream-Upload-Tempfile fixed the multipart upload memory copy, but left the same root in the CSV blob URL path: fetch the whole blob into `bytes`, then write those bytes back to a temp file for parsing. This PR streams CSV blob responses directly into the bounded temp file while preserving the existing blob URL validation, status/redirect handling, byte cap, response cleanup, and CSV parser behavior.

## Intentional
- Full-thread JSON blobs remain byte-oriented because `load_zendesk_full_thread_rows_from_json_bytes(...)` currently consumes a byte payload; that needs a separate JSON streaming design.
- The CSV parser still returns a row list. This removes the extra blob `bytes` materialization before parsing, not the parser row accumulation.
- Direct multipart upload staging is unchanged because #1556 already moved that path to chunked temp-file staging.

## Deferred
- Stream rows out of the CSV parser if live-volume profiling still shows memory pressure after the upload/blob-boundary fixes.
- Full-thread JSON follow-up: design a bounded streaming JSON artifact parser if full-thread exports approach the submit byte limit in live trials.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py`
- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` (58 passed)
- `bash scripts/check_ascii_python.sh`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/run_extracted_pipeline_checks.sh` (reasoning core: 295 passed; content pipeline: 4187 passed, 10 skipped)

## Diff size
3 files, +353 / -49
