### PR TITLE
FAQ macro writeback sandbox cleanup

### DIFF
--- a/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
+++ b/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
@@ -11,9 +11,12 @@ on:
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
+      - "scripts/cleanup_content_ops_faq_macro_sandbox.py"
       - "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
       - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_cleanup_content_ops_faq_macro_sandbox.py"
+      - "tests/test_extracted_ticket_faq_macro_writeback_zendesk.py"
       - "tests/test_faq_macro_writeback_sandbox_e2e_smoke.py"
       - "tests/test_seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_scheduler.py"
@@ -30,9 +33,12 @@ on:
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
+      - "scripts/cleanup_content_ops_faq_macro_sandbox.py"
       - "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
       - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_cleanup_content_ops_faq_macro_sandbox.py"
+      - "tests/test_extracted_ticket_faq_macro_writeback_zendesk.py"
       - "tests/test_faq_macro_writeback_sandbox_e2e_smoke.py"
       - "tests/test_seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_scheduler.py"
@@ -61,6 +67,8 @@ jobs:
         run: |
           python -m pytest \
             tests/test_autonomous_faq_macro_writeback_scheduled_publish.py \
+            tests/test_cleanup_content_ops_faq_macro_sandbox.py \
+            tests/test_extracted_ticket_faq_macro_writeback_zendesk.py \
             tests/test_faq_macro_writeback_sandbox_e2e_smoke.py \
             tests/test_seed_faq_macro_writeback_live_smoke_draft.py \
             tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in \

--- a/extracted_content_pipeline/faq_macro_writeback_zendesk.py
+++ b/extracted_content_pipeline/faq_macro_writeback_zendesk.py
@@ -135,6 +135,8 @@ class ZendeskHTTPMacroTransport:
             )
         if response.status_code >= 400:
             raise ZendeskMacroTransportError(status_code=response.status_code)
+        if not response.content:
+            return {}
         payload = response.json()
         return payload if isinstance(payload, Mapping) else {}
 

