### PR TITLE
Deflection full-funnel paid delivery proof

### DIFF
--- a/docs/extraction/validation/deflection_full_funnel_paid_delivery_proof_2026-06-15.md
+++ b/docs/extraction/validation/deflection_full_funnel_paid_delivery_proof_2026-06-15.md
@@ -1,0 +1,218 @@
+# Deflection Full-Funnel Paid Delivery Proof
+
+Date: 2026-06-15
+
+Issue: #1440
+
+## Result
+
+Partial full-funnel pass.
+
+The hosted revenue path is now proven for a fresh full-volume CFPB stress run:
+
+1. Hosted multipart intake accepted the near-50 MiB CSV.
+2. The unpaid artifact was locked before payment.
+3. A signed Stripe `checkout.session.completed` webhook unlocked the artifact.
+4. Webhook replay was idempotent.
+5. The hosted deflection delivery task sent one report email with no failures.
+
+The buyer-facing portfolio result page is still not proven. The canonical
+production URL returns HTTP 200, and the ATLAS snapshot/artifact endpoints both
+return 200 for the same paid request, but the portfolio page renders
+`SNAPSHOT TEMPORARILY UNAVAILABLE` instead of the result markers. That remains
+the next live blocker for #1440.
+
+Snapshot email/PDF delivery is also not independently observed in this proof.
+During this slice, no snapshot-email sender surface was found in the Atlas repo;
+the proven email send is the paid full-report delivery.
+
+## Input
+
+The raw CSV is not committed. It was regenerated locally from:
+
+```text
+tmp/faq_scale_stress_20260523/cfpb_50000_source_rows.jsonl
+```
+
+Generated upload CSV:
+
+| Field | Value |
+|---|---:|
+| CSV records written | 42,646 |
+| CSV bytes | 52,426,845 |
+| SHA-256 | `e812f4eb6c41f2d81cbb852f9e9898aec08703e02aacdd17d77b21ef9aa69bde` |
+
+Source role: CFPB remains stress/scale evidence. It is not Zendesk
+product-quality calibration.
+
+## Hosted Submit
+
+Command shape:
+
+```bash
+python scripts/smoke_content_ops_deflection_submit_handoff.py \
+  --csv-file tmp/deflection_full_funnel_paid_delivery_proof_20260615/cfpb_real_upload_under_50mib.csv \
+  --company-name "CFPB Public Archive" \
+  --contact-email "<contact-email>" \
+  --support-platform other \
+  --volume-gate-profile full-volume-cfpb \
+  --timeout 360 \
+  --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/submit-result.json \
+  --json
+```
+
+Observed result:
+
+| Check | Value |
+|---|---:|
+| Submit status | 200 |
+| Snapshot status | 200 |
+| Unpaid artifact status | 403 |
+| Uploaded bytes | 52,426,845 |
+| Source rows | 42,646 |
+| Submitted rows | 42,646 |
+| Generated questions | 1,757 |
+| Repeat-ticket count | 29,106 |
+| Top-question count | 5 |
+| Elapsed seconds | 60.80 |
+
+Request id:
+
+```text
+<redacted-paid-request-id>
+```
+
+The calibrated `full-volume-cfpb` profile passed.
+
+## Paid Unlock
+
+The first rerun against the old root `.env` webhook secret still failed with
+`Invalid signature`. The deployed host matched the 70-character webhook secret
+present in the portfolio env/old backend backup, not the 148-character root
+`.env` value. No secret value is committed.
+
+Command shape:
+
+```bash
+python scripts/smoke_content_ops_deflection_stripe_paid_unlock.py \
+  --request-id "<redacted-paid-request-id>" \
+  --timeout 180 \
+  --replay-webhook \
+  --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/paid-unlock-fresh-request.json \
+  --json
+```
+
+Observed result:
+
+| Check | Value |
+|---|---:|
+| Artifact before webhook | 403 |
+| Stripe webhook status | 200 |
+| Replay webhook status | 200 |
+| Replay payload status | `already_processed` |
+| Artifact after webhook | 200 |
+
+## Report Delivery
+
+The hosted autonomous delivery task was enabled and running:
+
+```text
+content_ops_deflection_report_delivery
+```
+
+Manual trigger:
+
+```bash
+POST /api/v1/autonomous/content_ops_deflection_report_delivery/run
+```
+
+Observed execution:
+
+| Check | Value |
+|---|---:|
+| Execution id | `5af4e50a-7044-4445-bc38-72ed3e9231d5` |
+| Task status | `completed` |
+| Scanned | 1 |
+| Sent | 1 |
+| Failed | 0 |
+| Dry run | 0 |
+| Duration | 16,134 ms |
+
+This proves the paid report-email delivery path for the fresh full-volume
+request.
+
+## Portfolio Result Page
+
+Command shape:
+
+```bash
+python scripts/smoke_content_ops_deflection_portfolio_result_page.py \
+  --result-url "<redacted-paid-result-url>" \
+  --request-id "<redacted-paid-request-id>" \
+  --timeout 120 \
+  --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/portfolio-result-page-fresh.json \
+  --json
+```
+
+Observed result:
+
+| Check | Value |
+|---|---:|
+| Portfolio page status | 200 |
+| ATLAS snapshot status | 200 |
+| ATLAS paid artifact status | 200 |
+| Page rendered unavailable state | true |
+| Required result markers present | false |
+
+Page text began:
+
+```text
+Support Ticket Deflection Report: Cut Repeat Support Tickets SNAPSHOT TEMPORARILY UNAVAILABLE
+```
+
+This is the remaining product blocker: production portfolio can reach a public
+route but still cannot render the paid result from the ATLAS data that exists.
+
+## Committed Evidence
+
+Sanitized summary:
+
+```text
+docs/extraction/validation/fixtures/deflection_full_funnel_paid_delivery_proof_20260615/summary.json
+```
+
+The summary intentionally excludes bearer tokens, webhook secrets, raw CFPB
+rows, paid report Markdown, PDFs, email bodies, and portfolio HTML.
+
+## Server-Side Invalidation Proof
+
+After review identified the redacted live request id as a leaked capability,
+the request was invalidated server-side through the deployed Stripe revocation
+path. The summary binds this check to the leaked value by SHA-256 only:
+
+```text
+1ebb65093faf3823d2b1413d2b34db28f786908885406acc48846f224ac1011d
+```
+
+Observed revocation proof:
+
+| Check | Value |
+|---|---:|
+| Revocation webhook status | 200 |
+| Artifact status after invalidation | 403 |
+| Artifact locked after invalidation | true |
+| Checked at | 2026-06-15T13:55:05Z |
+
+No request id, result URL, token, or report body is committed.
+
+## Next Action
+
+1. Fix portfolio production snapshot/artifact loading for the canonical paid
+   result URL, then rerun the result-page smoke against
+   a new paid request.
+2. Decide whether snapshot email/PDF is a real product surface. If yes, add or
+   identify the sender path and prove it under full-volume conditions; if no,
+   update #1440 acceptance language so it does not keep asking for a nonexistent
+   delivery surface.
+3. Align local operator env naming so future paid smokes use the deployed
+   Stripe webhook secret source, not the stale root `.env` value.

