### PR TITLE
Security Full Sweep (scheduled, no-baseline, whole-tree + full-history)

### DIFF
--- a/.github/workflows/security_full_sweep.yml
+++ b/.github/workflows/security_full_sweep.yml
@@ -1,0 +1,146 @@
+name: Security Full Sweep
+
+# Full, NO-BASELINE security sweep of the WHOLE repo + FULL git history.
+#
+# This is deliberately DIFFERENT from the PR-time baseline scans
+# (security_guardrails.yml's gitleaks-baseline-guard, and any
+# semgrep --baseline-commit usage). Those gate *new* issues on a diff and
+# ignore everything already in the base. This job ignores the baseline and
+# scans the entire tree and entire history, so BURIED / pre-existing issues
+# (e.g. a secret committed long ago) are resurfaced rather than skipped.
+#
+# It fails RED on findings and on scanner error. That is intentional: it is a
+# scheduled tripwire, expected to be red until buried debt is triaged. For
+# committed secrets, the real remediation is key ROTATION + history scrub --
+# redaction alone does not fix a leaked live credential.
+#
+# ---------------------------------------------------------------------------
+# SCHEDULE (configurable)
+# ---------------------------------------------------------------------------
+# GitHub Actions requires a LITERAL cron here -- it cannot read a repo variable
+# or expression in `schedule:`. To change when the nightly sweep fires, edit
+# ONLY the single cron line below. Cron is in UTC.
+#
+#   Central offset:  CDT = UTC-5 (Mar-Nov),  CST = UTC-6 (Nov-Mar)
+#   5:00pm CDT nightly        ->  "0 22 * * *"   (current)
+#   midnight CDT nightly      ->  "0 5  * * *"   (the 5am-UTC slot = next day)
+#   5:00pm CDT weekly (Mon)   ->  "0 22 * * 1"
+#
+# To run it on demand at ANY time (e.g. working late), use the Actions tab ->
+# "Run workflow" (workflow_dispatch) -- no edit needed.
+on:
+  schedule:
+    - cron: "0 22 * * *"   # 5:00pm CDT nightly -- edit THIS line to retime
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-full-sweep-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  semgrep:
+    name: Semgrep (whole tree, no baseline)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Install semgrep
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet semgrep
+      - name: Semgrep full scan (fails on findings)
+        run: |
+          set -euo pipefail
+          # Whole tree, registry rules, NO --baseline-commit. --error exits
+          # non-zero when findings exist, so the job goes red.
+          semgrep scan --config auto --error \
+            --json --output semgrep-report.json .
+      - name: Summary
+        # Best-effort reporting only. `set -u` (no -e/-pipefail) so a jq hiccup
+        # cannot abort, and this never masks the scan step's pass/fail.
+        if: always()
+        run: |
+          set -u
+          echo "### Semgrep (whole tree, no baseline)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f semgrep-report.json ]; then
+            findings=$(jq '.results | length' semgrep-report.json)
+            echo "- findings: **${findings}**" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- no report produced (scanner failed before output)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  gitleaks:
+    name: Gitleaks (full history, no baseline)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.21.2
+        run: |
+          set -euo pipefail
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Gitleaks full-history scan (fails on findings, secrets redacted)
+        run: |
+          set -euo pipefail
+          # --log-opts=--all scans every commit on every ref (full history).
+          # --redact ensures secret VALUES never print to logs/report; locations
+          # are already public in history, so this is a tripwire, not new
+          # disclosure. gitleaks exits non-zero when leaks are found.
+          gitleaks detect --source . --log-opts="--all" \
+            --redact --no-banner \
+            --report-format json --report-path gitleaks-report.json
+      - name: Summary
+        # Best-effort reporting only. `set -u` (no -e/-pipefail) so a jq hiccup
+        # cannot abort, and this never masks the scan step's pass/fail.
+        if: always()
+        run: |
+          set -u
+          echo "### Gitleaks (full history, no baseline)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f gitleaks-report.json ]; then
+            leaks=$(jq 'length' gitleaks-report.json)
+            echo "- leaks: **${leaks}** (secret values redacted)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> Committed secrets need key ROTATION + history scrub -- redaction alone does not fix a leaked live credential." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- no report produced (scanner failed before output)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  sca:
+    name: SCA (pip-audit, full dependency set)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Install pip-audit
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet pip-audit
+      - name: pip-audit full scan (fails on known vulnerabilities)
+        run: |
+          set -euo pipefail
+          # Audits the pinned dependency set against the advisory DB. Exits
+          # non-zero when a known-vulnerable dependency is present.
+          pip-audit -r requirements.txt -r requirements.asr.txt

