### PR TITLE
Deflection CSV parser API widening

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -45,8 +45,8 @@ from ..campaign_ports import TenantScope
 from ..campaign_customer_data import CsvCustomerDataParseError
 from ..brand_voice import BrandVoiceProfile, brand_voice_profile_from_mapping
 from ..campaign_postgres_import import import_campaign_opportunities
+from ..campaign_source_adapters import load_csv_source_rows_result_from_file
 from ..campaign_source_adapters import source_material_to_source_rows
-from ..campaign_source_adapters import load_source_rows_with_warnings_from_file
 from ..content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
@@ -159,6 +159,21 @@ _DEFLECTION_SUBMIT_PLATFORMS = frozenset({
     "other",
 })
 _DEFLECTION_SUBMIT_IMPORTER_MODES = frozenset({"csv", "full_thread"})
+
+
+@dataclass(frozen=True)
+class _DeflectionSubmitRowsLoad:
+    rows: list[Any]
+    byte_count: int
+    warnings: tuple[dict[str, Any], ...]
+    source_row_count: int | None = None
+
+    def __iter__(self):
+        yield self.rows
+        yield self.byte_count
+        yield self.warnings
+
+
 _UPLOAD_FILE_FORMATS = ("auto", "json", "jsonl", "csv")
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _MAX_FALSIFICATION_RULES = 20
@@ -1285,6 +1300,7 @@ def create_content_ops_control_surface_router(
             byte_count,
             byte_count_key,
             csv_load_warnings,
+            parser_source_row_count,
         ) = await _load_deflection_submit_rows_from_request(
             request,
             max_bytes=_MAX_DEFLECTION_SUBMIT_BLOB_BYTES,
@@ -1307,7 +1323,7 @@ def create_content_ops_control_surface_router(
                     ),
                 },
             )
-        loaded_row_count = len(rows)
+        loaded_row_count = parser_source_row_count or len(rows)
         rows, language_filtered_row_count = _deflection_submit_english_rows(rows)
         if not rows:
             raise HTTPException(
@@ -1319,7 +1335,11 @@ def create_content_ops_control_surface_router(
                     "language_filtered_row_count": language_filtered_row_count,
                 },
             )
-        raw_row_count = len(rows)
+        raw_row_count = (
+            len(rows)
+            if language_filtered_row_count
+            else parser_source_row_count or len(rows)
+        )
         max_rows = _deflection_submit_max_rows(data.get("limit"), raw_row_count)
         submitted_rows = _deflection_submit_rows_with_defaults(data, rows)[:max_rows]
         title = _deflection_submit_title(data)
@@ -1385,7 +1405,14 @@ async def _load_deflection_submit_rows_from_request(
     request: Any,
     *,
     max_bytes: int,
-) -> tuple[dict[str, Any], list[Any], int, str, tuple[dict[str, Any], ...]]:
+) -> tuple[
+    dict[str, Any],
+    list[Any],
+    int,
+    str,
+    tuple[dict[str, Any], ...],
+    int | None,
+]:
     if _is_deflection_submit_http_request(request):
         content_type = _request_content_type(request)
         if "multipart/form-data" in content_type:
@@ -1412,7 +1439,7 @@ async def _load_deflection_submit_rows_from_request(
                     json_file,
                     max_bytes=max_bytes,
                 )
