### PR TITLE
Docker base-image security bumps (safe subset)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an NVIDIA CUDA runtime as a parent image
-FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 
 # Set environment variables to make the installation non-interactive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/atlas_video-processing/ingest/drone_client/Dockerfile
+++ b/atlas_video-processing/ingest/drone_client/Dockerfile
@@ -1,6 +1,6 @@
 # Use an official Python runtime as a parent image
 #checkov:skip=CKV_DOCKER_2:Drone ingest is a worker process and does not expose an HTTP health endpoint.
-FROM python:3.9-slim-buster
+FROM python:3.11-slim-buster
 
 # Set the working directory in the container
 WORKDIR /app

--- a/atlas_video-processing/ingest/drone_client/Dockerfile
+++ b/atlas_video-processing/ingest/drone_client/Dockerfile
@@ -1,6 +1,6 @@
 # Use an official Python runtime as a parent image
 #checkov:skip=CKV_DOCKER_2:Drone ingest is a worker process and does not expose an HTTP health endpoint.
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 # Set the working directory in the container
 WORKDIR /app

--- a/plans/PR-Docker-Baseimage-Security-Bumps.md
+++ b/plans/PR-Docker-Baseimage-Security-Bumps.md
@@ -26,13 +26,27 @@ Two bumps qualify as low-risk:
   The only dependency is the pure-Python kafka-python, so the bookworm
   (Debian 12) base carries no native-build risk.
 
-## Scope
+## Scope (this PR)
 
 Slice phase: Production hardening
 
 Two one-line FROM edits to existing Dockerfiles. No application code, no
 compose files, no workflow files, no extracted_* changes. The plan doc is the
 only added file.
+
+### Review Contract
+
+Acceptance criteria:
+- Both FROM pins point at supported tags that resolve on their registries.
+- The drone_client image builds and runs on the new base with kafka-python
+  importable.
+- No application code, compose, workflow, or extracted_* files change.
+
+Risk areas:
+- CUDA minor bump on the production brain image: not built locally; the
+  deploy-time docker compose up --build is the real backstop (no CI build).
+- Worker base-OS currency: addressed by moving to bookworm (Debian 12), not
+  EOL buster (Debian 10).
 
 ### Files touched
 
@@ -88,8 +102,9 @@ Held for separate, dev-gated decisions (not in this PR):
 
 ## Estimated diff size
 
-| Area | LOC |
-|---|---|
-| Dockerfile FROM bumps (2 files) | 4 |
-| This plan doc (added) | ~95 |
-| **Total** | **~99** |
+| File | LOC |
+|---|---:|
+| `Dockerfile` | 2 |
+| `atlas_video-processing/ingest/drone_client/Dockerfile` | 2 |
+| `plans/PR-Docker-Baseimage-Security-Bumps.md` | 110 |
+| **Total** | **114** |

--- a/plans/PR-Docker-Baseimage-Security-Bumps.md
+++ b/plans/PR-Docker-Baseimage-Security-Bumps.md
@@ -20,9 +20,11 @@ Two bumps qualify as low-risk:
   -cudnn8-runtime-ubuntu22.04 variant). A CUDA minor bump within the 12.x line;
   torch/torchaudio are unpinned in requirements, so the pip wheels carry their
   own CUDA runtime and do not pin a +cu121 build that could mismatch the base.
-- drone_client worker image: python 3.9-slim-buster -> 3.11-slim-buster.
-  Retires end-of-life Python 3.9 on a worker whose only dependency is the
-  pure-Python kafka-python.
+- drone_client worker image: python 3.9-slim-buster -> 3.11-slim-bookworm.
+  Retires BOTH end-of-life Python 3.9 and end-of-life Debian 10 (buster) in one
+  bump (a buster-only bump would ship the security fix onto an unsupported OS).
+  The only dependency is the pure-Python kafka-python, so the bookworm
+  (Debian 12) base carries no native-build risk.
 
 ## Scope
 
@@ -73,14 +75,16 @@ Held for separate, dev-gated decisions (not in this PR):
 
 - docker manifest inspect nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04 -> tag
   EXISTS.
-- docker manifest inspect python:3.11-slim-buster -> tag EXISTS.
+- docker manifest inspect python:3.11-slim-bookworm -> tag EXISTS.
 - drone_client: docker build of atlas_video-processing/ingest/drone_client
   succeeded; docker run of the image with python -c "import sys, kafka" printed