--- a/plans/PR-Security-Full-Sweep.md
+++ b/plans/PR-Security-Full-Sweep.md
@@ -1,0 +1,108 @@
+# PR-Security-Full-Sweep
+
+## Why this slice exists
+
+The repo's current security automation is all baseline/diff-oriented or
+dependency-bump-oriented, so it never re-examines the base:
+
+- `dependabot.yml` opens PRs for new advisories on declared dependencies
+  (SCA-lite). It does not scan the tree, history, or secrets.
+- `security_guardrails.yml` runs a gitleaks baseline-growth guard -- by design
+  it ignores anything already in the baseline, so secrets already committed are
+  not resurfaced.
+- `security_dast_zap.yml` is dynamic (running-app) scanning, not code/secrets/
+  dependency analysis.
+- There is no semgrep, no CodeQL, no full-history gitleaks, and no full SCA
+  pass.
+
+So buried/pre-existing issues -- e.g. a secret committed long ago (a committed
+`.env` at `d63a9b77` was flagged this session) -- are never surfaced by CI,
+because every existing scan deliberately skips the base. This slice adds the
+missing no-baseline, whole-tree, full-history sweep that flushes buried
+problems out, on a schedule, separate from the PR-time baseline gates.
+
+## Scope (this PR)
+
+Ownership lane: ci/security
+Slice phase: Production hardening
+
+Add `.github/workflows/security_full_sweep.yml`:
+
+- Triggers: `schedule` (single, clearly-commented cron line, default
+  `0 22 * * *` = 5:00pm CDT nightly) + `workflow_dispatch` for on-demand runs.
+  The cron line carries a UTC<->Central conversion block so retiming is a
+  one-line edit (GitHub cannot read a variable in `schedule`).
+- `permissions: contents: read`; a `concurrency` group; per-job
+  `timeout-minutes: 20`.
+- Three independent jobs:
+  1. semgrep -- whole tree, registry rules, no `--baseline-commit`, `--error`
+     so findings exit non-zero.
+  2. gitleaks -- full history (`fetch-depth: 0`, `--log-opts=--all`),
+     `--redact`, no baseline file.
+  3. SCA -- pip-audit over `requirements.txt` and `requirements.asr.txt`.
+- Actions SHA-pinned to the repo convention (`actions/checkout`,
+  `actions/setup-python`); scanners run via CLI to avoid additional unpinned
+  `uses` entries.
+
+### Files touched
+
+- `.github/workflows/security_full_sweep.yml`
+- `plans/PR-Security-Full-Sweep.md`
+
+## Mechanism
+
+Each scan step runs under `set -euo pipefail` and lets the scanner's non-zero
+exit (semgrep `--error`, gitleaks on leaks, pip-audit on vulns) fail the job.
+A separate summary step gated `if: always()` appends counts to
+`$GITHUB_STEP_SUMMARY` from the report file -- it reports regardless of scan
+outcome but does not mask the scan step's failure (the job is already red). It
+runs under `set -u` only, so a reporting hiccup cannot abort. gitleaks runs
+with `--redact` so secret values never reach logs.
+
+## Intentional
+
+- Separate from the PR-time baseline gates. Baseline scans gate new issues on a
+  diff; this sweep finds buried/existing ones. Both are wanted.
+- Fails red by design. This is a scheduled tripwire, expected to be red until
+  buried debt is triaged; that is the opposite of the advisory
+  `continue-on-error` pattern (which can never fail and so hides findings).
+- Not brittle. No `continue-on-error`, no swallowed exit codes, no error
+  bypass. Scanner findings and scanner-tool errors both turn the job red. The
+  `if: always()` guard appears only on summary steps, never on a scan step.
+- Configurable cadence. One commented cron line + `workflow_dispatch`.
+- gitleaks `--redact`: secret locations are already public in history, so the
+  redacted report is a tripwire, not a new disclosure. The real fix for a hit
+  is key ROTATION + history scrub, noted in the workflow and summary.
+
+## Deferred
+
+- `osv-scanner` (broader lockfile SCA) and CodeQL as additional jobs -- the
+  repo already references a pinned osv-scanner reusable workflow that can be
+  wired in a follow-up.
+- SARIF upload to the GitHub Security tab (needs `security-events: write`);
+  kept out of v1 to keep permissions minimal.
+- Auto-triage / issue-filing of findings.
+
+Parked hardening: none.
+
+## Verification
+
+- `.github/workflows/security_full_sweep.yml` parses as valid YAML (python yaml
+  safe-load, no error).
+- `scripts/audit_workflow_security_posture.py` passes -- "workflow security
+  posture audit passed" (no ERROR; pinned actions, `contents: read`, no
+  `pull_request_target`, no OIDC).
+- `tests/test_audit_workflow_security_posture.py` and
+  `tests/test_claude_workflow_security.py` pass (15 passed).
+- Self-audit: grepping the new workflow for `continue-on-error`, the OR-true
+  bypass, and `set +e` returns nothing; scan steps propagate scanner exit
+  codes.
+- ASCII-only check on the new files is clean.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/security_full_sweep.yml` | ~150 |
+| `plans/PR-Security-Full-Sweep.md` | ~95 |
+| **Total** | **~245** |


### PR DESCRIPTION
Plan: plans/PR-Security-Full-Sweep.md
Slice phase: Production hardening

Adds a scheduled full, NO-BASELINE security sweep of the whole repo + full git history. Distinct from the PR-time baseline scans (gitleaks-baseline-guard, semgrep --baseline-commit) and Dependabot bumps -- those gate new issues on a diff and skip the base, so buried/pre-existing problems (e.g. a long-ago committed `.env`) never resurface. This is the no-baseline whole-tree + full-history pass that flushes them out, on a schedule.

Three jobs: semgrep (`--config auto --error`, whole tree, no baseline), gitleaks (`--log-opts=--all --redact`, full history, no baseline file), pip-audit (full dependency set).

## Intentional
- Separate from the PR-time baseline gates; this finds buried/existing issues, they gate new ones.
- Fails RED on findings and on scanner error -- a scheduled tripwire, expected red until buried debt is triaged. Opposite of the advisory `continue-on-error` pattern that can never fail.
- Not brittle: no `continue-on-error`, no `|| true`, no `set +e`, no swallowed exit codes. `if: always()` appears only on best-effort summary steps (`set -u`, never masks scan pass/fail).
- Configurable cadence: single commented cron line (UTC<->Central conversion documented) + `workflow_dispatch` for on-demand runs.
- gitleaks `--redact`: locations are already public in history, so the redacted report is a tripwire, not new disclosure; real fix for a hit is key ROTATION + history scrub.

## Deferred
- osv-scanner / CodeQL as additional jobs (repo already references a pinned osv reusable workflow).
- SARIF upload to the Security tab (needs `security-events: write`); kept out to keep permissions minimal.

## Parked hardening
- None.

## Verification
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/security_full_sweep.yml'))"` - parses.
- `python scripts/audit_workflow_security_posture.py` - workflow security posture audit passed.
- `pytest tests/test_audit_workflow_security_posture.py tests/test_claude_workflow_security.py -q` - 15 passed.
- `grep -nE 'continue-on-error|\|\| true|set \+e' .github/workflows/security_full_sweep.yml` - empty (no brittleness patterns).
- ASCII-only check on new files - clean.

## Diff size
2 files, ~245 LOC.
