### PR TITLE
FAQ macro writeback credential pool contract

### DIFF
--- a/atlas_brain/_content_ops_zendesk_credentials.py
+++ b/atlas_brain/_content_ops_zendesk_credentials.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 import logging
 import uuid as _uuid
 from dataclasses import dataclass
 from datetime import datetime
+from typing import AsyncIterator
 from typing import Optional
 
 from extracted_content_pipeline.faq_macro_writeback_zendesk import (
@@ -37,6 +39,10 @@ class ZendeskCredentialLookupError(RuntimeError):
     """Stored Zendesk credentials could not be read or decrypted."""
 
 
+class ZendeskCredentialWriteError(RuntimeError):
+    """Stored Zendesk credentials could not be written."""
+
+
 async def upsert_zendesk_credentials(
     pool,
     *,
@@ -59,7 +65,7 @@ async def upsert_zendesk_credentials(
     ciphertext, kid = encrypt_secret(cleaned_token)
     token_prefix = cleaned_token[:TOKEN_PREFIX_LEN]
 
-    async with pool.transaction() as conn:
+    async with _credential_write_transaction(pool) as conn:
         await conn.execute(
             "SELECT id FROM saas_accounts WHERE id = $1 FOR UPDATE",
             account_id,
@@ -94,6 +100,58 @@ async def upsert_zendesk_credentials(
         )
 
     return _display_record(row)
+
+
+@asynccontextmanager
+async def _credential_write_transaction(pool) -> AsyncIterator[object]:
+    """Yield a transaction connection from the supported credential DB shapes."""
+
+    transaction = getattr(pool, "transaction", None)
+    if callable(transaction):
+        async with transaction() as conn:
+            yield conn
+        return
+
+    acquire = getattr(pool, "acquire", None)
+    if not callable(acquire):
+        raise ZendeskCredentialWriteError("zendesk_credentials_write_pool_unsupported")
+
+    acquired = acquire()
+    if hasattr(acquired, "__await__"):
+        conn = await acquired
+        conn_transaction = getattr(conn, "transaction", None)
+        if not callable(conn_transaction):
+            await _release_if_supported(pool, conn)
+            raise ZendeskCredentialWriteError(
+                "zendesk_credentials_write_pool_unsupported"
+            )
+        try:
+            async with conn_transaction():
+                yield conn
+        finally:
+            await _release_if_supported(pool, conn)
+        return
+
+    if not (hasattr(acquired, "__aenter__") and hasattr(acquired, "__aexit__")):
+        raise ZendeskCredentialWriteError("zendesk_credentials_write_pool_unsupported")
+
+    async with acquired as conn:
+        conn_transaction = getattr(conn, "transaction", None)
+        if not callable(conn_transaction):
+            raise ZendeskCredentialWriteError(
+                "zendesk_credentials_write_pool_unsupported"
+            )
+        async with conn_transaction():
+            yield conn
+
+
+async def _release_if_supported(pool, conn: object) -> None:
+    release = getattr(pool, "release", None)
+    if not callable(release):
+        return
+    result = release(conn)
+    if hasattr(result, "__await__"):
+        await result
 
 
 async def list_zendesk_credentials(
@@ -260,6 +318,7 @@ __all__ = [
     "ContentOpsZendeskCredentialRecord",
     "TOKEN_PREFIX_LEN",
     "ZendeskCredentialLookupError",
+    "ZendeskCredentialWriteError",
     "list_zendesk_credentials",
     "lookup_zendesk_credentials",
     "revoke_zendesk_credentials",

--- a/plans/PR-FAQ-Macro-Writeback-Credential-Pool-Contract.md
+++ b/plans/PR-FAQ-Macro-Writeback-Credential-Pool-Contract.md
@@ -1,0 +1,113 @@
+# PR-FAQ-Macro-Writeback-Credential-Pool-Contract
+
+## Why this slice exists
+
+Issue #1606 tracks the one hardening gap found during the live FAQ macro
+writeback proof. The product proof succeeded, but setup exposed that
+`upsert_zendesk_credentials` only knew the Atlas `DatabasePool` wrapper
+transaction shape. The live setup path used a raw asyncpg-style pool and failed
+before writing tenant Zendesk credentials because that pool has `acquire()` and
+connection-level `transaction()`, not a wrapper-level `transaction()` helper.
+
+The repo's default credential API route still uses the Atlas wrapper. However,
+the service helpers already mostly behave like a database-bound utility:
+`list_zendesk_credentials`, `lookup_zendesk_credentials`, and
+`revoke_zendesk_credentials` call `fetch*`/`execute` directly and work with the
+wrapper or raw asyncpg pool shapes. The outlier is upsert because it needs one
+transaction spanning account lock, revoke, and insert.
+
+This slice makes that transaction boundary explicit and tested. It keeps the
+wrapper-backed API route working while adding coverage for the raw asyncpg pool
+shape that failed during setup.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+
+1. Add a small internal transaction adapter for Zendesk credential writes.
+2. Preserve the Atlas wrapper contract: if the object exposes
+   `transaction()`, use it exactly as today.
+3. Add raw asyncpg pool support for setup tooling: if the object exposes a
+   context-manager `acquire()`, acquire a connection and open
+   connection-level `transaction()`.
+4. Fail closed with a typed credential setup error when neither supported pool
+   shape is present.
+5. Add regression coverage for the raw asyncpg-style pool shape that failed in
+   the live setup path.
+6. Keep macro publish, Zendesk network, API auth, migrations, and live proof
+   behavior out of scope.
+
+### Files touched
+
+- `atlas_brain/_content_ops_zendesk_credentials.py`
+- `plans/PR-FAQ-Macro-Writeback-Credential-Pool-Contract.md`
+- `tests/test_content_ops_zendesk_credentials.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Wrapper-shaped `transaction()` upsert behavior remains covered.
+  - [ ] Raw asyncpg-shaped `acquire()` plus connection `transaction()` upsert
+        behavior is covered.
+  - [ ] Unsupported pool shapes fail closed before account lookup/revoke/insert.
+  - [ ] Upsert still encrypts the token and returns a display-safe record.
+  - [ ] Existing lookup/list/revoke behavior is unchanged.
+  - [ ] No account ids, FAQ ids, Zendesk macro ids, or token values from the
+        live proof are added to fixtures or docs.
+- Affected surfaces: tenant Zendesk credential service and its unit tests.
+- Risk areas: credential write transaction atomicity, silently bypassing
+  encryption, and widening database contract beyond the intended setup path.
+- Reviewer rules triggered: R1, R2, R3, R8, R10, R14.
+
+## Mechanism
+
+`upsert_zendesk_credentials` delegates the account lock, revoke, and insert
+block to an internal async context manager. The context manager first checks for
+the Atlas wrapper's `transaction()` method and yields that transaction's
+connection. If that method is absent, it uses the raw asyncpg pool pattern:
+acquire a connection through the pool's async context manager, then open the
+connection-level transaction.
+
+Tests add a raw asyncpg-shaped fake whose pool has no `transaction()` method,
+whose `acquire()` returns an async context manager, and whose connection owns
+the query methods. That reproduces the live setup failure class without a real
+database or secrets.
+
+## Intentional
+
+- No route or UI changes. The default API path already passes the Atlas wrapper
+  through `get_db_pool()`.
+- No live database integration test in this slice. The raw asyncpg shape is
+  reproduced with a focused fake so CI can run it without secrets.
+- No changes to lookup/list/revoke. They did not require a transaction and
+  already use query methods compatible with both shapes.
+
+## Deferred
+
+- If setup tooling becomes a first-class operator command, add that command as
+  a separate slice with dry-run behavior and no secret output.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_zendesk_credentials.py -q
+  - 8 passed.
+- python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_macro_writeback.py tests/test_content_ops_faq_macro_writeback_flow.py -q
+  - 24 passed.
+- python -m py_compile atlas_brain/_content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_credentials.py
+- python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - OK: 183 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh
+  - ASCII check passed for extracted_content_pipeline Python files.
+- Pending before push: local PR review via `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/_content_ops_zendesk_credentials.py` | 61 |
+| `plans/PR-FAQ-Macro-Writeback-Credential-Pool-Contract.md` | 113 |
+| `tests/test_content_ops_zendesk_credentials.py` | 118 |
+| **Total** | **292** |

--- a/tests/test_content_ops_zendesk_credentials.py
+++ b/tests/test_content_ops_zendesk_credentials.py
@@ -52,6 +52,61 @@ class _Transaction:
         return False
 
 
+class _RawAsyncpgPool:
+    def __init__(self, conn: "_RawAsyncpgConnection") -> None:
+        self.conn = conn
+        self.acquire_calls = 0
+
+    def acquire(self):
+        self.acquire_calls += 1
+        return _AcquireContext(self.conn)
+
+
+class _AcquireContext:
+    def __init__(self, conn: "_RawAsyncpgConnection") -> None:
+        self.conn = conn
+
+    async def __aenter__(self):
+        self.conn.acquired = True
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.conn.released = True
+        return False
+
+
+class _RawAsyncpgConnection:
+    def __init__(self, *, fetchrow_result=None) -> None:
+        self.fetchrow_result = fetchrow_result
+        self.execute_calls: list[dict] = []
+        self.fetchrow_calls: list[dict] = []
+        self.transaction_calls = 0
+        self.acquired = False
+        self.released = False
+
+    def transaction(self):
+        self.transaction_calls += 1
+        return _ConnectionTransaction(self)
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append({"query": query, "args": args})
+        return self.fetchrow_result
+
+
+class _ConnectionTransaction:
+    def __init__(self, conn: _RawAsyncpgConnection) -> None:
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 def _row(**overrides):
     row = {
         "id": uuid.uuid4(),
@@ -117,6 +172,69 @@ async def test_upsert_zendesk_credentials_encrypts_token_and_returns_display_rec
     assert not hasattr(record, "api_token")
     assert not hasattr(record, "encrypted_api_token")
     assert not hasattr(record, "encryption_kid")
+
+
+@pytest.mark.asyncio
+async def test_upsert_zendesk_credentials_accepts_raw_asyncpg_pool_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = uuid.uuid4()
+    conn = _RawAsyncpgConnection(fetchrow_result=_row(account_id=account_id))
+    pool = _RawAsyncpgPool(conn)
+    monkeypatch.setattr(
+        service,
+        "encrypt_secret",
+        lambda raw: (f"encrypted:{raw}".encode("utf-8"), "kid-1"),
+    )
+
+    record = await service.upsert_zendesk_credentials(
+        pool,
+        account_id=account_id,
+        email="agent@example.com",
+        api_token="secret-token",
+        subdomain="acme",
+        label="Primary",
+    )
+
+    assert pool.acquire_calls == 1
+    assert conn.acquired is True
+    assert conn.released is True
+    assert conn.transaction_calls == 1
+    assert conn.execute_calls[0]["query"].strip().startswith("SELECT id FROM saas_accounts")
+    insert_call = conn.fetchrow_calls[0]
+    assert "INSERT INTO content_ops_zendesk_credentials" in insert_call["query"]
+    assert insert_call["args"][0] == account_id
+    assert insert_call["args"][2] == b"encrypted:secret-token"
+    assert record.account_id == account_id
+
+
+@pytest.mark.asyncio
+async def test_upsert_zendesk_credentials_rejects_unsupported_pool_before_queries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _UnsupportedPool:
+        def __init__(self) -> None:
+            self.execute_calls = 0
+
+        async def execute(self, query, *args):
+            self.execute_calls += 1
+
+    pool = _UnsupportedPool()
+    monkeypatch.setattr(service, "encrypt_secret", lambda raw: (b"encrypted", "kid-1"))
+
+    with pytest.raises(
+        service.ZendeskCredentialWriteError,
+        match="zendesk_credentials_write_pool_unsupported",
+    ):
+        await service.upsert_zendesk_credentials(
+            pool,
+            account_id=uuid.uuid4(),
+            email="agent@example.com",
+            api_token="secret-token",
+            subdomain="acme",
+        )
+
+    assert pool.execute_calls == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Credential-Pool-Contract.md
Slice phase: Production hardening

This slice closes #1606 by making the tenant Zendesk credential upsert transaction boundary explicit: the existing Atlas database-wrapper path still works, and the raw asyncpg pool shape that failed during live proof setup now has focused regression coverage.

## Intentional
- No route or UI changes. The default API path already passes the Atlas wrapper through `get_db_pool()`.
- No live database integration test in this slice. The raw asyncpg shape is reproduced with a focused fake so CI can run it without secrets.
- No changes to lookup/list/revoke. They did not require a transaction and already use query methods compatible with both shapes.

## Deferred
- If setup tooling becomes a first-class operator command, add that command as a separate slice with dry-run behavior and no secret output.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_zendesk_credentials.py -q` - 8 passed.
- `python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_macro_writeback.py tests/test_content_ops_faq_macro_writeback_flow.py -q` - 24 passed.
- `python -m py_compile atlas_brain/_content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_credentials.py`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - OK: 183 matching tests are enrolled.
- `bash scripts/check_ascii_python.sh` - ASCII check passed for extracted_content_pipeline Python files.

## Diff size
3 files, +291 / -1
