### PR TITLE
Deflection parser CSV field limit

### DIFF
--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -34,6 +34,7 @@ _CSV_UTF8_MOJIBAKE_MARKER_TAIL_CHARS = max(
 ) - 1
 _CSV_IMPLAUSIBLE_LEGACY_FALLBACK_CHARS = ("\u00ff", "\u00fe")
 _CSV_READ_CHUNK_BYTES = 64 * 1024
+_CSV_FIELD_SIZE_LIMIT = 16 * 1024 * 1024
 _CSV_BOM_ENCODINGS = (
     (b"\xff\xfe\x00\x00", "utf-32"),
     (b"\x00\x00\xfe\xff", "utf-32"),
@@ -474,6 +475,7 @@ def _load_csv_dict_rows_result(
 ) -> CsvDictRowsLoadResult:
     if max_rows is not None and max_rows < 1:
         raise ValueError("max_rows must be at least 1")
+    _ensure_csv_field_size_limit()
     rows: list[dict[str, Any]] = []
     source_row_count = 0
     encoding_plan = _csv_encoding_plan(path)
@@ -1014,6 +1016,7 @@ def _csv_decode_warnings_from_stats(
 
 
 def _select_csv_delimiter(text: str) -> _CsvDelimiterCandidate:
+    _ensure_csv_field_size_limit()
     candidates = tuple(
         _score_csv_delimiter(text, delimiter=delimiter, quotechar=quotechar)
         for delimiter in _CSV_DETECT_DELIMITERS
@@ -1031,6 +1034,7 @@ def _select_csv_delimiter_from_stream(
     path: Path,
     plan: _CsvEncodingPlan,
 ) -> _CsvDelimiterCandidate:
+    _ensure_csv_field_size_limit()
     candidates = tuple(
         _score_csv_delimiter_stream(
             path,
@@ -1218,6 +1222,16 @@ def _csv_short_row_uses_competing_delimiter(
 
 def _csv_delimiter_sample_text(text: str) -> str:
     return "\n".join(text.splitlines()[:_CSV_DELIMITER_SAMPLE_LINES])
+
+
+def _ensure_csv_field_size_limit(
+    minimum: int = _CSV_FIELD_SIZE_LIMIT,
+) -> int:
+    current = csv.field_size_limit()
+    if current < minimum:
+        csv.field_size_limit(minimum)
+        return minimum
+    return current
 
 
 def _csv_delimiter_dialect(

--- a/plans/PR-Deflection-Parser-CSV-Field-Limit.md
+++ b/plans/PR-Deflection-Parser-CSV-Field-Limit.md
@@ -1,0 +1,121 @@
+# PR-Deflection-Parser-CSV-Field-Limit
+
+## Why this slice exists
+
+#1463 still lists a parser/admission hardening gap: Python's default
+`csv.field_size_limit` (~128 KiB) crashes on one long quoted HTML/body cell.
+I reproduced that on current `origin/main` through the real
+`inspect_ingestion_file(..., source_rows=True, source_format="csv")` path with
+a 200 KiB ticket body: `_csv.Error: field larger than field limit (131072)`.
+
+Root cause: the shared CSV reader boundary in
+`extracted_content_pipeline/campaign_customer_data.py` inherits Python's
+process-default field limit before delimiter scoring and row loading, so valid
+support-ticket exports with large body/comment cells fail before the parser
+can return the admission diagnostics #1467 requires.
+
+This PR fixes the root in safe scope by raising the CSV parser field ceiling
+at the shared reader boundary before any `csv.reader` is constructed. It is
+not a downstream symptom fix in `ingestion_diagnostics`: every CSV consumer
+that goes through the shared loader gets the larger ticket-body ceiling.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser-testing
+Slice phase: Robust testing
+
+1. Raise the shared CSV parser field-size ceiling deliberately before delimiter
+   scoring and source-row loading.
+2. Add focused parser/admission tests proving long quoted body cells no longer
+   crash and still produce the expected source-row admission outcome.
+3. Keep this slice scoped to long-cell parser survivability; do not add the
+   deferred low-coverage reject threshold or streaming/memory redesign.
+
+### Review Contract
+
+Acceptance criteria:
+- A source-row CSV with a body/comment cell larger than Python's default
+  128 KiB field limit is parsed by the real inspect/admission path instead of
+  raising `_csv.Error`.
+- The accepted long-cell fixture still yields a normal source-row admission
+  decision, not a swallowed exception or generic failure.
+- The field-limit helper only raises the process limit upward; it does not
+  lower an operator/runtime limit that is already higher.
+- Existing CSV diagnostics behavior for normal, zero-usable, and partial
+  coverage fixtures remains unchanged.
+
+Affected surfaces:
+- `extracted_content_pipeline/campaign_customer_data.py` shared CSV reader
+  setup.
+- Source-row ingestion diagnostics exercised through
+  `extracted_content_pipeline.ingestion_diagnostics.inspect_ingestion_file`.
+
+Risk areas:
+- Global `csv.field_size_limit` mutation must be monotonic and local to the
+  parser setup.
+- Delimiter scoring and row loading both construct `csv.reader`; both must be
+  covered by the raised ceiling.
+- The fix must not mask malformed CSV dialect/header errors as successful
+  parses.
+
+Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_customer_data.py`
+- `plans/PR-Deflection-Parser-CSV-Field-Limit.md`
+- `tests/test_extracted_campaign_customer_data.py`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+
+## Mechanism
+
+Add a small helper in `campaign_customer_data.py` that reads the current
+`csv.field_size_limit()` and raises it to a named support-ticket ceiling when
+the current value is lower. Call it before the module's `csv.reader`
+constructions used by delimiter scoring and CSV row loading.
+
+Tests exercise the public inspect path rather than the helper alone:
+
+```python
+report = inspect_ingestion_file(path, source_rows=True, source_format="csv")
+assert report.as_dict()["source_row_admission"]["admission_decision"] == {"status": "ACCEPT"}
+```
+
+A helper-level test pins the monotonic behavior by monkeypatching
+`csv.field_size_limit`, proving the helper does not lower an already-higher
+runtime setting.
+
+## Intentional
+
+- This PR raises the parser ceiling instead of rejecting large cells. Large
+  ticket bodies are valid customer support exports; rejecting at 128 KiB would
+  treat a Python default as product policy.
+- This PR does not introduce streaming/chunked CSV parsing. #1458 remains the
+  broader memory/streaming track; this slice only removes the immediate
+  parser-limit crash with bounded, focused tests.
+- The long-cell test uses synthetic adversarial CSV data because the failure
+  is deterministic and tied to Python's parser limit, not to a provider-specific
+  threshold policy.
+
+## Deferred
+
+- #1458 streaming upload memory hardening remains separate.
+- #1467 low non-zero usable-ratio reject threshold remains blocked on real
+  partial-provider evidence.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_content_ingestion_diagnostics.py tests/test_extracted_campaign_customer_data.py -q` -- 32 passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` -- 4612 passed, 10 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/campaign_customer_data.py` | 14 |
+| `plans/PR-Deflection-Parser-CSV-Field-Limit.md` | 121 |
+| `tests/test_extracted_campaign_customer_data.py` | 32 |
+| `tests/test_extracted_content_ingestion_diagnostics.py` | 37 |
+| **Total** | **204** |

--- a/tests/test_extracted_campaign_customer_data.py
+++ b/tests/test_extracted_campaign_customer_data.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import extracted_content_pipeline.campaign_customer_data as campaign_customer_data
 from extracted_content_pipeline.campaign_customer_data import (
     FileIntelligenceRepository,
     load_campaign_opportunities_from_file,
@@ -17,6 +18,37 @@ from extracted_content_pipeline.campaign_ports import TenantScope
 
 ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "scripts/run_extracted_campaign_generation_example.py"
+
+
+def test_csv_field_size_limit_helper_is_monotonic(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+    current_limit = 32 * 1024 * 1024
+
+    def fake_field_size_limit(value: int | None = None) -> int:
+        nonlocal current_limit
+        if value is None:
+            return current_limit
+        calls.append(value)
+        old = current_limit
+        current_limit = value
+        return old
+
+    monkeypatch.setattr(
+        campaign_customer_data.csv,
+        "field_size_limit",
+        fake_field_size_limit,
+    )
+
+    assert campaign_customer_data._ensure_csv_field_size_limit(16 * 1024 * 1024) == (
+        32 * 1024 * 1024
+    )
+    assert calls == []
+
+    current_limit = 128 * 1024
+    assert campaign_customer_data._ensure_csv_field_size_limit(16 * 1024 * 1024) == (
+        16 * 1024 * 1024
+    )
+    assert calls == [16 * 1024 * 1024]
 
 
 def test_load_campaign_opportunities_from_json_payload_preserves_custom_fields(

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -326,6 +326,43 @@ def test_inspect_source_csv_warns_when_partial_upload_has_machine_json_row(
     }]
 
 
+def test_inspect_source_csv_accepts_long_ticket_body_field(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "long-ticket-body.csv"
+    long_body = "Customer cannot export the weekly report. " + ("x" * 200_000)
+    path.write_text(
+        "Ticket ID,Message\n"
+        f"T-1,{long_body}\n",
+        encoding="utf-8",
+    )
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=1,
+        default_fields={
+            "company_name": "Acme Logistics",
+            "vendor_name": "Atlas",
+            "contact_email": "ops@example.com",
+        },
+    ).as_dict()
+
+    admission = payload["source_row_admission"]
+    assert payload["ok"] is True
+    assert payload["warning_counts"] == {}
+    assert admission["raw_source_row_count"] == 1
+    assert admission["usable_source_row_count"] == 1
+    assert admission["usable_source_ratio"] == 1.0
+    assert admission["mapped_fields"] == {
+        "source_id": ["Ticket ID"],
+        "source_text": ["Message"],
+    }
+    assert admission["admission_decision"] == {"status": "ACCEPT"}
+    assert "coverage_warnings" not in admission
+
+
 @pytest.mark.parametrize(
     ("header", "text"),
     (


### PR DESCRIPTION
Plan: plans/PR-Deflection-Parser-CSV-Field-Limit.md
Slice phase: Robust testing

#1463 still listed a parser/admission hardening gap where Python's default `csv.field_size_limit` crashes on one long quoted support-ticket body before #1467 admission diagnostics can return a defined outcome. This fixes the root at the shared CSV reader boundary by raising the parser field ceiling before delimiter scoring and row loading, so valid long ticket/comment cells parse normally instead of raising `_csv.Error`.

## Intentional
- Raises the parser ceiling instead of rejecting large cells; long support-ticket bodies are valid customer exports, not product-invalid inputs.
- Does not introduce streaming/chunked CSV parsing; #1458 remains the broader memory/streaming track.
- Uses synthetic adversarial CSV data because the failure is deterministic and tied to Python's parser limit, not provider-specific threshold policy.

## Deferred
- #1458 streaming upload memory hardening remains separate.
- #1467 low non-zero usable-ratio reject threshold remains blocked on real partial-provider evidence.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_ingestion_diagnostics.py tests/test_extracted_campaign_customer_data.py -q` -- 32 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4612 passed, 10 skipped, 1 warning.

## Diff size
4 files, +204 / -0.
