### PR TITLE
Batch lucide-react major updates

### DIFF
--- a/atlas-admin-ui/package-lock.json
+++ b/atlas-admin-ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.1",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.20.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "recharts": "^3.8.1",
@@ -2938,9 +2938,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
+      "integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/atlas-admin-ui/package.json
+++ b/atlas-admin-ui/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.3.1",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.20.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "recharts": "^3.8.1",

--- a/atlas-churn-ui/package-lock.json
+++ b/atlas-churn-ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "gsap": "^3.15.0",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^1.20.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.18.0",
@@ -3783,9 +3783,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
+      "integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/atlas-churn-ui/package.json
+++ b/atlas-churn-ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "gsap": "^3.15.0",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.20.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.0",

--- a/atlas-intel-ui/package-lock.json
+++ b/atlas-intel-ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "gsap": "^3.15.0",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^1.20.0",
         "marked": "^17.0.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -2997,9 +2997,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
+      "integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "gsap": "^3.15.0",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.20.0",
     "marked": "^17.0.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/atlas-ui/package-lock.json
+++ b/atlas-ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "clsx": "^2.1.1",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^1.20.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "tailwind-merge": "^3.6.0",
@@ -2748,9 +2748,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
+      "integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/atlas-ui/package.json
+++ b/atlas-ui/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.20.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tailwind-merge": "^3.6.0",

--- a/plans/PR-Lucide-React-Major-Batch.md
+++ b/plans/PR-Lucide-React-Major-Batch.md
@@ -1,0 +1,98 @@
+# PR-Lucide-React-Major-Batch
+
+## Why this slice exists
+
+The operator asked to move into Bucket 3 major Dependabot review/batching after
+the npm CI enrollment slice merged. Bucket 3 contains TypeScript 6, ESLint 10,
+and lucide-react 1.x major updates across the npm UI packages.
+
+The root cause for this slice is Dependabot's per-package major-update shape:
+lucide-react 1.x landed as four separate PRs (#1644, #1650, #1647, #1652), each
+missing Atlas plan/body compliance and several without package-specific CI when
+they were opened. This change fixes the review/batch root by superseding those
+four lucide-react PRs in one Atlas-shaped batch with the now-enrolled package
+checks.
+
+## Scope (this PR)
+
+Ownership lane: security/dependencies
+Slice phase: Production hardening
+
+1. Bump `lucide-react` to the Dependabot-requested `1.20.0` line in
+   `atlas-admin-ui`, `atlas-churn-ui`, `atlas-intel-ui`, and `atlas-ui`.
+2. Keep the batch limited to lucide-react package manifests and lockfiles unless
+   package checks expose a required icon API fix.
+3. Prove every touched package with its enrolled package-appropriate checks.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The four lucide-react source PRs (#1644, #1650, #1647, #1652) are
+        superseded by a single Atlas-shaped branch.
+  - [ ] No TypeScript 6 or ESLint 10 upgrades are included.
+  - [ ] Each touched package installs cleanly after the lockfile refresh.
+  - [ ] Package checks prove the upgrade did not break builds/tests for the
+        surfaces that now have npm package CI coverage.
+- Affected surfaces: icon component dependency graph for `atlas-admin-ui`,
+  `atlas-churn-ui`, `atlas-intel-ui`, and `atlas-ui`.
+- Risk areas: icon export/API changes in lucide-react 1.x, package lockfile
+  drift, local-vs-CI parity.
+- Reviewer rules triggered: R1, R2, R9, R12, R14.
+
+### Files touched
+
+- `atlas-admin-ui/package-lock.json`
+- `atlas-admin-ui/package.json`
+- `atlas-churn-ui/package-lock.json`
+- `atlas-churn-ui/package.json`
+- `atlas-intel-ui/package-lock.json`
+- `atlas-intel-ui/package.json`
+- `atlas-ui/package-lock.json`
+- `atlas-ui/package.json`
+- `plans/PR-Lucide-React-Major-Batch.md`
+
+## Mechanism
+
+Run `npm install lucide-react@1.20.0 --package-lock-only` in each target
+package, preserving the existing manifest style while refreshing the lockfile
+to the Dependabot-requested major. Then run the same package checks enrolled by
+PR #1664 so this batch does not depend on GitHub's non-compliant Dependabot PR
+body shape.
+
+## Intentional
+
+- Do not batch TypeScript 6 or ESLint 10 here. Those are separate compiler and
+  lint migrations with known breaking check output.
+- Do not touch package code unless the lucide-react 1.x export surface breaks a
+  build. Manifest-only is the target shape for this batch.
+
+## Deferred
+
+- TypeScript 6 PRs #1641, #1646, #1648, #1651, and #1654 remain in Bucket 3 for
+  a dedicated compiler-migration pass.
+- ESLint 10 PRs #1642, #1645, #1649, and #1655 remain in Bucket 3 for a
+  dedicated lint-rule migration pass.
+
+Parked hardening: none.
+
+## Verification
+
+- `cd atlas-admin-ui && npm ci && npm audit --audit-level=high && npm run lint && npm run build` - pass.
+- `cd atlas-churn-ui && npm ci && npm audit --audit-level=high && npm test && npm run build` - pass, 85 files / 681 tests.
+- `cd atlas-intel-ui && npm ci && npm audit --audit-level=high && npm run lint && npm run build` - pass.
+- `cd atlas-ui && npm ci && npm audit --audit-level=high && npm run build` - pass.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas-admin-ui/package-lock.json` | 8 |
+| `atlas-admin-ui/package.json` | 2 |
+| `atlas-churn-ui/package-lock.json` | 8 |
+| `atlas-churn-ui/package.json` | 2 |
+| `atlas-intel-ui/package-lock.json` | 8 |
+| `atlas-intel-ui/package.json` | 2 |
+| `atlas-ui/package-lock.json` | 8 |
+| `atlas-ui/package.json` | 2 |
+| `plans/PR-Lucide-React-Major-Batch.md` | 98 |
+| **Total** | **138** |


### PR DESCRIPTION
Plan: plans/PR-Lucide-React-Major-Batch.md
Slice phase: Production hardening

Batch the four Bucket 3 lucide-react 1.x Dependabot PRs (#1644, #1650, #1647, #1652) into one Atlas-shaped security/dependencies PR. This keeps TypeScript 6 and ESLint 10 out of scope while proving lucide-react 1.20.0 against the package checks enrolled by #1664.

## Intentional
- Do not batch TypeScript 6 or ESLint 10 here; those remain separate compiler/lint migrations.
- Keep this manifest/lockfile-only because package checks did not expose required icon API code changes.

## Deferred
- TypeScript 6 PRs #1641, #1646, #1648, #1651, and #1654 remain in Bucket 3.
- ESLint 10 PRs #1642, #1645, #1649, and #1655 remain in Bucket 3.

## Parked hardening
- None.

## Verification
- `cd atlas-admin-ui && npm ci && npm audit --audit-level=high && npm run lint && npm run build` - pass.
- `cd atlas-churn-ui && npm ci && npm audit --audit-level=high && npm test && npm run build` - pass, 85 files / 681 tests.
- `cd atlas-intel-ui && npm ci && npm audit --audit-level=high && npm run lint && npm run build` - pass.
- `cd atlas-ui && npm ci && npm audit --audit-level=high && npm run build` - pass.

## Diff size
9 files, 138 LOC touched.
