### PR TITLE
Deflection parser observed text aliases

### DIFF
--- a/docs/extraction/validation/deflection_csv_observed_text_alias_evidence_2026-06-17.md
+++ b/docs/extraction/validation/deflection_csv_observed_text_alias_evidence_2026-06-17.md
@@ -1,0 +1,56 @@
+# Deflection CSV Observed Text Alias Evidence
+
+Date: 2026-06-17
+
+Issues: #1467, #1582
+
+## What Ran
+
+Observed local CSV exports were inspected through the real source-row CSV
+diagnostics path after adding body-shaped aliases for `actionbody` and
+`Ticket Description`.
+
+Command:
+
+```bash
+python scripts/evaluate_csv_admission_threshold_evidence.py \
+  --out-dir <tmp-observed-evidence-dir> \
+  --doc <tmp-observed-evidence-doc> \
+  --observed-csv jira_utterances=<observed-csv: sample_utterances.csv> \
+  --observed-csv support_archive=<observed-csv: customer_support_tickets.csv> \
+  --json
+```
+
+The raw CSV files are local observed evidence and are not committed.
+
+## Result
+
+| Case | Raw rows | Usable rows | Usable ratio | Admission | Mapped source text | Notable warnings |
+|---|---:|---:|---:|---|---|---|
+| `jira_utterances` | 30104 | 21396 | 0.710736 | ACCEPT | `actionbody` | `private_source_text`: 8707; `missing_source_text`: 1 |
+| `support_archive` | 8469 | 8469 | 1.0 | ACCEPT | `Ticket Description` | none affecting source text |
+
+Status: `ok`
+
+Observed minimum usable source ratio: `0.710736`
+
+## Interpretation
+
+This is the first real non-zero partial-coverage evidence recorded for the
+parser-admission policy. The partial ratio is explained by rows explicitly
+marked private/internal in the observed Jira-style utterance export, not by
+parser uncertainty. The correct behavior is therefore:
+
+- map public `actionbody` values as source text;
+- skip rows marked private/internal before source-text extraction;
+- keep the upload on the ACCEPT path with coverage warnings;
+- do not set a hard low non-zero reject threshold from this evidence alone.
+
+The support archive evidence confirms that `Ticket Description` is a real
+body-shaped support-export alias and should map to source text.
+
+## Boundary
+
+This is offline validation. It does not call live Zendesk, upload a customer
+file, mutate data, charge Stripe, or change parser policy. It commits only the
+sanitized count/header summary above, not raw CSV content.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -135,6 +135,9 @@ _TEXT_KEYS = (
     "message",
     "description",
     "issue_description",
+    "ticket_description",
+    "actionbody",
+    "action_body",
     "requester_comment",
     "customer_comment",
     "customer_message",
@@ -208,6 +211,14 @@ _PRIVATE_TEXT_KEYS = (
     "internal_comments",
     "private_comment",
     "private_comments",
+)
+_PRIVATE_ROW_KEYS = (
+    "is_private",
+    "is_internal",
+)
+_PUBLIC_ROW_KEYS = (
+    "public",
+    "is_public",
 )
 _SOURCE_TYPE_KEYS = ("source_type", "type", "kind")
 _SOURCE_TITLE_KEYS = (
@@ -819,6 +830,14 @@ def source_row_to_campaign_opportunity(
 
     lookup = _SourceFieldLookup(row)
     warnings: list[CampaignOpportunityWarning] = []
+    if _is_private_source_row(lookup):
+        warnings.append(CampaignOpportunityWarning(
+            code="private_source_text",
+            row_index=row_index,
+            field="text",
+            message="Skipped source row because it is marked private/internal.",
+        ))
+        return {}, tuple(warnings)
     text, machine_payload_seen = _source_text(lookup)
     if not text:
         if machine_payload_seen:
@@ -1344,6 +1363,30 @@ def _is_private_source_text_key(key: str) -> bool:
         ):
             return True
     return False
+
+
+def _is_private_source_row(row: Mapping[str, Any]) -> bool:
+    for key in _PRIVATE_ROW_KEYS:
+        if _is_truthy_marker(_field_value(row, key)):
+            return True
+    for key in _PUBLIC_ROW_KEYS:
+        if _is_falsey_marker(_field_value(row, key)):
+            return True
+    return False
+
+
+def _is_truthy_marker(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    text = str(value or "").strip().lower()
+    return text in {"1", "1.0", "true", "yes", "y"}
+
+
+def _is_falsey_marker(value: Any) -> bool:
+    if isinstance(value, bool):
+        return not value
+    text = str(value if value is not None else "").strip().lower()
+    return text in {"0", "0.0", "false", "no", "n"}
 
 
 def _preserved_source_value(key: str, value: Any) -> Any:

--- a/plans/PR-Deflection-Parser-Observed-Text-Aliases.md
+++ b/plans/PR-Deflection-Parser-Observed-Text-Aliases.md
@@ -1,0 +1,125 @@
+# PR-Deflection-Parser-Observed-Text-Aliases
+
+## Why this slice exists
+
+#1582 asks for real observed CSV admission evidence before setting any low
+non-zero usable-ratio threshold. A read-only probe against local observed
+exports found no partial non-zero threshold case, but it did expose a more
+upstream deterministic reject: populated body fields from real exports are not
+recognized as source text.
+
+Root cause: `_TEXT_KEYS` does not include two observed producer aliases:
+Jira-style `actionbody` / `action_body`, and support-export
+`Ticket Description` / `ticket_description`. Because source-row conversion
+never maps those fields to source text, non-empty exports with usable customer
+wording can reject as `no_usable_source_rows`. The observed `actionbody`
+export also carries row-level `is_private` markers, so admitting the alias must
+be paired with a row-level private/internal skip before source-text extraction.
+
+This fixes the root at the shared source-text alias boundary. It is not a
+threshold-policy PR: #1582/#1467 low non-zero reject policy remains blocked
+until a real partial-coverage provider export exists.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-testing
+Slice phase: Production hardening
+
+1. Add observed source-text aliases for `actionbody`, `action_body`, and
+   `ticket_description`.
+2. Add row-level private/internal source-row skip for fields such as
+   `is_private=1.0` and `public=0.0`.
+3. Add focused fixtures proving public aliases produce usable source rows and
+   private rows do not.
+4. Add diagnostics fixtures proving these aliases do not reject as
+   zero-usable CSVs.
+5. Commit a sanitized observed-evidence note with counts/headers, without
+   committing raw downloaded CSVs.
+
+### Review Contract
+
+Acceptance criteria:
+- Jira-style `actionbody` rows become usable source text.
+- Support-export `Ticket Description` rows become usable source text.
+- Rows marked private/internal do not become usable source text even when they
+  contain `actionbody`.
+- Existing zero-usable rejection remains intact for unknown body-like columns.
+- No low non-zero usable-ratio reject threshold is introduced.
+- No raw local observed CSV is committed.
+
+Affected surfaces:
+- Extracted source-row text alias mapping, source adapter tests, ingestion
+  diagnostics tests, and the #1582 observed evidence trail.
+
+Risk areas:
+- Over-widening source-text aliases so metadata starts counting as customer
+  wording.
+- Leaking private/internal row text from observed exports.
+- Accidentally turning this alias fix into threshold policy.
+- Committing raw observed CSV data or PII.
+
+Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+### Files touched
+
+- `docs/extraction/validation/deflection_csv_observed_text_alias_evidence_2026-06-17.md`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `plans/PR-Deflection-Parser-Observed-Text-Aliases.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+
+## Mechanism
+
+- Extend `_TEXT_KEYS` with exact observed aliases:
+  `ticket_description`, `actionbody`, and `action_body`.
+- Rely on the existing normalized/compact field lookup so producer casing like
+  `Ticket Description` maps through the same path.
+- Add row-level private/public marker detection before source-text extraction.
+  Truthy `is_private`/`is_internal` and falsey `public`/`is_public` skip the
+  row with `private_source_text`; ambiguous bare `private`/`internal` columns
+  are intentionally not visibility markers.
+- Keep the current admission envelope and coverage policy unchanged.
+
+## Intentional
+
+- No threshold change: this PR fixes deterministic alias misses only.
+- No committed observed CSV fixture: the observed files are local and may
+  contain customer-like data. Tests use minimal synthetic rows that model the
+  discovered headers.
+- `actionbody` is intentionally scoped to a body-like source-text alias, not a
+  generic `action` alias.
+- Row-level private skips are intentionally fail-closed for common boolean
+  spellings (`true`, `1`, `1.0`, `yes`; and `false`, `0`, `0.0`, `no` for
+  public markers).
+
+## Deferred
+
+- #1582 threshold policy remains open; this PR records one real non-zero
+  partial-coverage observed export, but the partial coverage is explained by
+  private rows and does not justify a hard reject threshold.
+- #1467 low non-zero reject threshold remains blocked on observed partial
+  evidence.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_ingestion_diagnostics.py tests/test_evaluate_csv_admission_threshold_evidence.py -q`
+  - 180 passed in 0.86s.
+- `python scripts/evaluate_csv_admission_threshold_evidence.py --out-dir <tmp-observed-evidence-dir> --doc <tmp-observed-evidence-doc> --observed-csv jira_utterances=<observed-csv: sample_utterances.csv> --observed-csv support_archive=<observed-csv: customer_support_tickets.csv> --json`
+  - Passed; observed `jira_utterances` at 30104 raw / 21396 usable / ratio
+    0.710736 with 8707 `private_source_text` skips, and `support_archive` at
+    8469 raw / 8469 usable / ratio 1.0.
+- `./scripts/run_extracted_pipeline_checks.sh`
+  - 4610 passed, 10 skipped, 1 warning in 74.69s.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/deflection_csv_observed_text_alias_evidence_2026-06-17.md` | 56 |
+| `extracted_content_pipeline/campaign_source_adapters.py` | 43 |
+| `plans/PR-Deflection-Parser-Observed-Text-Aliases.md` | 125 |
+| `tests/test_extracted_campaign_source_adapters.py` | 85 |
+| `tests/test_extracted_content_ingestion_diagnostics.py` | 86 |
+| **Total** | **395** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -701,6 +701,91 @@ def test_source_rows_do_not_admit_private_note_aliases_as_customer_text(
     assert "missing_source_text" in [warning.code for warning in loaded.warnings]
 
 
+@pytest.mark.parametrize(
+    ("field", "text"),
+    (
+        ("actionbody", "Customer cannot download the invoice PDF."),
+        ("Action Body", "Customer cannot reset the account password."),
+        ("Ticket Description", "The customer cannot export the weekly report."),
+    ),
+)
+def test_source_rows_admit_observed_export_body_aliases(
+    field: str,
+    text: str,
+) -> None:
+    loaded = source_rows_to_campaign_opportunities([{
+        "ticket_id": "observed-1",
+        field: text,
+    }], default_fields={
+        "company_name": "Acme Logistics",
+        "vendor_name": "Atlas",
+        "contact_email": "ops@example.com",
+    })
+
+    assert loaded.warnings == ()
+    assert len(loaded.opportunities) == 1
+    assert loaded.opportunities[0]["evidence"] == [{
+        "text": text,
+        "source_id": "observed-1",
+        "source_type": "support_ticket",
+    }]
+
+
+@pytest.mark.parametrize(
+    "privacy_field",
+    (
+        {"is_private": "1.0"},
+        {"is_private": True},
+        {"is_internal": "yes"},
+        {"public": "0.0"},
+        {"public": 0},
+        {"public": 0.0},
+        {"is_public": False},
+    ),
+)
+def test_source_rows_skip_observed_body_alias_when_row_is_private(
+    privacy_field: dict[str, object],
+) -> None:
+    loaded = source_rows_to_campaign_opportunities([{
+        "ticket_id": "observed-private-1",
+        "actionbody": "Do not publish this internal workaround.",
+        **privacy_field,
+    }], default_fields={
+        "company_name": "Acme Logistics",
+        "vendor_name": "Atlas",
+        "contact_email": "ops@example.com",
+    })
+
+    assert loaded.opportunities == ()
+    assert [warning.as_dict() for warning in loaded.warnings] == [{
+        "code": "private_source_text",
+        "row_index": 1,
+        "field": "text",
+        "message": "Skipped source row because it is marked private/internal.",
+    }]
+
+
+@pytest.mark.parametrize("field", ("internal", "private"))
+def test_source_rows_keep_observed_body_alias_with_benign_private_named_column(
+    field: str,
+) -> None:
+    text = "Customer cannot download the invoice PDF."
+
+    loaded = source_rows_to_campaign_opportunities([{
+        "ticket_id": "observed-public-1",
+        "actionbody": text,
+        field: "1",
+    }], default_fields={
+        "company_name": "Acme Logistics",
+        "vendor_name": "Atlas",
+        "contact_email": "ops@example.com",
+    })
+
+    assert [warning.code for warning in loaded.warnings] == []
+    assert len(loaded.opportunities) == 1
+    assert loaded.opportunities[0]["evidence"][0]["text"] == text
+
+
 def test_source_rows_do_not_admit_machine_json_payload_as_customer_text() -> None:
     loaded = source_rows_to_campaign_opportunities([{
         "ticket_id": "zd-1",

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from extracted_content_pipeline.ingestion_diagnostics import inspect_ingestion_file
 
 
@@ -322,6 +324,90 @@ def test_inspect_source_csv_warns_when_partial_upload_has_machine_json_row(
         "skipped_source_row_count": 1,
         "usable_source_ratio": 0.5,
     }]
+
+
+@pytest.mark.parametrize(
+    ("header", "text"),
+    (
+        ("actionbody", "Customer cannot download the invoice PDF."),
+        ("Ticket Description", "The customer cannot export the weekly report."),
+    ),
+)
+def test_inspect_source_csv_accepts_observed_export_body_aliases(
+    tmp_path: Path,
+    header: str,
+    text: str,
+) -> None:
+    path = tmp_path / "observed-body-alias.csv"
+    path.write_text(
+        f"Ticket ID,{header}\n"
+        f"T-1,{text}\n",
+        encoding="utf-8",
+    )
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=1,
+        default_fields={
+            "company_name": "Acme Logistics",
+            "vendor_name": "Atlas",
+            "contact_email": "ops@example.com",
+        },
+    ).as_dict()
+
+    admission = payload["source_row_admission"]
+    assert payload["ok"] is True
+    assert payload["warning_counts"] == {}
+    assert admission["raw_source_row_count"] == 1
+    assert admission["usable_source_row_count"] == 1
+    assert admission["usable_source_ratio"] == 1.0
+    assert admission["mapped_fields"] == {
+        "source_id": ["Ticket ID"],
+        "source_text": [header],
+    }
+    assert admission["admission_decision"] == {"status": "ACCEPT"}
+    assert admission.get("coverage_warnings", []) == []
+
+
+def test_inspect_source_csv_rejects_observed_body_alias_when_row_is_private(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "private-observed-body-alias.csv"
+    path.write_text(
+        "Ticket ID,actionbody,is_private\n"
+        "T-1,Do not publish this internal workaround.,1.0\n",
+        encoding="utf-8",
+    )
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=1,
+        default_fields={
+            "company_name": "Acme Logistics",
+            "vendor_name": "Atlas",
+            "contact_email": "ops@example.com",
+        },
+    ).as_dict()
+
+    admission = payload["source_row_admission"]
+    assert payload["ok"] is False
+    assert payload["warning_counts"] == {"private_source_text": 1}
+    assert admission["raw_source_row_count"] == 1
+    assert admission["usable_source_row_count"] == 0
+    assert admission["usable_source_ratio"] == 0.0
+    assert admission["mapped_fields"] == {
+        "source_id": ["Ticket ID"],
+        "source_text": ["actionbody"],
+    }
+    assert admission["admission_decision"] == {
+        "status": "REJECT",
+        "reason": "no_usable_source_rows",
+        "location": "source_row_csv",
+    }
 
 
 def test_inspect_source_csv_sample_limit_does_not_make_known_aliases_unmapped(


### PR DESCRIPTION
Plan: plans/PR-Deflection-Parser-Observed-Text-Aliases.md
Slice phase: Production hardening

#1582 observed CSV evidence exposed real body fields (`actionbody`, `Ticket Description`) that were populated but unmapped, causing source-row CSVs with usable wording to reject as zero-usable. This fixes the root at the shared source-text alias boundary and adds a row-level private/internal skip so Jira-style private utterances do not become usable evidence.

## Intentional
- No low non-zero usable-ratio threshold. This PR fixes deterministic alias misses only.
- Raw local observed CSVs stay out of git; only sanitized count/header evidence is committed.
- `actionbody` is scoped to a body-like source-text alias, not a generic `action` alias.
- Row-level private/internal markers are scoped to unambiguous visibility fields: `is_private`, `is_internal`, `public`, and `is_public`.

## Deferred
- #1582 threshold policy remains open; this PR records one real non-zero partial-coverage observed export, but the partial coverage is explained by private rows and does not justify a hard reject threshold.
- #1467 low non-zero reject threshold remains blocked on observed product evidence that justifies reject rather than warn.

## Parked hardening
- None.

## AI Reconciliation
- All fixed or waived: Yes.
- Reviewer MAJOR private/internal over-skip: fixed by removing ambiguous bare `private`/`internal` row markers and adding a keep-direction test for benign columns with those names.
- Reviewer MAJOR absolute local paths: fixed by redacting committed evidence and plan/body verification to labels such as `<observed-csv: sample_utterances.csv>` and `<tmp-observed-evidence-dir>`.
- Copilot falsey numeric public marker: fixed by preserving numeric `0` / `0.0` through `_is_falsey_marker` instead of collapsing them with `value or ""`; tests now cover `public=0` and `public=0.0`.
- Copilot plan/code mismatch on bare `private`/`internal`: fixed by updating the plan mechanism to state only unambiguous `is_private`/`is_internal` and `public`/`is_public` markers trigger row-level skips.
- Copilot marker-shape coverage: fixed by extending the private-row parametrized test to cover `is_internal`, numeric `public=0`, and numeric `public=0.0`.

## Verification
- `pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_ingestion_diagnostics.py tests/test_evaluate_csv_admission_threshold_evidence.py -q` - 180 passed in 0.86s.
- `python scripts/evaluate_csv_admission_threshold_evidence.py --out-dir <tmp-observed-evidence-dir> --doc <tmp-observed-evidence-doc> --observed-csv jira_utterances=<observed-csv: sample_utterances.csv> --observed-csv support_archive=<observed-csv: customer_support_tickets.csv> --json` - passed; `jira_utterances` observed 30104 raw / 21396 usable / ratio 0.710736 with 8707 private rows skipped, and `support_archive` observed 8469 raw / 8469 usable / ratio 1.0.
- `./scripts/run_extracted_pipeline_checks.sh` - 4610 passed, 10 skipped, 1 warning in 74.69s.

## Diff size
5 files, +395 / -0.