### PR TITLE
Deflection CSV admission diagnostics

### DIFF
--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 import json
 from pathlib import Path
 import re
@@ -22,6 +23,7 @@ from .faq_output_ingestion import (
 
 
 SourceDataFormat = Literal["auto", "json", "jsonl", "csv"]
+_SOURCE_ADMISSION_FIELD_LIMIT = 25
 
 _ROW_LIST_KEYS = (
     "sources",
@@ -319,6 +321,41 @@ _MAX_BUNDLE_DEPTH = 8
 _MISSING = object()
 
 
+@dataclass(frozen=True)
+class SourceRowAdmissionDiagnostics:
+    """Source-row admission evidence for operator-facing diagnostics."""
+
+    input_format: str
+    raw_source_row_count: int
+    usable_source_row_count: int
+    mapped_fields: Mapping[str, tuple[str, ...]]
+    ignored_private_fields: tuple[str, ...]
+    populated_unmapped_fields: tuple[str, ...]
+    field_sample_limit: int = _SOURCE_ADMISSION_FIELD_LIMIT
+
+    @property
+    def usable_source_ratio(self) -> float | None:
+        if self.raw_source_row_count < 1:
+            return None
+        return round(self.usable_source_row_count / self.raw_source_row_count, 6)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "input_format": self.input_format,
+            "raw_source_row_count": self.raw_source_row_count,
+            "usable_source_row_count": self.usable_source_row_count,
+            "usable_source_ratio": self.usable_source_ratio,
+            "mapped_fields": {
+                key: list(values)
+                for key, values in sorted(self.mapped_fields.items())
+                if values
+            },
+            "ignored_private_fields": list(self.ignored_private_fields),
+            "populated_unmapped_fields": list(self.populated_unmapped_fields),
+            "field_sample_limit": self.field_sample_limit,
+        }
+
+
 class _SourceFieldLookup(Mapping[str, Any]):
     """Mapping wrapper that caches string-key alias lookups for one source row."""
 
@@ -528,6 +565,54 @@ def parse_default_fields_with_booking_url_or_exit(
     return defaults
 
 
+def build_source_row_admission_diagnostics(
+    rows: Sequence[Any],
+    *,
+    input_format: str,
+    usable_source_row_count: int,
+    field_sample_limit: int = _SOURCE_ADMISSION_FIELD_LIMIT,
+) -> SourceRowAdmissionDiagnostics:
+    """Classify source-row fields using the same aliases as extraction."""
+
+    populated_fields = _populated_source_fields(rows)
+    mapped: dict[str, tuple[str, ...]] = {}
+    private_fields = _matching_fields(populated_fields, _PRIVATE_TEXT_KEYS)
+    categories = (
+        ("source_id", _SOURCE_ID_KEYS),
+        ("source_text", _TEXT_KEYS),
+        ("thread_text", _THREAD_KEYS),
+        ("source_title", _SOURCE_TITLE_KEYS),
+        ("source_type", _SOURCE_TYPE_KEYS),
+        ("company", _COMPANY_KEYS),
+        ("vendor", _VENDOR_KEYS),
+        ("contact_name", _CONTACT_NAME_KEYS),
+        ("contact_email", _CONTACT_EMAIL_KEYS),
+        ("contact_title", _CONTACT_TITLE_KEYS),
+        ("nps_score", _NPS_SCORE_KEYS),
+        ("csat_score", _CSAT_SCORE_KEYS),
+        ("pain_points", _PAIN_KEYS),
+    )
+    matched_fields_by_category: dict[str, tuple[str, ...]] = {}
+    for category, aliases in categories:
+        fields = _matching_fields(populated_fields, aliases)
+        if fields:
+            matched_fields_by_category[category] = fields
+            mapped[category] = fields[:field_sample_limit]
+    known = set(private_fields)
+    for fields in matched_fields_by_category.values():
+        known.update(fields)
+    unmapped = tuple(field for field in populated_fields if field not in known)
+    return SourceRowAdmissionDiagnostics(
+        input_format=input_format,
+        raw_source_row_count=len(rows),
+        usable_source_row_count=max(0, int(usable_source_row_count)),
+        mapped_fields={key: value for key, value in mapped.items()},
+        ignored_private_fields=private_fields[:field_sample_limit],
+        populated_unmapped_fields=unmapped[:field_sample_limit],
+        field_sample_limit=field_sample_limit,
+    )
+
+
 def _clean_default_fields(default_fields: Mapping[str, Any] | None) -> dict[str, Any]:
     return {
         str(key): value
@@ -554,6 +639,37 @@ def _merge_default_fields(
         },
         **row_values,
     }
+
+
+def _populated_source_fields(rows: Sequence[Any]) -> tuple[str, ...]:
+    fields: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        for key, value in row.items():
+            field = str(key).strip()
+            if not field or field in seen or value in (None, "", [], {}):
+                continue
+            seen.add(field)
+            fields.append(field)
+    return tuple(fields)
+
+
+def _matching_fields(fields: Sequence[str], aliases: Sequence[str]) -> tuple[str, ...]:
+    return tuple(field for field in fields if _field_matches_aliases(field, aliases))
+
+
+def _field_matches_aliases(field: str, aliases: Sequence[str]) -> bool:
+    normalized = _normalized_field_key(field)
+    compact = _compact_field_key(field)
+    for alias in aliases:
+        if (
+            _normalized_field_key(alias) == normalized
+            or _compact_field_key(alias) == compact
+        ):
+            return True
+    return False
 
 
 def _canonical_alias_key(key: str) -> str | None:
@@ -992,6 +1108,8 @@ def _compact_field_key(key: str) -> str:
 
 __all__ = [
     "SourceDataFormat",
+    "SourceRowAdmissionDiagnostics",
+    "build_source_row_admission_diagnostics",
     "load_source_campaign_opportunities_from_file",
     "load_source_rows_from_file",
     "load_source_rows_with_warnings_from_file",

--- a/extracted_content_pipeline/ingestion_diagnostics.py
+++ b/extracted_content_pipeline/ingestion_diagnostics.py
@@ -16,7 +16,10 @@ from .campaign_customer_data import (
 )
 from .campaign_source_adapters import (
     SourceDataFormat,
+    SourceRowAdmissionDiagnostics,
+    build_source_row_admission_diagnostics,
     load_source_campaign_opportunities_from_file,
+    load_source_rows_with_warnings_from_file,
     source_rows_to_campaign_opportunities,
 )
 
@@ -39,13 +42,14 @@ class IngestionDiagnosticsReport:
     missing_field_counts: Mapping[str, int]
     source_type_counts: Mapping[str, int]
     sample_limit: int
+    source_row_admission: SourceRowAdmissionDiagnostics | None = None
 
     @property
     def ok(self) -> bool:
         return bool(self.opportunities) and not self.missing_field_counts.get("target_id", 0)
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "ok": self.ok,
             "mode": self.mode,
             "source": self.source,
@@ -57,6 +61,9 @@ class IngestionDiagnosticsReport:
             "samples": [dict(row) for row in self.opportunities[: self.sample_limit]],
             "warnings": list(self.warnings),
         }
+        if self.source_row_admission:
+            payload["source_row_admission"] = self.source_row_admission.as_dict()
+        return payload
 
 
 def inspect_ingestion_file(
@@ -78,14 +85,37 @@ def inspect_ingestion_file(
         raise ValueError("max_source_text_chars must be positive")
 
     source = Path(path)
+    source_row_admission: SourceRowAdmissionDiagnostics | None = None
     if source_rows:
-        loaded = load_source_campaign_opportunities_from_file(
-            source,
-            file_format=source_format,
-            target_mode=target_mode,
-            max_text_chars=max_source_text_chars,
-            default_fields=default_fields,
-        )
+        if _source_rows_file_is_csv(source, source_format):
+            rows, load_warnings = load_source_rows_with_warnings_from_file(
+                source,
+                file_format=source_format,
+            )
+            converted = source_rows_to_campaign_opportunities(
+                rows,
+                target_mode=target_mode,
+                max_text_chars=max_source_text_chars,
+                default_fields=default_fields,
+            )
+            source_row_admission = build_source_row_admission_diagnostics(
+                rows,
+                input_format="csv",
+                usable_source_row_count=len(converted.opportunities),
+            )
+            loaded = CampaignOpportunityLoadResult(
+                opportunities=converted.opportunities,
+                warnings=load_warnings + converted.warnings,
+                source=str(source),
+            )
+        else:
+            loaded = load_source_campaign_opportunities_from_file(
+                source,
+                file_format=source_format,
+                target_mode=target_mode,
+                max_text_chars=max_source_text_chars,
+                default_fields=default_fields,
+            )
         mode: IngestionMode = "source_rows"
     else:
         loaded = load_campaign_opportunities_from_file(
@@ -100,6 +130,7 @@ def inspect_ingestion_file(
         mode=mode,
         source=str(source),
         sample_limit=sample_limit,
+        source_row_admission=source_row_admission,
     )
 
 
@@ -149,6 +180,7 @@ def build_ingestion_diagnostics(
     mode: IngestionMode,
     source: str | None = None,
     sample_limit: int = 3,
+    source_row_admission: SourceRowAdmissionDiagnostics | None = None,
 ) -> IngestionDiagnosticsReport:
     """Build a diagnostics report from normalized opportunity rows."""
 
@@ -166,6 +198,7 @@ def build_ingestion_diagnostics(
         missing_field_counts=_missing_field_counts(opportunities),
         source_type_counts=_source_type_counts(opportunities),
         sample_limit=sample_limit,
+        source_row_admission=source_row_admission,
     )
 
 
@@ -207,6 +240,14 @@ def _row_source_type(row: Mapping[str, Any]) -> str:
                 if source_type:
                     return source_type
     return ""
+
+
+def _source_rows_file_is_csv(path: Path, source_format: SourceDataFormat) -> bool:
+    if source_format == "csv":
+        return True
+    if source_format != "auto":
+        return False
+    return path.suffix.lower() == ".csv"
 
 
 def _has_value(value: Any) -> bool:

--- a/plans/PR-Deflection-CSV-Admission-Diagnostics.md
+++ b/plans/PR-Deflection-CSV-Admission-Diagnostics.md
@@ -1,0 +1,119 @@
+# PR-Deflection-CSV-Admission-Diagnostics
+
+## Why this slice exists
+
+#1467 asks for a parser-admission boundary that does not silently turn a
+non-empty upload into zero useful rows. #1457 closed the first Zendesk header
+admission gap in #1571, but the remaining operator-facing gap is still
+diagnostic: when a CSV has populated columns that the source-row adapter does
+not understand, the current inspect output only reports row warnings such as
+`missing_source_text`. It does not say which headers mapped to source id,
+title, customer-visible text, private/internal text, or which populated columns
+were ignored.
+
+This slice adds the deterministic diagnostic surface first. It keeps ingestion
+permissive, but gives the existing inspect path enough structured evidence to
+make the later ACCEPT/REJECT boundary a small policy change instead of another
+heuristic rewrite.
+
+The final diff is slightly over the 400 LOC target because the Codex review
+surfaced a class bug in wide CSV alias classification; the regression keeps
+more than 25 mapped aliases from being mislabeled as unmapped.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-admission
+Slice phase: Production hardening
+
+1. Add source-row CSV admission diagnostics that report mapped source fields,
+   ignored private/internal fields, populated unmapped fields, raw source row
+   count, usable source row count, and usable source ratio.
+2. Surface those diagnostics through the existing ingestion inspection report
+   and CLI/API JSON payloads without changing import acceptance behavior.
+3. Add regression coverage for a CSV with an unmapped populated body column,
+   a CSV with mapped Zendesk public/private columns, and a non-CSV source-row
+   input that must not invent CSV-only diagnostics.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `extracted_content_pipeline/ingestion_diagnostics.py`
+- `plans/PR-Deflection-CSV-Admission-Diagnostics.md`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Source-row CSV inspection reports raw row count, usable source count,
+        usable ratio, mapped source fields, ignored private fields, and
+        populated unmapped fields.
+  - [ ] A non-empty CSV whose customer text lives only in an unknown populated
+        body column keeps the existing row-level warning and now names that
+        column in diagnostics.
+  - [ ] Zendesk public comment/history/private-note columns are classified in
+        diagnostics consistently with #1571 extraction behavior.
+  - [ ] JSON/JSONL and opportunity-row inspection payloads remain backwards
+        compatible and do not emit misleading CSV header diagnostics.
+- Affected surfaces: extracted package diagnostics, source-row CSV inspection,
+  CLI/API JSON response payloads.
+- Risk areas: backwards compatibility, false diagnostic precision, private text
+  handling, CI enrollment.
+- Reviewer rules triggered: R1, R2, R5, R10, R12, R13, R14.
+
+## Mechanism
+
+The source adapter already owns the alias sets that decide whether a source
+row has customer-visible text, source id, title, or private/internal text. This
+PR reuses those sets to classify the keys present in CSV-loaded source rows.
+The classifier produces an immutable diagnostics object with counts and bounded
+field-name lists; it does not read files itself and does not alter the
+normalized opportunities.
+
+`inspect_ingestion_file` attaches that diagnostics object only for
+`source_rows=true` CSV inspection. `inspect_ingestion_rows` stays generic
+because inline rows do not have a CSV header admission problem. The report
+serializes the diagnostic object as optional `source_row_admission`, so
+existing clients keep the current fields and new clients can show mapped versus
+unmapped column evidence.
+
+## Intentional
+
+- This PR does not reject uploads yet. It makes the evidence explicit first,
+  preserving current import compatibility while setting up #1467's final policy
+  boundary.
+- The classifier is source-adapter-owned rather than CSV-reader-owned because
+  the low-level CSV reader is shared by opportunity imports and has no product
+  knowledge about source text, Zendesk privacy, or support-ticket semantics.
+- Diagnostics report field names and counts only; it does not copy field
+  values, so private/internal note content is not exposed in the report.
+
+## Deferred
+
+- #1467 final admission policy: convert these diagnostics into an explicit
+  ACCEPT/REJECT boundary for non-empty uploads with zero or too-low usable
+  source coverage.
+- #1458 streaming upload memory hardening remains separate; this PR does not
+  change upload buffering.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused ingestion diagnostics tests: 12 passed.
+- Adjacent source-adapter plus diagnostics tests: 128 passed.
+- Extracted package validation: passed.
+- Standalone audit: 0 findings.
+- Reasoning-import guard: clean.
+- ASCII Python check: passed.
+- Extracted pipeline checks: 4278 passed, 10 skipped.
+- Pending before push: local PR review/pre-push hook.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_source_adapters.py` | 118 |
+| `extracted_content_pipeline/ingestion_diagnostics.py` | 57 |
+| `plans/PR-Deflection-CSV-Admission-Diagnostics.md` | 119 |
+| `tests/test_extracted_content_ingestion_diagnostics.py` | 157 |
+| **Total** | **451** |

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -33,6 +33,7 @@ def test_inspect_opportunity_json_reports_ready_rows(tmp_path: Path) -> None:
     assert payload["warning_count"] == 0
     assert payload["missing_field_counts"] == {}
     assert payload["samples"][0]["target_id"] == "opp-1"
+    assert "source_row_admission" not in payload
 
 
 def test_inspect_source_rows_counts_source_types_and_warnings(tmp_path: Path) -> None:
@@ -93,6 +94,130 @@ def test_inspect_source_rows_applies_default_fields(tmp_path: Path) -> None:
     assert report.ok is True
     assert report.opportunities[0]["company_name"] == "Acme Logistics"
     assert report.opportunities[0]["contact_email"] == "ops@example.com"
+
+
+def test_inspect_source_csv_reports_unmapped_populated_text_column(tmp_path: Path) -> None:
+    path = tmp_path / "tickets.csv"
+    path.write_text(
+        "Ticket ID,Conversation Text\n"
+        "T-1,Customer cannot export the weekly report.\n"
+    )
+
+    report = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=1,
+    )
+    payload = report.as_dict()
+
+    assert payload["ok"] is False
+    assert payload["warning_counts"] == {"missing_source_text": 1}
+    admission = payload["source_row_admission"]
+    assert admission["input_format"] == "csv"
+    assert admission["raw_source_row_count"] == 1
+    assert admission["usable_source_row_count"] == 0
+    assert admission["usable_source_ratio"] == 0.0
+    assert admission["mapped_fields"] == {"source_id": ["Ticket ID"]}
+    assert admission["populated_unmapped_fields"] == ["Conversation Text"]
+
+
+def test_inspect_source_csv_classifies_zendesk_public_and_private_columns(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "zendesk.csv"
+    path.write_text(
+        "Ticket ID,Subject,Public Comments,Internal Notes\n"
+        "T-1,Export failed,Customer cannot export the weekly report.,"
+        "Use the private workaround.\n"
+    )
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=1,
+    ).as_dict()
+
+    assert payload["ok"] is True
+    admission = payload["source_row_admission"]
+    assert admission["mapped_fields"] == {
+        "source_id": ["Ticket ID"],
+        "source_title": ["Subject"],
+        "thread_text": ["Public Comments"],
+    }
+    assert admission["ignored_private_fields"] == ["Internal Notes"]
+    assert admission["populated_unmapped_fields"] == []
+
+
+def test_inspect_source_csv_sample_limit_does_not_make_known_aliases_unmapped(
+    tmp_path: Path,
+) -> None:
+    id_fields = [
+        "Source ID",
+        "ID",
+        "Chat ID",
+        "Sales Objection ID",
+        "Objection ID",
+        "Review ID",
+        "Transcript ID",
+        "Call ID",
+        "Meeting ID",
+        "Recording ID",
+        "Deal ID",
+        "Opportunity ID",
+        "Note ID",
+        "Activity ID",
+        "Renewal ID",
+        "Contract ID",
+        "Subscription ID",
+        "Document ID",
+        "Search ID",
+        "Search Log ID",
+        "Search Query ID",
+        "Query ID",
+        "Zero Result Query ID",
+        "Complaint ID",
+        "Ticket ID",
+        "Ticket Number",
+    ]
+    path = tmp_path / "wide.csv"
+    path.write_text(
+        ",".join([*id_fields, "Message"]) + "\n"
+        + ",".join([f"src-{index}" for index in range(len(id_fields))])
+        + ",Customer cannot export the weekly report.\n"
+    )
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=1,
+    ).as_dict()
+
+    admission = payload["source_row_admission"]
+    assert len(admission["mapped_fields"]["source_id"]) == 25
+    assert "Ticket Number" not in admission["mapped_fields"]["source_id"]
+    assert admission["populated_unmapped_fields"] == []
+
+
+def test_inspect_source_jsonl_does_not_emit_csv_admission_diagnostics(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(json.dumps({
+        "ticket_id": "ticket-1",
+        "message": "Customer cannot export the weekly report.",
+    }))
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="jsonl",
+    ).as_dict()
+
+    assert payload["ok"] is True
+    assert "source_row_admission" not in payload
 
 
 def test_inspect_reports_missing_generation_fields(tmp_path: Path) -> None:
@@ -162,6 +287,38 @@ def test_inspection_cli_emits_valid_json_for_source_rows(tmp_path: Path) -> None
     assert payload["ok"] is True
     assert payload["source_type_counts"] == {"review": 1}
     assert len(payload["samples"]) == 1
+
+
+def test_inspection_cli_emits_csv_source_row_admission(tmp_path: Path) -> None:
+    path = tmp_path / "tickets.csv"
+    path.write_text(
+        "Ticket ID,Conversation Text\n"
+        "T-1,Customer cannot export the weekly report.\n"
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--source-rows",
+            "--source-format",
+            "csv",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(proc.stdout)
+
+    assert proc.returncode == 1
+    assert payload["source_row_admission"]["raw_source_row_count"] == 1
+    assert payload["source_row_admission"]["usable_source_row_count"] == 0
+    assert payload["source_row_admission"]["populated_unmapped_fields"] == [
+        "Conversation Text"
+    ]
 
 
 def test_inspection_cli_rejects_negative_sample_limit(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-CSV-Admission-Diagnostics.md
Slice phase: Production hardening

#1467 needs a parser-admission boundary that explains non-empty uploads before they collapse into zero usable source rows. This slice adds the deterministic CSV source-row diagnostics first: mapped source fields, populated unmapped fields, ignored private/internal fields, and usable source coverage now flow through the existing inspection JSON without changing import acceptance behavior.

## Intentional
- This PR does not reject uploads yet; it preserves current compatibility while making the evidence needed for #1467 explicit.
- The classifier lives in the source adapter, not the low-level CSV reader, because the adapter owns source-text, Zendesk privacy, and support-ticket semantics.
- Diagnostics report field names and counts only; field values, including private/internal note content, are not copied into the report.

## Deferred
- #1467 final admission policy: convert these diagnostics into an explicit ACCEPT/REJECT boundary for non-empty uploads with zero or too-low usable source coverage.
- #1458 streaming upload memory hardening remains separate; this PR does not change upload buffering.

## Parked hardening
- None.

## AI Reconciliation
- All fixed or waived: yes.
- Codex P2: wide CSVs with more than the field sample limit of recognized aliases could label extra recognized aliases as unmapped. Fixed by tracking the full matched alias set for classification and only applying the sample limit to serialized mapped-field samples; covered by a 26-ID-alias CSV regression.

## Verification
- Focused ingestion diagnostics tests: 12 passed.
- Adjacent source-adapter plus diagnostics tests: 128 passed.
- Extracted package validation: passed.
- Standalone audit: 0 findings.
- Reasoning-import guard: clean.
- ASCII Python check: passed.
- Extracted pipeline checks: 4278 passed, 10 skipped.

## Diff size
4 files, +443 / -8
