### PR TITLE
FAQ macro writeback sandbox seed

### DIFF
--- a/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
+++ b/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
@@ -11,7 +11,9 @@ on:
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
+      - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_scheduler.py"
       - "tests/test_synthesis.py"
   push:
@@ -26,7 +28,9 @@ on:
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
+      - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_scheduler.py"
       - "tests/test_synthesis.py"
 
@@ -53,6 +57,7 @@ jobs:
         run: |
           python -m pytest \
             tests/test_autonomous_faq_macro_writeback_scheduled_publish.py \
+            tests/test_seed_faq_macro_writeback_live_smoke_draft.py \
             tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in \
             tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary \
             tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message \

--- a/plans/PR-FAQ-Macro-Writeback-Sandbox-Seed.md
+++ b/plans/PR-FAQ-Macro-Writeback-Sandbox-Seed.md
@@ -1,0 +1,120 @@
+# PR-FAQ-Macro-Writeback-Sandbox-Seed
+
+## Why this slice exists
+
+The macro writeback lane already has a guarded live Zendesk smoke, but it assumes
+an approved, publishable FAQ draft already exists in Postgres. Now that we have
+a Zendesk test API available, the remaining operator friction is bootstrapping a
+safe draft for the smoke without hand-editing the database or depending on a
+real customer FAQ.
+
+This slice adds only the missing sandbox seed step. It does not write to
+Zendesk. The existing smoke remains the only command that creates or updates
+Zendesk macros, and it still requires `--confirm-live-zendesk-write` plus the
+expected Zendesk base URL guard.
+
+This PR is over the 400 LOC soft cap because the operator helper, fail-closed
+write guards, preview validation, CI enrollment, and focused tests for each
+error branch need to ship together. Splitting the tests or workflow enrollment
+from the script would create an unprotected live-validation helper.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Functional validation
+
+1. Add an operator-run script that inserts one disposable approved FAQ draft for
+   macro writeback live-smoke validation.
+2. Require explicit confirmation before the script writes to Postgres.
+3. Build the seed draft through the existing `TicketFAQDraft` shape and
+   `PostgresTicketFAQRepository`, then approve it through the repository status
+   path so the existing macro preview and publish service see a normal draft.
+4. Emit machine-readable JSON with the created FAQ draft id, publishable macro
+   count, and the exact next live Zendesk smoke command.
+5. Do not call Zendesk or create macros in this slice.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_macro_writeback_checks.yml`
+- `plans/PR-FAQ-Macro-Writeback-Sandbox-Seed.md`
+- `scripts/seed_faq_macro_writeback_live_smoke_draft.py`
+- `tests/test_seed_faq_macro_writeback_live_smoke_draft.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Missing confirmation exits with a skipped payload before any database
+        pool is opened.
+  - [ ] With confirmation, the script saves exactly one FAQ draft scoped to the
+        requested account and marks it `approved` through the repository.
+  - [ ] The seeded draft produces at least one publishable macro through
+        `build_macro_writeback_preview`.
+  - [ ] The JSON output includes the created `faq_id` and a next-step command
+        for `scripts/smoke_content_ops_faq_macro_live_zendesk.py`.
+  - [ ] The script never imports or calls the Zendesk transport/provider.
+- Affected surfaces: operator scripts, macro-writeback live validation tests,
+  Postgres draft seeding path.
+- Risk areas: accidental writes, tenant scope correctness, live Zendesk safety,
+  and drift from the existing publish path.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R14.
+
+## Mechanism
+
+The new script accepts `--database-url`, `--account-id`, optional seed labels,
+and `--confirm-create-draft`. Without confirmation, it returns a skipped JSON
+payload and exits before opening a database pool.
+
+When confirmed, the script opens a small asyncpg pool, builds one
+`TicketFAQDraft` with a single `resolution_evidence` FAQ item, saves it through
+`PostgresTicketFAQRepository.save_drafts`, and then calls `update_status` to mark
+the saved draft `approved`. The script validates the resulting draft shape with
+`build_macro_writeback_preview` using the saved id before printing the next
+operator command for the already-existing guarded Zendesk smoke.
+
+The helper does not publish anything to Zendesk. It prepares the local Atlas
+state needed for the existing live smoke to do the actual API write under its
+own confirmation and base-url guard.
+
+## Intentional
+
+- No live Zendesk call. This is the seed half only; the existing live smoke owns
+  the external write.
+- No cleanup/delete path in this PR. The seed draft is harmless local Atlas
+  state, and cleanup can be added after the first live test proves the path.
+- No new API route or UI. This is operator validation tooling for the sandbox
+  proof.
+- No credential reads. Zendesk credentials remain handled by the existing smoke
+  and tenant credential provider.
+
+## Deferred
+
+- Run the existing live Zendesk smoke against the seeded draft once the operator
+  chooses the test tenant/account and expected Zendesk base URL.
+- Future robust-testing slice: optional cleanup helper that deletes the seeded
+  draft and macro mapping after the sandbox write is verified.
+- Future robust-testing slice: create/update/delete a dedicated Zendesk macro
+  fixture when the test account lifecycle policy is settled.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_seed_faq_macro_writeback_live_smoke_draft.py -q`
+  - Result: 7 passed.
+- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q`
+  - Result: 19 passed, 1 warning.
+- Python compile check for the seed script and test module.
+  - Result: passed.
+- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Sandbox-Seed.md --check`
+  - Result: passed.
+- Pending before push: local PR review via `scripts/push_pr.sh`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_macro_writeback_checks.yml` | 5 |
+| `plans/PR-FAQ-Macro-Writeback-Sandbox-Seed.md` | 120 |
+| `scripts/seed_faq_macro_writeback_live_smoke_draft.py` | 311 |
+| `tests/test_seed_faq_macro_writeback_live_smoke_draft.py` | 212 |
+| **Total** | **648** |

