### PR TITLE
Deflection Zendesk API live smoke

### DIFF
--- a/plans/PR-Deflection-Zendesk-API-Live-Smoke.md
+++ b/plans/PR-Deflection-Zendesk-API-Live-Smoke.md
@@ -1,0 +1,115 @@
+# PR-Deflection-Zendesk-API-Live-Smoke
+
+## Why this slice exists
+
+#1527 added the tenant-scoped Zendesk full-thread export route, the portfolio
+credential flow wires that export into private Blob and submit, and #1563 made
+the full-thread JSON submit boundary match the bounded tempfile CSV path. The
+remaining deferred validation gap is operator-run proof for the actual portfolio
+Zendesk API mode. The existing live-smoke script proves direct private-Blob CSV,
+local full-thread JSON fixture, and portfolio submit-route mode, but not the
+credential-backed Zendesk API route handler that exports from ATLAS, stores the
+artifact privately, then submits it.
+
+This slice adds that smoke mode at the existing smoke-script seam. It does not
+change the production route behavior; it gives the operator a one-command path
+to exercise the already-built Zendesk API funnel with real deployed env, and
+tests the request/auth/preflight projection without live network calls in CI.
+The slice is slightly over the 400 LOC soft cap because the Codex review found
+two related start-time validation gaps after review; the fix and regression
+coverage belong in this PR because they protect the new Zendesk API smoke mode's
+preflight gate.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Functional validation
+
+1. Extend `portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs` with a
+   Zendesk API route-handler mode.
+2. Validate the mode requires the route access token and rejects file/blob
+   options that belong to the other smoke modes.
+3. Project the smoke output as `portfolio_zendesk_api_route` without exposing
+   ATLAS tokens, Blob tokens, Zendesk export access tokens, Blob URLs, or raw
+   ticket artifacts.
+4. Add enrolled shell-test coverage through the existing
+   `test:deflection-upload-shell` script.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] `--zendesk-api` / `ATLAS_DEFLECTION_ZENDESK_API_SMOKE=1` selects the
+        credential-backed portfolio route, not direct Blob submit.
+  - [ ] The smoke request sends `Authorization: Bearer <route access token>` to
+        the portfolio route handler and a JSON body with company/contact,
+        bounded limit, and `start_time`.
+  - [ ] The mode preflights missing access token, local/non-HTTPS ATLAS URLs,
+        invalid account id, invalid limit/start time, and incompatible
+        file/blob/route-handler options.
+  - [ ] Success output includes only status/request/result/account/base-host
+        fields; failure output uses static error codes and does not include
+        route token, service token, Blob token, Blob URL, or ticket artifact.
+  - [ ] Existing CSV, full-thread fixture, and submit-route smoke modes keep
+        their current behavior.
+- Affected surfaces: portfolio deflection submit live-smoke script and its
+  enrolled shell test.
+- Risk areas: accidentally making live smoke hit local hosts, leaking secrets in
+  output, confusing direct Blob mode with Zendesk API mode, and stale frontend
+  CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R9, R10, R12, R14.
+
+### Files touched
+
+- `plans/PR-Deflection-Zendesk-API-Live-Smoke.md`
+- `portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The live-smoke script imports the existing `zendesk-export-submit` route
+handler. A new boolean option (`--zendesk-api` or
+`ATLAS_DEFLECTION_ZENDESK_API_SMOKE=1`) selects that handler instead of
+`submitPrivateBlob` or the generic submit route. The script extends
+`withRouteEnv` to include `ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN`, builds
+the same public JSON payload the portfolio page sends, and calls the handler
+with `Authorization: Bearer <access token>`.
+
+The route response is projected through the same small output envelope pattern
+as the existing submit-route smoke. It records whether the smoke passed, source
+mode, HTTP status, request id, account id, result path, optional static error,
+optional upstream ATLAS status, and deployed base host. It never echoes raw
+route responses, ticket artifacts, Blob URLs, or configured secrets.
+
+## Intentional
+
+- No production route changes. The route/proxy already has unit coverage; this
+  slice validates the operator smoke entry point.
+- No new npm script. The existing enrolled `test:deflection-upload-shell` script
+  covers the new mode, so there is no new frontend CI enrollment surface.
+- No live Zendesk call in CI. Tests inject a fake handler and assert request
+  shape, preflight behavior, and sanitized projection.
+- This avoids #1564's docs/proof-framing files to prevent cross-session
+  conflicts.
+
+## Deferred
+
+- Browser-automated hosted smoke using the operator's deployed portfolio URL and
+  real Zendesk trial credentials.
+- Optional export progress/polling UX if live Zendesk exports are too slow for a
+  single request.
+
+Parked hardening: none.
+
+## Verification
+
+- `cd portfolio-ui && npm run test:deflection-upload-shell` -- 40 passed.
+- `cd portfolio-ui && npm run smoke:deflection-submit-live -- --preflight-only --zendesk-api --base-url https://atlas.example.com --token test-token --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 --blob-token blob-token --zendesk-export-access-token route-token` -- passed.
+- `python scripts/sync_pr_plan.py plans/PR-Deflection-Zendesk-API-Live-Smoke.md --check` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Zendesk-API-Live-Smoke.md` | 115 |
+| `portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs` | 101 |
+| `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs` | 199 |
+| **Total** | **415** |

--- a/portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs
+++ b/portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs
@@ -6,6 +6,7 @@ import submitHandler, {
   MAX_BLOB_CSV_BYTES,
   submitPrivateBlob,
 } from "../api/content-ops/deflection/submit.js";
+import zendeskExportSubmitHandler from "../api/content-ops/deflection/zendesk-export-submit.js";
 
 const SUPPORT_PLATFORMS = new Set(["zendesk", "intercom", "help_scout", "other"]);
 const IMPORTER_MODES = new Set(["csv", "full_thread"]);
@@ -41,6 +42,9 @@ function parseArgs(argv = process.argv.slice(2), sourceEnv = process.env) {
     jsonFile: clean(sourceEnv.ATLAS_DEFLECTION_SUBMIT_JSON_FILE),
     importerMode: clean(sourceEnv.ATLAS_DEFLECTION_IMPORTER_MODE) || "csv",
     supportPlatform: clean(sourceEnv.ATLAS_DEFLECTION_SUPPORT_PLATFORM) || "zendesk",
+    zendeskApi: clean(sourceEnv.ATLAS_DEFLECTION_ZENDESK_API_SMOKE) === "1",
+    zendeskExportAccessToken: clean(sourceEnv.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN),
+    startTime: clean(sourceEnv.ATLAS_DEFLECTION_ZENDESK_EXPORT_START_TIME) || "0",
     companyName: clean(sourceEnv.ATLAS_DEFLECTION_COMPANY_NAME) || "Atlas Smoke Co.",
     contactEmail: clean(sourceEnv.ATLAS_DEFLECTION_CONTACT_EMAIL) || "smoke@example.com",
     limit: clean(sourceEnv.ATLAS_DEFLECTION_LIMIT) || "1000",
@@ -59,6 +63,8 @@ function parseArgs(argv = process.argv.slice(2), sourceEnv = process.env) {
       options.preflightOnly = true;
     } else if (arg === "--route-handler") {
       options.routeHandler = true;
+    } else if (arg === "--zendesk-api") {
+      options.zendeskApi = true;
     } else if (arg.startsWith("--")) {
       const key = arg.slice(2).replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
       const value = argv[index + 1];
@@ -72,6 +78,7 @@ function parseArgs(argv = process.argv.slice(2), sourceEnv = process.env) {
 
   options.timeoutMs = Number.parseInt(String(options.timeoutMs), 10);
   options.limit = String(options.limit);
+  options.startTime = String(options.startTime);
   options.importerMode = clean(options.importerMode) || "csv";
   return options;
 }
@@ -102,11 +109,32 @@ function validationErrors(options) {
   if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
     errors.push("--limit must be between 1 and 1000");
   }
+  const startTimeText = clean(options.startTime) || "0";
+  if (options.zendeskApi && !/^\d+$/.test(startTimeText)) {
+    errors.push("--start-time must be a non-negative integer");
+  }
   if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0) {
     errors.push("--timeout-ms must be a positive integer");
   }
   if (clean(options.blobPathname) && !clean(options.blobToken)) {
     errors.push("BLOB_READ_WRITE_TOKEN or --blob-token is required with --blob-pathname");
+  }
+  if (options.zendeskApi && !clean(options.blobToken)) {
+    errors.push("BLOB_READ_WRITE_TOKEN or --blob-token is required with --zendesk-api");
+  }
+  if (options.zendeskApi && !clean(options.zendeskExportAccessToken)) {
+    errors.push(
+      "ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN or --zendesk-export-access-token is required with --zendesk-api",
+    );
+  }
+  if (options.zendeskApi && options.routeHandler) {
+    errors.push("use either --zendesk-api or --route-handler, not both");
+  }
+  if (options.zendeskApi && clean(options.blobPathname)) {
+    errors.push("--zendesk-api cannot use --blob-pathname");
+  }
+  if (options.zendeskApi && (clean(options.csvFile) || clean(options.jsonFile))) {
+    errors.push("--zendesk-api cannot use local fixture files");
   }
   if (options.routeHandler && !clean(options.blobPathname)) {
     errors.push("--route-handler requires --blob-pathname");
@@ -222,6 +250,7 @@ async function withRouteEnv(options, fn) {
     ATLAS_TOKEN: "",
     ATLAS_ACCOUNT_ID: clean(options.accountId),
     BLOB_READ_WRITE_TOKEN: clean(options.blobToken),
+    ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN: clean(options.zendeskExportAccessToken),
     ATLAS_PROXY_TIMEOUT_MS: String(options.timeoutMs),
   };
   const previous = {};
@@ -292,6 +321,65 @@ async function runRouteHandlerSmoke(options, handlerImpl = submitHandler) {
   return projected;
 }
 
+function zendeskApiPayloadFromOptions(options) {
+  return {
+    company_name: clean(options.companyName),
+    contact_email: clean(options.contactEmail),
+    limit: clean(options.limit),
+    start_time: clean(options.startTime) || "0",
+  };
+}
+
+function zendeskApiResultPayload(statusCode, payload, options) {
+  const ok = statusCode >= 200 && statusCode < 300 && Boolean(payload?.request_id);
+  return {
+    ok,
+    source_mode: "portfolio_zendesk_api_route",
+    statusCode,
+    request_id: payload?.request_id,
+    account_id: payload?.account_id,
+    result_path: payload?.result_path,
+    error: ok ? undefined : clean(payload?.error) || "portfolio_zendesk_api_route_failed",
+    atlas_status: payload?.atlas_status,
+    base_host: URL.canParse(options.baseUrl) ? new URL(options.baseUrl).host : "",
+  };
+}
+
+async function runZendeskApiRouteHandlerSmoke(
+  options,
+  handlerImpl = zendeskExportSubmitHandler,
+) {
+  const res = mockRouteResponse();
+  const req = {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "authorization": `Bearer ${clean(options.zendeskExportAccessToken)}`,
+    },
+    body: JSON.stringify(zendeskApiPayloadFromOptions(options)),
+  };
+  await withRouteEnv(options, async () => {
+    await handlerImpl(req, res);
+  });
+  let payload = {};
+  try {
+    payload = res.body ? JSON.parse(res.body) : {};
+  } catch {
+    return {
+      ok: false,
+      source_mode: "portfolio_zendesk_api_route",
+      statusCode: res.statusCode,
+      error: "portfolio_zendesk_api_route_invalid_json",
+      base_host: URL.canParse(options.baseUrl) ? new URL(options.baseUrl).host : "",
+    };
+  }
+  const projected = zendeskApiResultPayload(res.statusCode, payload, options);
+  if (projected.ok && !REQUEST_ID_RE.test(clean(projected.request_id))) {
+    return { ...projected, ok: false, error: "invalid_request_id" };
+  }
+  return projected;
+}
+
 async function runSubmitSmoke(options) {
   const errors = validationErrors(options);
   if (errors.length > 0) {
@@ -301,6 +389,8 @@ async function runSubmitSmoke(options) {
   const isFullThread = clean(options.importerMode) === "full_thread";
   const sourceMode = options.routeHandler
     ? "portfolio_submit_route"
+    : options.zendeskApi
+      ? "portfolio_zendesk_api_route"
     : clean(options.blobPathname)
       ? "private_blob"
       : isFullThread
@@ -311,6 +401,9 @@ async function runSubmitSmoke(options) {
   }
   if (options.routeHandler) {
     return runRouteHandlerSmoke(options);
+  }
+  if (options.zendeskApi) {
+    return runZendeskApiRouteHandlerSmoke(options);
   }
 
   const payload = {
@@ -389,4 +482,10 @@ if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
     });
 }
 
-export { parseArgs, runRouteHandlerSmoke, runSubmitSmoke, validationErrors };
+export {
+  parseArgs,
+  runRouteHandlerSmoke,
+  runSubmitSmoke,
+  runZendeskApiRouteHandlerSmoke,
+  validationErrors,
+};

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -35,6 +35,7 @@ import {
   parseArgs as parseSubmitSmokeArgs,
   runRouteHandlerSmoke,
   runSubmitSmoke,
+  runZendeskApiRouteHandlerSmoke,
   validationErrors as submitSmokeValidationErrors,
 } from "./faq-deflection-submit-live-smoke.mjs";
 
@@ -491,7 +492,12 @@ await test("submit live smoke exercises the production private blob helper", asy
   assert.match(submitSmokeSource, /ATLAS_DEFLECTION_SUBMIT_JSON_FILE/);
   assert.match(submitSmokeSource, /zendesk_full_thread_seed_sample\.json/);
   assert.match(submitSmokeSource, /portfolio_submit_route/);
+  assert.match(submitSmokeSource, /portfolio_zendesk_api_route/);
+  assert.match(submitSmokeSource, /ATLAS_DEFLECTION_ZENDESK_API_SMOKE/);
+  assert.match(submitSmokeSource, /ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN/);
+  assert.match(submitSmokeSource, /zendeskExportSubmitHandler/);
   assert.doesNotMatch(submitSmokeSource, /ATLAS_B2B_JWT[^\\n]*console\\.log/);
+  assert.doesNotMatch(submitSmokeSource, /ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN[^\\n]*console\\.log/);
   assert.deepEqual(
     submitSmokeValidationErrors({
       baseUrl: "http://localhost:8000",
@@ -514,6 +520,78 @@ await test("submit live smoke exercises the production private blob helper", asy
       routeHandler: true,
     }).includes("--route-handler requires --blob-pathname"),
     true,
+  );
+  assert.deepEqual(
+    submitSmokeValidationErrors({
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+      supportPlatform: "zendesk",
+      limit: "1000",
+      timeoutMs: 1000,
+      zendeskApi: true,
+    }),
+    [
+      "ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN or --zendesk-export-access-token is required with --zendesk-api",
+    ],
+  );
+  assert.equal(
+    submitSmokeValidationErrors({
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      blobPathname: `${BLOB_UPLOAD_PATH_PREFIX}zendesk-thread.json`,
+      blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+      zendeskExportAccessToken: ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN,
+      supportPlatform: "zendesk",
+      limit: "1000",
+      timeoutMs: 1000,
+      zendeskApi: true,
+    }).includes("--zendesk-api cannot use --blob-pathname"),
+    true,
+  );
+  assert.equal(
+    submitSmokeValidationErrors({
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+      zendeskExportAccessToken: ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN,
+      supportPlatform: "zendesk",
+      limit: "1000",
+      startTime: "-1",
+      timeoutMs: 1000,
+      zendeskApi: true,
+    }).includes("--start-time must be a non-negative integer"),
+    true,
+  );
+  assert.equal(
+    submitSmokeValidationErrors({
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+      zendeskExportAccessToken: ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN,
+      supportPlatform: "zendesk",
+      limit: "1000",
+      startTime: "1710000000abc",
+      timeoutMs: 1000,
+      zendeskApi: true,
+    }).includes("--start-time must be a non-negative integer"),
+    true,
+  );
+  assert.equal(
+    submitSmokeValidationErrors({
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      supportPlatform: "zendesk",
+      limit: "1000",
+      startTime: "not-used-outside-zendesk-api",
+      timeoutMs: 1000,
+    }).includes("--start-time must be a non-negative integer"),
+    false,
   );
   assert.equal(
     submitSmokeValidationErrors({
@@ -654,6 +732,20 @@ await test("submit live smoke exercises the production private blob helper", asy
     status: "preflight_ok",
     source_mode: "portfolio_submit_route",
   });
+
+  const zendeskApiOptions = parseSubmitSmokeArgs([
+    "--zendesk-api",
+    "--preflight-only",
+    "--start-time",
+    "1710000000",
+  ], {
+    ...ENV,
+  });
+  assert.deepEqual(await runSubmitSmoke(zendeskApiOptions), {
+    ok: true,
+    status: "preflight_ok",
+    source_mode: "portfolio_zendesk_api_route",
+  });
 });
 
 await test("submit live smoke route-handler mode omits buyer account header", async () => {
@@ -743,6 +835,113 @@ await test("submit live smoke route-handler mode carries full-thread importer mo
     result_path: "/services/faq-deflection/results/content-ops-json123",
     error: undefined,
     atlas_status: undefined,
+    base_host: "atlas.example.com",
+  });
+});
+
+await test("submit live smoke Zendesk API mode calls credential route with operator token", async () => {
+  const options = parseSubmitSmokeArgs([
+    "--zendesk-api",
+    "--limit",
+    "49",
+    "--start-time",
+    "1710000000",
+  ], {
+    ...ENV,
+  });
+  const result = await runZendeskApiRouteHandlerSmoke(options, async (req, res) => {
+    assert.equal(req.method, "POST");
+    assert.equal(req.headers["content-type"], "application/json");
+    assert.equal(
+      req.headers.authorization,
+      `Bearer ${ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN}`,
+    );
+    assert.equal("x-atlas-account-id" in req.headers, false);
+    assert.equal(process.env.ATLAS_API_BASE_URL, ENV.ATLAS_API_BASE_URL);
+    assert.equal(process.env.ATLAS_B2B_JWT, ENV.ATLAS_B2B_JWT);
+    assert.equal(process.env.ATLAS_ACCOUNT_ID, ACCOUNT_ID);
+    assert.equal(process.env.BLOB_READ_WRITE_TOKEN, ENV.BLOB_READ_WRITE_TOKEN);
+    assert.equal(
+      process.env.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN,
+      ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN,
+    );
+    assert.deepEqual(JSON.parse(req.body), {
+      company_name: "Atlas Smoke Co.",
+      contact_email: "smoke@example.com",
+      limit: "49",
+      start_time: "1710000000",
+    });
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(JSON.stringify({
+      request_id: "content-ops-zendeskapi456",
+      account_id: ACCOUNT_ID,
+      result_path: "/services/faq-deflection/results/content-ops-zendeskapi456",
+    }));
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    source_mode: "portfolio_zendesk_api_route",
+    statusCode: 200,
+    request_id: "content-ops-zendeskapi456",
+    account_id: ACCOUNT_ID,
+    result_path: "/services/faq-deflection/results/content-ops-zendeskapi456",
+    error: undefined,
+    atlas_status: undefined,
+    base_host: "atlas.example.com",
+  });
+});
+
+await test("submit live smoke Zendesk API mode sanitizes route failures", async () => {
+  const options = parseSubmitSmokeArgs(["--zendesk-api"], {
+    ...ENV,
+  });
+  const result = await runZendeskApiRouteHandlerSmoke(options, async (_req, res) => {
+    res.statusCode = 502;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(JSON.stringify({
+      ok: false,
+      error: "zendesk_export_unavailable",
+      detail: {
+        token: ENV.ATLAS_B2B_JWT,
+        access_token: ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN,
+        blob_token: ENV.BLOB_READ_WRITE_TOKEN,
+        tickets: [{ id: 1, subject: "Private ticket" }],
+      },
+    }));
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    source_mode: "portfolio_zendesk_api_route",
+    statusCode: 502,
+    request_id: undefined,
+    account_id: undefined,
+    result_path: undefined,
+    error: "zendesk_export_unavailable",
+    atlas_status: undefined,
+    base_host: "atlas.example.com",
+  });
+  const serialized = JSON.stringify(result);
+  assert.equal(serialized.includes(ENV.ATLAS_B2B_JWT), false);
+  assert.equal(serialized.includes(ENV.ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN), false);
+  assert.equal(serialized.includes(ENV.BLOB_READ_WRITE_TOKEN), false);
+  assert.equal(serialized.includes("Private ticket"), false);
+});
+
+await test("submit live smoke Zendesk API mode fails closed on invalid route JSON", async () => {
+  const options = parseSubmitSmokeArgs(["--zendesk-api"], {
+    ...ENV,
+  });
+  const result = await runZendeskApiRouteHandlerSmoke(options, async (_req, res) => {
+    res.statusCode = 502;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end("{not-json");
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    source_mode: "portfolio_zendesk_api_route",
+    statusCode: 502,
+    error: "portfolio_zendesk_api_route_invalid_json",
     base_host: "atlas.example.com",
   });
 });


### PR DESCRIPTION
Plan: plans/PR-Deflection-Zendesk-API-Live-Smoke.md
Slice phase: Functional validation

The Zendesk API product path exists now, but the operator smoke command only proved direct Blob submit, local full-thread JSON fixture submit, and the generic submit route. This adds the missing smoke mode for the credential-backed portfolio Zendesk API route: export through the portfolio server handler, private Blob persistence, and submit projection, without changing production route behavior.

## Intentional
- No production route changes. This validates the operator smoke entry point for the already-built route.
- No new npm script. The existing enrolled `test:deflection-upload-shell` script covers the new mode.
- No live Zendesk call in CI. Tests inject a fake handler and assert request shape, preflight behavior, and sanitized projection.
- Avoids #1564 docs/proof-framing files to prevent cross-session conflicts.

## Deferred
- Browser-automated hosted smoke using the operator's deployed portfolio URL and real Zendesk trial credentials.
- Optional export progress/polling UX if live Zendesk exports are too slow for a single request.

## Parked hardening
- None.

## Verification
- `cd portfolio-ui && npm run test:deflection-upload-shell` -- 40 passed.
- `cd portfolio-ui && npm run smoke:deflection-submit-live -- --preflight-only --zendesk-api --base-url https://atlas.example.com --token test-token --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 --blob-token blob-token --zendesk-export-access-token route-token` -- passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Zendesk-API-Live-Smoke.md --check` -- passed.

## Diff size
3 files, +383 / -1.
