### PR TITLE
Deflection submit smoke teaser contract alignment

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -41,15 +41,6 @@ register under `docs/technical-debt/`.
 - Owner/session: Codex security/dependencies
 - Found during: PR-ESLint-10-Web-Batch
 
-### Align deflection submit smoke forbidden snapshot paths with teaser contract
-- File/location: `scripts/smoke_content_ops_deflection_submit_handoff.py`, `docs/frontend/content_ops_faq_report_contract.md`
-- Description: The submit handoff smoke reports `teaser.full_answer.answer` and `teaser.full_answer.steps` as forbidden, but the checked-in snapshot contract permits answer text and steps inside `teaser.full_answer`.
-- Why it matters: A false paywall-leak report can steer QA work toward removing contract-required teaser content instead of fixing real paid-artifact delivery gaps.
-- Effort: S
-- Category: correctness
-- Owner/session: Codex content-ops/deflection-full-report-qa
-- Found during: PR-Deflection-Full-Report-QA-Live-Artifact review
-
 ### Mobile Expo 56 audit cleanup
 - File/location: `atlas-mobile/package-lock.json`, Expo/React Native dependency graph.
 - Description: `npm audit --audit-level=high` passes after this slice, but plain `npm audit` still reports 21 moderate findings in the Expo, React Native, and audio config-plugin chain; npm says clearing them requires `npm audit fix --force`, which would install `expo@56.0.12`, `react-native@0.86.0`, or downgrade `@siteed/audio-studio`.

