### PR TITLE
FAQ macro writeback sandbox lifecycle

### DIFF
--- a/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
+++ b/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
@@ -13,11 +13,13 @@ on:
       - "atlas_brain/config.py"
       - "scripts/cleanup_content_ops_faq_macro_sandbox.py"
       - "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
+      - "scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py"
       - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
       - "tests/test_cleanup_content_ops_faq_macro_sandbox.py"
       - "tests/test_extracted_ticket_faq_macro_writeback_zendesk.py"
       - "tests/test_faq_macro_writeback_sandbox_e2e_smoke.py"
+      - "tests/test_faq_macro_writeback_sandbox_lifecycle.py"
       - "tests/test_seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_scheduler.py"
       - "tests/test_synthesis.py"
@@ -35,11 +37,13 @@ on:
       - "atlas_brain/config.py"
       - "scripts/cleanup_content_ops_faq_macro_sandbox.py"
       - "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
+      - "scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py"
       - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
       - "tests/test_cleanup_content_ops_faq_macro_sandbox.py"
       - "tests/test_extracted_ticket_faq_macro_writeback_zendesk.py"
       - "tests/test_faq_macro_writeback_sandbox_e2e_smoke.py"
+      - "tests/test_faq_macro_writeback_sandbox_lifecycle.py"
       - "tests/test_seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_scheduler.py"
       - "tests/test_synthesis.py"
@@ -70,6 +74,7 @@ jobs:
             tests/test_cleanup_content_ops_faq_macro_sandbox.py \
             tests/test_extracted_ticket_faq_macro_writeback_zendesk.py \
             tests/test_faq_macro_writeback_sandbox_e2e_smoke.py \
+            tests/test_faq_macro_writeback_sandbox_lifecycle.py \
             tests/test_seed_faq_macro_writeback_live_smoke_draft.py \
             tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in \
             tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary \

