### PR TITLE
Deflection delivery email model wrapper

### DIFF
--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -14,6 +14,9 @@ from extracted_content_pipeline.campaign_ports import (
     SendRequest,
     SendResult,
 )
+from extracted_content_pipeline.deflection_report_access import (
+    stored_deflection_report_model,
+)
 from extracted_content_pipeline.storage._jsonb_helpers import decode_jsonb_field
 
 
@@ -46,6 +49,16 @@ class DeflectionReportDeliverySummary:
     sent: int
     failed: int
     dry_run: int
+
+
+@dataclass(frozen=True)
+class _DeliveryEmailSummary:
+    repeat_ticket_count: int
+    generated_question_count: int
+    estimated_support_cost: float
+    drafted_answer_count: int
+    no_proven_answer_count: int
+    ticket_source_count: int
 
 
 async def send_pending_deflection_report_deliveries(
@@ -92,10 +105,12 @@ async def send_pending_deflection_report_deliveries(
             dry_run += 1
             continue
         try:
+            artifact = _decoded_artifact(data.get("artifact"))
             attachments = _pdf_attachments(
-                artifact=data.get("artifact"),
+                artifact=artifact,
                 request_id=request_id,
             )
+            email_summary = _delivery_email_summary(artifact)
             if not await _confirm_delivery_still_sendable(pool, account_id, request_id):
                 await _emit_delivery_incident(
                     "paid_report_delivery_no_longer_sendable",
@@ -118,6 +133,7 @@ async def send_pending_deflection_report_deliveries(
                     email=email,
                     report_url=report_url,
                     attachments=attachments,
+                    email_summary=email_summary,
                     config=config,
                 )
             )
@@ -207,6 +223,7 @@ def _send_request(
     email: str,
     report_url: str,
     attachments: tuple[dict[str, str], ...] = (),
+    email_summary: _DeliveryEmailSummary | None = None,
     config: DeflectionReportDeliveryConfig,
 ) -> SendRequest:
     has_attachment = bool(attachments)
@@ -217,8 +234,16 @@ def _send_request(
         from_email=_required_text(config.from_email, "from_email"),
         reply_to=_clean(config.reply_to) or None,
         subject=_required_text(config.subject, "subject"),
-        html_body=_render_html(report_url, has_attachment=has_attachment),
-        text_body=_render_text(report_url, has_attachment=has_attachment),
+        html_body=_render_html(
+            report_url,
+            has_attachment=has_attachment,
+            email_summary=email_summary,
+        ),
+        text_body=_render_text(
+            report_url,
+            has_attachment=has_attachment,
+            email_summary=email_summary,
+        ),
         attachments=attachments,
         tags=(
             {"name": "source", "value": "content_ops_deflection_report"},
@@ -232,7 +257,18 @@ def _send_request(
     )
 
 
-def _render_html(report_url: str, *, has_attachment: bool = False) -> str:
+def _render_html(
+    report_url: str,
+    *,
+    has_attachment: bool = False,
+    email_summary: _DeliveryEmailSummary | None = None,
+) -> str:
+    if email_summary is not None:
+        return _render_model_summary_html(
+            report_url,
+            has_attachment=has_attachment,
+            summary=email_summary,
+        )
     safe_url = _escape(report_url)
     attachment_copy = (
         "<p>The full report PDF is attached for sharing and offline review.</p>"
@@ -248,7 +284,18 @@ def _render_html(report_url: str, *, has_attachment: bool = False) -> str:
     )
 
 
-def _render_text(report_url: str, *, has_attachment: bool = False) -> str:
+def _render_text(
+    report_url: str,
+    *,
+    has_attachment: bool = False,
+    email_summary: _DeliveryEmailSummary | None = None,
+) -> str:
+    if email_summary is not None:
+        return _render_model_summary_text(
+            report_url,
+            has_attachment=has_attachment,
+            summary=email_summary,
+        )
     attachment_copy = (
         "The full report PDF is attached for sharing and offline review.\n\n"
         if has_attachment
@@ -263,13 +310,165 @@ def _render_text(report_url: str, *, has_attachment: bool = False) -> str:
     )
 
 
+def _render_model_summary_html(
+    report_url: str,
+    *,
+    has_attachment: bool,
+    summary: _DeliveryEmailSummary,
+) -> str:
+    safe_url = _escape(report_url)
+    attachment_copy = (
+        "<p>The curated report PDF is attached for sharing and offline review.</p>"
+        if has_attachment
+        else ""
+    )
+    return (
+        "<h1>Your FAQ deflection report is ready</h1>"
+        "<p>Your paid report is available at the secure results page below.</p>"
+        "<h2>Key numbers</h2>"
+        "<ul>"
+        f"<li>{_html_count(summary.repeat_ticket_count)} repeat tickets across "
+        f"{_html_count(summary.generated_question_count)} ranked questions.</li>"
+        f"<li>{_html_money(summary.estimated_support_cost)} estimated assisted-contact "
+        "handling in this upload.</li>"
+        f"<li>{_html_count(summary.drafted_answer_count)} publishable answers drafted "
+        "from proven resolutions.</li>"
+        f"<li>{_html_count(summary.no_proven_answer_count)} questions still need "
+        "approved resolution evidence.</li>"
+        f"<li>{_html_count(summary.ticket_source_count)} ticket sources represented.</li>"
+        "</ul>"
+        f"{attachment_copy}"
+        "<p>The secure results page has the consolidated report, PDF, and complete "
+        "evidence export.</p>"
+        f'<p><a href="{safe_url}">Open your report</a></p>'
+    )
+
+
+def _render_model_summary_text(
+    report_url: str,
+    *,
+    has_attachment: bool,
+    summary: _DeliveryEmailSummary,
+) -> str:
+    attachment_copy = (
+        "The curated report PDF is attached for sharing and offline review.\n\n"
+        if has_attachment
+        else ""
+    )
+    return (
+        "Your FAQ deflection report is ready\n\n"
+        "Key numbers:\n"
+        f"- {_email_count(summary.repeat_ticket_count)} repeat tickets across "
+        f"{_email_count(summary.generated_question_count)} ranked questions.\n"
+        f"- {_email_money(summary.estimated_support_cost)} estimated assisted-contact "
+        "handling in this upload.\n"
+        f"- {_email_count(summary.drafted_answer_count)} publishable answers drafted "
+        "from proven resolutions.\n"
+        f"- {_email_count(summary.no_proven_answer_count)} questions still need approved "
+        "resolution evidence.\n"
+        f"- {_email_count(summary.ticket_source_count)} ticket sources represented.\n\n"
+        f"{attachment_copy}"
+        "The secure results page has the consolidated report, PDF, and complete "
+        "evidence export:\n\n"
+        f"{report_url}\n"
+    )
+
+
+def _delivery_email_summary(artifact: Any) -> _DeliveryEmailSummary | None:
+    model = stored_deflection_report_model(
+        artifact if isinstance(artifact, Mapping) else None
+    )
+    if model is None:
+        return None
+    for section in _model_sections(model, "email_summary"):
+        if _clean(section.get("id")) != "support_tax":
+            continue
+        summary = _support_tax_email_summary(section)
+        if summary is not None:
+            return summary
+    return None
+
+
+def _model_sections(model: Mapping[str, Any], surface: str) -> tuple[dict[str, Any], ...]:
+    sections = model.get("sections")
+    if not isinstance(sections, list):
+        return ()
+    filtered = [
+        dict(section)
+        for section in sections
+        if isinstance(section, Mapping)
+        and surface in {str(item).strip() for item in section.get("surfaces") or ()}
+    ]
+    filtered.sort(key=lambda section: _strict_int(section.get("priority")) or 0)
+    return tuple(filtered)
+
+
+def _support_tax_email_summary(
+    section: Mapping[str, Any],
+) -> _DeliveryEmailSummary | None:
+    data = section.get("data")
+    if not isinstance(data, Mapping):
+        return None
+    repeat_ticket_count = _strict_int(data.get("repeat_ticket_count"))
+    generated_question_count = _strict_int(data.get("generated_question_count"))
+    estimated_support_cost = _strict_number(data.get("estimated_support_cost"))
+    drafted_answer_count = _strict_int(data.get("drafted_answer_count"))
+    no_proven_answer_count = _strict_int(data.get("no_proven_answer_count"))
+    ticket_source_count = _strict_int(data.get("ticket_source_count"))
+    if (
+        repeat_ticket_count is None
+        or generated_question_count is None
+        or estimated_support_cost is None
+        or drafted_answer_count is None
+        or no_proven_answer_count is None
+        or ticket_source_count is None
+    ):
+        return None
+    return _DeliveryEmailSummary(
+        repeat_ticket_count=repeat_ticket_count,
+        generated_question_count=generated_question_count,
+        estimated_support_cost=estimated_support_cost,
+        drafted_answer_count=drafted_answer_count,
+        no_proven_answer_count=no_proven_answer_count,
+        ticket_source_count=ticket_source_count,
+    )
+
+
+def _strict_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def _strict_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _decoded_artifact(artifact: Any) -> Any:
+    return decode_jsonb_field(artifact, default={})
+
+
 def _pdf_attachments(
     *,
     artifact: Any,
     request_id: str,
 ) -> tuple[dict[str, str], ...]:
-    decoded_artifact = decode_jsonb_field(artifact, default={})
-    if not isinstance(decoded_artifact, Mapping):
+    if not isinstance(artifact, Mapping):
         logger.warning(
             "Skipping deflection report PDF attachment for %s: missing artifact",
             request_id,
@@ -278,7 +477,7 @@ def _pdf_attachments(
     try:
         from .deflection_pdf_renderer import render_deflection_full_report_pdf
 
-        pdf_bytes = render_deflection_full_report_pdf(decoded_artifact)
+        pdf_bytes = render_deflection_full_report_pdf(artifact)
     except Exception:
         logger.exception(
             "Deflection report PDF render failed for %s; sending link-only email",
@@ -420,6 +619,22 @@ def _required_text(value: Any, label: str) -> str:
 
 def _clean(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _email_count(value: int) -> str:
+    return f"{int(value):,}"
+
+
+def _html_count(value: int) -> str:
+    return _escape(_email_count(value))
+
+
+def _email_money(value: float) -> str:
+    return f"${float(value):,.0f}"
+
+
+def _html_money(value: float) -> str:
+    return _escape(_email_money(value))
 
 
 def _escape(value: str) -> str:

--- a/plans/PR-Deflection-Delivery-Email-Model-Wrapper.md
+++ b/plans/PR-Deflection-Delivery-Email-Model-Wrapper.md
@@ -1,0 +1,161 @@
+# PR-Deflection-Delivery-Email-Model-Wrapper
+
+## Why this slice exists
+
+#1588 split the paid deflection report into separate surfaces: hosted result
+page as the operating dashboard, PDF as a curated/shareable report, evidence
+export as the complete archive, and email as a short delivery wrapper with key
+numbers and links/attachments.
+
+The structured `deflection.v1` report model is now persisted and consumed by
+the PDF renderer and hosted paid result page, but the paid delivery email still
+renders a generic "your report is ready" body. That leaves the email as the last
+customer-facing surface that does not consume the model.
+
+Root cause: the delivery email body predates the structured report model, so it
+has no model projection seam and can only say "open the report." This fixes the
+root for the email surface by rendering its summary from the persisted
+`email_summary` model section, while preserving a legacy fallback for old
+artifacts that do not carry `report_model`.
+
+CI follow-up root cause: the dedicated delivery workflow collects
+`tests/test_deflection_report_delivery_task.py`, whose task-registration
+assertions import the autonomous scheduler. `apscheduler` requires `tzlocal`,
+but `requirements.txt` only named APScheduler and left that scheduler runtime
+dependency transitive. This PR makes `tzlocal` explicit so the delivery CI lane
+does not depend on resolver/transitive behavior to collect scheduler-backed
+task tests.
+
+Diff-size note: this is over the 400 LOC soft cap because the renderer change
+and its model/future-schema/malformed-data/legacy-fallback tests are one safety
+unit, plus the one-line explicit scheduler dependency needed to make the
+dedicated delivery CI lane collect. Splitting the tests into a follow-up would
+leave the new customer-facing email path under-proven in the PR that introduces
+it.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-shape
+Slice phase: Vertical slice
+
+1. Decode the paid report artifact once in the delivery path and derive a short
+   email summary from the stored `deflection.v1` model when available.
+2. Keep existing claim/send/finalize semantics, result URL generation,
+   idempotency key, PDF attachment behavior, and link-only fallback unchanged.
+3. Render HTML and text bodies with key numbers from the model plus the result
+   link and attachment copy.
+4. Add focused delivery tests covering model-backed email content, legacy
+   fallback, schema-drift fallback, no raw Markdown/evidence leakage, and
+   existing idempotency/attachment behavior.
+5. Make the scheduler's `tzlocal` runtime dependency explicit because the
+   dedicated delivery CI lane collects scheduler-backed task-registration tests.
+
+### Files touched
+
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `plans/PR-Deflection-Delivery-Email-Model-Wrapper.md`
+- `requirements.txt`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+
+### Review Contract
+
+Acceptance criteria:
+
+- Model-backed artifacts render a concise email wrapper using only
+  `deflection.v1` `email_summary` data, including repeat-ticket count,
+  generated question count, support-cost sizing, drafted answer count, gap
+  count, and ticket-source count.
+- Legacy or schema-drift artifacts still send the prior generic delivery email
+  instead of failing or rendering misleading zeroes.
+- Email bodies do not expose full Markdown, raw evidence quotes, source IDs, or
+  `resolution_evidence` internals.
+- Existing PDF attachment/link-only fallback and deterministic send
+  idempotency behavior remain unchanged.
+- The dedicated delivery workflow can collect the scheduler-backed delivery
+  task tests without relying on a hidden transitive dependency.
+
+Affected surfaces:
+
+- Paid FAQ deflection report delivery email body in
+  `atlas_brain/content_ops_deflection_delivery.py`.
+- Existing delivery worker tests in
+  `tests/test_atlas_content_ops_deflection_delivery.py`.
+
+Risk areas:
+
+- Accidentally changing the delivery claim/finalize transaction semantics.
+- Emitting misleading defaults when the model is missing, malformed, or a
+  future schema.
+- Pulling uncapped evidence into the email body instead of keeping email short.
+- Hiding a scheduler runtime dependency behind APScheduler's transitive install
+  edge.
+
+Triggered reviewer rules:
+
+- R1 requirements match, R2 test evidence, R8 idempotency/retry behavior,
+  R12 CI/test enrollment, R13 class fix, R14 codebase verification.
+
+## Mechanism
+
+The delivery worker already fetches `r.artifact` for PDF rendering. This slice
+decodes that artifact once, passes the decoded mapping to both the PDF
+attachment helper and the email body builder, and uses the extracted stored
+model projector to fail closed on malformed, missing, or future-schema models.
+
+A small email-summary helper selects model sections whose `surfaces` include
+`email_summary`; the current registry exposes `support_tax` for that surface.
+If a valid section is present, the helper formats key numbers into concise HTML
+and text bodies. If no valid summary is available, the existing generic body is
+used unchanged.
+
+The CI repair adds `tzlocal>=3.0,<6.0` next to `apscheduler>=3.10,<4.0` in
+`requirements.txt`. That matches APScheduler's declared runtime dependency and
+keeps the autonomous scheduler import collectable in the delivery workflow.
+
+## Intentional
+
+- This PR does not add a new section registry surface. It consumes the existing
+  `email_summary` marker already on `support_tax`, keeping the slice to the
+  delivery renderer instead of changing extracted model metadata.
+- This PR does not change delivery CLI env parsing or config. No new setting is
+  needed for a deterministic renderer choice.
+- This PR does not make the email a mini-report. The hosted page, PDF, and
+  export own detailed reading; email stays a delivery wrapper.
+- This PR does not change the delivery workflow file. The failure is addressed
+  at the runtime dependency boundary used by both CI and production imports.
+
+## Deferred
+
+- Direct per-section email-summary renderers can be added if future sections
+  earn an `email_summary` surface. This slice only needs the existing
+  `support_tax` summary to close the current surface gap.
+- Optional PDF bookmarks/navigation remain parked under #1588 and are not
+  required for email.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q`
+  - 18 passed.
+- `python scripts/sync_pr_plan.py plans/PR-Deflection-Delivery-Email-Model-Wrapper.md --check`
+  - Passed.
+- `rg -n "test_atlas_content_ops_deflection_delivery" scripts/run_extracted_pipeline_checks.sh .github/workflows -g '*.sh' -g '*.yml'`
+  - Confirmed existing test enrollment in the extracted check script and
+    dedicated delivery workflow.
+- `python -m compileall -q <changed Python files>`
+  - Passed.
+- `python -m pytest tests/test_alerts.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_content_ops_deflection_incidents.py tests/test_deflection_pdf_renderer.py tests/test_deflection_report_delivery_task.py tests/test_send_content_ops_deflection_report_deliveries.py -q`
+  - 119 passed, 1 warning.
+- Push-wrapper local review via the project wrapper.
+  - Passed before the CI dependency fix; pending rerun before push.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/content_ops_deflection_delivery.py` | 231 |
+| `plans/PR-Deflection-Delivery-Email-Model-Wrapper.md` | 161 |
+| `requirements.txt` | 1 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 165 |
+| **Total** | **558** |

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ langchain-core>=0.3.0
 
 # Autonomous task scheduling
 apscheduler>=3.10,<4.0
+tzlocal>=3.0,<6.0
 
 # Email draft generation (Anthropic Claude)
 anthropic>=0.39.0

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -91,6 +91,76 @@ def _row(**overrides: Any) -> dict[str, Any]:
     return row
 
 
+def _delivery_report_model_artifact(
+    *,
+    schema_version: str = "deflection.v1",
+    support_tax_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    support_tax_data = {
+        "repeat_ticket_count": 1234,
+        "non_repeat_ticket_count": 17,
+        "generated_question_count": 8,
+        "assisted_contact_cost": 13.50,
+        "estimated_support_cost": 16659.0,
+        "source_date_window": None,
+        "drafted_answer_count": 3,
+        "no_proven_answer_count": 5,
+        "ticket_source_count": 42,
+    }
+    support_tax_data.update(support_tax_overrides or {})
+    return {
+        "markdown": (
+            "# Support Ticket Deflection Report\n\n"
+            "RAW MARKDOWN BODY SHOULD NOT ENTER THE EMAIL\n"
+        ),
+        "report_model": {
+            "schema_version": schema_version,
+            "title": "Support Ticket Deflection Report",
+            "summary": {},
+            "sections": [
+                {
+                    "id": "support_tax",
+                    "title": "Support Tax Confirmation",
+                    "priority": 10,
+                    "surfaces": ["web", "pdf", "email_summary", "markdown"],
+                    "default_limit": None,
+                    "required_data": [
+                        "repeat_ticket_count",
+                        "non_repeat_ticket_count",
+                        "generated_question_count",
+                        "assisted_contact_cost",
+                        "estimated_support_cost",
+                        "source_date_window",
+                        "drafted_answer_count",
+                        "no_proven_answer_count",
+                        "ticket_source_count",
+                    ],
+                    "data": support_tax_data,
+                },
+                {
+                    "id": "question_details",
+                    "title": "Question Details and Evidence",
+                    "priority": 50,
+                    "surfaces": ["web", "pdf", "markdown"],
+                    "default_limit": None,
+                    "required_data": ["rows"],
+                    "data": {
+                        "rows": [
+                            {
+                                "source_ids": ["ticket-secret-123"],
+                                "evidence_quotes": [
+                                    "private evidence quote should stay out",
+                                ],
+                                "answer_evidence_status": "resolution_evidence",
+                            }
+                        ]
+                    },
+                },
+            ],
+        },
+    }
+
+
 def _config(**overrides: Any) -> DeflectionReportDeliveryConfig:
     values = {
         "from_email": "Atlas Content Ops <reports@example.com>",
@@ -154,6 +224,7 @@ async def test_delivery_worker_sends_pending_paid_report_link(
         "content-ops-abc123-support-deflection-report.pdf"
     )
     assert base64.b64decode(request.attachments[0]["content"]) == b"%PDF-fake-bytes"
+    assert "Key numbers" not in request.html_body
     assert "full report PDF is attached" in request.html_body
     assert "full report PDF is attached" in (request.text_body or "")
 
@@ -162,6 +233,100 @@ async def test_delivery_worker_sends_pending_paid_report_link(
     assert "delivery_status = 'sending'" in update_query
     assert update_args == ("acct-123", "content-ops-abc123", "resend:email-123")
     assert "buyer@example.com" not in str(update_args)
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_renders_model_backed_email_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = _Pool([_row(artifact=json.dumps(_delivery_report_model_artifact()))])
+    sender = _Sender()
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-model-bytes")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.sent == 1
+    request = sender.requests[0]
+    assert "Key numbers" in request.html_body
+    assert "1,234 repeat tickets across 8 ranked questions" in request.html_body
+    assert "$16,659 estimated assisted-contact handling" in request.html_body
+    assert "3 publishable answers drafted" in request.html_body
+    assert "5 questions still need approved resolution evidence" in request.html_body
+    assert "42 ticket sources represented" in request.html_body
+    assert "curated report PDF is attached" in request.html_body
+    assert "full report PDF is attached" not in request.html_body
+    assert "The secure results page has the consolidated report" in request.html_body
+    assert "RAW MARKDOWN BODY" not in request.html_body
+    assert "private evidence quote" not in request.html_body
+    assert "ticket-secret-123" not in request.html_body
+    assert "resolution_evidence" not in request.html_body
+    assert request.text_body is not None
+    assert "1,234 repeat tickets across 8 ranked questions" in request.text_body
+    assert "$16,659 estimated assisted-contact handling" in request.text_body
+    assert "curated report PDF is attached" in request.text_body
+    assert "RAW MARKDOWN BODY" not in request.text_body
+    assert "private evidence quote" not in request.text_body
+    assert "ticket-secret-123" not in request.text_body
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_falls_back_for_future_report_model_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = _Pool([
+        _row(
+            artifact=json.dumps(
+                _delivery_report_model_artifact(schema_version="deflection.v2")
+            )
+        )
+    ])
+    sender = _Sender()
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-model-bytes")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.sent == 1
+    request = sender.requests[0]
+    assert "Key numbers" not in request.html_body
+    assert "full report PDF is attached" in request.html_body
+    assert "secure results page remains the system of record" in request.html_body
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_falls_back_for_malformed_email_summary_numbers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = _Pool([
+        _row(
+            artifact=json.dumps(
+                _delivery_report_model_artifact(
+                    support_tax_overrides={"repeat_ticket_count": "not-a-number"}
+                )
+            )
+        )
+    ])
+    sender = _Sender()
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-model-bytes")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.sent == 1
+    request = sender.requests[0]
+    assert "Key numbers" not in request.html_body
+    assert "0 repeat tickets" not in request.html_body
+    assert "full report PDF is attached" in request.html_body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delivery-Email-Model-Wrapper.md
Slice phase: Vertical slice

#1588 split the paid deflection report into distinct surfaces. PDF and hosted result page now consume the structured `deflection.v1` model; this moves the delivery email from a generic "report ready" body to a short model-backed wrapper with key numbers, while preserving the legacy generic body for old/malformed/future-schema artifacts. Follow-up: make the scheduler's `tzlocal` runtime dependency explicit so the dedicated delivery workflow can collect scheduler-backed task tests reliably.

## Intentional
- Keep delivery claim/finalize semantics, result URL generation, deterministic idempotency key, PDF attachment behavior, and link-only fallback unchanged.
- Consume the existing `support_tax` `email_summary` section instead of changing extracted section registry metadata in this slice.
- Keep email as a delivery wrapper, not a mini-report; hosted page/PDF/export remain the detailed reading surfaces.
- Do not change the delivery workflow file; fix the red check at the runtime dependency boundary shared by CI and production imports.

## Deferred
- Direct per-section email-summary renderers can follow if future sections earn an `email_summary` surface.
- Optional PDF bookmarks/navigation remain parked under #1588 and are not required for email.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q` -- 18 passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Delivery-Email-Model-Wrapper.md --check` -- passed.
- `rg -n "test_atlas_content_ops_deflection_delivery" scripts/run_extracted_pipeline_checks.sh .github/workflows -g '*.sh' -g '*.yml'` -- confirmed existing test enrollment.
- `python -m compileall -q atlas_brain/content_ops_deflection_delivery.py tests/test_atlas_content_ops_deflection_delivery.py` -- passed.
- `python -m pytest tests/test_alerts.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_content_ops_deflection_incidents.py tests/test_deflection_pdf_renderer.py tests/test_deflection_report_delivery_task.py tests/test_send_content_ops_deflection_report_deliveries.py -q` -- 119 passed, 1 warning.

## Diff size
4 files, 558 LOC by plan sync. Over the 400 LOC soft cap because the renderer and its model/future-schema/malformed-data/legacy-fallback tests are one safety unit, plus the one-line explicit scheduler dependency needed to make delivery CI collect.
