### PR TITLE
Deflection parser JSONL line diagnostics

### DIFF
--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -345,22 +345,30 @@ def normalize_campaign_opportunity_rows(
                 )
             )
             continue
+        row_index = _source_row_warning_index(row, index)
         normalized = normalize_campaign_opportunity(row, target_mode=target_mode)
         if not normalized:
             warnings.append(
                 CampaignOpportunityWarning(
                     code="empty_row",
-                    row_index=index,
+                    row_index=row_index,
                     message="Skipped row because it did not contain usable values.",
                 )
             )
             continue
         opportunities.append(normalized)
-        warnings.extend(_validation_warnings(normalized, row_index=index))
+        warnings.extend(_validation_warnings(normalized, row_index=row_index))
     return CampaignOpportunityLoadResult(
         opportunities=tuple(opportunities),
         warnings=tuple(warnings),
     )
+
+
+def _source_row_warning_index(row: Mapping[str, Any], fallback: int) -> int:
+    raw_index = getattr(row, "source_row_index", None)
+    if isinstance(raw_index, int) and raw_index > 0:
+        return raw_index
+    return fallback
 
 
 @dataclass(frozen=True)

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -338,6 +338,14 @@ _MAX_BUNDLE_DEPTH = 8
 _MISSING = object()
 
 
+class _IndexedSourceRow(dict[str, Any]):
+    """Source row dict that remembers its physical JSONL line number."""
+
+    def __init__(self, row: Mapping[str, Any], *, source_row_index: int) -> None:
+        super().__init__(row)
+        self.source_row_index = source_row_index
+
+
 @dataclass(frozen=True)
 class SourceRowAdmissionDiagnostics:
     """Source-row admission evidence for operator-facing diagnostics."""
@@ -515,10 +523,17 @@ def load_source_rows_from_file(
 ) -> list[Any]:
     """Load source rows from a CSV, JSON, or JSONL file without opportunity mapping."""
 
-    rows, _warnings = load_source_rows_with_warnings_from_file(
+    rows, warnings = load_source_rows_with_warnings_from_file(
         path,
         file_format=file_format,
     )
+    malformed_jsonl_warnings = [
+        warning for warning in warnings if warning.code == "malformed_jsonl_line"
+    ]
+    if malformed_jsonl_warnings:
+        warning = malformed_jsonl_warnings[0]
+        line = f"line {warning.row_index}" if warning.row_index is not None else "a line"
+        raise ValueError(f"Malformed JSONL source row at {line}: {warning.message}")
     return rows
 
 
@@ -562,15 +577,19 @@ def source_rows_to_campaign_opportunities(
                 message="Skipped source row because it is not an object.",
             ))
             continue
+        row_index = _source_row_input_index(row, index)
         merged_row = _merge_default_fields(defaults, row) if defaults else row
         opportunity, row_warnings = source_row_to_campaign_opportunity(
             merged_row,
-            row_index=index,
+            row_index=row_index,
             max_text_chars=max_text_chars,
         )
         warnings.extend(row_warnings)
         if opportunity:
