### PR TITLE
Deflection full-thread JSON tempfile staging

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -90,6 +90,7 @@ from ..ticket_faq_input_contract import ticket_faq_input_contracts
 from ..support_ticket_input_package import build_support_ticket_input_package
 from ..support_ticket_zendesk_thread import (
     load_zendesk_full_thread_rows_from_json_bytes,
+    load_zendesk_full_thread_rows_from_json_file,
 )
 
 ExecutionServicesProvider = Callable[
@@ -1584,19 +1585,22 @@ async def _load_deflection_submit_upload_rows(
 
 
 async def _copy_deflection_submit_upload_to_tempfile(
-    csv_file: Any,
+    upload_file: Any,
     handle: Any,
     *,
     max_bytes: int,
+    too_large_reason: str = "deflection_submit_csv_too_large",
+    read_error_detail: str = "Uploaded CSV could not be read.",
+    stage_error_detail: str = "Uploaded CSV could not be staged.",
 ) -> int:
     byte_count = 0
     while True:
         try:
-            chunk = await csv_file.read(_DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES)
+            chunk = await upload_file.read(_DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES)
         except OSError as exc:
             raise HTTPException(
                 status_code=400,
-                detail="Uploaded CSV could not be read.",
+                detail=read_error_detail,
             ) from exc
         if not chunk:
             return byte_count
@@ -1605,7 +1609,7 @@ async def _copy_deflection_submit_upload_to_tempfile(
             raise HTTPException(
                 status_code=413,
                 detail={
-                    "reason": "deflection_submit_csv_too_large",
+                    "reason": too_large_reason,
                     "max_file_bytes": max_bytes,
                 },
             )
@@ -1614,7 +1618,7 @@ async def _copy_deflection_submit_upload_to_tempfile(
         except OSError as exc:
             raise HTTPException(
                 status_code=400,
-                detail="Uploaded CSV could not be staged.",
+                detail=stage_error_detail,
             ) from exc
         byte_count = next_byte_count
 
@@ -1624,27 +1628,41 @@ async def _load_deflection_submit_json_upload_rows(
     *,
     max_bytes: int,
 ) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    temp_path: Path | None = None
     try:
-        data = await json_file.read(max_bytes + 1)
-    except OSError as exc:
-        raise HTTPException(
-            status_code=400,
-            detail="Uploaded Zendesk full-thread JSON could not be read.",
-        ) from exc
-    if len(data) > max_bytes:
-        raise HTTPException(
-            status_code=413,
-            detail={
-                "reason": "deflection_submit_full_thread_too_large",
-                "max_file_bytes": max_bytes,
-            },
+        with tempfile.NamedTemporaryFile(
+            prefix="content-ops-deflection-submit-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            byte_count = await _copy_deflection_submit_upload_to_tempfile(
+                json_file,
+                handle,
+                max_bytes=max_bytes,
+                too_large_reason="deflection_submit_full_thread_too_large",
+                read_error_detail=(
+                    "Uploaded Zendesk full-thread JSON could not be read."
+                ),
+                stage_error_detail=(
+                    "Uploaded Zendesk full-thread JSON could not be staged."
+                ),
+            )
+        if byte_count == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Uploaded Zendesk full-thread JSON is empty.",
+            )
+        return _parse_deflection_submit_zendesk_thread_file(
+            temp_path,
+            byte_count=byte_count,
         )
-    if not data:
-        raise HTTPException(
-            status_code=400,
-            detail="Uploaded Zendesk full-thread JSON is empty.",
-        )
-    return _parse_deflection_submit_zendesk_thread_bytes(data)
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("Content Ops deflection submit temp cleanup failed")
 
 
 def _load_deflection_submit_blob_rows_sync(
@@ -1653,14 +1671,50 @@ def _load_deflection_submit_blob_rows_sync(
     importer_mode: str = "csv",
 ) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
     if importer_mode == "full_thread":
-        data = _read_bounded_https_blob(blob_url, max_bytes=max_bytes)
-        if not data:
+        return _load_deflection_submit_json_blob_rows_sync(
+            blob_url,
+            max_bytes=max_bytes,
+        )
+    return _load_deflection_submit_csv_blob_rows_sync(blob_url, max_bytes=max_bytes)
+
+
+def _load_deflection_submit_json_blob_rows_sync(
+    blob_url: str,
+    *,
+    max_bytes: int,
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="content-ops-deflection-submit-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            byte_count = _copy_bounded_https_blob_to_tempfile(
+                blob_url,
+                handle,
+                max_bytes=max_bytes,
+                stage_error_detail="Zendesk full-thread JSON could not be staged.",
+                stage_log_message=(
+                    "Content Ops deflection blob full-thread JSON staging failed"
+                ),
+            )
+        if byte_count == 0:
             raise HTTPException(
                 status_code=400,
                 detail="Zendesk full-thread JSON is empty.",
             )
-        return _parse_deflection_submit_zendesk_thread_bytes(data)
-    return _load_deflection_submit_csv_blob_rows_sync(blob_url, max_bytes=max_bytes)
+        return _parse_deflection_submit_zendesk_thread_file(
+            temp_path,
+            byte_count=byte_count,
+        )
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("Content Ops deflection submit temp cleanup failed")
 
 
 def _load_deflection_submit_csv_blob_rows_sync(
@@ -1704,6 +1758,10 @@ def _copy_bounded_https_blob_to_tempfile(
     handle: Any,
     *,
     max_bytes: int,
+    too_large_reason: str = "deflection_submit_blob_too_large",
+    stage_error_detail: str = "Blob CSV could not be staged.",
+    stage_log_message: str = "Content Ops deflection blob CSV staging failed",
+    fetch_log_message: str = "Content Ops deflection blob fetch failed",
 ) -> int:
     response: Any | None = None
     byte_count = 0
@@ -1718,7 +1776,7 @@ def _copy_bounded_https_blob_to_tempfile(
                 raise HTTPException(
                     status_code=413,
                     detail={
-                        "reason": "deflection_submit_blob_too_large",
+                        "reason": too_large_reason,
                         "max_file_bytes": max_bytes,
                     },
                 )
@@ -1727,11 +1785,11 @@ def _copy_bounded_https_blob_to_tempfile(
             except OSError as exc:
                 _log_deflection_blob_fetch_failure(
                     blob_url,
-                    "Content Ops deflection blob CSV staging failed",
+                    stage_log_message,
                 )
                 raise HTTPException(
                     status_code=400,
-                    detail="Blob CSV could not be staged.",
+                    detail=stage_error_detail,
                 ) from exc
             byte_count = next_byte_count
     except HTTPException:
@@ -1739,7 +1797,7 @@ def _copy_bounded_https_blob_to_tempfile(
     except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
         _log_deflection_blob_fetch_failure(
             blob_url,
-            "Content Ops deflection blob fetch failed",
+            fetch_log_message,
         )
         raise HTTPException(
             status_code=400,
@@ -1761,6 +1819,21 @@ def _parse_deflection_submit_zendesk_thread_bytes(
             detail="Zendesk full-thread JSON could not be parsed.",
         ) from exc
     return result.rows, len(data), result.warnings
+
+
+def _parse_deflection_submit_zendesk_thread_file(
+    temp_path: Path,
+    *,
+    byte_count: int,
+) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    try:
+        result = load_zendesk_full_thread_rows_from_json_file(temp_path)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Zendesk full-thread JSON could not be parsed.",
+        ) from exc
+    return result.rows, byte_count, result.warnings
 
 
 def _parse_deflection_submit_csv_file(

--- a/extracted_content_pipeline/support_ticket_zendesk_thread.py
+++ b/extracted_content_pipeline/support_ticket_zendesk_thread.py
@@ -6,6 +6,7 @@ import json
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from .support_ticket_clustering import support_ticket_plain_text
@@ -48,6 +49,18 @@ def load_zendesk_full_thread_rows_from_json_bytes(
     try:
         artifact = json.loads(data.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Zendesk full-thread JSON could not be parsed.") from exc
+    return rows_from_zendesk_full_thread(artifact)
+
+
+def load_zendesk_full_thread_rows_from_json_file(
+    path: str | Path,
+) -> ZendeskThreadImportResult:
+    """Parse a staged Zendesk thread JSON file into support-ticket rows."""
+
+    try:
+        artifact = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError("Zendesk full-thread JSON could not be parsed.") from exc
     return rows_from_zendesk_full_thread(artifact)
 
@@ -243,5 +256,6 @@ def _clean(value: Any) -> str:
 __all__ = [
     "ZendeskThreadImportResult",
     "load_zendesk_full_thread_rows_from_json_bytes",
+    "load_zendesk_full_thread_rows_from_json_file",
     "rows_from_zendesk_full_thread",
 ]

--- a/plans/PR-Deflection-Full-Thread-JSON-Tempfile.md
+++ b/plans/PR-Deflection-Full-Thread-JSON-Tempfile.md
@@ -1,0 +1,111 @@
+# PR-Deflection-Full-Thread-JSON-Tempfile
+
+## Why this slice exists
+
+#1556/#1561/#1562 moved CSV submit uploads and Blob CSV fetches off the old
+single-buffer path and into bounded tempfile staging. The Zendesk full-thread
+JSON path still takes the old shape: uploaded JSON reads `max_bytes + 1` at
+once, Blob JSON reads `max_bytes + 1` at once, and the route hands a bytes
+object to the thread normalizer. That leaves the submit boundary asymmetric
+right where the live Zendesk export path now feeds private Blob artifacts.
+
+This slice fixes the upstream submit boundary, not a downstream symptom: full
+thread JSON is staged through the same bounded tempfile pattern as CSV before
+parsing. The parser still loads JSON once it is time to parse; this PR does not
+pretend to be a streaming JSON parser. It closes the upload/blob read shape so
+large-but-allowed full-thread artifacts do not require a route-layer whole-file
+read before normalization.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Add a file/path entry point for Zendesk full-thread JSON normalization.
+2. Stage full-thread multipart JSON uploads into a bounded tempfile in chunks.
+3. Stage full-thread Blob JSON fetches into a bounded tempfile with the existing
+   pinned HTTPS fetch/SSRF guard, then parse from the file.
+4. Add focused tests proving chunked upload reads, chunked Blob reads, unchanged
+   metadata/output behavior, malformed JSON failure, empty failure, and oversize
+   failure.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] `importer_mode="full_thread"` multipart JSON no longer reads
+        `max_bytes + 1` in one call before parsing.
+  - [ ] `importer_mode="full_thread"` Blob JSON no longer reads
+        `max_bytes + 1` in one call before parsing.
+  - [ ] Existing public metadata remains stable: row counts, `uploaded_bytes` /
+        `blob_bytes`, support platform, resolution evidence, status, CSAT,
+        warnings, and private-note suppression.
+  - [ ] Empty, oversize, malformed, and wrong-file/mode cases still fail closed
+        with the existing public error shapes.
+  - [ ] Tempfiles are cleaned up on success and failure.
+- Affected surfaces: extracted Content Ops API submit loaders, Zendesk
+  full-thread normalizer, submit tests, support-ticket normalizer tests.
+- Risk areas: hidden whole-file reads, error-shape drift, tempfile leaks,
+  private-note leakage, and accidental changes to CSV submit behavior.
+- Reviewer rules triggered: R1, R2, R5, R8, R9, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/support_ticket_zendesk_thread.py`
+- `plans/PR-Deflection-Full-Thread-JSON-Tempfile.md`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+
+## Mechanism
+
+`support_ticket_zendesk_thread.py` gets
+`load_zendesk_full_thread_rows_from_json_file(path)`, which reads and parses a
+UTF-8 JSON artifact from an already-staged file, then delegates to the existing
+`rows_from_zendesk_full_thread` normalizer.
+
+The submit API keeps the existing mode contract. CSV remains the default. For
+`importer_mode="full_thread"`, multipart uploads are copied into a temporary
+JSON file using the same fixed-size upload chunk loop as CSV, then parsed via
+the file entry point. Blob full-thread artifacts reuse the existing pinned HTTPS
+fetch validation and response chunk copy into a temporary JSON file, then
+parse via the same file entry point. Both paths return the existing
+`(rows, byte_count, warnings)` tuple and clean up the tempfile in `finally`.
+
+## Intentional
+
+- This is not a streaming JSON parser. The correct safe upstream point for this
+  slice is the submit boundary that was still reading full-thread artifacts into
+  bytes before parsing. A true incremental parser would be a separate robustness
+  slice with a dependency and broader parser contract.
+- CSV behavior stays unchanged except for sharing generic copy helpers with
+  JSON-specific error details.
+- Blob oversize keeps the existing `deflection_submit_blob_too_large` reason so
+  callers do not see an error-contract rename for private Blob submits.
+
+## Deferred
+
+- True streaming JSON parsing if live Zendesk artifacts approach the submit byte
+  limit and route-layer tempfile staging is not enough.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused full-thread JSON submit tests -- 7 passed.
+- Full deflection submit test file -- 62 passed.
+- Extracted content pipeline validation script -- passed.
+- Atlas reasoning import guard -- passed.
+- Extracted standalone audit -- passed.
+- ASCII Python check -- passed.
+- Extracted sync script -- passed.
+- Extracted pipeline CI check script -- 4192 passed, 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 137 |
+| `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 14 |
+| `plans/PR-Deflection-Full-Thread-JSON-Tempfile.md` | 111 |
+| `tests/test_extracted_content_deflection_submit.py` | 99 |
+| `tests/test_extracted_support_ticket_input_package.py` | 14 |
+| **Total** | **375** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -172,6 +172,38 @@ async def test_deflection_submit_upload_copy_rejects_oversize_mid_stream() -> No
     ]
 
 
+@pytest.mark.asyncio
+async def test_deflection_submit_full_thread_upload_copy_streams_chunks_not_whole_limit() -> None:
+    data = (
+        b'{"tickets":[{"ticket":{"id":"zd-large","subject":"'
+        + (b"Billing refund " * 6000)
+        + b'","description":"How do I get a refund?"},"comments":[]}]}'
+    )
+    upload = _Upload(data, filename="zendesk-thread.json")
+
+    with tempfile.NamedTemporaryFile() as handle:
+        byte_count = await api_module._copy_deflection_submit_upload_to_tempfile(
+            upload,
+            handle,
+            max_bytes=len(data) + 1024,
+            too_large_reason="deflection_submit_full_thread_too_large",
+            read_error_detail="Uploaded Zendesk full-thread JSON could not be read.",
+            stage_error_detail="Uploaded Zendesk full-thread JSON could not be staged.",
+        )
+        handle.flush()
+        handle.seek(0)
+        staged = handle.read()
+
+    assert byte_count == len(data)
+    assert staged == data
+    assert upload.read_sizes
+    assert all(
+        size == api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES
+        for size in upload.read_sizes
+    )
+    assert len(data) + 1025 not in upload.read_sizes
+
+
 def _install_blob(
     monkeypatch: pytest.MonkeyPatch,
     data: bytes,
@@ -225,6 +257,64 @@ def test_deflection_submit_blob_csv_streams_response_to_tempfile(
     assert byte_count == len(data)
     assert load_warnings == ()
     assert rows[0]["ticket_id"] == "ticket-0"
+    assert response.closed
+    assert response.read_sizes
+    assert all(
+        size == api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES
+        for size in response.read_sizes
+    )
+    assert len(data) + 1025 not in response.read_sizes
+
+
+def test_deflection_submit_blob_full_thread_streams_response_to_tempfile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    data = json.dumps({
+        "tickets": [{
+            "ticket": {
+                "id": "zd-large-thread",
+                "subject": "Large refund thread",
+                "description": "How do I get a refund for duplicate billing?",
+                "requester_id": "requester-1",
+                "status": "solved",
+                "satisfaction_rating": {"score": "good"},
+            },
+            "comments": [
+                {
+                    "author_id": "requester-1",
+                    "public": True,
+                    "plain_body": "The duplicate invoice still appears on my account.",
+                },
+                {
+                    "author_id": "agent-1",
+                    "public": True,
+                    "plain_body": "We refunded the duplicate invoice. "
+                    + ("The refund appears in 5-10 business days. " * 4000),
+                },
+            ],
+        }],
+    }).encode("utf-8")
+    response = _BlobResponse(data)
+
+    monkeypatch.setattr(
+        api_module,
+        "_open_https_blob_request",
+        lambda _target, *, timeout: response,
+    )
+
+    rows, byte_count, load_warnings = api_module._load_deflection_submit_blob_rows_sync(
+        "https://portfolio.example/blob/zendesk-thread.json",
+        max_bytes=len(data) + 1024,
+        importer_mode="full_thread",
+    )
+
+    assert byte_count == len(data)
+    assert load_warnings == ()
+    assert rows[0]["ticket_id"] == "zd-large-thread"
+    assert rows[0]["ticket_status"] == "solved"
+    assert rows[0]["satisfaction_rating"] == "good"
+    assert "refunded the duplicate invoice" in rows[0]["resolution_text"]
     assert response.closed
     assert response.read_sizes
     assert all(
@@ -1052,8 +1142,9 @@ async def test_deflection_submit_accepts_full_thread_multipart_json_upload() -> 
     router = _router(InMemoryDeflectionReportArtifactStore())
     submit = _route(router, "/ops/deflection-reports/submit", "POST")
     artifact_data = ZENDESK_THREAD_SAMPLE.read_bytes()
+    upload = _Upload(artifact_data, filename="zendesk-thread.json")
     request = _FormRequest({
-        "json_file": _Upload(artifact_data, filename="zendesk-thread.json"),
+        "json_file": upload,
         "support_platform": "zendesk",
         "company_name": "Acme Co.",
         "contact_email": "lead@acme.example",
@@ -1063,6 +1154,12 @@ async def test_deflection_submit_accepts_full_thread_multipart_json_upload() -> 
     payload = await submit.endpoint(request)
 
     assert request.form_kwargs == {"max_part_size": api_module._MAX_DEFLECTION_SUBMIT_BLOB_BYTES}
+    assert upload.read_sizes
+    assert all(
+        size == api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES
+        for size in upload.read_sizes
+    )
+    assert api_module._MAX_DEFLECTION_SUBMIT_BLOB_BYTES + 1 not in upload.read_sizes
     assert payload["status"] == "completed"
     metadata = payload["input_provider"]["metadata"]
     assert metadata["source_row_count"] == 4

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -27,6 +27,7 @@ from extracted_content_pipeline.support_ticket_input_package import (
 )
 from extracted_content_pipeline.support_ticket_zendesk_thread import (
     load_zendesk_full_thread_rows_from_json_bytes,
+    load_zendesk_full_thread_rows_from_json_file,
     rows_from_zendesk_full_thread,
 )
 
@@ -1461,6 +1462,19 @@ def test_zendesk_full_thread_rows_preserve_public_roles_and_drop_private_notes()
     )
     assert "This is still broken after trying the steps" in by_id["41"]["description"]
     assert "A member of the support team will get back to you" not in str(by_id["41"])
+
+
+def test_zendesk_full_thread_rows_load_from_json_file() -> None:
+    result = load_zendesk_full_thread_rows_from_json_file(ZENDESK_THREAD_SAMPLE)
+
+    by_id = {row["ticket_id"]: row for row in result.rows}
+    assert set(by_id) == {"2", "28", "34", "41"}
+    assert by_id["2"]["resolution_text"].startswith(
+        "We confirmed the duplicate billing event"
+    )
+    assert by_id["2"]["satisfaction_rating"] == "good"
+    assert "Internal note" not in json.dumps(result.rows)
+    assert result.warnings == ()
 
 
 def test_zendesk_full_thread_rows_suppress_private_first_description() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Full-Thread-JSON-Tempfile.md
Slice phase: Vertical slice

Full-thread Zendesk JSON submit still used the pre-streaming shape: upload and Blob paths read `max_bytes + 1` into memory before parsing, while CSV had already moved to bounded tempfile staging. This moves full-thread JSON to the same submit-boundary contract: chunk into a `.json` tempfile first, then parse through a file entry point. It intentionally does not claim to be a streaming JSON parser; it removes the route-layer whole-file read before normalization.

## Intentional
- This is not a streaming JSON parser. A true incremental parser is deferred until live Zendesk artifacts prove tempfile staging is not enough.
- CSV behavior stays unchanged except for sharing generic copy helpers with JSON-specific error details.
- Blob oversize keeps the existing `deflection_submit_blob_too_large` reason so private Blob callers do not see an error-contract rename.

## Deferred
- True streaming JSON parsing if live Zendesk artifacts approach the submit byte limit and route-layer tempfile staging is not enough.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_support_ticket_input_package.py::test_zendesk_full_thread_rows_load_from_json_file tests/test_extracted_content_deflection_submit.py::test_deflection_submit_full_thread_upload_copy_streams_chunks_not_whole_limit tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_full_thread_multipart_json_upload tests/test_extracted_content_deflection_submit.py::test_deflection_submit_blob_full_thread_streams_response_to_tempfile tests/test_extracted_content_deflection_submit.py::test_deflection_submit_rejects_malformed_full_thread_json tests/test_extracted_content_deflection_submit.py::test_deflection_submit_rejects_oversize_uploaded_json tests/test_extracted_content_deflection_submit.py::test_deflection_submit_rejects_empty_uploaded_json -q` -- 7 passed.
- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` -- 62 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4192 passed, 10 skipped.

## Diff size
5 files, +342 / -33.
