### PR TITLE
Deflection CSV admission threshold evidence

### DIFF
--- a/docs/extraction/validation/deflection_csv_admission_threshold_evidence_2026-06-15.md
+++ b/docs/extraction/validation/deflection_csv_admission_threshold_evidence_2026-06-15.md
@@ -1,0 +1,41 @@
+# Deflection CSV Admission Threshold Evidence
+
+Date: 2026-06-15
+
+Issue: #1467
+
+## What Ran
+
+This validation projects the committed sanitized Zendesk product-proof corpus
+into source-row CSV shapes and inspects each CSV through the real ingestion
+diagnostics path with source-row mode enabled.
+
+## Result
+
+| Case | Raw rows | Usable rows | Usable ratio | Admission | Coverage warnings |
+|---|---:|---:|---:|---|---:|
+| zendesk_public_comments_csv | 50 | 50 | 1.0 | ACCEPT | 0 |
+| zendesk_description_csv | 50 | 50 | 1.0 | ACCEPT | 0 |
+
+Status: `ok`
+
+Observed minimum usable source ratio: `1.0`
+
+## Interpretation
+
+The committed product-shaped Zendesk CSV projections are accepted at full coverage. This supports the clean ACCEPT path, but does not justify a hard low-coverage reject threshold by itself.
+
+This artifact therefore supports keeping clean Zendesk-shaped CSV uploads on
+the ACCEPT path. It does not choose a low non-zero reject threshold. That
+threshold still needs observed partial-coverage exports, not a synthetic ratio
+derived from a clean corpus.
+
+## Artifact Links
+
+- Summary JSON:
+  `docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json`
+
+## Boundary
+
+This is offline validation. It does not call live Zendesk, upload a customer
+file, mutate data, charge Stripe, or change parser policy.

--- a/docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json
@@ -1,0 +1,80 @@
+{
+  "blocking_violation_codes": [],
+  "case_count": 2,
+  "cases": [
+    {
+      "admission_status": "ACCEPT",
+      "case_status": "ok",
+      "coverage_warnings": [],
+      "description": "Zendesk-shaped CSV with ticket id, subject, public comments, and internal notes.",
+      "expected_full_coverage": true,
+      "ignored_private_fields": [
+        "Internal Notes"
+      ],
+      "mapped_fields": {
+        "source_id": [
+          "Ticket ID"
+        ],
+        "source_title": [
+          "Subject"
+        ],
+        "thread_text": [
+          "Public Comments"
+        ]
+      },
+      "name": "zendesk_public_comments_csv",
+      "ok": true,
+      "populated_unmapped_fields": [],
+      "raw_source_row_count": 50,
+      "usable_source_ratio": 1.0,
+      "usable_source_row_count": 50,
+      "warning_counts": {
+        "missing_company_name": 50,
+        "missing_contact_email": 50,
+        "missing_vendor_name": 50
+      }
+    },
+    {
+      "admission_status": "ACCEPT",
+      "case_status": "ok",
+      "coverage_warnings": [],
+      "description": "Zendesk-shaped CSV with ticket id, subject, requester description, and internal notes.",
+      "expected_full_coverage": true,
+      "ignored_private_fields": [
+        "Internal Notes"
+      ],
+      "mapped_fields": {
+        "source_id": [
+          "Ticket ID"
+        ],
+        "source_text": [
+          "Description"
+        ],
+        "source_title": [
+          "Subject"
+        ]
+      },
+      "name": "zendesk_description_csv",
+      "ok": true,
+      "populated_unmapped_fields": [],
+      "raw_source_row_count": 50,
+      "usable_source_ratio": 1.0,
+      "usable_source_row_count": 50,
+      "warning_counts": {
+        "missing_company_name": 50,
+        "missing_contact_email": 50,
+        "missing_vendor_name": 50
+      }
+    }
+  ],
+  "corpus": {
+    "run_tag": "atlas_product_proof_20260614",
+    "source": "zendesk_trial_api",
+    "ticket_count": 50,
+    "tickets_with_private_notes": 4
+  },
+  "observed_max_usable_source_ratio": 1.0,
+  "observed_min_usable_source_ratio": 1.0,
+  "status": "ok",
+  "threshold_conclusion": "The committed product-shaped Zendesk CSV projections are accepted at full coverage. This supports the clean ACCEPT path, but does not justify a hard low-coverage reject threshold by itself."
+}