--- a/docs/extraction/validation/fixtures/deflection_full_funnel_paid_delivery_proof_20260615/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_full_funnel_paid_delivery_proof_20260615/summary.json
@@ -1,0 +1,103 @@
+{
+  "artifact_version": 1,
+  "csv_input": {
+    "bytes": 52426845,
+    "committed": false,
+    "records_written": 42646,
+    "sha256": "e812f4eb6c41f2d81cbb852f9e9898aec08703e02aacdd17d77b21ef9aa69bde",
+    "source_jsonl": "tmp/faq_scale_stress_20260523/cfpb_50000_source_rows.jsonl"
+  },
+  "delivery": {
+    "completed_at": "2026-06-15T04:03:56.904607+00:00",
+    "duration_ms": 16134,
+    "execution_id": "5af4e50a-7044-4445-bc38-72ed3e9231d5",
+    "result_text": "{'_skip_synthesis': 'Deflection report delivery complete', 'scanned': 1, 'sent': 1, 'failed': 0, 'dry_run': 0, 'dry_run_enabled': False}",
+    "started_at": "2026-06-15T04:03:40.765332+00:00",
+    "status": "completed",
+    "task_id": "a5370306-b465-403e-be04-dd521df91a9f",
+    "trigger_status": "accepted_running"
+  },
+  "hosted_submit": {
+    "elapsed_seconds": 60.79574222397059,
+    "ok": true,
+    "snapshot_status": 200,
+    "submit_status": 200,
+    "unpaid_artifact_status": 403,
+    "volume_gates": {
+      "actual": {
+        "generated_questions": 1757,
+        "repeat_ticket_count": 29106,
+        "source_row_count": 42646,
+        "submitted_row_count": 42646,
+        "top_question_count": 5,
+        "uploaded_bytes": 52426845
+      },
+      "configured": {
+        "generated_questions": 30,
+        "repeat_ticket_count": 25000,
+        "source_row_count": 30000,
+        "submitted_row_count": 30000,
+        "top_question_count": 5,
+        "uploaded_bytes": 50000000
+      },
+      "errors": [],
+      "ok": true,
+      "profile": "full-volume-cfpb"
+    }
+  },
+  "issue": 1440,
+  "paid_unlock": {
+    "after_artifact_status": 200,
+    "before_artifact_status": 403,
+    "ok": true,
+    "replay_payload_status": "already_processed",
+    "replay_webhook_status": 200,
+    "webhook_status": 200
+  },
+  "portfolio_result_page": {
+    "artifact_status": 200,
+    "missing_markers": [
+      "portfolio result page missing marker: data-atlas-deflection-result",
+      "portfolio result page missing marker: data-atlas-deflection-request-id",
+      "portfolio result page missing marker: data-atlas-deflection-unlock",
+      "portfolio result page missing marker: content_ops_deflection_report",
+      "portfolio result page missing marker: request_id",
+      "portfolio result page missing unlock CTA element"
+    ],
+    "ok": false,
+    "page_status": 200,
+    "rendered_unavailable_state": true,
+    "result_url": "<redacted-paid-result-url>",
+    "snapshot_status": 200,
+    "text_snippet": "Support Ticket Deflection Report: Cut Repeat Support Tickets SNAPSHOT TEMPORARILY UNAVAILABLE We couldn&#x27;t load your snapshot right now. Your upload may still be processing, or the report service may be temporarily unavailable. Try again in a moment. Try again Back to Support Ticket Deflection"
+  },
+  "redaction": {
+    "bearer_tokens_committed": false,
+    "live_request_artifact_locked_after_invalidation": true,
+    "live_request_artifact_status_after_invalidation": 403,
+    "live_request_id_sha256": "1ebb65093faf3823d2b1413d2b34db28f786908885406acc48846f224ac1011d",
+    "live_request_invalidated_server_side": true,
+    "live_request_invalidated_status": "artifact_relocked_403",
+    "live_request_invalidation_checked_at": "2026-06-15T13:55:05Z",
+    "live_request_revocation_webhook_status": 200,
+    "local_absolute_paths_committed": false,
+    "operator_email_committed": false,
+    "portfolio_html_committed": false,
+    "raw_csv_committed": false,
+    "raw_report_committed": false,
+    "request_id_committed": false,
+    "result_url_committed": false,
+    "secrets_committed": false
+  },
+  "remaining_blockers": [
+    "Portfolio production result page still renders SNAPSHOT TEMPORARILY UNAVAILABLE for the fresh paid request even though ATLAS snapshot/artifact endpoints return 200.",
+    "Snapshot email/PDF delivery is still not independently observed in code or artifacts; no snapshot-email sender surface was found in this repo during this slice."
+  ],
+  "request_id": "<redacted-paid-request-id>",
+  "result": "partial_full_funnel_pass_paid_delivery_proven_portfolio_page_unavailable",
+  "secret_alignment": {
+    "portfolio_env_webhook_secret_result": "webhook_200_replay_already_processed",
+    "root_env_webhook_secret_result": "invalid_signature",
+    "secret_values_committed": false
+  }
+}

