### PR TITLE
Reviewer boundary-probe contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,10 @@ named in Deferred or explicitly marked none.
 - R3 Security/auth ... R14 Codebase verification: Pass/Fail/N-A
 (List the rules the changed paths trigger, plus R14; cite file:line on any Fail.)
 
+**boundary-probe:** <N-A, or what guard-shaped probe applied + result. Required
+before LGTM on guards, validators, caps, classifiers, gates, sanitizers,
+denylists, parser admission rules, or safety checkers.>
+
 **AI reconciliation:** AI findings reviewed: Y/N. All fixed or waived: Y/N.
 Waivers justified in PR body: Y/N.
 
@@ -744,6 +748,12 @@ Before LGTM, the reviewer confirms:
       denylist/regex/phrase-matcher/pattern-list detection, the coverage
       includes an allowed near-miss fixture or the plan names the future PR
       that will add it.
+- [ ] For guard-shaped PRs (guards, validators, caps, classifiers, gates,
+      sanitizers, denylists, parser admission rules, or safety checkers), the
+      verdict includes `boundary-probe: <what applied + result>` before LGTM.
+      Missing proof is BLOCKER for security, billing, data deletion,
+      customer-visible output, or CI/release gates; otherwise it is at least
+      MAJOR.
 - [ ] No drift from the plan's stated scope (no scope creep, no
       "while I was at it" cleanups beyond the slice's contract).
 - [ ] Defensible trade-offs are explained in **Intentional**.

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -163,6 +163,37 @@ changed code; a shared-function or contract change lacks a caller/test/artifact
 spot-check; or skipped verification is omitted instead of listed as "not
 verified."
 
+## Boundary-probe before LGTM on guard-shaped PRs
+
+Before LGTM on any PR whose change is a guard, validator, cap, classifier,
+gate, sanitizer, denylist, parser admission rule, or safety checker, run a
+boundary probe and state `boundary-probe: <what applied + result>` in the
+review.
+
+A guard usually fails on its second side. Check both sides:
+
+- **Both error directions:** test one input that should pass but might be
+  rejected, and one input that should fail but might pass.
+- **Partial/mixed input:** test some-required-keys-present-some-missing, and
+  mixed valid/invalid collections. Do not test only full-valid and empty.
+- **Boundary values:** test min-1/min/max/max+1, empty, single-item, and
+  large-but-valid where relevant.
+- **Falsy/default defeat:** any `x or d`, `x || d`, or `if not x` default on a
+  cap, limit, count, permission, or threshold needs probes for `0`, `""`,
+  `False`, and past-the-max values. For `??`, probe only null/undefined.
+- **Original-vs-sanitized path:** verify downstream code uses the sanitized or
+  validated value, not the original raw value after the check.
+- **Constructed metadata:** a sanitizer must clean ids, keys, filenames,
+  labels, source ids, and derived paths it constructs from input, not only
+  field values it copies.
+- **Negative test exists:** never LGTM a guard whose tests only prove good
+  input passes. Require at least one test proving bad input fails, or record a
+  justified waiver.
+
+If the guard protects security, billing, data deletion, customer-visible
+output, or CI/release gates, missing boundary proof is BLOCKER. Otherwise it is
+at least MAJOR.
+
 ---
 
 ## Path-based rule triggers
@@ -182,6 +213,7 @@ these for the paths it touches:
 | `atlas_brain/config.py`, env/config | R11, R12 |
 | `scripts/audit_*.py`, `scripts/check_*.py`, evaluators / gate predicates | R2 (failure-branch fixtures per `AGENTS.md` 3h/3i), R10 |
 | `extracted_*/` synced files | R1, R10 (manifest sync discipline) |
+| Guard, validator, cap, classifier, gate, sanitizer, denylist, parser admission rule, or safety checker changes | R2, R14 (boundary-probe before LGTM) |
 | Review comments that name a defect class ("all X", "class of Y", "same failure mode") | R13 (held-out/propertied proof that the class, not only the example, is fixed) |
 | All reviewer verdicts | R14 (checked-out PR-head and codebase-backed verification) |
 

