### PR TITLE
Deflection request ID redaction

### DIFF
--- a/docs/extraction/validation/content_ops_faq_deflection_portfolio_hosted_smoke_2026-05-30.md
+++ b/docs/extraction/validation/content_ops_faq_deflection_portfolio_hosted_smoke_2026-05-30.md
@@ -15,6 +15,12 @@ The production portfolio URL returned `404`, so this run does not prove the
 production customer-facing result page. No bearer token, Stripe secret, or CSV
 contents are recorded here.
 
+Security update (2026-06-15): this historical request ID and result URL are now
+redacted. The history sweep found the historical artifact unlocked under
+service-token auth (`200`), relocked it through the signed Stripe revocation
+path, and verified the artifact endpoint returned `403` afterward. Hash label:
+`3a0db3e41b8f`.
+
 ## Inputs
 
 | Input | Value |
@@ -23,8 +29,8 @@ contents are recorded here.
 | Portfolio production host | `https://juancanfield.com` |
 | Submit CSV fixture | `extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv` |
 | Submit mode | multipart |
-| Request id | `content-ops-cb59b80f08cf4c2b9ceef769501e2fb7` |
-| Account id | `2b2b950d-f64b-4852-bc30-f92a34cdf169` |
+| Request id | `content-ops-[redacted:3a0db3e41b8f]` |
+| Account id | `<redacted-account-id>` |
 
 ## Commands
 
@@ -53,8 +59,8 @@ python scripts/smoke_content_ops_deflection_portfolio_result_page.py \
 with:
 
 ```text
-ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL=https://juancanfield.com/services/faq-deflection/results/content-ops-cb59b80f08cf4c2b9ceef769501e2fb7?account_id=2b2b950d-f64b-4852-bc30-f92a34cdf169
-ATLAS_DEFLECTION_REQUEST_ID=content-ops-cb59b80f08cf4c2b9ceef769501e2fb7
+ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL=<redacted-result-url:3a0db3e41b8f>
+ATLAS_DEFLECTION_REQUEST_ID=content-ops-[redacted:3a0db3e41b8f]
 ```
 
 ## Result

--- a/docs/extraction/validation/deflection_full_volume_live_proof_2026-06-14.md
+++ b/docs/extraction/validation/deflection_full_volume_live_proof_2026-06-14.md
@@ -31,7 +31,7 @@ buyer-readiness standard for product-quality support output.
 The raw CSV is not committed. It was regenerated locally from:
 
 ```text
-/home/juan-canfield/Desktop/Atlas/tmp/faq_scale_stress_20260523/cfpb_50000_source_rows.jsonl
+tmp/faq_scale_stress_20260523/cfpb_50000_source_rows.jsonl
 ```
 
 Generated upload CSV:
@@ -53,7 +53,7 @@ Command shape:
 python scripts/smoke_content_ops_deflection_submit_handoff.py \
   --csv-file tmp/deflection_full_volume_live_proof_20260614/cfpb_real_upload_under_50mb.csv \
   --company-name "CFPB Public Archive" \
-  --contact-email canfieldjuan24@gmail.com \
+  --contact-email ops@example.com \
   --support-platform other \
   --min-uploaded-bytes 50000000 \
   --min-source-row-count 30000 \
@@ -85,7 +85,7 @@ Observed scalar result:
 Request id:
 
 ```text
-content-ops-45c06a6950ec4677a214368d6e4dc44f
+content-ops-[redacted:a83f5c797c38]
 ```
 
 The submit transport and snapshot/artifact probes passed. The command exited
@@ -110,8 +110,8 @@ Command shape:
 
 ```bash
 python scripts/smoke_content_ops_deflection_portfolio_result_page.py \
-  --result-url https://juancanfield.com/services/faq-deflection/results/content-ops-45c06a6950ec4677a214368d6e4dc44f \
-  --request-id content-ops-45c06a6950ec4677a214368d6e4dc44f \
+  --result-url <redacted-result-url:a83f5c797c38> \
+  --request-id content-ops-[redacted:a83f5c797c38] \
   --timeout 120 \
   --output-result tmp/deflection_full_volume_live_proof_20260614/result-page.json \
   --json
@@ -145,7 +145,7 @@ Command shape:
 
 ```bash
 python scripts/smoke_content_ops_deflection_stripe_paid_unlock.py \
