### PR TITLE
Maturity sweep robust gate

### DIFF
--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -1,13 +1,11 @@
-name: Maturity Sweep (advisory)
+name: Maturity Sweep
 
 permissions:
   contents: read
 
-# Advisory brittleness triage -- NOT a gate. Ranks files in the content-ops
-# lane by structural-fragility signals (untested modules, happy-path-only
-# tests, swallowed exceptions, unguarded input) and prints a worst-first
-# agenda for an adversarial pass. It never fails the build: it surfaces
-# suspects, judgment stays with the reviewer.
+# Brittleness triage + ratchet gate. The advisory report ranks files in the
+# content-ops lane by structural-fragility signals, while the blocking baseline
+# gate prevents new brittleness without failing on existing debt.
 #
 # It catches STRUCTURAL brittleness only. Semantic / contract / logic bugs
 # (over-broad matchers, fail-open fields, asymmetric token handling) are NOT
@@ -20,6 +18,7 @@ on:
       - ".github/workflows/maturity_sweep_advisory.yml"
       - "scripts/maturity_sweep.py"
       - "tests/test_maturity_sweep.py"
+      - "tests/maturity_sweep/baseline_extracted_content_pipeline.json"
       - "extracted_content_pipeline/**"
       - "tests/test_extracted_*.py"
       - "tests/test_content_ops_*.py"
@@ -29,6 +28,7 @@ on:
     paths:
       - ".github/workflows/maturity_sweep_advisory.yml"
       - "scripts/maturity_sweep.py"
+      - "tests/maturity_sweep/baseline_extracted_content_pipeline.json"
       - "extracted_content_pipeline/**"
 
 jobs:
@@ -63,3 +63,16 @@ jobs:
           echo "A green sweep is not a production-hardening stamp."
           echo
           python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --top 25
+
+      - name: Maturity sweep ratchet gate (blocking)
+        run: |
+          python scripts/maturity_sweep.py extracted_content_pipeline \
+            --tests-root tests \
+            --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json \
+            --min-score 8 \
+            --sensitive-glob '**/billing/**' \
+            --sensitive-glob '**/paid*' \
+            --sensitive-glob '**/auth/**' \
+            --sensitive-glob '**/webhook*' \
+            --sensitive-glob '**/payment*' \
+            --sensitive-glob '**/*deletion*'

