### PR TITLE
Content-Ops text truncation helper

### DIFF
--- a/extracted_content_pipeline/ad_copy_generation.py
+++ b/extracted_content_pipeline/ad_copy_generation.py
@@ -10,6 +10,7 @@ from .ad_copy_ports import AdCopyDraft, AdCopyRepository
 from .campaign_customer_data import CampaignOpportunityWarning
 from .campaign_ports import TenantScope
 from .campaign_source_adapters import source_row_to_campaign_opportunity
+from .text_truncate import truncate_with_ellipsis
 
 _ROW_LIST_KEYS = ("sources", "opportunities", "reviews", "documents", "rows", "data")
 
@@ -184,8 +185,11 @@ def _ad_from_opportunity(
         "id": source_id or f"ad-copy-{index}",
         "channel": "paid_social",
         "format": "single_image",
-        "headline": _truncate(headline, max_headline_chars),
-        "primary_text": _truncate(" ".join(primary_parts), max_primary_text_chars),
+        "headline": truncate_with_ellipsis(headline, max_headline_chars),
+        "primary_text": truncate_with_ellipsis(
+            " ".join(primary_parts),
+            max_primary_text_chars,
+        ),
         "cta": "See the proof",
         "source_id": source_id,
         "source_type": _clean(opportunity.get("source_type")),
@@ -275,13 +279,6 @@ def _rows_from_source_material(source_material: Any) -> list[Any]:
     if isinstance(source_material, Sequence) and not isinstance(source_material, (bytes, bytearray)):
         return list(source_material)
     return []
-
-
-def _truncate(value: str, max_chars: int) -> str:
-    text = " ".join(value.split())
-    if len(text) <= max_chars:
-        return text
-    return text[: max(0, max_chars - 3)].rstrip() + "..."
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -196,6 +196,9 @@
       "target": "extracted_content_pipeline/content_image_provider.py"
     },
     {
+      "target": "extracted_content_pipeline/text_truncate.py"
+    },
+    {
       "target": "extracted_content_pipeline/brand_voice.py"
     },
     {

--- a/extracted_content_pipeline/quote_card_generation.py
+++ b/extracted_content_pipeline/quote_card_generation.py
@@ -13,6 +13,7 @@ from .campaign_source_adapters import (
     source_row_to_campaign_opportunity,
 )
 from .quote_card_ports import QuoteCardDraft, QuoteCardRepository
+from .text_truncate import truncate_with_ellipsis
 
 
 @dataclass(frozen=True)
@@ -186,10 +187,10 @@ def _card_from_opportunity(
     return {
         "id": source_id or f"quote-card-{index}",
         "theme": "customer_proof",
-        "quote": _truncate(evidence, max_quote_chars),
+        "quote": truncate_with_ellipsis(evidence, max_quote_chars),
         "attribution": company or "Customer evidence",
-        "headline": _truncate(headline, max_headline_chars),
-        "supporting_text": _truncate(
+        "headline": truncate_with_ellipsis(headline, max_headline_chars),
+        "supporting_text": truncate_with_ellipsis(
             supporting_text,
             max_supporting_text_chars,
         ),
@@ -273,13 +274,6 @@ def _rows_from_source_material(source_material: Any) -> list[Any]:
         text = source_material.strip()
         return [{"text": text}] if text else []
     return source_material_to_source_rows(source_material)
-
-
-def _truncate(value: str, max_chars: int) -> str:
-    text = " ".join(value.split())
-    if len(text) <= max_chars:
-        return text
-    return text[: max(0, max_chars - 3)].rstrip() + "..."
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/social_post_generation.py
+++ b/extracted_content_pipeline/social_post_generation.py
@@ -24,6 +24,7 @@ from .services._parse_retry_helpers import (
     retry_prompt_with_invalid_response,
 )
 from .social_post_ports import SocialPostDraft, SocialPostRepository
+from .text_truncate import truncate_with_ellipsis
 
 _ROW_LIST_KEYS = ("sources", "opportunities", "reviews", "documents", "rows", "data")
 DEFAULT_SOCIAL_POST_CHANNELS = ("linkedin",)
@@ -346,7 +347,7 @@ class SocialPostGenerationService:
                     limit=parse_retry_response_excerpt_chars,
                 )
                 continue
-            text = _truncate(parsed["text"], channel_max_post_chars)
+            text = truncate_with_ellipsis(parsed["text"], channel_max_post_chars)
             if not text:
                 prior_invalid_response = clip_invalid_response(
                     response.content,
@@ -560,7 +561,10 @@ def _post_from_opportunity(
     return {
         "id": f"{base_id}:{channel}" if include_channel_in_id else base_id,
         "channel": channel,
-        "text": _truncate(body, _max_post_chars_for_channel(channel, max_post_chars)),
+        "text": truncate_with_ellipsis(
+            body,
+            _max_post_chars_for_channel(channel, max_post_chars),
+        ),
         "source_id": source_id,
         "source_type": _clean(opportunity.get("source_type")),
         "target_id": _clean(opportunity.get("target_id")),
@@ -689,13 +693,6 @@ def _rows_from_source_material(source_material: Any) -> list[Any]:
     if isinstance(source_material, Sequence) and not isinstance(source_material, (bytes, bytearray)):
         return list(source_material)
     return []
-
-
-def _truncate(value: str, max_chars: int) -> str:
-    text = " ".join(value.split())
-    if len(text) <= max_chars:
-        return text
-    return text[: max(0, max_chars - 3)].rstrip() + "..."
 
 
 def _max_post_chars_for_channel(channel: str, max_post_chars: int) -> int:

--- a/extracted_content_pipeline/stat_card_generation.py
+++ b/extracted_content_pipeline/stat_card_generation.py
@@ -14,6 +14,7 @@ from .campaign_source_adapters import (
     source_row_to_campaign_opportunity,
 )
 from .stat_card_ports import StatCardDraft, StatCardRepository
+from .text_truncate import truncate_with_ellipsis
 
 
 _NUMBER_RE = re.compile(r"(?<![\w.])-?\d+(?:,\d{3})*(?:\.\d+)?%?")
@@ -287,11 +288,23 @@ def _supported_card(
         "metric_label": label,
         "metric_value": numeric_value,
         "metric_display": metric_display,
-        "claim": _truncate(claim, max_claim_chars),
-        "headline": _truncate(headline, max_headline_chars),
-        "supporting_text": _truncate(
+        "claim": truncate_with_ellipsis(
+            claim,
+            max_claim_chars,
+            compact_whitespace=False,
+            small_limit="text",
+        ),
+        "headline": truncate_with_ellipsis(
+            headline,
+            max_headline_chars,
+            compact_whitespace=False,
+            small_limit="text",
+        ),
+        "supporting_text": truncate_with_ellipsis(
             " ".join(supporting_parts) + ".",
             max_supporting_text_chars,
+            compact_whitespace=False,
+            small_limit="text",
         ),
         "evidence": evidence,
         "source_id": source_id,
@@ -418,7 +431,12 @@ def _bounded_evidence_snippet(
         return evidence[match_start:match_end][:max_chars]
     body_chars = max_chars - 3
     if match_end <= body_chars:
-        return _truncate(evidence, max_chars)
+        return truncate_with_ellipsis(
+            evidence,
+            max_chars,
+            compact_whitespace=False,
+            small_limit="text",
+        )
     start = max(0, match_end - body_chars)
     if start > match_start:
         start = match_start
@@ -428,7 +446,12 @@ def _bounded_evidence_snippet(
         start = max(0, end - body_chars)
     snippet = evidence[start:end].strip()
     if start <= 0:
-        return _truncate(evidence, max_chars)
+        return truncate_with_ellipsis(
+            evidence,
+            max_chars,
+            compact_whitespace=False,
+            small_limit="text",
+        )
     return "..." + snippet
 
 
@@ -473,15 +496,6 @@ def _format_number(value: int | float) -> str:
 
 def _compact_field_name(value: str) -> str:
     return _FIELD_SEPARATOR_RE.sub("", value.lower())
-
-
-def _truncate(value: str, limit: int) -> str:
-    text = _clean(value)
-    if len(text) <= limit:
-        return text
-    if limit <= 3:
-        return text[:limit]
-    return text[: limit - 3].rstrip() + "..."
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/text_truncate.py
+++ b/extracted_content_pipeline/text_truncate.py
@@ -1,0 +1,50 @@
+"""Shared text truncation helpers for deterministic content outputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def truncate_with_ellipsis(
+    value: Any,
+    max_chars: Any,
+    *,
+    suffix: str = "...",
+    compact_whitespace: bool = True,
+    small_limit: str = "suffix",
+) -> str:
+    """Return text no longer than max_chars, reserving room for suffix."""
+
+    text = _text(value, compact_whitespace=compact_whitespace)
+    limit = _limit(max_chars)
+    if len(text) <= limit:
+        return text
+    if limit <= 0:
+        return ""
+
+    suffix_text = str(suffix or "")
+    if not suffix_text:
+        return text[:limit].rstrip()
+
+    reserve = limit - len(suffix_text)
+    if reserve <= 0:
+        if small_limit == "text":
+            return text[:limit]
+        return suffix_text[:limit]
+    return text[:reserve].rstrip() + suffix_text
+
+
+def _text(value: Any, *, compact_whitespace: bool) -> str:
+    text = str(value or "")
+    if compact_whitespace:
+        return " ".join(text.split())
+    return text.strip()
+
+
+def _limit(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/plans/PR-Content-Ops-Text-Truncate-Helper.md
+++ b/plans/PR-Content-Ops-Text-Truncate-Helper.md
@@ -1,0 +1,88 @@
+# PR-Content-Ops-Text-Truncate-Helper
+
+## Why this slice exists
+
+Issue #1290 tracks repeated ellipsis truncation logic in the deterministic card
+generators. This slice centralizes the four private copies and adds CI-enrolled
+tests for bounded output, suffix reservation, and current card behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/review-contract
+Slice phase: Production hardening
+
+1. Add a package-owned shared ellipsis truncation helper.
+2. Migrate social posts, ad copy, quote cards, and stat cards to it.
+3. Add CI-enrolled helper/generator tests; leave non-card contracts untouched.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The helper reserves suffix length, including custom suffixes and tiny
+        limits.
+  - [ ] The four card generators no longer carry private `_truncate` copies.
+  - [ ] Card-generator truncation is preserved for all reachable configs: the
+        first three generators still compact whitespace, and stat-card still
+        preserves spacing plus the small-limit `text[:limit]` contract.
+  - [ ] Intentional change: social/ad/quote at `max_chars <= 2` now return a
+        bounded `"." * limit` / `""` instead of the old `"..."` overshoot.
+  - [ ] New tests are enrolled in `scripts/run_extracted_pipeline_checks.sh`.
+- Affected surfaces: deterministic card generators and package tests.
+- Risk areas: generated copy drift, CI enrollment, manifest ownership.
+- Reviewer rules triggered: R1, R2, R10, R12, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/ad_copy_generation.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/quote_card_generation.py`
+- `extracted_content_pipeline/social_post_generation.py`
+- `extracted_content_pipeline/stat_card_generation.py`
+- `extracted_content_pipeline/text_truncate.py`
+- `plans/PR-Content-Ops-Text-Truncate-Helper.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_content_text_truncate.py`
+
+## Mechanism
+
+The helper normalizes decoded text, reserves `len(suffix)`, then appends the
+suffix. The default compacts whitespace for social/ad/quote; keyword options
+preserve stat-card spacing and small-limit behavior. No service API, config
+field, or generated result shape changes.
+
+## Intentional
+
+- The helper keeps a whitespace-compaction option because stat cards differ.
+- Word-boundary, trim-only, report-builder, and campaign-sequence truncation
+  paths stay out of this slice.
+- Generated field limits and service configuration defaults do not change.
+
+## Deferred
+
+- `ticket_faq_markdown.py` overshoots stay deferred to the deflection lane.
+- Campaign sequence `-0` sites need call-site bound assessment first.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_content_text_truncate.py tests/test_extracted_quote_card_generation.py tests/test_extracted_stat_card_generation.py -q` - 31 passed.
+- `scripts/validate_extracted_content_pipeline.sh` via bash - Passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - Passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - Passed.
+- `scripts/check_ascii_python.sh` via bash - Passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/ad_copy_generation.py` | 15 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/quote_card_generation.py` | 14 |
+| `extracted_content_pipeline/social_post_generation.py` | 15 |
+| `extracted_content_pipeline/stat_card_generation.py` | 42 |
+| `extracted_content_pipeline/text_truncate.py` | 50 |
+| `plans/PR-Content-Ops-Text-Truncate-Helper.md` | 88 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_content_text_truncate.py` | 163 |
+| **Total** | **391** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -106,6 +106,7 @@ pytest \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \
   tests/test_extracted_content_reasoning_policy.py \
+  tests/test_extracted_content_text_truncate.py \
   tests/test_extracted_quote_card_generation.py \
   tests/test_extracted_stat_card_generation.py \
   tests/test_extracted_quote_card_postgres.py \

--- a/tests/test_extracted_content_text_truncate.py
+++ b/tests/test_extracted_content_text_truncate.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.ad_copy_generation import (
+    AdCopyGenerationConfig,
+    AdCopyGenerationService,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.social_post_generation import (
+    SocialPostGenerationConfig,
+    SocialPostGenerationService,
+)
+from extracted_content_pipeline.stat_card_generation import (
+    StatCardGenerationConfig,
+    StatCardGenerationService,
+)
+from extracted_content_pipeline.text_truncate import truncate_with_ellipsis
+
+
+def test_truncate_with_ellipsis_reserves_suffix_length() -> None:
+    output = truncate_with_ellipsis("alpha beta gamma delta", 16)
+
+    assert output == "alpha beta ga..."
+    assert len(output) <= 16
+    assert output.endswith("...")
+
+
+def test_truncate_with_ellipsis_compacts_whitespace_by_default() -> None:
+    output = truncate_with_ellipsis("alpha   beta\n\ngamma", 15)
+
+    assert output == "alpha beta g..."
+    assert len(output) <= 15
+
+
+def test_truncate_with_ellipsis_supports_custom_suffix() -> None:
+    output = truncate_with_ellipsis("abcdefghij", 7, suffix=" [x]")
+
+    assert output == "abc [x]"
+    assert len(output) <= 7
+    assert output.endswith(" [x]")
+
+
+@pytest.mark.parametrize("limit", [0, 1, 2])
+def test_truncate_with_ellipsis_keeps_tiny_limits_bounded(limit: int) -> None:
+    output = truncate_with_ellipsis("abcdef", limit)
+
+    assert output == "." * limit
+    assert len(output) <= limit
+
+
+def test_truncate_with_ellipsis_can_preserve_small_limit_text_contract() -> None:
+    output = truncate_with_ellipsis(
+        "abcdef", 2, compact_whitespace=False, small_limit="text"
+    )
+
+    assert output == "ab"
+    assert len(output) <= 2
+
+
+def test_truncate_with_ellipsis_treats_non_integer_limit_as_empty() -> None:
+    assert truncate_with_ellipsis("abcdef", None) == ""
+    assert truncate_with_ellipsis("abcdef", "not-a-limit") == ""
+    assert truncate_with_ellipsis("abcdef", True) == ""
+
+
+@pytest.mark.asyncio
+async def test_social_post_generation_uses_bounded_shared_truncation() -> None:
+    config = SocialPostGenerationConfig(max_post_chars=18)
+    service = SocialPostGenerationService(config=config)
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-long",
+                "vendor": "HubSpot",
+                "review_text": " ".join(["renewal pressure"] * 20),
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    post = result.as_dict()["posts"][0]
+    assert post["text"] == "Customer eviden..."
+    assert post["text"].endswith("...")
+    assert len(post["text"]) <= config.max_post_chars
+
+
+@pytest.mark.asyncio
+async def test_ad_copy_generation_uses_bounded_shared_truncation() -> None:
+    config = AdCopyGenerationConfig(max_headline_chars=16, max_primary_text_chars=22)
+    service = AdCopyGenerationService(config=config)
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-long",
+                "vendor": "HubSpot",
+                "review_text": " ".join(["renewal pressure"] * 20),
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    ad = result.as_dict()["ads"][0]
+    assert ad["headline"] == "HubSpot proof..."
+    assert len(ad["headline"]) <= config.max_headline_chars
+    assert ad["primary_text"].endswith("...")
+    assert len(ad["primary_text"]) <= config.max_primary_text_chars
+
+
+@pytest.mark.asyncio
+async def test_stat_card_generation_preserves_existing_small_limit_text_contract() -> None:
+    config = StatCardGenerationConfig(
+        max_claim_chars=2,
+        max_headline_chars=2,
+        max_supporting_text_chars=2,
+        max_evidence_chars=2,
+    )
+    service = StatCardGenerationService(config=config)
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-long",
+                "vendor": "VeryLongVendorName",
+                "review_text": "NPS score dropped to 42 after renewal pressure.",
+                "nps_score": 42,
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    stat = result.as_dict()["stats"][0]
+    assert stat["claim"] == "NP"
+    assert stat["headline"] == "Cu"
+    assert stat["supporting_text"] == "Us"
+    assert stat["evidence"] == "42"
+
+
+def test_truncate_no_compaction_retains_internal_whitespace() -> None:
+    value = "NPS   score   dropped here"
+
+    kept = truncate_with_ellipsis(
+        value, 18, compact_whitespace=False, small_limit="text"
+    )
+    collapsed = truncate_with_ellipsis(
+        value, 18, compact_whitespace=True, small_limit="text"
+    )
+
+    assert "  " in kept
+    assert "  " not in collapsed
+    assert kept != collapsed
+
+
+def test_truncate_rstrips_boundary_space_before_suffix() -> None:
+    assert truncate_with_ellipsis("alpha beta gamma", 14) == "alpha beta..."


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Text-Truncate-Helper.md
Slice phase: Production hardening

Issue #1290 tracks repeated ellipsis truncation helpers across deterministic content generators. This PR adds a shared extracted-content helper and migrates the four card generators to it, preserving reachable generator behavior while intentionally fixing the old social/ad/quote tiny-limit overshoot.

## Intentional
- The helper keeps a whitespace-compaction option because social/ad/quote compact whitespace and stat cards do not.
- Social/ad/quote at `max_chars <= 2` now return bounded output instead of the old `"..."` overshoot; that path is unreachable through public `generate()` args.
- Word-boundary, trim-only, report-builder, and campaign-sequence truncation paths stay out of this slice.
- No service APIs, config fields, or generated result shapes change.

## Deferred
- Deflection/report-builder overshoot sites in `ticket_faq_markdown.py` remain deferred to the deflection lane.
- Campaign sequence context `-0` ellipsis sites remain deferred until a follow-up assesses whether their downstream call sites hard-enforce the configured character limit.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_text_truncate.py tests/test_extracted_quote_card_generation.py tests/test_extracted_stat_card_generation.py -q` - 31 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - Passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - Passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - Passed.
- `bash scripts/check_ascii_python.sh` - Passed.

## AI reconciliation
- No AI review findings yet.
- All fixed or waived: yes, no findings.

## Diff size
9 files, +349 / -42
