### PR TITLE
FAQ macro writeback sandbox E2E smoke

### DIFF
--- a/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
+++ b/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
@@ -11,8 +11,10 @@ on:
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
+      - "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
       - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_faq_macro_writeback_sandbox_e2e_smoke.py"
       - "tests/test_seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_scheduler.py"
       - "tests/test_synthesis.py"
@@ -28,8 +30,10 @@ on:
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
+      - "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
       - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_faq_macro_writeback_sandbox_e2e_smoke.py"
       - "tests/test_seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_scheduler.py"
       - "tests/test_synthesis.py"
@@ -57,6 +61,7 @@ jobs:
         run: |
           python -m pytest \
             tests/test_autonomous_faq_macro_writeback_scheduled_publish.py \
+            tests/test_faq_macro_writeback_sandbox_e2e_smoke.py \
             tests/test_seed_faq_macro_writeback_live_smoke_draft.py \
             tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in \
             tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary \

--- a/plans/PR-FAQ-Macro-Writeback-Sandbox-E2E-Smoke.md
+++ b/plans/PR-FAQ-Macro-Writeback-Sandbox-E2E-Smoke.md
@@ -1,0 +1,127 @@
+# PR-FAQ-Macro-Writeback-Sandbox-E2E-Smoke
+
+## Why this slice exists
+
+PR #1593 closed the first sandbox gap by adding a safe helper that creates one
+approved FAQ draft for macro writeback validation. The next product proof is
+the actual end-to-end sandbox write: seed a disposable approved draft, publish
+it through the existing guarded Zendesk live smoke, and emit one JSON artifact
+that shows both stages.
+
+This slice exists because running two separate commands is still easy to botch:
+the operator can seed one draft, copy the wrong FAQ id, omit the expected
+Zendesk base URL guard, or lose the publish artifact. A thin wrapper gives us a
+single reproducible proof path while keeping all real publish behavior in the
+existing seed and live-smoke scripts.
+
+This PR is over the 400 LOC soft cap because the wrapper is live-write capable.
+The fail-closed branches, stage handoff, failure envelopes, CI enrollment, and
+tests need to ship together; splitting the safety tests from the wrapper would
+leave the live validation path under-proven.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add an operator-run sandbox E2E smoke wrapper for FAQ macro writeback.
+2. Require `--confirm-create-draft`, `--confirm-live-zendesk-write`, and a
+   non-empty `--expected-zendesk-base-url` before opening a database pool.
+3. Reuse the #1593 seed helper to create one approved draft, then pass the
+   returned `faq_id` into the existing guarded live Zendesk smoke.
+4. Emit one JSON artifact with `seed` and `live_smoke` stage payloads,
+   top-level `faq_id`, and top-level success/error state.
+5. Do not add a new Zendesk provider, transport, API route, scheduler, or UI.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Missing create confirmation exits skipped before any database pool is
+        opened.
+  - [ ] Missing live-write confirmation exits skipped before any database pool
+        is opened.
+  - [ ] Missing expected Zendesk base URL exits skipped before any database
+        pool is opened.
+  - [ ] The wrapper calls the seed stage first, then calls the existing live
+        smoke with the seeded `faq_id`.
+  - [ ] Seed-stage failure stops before the live smoke.
+  - [ ] Live-stage failure is surfaced in the combined artifact without
+        rewriting the live-smoke payload.
+  - [ ] The wrapper source does not import Zendesk transport/provider classes.
+- Affected surfaces: operator scripts, macro-writeback live validation tests,
+  macro-writeback CI workflow.
+- Risk areas: accidental Zendesk writes, wrong tenant or FAQ handoff,
+  false-green live artifacts, and scope drift into provider logic.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_macro_writeback_checks.yml`
+- `plans/PR-FAQ-Macro-Writeback-Sandbox-E2E-Smoke.md`
+- `scripts/smoke_content_ops_faq_macro_sandbox_e2e.py`
+- `tests/test_faq_macro_writeback_sandbox_e2e_smoke.py`
+
+## Mechanism
+
+The wrapper is a coordinator around two existing scripts:
+
+1. `scripts/seed_faq_macro_writeback_live_smoke_draft.py`
+2. `scripts/smoke_content_ops_faq_macro_live_zendesk.py`
+
+It accepts the same operator inputs needed for both stages: database URL,
+account id, optional user id, expected Zendesk base URL, the seed question and
+answer text, and both explicit confirmation flags. If any live-write guard is
+missing, it returns a skipped JSON payload before opening a database pool.
+
+When all guards are present, the wrapper opens one asyncpg pool, calls the seed
+stage, reads the returned `faq_id`, then builds a live-smoke argument namespace
+with that `faq_id` and calls the existing live-smoke stage. The wrapper does
+not inspect or alter Zendesk publish internals; it only carries the stage
+payloads into one combined artifact and returns the live-smoke exit code when
+the publish stage fails.
+
+## Intentional
+
+- No new Zendesk transport or provider. The live write remains owned by
+  `smoke_content_ops_faq_macro_live_zendesk.py` and the existing publish
+  service.
+- No cleanup/delete path in this slice. The purpose is to prove the sandbox
+  write path first; cleanup policy depends on how the test Zendesk account
+  should retain evidence.
+- No API route, UI, or scheduler. This is an operator proof harness.
+- The expected Zendesk base URL is mandatory for this combined live-write path
+  even though the lower-level live smoke accepts it as optional. The wrapper is
+  specifically for sandbox proof, not generic publishing.
+
+## Deferred
+
+- Run the wrapper against the Zendesk test account and attach the sanitized
+  artifact to the lane issue once credentials and account id are selected.
+- Future robust-testing slice: cleanup helper for seeded FAQ draft, macro
+  mapping, and sandbox macro lifecycle.
+- Future product slice: expose publish proof/history ergonomically if sandbox
+  validation shows the flow is ready for operators.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_faq_macro_writeback_sandbox_e2e_smoke.py -q`
+  - Result: 10 passed.
+- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q`
+  - Result: 29 passed, 1 warning.
+- Python compile check for the sandbox wrapper and test module.
+  - Result: passed.
+- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Sandbox-E2E-Smoke.md --check`
+  - Result: passed.
+- Pending before push: local PR review via `scripts/push_pr.sh`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_macro_writeback_checks.yml` | 5 |
+| `plans/PR-FAQ-Macro-Writeback-Sandbox-E2E-Smoke.md` | 127 |
+| `scripts/smoke_content_ops_faq_macro_sandbox_e2e.py` | 289 |
+| `tests/test_faq_macro_writeback_sandbox_e2e_smoke.py` | 298 |
+| **Total** | **719** |

--- a/scripts/smoke_content_ops_faq_macro_sandbox_e2e.py
+++ b/scripts/smoke_content_ops_faq_macro_sandbox_e2e.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Seed one FAQ draft and run the guarded Zendesk macro live smoke."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+SKIPPED_EXIT = 2
+
+
+def _load_script_module(module_name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load script module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_SEED_SCRIPT = _load_script_module(
+    "seed_faq_macro_writeback_live_smoke_draft_for_e2e",
+    ROOT / "scripts" / "seed_faq_macro_writeback_live_smoke_draft.py",
+)
+_LIVE_SMOKE_SCRIPT = _load_script_module(
+    "smoke_content_ops_faq_macro_live_zendesk_for_e2e",
+    ROOT / "scripts" / "smoke_content_ops_faq_macro_live_zendesk.py",
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        required=True,
+        help="Postgres DSN. Required explicitly; this script does not read env vars.",
+    )
+    parser.add_argument("--account-id", required=True, help="Tenant/account id.")
+    parser.add_argument("--user-id", default="", help="Optional operator user id.")
+    parser.add_argument(
+        "--expected-zendesk-base-url",
+        default="",
+        help="Required exact Zendesk base URL guard, for example https://acme.zendesk.com.",
+    )
+    parser.add_argument(
+        "--target-id",
+        default="macro-writeback-live-smoke-seed",
+        help="Target id stored on the seeded FAQ draft.",
+    )
+    parser.add_argument(
+        "--target-mode",
+        default="support_ticket_faq",
+        help="Target mode stored on the seeded FAQ draft.",
+    )
+    parser.add_argument(
+        "--title",
+        default="Zendesk macro writeback sandbox E2E smoke seed",
+        help="FAQ draft title.",
+    )
+    parser.add_argument(
+        "--question",
+        default="How do I refund a duplicate charge?",
+        help="Question used for the publishable FAQ item.",
+    )
+    parser.add_argument(
+        "--resolution-text",
+        default=(
+            "Open Billing, select the duplicate charge, and click Refund payment. "
+            "Confirm the refund and tell the customer it may take 3-5 business days."
+        ),
+        help="Verified answer text used for the publishable macro body.",
+    )
+    parser.add_argument(
+        "--confirm-create-draft",
+        action="store_true",
+        help="Required to create one approved FAQ draft in Postgres.",
+    )
+    parser.add_argument(
+        "--confirm-live-zendesk-write",
+        action="store_true",
+        help="Required to create or update real Zendesk macros.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSON output path. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for operator consistency; output is always JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not _clean(args.database_url):
+        raise SystemExit("--database-url is required")
+    if not _clean(args.account_id):
+        raise SystemExit("--account-id is required")
+    if not _clean(args.question):
+        raise SystemExit("--question is required")
+    if not _clean(args.resolution_text):
+        raise SystemExit("--resolution-text is required")
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for the sandbox FAQ macro writeback smoke; "
+            "install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def run_sandbox_e2e_smoke(
+    args: argparse.Namespace,
+    pool: Any,
+    *,
+    seed_stage: Any | None = None,
+    live_stage: Any | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Run seed then live-smoke stages and return one combined artifact."""
+
+    preflight = _preflight(args)
+    if preflight is not None:
+        return preflight
+
+    seed_runner = seed_stage or _seed_stage
+    live_runner = live_stage or _live_stage
+    seed_code, seed_payload = await seed_runner(args, pool)
+    if seed_code != 0 or not seed_payload.get("ok"):
+        return _stage_failure(
+            "seed",
+            seed_code,
+            account_id=_clean(args.account_id),
+            seed_payload=seed_payload,
+        )
+
+    faq_id = _clean(seed_payload.get("faq_id"))
+    if not faq_id:
+        return _stage_failure(
+            "seed",
+            1,
+            account_id=_clean(args.account_id),
+            seed_payload={
+                **dict(seed_payload),
+                "error": "seed_faq_id_missing",
+            },
+        )
+
+    live_args = _live_args(args, faq_id=faq_id)
+    live_code, live_payload = await live_runner(live_args, pool)
+    ok = live_code == 0 and bool(live_payload.get("ok"))
+    return (
+        0 if ok else live_code or 1,
+        {
+            "ok": ok,
+            "skipped": False,
+            "live_smoke_skipped": bool(live_payload.get("skipped", False)),
+            "stage": "complete" if ok else "live_smoke",
+            "account_id": _clean(args.account_id),
+            "faq_id": faq_id,
+            "zendesk_base_url": _clean(live_payload.get("zendesk_base_url")),
+            "seed": seed_payload,
+            "live_smoke": live_payload,
+            "errors": list(live_payload.get("errors") or ()),
+        },
+    )
+
+
+async def _seed_stage(args: argparse.Namespace, pool: Any) -> tuple[int, dict[str, Any]]:
+    return await _SEED_SCRIPT.seed_live_smoke_draft(args, pool)
+
+
+async def _live_stage(args: argparse.Namespace, pool: Any) -> tuple[int, dict[str, Any]]:
+    return await _LIVE_SMOKE_SCRIPT.run_live_zendesk_smoke(args, pool)
+
+
+def _preflight(args: argparse.Namespace) -> tuple[int, dict[str, Any]] | None:
+    if not getattr(args, "confirm_create_draft", False):
+        return _not_run("missing_confirm_create_draft", args)
+    if not getattr(args, "confirm_live_zendesk_write", False):
+        return _not_run("missing_confirm_live_zendesk_write", args)
+    if not _clean(getattr(args, "expected_zendesk_base_url", "")):
+        return _not_run("missing_expected_zendesk_base_url", args)
+    return None
+
+
+def _not_run(reason: str, args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    return (
+        SKIPPED_EXIT,
+        {
+            "ok": False,
+            "skipped": True,
+            "stage": "preflight",
+            "not_run_reason": reason,
+            "account_id": _clean(getattr(args, "account_id", "")),
+            "expected_zendesk_base_url": _clean(
+                getattr(args, "expected_zendesk_base_url", "")
+            ),
+        },
+    )
+
+
+def _stage_failure(
+    stage: str,
+    code: int,
+    *,
+    account_id: str,
+    seed_payload: dict[str, Any],
+) -> tuple[int, dict[str, Any]]:
+    return (
+        code or 1,
+        {
+            "ok": False,
+            "skipped": bool(seed_payload.get("skipped", False)),
+            "stage": stage,
+            "account_id": account_id,
+            "faq_id": _clean(seed_payload.get("faq_id")),
+            "seed": seed_payload,
+            "live_smoke": None,
+            "errors": [_clean(seed_payload.get("error")) or f"{stage}_stage_failed"],
+        },
+    )
+
+
+def _live_args(args: argparse.Namespace, *, faq_id: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        database_url=_clean(args.database_url),
+        account_id=_clean(args.account_id),
+        faq_id=faq_id,
+        user_id=_clean(getattr(args, "user_id", "")),
+        expected_zendesk_base_url=_clean(args.expected_zendesk_base_url),
+        confirm_live_zendesk_write=True,
+        output=None,
+        json=True,
+    )
+
+
+def _write_payload(payload: dict[str, Any], args: argparse.Namespace) -> None:
+    output = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    preflight = _preflight(args)
+    if preflight is not None:
+        code, payload = preflight
+        _write_payload(payload, args)
+        return code
+
+    pool = await _create_pool(_clean(args.database_url))
+    try:
+        code, payload = await run_sandbox_e2e_smoke(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    _write_payload(payload, args)
+    return code
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_faq_macro_writeback_sandbox_e2e_smoke.py
+++ b/tests/test_faq_macro_writeback_sandbox_e2e_smoke.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
+SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_faq_macro_sandbox_e2e",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+e2e = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(e2e)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"confirm_create_draft": False}, "missing_confirm_create_draft"),
+        ({"confirm_live_zendesk_write": False}, "missing_confirm_live_zendesk_write"),
+        ({"expected_zendesk_base_url": ""}, "missing_expected_zendesk_base_url"),
+    ],
+)
+async def test_e2e_skips_before_opening_pool_for_missing_live_guards(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, Any],
+    reason: str,
+) -> None:
+    async def fail_create_pool(database_url: str) -> object:
+        raise AssertionError(f"pool should not open for {database_url}")
+
+    output = tmp_path / f"{reason}.json"
+    monkeypatch.setattr(e2e, "_create_pool", fail_create_pool)
+
+    args = _args(**overrides)
+    code = await e2e._main(_argv(args, output=output))
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert code == e2e.SKIPPED_EXIT
+    assert payload["ok"] is False
+    assert payload["skipped"] is True
+    assert payload["stage"] == "preflight"
+    assert payload["not_run_reason"] == reason
+
+
+@pytest.mark.asyncio
+async def test_e2e_runs_seed_then_live_smoke_with_seeded_faq_id() -> None:
+    calls: list[dict[str, Any]] = []
+    pool = object()
+
+    async def seed_stage(args: argparse.Namespace, stage_pool: object) -> tuple[int, dict[str, Any]]:
+        calls.append({"stage": "seed", "pool": stage_pool, "args": args})
+        return 0, {
+            "ok": True,
+            "faq_id": "faq-seed-123",
+            "publishable_count": 1,
+        }
+
+    async def live_stage(args: argparse.Namespace, stage_pool: object) -> tuple[int, dict[str, Any]]:
+        calls.append({"stage": "live", "pool": stage_pool, "args": args})
+        return 0, {
+            "ok": True,
+            "skipped": False,
+            "faq_id": args.faq_id,
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+            "summary": {"published_count": 1},
+            "errors": [],
+        }
+
+    code, payload = await e2e.run_sandbox_e2e_smoke(
+        _args(user_id="operator-1"),
+        pool,
+        seed_stage=seed_stage,
+        live_stage=live_stage,
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["skipped"] is False
+    assert payload["live_smoke_skipped"] is False
+    assert payload["stage"] == "complete"
+    assert payload["faq_id"] == "faq-seed-123"
+    assert payload["zendesk_base_url"] == "https://sandbox.zendesk.com"
+    assert [call["stage"] for call in calls] == ["seed", "live"]
+    assert calls[0]["pool"] is pool
+    assert calls[1]["pool"] is pool
+    live_args = calls[1]["args"]
+    assert live_args.faq_id == "faq-seed-123"
+    assert live_args.account_id == "acct-1"
+    assert live_args.user_id == "operator-1"
+    assert live_args.expected_zendesk_base_url == "https://sandbox.zendesk.com"
+    assert live_args.confirm_live_zendesk_write is True
+
+
+@pytest.mark.asyncio
+async def test_e2e_seed_failure_stops_before_live_smoke() -> None:
+    live_calls = 0
+
+    async def seed_stage(args: argparse.Namespace, pool: object) -> tuple[int, dict[str, Any]]:
+        return 1, {
+            "ok": False,
+            "skipped": False,
+            "error": "seed_faq_draft_save_failed",
+        }
+
+    async def live_stage(args: argparse.Namespace, pool: object) -> tuple[int, dict[str, Any]]:
+        nonlocal live_calls
+        live_calls += 1
+        return 0, {"ok": True}
+
+    code, payload = await e2e.run_sandbox_e2e_smoke(
+        _args(),
+        object(),
+        seed_stage=seed_stage,
+        live_stage=live_stage,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["stage"] == "seed"
+    assert payload["errors"] == ["seed_faq_draft_save_failed"]
+    assert payload["live_smoke"] is None
+    assert live_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_e2e_seed_missing_faq_id_stops_before_live_smoke() -> None:
+    live_calls = 0
+
+    async def seed_stage(args: argparse.Namespace, pool: object) -> tuple[int, dict[str, Any]]:
+        return 0, {"ok": True, "faq_id": " "}
+
+    async def live_stage(args: argparse.Namespace, pool: object) -> tuple[int, dict[str, Any]]:
+        nonlocal live_calls
+        live_calls += 1
+        return 0, {"ok": True}
+
+    code, payload = await e2e.run_sandbox_e2e_smoke(
+        _args(),
+        object(),
+        seed_stage=seed_stage,
+        live_stage=live_stage,
+    )
+
+    assert code == 1
+    assert payload["stage"] == "seed"
+    assert payload["errors"] == ["seed_faq_id_missing"]
+    assert live_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_e2e_live_failure_surfaces_live_payload() -> None:
+    async def seed_stage(args: argparse.Namespace, pool: object) -> tuple[int, dict[str, Any]]:
+        return 0, {"ok": True, "faq_id": "faq-seed-123"}
+
+    async def live_stage(args: argparse.Namespace, pool: object) -> tuple[int, dict[str, Any]]:
+        return 1, {
+            "ok": False,
+            "skipped": False,
+            "faq_id": args.faq_id,
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+            "errors": ["macro_publish_failed"],
+        }
+
+    code, payload = await e2e.run_sandbox_e2e_smoke(
+        _args(),
+        object(),
+        seed_stage=seed_stage,
+        live_stage=live_stage,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["stage"] == "live_smoke"
+    assert payload["faq_id"] == "faq-seed-123"
+    assert payload["errors"] == ["macro_publish_failed"]
+    assert payload["live_smoke"]["errors"] == ["macro_publish_failed"]
+
+
+@pytest.mark.asyncio
+async def test_e2e_live_skip_after_seed_is_not_top_level_skipped() -> None:
+    async def seed_stage(args: argparse.Namespace, pool: object) -> tuple[int, dict[str, Any]]:
+        return 0, {"ok": True, "faq_id": "faq-seed-123"}
+
+    async def live_stage(args: argparse.Namespace, pool: object) -> tuple[int, dict[str, Any]]:
+        return e2e.SKIPPED_EXIT, {
+            "ok": False,
+            "skipped": True,
+            "not_run_reason": "zendesk_credentials_missing",
+            "faq_id": args.faq_id,
+        }
+
+    code, payload = await e2e.run_sandbox_e2e_smoke(
+        _args(),
+        object(),
+        seed_stage=seed_stage,
+        live_stage=live_stage,
+    )
+
+    assert code == e2e.SKIPPED_EXIT
+    assert payload["ok"] is False
+    assert payload["skipped"] is False
+    assert payload["live_smoke_skipped"] is True
+    assert payload["stage"] == "live_smoke"
+    assert payload["faq_id"] == "faq-seed-123"
+    assert payload["live_smoke"]["not_run_reason"] == "zendesk_credentials_missing"
+
+
+@pytest.mark.asyncio
+async def test_e2e_main_closes_pool_after_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Pool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    pool = Pool()
+
+    async def create_pool(database_url: str) -> Pool:
+        return pool
+
+    async def run(args: argparse.Namespace, stage_pool: Pool) -> tuple[int, dict[str, Any]]:
+        assert stage_pool is pool
+        return 0, {"ok": True, "skipped": False}
+
+    monkeypatch.setattr(e2e, "_create_pool", create_pool)
+    monkeypatch.setattr(e2e, "run_sandbox_e2e_smoke", run)
+
+    code = await e2e._main(_argv(_args()))
+
+    assert code == 0
+    assert pool.closed is True
+
+
+def test_e2e_wrapper_does_not_define_zendesk_transport_or_provider() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "ZendeskMacroPublishProvider" not in source
+    assert "ZendeskHTTPMacroTransport" not in source
+    assert "httpx" not in source
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values: dict[str, Any] = {
+        "database_url": "postgres://example",
+        "account_id": "acct-1",
+        "user_id": "",
+        "expected_zendesk_base_url": "https://sandbox.zendesk.com",
+        "target_id": "macro-writeback-live-smoke-seed",
+        "target_mode": "support_ticket_faq",
+        "title": "Zendesk macro writeback sandbox E2E smoke seed",
+        "question": "How do I refund a duplicate charge?",
+        "resolution_text": (
+            "Open Billing, select the duplicate charge, and click Refund payment. "
+            "Confirm the refund and tell the customer it may take 3-5 business days."
+        ),
+        "confirm_create_draft": True,
+        "confirm_live_zendesk_write": True,
+        "output": None,
+        "json": True,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _argv(args: argparse.Namespace, *, output: Path | None = None) -> list[str]:
+    argv = [
+        "--database-url",
+        args.database_url,
+        "--account-id",
+        args.account_id,
+        "--expected-zendesk-base-url",
+        args.expected_zendesk_base_url,
+        "--question",
+        args.question,
+        "--resolution-text",
+        args.resolution_text,
+    ]
+    if args.user_id:
+        argv.extend(["--user-id", args.user_id])
+    if args.confirm_create_draft:
+        argv.append("--confirm-create-draft")
+    if args.confirm_live_zendesk_write:
+        argv.append("--confirm-live-zendesk-write")
+    if output is not None:
+        argv.extend(["--output", str(output)])
+    return argv


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Sandbox-E2E-Smoke.md
Slice phase: Vertical slice

PR #1593 made it safe to seed one approved FAQ draft for macro writeback validation. This PR adds the thin end-to-end sandbox proof wrapper: it requires both seed and live-write confirmations plus an expected Zendesk base URL, creates the disposable approved draft, calls the existing guarded Zendesk live smoke with the seeded `faq_id`, and emits one combined JSON artifact.

## Intentional
- No new Zendesk provider or transport; the wrapper delegates to the existing seed and live-smoke scripts.
- No cleanup/delete path yet; first prove the sandbox write path and decide the test-account retention policy.
- No API route, UI, or scheduler; this is operator validation tooling.
- Expected Zendesk base URL is mandatory for this combined live-write path.

## Deferred
- Run the wrapper against the Zendesk test account and attach the sanitized artifact once account inputs are selected.
- Future cleanup helper for seeded FAQ draft, macro mapping, and sandbox macro lifecycle.
- Future product slice for publish proof/history ergonomics if sandbox validation shows the flow is ready.

## Parked hardening
- None.

## AI reconciliation
- Codex P2 top-level `skipped` after seeded live-stage skip -- fixed by reserving top-level `skipped` for pre-seed/preflight skips and adding `live_smoke_skipped` for delegated live-smoke skips.
- All fixed or waived: yes.

## Verification
- `python -m pytest tests/test_faq_macro_writeback_sandbox_e2e_smoke.py -q` -- 10 passed.
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q` -- 29 passed, 1 warning.
- Python compile check for the sandbox wrapper and test module -- passed.
- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Sandbox-E2E-Smoke.md --check` -- passed.
- Local PR review bundle via `scripts/push_pr.sh` -- passed.

## Diff size
4 files, +719 / -0