-            opportunities.append(opportunity)
+            opportunities.append(_IndexedSourceRow(
+                opportunity,
+                source_row_index=row_index,
+            ))
     normalized = normalize_campaign_opportunity_rows(
         opportunities,
         target_mode=target_mode,
@@ -739,6 +758,13 @@ def _populated_source_fields(rows: Sequence[Any]) -> tuple[str, ...]:
     return tuple(fields)
 
 
+def _source_row_input_index(row: Mapping[str, Any], fallback: int) -> int:
+    raw_index = getattr(row, "source_row_index", None)
+    if isinstance(raw_index, int) and raw_index > 0:
+        return raw_index
+    return fallback
+
+
 def _matching_fields(fields: Sequence[str], aliases: Sequence[str]) -> tuple[str, ...]:
     return tuple(field for field in fields if _field_matches_aliases(field, aliases))
 
@@ -872,11 +898,29 @@ def _load_source_rows(
         return _load_source_csv_rows(path)
     if resolved_format == "jsonl":
         rows: list[Any] = []
-        for line in path.read_text(encoding="utf-8").splitlines():
+        warnings: list[CampaignOpportunityWarning] = []
+        for line_index, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
             text = line.strip()
             if text:
-                rows.append(json.loads(text))
-        return rows, ()
+                try:
+                    parsed = json.loads(text)
+                    if isinstance(parsed, Mapping):
+                        parsed = _IndexedSourceRow(parsed, source_row_index=line_index)
+                    rows.append(parsed)
+                except json.JSONDecodeError as exc:
+                    warnings.append(CampaignOpportunityWarning(
+                        code="malformed_jsonl_line",
+                        row_index=line_index,
+                        field="jsonl",
+                        message=(
+                            "Skipped JSONL source row because it is not valid "
+                            f"JSON ({exc.msg} at column {exc.colno})."
+                        ),
+                    ))
+        return rows, tuple(warnings)
     data = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(data, list):
         return list(data), ()

--- a/plans/PR-Deflection-Parser-JSONL-Line-Diagnostics.md
+++ b/plans/PR-Deflection-Parser-JSONL-Line-Diagnostics.md
@@ -1,0 +1,120 @@
+# PR-Deflection-Parser-JSONL-Line-Diagnostics
+
+## Why this slice exists
+
+#1463 names a parser/admission hardening gap: the guarded JSONL path aborts the
+whole upload when one line is malformed. The observed root is in
+`campaign_source_adapters._load_source_rows(..., file_format="jsonl")`: it
+calls `json.loads(...)` for each non-empty line and lets `JSONDecodeError`
+escape, so a single bad source row prevents every other valid row from reaching
+the normal source-row admission diagnostics.
+
+This fixes the root at the JSONL loader boundary. The loader should treat
+malformed JSONL records like bad rows, not like a bad file: skip that one line,
+emit a precise non-fatal warning with the line number, and continue converting
+valid rows. This is not a CSV threshold-policy change and does not alter JSON
+array/object loading.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-testing
+Slice phase: Production hardening
+
+1. Add a JSONL malformed-line warning for non-empty lines that fail JSON parse.
+2. Preserve valid JSONL rows before/after the malformed line.
+3. Surface the warning through source-row diagnostics and the source-row CLI.
+4. Preserve physical JSONL line numbers for downstream row-level warnings.
+5. Fail closed in the warning-dropping raw-row helper when malformed JSONL
+   warnings would otherwise be discarded.
+6. Add negative/near-miss tests: one malformed line is skipped, blank lines are
+   still ignored, and a fully valid JSONL file stays warning-free.
+
+### Review Contract
+
+Acceptance criteria:
+- One malformed JSONL line no longer aborts
+  `load_source_rows_with_warnings_from_file`.
+- Valid JSONL rows before and after a malformed line are preserved and
+  converted.
+- The emitted warning includes code, row/line index, and a bounded message that
+  does not echo raw source content.
+- `inspect_ingestion_file(..., source_rows=True, source_format="jsonl")`
+  exposes the warning in `warning_counts` and `warnings`.
+- Downstream validation warnings, such as `missing_contact_email`, report the
+  physical JSONL line number after skipped malformed lines.
+- The legacy raw-row helper does not silently drop malformed-line warnings.
+- Valid JSONL and blank-line-only gaps remain warning-free.
+- CSV admission and low non-zero coverage policy remain unchanged.
+
+Affected surfaces:
+- Extracted source-row JSONL loader, opportunity warning row-index propagation,
+  source adapter tests, and ingestion diagnostics tests.
+
+Risk areas:
+- Hiding a wholly corrupt JSONL file as a clean zero-row upload.
+- Leaking raw customer text in parse-error messages.
+- Regressing valid JSONL loading or CSV loader behavior.
+
+Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `plans/PR-Deflection-Parser-JSONL-Line-Diagnostics.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+
+## Mechanism
+
+- Keep the existing JSONL resolution branch in `_load_source_rows`.
+- For each non-empty line, parse with `json.loads`.
+- On `JSONDecodeError`, append a `CampaignOpportunityWarning` with a new
+  `malformed_jsonl_line` code, `row_index` equal to the physical 1-based line
+  number, `field="jsonl"`, and a concise parser message.
+- Continue parsing subsequent lines and return `(rows, warnings)`.
+- The existing conversion path already concatenates loader warnings with
+  row-conversion warnings, so diagnostics/CLI output should pick up the new
+  warning without a second reporting path.
+- Carry the physical JSONL line number on an internal dict subclass attribute
+  so validation warnings emitted after source-row conversion still point to the
+  input line, without adding synthetic keys to returned opportunities.
+- Make `load_source_rows_from_file(...)` raise on `malformed_jsonl_line` because
+  that legacy helper returns only rows and would otherwise discard the warning.
+
+## Intentional
+
+- No hard REJECT envelope for JSONL in this PR. #1467's structured
+  `source_row_admission` object is currently CSV-specific, and extending that
+  envelope to JSONL is a separate product/API shape decision.
+- No raw line echo in warning messages; parse diagnostics can name the line and
+  parser reason without committing or logging customer text.
+- Empty/whitespace-only JSONL lines remain ignored without warning, matching
+  current behavior.
+
+## Deferred
+
+- #1467 low non-zero CSV reject threshold remains blocked on real partial
+  provider evidence.
+- A broader JSONL admission envelope can be added later if JSONL becomes a
+  buyer-facing upload format that needs ACCEPT/REJECT parity with CSV.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_ingestion_diagnostics.py -q`
+  - 155 passed in 1.34s.
+- `./scripts/run_extracted_pipeline_checks.sh`
+  - 4590 passed, 10 skipped, 1 warning in 75.01s.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_customer_data.py` | 12 |
+| `extracted_content_pipeline/campaign_source_adapters.py` | 56 |
+| `plans/PR-Deflection-Parser-JSONL-Line-Diagnostics.md` | 120 |
+| `tests/test_extracted_campaign_source_adapters.py` | 109 |
+| `tests/test_extracted_content_ingestion_diagnostics.py` | 54 |
+| **Total** | **351** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -1808,6 +1808,115 @@ def test_load_source_campaign_opportunities_from_jsonl(tmp_path: Path) -> None:
     assert loaded.opportunities[1]["evidence"][0]["source_type"] == "complaint"
 
 
+def test_load_source_rows_from_jsonl_skips_malformed_line_with_warning(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        "\n".join([
+            json.dumps({
+                "id": "ticket-1",
+                "company": "Acme",
+                "vendor": "Zendesk",
+                "message": "The export keeps failing.",
+            }),
+            "",
+            '{"id": "broken", "message": ',
+            json.dumps({
+                "id": "ticket-2",
+                "company": "Beta",
+                "vendor": "HubSpot",
+                "message": "The renewal quote is wrong.",
+            }),
+        ]),
+        encoding="utf-8",
+    )
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="jsonl",
+    )
+
+    assert [row["id"] for row in rows] == ["ticket-1", "ticket-2"]
+    assert [warning.as_dict() for warning in warnings] == [{
+        "code": "malformed_jsonl_line",
+        "message": (
+            "Skipped JSONL source row because it is not valid JSON "
+            "(Expecting value at column 28)."
+        ),
+        "row_index": 3,
+        "field": "jsonl",
+    }]
+    assert "broken" not in warnings[0].message
+
+    loaded = source_rows_to_campaign_opportunities(rows)
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "ticket-1",
+        "ticket-2",
+    ]
+    assert "__atlas_jsonl_source_line" not in loaded.opportunities[0]
+    assert [
+        warning.row_index
+        for warning in loaded.warnings
+        if warning.code == "missing_contact_email"
+    ] == [1, 4]
+
+
+def test_load_source_rows_from_jsonl_does_not_drop_malformed_line_warning(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        "\n".join([
+            json.dumps({
+                "id": "ticket-1",
+                "company": "Acme",
+                "vendor": "Zendesk",
+                "message": "The export keeps failing.",
+            }),
+            '{"id": "broken", "message": ',
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Malformed JSONL source row at line 2"):
+        load_source_rows_from_file(path, file_format="jsonl")
+
+
+def test_load_source_rows_from_valid_jsonl_stays_warning_free(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        "\n".join([
+            "",
+            json.dumps({
+                "id": "ticket-1",
+                "company": "Acme",
+                "vendor": "Zendesk",
+                "message": "The export keeps failing.",
+            }),
+            "   ",
+            json.dumps({
+                "id": "ticket-2",
+                "company": "Beta",
+                "vendor": "HubSpot",
+                "message": "The renewal quote is wrong.",
+            }),
+        ]),
+        encoding="utf-8",
+    )
+
+    rows, warnings = load_source_rows_with_warnings_from_file(
+        path,
+        file_format="jsonl",
+    )
+
+    assert [row["id"] for row in rows] == ["ticket-1", "ticket-2"]
+    assert warnings == ()
+
+
 def test_load_source_campaign_opportunities_from_csv(tmp_path: Path) -> None:
     path = tmp_path / "sources.csv"
     path.write_text(

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -73,6 +73,60 @@ def test_inspect_source_rows_counts_source_types_and_warnings(tmp_path: Path) ->
     assert payload["samples"][0]["evidence"][0]["source_type"] == "support_ticket"
 
 
+def test_inspect_source_jsonl_reports_malformed_line_without_aborting(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        "\n".join([
+            json.dumps({
+                "ticket_id": "ticket-1",
+                "company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "message": "Renewal quote jumped before export work finished.",
+            }),
+            '{"ticket_id": "bad", "message": ',
+            json.dumps({
+                "ticket_id": "ticket-2",
+                "company": "Beta",
+                "vendor": "Zendesk",
+                "message": "Ticket exports timeout after filtering.",
+            }),
+        ]),
+        encoding="utf-8",
+    )
+
+    report = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="jsonl",
+        sample_limit=2,
+    )
+    payload = report.as_dict()
+
+    assert payload["ok"] is True
+    assert payload["opportunity_count"] == 2
+    assert payload["warning_counts"] == {
+        "malformed_jsonl_line": 1,
+        "missing_contact_email": 2,
+    }
+    assert payload["warnings"][0] == {
+        "code": "malformed_jsonl_line",
+        "message": (
+            "Skipped JSONL source row because it is not valid JSON "
+            "(Expecting value at column 32)."
+        ),
+        "row_index": 2,
+        "field": "jsonl",
+    }
+    assert "bad" not in payload["warnings"][0]["message"]
+    assert [
+        warning["row_index"]
+        for warning in payload["warnings"]
+        if warning["code"] == "missing_contact_email"
+    ] == [1, 3]
+
+
 def test_inspect_source_rows_applies_default_fields(tmp_path: Path) -> None:
     path = tmp_path / "sources.jsonl"
     path.write_text(json.dumps({


### PR DESCRIPTION
Plan: plans/PR-Deflection-Parser-JSONL-Line-Diagnostics.md
Slice phase: Production hardening

#1463 names a parser/admission hardening gap: malformed JSONL currently aborts the whole source-row upload. The root is the JSONL loader boundary, where `json.loads` exceptions escape line-by-line parsing. This PR fixes that root by treating a malformed JSONL record as a bad row: skip that physical line, emit a bounded `malformed_jsonl_line` warning with row index and parser position, continue converting valid rows before and after it, and preserve physical JSONL line numbers for downstream row-level validation warnings.

## Intentional
- No hard REJECT envelope for JSONL in this PR. #1467's structured `source_row_admission` object is currently CSV-specific; JSONL parity is deferred unless JSONL becomes a buyer-facing upload shape.
- Warning messages do not echo raw source content.
- Empty/whitespace-only JSONL lines remain ignored without warning, matching current behavior.
- `load_source_rows_from_file(...)` raises on malformed JSONL because it returns only rows and would otherwise discard the new warning; warning-aware callers keep the non-fatal recovery path.

## Deferred
- #1467 low non-zero CSV reject threshold remains blocked on real partial provider evidence.
- A broader JSONL admission envelope can be added later if JSONL needs ACCEPT/REJECT parity with CSV.

## Parked hardening
- None.

## AI Reconciliation
- All fixed or waived: Yes.
- Codex P2 "Preserve JSONL line numbers for row warnings": fixed by carrying physical JSONL line numbers on an internal dict subclass attribute through source-row conversion and opportunity validation; tests assert `missing_contact_email` reports physical lines after skipped malformed rows.
- Codex P2 "Surface malformed JSONL warnings to raw-row callers": fixed by making `load_source_rows_from_file(...)` fail closed on `malformed_jsonl_line` instead of silently discarding warning-only diagnostics; warning-aware callers still receive rows plus warnings.

## Verification
- `pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_ingestion_diagnostics.py -q` - 155 passed in 1.34s.
- `./scripts/run_extracted_pipeline_checks.sh` - 4590 passed, 10 skipped, 1 warning in 75.01s.

## Diff size
5 files, +350 / -0.