### PR TITLE
Deflection full report QA live green rerun

### DIFF
--- a/docs/extraction/validation/fixtures/deflection_full_report_qa_live_green_rerun_20260617/summary.json
+++ b/docs/extraction/validation/fixtures/deflection_full_report_qa_live_green_rerun_20260617/summary.json
@@ -1,0 +1,620 @@
+{
+  "errors": [],
+  "fetches": {
+    "artifact": {
+      "status": 200
+    },
+    "report_model": {
+      "status": 200
+    }
+  },
+  "inputs": {
+    "base_url_present": true,
+    "pdf_bytes_present": true,
+    "pdf_text_present": false,
+    "preflight_only": false,
+    "request_id_present": true,
+    "token_present": true
+  },
+  "ok": true,
+  "pdf_text": {
+    "source": "extracted_from_pdf_bytes",
+    "verified_from_pdf_bytes": true
+  },
+  "schema_version": "deflection_full_report_qa_live_runner.v1",
+  "scorecard": {
+    "artifacts": {
+      "evidence_export": {
+        "evidence_rows": 2,
+        "questions": 2
+      },
+      "pdf": {
+        "bytes": 5436,
+        "text_chars": 3129
+      }
+    },
+    "assertions": [
+      {
+        "actual": "deflection.v1",
+        "expected": "deflection.v1",
+        "id": "model.schema_version",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.seo_targets.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.ranked_questions.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.question_details.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.complete_evidence.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.repeat_ticket_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.non_repeat_ticket_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.generated_question_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.assisted_contact_cost.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.estimated_support_cost.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.source_date_window.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.drafted_answer_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.no_proven_answer_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.support_tax.data.ticket_source_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.seo_targets.data.phrases.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.seo_targets.data.total_phrase_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.seo_targets.data.displayed_phrase_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.seo_targets.data.omitted_phrase_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.seo_targets.data.limit.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.ranked_questions.data.rows.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.question_details.data.rows.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.complete_evidence.data.question_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.complete_evidence.data.evidence_row_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.complete_evidence.data.source_id_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "model.section.complete_evidence.data.surfaces.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "evidence_export.present",
+        "ok": true
+      },
+      {
+        "actual": "deflection_evidence.v1",
+        "expected": "deflection_evidence.v1",
+        "id": "evidence_export.schema_version",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "evidence_export.summary.question_count",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "evidence_export.summary.evidence_row_count",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "evidence_export.summary.source_id_count",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "evidence_export.summary.drafted_answer_count",
+        "ok": true
+      },
+      {
+        "actual": 0,
+        "expected": 0,
+        "id": "evidence_export.summary.no_proven_answer_count",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "evidence_export.questions.present",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "evidence_export.questions.length",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "evidence_export.evidence_rows.present",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "evidence_export.evidence_rows.length",
+        "ok": true
+      },
+      {
+        "actual": {
+          "counts": true,
+          "displayed_rows": false
+        },
+        "expected": "<redacted-string>",
+        "id": "surface.evidence_export.observation_has_data",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.evidence_export.count.drafted_answer_count",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.evidence_export.count.evidence_question_count",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.evidence_export.count.evidence_row_count",
+        "ok": true
+      },
+      {
+        "actual": 0,
+        "expected": 0,
+        "id": "surface.evidence_export.count.no_proven_answer_count",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.evidence_export.count.source_id_count",
+        "ok": true
+      },
+      {
+        "actual": {
+          "counts": true,
+          "displayed_rows": true
+        },
+        "expected": "<redacted-string>",
+        "id": "surface.pdf.observation_has_data",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.pdf.count.drafted_answer_count",
+        "ok": true
+      },
+      {
+        "actual": 0.0,
+        "expected": 0.0,
+        "id": "surface.pdf.count.estimated_support_cost",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.pdf.count.generated_question_count",
+        "ok": true
+      },
+      {
+        "actual": 0,
+        "expected": 0,
+        "id": "surface.pdf.count.no_proven_answer_count",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.pdf.count.ranked_question_count",
+        "ok": true
+      },
+      {
+        "actual": 0,
+        "expected": 0,
+        "id": "surface.pdf.count.repeat_ticket_count",
+        "ok": true
+      },
+      {
+        "actual": 3,
+        "expected": 3,
+        "id": "surface.pdf.count.ticket_source_count",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.pdf.displayed_rows.question_details",
+        "ok": true
+      },
+      {
+        "actual": 2,
+        "expected": 2,
+        "id": "surface.pdf.displayed_rows.ranked_questions",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.count.repeat_ticket_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.count.generated_question_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.count.ranked_question_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.count.drafted_answer_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.count.no_proven_answer_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.count.ticket_source_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.count.estimated_support_cost.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.displayed_rows.question_details.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.pdf.displayed_rows.ranked_questions.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.evidence_export.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.evidence_export.count.evidence_question_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.evidence_export.count.evidence_row_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.evidence_export.count.source_id_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.evidence_export.count.drafted_answer_count.present",
+        "ok": true
+      },
+      {
+        "actual": true,
+        "expected": true,
+        "id": "harness.surface.evidence_export.count.no_proven_answer_count.present",
+        "ok": true
+      },
+      {
+        "actual": "present",
+        "expected": "%PDF-",
+        "id": "artifact.pdf.bytes.header",
+        "ok": true
+      },
+      {
+        "actual": 5436,
+        "expected": ">=32 bytes",
+        "id": "artifact.pdf.bytes.minimum_size",
+        "ok": true
+      },
+      {
+        "actual": "present",
+        "expected": "present",
+        "id": "artifact.pdf.text.marker.support_tax_confirmation",
+        "ok": true
+      },
+      {
+        "actual": "present",
+        "expected": "present",
+        "id": "artifact.pdf.text.marker.ranked_question_opportunities",
+        "ok": true
+      },
+      {
+        "actual": "present",
+        "expected": "present",
+        "id": "artifact.pdf.text.marker.question_details_and_evidence",
+        "ok": true
+      },
+      {
+        "actual": "present",
+        "expected": "present",
+        "id": "artifact.pdf.text.marker.complete_evidence_export",
+        "ok": true
+      },
+      {
+        "actual": "visible",
+        "expected": 0,
+        "id": "artifact.pdf.text.count.repeat_ticket_count",
+        "ok": true
+      },
+      {
+        "actual": "visible",
+        "expected": 2,
+        "id": "artifact.pdf.text.count.generated_question_count",
+        "ok": true
+      },
+      {
+        "actual": "visible",
+        "expected": 2,
+        "id": "artifact.pdf.text.count.ranked_question_count",
+        "ok": true
+      },
+      {
+        "actual": "visible",
+        "expected": 2,
+        "id": "artifact.pdf.text.count.drafted_answer_count",
+        "ok": true
+      },
+      {
+        "actual": "visible",
+        "expected": 0,
+        "id": "artifact.pdf.text.count.no_proven_answer_count",
+        "ok": true
+      },
+      {
+        "actual": "visible",
+        "expected": 3,
+        "id": "artifact.pdf.text.count.ticket_source_count",
+        "ok": true
+      },
+      {
+        "actual": "visible",
+        "expected": 0.0,
+        "id": "artifact.pdf.text.count.estimated_support_cost",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.request_id",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.result_url",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.customer_email",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.absolute_local_path",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.stripe_checkout_session_id",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.stripe_payment_intent_id",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.private_note",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.raw_evidence_quote",
+        "ok": true
+      },
+      {
+        "actual": "absent",
+        "expected": "absent",
+        "id": "artifact.pdf.leak.source_id_list",
+        "ok": true
+      }
+    ],
+    "counts": {
+      "drafted_answer_count": 2,
+      "estimated_support_cost": 0.0,
+      "evidence_question_count": 2,
+      "evidence_row_count": 2,
+      "generated_question_count": 2,
+      "no_proven_answer_count": 0,
+      "outcome_diagnostic_row_count": 0,
+      "question_detail_count": 2,
+      "ranked_question_count": 2,
+      "repeat_ticket_count": 0,
+      "seo_displayed_phrase_count": 2,
+      "seo_omitted_phrase_count": 0,
+      "seo_total_phrase_count": 2,
+      "source_id_count": 2,
+      "ticket_source_count": 3
+    },
+    "ok": true,
+    "schema_version": "deflection_full_report_qa_scorecard.v1",
+    "surfaces": {
+      "observed": [
+        "evidence_export",
+        "pdf"
+      ],
+      "required": [
+        "pdf",
+        "evidence_export"
+      ]
+    }
+  }
+}