--- a/plans/PR-Deflection-CSV-Admission-Threshold-Evidence.md
+++ b/plans/PR-Deflection-CSV-Admission-Threshold-Evidence.md
@@ -1,0 +1,119 @@
+# PR-Deflection-CSV-Admission-Threshold-Evidence
+
+## Why this slice exists
+
+#1467 now has the admission boundary pieces for source-row CSV uploads: #1575
+rejects non-empty CSVs with zero usable rows, and #1576 warns when accepted
+CSVs skip some rows. The remaining question is not another diagnostic shape;
+it is whether real product-shaped uploads justify a low non-zero coverage reject
+threshold. The reviewer note on #1576 called that sequencing out directly:
+before adding more policy, run the surface on a real/product-shaped export and
+record threshold evidence.
+
+This slice is over the 400 LOC target because it adds the evidence runner, its
+CI-enrolled tests, and the committed proof artifact together. Splitting those
+would leave either untested evidence tooling or an unrepeatable artifact.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-admission
+Slice phase: Functional validation
+
+1. Add a deterministic CSV admission evidence runner for the committed Zendesk
+   product-proof corpus.
+2. Commit the generated threshold-evidence artifact showing how the current
+   source-row CSV admission diagnostics behave on product-shaped Zendesk CSV
+   projections.
+3. Keep policy unchanged: no low non-zero usable-row reject threshold is added
+   in this PR.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The runner converts the committed Zendesk product-proof corpus into
+        source-row CSV projections and inspects them through the real ingestion
+        diagnostics path.
+  - [ ] The committed artifact records raw row count, usable row count, usable
+        ratio, admission status, coverage warnings, mapped fields, ignored
+        private fields, and unmapped populated fields for each projection.
+  - [ ] Clean product-shaped Zendesk projections remain accepted with no partial
+        coverage warning.
+  - [ ] A focused synthetic partial-coverage fixture proves the evidence runner
+        records the warning branch instead of hiding it.
+  - [ ] The PR does not add or change a hard low-coverage reject threshold.
+- Affected surfaces: scripts, validation docs, validation fixtures, tests.
+- Risk areas: false confidence from evidence artifacts, CI enrollment,
+  parser-admission scope drift.
+- Reviewer rules triggered: R1, R2, R10, R12, R14.
+
+### Files touched
+
+- `docs/extraction/validation/deflection_csv_admission_threshold_evidence_2026-06-15.md`
+- `docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json`
+- `plans/PR-Deflection-CSV-Admission-Threshold-Evidence.md`
+- `scripts/evaluate_csv_admission_threshold_evidence.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_evaluate_csv_admission_threshold_evidence.py`
+
+## Mechanism
+
+The runner loads
+`docs/extraction/validation/fixtures/zendesk_product_proof_corpus.json`,
+projects each ticket into two CSV shapes that match common Zendesk exports, and
+passes each temporary CSV through
+`inspect_ingestion_file` with `source_rows=True` and `source_format=csv`.
+
+The product-shaped projections are:
+
+1. public thread CSV: ticket id, subject, public comments, and internal notes;
+2. description CSV: ticket id, subject, description, and internal notes.
+
+The summary records the serialized `source_row_admission` block for each case
+plus a short interpretation. A clean run is evidence that current Zendesk-shaped
+CSV exports are accepted at full coverage; it is not evidence that a low
+non-zero reject threshold is safe. The tests therefore include a small
+partial-coverage CSV fixture that exercises the warning branch without treating
+that synthetic ratio as production threshold data.
+
+## Intentional
+
+- No hard threshold is added. The only product-shaped corpus available in-repo
+  is clean enough to produce full coverage, so using it to choose a low-coverage
+  cutoff would be false precision.
+- The partial-coverage fixture is test evidence for the runner, not threshold
+  evidence. The proof document names that boundary so the next policy slice does
+  not mistake a synthetic ratio for an observed customer-export distribution.
+- The runner writes a compact artifact rather than storing generated CSV files;
+  the generated rows are reproducible from the committed corpus.
+
+## Deferred
+
+- Product-backed low-coverage policy: gather observed partial-coverage uploads
+  from real provider exports before choosing a warn-only vs reject threshold.
+- #1458 streaming upload memory remains separate.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: .venv/bin/python scripts/evaluate_csv_admission_threshold_evidence.py --json
+  - Passed; generated the committed summary/doc artifact and reported both
+    Zendesk-shaped CSV projections at 50/50 usable rows.
+- Command: .venv/bin/python -m pytest tests/test_evaluate_csv_admission_threshold_evidence.py tests/test_extracted_content_ingestion_diagnostics.py
+  - Passed: 19 passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Passed: 4285 passed, 10 skipped.
+- Local PR review wrapper with the planned PR body file.
+  - Passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/deflection_csv_admission_threshold_evidence_2026-06-15.md` | 41 |
+| `docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json` | 80 |
+| `plans/PR-Deflection-CSV-Admission-Threshold-Evidence.md` | 121 |
+| `scripts/evaluate_csv_admission_threshold_evidence.py` | 347 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_evaluate_csv_admission_threshold_evidence.py` | 181 |
+| **Total** | **771** |

