### PR TITLE
FAQ macro writeback lifecycle artifact

### DIFF
--- a/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
+++ b/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
@@ -11,11 +11,13 @@ on:
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
+      - "scripts/check_content_ops_faq_macro_lifecycle_artifact.py"
       - "scripts/cleanup_content_ops_faq_macro_sandbox.py"
       - "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
       - "scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py"
       - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_check_content_ops_faq_macro_lifecycle_artifact.py"
       - "tests/test_cleanup_content_ops_faq_macro_sandbox.py"
       - "tests/test_extracted_ticket_faq_macro_writeback_zendesk.py"
       - "tests/test_faq_macro_writeback_sandbox_e2e_smoke.py"
@@ -35,11 +37,13 @@ on:
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
+      - "scripts/check_content_ops_faq_macro_lifecycle_artifact.py"
       - "scripts/cleanup_content_ops_faq_macro_sandbox.py"
       - "scripts/smoke_content_ops_faq_macro_sandbox_e2e.py"
       - "scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py"
       - "scripts/seed_faq_macro_writeback_live_smoke_draft.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_check_content_ops_faq_macro_lifecycle_artifact.py"
       - "tests/test_cleanup_content_ops_faq_macro_sandbox.py"
       - "tests/test_extracted_ticket_faq_macro_writeback_zendesk.py"
       - "tests/test_faq_macro_writeback_sandbox_e2e_smoke.py"
@@ -71,6 +75,7 @@ jobs:
         run: |
           python -m pytest \
             tests/test_autonomous_faq_macro_writeback_scheduled_publish.py \
+            tests/test_check_content_ops_faq_macro_lifecycle_artifact.py \
             tests/test_cleanup_content_ops_faq_macro_sandbox.py \
             tests/test_extracted_ticket_faq_macro_writeback_zendesk.py \
             tests/test_faq_macro_writeback_sandbox_e2e_smoke.py \