-  --request-id content-ops-45c06a6950ec4677a214368d6e4dc44f \
+  --request-id content-ops-[redacted:a83f5c797c38] \
   --timeout 180 \
   --replay-webhook \
   --output-result tmp/deflection_full_volume_live_proof_20260614/paid-unlock.json \
@@ -165,6 +165,13 @@ The local `ATLAS_SAAS_STRIPE_WEBHOOK_SECRET` does not match the deployed
 `atlas-brain.tailc7bd29.ts.net` Stripe webhook secret, or the deployed host is
 using a different secret source. Paid unlock and email delivery remain unproven.
 
+Security update (2026-06-15): this historical request ID and result URL are now
+redacted. A later history sweep found the historical artifact unlocked under
+service-token auth (`200`), relocked it through the signed Stripe revocation
+path, and verified the artifact endpoint returned `403` afterward. Hash label:
+`a83f5c797c38`. This does not change the original proof result above: the
+2026-06-14 paid-unlock smoke itself failed on signature mismatch.
+
 ## Committed Evidence
 
 The committed fixture summary is:
@@ -173,8 +180,8 @@ The committed fixture summary is:
 docs/extraction/validation/fixtures/deflection_full_volume_live_proof_20260614/summary.json
 ```
 
-The summary intentionally excludes bearer tokens, webhook secrets, raw CFPB
-rows, paid report Markdown, PDFs, and email bodies.
+The summary intentionally excludes bearer tokens, webhook secrets, raw request
+IDs, raw CFPB rows, paid report Markdown, PDFs, and email bodies.
 
 ## Next Action
 

--- a/docs/extraction/validation/fixtures/deflection_full_volume_live_proof_20260614/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_full_volume_live_proof_20260614/summary.json
@@ -19,13 +19,14 @@
     "committed": false,
     "records_written": 40383,
     "sha256": "43130a9a43c2bd821a16c2025694a14a45fc2a914f79cfe5278c88736b749193",
-    "source_jsonl": "/home/juan-canfield/Desktop/Atlas/tmp/faq_scale_stress_20260523/cfpb_50000_source_rows.jsonl"
+    "source_jsonl": "tmp/faq_scale_stress_20260523/cfpb_50000_source_rows.jsonl"
   },
   "hosted_submit": {
     "artifact_status": 403,
     "elapsed_seconds": 64.46874859603122,
     "ok": false,
-    "request_id": "content-ops-45c06a6950ec4677a214368d6e4dc44f",
+    "request_id": "content-ops-[redacted:a83f5c797c38]",
+    "request_id_sha256_prefix": "a83f5c797c38",
     "snapshot_status": 200,
     "submit_status": 200,
     "volume_gates": {
@@ -63,7 +64,7 @@
     "ok": false,
     "page_status": 404,
     "snapshot_status": 200,
-    "url": "https://juancanfield.com/services/faq-deflection/results/content-ops-45c06a6950ec4677a214368d6e4dc44f"
+    "url": "<redacted-result-url:a83f5c797c38>"
   },
   "preflight": {
     "csv_file_size": 52428276,
@@ -73,6 +74,14 @@
   "redaction": {
     "raw_csv_committed": false,
     "raw_report_committed": false,
+    "raw_request_id_committed": false,
+    "request_id_redacted": true,
+    "request_id_revocation_sweep_20260615": {
+      "post_revocation_artifact_status": 403,
+      "pre_revocation_artifact_status": 200,
+      "request_id_sha256_prefix": "a83f5c797c38",
+      "revocation_webhook_status": 200
+    },
     "secrets_committed": false
   }
 }

--- a/plans/PR-Deflection-Request-ID-Redaction.md
+++ b/plans/PR-Deflection-Request-ID-Redaction.md
@@ -1,0 +1,125 @@
+# PR-Deflection-Request-ID-Redaction
+
+## Why this slice exists
+
+The 2026-06-15 historical request-id sweep found two raw
+`content-ops-<32 hex>` request IDs still committed in current `origin/main`.
+Both were live artifact capabilities before the sweep and were relocked through
+the existing signed Stripe revocation path. The root cause is that older proof
+docs predated the paid-artifact redaction discipline introduced by the later
+full-funnel proof. This change fixes the repository exposure at the source by
+redacting the committed docs/fixture and adding a regression test so the same
+capability-shaped IDs cannot be recommitted silently.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Redact historical raw deflection request IDs and result URLs from the
+   committed validation docs/fixture that still contain them.
+2. Update stale proof wording to record the 2026-06-15 revocation sweep: both
+   historical IDs were `200` before revocation and `403` afterward.
+3. Redact the remaining stale personal email and local absolute path from the
+   same proof artifacts.
+4. Add and enroll a focused regression test for strict
+   `content-ops-<32 hex>` request IDs in committed files, plus proof-artifact
+   checks for local home paths and non-placeholder emails.
+
+### Review Contract
+
+Acceptance criteria:
+
+- No committed file in this PR's tree contains a strict
+  `content-ops-<32 hex>` request ID.
+- The touched proof artifacts contain no local `/home/...` paths and no
+  non-placeholder email addresses.
+- The affected validation docs retain proof value through stable sanitized
+  labels / SHA prefixes instead of runnable request IDs or result URLs.
+- The new test fails if a raw strict deflection request ID is reintroduced in a
+  committed file, and the test is enrolled in the extracted-checks CI runner.
+
+Affected surfaces:
+
+- Historical Content Ops deflection validation docs and one summary fixture.
+- Test-only repository hygiene coverage.
+- Extracted-checks CI runner enrollment list.
+
+Risk areas:
+
+- Over-redacting the docs so the historical proof loses useful status context.
+- Under-redacting URLs, personal emails, or local paths that still carry stale
+  proof capabilities/context.
+
+Triggered rules:
+
+- R1 requirements match, R2 test evidence, R8 docs/artifact truthfulness, R13
+  class fix, R14 codebase verification.
+
+### Files touched
+
+- `docs/extraction/validation/content_ops_faq_deflection_portfolio_hosted_smoke_2026-05-30.md`
+- `docs/extraction/validation/deflection_full_volume_live_proof_2026-06-14.md`
+- `docs/extraction/validation/fixtures/deflection_full_volume_live_proof_20260614/summary.json`
+- `plans/PR-Deflection-Request-ID-Redaction.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_docs_no_raw_deflection_request_ids.py`
+
+## Mechanism
+
+The docs replace each raw request ID with a deterministic
+`content-ops-[redacted:<sha12>]` label. Result URLs that previously embedded the
+raw ID become redacted URL placeholders with the same SHA label. The JSON
+fixture keeps scalar status evidence but stores a redacted request-id label plus
+the SHA prefix instead of the live request ID.
+
+The regression test asks git for tracked files via `git ls-files` and scans
+those files from the repository root for the strict request-id shape
+`content-ops-[0-9a-f]{32}`. It also scans the touched proof artifacts for local
+home paths and non-placeholder email addresses. The test fails with file paths
+and counts rather than printing matched sensitive values. The test is enrolled
+in `scripts/run_extracted_pipeline_checks.sh` next to the deflection proof-doc
+tests so CI runs the guard.
+
+## Intentional
+
+- The proof docs keep hosted status values, byte/row counts, and command shape,
+  but commands are no longer copy-paste runnable against historical requests.
+  That is intentional: these request IDs are capabilities when paired with the
+  tenant's auth context.
+- The test targets the strict request-id shape rather than every
+  `content-ops-*` token so branch names, plan slugs, route names, and prose
+  remain allowed.
+- The email/path checks are proof-artifact scoped, not repo-wide, because the
+  repository contains legitimate examples and fixtures that would make a global
+  email ban noisy.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: `python -m pytest` targeting
+  `tests/test_docs_no_raw_deflection_request_ids.py` -- 6 passed.
+- Sanitized working-tree scan over tracked files -- 0 strict raw request IDs.
+- Sanitized all-text working-tree scan including untracked PR files -- 0 strict raw request IDs.
+- Sanitized proof-artifact scan -- 0 non-placeholder emails and 0 local home
+  paths across touched proof docs/fixture.
+- Extracted pipeline check runner `scripts/run_extracted_pipeline_checks.sh` --
+  passed; content-ops pytest block reported 4,291 passed / 10 skipped, and
+  extracted reasoning-core checks reported 295 passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/content_ops_faq_deflection_portfolio_hosted_smoke_2026-05-30.md` | 14 |
+| `docs/extraction/validation/deflection_full_volume_live_proof_2026-06-14.md` | 23 |
+| `docs/extraction/validation/fixtures/deflection_full_volume_live_proof_20260614/summary.json` | 15 |
+| `plans/PR-Deflection-Request-ID-Redaction.md` | 125 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_docs_no_raw_deflection_request_ids.py` | 140 |
+| **Total** | **318** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -47,6 +47,7 @@ pytest \
   tests/test_content_ops_faq_deflection_live_upload_fixture.py \
   tests/test_content_ops_faq_report_contract_docs.py \
   tests/test_content_ops_deflection_source_proof_docs.py \
+  tests/test_docs_no_raw_deflection_request_ids.py \
   tests/test_capture_zendesk_product_proof_corpus.py \
   tests/test_evaluate_zendesk_product_proof_corpus.py \
   tests/test_evaluate_csv_admission_threshold_evidence.py \

--- a/tests/test_docs_no_raw_deflection_request_ids.py
+++ b/tests/test_docs_no_raw_deflection_request_ids.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import subprocess
+
+
+RAW_DEFLECTION_REQUEST_ID_RE = re.compile(r"content-ops-[0-9a-f]{32}")
+LOCAL_HOME_PATH_RE = re.compile(r"/home/[A-Za-z0-9._-]+/[^\s`\"']+")
+EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+PLACEHOLDER_EMAIL_DOMAINS = ("example.com", "example.org", "example.net")
+PROOF_REDACTION_FILES = (
+    Path("docs/extraction/validation/content_ops_faq_deflection_portfolio_hosted_smoke_2026-05-30.md"),
+    Path("docs/extraction/validation/deflection_full_volume_live_proof_2026-06-14.md"),
+    Path("docs/extraction/validation/fixtures/deflection_full_volume_live_proof_20260614/summary.json"),
+)
+
+
+def _raw_request_id_hits(paths: list[Path]) -> list[tuple[str, int]]:
+    hits: list[tuple[str, int]] = []
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        count = len(RAW_DEFLECTION_REQUEST_ID_RE.findall(text))
+        if count:
+            hits.append((str(path), count))
+    return hits
+
+
+def _proof_redaction_hits(paths: list[Path]) -> list[tuple[str, str, int]]:
+    hits: list[tuple[str, str, int]] = []
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        local_home_paths = LOCAL_HOME_PATH_RE.findall(text)
+        if local_home_paths:
+            hits.append((str(path), "local_home_path", len(local_home_paths)))
+        non_placeholder_emails = [
+            value
+            for value in EMAIL_RE.findall(text)
+            if not value.lower().endswith(PLACEHOLDER_EMAIL_DOMAINS)
+        ]
+        if non_placeholder_emails:
+            hits.append((str(path), "non_placeholder_email", len(non_placeholder_emails)))
+    return hits
+
+
+def _tracked_files(repo_root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=repo_root,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return [
+        repo_root / raw.decode("utf-8")
+        for raw in result.stdout.split(b"\0")
+        if raw
+    ]
+
+
+def test_raw_request_id_detector_catches_capability_shape(tmp_path: Path) -> None:
+    bad_id = "content-ops-" + ("a" * 32)
+    candidate = tmp_path / "proof.md"
+    candidate.write_text(f"request_id={bad_id}\n", encoding="utf-8")
+
+    assert _raw_request_id_hits([candidate]) == [(str(candidate), 1)]
+
+
+def test_raw_request_id_detector_allows_redacted_and_non_capability_tokens(
+    tmp_path: Path,
+) -> None:
+    candidate = tmp_path / "proof.md"
+    candidate.write_text(
+        "\n".join(
+            (
+                "content-ops-[redacted:a83f5c797c38]",
+                "content-ops-deflection-request-id-redaction",
+                "content-ops-123",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert _raw_request_id_hits([candidate]) == []
+
+
+def test_proof_redaction_detector_catches_local_paths_and_real_emails(
+    tmp_path: Path,
+) -> None:
+    candidate = tmp_path / "proof.md"
+    candidate.write_text(
+        "\n".join(
+            (
+                "/home/alice/Desktop/Atlas/tmp/source.csv",
+                "contact-email alice@gmail.com",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert _proof_redaction_hits([candidate]) == [
+        (str(candidate), "local_home_path", 1),
+        (str(candidate), "non_placeholder_email", 1),
+    ]
+
+
+def test_proof_redaction_detector_allows_placeholders_and_relative_paths(
+    tmp_path: Path,
+) -> None:
+    candidate = tmp_path / "proof.md"
+    candidate.write_text(
+        "\n".join(
+            (
+                "tmp/faq_scale_stress_20260523/cfpb_50000_source_rows.jsonl",
+                "contact-email ops@example.com",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert _proof_redaction_hits([candidate]) == []
+
+
+def test_committed_files_do_not_contain_raw_deflection_request_ids() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    hits = _raw_request_id_hits(_tracked_files(repo_root))
+
+    assert hits == []
+
+
+def test_deflection_proof_artifacts_do_not_reintroduce_stale_identifiers() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    paths = [repo_root / path for path in PROOF_REDACTION_FILES]
+
+    assert _proof_redaction_hits(paths) == []


### PR DESCRIPTION
Plan: plans/PR-Deflection-Request-ID-Redaction.md
Slice phase: Production hardening

Redacts historical raw Content Ops deflection request IDs from validation docs/fixtures after the 2026-06-15 sweep found two committed IDs still unlocked. The live access was already relocked through the signed Stripe revocation path; this PR removes the repository exposure and adds an enrolled regression guard so strict `content-ops-<32 hex>` IDs cannot be recommitted silently.

## Intentional
- Historical proof status, row/byte counts, and command shape remain, but request IDs and result URLs are hash-labeled redactions rather than runnable capabilities.
- The guard targets strict `content-ops-<32 hex>` IDs repo-wide, and checks local home paths / non-placeholder emails only for the touched proof artifacts to avoid noisy global email fixtures.

## Deferred
- None.

## Parked hardening
- None.

## AI reconciliation
- Codex P2: Enroll the redaction guard in CI -- fixed by adding `tests/test_docs_no_raw_deflection_request_ids.py` to `scripts/run_extracted_pipeline_checks.sh` and verifying it runs inside the extracted-checks script.
- Reviewer MAJOR: stale personal email/local absolute path in proof artifacts -- fixed by redacting to `ops@example.com` / relative `tmp/...` path and extending the proof-artifact guard.
- All fixed or waived: yes.

## Verification
- `python -m pytest tests/test_docs_no_raw_deflection_request_ids.py` -- 6 passed.
- Sanitized tracked working-tree scan -- 0 strict raw request IDs.
- Sanitized proof-artifact scan -- 0 non-placeholder emails and 0 local home paths.
- `bash scripts/run_extracted_pipeline_checks.sh` -- passed on rebased head; content-ops pytest block reported 4,291 passed / 10 skipped, and extracted reasoning-core checks reported 295 passed.

## Diff size
6 files, +303 / -15.