--- a/plans/PR-FAQ-Macro-Writeback-Sandbox-Lifecycle.md
+++ b/plans/PR-FAQ-Macro-Writeback-Sandbox-Lifecycle.md
@@ -1,0 +1,138 @@
+# PR-FAQ-Macro-Writeback-Sandbox-Lifecycle
+
+## Why this slice exists
+
+PR #1595 made sandbox macro writeback a one-command write proof, and PR #1597
+made cleanup a one-command delete proof. The remaining validation gap is that a
+real operator run is still a manual sequence: run E2E, copy the returned
+`faq_id`, run cleanup, then preserve two separate artifacts. That is exactly
+where live-proof mistakes happen: cleaning the wrong FAQ id, losing the write
+artifact, or reporting a green write while cleanup failed.
+
+This slice adds the thinnest lifecycle wrapper around the two existing guarded
+commands. It does not publish or delete directly; it composes the existing
+write wrapper and cleanup command into one artifact that proves the sandbox
+macro lifecycle from seed/write through cleanup.
+
+This PR may exceed the 400 LOC soft cap because the wrapper is both live-write
+and live-delete capable. The guard matrix, stage handoff, failure envelopes,
+cleanup skip semantics, and CI enrollment need to ship with focused tests.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add an operator-run sandbox lifecycle wrapper for one FAQ macro writeback
+   proof.
+2. Require create, live Zendesk write, and live Zendesk delete confirmations
+   plus a non-empty expected Zendesk base URL before opening a database pool.
+3. Reuse the existing sandbox E2E write wrapper, then pass its returned
+   `faq_id` to the existing sandbox cleanup command.
+4. Emit one JSON artifact with `write` and `cleanup` stage payloads, top-level
+   `faq_id`, and top-level success/error state.
+5. Stop before cleanup if the write stage fails or does not return a usable
+   `faq_id`.
+6. Surface cleanup failure as a non-green lifecycle artifact without rewriting
+   the cleanup payload.
+7. Do not add a new Zendesk provider, transport, API route, scheduler, or UI.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_macro_writeback_checks.yml`
+- `plans/PR-FAQ-Macro-Writeback-Sandbox-Lifecycle.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py`
+- `tests/test_faq_macro_writeback_sandbox_lifecycle.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Missing create confirmation exits skipped before any database pool is
+        opened.
+  - [ ] Missing live-write confirmation exits skipped before any database pool
+        is opened.
+  - [ ] Missing live-delete confirmation exits skipped before any database pool
+        is opened.
+  - [ ] Missing expected Zendesk base URL exits skipped before any database
+        pool is opened.
+  - [ ] The wrapper calls the existing E2E write stage first, then calls the
+        existing cleanup stage with the returned `faq_id`.
+  - [ ] Write-stage failure stops before cleanup and returns a non-green
+        lifecycle artifact.
+  - [ ] Cleanup-stage failure is surfaced as non-green with the cleanup payload
+        preserved.
+  - [ ] The wrapper source does not import Zendesk transport/provider classes.
+- Affected surfaces: operator scripts, macro-writeback live validation tests,
+  macro-writeback CI workflow.
+- Risk areas: accidental live Zendesk writes/deletes, wrong FAQ id handoff,
+  false-green lifecycle artifacts, and scope drift into provider logic.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R14.
+
+## Mechanism
+
+The lifecycle wrapper is a coordinator around two existing scripts:
+
+1. `scripts/smoke_content_ops_faq_macro_sandbox_e2e.py`
+2. `scripts/cleanup_content_ops_faq_macro_sandbox.py`
+
+It accepts the operator inputs needed for both stages: database URL, account
+id, optional user id, expected Zendesk base URL, seed question/answer text, and
+three explicit confirmation flags. If any live guard is missing, it returns a
+skipped JSON payload before opening a database pool.
+
+When all guards are present, the wrapper opens one asyncpg pool, calls the E2E
+write stage, reads the returned `faq_id`, then builds a cleanup argument
+namespace with that `faq_id` and calls the cleanup stage. The wrapper does not
+inspect Zendesk internals or directly call Zendesk; it only carries the stage
+payloads into one combined artifact and returns a non-zero code when either
+stage fails.
+
+## Intentional
+
+- No new Zendesk transport or provider. The write and delete behavior remains
+  owned by the existing E2E and cleanup scripts.
+- No automatic live execution. The wrapper is still operator-run and guarded by
+  explicit confirmations.
+- No UI, API route, or scheduler. This is a validation harness for the sandbox
+  proof lane.
+- No broad cleanup. The cleanup stage receives only the `faq_id` returned by
+  the write stage.
+
+## Deferred
+
+- Run the lifecycle wrapper against the Zendesk test account and attach the
+  sanitized artifact to the lane issue or proof log once the operator selects
+  credentials/account id.
+- Future robust-testing slice: manifest-based batch cleanup if repeated
+  sandbox lifecycle runs become common.
+- Future product slice: decide whether this validation harness graduates into
+  operator UI/status.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_faq_macro_writeback_sandbox_lifecycle.py -q
+  - 11 passed.
+- python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_faq_macro_writeback_sandbox_lifecycle.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q
+  - 65 passed, 1 warning.
+- python -m py_compile scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py tests/test_faq_macro_writeback_sandbox_lifecycle.py
+- python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - OK: 182 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh
+  - ASCII check passed for extracted_content_pipeline Python files.
+- python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Sandbox-Lifecycle.md --check
+  - plan already in sync.
+- Pending before push: local PR review via `scripts/push_pr.sh`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_macro_writeback_checks.yml` | 5 |
+| `plans/PR-FAQ-Macro-Writeback-Sandbox-Lifecycle.md` | 138 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py` | 297 |
+| `tests/test_faq_macro_writeback_sandbox_lifecycle.py` | 345 |
+| **Total** | **786** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -63,6 +63,7 @@ pytest \
   tests/test_content_ops_deflection_incidents.py \
   tests/test_send_content_ops_deflection_report_deliveries.py \
   tests/test_cleanup_content_ops_faq_macro_sandbox.py \
