### PR TITLE
Deflection Zendesk product proof

### DIFF
--- a/docs/extraction/validation/deflection_zendesk_product_proof_2026-06-14.md
+++ b/docs/extraction/validation/deflection_zendesk_product_proof_2026-06-14.md
@@ -1,0 +1,153 @@
+# Deflection Zendesk Product Proof
+
+Date: 2026-06-14
+
+Issues: #1419, #1440
+
+## What Ran
+
+This validation replaces the four-row Zendesk fixture as the product-shaped
+proof corpus for the paid FAQ deflection report. It exported a seeded Zendesk
+trial tenant through the live Zendesk API, normalized the ticket/comment
+threads with the full-thread importer, built the support-ticket input package,
+and generated the deterministic FAQ deflection report artifact locally.
+
+The source role is Zendesk product/integration evidence:
+
+- ticket descriptions and public requester comments became customer wording;
+- public agent replies became candidate resolution evidence;
+- `public=false` internal notes stayed out of customer-facing report excerpts;
+- Zendesk `status` and `satisfaction_rating` populated diagnostics without
+  creating publishable answers by themselves.
+
+This is not a full-volume stress proof. CFPB remains the scale corpus; this
+Zendesk trial export is the buyer-shaped corpus that proves the support desk
+object model, public/private role handling, status diagnostics, CSAT
+diagnostics, and proven-answer lane on a realistic Zendesk thread shape.
+
+## Proof Artifacts
+
+- Sanitized summary:
+  `docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/summary.json`
+- Sanitized report excerpt:
+  `docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/report_excerpt.md`
+- Raw Zendesk export: not committed. The local run wrote it under
+  `tmp/zendesk_product_proof/raw_zendesk_export.json` so credentials, raw
+  customer text, and full comment bodies do not enter git history.
+
+## Result
+
+| Metric | Value |
+|---|---:|
+| Tickets exported | 50 |
+| Comments exported | 126 |
+| Public comments | 122 |
+| Private comments | 4 |
+| Normalized rows | 50 |
+| Normalization warnings | 0 |
+| Answer drafts from proven resolutions | 7 |
+| Questions still needing proven answers | 1 |
+| Resolution evidence present | true |
+| Status diagnostics present | true |
+| CSAT diagnostics present | true |
+
+Observed Zendesk status distribution:
+
+| Status | Tickets |
+|---|---:|
+| open | 16 |
+| pending | 5 |
+| solved | 29 |
+
+Observed Zendesk satisfaction distribution:
+
+| Satisfaction score | Tickets |
+|---|---:|
+| good | 24 |
+| bad | 5 |
+| unoffered | 21 |
+
+The generated report drafted answer candidates for the seeded refund, MFA/login,
+replacement shipment, localized UI, password reset, and admin-step themes. The
+committed excerpt includes representative generated samples, and the committed
+summary records:
+
+```json
+{
+  "publishable_answer_count": 7,
+  "no_proven_answer_count": 1,
+  "private_note_leak_checks": {
+    "auto_ack_present_in_markdown": false,
+    "private_marker_present_in_markdown": false
+  }
+}
+```
+
+## Output-Quality Boundary
+
+These are ingestion/proven-resolution **drafts**, not buyer-ready FAQ entries.
+The committed excerpt intentionally preserves two visible output-quality
+defects:
+
+- Synthetic subject prefixes leak into generated question headings, for example
+  `[Atlas seed 10] Login and MFA access issue ...` and `[Atlas seed 22] Shipping
+  or replacement question ...`. That means this corpus proves the Zendesk
+  object model and public/private role handling, but not real-ticket
+  question-label polish.
+- The degraded question label `What should I do about atla?` appears three
+  times in `top_questions` (ranks 4, 6, and 8; ticket counts 4, 1, and 1).
+  That is a label degradation and clustering-quality gap, not a Zendesk
+  ingestion or private-note leak failure.
+
+Those defects are deliberately documented here instead of hidden behind the
+answer count. A later quality slice must clean up synthetic subject-prefix
+pollution and the degraded `atla` label before this proof can be treated as a
+buyer-ready FAQ quality pass.
+
+## Exporter Boundary
+
+The first proof attempt exposed a real Zendesk API mismatch in the exporter:
+the incremental cursor endpoint rejected the old URL shape that included
+`page[size]`.
+
+```text
+/api/v2/incremental/tickets/cursor?start_time=0&page%5Bsize%5D=50
+```
+
+The exporter URL fix and the committed 50-ticket corpus now live in #1567,
+which is the canonical source for Zendesk cursor-endpoint behavior. This proof
+doc does not claim page-size live validation or own exporter behavior; it
+records the sanitized report artifact produced from the seeded Zendesk trial
+export.
+
+## Boundaries
+
+- The raw export is intentionally excluded from git. Only sanitized scalar
+  metrics and short answer excerpts are committed.
+- The run did not mutate Stripe state, unlock a paid artifact, send email, or
+  run the public portfolio wrapper.
+- The hosted Atlas export route at the configured `ATLAS_API_BASE_URL` was not
+  available for this proof window (`/api/v1/content-ops/zendesk-export/full-thread`
+  returned 404/405, and the unversioned route returned 502). The product proof
+  therefore uses the same exporter code directly against Zendesk credentials.
+- Local portfolio wrapper prerequisites were also missing:
+  `BLOB_READ_WRITE_TOKEN` and `ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN`.
+- `output_checks.resolution_evidence_scoped` was false in the generated report
+  summary because two one-ticket seeded clusters had missing question scope.
+  That is a report-quality boundary, not a private-note or Zendesk-ingestion
+  failure; the publishable answer count remains based on proven public agent
+  replies.
+- The output-quality boundary above means the report is not buyer-ready as-is:
+  it has synthetic subject-prefix pollution and a repeated degraded question
+  label.
+
+## Launch Implication
+
+This closes the Zendesk ingestion/private-note proof gap for the full-thread
+path: a live Zendesk API export with public agent replies can produce answer
+drafts while private notes and diagnostics stay out of customer-facing copy. It
+does **not** close buyer-ready question-label quality because the committed
+samples still show subject-prefix pollution and the degraded `atla` label. Pair
+this evidence with the CFPB stress proof and a follow-up output-quality fix
+before claiming the whole #1440 funnel is proven at buyer-shaped quality and
+full-volume size.