--- a/plans/PR-Deflection-Submit-Smoke-Teaser-Contract-Alignment.md
+++ b/plans/PR-Deflection-Submit-Smoke-Teaser-Contract-Alignment.md
@@ -1,0 +1,111 @@
+# PR-Deflection-Submit-Smoke-Teaser-Contract-Alignment
+
+## Why this slice exists
+
+Issue #1612 is now green on the ATLAS-side paid artifact/report-model/PDF/export
+proof path, but the submit handoff smoke still has one parked false-positive
+from the live-artifact proof: it reports `teaser.full_answer.answer` and
+`teaser.full_answer.steps` as forbidden paid-report leaks even though
+`docs/frontend/content_ops_faq_report_contract.md` explicitly permits answer
+text and steps inside `snapshot.teaser.full_answer`.
+
+Root cause: the smoke uses a path-insensitive forbidden-key denylist for the
+snapshot payload. That is correct for `answer` and `steps` almost everywhere,
+but it cannot represent the one contracted exception at
+`$.teaser.full_answer`. This slice fixes the root by making the smoke's
+forbidden-field detector path-aware. It does not loosen the paywall boundary
+globally.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-full-report-qa
+Slice phase: Production hardening
+
+1. Update `scripts/smoke_content_ops_deflection_submit_handoff.py` so
+   `answer` and `steps` are allowed only at `$.teaser.full_answer.answer` and
+   `$.teaser.full_answer.steps`, and only when the full-answer object carries
+   scoped resolution evidence markers.
+2. Keep the existing denylist active for the same keys everywhere else,
+   including `top_questions`, `locked_questions`, teaser previews, and any
+   unexpected nested object.
+3. Add focused boundary tests covering:
+   - contracted `teaser.full_answer.answer` / `steps` passes;
+   - draft or unscoped `teaser.full_answer.answer` / `steps` fails;
+   - dotted-key and nested-alias paths fail;
+   - `top_questions[0].answer` still fails;
+   - `teaser.previews[0].answer` and `teaser.previews[0].steps` still fail.
+4. Remove the drained HARDENING.md item for the submit-smoke teaser false
+   positive.
+
+### Files touched
+
+- `HARDENING.md`
+- `plans/PR-Deflection-Submit-Smoke-Teaser-Contract-Alignment.md`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Submit smoke accepts `answer` and `steps` at the contract-approved
+        `$.teaser.full_answer` path only for scoped resolution-backed teaser
+        answers.
+  - [ ] Submit smoke still rejects paid-answer fields outside that exact path.
+  - [ ] The parked HARDENING.md item is removed only because this PR drains it.
+- Affected surfaces: operator submit-smoke validation and #1612 proof
+  interpretation.
+- Risk areas: paywall contract precision, false positives, false negatives.
+- Reviewer rules triggered: R1, R2, R10, R14
+
+## Mechanism
+
+Keep the existing `FORBIDDEN_SNAPSHOT_KEYS` denylist, but add an exact structural
+path allowlist for the contracted teaser body fields. `_forbidden_key_paths`
+walks the snapshot recursively with path segments, so a literal key such as
+`teaser.full_answer` cannot alias the real nested path. The exception also
+requires the parent full-answer object to carry `answer_evidence_status:
+resolution_evidence` and `resolution_evidence_scope: scoped` before body fields
+are exempted.
+
+This makes the detector precise without teaching it the whole snapshot schema:
+the smoke remains a leak guard, not a full TypeScript contract validator.
+
+## Intentional
+
+- No change to the producer contract. The docs already permit
+  `teaser.full_answer.answer` and `teaser.full_answer.steps`.
+- No blanket exception for key names under `teaser`. Preview entries still
+  withhold body text, so `teaser.previews[*].answer` and `steps` remain leaks.
+- No buyer hosted-result proof in this ATLAS slice; that remains the
+  atlas-portfolio/web lane unless reassigned.
+
+## Deferred
+
+- atlas-portfolio/web buyer hosted-result proof remains outside this ATLAS
+  session unless explicitly reassigned.
+
+Parked hardening: drains `Align deflection submit smoke forbidden snapshot paths
+with teaser contract` from `HARDENING.md`.
+
+## Verification
+
+- Focused submit-smoke pytest for `tests/test_smoke_content_ops_deflection_submit_handoff.py`.
+  - 47 passed.
+- Python compile check for `scripts/smoke_content_ops_deflection_submit_handoff.py`
+  and `tests/test_smoke_content_ops_deflection_submit_handoff.py`.
+  - passed.
+- Full extracted pipeline bundle via `scripts/run_extracted_pipeline_checks.sh`.
+  - extracted reasoning core: 295 passed.
+  - extracted content pipeline: 4636 passed, 10 skipped, 1 existing torch warning.
+- Pending before PR open:
+  - push-wrapper local PR review with `tmp/pr_body_deflection_submit_smoke_teaser_contract_alignment.md`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `HARDENING.md` | 9 |
+| `plans/PR-Deflection-Submit-Smoke-Teaser-Contract-Alignment.md` | 111 |
+| `scripts/smoke_content_ops_deflection_submit_handoff.py` | 37 |
+| `tests/test_smoke_content_ops_deflection_submit_handoff.py` | 139 |
+| **Total** | **296** |

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -47,6 +47,10 @@ FORBIDDEN_SNAPSHOT_KEYS = frozenset({
     "steps",
     "term_mappings",
 })
