### PR TITLE
CI trigger-coverage hardening (path filters only)

### DIFF
--- a/.github/workflows/admin_costs_checks.yml
+++ b/.github/workflows/admin_costs_checks.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/admin_costs_checks.yml"
       - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/api/admin_costs.py"
       - "tests/test_admin_costs.py"
   push:
@@ -13,6 +14,7 @@ on:
     paths:
       - ".github/workflows/admin_costs_checks.yml"
       - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/api/admin_costs.py"
       - "tests/test_admin_costs.py"
 

--- a/.github/workflows/admin_costs_checks.yml
+++ b/.github/workflows/admin_costs_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/admin_costs_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/api/admin_costs.py"
       - "tests/test_admin_costs.py"
   push:
@@ -11,6 +12,7 @@ on:
       - main
     paths:
       - ".github/workflows/admin_costs_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/api/admin_costs.py"
       - "tests/test_admin_costs.py"
 

--- a/.github/workflows/atlas_blog_public_checks.yml
+++ b/.github/workflows/atlas_blog_public_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_blog_public_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/api/blog_public.py"
       - "tests/test_blog_public.py"
   push:
@@ -11,6 +12,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_blog_public_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/api/blog_public.py"
       - "tests/test_blog_public.py"
 

--- a/.github/workflows/atlas_brand_voice_checks.yml
+++ b/.github/workflows/atlas_brand_voice_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_brand_voice_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/brand/**"
       - "atlas_brain/skills/brand/brand_voice.yml"
       - "tests/test_brand_voice_validator.py"
@@ -12,6 +13,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_brand_voice_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/brand/**"
       - "atlas_brain/skills/brand/brand_voice.yml"
       - "tests/test_brand_voice_validator.py"

--- a/.github/workflows/atlas_content_ops_auth_checks.yml
+++ b/.github/workflows/atlas_content_ops_auth_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_auth_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/auth/dependencies.py"
       - "tests/test_auth_dependencies.py"
@@ -12,6 +13,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_auth_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/auth/dependencies.py"
       - "tests/test_auth_dependencies.py"

--- a/.github/workflows/atlas_content_ops_claim_registry_checks.yml
+++ b/.github/workflows/atlas_content_ops_claim_registry_checks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_claim_registry_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/_content_ops_claim_registry.py"
       - "atlas_brain/_content_ops_review_workflow.py"
       - "atlas_brain/storage/migrations/334_content_ops_claim_registry.sql"
@@ -17,6 +19,8 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_claim_registry_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/_content_ops_claim_registry.py"
       - "atlas_brain/_content_ops_review_workflow.py"
       - "atlas_brain/storage/migrations/334_content_ops_claim_registry.sql"

--- a/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/alerts/**"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
@@ -24,6 +25,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/alerts/**"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/__init__.py"

--- a/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
       - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/alerts/**"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
@@ -26,6 +27,7 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
       - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/alerts/**"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/__init__.py"

--- a/.github/workflows/atlas_content_ops_deflection_report_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_report_checks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_report_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "extracted_content_pipeline/faq_deflection_report.py"
       - "extracted_content_pipeline/ticket_faq_markdown.py"
       - "scripts/build_content_ops_deflection_report.py"
@@ -15,6 +17,8 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_deflection_report_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "extracted_content_pipeline/faq_deflection_report.py"
       - "extracted_content_pipeline/ticket_faq_markdown.py"
       - "scripts/build_content_ops_deflection_report.py"

--- a/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/alerts/**"
       - "atlas_brain/api/auth.py"
       - "atlas_brain/api/b2b_vendor_briefing.py"
@@ -26,6 +28,8 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/alerts/**"
       - "atlas_brain/api/auth.py"
       - "atlas_brain/api/b2b_vendor_briefing.py"

--- a/.github/workflows/atlas_content_ops_generated_assets_checks.yml
+++ b/.github/workflows/atlas_content_ops_generated_assets_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_generated_assets_checks.yml"
+      - "extracted_content_pipeline/**"
       - "requirements.txt"
       - "requirements.asr.txt"
       - "atlas_brain/_content_ops_brand_voice_profiles.py"
@@ -23,6 +24,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_generated_assets_checks.yml"
+      - "extracted_content_pipeline/**"
       - "requirements.txt"
       - "requirements.asr.txt"
       - "atlas_brain/_content_ops_brand_voice_profiles.py"

--- a/.github/workflows/atlas_content_ops_input_provider_checks.yml
+++ b/.github/workflows/atlas_content_ops_input_provider_checks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/config.py"
       - "atlas_brain/_content_ops_infrastructure.py"
@@ -20,6 +22,8 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/config.py"
       - "atlas_brain/_content_ops_infrastructure.py"

--- a/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
+++ b/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_macro_writeback_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/autonomous/runner.py"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
@@ -17,6 +19,8 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_macro_writeback_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/autonomous/runner.py"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"

--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_review_workflow_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/_content_ops_review_workflow.py"
       - "atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py"
       - "atlas_brain/mcp/content_ops_marketer_verify_server.py"
@@ -38,6 +40,8 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_review_workflow_checks.yml"
+      - "requirements.txt"
+      - "extracted_content_pipeline/**"
       - "atlas_brain/_content_ops_review_workflow.py"
       - "atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py"
       - "atlas_brain/mcp/content_ops_marketer_verify_server.py"

--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_invoicing_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/mcp/invoicing_server.py"
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/storage/repositories/invoice.py"
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_invoicing_checks.yml"
+      - "requirements.txt"
       - "atlas_brain/mcp/invoicing_server.py"
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/storage/repositories/invoice.py"

--- a/.github/workflows/atlas_main_voice_startup_checks.yml
+++ b/.github/workflows/atlas_main_voice_startup_checks.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_main_voice_startup_checks.yml"
+      - "requirements.txt"
+      - "atlas_brain/api/__init__.py"
+      - "atlas_brain/config.py"
       - "atlas_brain/main.py"
       - "tests/test_atlas_main_voice_startup.py"
   push:
@@ -11,6 +14,9 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_main_voice_startup_checks.yml"
+      - "requirements.txt"
+      - "atlas_brain/api/__init__.py"
+      - "atlas_brain/config.py"
       - "atlas_brain/main.py"
       - "tests/test_atlas_main_voice_startup.py"
 

--- a/.github/workflows/extracted_competitive_intelligence_checks.yml
+++ b/.github/workflows/extracted_competitive_intelligence_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/extracted_competitive_intelligence_checks.yml"
+      - "requirements.txt"
       # Scaffold + script paths
       - "extracted_competitive_intelligence/**"
       - "scripts/sync_extracted_competitive_intelligence.sh"
@@ -56,6 +57,7 @@ on:
   push:
     paths:
       - ".github/workflows/extracted_competitive_intelligence_checks.yml"
+      - "requirements.txt"
       - "extracted_competitive_intelligence/**"
       - "scripts/sync_extracted_competitive_intelligence.sh"
       - "scripts/validate_extracted_competitive_intelligence.sh"

--- a/.github/workflows/extracted_llm_infrastructure_checks.yml
+++ b/.github/workflows/extracted_llm_infrastructure_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/extracted_llm_infrastructure_checks.yml"
+      - "requirements.txt"
       - "extracted_llm_infrastructure/**"
       - "scripts/sync_extracted_llm_infrastructure.sh"
       - "scripts/validate_extracted_llm_infrastructure.sh"
@@ -19,6 +20,7 @@ on:
   push:
     paths:
       - ".github/workflows/extracted_llm_infrastructure_checks.yml"
+      - "requirements.txt"
       - "extracted_llm_infrastructure/**"
       - "scripts/sync_extracted_llm_infrastructure.sh"
       - "scripts/validate_extracted_llm_infrastructure.sh"

--- a/plans/PR-CI-Trigger-Coverage-Hardening.md
+++ b/plans/PR-CI-Trigger-Coverage-Hardening.md
@@ -44,8 +44,12 @@ Slice phase: Production hardening
    atlas_content_ops_input_provider, atlas_content_ops_macro_writeback,
    atlas_content_ops_review_workflow, atlas_content_ops_deflection_report,
    atlas_content_ops_deflection_stripe_paid, atlas_content_ops_claim_registry,
-   atlas_content_ops_generated_assets. Use the `**` glob (not a hand-list of
-   modules) so the trigger does not drift as imports change.
+   atlas_content_ops_generated_assets, atlas_content_ops_deflection_delivery,
+   admin_costs (the last two added in review: their tests import
+   `extracted_content_pipeline` -- delivery imports `campaign_ports` /
+   `campaign_sender`; admin_costs imports `content_ops_usage_summary`). Use the
+   `**` glob (not a hand-list of modules) so the trigger does not drift as
+   imports change.
 3. Add `atlas_brain/api/__init__.py` + `atlas_brain/config.py` to
    atlas_main_voice_startup (the broad-import surface `main.py` loads).
 
@@ -124,7 +128,7 @@ Parked hardening: none.
 - `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
   -- all workflows parse.
 - Per-workflow grep: `requirements.txt` present in pull_request + push paths for
-  all 15; `extracted_content_pipeline/**` present for the 7 content-ops gates.
+  all 15; `extracted_content_pipeline/**` present for the 9 content-ops gates.
 - Confirm `git diff` touches only `on:`/`paths:` lines -- no `jobs:`/`steps:`.
 
 ## Estimated diff size
@@ -132,7 +136,7 @@ Parked hardening: none.
 | File group | LOC |
 |---|---:|
 | 15 workflows x `requirements.txt` (pull_request + push) | ~30 |
-| 7 content-ops workflows x `extracted_content_pipeline/**` (x2) | ~15 |
+| 9 content-ops workflows x `extracted_content_pipeline/**` (x2) | ~19 |
 | atlas_main_voice_startup api/config triggers | ~4 |
 | `plans/PR-CI-Trigger-Coverage-Hardening.md` | ~115 |
 | **Total** | **~164** |

--- a/plans/PR-CI-Trigger-Coverage-Hardening.md
+++ b/plans/PR-CI-Trigger-Coverage-Hardening.md
@@ -39,7 +39,7 @@ Slice phase: Production hardening
    atlas_content_ops_input_provider, atlas_content_ops_macro_writeback,
    atlas_content_ops_review_workflow, atlas_invoicing, atlas_main_voice_startup,
    extracted_competitive_intelligence, extracted_llm_infrastructure.
-2. Add `extracted_content_pipeline/**` to the `paths:` of the content-ops
+2. Add `extracted_content_pipeline/**` to the `paths:` of the
    workflows whose tests import package source not currently triggered:
    atlas_content_ops_input_provider, atlas_content_ops_macro_writeback,
    atlas_content_ops_review_workflow, atlas_content_ops_deflection_report,
@@ -47,9 +47,10 @@ Slice phase: Production hardening
    atlas_content_ops_generated_assets, atlas_content_ops_deflection_delivery,
    admin_costs (the last two added in review: their tests import
    `extracted_content_pipeline` -- delivery imports `campaign_ports` /
-   `campaign_sender`; admin_costs imports `content_ops_usage_summary`). Use the
-   `**` glob (not a hand-list of modules) so the trigger does not drift as
-   imports change.
+   `campaign_sender`; admin_costs imports `content_ops_usage_summary`. delivery
+   is a content-ops gate; admin_costs is not content-ops by name but imports the
+   package, so it gets the glob on the same logic). Use the `**` glob (not a
+   hand-list of modules) so the trigger does not drift as imports change.
 3. Add `atlas_brain/api/__init__.py` + `atlas_brain/config.py` to
    atlas_main_voice_startup (the broad-import surface `main.py` loads).
 
@@ -128,7 +129,8 @@ Parked hardening: none.
 - `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
   -- all workflows parse.
 - Per-workflow grep: `requirements.txt` present in pull_request + push paths for
-  all 15; `extracted_content_pipeline/**` present for the 9 content-ops gates.
+  all 15; `extracted_content_pipeline/**` present for the 8 content-ops gates
+  plus admin_costs (imports ecp; not content-ops-named).
 - Confirm `git diff` touches only `on:`/`paths:` lines -- no `jobs:`/`steps:`.
 
 ## Estimated diff size
@@ -136,7 +138,7 @@ Parked hardening: none.
 | File group | LOC |
 |---|---:|
 | 15 workflows x `requirements.txt` (pull_request + push) | ~30 |
-| 9 content-ops workflows x `extracted_content_pipeline/**` (x2) | ~19 |
+| 8 content-ops + admin_costs x `extracted_content_pipeline/**` (x2) | ~19 |
 | atlas_main_voice_startup api/config triggers | ~4 |
 | `plans/PR-CI-Trigger-Coverage-Hardening.md` | ~115 |
 | **Total** | **~164** |

--- a/plans/PR-CI-Trigger-Coverage-Hardening.md
+++ b/plans/PR-CI-Trigger-Coverage-Hardening.md
@@ -1,0 +1,138 @@
+# PR-CI-Trigger-Coverage-Hardening
+
+## Why this slice exists
+
+A 30-workflow audit found two systemic path-trigger gaps that let CI go green on
+changes it should test:
+
+1. **`requirements.txt` is not a trigger on 15 workflows that install it.** Each
+   does `pip install -r requirements.txt`, but `requirements.txt` is absent from
+   their `pull_request.paths` / `push.paths`, so a dependency bump that breaks
+   those suites does not retrigger them. This is the exact class that bit #1556:
+   FastAPI 0.137.0 (unpinned at the time) broke route introspection, and only
+   `atlas_content_ops_generated_assets_checks.yml` had `requirements.txt` in its
+   paths, so the rest stayed green on the dependency change. The pin (#1559)
+   stopped that one release; this closes the detection gap repo-wide so the next
+   drift is caught on the dep-change PR, not three PRs later.
+
+2. **~7 content-ops workflows do not trigger on the `extracted_content_pipeline`
+   source their own tests exercise.** Their tests import `control_surfaces.py`,
+   `content_ops_execution.py`, the macro-writeback modules, etc., but the
+   workflow `paths:` watch only a handful of brain-side host adapters. The change
+   is still caught by `extracted_pipeline_checks.yml`'s `**` glob, but the
+   *named* gate stays green, giving a false "the specific check passed" signal on
+   the PR (the same misleading-green that hid the #1556 break).
+
+This is a pure trigger-coverage fix: no test logic, no source logic, no new
+checks. It only makes existing checks fire when the files they depend on change.
+
+## Scope (this PR)
+
+Ownership lane: ci/trigger-coverage
+Slice phase: Production hardening
+
+1. Add `requirements.txt` to `pull_request.paths` and `push.paths` of the 15
+   workflows that install it but do not trigger on it:
+   admin_costs, atlas_blog_public, atlas_brand_voice, atlas_content_ops_auth,
+   atlas_content_ops_claim_registry, atlas_content_ops_deflection_delivery,
+   atlas_content_ops_deflection_report, atlas_content_ops_deflection_stripe_paid,
+   atlas_content_ops_input_provider, atlas_content_ops_macro_writeback,
+   atlas_content_ops_review_workflow, atlas_invoicing, atlas_main_voice_startup,
+   extracted_competitive_intelligence, extracted_llm_infrastructure.
+2. Add `extracted_content_pipeline/**` to the `paths:` of the content-ops
+   workflows whose tests import package source not currently triggered:
+   atlas_content_ops_input_provider, atlas_content_ops_macro_writeback,
+   atlas_content_ops_review_workflow, atlas_content_ops_deflection_report,
+   atlas_content_ops_deflection_stripe_paid, atlas_content_ops_claim_registry,
+   atlas_content_ops_generated_assets. Use the `**` glob (not a hand-list of
+   modules) so the trigger does not drift as imports change.
+3. Add `atlas_brain/api/__init__.py` + `atlas_brain/config.py` to
+   atlas_main_voice_startup (the broad-import surface `main.py` loads).
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Each of the 15 workflows has `requirements.txt` in BOTH `pull_request`
+        and `push` path lists.
+  - [ ] Each listed content-ops workflow triggers on
+        `extracted_content_pipeline/**`.
+  - [ ] No workflow `jobs:`/`steps:`/runner content changed -- triggers only.
+  - [ ] All edited YAML parses (CI lints / GitHub accepts the workflows).
+- Affected surfaces: the GitHub Actions workflow files listed under Files
+  touched (path filters only).
+- Risk areas: a too-broad trigger causes extra (not fewer) CI runs -- acceptable
+  / fail-safe; YAML indentation under `paths:`; not removing any existing
+  trigger.
+- Reviewer rules triggered: R2 (test/CI evidence), R10 (maintainability), R12
+  (CI enrollment), R14.
+
+### Files touched
+
+- `.github/workflows/admin_costs_checks.yml`
+- `.github/workflows/atlas_blog_public_checks.yml`
+- `.github/workflows/atlas_brand_voice_checks.yml`
+- `.github/workflows/atlas_content_ops_auth_checks.yml`
+- `.github/workflows/atlas_content_ops_claim_registry_checks.yml`
+- `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml`
+- `.github/workflows/atlas_content_ops_deflection_report_checks.yml`
+- `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml`
+- `.github/workflows/atlas_content_ops_input_provider_checks.yml`
+- `.github/workflows/atlas_content_ops_macro_writeback_checks.yml`
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+- `.github/workflows/atlas_content_ops_generated_assets_checks.yml`
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `.github/workflows/atlas_main_voice_startup_checks.yml`
+- `.github/workflows/extracted_competitive_intelligence_checks.yml`
+- `.github/workflows/extracted_llm_infrastructure_checks.yml`
+- `plans/PR-CI-Trigger-Coverage-Hardening.md`
+
+## Mechanism
+
+Each change appends entries to existing `on.pull_request.paths` and
+`on.push.paths` lists. `requirements.txt` makes a dependency bump retrigger the
+suites that install it; `extracted_content_pipeline/**` makes a package-source
+change retrigger the named content-ops gate that tests it. Triggers are additive
+and fail-safe -- the worst case is an extra CI run, never a skipped one. No job,
+step, install, or test content changes.
+
+## Intentional
+
+- Use `extracted_content_pipeline/**` rather than enumerating modules, so the
+  trigger tracks the import graph automatically (the hand-list was the original
+  source of drift).
+- Leave `requirements.asr.txt` alone except where a workflow installs it
+  (generated-assets already lists it; no other workflow installs it).
+- Do not touch always-run workflows (no `paths:` filter) or jobs/steps -- this is
+  strictly a trigger-surface change.
+
+## Deferred
+
+- **Redaction-guard enrollment** (`tests/test_docs_no_raw_deflection_request_ids.py`
+  from #1578) -- owned by that PR's lane; not duplicated here to avoid a
+  cross-session collision.
+- **Orphan-gate enrollment** -- `audit_content_ops_marketing_claims.py` (the
+  #1503 deflection-claim gate) and an `extracted_evidence_to_story` workflow
+  (the package has zero CI) are real gaps but are *new lanes*, not trigger
+  coverage; they belong in a separate `ci/orphan-gate-enrollment` slice.
+- LOW path-trigger items (script-self-edit smokes, the config->reasoning seam)
+  -- not worth the trigger churn.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
+  -- all workflows parse.
+- Per-workflow grep: `requirements.txt` present in pull_request + push paths for
+  all 15; `extracted_content_pipeline/**` present for the 7 content-ops gates.
+- Confirm `git diff` touches only `on:`/`paths:` lines -- no `jobs:`/`steps:`.
+
+## Estimated diff size
+
+| File group | LOC |
+|---|---:|
+| 15 workflows x `requirements.txt` (pull_request + push) | ~30 |
+| 7 content-ops workflows x `extracted_content_pipeline/**` (x2) | ~15 |
+| atlas_main_voice_startup api/config triggers | ~4 |
+| `plans/PR-CI-Trigger-Coverage-Hardening.md` | ~115 |
+| **Total** | **~164** |


### PR DESCRIPTION
Plan: plans/PR-CI-Trigger-Coverage-Hardening.md
Slice phase: Production hardening

A 30-workflow audit found two systemic path-trigger gaps that let CI go green on changes it should test:

1. **`requirements.txt` is not a trigger on 15 workflows that install it**, so a dependency bump that breaks those suites does not retrigger them -- the exact class that bit #1556 (FastAPI 0.137.0 broke route introspection and only `generated-assets` had the trigger). The pin (#1559) stopped that release; this closes the detection gap repo-wide.
2. **~7 content-ops workflows do not trigger on the `extracted_content_pipeline` source their tests exercise**, so the *named* gate stays green while the change is only caught by the umbrella glob -- a misleading "the specific check passed" signal on the PR.

Pure trigger coverage: no test logic, no source logic, no new checks -- only makes existing checks fire when the files they depend on change.

## Intentional
- `extracted_content_pipeline/**` glob rather than a hand-list of modules, so the trigger tracks the import graph automatically.
- Additive, fail-safe triggers only: worst case is an extra CI run, never a skipped one.
- `on:`/`paths:` lines only -- no `jobs:`, `steps:`, install, or test content changed.

## Deferred
- Redaction-guard enrollment (`tests/test_docs_no_raw_deflection_request_ids.py`) -- owned by #1578's lane; not duplicated here to avoid a cross-session collision.
- Orphan-gate enrollment -- `audit_content_ops_marketing_claims.py` (#1503 deflection-claim gate) and an `extracted_evidence_to_story` workflow (the package has zero CI) are real gaps but are new lanes, not trigger coverage; separate `ci/orphan-gate-enrollment` slice.


## Parked hardening

None.

## Verification
- `yaml.safe_load` over all 30 workflows -- parse OK.
- `requirements.txt` present in pull_request + push paths for all 15; `extracted_content_pipeline/**` for the 7 content-ops gates.
- `git diff` touches only `on:`/`paths:` lines: 16 files changed, +48 insertions, 0 deletions.

## Diff size
16 workflows (+48 trigger lines) + `plans/PR-CI-Trigger-Coverage-Hardening.md` (~115). Total ~164 LOC.
