### PR TITLE
Deflection CSV parser error UX

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -42,6 +42,7 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..campaign_ports import TenantScope
+from ..campaign_customer_data import CsvCustomerDataParseError
 from ..brand_voice import BrandVoiceProfile, brand_voice_profile_from_mapping
 from ..campaign_postgres_import import import_campaign_opportunities
 from ..campaign_source_adapters import source_material_to_source_rows
@@ -1887,12 +1888,25 @@ def _parse_deflection_submit_csv_file(
             temp_path,
             file_format="csv",
         )
+    except CsvCustomerDataParseError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=_deflection_submit_csv_parse_error_detail(exc),
+        ) from exc
     except (OSError, UnicodeDecodeError, ValueError) as exc:
         raise HTTPException(
             status_code=400,
             detail=parse_error_detail,
         ) from exc
     return rows, byte_count, tuple(warning.as_dict() for warning in load_warnings)
+
+
+def _deflection_submit_csv_parse_error_detail(
+    error: CsvCustomerDataParseError,
+) -> dict[str, Any]:
+    detail = error.as_dict()
+    detail["reason"] = "deflection_submit_csv_parse_error"
+    return detail
 
 
 def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -87,6 +87,17 @@ _CSV_HEADER_HINTS = frozenset({
     "vendor",
     "vendor_name",
 })
+_CSV_MISSING_HEADER_FIX = (
+    "Add a header row with column names such as ticket_id, subject, and message, "
+    "then export the CSV again."
+)
+_CSV_ENCODING_FIX = (
+    "Export the file again as UTF-8 or UTF-16 CSV, then upload the new export."
+)
+_CSV_INCONSISTENT_COLUMNS_FIX = (
+    "Use one delimiter consistently, keep every row within the header width, "
+    "and quote cells that contain commas, tabs, semicolons, pipes, or newlines."
+)
 
 
 @dataclass(frozen=True)
@@ -107,6 +118,29 @@ class CampaignOpportunityWarning:
             data["row_index"] = self.row_index
         if self.field:
             data["field"] = self.field
+        return data
+
+
+@dataclass(frozen=True)
+class CsvCustomerDataParseError(ValueError):
+    """Safe structured CSV parser error for user-facing upload feedback."""
+
+    code: str
+    message: str
+    how_to_fix: str
+    row_index: int | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+            "how_to_fix": self.how_to_fix,
+        }
+        if self.row_index is not None:
+            data["row_index"] = self.row_index
         return data
 
 
