### PR TITLE
Gitleaks baseline rotation escape hatch

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -61,4 +61,4 @@ jobs:
       - name: PR-review tooling unit tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio
-          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py tests/test_check_deflection_full_report_proof_bundle.py -q
+          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_check_gitleaks_baseline_rotation.py tests/test_security_guardrails_workflow.py -q

--- a/.github/workflows/security_guardrails.yml
+++ b/.github/workflows/security_guardrails.yml
@@ -2,6 +2,9 @@ name: Security Guardrails
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches:
       - main
@@ -17,42 +20,33 @@ permissions:
 jobs:
   gitleaks-baseline-guard:
     name: Gitleaks baseline growth guard
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
     steps:
-      - name: Checkout pull request
+      - name: Checkout trusted base
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
 
-      - name: Reject baseline changes after adoption
+      - name: Enforce baseline rotation policy
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "${BASE_REF}"
-
-          if ! git cat-file -e "origin/${BASE_REF}:docs/security/gitleaks-baseline.json" 2>/dev/null; then
-            echo "No baseline exists on ${BASE_REF}; allowing initial adoption baseline."
-            exit 0
-          fi
-
-          if git diff --quiet "origin/${BASE_REF}" -- docs/security/gitleaks-baseline.json; then
-            echo "Gitleaks baseline unchanged."
-            exit 0
-          fi
-
-          cat <<'MSG'
-          Gitleaks baseline changes are blocked by default.
-          Rotate/revoke the exposed provider secret, then use a dedicated security
-          rotation PR to justify any baseline change.
-          MSG
-          git diff --stat "origin/${BASE_REF}" -- docs/security/gitleaks-baseline.json
-          exit 1
+          git fetch --no-tags origin \
+            "${BASE_REF}:refs/remotes/origin/${BASE_REF}" \
+            "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-${PR_NUMBER}"
+          python scripts/check_gitleaks_baseline_rotation.py \
+            --base-ref "origin/${BASE_REF}" \
+            --head-ref "refs/remotes/origin/pr-${PR_NUMBER}" \
+            --labels-json "${PR_LABELS_JSON}"
 
   secrets-pr:
     name: Gitleaks PR secret scan
@@ -106,7 +100,7 @@ jobs:
 
   secrets-full-history:
     name: Gitleaks full-history secret scan
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -156,7 +150,7 @@ jobs:
 
   pip-audit:
     name: pip-audit (${{ matrix.requirements }})
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -189,7 +183,7 @@ jobs:
 
   osv-full:
     name: OSV dependency scan
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     permissions:
       contents: read
@@ -201,7 +195,7 @@ jobs:
 
   semgrep:
     name: Semgrep SAST
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -238,7 +232,7 @@ jobs:
 
   trivy-config:
     name: Trivy config scan
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -267,7 +261,7 @@ jobs:
 
   checkov:
     name: Checkov IaC scan
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -43,15 +43,6 @@ register under `docs/technical-debt/`.
 
 ## 2026-06-16
 
-### Add controlled Gitleaks baseline rotation escape hatch
-- File/location: `.github/workflows/security_guardrails.yml`, `gitleaks-baseline-guard`
-- Description: The baseline guard blocks all PR changes to `docs/security/gitleaks-baseline.json`, but its failure message references a dedicated security rotation PR. Add an explicit controlled path, such as requiring a `security-rotation` label plus narrow path ownership, so legitimate post-rotation baseline changes are possible without weakening normal PR protection.
-- Why it matters: The guard correctly prevents baseline poisoning, but without a controlled escape hatch a legitimate provider rotation or history rewrite can get stuck behind the same protection.
-- Effort: S
-- Category: security
-- Owner/session: Codex security/workflow
-- Found during: PR-Security-Guardrail-CI review
-
 ### Rotate archived IndexNow key
 - File/location: Historical `atlas-intel-next` / `_ARCHIVED_atlas-intel-next/scripts/indexnow.ts`
 - Description: The archived IndexNow script previously contained a real IndexNow key. The branch tip now requires `INDEXNOW_KEY`, but the old key remains in git history and should be rotated or replaced at the IndexNow key-hosting location.

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -20,6 +20,17 @@ the checked-out PR head. A lightweight PR guard also rejects changes to that
 baseline, so a future PR cannot add a secret and hide it by growing the
 baseline.
 
