### PR TITLE
Deflection report SEO target cap

### DIFF
--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -76,6 +76,11 @@ The report Markdown always contains these customer-facing sections:
 - `Ranked Question Opportunities`
 - `Question Details and Evidence`
 
+`Your Help-Desk SEO Targeting List` is a readability index, not the complete
+evidence surface. Large reports render a deterministic top-N phrase list and an
+omitted-count note; every ranked question and complete source evidence remains
+in `Question Details and Evidence`.
+
 `Question Details and Evidence` is the canonical per-question detail pass. It
 contains the answer status, publishable copy or no-proven-answer guidance,
 vocabulary mappings, and complete source evidence for each ranked question.

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -16,6 +16,7 @@ _RESOLUTION_EVIDENCE_SCOPE_SCOPED = "scoped"
 _DRAFT_NEEDS_REVIEW_STATUS = "draft_needs_review"
 DEFAULT_DEFLECTION_SNAPSHOT_TOP_N = 5
 DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT = 3
+DEFAULT_DEFLECTION_SEO_TARGET_LIMIT = 50
 _UNCAPPED_REPORT_MAX_ITEMS = 0
 _ASSISTED_CONTACT_COST = 13.50
 _ASSISTED_CONTACT_COST_LABEL = "$13.50"
@@ -385,8 +386,12 @@ def _support_tax_section(
 
 def _help_desk_seo_targeting_section(
     items: Sequence[Mapping[str, Any]],
+    *,
+    limit: int = DEFAULT_DEFLECTION_SEO_TARGET_LIMIT,
 ) -> list[str]:
     phrases = _customer_phrase_list(items)
+    display_limit = max(1, int(limit))
+    displayed_phrases = phrases[:display_limit]
     lines = [
         "## Your Help-Desk SEO Targeting List",
         "",
@@ -402,8 +407,18 @@ def _help_desk_seo_targeting_section(
         return [*lines, "No customer phrase targets were generated for this run.", ""]
     lines.extend(
         f"{index}. {_md(phrase)}"
-        for index, phrase in enumerate(phrases, start=1)
+        for index, phrase in enumerate(displayed_phrases, start=1)
     )
+    omitted_count = len(phrases) - len(displayed_phrases)
+    if omitted_count > 0:
+        lines.extend([
+            "",
+            (
+                f"SEO phrase index capped at {_count(display_limit)} entries for "
+                f"readability; {_count(omitted_count)} additional source-backed "
+                "phrases remain represented in the question detail blocks below."
+            ),
+        ])
     lines.append("")
     return lines
 
@@ -1057,6 +1072,7 @@ def _md(value: Any) -> str:
 
 __all__ = [
     "DEFAULT_DEFLECTION_SNAPSHOT_TOP_N",
+    "DEFAULT_DEFLECTION_SEO_TARGET_LIMIT",
     "DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT",
     "DeflectionSnapshot",
     "DeflectionReportArtifact",

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -529,6 +529,7 @@ def _question_detail_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
         lines.extend([
             f"### {index}. {_md(item.get('question'))}",
             "",
+            *_customer_wording_detail(item),
             f"**Answer status:** {_md(_status_label(item))}",
             "",
             (
@@ -545,6 +546,17 @@ def _question_detail_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
         lines.extend(_vocabulary_gap_detail(item))
         lines.extend(_complete_evidence_detail(item))
     return lines
+
+
+def _customer_wording_detail(item: Mapping[str, Any]) -> list[str]:
+    question = _text(item.get("question"))
+    customer_wording = _text(item.get("customer_wording"))
+    if not customer_wording or customer_wording == question:
+        return []
+    return [
+        f"**Customer wording:** {_md(customer_wording)}",
+        "",
+    ]
 
 
 def _publishable_answer_detail(item: Mapping[str, Any]) -> list[str]:

--- a/plans/PR-Deflection-Report-SEO-Target-Cap.md
+++ b/plans/PR-Deflection-Report-SEO-Target-Cap.md
@@ -1,0 +1,130 @@
+# PR-Deflection-Report-SEO-Target-Cap
+
+## Why this slice exists
+
+Issue #1579 flags the paid deflection report as too dense, with two remaining
+high-volume drivers after #1584 collapsed the repeated per-question passes:
+the uncapped Help-Desk SEO Targeting List and the still-complete per-question
+evidence blocks.
+
+This slice takes the safe half first. The SEO list is an index, not the
+complete-evidence promise. Capping that index reduces browser/PDF bulk without
+dropping ranked questions, source IDs, or evidence quotes from the paid report.
+Evidence caps require a real complete-evidence export/download path before they
+are safe; this PR deliberately does not pretend the internal persisted
+`faq_result` is a buyer-facing export.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Product polish
+
+1. Cap `## Your Help-Desk SEO Targeting List` to a deterministic top-N list.
+2. Add buyer-facing copy that says how many additional source-backed phrases
+   were omitted from the index for readability.
+3. Preserve every ranked question, every per-question vocabulary mapping, and
+   every complete evidence/source-ID block in `## Question Details and
+   Evidence`.
+4. Add regression coverage for capped and uncapped SEO-list behavior, including
+   boundary cases where the list length equals the cap.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Report-SEO-Target-Cap.md`
+- `tests/test_content_ops_deflection_report.py`
+
+### Review Contract
+
+Acceptance criteria:
+
+- The SEO targeting section renders at most the configured cap of phrases.
+- When phrases are omitted, the report states the omitted count and makes clear
+  the cap is only for the SEO index.
+- When phrases are at or below the cap, the report does not show an omitted
+  count.
+- Ranked questions remain uncapped.
+- Complete source IDs and evidence quotes remain uncapped inside
+  `Question Details and Evidence`.
+- The cap is deterministic and based on the existing `_customer_phrase_list`
+  order, not random sampling or LLM ranking.
+
+Affected surfaces:
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `tests/test_content_ops_deflection_report.py`
+- committed report contract/proof fixtures that assert the SEO section text
+
+Risk areas:
+
+- Accidentally changing the paid-report completeness promise.
+- Hiding full question/evidence data instead of only shortening the SEO index.
+- Off-by-one cap behavior at exactly-N phrases.
+- Stale proof fixtures that still imply the SEO list is complete.
+
+Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+## Mechanism
+
+Add a small renderer constant for the SEO index cap and apply it only in
+`_help_desk_seo_targeting_section`. The section continues to source phrases
+from `_customer_phrase_list(items)`, preserving the existing deterministic
+question/term-mapping order, then renders only the first N phrases.
+
+If the full phrase list is longer than N, the section appends a short note:
+the list is capped for readability and the remaining count is still represented
+in the per-question detail blocks. This avoids claiming the SEO index is
+complete while keeping the full paid report data intact.
+
+No evidence rendering code is changed in this slice.
+
+## Intentional
+
+- This PR does not cap evidence quotes or source IDs. Evidence capping is only
+  safe once the complete evidence is exposed through a real buyer-facing export
+  or download path; the persisted artifact JSON alone is not a product surface.
+- This PR does not add browser/PDF anchor navigation. The hosted result page
+  still renders Markdown inside a `<pre>`, and PDF navigation is a separate
+  renderer/delivery concern.
+- The cap is fixed in code for now, not a config field. This is a deterministic
+  report-shape constant, not tenant-specific runtime behavior.
+
+## Deferred
+
+- #1579 follow-up: add a real complete-evidence export/download path, then cap
+  inline evidence quotes/source IDs without breaking the buyer-facing
+  completeness promise.
+- #1579 follow-up: add true hosted-report navigation once the portfolio result
+  page renders structured Markdown/HTML instead of escaped `<pre>` text.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_content_ops_deflection_report.py -q
+  -- 43 passed.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -q
+  -- 48 passed.
+- Command: python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_extracted_content_ops_execution.py tests/test_content_ops_deflection_resolution_live_proof.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_deflection_pdf_renderer.py -q
+  -- 98 passed, 1 warning.
+- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py
+  -- passed.
+- Command: git diff --check -- passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  -- passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
+- Command: bash scripts/check_ascii_python.sh -- passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- 4300 passed, 10 skipped,
+  1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_report_contract.md` | 5 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 18 |
+| `plans/PR-Deflection-Report-SEO-Target-Cap.md` | 130 |
+| `tests/test_content_ops_deflection_report.py` | 90 |
+| **Total** | **243** |

--- a/plans/PR-Deflection-Report-SEO-Target-Cap.md
+++ b/plans/PR-Deflection-Report-SEO-Target-Cap.md
@@ -25,8 +25,12 @@ Slice phase: Product polish
 3. Preserve every ranked question, every per-question vocabulary mapping, and
    every complete evidence/source-ID block in `## Question Details and
    Evidence`.
-4. Add regression coverage for capped and uncapped SEO-list behavior, including
-   boundary cases where the list length equals the cap.
+4. Preserve explicit `customer_wording` in the question detail block when it
+   differs from the canonical question, so capped SEO phrases remain visible
+   below the index.
+5. Add regression coverage for capped and uncapped SEO-list behavior, including
+   boundary cases where the list length equals the cap and a past-cap customer
+   phrase differs from the canonical question.
 
 ### Files touched
 
@@ -47,6 +51,9 @@ Acceptance criteria:
 - Ranked questions remain uncapped.
 - Complete source IDs and evidence quotes remain uncapped inside
   `Question Details and Evidence`.
+- Customer wording that differs from the canonical question remains visible in
+  `Question Details and Evidence`, including for phrases omitted from the SEO
+  index.
 - The cap is deterministic and based on the existing `_customer_phrase_list`
   order, not random sampling or LLM ranking.
 
@@ -74,8 +81,9 @@ question/term-mapping order, then renders only the first N phrases.
 
 If the full phrase list is longer than N, the section appends a short note:
 the list is capped for readability and the remaining count is still represented
-in the per-question detail blocks. This avoids claiming the SEO index is
-complete while keeping the full paid report data intact.
+in the per-question detail blocks. To make that guarantee true for every phrase
+source, the detail section now renders `customer_wording` when it differs from
+the canonical `question` heading.
 
 No evidence rendering code is changed in this slice.
 
@@ -103,7 +111,7 @@ Parked hardening: none.
 ## Verification
 
 - Command: python -m pytest tests/test_content_ops_deflection_report.py -q
-  -- 43 passed.
+  -- 43 passed before review fix; 43 passed after review fix.
 - Command: python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -q
   -- 48 passed.
 - Command: python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_extracted_content_ops_execution.py tests/test_content_ops_deflection_resolution_live_proof.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_deflection_pdf_renderer.py -q
@@ -116,7 +124,7 @@ Parked hardening: none.
   -- passed.
 - Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
 - Command: bash scripts/check_ascii_python.sh -- passed.
-- Command: bash scripts/run_extracted_pipeline_checks.sh -- 4300 passed, 10 skipped,
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- 4303 passed, 10 skipped,
   1 warning.
 
 ## Estimated diff size
@@ -124,7 +132,7 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `docs/frontend/content_ops_faq_report_contract.md` | 5 |
-| `extracted_content_pipeline/faq_deflection_report.py` | 18 |
-| `plans/PR-Deflection-Report-SEO-Target-Cap.md` | 130 |
-| `tests/test_content_ops_deflection_report.py` | 90 |
-| **Total** | **243** |
+| `extracted_content_pipeline/faq_deflection_report.py` | 30 |
+| `plans/PR-Deflection-Report-SEO-Target-Cap.md` | 138 |
+| `tests/test_content_ops_deflection_report.py` | 95 |
+| **Total** | **268** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -259,7 +259,7 @@ def test_deflection_report_caps_seo_index_without_capping_details_or_evidence() 
     )
     items = tuple(
         {
-            "question": f"Customer phrase {index}",
+            "question": f"Canonical question {index}",
             "customer_wording": f"Customer phrase {index}",
             "ticket_count": 1,
             "answer_evidence_status": "resolution_evidence",
@@ -300,6 +300,10 @@ def test_deflection_report_caps_seo_index_without_capping_details_or_evidence() 
     assert "2 additional source-backed phrases remain represented" in seo_section
     assert (
         f"### {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT + 1}. "
+        f"Canonical question {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT + 1}"
+    ) in detail_section
+    assert (
+        f"**Customer wording:** "
         f"Customer phrase {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT + 1}"
     ) in detail_section
     assert "ticket-overflow-60" in detail_section
@@ -338,6 +342,7 @@ def test_deflection_report_does_not_show_seo_cap_note_at_exact_limit() -> None:
         f"Exact phrase {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT}"
     ) in seo_section
     assert "SEO phrase index capped" not in seo_section
+    assert "**Customer wording:** Exact phrase 1" not in markdown
 
 
 def test_deflection_report_uses_unknown_window_cost_fallback_without_inference() -> None:

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from extracted_content_pipeline.faq_deflection_report import (
+    DEFAULT_DEFLECTION_SEO_TARGET_LIMIT,
     build_deflection_snapshot,
     build_deflection_report_artifact,
     deflection_snapshot_content_opportunities,
@@ -248,6 +249,95 @@ def test_deflection_report_reframes_paid_artifact_with_cost_and_seo_sections() -
     assert "will rank" not in markdown
     assert "search volume" not in markdown
     assert "guaranteed traffic" not in markdown
+
+
+def test_deflection_report_caps_seo_index_without_capping_details_or_evidence() -> None:
+    source_ids = tuple(f"ticket-overflow-{index}" for index in range(1, 61))
+    evidence_quotes = tuple(
+        f"`ticket-overflow-{index}` - Overflow evidence {index}"
+        for index in range(1, 8)
+    )
+    items = tuple(
+        {
+            "question": f"Customer phrase {index}",
+            "customer_wording": f"Customer phrase {index}",
+            "ticket_count": 1,
+            "answer_evidence_status": "resolution_evidence",
+            "answer": "Use the documented workflow.",
+            "source_ids": source_ids if index == 1 else (f"ticket-{index}",),
+            "evidence_quotes": (
+                evidence_quotes if index == 1 else (f"`ticket-{index}` - Evidence",)
+            ),
+        }
+        for index in range(1, DEFAULT_DEFLECTION_SEO_TARGET_LIMIT + 3)
+    )
+    markdown = build_deflection_report_artifact(
+        TicketFAQMarkdownResult(
+            markdown="# FAQ",
+            source_count=len(items),
+            ticket_source_count=len(items),
+            output_checks={"condensed": True},
+            items=items,
+        )
+    ).markdown
+
+    seo_section = markdown.split("## Your Help-Desk SEO Targeting List", 1)[1].split(
+        "## Ranked Question Opportunities",
+        1,
+    )[0]
+    detail_section = markdown.split("## Question Details and Evidence", 1)[1]
+    seo_lines = [
+        line for line in seo_section.splitlines()
+        if line.split(".", 1)[0].isdigit()
+    ]
+
+    assert len(seo_lines) == DEFAULT_DEFLECTION_SEO_TARGET_LIMIT
+    assert (
+        f"{DEFAULT_DEFLECTION_SEO_TARGET_LIMIT}. "
+        f"Customer phrase {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT}"
+    ) in seo_section
+    assert f"Customer phrase {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT + 1}" not in seo_section
+    assert "2 additional source-backed phrases remain represented" in seo_section
+    assert (
+        f"### {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT + 1}. "
+        f"Customer phrase {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT + 1}"
+    ) in detail_section
+    assert "ticket-overflow-60" in detail_section
+    assert "`ticket-overflow-7` - Overflow evidence 7" in detail_section
+
+
+def test_deflection_report_does_not_show_seo_cap_note_at_exact_limit() -> None:
+    items = tuple(
+        {
+            "question": f"Exact phrase {index}",
+            "customer_wording": f"Exact phrase {index}",
+            "ticket_count": 1,
+            "answer_evidence_status": "draft_needs_review",
+            "source_ids": (f"ticket-{index}",),
+            "evidence_quotes": (f"`ticket-{index}` - Evidence",),
+        }
+        for index in range(1, DEFAULT_DEFLECTION_SEO_TARGET_LIMIT + 1)
+    )
+    markdown = build_deflection_report_artifact(
+        TicketFAQMarkdownResult(
+            markdown="# FAQ",
+            source_count=len(items),
+            ticket_source_count=len(items),
+            output_checks={"condensed": True},
+            items=items,
+        )
+    ).markdown
+
+    seo_section = markdown.split("## Your Help-Desk SEO Targeting List", 1)[1].split(
+        "## Ranked Question Opportunities",
+        1,
+    )[0]
+
+    assert (
+        f"{DEFAULT_DEFLECTION_SEO_TARGET_LIMIT}. "
+        f"Exact phrase {DEFAULT_DEFLECTION_SEO_TARGET_LIMIT}"
+    ) in seo_section
+    assert "SEO phrase index capped" not in seo_section
 
 
 def test_deflection_report_uses_unknown_window_cost_fallback_without_inference() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-SEO-Target-Cap.md
Slice phase: Product polish

Issue #1579 still has one safe density lever after the per-question consolidation: the Help-Desk SEO Targeting List is an uncapped cross-question index. This caps that index deterministically while preserving every ranked question and complete source evidence in the question detail blocks. The review fix also renders distinct `customer_wording` inside each question detail block so SEO phrases omitted from the capped index are genuinely represented below.

## Intentional
- This PR does not cap evidence quotes or source IDs. Evidence capping needs a real buyer-facing complete-evidence export/download path first.
- This PR does not add browser/PDF anchor navigation; those are separate hosted-renderer and PDF concerns.
- The cap is fixed in code as a report-shape constant, not tenant runtime config.

## Deferred
- #1579 follow-up: add a real complete-evidence export/download path, then cap inline evidence quotes/source IDs without breaking the buyer-facing completeness promise.
- #1579 follow-up: add true hosted-report navigation once the portfolio result page renders structured Markdown/HTML instead of escaped `<pre>` text.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: Codex P2 / reviewer MAJOR on omitted SEO phrases sourced from `customer_wording`. The detail block now renders distinct `customer_wording`, and the cap regression test uses a past-cap item where `customer_wording != question`.
- Waived: None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 43 passed before review fix; 43 passed after review fix.
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -q` -- 48 passed.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py` -- passed.
- `git diff --check` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4303 passed, 10 skipped, 1 warning.

## Diff size
4 files, +268 / -1