--- a/plans/PR-Deflection-Full-Funnel-Paid-Delivery-Proof.md
+++ b/plans/PR-Deflection-Full-Funnel-Paid-Delivery-Proof.md
@@ -1,0 +1,135 @@
+# PR-Deflection-Full-Funnel-Paid-Delivery-Proof
+
+## Why this slice exists
+
+#1440's title is the deliverable: test deflection delivery under real full-volume
+conditions through intake, snapshot, payment, and report email. #1557 proved
+hosted full-volume submit/snapshot/locked artifact, and #1569 proved offline
+Zendesk product-shaped quality, but neither proved the live paid revenue path.
+This docs/proof slice is slightly over the 400-line soft cap because it carries
+both the human proof narrative and the sanitized machine-readable evidence
+needed to review the live run without raw secrets or report payloads.
+
+Root cause: the prior #1440 evidence stopped before the deployed Stripe webhook
+secret and hosted delivery task were exercised together. This slice fixes the
+evidence gap, not product code: it runs the real hosted path, records the paid
+unlock and report-delivery proof, and keeps the still-failing portfolio render
+as an explicit remaining blocker instead of overclaiming full closure.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Functional validation
+
+1. Add a sanitized live proof doc for the fresh full-volume hosted funnel run.
+2. Commit a redacted machine-readable summary of the run: full-volume submit,
+   paid unlock, idempotent webhook replay, delivery task execution, and
+   portfolio page status.
+3. Do not commit raw CSV rows, paid report Markdown/PDF, email bodies, bearer
+   tokens, webhook secrets, or portfolio HTML.
+4. Do not change product code in this slice; the live proof identifies the next
+   code-owned blocker.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The proof demonstrates a fresh hosted full-volume request, not only the old
+  #1557 request.
+- Paid unlock is proven by before-artifact 403, webhook 200, replay 200 with
+  `already_processed`, and after-artifact 200.
+- Report delivery is proven by the hosted delivery task scanning 1, sending 1,
+  failing 0, and dry-run 0.
+- The proof does not overclaim #1440 completion: portfolio production still
+  renders `SNAPSHOT TEMPORARILY UNAVAILABLE`, and snapshot email/PDF remains
+  unobserved.
+- Committed artifacts are sanitized and exclude secrets/raw customer data.
+
+Affected surfaces:
+
+- `docs/extraction/validation/**`
+- `docs/extraction/validation/fixtures/**`
+- `plans/**`
+
+Risk areas:
+
+- Overclaiming a partial proof as full acceptance.
+- Accidentally committing raw CSV/report/email/HTML or secret-bearing outputs.
+- Confusing CFPB stress evidence with Zendesk product-quality calibration.
+
+Reviewer rules triggered: R1, R2, R6, R14.
+
+### Files touched
+
+- `docs/extraction/validation/deflection_full_funnel_paid_delivery_proof_2026-06-15.md`
+- `docs/extraction/validation/fixtures/deflection_full_funnel_paid_delivery_proof_20260615/summary.json`
+- `plans/PR-Deflection-Full-Funnel-Paid-Delivery-Proof.md`
+
+## Mechanism
+
+The slice records a live run using existing hosted-proof scripts and the
+deployed autonomous delivery task:
+
+1. Regenerate a near-50 MiB CFPB stress CSV locally from the existing 50k JSONL
+   source and keep it under ignored `tmp/`.
+2. Run `smoke_content_ops_deflection_submit_handoff.py` against hosted ATLAS
+   with `--volume-gate-profile full-volume-cfpb`.
+3. Run `smoke_content_ops_deflection_stripe_paid_unlock.py` against the fresh
+   request with the deployed-matching webhook secret source. The stale root env
+   secret still fails with `Invalid signature`; the portfolio/backup secret
+   matches deployed and passes.
+4. Trigger hosted `content_ops_deflection_report_delivery` via
+   `/api/v1/autonomous/content_ops_deflection_report_delivery/run` and poll the
+   task execution.
+5. Run the portfolio result-page smoke against the canonical paid result URL
+   and record the remaining unavailable-state blocker.
+
+Only sanitized scalar evidence is committed.
+
+## Intentional
+
+- This PR does not fix the portfolio result-page blocker. The proof shows the
+  blocker precisely: portfolio returns 200 but renders the unavailable state
+  while ATLAS snapshot/artifact endpoints return 200 for the same paid request.
+- This PR keeps CFPB framed as stress/scale evidence, not Zendesk
+  product-quality calibration.
+- The raw generated CSV, paid artifact, email body/PDF, bearer token, webhook
+  secrets, and fetched portfolio HTML stay local and uncommitted.
+- Live paid request ids, result URLs, local absolute paths, and operator email
+  addresses are redacted from committed proof artifacts and the PR body. The
+  live request id originally used for the proof was invalidated server-side
+  after review identified it as a capability.
+- The proof is partial rather than greenwashing #1440; the paid revenue path is
+  proven, but portfolio rendering and snapshot email/PDF are still open.
+
+## Deferred
+
+1. Portfolio production result rendering: fix the canonical result page so the
+   paid request renders the real snapshot/report markers instead of
+   `SNAPSHOT TEMPORARILY UNAVAILABLE`.
+2. Snapshot email/PDF decision: either identify/build the snapshot sender and
+   prove it under full-volume conditions, or update #1440 acceptance because no
+   snapshot-email sender surface was found in this repo during this slice.
+3. Local env cleanup: align operator env files so future paid smokes use the
+   deployed Stripe webhook secret source and do not hit the stale root `.env`
+   value first.
+
+Parked hardening: none.
+
+## Verification
+
+- `python scripts/smoke_content_ops_deflection_submit_handoff.py --csv-file tmp/deflection_full_funnel_paid_delivery_proof_20260615/cfpb_real_upload_under_50mib.csv --company-name "CFPB Public Archive" --contact-email "<contact-email>" --support-platform other --volume-gate-profile full-volume-cfpb --timeout 360 --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/submit-result.json --json` -> passed; 42,646 submitted rows, 52,426,845 uploaded bytes, 1,757 generated questions, 29,106 repeat tickets.
+- `python scripts/smoke_content_ops_deflection_stripe_paid_unlock.py --request-id "<redacted-paid-request-id>" --timeout 180 --replay-webhook --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/paid-unlock-fresh-request.json --json` -> passed; 403 before webhook, 200 webhook, 200 replay with `already_processed`, 200 artifact after webhook.
+- `POST /api/v1/autonomous/content_ops_deflection_report_delivery/run` and execution polling -> completed; scanned 1, sent 1, failed 0, dry_run 0.
+- `python scripts/smoke_content_ops_deflection_portfolio_result_page.py --result-url "<redacted-paid-result-url>" --request-id "<redacted-paid-request-id>" --timeout 120 --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/portfolio-result-page-fresh.json --json` -> failed as expected for the remaining blocker; page 200, ATLAS snapshot 200, ATLAS artifact 200, but portfolio rendered `SNAPSHOT TEMPORARILY UNAVAILABLE` and missed result markers.
+- Signed Stripe revocation webhook for the live proof request -> 200; artifact endpoint recheck after revocation -> 403 locked at 2026-06-15T13:55:05Z. The committed summary binds the proof to the leaked value by SHA-256 only: `1ebb65093faf3823d2b1413d2b34db28f786908885406acc48846f224ac1011d`.
+- `python -m json.tool docs/extraction/validation/fixtures/deflection_full_funnel_paid_delivery_proof_20260615/summary.json >/tmp/deflection-paid-summary.pretty.json` -> passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/deflection_full_funnel_paid_delivery_proof_2026-06-15.md` | 218 |
+| `docs/extraction/validation/fixtures/deflection_full_funnel_paid_delivery_proof_20260615/summary.json` | 103 |
+| `plans/PR-Deflection-Full-Funnel-Paid-Delivery-Proof.md` | 135 |
+| **Total** | **456** |


### PR DESCRIPTION
Plan: plans/PR-Deflection-Full-Funnel-Paid-Delivery-Proof.md
Slice phase: Functional validation

#1440 still needed the live revenue path, not another offline Zendesk proof: hosted full-volume submit had run, but pay -> report email had not. This PR commits the sanitized proof from a fresh hosted full-volume run: intake passed, unpaid artifact locked, Stripe webhook unlocked the report, replay was idempotent, and the hosted delivery task sent one report email. It also records the remaining live blocker honestly: the portfolio result page returns 200 but still renders `SNAPSHOT TEMPORARILY UNAVAILABLE`.

## Intentional
- No product code changes in this slice; this is a live validation/proof PR.
- Raw CSV, paid report Markdown/PDF, email bodies, bearer tokens, webhook secrets, and portfolio HTML are not committed.
- Live paid request ids, result URLs, local absolute paths, and operator email addresses are redacted. The live request id originally used for the proof was invalidated server-side after review identified it as a capability.
- CFPB remains stress/scale evidence, not Zendesk product-quality calibration.
- #1440 is not overclaimed as fully closed because portfolio rendering and snapshot email/PDF remain open.

## Deferred
- Fix portfolio production result rendering for the canonical paid result URL.
- Decide whether snapshot email/PDF is a real product surface; if yes, identify/build and prove it, and if no, update #1440 acceptance language.
- Align local operator env files so future paid smokes use the deployed Stripe webhook secret source.

## Parked hardening
- None.

## Verification
- `python scripts/smoke_content_ops_deflection_submit_handoff.py --csv-file tmp/deflection_full_funnel_paid_delivery_proof_20260615/cfpb_real_upload_under_50mib.csv --company-name "CFPB Public Archive" --contact-email "<contact-email>" --support-platform other --volume-gate-profile full-volume-cfpb --timeout 360 --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/submit-result.json --json` -> passed; 42,646 submitted rows, 52,426,845 uploaded bytes, 1,757 generated questions, 29,106 repeat tickets.
- `python scripts/smoke_content_ops_deflection_stripe_paid_unlock.py --request-id "<redacted-paid-request-id>" --timeout 180 --replay-webhook --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/paid-unlock-fresh-request.json --json` -> passed; 403 before webhook, webhook 200, replay 200 with `already_processed`, artifact 200 after webhook.
- `POST /api/v1/autonomous/content_ops_deflection_report_delivery/run` and execution polling -> completed; scanned 1, sent 1, failed 0, dry_run 0.
- `python scripts/smoke_content_ops_deflection_portfolio_result_page.py --result-url "<redacted-paid-result-url>" --request-id "<redacted-paid-request-id>" --timeout 120 --output-result tmp/deflection_full_funnel_paid_delivery_proof_20260615/portfolio-result-page-fresh.json --json` -> failed as expected for the remaining blocker; page 200, ATLAS snapshot 200, ATLAS artifact 200, but portfolio rendered `SNAPSHOT TEMPORARILY UNAVAILABLE`.
- Signed Stripe revocation webhook for the live proof request -> 200; artifact endpoint recheck after revocation -> 403 locked at 2026-06-15T13:55:05Z. The committed summary binds the proof to the leaked value by SHA-256 only: `1ebb65093faf3823d2b1413d2b34db28f786908885406acc48846f224ac1011d`.
- `python -m json.tool docs/extraction/validation/fixtures/deflection_full_funnel_paid_delivery_proof_20260615/summary.json >/tmp/deflection-paid-summary.pretty.json` -> passed.
- `python scripts/sync_pr_plan.py --check plans/PR-Deflection-Full-Funnel-Paid-Delivery-Proof.md` -> passed.
- `git diff --check` -> passed.

## Diff size
3 files, +456 / -0