--- a/plans/PR-Reviewer-Boundary-Probe-Contract.md
+++ b/plans/PR-Reviewer-Boundary-Probe-Contract.md
@@ -1,0 +1,95 @@
+# PR-Reviewer-Boundary-Probe-Contract
+
+## Why this slice exists
+
+Several recent review misses shared the same shape: a guard, validator,
+sanitizer, cap, or classifier was checked on the obvious side of its boundary,
+but the opposite failure direction was not probed before LGTM. Existing rules
+already require negative fixtures and codebase-backed review, but the reviewer
+template does not force the reviewer to state the second-side boundary probe in
+the verdict.
+
+Root cause: the review contract names test evidence and R14 verification, but
+does not make the two-sided guard boundary check a visible reviewer output.
+This fixes the root at the reviewer-contract layer by requiring a
+`boundary-probe:` line and defining the probe checklist for guard-shaped PRs.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Add a boundary-probe review requirement for guard-shaped PRs in the shared
+   reviewer rules pack.
+2. Add the matching `boundary-probe:` line to the AGENTS reviewer verdict
+   template and checklist.
+3. Keep the change documentation-only; no product code, tests, or CI behavior
+   changes ship in this slice.
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/REVIEWER_RULES.md`
+- `plans/PR-Reviewer-Boundary-Probe-Contract.md`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `docs/REVIEWER_RULES.md` defines guard-shaped PRs and the required
+        two-sided boundary-probe checklist.
+  - [ ] `AGENTS.md` tells reviewers to include a `boundary-probe:` verdict
+        line when that rule applies.
+  - [ ] The rule distinguishes missing boundary proof severity for
+        security/billing/data deletion/customer-visible/CI-release gates from
+        lower-risk guards.
+- Affected surfaces: reviewer workflow docs only.
+- Risk areas: process friction / reviewer ambiguity / stale template wording.
+- Reviewer rules triggered: R1, R10, R14.
+
+## Mechanism
+
+The reviewer rules pack gains a dedicated boundary-probe section after R14,
+where reviewers already have the universal codebase-verification rule. The new
+section describes when the probe applies, which input classes to check, and how
+to classify missing proof.
+
+The AGENTS reviewer template and audit checklist gain a `boundary-probe:` line
+so the rule is visible in every LGTM-shaped review when it applies. That output
+is intentionally explicit: if a guard-shaped PR review lacks the line, the
+operator can see that the reviewer skipped the required step.
+
+## Intentional
+
+- No mechanical audit in this slice. The immediate miss pattern is reviewer
+  judgment, so the first fix is the human-visible review contract. A future
+  audit could check for a `boundary-probe:` line in posted reviews, but that is
+  separate enforcement work.
+- No new rule number. This sits under existing R2/R13/R14 review obligations
+  rather than expanding the rule matrix.
+- No product-code tests. This is process documentation; verification is by
+  plan-shape, wording inspection, and local review.
+
+## Deferred
+
+- Optional mechanical enforcement: a future workflow/process slice can audit
+  reviewer verdict text for the `boundary-probe:` line when the PR diff touches
+  guard-shaped paths or declares R2/R10 gate risk.
+
+Parked hardening: none.
+
+## Verification
+
+- `python scripts/sync_pr_plan.py plans/PR-Reviewer-Boundary-Probe-Contract.md --check`
+  - Passed.
+- `scripts/local_pr_review.sh`
+  - Passed with `tmp/pr-body-reviewer-boundary-probe-contract.md` supplied as
+    the current PR body file.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 10 |
+| `docs/REVIEWER_RULES.md` | 32 |
+| `plans/PR-Reviewer-Boundary-Probe-Contract.md` | 95 |
+| **Total** | **137** |


### PR DESCRIPTION
Plan: plans/PR-Reviewer-Boundary-Probe-Contract.md
Slice phase: Workflow/process

Recent guard-shaped review misses came from checking the obvious boundary and stopping; this slice makes the second-side boundary probe a required, visible reviewer output before LGTM on guards, validators, caps, classifiers, gates, sanitizers, denylists, parser admission rules, and safety checkers.

## Intentional
- Documentation-only workflow contract; no mechanical audit in this slice.
- No new reviewer rule number; this strengthens existing R2/R13/R14 obligations.
- No product-code tests; verification is plan-shape, wording inspection, and local review.

## Deferred
- Optional mechanical enforcement can audit verdict text for the `boundary-probe:` line in a future workflow/process slice.

## Parked hardening
- None.

## Verification
- `python scripts/sync_pr_plan.py plans/PR-Reviewer-Boundary-Probe-Contract.md --check` - passed.
- `ATLAS_CURRENT_PR_BODY_FILE=tmp/pr-body-reviewer-boundary-probe-contract.md bash scripts/local_pr_review.sh` - passed.

## Diff size
3 files, +137 / -0.