--- a/docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/report_excerpt.md
+++ b/docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/report_excerpt.md
@@ -1,0 +1,32 @@
+# Zendesk Trial Product-Proof Report Excerpt
+
+Sanitized excerpt generated from the live Zendesk trial API export. Raw tickets/comments are not committed.
+
+## Summary
+
+- Tickets exported: 50
+- Comments exported: 126 (122 public / 4 private)
+- Drafted publishable answers: 7
+- No-proven-answer questions: 1
+
+## Generated Samples
+
+### How do I get the duplicate charge refunded?
+
+To resolve this, we confirmed the duplicate billing event and refunded the extra charge. Then refunds normally appear on the original payment method in 5-10 business days.
+
+### [Atlas seed 10] Login and MFA access issue How do I reset two factor authentication for a teammate who lost their phone?
+
+To resolve this, reset MFA from Admin Settings > Security > Two-factor authentication, then send the user a new invite. Then if SSO is enforced, confirm the user is assigned to the app in the identity provider.
+
+### [Atlas seed 22] Shipping or replacement question Where is my replacement device?
+
+To resolve this, open the order details page, confirm the destination address, and use the replacement shipment workflow. Then if tracking is stale for more than 72 hours, support can issue a replacement or return label.
+
+### Localized UI button question
+
+To resolve this, update the account setting from the admin profile, then retry the verification or billing workflow. Then if the localized page is missing the control, switch to English temporarily and contact support.
+
+### What should I do about atla?
+
+To resolve this, update the reset-password article link to the current route, then ask the user to request a fresh magic link. Then expired tokens cannot be reused.

