### PR TITLE
Deflection process contract live runner preflight

### DIFF
--- a/plans/PR-Deflection-Process-Contract-Live-Runner-Preflight.md
+++ b/plans/PR-Deflection-Process-Contract-Live-Runner-Preflight.md
@@ -1,0 +1,124 @@
+# PR-Deflection-Process-Contract-Live-Runner-Preflight
+
+## Why this slice exists
+
+#1684 added the durable process-contract endpoint and checker after #1682 proved
+that stale hosted API processes can make the paid full-report proof fail late,
+after the operator has already created a fresh request, paid/unlocked it, and
+fetched artifacts.
+
+Root cause: the live full-report QA runner still did not invoke that checker.
+The detector existed, but the paid proof path could bypass it and only discover
+stale process drift at the `/report-model` or `/artifact` fetch stage.
+
+This change fixes the root at the runner boundary by making the process-contract
+check a required preflight inside `run_deflection_full_report_qa_live_runner.py`
+before it fetches paid report-model/artifact endpoints. It does not attempt to
+solve deployment restart automation or the separate atlas-portfolio buyer page
+proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-full-report-qa
+Slice phase: Production hardening
+
+1. Add a process-contract preflight to the ATLAS live full-report QA runner,
+   using the checker from #1684 and the same hosted base URL/token inputs.
+2. Stop before paid artifact fetches when the hosted process contract is stale,
+   malformed, missing, or shape-drifted.
+3. Keep local validation/PDF leak failures before network calls, so bad local
+   proof inputs still fail without touching hosted endpoints.
+4. Add focused tests proving success order, stale-process fail-closed behavior,
+   and no paid endpoint fetch when the process preflight fails.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] The live runner fetches `/deflection-reports/process-contract` before
+        `/report-model` and `/artifact` on successful proof runs.
+  - [ ] A stale same-version report-model shape fails the runner with a
+        sanitized process-contract error.
+  - [ ] When process-contract preflight fails, the runner does not fetch paid
+        `/report-model` or `/artifact` endpoints.
+  - [ ] Existing local input/PDF leak failures still fail before any network
+        call.
+  - [ ] Runner output remains sanitized: no bearer token, raw request ID, local
+        path, endpoint URL, source IDs, evidence rows, Stripe IDs, or raw PDF
+        text.
+- Affected surfaces: ATLAS full-report QA live runner and its CI test file.
+- Risk areas: false-green live proofs, output sanitization, network call order,
+  checker reuse.
+- Reviewer rules triggered: R1, R2, R5, R10, R12, R14.
+
+### Files touched
+
+- `plans/PR-Deflection-Process-Contract-Live-Runner-Preflight.md`
+- `scripts/run_deflection_full_report_qa_live_runner.py`
+- `tests/test_run_deflection_full_report_qa_live_runner.py`
+
+## Mechanism
+
+The live runner imports `check_process_contract` from the #1684 checker and
+adds `--process-contract-path`, defaulting to the checker path. After argument
+validation and local PDF/text/leak checks pass, `_process_contract_preflight()`
+builds a checker namespace from the runner's base URL, token, timeout, and path.
+
+If the checker returns any error, the runner emits a sanitized failure payload:
+
+```json
+{
+  "ok": false,
+  "fetches": {"process_contract": {"status": 200, "ok": false}},
+  "errors": ["process contract preflight failed: ..."]
+}
+```
+
+Only a green process contract allows the existing live report-model/artifact
+fetches and downstream PDF/export scorecard to run. The process-contract summary
+is included in successful `fetches` output so proof artifacts show that the
+structural preflight ran.
+
+## Intentional
+
+- The runner still performs local PDF/read/leak validation before any network
+  request. A bad local proof bundle should fail locally instead of contacting
+  the hosted API.
+- The process-contract preflight does not replace the paid proof. It proves the
+  hosted process advertises the current structural contract; the existing paid
+  artifact/PDF/export checks still prove value-level output correctness.
+- No deployment restart/supervision automation. This slice makes stale process
+  drift visible before paid artifact fetches; operations automation remains a
+  separate hardening concern.
+- No atlas-portfolio buyer hosted-result smoke. #1612 keeps that in the
+  `atlas-portfolio/web` lane.
+
+## Deferred
+
+- Deployment restart/supervision automation remains a separate operations
+  hardening slice if stale long-running processes recur.
+- atlas-portfolio buyer hosted-result proof remains outside this repo/lane.
+- Submit-smoke teaser-path alignment remains outside this runner slice.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_run_deflection_full_report_qa_live_runner.py -q`
+  - 17 passed.
+- Python compile check for the live runner and test file.
+  - passed.
+- Extracted pipeline CI enrollment audit.
+  - OK: 185 matching tests are enrolled.
+- Extracted pipeline check bundle.
+  - extracted reasoning core: 295 passed.
+  - extracted content pipeline: 4630 passed, 10 skipped, 1 existing torch
+    warning.
+- Pending before push: local PR review.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Process-Contract-Live-Runner-Preflight.md` | 124 |
+| `scripts/run_deflection_full_report_qa_live_runner.py` | 51 |
+| `tests/test_run_deflection_full_report_qa_live_runner.py` | 89 |
+| **Total** | **264** |