--- a/plans/PR-Maturity-Sweep-Robust-Gate.md
+++ b/plans/PR-Maturity-Sweep-Robust-Gate.md
@@ -1,0 +1,119 @@
+# PR-Maturity-Sweep-Robust-Gate
+
+Slice phase: Production hardening (CI enforcement)
+Ownership lane: ci/maturity-sweep
+
+## Why this slice exists
+
+`maturity_sweep.py` (#1470) already detects the right brittleness -- `SWALLOWED_EXCEPT` (weight 5), `BARE_EXCEPT` (4), `HAPPY_PATH_TESTS` (4), unguarded indexing, brittle/quick-fix comments -- and already has a `--min-score` CI gate and `--json` output. But two things make it advisory in practice:
+
+1. **`.github/workflows/maturity_sweep_advisory.yml` runs it with `continue-on-error: true`** (`python scripts/maturity_sweep.py extracted_content_pipeline --top 25`). So brittleness is printed in logs and the PR still goes green. Reported, not prevented.
+2. **`--min-score` is an absolute threshold** (`print_report`: `over = [r for r in results if r.score >= min_score]` -> exit 1). You cannot turn it on across a codebase with existing debt -- every PR touching an already-brittle file floods red. There is no baseline/ratchet, so it can never be made blocking as-is.
+
+This slice adds the missing ratchet and a sensitive-path escalation, then flips the existing lane to blocking. Goal: a NEW swallowed-except can't merge; pre-existing debt doesn't block (it's tracked and burned down deliberately).
+
+This PR is expected to exceed the 400 LOC soft cap because the initial extracted-content baseline is a generated JSON snapshot. The handwritten logic and workflow diff stay scoped to the ratchet mechanism; splitting the baseline away would make the gate red on arrival.
+
+## Scope (this PR)
+
+Ownership lane: ci/maturity-sweep
+Slice phase: Production hardening
+
+1. **Baseline / ratchet mode in `scripts/maturity_sweep.py`.**
+   - `--baseline <path>`: JSON baseline of `{relpath: {"score": int, "counts": {code: n}}}` for the swept lane.
+   - `--update-baseline`: write/refresh the baseline from the current sweep (the deliberate "accept this debt" action).
+   - Gate semantics when `--baseline` is given (replaces the flat `--min-score` behavior, keep `--min-score` as the new-file ceiling): exit 1 when **any** of:
+     - a baselined file's `score` **increases** vs baseline, or
+     - a **new** (non-baselined) file scores `>= --min-score`, or
+     - the sensitive-path rule below fires.
+   - On failure, print exactly which files/findings caused it and the one-liner to accept intentionally (`--update-baseline`). Ratchet, not big-bang.
+
+2. **Sensitive-path zero-tolerance.**
+   - `--sensitive-glob <glob>` (repeatable) -- e.g. `**/billing/**`, `**/paid*`, `**/auth/**`, `**/webhook*`, `**/payment*`, `**/*deletion*`.
+   - For a file matching any sensitive glob, **any new** `SWALLOWED_EXCEPT` or `BARE_EXCEPT` finding (count increases vs baseline, or present on a new file) fails the gate **regardless** of `--min-score` or score delta. Silent failure in money/auth/delete paths is never acceptable as "below threshold."
+
+3. **Commit the initial baseline** at `tests/maturity_sweep/baseline_extracted_content_pipeline.json`, snapshotting current state so the gate starts green and only catches new debt.
+
+4. **Flip the workflow** (`.github/workflows/maturity_sweep_advisory.yml`):
+   - keep the existing advisory top-N step (visibility), and
+   - add a **blocking** gate step (NO `continue-on-error`) running `maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --min-score <N> --sensitive-glob ...`.
+
+5. **Tests** (`tests/test_maturity_sweep.py`):
+   - `--update-baseline` writes the expected JSON shape.
+   - **ratchet:** a pre-existing baselined finding does NOT fail the gate.
+   - a NEW finding raising a baselined file's score DOES fail.
+   - a new file `>= --min-score` fails; a new file below it passes.
+   - **sensitive-path:** a new `SWALLOWED_EXCEPT` on a sensitive-glob file fails even when its score is below `--min-score` and even on an otherwise-passing baseline.
+   - updating the baseline to include the new finding makes the gate pass again (deliberate acceptance works).
+
+### Review Contract
+
+Acceptance criteria:
+- `scripts/maturity_sweep.py` supports `--baseline`, `--update-baseline`, and repeatable `--sensitive-glob`.
+- Baseline mode fails on score increases, new files at or above `--min-score`, and new sensitive `SWALLOWED_EXCEPT` / `BARE_EXCEPT` findings.
+- Existing baselined debt does not fail the gate.
+- `tests/maturity_sweep/baseline_extracted_content_pipeline.json` is committed and makes the extracted content pipeline gate green on arrival.
+- `.github/workflows/maturity_sweep_advisory.yml` keeps the top-N advisory report and adds a blocking baseline-backed gate.
+
+Affected surfaces:
+- CI maturity sweep workflow for `extracted_content_pipeline`.
+- `scripts/maturity_sweep.py` gate semantics.
+- `tests/test_maturity_sweep.py` failure-branch coverage.
+
+Risk areas:
+- False red CI from baseline path mismatches or unstable JSON output.
+- False green if sensitive path matching or count deltas silently skip findings.
+- Baseline churn if output ordering is nondeterministic.
+
+Triggered reviewer rules:
+- R1 Requirements match.
+- R2 Test evidence.
+- R9 Thin-slice scope.
+- R10 Evaluator/checker precision.
+- R11 Configuration/workflow changes.
+- R13 Defect-class proof.
+- R14 Codebase verification.
+
+### Files touched
+
+- `.github/workflows/maturity_sweep_advisory.yml`
+- `plans/PR-Maturity-Sweep-Robust-Gate.md`
+- `scripts/maturity_sweep.py`
+- `tests/maturity_sweep/baseline_extracted_content_pipeline.json`
+- `tests/test_maturity_sweep.py`
+
+## Mechanism
+
+The existing `--min-score` compares an absolute score; the baseline makes the comparison **relative** (per-file delta vs a committed snapshot), which is what lets it run blocking without flooding on existing debt. Sensitive globs add an absolute floor (zero new silent-failure) exactly where it is most dangerous. No change to the detectors or weights -- this is purely the gate/enforcement layer plus a baseline artifact.
+
+## Intentional
+
+- Ratchet, not big-bang: existing debt is baselined and burned down deliberately; only NEW brittleness blocks.
+- Sensitive paths get zero-tolerance for swallowed/bare except, independent of score.
+- The advisory top-N report stays for visibility alongside the blocking gate.
+- `--update-baseline` is the explicit, reviewable escape hatch (a baseline diff in a PR is a visible "we accepted this debt" decision).
+
+## Deferred
+
+- Extending the gate to `atlas_brain/**`, the other `extracted_*` packages, and `scripts/**` -- follow-on slice (depends on this mechanism + per-lane baselines).
+- Auto-burndown reporting / trend tracking of baseline debt over time.
+
+Parked hardening: none.
+
+## Verification
+
+- PASS: `python -m pytest tests/test_maturity_sweep.py --noconftest -q` -- 14 passed.
+- PASS: `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/webhook*' --sensitive-glob '**/payment*' --sensitive-glob '**/*deletion*'`
+- PASS: `python -c "import yaml,glob; [yaml.safe_load(open(f, encoding='utf-8')) for f in glob.glob('.github/workflows/*.yml')]"`.
+- PASS: scratch sensitive-path proof: clean scratch baseline exits 0; after planting `try/except: pass` in a temporary paid probe file, the same gate exits 1 with `new sensitive-path SWALLOWED_EXCEPT`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/maturity_sweep_advisory.yml` | 25 |
+| `plans/PR-Maturity-Sweep-Robust-Gate.md` | 119 |
+| `scripts/maturity_sweep.py` | 163 |
+| `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 906 |
+| `tests/test_maturity_sweep.py` | 170 |
+| **Total** | **1383** |

--- a/scripts/maturity_sweep.py
+++ b/scripts/maturity_sweep.py
@@ -23,6 +23,7 @@ Usage:
 
 import argparse
 import ast
+import fnmatch
 import json
 import os
 import re
@@ -89,6 +90,7 @@ SKIP_DIRS = {
 }
 
 TEST_NAME_RE = re.compile(r"(^test_.+\.py$)|(.+_test\.py$)")
+SENSITIVE_ZERO_TOLERANCE = ("BARE_EXCEPT", "SWALLOWED_EXCEPT")
 
 
 @dataclass
@@ -108,6 +110,13 @@ class FileResult:
     score: int = 0
     findings: list = field(default_factory=list)
     counts: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GateFailure:
+    path: str
+    reason: str
+    detail: str
 
 
 # ---------------------------------------------------------------------------
@@ -409,10 +418,126 @@ def sweep(root, tests_root=None):
 
 
 # ---------------------------------------------------------------------------
+# baseline ratchet gate
+# ---------------------------------------------------------------------------
+
+def baseline_entry(result):
+    return {
+        "score": int(result.score),
+        "counts": {code: int(count) for code, count in sorted(result.counts.items())},
+    }
+
+
+def baseline_payload(results):
+    return {
+        result.path: baseline_entry(result)
+        for result in sorted(results, key=lambda item: item.path)
+        if result.score > 0
+    }
+
+
+def write_baseline(path, results):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(baseline_payload(results), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_baseline(path):
+    try:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit("baseline not found: %s" % path)
+    except json.JSONDecodeError as exc:
+        raise SystemExit("baseline is not valid JSON: %s: %s" % (path, exc))
+    if not isinstance(raw, dict):
+        raise SystemExit("baseline must be a JSON object: %s" % path)
+    return raw
+
+
+def _baseline_score(entry):
+    if not isinstance(entry, dict):
+        return 0
+    try:
+        return int(entry.get("score", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _baseline_counts(entry):
+    if not isinstance(entry, dict):
+        return {}
+    counts = entry.get("counts", {})
+    if not isinstance(counts, dict):
+        return {}
+    out = {}
+    for code, count in counts.items():
+        try:
+            out[str(code)] = int(count)
+        except (TypeError, ValueError):
+            out[str(code)] = 0
+    return out
+
+
+def _matches_sensitive(path, patterns):
+    return any(
+        fnmatch.fnmatch(path, pattern) or Path(path).match(pattern)
+        for pattern in patterns
+    )
+
+
+def ratchet_failures(results, baseline, min_score=None, sensitive_globs=()):
+    by_path = {result.path: result for result in results}
+    failures = []
+    for path, result in sorted(by_path.items()):
+        entry = baseline.get(path)
+        baseline_score = _baseline_score(entry)
+        baseline_counts = _baseline_counts(entry)
+        if entry is not None and result.score > baseline_score:
+            failures.append(GateFailure(
+                path=path,
+                reason="score increased",
+                detail="%d -> %d" % (baseline_score, result.score),
+            ))
+        if entry is None and min_score is not None and result.score >= min_score:
+            failures.append(GateFailure(
+                path=path,
+                reason="new file at or above min-score",
+                detail="score %d >= %d" % (result.score, min_score),
+            ))
+        if _matches_sensitive(path, sensitive_globs):
+            for code in SENSITIVE_ZERO_TOLERANCE:
+                old = baseline_counts.get(code, 0)
+                new = int(result.counts.get(code, 0))
+                if new > old:
+                    failures.append(GateFailure(
+                        path=path,
+                        reason="new sensitive-path %s" % code,
+                        detail="%d -> %d" % (old, new),
+                    ))
+    return failures
+
+
+def print_ratchet_failures(failures, baseline_path):
+    if not failures:
+        print("ratchet gate passed: no new brittleness above baseline")
+        return 0
+    print("RATCHET GATE FAILED: %d file(s) introduced new brittleness" % len(failures))
+    for failure in failures:
+        print("- %s: %s (%s)" % (failure.path, failure.reason, failure.detail))
+    print()
+    print("To accept this intentionally, rerun with:")
+    print("  python scripts/maturity_sweep.py <lane> --baseline %s --update-baseline" % baseline_path)
+    return 1
+
+
+# ---------------------------------------------------------------------------
 # reporting
 # ---------------------------------------------------------------------------
 
-def print_report(results, top, min_score):
+def print_report(results, top, min_score, ratchet=None, baseline_path=None):
     flagged = [r for r in results if r.score > 0]
     print("maturity sweep: %d files scanned, %d flagged\n" % (len(results), len(flagged)))
     print("score  file")
@@ -431,6 +556,9 @@ def print_report(results, top, min_score):
             loc = ("L%d" % f.lineno) if f.lineno else "file"
             print("     %-5s %s" % (loc, f.detail))
         print()
+
+    if ratchet is not None:
+        return print_ratchet_failures(ratchet, baseline_path)
 
     if min_score is not None:
         over = [r for r in results if r.score >= min_score]
@@ -451,9 +579,32 @@ def main(argv=None):
     ap.add_argument("--json", action="store_true", help="emit JSON instead of text")
     ap.add_argument("--min-score", type=int, default=None,
                     help="exit nonzero if any file scores at/above this (CI gate)")
+    ap.add_argument("--baseline", default=None,
+                    help="baseline JSON for ratchet mode")
+    ap.add_argument("--update-baseline", action="store_true",
+                    help="write/refresh the baseline from the current sweep and exit 0")
+    ap.add_argument("--sensitive-glob", action="append", default=[],
+                    help="glob for sensitive paths where new swallowed/bare except fails")
     args = ap.parse_args(argv)
 
     results = sweep(args.path, args.tests_root)
+
+    if args.update_baseline:
+        if not args.baseline:
+            raise SystemExit("--update-baseline requires --baseline")
+        write_baseline(args.baseline, results)
+        print("wrote maturity sweep baseline: %s" % args.baseline)
+        return 0
+
+    baseline = load_baseline(args.baseline) if args.baseline else None
+    ratchet = None
+    if baseline is not None:
+        ratchet = ratchet_failures(
+            results,
+            baseline,
+            min_score=args.min_score,
+            sensitive_globs=tuple(args.sensitive_glob),
+        )
 
     if args.json:
         payload = [
@@ -462,11 +613,19 @@ def main(argv=None):
             for r in results if r.score > 0
         ]
         print(json.dumps(payload, indent=2))
+        if ratchet is not None:
+            return 1 if ratchet else 0
         if args.min_score is not None:
             return 1 if any(r.score >= args.min_score for r in results) else 0
         return 0
 
-    return print_report(results, args.top, args.min_score)
+    return print_report(
+        results,
+        args.top,
+        args.min_score,
+        ratchet=ratchet,
+        baseline_path=args.baseline,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/maturity_sweep/baseline_extracted_content_pipeline.json
+++ b/tests/maturity_sweep/baseline_extracted_content_pipeline.json
@@ -1,0 +1,906 @@
+{
+  "extracted_content_pipeline/ad_copy_generation.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/ad_copy_postgres.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/api/control_surfaces.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "HEURISTIC_COMMENT": 5,
+      "SWALLOWED_EXCEPT": 3,
+      "UNGUARDED_INDEX": 6
+    },
+    "score": 29
+  },
+  "extracted_content_pipeline/api/generated_assets.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/api/seller_campaigns.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/autonomous/tasks/_b2b_cross_vendor_synthesis.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 15
+    },
+    "score": 16
+  },
+  "extracted_content_pipeline/autonomous/tasks/_b2b_pool_compression.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 11,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 17,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 19
+  },
+  "extracted_content_pipeline/autonomous/tasks/_b2b_reasoning_contracts.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 11
+  },
+  "extracted_content_pipeline/autonomous/tasks/_b2b_shared.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 4,
+      "SWALLOWED_EXCEPT": 26,
+      "UNGUARDED_INDEX": 130
+    },
+    "score": 140
+  },
+  "extracted_content_pipeline/autonomous/tasks/_b2b_specificity.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/autonomous/tasks/_b2b_synthesis_reader.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 5
+    },
+    "score": 25
+  },
+  "extracted_content_pipeline/autonomous/tasks/_blog_matching.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 4
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/autonomous/tasks/_blog_ts.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/autonomous/tasks/_execution_progress.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 10
+  },
+  "extracted_content_pipeline/autonomous/tasks/_google_news.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 4
+    },
+    "score": 11
+  },
+  "extracted_content_pipeline/autonomous/tasks/article_enrichment.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 16,
+      "UNGUARDED_INDEX": 42
+    },
+    "score": 90
+  },
+  "extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "HEURISTIC_COMMENT": 3,
+      "SWALLOWED_EXCEPT": 6,
+      "UNGUARDED_INDEX": 27
+    },
+    "score": 43
+  },
+  "extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 10,
+      "UNGUARDED_INDEX": 13
+    },
+    "score": 59
+  },
+  "extracted_content_pipeline/autonomous/tasks/blog_post_generation.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 15
+    },
+    "score": 9
+  },
+  "extracted_content_pipeline/autonomous/tasks/campaign_audit.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/autonomous/tasks/competitive_intelligence.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 4
+    },
+    "score": 9
+  },
+  "extracted_content_pipeline/autonomous/tasks/complaint_analysis.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/autonomous/tasks/complaint_content_generation.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "NO_TEST_FILE": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 11
+  },
+  "extracted_content_pipeline/autonomous/tasks/complaint_enrichment.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 3
+    },
+    "score": 15
+  },
+  "extracted_content_pipeline/autonomous/visibility.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 2
+    },
+    "score": 2
+  },
+  "extracted_content_pipeline/blog_blueprint_postgres.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/blog_generation.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 12
+  },
+  "extracted_content_pipeline/blog_post_export.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 14
+  },
+  "extracted_content_pipeline/blog_post_postgres.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "extracted_content_pipeline/calibration_anchors.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/campaign_analytics.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 13
+  },
+  "extracted_content_pipeline/campaign_customer_data.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 2,
+      "UNGUARDED_INPUT": 6
+    },
+    "score": 40
+  },
+  "extracted_content_pipeline/campaign_example.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1,
+      "WEAK_CONTRACT": 6
+    },
+    "score": 10
+  },
+  "extracted_content_pipeline/campaign_generation.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 20
+  },
+  "extracted_content_pipeline/campaign_install_check.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 9
+  },
+  "extracted_content_pipeline/campaign_llm_client.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 5
+    },
+    "score": 25
+  },
+  "extracted_content_pipeline/campaign_opportunities.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "extracted_content_pipeline/campaign_postgres.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/campaign_postgres_export.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/campaign_postgres_import.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/campaign_postgres_review.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/campaign_postgres_seller_category_intelligence.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "extracted_content_pipeline/campaign_postgres_seller_opportunities.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 14
+  },
+  "extracted_content_pipeline/campaign_postgres_seller_targets.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/campaign_reasoning_data.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 9
+  },
+  "extracted_content_pipeline/campaign_send.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/campaign_sender.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/campaign_sequence_context.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "extracted_content_pipeline/campaign_sequence_progression.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/campaign_source_adapters.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 1,
+      "WEAK_CONTRACT": 1
+    },
+    "score": 17
+  },
+  "extracted_content_pipeline/campaign_visibility.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "HEURISTIC_COMMENT": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INPUT": 3
+    },
+    "score": 22
+  },
+  "extracted_content_pipeline/campaign_webhooks.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 10
+  },
+  "extracted_content_pipeline/claim_evidence_benchmark.py": {
+    "counts": {
+      "ASSERT_AS_VALIDATION": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/claims_map.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/content_image_provider.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 16
+  },
+  "extracted_content_pipeline/content_ops_cache_policy.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/content_ops_execution.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 4
+    },
+    "score": 20
+  },
+  "extracted_content_pipeline/content_ops_usage_summary.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 10
+  },
+  "extracted_content_pipeline/control_surfaces.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/coverage_rows.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/csv_export.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/deflection_report_access.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 9
+  },
+  "extracted_content_pipeline/embedding_port.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/faq_deflection_report.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 3,
+      "UNGUARDED_INDEX": 3,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 29
+  },
+  "extracted_content_pipeline/faq_macro_writeback_postgres.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/faq_macro_writeback_publish.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/faq_macro_writeback_zendesk.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/faq_output_ingestion.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/generation_plan.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/ingestion_diagnostics.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/landing_page_export.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 14
+  },
+  "extracted_content_pipeline/landing_page_generation.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/landing_page_input_contract.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/landing_page_postgres.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 4
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/landing_page_readiness.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 10
+  },
+  "extracted_content_pipeline/landing_page_structured_data.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/pipelines/llm.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/pipelines/notify.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/podcast_example.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/podcast_extraction.py": {
+    "counts": {
+      "ASSERT_AS_VALIDATION": 1,
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 20
+  },
+  "extracted_content_pipeline/podcast_idea_data.py": {
+    "counts": {
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/podcast_postgres.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 11
+  },
+  "extracted_content_pipeline/podcast_postgres_extraction.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/podcast_postgres_repurpose.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/podcast_repurpose_generation.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 14
+  },
+  "extracted_content_pipeline/podcast_transcript_data.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 15
+  },
+  "extracted_content_pipeline/quote_card_export.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/quote_card_generation.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/quote_card_postgres.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/reasoning/evidence_engine.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/reasoning_policy.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/reasoning_signals.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/report_export.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/report_generation.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "extracted_content_pipeline/report_postgres.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/sales_brief_export.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/sales_brief_generation.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "extracted_content_pipeline/services/b2b/account_opportunity_claims.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/services/b2b/cache_runner.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/services/b2b/corrections.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/services/b2b/enrichment_contract.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "extracted_content_pipeline/services/b2b/vendor_briefing_repository.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 12
+  },
+  "extracted_content_pipeline/services/blog_quality.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/services/campaign_quality.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 9
+  },
+  "extracted_content_pipeline/services/campaign_reasoning_context.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/services/llm_router.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/services/multi_pass_reasoning_provider.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "extracted_content_pipeline/services/podcast_quality.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/services/scraping/sources.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/services/single_pass_reasoning_provider.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 12
+  },
+  "extracted_content_pipeline/services/vendor_registry.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/services/vendor_target_selection.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/social_post_export.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/social_post_generation.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 14
+  },
+  "extracted_content_pipeline/social_post_postgres.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/stat_card_export.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/stat_card_generation.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 9
+  },
+  "extracted_content_pipeline/stat_card_postgres.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "extracted_content_pipeline/storage/_jsonb_helpers.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "extracted_content_pipeline/storage/database.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/storage/migration_runner.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "extracted_content_pipeline/storage/models.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "extracted_content_pipeline/support_ticket_clustering.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 5
+    },
+    "score": 13
+  },
+  "extracted_content_pipeline/support_ticket_context_contract.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 12
+  },
+  "extracted_content_pipeline/support_ticket_dates.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 3
+    },
+    "score": 15
+  },
+  "extracted_content_pipeline/support_ticket_generated_content_eval.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 9
+  },
+  "extracted_content_pipeline/support_ticket_input_package.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "HEURISTIC_COMMENT": 2,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 16
+  },
+  "extracted_content_pipeline/text_truncate.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "extracted_content_pipeline/ticket_faq_input_contract.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "extracted_content_pipeline/ticket_faq_markdown.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 30
+    },
+    "score": 16
+  },
+  "extracted_content_pipeline/ticket_faq_postgres.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  }
+}

