### PR TITLE
FAQ macro writeback proof directory

### DIFF
--- a/plans/PR-FAQ-Macro-Writeback-Proof-Directory.md
+++ b/plans/PR-FAQ-Macro-Writeback-Proof-Directory.md
@@ -1,0 +1,112 @@
+# PR-FAQ-Macro-Writeback-Proof-Directory
+
+## Why this slice exists
+
+PR #1602 made the sandbox lifecycle command write a raw artifact and sanitized
+Markdown proof summary from the same in-memory payload. The remaining operator
+footgun is path selection: the live proof command still asks the operator to
+hand-type two related paths. A typo can leave the raw JSON in one location and
+the shareable summary somewhere else, or accidentally overwrite a stale proof
+from a previous run.
+
+This slice adds the narrow proof-directory mode before the live Zendesk proof
+run. It does not write to Zendesk, Postgres, or GitHub by itself. It makes the
+existing operator command choose the artifact and summary filenames together,
+fail closed on conflicting output arguments, and refuse stale proof-directory
+contents before any database pool or Zendesk operation can begin.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add `--proof-dir` to the sandbox lifecycle wrapper as a convenience mode for
+   writing both lifecycle proof files.
+2. In `--proof-dir` mode, write the lifecycle artifact and Markdown summary in
+   that directory by wiring the existing `--output` and `--summary-output`
+   behavior.
+3. Reject `--proof-dir` combined with explicit `--output` or
+   `--summary-output` so one invocation has one output contract.
+4. Refuse an existing proof directory that already contains files before
+   preflight/database/Zendesk work begins.
+5. Preserve existing stdout, `--output`, and `--summary-output` behavior when
+   `--proof-dir` is not used.
+6. Do not add live Zendesk execution, provider behavior, cleanup behavior, API,
+   scheduler, or UI changes.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Proof-Directory.md`
+- `scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py`
+- `tests/test_faq_macro_writeback_sandbox_lifecycle.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `--proof-dir` writes raw JSON and sanitized Markdown proof files from
+        the same lifecycle payload.
+  - [ ] `--proof-dir` cannot be combined with explicit `--output` or
+        `--summary-output`.
+  - [ ] A non-empty proof directory is rejected before opening a database pool
+        or running the write stage.
+  - [ ] Existing output modes keep their current behavior.
+  - [ ] Preflight skip behavior remains before pool creation.
+  - [ ] The wrapper still does not define Zendesk transport/provider classes.
+- Affected surfaces: operator lifecycle script and macro-writeback lifecycle
+  tests.
+- Risk areas: accidental stale proof reuse, output path mismatch, and scope
+  drift into live provider behavior.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R14.
+
+## Mechanism
+
+Argument normalization runs immediately after parsing. If `--proof-dir` is set,
+the wrapper refuses explicit output paths, checks the directory contents before
+any preflight/database work, creates the directory when safe, and fills
+`args.output` and `args.summary_output` with the paired proof-file paths.
+
+The rest of the lifecycle flow remains the PR #1602 path: the wrapper produces
+one lifecycle payload, validates the same payload through the artifact checker
+when summary output is requested, writes the sanitized Markdown summary, and
+then writes the raw JSON artifact.
+
+## Intentional
+
+- No automatic live run. The existing confirmation flags and credential
+  requirements remain unchanged.
+- No timestamped filenames. A single proof directory is simpler to reference
+  and safer to review; stale contents are rejected instead of silently creating
+  another variant.
+- No GitHub issue upload. Attaching the sanitized summary is still an operator
+  step after the live proof run succeeds.
+
+## Deferred
+
+- Run the proof-directory command against the Zendesk test account and attach
+  the sanitized summary to the lane tracker/proof log.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_faq_macro_writeback_sandbox_lifecycle.py -q
+  - 19 passed.
+- python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_check_content_ops_faq_macro_lifecycle_artifact.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_faq_macro_writeback_sandbox_lifecycle.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q
+  - 106 passed, 1 warning.
+- python -m py_compile scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py tests/test_faq_macro_writeback_sandbox_lifecycle.py
+- python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - OK: 183 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh
+  - ASCII check passed for extracted_content_pipeline Python files.
+- python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Proof-Directory.md --check
+  - plan already in sync.
+- Pending before push: local PR review via `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-FAQ-Macro-Writeback-Proof-Directory.md` | 112 |
+| `scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py` | 26 |
+| `tests/test_faq_macro_writeback_sandbox_lifecycle.py` | 85 |
+| **Total** | **223** |