@@ -408,7 +442,7 @@ def _load_csv_dict_rows(
     candidate = _select_csv_delimiter_for_path(path, encoding_plan)
     header_index = candidate.header_index
     if header_index is None:
-        raise ValueError("CSV customer data must include a header row.")
+        raise _csv_missing_header_error()
 
     skipped_leading_count = 0
     first_leading_row: tuple[int, Sequence[Any]] | None = None
@@ -439,7 +473,7 @@ def _load_csv_dict_rows(
                     if field is not None and str(field).strip()
                 )
                 if not header_fields:
-                    raise ValueError("CSV customer data must include a header row.")
+                    raise _csv_missing_header_error()
                 consistency = _CsvColumnConsistencyState(
                     header_index=header_index,
                     header_has_hint=candidate.header_has_hint,
@@ -450,9 +484,9 @@ def _load_csv_dict_rows(
             if not any(str(value or "").strip() for value in values):
                 continue
             if len(values) > header_width:
-                raise ValueError(
-                    f"CSV row {row_index} has more cells than the header; "
-                    "check the delimiter and header row."
+                raise _csv_inconsistent_columns_error(
+                    f"CSV row {row_index} has more cells than the header.",
+                    row_index=row_index,
                 )
             if consistency is not None:
                 consistency.add(row_index, values)
@@ -467,7 +501,7 @@ def _load_csv_dict_rows(
                     cleaned[cleaned_key] = cleaned_value
             rows.append(cleaned)
     if not header_fields or consistency is None:
-        raise ValueError("CSV customer data must include a header row.")
+        raise _csv_missing_header_error()
     consistency_candidate = consistency.as_candidate(quotechar=candidate.quotechar)
     if not consistency_candidate.valid:
         _raise_csv_delimiter_error(consistency_candidate)
@@ -477,6 +511,35 @@ def _load_csv_dict_rows(
         header_index,
     )
     return rows, load_warnings
+
+
+def _csv_missing_header_error() -> CsvCustomerDataParseError:
+    return CsvCustomerDataParseError(
+        code="csv_missing_header",
+        message="CSV customer data must include a header row.",
+        how_to_fix=_CSV_MISSING_HEADER_FIX,
+    )
+
+
+def _csv_encoding_error(message: str) -> CsvCustomerDataParseError:
+    return CsvCustomerDataParseError(
+        code="csv_encoding_error",
+        message=message,
+        how_to_fix=_CSV_ENCODING_FIX,
+    )
+
+
+def _csv_inconsistent_columns_error(
+    message: str,
+    *,
+    row_index: int | None = None,
+) -> CsvCustomerDataParseError:
+    return CsvCustomerDataParseError(
+        code="csv_inconsistent_columns",
+        message=message,
+        how_to_fix=_CSV_INCONSISTENT_COLUMNS_FIX,
+        row_index=row_index,
+    )
 
 
 def _open_csv_text(path: Path, plan: _CsvEncodingPlan):
@@ -523,7 +586,7 @@ def _csv_encoding_plan(path: Path) -> _CsvEncodingPlan:
         inferred = _utf16_encoding_from_nul_bytes(prefix)
         if inferred:
             return _csv_inferred_utf16_encoding_plan(path, encoding=inferred)
-        raise ValueError(
+        raise _csv_encoding_error(
             "CSV customer data decoded to NUL-heavy text; check the file encoding."
         )
     return _CsvEncodingPlan(
@@ -536,9 +599,15 @@ def _csv_encoding_plan(path: Path) -> _CsvEncodingPlan:
 
 
 def _csv_checked_encoding_plan(path: Path, *, encoding: str) -> _CsvEncodingPlan:
-    stats = _scan_csv_text_stats(path, encoding=encoding)
+    try:
+        stats = _scan_csv_text_stats(path, encoding=encoding)
+    except UnicodeDecodeError as exc:
+        raise _csv_encoding_error(
+            f"CSV customer data could not be decoded as {encoding}; "
+            "check the file encoding."
+        ) from exc
     if stats.nul_ratio >= _CSV_NUL_REDECODE_RATIO:
-        raise ValueError(
+        raise _csv_encoding_error(
             f"CSV customer data decoded as {encoding} but remained NUL-heavy; "
             "check the file encoding."
         )
@@ -549,9 +618,15 @@ def _csv_checked_encoding_plan(path: Path, *, encoding: str) -> _CsvEncodingPlan
 
 
 def _csv_inferred_utf16_encoding_plan(path: Path, *, encoding: str) -> _CsvEncodingPlan:
-    stats = _scan_csv_text_stats(path, encoding=encoding)
+    try:
+        stats = _scan_csv_text_stats(path, encoding=encoding)
+    except UnicodeDecodeError as exc:
+        raise _csv_encoding_error(
+            f"CSV customer data could not be decoded as {encoding}; "
+            "check the file encoding."
+        ) from exc
     if stats.nul_ratio >= _CSV_NUL_REDECODE_RATIO:
-        raise ValueError(
+        raise _csv_encoding_error(
             f"CSV customer data decoded as {encoding} but remained NUL-heavy; "
             "check the file encoding."
         )
@@ -697,12 +772,12 @@ def _legacy_csv_encoding_stats(path: Path) -> tuple[str, _CsvTextStats]:
         except UnicodeDecodeError:
             continue
         if stats.nul_ratio >= _CSV_NUL_REDECODE_RATIO:
-            raise ValueError(
+            raise _csv_encoding_error(
                 f"CSV customer data decoded as {encoding} but remained NUL-heavy; "
                 "check the file encoding."
             )
         return encoding, stats
-    raise ValueError(
+    raise _csv_encoding_error(
         "CSV customer data could not be decoded as UTF-8, UTF-16, UTF-32, "
         "CP1252, or Latin-1."
     )
@@ -904,7 +979,7 @@ def _select_csv_delimiter(text: str) -> _CsvDelimiterCandidate:
     if valid:
         return max(valid, key=_csv_delimiter_candidate_key)
     if all(candidate.header_index is None for candidate in candidates):
-        raise ValueError("CSV customer data must include a header row.")
+        raise _csv_missing_header_error()
     _raise_csv_delimiter_error(max(candidates, key=_csv_delimiter_candidate_key))
 
 
@@ -925,6 +1000,8 @@ def _select_csv_delimiter_from_stream(
     valid = [candidate for candidate in candidates if candidate.valid]
     if valid:
         return max(valid, key=_csv_delimiter_candidate_key)
+    if all(candidate.header_index is None for candidate in candidates):
+        raise _csv_missing_header_error()
     _raise_csv_delimiter_error(max(candidates, key=_csv_delimiter_candidate_key))
 
 
@@ -1153,12 +1230,12 @@ def _raise_csv_delimiter_error(candidate: _CsvDelimiterCandidate) -> None:
         if candidate.first_offending_row is not None
         else ""
     )
-    raise ValueError(
+    raise _csv_inconsistent_columns_error(
         "CSV customer data has inconsistent column counts under the best "
         f"delimiter candidate ({delimiter_name}); "
         f"{candidate.consistent_rows}/{candidate.data_rows} data row(s) "
-        f"matched the {candidate.header_width}-column header{row_hint}. "
-        "Check the delimiter and header row."
+        f"matched the {candidate.header_width}-column header{row_hint}.",
+        row_index=candidate.first_collapsed_row or candidate.first_offending_row,
     )
 
 
@@ -1241,6 +1318,7 @@ def _matches_filters(
 __all__ = [
     "CampaignOpportunityLoadResult",
     "CampaignOpportunityWarning",
+    "CsvCustomerDataParseError",
     "FileIntelligenceRepository",
     "load_campaign_opportunities_from_file",
     "normalize_campaign_opportunity_rows",

--- a/plans/PR-Deflection-CSV-Parser-Error-UX.md
+++ b/plans/PR-Deflection-CSV-Parser-Error-UX.md
@@ -1,0 +1,126 @@
+# PR-Deflection-CSV-Parser-Error-UX
+
+## Why this slice exists
+
+Issue #1458 now has the agreed three-step parser sequence. PR #1610 closed step
+1 by removing avoidable full-file CSV parser materialization while preserving the
+current parser API. The next user-visible gap is error clarity: the shared CSV
+loader can tell when a file has no header, cannot be decoded safely, or has
+inconsistent columns, but the deflection submit surface collapses those failures
+to generic "could not be parsed" strings. A buyer or operator can tell the
+upload failed, but not what to fix in the file.
+
+This slice keeps the fix upstream of the symptom. It classifies the parser's
+own failure modes at the shared CSV loader boundary, then translates those safe
+codes into deflection submit HTTP details. That avoids adding string matching in
+the API layer and keeps parser API widening deferred.
+
+The final diff is slightly over the 400-line soft cap because review found two
+same-scope detection gaps: malformed BOM-prefixed encoding failures and the
+delimiter-consistency branch both needed direct regressions. Splitting those
+tests out would leave the parser error UX contract partially unproved.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+Slice phase: Production hardening
+
+1. Add safe structured CSV parse errors for the deflection-relevant parser
+   classes: missing header, encoding failure, and inconsistent column counts.
+2. Return those parse errors from deflection CSV upload and blob submit paths as
+   structured 400 details with a stable code, safe user-facing message, and
+   "how to fix" guidance.
+3. Preserve the existing shared loader API for successful parses and keep
+   parser API widening out of scope.
+4. Add focused parser and submit-surface regressions proving each new error
+   branch fires without exposing raw uploaded row contents.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `plans/PR-Deflection-CSV-Parser-Error-UX.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Missing-header CSV input reaches deflection submit as a structured
+        `csv_missing_header` 400 response with correction guidance.
+  - [ ] Unsafe or undecodable CSV input reaches deflection submit as a
+        structured `csv_encoding_error` 400 response with correction guidance.
+  - [ ] Inconsistent-column CSV input reaches deflection submit as a structured
+        `csv_inconsistent_columns` 400 response with correction guidance.
+  - [ ] Structured parse details do not include raw row values, uploaded text,
+        email addresses, phone numbers, or other user-provided field contents.
+  - [ ] Successful CSV parsing, load warnings, row output shape, and existing
+        caller exception compatibility remain unchanged.
+- Affected surfaces: API, file upload, blob import, extracted package parser,
+  tests, CI enrollment.
+- Risk areas: user input safety, backcompat, error handling, parser correctness.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R10, R12, R14.
+
+## Mechanism
+
+Introduce a small structured parse error type in the shared CSV loader with a
+stable code, safe message, safe fix guidance, and optional non-sensitive row
+index metadata. It should inherit from `ValueError` so existing non-HTTP callers
+that catch parse failures keep working.
+
+Raise that structured error at the parser's existing decision points instead of
+raising plain text only:
+
+- no plausible header row, or an empty header after delimiter selection;
+- encoding scans that fail closed on undecodable or NUL-heavy text;
+- delimiter and row-width validation that finds inconsistent column counts.
+
+The deflection submit CSV parser wrapper then catches the structured type before
+the generic parser exception fallback and returns an HTTP 400 detail object. The
+detail object carries a deflection-specific reason plus the parser code,
+message, fix guidance, and optional row index. The generic fallback remains for
+unexpected parser exceptions.
+
+## Intentional
+
+- No parser API widening in this slice. Successful callers still receive the
+  existing row and warning tuple, and parser-level cap/count metadata remains a
+  later design issue.
+- No raw CSV snippets in error details. Even if a preview would help debugging,
+  the submit path is public input and the safe response should only include
+  codes, guidance, and numeric row metadata.
+- JSON and Zendesk full-thread parse errors stay out of scope. The user request
+  and #1458 are about CSV upload parser failures.
+- The shared parser still raises a `ValueError` subclass instead of a separate
+  result envelope so existing callers do not need a compatibility migration.
+
+## Deferred
+
+- Parser API widening remains deferred until after parser memory hardening and
+  parser error UX. When reached, open the separate GitHub issue the operator
+  requested for richer parser caps/counts/truncation metadata.
+- Ingestion-file and CLI presentation of the same structured parse errors is
+  deferred unless required by tests; this slice hardens the deflection submit
+  surface first.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused pytest for the campaign source adapter and deflection submit suites
+  passed with 190 tests after the review fixes.
+- The extracted pipeline check bundle passed: extracted reasoning core checks
+  passed with 295 tests, then extracted content pipeline checks passed with
+  4,409 tests and 10 skipped after the review fixes.
+- Local PR review passed with the PR body file supplied.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 14 |
+| `extracted_content_pipeline/campaign_customer_data.py` | 112 |
+| `plans/PR-Deflection-CSV-Parser-Error-UX.md` | 126 |
+| `tests/test_extracted_campaign_source_adapters.py` | 91 |
+| `tests/test_extracted_content_deflection_submit.py` | 87 |
+| **Total** | **430** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from extracted_content_pipeline import campaign_source_adapters as adapters
+from extracted_content_pipeline.campaign_customer_data import CsvCustomerDataParseError
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
     load_source_rows_from_file,
@@ -371,6 +372,86 @@ def test_load_source_rows_rejects_inconsistent_mixed_delimiters(
         load_source_rows_from_file(path, file_format="csv")
 
 
+def test_load_source_rows_structures_missing_header_parse_error(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "missing_header.csv"
+    path.write_text(
+        "\n".join([
+            "I need help exporting reports",
+            "Where can I download invoices?",
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CsvCustomerDataParseError) as exc:
+        load_source_rows_from_file(path, file_format="csv")
+
+    assert exc.value.code == "csv_missing_header"
+    assert "header row" in exc.value.message
+    assert "ticket_id" in exc.value.how_to_fix
+
+
+def test_load_source_rows_structures_encoding_parse_error(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "nul_heavy.csv"
+    path.write_bytes(b"\x00" * 128)
+
+    with pytest.raises(CsvCustomerDataParseError) as exc:
+        load_source_rows_from_file(path, file_format="csv")
+
+    assert exc.value.code == "csv_encoding_error"
+    assert "NUL-heavy" in exc.value.message
+    assert "UTF-8 or UTF-16" in exc.value.how_to_fix
+
+
+@pytest.mark.parametrize(
+    ("payload", "encoding_name"),
+    [
+        (b"\xff\xfeticket_id\x00\xff", "utf-16"),
+        (b"\x00\x00\xfe\xffnot-a-valid-utf32", "utf-32"),
+    ],
+)
+def test_load_source_rows_structures_malformed_bom_encoding_errors(
+    tmp_path: Path,
+    payload: bytes,
+    encoding_name: str,
+) -> None:
+    path = tmp_path / "malformed_bom.csv"
+    path.write_bytes(payload)
+
+    with pytest.raises(CsvCustomerDataParseError) as exc:
+        load_source_rows_from_file(path, file_format="csv")
+
+    assert exc.value.code == "csv_encoding_error"
+    assert encoding_name in exc.value.message
+    assert "UTF-8 or UTF-16" in exc.value.how_to_fix
+
+
+def test_load_source_rows_structures_inconsistent_columns_without_raw_row(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_extra_cell.csv"
+    path.write_text(
+        "\n".join([
+            "ticket_id,subject,message",
+            "ticket-1,Export help,How do I export reports?",
+            "ticket-2,Billing help,Invoice portal is wrong,lead@example.com",
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CsvCustomerDataParseError) as exc:
+        load_source_rows_from_file(path, file_format="csv")
+
+    detail = exc.value.as_dict()
+    assert detail["code"] == "csv_inconsistent_columns"
+    assert detail["row_index"] == 3
+    assert "more cells than the header" in detail["message"]
+    assert "lead@example.com" not in json.dumps(detail)
+
+
 def test_load_source_rows_rejects_collapsed_mixed_delimiter_at_threshold(
     tmp_path: Path,
 ) -> None:
@@ -380,11 +461,17 @@ def test_load_source_rows_rejects_collapsed_mixed_delimiter_at_threshold(
         f"ticket-{index},Export help,How do I export report {index}?"
         for index in range(1, 10)
     )
-    lines.append("ticket-bad;Billing help;Invoice portal is wrong")
+    lines.append("ticket-bad;Billing help;Invoice portal is wrong for lead@example.com")
     path.write_text("\n".join(lines), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="first collapsed mixed-delimiter row 11"):
+    with pytest.raises(CsvCustomerDataParseError) as exc:
         load_source_rows_from_file(path, file_format="csv")
+
+    detail = exc.value.as_dict()
+    assert detail["code"] == "csv_inconsistent_columns"
+    assert detail["row_index"] == 11
+    assert "first collapsed mixed-delimiter row 11" in detail["message"]
+    assert "lead@example.com" not in json.dumps(detail)
 
 
 def test_load_source_rows_allows_single_column_message_with_delimiters(

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -460,6 +460,93 @@ async def test_deflection_submit_upload_skips_provider_metadata_header() -> None
     }]
 
 
+@pytest.mark.asyncio
+async def test_deflection_submit_upload_structures_missing_header_csv_error() -> None:
+    data = _csv_bytes([
+        "Need export help",
+        "Invoice portal is wrong",
+    ])
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await api_module._load_deflection_submit_upload_rows(
+            _Upload(data),
+            max_bytes=1024,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "code": "csv_missing_header",
+        "message": "CSV customer data must include a header row.",
+        "how_to_fix": (
+            "Add a header row with column names such as ticket_id, subject, "
+            "and message, then export the CSV again."
+        ),
+        "reason": "deflection_submit_csv_parse_error",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_upload_structures_encoding_csv_error() -> None:
+    data = b"\x00" * 128
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await api_module._load_deflection_submit_upload_rows(
+            _Upload(data),
+            max_bytes=1024,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["reason"] == "deflection_submit_csv_parse_error"
+    assert exc.value.detail["code"] == "csv_encoding_error"
+    assert "NUL-heavy" in exc.value.detail["message"]
+    assert "UTF-8 or UTF-16" in exc.value.detail["how_to_fix"]
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_upload_structures_malformed_bom_csv_error() -> None:
+    data = b"\xff\xfeticket_id\x00\xff"
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await api_module._load_deflection_submit_upload_rows(
+            _Upload(data),
+            max_bytes=1024,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["reason"] == "deflection_submit_csv_parse_error"
+    assert exc.value.detail["code"] == "csv_encoding_error"
+    assert "utf-16" in exc.value.detail["message"]
+    assert "UTF-8 or UTF-16" in exc.value.detail["how_to_fix"]
+
+
+def test_deflection_submit_blob_structures_inconsistent_columns_csv_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    _install_blob(
+        monkeypatch,
+        _csv_bytes([
+            "ticket_id,subject,message",
+            "ticket-1,Export help,How do I export reports?",
+            "ticket-2,Billing help,Invoice portal is wrong,lead@example.com",
+        ]),
+    )
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        api_module._load_deflection_submit_blob_rows_sync(
+            "https://portfolio.example/blob/tickets.csv",
+            max_bytes=2048,
+        )
+
+    detail_json = json.dumps(exc.value.detail)
+    assert exc.value.status_code == 400
+    assert exc.value.detail["reason"] == "deflection_submit_csv_parse_error"
+    assert exc.value.detail["code"] == "csv_inconsistent_columns"
+    assert exc.value.detail["row_index"] == 3
+    assert "more cells than the header" in exc.value.detail["message"]
+    assert "lead@example.com" not in detail_json
+
+
 def _router(
     store: InMemoryDeflectionReportArtifactStore,
 ):


### PR DESCRIPTION
Plan: plans/PR-Deflection-CSV-Parser-Error-UX.md
Slice phase: Production hardening

Deflection CSV submit currently collapses parser-specific failures into generic "could not be parsed" strings, so users can tell an upload failed but not whether they need to add a header, fix encoding, or repair inconsistent columns. This PR classifies those failures at the shared CSV parser boundary and returns only safe structured correction guidance at the upload/blob submit surface.

## Intentional
- Preserve the existing successful parser API and ValueError compatibility.
- Do not include raw CSV row text in user-facing parse details.
- Keep JSON/full-thread parse error UX and parser API widening deferred.

## Deferred
- Parser API widening remains a later issue after parser error UX.
- Ingestion-file and CLI presentation of these structured parse errors is deferred unless a later slice needs it.

## AI Reconciliation
All fixed or waived: yes.

- Fixed Codex/reviewer malformed BOM encoding finding: BOM-prefixed malformed UTF-16/UTF-32 CSVs now return structured `csv_encoding_error` details instead of falling back to generic parse errors.
- Fixed Codex/reviewer delimiter-consistency proof finding: mixed-delimiter consistency failures now have a direct structured-error regression with no raw row content in the detail.

## Parked hardening
- None.

## Verification
- Focused pytest for the campaign source adapter and deflection submit suites passed with 190 tests.
- The extracted pipeline check bundle passed: extracted reasoning core checks passed with 295 tests, then extracted content pipeline checks passed with 4,409 tests and 10 skipped.
- Local PR review passed before push.

## Diff size
5 files, +383 / -15