--- a/scripts/evaluate_csv_admission_threshold_evidence.py
+++ b/scripts/evaluate_csv_admission_threshold_evidence.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Generate CSV source-row admission evidence from product-shaped fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
+    inspect_ingestion_file,
+)
+
+
+DEFAULT_CORPUS = (
+    ROOT / "docs/extraction/validation/fixtures/zendesk_product_proof_corpus.json"
+)
+DEFAULT_OUT_DIR = (
+    ROOT
+    / "docs/extraction/validation/fixtures/"
+    / "deflection_csv_admission_threshold_evidence_20260615"
+)
+DEFAULT_DOC = (
+    ROOT
+    / "docs/extraction/validation/"
+    / "deflection_csv_admission_threshold_evidence_2026-06-15.md"
+)
+
+
+@dataclass(frozen=True)
+class CsvAdmissionCase:
+    """One CSV projection to inspect through source-row admission diagnostics."""
+
+    name: str
+    description: str
+    fieldnames: tuple[str, ...]
+    rows: tuple[dict[str, str], ...]
+    expected_full_coverage: bool
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    corpus = _load_corpus(args.corpus)
+    summary = evaluate_zendesk_corpus(corpus)
+
+    if args.out_dir:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        (args.out_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.doc:
+        args.doc.parent.mkdir(parents=True, exist_ok=True)
+        args.doc.write_text(_proof_doc(summary), encoding="utf-8")
+    if args.json:
+        print(json.dumps(summary, sort_keys=True))
+    if summary["status"] != "ok":
+        print(
+            "CSV admission threshold evidence failed: "
+            + ", ".join(summary["blocking_violation_codes"]),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def evaluate_zendesk_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
+    """Inspect product-shaped Zendesk CSV projections and summarize evidence."""
+
+    cases = _zendesk_cases(corpus)
+    case_results = [evaluate_csv_case(case) for case in cases]
+    blocking = _blocking_codes(case_results)
+    ratios = [
+        float(result["usable_source_ratio"])
+        for result in case_results
+        if isinstance(result.get("usable_source_ratio"), (int, float))
+    ]
+    return {
+        "status": "ok" if not blocking else "failed",
+        "blocking_violation_codes": blocking,
+        "corpus": _corpus_summary(corpus),
+        "case_count": len(case_results),
+        "observed_min_usable_source_ratio": min(ratios) if ratios else None,
+        "observed_max_usable_source_ratio": max(ratios) if ratios else None,
+        "threshold_conclusion": (
+            "The committed product-shaped Zendesk CSV projections are accepted "
+            "at full coverage. This supports the clean ACCEPT path, but does "
+            "not justify a hard low-coverage reject threshold by itself."
+        ),
+        "cases": case_results,
+    }
+
+
+def evaluate_csv_case(case: CsvAdmissionCase) -> dict[str, Any]:
+    """Write a projection to a temporary CSV and inspect the real diagnostics path."""
+
+    with TemporaryDirectory(prefix="atlas-csv-admission-") as tmp_dir:
+        path = Path(tmp_dir) / f"{case.name}.csv"
+        _write_csv(path, fieldnames=case.fieldnames, rows=case.rows)
+        payload = inspect_ingestion_file(
+            path,
+            source_rows=True,
+            source_format="csv",
+            sample_limit=0,
+        ).as_dict()
+
+    admission = dict(payload.get("source_row_admission") or {})
+    decision = dict(admission.get("admission_decision") or {})
+    warnings = list(admission.get("coverage_warnings") or [])
+    usable_ratio = admission.get("usable_source_ratio")
+    result = {
+        "name": case.name,
+        "description": case.description,
+        "expected_full_coverage": case.expected_full_coverage,
+        "ok": payload.get("ok") is True,
+        "warning_counts": dict(payload.get("warning_counts") or {}),
+        "admission_status": decision.get("status"),
+        "raw_source_row_count": _int(admission.get("raw_source_row_count")),
+        "usable_source_row_count": _int(admission.get("usable_source_row_count")),
+        "usable_source_ratio": usable_ratio,
+        "mapped_fields": dict(admission.get("mapped_fields") or {}),
+        "ignored_private_fields": list(admission.get("ignored_private_fields") or []),
+        "populated_unmapped_fields": list(
+            admission.get("populated_unmapped_fields") or []
+        ),
+        "coverage_warnings": warnings,
+    }
+    result["case_status"] = _case_status(result)
+    return result
+
+
+def _case_status(result: Mapping[str, Any]) -> str:
+    if result.get("expected_full_coverage") is not True:
+        return "observed"
+    if result.get("admission_status") != "ACCEPT":
+        return "failed"
+    if result.get("raw_source_row_count") != result.get("usable_source_row_count"):
+        return "failed"
+    if result.get("coverage_warnings"):
+        return "failed"
+    return "ok"
+
+
+def _blocking_codes(case_results: Sequence[Mapping[str, Any]]) -> list[str]:
+    codes: list[str] = []
+    for result in case_results:
+        if result.get("case_status") != "ok":
+            codes.append(f"{result.get('name')}:unexpected_admission_result")
+    return codes
+
+
+def _zendesk_cases(corpus: Mapping[str, Any]) -> tuple[CsvAdmissionCase, ...]:
+    tickets = _tickets(corpus)
+    public_rows = tuple(
+        {
+            "Ticket ID": _text(ticket.get("id")),
+            "Subject": _text(ticket.get("subject")),
+            "Public Comments": _public_comments(ticket),
+            "Internal Notes": _private_comments(ticket),
+        }
+        for ticket in tickets
+    )
+    description_rows = tuple(
+        {
+            "Ticket ID": _text(ticket.get("id")),
+            "Subject": _text(ticket.get("subject")),
+            "Description": _text(ticket.get("description")),
+            "Internal Notes": _private_comments(ticket),
+        }
+        for ticket in tickets
+    )
+    return (
+        CsvAdmissionCase(
+            name="zendesk_public_comments_csv",
+            description=(
+                "Zendesk-shaped CSV with ticket id, subject, public comments, "
+                "and internal notes."
+            ),
+            fieldnames=("Ticket ID", "Subject", "Public Comments", "Internal Notes"),
+            rows=public_rows,
+            expected_full_coverage=True,
+        ),
+        CsvAdmissionCase(
+            name="zendesk_description_csv",
+            description=(
+                "Zendesk-shaped CSV with ticket id, subject, requester "
+                "description, and internal notes."
+            ),
+            fieldnames=("Ticket ID", "Subject", "Description", "Internal Notes"),
+            rows=description_rows,
+            expected_full_coverage=True,
+        ),
+    )
+
+
+def _load_corpus(path: Path) -> Mapping[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"could not load Zendesk corpus: {path}") from exc
+    if not isinstance(value, Mapping):
+        raise SystemExit("Zendesk corpus must be a JSON object")
+    return value
+
+
+def _tickets(corpus: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    tickets = corpus.get("tickets")
+    if not isinstance(tickets, Sequence) or isinstance(tickets, (str, bytes)):
+        return ()
+    return tuple(ticket for ticket in tickets if isinstance(ticket, Mapping))
+
+
+def _comments(ticket: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    comments = ticket.get("comments")
+    if not isinstance(comments, Sequence) or isinstance(comments, (str, bytes)):
+        return ()
+    return tuple(comment for comment in comments if isinstance(comment, Mapping))
+
+
+def _public_comments(ticket: Mapping[str, Any]) -> str:
+    return "\n".join(
+        _text(comment.get("body"))
+        for comment in _comments(ticket)
+        if comment.get("public") is not False and _text(comment.get("body"))
+    )
+
+
+def _private_comments(ticket: Mapping[str, Any]) -> str:
+    return "\n".join(
+        _text(comment.get("body"))
+        for comment in _comments(ticket)
+        if comment.get("public") is False and _text(comment.get("body"))
+    )
+
+
+def _corpus_summary(corpus: Mapping[str, Any]) -> dict[str, Any]:
+    tickets = _tickets(corpus)
+    private_count = sum(1 for ticket in tickets if _private_comments(ticket))
+    return {
+        "source": _text(corpus.get("source")),
+        "run_tag": _text(corpus.get("run_tag")),
+        "ticket_count": len(tickets),
+        "tickets_with_private_notes": private_count,
+    }
+
+
+def _write_csv(
+    path: Path,
+    *,
+    fieldnames: Sequence[str],
+    rows: Sequence[Mapping[str, str]],
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: _text(row.get(field)) for field in fieldnames})
+
+
+def _proof_doc(summary: Mapping[str, Any]) -> str:
+    rows = "\n".join(
+        "| {name} | {raw} | {usable} | {ratio} | {status} | {warnings} |".format(
+            name=case["name"],
+            raw=case["raw_source_row_count"],
+            usable=case["usable_source_row_count"],
+            ratio=case["usable_source_ratio"],
+            status=case["admission_status"],
+            warnings=len(case["coverage_warnings"]),
+        )
+        for case in summary["cases"]
+    )
+    return f"""# Deflection CSV Admission Threshold Evidence
+
+Date: 2026-06-15
+
+Issue: #1467
+
+## What Ran
+
+This validation projects the committed sanitized Zendesk product-proof corpus
+into source-row CSV shapes and inspects each CSV through the real ingestion
+diagnostics path with source-row mode enabled.
+
+## Result
+
+| Case | Raw rows | Usable rows | Usable ratio | Admission | Coverage warnings |
+|---|---:|---:|---:|---|---:|
+{rows}
+
+Status: `{summary["status"]}`
+
+Observed minimum usable source ratio: `{summary["observed_min_usable_source_ratio"]}`
+
+## Interpretation
+
+{summary["threshold_conclusion"]}
+
+This artifact therefore supports keeping clean Zendesk-shaped CSV uploads on
+the ACCEPT path. It does not choose a low non-zero reject threshold. That
+threshold still needs observed partial-coverage exports, not a synthetic ratio
+derived from a clean corpus.
+
+## Artifact Links
+
+- Summary JSON:
+  `docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json`
+
+## Boundary
+
+This is offline validation. It does not call live Zendesk, upload a customer
+file, mutate data, charge Stripe, or change parser policy.
+"""
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--doc", type=Path, default=DEFAULT_DOC)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -49,6 +49,7 @@ pytest \
   tests/test_content_ops_deflection_source_proof_docs.py \
   tests/test_capture_zendesk_product_proof_corpus.py \
   tests/test_evaluate_zendesk_product_proof_corpus.py \
+  tests/test_evaluate_csv_admission_threshold_evidence.py \
   tests/test_content_ops_deflection_report.py \
   tests/test_content_ops_deflection_resolution_live_proof.py \
   tests/test_extracted_content_deflection_submit.py \

--- a/tests/test_evaluate_csv_admission_threshold_evidence.py
+++ b/tests/test_evaluate_csv_admission_threshold_evidence.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "evaluate_csv_admission_threshold_evidence",
+    ROOT / "scripts" / "evaluate_csv_admission_threshold_evidence.py",
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+def test_zendesk_product_proof_corpus_records_full_csv_admission() -> None:
+    corpus = json.loads(
+        (
+            ROOT
+            / "docs/extraction/validation/fixtures/zendesk_product_proof_corpus.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    summary = MOD.evaluate_zendesk_corpus(corpus)
+
+    assert summary["status"] == "ok"
+    assert summary["blocking_violation_codes"] == []
+    assert summary["corpus"]["ticket_count"] == 50
+    assert summary["case_count"] == 2
+    assert summary["observed_min_usable_source_ratio"] == 1.0
+    assert {
+        case["name"]: case["usable_source_row_count"] for case in summary["cases"]
+    } == {
+        "zendesk_public_comments_csv": 50,
+        "zendesk_description_csv": 50,
+    }
+    for case in summary["cases"]:
+        assert case["admission_status"] == "ACCEPT"
+        assert case["raw_source_row_count"] == 50
+        assert case["usable_source_ratio"] == 1.0
+        assert case["coverage_warnings"] == []
+
+
+def test_public_comments_projection_ignores_private_note_column() -> None:
+    corpus = {
+        "source": "unit",
+        "run_tag": "unit",
+        "tickets": [{
+            "id": "zd-proof-001",
+            "subject": "Duplicate charge",
+            "description": "Why was I charged twice?",
+            "comments": [
+                {
+                    "public": True,
+                    "body": "Why was I charged twice?",
+                },
+                {
+                    "public": False,
+                    "body": "Known proration bug. Do not publish this detail.",
+                },
+            ],
+        }],
+    }
+
+    summary = MOD.evaluate_zendesk_corpus(corpus)
+    public_case = {
+        case["name"]: case for case in summary["cases"]
+    }["zendesk_public_comments_csv"]
+
+    assert public_case["admission_status"] == "ACCEPT"
+    assert public_case["mapped_fields"] == {
+        "source_id": ["Ticket ID"],
+        "source_title": ["Subject"],
+        "thread_text": ["Public Comments"],
+    }
+    assert public_case["ignored_private_fields"] == ["Internal Notes"]
+    assert public_case["populated_unmapped_fields"] == []
+
+
+def test_partial_coverage_case_records_warning_without_rejecting() -> None:
+    case = MOD.CsvAdmissionCase(
+        name="partial_product_shape_probe",
+        description="Synthetic partial-coverage probe for the evidence runner.",
+        fieldnames=("Ticket ID", "Subject", "Public Comments"),
+        rows=(
+            {
+                "Ticket ID": "T-1",
+                "Subject": "Export failed",
+                "Public Comments": "Customer cannot export reports.",
+            },
+            {
+                "Ticket ID": "T-2",
+                "Subject": "Invite failed",
+                "Public Comments": "",
+            },
+        ),
+        expected_full_coverage=False,
+    )
+
+    result = MOD.evaluate_csv_case(case)
+
+    assert result["case_status"] == "observed"
+    assert result["admission_status"] == "ACCEPT"
+    assert result["raw_source_row_count"] == 2
+    assert result["usable_source_row_count"] == 1
+    assert result["usable_source_ratio"] == 0.5
+    assert result["coverage_warnings"] == [{
+        "code": "partial_source_row_coverage",
+        "location": "source_row_csv",
+        "raw_source_row_count": 2,
+        "usable_source_row_count": 1,
+        "skipped_source_row_count": 1,
+        "usable_source_ratio": 0.5,
+    }]
+
+
+def test_expected_full_coverage_partial_csv_fails_closed(tmp_path: Path) -> None:
+    corpus = {
+        "source": "unit",
+        "run_tag": "unit",
+        "tickets": [
+            {
+                "id": "zd-proof-001",
+                "subject": "Export failed",
+                "description": "Customer cannot export reports.",
+                "comments": [{
+                    "public": True,
+                    "body": "Customer cannot export reports.",
+                }],
+            },
+            {
+                "id": "zd-proof-002",
+                "subject": "Invite failed",
+                "description": "",
+                "comments": [],
+            },
+        ],
+    }
+    corpus_path = tmp_path / "bad-corpus.json"
+    out_dir = tmp_path / "artifact"
+    doc = tmp_path / "proof.md"
+    corpus_path.write_text(json.dumps(corpus), encoding="utf-8")
+
+    summary = MOD.evaluate_zendesk_corpus(corpus)
+    code = MOD.main([
+        "--corpus",
+        str(corpus_path),
+        "--out-dir",
+        str(out_dir),
+        "--doc",
+        str(doc),
+    ])
+
+    assert summary["status"] == "failed"
+    assert summary["blocking_violation_codes"] == [
+        "zendesk_public_comments_csv:unexpected_admission_result",
+        "zendesk_description_csv:unexpected_admission_result",
+    ]
+    assert [case["case_status"] for case in summary["cases"]] == ["failed", "failed"]
+    assert code == 1
+    written = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
+    assert written["status"] == "failed"
+
+
+def test_main_writes_summary_and_doc(tmp_path: Path) -> None:
+    out_dir = tmp_path / "artifact"
+    doc = tmp_path / "proof.md"
+
+    code = MOD.main(["--out-dir", str(out_dir), "--doc", str(doc)])
+
+    assert code == 0
+    summary = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "ok"
+    assert summary["observed_min_usable_source_ratio"] == 1.0
+    proof = doc.read_text(encoding="utf-8")
+    assert "does not choose a low non-zero reject threshold" in proof


### PR DESCRIPTION
Plan: plans/PR-Deflection-CSV-Admission-Threshold-Evidence.md
Slice phase: Functional validation

#1467 has zero-usable rejection and partial-coverage warning diagnostics; this slice records product-shaped CSV admission evidence before we choose any low non-zero coverage threshold. The committed Zendesk corpus projects into two common CSV shapes, both admit 50/50 rows, and the proof explicitly says that clean evidence supports the ACCEPT path but does not justify a hard low-coverage reject cutoff yet.

## Intentional
- No hard threshold is added from a clean corpus.
- The partial-coverage fixture tests the evidence runner warning path; it is not threshold evidence.
- Generated CSV files are not committed because the summary is reproducible from the committed corpus.

## Deferred
- Product-backed low-coverage policy after observed partial provider exports.
- #1458 streaming upload memory remains separate.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed Codex P2 on evaluator failure coverage by adding `test_expected_full_coverage_partial_csv_fails_closed`, which asserts blocking codes, failed case status, non-zero CLI exit, and written failed summary for a bad expected-full-coverage corpus.

## Verification
- .venv/bin/python scripts/evaluate_csv_admission_threshold_evidence.py --json
  - Passed; both Zendesk-shaped CSV projections reported 50/50 usable rows.
- .venv/bin/python -m pytest tests/test_evaluate_csv_admission_threshold_evidence.py tests/test_extracted_content_ingestion_diagnostics.py
  - Passed: 19 passed.
- bash scripts/run_extracted_pipeline_checks.sh
  - Passed: 4285 passed, 10 skipped.
- bash scripts/local_pr_review.sh
  - Passed with the planned PR body file.

## Diff size
6 files, +771 / -0