-  Python 3.11.4 and kafka-python 3.0.0.
+  Python 3.11.15 and kafka-python 3.0.0, on Debian GNU/Linux 12 (bookworm).
 - Root CUDA Dockerfile: NOT built locally (multi-GB CUDA base plus the full
   requirements install, including torch, is too heavy to build in this
   environment). Verification ceiling: tag existence, CUDA 12.x minor-compat,
-  and torch being unpinned. CI / dev build is the backstop.
+  and torch being unpinned. NOTE: no CI workflow runs docker build of the brain
+  image (the check workflows run pytest), so the real backstop is the
+  deploy-time docker compose up --build, not CI.
 
 ## Estimated diff size
 

--- a/plans/PR-Docker-Baseimage-Security-Bumps.md
+++ b/plans/PR-Docker-Baseimage-Security-Bumps.md
@@ -1,0 +1,91 @@
+# PR-Docker-Baseimage-Security-Bumps
+
+Plan: plans/PR-Docker-Baseimage-Security-Bumps.md
+Slice phase: Production hardening
+Ownership lane: infra/docker-base-images
+Reviewer rules triggered: none (Docker base-image FROM bumps only; no path
+glob in docs/REVIEWER_RULES.md matches Dockerfiles).
+
+## Why this slice exists
+
+Dependabot opened a batch of Docker base-image security bumps. This slice lands
+only the low-risk, verifiable subset and deliberately holds the risky majors
+for separate, dev-gated decisions. It runs in its own worktree to stay clear of
+the parallel npm security batch and the in-flight workflow-action-pin work,
+which touch entirely different files.
+
+Two bumps qualify as low-risk:
+
+- Root Dockerfile (the Atlas brain image): nvidia/cuda 12.1.1 -> 12.2.2 (same
+  -cudnn8-runtime-ubuntu22.04 variant). A CUDA minor bump within the 12.x line;
+  torch/torchaudio are unpinned in requirements, so the pip wheels carry their
+  own CUDA runtime and do not pin a +cu121 build that could mismatch the base.
+- drone_client worker image: python 3.9-slim-buster -> 3.11-slim-buster.
+  Retires end-of-life Python 3.9 on a worker whose only dependency is the
+  pure-Python kafka-python.
+
+## Scope
+
+Slice phase: Production hardening
+
+Two one-line FROM edits to existing Dockerfiles. No application code, no
+compose files, no workflow files, no extracted_* changes. The plan doc is the
+only added file.
+
+### Files touched
+
+- `Dockerfile`
+- `atlas_video-processing/ingest/drone_client/Dockerfile`
+- `plans/PR-Docker-Baseimage-Security-Bumps.md`
+
+## Mechanism
+
+Bump the two FROM pins to the Dependabot-proposed tags. Both proposed tags were
+confirmed to exist on their registries with docker manifest inspect before
+editing. The drone-client image was then built and run to confirm the bumped
+interpreter and its dependency import cleanly.
+
+## Intentional
+
+- Only the brain-image CUDA minor bump and the drone-client Python 3.9 -> 3.11
+  bump are included, because both are verifiable as low-risk here.
+- The drone-client image is fully build-verified (built, ran, imported its
+  dependency). The CUDA bump is verified by tag existence plus CUDA
+  minor-version compatibility reasoning, not by a full local image build (see
+  Verification).
+
+## Deferred
+
+Held for separate, dev-gated decisions (not in this PR):
+
+- video_stream_processor python 3.9 -> 3.13: the dependency
+  (opencv-python-headless) installs cleanly on 3.13, but that Dockerfile has a
+  pre-existing missing-WORKDIR bug that makes it fail to build on BOTH the old
+  3.9 and the new 3.13 base. Needs a dedicated slice that fixes the Dockerfile
+  and bumps Python together so the bump is build-verifiable.
+- graphiti-wrapper and vision images python 3.11 -> 3.14: Python 3.14 is too
+  new for the torch / graphiti / SAM dependency graphs.
+- confluentinc/cp-kafka 5.5.3 -> 8.2.1: major Confluent Platform jump (KRaft
+  removes ZooKeeper, but the compose still runs cp-zookeeper).
+- postgres 13 -> 18: five-major data-directory migration.
+
+## Verification
+
+- docker manifest inspect nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04 -> tag
+  EXISTS.
+- docker manifest inspect python:3.11-slim-buster -> tag EXISTS.
+- drone_client: docker build of atlas_video-processing/ingest/drone_client
+  succeeded; docker run of the image with python -c "import sys, kafka" printed
+  Python 3.11.4 and kafka-python 3.0.0.
+- Root CUDA Dockerfile: NOT built locally (multi-GB CUDA base plus the full
+  requirements install, including torch, is too heavy to build in this
+  environment). Verification ceiling: tag existence, CUDA 12.x minor-compat,
+  and torch being unpinned. CI / dev build is the backstop.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---|
+| Dockerfile FROM bumps (2 files) | 4 |
+| This plan doc (added) | ~95 |
+| **Total** | **~99** |


