### PR TITLE
Churn UI async race sweep

### DIFF
--- a/atlas-churn-ui/src/pages/Affiliates.test.tsx
+++ b/atlas-churn-ui/src/pages/Affiliates.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -155,7 +155,9 @@ describe('Affiliates', () => {
 
     expect(await screen.findByDisplayValue('Zendesk')).toBeInTheDocument()
 
-    await router.navigate('/affiliates')
+    await act(async () => {
+      await router.navigate('/affiliates')
+    })
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Filter vendor...')).toHaveValue('')

--- a/atlas-churn-ui/src/pages/Challengers.test.tsx
+++ b/atlas-churn-ui/src/pages/Challengers.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -183,7 +183,9 @@ describe('Challengers', () => {
 
     expect(await screen.findByDisplayValue('Zendesk')).toBeInTheDocument()
 
-    await router.navigate('/challengers')
+    await act(async () => {
+      await router.navigate('/challengers')
+    })
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search challenger...')).toHaveValue('')

--- a/atlas-churn-ui/src/pages/Onboarding.test.tsx
+++ b/atlas-churn-ui/src/pages/Onboarding.test.tsx
@@ -128,8 +128,8 @@ describe('Onboarding', () => {
 
     await router.navigate('/onboarding?q=HubSpot')
 
+    expect(await screen.findByDisplayValue('HubSpot')).toBeInTheDocument()
     await waitFor(() => {
-      expect(screen.getByDisplayValue('HubSpot')).toBeInTheDocument()
       expect(api.searchAvailableVendors).toHaveBeenLastCalledWith('HubSpot')
     })
     router.dispose()
@@ -158,17 +158,19 @@ describe('Onboarding', () => {
 
     await router.navigate('/onboarding?q=HubSpot')
 
+    expect(await screen.findByDisplayValue('HubSpot')).toBeInTheDocument()
     await waitFor(() => {
-      expect(screen.getByDisplayValue('HubSpot')).toBeInTheDocument()
       expect(api.searchAvailableVendors).toHaveBeenLastCalledWith('HubSpot')
     })
 
     zendesk.resolve({ vendors: [{ vendor_name: 'Zendesk', product_category: 'Helpdesk', total_reviews: 120, avg_urgency: 6.2 }] })
+    await zendesk.promise
     await waitFor(() => {
       expect(screen.queryByText('Zendesk')).not.toBeInTheDocument()
     })
 
     hubspot.resolve({ vendors: [{ vendor_name: 'HubSpot', product_category: 'CRM', total_reviews: 220, avg_urgency: 5.8 }] })
+    await hubspot.promise
     expect(await screen.findByText('HubSpot')).toBeInTheDocument()
     router.dispose()
   })

--- a/atlas-churn-ui/src/pages/Opportunities.test.tsx
+++ b/atlas-churn-ui/src/pages/Opportunities.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import Opportunities from './Opportunities'
 
 const planGate = vi.hoisted(() => ({
@@ -94,6 +94,10 @@ function opportunityRow(overrides = {}) {
 }
 
 describe('Opportunities', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   beforeEach(() => {
     cleanup()
     vi.clearAllMocks()
@@ -147,7 +151,9 @@ describe('Opportunities', () => {
     const input = await screen.findByPlaceholderText('Filter vendor...')
     expect(input).toHaveValue('Zendesk')
 
-    await router.navigate('/opportunities?vendor=HubSpot')
+    await act(async () => {
+      await router.navigate('/opportunities?vendor=HubSpot')
+    })
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Filter vendor...')).toHaveValue('HubSpot')
@@ -168,7 +174,9 @@ describe('Opportunities', () => {
 
     expect(await screen.findByPlaceholderText('Filter vendor...')).toHaveValue('Zendesk')
 
-    await router.navigate('/opportunities')
+    await act(async () => {
+      await router.navigate('/opportunities')
+    })
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Filter vendor...')).toHaveValue('')

--- a/atlas-churn-ui/src/pages/Prospects.test.tsx
+++ b/atlas-churn-ui/src/pages/Prospects.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, RouterProvider, Routes, createMemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ProspectsPage from './Prospects'
@@ -152,7 +152,9 @@ describe('ProspectsPage', () => {
 
     expect(await screen.findByDisplayValue('Acme')).toBeInTheDocument()
 
-    await router.navigate('/prospects')
+    await act(async () => {
+      await router.navigate('/prospects')
+    })
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search company...')).toHaveValue('')
@@ -179,7 +181,9 @@ describe('ProspectsPage', () => {
 
     expect(await screen.findByDisplayValue('Acme')).toBeInTheDocument()
 
-    await router.navigate('/prospects?tab=manual_queue')
+    await act(async () => {
+      await router.navigate('/prospects?tab=manual_queue')
+    })
 
     await waitFor(() => {
       expect(screen.getByText('0 queue entries')).toBeInTheDocument()

--- a/atlas-churn-ui/src/pages/Reports.test.tsx
+++ b/atlas-churn-ui/src/pages/Reports.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Reports from './Reports'
@@ -215,7 +215,9 @@ describe('Reports', () => {
       })
     })
 
-    await router.navigate('/reports')
+    await act(async () => {
+      await router.navigate('/reports')
+    })
 
     await waitFor(() => {
       expect(screen.getByTestId('location-probe')).toHaveTextContent('/reports')
@@ -1516,11 +1518,15 @@ describe('Reports', () => {
 
     expect(await screen.findByRole('button', { name: 'Subscribe to Library' })).toBeInTheDocument()
 
-    await router.navigate('/reports?tab=subscriptions')
+    await act(async () => {
+      await router.navigate('/reports?tab=subscriptions')
+    })
 
     expect(await screen.findByText('No subscriptions yet. Subscribe from a report or the library view.')).toBeInTheDocument()
 
-    await router.navigate('/reports')
+    await act(async () => {
+      await router.navigate('/reports')
+    })
 
     expect(await screen.findByRole('button', { name: 'Subscribe to Library' })).toBeInTheDocument()
 

--- a/atlas-churn-ui/src/pages/Reviews.test.tsx
+++ b/atlas-churn-ui/src/pages/Reviews.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -154,7 +154,9 @@ describe('Reviews', () => {
     expect(await screen.findByDisplayValue('Zendesk')).toBeInTheDocument()
     expect(screen.getByDisplayValue('Acme')).toBeInTheDocument()
 
-    await router.navigate('/reviews')
+    await act(async () => {
+      await router.navigate('/reviews')
+    })
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Filter by vendor...')).toHaveValue('')

--- a/atlas-churn-ui/src/pages/VendorTargets.test.tsx
+++ b/atlas-churn-ui/src/pages/VendorTargets.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -146,7 +146,9 @@ describe('VendorTargets', () => {
 
     expect(await screen.findByDisplayValue('Zendesk')).toBeInTheDocument()
 
-    await router.navigate('/vendor-targets')
+    await act(async () => {
+      await router.navigate('/vendor-targets')
+    })
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search company...')).toHaveValue('')

--- a/atlas-churn-ui/src/pages/Vendors.test.tsx
+++ b/atlas-churn-ui/src/pages/Vendors.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -141,7 +141,9 @@ describe('Vendors', () => {
 
     expect(await screen.findByDisplayValue('Zendesk')).toBeInTheDocument()
 
-    await router.navigate('/vendors')
+    await act(async () => {
+      await router.navigate('/vendors')
+    })
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search vendors...')).toHaveValue('')

--- a/atlas-churn-ui/src/pages/Watchlists.test.tsx
+++ b/atlas-churn-ui/src/pages/Watchlists.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -890,7 +890,9 @@ describe('Watchlists', () => {
       })
     })
 
-    await router.navigate('/watchlists')
+    await act(async () => {
+      await router.navigate('/watchlists')
+    })
 
     await waitFor(() => {
       expect(screen.getByTestId('location-search').textContent).toBe('')

--- a/plans/PR-Churn-UI-Async-Race-Sweep.md
+++ b/plans/PR-Churn-UI-Async-Race-Sweep.md
@@ -1,0 +1,113 @@
+# PR-Churn-UI-Async-Race-Sweep
+
+## Why this slice exists
+
+The dependency queue has repeatedly been blocked by churn-ui test failures on
+PRs that do not touch churn-ui. The latest review escalation named the
+`Onboarding.test.tsx` stale-response case and the broader class of synchronous
+`getBy*`/`getByText` assertions after async UI transitions.
+
+Root cause: churn-ui tests mix route/data updates, mocked network promises, and
+immediate synchronous DOM reads. That leaves assertions racing React's async
+render cycle and can make an older mocked response look like product breakage
+when the real issue is an unstable test harness. This slice fixes the root for
+the queue-level flake class by awaiting the user-visible async states and by
+locking the stale-response proof around explicit request ordering.
+
+## Scope (this PR)
+
+Ownership lane: security/dependencies
+Slice phase: Production hardening
+
+1. Stabilize churn-ui async tests that have blocked unrelated dependency PRs,
+   starting with the reported Onboarding stale-response failure and same-route
+   query hydration path.
+2. Sweep the churn-ui test suite for the same failure mode where a test reads
+   async UI state synchronously after navigation, user events, or mocked
+   request resolution.
+3. Keep production behavior changes limited to concurrency hardening required
+   by the stale-response contract, if the focused tests expose a real product
+   race.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] The reported Onboarding same-route stale-response scenario waits for
+        the newer request and proves the older response cannot render.
+  - [ ] Same-class churn-ui test assertions changed by this PR use `findBy*`
+        or `waitFor` around async route/data/user-event transitions rather
+        than immediate synchronous reads.
+  - [ ] The churn-ui focused test command and package test suite pass locally.
+  - [ ] The existing broader churn-ui lint debt remains deferred and is not
+        widened into this slice.
+- Affected surfaces: frontend, tests.
+- Risk areas: concurrency, CI stability, frontend behavior.
+- Reviewer rules triggered: R1, R2, R9, R12, R13, R14.
+
+### Files touched
+
+- `atlas-churn-ui/src/pages/Affiliates.test.tsx`
+- `atlas-churn-ui/src/pages/Challengers.test.tsx`
+- `atlas-churn-ui/src/pages/Onboarding.test.tsx`
+- `atlas-churn-ui/src/pages/Opportunities.test.tsx`
+- `atlas-churn-ui/src/pages/Prospects.test.tsx`
+- `atlas-churn-ui/src/pages/Reports.test.tsx`
+- `atlas-churn-ui/src/pages/Reviews.test.tsx`
+- `atlas-churn-ui/src/pages/VendorTargets.test.tsx`
+- `atlas-churn-ui/src/pages/Vendors.test.tsx`
+- `atlas-churn-ui/src/pages/Watchlists.test.tsx`
+- `plans/PR-Churn-UI-Async-Race-Sweep.md`
+
+## Mechanism
+
+The Onboarding test drives the same route-change sequence with deferred
+promises, asserts the first request starts, navigates to the second query,
+asserts the second request starts, then resolves the stale request before the
+current request. The proof only accepts the current vendor after the current
+request resolves and keeps the stale vendor absent.
+
+The sweep applies the same principle to nearby churn-ui tests that wait on
+async data, route, or user-event state: external router transitions run inside
+React `act`, async DOM state is awaited with `findBy*`/`waitFor`, and
+Opportunities now performs explicit `afterEach` cleanup so grouped suite runs
+do not leak React work into environment teardown.
+
+## Intentional
+
+- This slice is a test-stability and concurrency-proof slice, not the full
+  churn-ui ESLint 10 lint-debt cleanup.
+- The scan is targeted at async race patterns that have blocked the dependency
+  queue; broad style rewrites are intentionally out of scope.
+
+## Deferred
+
+- Churn and Atlas UI lint debt blocks ESLint 10: parked in `HARDENING.md` from
+  the previous ESLint 10 batch. That lint cleanup remains a separate medium
+  effort slice.
+
+Parked hardening: none added by this slice.
+
+## Verification
+
+- PASS: `npm --prefix atlas-churn-ui test -- --run src/pages/Onboarding.test.tsx`.
+- PASS: `for i in $(seq 1 20); do npm --prefix atlas-churn-ui test -- --run src/pages/Onboarding.test.tsx >/tmp/churn-onboarding-after-$i.log 2>&1 || { echo "failed run $i"; cat /tmp/churn-onboarding-after-$i.log; exit 1; }; done; echo "20 focused Onboarding runs passed after sweep"`.
+- PASS: `npm --prefix atlas-churn-ui test -- --run src/pages/Onboarding.test.tsx src/pages/Reviews.test.tsx src/pages/Prospects.test.tsx src/pages/Reports.test.tsx src/pages/Watchlists.test.tsx src/pages/Challengers.test.tsx src/pages/Vendors.test.tsx src/pages/Affiliates.test.tsx src/pages/Opportunities.test.tsx src/pages/VendorTargets.test.tsx`.
+- PASS: `npm --prefix atlas-churn-ui test`.
+- PASS: `npm --prefix atlas-churn-ui run build`.
+- Pending before push: `python scripts/sync_pr_plan.py plans/PR-Churn-UI-Async-Race-Sweep.md --check`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas-churn-ui/src/pages/Affiliates.test.tsx` | 6 |
+| `atlas-churn-ui/src/pages/Challengers.test.tsx` | 6 |
+| `atlas-churn-ui/src/pages/Onboarding.test.tsx` | 6 |
+| `atlas-churn-ui/src/pages/Opportunities.test.tsx` | 16 |
+| `atlas-churn-ui/src/pages/Prospects.test.tsx` | 10 |
+| `atlas-churn-ui/src/pages/Reports.test.tsx` | 14 |
+| `atlas-churn-ui/src/pages/Reviews.test.tsx` | 6 |
+| `atlas-churn-ui/src/pages/VendorTargets.test.tsx` | 6 |
+| `atlas-churn-ui/src/pages/Vendors.test.tsx` | 6 |
+| `atlas-churn-ui/src/pages/Watchlists.test.tsx` | 6 |
+| `plans/PR-Churn-UI-Async-Race-Sweep.md` | 113 |
+| **Total** | **195** |


### PR DESCRIPTION
Plan: plans/PR-Churn-UI-Async-Race-Sweep.md
Slice phase: Production hardening

Stabilizes the churn-ui async route/stale-response test class that has been blocking unrelated dependency PRs. The root cause is test harness timing: route-driven renders and mocked request resolution were being checked with synchronous reads or without final cleanup, so React work could leak into grouped runs.

## Intentional
- Keep production code unchanged; this slice hardens the flaky test contract and teardown.
- Leave the broader churn-ui ESLint 10 lint-debt cleanup out of scope.

## Deferred
- Churn and Atlas UI lint debt blocks ESLint 10 remains parked in `HARDENING.md` for a separate cleanup slice.

## Parked hardening
- None added by this slice.

## Verification
- PASS: `npm --prefix atlas-churn-ui test -- --run src/pages/Onboarding.test.tsx`
- PASS: `for i in $(seq 1 20); do npm --prefix atlas-churn-ui test -- --run src/pages/Onboarding.test.tsx >/tmp/churn-onboarding-after-$i.log 2>&1 || { echo "failed run $i"; cat /tmp/churn-onboarding-after-$i.log; exit 1; }; done; echo "20 focused Onboarding runs passed after sweep"`
- PASS: `npm --prefix atlas-churn-ui test -- --run src/pages/Onboarding.test.tsx src/pages/Reviews.test.tsx src/pages/Prospects.test.tsx src/pages/Reports.test.tsx src/pages/Watchlists.test.tsx src/pages/Challengers.test.tsx src/pages/Vendors.test.tsx src/pages/Affiliates.test.tsx src/pages/Opportunities.test.tsx src/pages/VendorTargets.test.tsx`
- PASS: `npm --prefix atlas-churn-ui test`
- PASS: `npm --prefix atlas-churn-ui run build`
- PASS: `python scripts/sync_pr_plan.py plans/PR-Churn-UI-Async-Race-Sweep.md --check`

## Diff size
11 files, +170 / -25
