### PR TITLE
Deflection CSV admission policy

### DIFF
--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -339,8 +339,20 @@ class SourceRowAdmissionDiagnostics:
             return None
         return round(self.usable_source_row_count / self.raw_source_row_count, 6)
 
+    @property
+    def admission_decision(self) -> dict[str, str] | None:
+        if self.input_format != "csv" or self.raw_source_row_count < 1:
+            return None
+        if self.usable_source_row_count < 1:
+            return {
+                "status": "REJECT",
+                "reason": "no_usable_source_rows",
+                "location": "source_row_csv",
+            }
+        return {"status": "ACCEPT"}
+
     def as_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "input_format": self.input_format,
             "raw_source_row_count": self.raw_source_row_count,
             "usable_source_row_count": self.usable_source_row_count,
@@ -354,6 +366,10 @@ class SourceRowAdmissionDiagnostics:
             "populated_unmapped_fields": list(self.populated_unmapped_fields),
             "field_sample_limit": self.field_sample_limit,
         }
+        decision = self.admission_decision
+        if decision:
+            payload["admission_decision"] = decision
+        return payload
 
 
 class _SourceFieldLookup(Mapping[str, Any]):

--- a/plans/PR-Deflection-CSV-Admission-Policy.md
+++ b/plans/PR-Deflection-CSV-Admission-Policy.md
@@ -1,0 +1,115 @@
+# PR-Deflection-CSV-Admission-Policy
+
+## Why this slice exists
+
+#1467 asks for an explicit parser-admission boundary so a non-empty upload
+cannot silently become zero useful rows. #1573 added the deterministic evidence
+surface: source-row CSV inspection now reports raw rows, usable rows, usable
+ratio, mapped fields, ignored private/internal fields, and populated unmapped
+fields. The remaining product gap is policy: the report still exposes those
+facts as diagnostics only, so callers have to infer whether the upload is
+accepted or rejected.
+
+This slice adds the first hard boundary at the safest point: a non-empty
+source-row CSV with zero usable source rows is rejected with a stable reason
+and location. It does not guess at low-coverage thresholds yet.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-admission
+Slice phase: Production hardening
+
+1. Add an explicit source-row CSV admission decision to the existing
+   diagnostics payload: `ACCEPT` for usable uploads, `REJECT` for non-empty
+   CSV source uploads with zero usable rows, and a stable reason/location for
+   the reject case.
+2. Keep import behavior compatible with the existing `ok=false` gate, while
+   making the reject reason machine-readable in file inspect and file import
+   diagnostics.
+3. Add focused coverage for zero-usable rejection, usable CSV acceptance, empty
+   CSV/no-data behavior, and non-CSV compatibility.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `plans/PR-Deflection-CSV-Admission-Policy.md`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Non-empty source-row CSV uploads with zero usable rows serialize a
+        `REJECT` decision with reason `no_usable_source_rows` and location
+        `source_row_csv`.
+  - [ ] The reject payload includes raw row count, usable row count, usable
+        ratio, and populated unmapped fields from the existing diagnostics.
+  - [ ] Source-row CSV uploads with at least one usable row serialize `ACCEPT`
+        and keep existing warnings as warnings.
+  - [ ] Opportunity-row, JSON, and JSONL inspection payloads remain backwards
+        compatible and do not emit source-row CSV policy decisions.
+  - [ ] Existing import rejection behavior remains `ingestion_not_ready`, with
+        the new decision nested in diagnostics rather than a new route
+        contract.
+- Affected surfaces: extracted package diagnostics, source-row CSV inspection,
+  file import diagnostics, CLI/API JSON response payloads.
+- Risk areas: backwards compatibility, false rejection, diagnostic contract
+  drift, CI enrollment.
+- Reviewer rules triggered: R1, R2, R5, R10, R12, R13, R14.
+
+## Mechanism
+
+The policy lives beside the source-row CSV diagnostics created in #1573. The
+diagnostic object derives a small admission decision from facts it already
+owns: input format, raw source row count, and usable source row count.
+
+For this slice the hard rule is deliberately narrow:
+
+- source-row CSV and raw rows > 0 and usable rows == 0 -> `REJECT`
+- source-row CSV and usable rows > 0 -> `ACCEPT`
+- raw rows == 0 -> no hard source-row CSV reject reason; the existing empty
+  file/header behavior continues to govern
+- non-CSV inputs -> no source-row CSV policy object
+
+`IngestionDiagnosticsReport.as_dict` continues to emit the optional
+`source_row_admission` section only when CSV source-row diagnostics exist. The
+new decision is nested inside that section so clients that ignore unknown keys
+continue to work, while newer callers can show a clear reject reason and
+location.
+
+## Intentional
+
+- No low-coverage threshold in this PR. A 1-of-100 usable upload may deserve a
+  future reject or warning policy, but setting that threshold is a product
+  decision and needs real upload evidence.
+- No streaming or file-buffering changes. #1458 owns upload memory hardening.
+- No route-level error code change. File import already rejects `ok=false` as
+  `ingestion_not_ready`; this PR enriches diagnostics instead of breaking that
+  contract.
+
+## Deferred
+
+- #1467 low-coverage policy: decide whether non-zero but low usable source
+  ratios should warn only or reject, and set a threshold with fixture evidence.
+- #1458 streaming upload memory hardening remains separate.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused ingestion diagnostics tests: 13 passed.
+- Adjacent source-adapter plus diagnostics tests: 129 passed.
+- Extracted package validation: passed.
+- Standalone audit: 0 findings.
+- Reasoning-import guard: clean.
+- ASCII Python check: passed.
+- Extracted pipeline checks: 4279 passed, 10 skipped.
+- Pending before push: local PR review/pre-push hook.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_source_adapters.py` | 18 |
+| `plans/PR-Deflection-CSV-Admission-Policy.md` | 115 |
+| `tests/test_extracted_content_ingestion_diagnostics.py` | 31 |
+| **Total** | **164** |

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -120,6 +120,11 @@ def test_inspect_source_csv_reports_unmapped_populated_text_column(tmp_path: Pat
     assert admission["usable_source_ratio"] == 0.0
     assert admission["mapped_fields"] == {"source_id": ["Ticket ID"]}
     assert admission["populated_unmapped_fields"] == ["Conversation Text"]
+    assert admission["admission_decision"] == {
+        "status": "REJECT",
+        "reason": "no_usable_source_rows",
+        "location": "source_row_csv",
+    }
 
 
 def test_inspect_source_csv_classifies_zendesk_public_and_private_columns(
@@ -148,6 +153,7 @@ def test_inspect_source_csv_classifies_zendesk_public_and_private_columns(
     }
     assert admission["ignored_private_fields"] == ["Internal Notes"]
     assert admission["populated_unmapped_fields"] == []
+    assert admission["admission_decision"] == {"status": "ACCEPT"}
 
 
 def test_inspect_source_csv_sample_limit_does_not_make_known_aliases_unmapped(
@@ -218,6 +224,26 @@ def test_inspect_source_jsonl_does_not_emit_csv_admission_diagnostics(
 
     assert payload["ok"] is True
     assert "source_row_admission" not in payload
+
+
+def test_inspect_source_csv_with_header_only_has_no_hard_policy_decision(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "empty.csv"
+    path.write_text("Ticket ID,Message\n")
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+    ).as_dict()
+
+    admission = payload["source_row_admission"]
+    assert payload["ok"] is False
+    assert admission["raw_source_row_count"] == 0
+    assert admission["usable_source_row_count"] == 0
+    assert admission["usable_source_ratio"] is None
+    assert "admission_decision" not in admission
 
 
 def test_inspect_reports_missing_generation_fields(tmp_path: Path) -> None:
@@ -319,6 +345,11 @@ def test_inspection_cli_emits_csv_source_row_admission(tmp_path: Path) -> None:
     assert payload["source_row_admission"]["populated_unmapped_fields"] == [
         "Conversation Text"
     ]
+    assert payload["source_row_admission"]["admission_decision"] == {
+        "status": "REJECT",
+        "reason": "no_usable_source_rows",
+        "location": "source_row_csv",
+    }
 
 
 def test_inspection_cli_rejects_negative_sample_limit(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-CSV-Admission-Policy.md
Slice phase: Production hardening

#1467 now has the deterministic CSV source-row diagnostics from #1573; this slice adds the first explicit policy boundary on top of those facts. Non-empty source-row CSV uploads with zero usable rows now carry a machine-readable REJECT decision with reason and location, while usable CSVs carry ACCEPT and low-coverage thresholding remains deferred.

## Intentional
- No low-coverage threshold in this PR; that remains a product decision needing real upload evidence.
- No streaming or file-buffering changes; #1458 owns upload memory hardening.
- No route-level error code change; existing file import rejection remains ingestion_not_ready with richer diagnostics nested inside it.

## Deferred
- #1467 low-coverage policy: decide whether non-zero but low usable source ratios should warn only or reject, and set a threshold with fixture evidence.
- #1458 streaming upload memory hardening remains separate.

## Parked hardening
- None.

## Verification
- Focused ingestion diagnostics tests: 13 passed.
- Adjacent source-adapter plus diagnostics tests: 129 passed.
- Extracted package validation: passed.
- Standalone audit: 0 findings.
- Reasoning-import guard: clean.
- ASCII Python check: passed.
- Extracted pipeline checks: 4279 passed, 10 skipped.

## Diff size
3 files, +163 / -1