--- a/scripts/seed_faq_macro_writeback_live_smoke_draft.py
+++ b/scripts/seed_faq_macro_writeback_live_smoke_draft.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Seed one approved FAQ draft for the guarded Zendesk macro live smoke."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import shlex
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.faq_macro_writeback import (  # noqa: E402
+    APPROVED_FAQ_STATUS,
+    build_macro_writeback_preview,
+)
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft  # noqa: E402
+from extracted_content_pipeline.ticket_faq_postgres import (  # noqa: E402
+    PostgresTicketFAQRepository,
+)
+
+
+SKIPPED_EXIT = 2
+DATABASE_URL_ENV_EXPR = "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        required=True,
+        help="Postgres DSN. Required explicitly; the script does not read env vars.",
+    )
+    parser.add_argument("--account-id", required=True, help="Tenant/account id.")
+    parser.add_argument("--user-id", default="", help="Optional operator user id.")
+    parser.add_argument(
+        "--target-id",
+        default="macro-writeback-live-smoke-seed",
+        help="Target id stored on the seeded FAQ draft.",
+    )
+    parser.add_argument(
+        "--target-mode",
+        default="support_ticket_faq",
+        help="Target mode stored on the seeded FAQ draft.",
+    )
+    parser.add_argument(
+        "--title",
+        default="Zendesk macro writeback live smoke seed",
+        help="FAQ draft title.",
+    )
+    parser.add_argument(
+        "--question",
+        default="How do I refund a duplicate charge?",
+        help="Question used for the publishable FAQ item.",
+    )
+    parser.add_argument(
+        "--resolution-text",
+        default=(
+            "Open Billing, select the duplicate charge, and click Refund payment. "
+            "Confirm the refund and tell the customer it may take 3-5 business days."
+        ),
+        help="Verified answer text used for the publishable macro body.",
+    )
+    parser.add_argument(
+        "--expected-zendesk-base-url",
+        default="",
+        help=(
+            "Optional expected Zendesk base URL included in the printed next "
+            "live-smoke command."
+        ),
+    )
+    parser.add_argument(
+        "--confirm-create-draft",
+        action="store_true",
+        help="Required to write one approved FAQ draft to Postgres.",
+    )
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for operator consistency; output is always JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not _clean(args.database_url):
+        raise SystemExit("--database-url is required")
+    if not _clean(args.account_id):
+        raise SystemExit("--account-id is required")
+    if not _clean(args.question):
+        raise SystemExit("--question is required")
+    if not _clean(args.resolution_text):
+        raise SystemExit("--resolution-text is required")
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to seed the macro writeback live-smoke draft; "
+            "install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def seed_live_smoke_draft(
+    args: argparse.Namespace,
+    pool: Any,
+    *,
+    faq_repository: Any | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Seed one approved FAQ draft and return a machine-readable payload."""
+
+    scope = TenantScope(
+        account_id=_clean(args.account_id),
+        user_id=_clean(getattr(args, "user_id", "")) or None,
+    )
+    if not getattr(args, "confirm_create_draft", False):
+        return _not_run(
+            "missing_confirm_create_draft",
+            account_id=scope.account_id or "",
+        )
+
+    repo = faq_repository or PostgresTicketFAQRepository(pool)
+    draft = _seed_draft(args)
+    saved_ids = tuple(await repo.save_drafts((draft,), scope=scope))
+    if len(saved_ids) != 1 or not _clean(saved_ids[0]):
+        return 1, {
+            "ok": False,
+            "skipped": False,
+            "account_id": scope.account_id or "",
+            "error": "seed_faq_draft_save_failed",
+        }
+    faq_id = _clean(saved_ids[0])
+    if not await repo.update_status(faq_id, APPROVED_FAQ_STATUS, scope=scope):
+        return 1, {
+            "ok": False,
+            "skipped": False,
+            "account_id": scope.account_id or "",
+            "faq_id": faq_id,
+            "error": "seed_faq_draft_approve_failed",
+        }
+
+    approved = _with_identity(draft, faq_id=faq_id, status=APPROVED_FAQ_STATUS)
+    preview = build_macro_writeback_preview((approved,))
+    if preview.publishable_count < 1:
+        return 1, {
+            "ok": False,
+            "skipped": False,
+            "account_id": scope.account_id or "",
+            "faq_id": faq_id,
+            "error": "seed_faq_draft_not_publishable",
+            "preview": preview.as_dict(),
+        }
+
+    return 0, {
+        "ok": True,
+        "skipped": False,
+        "account_id": scope.account_id or "",
+        "faq_id": faq_id,
+        "draft_status": APPROVED_FAQ_STATUS,
+        "publishable_count": preview.publishable_count,
+        "macro_titles": [macro.title for macro in preview.macros],
+        "next_command": _next_live_smoke_command(args, faq_id=faq_id),
+    }
+
+
+def _seed_draft(args: argparse.Namespace) -> TicketFAQDraft:
+    question = _clean(args.question)
+    resolution_text = _clean(args.resolution_text)
+    item = {
+        "faq_item_id": "macro-writeback-live-smoke-item",
+        "topic": "billing",
+        "question": question,
+        "answer": resolution_text,
+        "resolution_text": resolution_text,
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
+        "source_ids": ("macro-writeback-live-smoke-ticket",),
+    }
+    return TicketFAQDraft(
+        target_id=_clean(args.target_id),
+        target_mode=_clean(args.target_mode),
+        title=_clean(args.title),
+        markdown=_seed_markdown(question=question, resolution_text=resolution_text),
+        items=(item,),
+        source_count=1,
+        ticket_source_count=1,
+        output_checks={
+            "condensed": True,
+            "has_action_items": True,
+            "resolution_evidence_scoped": True,
+            "uses_user_vocabulary": True,
+        },
+        warnings=(),
+        metadata={
+            "macro_writeback_live_smoke_seed": True,
+            "zendesk_write": False,
+        },
+    )
+
+
+def _with_identity(draft: TicketFAQDraft, *, faq_id: str, status: str) -> TicketFAQDraft:
+    return TicketFAQDraft(
+        target_id=draft.target_id,
+        target_mode=draft.target_mode,
+        title=draft.title,
+        markdown=draft.markdown,
+        items=draft.items,
+        source_count=draft.source_count,
+        ticket_source_count=draft.ticket_source_count,
+        output_checks=draft.output_checks,
+        warnings=draft.warnings,
+        metadata=draft.metadata,
+        id=faq_id,
+        status=status,
+    )
+
+
+def _seed_markdown(*, question: str, resolution_text: str) -> str:
+    return (
+        "# Zendesk macro writeback live smoke seed\n\n"
+        f"## {question}\n\n"
+        f"{resolution_text}\n"
+    )
+
+
+def _next_live_smoke_command(args: argparse.Namespace, *, faq_id: str) -> str:
+    command = [
+        "python",
+        "scripts/smoke_content_ops_faq_macro_live_zendesk.py",
+        "--database-url",
+        DATABASE_URL_ENV_EXPR,
+        "--account-id",
+        _clean(args.account_id),
+        "--faq-id",
+        faq_id,
+    ]
+    if _clean(getattr(args, "user_id", "")):
+        command.extend(["--user-id", _clean(args.user_id)])
+    expected_base_url = _clean(getattr(args, "expected_zendesk_base_url", ""))
+    command.extend([
+        "--expected-zendesk-base-url",
+        expected_base_url or "<expected-zendesk-base-url>",
+        "--confirm-live-zendesk-write",
+        "--json",
+    ])
+    return " ".join(_shell_quote(part) for part in command)
+
+
+def _shell_quote(part: str) -> str:
+    if part == DATABASE_URL_ENV_EXPR:
+        return f'"{DATABASE_URL_ENV_EXPR}"'
+    return shlex.quote(part)
+
+
+def _not_run(reason: str, **extra: Any) -> tuple[int, dict[str, Any]]:
+    payload = {
+        "ok": False,
+        "skipped": True,
+        "not_run_reason": reason,
+    }
+    payload.update(extra)
+    return SKIPPED_EXIT, payload
+
+
+def _write_payload(payload: dict[str, Any], args: argparse.Namespace) -> None:
+    output = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    if not args.confirm_create_draft:
+        code, payload = _not_run(
+            "missing_confirm_create_draft",
+            account_id=_clean(args.account_id),
+        )
+        _write_payload(payload, args)
+        return code
+
+    pool = await _create_pool(_clean(args.database_url))
+    try:
+        code, payload = await seed_live_smoke_draft(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            await close()
+    _write_payload(payload, args)
+    return code
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_seed_faq_macro_writeback_live_smoke_draft.py
+++ b/tests/test_seed_faq_macro_writeback_live_smoke_draft.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+from typing import Any, Sequence
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
+SPEC = importlib.util.spec_from_file_location(
+    "seed_faq_macro_writeback_live_smoke_draft",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+seed = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(seed)
+
+
+class _FAQRepo:
+    def __init__(
+        self,
+        *,
+        saved_ids: Sequence[str] = ("faq-seed-1",),
+        approve_result: bool = True,
+    ) -> None:
+        self.saved_ids = tuple(saved_ids)
+        self.approve_result = approve_result
+        self.save_calls: list[dict[str, Any]] = []
+        self.update_calls: list[dict[str, Any]] = []
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[TicketFAQDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        self.save_calls.append({"drafts": tuple(drafts), "scope": scope})
+        return self.saved_ids
+
+    async def update_status(
+        self,
+        faq_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        self.update_calls.append({
+            "faq_id": faq_id,
+            "status": status,
+            "scope": scope,
+        })
+        return self.approve_result
+
+
+@pytest.mark.asyncio
+async def test_seed_skips_before_opening_pool_when_confirmation_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def fail_create_pool(database_url: str) -> object:
+        raise AssertionError(f"pool should not open for {database_url}")
+
+    output = tmp_path / "seed.json"
+    monkeypatch.setattr(seed, "_create_pool", fail_create_pool)
+
+    code = await seed._main([
+        "--database-url",
+        "postgres://example",
+        "--account-id",
+        "acct-1",
+        "--output",
+        str(output),
+    ])
+
+    assert code == seed.SKIPPED_EXIT
+    assert '"not_run_reason": "missing_confirm_create_draft"' in output.read_text()
+
+
+@pytest.mark.asyncio
+async def test_seed_creates_one_approved_publishable_draft() -> None:
+    repo = _FAQRepo()
+
+    code, payload = await seed.seed_live_smoke_draft(
+        _args(user_id="operator-1"),
+        pool=object(),
+        faq_repository=repo,
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["faq_id"] == "faq-seed-1"
+    assert payload["draft_status"] == "approved"
+    assert payload["publishable_count"] == 1
+    assert payload["macro_titles"] == ["How do I refund a duplicate charge?"]
+    assert repo.save_calls[0]["scope"] == TenantScope(
+        account_id="acct-1",
+        user_id="operator-1",
+    )
+    saved_draft = repo.save_calls[0]["drafts"][0]
+    assert saved_draft.status == ""
+    assert saved_draft.metadata["macro_writeback_live_smoke_seed"] is True
+    assert saved_draft.metadata["zendesk_write"] is False
+    assert saved_draft.items[0]["answer_evidence_status"] == "resolution_evidence"
+    assert repo.update_calls == [
+        {
+            "faq_id": "faq-seed-1",
+            "status": "approved",
+            "scope": TenantScope(account_id="acct-1", user_id="operator-1"),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_seed_outputs_next_command_without_raw_database_url() -> None:
+    code, payload = await seed.seed_live_smoke_draft(
+        _args(
+            database_url="postgres://user:secret@example/db",
+            expected_zendesk_base_url="https://sandbox.zendesk.com",
+        ),
+        pool=object(),
+        faq_repository=_FAQRepo(saved_ids=("faq with spaces",)),
+    )
+
+    assert code == 0
+    command = payload["next_command"]
+    assert "postgres://user:secret@example/db" not in command
+    assert '--database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"' in command
+    assert "--faq-id 'faq with spaces'" in command
+    assert "--expected-zendesk-base-url https://sandbox.zendesk.com" in command
+    assert "--confirm-live-zendesk-write" in command
+
+
+@pytest.mark.asyncio
+async def test_seed_reports_save_failure_without_approval_attempt() -> None:
+    repo = _FAQRepo(saved_ids=())
+
+    code, payload = await seed.seed_live_smoke_draft(
+        _args(),
+        pool=object(),
+        faq_repository=repo,
+    )
+
+    assert code == 1
+    assert payload["error"] == "seed_faq_draft_save_failed"
+    assert repo.save_calls
+    assert repo.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_seed_reports_approval_failure() -> None:
+    repo = _FAQRepo(approve_result=False)
+
+    code, payload = await seed.seed_live_smoke_draft(
+        _args(),
+        pool=object(),
+        faq_repository=repo,
+    )
+
+    assert code == 1
+    assert payload["faq_id"] == "faq-seed-1"
+    assert payload["error"] == "seed_faq_draft_approve_failed"
+
+
+@pytest.mark.asyncio
+async def test_seed_reports_non_publishable_override() -> None:
+    code, payload = await seed.seed_live_smoke_draft(
+        _args(resolution_text=""),
+        pool=object(),
+        faq_repository=_FAQRepo(),
+    )
+
+    assert code == 1
+    assert payload["error"] == "seed_faq_draft_not_publishable"
+    assert payload["preview"]["publishable_count"] == 0
+    assert payload["preview"]["skipped"][0]["reason"] == "missing_resolution_body"
+
+
+def test_seed_script_does_not_import_zendesk_transport() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "ZendeskMacroPublishProvider" not in source
+    assert "ZendeskHTTPMacroTransport" not in source
+    assert "faq_macro_writeback_zendesk" not in source
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values: dict[str, Any] = {
+        "database_url": "postgres://example",
+        "account_id": "acct-1",
+        "user_id": "",
+        "target_id": "macro-writeback-live-smoke-seed",
+        "target_mode": "support_ticket_faq",
+        "title": "Zendesk macro writeback live smoke seed",
+        "question": "How do I refund a duplicate charge?",
+        "resolution_text": (
+            "Open Billing, select the duplicate charge, and click Refund payment. "
+            "Confirm the refund and tell the customer it may take 3-5 business days."
+        ),
+        "expected_zendesk_base_url": "",
+        "confirm_create_draft": True,
+        "output": None,
+        "json": True,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Sandbox-Seed.md
Slice phase: Functional validation

The macro-writeback lane already has a guarded Zendesk live smoke, but it requires an approved publishable FAQ draft to exist first. This PR adds the missing operator seed helper: it creates one approved sandbox FAQ draft in Postgres and prints the existing guarded Zendesk smoke command, without calling Zendesk itself.

## Intentional
- No Zendesk API call in this PR; the existing live smoke owns external writes.
- No cleanup/delete path yet; first prove the sandbox write path, then add cleanup if needed.
- No API/UI route; this is operator validation tooling.
- No credential reads; Zendesk credentials stay in the existing smoke and tenant provider.

## Deferred
- Run the existing live Zendesk smoke against the seeded draft once the operator chooses the account and expected Zendesk base URL.
- Future cleanup helper for seeded draft/macro mapping after sandbox write is verified.
- Future dedicated Zendesk macro fixture lifecycle when sandbox policy is settled.

## Parked hardening
- None.

## AI reconciliation
- Codex P2 next-command database-url placeholder mismatch -- fixed by generating `${EXTRACTED_DATABASE_URL:-$DATABASE_URL}` instead of bare `$DATABASE_URL`.
- All fixed or waived: yes.

## Verification
- `python -m pytest tests/test_seed_faq_macro_writeback_live_smoke_draft.py -q` -- 7 passed.
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q` -- 19 passed, 1 warning.
- Python compile check for the seed script and test module -- passed.
- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Sandbox-Seed.md --check` -- passed.
- Local PR review bundle via `scripts/push_pr.sh` -- passed.

## Diff size
4 files, +648 / -0