### PR DESCRIPTION
Plan: plans/PR-Docker-Baseimage-Security-Bumps.md
Slice phase: Production hardening
Ownership lane: infra/docker-base-images

Lands the low-risk, verifiable subset of the Dependabot Docker base-image
security batch and holds the risky majors for separate, dev-gated decisions.
Runs in its own worktree, clear of the parallel npm batch and the in-flight
workflow-action-pin work (different files).

Two bumps, both low-risk:
- Root Dockerfile (Atlas brain image): nvidia/cuda 12.1.1 -> 12.2.2 (same
  -cudnn8-runtime-ubuntu22.04). CUDA minor bump; torch/torchaudio unpinned, so
  the wheels carry their own CUDA runtime.
- drone_client worker: python 3.9-slim-buster -> 3.11-slim-bookworm. Retires
  BOTH end-of-life Python 3.9 and end-of-life Debian 10 (buster); only
  dependency is pure-Python kafka-python, so the bookworm (Debian 12) base
  carries no native-build risk.

## Intentional
- Only the CUDA minor bump and the drone-client Python 3.9 -> 3.11 (bookworm)
  bump are included; both are verifiable as low-risk here.
- drone_client is fully build-verified (built, ran, imported its dependency).
- The CUDA bump is verified by tag existence + CUDA minor-version compatibility,
  NOT a full local image build (the multi-GB CUDA + torch install is too heavy
  here). Stated as a verification ceiling; see the backstop note below.

## Deferred
Held for separate, dev-gated decisions (the corresponding Dependabot PRs stay
open for the dev to triage):
- video_stream_processor python 3.9 -> 3.13 (#1639): opencv-python-headless
  installs on 3.13, but that Dockerfile has a pre-existing missing-WORKDIR bug
  that fails the build on BOTH 3.9 and 3.13. Needs a dedicated
  fix-Dockerfile + bump slice.
- graphiti-wrapper / vision python 3.11 -> 3.14 (#1635 / #1636): too new for
  torch / graphiti / SAM.
- confluentinc/cp-kafka 5.5.3 -> 8.2.1 (#1632): major CP jump (KRaft removes
  ZooKeeper, compose still runs cp-zookeeper).
- postgres 13 -> 18 (#1633): five-major data-directory migration.

## Parked hardening
None. The held items above remain as their original open Dependabot PRs
(#1632, #1633, #1635, #1636, #1639) for dev triage; nothing is parked in
HARDENING.md by this slice.

## Verification
- `docker manifest inspect nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04` -> EXISTS.
- `docker manifest inspect python:3.11-slim-bookworm` -> EXISTS.
- drone_client: `docker build atlas_video-processing/ingest/drone_client` succeeded;
  `docker run <img> python -c "import sys, kafka"` -> Python 3.11.15, kafka-python
  3.0.0, on Debian GNU/Linux 12 (bookworm).
- Root CUDA Dockerfile: not built locally (multi-GB CUDA + full requirements/torch
  install too heavy here); relies on tag existence + CUDA 12.x minor-compat + torch
  unpinned. NOTE (per review): no CI workflow runs `docker build` of the brain image
  (checks run pytest), so the real backstop is the deploy-time
  `docker compose up --build`, not CI.

## Diff size
2 Dockerfiles (+2 / -2) plus the plan doc. Well under the 400 LOC budget.

## AI reconciliation
All fixed or waived: yes.
- Codex P1 (plan Scope section shape): FIXED. Renamed `## Scope` ->
  `## Scope (this PR)` and added a `### Review Contract` block;
  `python scripts/sync_pr_plan.py <plan> <base> --check` now exits 0.
- Codex P2 (drone image on EOL Debian buster): FIXED. Switched drone_client to
  `python:3.11-slim-bookworm` (Debian 12); rebuilt and verified.
- Codex P2 (CUDA build backstop): ADDRESSED. Removed the inaccurate "CI is the
  backstop" claim (no CI workflow docker-builds the brain image); the human
  reviewer assessed the CUDA minor bump as low-risk and non-blocking, so the
  bump ships with an honest deploy-time-build backstop note rather than deferring.
- Human reviewer Medium recommendation (buster -> bookworm): FIXED (same change).
