### PR TITLE
Deflection parser invariant test pack

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -314,6 +314,12 @@ _RESOLUTION_ACTION_TERMS = {
     "update",
     "verify",
 }
+_RESOLUTION_ACTION_IRREGULAR_PAST_TERMS = {
+    "chose": "choose",
+    "ran": "run",
+    "reran": "rerun",
+    "sent": "send",
+}
 _RESOLUTION_TOPIC_STOPWORDS = {
     "about",
     "after",
@@ -1826,6 +1832,9 @@ def _resolution_overlap_tokens(tokens: set[str]) -> set[str]:
 
 
 def _resolution_signal_token(token: str) -> str:
+    irregular = _RESOLUTION_ACTION_IRREGULAR_PAST_TERMS.get(token)
+    if irregular:
+        return irregular
     if len(token) > 4 and token.endswith("ies"):
         return f"{token[:-3]}y"
     if len(token) > 5 and token.endswith("ing"):

--- a/plans/PR-Deflection-Parser-Invariant-Test-Pack.md
+++ b/plans/PR-Deflection-Parser-Invariant-Test-Pack.md
@@ -1,0 +1,113 @@
+# PR-Deflection-Parser-Invariant-Test-Pack
+
+## Why this slice exists
+
+#1471 tracks the deterministic half of the parser/admission hardening lane:
+recent deflection fixes repeatedly caught matching and projection boundary
+bugs after review rather than before push (#1439, #1446, #1453, #1466). The
+root cause is that mutable recognition sets and fail-closed snapshot contracts
+have only example-level coverage, so a future term/fold/field addition can
+break the class while the cited happy path stays green. This slice fixes the
+root for those deterministic classes by turning them into invariants.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-testing
+Slice phase: Robust testing
+
+1. Add an inflection-coverage invariant for FAQ resolution action terms.
+2. Add a fold-target invariant for support-ticket token and phrase folds.
+3. Generalize snapshot summary field-deletion checks across both portfolio-ui
+   snapshot projectors.
+4. Add the smallest upstream normalizer support needed for irregular
+   resolution-action past tense (`chose`, `ran`, `reran`, `sent`).
+
+### Review Contract
+
+Acceptance criteria:
+- Every `_RESOLUTION_ACTION_TERMS` entry recognizes generated standard
+  inflections through the real `_resolution_signal_token` path.
+- Every non-empty `_TOKEN_FOLDS` target and `_PHRASE_FOLDS` replacement token
+  survives `support_ticket_tokens(...)`.
+- Dropping any required snapshot summary field invalidates `projectSnapshot`
+  and the React fallback guard instead of defaulting to `0`/empty values.
+- Existing CI enrollment remains intact: touched Python tests are already in
+  `run_extracted_pipeline_checks.sh`, and touched portfolio-ui scripts are
+  already in `.github/workflows/portfolio_ui_checks.yml`.
+
+Affected surfaces:
+- Extracted content-pipeline parser/FAQ tests.
+- portfolio-ui result-page/proxy contract tests as legacy/Vite maintenance
+  because #1471 names those projectors. This is not buyer-page coverage for
+  the atlas-portfolio Next.js result route.
+
+Risk areas:
+- Over-generating non-standard inflections and creating brittle tests.
+- Source-only React fallback checks are weaker than executing TSX directly;
+  this PR keeps the current local test style but sweeps every required field.
+
+Reviewer rules triggered: R1, R2, R8, R10, R12, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Parser-Invariant-Test-Pack.md`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+## Mechanism
+
+- Generate a bounded set of standard action-term inflections in the test file
+  and assert each maps back to its canonical action term through the real
+  token normalizer.
+- Import the clustering fold tables in the support-ticket input-package test
+  and assert each emitted fold target remains visible after normal
+  tokenization.
+- Replace single-field snapshot omission checks with required-field sweeps for
+  `projectSnapshot` and the React fallback guard.
+
+## Intentional
+
+- Production behavior changes are limited to the upstream
+  `_resolution_signal_token` irregular past-tense map needed by the invariant;
+  no parser/admission envelope behavior changes.
+- The low non-zero CSV admission threshold from #1467 remains deferred until a
+  real partial provider CSV justifies warn-vs-reject product policy.
+- The React fallback test continues to inspect the TSX source because the
+  existing portfolio-ui test harness is source-based for that component.
+- The portfolio-ui snapshot field sweep is legacy/Vite projector maintenance,
+  not a claim that this PR tests the buyer-facing atlas-portfolio Next.js
+  results page.
+
+## Deferred
+
+- #1467 parser-breakage evidence runner: generate the adversarial admission
+  matrix and score fail-closed vs fail-open mechanics.
+- #1467 low non-zero usable-ratio reject threshold: blocked on real partial
+  provider CSV evidence, not synthetic ratios.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py -q` -- 464 passed.
+- `pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` -- 1 passed.
+- `npm --prefix portfolio-ui run test:deflection-atlas-proxy` -- passed.
+- `npm --prefix portfolio-ui run test:deflection-result` -- passed.
+- `./scripts/run_extracted_pipeline_checks.sh` -- 4545 passed, 10 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 9 |
+| `plans/PR-Deflection-Parser-Invariant-Test-Pack.md` | 113 |
+| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 72 |
+| `portfolio-ui/scripts/faq-deflection-result-page.test.mjs` | 57 |
+| `tests/test_extracted_content_deflection_submit.py` | 13 |
+| `tests/test_extracted_support_ticket_input_package.py` | 12 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 70 |
+| **Total** | **346** |

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -37,6 +37,15 @@ const SNAPSHOT = {
   ],
 };
 
+const REQUIRED_SNAPSHOT_SUMMARY_FIELDS = [
+  "generated",
+  "repeat_ticket_count",
+  "drafted_answer_count",
+  "no_proven_answer_count",
+  "support_ticket_resolution_evidence_present",
+  "support_ticket_resolution_evidence_count",
+];
+
 const EVIDENCE_EXPORT = {
   schema_version: "deflection_evidence.v1",
   summary: {
@@ -263,51 +272,26 @@ await test("snapshot projection only returns known safe fields", async () => {
   ]);
 });
 
-await test("proxy rejects snapshots that omit repeat-ticket counts", async () => {
-  const { repeat_ticket_count: _repeatTicketCount, ...summaryWithoutRepeatCount } =
-    SNAPSHOT.summary;
-  const missingRepeatCount = {
-    ...SNAPSHOT,
-    summary: summaryWithoutRepeatCount,
-  };
-  const result = await loadDeflectionReport({
-    requestId: REQUEST_ID,
-    accountId: ACCOUNT_ID,
-    env: ENV,
-    fetchImpl: mockFetch([response(missingRepeatCount, 200)]).fetchImpl,
-  });
+await test("proxy rejects snapshots that omit required summary fields", async () => {
+  for (const field of REQUIRED_SNAPSHOT_SUMMARY_FIELDS) {
+    const { [field]: _omitted, ...summaryWithoutField } = SNAPSHOT.summary;
+    const result = await loadDeflectionReport({
+      requestId: REQUEST_ID,
+      accountId: ACCOUNT_ID,
+      env: ENV,
+      fetchImpl: mockFetch([response({ ...SNAPSHOT, summary: summaryWithoutField }, 200)])
+        .fetchImpl,
+    });
 
-  assert.equal(result.ok, false);
-  assert.equal(result.statusCode, 502);
-  assert.equal(result.error, "atlas_snapshot_contract_violation");
-  assert.deepEqual(result.details, [
-    "snapshot.summary metrics must include finite counts and resolution evidence",
-  ]);
-});
-
-await test("proxy rejects snapshots that omit resolution evidence diagnostics", async () => {
-  const missingResolutionEvidence = {
-    ...SNAPSHOT,
-    summary: {
-      generated: 3,
-      repeat_ticket_count: 12,
-      drafted_answer_count: 2,
-      no_proven_answer_count: 1,
-    },
-  };
-  const result = await loadDeflectionReport({
-    requestId: REQUEST_ID,
-    accountId: ACCOUNT_ID,
-    env: ENV,
-    fetchImpl: mockFetch([response(missingResolutionEvidence, 200)]).fetchImpl,
-  });
-
-  assert.equal(result.ok, false);
-  assert.equal(result.statusCode, 502);
-  assert.equal(result.error, "atlas_snapshot_contract_violation");
-  assert.deepEqual(result.details, [
-    "snapshot.summary metrics must include finite counts and resolution evidence",
-  ]);
+    assert.equal(result.ok, false, field);
+    assert.equal(result.statusCode, 502, field);
+    assert.equal(result.error, "atlas_snapshot_contract_violation", field);
+    assert.deepEqual(
+      result.details,
+      ["snapshot.summary metrics must include finite counts and resolution evidence"],
+      field,
+    );
+  }
 });
 
 await test("ATLAS fetches carry abort signals and timeout failures return errors", async () => {

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -33,6 +33,47 @@ const evidenceExportSource = await readFile(
   resolve(root, "api/content-ops/deflection/evidence-export.js"),
   "utf8",
 );
+const REQUIRED_SNAPSHOT_SUMMARY_GUARDS = [
+  {
+    field: "generated",
+    read: /const generated = finiteNumber\(value\.summary\.generated\);/,
+    guard: /generated === null/,
+    failOpen: /finiteNumber\(value\.summary\.generated\)\s*\?\?\s*0/,
+  },
+  {
+    field: "repeat_ticket_count",
+    read: /const repeatTicketCount = finiteNumber\(value\.summary\.repeat_ticket_count\);/,
+    guard: /repeatTicketCount === null/,
+    failOpen: /finiteNumber\(value\.summary\.repeat_ticket_count\)\s*\?\?\s*0/,
+  },
+  {
+    field: "drafted_answer_count",
+    read: /const draftedAnswerCount = finiteNumber\(value\.summary\.drafted_answer_count\);/,
+    guard: /draftedAnswerCount === null/,
+    failOpen: /finiteNumber\(value\.summary\.drafted_answer_count\)\s*\?\?\s*0/,
+  },
+  {
+    field: "no_proven_answer_count",
+    read: /const noProvenAnswerCount = finiteNumber\(value\.summary\.no_proven_answer_count\);/,
+    guard: /noProvenAnswerCount === null/,
+    failOpen: /finiteNumber\(value\.summary\.no_proven_answer_count\)\s*\?\?\s*0/,
+  },
+  {
+    field: "support_ticket_resolution_evidence_present",
+    read:
+      /const resolutionEvidencePresent = value\.summary\.support_ticket_resolution_evidence_present;/,
+    guard: /typeof resolutionEvidencePresent !== "boolean"/,
+    failOpen: /value\.summary\.support_ticket_resolution_evidence_present\s*\?\?\s*false/,
+  },
+  {
+    field: "support_ticket_resolution_evidence_count",
+    read:
+      /const resolutionEvidenceCount = finiteNumber\( value\.summary\.support_ticket_resolution_evidence_count, \);/,
+    guard: /resolutionEvidenceCount === null/,
+    failOpen:
+      /finiteNumber\(\s*value\.summary\.support_ticket_resolution_evidence_count,?\s*\)\s*\?\?\s*0/,
+  },
+];
 
 async function test(name, fn) {
   try {
@@ -215,17 +256,13 @@ await test("snapshot guard names paid report fields that must not render pre-pay
   assert.match(pageSource, /collectForbiddenKeys/);
 });
 
-await test("React fallback rejects snapshots that omit repeat-ticket counts", () => {
+await test("React fallback rejects snapshots that omit required summary fields", () => {
   const compactPageSource = pageSource.replace(/\s+/g, " ");
-  assert.match(
-    compactPageSource,
-    /const repeatTicketCount = finiteNumber\(value\.summary\.repeat_ticket_count\);/,
-  );
-  assert.match(compactPageSource, /repeatTicketCount === null \|\| draftedAnswerCount === null/);
-  assert.doesNotMatch(
-    pageSource,
-    /finiteNumber\(value\.summary\.repeat_ticket_count\)\s*\?\?\s*0/,
-  );
+  for (const { field, read, guard, failOpen } of REQUIRED_SNAPSHOT_SUMMARY_GUARDS) {
+    assert.match(compactPageSource, read, field);
+    assert.match(compactPageSource, guard, field);
+    assert.doesNotMatch(compactPageSource, failOpen, field);
+  }
 });
 
 await test("real snapshot page groups bounded customer wording examples", () => {

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -768,11 +768,18 @@ async def test_deflection_submit_accepts_zendesk_full_thread_blob(
     assert summary["drafted_answer_count"] == 1
     assert summary["support_ticket_resolution_evidence_present"] is True
     assert summary["support_ticket_resolution_evidence_count"] == 1
-    assert summary["no_proven_answer_count"] == 0
+    assert summary["no_proven_answer_count"] == 1
     assert artifact_payload["faq_result"]["items"][0]["answer_evidence_status"] == (
+        "draft_needs_review"
+    )
+    assert artifact_payload["faq_result"]["items"][0]["resolution_evidence_scope"] == (
+        "missing_question_scope"
+    )
+    assert list(artifact_payload["faq_result"]["items"][0]["source_ids"]) == ["41"]
+    assert artifact_payload["faq_result"]["items"][1]["answer_evidence_status"] == (
         "resolution_evidence"
     )
-    assert list(artifact_payload["faq_result"]["items"][0]["source_ids"]) == ["2"]
+    assert list(artifact_payload["faq_result"]["items"][1]["source_ids"]) == ["2"]
     assert "duplicate billing event and refunded the extra charge" in (
         artifact_payload["markdown"]
     )
@@ -781,7 +788,7 @@ async def test_deflection_submit_accepts_zendesk_full_thread_blob(
         artifact_payload
     )
     assert "We sent the standard resolution steps" not in artifact_payload["markdown"]
-    assert "This is still broken after trying the steps" not in artifact_payload[
+    assert "This is still broken after trying the steps" in artifact_payload[
         "markdown"
     ]
     assert "lead@acme.example" not in json.dumps(artifact_payload)

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -14,6 +14,8 @@ from extracted_content_pipeline.control_surfaces import (
 )
 from extracted_content_pipeline.generation_plan import build_generation_plan
 from extracted_content_pipeline.support_ticket_clustering import (
+    _PHRASE_FOLDS,
+    _TOKEN_FOLDS,
     support_ticket_plain_text,
     support_ticket_tokens,
 )
@@ -34,6 +36,16 @@ from extracted_content_pipeline.support_ticket_zendesk_thread import (
 
 ROOT = Path(__file__).resolve().parents[1]
 ZENDESK_THREAD_SAMPLE = ROOT / "tests/fixtures/zendesk_full_thread_seed_sample.json"
+
+
+def test_support_ticket_fold_targets_survive_tokenization() -> None:
+    token_fold_targets = {
+        target for target in _TOKEN_FOLDS.values() if target and len(target) >= 2
+    }
+    phrase_fold_targets = {replacement for _pattern, replacement in _PHRASE_FOLDS}
+
+    for target in sorted(token_fold_targets | phrase_fold_targets):
+        assert target in support_ticket_tokens(f"customer mentioned {target} issue"), target
 
 
 def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -25,8 +25,10 @@ from extracted_content_pipeline.support_ticket_zendesk_thread import (
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
+    _RESOLUTION_ACTION_TERMS,
     _output_checks,
     _resolution_advisory_signals,
+    _resolution_signal_token,
     _resolution_signal_tokens,
     _resolution_text_is_publishable,
     _safe_vocabulary_representative_label,
@@ -49,6 +51,16 @@ FAQ_DOCUMENTATION_TERMS = (
 ZENDESK_PRODUCT_PROOF_CORPUS = (
     ROOT / "docs/extraction/validation/fixtures/zendesk_product_proof_corpus.json"
 )
+_VOWELS = frozenset("aeiou")
+_IRREGULAR_PAST_RESOLUTION_ACTION_TERMS = frozenset(
+    {"choose", "rerun", "reset", "run", "send", "set"}
+)
+_IRREGULAR_PAST_RESOLUTION_ACTION_INFLECTIONS = {
+    "chose": "choose",
+    "ran": "run",
+    "reran": "rerun",
+    "sent": "send",
+}
 
 
 class _StubEmbeddingPort:
@@ -104,6 +116,64 @@ class _RenderedFAQHTML(HTMLParser):
             self._stack.pop()
         elif tag in self._stack:
             self._stack.remove(tag)
+
+
+def _standard_resolution_action_inflections(term: str) -> tuple[str, ...]:
+    forms = {f"{term}s"}
+    if term.endswith("y") and len(term) > 1 and term[-2] not in _VOWELS:
+        forms.add(f"{term[:-1]}ies")
+        forms.add(f"{term}ing")
+        if term not in _IRREGULAR_PAST_RESOLUTION_ACTION_TERMS:
+            forms.add(f"{term[:-1]}ied")
+        return tuple(sorted(forms))
+
+    if term.endswith("e"):
+        forms.add(f"{term[:-1]}ing")
+        if term not in _IRREGULAR_PAST_RESOLUTION_ACTION_TERMS:
+            forms.add(f"{term}d")
+        return tuple(sorted(forms))
+
+    is_cvc = (
+        len(term) == 3
+        and term[-1] not in _VOWELS
+        and term[-2] in _VOWELS
+        and term[-3] not in _VOWELS
+        and term[-1] not in {"w", "x", "y"}
+    )
+    if is_cvc:
+        forms.add(f"{term}{term[-1]}ing")
+        if term not in _IRREGULAR_PAST_RESOLUTION_ACTION_TERMS:
+            forms.add(f"{term}{term[-1]}ed")
+        return tuple(sorted(forms))
+
+    forms.add(f"{term}ing")
+    if term not in _IRREGULAR_PAST_RESOLUTION_ACTION_TERMS:
+        forms.add(f"{term}ed")
+    return tuple(sorted(forms))
+
+
+@pytest.mark.parametrize(
+    ("term", "inflection"),
+    [
+        (term, inflection)
+        for term in sorted(_RESOLUTION_ACTION_TERMS)
+        for inflection in _standard_resolution_action_inflections(term)
+    ],
+)
+def test_resolution_action_terms_recognize_standard_inflections(
+    term: str, inflection: str
+) -> None:
+    assert _resolution_signal_token(inflection) == term
+
+
+@pytest.mark.parametrize(
+    ("inflection", "term"),
+    sorted(_IRREGULAR_PAST_RESOLUTION_ACTION_INFLECTIONS.items()),
+)
+def test_resolution_action_terms_recognize_irregular_past_forms(
+    inflection: str, term: str
+) -> None:
+    assert _resolution_signal_token(inflection) == term
 
 
 class _FAQRepository:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Parser-Invariant-Test-Pack.md
Slice phase: Robust testing

#1471 needs deterministic parser invariants so recognition-set, fold-target, and snapshot fail-closed regressions go red before review. This PR adds those invariants and the smallest upstream normalizer support needed for irregular resolution-action past tense.

## Intentional
- Production behavior changes are limited to `_resolution_signal_token` recognizing irregular past forms (`chose`, `ran`, `reran`, `sent`).
- The low non-zero CSV admission threshold from #1467 remains deferred until a real partial provider CSV justifies warn-vs-reject product policy.
- The React fallback test continues to inspect the TSX source because the existing portfolio-ui test harness is source-based for that component.
- The portfolio-ui snapshot field sweep is legacy/Vite projector maintenance because #1471 names those projectors. This PR does not claim buyer-page coverage for the atlas-portfolio Next.js result route.

## Deferred
- #1467 parser-breakage evidence runner: generate the adversarial admission matrix and score fail-closed vs fail-open mechanics.
- #1467 low non-zero usable-ratio reject threshold: blocked on real partial provider CSV evidence, not synthetic ratios.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed Codex #57: added explicit irregular past-tense recognition for `chose`, `ran`, `reran`, and `sent`, with parametrized tests.
- Fixed Codex #141: narrowed the generated doubled-consonant CVC branch so `open` now exercises standard `opening`/`opened`, not `openning`/`openned`.
- Reviewer surface note handled: portfolio-ui assertions are documented as legacy/Vite projector maintenance, not buyer-facing atlas-portfolio coverage.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_support_ticket_input_package.py -q` -- 464 passed.
- `pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` -- 1 passed.
- `npm --prefix portfolio-ui run test:deflection-atlas-proxy` -- passed.
- `npm --prefix portfolio-ui run test:deflection-result` -- passed.
- `./scripts/run_extracted_pipeline_checks.sh` -- 4545 passed, 10 skipped.

## Diff size
7 files, +289 / -57.