--- a/scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py
+++ b/scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py
@@ -108,6 +108,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Optional sanitized Markdown proof summary output path.",
     )
     parser.add_argument(
+        "--proof-dir",
+        type=Path,
+        help=(
+            "Optional proof directory. Writes lifecycle.json and summary.md "
+            "there; cannot be combined with --output or --summary-output."
+        ),
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Accepted for operator consistency; output is always JSON.",
@@ -124,6 +132,23 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("--question is required")
     if not _clean(args.resolution_text):
         raise SystemExit("--resolution-text is required")
+
+
+def _normalize_output_args(args: argparse.Namespace) -> None:
+    proof_dir = getattr(args, "proof_dir", None)
+    if proof_dir is None:
+        return
+    if args.output is not None:
+        raise SystemExit("--proof-dir cannot be combined with --output")
+    if args.summary_output is not None:
+        raise SystemExit("--proof-dir cannot be combined with --summary-output")
+    if proof_dir.exists() and not proof_dir.is_dir():
+        raise SystemExit("--proof-dir must be a directory")
+    if proof_dir.exists() and any(proof_dir.iterdir()):
+        raise SystemExit("--proof-dir must be empty")
+    proof_dir.mkdir(parents=True, exist_ok=True)
+    args.output = proof_dir / "lifecycle.json"
+    args.summary_output = proof_dir / "summary.md"
 
 
 async def _create_pool(database_url: str) -> Any:
@@ -307,6 +332,7 @@ def _write_proof_summary(
 
 async def _main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    _normalize_output_args(args)
     _validate_args(args)
     preflight = _preflight(args)
     if preflight is not None:

--- a/tests/test_faq_macro_writeback_sandbox_lifecycle.py
+++ b/tests/test_faq_macro_writeback_sandbox_lifecycle.py
@@ -325,6 +325,88 @@ async def test_lifecycle_main_writes_raw_artifact_and_sanitized_summary(
 
 
 @pytest.mark.asyncio
+async def test_lifecycle_proof_dir_writes_raw_artifact_and_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    proof_dir = tmp_path / "proof"
+
+    class Pool:
+        async def close(self) -> None:
+            return None
+
+    async def create_pool(database_url: str) -> Pool:
+        return Pool()
+
+    async def run(
+        args: argparse.Namespace,
+        stage_pool: Pool,
+    ) -> tuple[int, dict[str, Any]]:
+        assert args.output == proof_dir / "lifecycle.json"
+        assert args.summary_output == proof_dir / "summary.md"
+        return 0, _complete_lifecycle_payload()
+
+    monkeypatch.setattr(lifecycle, "_create_pool", create_pool)
+    monkeypatch.setattr(lifecycle, "run_sandbox_lifecycle_smoke", run)
+
+    code = await lifecycle._main(_argv(_args(), proof_dir=proof_dir))
+
+    payload = json.loads((proof_dir / "lifecycle.json").read_text(encoding="utf-8"))
+    summary_text = (proof_dir / "summary.md").read_text(encoding="utf-8")
+    assert code == 0
+    assert payload["ok"] is True
+    assert "Status: PASS" in summary_text
+    assert "macro-123: ok" in summary_text
+    assert "next_command" not in summary_text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("conflicting_arg", ["output", "summary"])
+async def test_lifecycle_proof_dir_rejects_explicit_output_modes_before_pool(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    conflicting_arg: str,
+) -> None:
+    async def fail_create_pool(database_url: str) -> object:
+        raise AssertionError(f"pool should not open for {database_url}")
+
+    monkeypatch.setattr(lifecycle, "_create_pool", fail_create_pool)
+    kwargs: dict[str, Path] = {"proof_dir": tmp_path / "proof"}
+    if conflicting_arg == "output":
+        kwargs["output"] = tmp_path / "manual.json"
+    else:
+        kwargs["summary"] = tmp_path / "manual.md"
+
+    with pytest.raises(SystemExit) as excinfo:
+        await lifecycle._main(_argv(_args(), **kwargs))
+
+    message = str(excinfo.value)
+    assert "--proof-dir cannot be combined with" in message
+    assert not (tmp_path / "proof").exists()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_proof_dir_rejects_stale_directory_before_pool(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    proof_dir = tmp_path / "proof"
+    proof_dir.mkdir()
+    (proof_dir / "summary.md").write_text("stale proof\n", encoding="utf-8")
+
+    async def fail_create_pool(database_url: str) -> object:
+        raise AssertionError(f"pool should not open for {database_url}")
+
+    monkeypatch.setattr(lifecycle, "_create_pool", fail_create_pool)
+
+    with pytest.raises(SystemExit) as excinfo:
+        await lifecycle._main(_argv(_args(), proof_dir=proof_dir))
+
+    assert str(excinfo.value) == "--proof-dir must be empty"
+    assert (proof_dir / "summary.md").read_text(encoding="utf-8") == "stale proof\n"
+
+
+@pytest.mark.asyncio
 async def test_lifecycle_preflight_skip_writes_failure_summary_before_pool(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -521,6 +603,7 @@ def _argv(
     *,
     output: Path | None = None,
     summary: Path | None = None,
+    proof_dir: Path | None = None,
 ) -> list[str]:
     argv = [
         "--database-url",
@@ -546,4 +629,6 @@ def _argv(
         argv.extend(["--output", str(output)])
     if summary is not None:
         argv.extend(["--summary-output", str(summary)])
+    if proof_dir is not None:
+        argv.extend(["--proof-dir", str(proof_dir)])
     return argv


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Proof-Directory.md
Slice phase: Vertical slice

This slice makes the FAQ macro sandbox lifecycle proof harder to mis-capture: operators can pass one `--proof-dir`, and the wrapper owns the paired raw JSON and sanitized Markdown paths while refusing stale proof contents before any database or Zendesk work begins.

## Intentional
- No automatic live run. The existing confirmation flags and credential requirements remain unchanged.
- No timestamped filenames. A single proof directory is simpler to reference and safer to review; stale contents are rejected instead of silently creating another variant.
- No GitHub issue upload. Attaching the sanitized summary is still an operator step after the live proof run succeeds.

## Deferred
- Run the proof-directory command against the Zendesk test account and attach the sanitized summary to the lane tracker/proof log.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_faq_macro_writeback_sandbox_lifecycle.py -q` - 19 passed.
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_check_content_ops_faq_macro_lifecycle_artifact.py tests/test_cleanup_content_ops_faq_macro_sandbox.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_faq_macro_writeback_sandbox_e2e_smoke.py tests/test_faq_macro_writeback_sandbox_lifecycle.py tests/test_seed_faq_macro_writeback_live_smoke_draft.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q` - 106 passed, 1 warning.
- `python -m py_compile scripts/smoke_content_ops_faq_macro_sandbox_lifecycle.py tests/test_faq_macro_writeback_sandbox_lifecycle.py`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - OK: 183 matching tests are enrolled.
- `bash scripts/check_ascii_python.sh` - ASCII check passed for extracted_content_pipeline Python files.
- `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Proof-Directory.md --check` - plan already in sync.

## Diff size
3 files, +223 / -0
