### PR TITLE
FAQ macro writeback credential setup CLI

### DIFF
--- a/.github/workflows/atlas_content_ops_generated_assets_checks.yml
+++ b/.github/workflows/atlas_content_ops_generated_assets_checks.yml
@@ -11,6 +11,7 @@ on:
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/api/content_ops_brand_voice_profiles.py"
       - "atlas_brain/api/content_ops_zendesk_export.py"
+      - "scripts/setup_content_ops_zendesk_credentials.py"
       - "atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql"
       - "extracted_content_pipeline/api/control_surfaces.py"
       - "extracted_content_pipeline/api/generated_assets.py"
@@ -19,6 +20,7 @@ on:
       - "tests/test_content_ops_brand_voice_profiles_api.py"
       - "tests/test_content_ops_zendesk_credentials.py"
       - "tests/test_content_ops_zendesk_export_api.py"
+      - "tests/test_setup_content_ops_zendesk_credentials.py"
   push:
     branches:
       - main
@@ -31,6 +33,7 @@ on:
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/api/content_ops_brand_voice_profiles.py"
       - "atlas_brain/api/content_ops_zendesk_export.py"
+      - "scripts/setup_content_ops_zendesk_credentials.py"
       - "atlas_brain/storage/migrations/333_content_ops_brand_voice_profiles.sql"
       - "extracted_content_pipeline/api/control_surfaces.py"
       - "extracted_content_pipeline/api/generated_assets.py"
@@ -39,6 +42,7 @@ on:
       - "tests/test_content_ops_brand_voice_profiles_api.py"
       - "tests/test_content_ops_zendesk_credentials.py"
       - "tests/test_content_ops_zendesk_export_api.py"
+      - "tests/test_setup_content_ops_zendesk_credentials.py"
 
 jobs:
   atlas-content-ops-generated-assets-checks:
@@ -67,4 +71,5 @@ jobs:
             tests/test_content_ops_brand_voice_profiles_api.py \
             tests/test_content_ops_zendesk_credentials.py \
             tests/test_content_ops_zendesk_export_api.py \
+            tests/test_setup_content_ops_zendesk_credentials.py \
             -q

--- a/atlas_brain/_content_ops_zendesk_credentials.py
+++ b/atlas_brain/_content_ops_zendesk_credentials.py
@@ -63,7 +63,7 @@ async def upsert_zendesk_credentials(
     )
     cleaned_token = str(api_token or "").strip()
     ciphertext, kid = encrypt_secret(cleaned_token)
