### PR TITLE
Deflection blob fetch hardening

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1725,6 +1725,10 @@ def _copy_bounded_https_blob_to_tempfile(
             try:
                 handle.write(chunk)
             except OSError as exc:
+                _log_deflection_blob_fetch_failure(
+                    blob_url,
+                    "Content Ops deflection blob CSV staging failed",
+                )
                 raise HTTPException(
                     status_code=400,
                     detail="Blob CSV could not be staged.",
@@ -1733,6 +1737,10 @@ def _copy_bounded_https_blob_to_tempfile(
     except HTTPException:
         raise
     except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
+        _log_deflection_blob_fetch_failure(
+            blob_url,
+            "Content Ops deflection blob fetch failed",
+        )
         raise HTTPException(
             status_code=400,
             detail="Blob URL could not be fetched.",
@@ -1782,6 +1790,10 @@ def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
     except HTTPException:
         raise
     except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
+        _log_deflection_blob_fetch_failure(
+            blob_url,
+            "Content Ops deflection blob fetch failed",
+        )
         raise HTTPException(
             status_code=400,
             detail="Blob URL could not be fetched.",
@@ -1820,21 +1832,17 @@ def _open_validated_https_blob_response(blob_url: str) -> Any:
                 detail="Blob URL could not be fetched.",
             )
         return response
-    except urllib.error.HTTPError as exc:
-        if 300 <= int(getattr(exc, "code", 0) or 0) < 400:
-            raise HTTPException(
-                status_code=400,
-                detail="Blob URL redirects are not allowed.",
-            ) from exc
-        raise HTTPException(
-            status_code=400,
-            detail="Blob URL could not be fetched.",
-        ) from exc
     except HTTPException:
         if response is not None:
             _close_https_blob_response(response)
         raise
     except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
+        if response is not None:
+            _close_https_blob_response(response)
+        _log_deflection_blob_fetch_failure(
+            blob_url,
+            "Content Ops deflection blob fetch failed",
+        )
         raise HTTPException(
             status_code=400,
             detail="Blob URL could not be fetched.",
@@ -1896,8 +1904,10 @@ class _PinnedBlobResponse:
         return self._response.read(size)
 
     def close(self) -> None:
-        self._response.close()
-        self._connection.close()
+        try:
+            self._response.close()
+        finally:
+            self._connection.close()
 
 
 def _open_https_blob_request(
@@ -1931,6 +1941,18 @@ def _close_https_blob_response(response: Any) -> None:
     close = getattr(response, "close", None)
     if callable(close):
         close()
+
+
+def _log_deflection_blob_fetch_failure(blob_url: str, message: str) -> None:
+    parsed = urllib.parse.urlparse(blob_url)
+    logger.warning(
+        message,
+        extra={
+            "blob_host": parsed.hostname or "",
+            "blob_path": parsed.path or "/",
+        },
+        exc_info=True,
+    )
 
 
 def _validate_https_blob_url(value: Any) -> str:

--- a/plans/PR-Deflection-Blob-Fetch-Hardening.md
+++ b/plans/PR-Deflection-Blob-Fetch-Hardening.md
@@ -1,0 +1,96 @@
+# PR-Deflection-Blob-Fetch-Hardening
+
+## Why this slice exists
+
+#1561 drained the CSV blob same-root memory copy, and review verified the
+streaming behavior. The remaining review NITs were all small fetch-boundary
+survivability gaps on the same public paid-submit path: response close should
+not be able to leak the underlying connection, validated-response setup should
+cleanup symmetrically if a future edit raises after response creation, dead
+transport branches should not obscure the actual http.client path, and transport
+failures need a warning for operational diagnosis. This slice tightens those
+edges without changing submit behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Make `_PinnedBlobResponse.close()` close the pinned HTTPS connection even if
+   response close raises.
+2. Make `_open_validated_https_blob_response(...)` cleanup any opened response
+   on all exception exits.
+3. Remove the dead `urllib.error.HTTPError` branch from the pinned
+   `http.client` fetch helper and keep redirect rejection on the status check.
+4. Log transport/staging failures before returning the existing generic 400
+   envelope.
+5. Add focused regression tests for connection-close-on-response-close-error and
+   fetch-failure logging/cleanup.
+
+### Review Contract
+
+- Acceptance criteria:
+  - A response-close failure cannot prevent the connection from closing.
+  - A fetch helper exception after response creation closes that response.
+  - Blob URL public error envelopes remain unchanged.
+  - Transport failures are logged without leaking URLs with credentials.
+- Affected surfaces: `extracted_content_pipeline/api/control_surfaces.py`,
+  `tests/test_extracted_content_deflection_submit.py`.
+- Risk areas: accidentally changing SSRF validation, surfacing internal fetch
+  details to users, and broad catch blocks swallowing actionable exceptions.
+- Reviewer rules triggered: R1, R2, R8, R9, R10, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Blob-Fetch-Hardening.md`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+`_PinnedBlobResponse.close()` becomes a `try/finally`: attempt to close the
+HTTP response, always close the pinned connection. Fetch helper cleanup also uses
+a small local helper so every exception branch closes an already-opened response
+before raising. The public exception detail remains the existing
+`"Blob URL could not be fetched."` or redirect-specific message.
+
+Transport exceptions are logged with the URL host/path only after validation has
+accepted the target. The log keeps user-facing envelopes stable while giving
+operators a diagnostic reason for origin-side failures.
+
+## Intentional
+
+- This PR does not change the redirect/status behavior from #1561. Redirects are
+  still rejected by status code and not followed.
+- This PR does not surface raw exception details to the buyer-facing API
+  response; it logs them server-side and preserves the existing generic 400.
+- This PR does not take over #1560 or any repeat-gate work.
+
+## Deferred
+
+- None.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m py_compile extracted_content_pipeline/api/control_surfaces.py
+  tests/test_extracted_content_deflection_submit.py
+- python -m pytest tests/test_extracted_content_deflection_submit.py -q
+  (60 passed)
+- bash scripts/check_ascii_python.sh
+- bash scripts/validate_extracted_content_pipeline.sh
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline
+- python scripts/audit_extracted_standalone.py --fail-on-debt
+- bash scripts/run_extracted_pipeline_checks.sh (reasoning core: 295 passed;
+  content pipeline: 4189 passed, 10 skipped)
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 46 |
+| `plans/PR-Deflection-Blob-Fetch-Hardening.md` | 96 |
+| `tests/test_extracted_content_deflection_submit.py` | 77 |
+| **Total** | **219** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -1439,13 +1439,7 @@ async def test_deflection_submit_rejects_blob_redirects(
 
     def _open(target: Any, *, timeout: int) -> _BlobResponse:
         calls.append(target.url)
-        raise urllib.error.HTTPError(
-            target.url,
-            302,
-            "Found",
-            {"Location": "http://169.254.169.254/latest/meta-data"},
-            None,
-        )
+        return _BlobResponse(b"", status=302)
 
     monkeypatch.setattr(api_module, "_open_https_blob_request", _open)
     router = _router(InMemoryDeflectionReportArtifactStore())
@@ -1462,6 +1456,75 @@ async def test_deflection_submit_rejects_blob_redirects(
     assert calls == ["https://portfolio.example/blob/tickets.csv"]
     assert exc.value.status_code == 400
     assert exc.value.detail == "Blob URL redirects are not allowed."
+
+
+def test_pinned_blob_response_closes_connection_if_response_close_fails() -> None:
+    class _Response:
+        status = 200
+
+        def read(self, _size: int) -> bytes:
+            return b""
+
+        def close(self) -> None:
+            raise OSError("response close failed")
+
+    class _Connection:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    connection = _Connection()
+    response = api_module._PinnedBlobResponse(_Response(), connection)  # type: ignore[arg-type]
+
+    with pytest.raises(OSError, match="response close failed"):
+        response.close()
+
+    assert connection.closed
+
+
+def test_open_validated_https_blob_response_closes_and_logs_setup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _install_public_dns(monkeypatch)
+
+    class _StatusRaisesResponse:
+        closed = False
+
+        @property
+        def status(self) -> int:
+            raise OSError("status failed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = _StatusRaisesResponse()
+    caplog.set_level("WARNING", logger=api_module.logger.name)
+    monkeypatch.setattr(
+        api_module,
+        "_open_https_blob_request",
+        lambda _target, *, timeout: response,
+    )
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        api_module._open_validated_https_blob_response(
+            "https://portfolio.example/blob/tickets.csv?sig=secret",
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Blob URL could not be fetched."
+    assert response.closed
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "Content Ops deflection blob fetch failed"
+    ]
+    assert len(records) == 1
+    assert getattr(records[0], "blob_host") == "portfolio.example"
+    assert getattr(records[0], "blob_path") == "/blob/tickets.csv"
+    assert "secret" not in caplog.text
 
 
 def test_read_bounded_https_blob_rejects_redirect_status_without_following() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Blob-Fetch-Hardening.md
Slice phase: Production hardening

#1561 shipped the CSV blob streaming fix; this follow-up drains the small blob-fetch hardening NITs from that review. It makes pinned-response close leak-safe, closes any opened response on all validated-fetch exception exits, removes the dead urllib redirect branch in favor of the real status-code path, and logs origin-side fetch/staging failures while keeping buyer-facing error envelopes unchanged.

## Intentional
- Redirect behavior remains status-code based and fail-closed.
- Raw transport exception details stay out of the public API response; they are logged server-side.
- This does not take over #1560 or any repeat-gate calibration work.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py`
- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` (60 passed)
- `bash scripts/check_ascii_python.sh`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/run_extracted_pipeline_checks.sh` (reasoning core: 295 passed; content pipeline: 4189 passed, 10 skipped)

## Diff size
3 files, +219 / -19