--- a/scripts/run_deflection_full_report_qa_live_runner.py
+++ b/scripts/run_deflection_full_report_qa_live_runner.py
@@ -29,6 +29,11 @@ from check_deflection_full_report_pdf_export_artifacts import (  # noqa: E402
     LEAK_PATTERNS as PDF_LEAK_PATTERNS,
     build_pdf_export_scorecard,
 )
+from check_deflection_process_contract import (  # noqa: E402
+    DEFAULT_CONTRACT_PATH as PROCESS_CONTRACT_PATH,
+    EXPECTED_REPORT_MODEL_CONTRACT,
+    check_process_contract,
+)
 
 
 SCHEMA_VERSION = "deflection_full_report_qa_live_runner.v1"
@@ -92,6 +97,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional extracted PDF text override. Omit to extract from --pdf-bytes.",
     )
     parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--process-contract-path", default=PROCESS_CONTRACT_PATH)
     parser.add_argument("--report-model-path-template", default=REPORT_MODEL_PATH_TEMPLATE)
     parser.add_argument("--artifact-path-template", default=ARTIFACT_PATH_TEMPLATE)
     parser.add_argument(
@@ -150,13 +156,14 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
     if not math.isfinite(float(args.timeout)) or float(args.timeout) <= 0:
         errors.append("--timeout must be a positive finite number")
     for attr, label in (
+        ("process_contract_path", "--process-contract-path"),
         ("report_model_path_template", "--report-model-path-template"),
         ("artifact_path_template", "--artifact-path-template"),
     ):
         value = _clean(getattr(args, attr))
         if not value.startswith("/"):
             errors.append(f"{label} must start with /")
-        if "{request_id}" not in value:
+        if label != "--process-contract-path" and "{request_id}" not in value:
             errors.append(f"{label} must include {{request_id}}")
     errors.extend(_validate_file(args.pdf_bytes, label="--pdf-bytes"))
     if args.pdf_text is not None:
@@ -508,6 +515,37 @@ def _fetch_live_inputs(args: argparse.Namespace) -> tuple[HttpResult, HttpResult
     )
 
 
+def _process_contract_preflight(args: argparse.Namespace) -> tuple[list[str], dict[str, Any]]:
+    code, payload = check_process_contract(argparse.Namespace(
+        base_url=_clean(args.base_url),
+        token=_clean(args.token),
+        timeout=float(args.timeout),
+        path=_clean(args.process_contract_path),
+        output_result=None,
+        json=False,
+        pretty=False,
+    ))
+    if not isinstance(payload, Mapping):
+        return ["process contract preflight failed"], {"status": None}
+    endpoint = payload.get("endpoint")
+    errors = payload.get("errors")
+    error_list = [
+        str(error)
+        for error in (errors if isinstance(errors, Sequence) and not isinstance(errors, str) else ())
+    ]
+    summary = {
+        "status": endpoint.get("status") if isinstance(endpoint, Mapping) else None,
+        "ok": code == 0 and payload.get("ok") is True,
+    }
+    if error_list:
+        summary["errors"] = error_list
+    return (
+        [f"process contract preflight failed: {error}" for error in error_list]
+        or ([] if summary["ok"] else ["process contract preflight failed"]),
+        summary,
+    )
+
+
 def _live_payload_errors(
     *,
     report_model: HttpResult,
@@ -557,12 +595,23 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
     if read_errors:
         return _safe_failure_payload(args, read_errors)
 
+    process_contract_errors, process_contract_summary = _process_contract_preflight(args)
+    if process_contract_errors:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "ok": False,
+            "inputs": _input_summary(args),
+            "fetches": {"process_contract": process_contract_summary},
+            "errors": process_contract_errors,
+        }
+
     report_model_result, artifact_result = _fetch_live_inputs(args)
     payload_errors, report_model, _artifact, evidence_export = _live_payload_errors(
         report_model=report_model_result,
         artifact=artifact_result,
     )
     fetches = {
+        "process_contract": process_contract_summary,
         "report_model": _status_summary(report_model_result),
         "artifact": _status_summary(artifact_result),
     }

--- a/tests/test_run_deflection_full_report_qa_live_runner.py
+++ b/tests/test_run_deflection_full_report_qa_live_runner.py
@@ -148,6 +148,30 @@ def _evidence_export() -> dict[str, object]:
     }
 
 
