### PR TITLE
Deflection question label quality

### DIFF
--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -13,6 +13,7 @@ from typing import Any
 
 _WHITESPACE_RE = re.compile(r"\s+")
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
+_LEADING_BRACKETED_METADATA_RE = re.compile(r"^(?:\[[^\]\n]{1,80}\]\s*)+")
 _HTML_TAG_NAMES_RE = (
     r"(?:a|abbr|article|aside|b|blockquote|body|br|button|cite|code|dd|"
     r"del|div|dl|dt|em|figcaption|figure|footer|h[1-6]|header|hr|html|i|"
@@ -347,8 +348,7 @@ def support_ticket_tokens(value: Any) -> frozenset[str]:
             continue
         if token in _STOPWORDS:
             continue
-        if token.endswith("s") and len(token) > 3 and not token.endswith("ss"):
-            token = token[:-1]
+        token = _strip_plural_suffix(token)
         token = _TOKEN_FOLDS.get(token, token)
         if not token or token in _STOPWORDS or len(token) < 2:
             continue
@@ -615,12 +615,24 @@ def _row_tokens(row: Mapping[str, Any]) -> frozenset[str]:
     for key in _TEXT_KEYS:
         value = support_ticket_plain_text(row.get(key))
         if value:
-            parts.append(value)
+            parts.append(_strip_leading_ticket_metadata(value))
     source_id = support_ticket_plain_text(row.get("source_id"))
     source_title = support_ticket_plain_text(row.get("source_title"))
     if source_title and source_title != source_id:
-        parts.append(source_title)
+        parts.append(_strip_leading_ticket_metadata(source_title))
     return support_ticket_tokens(" ".join(part for part in parts if part))
+
+
+def _strip_plural_suffix(token: str) -> str:
+    if token.endswith(("ss", "us", "is", "as")):
+        return token
+    if token.endswith("s") and len(token) > 3:
+        return token[:-1]
+    return token
+
+
+def _strip_leading_ticket_metadata(value: str) -> str:
+    return _compact(_LEADING_BRACKETED_METADATA_RE.sub("", value))
 
 
 def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -103,6 +103,11 @@ _REDACTED_DATE_RE = re.compile(r"\bX{2}/X{2}/(?:X{2,4}|\d{2,4})\b", re.IGNORECAS
 _REDACTED_MONEY_RE = re.compile(r"\{\$|\$\s*X{2,}", re.IGNORECASE)
 _TRAILING_TITLE_RE = re.compile(r"\b(?:mr|mrs|ms|dr)\.?$", re.IGNORECASE)
 _QUOTE_ARTIFACT_RE = re.compile(r"(?:''|``)")
+_LEADING_BRACKETED_METADATA_RE = re.compile(r"^(?:\[[^\]\n]{1,80}\]\s*)+")
+_METADATA_QUESTION_START_RE = re.compile(
+    r"\b(?:how|what|where|when|why|can|could|do|does)\s+",
+    re.IGNORECASE,
+)
 _MORTGAGE_INTENT_TERMS = (
     "mortgage",
     "home loan",
@@ -2515,6 +2520,9 @@ def _question_text_matching(
             prefix = prefix.strip()
             sentence_parts = [part.strip() for part in re.split(r"[.!:;]+", prefix) if part.strip()]
             candidate = sentence_parts[-1] if sentence_parts else prefix
+            normalized = _question_start_text(candidate, predicate=predicate)
+            if normalized:
+                return normalized
             normalized = _normalize_question_text(candidate)
             if predicate(normalized):
                 return normalized
@@ -2542,7 +2550,7 @@ def _question_candidate_texts(value: Any) -> tuple[str, ...]:
         return ()
     matches = list(_SPEAKER_LABEL_RE.finditer(text))
     if not matches:
-        return (_compact(_URL_RE.sub("", text)),)
+        return _question_candidate_variants(text)
 
     candidates = []
     leading = _question_segment(text[:matches[0].start()])
@@ -2559,7 +2567,37 @@ def _question_candidate_texts(value: Any) -> tuple[str, ...]:
 
 
 def _question_segment(value: str) -> str:
-    return _compact(_URL_RE.sub("", value))
+    variants = _question_candidate_variants(value)
+    return variants[0] if variants else ""
+
+
+def _question_candidate_variants(value: str) -> tuple[str, ...]:
+    text = _compact(_URL_RE.sub("", value))
+    if not text:
+        return ()
+    stripped = _strip_leading_question_metadata(text)
+    variants = []
+    if stripped != text:
+        tail = _question_after_metadata_prefix(stripped)
+        if tail:
+            variants.append(tail)
+        variants.append(stripped)
+        variants.append(text)
+    else:
+        variants.append(text)
+    return tuple(dict.fromkeys(candidate for candidate in variants if candidate))
+
+
+def _strip_leading_question_metadata(value: str) -> str:
+    return _compact(_LEADING_BRACKETED_METADATA_RE.sub("", value))
+
+
+def _question_after_metadata_prefix(value: str) -> str:
+    for match in _METADATA_QUESTION_START_RE.finditer(value):
+        if match.start() <= 0:
+            continue
+        return _compact(value[match.start():])
+    return ""
 
 
 def _question_start_text(

--- a/plans/PR-Deflection-Question-Label-Quality.md
+++ b/plans/PR-Deflection-Question-Label-Quality.md
@@ -1,0 +1,108 @@
+# PR-Deflection-Question-Label-Quality
+
+## Why this slice exists
+
+#1566 proved the Zendesk product-shaped path but deliberately preserved two
+buyer-facing output defects in the committed proof artifact: seeded subject
+prefixes such as `[Atlas seed 10] Login and MFA access issue` leaked into FAQ
+headings, and the weak source-policy label `What should I do about atla?`
+appeared repeatedly. The user asked for the next vertical slice after that
+review, and this is the narrow upstream fix before treating the Zendesk proof
+as buyer-ready question-label evidence.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-product-proof
+Slice phase: Vertical slice
+
+1. Clean provenance-like ticket subject prefixes before FAQ customer-question
+   extraction so the label keeps the real customer question and drops seeded or
+   tracker metadata.
+2. Fix the upstream support-ticket tokenizer/cluster preview path that turned
+   non-plural final-`s` words such as `Atlas` and `status` into `atla` and
+   `statu`, and stop bracketed seed metadata from dominating cluster anchors.
+3. Add focused regression coverage for the cited Zendesk proof examples plus
+   held-out same-class cases the reviewer did not provide.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_clustering.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Question-Label-Quality.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] FAQ headings extracted from seeded Zendesk-style title plus question
+        text no longer include the bracketed seed or theme prefix.
+  - [ ] Customer wording with legitimate unbracketed context before a question
+        word stays intact instead of being truncated to a generic tail.
+  - [ ] The committed Zendesk product corpus no longer clusters or renders FAQ
+        labels from the synthetic `Atlas seed` metadata token.
+  - [ ] Existing safe representative labels, including short acronyms such as
+        `VPN` and `GDPR`, still publish when they are specific enough.
+  - [ ] The committed Zendesk proof docs still honestly describe the existing
+        artifact boundary; this slice fixes the generator path, not historical
+        proof files.
+- Affected surfaces: deterministic support-ticket FAQ Markdown generation and
+  extracted pipeline tests.
+- Risk areas: buyer-facing output quality, false-positive question rejection,
+  and source-policy fallback specificity.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+## Mechanism
+
+The FAQ label path already prefers customer wording before source-policy
+fallbacks. This slice adds a small normalization step inside that upstream
+question-candidate path: strip leading bracketed seed/tracker metadata and, only
+when that metadata was actually stripped, offer the later natural question as a
+candidate before the metadata-bearing text. Ordinary unbracketed customer
+phrasing is not split on embedded question words.
+
+The `atla` label root is upstream of FAQ Markdown formatting. The shared support
+ticket tokenizer used to strip a trailing `s` from any token longer than three
+characters, so `Atlas` became `atla` and `status` became `statu`. This slice
+tightens that plural stripping and removes leading bracketed seed metadata from
+cluster-preview token input, so source-policy labels are built from actual
+ticket topics instead of the synthetic corpus marker.
+
+## Intentional
+
+- This does not rewrite the committed #1566 proof artifact. The proof doc
+  intentionally records historical defects from that run; rewriting it would
+  hide the evidence that motivated this slice.
+- This does not trust arbitrary ticket subjects or structured fields as safe
+  representative vocabulary. Labels still need documentation or injected
+  taxonomy terms, preserving the prior root-cause fix for unlisted structured
+  vocabulary.
+- This does not add a short-acronym denylist. The review showed that such a
+  gate collapses real topics like `VPN`, `SSL`, and `GDPR`; this PR fixes the
+  tokenizer/metadata root instead.
+- This does not resume embedding-booster work. The booster remains outside this
+  lane until the enablement decision is made separately.
+
+## Deferred
+
+- Re-run the full Zendesk product proof artifact after this generator fix in a
+  follow-up validation slice, so the historical proof remains intact and the new
+  artifact can show buyer-ready labels from a fresh run.
+
+Parked hardening: none.
+
+## Verification
+
+- `PATH=/home/juan-canfield/Desktop/Atlas/.venv/bin:$PATH pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_deflection_submit.py::test_deflection_submit_surfaces_cluster_preview_for_messy_untagged_csv -q` -- 351 passed.
+- `PATH=/home/juan-canfield/Desktop/Atlas/.venv/bin:$PATH bash scripts/run_extracted_pipeline_checks.sh` -- 4236 passed, 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_clustering.py` | 20 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 42 |
+| `plans/PR-Deflection-Question-Label-Quality.md` | 108 |
+| `tests/test_extracted_support_ticket_input_package.py` | 20 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 189 |
+| **Total** | **379** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -673,6 +673,26 @@ def test_support_ticket_inline_provider_html_strips_link_attribute_tokens() -> N
         "Why did <email>user@example.test</email> fail when "
         "<config>retries=3</config> was set?"
     )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected", "rejected"),
+    (
+        ("Atlas seed", {"atlas", "seed"}, {"atla"}),
+        ("ticket status", {"status"}, {"statu"}),
+        ("analysis report", {"analysis", "report"}, {"analysi"}),
+        ("damaged devices", {"damaged", "device"}, {"devices"}),
+    ),
+)
+def test_support_ticket_tokens_do_not_depluralize_non_plural_final_s_words(
+    text: str,
+    expected: set[str],
+    rejected: set[str],
+) -> None:
+    tokens = support_ticket_tokens(text)
+
+    assert expected.issubset(tokens)
+    assert tokens.isdisjoint(rejected)
     assert support_ticket_plain_text("If a<b and c>d then fail") == (
         "If a<b and c>d then fail"
     )

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -19,6 +19,9 @@ from extracted_content_pipeline.embedding_port import cosine_similarity
 from extracted_content_pipeline.support_ticket_input_package import (
     build_support_ticket_input_package,
 )
+from extracted_content_pipeline.support_ticket_zendesk_thread import (
+    rows_from_zendesk_full_thread,
+)
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
@@ -42,6 +45,9 @@ SUPPORT_TICKET_BUNDLE = ROOT / "extracted_content_pipeline/examples/support_tick
 FAQ_CUSTOM_RULES = ROOT / "extracted_content_pipeline/examples/faq_custom_rules.json"
 FAQ_DOCUMENTATION_TERMS = (
     ROOT / "extracted_content_pipeline/examples/faq_documentation_terms.txt"
+)
+ZENDESK_PRODUCT_PROOF_CORPUS = (
+    ROOT / "docs/extraction/validation/fixtures/zendesk_product_proof_corpus.json"
 )
 
 
@@ -1744,6 +1750,121 @@ def test_build_ticket_faq_markdown_uses_representative_label_when_customer_wordi
     assert result.output_checks["uses_user_vocabulary"] is True
 
 
+@pytest.mark.parametrize(
+    ("text", "expected_question"),
+    (
+        (
+            "[Atlas seed 10] Login and MFA access issue "
+            "How do I reset two factor authentication for a teammate who lost their phone?",
+            "How do I reset two factor authentication for a teammate who lost their phone?",
+        ),
+        (
+            "[Atlas seed 22] Shipping or replacement question "
+            "Where is my replacement device?",
+            "Where is my replacement device?",
+        ),
+        (
+            "[Zendesk trial 17] API or webhook integration issue "
+            "Why is webhook delivery delayed?",
+            "Why is webhook delivery delayed?",
+        ),
+        (
+            "[QA import 04] Billing question duplicate charge "
+            "What should I do if I was charged twice?",
+            "What should I do if I was charged twice?",
+        ),
+        (
+            "[Seeded ticket 31] Export permission issue "
+            "Can admins export the audit log?",
+            "Can admins export the audit log?",
+        ),
+    ),
+)
+def test_build_ticket_faq_markdown_strips_seed_subject_prefix_from_customer_question(
+    text: str,
+    expected_question: str,
+) -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": text.split("]", 1)[0] + "]",
+                "text": text,
+                "source_id": "ticket-1",
+                "resolution_text": "Open Admin Settings, update the saved setting, and retry.",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "technical support",
+                "source_title": text.split("]", 1)[0] + "]",
+                "text": text,
+                "source_id": "ticket-2",
+                "resolution_text": "Open Admin Settings, update the saved setting, and retry.",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == expected_question
+    assert result.items[0]["question_source"] == "customer_wording"
+    assert "[" not in result.items[0]["question"]
+    assert expected_question in result.markdown
+    assert f"## 1. {expected_question}" in result.markdown
+    assert "## 1. [Atlas seed" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_cleans_committed_zendesk_product_corpus_labels() -> None:
+    corpus = json.loads(ZENDESK_PRODUCT_PROOF_CORPUS.read_text(encoding="utf-8"))
+    rows = rows_from_zendesk_full_thread(corpus).rows
+    package = build_support_ticket_input_package(rows)
+    result = build_ticket_faq_markdown(package.inputs["source_material"], max_items=0)
+    questions = [item["question"] for item in result.items]
+    cluster_labels = {
+        item["label"] for item in package.inputs["top_ticket_clusters"]
+    }
+
+    assert "How do I reset two factor authentication for a teammate who lost their phone?" in questions
+    assert "Where is my replacement device?" in questions
+    assert not any("[Atlas seed" in question for question in questions)
+    assert "What should I do about atla?" not in questions
+    assert cluster_labels.isdisjoint({"atla", "atlas"})
+
+
+@pytest.mark.parametrize(
+    "question_text",
+    (
+        "My refund of $49 for order 99 - how do I track it?",
+        "I was billed $199 instead of $49 how do I dispute this charge?",
+        "The invoice from March is wrong what should I do?",
+        "Login issue is still happening?",
+    ),
+)
+def test_build_ticket_faq_markdown_preserves_real_context_before_question_words(
+    question_text: str,
+) -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Customer ticket",
+                "text": question_text,
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Customer ticket",
+                "text": question_text,
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == question_text
+    assert result.items[0]["question_source"] == "customer_wording"
+
+
 def test_build_ticket_faq_markdown_uses_safe_terms_instead_of_pii_source_title() -> None:
     result = build_ticket_faq_markdown(
         [
@@ -2109,6 +2230,74 @@ def test_build_ticket_faq_markdown_uses_repeated_gist_tokens_for_representative_
     )
 
     assert result.items[0]["question"] == "What should I do about export timeout?"
+
+
+@pytest.mark.parametrize("topic", ("api", "sso", "mfa", "billing", "ssl", "vpn", "crm", "gdpr"))
+def test_build_ticket_faq_markdown_keeps_specific_source_policy_topic_labels(topic: str) -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": topic,
+                "source_title": f"{topic} issue",
+                "text": f"{topic} access remains blocked.",
+                "source_id": "ticket-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": topic,
+                "source_title": f"{topic} issue",
+                "text": f"{topic} setup is still blocked.",
+                "source_id": "ticket-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert result.items[0]["question"] == f"What should I do about {topic}?"
+    assert result.items[0]["question_source"] == "source_policy"
+
+
+def test_build_ticket_faq_markdown_keeps_distinct_short_acronym_policy_labels() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "gdpr",
+                "source_title": "gdpr export",
+                "text": "gdpr export remains blocked for the legal team.",
+                "source_id": "gdpr-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "gdpr",
+                "source_title": "gdpr export",
+                "text": "gdpr export remains blocked for the legal team.",
+                "source_id": "gdpr-2",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "vpn",
+                "source_title": "vpn access",
+                "text": "vpn access remains blocked for remote users.",
+                "source_id": "vpn-1",
+            },
+            {
+                "source_type": "support_ticket",
+                "support_ticket_cluster": "vpn",
+                "source_title": "vpn access",
+                "text": "vpn access remains blocked for remote users.",
+                "source_id": "vpn-2",
+            },
+        ],
+        max_items=0,
+    )
+
+    assert [item["question"] for item in result.items] == [
+        "What should I do about gdpr?",
+        "What should I do about vpn?",
+    ]
+    assert result.warnings == ()
 
 
 def test_build_ticket_faq_markdown_disambiguates_colliding_safe_source_policy_labels() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Question-Label-Quality.md
Slice phase: Vertical slice

#1566 proved the Zendesk product-shaped path but deliberately preserved two buyer-facing output defects: seeded subject prefixes leaked into FAQ headings, and the weak source-policy label `What should I do about atla?` appeared repeatedly. This PR fixes that upstream label path and the shared tokenizer/cluster-preview root before the Zendesk proof is treated as buyer-ready question-label evidence.

## Intentional
- Keep the committed #1566 proof artifact historical; this changes the generator path and tests, not the old artifact.
- Preserve the controlled-vocabulary gate for representative labels instead of trusting arbitrary ticket subjects or structured fields.
- Do not use a short-acronym denylist; the review showed that would collapse real topics like `VPN`, `SSL`, and `GDPR`.
- Do not resume embedding-booster work; that enablement decision remains separate.

## Deferred
- Re-run the Zendesk product proof artifact in a follow-up validation slice so the fresh artifact shows buyer-ready labels.

## AI reconciliation
- All findings fixed or waived: Yes.
- Fixed: Codex P2 / human BLOCKER on embedded question extraction over-stripping legitimate context. Embedded-tail extraction now only runs for text that actually had leading bracket metadata stripped, and held-out customer-wording tests preserve refund, billing, invoice, and login context.
- Fixed: Human MAJOR on short-acronym over-rejection and collisions. Removed the short-token denylist, restored specific labels for `SSL`, `VPN`, `CRM`, and `GDPR`, and added a no-collision acronym regression.
- Fixed: Human MAJOR / AGENTS.md 3k upstream-root finding. The `atla` root is now handled in `support_ticket_clustering.py`: non-plural final-`s` words such as `Atlas` and `status` are no longer mangled, and leading bracketed seed metadata is excluded from cluster-preview token input.
- Fixed: Human MAJOR on tests sized to the repro. Added false-positive coverage for legitimate context prefixes and real short acronyms, plus tokenizer tests for held-out final-`s` words.

## Parked hardening
- None.

## Verification
- `PATH=/home/juan-canfield/Desktop/Atlas/.venv/bin:$PATH pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_deflection_submit.py::test_deflection_submit_surfaces_cluster_preview_for_messy_untagged_csv -q` -- 351 passed.
- `PATH=/home/juan-canfield/Desktop/Atlas/.venv/bin:$PATH bash scripts/run_extracted_pipeline_checks.sh` -- 4236 passed, 10 skipped.

## Diff size
5 files, +166 / -108.
