### PR TITLE
Deflection public endpoint rate limiting

### DIFF
--- a/.github/workflows/atlas_content_ops_auth_checks.yml
+++ b/.github/workflows/atlas_content_ops_auth_checks.yml
@@ -7,7 +7,9 @@ on:
       - "requirements.txt"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/auth/dependencies.py"
+      - "atlas_brain/auth/rate_limit.py"
       - "tests/test_auth_dependencies.py"
+      - "tests/test_llm_gateway_plan_tier.py"
   push:
     branches:
       - main
@@ -16,7 +18,9 @@ on:
       - "requirements.txt"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/auth/dependencies.py"
+      - "atlas_brain/auth/rate_limit.py"
       - "tests/test_auth_dependencies.py"
+      - "tests/test_llm_gateway_plan_tier.py"
 
 jobs:
   atlas-content-ops-auth-checks:
@@ -41,4 +45,5 @@ jobs:
         run: |
           python -m pytest \
             tests/test_auth_dependencies.py \
+            tests/test_llm_gateway_plan_tier.py \
             -q

--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -286,7 +286,7 @@ jobs:
         # pydantic-settings; this is purely the cross-boundary seam test.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings markdown 'fastapi<0.137' python-multipart
+          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings markdown 'fastapi<0.137' python-multipart slowapi
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -59,7 +59,7 @@ from .b2b_win_loss import router as b2b_win_loss_router
 from .b2b_evidence import router as b2b_evidence_router
 from .b2b_vendor_claims import router as b2b_vendor_claims_router
 from .b2b_challenger_claims import router as b2b_challenger_claims_router
-from fastapi import Depends
+from fastapi import Depends, Request
 from ..auth.dependencies import require_b2b_plan_or_api_key
 
 logger = logging.getLogger("atlas.api")
@@ -204,10 +204,12 @@ try:
         create_content_ops_claim_registry_router,
     )
     from ..auth.dependencies import AuthUser
+    from ..auth.rate_limit import _dynamic_limit, limiter
     from ..config import settings
     from ..storage.database import get_db_pool
 
     async def _capture_content_ops_auth_user(
+        request: Request,
         user: AuthUser = Depends(require_b2b_plan_or_api_key("b2b_growth")),
     ) -> AuthUser:
         """Bridge the per-request AuthUser to the
@@ -223,6 +225,8 @@ try:
         """
 
         set_current_auth_user(user)
+        request.state.rate_limit_key = str(getattr(user, "account_id", "") or "")
+        request.state.rate_limit_plan = str(getattr(user, "plan", "") or "trial")
         return user
 
     async def _require_content_ops_usage_operator(
@@ -231,6 +235,16 @@ try:
         if bool(getattr(user, "is_platform_admin", False)):
             return user
         raise HTTPException(status_code=403, detail="Platform admin access required")
+
+    @limiter.shared_limit(
+        _dynamic_limit,
+        scope="content_ops_deflection_public",
+    )
+    async def _rate_limit_public_deflection_report(
+        request: Request,
+        _user: AuthUser = Depends(_capture_content_ops_auth_user),
+    ) -> None:
+        return None
 
     def _content_ops_cache_policy_default(_scope: object) -> str | None:
         policy = str(
@@ -291,6 +305,9 @@ try:
                 profile_id=profile_id,
             )
         ),