--- a/plans/PR-Deflection-Full-Report-QA-Live-Green-Rerun.md
+++ b/plans/PR-Deflection-Full-Report-QA-Live-Green-Rerun.md
@@ -1,0 +1,130 @@
+# PR-Deflection-Full-Report-QA-Live-Green-Rerun
+
+## Why this slice exists
+
+#1612 has been driving the full-report delivery proof arc. #1671 and #1678
+both failed safe on the live paid artifact contract: the hosted
+`/report-model` endpoint returned 404 and `/artifact` omitted object
+`report_model` / `evidence_export` for fresh paid requests, even after #1674
+pinned that source contract.
+
+Root cause: the public Tailscale Funnel `/api` route was still serving a
+long-running Atlas API process started before the report-model/export contract
+landed. The source producer path was already pinned by #1674; the hosted proof
+was hitting a stale process. After restarting the API process from the current
+worktree, a fresh paid Zendesk-shaped request exposed the modern contract and
+the live QA runner passed.
+
+This PR records that green live proof as a sanitized artifact. It fixes the
+proof gap for the ATLAS-side paid artifact/report-model contract; it does not
+pretend to add a durable deploy-freshness guard or prove the separate
+atlas-portfolio buyer hosted-result page.
+
+This PR is over the 400 LOC soft cap because the committed deliverable is a
+machine-readable scorecard with the full assertion matrix. Splitting the
+summary away from the plan would make the proof harder to review and would not
+reduce product risk; the artifact itself is the evidence.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-full-report-qa
+Slice phase: Functional validation
+
+1. Commit only the sanitized green live-runner summary for the fresh paid
+   after-restart run.
+2. Record that the fresh hosted paid request returned HTTP 200 from both
+   `/report-model` and `/artifact`.
+3. Record that the artifact contained object `report_model` with
+   `deflection.v1` and object `evidence_export` with
+   `deflection_evidence.v1`.
+4. Record that the live runner validated PDF bytes with text extracted from
+   those bytes and produced an all-green scorecard.
+5. Do not commit the raw request id, result URL, token, webhook payload, raw
+   artifact JSON, report model JSON, PDF bytes, source ids, or evidence rows.
+
+### Review Contract
+
+Acceptance criteria:
+- The committed proof artifact is sanitized and passes the existing proof-bundle
+  checker.
+- The proof artifact shows `ok: true`, report-model fetch 200, artifact fetch
+  200, and PDF text verified from PDF bytes.
+- The PR does not change production code or harness code; this slice is proof
+  of the live path after the hosted API process restart.
+- The plan clearly defers durable deploy-freshness detection and
+  atlas-portfolio buyer hosted-result proof.
+
+Affected surfaces:
+- Full-report QA validation fixture only.
+- Plan doc only.
+
+Risk areas:
+- Accidentally committing live request ids, URLs, source ids, raw evidence, or
+  PDF bytes.
+- Overclaiming that #1612 is fully complete when buyer hosted-result proof is
+  still outside this ATLAS repo slice.
+- Mistaking this operational fix proof for a durable deployment freshness
+  guard.
+
+- Reviewer rules triggered: R1, R2, R3, R14.
+
+### Files touched
+
+- `docs/extraction/validation/fixtures/deflection_full_report_qa_live_green_rerun_20260617/summary.json`
+- `plans/PR-Deflection-Full-Report-QA-Live-Green-Rerun.md`
+
+## Mechanism
+
+The live run used the existing proof chain:
+
+1. Submit a Zendesk-shaped CSV through the hosted API.
+2. Mark the fresh request paid through the Stripe webhook smoke with the
+   correct hosted webhook secret.
+3. Fetch the fresh paid `/report-model` and `/artifact` endpoints through the
+   public Funnel URL.
+4. Render local PDF bytes from the paid artifact using the existing deflection
+   delivery renderer path.
+5. Run `scripts/run_deflection_full_report_qa_live_runner.py` with those PDF
+   bytes and no text override, so the runner extracts PDF text from the bytes.
+6. Commit only the runner's sanitized `summary.json`.
+
+The raw local working files stay under `tmp/deflection_full_report_qa_live_after_restart_20260617/`
+and are not part of this diff.
+
+## Intentional
+
+- No production code change: the fresh live proof passes after the hosted API
+  process restart, so changing the artifact producer would be a symptom fix.
+- No raw live bundle commit: the proof-bundle policy from #1613 allows only
+  sanitized scorecards in git.
+- No #1612 closure claim: the ATLAS-side artifact/report-model proof is green,
+  but buyer hosted-result proof belongs to the `atlas-portfolio/web` surface.
+
+## Deferred
+
+- Durable deploy/process freshness detection so a stale public API process is
+  visible before a live proof burns a run.
+- Separate `atlas-portfolio/web` buyer hosted-result proof for the URL emailed
+  to buyers.
+- Align the submit smoke's forbidden snapshot paths with the checked-in teaser
+  contract before using that smoke as paywall validation evidence.
+
+Parked hardening: none.
+
+## Verification
+
+- `python scripts/smoke_content_ops_deflection_submit_handoff.py ... --csv-file extracted_content_pipeline/examples/support_ticket_provider_exports/zendesk_full_thread_export.csv --output-result tmp/deflection_full_report_qa_live_after_restart_20260617/submit-result.json --json` - created a fresh request; exited nonzero only on the known parked teaser-field smoke drift.
+- `python scripts/smoke_content_ops_deflection_stripe_paid_unlock.py ... --replay-webhook --output-result tmp/deflection_full_report_qa_live_after_restart_20260617/paid-unlock-result.json --json` - passed after using the hosted portfolio webhook secret and public Funnel API base.
+- Direct endpoint shape probe - report-model 200 with `deflection.v1`; artifact 200 with object `report_model` and object `evidence_export`.
+- Local PDF render from the paid artifact - produced a valid PDF header and
+  5436 bytes.
+- `python scripts/run_deflection_full_report_qa_live_runner.py ... --pdf-bytes tmp/deflection_full_report_qa_live_after_restart_20260617/report.pdf --output-result tmp/deflection_full_report_qa_live_after_restart_20260617/live-runner-result.json --pretty --json` - passed.
+- `python scripts/check_deflection_full_report_proof_bundle.py docs/extraction/validation/fixtures/deflection_full_report_qa_live_green_rerun_20260617 --pretty` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/fixtures/deflection_full_report_qa_live_green_rerun_20260617/summary.json` | 620 |
+| `plans/PR-Deflection-Full-Report-QA-Live-Green-Rerun.md` | 130 |
+| **Total** | **750** |


### PR DESCRIPTION
Plan: plans/PR-Deflection-Full-Report-QA-Live-Green-Rerun.md
Slice phase: Functional validation

This records the green #1612 ATLAS-side live proof after the public API process was restarted from current source. Fresh hosted paid artifacts now expose `deflection.v1` `report_model` and `deflection_evidence.v1` `evidence_export`; the live QA runner passed with PDF text extracted from rendered PDF bytes. The PR commits only the sanitized scorecard summary, not the raw request id, result URL, token, webhook payload, artifact JSON, PDF bytes, source ids, or evidence rows.

## Intentional
- No production code change; the failed live proof was caused by a stale hosted API process, and the current source path now passes.
- The diff is over the soft 400 LOC cap because the scorecard assertion matrix is the proof artifact.
- This does not claim the separate `atlas-portfolio/web` buyer hosted-result page proof is complete.

## Deferred
- Durable deploy/process freshness detection so stale public API processes are caught before live proof runs.
- Separate `atlas-portfolio/web` buyer hosted-result proof for the URL emailed to buyers.
- Align the submit smoke forbidden snapshot paths with the checked-in teaser contract before using that smoke as paywall validation evidence.

## Parked hardening
- None.

## Verification
- `python scripts/smoke_content_ops_deflection_submit_handoff.py ... --csv-file extracted_content_pipeline/examples/support_ticket_provider_exports/zendesk_full_thread_export.csv --output-result tmp/deflection_full_report_qa_live_after_restart_20260617/submit-result.json --json` created a fresh request; nonzero only on known parked teaser-field smoke drift.
- `python scripts/smoke_content_ops_deflection_stripe_paid_unlock.py ... --replay-webhook --output-result tmp/deflection_full_report_qa_live_after_restart_20260617/paid-unlock-result.json --json` passed.
- Direct endpoint probe: report-model 200 with `deflection.v1`; artifact 200 with object `report_model` and object `evidence_export`.
- Local PDF render from the paid artifact produced a valid PDF header and 5436 bytes.
- `python scripts/run_deflection_full_report_qa_live_runner.py ... --pdf-bytes tmp/deflection_full_report_qa_live_after_restart_20260617/report.pdf --output-result tmp/deflection_full_report_qa_live_after_restart_20260617/live-runner-result.json --pretty --json` passed.
- `python scripts/check_deflection_full_report_proof_bundle.py docs/extraction/validation/fixtures/deflection_full_report_qa_live_green_rerun_20260617 --pretty` passed.

## Diff size
2 files, +750 / -0