+Legitimate baseline rotations are allowed only through a narrow controlled
+path: rotate or revoke the exposed provider credential first, add the
+`security-rotation` PR label, and keep the diff limited to
+`docs/security/gitleaks-baseline.json`, `docs/SECURITY_GUARDRAILS.md`,
+`HARDENING.md`, and the slice plan under `plans/PR-*.md`. The label alone is
+not enough; product-code or workflow changes in the same PR still fail the
+baseline guard. The baseline guard runs from trusted base-branch workflow code
+on `pull_request_target`, fetches the PR head only as git data, parses labels
+from GitHub's JSON event payload, and rejects candidate baselines that drop
+trusted-base fingerprints.
+
 Current blocking posture: new unbaselined secrets block PRs; Semgrep, Trivy,
 Checkov, pip-audit, and OSV are advisory/report-only until their adoption
 backlogs are triaged and ratcheted.
@@ -103,8 +114,6 @@ decide whether to rewrite history or keep the redacted baseline as the permanent
 
 - Rotate/revoke the provider credentials exposed in historical commit
   `d63a9b77b9727766e14e523626c22dd6c1c80da8`.
-- Add a controlled Gitleaks baseline rotation escape hatch for legitimate
-  post-rotation baseline changes.
 - Rotate the archived IndexNow key that was removed from the branch tip but
   remains in git history.
 - Audit and pin remaining non-security workflow actions, and review