--- a/tests/test_maturity_sweep.py
+++ b/tests/test_maturity_sweep.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -123,3 +124,172 @@ def test_unguarded_boundary_input_detector_fires_and_guarded_is_quiet() -> None:
         "    except OSError:\n        raise ValueError(p)\n"
     )
     assert "UNGUARDED_INPUT" not in {f.code for f in guarded}
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_reference_test(tests: Path, *module_names: str) -> None:
+    _write(
+        tests / "test_refs.py",
+        "\n".join("import %s" % name for name in module_names) + "\n",
+    )
+
+
+def _module_with_swallowed_except() -> str:
+    return (
+        "def run():\n"
+        "    try:\n"
+        "        risky()\n"
+        "    except Exception:\n"
+        "        pass\n"
+    )
+
+
+def test_update_baseline_writes_expected_json_shape(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    _write(lane / "paid_flow.py", _module_with_swallowed_except())
+    _write_reference_test(tests, "paid_flow")
+    baseline = tmp_path / "baseline.json"
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--update-baseline",
+    ]) == 0
+
+    payload = json.loads(baseline.read_text(encoding="utf-8"))
+    entry = payload[str(lane / "paid_flow.py")]
+    assert entry["score"] == 5
+    assert entry["counts"] == {"SWALLOWED_EXCEPT": 1}
+
+
+def test_baselined_finding_does_not_fail_ratchet(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    _write(lane / "paid_flow.py", _module_with_swallowed_except())
+    _write_reference_test(tests, "paid_flow")
+    baseline = tmp_path / "baseline.json"
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--update-baseline",
+    ]) == 0
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--min-score", "5",
+    ]) == 0
+
+
+def test_score_increase_in_baselined_file_fails(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    _write(lane / "parser.py", "# TODO tighten parser\n")
+    _write_reference_test(tests, "parser")
+    baseline = tmp_path / "baseline.json"
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--update-baseline",
+    ]) == 0
+    _write(lane / "parser.py", "# TODO tighten parser\n" + _module_with_swallowed_except())
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--min-score", "99",
+    ]) == 1
+
+
+def test_new_file_min_score_ratchet(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    _write(lane / "existing.py", "VALUE = 1\n")
+    _write_reference_test(tests, "existing", "new_risky")
+    baseline = tmp_path / "baseline.json"
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--update-baseline",
+    ]) == 0
+    _write(lane / "new_risky.py", _module_with_swallowed_except())
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--min-score", "6",
+    ]) == 0
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--min-score", "5",
+    ]) == 1
+
+
+def test_sensitive_path_swallowed_except_fails_below_min_score(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    _write(lane / "billing_paid.py", "VALUE = 1\n")
+    _write_reference_test(tests, "billing_paid")
+    baseline = tmp_path / "baseline.json"
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--update-baseline",
+    ]) == 0
+    _write(lane / "billing_paid.py", _module_with_swallowed_except())
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--min-score", "99",
+        "--sensitive-glob", "**/billing_paid.py",
+    ]) == 1
+
+
+def test_update_baseline_accepts_new_sensitive_finding(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    _write(lane / "billing_paid.py", "VALUE = 1\n")
+    _write_reference_test(tests, "billing_paid")
+    baseline = tmp_path / "baseline.json"
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--update-baseline",
+    ]) == 0
+    _write(lane / "billing_paid.py", _module_with_swallowed_except())
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--update-baseline",
+    ]) == 0
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--min-score", "99",
+        "--sensitive-glob", "**/billing_paid.py",
+    ]) == 0