-                return data, rows, byte_count, "uploaded_bytes", load_warnings
+                return data, rows, byte_count, "uploaded_bytes", load_warnings, None
             json_file = form.get("json_file") if hasattr(form, "get") else None
             if json_file is not None:
                 raise HTTPException(
@@ -1422,11 +1449,19 @@ async def _load_deflection_submit_rows_from_request(
             csv_file = form.get("csv_file") if hasattr(form, "get") else None
             if csv_file is None:
                 raise HTTPException(status_code=422, detail="csv_file is required")
-            rows, byte_count, load_warnings = await _load_deflection_submit_upload_rows(
+            loaded = await _load_deflection_submit_upload_rows(
                 csv_file,
                 max_bytes=max_bytes,
+                max_rows=_deflection_submit_parse_max_rows(data.get("limit")),
             )
-            return data, rows, byte_count, "uploaded_bytes", load_warnings
+            return (
+                data,
+                loaded.rows,
+                loaded.byte_count,
+                "uploaded_bytes",
+                loaded.warnings,
+                loaded.source_row_count,
+            )
 
         try:
             payload = await request.json()
@@ -1436,20 +1471,36 @@ async def _load_deflection_submit_rows_from_request(
                 detail="JSON deflection submit body could not be parsed.",
             ) from exc
         data = _deflection_submit_payload_to_mapping(payload)
-        rows, byte_count, load_warnings = await _load_deflection_submit_blob_rows(
+        loaded = await _load_deflection_submit_blob_rows(
             data["blob_url"],
             max_bytes=max_bytes,
             importer_mode=data.get("importer_mode") or "csv",
+            max_rows=_deflection_submit_parse_max_rows(data.get("limit")),
         )
-        return data, rows, byte_count, "blob_bytes", load_warnings
+        return (
+            data,
+            loaded.rows,
+            loaded.byte_count,
+            "blob_bytes",
+            loaded.warnings,
+            loaded.source_row_count,
+        )
 
     data = _deflection_submit_payload_to_mapping(request)
-    rows, byte_count, load_warnings = await _load_deflection_submit_blob_rows(
+    loaded = await _load_deflection_submit_blob_rows(
         data["blob_url"],
         max_bytes=max_bytes,
         importer_mode=data.get("importer_mode") or "csv",
+        max_rows=_deflection_submit_parse_max_rows(data.get("limit")),
     )
-    return data, rows, byte_count, "blob_bytes", load_warnings
+    return (
+        data,
+        loaded.rows,
+        loaded.byte_count,
+        "blob_bytes",
+        loaded.warnings,
+        loaded.source_row_count,
+    )
 
 
 def _is_deflection_submit_http_request(value: Any) -> bool:
@@ -1513,6 +1564,12 @@ def _deflection_submit_max_rows(limit: Any, raw_row_count: int) -> int:
     if limit is None:
         return raw_row_count
     return min(int(limit), raw_row_count)
+
+
+def _deflection_submit_parse_max_rows(limit: Any) -> int | None:
+    if limit is None:
+        return None
+    return int(limit)
 
 
 async def _inspect_uploaded_ingestion_file(
@@ -1580,12 +1637,14 @@ async def _load_deflection_submit_blob_rows(
     *,
     max_bytes: int,
     importer_mode: str = "csv",
-) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    max_rows: int | None = None,
+) -> _DeflectionSubmitRowsLoad:
     return await asyncio.to_thread(
         _load_deflection_submit_blob_rows_sync,
         blob_url,
         max_bytes,
         importer_mode,
+        max_rows,
     )
 
 
@@ -1593,7 +1652,8 @@ async def _load_deflection_submit_upload_rows(
     csv_file: Any,
     *,
     max_bytes: int,
-) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    max_rows: int | None = None,
+) -> _DeflectionSubmitRowsLoad:
     temp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -1616,6 +1676,7 @@ async def _load_deflection_submit_upload_rows(
             temp_path,
             byte_count=byte_count,
             parse_error_detail="Uploaded CSV could not be parsed.",
+            max_rows=max_rows,
         )
     finally:
         if temp_path is not None:
@@ -1710,13 +1771,19 @@ def _load_deflection_submit_blob_rows_sync(
     blob_url: str,
     max_bytes: int,
     importer_mode: str = "csv",
-) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    max_rows: int | None = None,
+) -> _DeflectionSubmitRowsLoad:
     if importer_mode == "full_thread":
-        return _load_deflection_submit_json_blob_rows_sync(
+        rows, byte_count, warnings = _load_deflection_submit_json_blob_rows_sync(
             blob_url,
             max_bytes=max_bytes,
         )
-    return _load_deflection_submit_csv_blob_rows_sync(blob_url, max_bytes=max_bytes)
+        return _DeflectionSubmitRowsLoad(rows, byte_count, warnings)
+    return _load_deflection_submit_csv_blob_rows_sync(
+        blob_url,
+        max_bytes=max_bytes,
+        max_rows=max_rows,
+    )
 
 
 def _load_deflection_submit_json_blob_rows_sync(
@@ -1762,7 +1829,8 @@ def _load_deflection_submit_csv_blob_rows_sync(
     blob_url: str,
     *,
     max_bytes: int,
-) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    max_rows: int | None = None,
+) -> _DeflectionSubmitRowsLoad:
     temp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -1785,6 +1853,7 @@ def _load_deflection_submit_csv_blob_rows_sync(
             temp_path,
             byte_count=byte_count,
             parse_error_detail="Blob CSV could not be parsed.",
+            max_rows=max_rows,
         )
     finally:
         if temp_path is not None:
@@ -1882,11 +1951,12 @@ def _parse_deflection_submit_csv_file(
     *,
     byte_count: int,
     parse_error_detail: str,
-) -> tuple[list[Any], int, tuple[dict[str, Any], ...]]:
+    max_rows: int | None = None,
+) -> _DeflectionSubmitRowsLoad:
     try:
-        rows, load_warnings = load_source_rows_with_warnings_from_file(
+        result = load_csv_source_rows_result_from_file(
             temp_path,
-            file_format="csv",
+            max_rows=max_rows,
         )
     except CsvCustomerDataParseError as exc:
         raise HTTPException(
@@ -1898,7 +1968,12 @@ def _parse_deflection_submit_csv_file(
             status_code=400,
             detail=parse_error_detail,
         ) from exc
-    return rows, byte_count, tuple(warning.as_dict() for warning in load_warnings)
+    return _DeflectionSubmitRowsLoad(
+        rows=result.rows,
+        byte_count=byte_count,
+        warnings=tuple(warning.as_dict() for warning in result.warnings),
+        source_row_count=result.source_row_count,
+    )
 
 
 def _deflection_submit_csv_parse_error_detail(

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1323,7 +1323,9 @@ def create_content_ops_control_surface_router(
                     ),
                 },
             )
-        loaded_row_count = parser_source_row_count or len(rows)
+        source_row_count = parser_source_row_count or len(rows)
+        loaded_row_count = source_row_count
+        loaded_included_row_count = len(rows)
         rows, language_filtered_row_count = _deflection_submit_english_rows(rows)
         if not rows:
             raise HTTPException(
@@ -1335,13 +1337,15 @@ def create_content_ops_control_surface_router(
                     "language_filtered_row_count": language_filtered_row_count,
                 },
             )
-        raw_row_count = (
-            len(rows)
-            if language_filtered_row_count
-            else parser_source_row_count or len(rows)
-        )
-        max_rows = _deflection_submit_max_rows(data.get("limit"), raw_row_count)
+        max_rows = _deflection_submit_max_rows(data.get("limit"), source_row_count)
         submitted_rows = _deflection_submit_rows_with_defaults(data, rows)[:max_rows]
+        truncated_row_count = _deflection_submit_truncated_row_count(
+            source_row_count=source_row_count,
+            loaded_included_row_count=loaded_included_row_count,
+            eligible_row_count=len(rows),
+            submitted_row_count=len(submitted_rows),
+            parser_source_row_count=parser_source_row_count,
+        )
         title = _deflection_submit_title(data)
         package = build_support_ticket_input_package(
             submitted_rows,
@@ -1364,7 +1368,7 @@ def create_content_ops_control_surface_router(
                     "message": (
                         f"{source_label} did not include usable support-ticket wording."
                     ),
-                    "source_row_count": raw_row_count,
+                    "source_row_count": source_row_count,
                     "max_source_material_rows": max_rows,
                 },
             )
@@ -1388,8 +1392,9 @@ def create_content_ops_control_surface_router(
             byte_count=byte_count,
             max_rows=max_rows,
             loaded_row_count=loaded_row_count,
-            source_row_count=raw_row_count,
+            source_row_count=source_row_count,
             submitted_row_count=len(submitted_rows),
+            truncated_row_count=truncated_row_count,
             language_filtered_row_count=language_filtered_row_count,
             csv_load_warnings=csv_load_warnings,
             package=package.as_dict(),
@@ -1564,6 +1569,23 @@ def _deflection_submit_max_rows(limit: Any, raw_row_count: int) -> int:
     if limit is None:
         return raw_row_count
     return min(int(limit), raw_row_count)
+
+
+def _deflection_submit_truncated_row_count(
+    *,
+    source_row_count: int,
+    loaded_included_row_count: int,
+    eligible_row_count: int,
+    submitted_row_count: int,
+    parser_source_row_count: int | None,
+) -> int:
+    parser_truncated = (
+        max(0, source_row_count - loaded_included_row_count)
+        if parser_source_row_count is not None
+        else 0
+    )
+    post_filter_truncated = max(0, eligible_row_count - submitted_row_count)
+    return parser_truncated + post_filter_truncated
 
 
 def _deflection_submit_parse_max_rows(limit: Any) -> int | None:
@@ -2379,6 +2401,7 @@ def _with_deflection_submit_diagnostics(
     loaded_row_count: int,
     source_row_count: int,
     submitted_row_count: int,
+    truncated_row_count: int,
     language_filtered_row_count: int,
     package: Mapping[str, Any],
     support_platform: str,
@@ -2428,7 +2451,6 @@ def _with_deflection_submit_diagnostics(
                 )
                 if key in package_metadata
             })
-    truncated_row_count = max(0, source_row_count - submitted_row_count)
     metadata.update({
         "source": "portfolio_deflection_submit",
         "source_row_count": source_row_count,

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -145,6 +145,23 @@ class CsvCustomerDataParseError(ValueError):
 
 
 @dataclass(frozen=True)
+class CsvDictRowsLoadResult:
+    """CSV rows plus parser-level count metadata."""
+
+    rows: list[dict[str, Any]]
+    warnings: tuple[CampaignOpportunityWarning, ...]
+    source_row_count: int
+
+    @property
+    def included_row_count(self) -> int:
+        return len(self.rows)
+
+    @property
+    def truncated_row_count(self) -> int:
+        return max(0, self.source_row_count - self.included_row_count)
+
+
+@dataclass(frozen=True)
 class _CsvDelimiterCandidate:
     delimiter: str
     quotechar: str
@@ -437,7 +454,20 @@ def _load_csv_dict_rows(
     *,
     value_coercer: Callable[[Any], Any] | None = None,
 ) -> tuple[list[dict[str, Any]], tuple[CampaignOpportunityWarning, ...]]:
+    result = _load_csv_dict_rows_result(path, value_coercer=value_coercer)
+    return result.rows, result.warnings
+
+
+def _load_csv_dict_rows_result(
+    path: Path,
+    *,
+    value_coercer: Callable[[Any], Any] | None = None,
+    max_rows: int | None = None,
+) -> CsvDictRowsLoadResult:
+    if max_rows is not None and max_rows < 1:
+        raise ValueError("max_rows must be at least 1")
     rows: list[dict[str, Any]] = []
+    source_row_count = 0
     encoding_plan = _csv_encoding_plan(path)
     candidate = _select_csv_delimiter_for_path(path, encoding_plan)
     header_index = candidate.header_index
@@ -483,6 +513,7 @@ def _load_csv_dict_rows(
                 continue
             if not any(str(value or "").strip() for value in values):
                 continue
+            source_row_count += 1
             if len(values) > header_width:
                 raise _csv_inconsistent_columns_error(
                     f"CSV row {row_index} has more cells than the header.",
@@ -499,7 +530,8 @@ def _load_csv_dict_rows(
                 cleaned_value = value_coercer(value) if value_coercer else value
                 if cleaned_value not in (None, ""):
                     cleaned[cleaned_key] = cleaned_value
-            rows.append(cleaned)
+            if max_rows is None or len(rows) < max_rows:
+                rows.append(cleaned)
     if not header_fields or consistency is None:
         raise _csv_missing_header_error()
     consistency_candidate = consistency.as_candidate(quotechar=candidate.quotechar)
@@ -510,7 +542,11 @@ def _load_csv_dict_rows(
         first_leading_row,
         header_index,
     )
-    return rows, load_warnings
+    return CsvDictRowsLoadResult(
+        rows=rows,
+        warnings=load_warnings,
+        source_row_count=source_row_count,
+    )
 
 
 def _csv_missing_header_error() -> CsvCustomerDataParseError:
@@ -1318,6 +1354,7 @@ def _matches_filters(
 __all__ = [
     "CampaignOpportunityLoadResult",
     "CampaignOpportunityWarning",
+    "CsvDictRowsLoadResult",
     "CsvCustomerDataParseError",
     "FileIntelligenceRepository",
     "load_campaign_opportunities_from_file",

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -12,7 +12,8 @@ from typing import Any, Literal
 from .campaign_customer_data import (
     CampaignOpportunityLoadResult,
     CampaignOpportunityWarning,
-    _load_csv_dict_rows,
+    CsvDictRowsLoadResult,
+    _load_csv_dict_rows_result,
     normalize_campaign_opportunity_rows,
 )
 from .campaign_opportunities import normalize_campaign_opportunity
@@ -395,6 +396,23 @@ class SourceRowAdmissionDiagnostics:
         return payload
 
 
+@dataclass(frozen=True)
+class SourceRowsLoadResult:
+    """Source rows plus parser-level count metadata."""
+
+    rows: list[Any]
+    warnings: tuple[CampaignOpportunityWarning, ...]
+    source_row_count: int
+
+    @property
+    def included_row_count(self) -> int:
+        return len(self.rows)
+
+    @property
+    def truncated_row_count(self) -> int:
+        return max(0, self.source_row_count - self.included_row_count)
+
+
 class _SourceFieldLookup(Mapping[str, Any]):
     """Mapping wrapper that caches string-key alias lookups for one source row."""
 
@@ -496,6 +514,16 @@ def load_source_rows_with_warnings_from_file(
     """Load source rows plus non-fatal load warnings (e.g. skipped prologue rows)."""
 
     return _load_source_rows(Path(path), file_format=file_format)
+
+
+def load_csv_source_rows_result_from_file(
+    path: str | Path,
+    *,
+    max_rows: int | None = None,
+) -> SourceRowsLoadResult:
+    """Load CSV source rows with source/included/truncated row counts."""
+
+    return _load_source_csv_rows_result(Path(path), max_rows=max_rows)
 
 
 def source_rows_to_campaign_opportunities(
@@ -897,7 +925,24 @@ def _is_safe_parent_value(value: Any) -> bool:
 def _load_source_csv_rows(
     path: Path,
 ) -> tuple[list[dict[str, Any]], tuple[CampaignOpportunityWarning, ...]]:
-    return _load_csv_dict_rows(path)
+    result = _load_source_csv_rows_result(path)
+    return result.rows, result.warnings
+
+
+def _load_source_csv_rows_result(
+    path: Path,
+    *,
+    max_rows: int | None = None,
+) -> SourceRowsLoadResult:
+    result: CsvDictRowsLoadResult = _load_csv_dict_rows_result(
+        path,
+        max_rows=max_rows,
+    )
+    return SourceRowsLoadResult(
+        rows=list(result.rows),
+        warnings=result.warnings,
+        source_row_count=result.source_row_count,
+    )
 
 
 def _resolve_format(
@@ -1147,8 +1192,10 @@ def _compact_field_key(key: str) -> str:
 
 __all__ = [
     "SourceDataFormat",
+    "SourceRowsLoadResult",
     "SourceRowAdmissionDiagnostics",
     "build_source_row_admission_diagnostics",
+    "load_csv_source_rows_result_from_file",
     "load_source_campaign_opportunities_from_file",
     "load_source_rows_from_file",
     "load_source_rows_with_warnings_from_file",

--- a/plans/PR-Deflection-CSV-Parser-API-Widening.md
+++ b/plans/PR-Deflection-CSV-Parser-API-Widening.md
@@ -1,0 +1,111 @@
+# PR-Deflection-CSV-Parser-API-Widening
+
+## Why this slice exists
+
+Issue #1615 is the deferred third step from #1458. PR #1610 removed avoidable
+full-file parser copies while preserving the tuple API. PR #1614 added safe
+structured parser error UX. The remaining gap is contract shape: the parser can
+stream internally, but CSV callers still receive only `(rows, warnings)`, so the
+deflection submit path has to parse all rows before applying its row cap and
+cannot represent parser-level source/count/truncation metadata directly.
+
+This slice widens the CSV parser API at the narrowest correct boundary. Existing
+tuple callers stay compatible, while deflection submit can request a capped CSV
+load result that carries source row count, included row count, and truncation
+metadata.
+
+The synced diff is slightly over the 400 LOC soft cap because the slice has to
+land the parser result type, the deflection submit wiring, and both adapter-level
+and route-level regression tests together. Splitting the tests from the API
+widening would leave the new contract under-proven.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+Slice phase: Production hardening
+
+1. Add a structured CSV load result for source rows with `rows`, `warnings`,
+   `source_row_count`, `included_row_count`, and `truncated_row_count`.
+2. Preserve existing tuple APIs for successful parser callers.
+3. Route deflection CSV upload/blob submits through the widened CSV result so
+   the submit `limit` can cap rows during parse while retaining honest source
+   row and truncation metadata.
+4. Add focused parser/adapter and deflection-submit regressions for capped,
+   uncapped, warnings-preserving, and compatibility behavior.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `plans/PR-Deflection-CSV-Parser-API-Widening.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Existing CSV tuple callers still receive the same `(rows, warnings)`
+        shape for uncapped successful parses.
+  - [ ] A new CSV result API reports source row count, included row count, and
+        truncated row count without including raw row content in metadata.
+  - [ ] Deflection CSV submit applies `limit` at parse time and still reports
+        source row count, submitted row count, and truncation warnings honestly.
+  - [ ] CSV load warnings such as skipped prologue rows survive the widened API.
+  - [ ] JSON and Zendesk full-thread submit behavior is unchanged.
+- Affected surfaces: extracted package parser, source adapter API, deflection
+  submit API, tests, CI enrollment.
+- Risk areas: backcompat, parser correctness, user input safety, metadata
+  truthfulness, performance.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R7, R10, R12, R14.
+
+## Mechanism
+
+Add a small dataclass for CSV source-row load results. The existing private CSV
+loader can build that result while still backing the old tuple-returning helper.
+The cap is parser-local: it counts every non-empty data row that passes CSV
+shape validation, appends only the first requested rows, and reports truncation
+from the difference between source and included row counts.
+
+Expose the result through `campaign_source_adapters` with a CSV-specific helper
+instead of widening JSON/JSONL loaders in the same PR. Deflection submit uses
+the helper for CSV upload and blob paths. JSON/Zendesk full-thread paths keep
+their current tuple shape.
+
+## Intentional
+
+- This is CSV-only. JSON and Zendesk full-thread sources already have separate
+  parser contracts and should not be pulled into this slice unless a later
+  shared result type is warranted.
+- The old tuple API remains in place. This avoids a broad migration of campaign
+  generation, ingestion diagnostics, and other source-row callers.
+- The result metadata is numeric only. It does not include row previews, field
+  values, or customer content.
+
+## Deferred
+
+- A broader generic source-row result type for JSON/JSONL/full-thread imports is
+  deferred until a caller actually needs shared metadata across formats.
+- Further upload UX around parser caps is deferred; this slice only preserves
+  existing diagnostics and makes their counts parser-backed.
+
+Parked hardening: none.
+
+## Verification
+
+- `.venv/bin/python -m compileall -q extracted_content_pipeline/campaign_customer_data.py extracted_content_pipeline/campaign_source_adapters.py extracted_content_pipeline/api/control_surfaces.py` — passed.
+- `.venv/bin/python -m pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_deflection_submit.py` — 194 passed.
+- `bash` with `scripts/run_extracted_pipeline_checks.sh` — 4413 passed, 10 skipped.
+- `bash` with `scripts/local_pr_review.sh` and the PR body file — passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 117 |
+| `extracted_content_pipeline/campaign_customer_data.py` | 41 |
+| `extracted_content_pipeline/campaign_source_adapters.py` | 51 |
+| `plans/PR-Deflection-CSV-Parser-API-Widening.md` | 111 |
+| `tests/test_extracted_campaign_source_adapters.py` | 47 |
+| `tests/test_extracted_content_deflection_submit.py` | 71 |
+| **Total** | **438** |

--- a/plans/PR-Deflection-CSV-Parser-API-Widening.md
+++ b/plans/PR-Deflection-CSV-Parser-API-Widening.md
@@ -14,10 +14,16 @@ tuple callers stay compatible, while deflection submit can request a capped CSV
 load result that carries source row count, included row count, and truncation
 metadata.
 
-The synced diff is slightly over the 400 LOC soft cap because the slice has to
-land the parser result type, the deflection submit wiring, and both adapter-level
-and route-level regression tests together. Splitting the tests from the API
-widening would leave the new contract under-proven.
+The synced diff is over the 400 LOC soft cap because the slice has to land the
+parser result type, the deflection submit wiring, the review-finding fix, and
+both adapter-level and route-level regression tests together. Splitting the
+tests from the API widening would leave the new contract under-proven.
+
+Review update: Codex thread #1342 found that the first version reused the
+post-language row count as the source/truncation basis, hiding parser-cap
+truncation when a non-English row appeared inside the capped prefix. This update
+fixes the root by separating total parser source count, loaded included count,
+post-language eligible count, submitted count, and explicit truncation count.
 
 ## Scope (this PR)
 
@@ -70,7 +76,9 @@ from the difference between source and included row counts.
 Expose the result through `campaign_source_adapters` with a CSV-specific helper
 instead of widening JSON/JSONL loaders in the same PR. Deflection submit uses
 the helper for CSV upload and blob paths. JSON/Zendesk full-thread paths keep
-their current tuple shape.
+their current tuple shape. Submit diagnostics compute truncation from the parser
+cap and post-filter submission separately, so language filtering cannot erase a
+real parser cap or create a fake truncation warning by itself.
 
 ## Intentional
 
@@ -94,7 +102,7 @@ Parked hardening: none.
 ## Verification
 
 - `.venv/bin/python -m compileall -q extracted_content_pipeline/campaign_customer_data.py extracted_content_pipeline/campaign_source_adapters.py extracted_content_pipeline/api/control_surfaces.py` — passed.
-- `.venv/bin/python -m pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_deflection_submit.py` — 194 passed.
+- `.venv/bin/python -m pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_deflection_submit.py` — 195 passed after review fix.
 - `bash` with `scripts/run_extracted_pipeline_checks.sh` — 4413 passed, 10 skipped.
 - `bash` with `scripts/local_pr_review.sh` and the PR body file — passed.
 
@@ -102,10 +110,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/api/control_surfaces.py` | 117 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 147 |
 | `extracted_content_pipeline/campaign_customer_data.py` | 41 |
 | `extracted_content_pipeline/campaign_source_adapters.py` | 51 |
-| `plans/PR-Deflection-CSV-Parser-API-Widening.md` | 111 |
+| `plans/PR-Deflection-CSV-Parser-API-Widening.md` | 119 |
 | `tests/test_extracted_campaign_source_adapters.py` | 47 |
-| `tests/test_extracted_content_deflection_submit.py` | 71 |
-| **Total** | **438** |
+| `tests/test_extracted_content_deflection_submit.py` | 133 |
+| **Total** | **538** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -10,6 +10,7 @@ import pytest
 from extracted_content_pipeline import campaign_source_adapters as adapters
 from extracted_content_pipeline.campaign_customer_data import CsvCustomerDataParseError
 from extracted_content_pipeline.campaign_source_adapters import (
+    load_csv_source_rows_result_from_file,
     load_source_campaign_opportunities_from_file,
     load_source_rows_from_file,
     load_source_rows_with_warnings_from_file,
@@ -316,6 +317,52 @@ def test_load_source_rows_finds_header_after_large_provider_preamble(
     assert [warning.code for warning in warnings] == ["csv_leading_rows_skipped"]
     assert warnings[0].row_index == 1
     assert "CSV header on row 2" in warnings[0].message
+
+
+def test_load_csv_source_rows_result_reports_counts_and_preserves_warnings(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets_capped.csv"
+    path.write_text(
+        "\n".join([
+            "Zendesk export metadata",
+            "ticket_id,subject,message",
+            "ticket-1,Export help,How do I export reports?",
+            "ticket-2,Billing help,Where can I download invoices?",
+            "ticket-3,Password help,How do I reset my password?",
+        ]),
+        encoding="utf-8",
+    )
+
+    result = load_csv_source_rows_result_from_file(path, max_rows=2)
+
+    assert result.source_row_count == 3
+    assert result.included_row_count == 2
+    assert result.truncated_row_count == 1
+    assert [row["ticket_id"] for row in result.rows] == ["ticket-1", "ticket-2"]
+    assert [warning.code for warning in result.warnings] == ["csv_leading_rows_skipped"]
+
+
+def test_load_source_rows_with_warnings_keeps_tuple_contract_after_result_api(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "support_tickets.csv"
+    path.write_text(
+        "\n".join([
+            "ticket_id,subject,message",
+            "ticket-1,Export help,How do I export reports?",
+        ]),
+        encoding="utf-8",
+    )
+
+    rows, warnings = load_source_rows_with_warnings_from_file(path, file_format="csv")
+
+    assert rows == [{
+        "ticket_id": "ticket-1",
+        "subject": "Export help",
+        "message": "How do I export reports?",
+    }]
+    assert warnings == ()
 
 
 def test_load_source_rows_keeps_comma_delimiter_when_body_has_tabs_semicolons(

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -461,6 +461,29 @@ async def test_deflection_submit_upload_skips_provider_metadata_header() -> None
 
 
 @pytest.mark.asyncio
+async def test_deflection_submit_upload_load_result_caps_rows_and_counts_source() -> None:
+    data = _csv_bytes([
+        "ticket_id,subject,message",
+        "ticket-1,Export help,How do I export attribution reports?",
+        "ticket-2,Billing help,Where can I download invoices?",
+        "ticket-3,Password help,How do I reset my password?",
+    ])
+
+    loaded = await api_module._load_deflection_submit_upload_rows(
+        _Upload(data),
+        max_bytes=2048,
+        max_rows=2,
+    )
+
+    assert loaded.source_row_count == 3
+    assert [row["ticket_id"] for row in loaded.rows] == ["ticket-1", "ticket-2"]
+    rows, byte_count, load_warnings = loaded
+    assert rows == loaded.rows
+    assert byte_count == len(data)
+    assert load_warnings == ()
+
+
+@pytest.mark.asyncio
 async def test_deflection_submit_upload_structures_missing_header_csv_error() -> None:
     data = _csv_bytes([
         "Need export help",
@@ -870,6 +893,54 @@ async def test_deflection_submit_defaults_to_all_rows_that_fit_upload_guard() ->
         "status": "locked",
         "reason": "payment_required",
     }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_request_limit_becomes_csv_parse_cap() -> None:
+    csv_data = _csv_bytes([
+        "ticket_id,subject,message,resolution_text,pain_category",
+        (
+            "ticket-export-1,Export attribution,"
+            "How do I export attribution reports?,"
+            "Open Analytics and click Download report.,exports"
+        ),
+        (
+            "ticket-export-2,Report download,"
+            "Where is the report download for attribution exports?,"
+            "Open Analytics and click Download report.,exports"
+        ),
+        "ticket-sso-1,SSO setup,How do I enable SSO for my team?,,auth",
+    ])
+
+    request = _FormRequest({
+        "csv_file": _Upload(csv_data),
+        "support_platform": "help-scout",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+        "limit": "2",
+    })
+
+    (
+        data,
+        rows,
+        byte_count,
+        byte_count_key,
+        load_warnings,
+        parser_source_row_count,
+    ) = await api_module._load_deflection_submit_rows_from_request(
+        request,
+        max_bytes=2048,
+    )
+
+    assert data["limit"] == 2
+    assert byte_count == len(csv_data)
+    assert byte_count_key == "uploaded_bytes"
+    assert load_warnings == ()
+    assert parser_source_row_count == 3
+    assert [row["ticket_id"] for row in rows] == [
+        "ticket-export-1",
+        "ticket-export-2",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -978,8 +978,9 @@ async def test_deflection_submit_filters_non_english_huggingface_shaped_rows() -
 
     metadata = payload["input_provider"]["metadata"]
     assert metadata["loaded_source_row_count"] == 2
-    assert metadata["source_row_count"] == 1
+    assert metadata["source_row_count"] == 2
     assert metadata["submitted_row_count"] == 1
+    assert metadata["truncated_row_count"] == 0
     assert metadata["included_row_count"] == 1
     assert metadata["language_filtered_row_count"] == 1
     assert metadata["support_ticket_resolution_evidence_count"] == 1
@@ -993,6 +994,65 @@ async def test_deflection_submit_filters_non_english_huggingface_shaped_rows() -
     assert snapshot["summary"]["support_ticket_resolution_evidence_count"] == 1
     assert snapshot["summary"]["drafted_answer_count"] == 1
     assert "Synchronisationsproblem" not in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_preserves_parser_truncation_after_language_filter() -> None:
+    csv_data = _csv_dict_bytes([
+        {
+            "ticket_id": "ticket-export-1",
+            "subject": "Export reports",
+            "body": "How do I export attribution reports?",
+            "answer": "Open Analytics and click Download report.",
+            "language": "en",
+            "queue": "Exports",
+        },
+        {
+            "ticket_id": "ticket-sync-de",
+            "subject": "Synchronisationsproblem",
+            "body": "Ich erfahre Schwierigkeiten bei der Synchronisation.",
+            "answer": "Bitte senden Sie aktuelle Fehlerprotokolle.",
+            "language": "de",
+            "queue": "Technical Support",
+        },
+        {
+            "ticket_id": "ticket-sso-1",
+            "subject": "SSO setup",
+            "body": "How do I enable SSO for my team?",
+            "answer": "Open Settings, then configure SAML SSO.",
+            "language": "en",
+            "queue": "Authentication",
+        },
+    ])
+    store = InMemoryDeflectionReportArtifactStore()
+    router = _router(store)
+
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    request = _FormRequest({
+        "csv_file": _Upload(csv_data),
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+        "limit": "2",
+    })
+    payload = await submit.endpoint(request)
+
+    metadata = payload["input_provider"]["metadata"]
+    assert metadata["loaded_source_row_count"] == 3
+    assert metadata["source_row_count"] == 3
+    assert metadata["submitted_row_count"] == 1
+    assert metadata["truncated_row_count"] == 1
+    assert metadata["max_source_material_rows"] == 2
+    assert metadata["language_filtered_row_count"] == 1
+    warnings = payload["input_provider"]["warnings"]
+    assert [warning["code"] for warning in warnings] == [
+        "deflection_submit_non_english_rows_filtered",
+        "deflection_submit_rows_truncated",
+    ]
+    assert warnings[1]["row_count"] == 3
+    assert warnings[1]["max_rows"] == 2
+    assert warnings[1]["truncated_row_count"] == 1
+    assert "ticket-sso-1" not in str(payload)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-CSV-Parser-API-Widening.md
Slice phase: Production hardening

Issue #1615 is the deferred parser API widening step after #1610 and #1614: CSV parsing can now stream internally and surface safe parser errors, but deflection submit still needs a result contract that can cap rows during parse while preserving honest source/count/truncation metadata.

## Intentional
- CSV-only result API; JSON and Zendesk full-thread contracts stay unchanged.
- Existing tuple callers keep their current `(rows, warnings)` shape.
- Numeric metadata only; no row previews or customer content are added to parser metadata.

## Deferred
- Generic source-row result types for JSON/JSONL/full-thread imports wait for a real shared caller.
- Further upload UX around parser caps is deferred.

## AI Reconciliation
All fixed or waived: yes.
- Codex #1342: fixed by separating parser source, loaded included, post-language eligible, submitted, and truncation counts. Added a cap-plus-language regression.
- Inherited #1613/#1578 raw-request-id extracted-check failure was outside this PR diff and is now resolved on `main` by #1619; this rebased head includes that remediation.

## Parked hardening
- None.

## Verification
- `.venv/bin/python -m compileall -q extracted_content_pipeline/campaign_customer_data.py extracted_content_pipeline/campaign_source_adapters.py extracted_content_pipeline/api/control_surfaces.py` — passed.
- `.venv/bin/python -m pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_deflection_submit.py` — 195 passed after review fix.
- `bash` with `scripts/run_extracted_pipeline_checks.sh` — 4413 passed, 10 skipped.
- `bash` with `scripts/local_pr_review.sh` and the PR body file — passed.

## Diff size
6 files, +508 / -30.