--- a/plans/PR-FAQ-Macro-Writeback-Sandbox-Cleanup.md
+++ b/plans/PR-FAQ-Macro-Writeback-Sandbox-Cleanup.md
@@ -1,0 +1,165 @@
+# PR-FAQ-Macro-Writeback-Sandbox-Cleanup
+
+## Why this slice exists
+
+PR #1595 made the first real sandbox Zendesk macro write one guarded command
+away. That command can create two kinds of cleanup work: an external Zendesk
+macro and local Atlas rows for the seeded FAQ draft, macro mapping, publish
+attempts, and search projection. Without an explicit cleanup command, operators
+must either leave sandbox artifacts around or hand-edit Postgres after a live
+proof.
+
+This slice adds the missing reversible path for the sandbox proof. Cleanup is
+intentionally narrow: one account, one explicit `faq_id`, preview by default,
+and execute only with a live Zendesk delete confirmation plus expected base URL.
+It deletes external macros first and deletes the FAQ draft last, relying on the
+existing `ON DELETE CASCADE` relationships for local mapping, attempt, and
+search rows.
+
+This PR is over the 400 LOC soft cap because the command is live-delete
+capable. The preview result, live-delete guards, external-before-local ordering,
+partial-failure behavior, and CI enrollment need to ship together with focused
+negative fixtures.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add an operator-run cleanup script for one sandbox FAQ macro writeback proof.
+2. Preview draft, macro mapping, publish attempt, and search projection counts
+   for a tenant-scoped `faq_id` without deleting anything by default.
+3. Require `--execute`, `--confirm-live-zendesk-delete`, and
+   `--expected-zendesk-base-url` before deleting mapped external Zendesk macros
+   or local FAQ rows.
+4. Delete mapped Zendesk macros before deleting the FAQ draft; if any external
+   delete fails, leave local rows in place for retry/audit.
+5. Delete only the explicit tenant-scoped FAQ draft row; local mapping,
+   attempt, and search projection cleanup relies on existing database cascades.
+6. Let the shared Zendesk HTTP transport treat successful empty-body DELETE
+   responses as an empty payload instead of trying to parse JSON.
+7. Fail closed before any delete when a mapping row is present without a usable
+   external Zendesk macro id.
+8. Restrict cleanup mappings to Zendesk rows, treat Zendesk 404 deletes as
+   idempotent success on retry, and fail closed when a stored macro URL points
+   at a different Zendesk base.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_macro_writeback_checks.yml`
+- `extracted_content_pipeline/faq_macro_writeback_zendesk.py`
+- `plans/PR-FAQ-Macro-Writeback-Sandbox-Cleanup.md`
+- `scripts/cleanup_content_ops_faq_macro_sandbox.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_cleanup_content_ops_faq_macro_sandbox.py`
+- `tests/test_extracted_ticket_faq_macro_writeback_zendesk.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Preview mode opens the database, returns scoped counts and mapped
+        external ids, and performs no Zendesk or local deletes.
+  - [ ] Missing `--execute` never calls the Zendesk transport and never deletes
+        local rows.
+  - [ ] Execute mode requires `--confirm-live-zendesk-delete` and a non-empty
+        expected Zendesk base URL before any database pool is opened.
+  - [ ] Execute mode resolves credentials and rejects unexpected Zendesk base
+        URLs before any delete.
+  - [ ] External Zendesk macro deletes run before the local FAQ row delete.
+  - [ ] A mapping row with a missing `external_id` returns a non-green artifact
+        and leaves local rows in place.
+  - [ ] Non-Zendesk mappings are not included in the Zendesk cleanup snapshot.
+  - [ ] A retry where Zendesk reports a mapped macro as already missing can
+        still finish local cleanup.
+  - [ ] A mapping whose stored URL points at a different Zendesk base returns a
+        non-green artifact before any delete.
+  - [ ] External delete failure leaves local rows in place and returns a
+        non-green artifact.
+  - [ ] Local delete is tenant-scoped by `faq_id` and `account_id`.
+- Affected surfaces: operator scripts, macro-writeback live validation tests,
+  macro-writeback CI workflow.
+- Risk areas: accidental live Zendesk deletes, broad tenant cleanup, partial
+  cleanup false-greens, and deleting local audit state before external cleanup.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R14.
+
+## Mechanism
+
+The cleanup script accepts `--database-url`, `--account-id`, and `--faq-id`.
+Without `--execute`, it queries the tenant-scoped FAQ row plus dependent local
+row counts and returns a JSON preview artifact. Preview mode does not resolve
+Zendesk credentials and does not call the Zendesk transport.
+
+With `--execute`, the script first checks `--confirm-live-zendesk-delete` and
+`--expected-zendesk-base-url` before opening a pool. It loads tenant Zendesk
+credentials through the existing macro-writeback credential provider, verifies
+the normalized base URL against the expected URL, then deletes each mapped
+external Zendesk macro id with the existing Zendesk transport boundary. Only
+after all external deletes succeed does it delete the tenant-scoped
+`ticket_faq_markdown` row. The existing database foreign keys cascade local
+`ticket_faq_search_documents`, `ticket_faq_macro_writebacks`, and
+`ticket_faq_macro_publish_attempts` rows.
+
+The script reuses `ZendeskHTTPMacroTransport`. That transport now returns an
+empty mapping for successful empty-body responses so a normal Zendesk DELETE
+success path does not fail during JSON parsing.
+
+Before resolving credentials or deleting anything, execute mode also checks
+that every local macro mapping has a usable external id. Pending or
+persist-failed mappings are not safe to cascade-delete because they may be the
+only local evidence needed to reconcile an orphaned live Zendesk macro.
+
+The mapping lookup is restricted to `ZENDESK_PLATFORM`, since this cleanup
+command only knows how to delete Zendesk macros. Before delete, each stored
+macro URL base is compared with the expected/current Zendesk base; mismatches
+fail closed instead of deleting from the current credentials' instance. During
+retry after a partial external cleanup, Zendesk 404/not-found deletes are
+treated as already cleaned so the command can continue to the local cascade.
+
+## Intentional
+
+- No broad delete by account, target id, or age. The command accepts one
+  explicit `faq_id` so cleanup cannot sweep unrelated customer artifacts.
+- No new Zendesk HTTP client. The command uses the existing
+  `ZendeskHTTPMacroTransport` boundary and credentials shape.
+- No cleanup built into the E2E smoke wrapper. The write proof and cleanup proof
+  remain separate explicit operator actions.
+- No deletion when the external Zendesk delete fails. Local rows stay available
+  for retry and audit.
+
+## Deferred
+
+- Run the cleanup command against the first live sandbox artifact after the
+  write proof is captured.
+- Future robust-testing slice: batch cleanup by a manifest of explicit FAQ ids
+  if repeated sandbox runs become common.
+- Future product slice: expose sandbox/live proof cleanup status in operator
+  docs or UI if this flow graduates beyond validation tooling.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_cleanup_content_ops_faq_macro_sandbox.py -q`
+  - 11 passed.
+- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py -q`
+  - 14 passed.
+- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q`
+  - 54 passed, 1 warning.
+- Python compile check for the modified Python files.
+  - Passed.
+- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Sandbox-Cleanup.md --check`
+  - Passed.
+- Pending before push: local PR review via `scripts/push_pr.sh`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_macro_writeback_checks.yml` | 8 |
+| `extracted_content_pipeline/faq_macro_writeback_zendesk.py` | 2 |
+| `plans/PR-FAQ-Macro-Writeback-Sandbox-Cleanup.md` | 165 |
+| `scripts/cleanup_content_ops_faq_macro_sandbox.py` | 536 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_cleanup_content_ops_faq_macro_sandbox.py` | 483 |
+| `tests/test_extracted_ticket_faq_macro_writeback_zendesk.py` | 92 |
+| **Total** | **1287** |

