### PR TITLE
Deflection checkout concurrency guard

### DIFF
--- a/plans/PR-Deflection-Checkout-Concurrency-Guard.md
+++ b/plans/PR-Deflection-Checkout-Concurrency-Guard.md
@@ -1,0 +1,139 @@
+# PR-Deflection-Checkout-Concurrency-Guard
+
+## Why this slice exists
+
+The operator explicitly deferred true multi-tenant work until after customer
+traction and asked to harden the current paid funnel for multiple simultaneous
+users/actions instead. The concrete concurrent-use gap already tracked in
+#1386 is duplicate checkout creation: two clicks, two browser tabs, or a retry
+can create more than one Stripe Checkout Session for the same deflection
+report.
+
+This is narrower than multi-tenant. It keeps the current configured-account
+model, but makes the checkout boundary tolerate concurrent attempts against
+the same report.
+
+The estimated diff is over the 400 LOC soft cap because the slice needs both
+the endpoint implementation and behavior-level portfolio tests for authorized,
+duplicate, and unauthorized checkout paths. Splitting those would leave a
+payment/idempotency change without its regression proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Before creating a Stripe Checkout Session, the portfolio checkout endpoint
+   asks Atlas for deflection checkout authorization for the requested report.
+   The backend authorization route already fails closed when the report is
+   missing, already paid, lacks an artifact, or has payment terms that do not
+   match the backend gate.
+2. The Stripe Checkout create request carries a stable idempotency key derived
+   from the checkout source, configured account, and request id, so duplicate
+   concurrent checkout attempts converge at Stripe instead of creating
+   independent sessions.
+3. Fallback-key deployments validate the exact Stripe Price id chosen for the
+   session after Atlas authorization, so Atlas/portfolio price drift fails
+   before payment rather than after the webhook.
+4. Inline amount-mode checkout validates the selected amount and currency
+   before Stripe session creation, so Atlas-authorized inline terms cannot
+   charge below the backend webhook floor or outside USD.
+5. Portfolio tests cover authorized checkout, already-paid/missing-report
+   rejection, Atlas authorization failure, the Stripe idempotency header, and
+   the Atlas-authorized-price and inline-amount validation failures.
+6. Update #1386 after the PR opens/merges so the issue records that this is
+   concurrent-checkout hardening, not multi-tenant work.
+
+### Files touched
+
+- `plans/PR-Deflection-Checkout-Concurrency-Guard.md`
+- `portfolio-ui/api/content-ops/deflection/checkout.js`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Checkout creation calls Atlas checkout authorization before Stripe.
+  - [ ] Missing, already-paid, or otherwise unauthorized reports return a
+        non-2xx response and do not call Stripe.
+  - [ ] Stripe Checkout creation uses a stable idempotency key for the same
+        configured account and request id.
+  - [ ] The Stripe Price preflight validates the same price id that the handler
+        will send to Stripe.
+  - [ ] Inline Checkout amount-mode rejects non-USD terms and terms below
+        150000 cents before creating a Stripe session.
+  - [ ] Existing metadata, success/cancel URL, restricted-key, and no-privileged
+        paid-route behavior stay intact.
+- Affected surfaces: portfolio API, Atlas proxy boundary, Stripe Checkout,
+  tests, #1386 tracker.
+- Risk areas: payment correctness, concurrency/idempotency, authorization,
+  public API behavior, CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R5, R8, R9, R12, R13, R14.
+
+## Mechanism
+
+The portfolio checkout handler already validates the request id and configured
+account, builds return URLs, and creates a Stripe Checkout Session. This slice
+adds a pre-Stripe authorization call to the Atlas route
+`/api/v1/content-ops/deflection-reports/{request_id}/checkout-authorization`
+using the same service token and configured account used by the result-page
+proxy. The handler accepts only the backend's authorized response and fails
+closed for missing, already-paid, unavailable-artifact, or proxy/config errors.
+
+After authorization succeeds, the Stripe create request includes an
+`Idempotency-Key` header built from a fixed namespace plus the configured
+account and request id. That key is stable for duplicate attempts on the same
+report and different for different reports/accounts. Stripe then owns
+deduplicating concurrent create attempts at the payment boundary.
+
+For fallback-key deployments that can read Stripe Price metadata, the handler
+validates the same price id it will send to Stripe. Atlas-authorized price ids
+win over portfolio env fallback; if that selected Price is inactive, non-USD,
+or below the backend webhook floor, checkout fails before payment.
+
+When no Stripe Price id resolves and the handler would create inline
+`price_data`, it validates the selected inline terms first. Atlas inline terms
+win over env fallback, and the selected amount/currency must be USD and at
+least 150000 cents before any Stripe Checkout create call is attempted.
+
+## Intentional
+
+- Do not add multi-tenant account selection or per-company configuration in this
+  slice. The operator explicitly deferred that until after customer traction.
+- Do not call the privileged paid-release route from the portfolio checkout
+  endpoint. Checkout authorization is read-only/payability proof; Stripe
+  webhook fulfillment remains the only unlock path.
+- Do not add captcha or website-edge IP throttling here. #1583 already hardened
+  the Atlas backend route limiter; this slice targets duplicate paid-session
+  creation.
+- Keep restricted-key deployments on the existing no-Price-read path; restricted
+  keys may be scoped to Checkout creation only. Atlas authorization remains the
+  fail-closed terms source there, and inline amount-mode terms still pass the
+  local USD/floor guard before Checkout creation.
+
+## Deferred
+
+- Real resolution-bearing export report-quality proof remains the next
+  launch-gating product slice (#1419).
+- Broad public-traffic edge controls, such as captcha or per-IP website
+  throttles, remain operational hardening before a fully unattended launch.
+- True multi-tenant auth/config remains future work after customer traction.
+
+Parked hardening: none.
+
+## Verification
+
+- Local verification:
+  - `npm run test:deflection-result` from `portfolio-ui/`
+  - `npm run test:deflection-upload-shell` from `portfolio-ui/`
+  - `npm run test:deflection-atlas-proxy` from `portfolio-ui/`
+  - Local PR review bundle.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Checkout-Concurrency-Guard.md` | 139 |
+| `portfolio-ui/api/content-ops/deflection/checkout.js` | 187 |
+| `portfolio-ui/scripts/faq-deflection-result-page.test.mjs` | 466 |
+| **Total** | **792** |

--- a/portfolio-ui/api/content-ops/deflection/checkout.js
+++ b/portfolio-ui/api/content-ops/deflection/checkout.js
@@ -1,6 +1,7 @@
 const CHECKOUT_SOURCE = "content_ops_deflection_report";
 const DEFAULT_AMOUNT_CENTS = 150000;
 const DEFAULT_CURRENCY = "usd";
+const DEFAULT_ATLAS_TIMEOUT_MS = 5000;
 const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -24,6 +25,31 @@ function parseAmount(value) {
 function normalizeCurrency(value) {
   const normalized = clean(value).toLowerCase();
   return /^[a-z]{3}$/.test(normalized) ? normalized : DEFAULT_CURRENCY;
+}
+
+function atlasConfigFromEnv(env = process.env) {
+  const timeoutMs = Number.parseInt(clean(env.ATLAS_PROXY_TIMEOUT_MS), 10);
+  return {
+    baseUrl: clean(env.ATLAS_API_BASE_URL),
+    token: clean(env.ATLAS_B2B_JWT || env.ATLAS_TOKEN),
+    timeoutMs:
+      Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_ATLAS_TIMEOUT_MS,
+  };
+}
+
+function checkoutAuthorizationConfigErrors(config) {
+  const errors = [];
+  if (!config.baseUrl) errors.push("ATLAS_API_BASE_URL is not configured");
+  if (!config.token) errors.push("ATLAS_B2B_JWT is not configured");
+  return errors;
+}
+
+function atlasUrl(baseUrl, path) {
+  return `${baseUrl.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function checkoutAuthorizationPath(requestId) {
+  return `/api/v1/content-ops/deflection-reports/${encodeURIComponent(requestId)}/checkout-authorization`;
 }
 
 function stripeAuthHeaders(stripeSecretKey) {
@@ -112,7 +138,52 @@ function checkoutUrls(req, requestId, accountId) {
   return { successUrl, cancelUrl, errors: [] };
 }
 
-function buildStripeCheckoutBody({ requestId, accountId, successUrl, cancelUrl }) {
+function normalizeCheckoutTerms(terms = {}) {
+  const source = terms && typeof terms === "object" ? terms : {};
+  const priceId = clean(source.price_id);
+  const amount = Number.parseInt(String(source.amount_cents ?? ""), 10);
+  const currency = clean(source.currency).toLowerCase();
+  return {
+    priceId,
+    amount: Number.isFinite(amount) && amount > 0 ? amount : null,
+    currency: /^[a-z]{3}$/.test(currency) ? currency : "",
+  };
+}
+
+function stripeCheckoutIdempotencyKey({ requestId, accountId }) {
+  return `deflection-checkout:${accountId}:${requestId}`;
+}
+
+function stripeCheckoutPriceId(checkout = null, env = process.env) {
+  const terms = normalizeCheckoutTerms(checkout);
+  return terms.priceId || clean(env.STRIPE_DEFLECTION_REPORT_PRICE_ID);
+}
+
+function stripeCheckoutInlineTerms(checkout = null, env = process.env) {
+  const terms = normalizeCheckoutTerms(checkout);
+  return {
+    amount: terms.amount || parseAmount(env.DEFLECTION_REPORT_AMOUNT_CENTS),
+    currency: terms.currency || normalizeCurrency(env.DEFLECTION_REPORT_CURRENCY),
+  };
+}
+
+function validateInlineCheckoutTerms({ amount, currency }) {
+  if (currency !== DEFAULT_CURRENCY || amount < DEFAULT_AMOUNT_CENTS) {
+    return {
+      ok: false,
+      message: "configured inline Checkout amount must be usd and at least 150000 cents",
+    };
+  }
+  return { ok: true };
+}
+
+function buildStripeCheckoutBody({
+  requestId,
+  accountId,
+  successUrl,
+  cancelUrl,
+  checkout = null,
+}) {
   const params = new URLSearchParams();
   params.set("mode", "payment");
   params.set("success_url", successUrl);
@@ -126,14 +197,13 @@ function buildStripeCheckoutBody({ requestId, accountId, successUrl, cancelUrl }
   params.set("client_reference_id", requestId);
   params.set("line_items[0][quantity]", "1");
 
-  const priceId = clean(process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID);
+  const priceId = stripeCheckoutPriceId(checkout);
   if (priceId) {
     params.set("line_items[0][price]", priceId);
     return params;
   }
 
-  const amount = parseAmount(process.env.DEFLECTION_REPORT_AMOUNT_CENTS);
-  const currency = normalizeCurrency(process.env.DEFLECTION_REPORT_CURRENCY);
+  const { amount, currency } = stripeCheckoutInlineTerms(checkout);
   params.set("line_items[0][price_data][currency]", currency);
   params.set("line_items[0][price_data][unit_amount]", String(amount));
   params.set("line_items[0][price_data][product_data][name]", "FAQ Deflection Report");
@@ -144,8 +214,11 @@ function buildStripeCheckoutBody({ requestId, accountId, successUrl, cancelUrl }
   return params;
 }
 
-async function validateConfiguredPrice(stripeSecretKey) {
-  const priceId = clean(process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID);
+async function validateConfiguredPrice(
+  stripeSecretKey,
+  priceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID,
+) {
+  priceId = clean(priceId);
   if (!priceId) return { ok: true };
 
   const response = await fetch(
@@ -174,12 +247,76 @@ async function validateConfiguredPrice(stripeSecretKey) {
   return { ok: true };
 }
 
-async function createCheckoutSession(params, stripeSecretKey) {
+async function authorizeCheckout({ requestId, env = process.env, fetchImpl = fetch }) {
+  const config = atlasConfigFromEnv(env);
+  const configErrors = checkoutAuthorizationConfigErrors(config);
+  if (configErrors.length > 0) {
+    return {
+      ok: false,
+      status: 503,
+      error: "checkout_authorization_not_configured",
+      details: configErrors,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+  try {
+    const response = await fetchImpl(
+      atlasUrl(config.baseUrl, checkoutAuthorizationPath(requestId)),
+      {
+        method: "POST",
+        headers: {
+          "Accept": "application/json",
+          "Authorization": `Bearer ${config.token}`,
+        },
+        signal: controller.signal,
+      },
+    );
+    const payload = await response.json().catch(() => null);
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        error: "checkout_not_authorized",
+        details:
+          payload && typeof payload.detail === "string"
+            ? payload.detail
+            : "Deflection report is not ready for checkout.",
+      };
+    }
+    if (
+      !payload ||
+      payload.status !== "authorized" ||
+      !payload.checkout ||
+      typeof payload.checkout !== "object"
+    ) {
+      return {
+        ok: false,
+        status: 502,
+        error: "checkout_authorization_contract_violation",
+      };
+    }
+    return { ok: true, checkout: payload.checkout };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 502,
+      error: "checkout_authorization_failed",
+      details: error && typeof error === "object" ? error.name || "fetch_error" : "fetch_error",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function createCheckoutSession(params, stripeSecretKey, idempotencyKey) {
   const response = await fetch("https://api.stripe.com/v1/checkout/sessions", {
     method: "POST",
     headers: {
       ...stripeAuthHeaders(stripeSecretKey),
       "Content-Type": "application/x-www-form-urlencoded",
+      "Idempotency-Key": idempotencyKey,
     },
     body: params,
   });
@@ -196,10 +333,15 @@ async function createCheckoutSession(params, stripeSecretKey) {
 
 export {
   CHECKOUT_SOURCE,
+  authorizeCheckout,
   buildStripeCheckoutBody,
   checkoutUrls,
   resultPath,
   stripeCheckoutKeyConfig,
+  stripeCheckoutIdempotencyKey,
+  stripeCheckoutInlineTerms,
+  stripeCheckoutPriceId,
+  validateInlineCheckoutTerms,
   validateConfiguredPrice,
   validatePayload,
 };
@@ -236,10 +378,32 @@ export default async function handler(req, res) {
     json(res, 503, { error: "checkout_url_not_configured", details: urls.errors });
     return;
   }
+
+  const authorization = await authorizeCheckout({ requestId });
+  if (!authorization.ok) {
+    json(res, authorization.status, {
+      error: authorization.error,
+      details: authorization.details,
+    });
+    return;
+  }
+
   if (stripeKey.source !== "restricted") {
-    const priceValidation = await validateConfiguredPrice(stripeKey.key);
+    const priceValidation = await validateConfiguredPrice(
+      stripeKey.key,
+      stripeCheckoutPriceId(authorization.checkout),
+    );
     if (!priceValidation.ok) {
       json(res, 503, { error: "checkout_price_not_configured", details: priceValidation.message });
+      return;
+    }
+  }
+  if (!stripeCheckoutPriceId(authorization.checkout)) {
+    const inlineValidation = validateInlineCheckoutTerms(
+      stripeCheckoutInlineTerms(authorization.checkout),
+    );
+    if (!inlineValidation.ok) {
+      json(res, 503, { error: "checkout_price_not_configured", details: inlineValidation.message });
       return;
     }
   }
@@ -249,8 +413,13 @@ export default async function handler(req, res) {
     accountId,
     successUrl: urls.successUrl,
     cancelUrl: urls.cancelUrl,
+    checkout: authorization.checkout,
   });
-  const session = await createCheckoutSession(body, stripeKey.key);
+  const session = await createCheckoutSession(
+    body,
+    stripeKey.key,
+    stripeCheckoutIdempotencyKey({ requestId, accountId }),
+  );
   if (!session.ok) {
     json(res, 502, { error: "stripe_checkout_failed", details: session.message });
     return;

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -8,6 +8,10 @@ import handler, {
   checkoutUrls,
   resultPath,
   stripeCheckoutKeyConfig,
+  stripeCheckoutIdempotencyKey,
+  stripeCheckoutInlineTerms,
+  stripeCheckoutPriceId,
+  validateInlineCheckoutTerms,
   validateConfiguredPrice,
   validatePayload,
 } from "../api/content-ops/deflection/checkout.js";
@@ -413,6 +417,85 @@ await test("checkout body carries the Stripe metadata contract and one-time pric
   assert.equal(body.get("line_items[0][price_data][unit_amount]"), "150000");
 });
 
+await test("checkout idempotency key is stable per configured report", () => {
+  const first = stripeCheckoutIdempotencyKey({
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    requestId: "content-ops-abc123",
+  });
+  const duplicate = stripeCheckoutIdempotencyKey({
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    requestId: "content-ops-abc123",
+  });
+  const otherReport = stripeCheckoutIdempotencyKey({
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    requestId: "content-ops-def456",
+  });
+
+  assert.equal(first, duplicate);
+  assert.notEqual(first, otherReport);
+  assert.equal(first, "deflection-checkout:2b2b950d-f64b-4852-bc30-f92a34cdf169:content-ops-abc123");
+});
+
+await test("checkout price id uses Atlas authorization before env fallback", () => {
+  const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = "price_env_report";
+  try {
+    assert.equal(
+      stripeCheckoutPriceId({ price_id: "price_atlas_report" }),
+      "price_atlas_report",
+    );
+    assert.equal(stripeCheckoutPriceId({ amount_cents: 150000 }), "price_env_report");
+  } finally {
+    if (previousPriceId === undefined) {
+      delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+    } else {
+      process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = previousPriceId;
+    }
+  }
+});
+
+await test("inline checkout terms use Atlas authorization before env fallback", () => {
+  const previousAmount = process.env.DEFLECTION_REPORT_AMOUNT_CENTS;
+  const previousCurrency = process.env.DEFLECTION_REPORT_CURRENCY;
+  process.env.DEFLECTION_REPORT_AMOUNT_CENTS = "200000";
+  process.env.DEFLECTION_REPORT_CURRENCY = "cad";
+  try {
+    assert.deepEqual(
+      stripeCheckoutInlineTerms({ amount_cents: 150000, currency: "USD" }),
+      { amount: 150000, currency: "usd" },
+    );
+    assert.deepEqual(
+      stripeCheckoutInlineTerms({ amount_cents: 149999, currency: "usd" }),
+      { amount: 149999, currency: "usd" },
+    );
+    assert.deepEqual(
+      validateInlineCheckoutTerms({ amount: 149999, currency: "usd" }),
+      {
+        ok: false,
+        message: "configured inline Checkout amount must be usd and at least 150000 cents",
+      },
+    );
+    assert.deepEqual(
+      validateInlineCheckoutTerms({ amount: 150000, currency: "eur" }),
+      {
+        ok: false,
+        message: "configured inline Checkout amount must be usd and at least 150000 cents",
+      },
+    );
+  } finally {
+    if (previousAmount === undefined) {
+      delete process.env.DEFLECTION_REPORT_AMOUNT_CENTS;
+    } else {
+      process.env.DEFLECTION_REPORT_AMOUNT_CENTS = previousAmount;
+    }
+    if (previousCurrency === undefined) {
+      delete process.env.DEFLECTION_REPORT_CURRENCY;
+    } else {
+      process.env.DEFLECTION_REPORT_CURRENCY = previousCurrency;
+    }
+  }
+});
+
 await test("configured Stripe Price must validate against webhook floor before Checkout", async () => {
   const previousFetch = globalThis.fetch;
   const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
@@ -453,13 +536,34 @@ await test("restricted Checkout key skips configured Price read preflight", asyn
   const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
   const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
   const previousAccountId = process.env.ATLAS_ACCOUNT_ID;
+  const previousAtlasBaseUrl = process.env.ATLAS_API_BASE_URL;
+  const previousAtlasToken = process.env.ATLAS_B2B_JWT;
   const calls = [];
   process.env.STRIPE_SECRET_KEY = "sk_live_full_secret";
   process.env.ATLAS_SAAS_STRIPE_RAK = "rk_test_checkout_only";
   process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = "price_deflection_report";
   process.env.ATLAS_ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
+  process.env.ATLAS_API_BASE_URL = "https://atlas.example.com";
+  process.env.ATLAS_B2B_JWT = "secret-service-token";
   globalThis.fetch = async (url, options) => {
     calls.push({ url, options });
+    if (url === "https://atlas.example.com/api/v1/content-ops/deflection-reports/content-ops-abc123/checkout-authorization") {
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            request_id: "content-ops-abc123",
+            status: "authorized",
+            checkout: {
+              amount_cents: 150000,
+              currency: "usd",
+              price_id: "price_deflection_report",
+            },
+          };
+        },
+      };
+    }
     return {
       ok: true,
       status: 200,
@@ -505,13 +609,232 @@ await test("restricted Checkout key skips configured Price read preflight", asyn
     } else {
       process.env.ATLAS_ACCOUNT_ID = previousAccountId;
     }
+    if (previousAtlasBaseUrl === undefined) {
+      delete process.env.ATLAS_API_BASE_URL;
+    } else {
+      process.env.ATLAS_API_BASE_URL = previousAtlasBaseUrl;
+    }
+    if (previousAtlasToken === undefined) {
+      delete process.env.ATLAS_B2B_JWT;
+    } else {
+      process.env.ATLAS_B2B_JWT = previousAtlasToken;
+    }
   }
 
   assert.equal(res.statusCode, 200);
   assert.deepEqual(JSON.parse(res.body), { url: "https://checkout.stripe.com/c/session" });
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, "https://api.stripe.com/v1/checkout/sessions");
-  assert.equal(calls[0].options.body.get("line_items[0][price]"), "price_deflection_report");
+  assert.equal(calls.length, 2);
+  assert.equal(
+    calls[0].url,
+    "https://atlas.example.com/api/v1/content-ops/deflection-reports/content-ops-abc123/checkout-authorization",
+  );
+  assert.equal(calls[0].options.method, "POST");
+  assert.equal(calls[0].options.headers.Authorization, "Bearer secret-service-token");
+  assert.equal(calls[1].url, "https://api.stripe.com/v1/checkout/sessions");
+  assert.equal(calls[1].options.body.get("line_items[0][price]"), "price_deflection_report");
+});
+
+await test("fallback Checkout validates the Atlas-authorized Stripe Price before creating session", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSecret = process.env.STRIPE_SECRET_KEY;
+  const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
+  const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  const previousAccountId = process.env.ATLAS_ACCOUNT_ID;
+  const previousAtlasBaseUrl = process.env.ATLAS_API_BASE_URL;
+  const previousAtlasToken = process.env.ATLAS_B2B_JWT;
+  const calls = [];
+  process.env.STRIPE_SECRET_KEY = "sk_test_123";
+  delete process.env.ATLAS_SAAS_STRIPE_RAK;
+  process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = "price_env_report";
+  process.env.ATLAS_ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
+  process.env.ATLAS_API_BASE_URL = "https://atlas.example.com";
+  process.env.ATLAS_B2B_JWT = "secret-service-token";
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    if (url === "https://atlas.example.com/api/v1/content-ops/deflection-reports/content-ops-abc123/checkout-authorization") {
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            request_id: "content-ops-abc123",
+            status: "authorized",
+            checkout: {
+              amount_cents: 150000,
+              currency: "usd",
+              price_id: "price_atlas_low",
+            },
+          };
+        },
+      };
+    }
+    if (url === "https://api.stripe.com/v1/prices/price_atlas_low") {
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { active: true, currency: "usd", unit_amount: 149999 };
+        },
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+
+  const req = {
+    method: "POST",
+    headers: {
+      host: "portfolio.example.com",
+      "x-forwarded-proto": "https",
+    },
+    body: {
+      request_id: "content-ops-abc123",
+    },
+  };
+  const res = mockResponse();
+
+  try {
+    await handler(req, res);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousSecret === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = previousSecret;
+    }
+    if (previousRak === undefined) {
+      delete process.env.ATLAS_SAAS_STRIPE_RAK;
+    } else {
+      process.env.ATLAS_SAAS_STRIPE_RAK = previousRak;
+    }
+    if (previousPriceId === undefined) {
+      delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+    } else {
+      process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = previousPriceId;
+    }
+    if (previousAccountId === undefined) {
+      delete process.env.ATLAS_ACCOUNT_ID;
+    } else {
+      process.env.ATLAS_ACCOUNT_ID = previousAccountId;
+    }
+    if (previousAtlasBaseUrl === undefined) {
+      delete process.env.ATLAS_API_BASE_URL;
+    } else {
+      process.env.ATLAS_API_BASE_URL = previousAtlasBaseUrl;
+    }
+    if (previousAtlasToken === undefined) {
+      delete process.env.ATLAS_B2B_JWT;
+    } else {
+      process.env.ATLAS_B2B_JWT = previousAtlasToken;
+    }
+  }
+
+  assert.equal(res.statusCode, 503);
+  assert.deepEqual(JSON.parse(res.body), {
+    error: "checkout_price_not_configured",
+    details: "configured Stripe Price must be active, usd, and at least 150000 cents",
+  });
+  assert.deepEqual(calls.map((call) => call.url), [
+    "https://atlas.example.com/api/v1/content-ops/deflection-reports/content-ops-abc123/checkout-authorization",
+    "https://api.stripe.com/v1/prices/price_atlas_low",
+  ]);
+});
+
+await test("handler rejects Atlas inline checkout terms below floor or outside usd", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSecret = process.env.STRIPE_SECRET_KEY;
+  const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
+  const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  const previousAccountId = process.env.ATLAS_ACCOUNT_ID;
+  const previousAtlasBaseUrl = process.env.ATLAS_API_BASE_URL;
+  const previousAtlasToken = process.env.ATLAS_B2B_JWT;
+  const calls = [];
+  process.env.STRIPE_SECRET_KEY = "sk_test_123";
+  process.env.ATLAS_SAAS_STRIPE_RAK = "rk_test_checkout_only";
+  delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  process.env.ATLAS_ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
+  process.env.ATLAS_API_BASE_URL = "https://atlas.example.com";
+  process.env.ATLAS_B2B_JWT = "secret-service-token";
+
+  try {
+    for (const checkout of [
+      { amount_cents: 149999, currency: "usd" },
+      { amount_cents: 150000, currency: "eur" },
+    ]) {
+      calls.length = 0;
+      globalThis.fetch = async (url, options) => {
+        calls.push({ url, options });
+        if (url === "https://atlas.example.com/api/v1/content-ops/deflection-reports/content-ops-abc123/checkout-authorization") {
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                request_id: "content-ops-abc123",
+                status: "authorized",
+                checkout,
+              };
+            },
+          };
+        }
+        throw new Error(`Stripe should not be called for inline terms: ${url}`);
+      };
+
+      const req = {
+        method: "POST",
+        headers: {
+          host: "portfolio.example.com",
+          "x-forwarded-proto": "https",
+        },
+        body: {
+          request_id: "content-ops-abc123",
+        },
+      };
+      const res = mockResponse();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, 503);
+      assert.deepEqual(JSON.parse(res.body), {
+        error: "checkout_price_not_configured",
+        details: "configured inline Checkout amount must be usd and at least 150000 cents",
+      });
+      assert.deepEqual(calls.map((call) => call.url), [
+        "https://atlas.example.com/api/v1/content-ops/deflection-reports/content-ops-abc123/checkout-authorization",
+      ]);
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousSecret === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = previousSecret;
+    }
+    if (previousRak === undefined) {
+      delete process.env.ATLAS_SAAS_STRIPE_RAK;
+    } else {
+      process.env.ATLAS_SAAS_STRIPE_RAK = previousRak;
+    }
+    if (previousPriceId === undefined) {
+      delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+    } else {
+      process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = previousPriceId;
+    }
+    if (previousAccountId === undefined) {
+      delete process.env.ATLAS_ACCOUNT_ID;
+    } else {
+      process.env.ATLAS_ACCOUNT_ID = previousAccountId;
+    }
+    if (previousAtlasBaseUrl === undefined) {
+      delete process.env.ATLAS_API_BASE_URL;
+    } else {
+      process.env.ATLAS_API_BASE_URL = previousAtlasBaseUrl;
+    }
+    if (previousAtlasToken === undefined) {
+      delete process.env.ATLAS_B2B_JWT;
+    } else {
+      process.env.ATLAS_B2B_JWT = previousAtlasToken;
+    }
+  }
 });
 
 await test("checkout key config prefers restricted key and rejects live secret fallback", () => {
@@ -621,13 +944,34 @@ await test("handler creates Stripe Checkout without calling privileged ATLAS pai
   const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
   const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
   const previousAccountId = process.env.ATLAS_ACCOUNT_ID;
+  const previousAtlasBaseUrl = process.env.ATLAS_API_BASE_URL;
+  const previousAtlasToken = process.env.ATLAS_B2B_JWT;
   const calls = [];
   process.env.STRIPE_SECRET_KEY = "sk_test_123";
   process.env.ATLAS_SAAS_STRIPE_RAK = "rk_test_checkout_only";
   process.env.ATLAS_ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
+  process.env.ATLAS_API_BASE_URL = "https://atlas.example.com";
+  process.env.ATLAS_B2B_JWT = "secret-service-token";
   delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
   globalThis.fetch = async (url, options) => {
     calls.push({ url, options });
+    if (url === "https://atlas.example.com/api/v1/content-ops/deflection-reports/content-ops-abc123/checkout-authorization") {
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            request_id: "content-ops-abc123",
+            status: "authorized",
+            checkout: {
+              amount_cents: 150000,
+              currency: "usd",
+              price_id: "price_deflection_report",
+            },
+          };
+        },
+      };
+    }
     return {
       ok: true,
       status: 200,
@@ -673,18 +1017,124 @@ await test("handler creates Stripe Checkout without calling privileged ATLAS pai
     } else {
       process.env.ATLAS_ACCOUNT_ID = previousAccountId;
     }
+    if (previousAtlasBaseUrl === undefined) {
+      delete process.env.ATLAS_API_BASE_URL;
+    } else {
+      process.env.ATLAS_API_BASE_URL = previousAtlasBaseUrl;
+    }
+    if (previousAtlasToken === undefined) {
+      delete process.env.ATLAS_B2B_JWT;
+    } else {
+      process.env.ATLAS_B2B_JWT = previousAtlasToken;
+    }
   }
 
   assert.equal(res.statusCode, 200);
   assert.deepEqual(JSON.parse(res.body), { url: "https://checkout.stripe.com/c/session" });
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, "https://api.stripe.com/v1/checkout/sessions");
+  assert.equal(calls.length, 2);
   assert.equal(
-    calls[0].options.headers.Authorization,
+    calls[0].url,
+    "https://atlas.example.com/api/v1/content-ops/deflection-reports/content-ops-abc123/checkout-authorization",
+  );
+  assert.equal(calls[0].options.method, "POST");
+  assert.equal(calls[1].url, "https://api.stripe.com/v1/checkout/sessions");
+  assert.equal(
+    calls[1].options.headers.Authorization,
     `Basic ${Buffer.from("rk_test_checkout_only:").toString("base64")}`,
   );
-  assert.equal(calls[0].options.body.get("metadata[source]"), CHECKOUT_SOURCE);
-  assert.equal(calls[0].options.body.get("metadata[request_id]"), "content-ops-abc123");
+  assert.equal(
+    calls[1].options.headers["Idempotency-Key"],
+    "deflection-checkout:2b2b950d-f64b-4852-bc30-f92a34cdf169:content-ops-abc123",
+  );
+  assert.equal(calls[1].options.body.get("metadata[source]"), CHECKOUT_SOURCE);
+  assert.equal(calls[1].options.body.get("metadata[request_id]"), "content-ops-abc123");
+  assert.equal(calls[1].options.body.get("line_items[0][price]"), "price_deflection_report");
+});
+
+await test("handler refuses unauthorized checkout states before calling Stripe", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSecret = process.env.STRIPE_SECRET_KEY;
+  const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
+  const previousAccountId = process.env.ATLAS_ACCOUNT_ID;
+  const previousAtlasBaseUrl = process.env.ATLAS_API_BASE_URL;
+  const previousAtlasToken = process.env.ATLAS_B2B_JWT;
+  const calls = [];
+  process.env.STRIPE_SECRET_KEY = "sk_test_123";
+  process.env.ATLAS_SAAS_STRIPE_RAK = "rk_test_checkout_only";
+  process.env.ATLAS_ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
+  process.env.ATLAS_API_BASE_URL = "https://atlas.example.com";
+  process.env.ATLAS_B2B_JWT = "secret-service-token";
+
+  try {
+    for (const denied of [
+      { status: 409, detail: "Deflection report is already paid." },
+      { status: 404, detail: "Deflection report not found." },
+    ]) {
+      calls.length = 0;
+      globalThis.fetch = async (url, options) => {
+        calls.push({ url, options });
+        if (url.includes("checkout-authorization")) {
+          return {
+            ok: false,
+            status: denied.status,
+            async json() {
+              return { detail: denied.detail };
+            },
+          };
+        }
+        throw new Error("Stripe should not be called when authorization fails");
+      };
+
+      const req = {
+        method: "POST",
+        headers: {
+          host: "portfolio.example.com",
+          "x-forwarded-proto": "https",
+        },
+        body: {
+          request_id: "content-ops-abc123",
+        },
+      };
+      const res = mockResponse();
+
+      await handler(req, res);
+
+      assert.equal(res.statusCode, denied.status);
+      assert.deepEqual(JSON.parse(res.body), {
+        error: "checkout_not_authorized",
+        details: denied.detail,
+      });
+      assert.equal(calls.length, 1);
+      assert.match(calls[0].url, /checkout-authorization$/);
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousSecret === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = previousSecret;
+    }
+    if (previousRak === undefined) {
+      delete process.env.ATLAS_SAAS_STRIPE_RAK;
+    } else {
+      process.env.ATLAS_SAAS_STRIPE_RAK = previousRak;
+    }
+    if (previousAccountId === undefined) {
+      delete process.env.ATLAS_ACCOUNT_ID;
+    } else {
+      process.env.ATLAS_ACCOUNT_ID = previousAccountId;
+    }
+    if (previousAtlasBaseUrl === undefined) {
+      delete process.env.ATLAS_API_BASE_URL;
+    } else {
+      process.env.ATLAS_API_BASE_URL = previousAtlasBaseUrl;
+    }
+    if (previousAtlasToken === undefined) {
+      delete process.env.ATLAS_B2B_JWT;
+    } else {
+      process.env.ATLAS_B2B_JWT = previousAtlasToken;
+    }
+  }
 });
 
 await test("handler rejects live full secret fallback before calling Stripe", async () => {


### PR DESCRIPTION
Plan: plans/PR-Deflection-Checkout-Concurrency-Guard.md
Slice phase: Production hardening

#1386's multi-user hardening lane has one current-account concurrency gap left before we worry about true multi-tenant: duplicate checkout creation. This PR makes portfolio checkout prove the report is payable through Atlas before calling Stripe, then sends Stripe a stable idempotency key so duplicate concurrent checkout attempts for the same configured account and request id converge instead of creating independent sessions.

## Intentional
- Keep multi-tenant account selection deferred; this hardens the current configured-account funnel.
- Do not call the privileged paid-release route from portfolio checkout.
- Do not add captcha or website-edge IP throttling in this slice.

## Deferred
- #1419 remains the next launch-gating real-data report-quality proof.
- Public website-edge abuse controls remain later operational hardening before broad unattended traffic.
- True multi-tenant auth/config remains future work after customer traction.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: yes.

- Fixed Codex P2 / reviewer MAJOR: fallback-key Stripe Price validation now checks the exact price id selected after Atlas checkout authorization, not only `STRIPE_DEFLECTION_REPORT_PRICE_ID`.
- Added regression coverage where Atlas authorizes `price_atlas_low`, portfolio env still has `price_env_report`, and the handler validates/rejects `price_atlas_low` before creating a Checkout Session.
- Fixed reviewer residual MINOR: amount-mode inline `price_data` now validates the selected Atlas/env amount and currency before Stripe session creation, rejecting non-USD terms or terms below 150000 cents; tests cover both rejection paths.
- Restricted-key deployments intentionally keep the existing no-Price-read behavior because restricted keys may be scoped to Checkout creation only; Atlas checkout authorization remains the fail-closed terms source there, with local inline USD/floor validation before Checkout creation.

## Verification
- `npm run test:deflection-result` from `portfolio-ui/`
- `npm run test:deflection-upload-shell` from `portfolio-ui/`
- `npm run test:deflection-atlas-proxy` from `portfolio-ui/`
- Local PR review bundle.

## Diff size
3 files, +775 / -17
