### PR TITLE
Deflection CSV admission observed evidence

### DIFF
--- a/docs/extraction/validation/deflection_csv_admission_threshold_evidence_2026-06-15.md
+++ b/docs/extraction/validation/deflection_csv_admission_threshold_evidence_2026-06-15.md
@@ -12,23 +12,27 @@ diagnostics path with source-row mode enabled.
 
 ## Result
 
-| Case | Raw rows | Usable rows | Usable ratio | Admission | Coverage warnings |
-|---|---:|---:|---:|---|---:|
-| zendesk_public_comments_csv | 50 | 50 | 1.0 | ACCEPT | 0 |
-| zendesk_description_csv | 50 | 50 | 1.0 | ACCEPT | 0 |
+| Case | Case status | Raw rows | Usable rows | Usable ratio | Admission | Coverage warnings |
+|---|---|---:|---:|---:|---|---:|
+| zendesk_public_comments_csv | ok | 50 | 50 | 1.0 | ACCEPT | 0 |
+| zendesk_description_csv | ok | 50 | 50 | 1.0 | ACCEPT | 0 |
 
 Status: `ok`
 
 Observed minimum usable source ratio: `1.0`
 
+Observed evidence cases: `0`
+
 ## Interpretation
 
-The committed product-shaped Zendesk CSV projections are accepted at full coverage. This supports the clean ACCEPT path, but does not justify a hard low-coverage reject threshold by itself.
+The committed product-shaped Zendesk CSV projections are accepted at full coverage. This supports the clean ACCEPT path, but does not justify a hard low-coverage reject threshold by itself. Operator-supplied observed CSVs are evidence only until a later policy slice promotes a threshold.
 
 This artifact therefore supports keeping clean Zendesk-shaped CSV uploads on
 the ACCEPT path. It does not choose a low non-zero reject threshold. That
 threshold still needs observed partial-coverage exports, not a synthetic ratio
-derived from a clean corpus.
+derived from a clean corpus. Operator-supplied observed CSVs are recorded as
+evidence and do not block this runner until a later policy slice promotes a
+threshold.
 
 ## Artifact Links
 

--- a/docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json
@@ -1,4 +1,5 @@
 {
+  "blocking_case_count": 0,
   "blocking_violation_codes": [],
   "case_count": 2,
   "cases": [
@@ -73,8 +74,10 @@
     "ticket_count": 50,
     "tickets_with_private_notes": 4
   },
+  "observed_case_count": 0,
   "observed_max_usable_source_ratio": 1.0,
   "observed_min_usable_source_ratio": 1.0,
   "status": "ok",
-  "threshold_conclusion": "The committed product-shaped Zendesk CSV projections are accepted at full coverage. This supports the clean ACCEPT path, but does not justify a hard low-coverage reject threshold by itself."
+  "strict_case_count": 2,
+  "threshold_conclusion": "The committed product-shaped Zendesk CSV projections are accepted at full coverage. This supports the clean ACCEPT path, but does not justify a hard low-coverage reject threshold by itself. Operator-supplied observed CSVs are evidence only until a later policy slice promotes a threshold."
 }