--- a/docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/summary.json
@@ -1,0 +1,178 @@
+{
+  "comment_count": 126,
+  "no_proven_answer_count": 1,
+  "normalization_warning_count": 0,
+  "normalized_row_count": 50,
+  "package_metadata": {
+    "csat_present": true,
+    "csat_present_count": 29,
+    "csat_score_average": null,
+    "csat_score_count": 0,
+    "source_row_count": 50,
+    "support_ticket_resolution_evidence_count": 40,
+    "support_ticket_resolution_evidence_present": true,
+    "ticket_status_present": true,
+    "ticket_status_present_count": 50,
+    "ticket_status_summary": {
+      "open": 21,
+      "resolved": 29
+    }
+  },
+  "private_comment_count": 4,
+  "private_note_leak_checks": {
+    "auto_ack_present_in_markdown": false,
+    "private_marker_present_in_markdown": false
+  },
+  "public_comment_count": 122,
+  "publishable_answer_count": 7,
+  "publishable_samples": [
+    {
+      "answer_excerpt": "To resolve this, we confirmed the duplicate billing event and refunded the extra charge. Then refunds normally appear on the original payment method in 5-10 business days.",
+      "question": "How do I get the duplicate charge refunded?",
+      "source_count": null
+    },
+    {
+      "answer_excerpt": "To resolve this, reset MFA from Admin Settings > Security > Two-factor authentication, then send the user a new invite. Then if SSO is enforced, confirm the user is assigned to the app in the identity provider.",
+      "question": "[Atlas seed 10] Login and MFA access issue How do I reset two factor authentication for a teammate who lost their phone?",
+      "source_count": null
+    },
+    {
+      "answer_excerpt": "To resolve this, open the order details page, confirm the destination address, and use the replacement shipment workflow. Then if tracking is stale for more than 72 hours, support can issue a replacement or return label.",
+      "question": "[Atlas seed 22] Shipping or replacement question Where is my replacement device?",
+      "source_count": null
+    },
+    {
+      "answer_excerpt": "To resolve this, update the account setting from the admin profile, then retry the verification or billing workflow. Then if the localized page is missing the control, switch to English temporarily and contact support.",
+      "question": "\u00bfD\u00f3nde est\u00e1 el bot\u00f3n correcto?",
+      "source_count": null
+    },
+    {
+      "answer_excerpt": "To resolve this, update the reset-password article link to the current route, then ask the user to request a fresh magic link. Then expired tokens cannot be reused.",
+      "question": "What should I do about atla?",
+      "source_count": null
+    }
+  ],
+  "raw_export_committed": false,
+  "report_summary": {
+    "csat_present_count": 22,
+    "drafted_answer_count": 7,
+    "generated": 8,
+    "negative_csat_ticket_count": 4,
+    "no_proven_answer_count": 1,
+    "non_repeat_question_count": 19,
+    "non_repeat_ticket_count": 19,
+    "outcome_diagnostic_ticket_count": 31,
+    "outcome_diagnostics_present": true,
+    "outcome_risk_ticket_count": 4,
+    "output_checks": {
+      "condensed": true,
+      "has_action_items": true,
+      "resolution_evidence_scoped": false,
+      "uses_user_vocabulary": true
+    },
+    "reopened_ticket_count": 0,
+    "source_count": 50,
+    "source_date_end": "2026-06-13",
+    "source_date_start": "2026-06-13",
+    "source_window_days": 1,
+    "support_ticket_resolution_evidence_count": 7,
+    "support_ticket_resolution_evidence_present": true,
+    "ticket_source_count": 50,
+    "ticket_status_summary": {
+      "open": 9,
+      "resolved": 22
+    },
+    "top_opportunity_score": 24,
+    "top_question": "How do I get the duplicate charge refunded?"
+  },
+  "snapshot_summary": {
+    "drafted_answer_count": 7,
+    "generated": 8,
+    "no_proven_answer_count": 1,
+    "non_repeat_ticket_count": 22,
+    "repeat_ticket_count": 28,
+    "source_date_end": "2026-06-13",
+    "source_date_start": "2026-06-13",
+    "source_window_days": 1,
+    "support_ticket_resolution_evidence_count": 7,
+    "support_ticket_resolution_evidence_present": true
+  },
+  "source": "zendesk_trial_api_live_export",
+  "ticket_count": 50,
+  "top_questions": [
+    {
+      "answer_evidence_status": "resolution_evidence",
+      "question": "How do I get the duplicate charge refunded?",
+      "rank": 1,
+      "resolution_evidence_scope": "scoped",
+      "ticket_count": 8,
+      "weighted_frequency": 8
+    },
+    {
+      "answer_evidence_status": "resolution_evidence",
+      "question": "[Atlas seed 10] Login and MFA access issue How do I reset two factor authentication for a teammate who lost their phone?",
+      "rank": 2,
+      "resolution_evidence_scope": "scoped",
+      "ticket_count": 7,
+      "weighted_frequency": 7
+    },
+    {
+      "answer_evidence_status": "resolution_evidence",
+      "question": "[Atlas seed 22] Shipping or replacement question Where is my replacement device?",
+      "rank": 3,
+      "resolution_evidence_scope": "scoped",
+      "ticket_count": 5,
+      "weighted_frequency": 5
+    },
+    {
+      "answer_evidence_status": "draft_needs_review",
+      "question": "What should I do about atla?",
+      "rank": 4,
+      "resolution_evidence_scope": "not_applicable",
+      "ticket_count": 4,
+      "weighted_frequency": 4
+    },
+    {
+      "answer_evidence_status": "resolution_evidence",
+      "question": "\u00bfD\u00f3nde est\u00e1 el bot\u00f3n correcto?",
+      "rank": 5,
+      "resolution_evidence_scope": "scoped",
+      "ticket_count": 4,
+      "weighted_frequency": 4
+    },
+    {
+      "answer_evidence_status": "resolution_evidence",
+      "question": "What should I do about atla?",
+      "rank": 6,
+      "resolution_evidence_scope": "missing_question_scope",
+      "ticket_count": 1,
+      "weighted_frequency": 1
+    },
+    {
+      "answer_evidence_status": "resolution_evidence",
+      "question": "Can admins skip that step?",
+      "rank": 7,
+      "resolution_evidence_scope": "scoped",
+      "ticket_count": 1,
+      "weighted_frequency": 1
+    },
+    {
+      "answer_evidence_status": "resolution_evidence",
+      "question": "What should I do about atla?",
+      "rank": 8,
+      "resolution_evidence_scope": "missing_question_scope",
+      "ticket_count": 1,
+      "weighted_frequency": 1
+    }
+  ],
+  "zendesk_satisfaction_score_counts": {
+    "bad": 5,
+    "good": 24,
+    "unoffered": 21
+  },
+  "zendesk_status_counts": {
+    "open": 16,
+    "pending": 5,
+    "solved": 29
+  }
+}

