### PR TITLE
Deflection full report QA redaction policy

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -61,4 +61,4 @@ jobs:
       - name: PR-review tooling unit tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio
-          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py -q
+          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py tests/test_check_deflection_full_report_proof_bundle.py -q

--- a/plans/PR-Deflection-Full-Report-QA-Redaction-Policy.md
+++ b/plans/PR-Deflection-Full-Report-QA-Redaction-Policy.md
@@ -1,0 +1,125 @@
+# PR-Deflection-Full-Report-QA-Redaction-Policy
+
+## Why this slice exists
+
+#1612 starts the full-report delivery QA epic, but its initial proof-bundle
+shape named live `report_model.json`, `email.eml`, `result_page.html`,
+`report.pdf`, and `evidence_export.csv/jsonl` fixtures. That repeats the #1572
+risk: a real paid-report `request_id`/result URL is a live capability, and the
+evidence export is the uncapped customer ticket surface.
+
+Root cause: the QA harness planned committed artifacts before defining the
+artifact safety boundary. This PR fixes that root for the epic with the
+redaction policy and reusable self-check. Later harness slices must commit only
+a sanitized scorecard for live runs unless the data and IDs are synthetic.
+
+The amended PR exceeds the 400 LOC soft cap because review found leak-gate
+false negatives in the checker itself: snippets could echo raw evidence, paths
+were not scanned/redacted, PDFs and missing bundles could pass as clean, and
+the detector test was not enrolled in CI. Those are part of the same safety
+boundary, so splitting them would leave the gate knowingly unsafe.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-full-report-qa
+Slice phase: Production hardening
+
+1. Update #1612 with the slice-0 artifact policy.
+2. Add a proof-bundle redaction checker for future QA artifacts.
+3. Emit an assertions-JSON-shaped result with explicit fields for request
+   IDs, result URLs, customer emails, local paths, Stripe IDs, raw evidence,
+   source-ID lists, and private notes.
+4. Fail closed on any forbidden committed-bundle content.
+5. Reject missing, empty, PDF, binary, and non-UTF-8 bundles rather than
+   treating unscannable artifacts as clean.
+6. Scan and redact artifact path names as data.
+7. Test every detector plus safe synthetic/example near-misses and enroll the
+   checker test in CI.
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `plans/PR-Deflection-Full-Report-QA-Redaction-Policy.md`
+- `scripts/check_deflection_full_report_proof_bundle.py`
+- `tests/test_check_deflection_full_report_proof_bundle.py`
+- `tests/test_pre_push_audit_workflow.py`
+
+### Review Contract
+
+Acceptance criteria:
+
+- #1612 records the rule: live proof runs commit only sanitized scorecards, not
+  real email/page/PDF/export bundles.
+- The checker scans proof files and reports named rows for every forbidden
+  class, including live capabilities, PII-ish fields, Stripe IDs, raw evidence,
+  source-ID lists, and private notes.
+- Missing, empty, PDF, binary, non-UTF-8, and identifier-named bundles fail
+  closed.
+- Serialized findings do not echo raw evidence/private-note bodies or raw
+  request IDs from path metadata.
+- Every detector has a failing negative fixture, and safe synthetic/example
+  identifiers remain allowed.
+- This PR introduces no live identifiers, customer data, private notes, or raw
+  evidence fixtures.
+
+Affected surfaces: future #1612 proof-bundle validation and issue-tracker
+contract.
+
+Risk areas: broad regexes can false-positive; narrow regexes can repeat #1572;
+generic `secrets_committed` checks are not specific enough.
+
+- Reviewer rules triggered: R1, R2, R3, R9, R10, R12, R13, R14.
+
+## Mechanism
+
+The checker walks a proof-bundle file or directory, scans artifact names and
+UTF-8 text content with named detectors, and rejects missing, empty, PDF,
+binary, and non-UTF-8 inputs as unreadable. Each detector returns redacted path,
+label, and snippet metadata. The CLI prints JSON and exits non-zero on any
+violation.
+
+The result object is shaped like future assertions JSON: every sensitive class
+is present whether it passes or fails, so omission cannot masquerade as safety.
+
+## Intentional
+
+- This PR blocks the unsafe artifact path before building the full
+  email/page/PDF/export harness.
+- Tests use tiny synthetic snippets with example domains and fake IDs.
+- The checker is fail-closed and conservative for committed bundles. If a
+  future live run needs richer local artifacts, they stay uncommitted and only
+  the sanitized scorecard is committed.
+
+## Deferred
+
+- PR-Deflection-Full-Report-QA-Scorecard: shared scorecard and model-anchored
+  count assertions.
+- PR-Deflection-Full-Report-QA-Deterministic-Harness: fake-transport
+  email/page/PDF/export consistency tests.
+- PR-Deflection-Full-Report-QA-Live-Runner: live Zendesk-shaped proof runner
+  that commits only sanitized scorecards.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_check_deflection_full_report_proof_bundle.py -q
+  (30 passed)
+- python -m pytest tests/test_pre_push_audit_workflow.py -q
+  (4 passed)
+- python -m compileall -q scripts/check_deflection_full_report_proof_bundle.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_pre_push_audit_workflow.py
+  (passed)
+- python scripts/sync_pr_plan.py plans/PR-Deflection-Full-Report-QA-Redaction-Policy.md --check
+  (passed)
+- Pending before push: push-wrapper local review.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pre_push_audit.yml` | 2 |
+| `plans/PR-Deflection-Full-Report-QA-Redaction-Policy.md` | 125 |
+| `scripts/check_deflection_full_report_proof_bundle.py` | 288 |
+| `tests/test_check_deflection_full_report_proof_bundle.py` | 242 |
+| `tests/test_pre_push_audit_workflow.py` | 6 |
+| **Total** | **663** |

--- a/scripts/check_deflection_full_report_proof_bundle.py
+++ b/scripts/check_deflection_full_report_proof_bundle.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Fail-closed redaction check for deflection full-report proof bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+
+ALLOWED_EMAIL_DOMAINS = {"example.com", "example.org", "example.net", "example.test", "invalid"}
+CHECK_KEYS = (
+    "request_id",
+    "result_url",
+    "customer_email",
+    "absolute_local_path",
+    "stripe_checkout_session_id",
+    "stripe_payment_intent_id",
+    "raw_evidence_quote",
+    "source_id_list",
+    "private_note",
+    "artifact_readability",
+)
+MATCH_ONLY_SNIPPET_KEYS = {"raw_evidence_quote", "source_id_list", "private_note", "artifact_readability"}
+
+_REQUEST_ID_RE = re.compile(r"\bcontent-ops-[A-Za-z0-9_-]{8,}\b")
+_RESULT_URL_RE = re.compile(
+    r"https?://[^\s\"'<>]+/"
+    r"(?:systems/support-ticket-deflection|services/faq-deflection)/results/"
+    r"[^\s\"'<>]+"
+)
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,}|invalid)\b", re.IGNORECASE)
+_ABSOLUTE_LOCAL_PATH_RE = re.compile(
+    r"(?<![\w:.-])(?:/(?:home|Users|tmp|var|root|workspace|mnt|opt)/[^\s\"'<>]+|[A-Za-z]:\\[^\s\"'<>]+)"
+)
+_STRIPE_CHECKOUT_RE = re.compile(r"\bcs_(?:test|live)_[A-Za-z0-9]{8,}\b")
+_STRIPE_PAYMENT_RE = re.compile(r"\bpi_[A-Za-z0-9]{8,}\b")
+_RAW_EVIDENCE_RE = re.compile(r"(?i)(\"evidence_quotes?\"\s*:|`[^`]+`\s*-\s+|raw evidence|complete evidence)")
+_SOURCE_ID_LIST_RE = re.compile(
+    r"(?im)(\"source_ids?\"\s*:|(?:^|[\n\r,])source_ids?(?:[, \t\r\n]|$)|source ids? \(full list\)|full source[-_ ]id list)"
+)
+_PRIVATE_NOTE_RE = re.compile(
+    r"(?im)(private note|\"public\"\s*:\s*false|\"is_public\"\s*:\s*false|\"visibility\"\s*:\s*\"private\"|(?:^|[\n\r,])(?:public|is_public)\s*,\s*false(?:[, \t\r\n]|$)|(?:^|[\n\r,])visibility\s*,\s*private(?:[, \t\r\n]|$))"
+)
+
+DETECTORS = (
+    ("request_id", _REQUEST_ID_RE, lambda value: _is_safe_request_id(value)),
+    ("result_url", _RESULT_URL_RE, lambda value: _is_safe_result_url(value)),
+    ("customer_email", _EMAIL_RE, lambda value: _is_safe_email(value)),
+    ("absolute_local_path", _ABSOLUTE_LOCAL_PATH_RE, None),
+    ("stripe_checkout_session_id", _STRIPE_CHECKOUT_RE, None),
+    ("stripe_payment_intent_id", _STRIPE_PAYMENT_RE, None),
+    ("raw_evidence_quote", _RAW_EVIDENCE_RE, None),
+    ("source_id_list", _SOURCE_ID_LIST_RE, None),
+    ("private_note", _PRIVATE_NOTE_RE, None),
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    label: str
+    snippet: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "path": _redact_sensitive_text(self.path),
+            "label": self.label,
+            "snippet": self.snippet,
+        }
+
+
+def iter_files(path: Path) -> Iterable[Path]:
+    if path.is_file():
+        yield path
+        return
+    for child in sorted(path.rglob("*")):
+        if child.is_file():
+            yield child
+
+
+def iter_artifact_paths(path: Path) -> Iterable[Path]:
+    yield path
+    if path.is_dir():
+        yield from sorted(path.rglob("*"))
+
+
+def _read_text_or_readability_finding(path: Path, root: Path) -> tuple[str | None, Finding | None]:
+    if path.suffix.lower() == ".pdf":
+        return None, _readability_finding(path, root, "unsupported_pdf_artifact")
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None, _readability_finding(path, root, "unreadable_artifact")
+    if b"\x00" in data:
+        return None, _readability_finding(path, root, "binary_artifact")
+    try:
+        return data.decode("utf-8"), None
+    except UnicodeDecodeError:
+        return None, _readability_finding(path, root, "non_utf8_artifact")
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _display_path(path: Path, root: Path) -> str:
+    if path == root:
+        return path.name or "."
+    return _relative(path, root)
+
+
+def _redact_sensitive_text(text: str) -> str:
+    text = _RESULT_URL_RE.sub("[result_url]", text)
+    text = _REQUEST_ID_RE.sub("[request_id]", text)
+    text = _EMAIL_RE.sub("[email]", text)
+    text = _STRIPE_CHECKOUT_RE.sub("[stripe_checkout_session_id]", text)
+    text = _STRIPE_PAYMENT_RE.sub("[stripe_payment_intent_id]", text)
+    text = _ABSOLUTE_LOCAL_PATH_RE.sub("[absolute_local_path]", text)
+    return text
+
+
+def _safe_snippet(key: str, text: str, start: int, end: int) -> str:
+    if key in MATCH_ONLY_SNIPPET_KEYS:
+        return f"[{key}]"
+    snippet = text[max(0, start - 40) : min(len(text), end + 40)]
+    snippet = _redact_sensitive_text(snippet)
+    return " ".join(snippet.split())
+
+
+def _is_safe_request_id(value: str) -> bool:
+    lowered = value.lower()
+    return "synthetic" in lowered or "example" in lowered
+
+
+def _is_safe_result_url(value: str) -> bool:
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").lower()
+    if host.endswith((".example.com", ".example.org", ".example.net", ".example.test")):
+        return True
+    result_id = unquote(parsed.path.rstrip("/").rsplit("/", 1)[-1])
+    return _is_safe_request_id(result_id)
+
+
+def _is_safe_email(value: str) -> bool:
+    domain = value.rsplit("@", 1)[-1].lower()
+    return domain in ALLOWED_EMAIL_DOMAINS or domain.endswith(".example.com")
+
+
+def _regex_findings(
+    *,
+    key: str,
+    pattern: re.Pattern[str],
+    path: Path,
+    root: Path,
+    text: str,
+    safe_value: Any = None,
+    display_path: str | None = None,
+) -> list[Finding]:
+    findings: list[Finding] = []
+    for match in pattern.finditer(text):
+        value = match.group(0)
+        if safe_value is not None and safe_value(value):
+            continue
+        findings.append(
+            Finding(
+                path=display_path or _display_path(path, root),
+                label=key,
+                snippet=_safe_snippet(key, text, match.start(), match.end()),
+            )
+        )
+    return findings
+
+
+def _readability_finding(path: Path, root: Path, reason: str) -> Finding:
+    return Finding(
+        path=_display_path(path, root),
+        label="artifact_readability",
+        snippet=f"[{reason}]",
+    )
+
+
+def _record_findings(checks: dict[str, dict[str, Any]], findings: list[Finding]) -> None:
+    for finding in findings:
+        checks[finding.label]["ok"] = False
+        checks[finding.label]["findings"].append(finding.as_dict())
+
+
+def scan_bundle(path: Path) -> dict[str, Any]:
+    root = path if path.is_dir() else path.parent
+    checks: dict[str, dict[str, Any]] = {
+        key: {"ok": True, "findings": []} for key in CHECK_KEYS
+    }
+    if not path.exists():
+        checks["artifact_readability"]["ok"] = False
+        checks["artifact_readability"]["findings"].append(
+            Finding(path=path.as_posix(), label="artifact_readability", snippet="[missing_bundle_path]").as_dict()
+        )
+        return _result(scanned_files=0, checks=checks)
+
+    for artifact_path in iter_artifact_paths(path):
+        display_path = _display_path(artifact_path, root)
+        for key, pattern, safe_value in DETECTORS:
+            _record_findings(
+                checks,
+                _regex_findings(
+                    key=key,
+                    pattern=pattern,
+                    path=artifact_path,
+                    root=root,
+                    text=display_path,
+                    safe_value=safe_value,
+                    display_path=display_path,
+                ),
+            )
+
+    scanned_files = 0
+    for file_path in iter_files(path):
+        scanned_files += 1
+        text, readability_finding = _read_text_or_readability_finding(file_path, root)
+        if readability_finding is not None:
+            _record_findings(checks, [readability_finding])
+            continue
+        if text is None:
+            continue
+        for key, pattern, safe_value in DETECTORS:
+            _record_findings(
+                checks,
+                _regex_findings(
+                    key=key,
+                    pattern=pattern,
+                    path=file_path,
+                    root=root,
+                    text=text,
+                    safe_value=safe_value,
+                ),
+            )
+
+    if scanned_files == 0:
+        _record_findings(
+            checks,
+            [Finding(path=_display_path(path, root), label="artifact_readability", snippet="[empty_bundle]")],
+        )
+    return _result(scanned_files=scanned_files, checks=checks)
+
+
+def _result(*, scanned_files: int, checks: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    ok = all(check["ok"] for check in checks.values())
+    return {
+        "schema_version": "deflection_full_report_proof_redaction.v1",
+        "ok": ok,
+        "policy": "live proof runs may commit sanitized scorecards only; raw live bundles stay uncommitted",
+        "scanned_files": scanned_files,
+        "checks": checks,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check a deflection full-report proof bundle for commit-blocking leaks."
+    )
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    result = scan_bundle(args.path)
+    text = json.dumps(result, indent=2 if args.pretty else None, sort_keys=True)
+    if args.output:
+        args.output.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_deflection_full_report_proof_bundle.py
+++ b/tests/test_check_deflection_full_report_proof_bundle.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_deflection_full_report_proof_bundle.py"
+SPEC = importlib.util.spec_from_file_location(
+    "check_deflection_full_report_proof_bundle",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+FORBIDDEN_FIXTURES = {
+    "request_id": '"request_id": "content-ops-45c06a6950ec4677a214368d6e4dc44f"',
+    "result_url": "https://www.juancanfield.com/systems/support-ticket-deflection/results/content-ops-45c06a6950ec4677a214368d6e4dc44f",
+    "customer_email": "Delivered-To: buyer@realcustomer.com",
+    "absolute_local_path": "artifact written to /home/juan-canfield/Desktop/live/report.pdf",
+    "stripe_checkout_session_id": "checkout session cs_live_a1b2c3d4e5f6g7h8",
+    "stripe_payment_intent_id": "payment intent pi_3Pmtlivea1b2c3d4",
+    "raw_evidence_quote": '{"evidence_quote": "Customer says their invoice exposes PII"}',
+    "source_id_list": '{"source_ids": ["zd-proof-001", "zd-proof-002"]}',
+    "private_note": '{"public": false, "body": "private note from agent"}',
+}
+
+RAW_CUSTOMER_TEXT = "Customer says account 555-12-9999 cannot be published"
+
+
+def _write_bundle(tmp_path: Path, text: str) -> Path:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "artifact.txt").write_text(text, encoding="utf-8")
+    return bundle
+
+
+@pytest.mark.parametrize("expected_key,text", sorted(FORBIDDEN_FIXTURES.items()))
+def test_checker_names_each_forbidden_class(expected_key: str, text: str, tmp_path: Path) -> None:
+    result = checker.scan_bundle(_write_bundle(tmp_path, text))
+
+    assert result["ok"] is False
+    assert set(result["checks"]) == set(checker.CHECK_KEYS)
+    assert result["checks"][expected_key]["ok"] is False
+    assert result["checks"][expected_key]["findings"]
+
+
+def test_checker_allows_synthetic_and_example_values(tmp_path: Path) -> None:
+    bundle = _write_bundle(
+        tmp_path,
+        "\n".join([
+            '"request_id": "synthetic-request-id"',
+            "https://qa.example.com/systems/support-ticket-deflection/results/synthetic-request-id",
+            "To: buyer@example.com",
+            '{"scorecard": "only"}',
+        ]),
+    )
+
+    result = checker.scan_bundle(bundle)
+
+    assert result["ok"] is True
+    assert all(check["ok"] for check in result["checks"].values())
+    assert set(result["checks"]) == set(checker.CHECK_KEYS)
+
+
+def test_cli_writes_assertions_without_echoing_raw_sensitive_values(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    raw_request_id = "content-ops-45c06a6950ec4677a214368d6e4dc44f"
+    bundle = _write_bundle(tmp_path, f'"request_id": "{raw_request_id}"')
+    output = tmp_path / "assertions.json"
+
+    code = checker.main([str(bundle), "--output", str(output), "--pretty"])
+    printed = capsys.readouterr().out
+    payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["checks"]["request_id"]["ok"] is False
+    assert raw_request_id not in output.read_text(encoding="utf-8")
+    assert raw_request_id not in printed
+    assert "[request_id]" in output.read_text(encoding="utf-8")
+
+
+def test_raw_evidence_and_private_note_do_not_echo_customer_text(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle = _write_bundle(
+        tmp_path,
+        "\n".join([
+            f'{{"evidence_quote": "{RAW_CUSTOMER_TEXT}"}}',
+            f'{{"public": false, "body": "{RAW_CUSTOMER_TEXT}"}}',
+        ]),
+    )
+    output = tmp_path / "assertions.json"
+
+    code = checker.main([str(bundle), "--output", str(output), "--pretty"])
+    printed = capsys.readouterr().out
+    payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert code == 1
+    assert payload["checks"]["raw_evidence_quote"]["findings"][0]["snippet"] == "[raw_evidence_quote]"
+    assert payload["checks"]["private_note"]["findings"][0]["snippet"] == "[private_note]"
+    assert RAW_CUSTOMER_TEXT not in output.read_text(encoding="utf-8")
+    assert RAW_CUSTOMER_TEXT not in printed
+
+
+def test_request_id_in_bundle_path_is_detected_and_redacted(tmp_path: Path) -> None:
+    raw_request_id = "content-ops-45c06a6950ec4677a214368d6e4dc44f"
+    bundle = tmp_path / raw_request_id
+    bundle.mkdir()
+    (bundle / "artifact.txt").write_text('{"scorecard": "only"}', encoding="utf-8")
+
+    result = checker.scan_bundle(bundle)
+    encoded = json.dumps(result)
+
+    assert result["ok"] is False
+    assert result["checks"]["request_id"]["ok"] is False
+    assert raw_request_id not in encoded
+    assert "[request_id]" in encoded
+
+
+def test_finding_paths_are_redacted(tmp_path: Path) -> None:
+    raw_request_id = "content-ops-45c06a6950ec4677a214368d6e4dc44f"
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    artifact = bundle / f"{raw_request_id}.txt"
+    artifact.write_text("Delivered-To: buyer@realcustomer.com", encoding="utf-8")
+
+    result = checker.scan_bundle(bundle)
+    finding = result["checks"]["customer_email"]["findings"][0]
+
+    assert finding["path"] == "[request_id].txt"
+    assert raw_request_id not in json.dumps(result)
+
+
+def test_missing_bundle_path_fails_closed(tmp_path: Path) -> None:
+    result = checker.scan_bundle(tmp_path / "missing")
+
+    assert result["ok"] is False
+    assert result["checks"]["artifact_readability"]["ok"] is False
+    assert result["checks"]["artifact_readability"]["findings"][0]["snippet"] == "[missing_bundle_path]"
+
+
+def test_empty_bundle_directory_fails_closed(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+
+    result = checker.scan_bundle(bundle)
+
+    assert result["ok"] is False
+    assert result["scanned_files"] == 0
+    assert result["checks"]["artifact_readability"]["findings"][0]["snippet"] == "[empty_bundle]"
+
+
+def test_pdf_artifact_is_rejected_fail_closed(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "report.pdf").write_bytes(b"%PDF-1.7\ncompressed content")
+
+    result = checker.scan_bundle(bundle)
+
+    assert result["ok"] is False
+    assert result["checks"]["artifact_readability"]["ok"] is False
+    assert result["checks"]["artifact_readability"]["findings"][0]["snippet"] == "[unsupported_pdf_artifact]"
+
+
+@pytest.mark.parametrize(
+    "path_text",
+    [
+        "/Users/alice/Desktop/report.pdf",
+        "/workspace/ATLAS/report.pdf",
+        "/var/tmp/report.pdf",
+        "/root/report.pdf",
+        "C:\\Users\\Alice\\Desktop\\report.pdf",
+    ],
+)
+def test_absolute_path_detector_covers_common_local_roots(path_text: str, tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path, f"artifact written to {path_text}")
+
+    result = checker.scan_bundle(bundle)
+
+    assert result["ok"] is False
+    assert result["checks"]["absolute_local_path"]["ok"] is False
+
+
+@pytest.mark.parametrize(
+    ("expected_key", "text"),
+    [
+        ("source_id_list", "source_id,body\nzd-proof-001,customer text\n"),
+        ("source_id_list", '{"source_id": "zd-proof-001", "body": "customer text"}'),
+        ("private_note", "public,false,do not publish this body\n"),
+        ("private_note", "is_public,false,do not publish this body\n"),
+        ("private_note", "visibility,private,do not publish this body\n"),
+    ],
+)
+def test_csv_and_jsonl_export_markers_fail_closed(expected_key: str, text: str, tmp_path: Path) -> None:
+    result = checker.scan_bundle(_write_bundle(tmp_path, text))
+
+    assert result["ok"] is False
+    assert result["checks"][expected_key]["ok"] is False
+
+
+def test_real_result_url_with_example_query_is_not_allowlisted(tmp_path: Path) -> None:
+    bundle = _write_bundle(
+        tmp_path,
+        "https://www.juancanfield.com/systems/support-ticket-deflection/results/req_123456789?account=exampleco",
+    )
+
+    result = checker.scan_bundle(bundle)
+
+    assert result["ok"] is False
+    assert result["checks"]["result_url"]["ok"] is False
+
+
+def test_real_result_url_with_synthetic_result_id_is_allowed(tmp_path: Path) -> None:
+    bundle = _write_bundle(
+        tmp_path,
+        "https://www.juancanfield.com/systems/support-ticket-deflection/results/synthetic-request-id",
+    )
+
+    result = checker.scan_bundle(bundle)
+
+    assert result["ok"] is True
+
+
+def test_absolute_path_redaction_preserves_neighboring_context(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path, "before /tmp/live/report.pdf after")
+
+    result = checker.scan_bundle(bundle)
+    snippet = result["checks"]["absolute_local_path"]["findings"][0]["snippet"]
+
+    assert snippet == "before [absolute_local_path] after"

--- a/tests/test_pre_push_audit_workflow.py
+++ b/tests/test_pre_push_audit_workflow.py
@@ -27,3 +27,9 @@ def test_pre_push_audit_workflow_enrolls_push_pr_wrapper_tests() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "tests/test_push_pr_wrapper.py" in text
+
+
+def test_pre_push_audit_workflow_enrolls_full_report_redaction_checker_tests() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "tests/test_check_deflection_full_report_proof_bundle.py" in text


### PR DESCRIPTION
Plan: plans/PR-Deflection-Full-Report-QA-Redaction-Policy.md
Slice phase: Production hardening

#1612 starts the full-report delivery QA epic, but live proof artifacts are a credential/PII leak vector unless the artifact boundary is defined first. This slice adds the slice-0 policy to #1612 and ships a fail-closed proof-bundle checker that names the sensitive classes explicitly before future harness slices commit any scorecard.

Issue update: https://github.com/canfieldjuan/ATLAS/issues/1612#issuecomment-4723770800

Review fix update: the checker now redacts path metadata, scans artifact path names, uses match-only snippets for raw evidence/private notes/source-ID lists, rejects missing/empty/PDF/binary/non-UTF-8 bundles, tightens result-URL synthetic allowlisting, catches singular source_id and CSV private-note markers, and enrolls the checker test in CI.

## Intentional
- This does not build the full email/page/PDF/export harness; it blocks unsafe proof bundles first.
- Tests use synthetic snippets, fake IDs, and example domains only.
- The checker is conservative for committed bundles; richer live artifacts stay uncommitted and only sanitized scorecards are committed.

## Deferred
- PR-Deflection-Full-Report-QA-Scorecard: shared scorecard and model-anchored count assertions.
- PR-Deflection-Full-Report-QA-Deterministic-Harness: fake-transport email/page/PDF/export consistency tests.
- PR-Deflection-Full-Report-QA-Live-Runner: live Zendesk-shaped proof runner that commits only sanitized scorecards.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed in `309d070c0683174847d787917aab340fe74c7dea`: Codex `#76` raw evidence/private-note snippets now use match-only serialized snippets.
- Fixed in `309d070c0683174847d787917aab340fe74c7dea`: Codex `#59` missing bundle paths now fail closed through `artifact_readability`.
- Fixed in `309d070c0683174847d787917aab340fe74c7dea`: Codex `test#43` checker tests are enrolled in `pre_push_audit.yml` and pinned by `test_pre_push_audit_workflow.py`.
- No waivers.

## Verification
- `python -m pytest tests/test_check_deflection_full_report_proof_bundle.py -q` (30 passed)
- `python -m pytest tests/test_pre_push_audit_workflow.py -q` (4 passed)
- `python -m pytest tests/test_check_deflection_full_report_proof_bundle.py tests/test_pre_push_audit_workflow.py -q` (34 passed)
- `python -m compileall -q scripts/check_deflection_full_report_proof_bundle.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_pre_push_audit_workflow.py` (passed)
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Full-Report-QA-Redaction-Policy.md --check` (passed)
- `bash scripts/push_pr.sh /tmp/pr-body-deflection-full-report-qa-redaction-policy.md -u origin claude/pr-deflection-full-report-qa-redaction-policy` (runs local PR review before push)

## Diff size
5 files, +662 / -1