--- a/plans/PR-Deflection-CSV-Admission-Observed-Evidence.md
+++ b/plans/PR-Deflection-CSV-Admission-Observed-Evidence.md
@@ -1,0 +1,117 @@
+# PR-Deflection-CSV-Admission-Observed-Evidence
+
+## Why this slice exists
+
+#1577 proved clean Zendesk-shaped CSV projections admit at full coverage, then
+explicitly deferred low-coverage policy until observed partial provider exports
+exist. Its final review also called out the next implementation constraint:
+the runner currently marks non-full-coverage cases as `observed`, but the
+summary still treats any non-`ok` case as blocking. That is fail-safe, but it
+prevents the next evidence slice from recording real partial-coverage exports
+without turning the proof red.
+
+This slice makes observed evidence a first-class, non-gating case type while
+keeping expected-full-coverage failures blocking. It does not set a threshold.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-admission
+Slice phase: Vertical slice
+
+1. Add optional observed CSV inputs to the CSV admission evidence runner.
+2. Include observed cases in the generated summary/doc without making them
+   fail the run.
+3. Keep expected-full-coverage cases fail-closed when they reject, skip rows,
+   or emit coverage warnings.
+4. Keep the default committed Zendesk artifact clean: observed case count is
+   zero until an operator supplies observed partial exports.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The runner accepts optional observed CSV evidence files and inspects
+        them through the same source-row CSV diagnostics path.
+  - [ ] Observed cases with partial coverage are recorded with raw/usable
+        counts, usable ratio, admission status, and coverage warnings.
+  - [ ] Observed cases do not add blocking violation codes or make the CLI
+        return non-zero.
+  - [ ] Expected-full-coverage cases still fail closed on partial coverage.
+  - [ ] The default committed artifact remains policy-neutral and does not
+        add a low-coverage reject threshold.
+- Affected surfaces: scripts, validation docs, validation fixtures, tests.
+- Risk areas: false-green evaluator behavior, threshold overclaiming, CI
+  enrollment.
+- Reviewer rules triggered: R1, R2, R10, R12, R14.
+
+### Files touched
+
+- `docs/extraction/validation/deflection_csv_admission_threshold_evidence_2026-06-15.md`
+- `docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json`
+- `plans/PR-Deflection-CSV-Admission-Observed-Evidence.md`
+- `scripts/evaluate_csv_admission_threshold_evidence.py`
+- `tests/test_evaluate_csv_admission_threshold_evidence.py`
+
+## Mechanism
+
+The runner keeps the two built-in Zendesk product-proof projections as
+expected-full-coverage cases. It also accepts repeatable observed CSV inputs
+from the CLI using name/path pairs. Each observed file is inspected through the
+same `inspect_ingestion_file` source-row CSV path and appears in the same
+`cases` array.
+
+Case status stays explicit:
+
+- `ok`: expected-full-coverage case admitted every row with no partial warning.
+- `failed`: expected-full-coverage case rejected, skipped rows, or warned.
+- `observed`: operator-supplied evidence case. It records what happened, but
+  does not block the run.
+
+The generated summary separates `blocking_violation_codes` from
+`observed_case_count` so the next threshold-policy slice can look at observed
+partial ratios without confusing evidence collection with enforcement.
+
+## Intentional
+
+- This does not commit a synthetic partial-coverage artifact as product
+  evidence. Tests use synthetic partial CSVs to prove behavior; the committed
+  default artifact still reflects the clean Zendesk corpus only.
+- Observed cases are non-gating by design. A later threshold-policy PR can
+  promote an observed ratio into a reject rule after the operator has real
+  provider-export evidence.
+- No source CSV content is committed. Observed CSV files are read locally and
+  summarized as counts, statuses, warning codes, and field names.
+- Local cross-layer caller hints are generic script symbol name collisions
+  (`main`, `_parse_args`, `_proof_doc`), not real non-diff callers of this
+  standalone evaluator. The touched behavior is covered through the enrolled
+  evaluator tests.
+
+## Deferred
+
+- Product-backed low-coverage policy: choose warn-only vs reject after observed
+  partial provider exports are collected.
+- #1458 streaming upload memory remains separate.
+
+Parked hardening: none.
+
+## Verification
+
+- Pending before push:
+  - Command: /home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/evaluate_csv_admission_threshold_evidence.py --json
+    - Passed; regenerated the committed summary/doc artifact with observed case count zero.
+  - Command: /home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_evaluate_csv_admission_threshold_evidence.py tests/test_extracted_content_ingestion_diagnostics.py
+    - Passed: 21 passed.
+  - Command: bash scripts/run_extracted_pipeline_checks.sh
+    - Passed: 4287 passed, 10 skipped.
+  - Local PR review wrapper with the planned PR body file.
+    - Passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/deflection_csv_admission_threshold_evidence_2026-06-15.md` | 16 |
+| `docs/extraction/validation/fixtures/deflection_csv_admission_threshold_evidence_20260615/summary.json` | 5 |
+| `plans/PR-Deflection-CSV-Admission-Observed-Evidence.md` | 117 |
+| `scripts/evaluate_csv_admission_threshold_evidence.py` | 111 |
+| `tests/test_evaluate_csv_admission_threshold_evidence.py` | 80 |
+| **Total** | **329** |

--- a/scripts/evaluate_csv_admission_threshold_evidence.py
+++ b/scripts/evaluate_csv_admission_threshold_evidence.py
@@ -52,7 +52,8 @@ class CsvAdmissionCase:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     corpus = _load_corpus(args.corpus)
-    summary = evaluate_zendesk_corpus(corpus)
+    observed_csvs = _parse_observed_csvs(args.observed_csv)
+    summary = evaluate_zendesk_corpus(corpus, observed_csvs=observed_csvs)
 
     if args.out_dir:
         args.out_dir.mkdir(parents=True, exist_ok=True)
@@ -75,11 +76,19 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def evaluate_zendesk_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
+def evaluate_zendesk_corpus(
+    corpus: Mapping[str, Any],
+    *,
+    observed_csvs: Sequence[tuple[str, Path]] = (),
+) -> dict[str, Any]:
     """Inspect product-shaped Zendesk CSV projections and summarize evidence."""
 
     cases = _zendesk_cases(corpus)
     case_results = [evaluate_csv_case(case) for case in cases]
+    case_results.extend(
+        evaluate_observed_csv(name=name, path=path)
+        for name, path in observed_csvs
+    )
     blocking = _blocking_codes(case_results)
     ratios = [
         float(result["usable_source_ratio"])
@@ -91,12 +100,23 @@ def evaluate_zendesk_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
         "blocking_violation_codes": blocking,
         "corpus": _corpus_summary(corpus),
         "case_count": len(case_results),
+        "strict_case_count": sum(
+            1 for result in case_results if result.get("expected_full_coverage") is True
+        ),
+        "observed_case_count": sum(
+            1 for result in case_results if result.get("case_status") == "observed"
+        ),
+        "blocking_case_count": sum(
+            1 for result in case_results if result.get("case_status") == "failed"
+        ),
         "observed_min_usable_source_ratio": min(ratios) if ratios else None,
         "observed_max_usable_source_ratio": max(ratios) if ratios else None,
         "threshold_conclusion": (
             "The committed product-shaped Zendesk CSV projections are accepted "
             "at full coverage. This supports the clean ACCEPT path, but does "
-            "not justify a hard low-coverage reject threshold by itself."
+            "not justify a hard low-coverage reject threshold by itself. "
+            "Operator-supplied observed CSVs are evidence only until a later "
+            "policy slice promotes a threshold."
         ),
         "cases": case_results,
     }
@@ -108,21 +128,47 @@ def evaluate_csv_case(case: CsvAdmissionCase) -> dict[str, Any]:
     with TemporaryDirectory(prefix="atlas-csv-admission-") as tmp_dir:
         path = Path(tmp_dir) / f"{case.name}.csv"
         _write_csv(path, fieldnames=case.fieldnames, rows=case.rows)
-        payload = inspect_ingestion_file(
-            path,
-            source_rows=True,
-            source_format="csv",
-            sample_limit=0,
-        ).as_dict()
+        return _evaluate_csv_path(
+            name=case.name,
+            description=case.description,
+            path=path,
+            expected_full_coverage=case.expected_full_coverage,
+        )
+
+
+def evaluate_observed_csv(*, name: str, path: Path) -> dict[str, Any]:
+    """Inspect an operator-supplied CSV as non-gating threshold evidence."""
+
+    return _evaluate_csv_path(
+        name=name,
+        description=f"Observed source-row CSV evidence from {path.name}.",
+        path=path,
+        expected_full_coverage=False,
+    )
+
+
+def _evaluate_csv_path(
+    *,
+    name: str,
+    description: str,
+    path: Path,
+    expected_full_coverage: bool,
+) -> dict[str, Any]:
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=0,
+    ).as_dict()
 
     admission = dict(payload.get("source_row_admission") or {})
     decision = dict(admission.get("admission_decision") or {})
     warnings = list(admission.get("coverage_warnings") or [])
     usable_ratio = admission.get("usable_source_ratio")
     result = {
-        "name": case.name,
-        "description": case.description,
-        "expected_full_coverage": case.expected_full_coverage,
+        "name": name,
+        "description": description,
+        "expected_full_coverage": expected_full_coverage,
         "ok": payload.get("ok") is True,
         "warning_counts": dict(payload.get("warning_counts") or {}),
         "admission_status": decision.get("status"),
@@ -155,7 +201,7 @@ def _case_status(result: Mapping[str, Any]) -> str:
 def _blocking_codes(case_results: Sequence[Mapping[str, Any]]) -> list[str]:
     codes: list[str] = []
     for result in case_results:
-        if result.get("case_status") != "ok":
+        if result.get("case_status") == "failed":
             codes.append(f"{result.get('name')}:unexpected_admission_result")
     return codes
 
@@ -270,8 +316,9 @@ def _write_csv(
 
 def _proof_doc(summary: Mapping[str, Any]) -> str:
     rows = "\n".join(
-        "| {name} | {raw} | {usable} | {ratio} | {status} | {warnings} |".format(
+        "| {name} | {case_status} | {raw} | {usable} | {ratio} | {status} | {warnings} |".format(
             name=case["name"],
+            case_status=case["case_status"],
             raw=case["raw_source_row_count"],
             usable=case["usable_source_row_count"],
             ratio=case["usable_source_ratio"],
@@ -294,13 +341,15 @@ diagnostics path with source-row mode enabled.
 
 ## Result
 
-| Case | Raw rows | Usable rows | Usable ratio | Admission | Coverage warnings |
-|---|---:|---:|---:|---|---:|
+| Case | Case status | Raw rows | Usable rows | Usable ratio | Admission | Coverage warnings |
+|---|---|---:|---:|---:|---|---:|
 {rows}
 
 Status: `{summary["status"]}`
 
 Observed minimum usable source ratio: `{summary["observed_min_usable_source_ratio"]}`
+
+Observed evidence cases: `{summary["observed_case_count"]}`
 
 ## Interpretation
 
@@ -309,7 +358,9 @@ Observed minimum usable source ratio: `{summary["observed_min_usable_source_rati
 This artifact therefore supports keeping clean Zendesk-shaped CSV uploads on
 the ACCEPT path. It does not choose a low non-zero reject threshold. That
 threshold still needs observed partial-coverage exports, not a synthetic ratio
-derived from a clean corpus.
+derived from a clean corpus. Operator-supplied observed CSVs are recorded as
+evidence and do not block this runner until a later policy slice promotes a
+threshold.
 
 ## Artifact Links
 
@@ -328,8 +379,34 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--doc", type=Path, default=DEFAULT_DOC)
+    parser.add_argument(
+        "--observed-csv",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help=(
+            "Optional observed source-row CSV evidence to summarize without "
+            "failing the run. May be supplied more than once."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
+
+
+def _parse_observed_csvs(values: Sequence[str]) -> tuple[tuple[str, Path], ...]:
+    observed: list[tuple[str, Path]] = []
+    for raw in values:
+        if "=" not in raw:
+            raise SystemExit("--observed-csv values must use NAME=PATH")
+        name, path_text = raw.split("=", 1)
+        name = name.strip()
+        path = Path(path_text.strip())
+        if not name:
+            raise SystemExit("--observed-csv name must be non-empty")
+        if not path.exists():
+            raise SystemExit(f"--observed-csv path does not exist: {path}")
+        observed.append((name, path))
+    return tuple(observed)
 
 
 def _text(value: Any) -> str:

--- a/tests/test_evaluate_csv_admission_threshold_evidence.py
+++ b/tests/test_evaluate_csv_admission_threshold_evidence.py
@@ -119,6 +119,67 @@ def test_partial_coverage_case_records_warning_without_rejecting() -> None:
     }]
 
 
+def test_observed_partial_csv_is_recorded_without_blocking(tmp_path: Path) -> None:
+    corpus = {
+        "source": "unit",
+        "run_tag": "unit",
+        "tickets": [{
+            "id": "zd-proof-001",
+            "subject": "Export failed",
+            "description": "Customer cannot export reports.",
+            "comments": [{
+                "public": True,
+                "body": "Customer cannot export reports.",
+            }],
+        }],
+    }
+    corpus_path = tmp_path / "corpus.json"
+    observed_path = tmp_path / "partial.csv"
+    out_dir = tmp_path / "artifact"
+    doc = tmp_path / "proof.md"
+    corpus_path.write_text(json.dumps(corpus), encoding="utf-8")
+    observed_path.write_text(
+        "Ticket ID,Subject,Public Comments\n"
+        "T-1,Export failed,Customer cannot export reports.\n"
+        "T-2,Invite failed,\n",
+        encoding="utf-8",
+    )
+
+    code = MOD.main([
+        "--corpus",
+        str(corpus_path),
+        "--observed-csv",
+        f"observed_partial={observed_path}",
+        "--out-dir",
+        str(out_dir),
+        "--doc",
+        str(doc),
+    ])
+
+    summary = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
+    observed = {
+        case["name"]: case for case in summary["cases"]
+    }["observed_partial"]
+    assert code == 0
+    assert summary["status"] == "ok"
+    assert summary["blocking_violation_codes"] == []
+    assert summary["observed_case_count"] == 1
+    assert summary["blocking_case_count"] == 0
+    assert observed["case_status"] == "observed"
+    assert observed["admission_status"] == "ACCEPT"
+    assert observed["raw_source_row_count"] == 2
+    assert observed["usable_source_row_count"] == 1
+    assert observed["coverage_warnings"] == [{
+        "code": "partial_source_row_coverage",
+        "location": "source_row_csv",
+        "raw_source_row_count": 2,
+        "usable_source_row_count": 1,
+        "skipped_source_row_count": 1,
+        "usable_source_ratio": 0.5,
+    }]
+    assert "Observed evidence cases: `1`" in doc.read_text(encoding="utf-8")
+
+
 def test_expected_full_coverage_partial_csv_fails_closed(tmp_path: Path) -> None:
     corpus = {
         "source": "unit",
@@ -167,6 +228,24 @@ def test_expected_full_coverage_partial_csv_fails_closed(tmp_path: Path) -> None
     assert written["status"] == "failed"
 
 
+def test_observed_csv_argument_requires_name_and_existing_path(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.csv"
+
+    try:
+        MOD.main(["--observed-csv", str(missing)])
+    except SystemExit as exc:
+        assert str(exc) == "--observed-csv values must use NAME=PATH"
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("missing NAME=PATH did not fail")
+
+    try:
+        MOD.main(["--observed-csv", f"observed={missing}"])
+    except SystemExit as exc:
+        assert str(exc) == f"--observed-csv path does not exist: {missing}"
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("missing observed path did not fail")
+
+
 def test_main_writes_summary_and_doc(tmp_path: Path) -> None:
     out_dir = tmp_path / "artifact"
     doc = tmp_path / "proof.md"
@@ -176,6 +255,7 @@ def test_main_writes_summary_and_doc(tmp_path: Path) -> None:
     assert code == 0
     summary = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
     assert summary["status"] == "ok"
+    assert summary["observed_case_count"] == 0
     assert summary["observed_min_usable_source_ratio"] == 1.0
     proof = doc.read_text(encoding="utf-8")
     assert "does not choose a low non-zero reject threshold" in proof


### PR DESCRIPTION
Plan: plans/PR-Deflection-CSV-Admission-Observed-Evidence.md
Slice phase: Vertical slice

#1577 proved the clean Zendesk CSV ACCEPT path, but its reviewer note caught that the evidence runner could not yet record partial-coverage observations without failing the proof. This slice adds operator-supplied observed CSV inputs that are summarized through the same admission diagnostics path while strict built-in cases remain fail-closed. No low-coverage reject threshold is added.

## Intentional
- Observed cases are non-gating evidence, not policy.
- The committed default artifact still reflects only the clean Zendesk product-proof corpus; synthetic partial CSVs live in tests, not as product evidence.
- No observed source CSV content is committed.

## Deferred
- Product-backed low-coverage policy after observed partial provider exports.
- #1458 streaming upload memory remains separate.

## Parked hardening
- None.

## Verification
- /home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/evaluate_csv_admission_threshold_evidence.py --json
  - Passed; regenerated the committed summary/doc artifact with observed case count zero.
- /home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_evaluate_csv_admission_threshold_evidence.py tests/test_extracted_content_ingestion_diagnostics.py
  - Passed: 21 passed.
- bash scripts/run_extracted_pipeline_checks.sh
  - Passed: 4287 passed, 10 skipped.
- bash scripts/local_pr_review.sh
  - Passed with the planned PR body file.

## Diff size
5 files, +305 / -24