+  tests/test_faq_macro_writeback_sandbox_lifecycle.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \

--- a/scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py
+++ b/scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Run the guarded FAQ macro sandbox write and cleanup lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+SKIPPED_EXIT = 2
+
+
+def _load_script_module(module_name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load script module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_E2E_SCRIPT = _load_script_module(
+    "smoke_content_ops_faq_macro_sandbox_e2e_for_lifecycle",
+    ROOT / "scripts" / "smoke_content_ops_faq_macro_sandbox_e2e.py",
+)
+_CLEANUP_SCRIPT = _load_script_module(
+    "cleanup_content_ops_faq_macro_sandbox_for_lifecycle",
+    ROOT / "scripts" / "cleanup_content_ops_faq_macro_sandbox.py",
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        required=True,
+        help="Postgres DSN. Required explicitly; this script does not read env vars.",
+    )
+    parser.add_argument("--account-id", required=True, help="Tenant/account id.")
+    parser.add_argument("--user-id", default="", help="Optional operator user id.")
+    parser.add_argument(
+        "--expected-zendesk-base-url",
+        default="",
+        help="Required exact Zendesk base URL guard.",
+    )
+    parser.add_argument(
+        "--target-id",
+        default="macro-writeback-live-smoke-seed",
+        help="Target id stored on the seeded FAQ draft.",
+    )
+    parser.add_argument(
+        "--target-mode",
+        default="support_ticket_faq",
+        help="Target mode stored on the seeded FAQ draft.",
+    )
+    parser.add_argument(
+        "--title",
+        default="Zendesk macro writeback sandbox lifecycle smoke seed",
+        help="FAQ draft title.",
+    )
+    parser.add_argument(
+        "--question",
+        default="How do I refund a duplicate charge?",
+        help="Question used for the publishable FAQ item.",
+    )
+    parser.add_argument(
+        "--resolution-text",
+        default=(
+            "Open Billing, select the duplicate charge, and click Refund payment. "
+            "Confirm the refund and tell the customer it may take 3-5 business days."
+        ),
+        help="Verified answer text used for the publishable macro body.",
+    )
+    parser.add_argument(
+        "--confirm-create-draft",
+        action="store_true",
+        help="Required to create one approved FAQ draft in Postgres.",
+    )
+    parser.add_argument(
+        "--confirm-live-zendesk-write",
+        action="store_true",
+        help="Required to create or update real Zendesk macros.",
+    )
+    parser.add_argument(
+        "--confirm-live-zendesk-delete",
+        action="store_true",
+        help="Required to delete real Zendesk macros during cleanup.",
+    )
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for operator consistency; output is always JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not _clean(args.database_url):
+        raise SystemExit("--database-url is required")
+    if not _clean(args.account_id):
+        raise SystemExit("--account-id is required")
+    if not _clean(args.question):
+        raise SystemExit("--question is required")
+    if not _clean(args.resolution_text):
+        raise SystemExit("--resolution-text is required")
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for the sandbox FAQ macro lifecycle smoke; "
+            "install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def run_sandbox_lifecycle_smoke(
+    args: argparse.Namespace,
+    pool: Any,
+    *,
+    write_stage: Any | None = None,
+    cleanup_stage: Any | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Run sandbox write then cleanup stages and return one lifecycle artifact."""
+
+    preflight = _preflight(args)
+    if preflight is not None:
+        return preflight
+
+    write_runner = write_stage or _write_stage
+    cleanup_runner = cleanup_stage or _cleanup_stage
+    write_code, write_payload = await write_runner(args, pool)
+    if write_code != 0 or not write_payload.get("ok"):
+        return _stage_failure(
+            "write",
+            write_code,
+            account_id=_clean(args.account_id),
+            write_payload=write_payload,
+        )
+
+    faq_id = _clean(write_payload.get("faq_id"))
+    if not faq_id:
+        return _stage_failure(
+            "write",
+            1,
+            account_id=_clean(args.account_id),
+            write_payload={
+                **dict(write_payload),
+                "error": "write_faq_id_missing",
+            },
+        )
+
+    cleanup_args = _cleanup_args(args, faq_id=faq_id)
+    cleanup_code, cleanup_payload = await cleanup_runner(cleanup_args, pool)
+    ok = cleanup_code == 0 and bool(cleanup_payload.get("ok"))
+    return (
+        0 if ok else cleanup_code or 1,
+        {
+            "ok": ok,
+            "skipped": False,
+            "cleanup_skipped": bool(cleanup_payload.get("skipped", False)),
+            "stage": "complete" if ok else "cleanup",
+            "account_id": _clean(args.account_id),
+            "faq_id": faq_id,
+            "zendesk_base_url": _clean(
+                cleanup_payload.get("zendesk_base_url")
+                or write_payload.get("zendesk_base_url")
+            ),
+            "write": write_payload,
+            "cleanup": cleanup_payload,
+            "errors": list(cleanup_payload.get("errors") or ()),
+        },
+    )
+
+
+async def _write_stage(args: argparse.Namespace, pool: Any) -> tuple[int, dict[str, Any]]:
+    return await _E2E_SCRIPT.run_sandbox_e2e_smoke(args, pool)
+
+
+async def _cleanup_stage(args: argparse.Namespace, pool: Any) -> tuple[int, dict[str, Any]]:
+    return await _CLEANUP_SCRIPT.cleanup_sandbox_macro_writeback(args, pool)
+
+
+def _preflight(args: argparse.Namespace) -> tuple[int, dict[str, Any]] | None:
+    if not getattr(args, "confirm_create_draft", False):
+        return _not_run("missing_confirm_create_draft", args)
+    if not getattr(args, "confirm_live_zendesk_write", False):
+        return _not_run("missing_confirm_live_zendesk_write", args)
+    if not getattr(args, "confirm_live_zendesk_delete", False):
+        return _not_run("missing_confirm_live_zendesk_delete", args)
+    if not _clean(getattr(args, "expected_zendesk_base_url", "")):
+        return _not_run("missing_expected_zendesk_base_url", args)
+    return None
+
+
+def _not_run(reason: str, args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    return (
+        SKIPPED_EXIT,
+        {
+            "ok": False,
+            "skipped": True,
+            "stage": "preflight",
+            "not_run_reason": reason,
+            "account_id": _clean(getattr(args, "account_id", "")),
+            "expected_zendesk_base_url": _clean(
+                getattr(args, "expected_zendesk_base_url", "")
+            ),
+        },
+    )
+
+
+def _stage_failure(
+    stage: str,
+    code: int,
+    *,
+    account_id: str,
+    write_payload: dict[str, Any],
+) -> tuple[int, dict[str, Any]]:
+    return (
+        code or 1,
+        {
+            "ok": False,
+            "skipped": bool(write_payload.get("skipped", False)),
+            "cleanup_skipped": False,
+            "stage": stage,
+            "account_id": account_id,
+            "faq_id": _clean(write_payload.get("faq_id")),
+            "write": write_payload,
+            "cleanup": None,
+            "errors": [_clean(write_payload.get("error")) or f"{stage}_stage_failed"],
+        },
+    )
+
+
+def _cleanup_args(args: argparse.Namespace, *, faq_id: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        database_url=_clean(args.database_url),
+        account_id=_clean(args.account_id),
+        faq_id=faq_id,
+        expected_zendesk_base_url=_clean(args.expected_zendesk_base_url),
+        execute=True,
+        confirm_live_zendesk_delete=True,
+        output=None,
+        json=True,
+    )
+
+
+def _write_payload(payload: dict[str, Any], args: argparse.Namespace) -> None:
+    output = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    preflight = _preflight(args)
+    if preflight is not None:
+        code, payload = preflight
+        _write_payload(payload, args)
+        return code
+
+    pool = await _create_pool(_clean(args.database_url))
+    try:
+        code, payload = await run_sandbox_lifecycle_smoke(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    _write_payload(payload, args)
+    return code
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_faq_macro_writeback_sandbox_lifecycle.py
+++ b/tests/test_faq_macro_writeback_sandbox_lifecycle.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py"
+SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_faq_macro_sandbox_lifecycle",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+lifecycle = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = lifecycle
+SPEC.loader.exec_module(lifecycle)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"confirm_create_draft": False}, "missing_confirm_create_draft"),
+        ({"confirm_live_zendesk_write": False}, "missing_confirm_live_zendesk_write"),
+        ({"confirm_live_zendesk_delete": False}, "missing_confirm_live_zendesk_delete"),
+        ({"expected_zendesk_base_url": ""}, "missing_expected_zendesk_base_url"),
+    ],
+)
+async def test_lifecycle_skips_before_opening_pool_for_missing_live_guards(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, Any],
+    reason: str,
+) -> None:
+    async def fail_create_pool(database_url: str) -> object:
+        raise AssertionError(f"pool should not open for {database_url}")
+
+    output = tmp_path / f"{reason}.json"
+    monkeypatch.setattr(lifecycle, "_create_pool", fail_create_pool)
+
+    args = _args(**overrides)
+    code = await lifecycle._main(_argv(args, output=output))
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert code == lifecycle.SKIPPED_EXIT
+    assert payload["ok"] is False
+    assert payload["skipped"] is True
+    assert payload["stage"] == "preflight"
+    assert payload["not_run_reason"] == reason
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_runs_write_then_cleanup_with_seeded_faq_id() -> None:
+    calls: list[dict[str, Any]] = []
+    pool = object()
+
+    async def write_stage(
+        args: argparse.Namespace,
+        stage_pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        calls.append({"stage": "write", "pool": stage_pool, "args": args})
+        return 0, {
+            "ok": True,
+            "skipped": False,
+            "faq_id": "faq-seed-123",
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+        }
+
+    async def cleanup_stage(
+        args: argparse.Namespace,
+        stage_pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        calls.append({"stage": "cleanup", "pool": stage_pool, "args": args})
+        return 0, {
+            "ok": True,
+            "skipped": False,
+            "faq_id": args.faq_id,
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+            "deleted_faq_count": 1,
+            "errors": [],
+        }
+
+    code, payload = await lifecycle.run_sandbox_lifecycle_smoke(
+        _args(user_id="operator-1"),
+        pool,
+        write_stage=write_stage,
+        cleanup_stage=cleanup_stage,
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["skipped"] is False
+    assert payload["cleanup_skipped"] is False
+    assert payload["stage"] == "complete"
+    assert payload["faq_id"] == "faq-seed-123"
+    assert payload["zendesk_base_url"] == "https://sandbox.zendesk.com"
+    assert [call["stage"] for call in calls] == ["write", "cleanup"]
+    assert calls[0]["pool"] is pool
+    assert calls[1]["pool"] is pool
+    cleanup_args = calls[1]["args"]
+    assert cleanup_args.database_url == "postgres://example"
+    assert cleanup_args.account_id == "acct-1"
+    assert cleanup_args.faq_id == "faq-seed-123"
+    assert cleanup_args.expected_zendesk_base_url == "https://sandbox.zendesk.com"
+    assert cleanup_args.execute is True
+    assert cleanup_args.confirm_live_zendesk_delete is True
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_write_failure_stops_before_cleanup() -> None:
+    cleanup_calls = 0
+
+    async def write_stage(
+        args: argparse.Namespace,
+        pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        return 1, {
+            "ok": False,
+            "skipped": False,
+            "error": "macro_publish_failed",
+        }
+
+    async def cleanup_stage(
+        args: argparse.Namespace,
+        pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        return 0, {"ok": True}
+
+    code, payload = await lifecycle.run_sandbox_lifecycle_smoke(
+        _args(),
+        object(),
+        write_stage=write_stage,
+        cleanup_stage=cleanup_stage,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["stage"] == "write"
+    assert payload["errors"] == ["macro_publish_failed"]
+    assert payload["cleanup"] is None
+    assert cleanup_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_write_missing_faq_id_stops_before_cleanup() -> None:
+    cleanup_calls = 0
+
+    async def write_stage(
+        args: argparse.Namespace,
+        pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        return 0, {"ok": True, "faq_id": " "}
+
+    async def cleanup_stage(
+        args: argparse.Namespace,
+        pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        return 0, {"ok": True}
+
+    code, payload = await lifecycle.run_sandbox_lifecycle_smoke(
+        _args(),
+        object(),
+        write_stage=write_stage,
+        cleanup_stage=cleanup_stage,
+    )
+
+    assert code == 1
+    assert payload["stage"] == "write"
+    assert payload["errors"] == ["write_faq_id_missing"]
+    assert cleanup_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_cleanup_failure_surfaces_cleanup_payload() -> None:
+    async def write_stage(
+        args: argparse.Namespace,
+        pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        return 0, {
+            "ok": True,
+            "faq_id": "faq-seed-123",
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+        }
+
+    async def cleanup_stage(
+        args: argparse.Namespace,
+        pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        return 1, {
+            "ok": False,
+            "skipped": False,
+            "faq_id": args.faq_id,
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+            "errors": ["zendesk_macro_delete_failed"],
+        }
+
+    code, payload = await lifecycle.run_sandbox_lifecycle_smoke(
+        _args(),
+        object(),
+        write_stage=write_stage,
+        cleanup_stage=cleanup_stage,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["stage"] == "cleanup"
+    assert payload["faq_id"] == "faq-seed-123"
+    assert payload["errors"] == ["zendesk_macro_delete_failed"]
+    assert payload["cleanup"]["errors"] == ["zendesk_macro_delete_failed"]
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_cleanup_skip_after_write_is_not_top_level_skipped() -> None:
+    async def write_stage(
+        args: argparse.Namespace,
+        pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        return 0, {"ok": True, "faq_id": "faq-seed-123"}
+
+    async def cleanup_stage(
+        args: argparse.Namespace,
+        pool: object,
+    ) -> tuple[int, dict[str, Any]]:
+        return lifecycle.SKIPPED_EXIT, {
+            "ok": False,
+            "skipped": True,
+            "not_run_reason": "zendesk_credentials_missing",
+            "faq_id": args.faq_id,
+        }
+
+    code, payload = await lifecycle.run_sandbox_lifecycle_smoke(
+        _args(),
+        object(),
+        write_stage=write_stage,
+        cleanup_stage=cleanup_stage,
+    )
+
+    assert code == lifecycle.SKIPPED_EXIT
+    assert payload["ok"] is False
+    assert payload["skipped"] is False
+    assert payload["cleanup_skipped"] is True
+    assert payload["stage"] == "cleanup"
+    assert payload["faq_id"] == "faq-seed-123"
+    assert payload["cleanup"]["not_run_reason"] == "zendesk_credentials_missing"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_main_closes_pool_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Pool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    pool = Pool()
+
+    async def create_pool(database_url: str) -> Pool:
+        return pool
+
+    async def run(
+        args: argparse.Namespace,
+        stage_pool: Pool,
+    ) -> tuple[int, dict[str, Any]]:
+        assert stage_pool is pool
+        return 0, {"ok": True, "skipped": False}
+
+    monkeypatch.setattr(lifecycle, "_create_pool", create_pool)
+    monkeypatch.setattr(lifecycle, "run_sandbox_lifecycle_smoke", run)
+
+    code = await lifecycle._main(_argv(_args()))
+
+    assert code == 0
+    assert pool.closed is True
+
+
+def test_lifecycle_wrapper_does_not_define_zendesk_transport_or_provider() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "ZendeskMacroPublishProvider" not in source
+    assert "ZendeskHTTPMacroTransport" not in source
+    assert "httpx" not in source
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values: dict[str, Any] = {
+        "database_url": "postgres://example",
+        "account_id": "acct-1",
+        "user_id": "",
+        "expected_zendesk_base_url": "https://sandbox.zendesk.com",
+        "target_id": "macro-writeback-live-smoke-seed",
+        "target_mode": "support_ticket_faq",
+        "title": "Zendesk macro writeback sandbox lifecycle smoke seed",
+        "question": "How do I refund a duplicate charge?",
+        "resolution_text": (
+            "Open Billing, select the duplicate charge, and click Refund payment. "
+            "Confirm the refund and tell the customer it may take 3-5 business days."
+        ),
+        "confirm_create_draft": True,
+        "confirm_live_zendesk_write": True,
+        "confirm_live_zendesk_delete": True,
+        "output": None,
+        "json": True,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _argv(args: argparse.Namespace, *, output: Path | None = None) -> list[str]:
+    argv = [
+        "--database-url",
+        args.database_url,
+        "--account-id",
+        args.account_id,
+        "--expected-zendesk-base-url",
+        args.expected_zendesk_base_url,
+        "--question",
+        args.question,
+        "--resolution-text",
+        args.resolution_text,
+    ]
+    if args.user_id:
+        argv.extend(["--user-id", args.user_id])
+    if args.confirm_create_draft:
+        argv.append("--confirm-create-draft")
+    if args.confirm_live_zendesk_write:
+        argv.append("--confirm-live-zendesk-write")
+    if args.confirm_live_zendesk_delete:
+        argv.append("--confirm-live-zendesk-delete")
+    if output is not None:
+        argv.extend(["--output", str(output)])
+    return argv


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Sandbox-Lifecycle.md
Slice phase: Vertical slice

The sandbox macro writeback lane now has a guarded write proof and a guarded cleanup proof, but an operator still has to run two commands, copy the returned `faq_id`, and preserve two artifacts manually. This PR adds the narrow lifecycle wrapper that composes those existing scripts into one guarded write-then-delete proof with one JSON artifact.

## Intentional
- No new Zendesk transport or provider. The write and delete behavior remains owned by the existing E2E and cleanup scripts.
- No automatic live execution. The wrapper is still operator-run and guarded by explicit confirmations.
- No UI, API route, or scheduler. This is a validation harness for the sandbox proof lane.
- No broad cleanup. The cleanup stage receives only the `faq_id` returned by the write stage.

## Deferred
- Run the lifecycle wrapper against the Zendesk test account and attach the sanitized artifact to the lane issue or proof log once the operator selects credentials/account id.
- Future robust-testing slice: manifest-based batch cleanup if repeated sandbox lifecycle runs become common.
- Future product slice: decide whether this validation harness graduates into operator UI/status.

## Parked hardening
- None.

## AI reconciliation
- No automated-review findings.
- All fixed or waived: Yes.

## Verification
- `python -m pytest tests/test_faq_macro_writeback_sandbox_lifecycle.py -q`
  - 11 passed.
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_faq_macro_writeback_sandbox_lifecycle.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q`
  - 65 passed, 1 warning.
- `python -m py_compile scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py tests/test_faq_macro_writeback_sandbox_lifecycle.py`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
  - OK: 182 matching tests are enrolled.
- `bash scripts/check_ascii_python.sh`
  - ASCII check passed for extracted_content_pipeline Python files.
- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Sandbox-Lifecycle.md --check`
  - plan already in sync.

## Diff size
5 files, +779 / -0