+def _process_contract(**contract_overrides: Any) -> dict[str, Any]:
+    contract: dict[str, Any] = {
+        "report_model_schema_version": "deflection.v1",
+        "report_model_contract": runner.EXPECTED_REPORT_MODEL_CONTRACT,
+        "evidence_export_schema_version": "deflection_evidence.v1",
+        "paid_artifact_requires": {
+            "report_model": "object",
+            "evidence_export": "object",
+        },
+    }
+    contract.update(contract_overrides)
+    return {
+        "schema_version": "deflection_report_process.v1",
+        "service": "content_ops_deflection_reports",
+        "contract": contract,
+        "routes": {
+            "process_contract": "/api/v1/content-ops/deflection-reports/process-contract",
+            "snapshot": "/api/v1/content-ops/deflection-reports/{request_id}/snapshot",
+            "artifact": "/api/v1/content-ops/deflection-reports/{request_id}/artifact",
+            "report_model": "/api/v1/content-ops/deflection-reports/{request_id}/report-model",
+        },
+    }
+
+
 def _pdf_text() -> str:
     return """
     Support Ticket Deflection Report
@@ -251,6 +275,8 @@ def test_live_runner_extracts_pdf_text_from_renderer_bytes_by_default(
 
     def _urlopen(request, *, timeout):
         calls.append(request.full_url)
+        if request.full_url.endswith("/process-contract"):
+            return FakeResponse(200, _process_contract())
         if request.full_url.endswith(f"/{REQUEST_ID}/report-model"):
             return FakeResponse(200, _pdf_report_model())
         if request.full_url.endswith(f"/{REQUEST_ID}/artifact"):
@@ -285,6 +311,7 @@ def test_live_runner_extracts_pdf_text_from_renderer_bytes_by_default(
     assert payload["inputs"]["pdf_text_present"] is False
     assert payload["scorecard"]["artifacts"]["pdf"]["text_chars"] > 0
     assert calls == [
+        "https://atlas.example.com/api/v1/content-ops/deflection-reports/process-contract",
         f"https://atlas.example.com/api/v1/content-ops/deflection-reports/{REQUEST_ID}/report-model",
         f"https://atlas.example.com/api/v1/content-ops/deflection-reports/{REQUEST_ID}/artifact",
     ]
@@ -345,6 +372,8 @@ def test_live_runner_fetches_live_json_and_writes_redacted_scorecard(
             "headers": dict(request.header_items()),
             "timeout": timeout,
         })
+        if request.full_url.endswith("/process-contract"):
+            return FakeResponse(200, _process_contract())
         if request.full_url.endswith(f"/{REQUEST_ID}/report-model"):
             return FakeResponse(200, _report_model())
         if request.full_url.endswith(f"/{REQUEST_ID}/artifact"):
@@ -360,6 +389,7 @@ def test_live_runner_fetches_live_json_and_writes_redacted_scorecard(
     payload = _payload(tmp_path)
     assert printed == payload
     assert payload["ok"] is True
+    assert payload["fetches"]["process_contract"] == {"status": 200, "ok": True}
     assert payload["fetches"]["report_model"] == {"status": 200}
     assert payload["fetches"]["artifact"] == {"status": 200}
     assert payload["scorecard"]["ok"] is True
@@ -369,6 +399,7 @@ def test_live_runner_fetches_live_json_and_writes_redacted_scorecard(
     }
     assert payload["scorecard"]["artifacts"]["pdf"]["text_chars"] > 0
     assert [call["url"] for call in calls] == [
+        "https://atlas.example.com/api/v1/content-ops/deflection-reports/process-contract",
         f"https://atlas.example.com/api/v1/content-ops/deflection-reports/{REQUEST_ID}/report-model",
         f"https://atlas.example.com/api/v1/content-ops/deflection-reports/{REQUEST_ID}/artifact",
     ]
@@ -570,6 +601,8 @@ def test_unsupported_pdf_stream_filter_fails_before_network(monkeypatch, tmp_pat
 
 def test_artifact_missing_evidence_export_fails_closed(monkeypatch, tmp_path) -> None:
     def _urlopen(request, *, timeout):
+        if request.full_url.endswith("/process-contract"):
+            return FakeResponse(200, _process_contract())
         if request.full_url.endswith("/report-model"):
             return FakeResponse(200, _report_model())
         return FakeResponse(200, {"report_model": _report_model()})
@@ -586,11 +619,59 @@ def test_artifact_missing_evidence_export_fails_closed(monkeypatch, tmp_path) ->
     assert "evidence_rows" not in json.dumps(payload)
 
 
+def test_process_contract_drift_fails_before_paid_artifact_fetches(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    calls: list[str] = []
+
+    def _urlopen(request, *, timeout):
+        del timeout
+        calls.append(request.full_url)
+        if request.full_url.endswith("/process-contract"):
+            stale_shape = dict(runner.EXPECTED_REPORT_MODEL_CONTRACT)
+            stale_shape["sections"] = [
+                section
+                for section in runner.EXPECTED_REPORT_MODEL_CONTRACT["sections"]
+                if section["id"] != "complete_evidence"
+            ]
+            return FakeResponse(
+                200,
+                _process_contract(report_model_contract=stale_shape),
+            )
+        raise AssertionError("paid artifact endpoints must not be fetched")
+
+    monkeypatch.setattr(runner.urllib.request, "urlopen", _urlopen)
+
+    code = runner.main(_base_args(tmp_path))
+
+    assert code == 1
+    payload = _payload(tmp_path)
+    assert calls == [
+        "https://atlas.example.com/api/v1/content-ops/deflection-reports/process-contract"
+    ]
+    assert payload["fetches"] == {
+        "process_contract": {
+            "status": 200,
+            "ok": False,
+            "errors": [
+                "contract.report_model_contract must match current deflection.v1 shape"
+            ],
+        }
+    }
+    assert payload["errors"] == [
+        "process contract preflight failed: "
+        "contract.report_model_contract must match current deflection.v1 shape"
+    ]
+
+
 def test_artifact_report_model_drift_fails_closed(monkeypatch, tmp_path) -> None:
     drifted_model = dict(_report_model())
     drifted_model["title"] = "Different report"
 
     def _urlopen(request, *, timeout):
+        if request.full_url.endswith("/process-contract"):
+            return FakeResponse(200, _process_contract())
         if request.full_url.endswith("/report-model"):
             return FakeResponse(200, _report_model())
         return FakeResponse(200, _artifact(report_model=drifted_model))
@@ -618,6 +699,8 @@ def test_artifact_report_model_must_be_object_when_present(
     raw_report_model,
 ) -> None:
     def _urlopen(request, *, timeout):
+        if request.full_url.endswith("/process-contract"):
+            return FakeResponse(200, _process_contract())
         if request.full_url.endswith("/report-model"):
             return FakeResponse(200, _report_model())
         return FakeResponse(200, _artifact(report_model=raw_report_model))
@@ -633,6 +716,8 @@ def test_artifact_report_model_must_be_object_when_present(
 
 def test_invalid_json_response_fails_without_raw_body(monkeypatch, tmp_path) -> None:
     def _urlopen(request, *, timeout):
+        if request.full_url.endswith("/process-contract"):
+            return FakeResponse(200, _process_contract())
         if request.full_url.endswith("/report-model"):
             return FakeResponse(200, "{not json")
         return FakeResponse(200, _artifact())
@@ -653,6 +738,8 @@ def test_invalid_json_response_fails_without_raw_body(monkeypatch, tmp_path) -> 
 
 def test_http_error_status_is_sanitized(monkeypatch, tmp_path) -> None:
     def _urlopen(request, *, timeout):
+        if request.full_url.endswith("/process-contract"):
+            return FakeResponse(200, _process_contract())
         if request.full_url.endswith("/report-model"):
             raise _http_error(request.full_url, 403)
         return FakeResponse(200, _artifact())
@@ -678,6 +765,8 @@ def test_output_sanitizer_rewrites_sensitive_scorecard_and_returns_one(
     tmp_path,
 ) -> None:
     def _urlopen(request, *, timeout):
+        if request.full_url.endswith("/process-contract"):
+            return FakeResponse(200, _process_contract())
         if request.full_url.endswith("/report-model"):
             return FakeResponse(200, _report_model())
         return FakeResponse(200, _artifact())


### PR DESCRIPTION
Plan: plans/PR-Deflection-Process-Contract-Live-Runner-Preflight.md
Slice phase: Production hardening

#1684 added the process-contract endpoint and checker, but the live full-report QA runner still did not invoke it. This slice makes that detector part of the paid proof path: the runner now validates the hosted process contract after local PDF/input checks and before fetching paid `/report-model` or `/artifact`, so stale deploy/process drift fails early and safely.

## Intentional
- Local PDF/read/leak validation still runs before any network call; bad local proof bundles fail locally.
- The process-contract preflight does not replace the paid proof. It proves hosted structural freshness; the existing paid artifact/PDF/export checks still prove value-level output correctness.
- No deployment restart/supervision automation in this slice.
- No atlas-portfolio buyer hosted-result smoke; that remains outside this repo/lane.

## Deferred
- Deployment restart/supervision automation remains a separate operations hardening slice if stale long-running processes recur.
- atlas-portfolio buyer hosted-result proof remains outside this repo/lane.
- Submit-smoke teaser-path alignment remains outside this runner slice.

## Parked hardening
- None.

## Verification
- `pytest tests/test_run_deflection_full_report_qa_live_runner.py -q`
  - 17 passed.
- `python -m py_compile scripts/run_deflection_full_report_qa_live_runner.py tests/test_run_deflection_full_report_qa_live_runner.py`
  - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
  - OK: 185 matching tests are enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh`
  - extracted reasoning core: 295 passed.
  - extracted content pipeline: 4630 passed, 10 skipped, 1 existing torch warning.

## Diff size
3 files, +263 / -1.

## AI reconciliation
- No AI findings yet. All fixed or waived: yes.
