### PR TITLE
FAQ macro writeback lifecycle proof bundle

### DIFF
--- a/plans/PR-FAQ-Macro-Writeback-Lifecycle-Proof-Bundle.md
+++ b/plans/PR-FAQ-Macro-Writeback-Lifecycle-Proof-Bundle.md
@@ -1,0 +1,115 @@
+# PR-FAQ-Macro-Writeback-Lifecycle-Proof-Bundle
+
+## Why this slice exists
+
+PR #1599 made the sandbox FAQ macro lifecycle one guarded command, and PR #1601
+added a fail-closed checker plus sanitized Markdown proof summary for the JSON
+artifact. The remaining operator gap is that the real proof still requires two
+manual commands: run lifecycle, then remember to run the checker against the
+right output file. That creates the same class of live-proof mistake we have
+been removing in this lane: a raw lifecycle artifact can be captured without
+the sanitized proof summary, or a summary can be generated from the wrong file.
+
+This slice bundles the two existing pieces without adding new live behavior.
+The lifecycle wrapper can now write the raw JSON artifact and, when requested,
+write the sanitized proof summary from the same in-memory lifecycle payload.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add an optional `--summary-output` argument to the sandbox lifecycle wrapper.
+2. After the lifecycle payload is produced, validate that exact payload through
+   the existing lifecycle artifact checker and write the sanitized Markdown
+   summary to `--summary-output`.
+3. Preserve existing raw JSON behavior: stdout by default, `--output` when
+   provided.
+4. Keep preflight skips before any database pool is opened.
+5. If the lifecycle stage returns success but the checker rejects the payload,
+   return non-zero with a `proof_summary_validation_failed` error instead of
+   false-greening the run.
+6. Do not add new Zendesk, Postgres, provider, scheduler, API, or UI behavior.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Lifecycle-Proof-Bundle.md`
+- `scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py`
+- `tests/test_faq_macro_writeback_sandbox_lifecycle.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A successful lifecycle run with `--summary-output` writes raw JSON and
+        a sanitized Markdown proof summary from the same payload.
+  - [ ] Preflight skips with `--summary-output` still skip before opening a
+        database pool and write a failure summary.
+  - [ ] A lifecycle failure writes a failure summary without masking the
+        lifecycle exit code.
+  - [ ] If a green lifecycle payload fails proof validation, the wrapper
+        returns non-zero and records `proof_summary_validation_failed`.
+  - [ ] The summary excludes raw seed FAQ copy and operational `next_command`
+        text by delegating to the existing checker.
+  - [ ] The wrapper still does not define Zendesk transport/provider classes.
+- Affected surfaces: operator lifecycle script and macro-writeback lifecycle
+  tests.
+- Risk areas: false-green proof bundles, summary/raw artifact mismatch, and
+  scope drift into live provider behavior.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R14.
+
+## Mechanism
+
+The lifecycle wrapper dynamically loads
+`scripts/check_content_ops_faq_macro_lifecycle_artifact.py` alongside the
+existing E2E and cleanup scripts. The wrapper still produces the lifecycle
+payload exactly once. If `--summary-output` is provided, it passes the in-memory
+payload to `validate_lifecycle_artifact`, renders the sanitized Markdown via
+`render_summary`, and writes that Markdown to the requested path.
+
+If the lifecycle exit code is already non-zero, the wrapper keeps that exit code
+and writes a failure summary. If the lifecycle exit code is zero but validation
+fails, the wrapper changes the exit code to non-zero and adds the checker
+errors to the lifecycle JSON payload under `proof_summary_errors`.
+
+## Intentional
+
+- No new validation rules. The proof bundle delegates validation and Markdown
+  rendering to the checker from PR #1601.
+- No automatic live execution. The existing lifecycle confirmation flags remain
+  required.
+- No raw JSON redump inside the Markdown summary. The summary stays sanitized by
+  construction because the checker owns rendering.
+- No UI or route. This is still an operator-run proof command.
+
+## Deferred
+
+- Run the proof bundle against the Zendesk test account and attach the sanitized
+  summary to the lane issue or proof log.
+- Future robust-testing slice: batch proof bundle validation if repeated
+  lifecycle artifacts become common.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_faq_macro_writeback_sandbox_lifecycle.py -q
+  - 15 passed.
+- python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_check_content_ops_faq_macro_lifecycle_artifact.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_faq_macro_writeback_sandbox_lifecycle.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q
+  - 102 passed, 1 warning.
+- python -m py_compile scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py tests/test_faq_macro_writeback_sandbox_lifecycle.py
+- python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - OK: 183 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh
+  - ASCII check passed for extracted_content_pipeline Python files.
+- python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Lifecycle-Proof-Bundle.md --check
+  - plan already in sync.
+- Pending before push: local PR review via `scripts/push_pr.sh`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-FAQ-Macro-Writeback-Lifecycle-Proof-Bundle.md` | 115 |
+| `scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py` | 40 |
+| `tests/test_faq_macro_writeback_sandbox_lifecycle.py` | 206 |
+| **Total** | **361** |

--- a/scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py
+++ b/scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py
@@ -38,6 +38,10 @@ _CLEANUP_SCRIPT = _load_script_module(
     "cleanup_content_ops_faq_macro_sandbox_for_lifecycle",
     ROOT / "scripts" / "cleanup_content_ops_faq_macro_sandbox.py",
 )
+_CHECKER_SCRIPT = _load_script_module(
+    "check_content_ops_faq_macro_lifecycle_artifact_for_lifecycle",
+    ROOT / "scripts" / "check_content_ops_faq_macro_lifecycle_artifact.py",
+)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -98,6 +102,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Required to delete real Zendesk macros during cleanup.",
     )
     parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    parser.add_argument(
+        "--summary-output",
+        type=Path,
+        help="Optional sanitized Markdown proof summary output path.",
+    )
     parser.add_argument(
         "--json",
         action="store_true",
@@ -267,12 +276,42 @@ def _write_payload(payload: dict[str, Any], args: argparse.Namespace) -> None:
         print(output, end="")
 
 
+def _write_proof_summary(
+    code: int,
+    payload: dict[str, Any],
+    args: argparse.Namespace,
+) -> tuple[int, dict[str, Any]]:
+    if not args.summary_output:
+        return code, payload
+
+    result = _CHECKER_SCRIPT.validate_lifecycle_artifact(payload)
+    args.summary_output.write_text(
+        _CHECKER_SCRIPT.render_summary(result),
+        encoding="utf-8",
+    )
+    if code == 0 and not result.get("ok"):
+        errors = list(payload.get("errors") or ())
+        errors.append("proof_summary_validation_failed")
+        return (
+            1,
+            {
+                **payload,
+                "ok": False,
+                "stage": "proof_summary",
+                "errors": errors,
+                "proof_summary_errors": list(result.get("errors") or ()),
+            },
+        )
+    return code, payload
+
+
 async def _main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     _validate_args(args)
     preflight = _preflight(args)
     if preflight is not None:
         code, payload = preflight
+        code, payload = _write_proof_summary(code, payload, args)
         _write_payload(payload, args)
         return code
 
@@ -285,6 +324,7 @@ async def _main(argv: list[str] | None = None) -> int:
             maybe_awaitable = close()
             if hasattr(maybe_awaitable, "__await__"):
                 await maybe_awaitable
+    code, payload = _write_proof_summary(code, payload, args)
     _write_payload(payload, args)
     return code
 

--- a/tests/test_faq_macro_writeback_sandbox_lifecycle.py
+++ b/tests/test_faq_macro_writeback_sandbox_lifecycle.py
@@ -287,6 +287,157 @@ async def test_lifecycle_main_closes_pool_after_success(
     assert pool.closed is True
 
 
+@pytest.mark.asyncio
+async def test_lifecycle_main_writes_raw_artifact_and_sanitized_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "lifecycle.json"
+    summary = tmp_path / "summary.md"
+
+    class Pool:
+        async def close(self) -> None:
+            return None
+
+    async def create_pool(database_url: str) -> Pool:
+        return Pool()
+
+    async def run(
+        args: argparse.Namespace,
+        stage_pool: Pool,
+    ) -> tuple[int, dict[str, Any]]:
+        return 0, _complete_lifecycle_payload()
+
+    monkeypatch.setattr(lifecycle, "_create_pool", create_pool)
+    monkeypatch.setattr(lifecycle, "run_sandbox_lifecycle_smoke", run)
+
+    code = await lifecycle._main(_argv(_args(), output=output, summary=summary))
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    summary_text = summary.read_text(encoding="utf-8")
+    assert code == 0
+    assert payload["ok"] is True
+    assert "Status: PASS" in summary_text
+    assert "faq-seed-123" in summary_text
+    assert "macro-123: ok" in summary_text
+    assert "How do I refund a duplicate charge" not in summary_text
+    assert "next_command" not in summary_text
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_preflight_skip_writes_failure_summary_before_pool(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "preflight.json"
+    summary = tmp_path / "summary.md"
+
+    async def fail_create_pool(database_url: str) -> object:
+        raise AssertionError(f"pool should not open for {database_url}")
+
+    monkeypatch.setattr(lifecycle, "_create_pool", fail_create_pool)
+
+    code = await lifecycle._main(
+        _argv(
+            _args(confirm_live_zendesk_delete=False),
+            output=output,
+            summary=summary,
+        )
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    summary_text = summary.read_text(encoding="utf-8")
+    assert code == lifecycle.SKIPPED_EXIT
+    assert payload["not_run_reason"] == "missing_confirm_live_zendesk_delete"
+    assert "Status: FAIL" in summary_text
+    assert "missing_write_payload" in summary_text
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_failure_writes_summary_without_masking_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "lifecycle.json"
+    summary = tmp_path / "summary.md"
+
+    class Pool:
+        async def close(self) -> None:
+            return None
+
+    async def create_pool(database_url: str) -> Pool:
+        return Pool()
+
+    async def run(
+        args: argparse.Namespace,
+        stage_pool: Pool,
+    ) -> tuple[int, dict[str, Any]]:
+        payload = _complete_lifecycle_payload()
+        payload.update({
+            "ok": False,
+            "stage": "cleanup",
+            "errors": ["zendesk_macro_delete_failed"],
+        })
+        payload["cleanup"].update({
+            "ok": False,
+            "stage": "external_delete",
+            "errors": ["zendesk_macro_delete_failed"],
+        })
+        return 1, payload
+
+    monkeypatch.setattr(lifecycle, "_create_pool", create_pool)
+    monkeypatch.setattr(lifecycle, "run_sandbox_lifecycle_smoke", run)
+
+    code = await lifecycle._main(_argv(_args(), output=output, summary=summary))
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    summary_text = summary.read_text(encoding="utf-8")
+    assert code == 1
+    assert payload["stage"] == "cleanup"
+    assert payload["errors"] == ["zendesk_macro_delete_failed"]
+    assert "proof_summary_validation_failed" not in payload["errors"]
+    assert "Status: FAIL" in summary_text
+    assert "zendesk_macro_delete_failed" in summary_text
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_summary_validation_failure_blocks_green_run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "lifecycle.json"
+    summary = tmp_path / "summary.md"
+
+    class Pool:
+        async def close(self) -> None:
+            return None
+
+    async def create_pool(database_url: str) -> Pool:
+        return Pool()
+
+    async def run(
+        args: argparse.Namespace,
+        stage_pool: Pool,
+    ) -> tuple[int, dict[str, Any]]:
+        payload = _complete_lifecycle_payload()
+        payload["cleanup"]["external_deletes"] = []
+        return 0, payload
+
+    monkeypatch.setattr(lifecycle, "_create_pool", create_pool)
+    monkeypatch.setattr(lifecycle, "run_sandbox_lifecycle_smoke", run)
+
+    code = await lifecycle._main(_argv(_args(), output=output, summary=summary))
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    summary_text = summary.read_text(encoding="utf-8")
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["stage"] == "proof_summary"
+    assert "proof_summary_validation_failed" in payload["errors"]
+    assert payload["proof_summary_errors"] == ["missing_external_delete_proof"]
+    assert "Status: FAIL" in summary_text
+
+
 def test_lifecycle_wrapper_does_not_define_zendesk_transport_or_provider() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
 
@@ -319,7 +470,58 @@ def _args(**overrides: Any) -> argparse.Namespace:
     return argparse.Namespace(**values)
 
 
-def _argv(args: argparse.Namespace, *, output: Path | None = None) -> list[str]:
+def _complete_lifecycle_payload() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "skipped": False,
+        "cleanup_skipped": False,
+        "stage": "complete",
+        "account_id": "acct-1",
+        "faq_id": "faq-seed-123",
+        "zendesk_base_url": "https://sandbox.zendesk.com",
+        "write": {
+            "ok": True,
+            "skipped": False,
+            "stage": "complete",
+            "account_id": "acct-1",
+            "faq_id": "faq-seed-123",
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+            "publishable_count": 1,
+            "seed": {
+                "macro_titles": ["How do I refund a duplicate charge?"],
+                "next_command": "DATABASE_URL=secret python smoke.py",
+            },
+            "live_smoke": {
+                "ok": True,
+                "skipped": False,
+                "faq_id": "faq-seed-123",
+                "zendesk_base_url": "https://sandbox.zendesk.com",
+                "publishable_count": 1,
+            },
+        },
+        "cleanup": {
+            "ok": True,
+            "skipped": False,
+            "stage": "complete",
+            "account_id": "acct-1",
+            "faq_id": "faq-seed-123",
+            "zendesk_base_url": "https://sandbox.zendesk.com",
+            "deleted_faq_count": 1,
+            "external_deletes": [
+                {"external_id": "macro-123", "ok": True, "error": ""}
+            ],
+            "errors": [],
+        },
+        "errors": [],
+    }
+
+
+def _argv(
+    args: argparse.Namespace,
+    *,
+    output: Path | None = None,
+    summary: Path | None = None,
+) -> list[str]:
     argv = [
         "--database-url",
         args.database_url,
@@ -342,4 +544,6 @@ def _argv(args: argparse.Namespace, *, output: Path | None = None) -> list[str]:
         argv.append("--confirm-live-zendesk-delete")
     if output is not None:
         argv.extend(["--output", str(output)])
+    if summary is not None:
+        argv.extend(["--summary-output", str(summary)])
     return argv


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Lifecycle-Proof-Bundle.md
Slice phase: Vertical slice

PR #1599 made the sandbox lifecycle one guarded command, and PR #1601 added a fail-closed artifact checker. This PR bundles those pieces so one lifecycle run can produce the raw JSON artifact and the sanitized Markdown proof summary from the same in-memory payload.

## Intentional
- No new validation rules; this delegates proof validation and Markdown rendering to the checker from PR #1601.
- No automatic live execution. The existing lifecycle confirmation flags remain required.
- No raw JSON redump inside the Markdown summary.
- No UI or route. This is still an operator-run proof command.

## Deferred
- Run the proof bundle against the Zendesk test account and attach the sanitized summary to the lane issue or proof log.
- Future robust-testing slice: batch proof bundle validation if repeated lifecycle artifacts become common.

## Parked hardening
- None.

## AI reconciliation
- No automated-review findings.
- All fixed or waived: Yes.

## Verification
- `python -m pytest tests/test_faq_macro_writeback_sandbox_lifecycle.py -q`
  - 15 passed.
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_check_content_ops_faq_macro_lifecycle_artifact.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_faq_macro_writeback_sandbox_lifecycle.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q`
  - 102 passed, 1 warning.
- `python -m py_compile scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py tests/test_faq_macro_writeback_sandbox_lifecycle.py`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
  - OK: 183 matching tests are enrolled.
- `bash scripts/check_ascii_python.sh`
  - ASCII check passed for extracted_content_pipeline Python files.
- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Lifecycle-Proof-Bundle.md --check`
  - plan already in sync.

## Diff size
3 files, +361 / -0