+ALLOWED_SNAPSHOT_BODY_PATHS = frozenset({
+    ("teaser", "full_answer", "answer"),
+    ("teaser", "full_answer", "steps"),
+})
 OPTIONAL_CUSTOMER_WORDING_QUESTION_SOURCES = frozenset({
     "source_policy",
     "topic_fallback",
@@ -433,18 +437,39 @@ def _multipart_submit_request(
     return _parse_http_json_response("POST", url, request=request, timeout=timeout)
 
 
-def _forbidden_key_paths(value: Any, *, prefix: str = "$") -> list[str]:
+def _snapshot_path_text(path: Sequence[str | int]) -> str:
+    text = "$"
+    for segment in path:
+        if isinstance(segment, int):
+            text += f"[{segment}]"
+        else:
+            text += f".{segment}"
+    return text
+
+
+def _allows_snapshot_body_path(path: tuple[str | int, ...], parent: Mapping[str, Any]) -> bool:
+    return (
+        path in ALLOWED_SNAPSHOT_BODY_PATHS
+        and parent.get("answer_evidence_status") == "resolution_evidence"
+        and parent.get("resolution_evidence_scope") == "scoped"
+    )
+
+
+def _forbidden_key_paths(value: Any, *, path: tuple[str | int, ...] = ()) -> list[str]:
     paths: list[str] = []
     if isinstance(value, Mapping):
         for key, child in value.items():
             key_text = str(key)
-            child_prefix = f"{prefix}.{key_text}"
-            if key_text in FORBIDDEN_SNAPSHOT_KEYS:
-                paths.append(child_prefix)
-            paths.extend(_forbidden_key_paths(child, prefix=child_prefix))
+            child_path = (*path, key_text)
+            if (
+                key_text in FORBIDDEN_SNAPSHOT_KEYS
+                and not _allows_snapshot_body_path(child_path, value)
+            ):
+                paths.append(_snapshot_path_text(child_path))
+            paths.extend(_forbidden_key_paths(child, path=child_path))
     elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         for index, child in enumerate(value):
-            paths.extend(_forbidden_key_paths(child, prefix=f"{prefix}[{index}]"))
+            paths.extend(_forbidden_key_paths(child, path=(*path, index)))
     return paths
 
 

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -429,6 +429,116 @@ def test_validate_submit_envelope_rejects_missing_deflection_step() -> None:
     assert "submit response must include faq_deflection_report step" in errors
 
 
+def test_validate_submit_envelope_allows_contract_teaser_full_answer_body() -> None:
+    snapshot = {
+        **SNAPSHOT,
+        "teaser": {
+            "full_answer": {
+                "rank": 1,
+                "question": "How do I export reports?",
+                "answer": "Open Reports and choose Export.",
+                "steps": ["Open Reports.", "Choose Export."],
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "weighted_frequency": 3,
+                "source_count": 2,
+            },
+            "previews": [],
+        },
+    }
+
+    request_id, validated_snapshot, _diagnostics, errors = smoke._validate_submit_envelope(
+        _submit_payload(snapshot=snapshot)
+    )
+
+    assert request_id == "content-ops-123"
+    assert validated_snapshot is snapshot
+    assert errors == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("answer_evidence_status", "draft_needs_review"),
+        ("resolution_evidence_scope", "unscoped"),
+    ),
+)
+def test_validate_submit_envelope_rejects_unscoped_teaser_full_answer_body(
+    field: str,
+    value: str,
+) -> None:
+    full_answer = {
+        "rank": 1,
+        "question": "How do I export reports?",
+        "answer": "Open Reports and choose Export.",
+        "steps": ["Open Reports.", "Choose Export."],
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
+        "weighted_frequency": 3,
+        "source_count": 2,
+    }
+    full_answer[field] = value
+    snapshot = {
+        **SNAPSHOT,
+        "teaser": {
+            "full_answer": full_answer,
+            "previews": [],
+        },
+    }
+
+    _request_id, _snapshot, _diagnostics, errors = smoke._validate_submit_envelope(
+        _submit_payload(snapshot=snapshot)
+    )
+
+    assert any("$.teaser.full_answer.answer" in error for error in errors)
+    assert any("$.teaser.full_answer.steps" in error for error in errors)
+
+
+def test_validate_submit_envelope_rejects_dotted_key_teaser_alias() -> None:
+    snapshot = {
+        **SNAPSHOT,
+        "teaser.full_answer": {
+            "answer": "Open Reports and choose Export.",
+            "steps": ["Open Reports.", "Choose Export."],
+            "answer_evidence_status": "resolution_evidence",
+            "resolution_evidence_scope": "scoped",
+        },
+    }
+
+    _request_id, _snapshot, _diagnostics, errors = smoke._validate_submit_envelope(
+        _submit_payload(snapshot=snapshot)
+    )
+
+    assert any("$.teaser.full_answer.answer" in error for error in errors)
+    assert any("$.teaser.full_answer.steps" in error for error in errors)
+
+
+def test_validate_submit_envelope_rejects_nested_teaser_full_answer_alias() -> None:
+    snapshot = {
+        **SNAPSHOT,
+        "teaser": {
+            "full_answer": {
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "full_answer": {
+                    "answer": "Open Reports and choose Export.",
+                    "steps": ["Open Reports.", "Choose Export."],
+                    "answer_evidence_status": "resolution_evidence",
+                    "resolution_evidence_scope": "scoped",
+                },
+            },
+            "previews": [],
+        },
+    }
+
+    _request_id, _snapshot, _diagnostics, errors = smoke._validate_submit_envelope(
+        _submit_payload(snapshot=snapshot)
+    )
+
+    assert any("$.teaser.full_answer.full_answer.answer" in error for error in errors)
+    assert any("$.teaser.full_answer.full_answer.steps" in error for error in errors)
+
+
 def test_validate_submit_envelope_rejects_snapshot_leaks() -> None:
     snapshot = {
         **SNAPSHOT,
@@ -446,6 +556,35 @@ def test_validate_submit_envelope_rejects_snapshot_leaks() -> None:
     )
 
     assert any("leaked forbidden fields" in error for error in errors)
+
+
+def test_validate_submit_envelope_rejects_teaser_preview_body_leaks() -> None:
+    snapshot = {
+        **SNAPSHOT,
+        "teaser": {
+            "full_answer": None,
+            "previews": [
+                {
+                    "rank": 1,
+                    "question": "How do I export reports?",
+                    "answer": "Open Reports and choose Export.",
+                    "steps": ["Open Reports.", "Choose Export."],
+                    "answer_evidence_status": "resolution_evidence",
+                    "resolution_evidence_scope": "scoped",
+                    "weighted_frequency": 3,
+                    "source_count": 2,
+                    "body_withheld": True,
+                }
+            ],
+        },
+    }
+
+    _request_id, _snapshot, _diagnostics, errors = smoke._validate_submit_envelope(
+        _submit_payload(snapshot=snapshot)
+    )
+
+    assert any("$.teaser.previews[0].answer" in error for error in errors)
+    assert any("$.teaser.previews[0].steps" in error for error in errors)
 
 
 def test_validate_submit_envelope_rejects_singular_source_id_leak() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Submit-Smoke-Teaser-Contract-Alignment.md
Slice phase: Production hardening

Issue #1612 is green on the ATLAS-side paid artifact/report-model/PDF/export proof path, but the submit handoff smoke still had one parked false positive from the live-artifact proof: it reported `teaser.full_answer.answer` and `teaser.full_answer.steps` as forbidden paid-report leaks even though the frontend contract explicitly permits answer text and steps inside scoped resolution-backed `snapshot.teaser.full_answer`. This slice makes the forbidden-field detector path-aware and eligibility-aware without relaxing the paywall boundary anywhere else.

## Intentional
- No producer contract change; the docs already permit `teaser.full_answer.answer` and `teaser.full_answer.steps`.
- No blanket exception for key names under `teaser`; preview entries still withhold body text, so `teaser.previews[*].answer` and `steps` remain leaks.
- No buyer hosted-result proof in this ATLAS slice; that remains the atlas-portfolio/web lane unless reassigned.

## Deferred
- atlas-portfolio/web buyer hosted-result proof remains outside this ATLAS session unless explicitly reassigned.

## Parked hardening
- Drains `Align deflection submit smoke forbidden snapshot paths with teaser contract` from `HARDENING.md`.

## Verification
- `pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q`
  - 47 passed.
- `python -m py_compile scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_submit_handoff.py`
  - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
  - OK: 185 matching tests are enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh`
  - extracted reasoning core: 295 passed.
  - extracted content pipeline: 4632 passed, 10 skipped, 1 existing torch warning.

## Diff size
4 files, +281 / -15.

## AI reconciliation
- All fixed or waived: yes.
- Codex P2: path-only teaser exception could allow malformed/draft/unscoped `teaser.full_answer` body fields. Fixed by matching structural path segments and requiring the parent full-answer object to carry `answer_evidence_status: resolution_evidence` plus `resolution_evidence_scope: scoped`; added draft/unscoped, dotted-key alias, and nested-alias regressions.