--- a/plans/PR-FAQ-Macro-Writeback-Lifecycle-Artifact.md
+++ b/plans/PR-FAQ-Macro-Writeback-Lifecycle-Artifact.md
@@ -1,0 +1,136 @@
+# PR-FAQ-Macro-Writeback-Lifecycle-Artifact
+
+## Why this slice exists
+
+PR #1599 made the sandbox macro lifecycle one guarded command, but the
+operator still needs a safe way to decide whether the resulting JSON artifact
+is the proof we meant to capture. The raw artifact can include nested stage
+payloads, operational command text, seed copy, and partial-lifecycle states.
+Attaching that raw JSON directly to an issue or proof log makes review noisy and
+increases the chance that a write-ok/cleanup-failed run is mistaken for a clean
+proof.
+
+This slice adds the thinnest post-run artifact gate: read one lifecycle JSON
+artifact, fail closed unless the write and cleanup stages both completed, and
+emit a sanitized proof summary that carries only IDs, stage/status fields, base
+URL, and counts. It does not run Zendesk or Postgres; it validates the artifact
+that the already-merged lifecycle wrapper produced.
+
+This PR exceeds the 400 LOC soft cap because the checker is mostly failure
+detection logic. The malformed JSON, partial lifecycle states, FAQ-id mismatch,
+external-delete proof, summary-redaction, CI enrollment, and no-live-client
+guards need to ship with the checker rather than in a later proof-only PR.
+Review on #1601 found same-class false-green holes in the first checker version:
+truthy string success flags, blank external delete ids, incomplete write stages,
+missing or mismatched live-smoke proof, cross-instance base URLs, and non-UTF-8
+input crashes. This update fixes those at the artifact gate and expands the
+negative fixture matrix so the checker proves those failures fire.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add an operator-run lifecycle artifact checker for the sandbox FAQ macro
+   writeback proof.
+2. Require a complete, non-skipped lifecycle artifact: top-level `ok`, stage
+   `complete`, non-empty `faq_id`, matching stage FAQ ids, strict JSON boolean
+   success flags, write success, live-smoke success, and cleanup success.
+3. Require matching non-empty Zendesk base URLs across every stage that records
+   one.
+4. Fail closed on partial or misleading states: top-level skipped, cleanup
+   skipped, write failure, cleanup failure, missing delete count, missing
+   external delete proof, blank external delete id, or mismatched FAQ ids.
+5. Emit a JSON validation result by default and optionally write a sanitized
+   Markdown proof summary.
+6. Keep the summary free of seed question/answer text, raw `next_command`
+   values, and nested raw payload dumps.
+7. Do not add Zendesk, Postgres, scheduler, API, or UI behavior.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_macro_writeback_checks.yml`
+- `plans/PR-FAQ-Macro-Writeback-Lifecycle-Artifact.md`
+- `scripts/check_content_ops_faq_macro_lifecycle_artifact.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_check_content_ops_faq_macro_lifecycle_artifact.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Missing or malformed JSON returns non-zero with a specific error.
+  - [ ] A complete lifecycle artifact returns green and exposes a sanitized
+        summary payload.
+  - [ ] Top-level skipped and cleanup-skipped states fail closed.
+  - [ ] String-typed success flags fail closed instead of passing by
+        truthiness.
+  - [ ] Write or cleanup failure fails closed without hiding the stage errors.
+  - [ ] Incomplete write stage and missing live-smoke proof fail closed.
+  - [ ] Mismatched top-level/write/cleanup/live-smoke FAQ ids fail closed.
+  - [ ] Mismatched non-empty Zendesk base URLs fail closed.
+  - [ ] Missing, blank-id, or failed external delete proof fails closed.
+  - [ ] The optional Markdown proof summary excludes raw seed FAQ copy and
+        operational `next_command` text.
+  - [ ] The checker source does not import Zendesk or Postgres clients.
+- Affected surfaces: operator scripts, macro-writeback validation tests, and
+  macro-writeback CI enrollment.
+- Risk areas: false-green proof artifacts, leaking raw seed/operator text in a
+  summary, and scope drift into live Zendesk/Postgres behavior.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R14.
+
+## Mechanism
+
+The checker reads a JSON file from `--artifact`, validates only the lifecycle
+artifact envelope and the nested write/cleanup status fields, then returns a
+small validation payload. The payload includes `ok`, `errors`, `account_id`,
+`faq_id`, `zendesk_base_url`, stage names, write publishable count, cleanup
+deleted count, and external delete ids/statuses.
+
+When `--summary-output` is provided, the checker writes a Markdown proof summary
+from the sanitized validation payload. The summary intentionally does not render
+raw nested `write`, `cleanup`, `seed`, or `live_smoke` payloads. It also does not
+render seed FAQ question/answer copy or command strings such as `next_command`.
+
+## Intentional
+
+- No live Zendesk or Postgres access. This slice validates the artifact after an
+  operator-run lifecycle command; it does not trigger the lifecycle itself.
+- No raw artifact redump in the Markdown summary. The raw JSON remains available
+  locally if needed, but the shareable proof should be small and low-risk.
+- No broad schema model. The checker validates only the fields needed to prove
+  a clean sandbox write/delete lifecycle.
+
+## Deferred
+
+- Run the lifecycle wrapper against the Zendesk test account and validate the
+  produced artifact with this checker.
+- Future robust-testing slice: batch manifest validation if repeated lifecycle
+  artifacts become common.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_check_content_ops_faq_macro_lifecycle_artifact.py -q
+  - 33 passed.
+- python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_check_content_ops_faq_macro_lifecycle_artifact.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_faq_macro_writeback_sandbox_lifecycle.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q
+  - 98 passed, 1 warning.
+- python -m py_compile scripts/check_content_ops_faq_macro_lifecycle_artifact.py tests/test_check_content_ops_faq_macro_lifecycle_artifact.py
+- python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - OK: 183 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh
+  - ASCII check passed for extracted_content_pipeline Python files.
+- python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Lifecycle-Artifact.md --check
+  - plan already in sync.
+- Pending before push: local PR review via `scripts/push_pr.sh`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_macro_writeback_checks.yml` | 5 |
+| `plans/PR-FAQ-Macro-Writeback-Lifecycle-Artifact.md` | 136 |
+| `scripts/check_content_ops_faq_macro_lifecycle_artifact.py` | 263 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_check_content_ops_faq_macro_lifecycle_artifact.py` | 303 |
+| **Total** | **708** |