+        deflection_report_public_dependencies=[
+            Depends(_rate_limit_public_deflection_report)
+        ],
         usage_dependencies=[Depends(_require_content_ops_usage_operator)],
         deflection_report_paid_dependencies=[
             Depends(_require_content_ops_usage_operator)

--- a/atlas_brain/auth/rate_limit.py
+++ b/atlas_brain/auth/rate_limit.py
@@ -18,6 +18,10 @@ PLAN_RATE_LIMITS: dict[str, str] = {
     "starter": "100/hour",
     "growth": "1000/hour",
     "pro": "10000/hour",
+    "b2b_trial": "100/hour",
+    "b2b_starter": "100/hour",
+    "b2b_growth": "1000/hour",
+    "b2b_pro": "10000/hour",
     # LLM Gateway plan tiers (PR-D2). The gateway endpoints
     # (PR-D4) are higher-throughput than dashboard reads -- bumped
     # an order of magnitude over consumer/B2B equivalents.

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -709,6 +709,7 @@ def create_content_ops_control_surface_router(
     opportunity_import_pool_provider: PoolProvider | None = None,
     usage_pool_provider: PoolProvider | None = None,
     usage_dependencies: Sequence[Any] | None = None,
+    deflection_report_public_dependencies: Sequence[Any] | None = None,
     deflection_report_paid_dependencies: Sequence[Any] | None = None,
     ingestion_import_admission_provider: ImportAdmissionProvider | None = None,
     cache_policy_default_provider: CachePolicyDefaultProvider | None = None,
@@ -798,7 +799,12 @@ def create_content_ops_control_surface_router(
             request_id=request_id,
         )
 
-    @router.get("/deflection-reports/{request_id}/snapshot")
+    public_deflection_dependencies = list(deflection_report_public_dependencies or ())
+
+    @router.get(
+        "/deflection-reports/{request_id}/snapshot",
+        dependencies=public_deflection_dependencies,
+    )
     async def deflection_report_snapshot(
         request_id: str = PathParam(..., min_length=1, max_length=200),
     ) -> dict[str, Any]:
@@ -812,7 +818,10 @@ def create_content_ops_control_surface_router(
             raise HTTPException(status_code=404, detail="Deflection report not found.")
         return snapshot
 
-    @router.get("/deflection-reports/{request_id}/artifact")
+    @router.get(
+        "/deflection-reports/{request_id}/artifact",
+        dependencies=public_deflection_dependencies,
+    )
     async def deflection_report_artifact(
         request_id: str = PathParam(..., min_length=1, max_length=200),
     ) -> dict[str, Any]:
@@ -828,7 +837,10 @@ def create_content_ops_control_surface_router(
             raise HTTPException(status_code=403, detail="Deflection report is locked.")
         return dict(record.artifact or {})
 
-    @router.post("/deflection-reports/{request_id}/checkout-authorization")
+    @router.post(
+        "/deflection-reports/{request_id}/checkout-authorization",
+        dependencies=public_deflection_dependencies,
+    )
     async def deflection_report_checkout_authorization(
         request_id: str = PathParam(..., min_length=1, max_length=200),
     ) -> dict[str, Any]:
@@ -1234,7 +1246,10 @@ def create_content_ops_control_surface_router(
         finally:
             await execute_gate.release()
 
-    @router.post("/deflection-reports/submit")
+    @router.post(
+        "/deflection-reports/submit",
+        dependencies=public_deflection_dependencies,
+    )
     async def submit_deflection_report(
         request: Request,
     ) -> dict[str, Any]:

--- a/plans/PR-Deflection-Public-Endpoint-Rate-Limit.md
+++ b/plans/PR-Deflection-Public-Endpoint-Rate-Limit.md
@@ -1,0 +1,132 @@
+# PR-Deflection-Public-Endpoint-Rate-Limit
+
+## Why this slice exists
+
+#1386's current-state verification marks paid-report access control as
+half-done: request ID entropy is now closed, but the public deflection submit,
+snapshot, artifact, and checkout-authorization endpoints are still reachable
+without route-level throttling. That leaves the paid funnel exposed to brute
+force attempts against request IDs and public submit abuse even though the
+shared Atlas slowapi limiter already exists for other API surfaces.
+
+Root cause: the deflection routes live in the standalone extracted router while
+the concrete limiter lives in the Atlas host. Fixing one route body would be a
+symptom patch; the upstream boundary is the router dependency seam that lets
+the host attach abuse controls without making the extracted package import
+Atlas auth code.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Add an extracted-router dependency seam for the public paid-deflection
+   endpoints: submit, snapshot, artifact, and checkout authorization.
+2. Wire Atlas to pass the existing slowapi limiter through that seam using a
+   shared paid-funnel scope, so rotating request IDs does not reset the bucket.
+3. Set the rate-limit identity from the authenticated content-ops user or
+   scoped API key before the limiter runs, and add B2B plan entries to the
+   shared rate table so `b2b_growth` does not silently fall back to `trial`.
+4. Preserve the trusted paid-release endpoint's separate operator dependency
+   path; Stripe/webhook unlocks must not inherit the public limiter.
+5. Add focused tests that prove the public deflection routes receive the seam
+   dependency, the paid route does not, Atlas mounts the seam, request-id route
+   rotation shares a bucket, and separate accounts get separate budgets.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Public paid-deflection submit, snapshot, artifact, and checkout
+        authorization routes have the injected public dependency when a host
+        supplies it.
+  - [ ] The paid-release route remains protected only by its existing trusted
+        dependency path and does not inherit public throttling.
+  - [ ] Atlas host wiring supplies a slowapi-backed limiter dependency for the
+        public deflection routes without importing Atlas auth code into the
+        extracted package.
+  - [ ] Rotating request IDs across snapshot/artifact/checkout paths does not
+        bypass the public paid-funnel throttle.
+  - [ ] Content-ops authenticated accounts/API keys receive account-scoped
+        rate-limit buckets instead of collapsing all traffic to proxy IP.
+  - [ ] Existing route behavior and response contracts are unchanged aside from
+        FastAPI dependency execution.
+- Affected surfaces: API, auth, CI, extracted package boundary.
+- Risk areas: security, backcompat, standalone package imports.
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R12, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_auth_checks.yml`
+- `.github/workflows/extracted_pipeline_checks.yml`
+- `atlas_brain/api/__init__.py`
+- `atlas_brain/auth/rate_limit.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Public-Endpoint-Rate-Limit.md`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_llm_gateway_plan_tier.py`
+
+## Mechanism
+
+The extracted router factory gains an optional
+`deflection_report_public_dependencies` sequence. The four public paid-funnel
+routes use that sequence in their route decorators. The existing
+`deflection_report_paid_dependencies` sequence stays attached only to the
+paid-release route.
+
+Atlas defines a small host-local dependency by applying the existing slowapi
+shared limiter with the existing dynamic rate selection and a stable
+`content_ops_deflection_public` scope, then passes that dependency to the
+extracted router. The content-ops auth bridge writes `rate_limit_key` and
+`rate_limit_plan` onto `request.state` from the authenticated user/API key
+before the route-level limiter runs. The shared rate table now includes B2B
+plans, so `b2b_growth|account_id` selects the intended B2B bucket instead of
+falling back to the default.
+
+## Intentional
+
+- No Atlas auth import inside `extracted_content_pipeline`: the extracted
+  package remains standalone and host-neutral.
+- No new env vars in this slice: the shared Atlas rate table remains the
+  policy source, with B2B tier entries added because content-ops uses B2B plans.
+- No rate limit on the trusted paid-release path: Stripe/webhook unlocks are
+  already behind the trusted operator dependency and should not be throttled by
+  buyer/browser traffic.
+
+## Deferred
+
+- Stronger paid-funnel-specific limits or captcha can be added later if public
+  traffic needs a stricter policy than the shared trial fallback.
+- #1419 remains the report-quality proof gate on a real resolution-bearing
+  export; this slice only closes the access-control abuse-control gap.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_generated_assets_api.py tests/test_llm_gateway_plan_tier.py -q`
+  - 185 passed, 1 skipped, 1 warning.
+- `scripts/run_extracted_pipeline_checks.sh`
+  - 4300 passed, 10 skipped, 1 warning.
+- `python -m pytest tests/test_auth_dependencies.py tests/test_llm_gateway_plan_tier.py -q`
+  - 43 passed, 1 warning.
+- `scripts/audit_extracted_pipeline_ci_enrollment.py`
+  - Passed; 182 matching tests enrolled.
+- Pending before push:
+  - `python scripts/sync_pr_plan.py plans/PR-Deflection-Public-Endpoint-Rate-Limit.md --check`
+  - local review via `scripts/local_pr_review.sh`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_auth_checks.yml` | 5 |
+| `.github/workflows/extracted_pipeline_checks.yml` | 2 |
+| `atlas_brain/api/__init__.py` | 19 |
+| `atlas_brain/auth/rate_limit.py` | 4 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 23 |
+| `plans/PR-Deflection-Public-Endpoint-Rate-Limit.md` | 132 |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | 133 |
+| `tests/test_extracted_content_control_surface_api.py` | 14 |
+| `tests/test_llm_gateway_plan_tier.py` | 10 |
+| **Total** | **342** |

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 from dataclasses import replace
 import importlib
 import inspect
+from types import SimpleNamespace
 import sys
 from typing import Any
 
 import pytest
 
 from atlas_brain.auth.dependencies import AuthUser
+from atlas_brain.auth.rate_limit import PLAN_RATE_LIMITS
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.landing_page_ports import (
     LandingPageDraft,
@@ -23,6 +25,12 @@ from extracted_content_pipeline.landing_page_ports import (
 )
 
 pytest.importorskip("asyncpg")
+fastapi = pytest.importorskip("fastapi")
+testclient_mod = pytest.importorskip("fastapi.testclient")
+Depends = fastapi.Depends
+FastAPI = fastapi.FastAPI
+Request = fastapi.Request
+TestClient = testclient_mod.TestClient
 
 
 def _fresh_api_package():
@@ -51,6 +59,23 @@ def _router_route(router, path: str, method: str):
     )
     assert route is not None, f"Route {method.upper()} {path!r} not mounted"
     return route
+
+
+def _content_ops_user(
+    account_id: str = "account-1",
+    *,
+    plan: str = "b2b_growth",
+) -> AuthUser:
+    return AuthUser(
+        user_id=f"user-{account_id}",
+        account_id=account_id,
+        plan=plan,
+        plan_status="active",
+        role="owner",
+        product="b2b_retention",
+        auth_method="api_key",
+        api_key_scopes=("content_ops:deflection:*",),
+    )
 
 
 def _public_ready_landing_page(landing_page_id: str) -> LandingPageDraft:
@@ -457,6 +482,114 @@ def test_content_ops_deflection_paid_route_uses_operator_gate() -> None:
 
     assert "_capture_content_ops_auth_user" in dependency_names
     assert "_require_content_ops_usage_operator" in dependency_names
+
+
+def test_content_ops_public_deflection_routes_use_rate_limit_gate() -> None:
+    api_pkg = _fresh_api_package()
+    public_routes = [
+        ("/content-ops/deflection-reports/submit", "POST"),
+        ("/content-ops/deflection-reports/{request_id}/snapshot", "GET"),
+        ("/content-ops/deflection-reports/{request_id}/artifact", "GET"),
+        (
+            "/content-ops/deflection-reports/{request_id}/checkout-authorization",
+            "POST",
+        ),
+    ]
+
+    for path, method in public_routes:
+        route = _router_route(api_pkg.router, path, method)
+        dependency_names = [
+            getattr(dependency.call, "__name__", "")
+            for dependency in route.dependant.dependencies
+        ]
+        assert "_capture_content_ops_auth_user" in dependency_names
+        assert "_rate_limit_public_deflection_report" in dependency_names
+        assert "_require_content_ops_usage_operator" not in dependency_names
+
+    paid_route = _router_route(
+        api_pkg.router,
+        "/content-ops/deflection-reports/{request_id}/paid",
+        "POST",
+    )
+    paid_dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in paid_route.dependant.dependencies
+    ]
+    assert "_rate_limit_public_deflection_report" not in paid_dependency_names
+    assert "_require_content_ops_usage_operator" in paid_dependency_names
+
+
+@pytest.mark.asyncio
+async def test_content_ops_auth_bridge_sets_rate_limit_identity() -> None:
+    api_pkg = _fresh_api_package()
+    request = SimpleNamespace(state=SimpleNamespace())
+    user = _content_ops_user("account-rl", plan="b2b_growth")
+
+    assert (
+        await api_pkg._capture_content_ops_auth_user(request=request, user=user)
+    ) is user
+
+    assert request.state.rate_limit_key == "account-rl"
+    assert request.state.rate_limit_plan == "b2b_growth"
+
+
+def test_public_deflection_rate_limit_shares_scope_and_keys_by_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    api_pkg = _fresh_api_package()
+    app = FastAPI()
+    app.state.limiter = api_pkg.limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def _fake_content_ops_auth_user(request: Request) -> AuthUser:
+        account_id = request.headers.get("x-test-account", "account-a")
+        plan = request.headers.get("x-test-plan", "b2b_growth")
+        user = _content_ops_user(account_id, plan=plan)
+        request.state.rate_limit_key = user.account_id
+        request.state.rate_limit_plan = user.plan
+        return user
+
+    app.dependency_overrides[api_pkg._capture_content_ops_auth_user] = (
+        _fake_content_ops_auth_user
+    )
+
+    @app.get(
+        "/snapshot/{request_id}",
+        dependencies=[Depends(api_pkg._rate_limit_public_deflection_report)],
+    )
+    async def _snapshot(request_id: str) -> dict[str, str]:
+        return {"request_id": request_id}
+
+    @app.get(
+        "/artifact/{request_id}",
+        dependencies=[Depends(api_pkg._rate_limit_public_deflection_report)],
+    )
+    async def _artifact(request_id: str) -> dict[str, str]:
+        return {"request_id": request_id}
+
+    limit_name = (
+        f"{api_pkg._rate_limit_public_deflection_report.__module__}."
+        f"{api_pkg._rate_limit_public_deflection_report.__name__}"
+    )
+    api_pkg.limiter._dynamic_route_limits[limit_name] = (
+        api_pkg.limiter._dynamic_route_limits[limit_name][-1:]
+    )
+    monkeypatch.setitem(PLAN_RATE_LIMITS, "b2b_growth", "2/hour")
+    api_pkg.limiter._limiter.storage.reset()
+    try:
+        client = TestClient(app)
+        headers_a = {"x-test-account": "account-a"}
+        headers_b = {"x-test-account": "account-b"}
+
+        assert client.get("/snapshot/aaa", headers=headers_a).status_code == 200
+        assert client.get("/artifact/bbb", headers=headers_a).status_code == 200
+        assert client.get("/snapshot/ccc", headers=headers_a).status_code == 429
+        assert client.get("/snapshot/ccc", headers=headers_b).status_code == 200
+    finally:
+        api_pkg.limiter._limiter.storage.reset()
 
 
 def test_content_ops_preview_route_uses_host_cache_policy_default(

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -3029,8 +3029,11 @@ async def test_deflection_checkout_authorization_fails_when_terms_misconfigured(
     assert exc.value.detail == detail
 
 
-def test_deflection_report_paid_route_uses_trusted_dependency() -> None:
+def test_deflection_report_routes_use_public_and_trusted_dependencies() -> None:
     async def _tenant_user() -> None:
+        return None
+
+    async def _public_deflection_gate() -> None:
         return None
 
     async def _trusted_paid_release() -> None:
@@ -3039,10 +3042,12 @@ def test_deflection_report_paid_route_uses_trusted_dependency() -> None:
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
         dependencies=[Depends(_tenant_user)],
+        deflection_report_public_dependencies=[Depends(_public_deflection_gate)],
         deflection_report_paid_dependencies=[Depends(_trusted_paid_release)],
     )
 
     paid_route = _route(router, "/ops/deflection-reports/{request_id}/paid", "POST")
+    submit_route = _route(router, "/ops/deflection-reports/submit", "POST")
     artifact_route = _route(
         router,
         "/ops/deflection-reports/{request_id}/artifact",
@@ -3061,6 +3066,13 @@ def test_deflection_report_paid_route_uses_trusted_dependency() -> None:
 
     assert "_tenant_user" in _dependency_names(paid_route)
     assert "_trusted_paid_release" in _dependency_names(paid_route)
+    assert "_public_deflection_gate" not in _dependency_names(paid_route)
+    assert "_public_deflection_gate" in _dependency_names(submit_route)
+    assert "_public_deflection_gate" in _dependency_names(artifact_route)
+    assert "_public_deflection_gate" in _dependency_names(
+        checkout_authorization_route
+    )
+    assert "_public_deflection_gate" in _dependency_names(snapshot_route)
     assert "_trusted_paid_release" not in _dependency_names(artifact_route)
     assert "_trusted_paid_release" not in _dependency_names(
         checkout_authorization_route

--- a/tests/test_llm_gateway_plan_tier.py
+++ b/tests/test_llm_gateway_plan_tier.py
@@ -94,6 +94,15 @@ def test_plan_rate_limits_covers_llm_tiers():
     assert PLAN_RATE_LIMITS["llm_pro"] == "100000/hour"
 
 
+def test_plan_rate_limits_covers_b2b_tiers():
+    from atlas_brain.auth.rate_limit import PLAN_RATE_LIMITS
+
+    assert PLAN_RATE_LIMITS["b2b_trial"] == "100/hour"
+    assert PLAN_RATE_LIMITS["b2b_starter"] == "100/hour"
+    assert PLAN_RATE_LIMITS["b2b_growth"] == "1000/hour"
+    assert PLAN_RATE_LIMITS["b2b_pro"] == "10000/hour"
+
+
 def test_plan_rate_limits_lookup_via_dynamic_limit():
     """``_dynamic_limit`` is the slowapi callable that maps the
     composite rate-limit key back to a rate string. It must resolve
@@ -102,6 +111,7 @@ def test_plan_rate_limits_lookup_via_dynamic_limit():
 
     assert _dynamic_limit("llm_starter|account-uuid") == "1000/hour"
     assert _dynamic_limit("llm_pro|account-uuid") == "100000/hour"
+    assert _dynamic_limit("b2b_growth|account-uuid") == "1000/hour"
 
 
 def test_plan_rate_limits_unknown_plan_falls_back():


### PR DESCRIPTION
Plan: plans/PR-Deflection-Public-Endpoint-Rate-Limit.md
Slice phase: Production hardening

#1386's current-state verification left one paid-report access-control gap open: the public paid-deflection submit, snapshot, artifact, and checkout-authorization routes had no route-level throttling. This PR fixes the upstream boundary by letting the extracted router accept host-injected public deflection dependencies, then wiring Atlas to attach the existing slowapi limiter there with a stable paid-funnel scope and authenticated account identity while keeping the trusted paid-release path separate.

## Intentional
- Keep Atlas auth imports out of `extracted_content_pipeline`; the host supplies dependencies through the router seam.
- Use the existing shared limiter policy table, with B2B plan entries added because content-ops authenticates through B2B plans.
- Do not rate-limit the trusted paid-release route through the public buyer/browser dependency.

## Deferred
- Stronger paid-funnel-specific limits or captcha can follow if public traffic needs stricter controls.
- #1419 remains the real resolution-bearing export quality proof gate.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: yes.

- Fixed Codex P1 / reviewer BLOCKER 1: public deflection routes now use `shared_limit` with stable scope `content_ops_deflection_public`, so rotating request IDs does not create fresh buckets.
- Fixed reviewer BLOCKER 2: the content-ops auth bridge now sets `request.state.rate_limit_key` and `request.state.rate_limit_plan` from the authenticated user/API key before the limiter runs, and the rate table now includes B2B plans.
- Fixed reviewer MAJOR: added `TestClient` enforcement coverage proving cross-route request-id rotation still hits one bucket and different accounts get independent budgets.
- Fixed CI red after review push: the extracted workflow now installs `slowapi`, matching the Atlas host route dependency exercised by `tests/test_atlas_content_ops_generated_assets_api.py`.

## Verification
- `python -m pytest tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_generated_assets_api.py tests/test_llm_gateway_plan_tier.py -q`
  - 185 passed, 1 skipped, 1 warning.
- `scripts/run_extracted_pipeline_checks.sh`
  - 4300 passed, 10 skipped, 1 warning.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Public-Endpoint-Rate-Limit.md --check`
  - Passed.

## Diff size
9 files, +335 / -7