--- a/plans/PR-Deflection-Zendesk-Product-Proof.md
+++ b/plans/PR-Deflection-Zendesk-Product-Proof.md
@@ -1,0 +1,145 @@
+# PR-Deflection-Zendesk-Product-Proof
+
+## Why this slice exists
+
+Issue #1419 needs product-shaped evidence that the paid FAQ deflection report
+can ingest a real Zendesk full-thread export and produce publishable answer
+drafts from public agent replies. The previous Zendesk proof was a four-row
+fixture; it proved the object shape but not a seeded trial tenant report output
+that can be inspected as buyer-shaped proof.
+
+#1567 now owns the Zendesk exporter URL fix and the committed 50-ticket
+product-proof corpus. This PR no longer changes exporter behavior. It keeps the
+sanitized proof artifacts generated from the seeded Zendesk trial export and
+documents exactly what that report proof did and did not validate. A review pass
+found the committed samples also show buyer-facing label defects (`[Atlas seed
+N]` subject-prefix pollution and repeated `What should I do about atla?`
+labels), so this PR now records those as explicit output-quality boundaries
+instead of overstating buyer-readiness.
+
+The diff is above the 400 LOC target because the slice commits sanitized proof
+artifacts (`summary.json` plus report excerpt). Those extra lines are the
+reviewable evidence the slice exists to produce.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Functional validation
+
+1. Commit sanitized proof artifacts from the live Zendesk trial export and
+   deterministic FAQ deflection report generation.
+2. Add a proof doc that separates Zendesk product/integration evidence from
+   CFPB full-volume stress evidence and names the remaining portfolio-wrapper
+   blockers.
+3. Extend CI-facing tests to pin the proof boundaries, including private-note
+   non-leakage.
+4. Explicitly defer exporter URL behavior to #1567.
+5. Pin the output-quality boundary: generated samples include synthetic subject
+   prefixes and the degraded `What should I do about atla?` label, so this is
+   not a buyer-ready FAQ quality pass.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The committed Zendesk product proof records 50 tickets, 126 comments, more
+  than zero answer drafts, status diagnostics, CSAT diagnostics, and no
+  private-note markers in the sanitized report excerpt.
+- The doc does not claim raw export, paid unlock, email delivery, or the public
+  portfolio wrapper were proven.
+- The plan and PR body do not claim ownership of Zendesk exporter URL behavior;
+  #1567 remains the canonical exporter fix.
+- The proof doc names the output-quality defects visible in the committed
+  artifacts and does not claim buyer-ready question-label quality.
+
+Affected surfaces:
+
+- Deflection validation docs and sanitized proof artifacts.
+
+Risk areas:
+
+- Accidentally committing raw Zendesk export data.
+- Overclaiming product proof as full-volume or paid-funnel proof.
+- Overclaiming generated report samples as buyer-ready despite degraded labels.
+- Private internal notes leaking into committed report excerpts.
+
+Reviewer rules triggered: R1, R2, R7, R8, R10, R12, R13, R14.
+
+### Files touched
+
+- `docs/extraction/validation/deflection_zendesk_product_proof_2026-06-14.md`
+- `docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/report_excerpt.md`
+- `docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/summary.json`
+- `plans/PR-Deflection-Zendesk-Product-Proof.md`
+- `tests/test_content_ops_deflection_source_proof_docs.py`
+
+## Mechanism
+
+The live proof run used the exporter directly against the seeded Zendesk trial
+tenant, normalized the `{ticket, comments}` artifact through the full-thread
+importer, built the support-ticket input package, and generated the deterministic
+FAQ deflection report artifact. Only sanitized scalar metrics and short answer
+excerpts are committed; the raw export remains under `tmp/` and outside git.
+
+Exporter URL behavior is intentionally out of this PR after #1567. #1567 is the
+canonical fix for the live-compatible Zendesk cursor endpoint and the committed
+50-ticket product-proof corpus; this PR is the report-proof artifact slice.
+
+## Intentional
+
+- No raw Zendesk export is committed. The committed artifacts are summary JSON
+  and a short report excerpt only.
+- This PR does not mutate Stripe state, unlock paid reports, or send email.
+- This PR does not change the Zendesk exporter. The earlier `per_page` follow-up
+  was dropped after #1567 became the canonical exporter fix.
+- This PR keeps the degraded report samples instead of regenerating or editing
+  them, because the slice is proof honesty: the artifacts should show the real
+  output and the doc should name the boundary.
+- This PR does not claim the portfolio wrapper was proven. The hosted
+  `ATLAS_API_BASE_URL` export route was stale during the proof window, and the
+  local portfolio env lacked the Blob/export access-token prerequisites.
+- The proof records `output_checks.resolution_evidence_scoped: false` as a
+  boundary because two one-ticket seeded clusters had missing question scope.
+  That is not fixed in this functional-validation slice.
+
+## Deferred
+
+- Re-run the public portfolio wrapper once the deployed Atlas route accepts
+  `/api/v1/content-ops/zendesk-export/full-thread` and local/deployed env has
+  `BLOB_READ_WRITE_TOKEN` plus `ATLAS_DEFLECTION_ZENDESK_EXPORT_ACCESS_TOKEN`.
+- Keep CFPB as the full-volume stress proof; this Zendesk trial export is the
+  product-shaped proof corpus, not a scale corpus.
+- Investigate the two one-ticket missing-question-scope clusters if that
+  quality boundary persists on future seeded exports.
+- Any exporter URL or page-size validation belongs to #1567 follow-up work, not
+  this proof-artifact PR.
+- Fix synthetic subject-prefix pollution and the repeated degraded `atla` label
+  in the next output-quality slice before claiming buyer-ready FAQ quality.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_content_ops_deflection_source_proof_docs.py -q` - passed.
+- `scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `scripts/check_ascii_python.sh` - passed.
+- `scripts/run_extracted_pipeline_checks.sh` - 4200 passed, 10 skipped.
+- After rebasing on #1567 and dropping exporter changes:
+  `pytest tests/test_content_ops_deflection_source_proof_docs.py -q` - 4 passed.
+- After adding the output-quality boundary:
+  `pytest tests/test_content_ops_deflection_source_proof_docs.py -q` - 5 passed.
+  `tests/test_content_ops_deflection_source_proof_docs.py` compiled with
+  `py_compile` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/deflection_zendesk_product_proof_2026-06-14.md` | 153 |
+| `docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/report_excerpt.md` | 32 |
+| `docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/summary.json` | 178 |
+| `plans/PR-Deflection-Zendesk-Product-Proof.md` | 145 |
+| `tests/test_content_ops_deflection_source_proof_docs.py` | 56 |
+| **Total** | **564** |

--- a/tests/test_content_ops_deflection_source_proof_docs.py
+++ b/tests/test_content_ops_deflection_source_proof_docs.py
@@ -1,3 +1,4 @@
+import json
 import re
 from pathlib import Path
 
@@ -6,6 +7,15 @@ ROOT = Path(__file__).resolve().parents[1]
 RUNBOOK = ROOT / "docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md"
 CFPB_PROOF = ROOT / "docs/extraction/validation/deflection_full_volume_live_proof_2026-06-14.md"
 ZENDESK_PROOF = ROOT / "docs/extraction/validation/deflection_zendesk_full_thread_proof_2026-06-13.md"
+ZENDESK_PRODUCT_PROOF = ROOT / "docs/extraction/validation/deflection_zendesk_product_proof_2026-06-14.md"
+ZENDESK_PRODUCT_SUMMARY = (
+    ROOT
+    / "docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/summary.json"
+)
+ZENDESK_PRODUCT_EXCERPT = (
+    ROOT
+    / "docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/report_excerpt.md"
+)
 
 
 def _doc(path: Path) -> str:
@@ -41,3 +51,49 @@ def test_zendesk_full_thread_proof_states_small_fixture_boundary() -> None:
     assert re.search(r"buyer.*actual support workflow", text)
     assert re.search(r"not a full-volume stress proof", text)
     assert re.search(r"product-quality shape and full-volume size", text)
+
+
+def test_zendesk_product_proof_records_live_api_boundaries_and_sanitized_artifacts() -> None:
+    text = _flat_doc(ZENDESK_PRODUCT_PROOF)
+    summary = json.loads(ZENDESK_PRODUCT_SUMMARY.read_text(encoding="utf-8"))
+
+    assert re.search(r"replaces the four-row Zendesk fixture", text)
+    assert re.search(r"Zendesk product/integration evidence", text)
+    assert re.search(r"This is not a full-volume stress proof", text)
+    assert re.search(r"Raw Zendesk export: not committed", text)
+    assert re.search(r"hosted Atlas export route.*was not available", text)
+    assert re.search(r"portfolio wrapper prerequisites were also missing", text)
+    assert re.search(r"#1567.*canonical source for Zendesk cursor-endpoint behavior", text)
+    assert "per_page" not in text
+
+    assert summary["source"] == "zendesk_trial_api_live_export"
+    assert summary["raw_export_committed"] is False
+    assert summary["ticket_count"] >= 20
+    assert summary["comment_count"] >= summary["ticket_count"]
+    assert summary["private_comment_count"] > 0
+    assert summary["normalization_warning_count"] == 0
+    assert summary["publishable_answer_count"] > 0
+    assert summary["package_metadata"]["support_ticket_resolution_evidence_present"] is True
+    assert summary["package_metadata"]["ticket_status_present"] is True
+    assert summary["package_metadata"]["csat_present"] is True
+    assert summary["private_note_leak_checks"]["private_marker_present_in_markdown"] is False
+    assert summary["private_note_leak_checks"]["auto_ack_present_in_markdown"] is False
+
+
+def test_zendesk_product_proof_names_output_quality_boundaries() -> None:
+    text = _flat_doc(ZENDESK_PRODUCT_PROOF)
+    excerpt = _doc(ZENDESK_PRODUCT_EXCERPT)
+    summary = json.loads(ZENDESK_PRODUCT_SUMMARY.read_text(encoding="utf-8"))
+
+    assert "[Atlas seed" in excerpt
+    assert "What should I do about atla?" in excerpt
+    atla_questions = [
+        q for q in summary["top_questions"]
+        if q["question"] == "What should I do about atla?"
+    ]
+    assert [q["rank"] for q in atla_questions] == [4, 6, 8]
+
+    assert re.search(r"Output-Quality Boundary", text)
+    assert re.search(r"Synthetic subject prefixes leak", text)
+    assert re.search(r"degraded question label `What should I do about atla\?`", text)
+    assert re.search(r"not buyer-ready as-is", text)


### PR DESCRIPTION
Plan: plans/PR-Deflection-Zendesk-Product-Proof.md
Slice phase: Functional validation

This slice commits sanitized Zendesk product-proof report artifacts generated from the seeded trial tenant: 50 tickets, 126 comments, status/CSAT diagnostics, answer-draft samples, and private-note non-leakage checks. Exporter URL behavior is intentionally deferred to #1567, which is now the canonical Zendesk exporter fix and corpus slice; #1566 is proof artifacts only, and it explicitly records output-quality boundaries rather than claiming buyer-ready FAQ quality.

## Intentional
- Raw Zendesk export is not committed; only sanitized scalar metrics and short answer excerpts are committed.
- This does not claim paid unlock, email delivery, or the public portfolio wrapper were proven.
- This PR no longer changes `extracted_content_pipeline/support_ticket_zendesk_export.py` or its tests; #1567 owns exporter URL behavior.
- The degraded report samples are kept as evidence. The proof doc names the `[Atlas seed N]` subject-prefix pollution and repeated `What should I do about atla?` label instead of hiding or editing them.
- `output_checks.resolution_evidence_scoped: false` is recorded as a quality boundary from two one-ticket missing-scope clusters, not hidden.

## Deferred
- Re-run the public portfolio wrapper after deployed route/env prerequisites are available.
- Keep CFPB as the full-volume stress proof; this Zendesk trial export is the product-shaped report proof, not a scale corpus.
- Fix synthetic subject-prefix pollution and the repeated degraded `atla` label before claiming buyer-ready FAQ quality.
- Investigate the two one-ticket missing-question-scope clusters if the boundary persists on future seeded exports.
- Any Zendesk exporter URL or page-size validation belongs to #1567 follow-up work, not this proof-artifact PR.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_deflection_source_proof_docs.py -q` - 5 passed.
- `python -m py_compile tests/test_content_ops_deflection_source_proof_docs.py` - passed.
- Prior verification retained by the proof artifacts: `bash scripts/run_extracted_pipeline_checks.sh` - 4200 passed, 10 skipped.

## AI reconciliation
- Codex finding on preserving the requested Zendesk page limit: resolved by removing #1566's exporter URL change and deferring exporter behavior to #1567, which merged as the canonical exporter fix. The proof doc now explicitly says #1566 does not claim page-size live validation or own exporter behavior, and the doc test asserts no `per_page` claim in the proof doc.
- Reviewer MAJOR on output-quality honesty: fixed by adding an explicit Output-Quality Boundary section naming the synthetic subject-prefix leakage and repeated degraded `What should I do about atla?` label. The proof now says these are ingestion/proven-resolution drafts, not buyer-ready FAQ entries, and a test pins the boundary against the committed excerpt and summary.

All fixed or waived: yes.

## Proof artifacts
- `docs/extraction/validation/deflection_zendesk_product_proof_2026-06-14.md`
- `docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/summary.json`
- `docs/extraction/validation/fixtures/deflection_zendesk_product_proof_20260614/report_excerpt.md`

## Diff size
5 files, +564 / -0