--- a/scripts/check_content_ops_faq_macro_lifecycle_artifact.py
+++ b/scripts/check_content_ops_faq_macro_lifecycle_artifact.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Validate and summarize one FAQ macro writeback lifecycle artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--summary-output", type=Path)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for operator consistency; output is always JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def validate_lifecycle_artifact(payload: Any) -> dict[str, Any]:
+    """Return a sanitized validation result for one lifecycle artifact."""
+
+    if not isinstance(payload, Mapping):
+        return _result(errors=["artifact_not_object"])
+
+    write = payload.get("write")
+    cleanup = payload.get("cleanup")
+    write_map = write if isinstance(write, Mapping) else {}
+    cleanup_map = cleanup if isinstance(cleanup, Mapping) else {}
+    live_smoke = write_map.get("live_smoke")
+    live_smoke_map = live_smoke if isinstance(live_smoke, Mapping) else {}
+
+    errors: list[str] = []
+    faq_id = _clean(payload.get("faq_id"))
+    write_faq_id = _clean(write_map.get("faq_id"))
+    cleanup_faq_id = _clean(cleanup_map.get("faq_id"))
+    live_smoke_faq_id = _clean(live_smoke_map.get("faq_id"))
+    external_deletes = _external_delete_summaries(cleanup_map.get("external_deletes"))
+
+    _require(errors, payload.get("ok") is True, "lifecycle_not_ok")
+    _require(errors, payload.get("skipped") is False, "lifecycle_skipped")
+    _require(errors, payload.get("cleanup_skipped") is False, "cleanup_skipped")
+    _require(errors, _clean(payload.get("stage")) == "complete", "lifecycle_incomplete")
+    _require(errors, bool(faq_id), "missing_faq_id")
+    _require(errors, isinstance(write, Mapping), "missing_write_payload")
+    _require(errors, isinstance(cleanup, Mapping), "missing_cleanup_payload")
+    _require(errors, write_map.get("ok") is True, "write_not_ok")
+    _require(errors, write_map.get("skipped") is False, "write_skipped")
+    _require(errors, _clean(write_map.get("stage")) == "complete", "write_incomplete")
+    _require(errors, cleanup_map.get("ok") is True, "cleanup_not_ok")
+    _require(errors, cleanup_map.get("skipped") is False, "cleanup_skipped")
+    _require(errors, _clean(cleanup_map.get("stage")) == "complete", "cleanup_incomplete")
+    _require(errors, bool(write_faq_id), "missing_write_faq_id")
+    _require(errors, bool(cleanup_faq_id), "missing_cleanup_faq_id")
+    _require(errors, isinstance(live_smoke, Mapping), "missing_live_smoke_payload")
+    if isinstance(live_smoke, Mapping):
+        _require(errors, bool(live_smoke_faq_id), "missing_live_smoke_faq_id")
+
+    if faq_id and write_faq_id and faq_id != write_faq_id:
+        errors.append("write_faq_id_mismatch")
+    if faq_id and cleanup_faq_id and faq_id != cleanup_faq_id:
+        errors.append("cleanup_faq_id_mismatch")
+    if faq_id and live_smoke_faq_id and faq_id != live_smoke_faq_id:
+        errors.append("live_smoke_faq_id_mismatch")
+
+    if live_smoke_map:
+        _require(errors, live_smoke_map.get("ok") is True, "live_smoke_not_ok")
+        _require(
+            errors,
+            live_smoke_map.get("skipped") is False,
+            "live_smoke_skipped",
+        )
+
+    deleted_faq_count = _int(cleanup_map.get("deleted_faq_count"))
+    _require(errors, deleted_faq_count == 1, "cleanup_deleted_faq_count_not_one")
+    _require(errors, bool(external_deletes), "missing_external_delete_proof")
+    for item in external_deletes:
+        if not item["external_id"]:
+            errors.append("missing_external_delete_id")
+            break
+        if not item["ok"]:
+            errors.append("external_delete_not_ok")
+            break
+    zendesk_base_url = _clean(
+        payload.get("zendesk_base_url")
+        or cleanup_map.get("zendesk_base_url")
+        or write_map.get("zendesk_base_url")
+        or live_smoke_map.get("zendesk_base_url")
+    )
+    if _base_url_mismatched(payload, write_map, cleanup_map, live_smoke_map):
+        errors.append("zendesk_base_url_mismatch")
+
+    stage_errors = _stage_errors(payload, write_map, cleanup_map, live_smoke_map)
+    for error in stage_errors:
+        if error not in errors:
+            errors.append(error)
+
+    return _result(
+        errors=errors,
+        account_id=_clean(payload.get("account_id")),
+        faq_id=faq_id,
+        zendesk_base_url=zendesk_base_url,
+        lifecycle_stage=_clean(payload.get("stage")),
+        write_stage=_clean(write_map.get("stage")),
+        cleanup_stage=_clean(cleanup_map.get("stage")),
+        publishable_count=_int(
+            write_map.get("publishable_count") or live_smoke_map.get("publishable_count")
+        ),
+        deleted_faq_count=deleted_faq_count,
+        external_deletes=external_deletes,
+    )
+
+
+def render_summary(result: Mapping[str, Any]) -> str:
+    """Render a sanitized Markdown proof summary from a validation result."""
+
+    lines = [
+        "# FAQ macro writeback sandbox lifecycle proof",
+        "",
+        f"- Status: {'PASS' if result.get('ok') else 'FAIL'}",
+        f"- Account id: {_clean(result.get('account_id')) or '(missing)'}",
+        f"- FAQ id: {_clean(result.get('faq_id')) or '(missing)'}",
+        f"- Zendesk base URL: {_clean(result.get('zendesk_base_url')) or '(missing)'}",
+        f"- Lifecycle stage: {_clean(result.get('lifecycle_stage')) or '(missing)'}",
+        f"- Write stage: {_clean(result.get('write_stage')) or '(missing)'}",
+        f"- Cleanup stage: {_clean(result.get('cleanup_stage')) or '(missing)'}",
+        f"- Publishable macro count: {_int(result.get('publishable_count'))}",
+        f"- Deleted FAQ rows: {_int(result.get('deleted_faq_count'))}",
+        "",
+        "## External Deletes",
+    ]
+    external_deletes = result.get("external_deletes")
+    if isinstance(external_deletes, list) and external_deletes:
+        for item in external_deletes:
+            if not isinstance(item, Mapping):
+                continue
+            status = "ok" if item.get("ok") else "failed"
+            suffix = " already deleted" if item.get("already_deleted") else ""
+            lines.append(
+                f"- {_clean(item.get('external_id')) or '(missing)'}: {status}{suffix}"
+            )
+    else:
+        lines.append("- None recorded.")
+
+    errors = result.get("errors")
+    if isinstance(errors, list) and errors:
+        lines.extend(["", "## Errors"])
+        lines.extend(f"- {_clean(error)}" for error in errors)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _result(
+    *,
+    errors: list[str],
+    account_id: str = "",
+    faq_id: str = "",
+    zendesk_base_url: str = "",
+    lifecycle_stage: str = "",
+    write_stage: str = "",
+    cleanup_stage: str = "",
+    publishable_count: int = 0,
+    deleted_faq_count: int = 0,
+    external_deletes: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "account_id": account_id,
+        "faq_id": faq_id,
+        "zendesk_base_url": zendesk_base_url,
+        "lifecycle_stage": lifecycle_stage,
+        "write_stage": write_stage,
+        "cleanup_stage": cleanup_stage,
+        "publishable_count": publishable_count,
+        "deleted_faq_count": deleted_faq_count,
+        "external_deletes": list(external_deletes or ()),
+    }
+
+
+def _external_delete_summaries(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    rows: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        rows.append({
+            "external_id": _clean(item.get("external_id")),
+            "ok": item.get("ok") is True,
+            "already_deleted": bool(item.get("already_deleted")),
+        })
+    return rows
+
+
+def _base_url_mismatched(*payloads: Mapping[str, Any]) -> bool:
+    values = {
+        _clean(payload.get("zendesk_base_url")).rstrip("/")
+        for payload in payloads
+        if _clean(payload.get("zendesk_base_url"))
+    }
+    return len(values) > 1
+
+
+def _stage_errors(*payloads: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for payload in payloads:
+        value = payload.get("errors")
+        if not isinstance(value, list):
+            continue
+        for item in value:
+            error = _clean(item)
+            if error:
+                errors.append(error)
+    return errors
+
+
+def _require(errors: list[str], condition: bool, code: str) -> None:
+    if not condition and code not in errors:
+        errors.append(code)
+
+
+def _int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return 0
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _read_artifact(path: Path) -> tuple[Any | None, list[str]]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), []
+    except FileNotFoundError:
+        return None, ["artifact_not_found"]
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, ["artifact_json_invalid"]
+    except OSError:
+        return None, ["artifact_read_failed"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    payload, read_errors = _read_artifact(args.artifact)
+    result = _result(errors=read_errors) if read_errors else validate_lifecycle_artifact(payload)
+    if args.summary_output:
+        args.summary_output.write_text(render_summary(result), encoding="utf-8")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -62,6 +62,7 @@ pytest \
   tests/test_alerts.py \
   tests/test_content_ops_deflection_incidents.py \
   tests/test_send_content_ops_deflection_report_deliveries.py \
+  tests/test_check_content_ops_faq_macro_lifecycle_artifact.py \
   tests/test_cleanup_content_ops_faq_macro_sandbox.py \
   tests/test_faq_macro_writeback_sandbox_lifecycle.py \
   tests/test_extracted_ticket_faq_markdown.py \

--- a/tests/test_check_content_ops_faq_macro_lifecycle_artifact.py
+++ b/tests/test_check_content_ops_faq_macro_lifecycle_artifact.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_content_ops_faq_macro_lifecycle_artifact.py"
+SPEC = importlib.util.spec_from_file_location(
+    "check_content_ops_faq_macro_lifecycle_artifact",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+def test_validate_complete_lifecycle_artifact_is_green() -> None:
+    result = checker.validate_lifecycle_artifact(_artifact())
+
+    assert result == {
+        "ok": True,
+        "errors": [],
+        "account_id": "acct-1",
+        "faq_id": "faq-123",
+        "zendesk_base_url": "https://sandbox.zendesk.com",
+        "lifecycle_stage": "complete",
+        "write_stage": "complete",
+        "cleanup_stage": "complete",
+        "publishable_count": 1,
+        "deleted_faq_count": 1,
+        "external_deletes": [
+            {
+                "external_id": "macro-123",
+                "ok": True,
+                "already_deleted": False,
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutator", "error"),
+    [
+        (lambda artifact: artifact.update({"skipped": True}), "lifecycle_skipped"),
+        (lambda artifact: artifact.update({"cleanup_skipped": True}), "cleanup_skipped"),
+        (lambda artifact: artifact.update({"stage": "cleanup"}), "lifecycle_incomplete"),
+        (lambda artifact: artifact["write"].update({"ok": False}), "write_not_ok"),
+        (lambda artifact: artifact["write"].update({"stage": "live_smoke"}), "write_incomplete"),
+        (lambda artifact: artifact["cleanup"].update({"ok": False}), "cleanup_not_ok"),
+        (lambda artifact: artifact["cleanup"].update({"stage": "external_delete"}), "cleanup_incomplete"),
+        (lambda artifact: artifact["cleanup"].update({"deleted_faq_count": 0}), "cleanup_deleted_faq_count_not_one"),
+        (lambda artifact: artifact["cleanup"].update({"external_deletes": []}), "missing_external_delete_proof"),
+        (lambda artifact: artifact["write"].pop("live_smoke"), "missing_live_smoke_payload"),
+    ],
+)
+def test_validate_rejects_partial_or_misleading_lifecycle_states(
+    mutator: Any,
+    error: str,
+) -> None:
+    artifact = _artifact()
+    mutator(artifact)
+
+    result = checker.validate_lifecycle_artifact(artifact)
+
+    assert result["ok"] is False
+    assert error in result["errors"]
+
+
+@pytest.mark.parametrize(
+    ("mutator", "error"),
+    [
+        (lambda artifact: artifact.update({"ok": "false"}), "lifecycle_not_ok"),
+        (lambda artifact: artifact.update({"skipped": "false"}), "lifecycle_skipped"),
+        (lambda artifact: artifact["write"].update({"ok": "false"}), "write_not_ok"),
+        (lambda artifact: artifact["write"].update({"skipped": "false"}), "write_skipped"),
+        (lambda artifact: artifact["cleanup"].update({"ok": "false"}), "cleanup_not_ok"),
+        (lambda artifact: artifact["cleanup"].update({"skipped": "false"}), "cleanup_skipped"),
+        (lambda artifact: artifact["write"]["live_smoke"].update({"ok": "false"}), "live_smoke_not_ok"),
+        (lambda artifact: artifact["write"]["live_smoke"].update({"skipped": "false"}), "live_smoke_skipped"),
+        (lambda artifact: artifact["cleanup"]["external_deletes"][0].update({"ok": "true"}), "external_delete_not_ok"),
+    ],
+)
+def test_validate_rejects_string_typed_success_flags(
+    mutator: Any,
+    error: str,
+) -> None:
+    artifact = _artifact()
+    mutator(artifact)
+
+    result = checker.validate_lifecycle_artifact(artifact)
+
+    assert result["ok"] is False
+    assert error in result["errors"]
+
+
+def test_validate_rejects_mismatched_faq_ids() -> None:
+    artifact = _artifact()
+    artifact["write"]["faq_id"] = "faq-other"
+    artifact["cleanup"]["faq_id"] = "faq-third"
+    artifact["write"]["live_smoke"]["faq_id"] = "faq-fourth"
+
+    result = checker.validate_lifecycle_artifact(artifact)
+
+    assert result["ok"] is False
+    assert "write_faq_id_mismatch" in result["errors"]
+    assert "cleanup_faq_id_mismatch" in result["errors"]
+    assert "live_smoke_faq_id_mismatch" in result["errors"]
+
+
+def test_validate_rejects_missing_live_smoke_faq_id() -> None:
+    artifact = _artifact()
+    artifact["write"]["live_smoke"].pop("faq_id")
+
+    result = checker.validate_lifecycle_artifact(artifact)
+
+    assert result["ok"] is False
+    assert "missing_live_smoke_faq_id" in result["errors"]
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda artifact: artifact.update({"zendesk_base_url": "https://other.zendesk.com"}),
+        lambda artifact: artifact["write"].update({"zendesk_base_url": "https://other.zendesk.com"}),
+        lambda artifact: artifact["cleanup"].update({"zendesk_base_url": "https://other.zendesk.com"}),
+        lambda artifact: artifact["write"]["live_smoke"].update({"zendesk_base_url": "https://other.zendesk.com"}),
+    ],
+)
+def test_validate_rejects_cross_instance_base_url_mismatch(mutator: Any) -> None:
+    artifact = _artifact()
+    artifact["write"]["live_smoke"]["zendesk_base_url"] = "https://sandbox.zendesk.com"
+    mutator(artifact)
+
+    result = checker.validate_lifecycle_artifact(artifact)
+
+    assert result["ok"] is False
+    assert "zendesk_base_url_mismatch" in result["errors"]
+
+
+def test_validate_rejects_blank_external_delete_id() -> None:
+    artifact = _artifact()
+    artifact["cleanup"]["external_deletes"] = [
+        {"external_id": " ", "ok": True, "error": ""}
+    ]
+
+    result = checker.validate_lifecycle_artifact(artifact)
+
+    assert result["ok"] is False
+    assert "missing_external_delete_id" in result["errors"]
+
+
+def test_validate_preserves_stage_errors_without_raw_payload_dump() -> None:
+    artifact = _artifact()
+    artifact["cleanup"].update({
+        "ok": False,
+        "errors": ["zendesk_macro_delete_failed"],
+        "external_deletes": [
+            {
+                "external_id": "macro-123",
+                "ok": False,
+                "error": "secret transport detail",
+            }
+        ],
+    })
+
+    result = checker.validate_lifecycle_artifact(artifact)
+
+    assert result["ok"] is False
+    assert "zendesk_macro_delete_failed" in result["errors"]
+    assert "external_delete_not_ok" in result["errors"]
+    assert result["external_deletes"] == [
+        {
+            "external_id": "macro-123",
+            "ok": False,
+            "already_deleted": False,
+        }
+    ]
+
+
+def test_render_summary_excludes_seed_copy_and_next_command() -> None:
+    artifact = _artifact()
+    result = checker.validate_lifecycle_artifact(artifact)
+
+    summary = checker.render_summary(result)
+
+    assert "How do I refund a duplicate charge" not in summary
+    assert "Open Billing" not in summary
+    assert "next_command" not in summary
+    assert "DATABASE_URL" not in summary
+    assert "faq-123" in summary
+    assert "macro-123: ok" in summary
+
+
+def test_main_rejects_invalid_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text("{", encoding="utf-8")
+
+    code = checker.main(["--artifact", str(artifact)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert code == 1
+    assert payload["errors"] == ["artifact_json_invalid"]
+
+
+def test_main_rejects_non_utf8_artifact_as_invalid_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact = tmp_path / "artifact.json"
+    artifact.write_bytes(b"\xff\xfe\x00")
+
+    code = checker.main(["--artifact", str(artifact)])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert payload["errors"] == ["artifact_json_invalid"]
+
+
+def test_main_writes_sanitized_markdown_summary(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact = tmp_path / "artifact.json"
+    summary = tmp_path / "summary.md"
+    artifact.write_text(json.dumps(_artifact()), encoding="utf-8")
+
+    code = checker.main([
+        "--artifact",
+        str(artifact),
+        "--summary-output",
+        str(summary),
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    summary_text = summary.read_text(encoding="utf-8")
+    assert code == 0
+    assert payload["ok"] is True
+    assert "Status: PASS" in summary_text
+    assert "How do I refund a duplicate charge" not in summary_text
+
+
+def test_checker_does_not_import_live_zendesk_or_postgres_clients() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "ZendeskMacroPublishProvider" not in source
+    assert "ZendeskHTTPMacroTransport" not in source
+    assert "asyncpg" not in source
+    assert "atlas_brain" not in source
+    assert "extracted_content_pipeline" not in source
+
+
+def _artifact() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "skipped": False,
+        "cleanup_skipped": False,
+        "stage": "complete",
+        "account_id": "acct-1",
+        "faq_id": "faq-123",
+        "zendesk_base_url": "https://sandbox.zendesk.com",
+        "write": {
+            "ok": True,
+            "skipped": False,
+            "stage": "complete",
+            "account_id": "acct-1",
+            "faq_id": "faq-123",
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+            "publishable_count": 1,
+            "seed": {
+                "macro_titles": ["How do I refund a duplicate charge?"],
+                "next_command": "DATABASE_URL=secret python smoke.py",
+            },
+            "live_smoke": {
+                "ok": True,
+                "skipped": False,
+                "faq_id": "faq-123",
+                "publishable_count": 1,
+                "summary": {"published_count": 1},
+            },
+        },
+        "cleanup": {
+            "ok": True,
+            "skipped": False,
+            "stage": "complete",
+            "account_id": "acct-1",
+            "faq_id": "faq-123",
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+            "deleted_faq_count": 1,
+            "external_deletes": [
+                {"external_id": "macro-123", "ok": True, "error": ""}
+            ],
+            "errors": [],
+        },
+    }


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Lifecycle-Artifact.md
Slice phase: Vertical slice

PR #1599 made the sandbox macro lifecycle one guarded command, but the resulting raw JSON still needed a safe proof gate before it could be shared in an issue or proof log. This PR adds a pure artifact checker that fails closed on partial lifecycle states and emits a sanitized summary with only IDs, stages, URL, and counts.

## Intentional
- No live Zendesk or Postgres access. This validates an artifact after an operator-run lifecycle command.
- No raw artifact redump in the Markdown summary; the shareable proof is small and low-risk.
- No broad schema model. The checker validates only the fields needed to prove a clean sandbox write/delete lifecycle.

## Deferred
- Run the lifecycle wrapper against the Zendesk test account and validate the produced artifact with this checker.
- Future robust-testing slice: batch manifest validation if repeated lifecycle artifacts become common.

## Parked hardening
- None.

## AI reconciliation
- Addressed Codex/reviewer findings: strict JSON boolean checks, non-empty external delete IDs, completed write stage, required live-smoke proof plus FAQ-id match, Zendesk base URL consistency, and non-UTF-8 artifact JSON error handling.
- All fixed or waived: Yes.

## Verification
- `python -m pytest tests/test_check_content_ops_faq_macro_lifecycle_artifact.py -q`
  - 33 passed.
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_check_content_ops_faq_macro_lifecycle_artifact.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_faq_macro_writeback_sandbox_lifecycle.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q`
  - 98 passed, 1 warning.
- `python -m py_compile scripts/check_content_ops_faq_macro_lifecycle_artifact.py tests/test_check_content_ops_faq_macro_lifecycle_artifact.py`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
  - OK: 183 matching tests are enrolled.
- `bash scripts/check_ascii_python.sh`
  - ASCII check passed for extracted_content_pipeline Python files.
- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Lifecycle-Artifact.md --check`
  - plan already in sync.

## Diff size
5 files, +586 / -0