--- a/scripts/cleanup_content_ops_faq_macro_sandbox.py
+++ b/scripts/cleanup_content_ops_faq_macro_sandbox.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""Clean up one sandbox FAQ macro writeback proof by explicit FAQ id."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain._content_ops_macro_writeback import (  # noqa: E402
+    ConfigZendeskMacroCredentialsProvider,
+    TenantZendeskMacroCredentialsProvider,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (  # noqa: E402
+    ZENDESK_PLATFORM,
+    ZendeskHTTPMacroTransport,
+    ZendeskMacroCredentialsProvider,
+    ZendeskMacroTransport,
+    ZendeskMacroTransportError,
+)
+
+
+SKIPPED_EXIT = 2
+
+
+@dataclass(frozen=True)
+class CleanupSnapshot:
+    """Preview of local rows tied to one FAQ macro writeback proof."""
+
+    found: bool
+    draft_status: str = ""
+    macro_mappings: tuple[dict[str, Any], ...] = ()
+    publish_attempt_count: int = 0
+    search_document_count: int = 0
+
+    @property
+    def external_ids(self) -> tuple[str, ...]:
+        return tuple(
+            mapping["external_id"]
+            for mapping in self.macro_mappings
+            if _clean(mapping.get("external_id"))
+        )
+
+    @property
+    def missing_external_id_count(self) -> int:
+        return sum(
+            1
+            for mapping in self.macro_mappings
+            if not _clean(mapping.get("external_id"))
+        )
+
+    def unexpected_external_urls(
+        self,
+        *,
+        expected_base_url: str,
+    ) -> tuple[dict[str, str], ...]:
+        expected = _url_base(expected_base_url)
+        unexpected: list[dict[str, str]] = []
+        for mapping in self.macro_mappings:
+            external_url = _clean(mapping.get("external_url"))
+            if external_url and _url_base(external_url) != expected:
+                unexpected.append({
+                    "external_id": _clean(mapping.get("external_id")),
+                    "external_url": external_url,
+                })
+        return tuple(unexpected)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "found": self.found,
+            "draft_status": self.draft_status,
+            "macro_mapping_count": len(self.macro_mappings),
+            "external_ids": list(self.external_ids),
+            "missing_external_id_count": self.missing_external_id_count,
+            "publish_attempt_count": self.publish_attempt_count,
+            "search_document_count": self.search_document_count,
+            "macro_mappings": [dict(mapping) for mapping in self.macro_mappings],
+        }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        required=True,
+        help="Postgres DSN. Required explicitly; this script does not read env vars.",
+    )
+    parser.add_argument("--account-id", required=True, help="Tenant/account id.")
+    parser.add_argument("--faq-id", required=True, help="FAQ draft id to clean up.")
+    parser.add_argument(
+        "--expected-zendesk-base-url",
+        default="",
+        help="Required exact Zendesk base URL guard in execute mode.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Delete external Zendesk macros and the local FAQ draft.",
+    )
+    parser.add_argument(
+        "--confirm-live-zendesk-delete",
+        action="store_true",
+        help="Required with --execute to delete real Zendesk macros.",
+    )
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for operator consistency; output is always JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not _clean(args.database_url):
+        raise SystemExit("--database-url is required")
+    if not _clean(args.account_id):
+        raise SystemExit("--account-id is required")
+    if not _clean(args.faq_id):
+        raise SystemExit("--faq-id is required")
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for FAQ macro sandbox cleanup; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def cleanup_sandbox_macro_writeback(
+    args: argparse.Namespace,
+    pool: Any,
+    *,
+    credentials_provider: ZendeskMacroCredentialsProvider | None = None,
+    transport: ZendeskMacroTransport | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Preview or execute cleanup for one tenant-scoped FAQ draft."""
+
+    scope = TenantScope(account_id=_clean(args.account_id))
+    faq_id = _clean(args.faq_id)
+    if getattr(args, "execute", False):
+        preflight = _execute_preflight(args)
+        if preflight is not None:
+            return preflight
+
+    snapshot = await _snapshot(pool, scope=scope, faq_id=faq_id)
+    if not getattr(args, "execute", False):
+        return 0, _payload(
+            ok=True,
+            execute=False,
+            stage="preview",
+            scope=scope,
+            faq_id=faq_id,
+            snapshot=snapshot,
+        )
+    if not snapshot.found:
+        return SKIPPED_EXIT, _payload(
+            ok=False,
+            execute=True,
+            stage="local_lookup",
+            scope=scope,
+            faq_id=faq_id,
+            snapshot=snapshot,
+            skipped=True,
+            not_run_reason="faq_draft_not_found",
+        )
+    if snapshot.missing_external_id_count:
+        return 1, _payload(
+            ok=False,
+            execute=True,
+            stage="mapping_preflight",
+            scope=scope,
+            faq_id=faq_id,
+            snapshot=snapshot,
+            errors=("macro_mapping_missing_external_id",),
+        )
+
+    credentials_source = credentials_provider or _build_credentials_provider(pool)
+    credentials = await credentials_source.credentials_for_scope(scope)
+    if credentials is None or not credentials.is_complete():
+        return SKIPPED_EXIT, _payload(
+            ok=False,
+            execute=True,
+            stage="credential_preflight",
+            scope=scope,
+            faq_id=faq_id,
+            snapshot=snapshot,
+            skipped=True,
+            not_run_reason="zendesk_credentials_missing",
+        )
+
+    zendesk_base_url = credentials.normalized_base_url().rstrip("/")
+    expected_url = _clean(args.expected_zendesk_base_url).rstrip("/")
+    if zendesk_base_url != expected_url:
+        return SKIPPED_EXIT, _payload(
+            ok=False,
+            execute=True,
+            stage="credential_preflight",
+            scope=scope,
+            faq_id=faq_id,
+            snapshot=snapshot,
+            skipped=True,
+            not_run_reason="unexpected_zendesk_base_url",
+            expected_zendesk_base_url=expected_url,
+            observed_zendesk_base_url=zendesk_base_url,
+        )
+    unexpected_urls = snapshot.unexpected_external_urls(
+        expected_base_url=expected_url,
+    )
+    if unexpected_urls:
+        return 1, _payload(
+            ok=False,
+            execute=True,
+            stage="mapping_preflight",
+            scope=scope,
+            faq_id=faq_id,
+            snapshot=snapshot,
+            zendesk_base_url=zendesk_base_url,
+            unexpected_external_urls=unexpected_urls,
+            errors=("zendesk_macro_url_base_mismatch",),
+        )
+
+    delete_results = await _delete_external_macros(
+        snapshot.external_ids,
+        credentials=credentials,
+        transport=transport or ZendeskHTTPMacroTransport(),
+    )
+    failed_deletes = [item for item in delete_results if not item["ok"]]
+    if failed_deletes:
+        return 1, _payload(
+            ok=False,
+            execute=True,
+            stage="external_delete",
+            scope=scope,
+            faq_id=faq_id,
+            snapshot=snapshot,
+            zendesk_base_url=zendesk_base_url,
+            external_deletes=delete_results,
+            errors=("zendesk_macro_delete_failed",),
+        )
+
+    deleted_faq_count = await _delete_local_faq(pool, scope=scope, faq_id=faq_id)
+    ok = deleted_faq_count == 1
+    return (
+        0 if ok else 1,
+        _payload(
+            ok=ok,
+            execute=True,
+            stage="complete" if ok else "local_delete",
+            scope=scope,
+            faq_id=faq_id,
+            snapshot=snapshot,
+            zendesk_base_url=zendesk_base_url,
+            external_deletes=delete_results,
+            deleted_faq_count=deleted_faq_count,
+            errors=() if ok else ("faq_draft_delete_missed",),
+        ),
+    )
+
+
+def _execute_preflight(args: argparse.Namespace) -> tuple[int, dict[str, Any]] | None:
+    if not getattr(args, "confirm_live_zendesk_delete", False):
+        return _not_run("missing_confirm_live_zendesk_delete", args)
+    if not _clean(getattr(args, "expected_zendesk_base_url", "")):
+        return _not_run("missing_expected_zendesk_base_url", args)
+    return None
+
+
+def _not_run(reason: str, args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    return (
+        SKIPPED_EXIT,
+        {
+            "ok": False,
+            "execute": bool(getattr(args, "execute", False)),
+            "skipped": True,
+            "stage": "preflight",
+            "not_run_reason": reason,
+            "account_id": _clean(getattr(args, "account_id", "")),
+            "faq_id": _clean(getattr(args, "faq_id", "")),
+            "expected_zendesk_base_url": _clean(
+                getattr(args, "expected_zendesk_base_url", "")
+            ),
+        },
+    )
+
+
+async def _snapshot(pool: Any, *, scope: TenantScope, faq_id: str) -> CleanupSnapshot:
+    row = await pool.fetchrow(
+        """
+        SELECT id, status
+          FROM ticket_faq_markdown
+         WHERE account_id = $1
+           AND id = $2
+         LIMIT 1
+        """,
+        scope.account_id or "",
+        faq_id,
+    )
+    if row is None:
+        return CleanupSnapshot(found=False)
+
+    mappings = await pool.fetch(
+        """
+        SELECT platform, faq_item_id, external_id, external_url, publish_status
+         FROM ticket_faq_macro_writebacks
+         WHERE account_id = $1
+           AND faq_draft_id = $2
+           AND platform = $3
+         ORDER BY platform ASC, faq_item_id ASC
+        """,
+        scope.account_id or "",
+        faq_id,
+        ZENDESK_PLATFORM,
+    )
+    attempt_count = await pool.fetchval(
+        """
+        SELECT COUNT(*)
+          FROM ticket_faq_macro_publish_attempts
+         WHERE account_id = $1
+           AND faq_draft_id = $2
+        """,
+        scope.account_id or "",
+        faq_id,
+    )
+    search_count = await pool.fetchval(
+        """
+        SELECT COUNT(*)
+          FROM ticket_faq_search_documents
+         WHERE account_id = $1
+           AND faq_id = $2
+        """,
+        scope.account_id or "",
+        faq_id,
+    )
+    return CleanupSnapshot(
+        found=True,
+        draft_status=_clean(_row_get(row, "status")),
+        macro_mappings=tuple(_mapping_row_to_dict(mapping) for mapping in mappings),
+        publish_attempt_count=int(attempt_count or 0),
+        search_document_count=int(search_count or 0),
+    )
+
+
+async def _delete_external_macros(
+    external_ids: Sequence[str],
+    *,
+    credentials: Any,
+    transport: ZendeskMacroTransport,
+) -> tuple[dict[str, Any], ...]:
+    results: list[dict[str, Any]] = []
+    base_url = credentials.normalized_base_url().rstrip("/")
+    for external_id in external_ids:
+        cleaned_id = _clean(external_id)
+        if not cleaned_id:
+            continue
+        try:
+            await transport.request(
+                "DELETE",
+                f"{base_url}/api/v2/macros/{cleaned_id}",
+                headers=_headers(credentials),
+                json={},
+            )
+            results.append({"external_id": cleaned_id, "ok": True, "error": ""})
+        except Exception as exc:
+            if (
+                isinstance(exc, ZendeskMacroTransportError)
+                and exc.status_code == 404
+            ):
+                results.append({
+                    "external_id": cleaned_id,
+                    "ok": True,
+                    "error": "zendesk_macro_not_found",
+                    "already_deleted": True,
+                })
+                continue
+            results.append({
+                "external_id": cleaned_id,
+                "ok": False,
+                "error": _clean(str(exc)) or exc.__class__.__name__,
+            })
+    return tuple(results)
+
+
+async def _delete_local_faq(pool: Any, *, scope: TenantScope, faq_id: str) -> int:
+    rows = await pool.fetch(
+        """
+        DELETE FROM ticket_faq_markdown
+         WHERE account_id = $1
+           AND id = $2
+        RETURNING id
+        """,
+        scope.account_id or "",
+        faq_id,
+    )
+    return len(rows)
+
+
+def _payload(
+    *,
+    ok: bool,
+    execute: bool,
+    stage: str,
+    scope: TenantScope,
+    faq_id: str,
+    snapshot: CleanupSnapshot,
+    skipped: bool = False,
+    not_run_reason: str = "",
+    zendesk_base_url: str = "",
+    expected_zendesk_base_url: str = "",
+    observed_zendesk_base_url: str = "",
+    external_deletes: Sequence[Mapping[str, Any]] = (),
+    unexpected_external_urls: Sequence[Mapping[str, str]] = (),
+    deleted_faq_count: int = 0,
+    errors: Sequence[str] = (),
+) -> dict[str, Any]:
+    payload = {
+        "ok": ok,
+        "execute": execute,
+        "skipped": skipped,
+        "stage": stage,
+        "account_id": scope.account_id or "",
+        "faq_id": faq_id,
+        "platform": ZENDESK_PLATFORM,
+        "snapshot": snapshot.as_dict(),
+        "zendesk_base_url": zendesk_base_url,
+        "external_deletes": [dict(item) for item in external_deletes],
+        "unexpected_external_urls": [
+            dict(item) for item in unexpected_external_urls
+        ],
+        "deleted_faq_count": deleted_faq_count,
+        "errors": list(errors),
+    }
+    if not_run_reason:
+        payload["not_run_reason"] = not_run_reason
+    if expected_zendesk_base_url:
+        payload["expected_zendesk_base_url"] = expected_zendesk_base_url
+    if observed_zendesk_base_url:
+        payload["observed_zendesk_base_url"] = observed_zendesk_base_url
+    return payload
+
+
+def _build_credentials_provider(pool: Any) -> TenantZendeskMacroCredentialsProvider:
+    return TenantZendeskMacroCredentialsProvider(
+        pool=pool,
+        fallback_provider=ConfigZendeskMacroCredentialsProvider(_host_config()),
+    )
+
+
+def _host_config() -> Any:
+    from atlas_brain.config import settings
+
+    return settings.b2b_campaign
+
+
+def _headers(credentials: Any) -> dict[str, str]:
+    return {
+        "Authorization": credentials.authorization_header(),
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _mapping_row_to_dict(row: Any) -> dict[str, Any]:
+    return {
+        "platform": _clean(_row_get(row, "platform")),
+        "faq_item_id": _clean(_row_get(row, "faq_item_id")),
+        "external_id": _clean(_row_get(row, "external_id")),
+        "external_url": _clean(_row_get(row, "external_url")),
+        "publish_status": _clean(_row_get(row, "publish_status")),
+    }
+
+
+def _row_get(row: Any, key: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return row[key]
+
+
+def _write_payload(payload: dict[str, Any], args: argparse.Namespace) -> None:
+    output = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    if args.execute:
+        preflight = _execute_preflight(args)
+        if preflight is not None:
+            code, payload = preflight
+            _write_payload(payload, args)
+            return code
+
+    pool = await _create_pool(_clean(args.database_url))
+    try:
+        code, payload = await cleanup_sandbox_macro_writeback(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    _write_payload(payload, args)
+    return code
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _url_base(value: str) -> str:
+    parsed = urlparse(_clean(value).rstrip("/"))
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}".lower()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -62,6 +62,7 @@ pytest \
   tests/test_alerts.py \
   tests/test_content_ops_deflection_incidents.py \
   tests/test_send_content_ops_deflection_report_deliveries.py \
+  tests/test_cleanup_content_ops_faq_macro_sandbox.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \

--- a/tests/test_cleanup_content_ops_faq_macro_sandbox.py
+++ b/tests/test_cleanup_content_ops_faq_macro_sandbox.py
@@ -1,0 +1,483 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZENDESK_PLATFORM,
+    ZendeskMacroCredentials,
+    ZendeskMacroTransportError,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "cleanup_content_ops_faq_macro_sandbox.py"
+SPEC = importlib.util.spec_from_file_location(
+    "cleanup_content_ops_faq_macro_sandbox",
+    SCRIPT_PATH,
+)
+cleanup = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = cleanup
+SPEC.loader.exec_module(cleanup)
+
+
+ACCOUNT_ID = "acct-1"
+FAQ_ID = "faq-1"
+EXPECTED_BASE_URL = "https://sandbox.zendesk.com"
+
+
+class _Pool:
+    def __init__(
+        self,
+        *,
+        fetchrow_rows: list[Any] | None = None,
+        fetch_rows: list[list[Any]] | None = None,
+        fetchval_rows: list[Any] | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        self.fetchrow_rows = list(fetchrow_rows or [])
+        self.fetch_rows = list(fetch_rows or [])
+        self.fetchval_rows = list(fetchval_rows or [])
+        self.fetchrow_calls: list[dict[str, Any]] = []
+        self.fetch_calls: list[dict[str, Any]] = []
+        self.fetchval_calls: list[dict[str, Any]] = []
+        self.events = events
+        self.closed = False
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        self.fetchrow_calls.append({"query": query, "args": args})
+        return self.fetchrow_rows.pop(0) if self.fetchrow_rows else None
+
+    async def fetch(self, query: str, *args: Any) -> list[Any]:
+        self.fetch_calls.append({"query": query, "args": args})
+        if "DELETE FROM ticket_faq_markdown" in query and self.events is not None:
+            self.events.append("local_delete")
+        rows = self.fetch_rows.pop(0) if self.fetch_rows else []
+        if "platform = $3" in query:
+            return [row for row in rows if row.get("platform") == args[2]]
+        return rows
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_rows.pop(0) if self.fetchval_rows else 0
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _CredentialsProvider:
+    def __init__(self, credentials: ZendeskMacroCredentials | None) -> None:
+        self.credentials = credentials
+        self.calls: list[TenantScope] = []
+
+    async def credentials_for_scope(
+        self,
+        scope: TenantScope,
+    ) -> ZendeskMacroCredentials | None:
+        self.calls.append(scope)
+        return self.credentials
+
+
+class _Transport:
+    def __init__(
+        self,
+        *,
+        error: Exception | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        self.error = error
+        self.events = events
+        self.calls: list[dict[str, Any]] = []
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        json: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        self.calls.append({
+            "method": method,
+            "url": url,
+            "headers": dict(headers),
+            "json": dict(json),
+        })
+        if self.events is not None:
+            self.events.append("external_delete")
+        if self.error is not None:
+            raise self.error
+        return {}
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values: dict[str, Any] = {
+        "database_url": "postgres://example",
+        "account_id": ACCOUNT_ID,
+        "faq_id": FAQ_ID,
+        "expected_zendesk_base_url": "",
+        "execute": False,
+        "confirm_live_zendesk_delete": False,
+        "output": None,
+        "json": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _credentials(*, subdomain: str = "sandbox") -> ZendeskMacroCredentials:
+    return ZendeskMacroCredentials(
+        subdomain=subdomain,
+        email="agent@example.com",
+        api_token="secret-token",
+    )
+
+
+def _pool_with_snapshot(
+    *,
+    events: list[str] | None = None,
+    mappings: list[dict[str, Any]] | None = None,
+    external_id: str = "macro-1",
+    external_url: str | None = None,
+    publish_status: str = "published",
+) -> _Pool:
+    if mappings is None:
+        mappings = [
+            {
+                "platform": ZENDESK_PLATFORM,
+                "faq_item_id": "item-1",
+                "external_id": external_id,
+                "external_url": (
+                    external_url
+                    if external_url is not None
+                    else f"{EXPECTED_BASE_URL}/api/v2/macros/{external_id}"
+                ),
+                "publish_status": publish_status,
+            }
+        ]
+    return _Pool(
+        fetchrow_rows=[{"id": FAQ_ID, "status": "draft"}],
+        fetch_rows=[mappings],
+        fetchval_rows=[2, 3],
+        events=events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_reports_scoped_counts_without_deletes() -> None:
+    pool = _pool_with_snapshot()
+    transport = _Transport()
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(),
+        pool,
+        credentials_provider=_CredentialsProvider(_credentials()),
+        transport=transport,
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["execute"] is False
+    assert payload["stage"] == "preview"
+    assert payload["account_id"] == ACCOUNT_ID
+    assert payload["faq_id"] == FAQ_ID
+    assert payload["snapshot"]["found"] is True
+    assert payload["snapshot"]["external_ids"] == ["macro-1"]
+    assert payload["snapshot"]["missing_external_id_count"] == 0
+    assert payload["snapshot"]["publish_attempt_count"] == 2
+    assert payload["snapshot"]["search_document_count"] == 3
+    mapping_query = pool.fetch_calls[0]
+    assert "platform = $3" in mapping_query["query"]
+    assert mapping_query["args"] == (ACCOUNT_ID, FAQ_ID, ZENDESK_PLATFORM)
+    assert transport.calls == []
+    assert all("DELETE FROM ticket_faq_markdown" not in call["query"] for call in pool.fetch_calls)
+
+
+@pytest.mark.asyncio
+async def test_execute_missing_confirm_skips_before_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _raise_create_pool(database_url: str) -> Any:
+        raise AssertionError(f"pool opened unexpectedly: {database_url}")
+
+    monkeypatch.setattr(cleanup, "_create_pool", _raise_create_pool)
+
+    code = await cleanup._main([
+        "--database-url",
+        "postgres://example",
+        "--account-id",
+        ACCOUNT_ID,
+        "--faq-id",
+        FAQ_ID,
+        "--execute",
+        "--expected-zendesk-base-url",
+        EXPECTED_BASE_URL,
+    ])
+
+    assert code == cleanup.SKIPPED_EXIT
+
+
+@pytest.mark.asyncio
+async def test_execute_missing_expected_url_skips_before_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _raise_create_pool(database_url: str) -> Any:
+        raise AssertionError(f"pool opened unexpectedly: {database_url}")
+
+    monkeypatch.setattr(cleanup, "_create_pool", _raise_create_pool)
+
+    code = await cleanup._main([
+        "--database-url",
+        "postgres://example",
+        "--account-id",
+        ACCOUNT_ID,
+        "--faq-id",
+        FAQ_ID,
+        "--execute",
+        "--confirm-live-zendesk-delete",
+    ])
+
+    assert code == cleanup.SKIPPED_EXIT
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_unexpected_zendesk_base_url_before_deletes() -> None:
+    pool = _pool_with_snapshot()
+    transport = _Transport()
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(
+            execute=True,
+            confirm_live_zendesk_delete=True,
+            expected_zendesk_base_url="https://other.zendesk.com",
+        ),
+        pool,
+        credentials_provider=_CredentialsProvider(_credentials()),
+        transport=transport,
+    )
+
+    assert code == cleanup.SKIPPED_EXIT
+    assert payload["not_run_reason"] == "unexpected_zendesk_base_url"
+    assert payload["observed_zendesk_base_url"] == EXPECTED_BASE_URL
+    assert transport.calls == []
+    assert all("DELETE FROM ticket_faq_markdown" not in call["query"] for call in pool.fetch_calls)
+
+
+@pytest.mark.asyncio
+async def test_execute_missing_mapping_external_id_leaves_local_rows() -> None:
+    pool = _pool_with_snapshot(external_id="", publish_status="pending")
+    credentials_provider = _CredentialsProvider(_credentials())
+    transport = _Transport()
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(
+            execute=True,
+            confirm_live_zendesk_delete=True,
+            expected_zendesk_base_url=EXPECTED_BASE_URL,
+        ),
+        pool,
+        credentials_provider=credentials_provider,
+        transport=transport,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["stage"] == "mapping_preflight"
+    assert payload["errors"] == ["macro_mapping_missing_external_id"]
+    assert payload["snapshot"]["macro_mapping_count"] == 1
+    assert payload["snapshot"]["external_ids"] == []
+    assert payload["snapshot"]["missing_external_id_count"] == 1
+    assert credentials_provider.calls == []
+    assert transport.calls == []
+    assert all("DELETE FROM ticket_faq_markdown" not in call["query"] for call in pool.fetch_calls)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_ignores_non_zendesk_mappings() -> None:
+    pool = _pool_with_snapshot(
+        mappings=[
+            {
+                "platform": "freshdesk",
+                "faq_item_id": "item-1",
+                "external_id": "",
+                "external_url": "https://freshdesk.example/macros/1",
+                "publish_status": "pending",
+            },
+            {
+                "platform": ZENDESK_PLATFORM,
+                "faq_item_id": "item-1",
+                "external_id": "macro-1",
+                "external_url": f"{EXPECTED_BASE_URL}/api/v2/macros/macro-1",
+                "publish_status": "published",
+            },
+        ]
+    )
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(),
+        pool,
+        credentials_provider=_CredentialsProvider(_credentials()),
+        transport=_Transport(),
+    )
+
+    assert code == 0
+    assert payload["snapshot"]["macro_mapping_count"] == 1
+    assert payload["snapshot"]["external_ids"] == ["macro-1"]
+    assert payload["snapshot"]["missing_external_id_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_mapping_url_from_unexpected_zendesk_base() -> None:
+    pool = _pool_with_snapshot(
+        external_url="https://other.zendesk.com/api/v2/macros/macro-1",
+    )
+    transport = _Transport()
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(
+            execute=True,
+            confirm_live_zendesk_delete=True,
+            expected_zendesk_base_url=EXPECTED_BASE_URL,
+        ),
+        pool,
+        credentials_provider=_CredentialsProvider(_credentials()),
+        transport=transport,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["stage"] == "mapping_preflight"
+    assert payload["errors"] == ["zendesk_macro_url_base_mismatch"]
+    assert payload["unexpected_external_urls"] == [
+        {
+            "external_id": "macro-1",
+            "external_url": "https://other.zendesk.com/api/v2/macros/macro-1",
+        }
+    ]
+    assert transport.calls == []
+    assert all("DELETE FROM ticket_faq_markdown" not in call["query"] for call in pool.fetch_calls)
+
+
+@pytest.mark.asyncio
+async def test_execute_deletes_external_macro_before_local_faq_row() -> None:
+    events: list[str] = []
+    pool = _pool_with_snapshot(events=events)
+    pool.fetch_rows.append([{"id": FAQ_ID}])
+    transport = _Transport(events=events)
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(
+            execute=True,
+            confirm_live_zendesk_delete=True,
+            expected_zendesk_base_url=EXPECTED_BASE_URL,
+        ),
+        pool,
+        credentials_provider=_CredentialsProvider(_credentials()),
+        transport=transport,
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["stage"] == "complete"
+    assert payload["deleted_faq_count"] == 1
+    assert payload["external_deletes"] == [
+        {"external_id": "macro-1", "ok": True, "error": ""}
+    ]
+    assert events == ["external_delete", "local_delete"]
+    assert transport.calls[0]["method"] == "DELETE"
+    assert transport.calls[0]["url"] == f"{EXPECTED_BASE_URL}/api/v2/macros/macro-1"
+    local_delete = pool.fetch_calls[-1]
+    assert "DELETE FROM ticket_faq_markdown" in local_delete["query"]
+    assert "account_id = $1" in local_delete["query"]
+    assert "id = $2" in local_delete["query"]
+    assert local_delete["args"] == (ACCOUNT_ID, FAQ_ID)
+
+
+@pytest.mark.asyncio
+async def test_execute_treats_not_found_macro_delete_as_idempotent_success() -> None:
+    events: list[str] = []
+    pool = _pool_with_snapshot(events=events)
+    pool.fetch_rows.append([{"id": FAQ_ID}])
+    transport = _Transport(
+        error=ZendeskMacroTransportError(status_code=404),
+        events=events,
+    )
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(
+            execute=True,
+            confirm_live_zendesk_delete=True,
+            expected_zendesk_base_url=EXPECTED_BASE_URL,
+        ),
+        pool,
+        credentials_provider=_CredentialsProvider(_credentials()),
+        transport=transport,
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["stage"] == "complete"
+    assert payload["external_deletes"] == [
+        {
+            "external_id": "macro-1",
+            "ok": True,
+            "error": "zendesk_macro_not_found",
+            "already_deleted": True,
+        }
+    ]
+    assert events == ["external_delete", "local_delete"]
+
+
+@pytest.mark.asyncio
+async def test_external_delete_failure_leaves_local_rows() -> None:
+    events: list[str] = []
+    pool = _pool_with_snapshot(events=events)
+    transport = _Transport(error=RuntimeError("delete failed"), events=events)
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(
+            execute=True,
+            confirm_live_zendesk_delete=True,
+            expected_zendesk_base_url=EXPECTED_BASE_URL,
+        ),
+        pool,
+        credentials_provider=_CredentialsProvider(_credentials()),
+        transport=transport,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["stage"] == "external_delete"
+    assert payload["errors"] == ["zendesk_macro_delete_failed"]
+    assert events == ["external_delete"]
+    assert all("DELETE FROM ticket_faq_markdown" not in call["query"] for call in pool.fetch_calls)
+
+
+@pytest.mark.asyncio
+async def test_execute_missing_draft_skips_without_credentials_or_deletes() -> None:
+    pool = _Pool(fetchrow_rows=[None])
+    credentials_provider = _CredentialsProvider(_credentials())
+    transport = _Transport()
+
+    code, payload = await cleanup.cleanup_sandbox_macro_writeback(
+        _args(
+            execute=True,
+            confirm_live_zendesk_delete=True,
+            expected_zendesk_base_url=EXPECTED_BASE_URL,
+        ),
+        pool,
+        credentials_provider=credentials_provider,
+        transport=transport,
+    )
+
+    assert code == cleanup.SKIPPED_EXIT
+    assert payload["not_run_reason"] == "faq_draft_not_found"
+    assert credentials_provider.calls == []
+    assert transport.calls == []
+    assert all("DELETE FROM ticket_faq_markdown" not in call["query"] for call in pool.fetch_calls)

--- a/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
@@ -14,6 +14,7 @@ from extracted_content_pipeline.faq_macro_writeback import (
 from extracted_content_pipeline.faq_macro_writeback_zendesk import (
     StaticZendeskMacroCredentialsProvider,
     ZENDESK_PLATFORM,
+    ZendeskHTTPMacroTransport,
     ZendeskMacroCredentials,
     ZendeskMacroPublishProvider,
     ZendeskMacroTransportError,
@@ -117,6 +118,97 @@ def _macro(
         faq_item_id=item_id,
         source_ids=("ticket-1",),
     )
+
+
+@pytest.mark.asyncio
+async def test_zendesk_http_transport_accepts_successful_empty_delete_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Response:
+        status_code = 204
+        content = b""
+
+        def json(self) -> Mapping[str, Any]:
+            raise AssertionError("empty response body should not be parsed")
+
+    class _Client:
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            headers: Mapping[str, str],
+            json: Mapping[str, Any],
+        ) -> _Response:
+            assert method == "DELETE"
+            assert url == "https://example.zendesk.com/api/v2/macros/123"
+            assert dict(headers) == {"Authorization": "Basic token"}
+            assert dict(json) == {}
+            return _Response()
+
+    monkeypatch.setattr(
+        "extracted_content_pipeline.faq_macro_writeback_zendesk.httpx.AsyncClient",
+        lambda timeout: _Client(),
+    )
+
+    payload = await ZendeskHTTPMacroTransport().request(
+        "DELETE",
+        "https://example.zendesk.com/api/v2/macros/123",
+        headers={"Authorization": "Basic token"},
+        json={},
+    )
+
+    assert payload == {}
+
+
+@pytest.mark.asyncio
+async def test_zendesk_http_transport_rejects_empty_error_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Response:
+        status_code = 500
+        content = b""
+
+        def json(self) -> Mapping[str, Any]:
+            raise AssertionError("error response body should not be parsed")
+
+    class _Client:
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            headers: Mapping[str, str],
+            json: Mapping[str, Any],
+        ) -> _Response:
+            assert method == "DELETE"
+            assert url == "https://example.zendesk.com/api/v2/macros/123"
+            return _Response()
+
+    monkeypatch.setattr(
+        "extracted_content_pipeline.faq_macro_writeback_zendesk.httpx.AsyncClient",
+        lambda timeout: _Client(),
+    )
+
+    with pytest.raises(ZendeskMacroTransportError):
+        await ZendeskHTTPMacroTransport().request(
+            "DELETE",
+            "https://example.zendesk.com/api/v2/macros/123",
+            headers={"Authorization": "Basic token"},
+            json={},
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Sandbox-Cleanup.md
Slice phase: Vertical slice

This slice adds the reversible cleanup path for the sandbox FAQ macro writeback proof: preview one tenant-scoped FAQ artifact by default, require explicit live Zendesk delete confirmation before execution, delete external Zendesk macros before local rows, and preserve local audit state when external cleanup fails.

## Intentional
- Cleanup accepts one explicit `faq_id` and never performs broad tenant cleanup.
- Cleanup uses the existing `ZendeskHTTPMacroTransport` and tenant credential provider instead of adding a second HTTP path.
- Cleanup fails closed when a mapping row lacks an external Zendesk macro id, because deleting local rows would destroy the reconciliation handle for a pending or persist-failed write.
- Cleanup restricts mapped deletes to Zendesk rows, treats 404 deletes as idempotent retry success, and validates stored macro URL bases before deleting.
- The write proof and cleanup proof remain separate operator actions.
- Local rows are not deleted when the external Zendesk delete fails, so the artifact remains available for retry and audit.

## Deferred
- Run the cleanup command against the first live sandbox artifact after the write proof is captured.
- Batch cleanup by explicit FAQ-id manifest remains future robust-testing work.
- Operator docs/UI cleanup status can follow later if this validation flow graduates beyond proof tooling.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_cleanup_content_ops_faq_macro_sandbox.py -q` - 11 passed.
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py -q` - 14 passed.
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q` - 54 passed, 1 warning.
- Python compile check for the modified Python files - passed.
- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Sandbox-Cleanup.md --check` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed.
- `bash scripts/check_ascii_python.sh` - passed.

## AI reconciliation
All findings fixed or waived: Yes.
- Codex :299 fixed: cleanup now refuses local deletion when a mapping lacks an external Zendesk id, preserving the mapping/attempt evidence needed for manual reconciliation.
- Codex :347 fixed: Zendesk 404/not-found delete responses are treated as already cleaned so a retry after partial external cleanup can finish.
- Codex :288 fixed: the mapping snapshot is filtered to `ZENDESK_PLATFORM` before external delete selection.
- Codex :338 fixed: stored macro URL bases are validated against the expected/current Zendesk base before any external delete.

## Diff size
7 files, +1287 / -0.