-    token_prefix = cleaned_token[:TOKEN_PREFIX_LEN]
+    token_prefix = _safe_token_prefix(cleaned_token)
 
     async with _credential_write_transaction(pool) as conn:
         await conn.execute(
@@ -264,6 +264,13 @@ def _validated_credentials(
     if not credentials.is_complete():
         raise ValueError("Complete Zendesk email, API token, and endpoint are required")
     return credentials
+
+
+def _safe_token_prefix(token: str) -> str:
+    cleaned = str(token or "").strip()
+    if len(cleaned) <= TOKEN_PREFIX_LEN:
+        return ""
+    return cleaned[:TOKEN_PREFIX_LEN]
 
 
 def encrypt_secret(raw: str) -> tuple[bytes, str]:

--- a/plans/PR-FAQ-Macro-Writeback-Credential-Setup-CLI.md
+++ b/plans/PR-FAQ-Macro-Writeback-Credential-Setup-CLI.md
@@ -1,0 +1,150 @@
+# PR-FAQ-Macro-Writeback-Credential-Setup-CLI
+
+## Why this slice exists
+
+The live FAQ macro writeback proof succeeded, but the setup path still required
+manual credential insertion to provision the tenant Zendesk credential row. PR
+#1607 fixed the underlying pool contract so the credential service can accept
+the raw asyncpg pool shape used by operator scripts. The remaining upstream gap
+is delivery: future live proofs should not rely on ad hoc SQL for encrypted
+tenant credential setup.
+
+This slice turns the fixed service seam into a small operator command. It is
+production hardening because it removes a manual secret-handling step from the
+live-proof workflow without changing macro publish behavior.
+
+The diff is over the 400 LOC soft target because the command is
+security-sensitive: the slice includes direct negative coverage for dry-run
+no-DB behavior, missing config, endpoint guard mismatch, missing write
+confirmation, pool-open failure, validation failure, generic write failure, and
+lazy asyncpg import. Review fixes added same-class coverage for short-token
+redaction, close-failure cleanup after success and handled failure, and
+encryption setup diagnostics. Splitting those tests out would make the operator
+command look safer than the PR proves.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+
+1. Add an operator CLI that provisions one tenant-scoped Content Ops Zendesk
+   credential by calling the existing encrypted credential service.
+2. Read Zendesk credentials through the typed Atlas config path by default, not
+   raw environment access, and keep the database DSN as an explicit operator
+   argument consistent with the live proof scripts.
+3. Add a dry-run mode that validates account id and configured Zendesk endpoint
+   without opening a database pool or writing credentials.
+4. Require `--confirm-write` for actual credential writes.
+5. Emit display-safe JSON only: account id, endpoint, label, token prefix, and
+   status; never print the API token, ciphertext, encryption key id, or DSN.
+6. Add focused tests for dry-run, missing config, successful upsert delegation,
+   and sanitized error output.
+7. Suppress complete short-token prefixes at the shared credential service
+   boundary so API and CLI display paths cannot expose a whole token.
+8. Treat pool-close failures as cleanup warnings so they cannot mask a
+   successful write or a handled safe failure payload.
+9. Distinguish encryption setup failures from invalid Zendesk credentials.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_generated_assets_checks.yml`
+- `atlas_brain/_content_ops_zendesk_credentials.py`
+- `plans/PR-FAQ-Macro-Writeback-Credential-Setup-CLI.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `scripts/setup_content_ops_zendesk_credentials.py`
+- `tests/test_content_ops_zendesk_credentials.py`
+- `tests/test_setup_content_ops_zendesk_credentials.py`
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] The setup CLI can validate config in dry-run mode without DB access.
+  - [ ] The setup CLI delegates actual writes to the existing encrypted
+        credential service and never hand-builds SQL.
+  - [ ] Actual writes require an explicit confirmation flag.
+  - [ ] Output is display-safe and tests prove token, ciphertext, encryption
+        key id, DSN, and operator email values are not emitted on success or
+        failure.
+  - [ ] Short tokens are not emitted in full as display prefixes.
+  - [ ] Pool-close failures cannot override a successful write or handled
+        write failure.
+  - [ ] Encryption setup failures return a distinct non-secret diagnostic.
+  - [ ] Missing/incomplete Zendesk config fails before DB access with a
+        non-secret diagnostic.
+  - [ ] New tests are enrolled in the extracted pipeline wrapper and generated
+        assets workflow path/test lists.
+- Affected surfaces: scripts, config consumption, credential setup, CI.
+- Risk areas: security, tenant isolation, operator error, CI enrollment.
+- Reviewer rules triggered: R1, R2, R3, R6, R10, R11, R12, R14.
+
+## Mechanism
+
+The command accepts `--database-url`, `--account-id`, optional `--label`, and an
+optional exact `--expected-zendesk-base-url` guard. Zendesk email/token/endpoint
+come from `settings.b2b_campaign` through
+`zendesk_macro_credentials_from_config`, matching the existing macro writeback
+host path.
+
+With `--dry-run`, the command validates the account id and config-derived
+endpoint, applies the optional expected-endpoint guard, then emits a safe
+preview and exits before importing asyncpg or opening a pool. Without
+`--dry-run`, it still refuses side effects until `--confirm-write` is present.
+With confirmation, it creates a raw asyncpg pool from the explicit DSN and
+delegates the write to `upsert_zendesk_credentials`. The returned display
+record is the only source for success output.
+
+Errors are mapped to concise reason codes and sanitized messages. The command
+does not log or print raw tokens, ciphertext, encryption key ids, or the DSN.
+Pool close is best-effort after the write attempt: failures become a
+`database_pool_close_failed` warning on the already-determined payload instead
+of replacing the payload with a traceback.
+
+The token-prefix helper suppresses prefixes when a token is not longer than the
+display prefix length. That fix lives in the shared credential service as well
+as the CLI preview path so the hosted API cannot display a complete short token
+either.
+
+## Intentional
+
+- No API route or frontend credential form changes. The hosted route already
+  exists; this slice is the operator path for live proofs and setup.
+- No live Zendesk network validation. The macro publish proof already validates
+  the stored credential when it talks to Zendesk; this command only stores the
+  tenant credential.
+- No raw environment reads. Existing config aliases remain in
+  `atlas_brain/config.py`; the script consumes typed settings only.
+- No migration changes. The credential table and encrypted storage semantics
+  are already present.
+
+## Deferred
+
+- A product UI for customer self-service credential setup remains future work.
+- A live operator run with real credentials remains manual and should be
+  recorded in #1338 only when the operator chooses to run it.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_setup_content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_credentials.py -q -
+  21 passed.
+- python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_macro_writeback.py -q -
+  23 passed.
+- python -m py_compile scripts/setup_content_ops_zendesk_credentials.py atlas_brain/_content_ops_zendesk_credentials.py -
+  passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py - OK: 183
+  matching tests are enrolled.
+- Explicit ASCII check for touched Python files - passed.
+- Pending before push: bash scripts/local_pr_review.sh.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_generated_assets_checks.yml` | 5 |
+| `atlas_brain/_content_ops_zendesk_credentials.py` | 9 |
+| `plans/PR-FAQ-Macro-Writeback-Credential-Setup-CLI.md` | 148 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `scripts/setup_content_ops_zendesk_credentials.py` | 293 |
+| `tests/test_content_ops_zendesk_credentials.py` | 25 |
+| `tests/test_setup_content_ops_zendesk_credentials.py` | 402 |
+| **Total** | **883** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -154,6 +154,7 @@ pytest \
   tests/test_content_ops_zendesk_credentials.py \
   tests/test_content_ops_zendesk_credentials_api.py \
   tests/test_content_ops_zendesk_export_api.py \
+  tests/test_setup_content_ops_zendesk_credentials.py \
   tests/test_atlas_content_ops_reasoning.py \
   tests/test_atlas_content_ops_scope.py \
   tests/test_support_ticket_provider_landing_blog_execute.py \

--- a/scripts/setup_content_ops_zendesk_credentials.py
+++ b/scripts/setup_content_ops_zendesk_credentials.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Provision tenant-scoped Zendesk credentials for Content Ops macro writeback."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import sys
+from typing import Any, Awaitable, Callable
+import uuid as _uuid
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+SKIPPED_EXIT = 2
+TOKEN_PREFIX_LEN = 8
+
+
+PoolFactory = Callable[[str], Awaitable[Any]]
+CredentialProvider = Callable[[], Any | None]
+UpsertFunc = Callable[..., Awaitable[Any]]
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        default="",
+        help=(
+            "Postgres DSN. Required for writes; not required with --dry-run. "
+            "This script does not read database credentials from env vars."
+        ),
+    )
+    parser.add_argument("--account-id", required=True, help="Tenant/account UUID.")
+    parser.add_argument(
+        "--label",
+        default="Content Ops Zendesk",
+        help="Display label for the stored Zendesk credential row.",
+    )
+    parser.add_argument(
+        "--expected-zendesk-base-url",
+        default="",
+        help="Optional exact Zendesk base URL guard, for example https://acme.zendesk.com.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate config and guards without opening a database pool or writing.",
+    )
+    parser.add_argument(
+        "--confirm-write",
+        action="store_true",
+        help="Required to write encrypted tenant Zendesk credentials.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for operator consistency; output is always JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+async def run_setup(
+    args: argparse.Namespace,
+    *,
+    pool_factory: PoolFactory | None = None,
+    credentials_provider: CredentialProvider | None = None,
+    upsert_func: UpsertFunc | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Validate and optionally store one tenant Zendesk credential."""
+
+    try:
+        account_id = _uuid.UUID(str(args.account_id))
+    except (TypeError, ValueError):
+        return _failure("invalid_account_id", "Account id must be a UUID.")
+
+    credentials = (credentials_provider or _credentials_from_settings)()
+    if credentials is None or not credentials.is_complete():
+        return _failure(
+            "zendesk_credentials_incomplete",
+            "Zendesk credentials are incomplete in Atlas config.",
+            account_id=str(account_id),
+        )
+
+    zendesk_base_url = credentials.normalized_base_url().rstrip("/")
+    expected_url = _clean(getattr(args, "expected_zendesk_base_url", "")).rstrip("/")
+    if expected_url and zendesk_base_url != expected_url:
+        return _failure(
+            "unexpected_zendesk_base_url",
+            "Configured Zendesk endpoint did not match the expected guard.",
+            account_id=str(account_id),
+            expected_zendesk_base_url=expected_url,
+            observed_zendesk_base_url=zendesk_base_url,
+        )
+
+    label = _clean(getattr(args, "label", ""))
+    preview = _display_payload(
+        account_id=str(account_id),
+        zendesk_base_url=zendesk_base_url,
+        label=label,
+        api_token_prefix=_token_prefix(credentials.api_token),
+    )
+    if bool(getattr(args, "dry_run", False)):
+        return 0, {
+            "ok": True,
+            "dry_run": True,
+            "would_write": True,
+            **preview,
+        }
+
+    if not bool(getattr(args, "confirm_write", False)):
+        return SKIPPED_EXIT, {
+            "ok": False,
+            "skipped": True,
+            "not_run_reason": "missing_confirm_write",
+            **preview,
+        }
+
+    database_url = _clean(getattr(args, "database_url", ""))
+    if not database_url:
+        return _failure(
+            "database_url_missing",
+            "Database URL is required for writes.",
+            **preview,
+        )
+
+    try:
+        pool = await (pool_factory or _create_pool)(database_url)
+    except Exception:
+        return _failure(
+            "database_pool_unavailable",
+            "Database pool could not be opened.",
+            **preview,
+        )
+
+    close_warning = ""
+    try:
+        upsert = upsert_func or _upsert_zendesk_credentials
+        record = await upsert(
+            pool,
+            account_id=account_id,
+            email=credentials.email,
+            api_token=credentials.api_token,
+            subdomain=credentials.subdomain,
+            base_url=credentials.base_url,
+            label=label,
+        )
+    except ValueError as exc:
+        close_warning = await _close_warning(pool)
+        _code, payload = (
+            _failure(
+                "credential_encryption_unavailable",
+                "Credential encryption is not configured correctly.",
+                **preview,
+            )
+            if _is_encryption_setup_error(exc)
+            else _failure(
+                "zendesk_credentials_invalid",
+                "Zendesk credentials are invalid.",
+                **preview,
+            )
+        )
+        return 1, _with_optional_warning(payload, close_warning)
+    except Exception:
+        close_warning = await _close_warning(pool)
+        _code, payload = _failure(
+            "zendesk_credentials_write_failed",
+            "Zendesk credential write failed.",
+            **preview,
+        )
+        return 1, _with_optional_warning(payload, close_warning)
+    close_warning = await _close_warning(pool)
+
+    payload = {
+        "ok": True,
+        "dry_run": False,
+        "credential_id": str(record.id),
+        "account_id": str(record.account_id),
+        "zendesk_base_url": str(record.base_url or zendesk_base_url),
+        "subdomain": str(record.subdomain or credentials.subdomain),
+        "label": str(record.label or label),
+        "api_token_prefix": str(record.api_token_prefix or ""),
+    }
+    return 0, _with_optional_warning(payload, close_warning)
+
+
+def _credentials_from_settings() -> Any | None:
+    from atlas_brain._content_ops_macro_writeback import (
+        zendesk_macro_credentials_from_config,
+    )
+    from atlas_brain.config import settings
+
+    return zendesk_macro_credentials_from_config(settings.b2b_campaign)
+
+
+async def _upsert_zendesk_credentials(pool: Any, **kwargs: Any) -> Any:
+    from atlas_brain._content_ops_zendesk_credentials import upsert_zendesk_credentials
+
+    return await upsert_zendesk_credentials(pool, **kwargs)
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for Zendesk credential setup; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _close_warning(pool: Any) -> str:
+    close = getattr(pool, "close", None)
+    if close is None:
+        return ""
+    try:
+        result = close()
+        if hasattr(result, "__await__"):
+            await result
+    except Exception:
+        return "database_pool_close_failed"
+    return ""
+
+
+def _with_optional_warning(payload: dict[str, Any], warning: str) -> dict[str, Any]:
+    if not warning:
+        return payload
+    return {**payload, "warnings": [warning]}
+
+
+def _display_payload(
+    *,
+    account_id: str,
+    zendesk_base_url: str,
+    label: str,
+    api_token_prefix: str,
+) -> dict[str, str]:
+    return {
+        "account_id": account_id,
+        "zendesk_base_url": zendesk_base_url,
+        "label": label,
+        "api_token_prefix": api_token_prefix,
+    }
+
+
+def _failure(reason: str, message: str, **extra: Any) -> tuple[int, dict[str, Any]]:
+    payload = {
+        "ok": False,
+        "reason": reason,
+        "message": message,
+    }
+    payload.update(extra)
+    return 1, payload
+
+
+def _token_prefix(token: str) -> str:
+    cleaned = str(token or "").strip()
+    if len(cleaned) <= TOKEN_PREFIX_LEN:
+        return ""
+    return cleaned[:TOKEN_PREFIX_LEN]
+
+
+def _is_encryption_setup_error(exc: ValueError) -> bool:
+    message = str(exc)
+    return (
+        "ATLAS_SAAS_BYOK_ENCRYPTION_KEK" in message
+        or "BYOK KEK" in message
+        or "encrypt_secret" in message
+    )
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _write_payload(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True), flush=True)
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    code, payload = await run_setup(args)
+    _write_payload(payload)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_content_ops_zendesk_credentials.py
+++ b/tests/test_content_ops_zendesk_credentials.py
@@ -175,6 +175,31 @@ async def test_upsert_zendesk_credentials_encrypts_token_and_returns_display_rec
 
 
 @pytest.mark.asyncio
+async def test_upsert_zendesk_credentials_suppresses_complete_short_token_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result=_row(account_id=account_id, api_token_prefix=""))
+    monkeypatch.setattr(
+        service,
+        "encrypt_secret",
+        lambda raw: (f"encrypted:{raw}".encode("utf-8"), "kid-1"),
+    )
+
+    record = await service.upsert_zendesk_credentials(
+        pool,
+        account_id=account_id,
+        email="agent@example.com",
+        api_token="short",
+        subdomain="acme",
+    )
+
+    insert_call = pool.fetchrow_calls[0]
+    assert insert_call["args"][4] == ""
+    assert record.api_token_prefix == ""
+
+
+@pytest.mark.asyncio
 async def test_upsert_zendesk_credentials_accepts_raw_asyncpg_pool_shape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_setup_content_ops_zendesk_credentials.py
+++ b/tests/test_setup_content_ops_zendesk_credentials.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import uuid
+
+import pytest
+
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZendeskMacroCredentials,
+)
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "setup_content_ops_zendesk_credentials.py"
+)
+ACCOUNT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+CREDENTIAL_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+SECRET_TOKEN = "secret-token-value"
+DATABASE_URL = "postgres://user:database-secret@example.test/db"
+script = None
+
+
+def setup_module() -> None:
+    global script
+    script = _load_script_module()
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "setup_content_ops_zendesk_credentials_for_test",
+        SCRIPT_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides) -> argparse.Namespace:
+    values = {
+        "database_url": DATABASE_URL,
+        "account_id": str(ACCOUNT_ID),
+        "label": "Primary",
+        "expected_zendesk_base_url": "",
+        "dry_run": False,
+        "confirm_write": False,
+        "json": True,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _credentials(**overrides) -> ZendeskMacroCredentials:
+    values = {
+        "email": "agent@example.com",
+        "api_token": SECRET_TOKEN,
+        "subdomain": "acme",
+        "base_url": "",
+    }
+    values.update(overrides)
+    return ZendeskMacroCredentials(**values)
+
+
+class _Pool:
+    def __init__(self, *, close_error: Exception | None = None) -> None:
+        self.closed = False
+        self.close_error = close_error
+
+    async def close(self) -> None:
+        self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _Record:
+    id = CREDENTIAL_ID
+    account_id = ACCOUNT_ID
+    api_token_prefix = SECRET_TOKEN[:8]
+    subdomain = "acme"
+    base_url = "https://acme.zendesk.com"
+    label = "Primary"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_validates_config_without_database_access() -> None:
+    pool_calls = 0
+
+    async def pool_factory(database_url: str):
+        nonlocal pool_calls
+        pool_calls += 1
+        raise AssertionError("dry-run must not open a database pool")
+
+    code, payload = await script.run_setup(
+        _args(
+            database_url="",
+            dry_run=True,
+            expected_zendesk_base_url="https://acme.zendesk.com",
+        ),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+    )
+
+    assert code == 0
+    assert payload == {
+        "ok": True,
+        "dry_run": True,
+        "would_write": True,
+        "account_id": str(ACCOUNT_ID),
+        "zendesk_base_url": "https://acme.zendesk.com",
+        "label": "Primary",
+        "api_token_prefix": SECRET_TOKEN[:8],
+    }
+    assert pool_calls == 0
+    assert SECRET_TOKEN not in _payload_text(payload)
+    assert DATABASE_URL not in _payload_text(payload)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_suppresses_complete_short_api_token() -> None:
+    credentials = _credentials(api_token="short")
+
+    code, payload = await script.run_setup(
+        _args(database_url="", dry_run=True),
+        credentials_provider=lambda: credentials,
+    )
+
+    assert code == 0
+    assert payload["api_token_prefix"] == ""
+    assert "short" not in _payload_text(payload)
+
+
+@pytest.mark.asyncio
+async def test_missing_config_fails_before_database_access() -> None:
+    async def pool_factory(database_url: str):
+        raise AssertionError("missing config must fail before database access")
+
+    code, payload = await script.run_setup(
+        _args(dry_run=True),
+        pool_factory=pool_factory,
+        credentials_provider=lambda: None,
+    )
+
+    assert code == 1
+    assert payload["reason"] == "zendesk_credentials_incomplete"
+    assert payload["account_id"] == str(ACCOUNT_ID)
+    assert SECRET_TOKEN not in _payload_text(payload)
+    assert DATABASE_URL not in _payload_text(payload)
+
+
+@pytest.mark.asyncio
+async def test_expected_zendesk_guard_fails_before_database_access() -> None:
+    async def pool_factory(database_url: str):
+        raise AssertionError("endpoint mismatch must fail before database access")
+
+    code, payload = await script.run_setup(
+        _args(
+            dry_run=True,
+            expected_zendesk_base_url="https://other.zendesk.com",
+        ),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+    )
+
+    assert code == 1
+    assert payload["reason"] == "unexpected_zendesk_base_url"
+    assert payload["expected_zendesk_base_url"] == "https://other.zendesk.com"
+    assert payload["observed_zendesk_base_url"] == "https://acme.zendesk.com"
+    assert SECRET_TOKEN not in _payload_text(payload)
+
+
+@pytest.mark.asyncio
+async def test_write_requires_confirmation_before_database_access() -> None:
+    async def pool_factory(database_url: str):
+        raise AssertionError("missing confirmation must fail before database access")
+
+    code, payload = await script.run_setup(
+        _args(confirm_write=False),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+    )
+
+    assert code == script.SKIPPED_EXIT
+    assert payload["skipped"] is True
+    assert payload["not_run_reason"] == "missing_confirm_write"
+    assert SECRET_TOKEN not in _payload_text(payload)
+    assert DATABASE_URL not in _payload_text(payload)
+
+
+@pytest.mark.asyncio
+async def test_write_delegates_to_credential_service_and_closes_pool() -> None:
+    pool = _Pool()
+    calls: list[dict] = []
+
+    async def pool_factory(database_url: str):
+        calls.append({"database_url": database_url, "stage": "pool"})
+        return pool
+
+    async def upsert(pool_arg, **kwargs):
+        calls.append({"pool": pool_arg, **kwargs})
+        return _Record()
+
+    code, payload = await script.run_setup(
+        _args(confirm_write=True, label=" Primary "),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+        upsert_func=upsert,
+    )
+
+    assert code == 0
+    assert calls[0] == {"database_url": DATABASE_URL, "stage": "pool"}
+    assert calls[1] == {
+        "pool": pool,
+        "account_id": ACCOUNT_ID,
+        "email": "agent@example.com",
+        "api_token": SECRET_TOKEN,
+        "subdomain": "acme",
+        "base_url": "",
+        "label": "Primary",
+    }
+    assert pool.closed is True
+    assert payload["credential_id"] == str(CREDENTIAL_ID)
+    assert payload["api_token_prefix"] == SECRET_TOKEN[:8]
+    assert SECRET_TOKEN not in _payload_text(payload)
+    assert DATABASE_URL not in _payload_text(payload)
+    assert "agent@example.com" not in _payload_text(payload)
+
+
+@pytest.mark.asyncio
+async def test_close_failure_after_success_keeps_success_payload_sanitized() -> None:
+    pool = _Pool(close_error=RuntimeError(f"close leaked {DATABASE_URL}"))
+
+    async def pool_factory(database_url: str):
+        return pool
+
+    async def upsert(pool_arg, **kwargs):
+        return _Record()
+
+    code, payload = await script.run_setup(
+        _args(confirm_write=True),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+        upsert_func=upsert,
+    )
+
+    text = _payload_text(payload)
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["warnings"] == ["database_pool_close_failed"]
+    assert pool.closed is True
+    assert DATABASE_URL not in text
+    assert SECRET_TOKEN not in text
+
+
+@pytest.mark.asyncio
+async def test_pool_creation_failure_output_is_sanitized() -> None:
+    async def pool_factory(database_url: str):
+        raise RuntimeError(f"could not connect to {DATABASE_URL}")
+
+    code, payload = await script.run_setup(
+        _args(confirm_write=True),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+    )
+
+    text = _payload_text(payload)
+    assert code == 1
+    assert payload["reason"] == "database_pool_unavailable"
+    assert DATABASE_URL not in text
+    assert SECRET_TOKEN not in text
+
+
+@pytest.mark.asyncio
+async def test_validation_error_output_is_sanitized_and_pool_is_closed() -> None:
+    pool = _Pool()
+
+    async def pool_factory(database_url: str):
+        return pool
+
+    async def upsert(pool_arg, **kwargs):
+        raise ValueError(f"bad token {SECRET_TOKEN} for {DATABASE_URL}")
+
+    code, payload = await script.run_setup(
+        _args(confirm_write=True),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+        upsert_func=upsert,
+    )
+
+    text = _payload_text(payload)
+    assert code == 1
+    assert payload["reason"] == "zendesk_credentials_invalid"
+    assert pool.closed is True
+    assert SECRET_TOKEN not in text
+    assert DATABASE_URL not in text
+
+
+@pytest.mark.asyncio
+async def test_encryption_setup_error_is_distinct_and_sanitized() -> None:
+    pool = _Pool()
+
+    async def pool_factory(database_url: str):
+        return pool
+
+    async def upsert(pool_arg, **kwargs):
+        raise ValueError(
+            f"ATLAS_SAAS_BYOK_ENCRYPTION_KEK missing for {DATABASE_URL} {SECRET_TOKEN}"
+        )
+
+    code, payload = await script.run_setup(
+        _args(confirm_write=True),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+        upsert_func=upsert,
+    )
+
+    text = _payload_text(payload)
+    assert code == 1
+    assert payload["reason"] == "credential_encryption_unavailable"
+    assert payload["message"] == "Credential encryption is not configured correctly."
+    assert pool.closed is True
+    assert "ATLAS_SAAS_BYOK_ENCRYPTION_KEK" not in text
+    assert SECRET_TOKEN not in text
+    assert DATABASE_URL not in text
+
+
+@pytest.mark.asyncio
+async def test_write_failure_output_is_sanitized_and_pool_is_closed() -> None:
+    pool = _Pool(close_error=RuntimeError(f"close leaked {DATABASE_URL}"))
+
+    async def pool_factory(database_url: str):
+        return pool
+
+    async def upsert(pool_arg, **kwargs):
+        raise RuntimeError(
+            f"failed with {SECRET_TOKEN} {DATABASE_URL} ciphertext kid-1"
+        )
+
+    code, payload = await script.run_setup(
+        _args(confirm_write=True),
+        pool_factory=pool_factory,
+        credentials_provider=_credentials,
+        upsert_func=upsert,
+    )
+
+    text = _payload_text(payload)
+    assert code == 1
+    assert payload["reason"] == "zendesk_credentials_write_failed"
+    assert payload["warnings"] == ["database_pool_close_failed"]
+    assert pool.closed is True
+    assert SECRET_TOKEN not in text
+    assert DATABASE_URL not in text
+    assert "ciphertext" not in text
+    assert "kid-1" not in text
+
+
+def test_cli_import_does_not_require_asyncpg() -> None:
+    code = textwrap.dedent(
+        f"""
+        import sys
+        import importlib.util
+        from pathlib import Path
+
+        class BlockAsyncpg:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == 'asyncpg' or fullname.startswith('asyncpg.'):
+                    raise ModuleNotFoundError("No module named 'asyncpg'")
+                return None
+
+        sys.meta_path.insert(0, BlockAsyncpg())
+        path = Path({str(SCRIPT_PATH)!r})
+        spec = importlib.util.spec_from_file_location(
+            'setup_content_ops_zendesk_credentials_block_asyncpg_test',
+            path,
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        print(module.SKIPPED_EXIT)
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert str(script.SKIPPED_EXIT) in result.stdout
+
+
+def _payload_text(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True)


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Credential-Setup-CLI.md
Slice phase: Production hardening

This removes the last manual SQL step from the FAQ macro writeback live-proof path by adding an operator-safe credential setup command that delegates to the existing encrypted tenant Zendesk credential service, uses typed Atlas config for Zendesk credentials, and emits only display-safe JSON.

## Intentional
- No API route, frontend credential form, macro publish, reconcile, or live Zendesk behavior changes.
- No raw environment reads; Zendesk credentials come through `settings.b2b_campaign`.
- Actual credential writes require `--confirm-write`; `--dry-run` validates config and guards without DB access.
- No live Zendesk network validation in this slice; the macro publish proof remains the live credential validation point.
- Review fix: short-token prefix suppression is applied at the shared credential service boundary so API and CLI display paths cannot expose a complete short token.
- Review fix: pool close failures become `database_pool_close_failed` warnings instead of masking successful writes or handled safe failures.
- Review fix: encryption setup failures return a distinct sanitized diagnostic instead of reporting invalid Zendesk credentials.

## Deferred
- Product UI/customer self-service credential setup remains future work.
- A live operator run with real credentials remains manual and should be recorded in #1338 only when the operator chooses to run it.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_setup_content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_credentials.py -q` - 21 passed.
- `python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_macro_writeback.py -q` - 23 passed.
- `python -m py_compile scripts/setup_content_ops_zendesk_credentials.py atlas_brain/_content_ops_zendesk_credentials.py` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - OK: 183 matching tests are enrolled.
- Explicit ASCII check for touched Python files - passed.

## AI Reconciliation
- All fixed or waived: yes.
- Fixed Codex P2: short configured API tokens are no longer emitted in full as display prefixes.
- Fixed Codex P2: pool close failures no longer mask successful writes or handled write failures.
- Fixed Codex P2: encryption setup failures now return a distinct sanitized diagnostic.

## Diff size
7 files, synced in plan.