--- a/plans/PR-Gitleaks-Baseline-Rotation-Escape-Hatch.md
+++ b/plans/PR-Gitleaks-Baseline-Rotation-Escape-Hatch.md
@@ -1,0 +1,131 @@
+# PR-Gitleaks-Baseline-Rotation-Escape-Hatch
+
+## Why this slice exists
+
+The PR-Security-Guardrail-CI review parked a security/workflow follow-up:
+`gitleaks-baseline-guard` blocks every change to
+`docs/security/gitleaks-baseline.json`, but its own failure message tells
+builders to use a dedicated security rotation PR. The root cause is that the
+baseline rotation policy exists only as prose, so the CI gate has no
+machine-checkable path for legitimate post-rotation baseline updates.
+
+This change fixes the root by moving the baseline-change decision into a
+tested checker and wiring CI to allow baseline edits only when the PR carries
+an explicit rotation label and stays inside a narrow rotation/doc/plan path
+allowlist.
+
+The slice is over the 400 LOC target because the review findings expanded the
+root fix from a small script extraction into a trusted-code workflow change
+with CI-enrolled regression tests. Splitting the tests or workflow enrollment
+out would leave the security gate either untrusted or unprotected in CI.
+
+## Scope (this PR)
+
+Ownership lane: security/workflow
+Slice phase: Production hardening
+
+1. Add a controlled Gitleaks baseline rotation path guarded by the
+   `security-rotation` PR label plus a narrow changed-file allowlist.
+2. Preserve the default fail-closed behavior for ordinary PRs that touch
+   `docs/security/gitleaks-baseline.json`.
+3. Run the baseline decision from trusted base-branch workflow/script code,
+   not from PR-controlled code.
+4. Re-run the label-dependent guard when `security-rotation` is added or
+   removed.
+5. Document the rotation ritual and remove the promoted HARDENING item.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] Baseline changes without `security-rotation` still fail.
+  - [ ] Baseline changes with `security-rotation` pass only when the diff is
+        limited to the baseline, security/hardening docs, and a slice plan.
+  - [ ] Initial baseline adoption remains allowed when the trusted base has no
+        baseline.
+  - [ ] The baseline guard uses `pull_request_target`, checks out the trusted
+        base, and fetches the PR head only as git data.
+  - [ ] Label changes re-trigger the baseline guard, and labels are parsed as
+        JSON rather than comma-split text.
+  - [ ] Candidate rotated baselines preserve trusted-base fingerprints.
+  - [ ] Checker and workflow-shape regression tests are enrolled in CI.
+  - [ ] The human-facing security docs describe the exact label and path
+        limits.
+- Affected surfaces: CI / security workflow / developer docs.
+- Risk areas: security / CI correctness / workflow abuse.
+- Reviewer rules triggered: R1, R2, R3, R10, R11, R12, R14.
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `.github/workflows/security_guardrails.yml`
+- `HARDENING.md`
+- `docs/SECURITY_GUARDRAILS.md`
+- `plans/PR-Gitleaks-Baseline-Rotation-Escape-Hatch.md`
+- `scripts/check_gitleaks_baseline_rotation.py`
+- `tests/test_check_gitleaks_baseline_rotation.py`
+- `tests/test_pre_push_audit_workflow.py`
+- `tests/test_security_guardrails_workflow.py`
+
+## Mechanism
+
+`scripts/check_gitleaks_baseline_rotation.py` compares the PR diff against the
+trusted base ref. If the base does not yet have the baseline file, it preserves
+the original initial-adoption allow path. If the baseline is unchanged, it exits
+green. If the baseline changed, the checker requires the `security-rotation`
+label and rejects any changed file outside:
+
+- `docs/security/gitleaks-baseline.json`
+- `docs/SECURITY_GUARDRAILS.md`
+- `HARDENING.md`
+- the slice plan under `plans/` using the PR plan naming convention
+
+The `gitleaks-baseline-guard` job runs on `pull_request_target`, checks out
+the trusted base commit, fetches the PR head only as git data, and calls the
+base-branch copy of this checker with JSON-encoded PR labels. The workflow
+listens for `labeled` and `unlabeled` activity so changing
+`security-rotation` re-runs the required guard. For rotation PRs, the checker
+also parses the proposed baseline and rejects any candidate that drops
+fingerprints already present in the trusted-base baseline.
+
+## Intentional
+
+- The escape hatch is label-based rather than actor-based so it is visible in
+  the PR UI and can be removed by reviewers if the diff is not a real rotation.
+- The label alone is insufficient; the changed-file allowlist prevents using a
+  rotation PR to smuggle product-code or workflow changes alongside a baseline
+  update.
+- The path allowlist permits this plan doc and the security/hardening docs
+  because Atlas requires plan/docs alignment for non-trivial workflow changes.
+- The baseline guard uses `pull_request_target` only for metadata and git-data
+  inspection; it does not execute PR-controlled code.
+
+## Deferred
+
+- Provider-side credential rotation remains deferred to the existing
+  `HARDENING.md` item; this PR only makes the post-rotation baseline update
+  possible without weakening normal PR protection.
+
+Parked hardening: promoted and removed `Add controlled Gitleaks baseline
+rotation escape hatch`.
+
+## Verification
+
+- Focused pytest for checker and workflow enrollment/shape tests - 19 passed.
+- Direct checker smoke using `scripts/check_gitleaks_baseline_rotation.py` against `origin/main` with `security-rotation` - passed, reported "Gitleaks baseline unchanged."
+- YAML parse smoke for `.github/workflows/security_guardrails.yml` and `.github/workflows/pre_push_audit.yml` - passed.
+- Plan sync check for this plan doc - passed.
+- Local review bundle with the PR body file - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pre_push_audit.yml` | 2 |
+| `.github/workflows/security_guardrails.yml` | 52 |
+| `HARDENING.md` | 9 |
+| `docs/SECURITY_GUARDRAILS.md` | 13 |
+| `plans/PR-Gitleaks-Baseline-Rotation-Escape-Hatch.md` | 131 |
+| `scripts/check_gitleaks_baseline_rotation.py` | 189 |
+| `tests/test_check_gitleaks_baseline_rotation.py` | 142 |
+| `tests/test_pre_push_audit_workflow.py` | 12 |
+| `tests/test_security_guardrails_workflow.py` | 40 |
+| **Total** | **590** |

--- a/scripts/check_gitleaks_baseline_rotation.py
+++ b/scripts/check_gitleaks_baseline_rotation.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Gate Gitleaks baseline changes to an explicit rotation path."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+BASELINE_PATH = "docs/security/gitleaks-baseline.json"
+DEFAULT_ROTATION_LABEL = "security-rotation"
+ALLOWED_ROTATION_PATHS = {
+    BASELINE_PATH,
+    "HARDENING.md",
+    "docs/SECURITY_GUARDRAILS.md",
+}
+ALLOWED_ROTATION_PATTERNS = ("plans/PR-*.md",)
+
+
+@dataclass(frozen=True)
+class Decision:
+    allowed: bool
+    reason: str
+    disallowed_paths: tuple[str, ...] = ()
+    missing_fingerprints: tuple[str, ...] = ()
+
+
+def parse_labels(raw: str | None) -> set[str]:
+    if not raw:
+        return set()
+    return {label.strip() for label in raw.split(",") if label.strip()}
+
+
+def parse_labels_json(raw: str | None) -> set[str]:
+    if not raw:
+        return set()
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list) or not all(isinstance(label, str) for label in parsed):
+        raise ValueError("labels JSON must be an array of strings")
+    return set(parsed)
+
+
+def is_rotation_path_allowed(path: str) -> bool:
+    return path in ALLOWED_ROTATION_PATHS or any(
+        fnmatch.fnmatchcase(path, pattern) for pattern in ALLOWED_ROTATION_PATTERNS
+    )
+
+
+def evaluate_baseline_rotation(
+    changed_paths: set[str],
+    *,
+    labels: set[str],
+    base_has_baseline: bool,
+    base_fingerprints: set[str] | None = None,
+    candidate_fingerprints: set[str] | None = None,
+    rotation_label: str = DEFAULT_ROTATION_LABEL,
+) -> Decision:
+    if not base_has_baseline:
+        return Decision(True, "No trusted-base Gitleaks baseline exists; initial adoption is allowed.")
+
+    if BASELINE_PATH not in changed_paths:
+        return Decision(True, "Gitleaks baseline unchanged.")
+
+    if rotation_label not in labels:
+        return Decision(
+            False,
+            (
+                "Gitleaks baseline changes require the "
+                f"`{rotation_label}` PR label after provider rotation/revocation."
+            ),
+        )
+
+    disallowed = tuple(sorted(path for path in changed_paths if not is_rotation_path_allowed(path)))
+    if disallowed:
+        return Decision(
+            False,
+            "Baseline rotation PRs may only touch the baseline, hardening/security docs, and their plan.",
+            disallowed,
+        )
+
+    missing = tuple(sorted((base_fingerprints or set()) - (candidate_fingerprints or set())))
+    if missing:
+        return Decision(
+            False,
+            "Proposed Gitleaks baseline drops trusted-base fingerprints.",
+            missing_fingerprints=missing,
+        )
+
+    return Decision(True, f"Gitleaks baseline rotation accepted with `{rotation_label}` label.")
+
+
+def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], check=False, capture_output=True, text=True)
+
+
+def ref_has_baseline(ref: str) -> bool:
+    proc = run_git(["cat-file", "-e", f"{ref}:{BASELINE_PATH}"])
+    return proc.returncode == 0
+
+
+def read_baseline(ref: str) -> list[dict[str, object]] | None:
+    proc = run_git(["show", f"{ref}:{BASELINE_PATH}"])
+    if proc.returncode != 0:
+        return None
+    parsed = json.loads(proc.stdout)
+    if not isinstance(parsed, list) or not all(isinstance(item, dict) for item in parsed):
+        raise ValueError(f"{BASELINE_PATH} must be a JSON array of objects")
+    return parsed
+
+
+def baseline_fingerprints(ref: str) -> set[str]:
+    entries = read_baseline(ref) or []
+    fingerprints = set()
+    for entry in entries:
+        fingerprint = entry.get("Fingerprint")
+        if isinstance(fingerprint, str) and fingerprint:
+            fingerprints.add(fingerprint)
+    return fingerprints
+
+
+def changed_paths(base_ref: str, head_ref: str = "HEAD") -> set[str]:
+    proc = run_git(["diff", "--name-only", f"{base_ref}...{head_ref}", "--"])
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "git diff failed")
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", required=True, help="Trusted base ref, for example origin/main.")
+    parser.add_argument("--head-ref", default="HEAD", help="Candidate PR head ref. Defaults to HEAD.")
+    parser.add_argument(
+        "--labels",
+        default="",
+        help="Deprecated comma-separated pull request labels. Prefer --labels-json.",
+    )
+    parser.add_argument(
+        "--labels-json",
+        default="",
+        help="JSON array of pull request label names from GitHub Actions toJson().",
+    )
+    parser.add_argument(
+        "--rotation-label",
+        default=DEFAULT_ROTATION_LABEL,
+        help="PR label required to allow a controlled baseline rotation.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        paths = changed_paths(args.base_ref, args.head_ref)
+        labels = parse_labels_json(args.labels_json) if args.labels_json else parse_labels(args.labels)
+        base_fps = baseline_fingerprints(args.base_ref) if ref_has_baseline(args.base_ref) else set()
+        candidate_fps = (
+            baseline_fingerprints(args.head_ref) if BASELINE_PATH in paths and ref_has_baseline(args.head_ref) else set()
+        )
+    except (RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    decision = evaluate_baseline_rotation(
+        paths,
+        labels=labels,
+        base_has_baseline=ref_has_baseline(args.base_ref),
+        base_fingerprints=base_fps,
+        candidate_fingerprints=candidate_fps,
+        rotation_label=args.rotation_label,
+    )
+    print(decision.reason)
+    if decision.disallowed_paths:
+        print("Disallowed files:")
+        for path in decision.disallowed_paths:
+            print(f"- {path}")
+    if decision.missing_fingerprints:
+        print("Missing trusted-base fingerprints:")
+        for fingerprint in decision.missing_fingerprints:
+            print(f"- {fingerprint}")
+    return 0 if decision.allowed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_gitleaks_baseline_rotation.py
+++ b/tests/test_check_gitleaks_baseline_rotation.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_gitleaks_baseline_rotation.py"
+
+
+def load_checker():
+    name = "check_gitleaks_baseline_rotation"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _changed(*paths: str) -> set[str]:
+    return set(paths)
+
+
+def test_allows_unchanged_baseline_without_label() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed("app/api/foo.py"),
+        labels=set(),
+        base_has_baseline=True,
+    )
+
+    assert decision.allowed is True
+    assert "unchanged" in decision.reason
+
+
+def test_rejects_baseline_change_without_rotation_label() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.BASELINE_PATH),
+        labels=set(),
+        base_has_baseline=True,
+    )
+
+    assert decision.allowed is False
+    assert "security-rotation" in decision.reason
+
+
+def test_allows_labeled_rotation_with_only_baseline_docs_and_plan() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(
+            checker.BASELINE_PATH,
+            "docs/SECURITY_GUARDRAILS.md",
+            "HARDENING.md",
+            "plans/PR-Gitleaks-Baseline-Rotation.md",
+        ),
+        labels={"security-rotation"},
+        base_has_baseline=True,
+        base_fingerprints={"base-a", "base-b"},
+        candidate_fingerprints={"base-a", "base-b", "new-c"},
+    )
+
+    assert decision.allowed is True
+    assert "accepted" in decision.reason
+
+
+def test_rejects_labeled_rotation_that_changes_product_code() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(
+            checker.BASELINE_PATH,
+            "app/api/graphrag/upload/route.ts",
+            "plans/PR-Gitleaks-Baseline-Rotation.md",
+        ),
+        labels={"security-rotation"},
+        base_has_baseline=True,
+        base_fingerprints={"base-a"},
+        candidate_fingerprints={"base-a"},
+    )
+
+    assert decision.allowed is False
+    assert decision.disallowed_paths == ("app/api/graphrag/upload/route.ts",)
+
+
+def test_rejects_labeled_rotation_that_drops_existing_fingerprint() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.BASELINE_PATH, "plans/PR-Gitleaks-Baseline-Rotation.md"),
+        labels={"security-rotation"},
+        base_has_baseline=True,
+        base_fingerprints={"kept-fingerprint", "dropped-fingerprint"},
+        candidate_fingerprints={"kept-fingerprint"},
+    )
+
+    assert decision.allowed is False
+    assert decision.missing_fingerprints == ("dropped-fingerprint",)
+
+
+def test_allows_initial_adoption_when_base_has_no_baseline() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.BASELINE_PATH, "app/api/foo.py"),
+        labels=set(),
+        base_has_baseline=False,
+    )
+
+    assert decision.allowed is True
+    assert "initial adoption" in decision.reason
+
+
+def test_parse_labels_strips_empty_entries() -> None:
+    checker = load_checker()
+    assert checker.parse_labels(" security-rotation, ,docs-only ") == {
+        "security-rotation",
+        "docs-only",
+    }
+
+
+def test_parse_labels_json_preserves_comma_inside_label() -> None:
+    checker = load_checker()
+    assert checker.parse_labels_json('["security-rotation","contains,comma"]') == {
+        "security-rotation",
+        "contains,comma",
+    }
+
+
+def test_parse_labels_json_rejects_non_string_labels() -> None:
+    checker = load_checker()
+    try:
+        checker.parse_labels_json('["security-rotation", 123]')
+    except ValueError as exc:
+        assert "array of strings" in str(exc)
+    else:
+        raise AssertionError("non-string label should fail closed")

--- a/tests/test_pre_push_audit_workflow.py
+++ b/tests/test_pre_push_audit_workflow.py
@@ -33,3 +33,15 @@ def test_pre_push_audit_workflow_enrolls_full_report_redaction_checker_tests() -
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "tests/test_check_deflection_full_report_proof_bundle.py" in text
+
+
+def test_pre_push_audit_workflow_enrolls_gitleaks_baseline_rotation_tests() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "tests/test_check_gitleaks_baseline_rotation.py" in text
+
+
+def test_pre_push_audit_workflow_enrolls_security_guardrails_workflow_tests() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "tests/test_security_guardrails_workflow.py" in text

--- a/tests/test_security_guardrails_workflow.py
+++ b/tests/test_security_guardrails_workflow.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "security_guardrails.yml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_baseline_guard_runs_on_pull_request_target_label_changes() -> None:
+    text = _workflow_text()
+
+    assert "pull_request_target:" in text
+    assert "types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]" in text
+    assert "if: github.event_name == 'pull_request_target'" in text
+
+
+def test_baseline_guard_checks_out_trusted_base_and_fetches_pr_as_data() -> None:
+    text = _workflow_text()
+
+    assert "Checkout trusted base" in text
+    assert "ref: ${{ github.event.pull_request.base.sha }}" in text
+    assert '"pull/${PR_NUMBER}/head:refs/remotes/origin/pr-${PR_NUMBER}"' in text
+    assert "--head-ref \"refs/remotes/origin/pr-${PR_NUMBER}\"" in text
+
+
+def test_baseline_guard_uses_json_labels() -> None:
+    text = _workflow_text()
+
+    assert "PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}" in text
+    assert "--labels-json \"${PR_LABELS_JSON}\"" in text
+
+
+def test_heavy_scans_do_not_run_on_pull_request_target() -> None:
+    text = _workflow_text()
+
+    assert "if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'" in text


### PR DESCRIPTION
Plan: plans/PR-Gitleaks-Baseline-Rotation-Escape-Hatch.md
Slice phase: Production hardening

This slice fixes the Gitleaks baseline rotation policy gap: the baseline guard previously told builders to use a dedicated security rotation PR, but CI had no controlled path for one. The PR moves the decision into a tested checker, runs the guard from trusted base-branch code via `pull_request_target`, and allows baseline edits only when the PR has the `security-rotation` label, preserves trusted-base fingerprints, and keeps the diff limited to the baseline, security/hardening docs, and the slice plan.

## Intentional
- The escape hatch is label-based so reviewers can see and remove it in the PR UI.
- The label alone is not enough; product-code or workflow changes in the same baseline-rotation PR still fail.
- `pull_request_target` is used only to inspect metadata and git data; the guard checks out trusted base code and does not execute PR-controlled code.
- Provider-side credential rotation remains outside this repo-code slice.

## AI reconciliation
- [chatgpt-codex-connector] P1 Run the baseline guard from trusted code: fixed by moving `gitleaks-baseline-guard` to `pull_request_target`, checking out the trusted base SHA, fetching the PR head only as git data, and running the base-branch checker.
- [chatgpt-codex-connector] P2 Re-run the guard when rotation labels change: fixed by adding explicit `labeled` and `unlabeled` `pull_request_target` activity types.
- [chatgpt-codex-connector] P1 Validate the proposed baseline before accepting rotations: fixed by parsing candidate baselines and rejecting rotations that drop trusted-base fingerprints.
- [chatgpt-codex-connector] P2 Enroll the checker regression test in CI: fixed by enrolling `tests/test_check_gitleaks_baseline_rotation.py` in `pre_push_audit.yml`.
- [copilot-pull-request-reviewer] Use triple-dot diff against merge-base: fixed by diffing `base...head`.
- [copilot-pull-request-reviewer] Avoid comma-ambiguous labels: fixed by passing labels as JSON and parsing a JSON array.

All findings fixed or waived: yes.

## Deferred
- Provider-side rotation/revocation for the historical credentials remains tracked in `HARDENING.md`.

## Parked hardening
- Promoted and removed `Add controlled Gitleaks baseline rotation escape hatch`.

## Verification
- `python -m pytest tests/test_check_gitleaks_baseline_rotation.py tests/test_pre_push_audit_workflow.py tests/test_security_guardrails_workflow.py -q` - 19 passed.
- `python scripts/check_gitleaks_baseline_rotation.py --base-ref origin/main --head-ref HEAD --labels-json '["security-rotation"]'` - passed, reported "Gitleaks baseline unchanged."
- YAML parse smoke for `.github/workflows/security_guardrails.yml` and `.github/workflows/pre_push_audit.yml` - passed.
- `python scripts/sync_pr_plan.py plans/PR-Gitleaks-Baseline-Rotation-Escape-Hatch.md --check` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_gitleaks_baseline_rotation_escape_hatch.md` - passed.

## Diff size
9 files, +549 / -41