### PR TITLE
Deflection CSV partial coverage warning

### DIFF
--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -351,6 +351,26 @@ class SourceRowAdmissionDiagnostics:
             }
         return {"status": "ACCEPT"}
 
+    @property
+    def coverage_warnings(self) -> tuple[dict[str, Any], ...]:
+        if (
+            self.input_format != "csv"
+            or self.raw_source_row_count < 1
+            or self.usable_source_row_count < 1
+            or self.usable_source_row_count >= self.raw_source_row_count
+        ):
+            return ()
+        return ({
+            "code": "partial_source_row_coverage",
+            "location": "source_row_csv",
+            "raw_source_row_count": self.raw_source_row_count,
+            "usable_source_row_count": self.usable_source_row_count,
+            "skipped_source_row_count": (
+                self.raw_source_row_count - self.usable_source_row_count
+            ),
+            "usable_source_ratio": self.usable_source_ratio,
+        },)
+
     def as_dict(self) -> dict[str, Any]:
         payload = {
             "input_format": self.input_format,
@@ -369,6 +389,9 @@ class SourceRowAdmissionDiagnostics:
         decision = self.admission_decision
         if decision:
             payload["admission_decision"] = decision
+        warnings = self.coverage_warnings
+        if warnings:
+            payload["coverage_warnings"] = [dict(warning) for warning in warnings]
         return payload
 
 

--- a/plans/PR-Deflection-CSV-Partial-Coverage-Warning.md
+++ b/plans/PR-Deflection-CSV-Partial-Coverage-Warning.md
@@ -1,0 +1,105 @@
+# PR-Deflection-CSV-Partial-Coverage-Warning
+
+## Why this slice exists
+
+#1467 still has one admission gap after #1573 and #1575: accepted source-row
+CSV uploads can hide partial row loss. #1575 rejects the total failure case
+where a non-empty source-row CSV yields zero usable rows, but a file with at
+least one usable row still serializes `ACCEPT` even when other rows were
+dropped. The diagnostics expose raw/usable counts, but there is no explicit
+warning saying the accepted upload was partial.
+
+This slice adds a warning-only boundary for accepted-but-partial CSV source
+uploads. It does not invent a low-coverage reject threshold; it makes row loss
+visible while leaving threshold policy to a later product decision.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-admission
+Slice phase: Production hardening
+
+1. Add a `coverage_warnings` list under `source_row_admission` when a
+   source-row CSV has raw rows greater than usable rows and at least one usable
+   row.
+2. Report a stable warning code, location, raw count, usable count, skipped
+   count, and usable ratio without changing `admission_decision`.
+3. Add focused coverage for accepted-but-partial CSVs, clean accepted CSVs,
+   zero-usable rejects, and non-CSV compatibility.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `plans/PR-Deflection-CSV-Partial-Coverage-Warning.md`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Accepted source-row CSV uploads with skipped rows serialize a
+        `coverage_warnings` entry with code `partial_source_row_coverage`.
+  - [ ] The warning includes location `source_row_csv`, raw source row count,
+        usable source row count, skipped source row count, and usable source
+        ratio.
+  - [ ] Clean accepted source-row CSV uploads do not serialize coverage
+        warnings.
+  - [ ] Zero-usable source-row CSV uploads keep the existing `REJECT` decision
+        and do not need a duplicate partial-coverage warning.
+  - [ ] JSON/JSONL and opportunity-row inspection payloads remain backwards
+        compatible and do not emit source-row CSV warning policy.
+- Affected surfaces: extracted package diagnostics, source-row CSV inspection,
+  CLI/API JSON response payloads.
+- Risk areas: backwards compatibility, false diagnostic precision, policy
+  threshold drift, CI enrollment.
+- Reviewer rules triggered: R1, R2, R5, R10, R12, R13, R14.
+
+## Mechanism
+
+`SourceRowAdmissionDiagnostics` already owns the input format, raw row count,
+usable row count, and ratio. This PR adds a derived warning list beside the
+derived admission decision:
+
+- source-row CSV and raw rows > usable rows > 0 -> one warning
+- source-row CSV and usable rows == raw rows -> no warning
+- source-row CSV and usable rows == 0 -> existing reject decision, no duplicate
+  partial warning
+- non-CSV inputs -> no source-row CSV warning object
+
+The warning is nested under `source_row_admission`, so clients that ignore
+unknown keys remain compatible. It is warning-only and does not change `ok`,
+`admission_decision`, import behavior, or route status codes.
+
+## Intentional
+
+- No low-coverage reject threshold in this PR. Any partial accepted upload gets
+  a warning; whether a 10%, 25%, or 50% usable ratio should reject is still a
+  product decision.
+- No route-level behavior change. This is diagnostics enrichment only.
+- No streaming or upload-buffering changes. #1458 owns that lane.
+
+## Deferred
+
+- #1467 low-coverage reject threshold: decide whether warning-only partial
+  coverage is enough, or whether a product-backed threshold should hard reject.
+- #1458 streaming upload memory hardening remains separate.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused ingestion diagnostics tests: 14 passed.
+- Adjacent source-adapter plus diagnostics tests: 130 passed.
+- Extracted package validation: passed.
+- Standalone audit: 0 findings.
+- Reasoning-import guard: clean.
+- ASCII Python check: passed.
+- Extracted pipeline checks: 4280 passed, 10 skipped.
+- Pending before push: local PR review/pre-push hook.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_source_adapters.py` | 23 |
+| `plans/PR-Deflection-CSV-Partial-Coverage-Warning.md` | 105 |
+| `tests/test_extracted_content_ingestion_diagnostics.py` | 39 |
+| **Total** | **167** |

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -125,6 +125,7 @@ def test_inspect_source_csv_reports_unmapped_populated_text_column(tmp_path: Pat
         "reason": "no_usable_source_rows",
         "location": "source_row_csv",
     }
+    assert "coverage_warnings" not in admission
 
 
 def test_inspect_source_csv_classifies_zendesk_public_and_private_columns(
@@ -154,6 +155,43 @@ def test_inspect_source_csv_classifies_zendesk_public_and_private_columns(
     assert admission["ignored_private_fields"] == ["Internal Notes"]
     assert admission["populated_unmapped_fields"] == []
     assert admission["admission_decision"] == {"status": "ACCEPT"}
+    assert "coverage_warnings" not in admission
+
+
+def test_inspect_source_csv_warns_when_accepted_upload_has_skipped_rows(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "partial.csv"
+    path.write_text(
+        "Ticket ID,Message,Conversation Text\n"
+        "T-1,Customer cannot export the weekly report.,\n"
+        "T-2,,Customer cannot invite a teammate.\n"
+    )
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=1,
+        default_fields={
+            "company_name": "Acme Logistics",
+            "vendor_name": "Atlas",
+            "contact_email": "ops@example.com",
+        },
+    ).as_dict()
+
+    admission = payload["source_row_admission"]
+    assert payload["ok"] is True
+    assert payload["warning_counts"] == {"missing_source_text": 1}
+    assert admission["admission_decision"] == {"status": "ACCEPT"}
+    assert admission["coverage_warnings"] == [{
+        "code": "partial_source_row_coverage",
+        "location": "source_row_csv",
+        "raw_source_row_count": 2,
+        "usable_source_row_count": 1,
+        "skipped_source_row_count": 1,
+        "usable_source_ratio": 0.5,
+    }]
 
 
 def test_inspect_source_csv_sample_limit_does_not_make_known_aliases_unmapped(
@@ -244,6 +282,7 @@ def test_inspect_source_csv_with_header_only_has_no_hard_policy_decision(
     assert admission["usable_source_row_count"] == 0
     assert admission["usable_source_ratio"] is None
     assert "admission_decision" not in admission
+    assert "coverage_warnings" not in admission
 
 
 def test_inspect_reports_missing_generation_fields(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-CSV-Partial-Coverage-Warning.md
Slice phase: Production hardening

#1467 now rejects total source-row CSV admission failure, but accepted CSV uploads can still hide partial row loss. This slice adds a warning-only partial-coverage signal under source_row_admission so operators see accepted-but-skipped-row uploads without inventing a low-coverage reject threshold.

## Intentional
- No low-coverage reject threshold in this PR. Any partial accepted upload gets a warning; product-backed reject thresholds remain deferred.
- No route-level behavior change; this is diagnostics enrichment only.
- No streaming or upload-buffering changes; #1458 owns that lane.

## Deferred
- #1467 low-coverage reject threshold: decide whether warning-only partial coverage is enough, or whether a product-backed threshold should hard reject.
- #1458 streaming upload memory hardening remains separate.

## Parked hardening
- None.

## Verification
- Focused ingestion diagnostics tests: 14 passed.
- Adjacent source-adapter plus diagnostics tests: 130 passed.
- Extracted package validation: passed.
- Standalone audit: 0 findings.
- Reasoning-import guard: clean.
- ASCII Python check: passed.
- Extracted pipeline checks: 4280 passed, 10 skipped.

## Diff size
3 files, +167 / -0