### PR DESCRIPTION
Plan: plans/PR-Maturity-Sweep-Robust-Gate.md
Slice phase: Production hardening

Closes #1688 by turning the advisory maturity sweep into a blocking ratchet for `extracted_content_pipeline`: existing brittleness is snapshotted in a committed baseline, new score increases fail, new files over the threshold fail, and new swallowed/bare exceptions on sensitive paths fail regardless of score.

## Intentional
- Ratchet, not big-bang: existing debt is baselined, while new brittleness blocks.
- Keep the advisory top-N report for reviewer visibility alongside the blocking gate.
- `--update-baseline` is the explicit, reviewable escape hatch for accepting new debt.
- This PR exceeds the 400 LOC soft cap because the initial baseline is a generated JSON snapshot; splitting it away would make the gate red on arrival.

## Deferred
- #1689 extends the robust gate to `atlas_brain/**`, the other `extracted_*` packages, and `scripts/**` with per-lane baselines.
- Baseline debt burndown/trend reporting remains separate.

## Parked hardening
- None.

## AI reconciliation
- All fixed or waived: yes.
- No AI review findings are open for this PR yet.

## Verification
- PASS: `python -m pytest tests/test_maturity_sweep.py --noconftest -q` -- 14 passed.
- PASS: `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/webhook*' --sensitive-glob '**/payment*' --sensitive-glob '**/*deletion*'`
- PASS: `python -c "import yaml,glob; [yaml.safe_load(open(f, encoding='utf-8')) for f in glob.glob('.github/workflows/*.yml')]"`
- PASS: scratch sensitive-path proof: clean scratch baseline exits 0; after planting `try/except: pass` in `paid_probe.py`, the same gate exits 1 with `new sensitive-path SWALLOWED_EXCEPT`.
- PASS: `python scripts/sync_pr_plan.py plans/PR-Maturity-Sweep-Robust-Gate.md --check`

## Diff size
5 files, +1375 / -8
