### PR TITLE
Deflection complete evidence export

### DIFF
--- a/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md
+++ b/docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md
@@ -8,7 +8,7 @@ The source window is 2026-05-02 to 2026-05-08 (7 days). At the same measured dai
 
 Estimate only. This is not a savings guarantee; adjust the $13.50 benchmark to your own loaded support cost.
 
-The full unlocked report below gives you every ranked question, the estimated support cost by question, publishable help-center copy where your uploaded resolutions prove the answer, the no-proven-answer roadmap, and complete evidence inside each question detail block.
+The full unlocked report below gives you every ranked question, the estimated support cost by question, publishable help-center copy where your uploaded resolutions prove the answer, the no-proven-answer roadmap, and a complete evidence export for audit/detail review.
 
 - Publishable answers drafted from proven resolutions: 2
 - Questions still needing an approved resolution: 2

--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -1,4 +1,174 @@
 {
+  "evidence_export": {
+    "evidence_rows": [
+      {
+        "answer_evidence_status": "resolution_evidence",
+        "answer_linkage": "publishable_answer",
+        "evidence_quote": "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\"",
+        "question": "How do I export attribution reports?",
+        "question_id": "q001",
+        "rank": 1,
+        "resolution_evidence_scope": "scoped",
+        "row_id": "q001-e001",
+        "source_field": "evidence_quote",
+        "source_id": "ticket-export-1"
+      },
+      {
+        "answer_evidence_status": "resolution_evidence",
+        "answer_linkage": "publishable_answer",
+        "evidence_quote": "",
+        "question": "How do I export attribution reports?",
+        "question_id": "q001",
+        "rank": 1,
+        "resolution_evidence_scope": "scoped",
+        "row_id": "q001-e002",
+        "source_field": "source_id",
+        "source_id": "ticket-export-2"
+      },
+      {
+        "answer_evidence_status": "draft_needs_review",
+        "answer_linkage": "needs_review",
+        "evidence_quote": "`ticket-sso-1` - SSO setup: \"How do I enable SSO for my team?\"",
+        "question": "How do I enable SSO for my team?",
+        "question_id": "q002",
+        "rank": 2,
+        "resolution_evidence_scope": "not_applicable",
+        "row_id": "q002-e001",
+        "source_field": "evidence_quote",
+        "source_id": "ticket-sso-1"
+      },
+      {
+        "answer_evidence_status": "draft_needs_review",
+        "answer_linkage": "needs_review",
+        "evidence_quote": "",
+        "question": "How do I enable SSO for my team?",
+        "question_id": "q002",
+        "rank": 2,
+        "resolution_evidence_scope": "not_applicable",
+        "row_id": "q002-e002",
+        "source_field": "source_id",
+        "source_id": "ticket-sso-2"
+      }
+    ],
+    "questions": [
+      {
+        "answer": "To resolve this, open Analytics, choose Attribution, then click Download report.",
+        "answer_evidence_status": "resolution_evidence",
+        "answer_linkage": "publishable_answer",
+        "customer_wording": "",
+        "evidence_quote_count": 1,
+        "opportunity_score": 2,
+        "outcome_diagnostics": {},
+        "question": "How do I export attribution reports?",
+        "question_id": "q001",
+        "rank": 1,
+        "resolution_evidence_scope": "scoped",
+        "source_ids": [
+          "ticket-export-1",
+          "ticket-export-2"
+        ],
+        "steps": [
+          "Open Analytics, choose Attribution, then click Download report.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
+        "term_mappings": [
+          {
+            "customer_term": "export",
+            "documentation_term": "Download report",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-export-1",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          },
+          {
+            "customer_term": "report download",
+            "documentation_term": "Download report",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-export-1",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          }
+        ],
+        "ticket_count": 2,
+        "topic": "reporting friction",
+        "weighted_frequency": 2
+      },
+      {
+        "answer": "No verified resolution evidence was found in 2 ticket sources; keep this FAQ in review before answering: How do I enable SSO for my team?",
+        "answer_evidence_status": "draft_needs_review",
+        "answer_linkage": "needs_review",
+        "customer_wording": "",
+        "evidence_quote_count": 1,
+        "opportunity_score": 2,
+        "outcome_diagnostics": {},
+        "question": "How do I enable SSO for my team?",
+        "question_id": "q002",
+        "rank": 2,
+        "resolution_evidence_scope": "not_applicable",
+        "source_ids": [
+          "ticket-sso-1",
+          "ticket-sso-2"
+        ],
+        "steps": [
+          "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+          "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
+        "term_mappings": [
+          {
+            "customer_term": "SSO",
+            "documentation_term": "Single sign-on setup",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-sso-1",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          }
+        ],
+        "ticket_count": 2,
+        "topic": "sso setup",
+        "weighted_frequency": 2
+      }
+    ],
+    "report_summary": {
+      "drafted_answer_count": 1,
+      "generated": 2,
+      "no_proven_answer_count": 1,
+      "non_repeat_question_count": 0,
+      "non_repeat_ticket_count": 0,
+      "output_checks": {
+        "condensed": true,
+        "has_action_items": true,
+        "resolution_evidence_scoped": true,
+        "uses_user_vocabulary": true
+      },
+      "source_count": 4,
+      "source_date_end": "2026-05-15",
+      "source_date_start": "2026-05-01",
+      "source_window_days": 15,
+      "support_ticket_resolution_evidence_count": 1,
+      "support_ticket_resolution_evidence_present": true,
+      "ticket_source_count": 4,
+      "top_opportunity_score": 2,
+      "top_question": "How do I export attribution reports?"
+    },
+    "schema_version": "deflection_evidence.v1",
+    "summary": {
+      "drafted_answer_count": 1,
+      "evidence_row_count": 4,
+      "no_proven_answer_count": 1,
+      "question_count": 2,
+      "source_id_count": 4
+    }
+  },
   "faq_result": {
     "generated": 2,
     "items": [
@@ -156,7 +326,7 @@
     "ticket_source_count": 4,
     "warnings": []
   },
-  "markdown": "# Support Ticket Deflection Report\n\n## Support Tax Confirmation\n\nThis report found 4 question-level repeat tickets across 2 ranked questions. At the Gartner $13.50 assisted-contact benchmark, that repeated-question work sizes to about $54 of assisted-contact handling.\n\nThe source window is 2026-05-01 to 2026-05-15 (15 days). At the same measured daily pace, that is about $1,314 over 12 months.\n\nEstimate only. This is not a savings guarantee; adjust the $13.50 benchmark to your own loaded support cost.\n\nThe full unlocked report below gives you every ranked question, the estimated support cost by question, publishable help-center copy where your uploaded resolutions prove the answer, the no-proven-answer roadmap, and complete evidence inside each question detail block.\n\n- Publishable answers drafted from proven resolutions: 1\n- Questions still needing an approved resolution: 1\n- Ticket sources represented: 4\n\n## Your Help-Desk SEO Targeting List\n\nUse these source-backed phrases as help-center headings, internal-search synonyms, and FAQ wording. These were mined from the tickets you uploaded; this report does not claim keyword volume, search rank, or traffic.\n\n1. How do I export attribution reports?\n2. export\n3. report download\n4. How do I enable SSO for my team?\n5. SSO\n\n## Ranked Question Opportunities\n\n| Rank | Customer question | Tickets | Estimated support cost | Opportunity | Answer status | Source proof |\n|---:|---|---:|---:|---:|---|---|\n| 1 | How do I export attribution reports? | 2 | $27 | 2 | drafted from resolution evidence | 2 source tickets |\n| 2 | How do I enable SSO for my team? | 2 | $27 | 2 | no proven answer yet | 2 source tickets |\n\n## Question Details and Evidence\n\nEach ranked question appears once below with its answer status, publishable copy or review guidance, vocabulary gaps, and complete source evidence.\n\nQuestions without uploaded resolution evidence stay in review: outcome/status signals can prioritize them, but only resolution evidence can make an answer publishable.\n\n### 1. How do I export attribution reports?\n\n**Answer status:** drafted from resolution evidence\n\n**Ticket/support-cost context:** 2 tickets, estimated at $27 of assisted-contact handling.\n\n**Publishable answer draft:**\n\nTo resolve this, open Analytics, choose Attribution, then click Download report.\n\n**Draft answer steps:**\n\n1. Open Analytics, choose Attribution, then click Download report.\n2. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**Evidence backing:** Backed by 2 resolved tickets (ticket-export-1, ticket-export-2). Complete source IDs are in this question detail block.\n\n**Vocabulary gaps:**\n\n- export -> Download report: Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (2 sources)\n- report download -> Download report: Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (2 sources)\n\n**Complete evidence:**\n\n**Source IDs (full list):** ticket-export-1, ticket-export-2\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n### 2. How do I enable SSO for my team?\n\n**Answer status:** no proven answer yet\n\n**Ticket/support-cost context:** 2 tickets, estimated at $27 of assisted-contact handling.\n\n**No proven answer yet:**\n\nNo uploaded resolution evidence was present for this question.\n\n**Ticket backing:** Seen in 2 repeated tickets (ticket-sso-1, ticket-sso-2). Complete source IDs are in this question detail block.\n\n**Vocabulary gaps:**\n\n- SSO -> Single sign-on setup: Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. (2 sources)\n\n**Complete evidence:**\n\n**Source IDs (full list):** ticket-sso-1, ticket-sso-2\n\n- `ticket-sso-1` - SSO setup: \"How do I enable SSO for my team?\"\n",
+  "markdown": "# Support Ticket Deflection Report\n\n## Support Tax Confirmation\n\nThis report found 4 question-level repeat tickets across 2 ranked questions. At the Gartner $13.50 assisted-contact benchmark, that repeated-question work sizes to about $54 of assisted-contact handling.\n\nThe source window is 2026-05-01 to 2026-05-15 (15 days). At the same measured daily pace, that is about $1,314 over 12 months.\n\nEstimate only. This is not a savings guarantee; adjust the $13.50 benchmark to your own loaded support cost.\n\nThe full unlocked report below gives you every ranked question, the estimated support cost by question, publishable help-center copy where your uploaded resolutions prove the answer, the no-proven-answer roadmap, and a complete evidence export for audit/detail review.\n\n- Publishable answers drafted from proven resolutions: 1\n- Questions still needing an approved resolution: 1\n- Ticket sources represented: 4\n\n## Your Help-Desk SEO Targeting List\n\nUse these source-backed phrases as help-center headings, internal-search synonyms, and FAQ wording. These were mined from the tickets you uploaded; this report does not claim keyword volume, search rank, or traffic.\n\n1. How do I export attribution reports?\n2. export\n3. report download\n4. How do I enable SSO for my team?\n5. SSO\n\n## Ranked Question Opportunities\n\n| Rank | Customer question | Tickets | Estimated support cost | Opportunity | Answer status | Source proof |\n|---:|---|---:|---:|---:|---|---|\n| 1 | How do I export attribution reports? | 2 | $27 | 2 | drafted from resolution evidence | 2 source tickets |\n| 2 | How do I enable SSO for my team? | 2 | $27 | 2 | no proven answer yet | 2 source tickets |\n\n## Question Details and Evidence\n\nEach ranked question appears once below with its answer status, publishable copy or review guidance, vocabulary gaps, and complete source evidence.\n\nQuestions without uploaded resolution evidence stay in review: outcome/status signals can prioritize them, but only resolution evidence can make an answer publishable.\n\n### 1. How do I export attribution reports?\n\n**Answer status:** drafted from resolution evidence\n\n**Ticket/support-cost context:** 2 tickets, estimated at $27 of assisted-contact handling.\n\n**Publishable answer draft:**\n\nTo resolve this, open Analytics, choose Attribution, then click Download report.\n\n**Draft answer steps:**\n\n1. Open Analytics, choose Attribution, then click Download report.\n2. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**Evidence backing:** Backed by 2 resolved tickets (ticket-export-1, ticket-export-2). Complete source IDs are in this question detail block.\n\n**Vocabulary gaps:**\n\n- export -> Download report: Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (2 sources)\n- report download -> Download report: Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (2 sources)\n\n**Complete evidence:**\n\n**Source IDs (full list):** ticket-export-1, ticket-export-2\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n### 2. How do I enable SSO for my team?\n\n**Answer status:** no proven answer yet\n\n**Ticket/support-cost context:** 2 tickets, estimated at $27 of assisted-contact handling.\n\n**No proven answer yet:**\n\nNo uploaded resolution evidence was present for this question.\n\n**Ticket backing:** Seen in 2 repeated tickets (ticket-sso-1, ticket-sso-2). Complete source IDs are in this question detail block.\n\n**Vocabulary gaps:**\n\n- SSO -> Single sign-on setup: Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. (2 sources)\n\n**Complete evidence:**\n\n**Source IDs (full list):** ticket-sso-1, ticket-sso-2\n\n- `ticket-sso-1` - SSO setup: \"How do I enable SSO for my team?\"\n",
   "summary": {
     "drafted_answer_count": 1,
     "generated": 2,

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -78,12 +78,61 @@ The report Markdown always contains these customer-facing sections:
 
 `Your Help-Desk SEO Targeting List` is a readability index, not the complete
 evidence surface. Large reports render a deterministic top-N phrase list and an
-omitted-count note; every ranked question and complete source evidence remains
-in `Question Details and Evidence`.
+omitted-count note. Complete source evidence is available in the paid artifact's
+`evidence_export`; inline web/PDF renderers may stay bounded as long as they
+link to or attach that export.
 
 `Question Details and Evidence` is the canonical per-question detail pass. It
 contains the answer status, publishable copy or no-proven-answer guidance,
-vocabulary mappings, and complete source evidence for each ranked question.
+vocabulary mappings, and representative source evidence for each ranked
+question.
+
+The paid artifact also includes a complete evidence export:
+
+```ts
+type DeflectionEvidenceExport = {
+  schema_version: "deflection_evidence.v1";
+  summary: {
+    question_count: number;
+    evidence_row_count: number;
+    source_id_count: number;
+    drafted_answer_count: number;
+    no_proven_answer_count: number;
+  };
+  report_summary: DeflectionReportSummary;
+  questions: Array<{
+    question_id: string;
+    rank: number;
+    question: string;
+    customer_wording: string;
+    topic: string;
+    ticket_count: number;
+    weighted_frequency: number;
+    opportunity_score: number;
+    answer_evidence_status: "resolution_evidence" | "draft_needs_review" | string;
+    resolution_evidence_scope: string;
+    answer_linkage: "publishable_answer" | "needs_review";
+    answer: string;
+    steps: string[];
+    source_ids: string[];
+    evidence_quote_count: number;
+    term_mappings: Array<Record<string, unknown>>;
+    outcome_diagnostics: Record<string, unknown>;
+  }>;
+  evidence_rows: Array<{
+    row_id: string;
+    question_id: string;
+    rank: number;
+    question: string;
+    source_id: string;
+    source_field: "evidence_quote" | "source_id" | string;
+    evidence_quote: string;
+    answer_evidence_status: string;
+    resolution_evidence_scope: string;
+    answer_linkage: "publishable_answer" | "needs_review";
+  }>;
+};
+```
 
 ## Deflection Snapshot
 
@@ -306,6 +355,9 @@ type TicketFAQSearchResponse = {
   supplied documentation terms/rules and customer wording.
 - Treat `source_ids` and `evidence_quotes` as proof links/footnotes, not primary
   marketing copy.
+- Treat `evidence_export` as the uncapped audit/detail surface. Hosted web and
+  PDF renderers can cap inline evidence only when they preserve access to this
+  export.
 
 See [`content_ops_faq_report_example.json`](./content_ops_faq_report_example.json)
 for a current compact FAQ example and

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -17,6 +17,7 @@ _DRAFT_NEEDS_REVIEW_STATUS = "draft_needs_review"
 DEFAULT_DEFLECTION_SNAPSHOT_TOP_N = 5
 DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT = 3
 DEFAULT_DEFLECTION_SEO_TARGET_LIMIT = 50
+DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION = "deflection_evidence.v1"
 _UNCAPPED_REPORT_MAX_ITEMS = 0
 _ASSISTED_CONTACT_COST = 13.50
 _ASSISTED_CONTACT_COST_LABEL = "$13.50"
@@ -67,6 +68,7 @@ class DeflectionReportArtifact:
             "markdown": self.markdown,
             "summary": dict(self.summary),
             "faq_result": self.faq_result.as_dict(),
+            "evidence_export": build_deflection_evidence_export(self),
         }
 
     def snapshot(self, *, top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N) -> DeflectionSnapshot:
@@ -144,6 +146,42 @@ def build_deflection_report_artifact(
         summary=summary,
         faq_result=faq_result,
     )
+
+
+def build_deflection_evidence_export(
+    artifact: DeflectionReportArtifact | Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the uncapped structured evidence export for a paid report."""
+
+    summary = dict(_artifact_summary(artifact))
+    items = _artifact_items(artifact)
+    questions = tuple(
+        _evidence_export_question(rank, item)
+        for rank, item in enumerate(items, start=1)
+    )
+    evidence_rows = tuple(
+        row
+        for rank, item in enumerate(items, start=1)
+        for row in _evidence_export_rows(rank, item)
+    )
+    source_ids = sorted({
+        source_id
+        for item in items
+        for source_id in _texts(item.get("source_ids"))
+    })
+    return {
+        "schema_version": DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION,
+        "summary": {
+            "question_count": len(questions),
+            "evidence_row_count": len(evidence_rows),
+            "source_id_count": len(source_ids),
+            "drafted_answer_count": _int(summary.get("drafted_answer_count")),
+            "no_proven_answer_count": _int(summary.get("no_proven_answer_count")),
+        },
+        "report_summary": summary,
+        "questions": [dict(question) for question in questions],
+        "evidence_rows": [dict(row) for row in evidence_rows],
+    }
 
 
 def build_deflection_snapshot(
@@ -373,7 +411,7 @@ def _support_tax_section(
             "The full unlocked report below gives you every ranked question, "
             "the estimated support cost by question, publishable help-center copy "
             "where your uploaded resolutions prove the answer, the no-proven-answer "
-            "roadmap, and complete evidence inside each question detail block."
+            "roadmap, and a complete evidence export for audit/detail review."
         ),
         "",
         f"- Publishable answers drafted from proven resolutions: {_count(_int(summary.get('drafted_answer_count')))}",
@@ -650,6 +688,121 @@ def _complete_evidence_detail(item: Mapping[str, Any]) -> list[str]:
         lines.append(f"- {_md(quote)}")
     lines.append("")
     return lines
+
+
+def _evidence_export_question(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
+    source_ids = _texts(item.get("source_ids"))
+    return {
+        "question_id": _evidence_question_id(rank),
+        "rank": rank,
+        "question": _text(item.get("question")),
+        "customer_wording": _text(item.get("customer_wording")),
+        "topic": _text(item.get("topic")),
+        "ticket_count": _ticket_count(item),
+        "weighted_frequency": _int(item.get("weighted_frequency") or item.get("frequency")),
+        "opportunity_score": _int(item.get("opportunity_score")),
+        "answer_evidence_status": _text(item.get("answer_evidence_status")),
+        "resolution_evidence_scope": _text(item.get("resolution_evidence_scope")),
+        "answer_linkage": _evidence_answer_linkage(item),
+        "answer": _text(item.get("answer")),
+        "steps": _texts(item.get("steps")),
+        "source_ids": source_ids,
+        "evidence_quote_count": len(_texts(item.get("evidence_quotes"))),
+        "term_mappings": [
+            dict(mapping)
+            for mapping in item.get("term_mappings") or ()
+            if isinstance(mapping, Mapping)
+        ],
+        "outcome_diagnostics": dict(_item_outcome_diagnostics(item)),
+    }
+
+
+def _evidence_export_rows(rank: int, item: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+    question_id = _evidence_question_id(rank)
+    source_ids = _texts(item.get("source_ids"))
+    quotes = _texts(item.get("evidence_quotes"))
+    rows: list[dict[str, Any]] = []
+    used_quotes: set[int] = set()
+
+    for source_index, source_id in enumerate(source_ids, start=1):
+        quote_index, quote = _evidence_quote_for_source(source_id, quotes, used_quotes)
+        if quote_index is not None:
+            used_quotes.add(quote_index)
+        rows.append(
+            _evidence_row(
+                question_id=question_id,
+                rank=rank,
+                item=item,
+                row_index=source_index,
+                source_id=source_id,
+                quote=quote,
+                source_field="evidence_quote" if quote else "source_id",
+            )
+        )
+
+    for quote_index, quote in enumerate(quotes):
+        if quote_index in used_quotes:
+            continue
+        rows.append(
+            _evidence_row(
+                question_id=question_id,
+                rank=rank,
+                item=item,
+                row_index=len(rows) + 1,
+                source_id="",
+                quote=quote,
+                source_field="evidence_quote",
+            )
+        )
+    return tuple(rows)
+
+
+def _evidence_row(
+    *,
+    question_id: str,
+    rank: int,
+    item: Mapping[str, Any],
+    row_index: int,
+    source_id: str,
+    quote: str,
+    source_field: str,
+) -> dict[str, Any]:
+    return {
+        "row_id": f"{question_id}-e{row_index:03d}",
+        "question_id": question_id,
+        "rank": rank,
+        "question": _text(item.get("question")),
+        "source_id": source_id,
+        "source_field": source_field,
+        "evidence_quote": quote,
+        "answer_evidence_status": _text(item.get("answer_evidence_status")),
+        "resolution_evidence_scope": _text(item.get("resolution_evidence_scope")),
+        "answer_linkage": _evidence_answer_linkage(item),
+    }
+
+
+def _evidence_question_id(rank: int) -> str:
+    return f"q{rank:03d}"
+
+
+def _evidence_answer_linkage(item: Mapping[str, Any]) -> str:
+    if _text(item.get("answer_evidence_status")) == _RESOLUTION_EVIDENCE_STATUS:
+        return "publishable_answer"
+    return "needs_review"
+
+
+def _evidence_quote_for_source(
+    source_id: str,
+    quotes: Sequence[str],
+    used_quotes: set[int],
+) -> tuple[int | None, str]:
+    normalized_source = source_id.casefold()
+    for index, quote in enumerate(quotes):
+        if index in used_quotes:
+            continue
+        if normalized_source and normalized_source in quote.casefold():
+            return index, quote
+    return None, ""
 
 
 def _status_label(item: Mapping[str, Any]) -> str:

--- a/plans/PR-Deflection-Complete-Evidence-Export.md
+++ b/plans/PR-Deflection-Complete-Evidence-Export.md
@@ -1,0 +1,131 @@
+# PR-Deflection-Complete-Evidence-Export
+
+## Why this slice exists
+
+#1588 says the paid deflection report needs separate surfaces: concise hosted
+view, curated PDF, and a complete evidence export. #1590 merged the hosted
+view, so this slice builds the prerequisite that keeps future web/PDF
+caps honest: an uncapped structured evidence export derived from the same
+deterministic FAQ result data as the paid report.
+
+Without the export, later PDF/report-polish slices would have to either keep
+every evidence row inline or weaken the completeness promise. This PR gives
+later renderers a stable export contract first, while avoiding the #1590
+portfolio files.
+
+This is over the 400 LOC soft cap because the artifact projection, CLI writer,
+contract docs, and regression tests need to land together. Splitting the CLI or
+tests from the projection would create an export contract without a reproducible
+operator artifact path or failure proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Vertical slice
+
+1. Add a `deflection_evidence.v1` JSON export to the paid deflection artifact.
+2. Project existing FAQ item data into stable question rows and evidence rows:
+   question id/rank, source ticket ids, evidence quote, answer classification,
+   answer linkage, term mappings, and outcome diagnostics.
+3. Add a CLI flag that writes only the evidence export JSON for validation and
+   future attachment/download wiring.
+4. Update the report promise text so completeness is satisfied by the export,
+   not by forcing every evidence row into inline web/PDF content.
+5. Do not touch paid result-page files or add a new public download route in
+   this slice.
+
+### Files touched
+
+- `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md`
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Complete-Evidence-Export.md`
+- `scripts/build_content_ops_deflection_report.py`
+- `tests/test_content_ops_deflection_report.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Paid artifact dictionaries include a structured `evidence_export` with
+        schema version `deflection_evidence.v1`.
+  - [ ] The export is derived from existing structured FAQ result items, not
+        parsed from Markdown.
+  - [ ] Source ids and evidence quotes are preserved in evidence rows, including
+        rows that have source ids but no rendered quote.
+  - [ ] Publishable and no-proven-answer questions keep distinct answer linkage
+        and classification fields.
+  - [ ] The CLI can write the evidence export JSON independently of Markdown.
+  - [ ] Promise text no longer implies inline web/PDF content is the uncapped
+        completeness surface.
+- Affected surfaces: extracted deflection artifact shape, local report CLI,
+  report contract docs, focused report tests.
+- Risk areas: persisted artifact compatibility, evidence row truncation, future
+  renderer contract drift, and collision with #1590 portfolio rendering work.
+- Reviewer rules triggered: R1, R2, R5, R9, R10, R12, R14.
+
+## Mechanism
+
+The deflection artifact already stores `faq_result.items` as structured data.
+This slice adds a pure projection over those items. Each ranked question gets a
+stable export question id, answer status, answer linkage, source ids,
+publishable answer/steps when present, term mappings, and outcome diagnostics.
+Evidence rows are then emitted from the same items with stable row ids and
+source-id/quote fields.
+
+The projection is added to the artifact dictionary so paid artifact consumers
+can retrieve it after unlock. The CLI also gains an evidence-output path that
+writes only the export JSON, giving operator proofs and future download wiring a
+single contract to consume.
+
+## Intentional
+
+- No new portfolio route in this PR. #1590 owns the paid result-page rendering
+  surface, and a later download route can expose the already-persisted export.
+- No PDF redesign here. #1588 explicitly says the curated PDF should wait until
+  the complete export exists.
+- No Markdown parsing. Markdown remains a renderer; the export is built from
+  the structured FAQ item data.
+- Evidence rows may have an empty quote when a source id exists but the current
+  rendered FAQ item did not include a quote for that source. The row still
+  preserves the source id so the export is not silently truncated to rendered
+  quote count.
+
+## Deferred
+
+- #1590 merged the hosted paid result-page consolidated view.
+- #1588 follow-up: public download route/button for the evidence export after
+  the paid web surface settles.
+- #1588 follow-up: curated/shareable PDF that links to or attaches this export
+  instead of trying to inline every evidence row.
+- #1588 follow-up: full structured `deflection.v1` paid report model.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_deflection_report.py -q`
+  - Result: included in focused 54-test rerun after review fixes.
+- `python -m pytest tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_resolution_live_proof.py -q`
+  - Result: included in focused 54-test rerun after review fixes.
+- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_resolution_live_proof.py -q`
+  - Result: 54 passed.
+- `scripts/run_extracted_pipeline_checks.sh` via `bash`
+  - Result: 4306 passed, 10 skipped.
+- Python compile check for changed Python files.
+  - Result: passed.
+- Local PR review bundle.
+  - Pending via push wrapper before push.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/fixtures/deflection_resolution_evidence_live_proof_20260609/report.md` | 2 |
+| `docs/frontend/content_ops_faq_deflection_report_example.json` | 172 |
+| `docs/frontend/content_ops_faq_report_contract.md` | 58 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 155 |
+| `plans/PR-Deflection-Complete-Evidence-Export.md` | 131 |
+| `scripts/build_content_ops_deflection_report.py` | 13 |
+| `tests/test_content_ops_deflection_report.py` | 177 |
+| **Total** | **708** |

--- a/scripts/build_content_ops_deflection_report.py
+++ b/scripts/build_content_ops_deflection_report.py
@@ -24,6 +24,7 @@ from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     parse_default_fields_or_exit,
 )
 from extracted_content_pipeline.faq_deflection_report import (  # noqa: E402
+    build_deflection_evidence_export,
     build_deflection_report_artifact,
 )
 from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
@@ -67,6 +68,16 @@ def main(argv: list[str] | None = None) -> int:
         args.result_output.write_text(
             json.dumps(
                 _result_payload(args, artifact, failed_checks),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    if args.evidence_output:
+        args.evidence_output.write_text(
+            json.dumps(
+                build_deflection_evidence_export(artifact),
                 indent=2,
                 sort_keys=True,
             )
@@ -164,6 +175,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--output", type=Path)
     parser.add_argument("--summary-output", type=Path)
     parser.add_argument("--result-output", type=Path)
+    parser.add_argument("--evidence-output", type=Path)
     parser.add_argument(
         "--require-output-checks",
         action="store_true",
@@ -238,6 +250,7 @@ def _result_payload(
             "markdown_path": str(args.output) if args.output else None,
             "summary_path": str(args.summary_output) if args.summary_output else None,
             "result_path": str(args.result_output) if args.result_output else None,
+            "evidence_path": str(args.evidence_output) if args.evidence_output else None,
         },
         "config": {
             "title": args.title,

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -8,6 +8,8 @@ import pytest
 
 from extracted_content_pipeline.faq_deflection_report import (
     DEFAULT_DEFLECTION_SEO_TARGET_LIMIT,
+    DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION,
+    build_deflection_evidence_export,
     build_deflection_snapshot,
     build_deflection_report_artifact,
     deflection_snapshot_content_opportunities,
@@ -138,6 +140,128 @@ def test_deflection_report_partitions_proven_and_unproven_answers() -> None:
     assert "No verified support resolution was present" not in artifact.markdown
     assert "export" in artifact.markdown
     assert "Download report" in artifact.markdown
+
+
+def test_deflection_report_artifact_includes_complete_evidence_export() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=4,
+        ticket_source_count=4,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "How do I export attribution reports?",
+                "customer_wording": "export attribution reports",
+                "topic": "exports",
+                "weighted_frequency": 8,
+                "ticket_count": 2,
+                "opportunity_score": 14,
+                "answer": "Open Analytics, choose Attribution, then select Download report.",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "steps": ["Open Analytics and select Download report."],
+                "source_ids": ("ticket-1", "ticket-2"),
+                "evidence_quotes": (
+                    "`ticket-1` - Export question: How do I export reports?",
+                ),
+                "term_mappings": (
+                    {
+                        "customer_term": "export",
+                        "documentation_term": "Download report",
+                    },
+                ),
+                "outcome_diagnostics": {
+                    "ticket_status_summary": {"resolved": 2},
+                    "diagnostic_ticket_count": 2,
+                },
+            },
+            {
+                "question": "Why is the dashboard stale?",
+                "weighted_frequency": 3,
+                "ticket_count": 2,
+                "opportunity_score": 6,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": ("ticket-3", "ticket-4"),
+                "evidence_quotes": (
+                    "`ticket-3` - Stale dashboard: why is the dashboard stale?",
+                ),
+            },
+        ),
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    export = build_deflection_evidence_export(artifact)
+
+    assert artifact.as_dict()["evidence_export"] == export
+    assert export["schema_version"] == DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION
+    assert export["summary"] == {
+        "question_count": 2,
+        "evidence_row_count": 4,
+        "source_id_count": 4,
+        "drafted_answer_count": 1,
+        "no_proven_answer_count": 1,
+    }
+    assert export["questions"][0]["question_id"] == "q001"
+    assert export["questions"][0]["answer_linkage"] == "publishable_answer"
+    assert export["questions"][0]["term_mappings"] == [
+        {"customer_term": "export", "documentation_term": "Download report"}
+    ]
+    assert export["questions"][0]["outcome_diagnostics"] == {
+        "ticket_status_summary": {"resolved": 2},
+        "diagnostic_ticket_count": 2,
+    }
+    assert export["questions"][1]["answer_linkage"] == "needs_review"
+    assert export["evidence_rows"][0] == {
+        "row_id": "q001-e001",
+        "question_id": "q001",
+        "rank": 1,
+        "question": "How do I export attribution reports?",
+        "source_id": "ticket-1",
+        "source_field": "evidence_quote",
+        "evidence_quote": "`ticket-1` - Export question: How do I export reports?",
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
+        "answer_linkage": "publishable_answer",
+    }
+    assert export["evidence_rows"][1]["source_id"] == "ticket-2"
+    assert export["evidence_rows"][1]["source_field"] == "source_id"
+    assert export["evidence_rows"][1]["evidence_quote"] == ""
+    assert export["evidence_rows"][2]["answer_linkage"] == "needs_review"
+
+
+def test_deflection_snapshot_excludes_complete_evidence_export() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=2,
+        ticket_source_count=2,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "How do I export attribution reports?",
+                "weighted_frequency": 4,
+                "ticket_count": 2,
+                "answer": "Open Analytics, choose Attribution, then select Download report.",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "steps": ["Open Analytics and select Download report."],
+                "source_ids": ("ticket-export-1", "ticket-export-2"),
+                "evidence_quotes": (
+                    "`ticket-export-1` - Export question: How do I export reports?",
+                ),
+            },
+        ),
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    snapshot = build_deflection_snapshot(artifact).as_dict()
+    encoded = json.dumps(snapshot, sort_keys=True)
+
+    assert "evidence_export" in artifact.as_dict()
+    assert "evidence_export" not in snapshot
+    assert "evidence_export" not in encoded
+    assert "evidence_quotes" not in encoded
+    assert "source_ids" not in encoded
+    assert "ticket-export-1" not in encoded
 
 
 def test_deflection_report_reframes_paid_artifact_with_cost_and_seo_sections() -> None:
@@ -1424,6 +1548,58 @@ def test_deflection_report_cli_builds_saas_demo_artifact(tmp_path: Path) -> None
     assert "tell users exactly what to try next" not in markdown
 
 
+def test_deflection_report_cli_writes_complete_evidence_export(tmp_path: Path) -> None:
+    source = tmp_path / "mixed-support-tickets.json"
+    evidence_output = tmp_path / "deflection-evidence.json"
+    source.write_text(
+        json.dumps([
+            {
+                "ticket_id": "ticket-export-1",
+                "source_type": "support_ticket",
+                "subject": "Export attribution report",
+                "message": "How do I export attribution reports?",
+                "pain_category": "exports",
+                "resolution_text": (
+                    "Open Analytics then Attribution then click Download report."
+                ),
+            },
+            {
+                "ticket_id": "ticket-export-2",
+                "source_type": "support_ticket",
+                "subject": "Export attribution report",
+                "message": "How do I export attribution reports?",
+                "pain_category": "exports",
+                "resolution_text": (
+                    "Open Analytics then Attribution then click Download report."
+                ),
+            },
+        ]),
+        encoding="utf-8",
+    )
+
+    exit_code = MODULE.main([
+        str(source),
+        "--source-format",
+        "json",
+        "--evidence-output",
+        str(evidence_output),
+    ])
+
+    assert exit_code == 0
+    export = json.loads(evidence_output.read_text(encoding="utf-8"))
+    assert export["schema_version"] == DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION
+    assert export["summary"]["question_count"] == 1
+    assert export["summary"]["source_id_count"] == 2
+    assert export["questions"][0]["answer_linkage"] == "publishable_answer"
+    assert export["questions"][0]["source_ids"] == [
+        "ticket-export-1",
+        "ticket-export-2",
+    ]
+    assert {
+        row["source_id"] for row in export["evidence_rows"]
+    } == {"ticket-export-1", "ticket-export-2"}
+
+
 def test_deflection_report_cli_ignores_legacy_max_items_cap(tmp_path: Path) -> None:
     source = tmp_path / "uncapped-support-tickets.json"
     result_output = tmp_path / "deflection-report-result.json"
@@ -1618,6 +1794,7 @@ def test_deflection_report_cli_fails_required_output_checks_for_weak_rows(
     assert result["output"]["markdown_path"] == str(output)
     assert result["output"]["summary_path"] == str(summary_output)
     assert result["output"]["result_path"] == str(result_output)
+    assert result["output"]["evidence_path"] is None
     assert result["diagnostics"]["item_count"] == 0
     assert result["diagnostics"]["items"] == []
     assert "markdown" not in result


### PR DESCRIPTION
Plan: plans/PR-Deflection-Complete-Evidence-Export.md
Slice phase: Vertical slice

#1588 needs a complete evidence surface before web/PDF renderers can safely become concise. This PR adds a deterministic `deflection_evidence.v1` export to the paid deflection artifact and CLI so completeness lives in structured JSON, not in ever-longer inline Markdown/PDF output.

## Intentional
- No portfolio route in this PR; #1590 owns the paid result-page surface.
- No PDF redesign here; the curated PDF waits until the export contract exists.
- No Markdown parsing; the export is projected from structured FAQ result items.
- Evidence rows preserve source IDs even when the current rendered item did not include a quote for that source.

## Deferred
- #1590 remains the hosted paid result-page consolidated view.
- #1588 follow-up: public download route/button for the evidence export after the paid web surface settles.
- #1588 follow-up: curated/shareable PDF that links to or attaches this export instead of inlining every evidence row.
- #1588 follow-up: full structured `deflection.v1` paid report model.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: regenerated the producer-bound report example JSON after adding `evidence_export`; updated the committed live-proof Markdown for the new promise text; added a snapshot paywall regression so the complete evidence export stays out of the free snapshot.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_resolution_live_proof.py -q` -- 54 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4306 passed, 10 skipped.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py` -- passed.
- Local PR review bundle -- pending via push wrapper before push.

## Diff size
7 files, +702 / -6