### PR TITLE
Deflection see-something invariant

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs
@@ -96,6 +96,58 @@ test('domain mapper preserves ingestion parse errors', () => {
   })
 })
 
+test('domain mapper preserves source-row admission guidance', () => {
+  const diagnostics = fromWireIngestionDiagnostics({
+    ok: false,
+    mode: 'source_rows',
+    source: 'tickets.csv',
+    opportunity_count: 0,
+    warning_count: 0,
+    warning_counts: {},
+    missing_field_counts: {},
+    source_type_counts: {},
+    samples: [],
+    warnings: [],
+    source_row_admission: {
+      input_format: 'csv',
+      raw_source_row_count: 1,
+      usable_source_row_count: 0,
+      usable_source_ratio: 0,
+      mapped_fields: { source_id: ['Ticket ID'] },
+      ignored_private_fields: ['Internal Notes'],
+      populated_unmapped_fields: ['Conversation Text'],
+      field_sample_limit: 12,
+      admission_decision: {
+        status: 'REJECT',
+        reason: 'no_usable_source_rows',
+        location: 'source_row_csv',
+        message: 'No usable support-ticket text was found in this file.',
+        how_to_fix: 'Re-export your tickets with customer text.',
+      },
+      coverage_warnings: [],
+    },
+  })
+
+  assert.deepEqual(diagnostics.sourceRowAdmission, {
+    inputFormat: 'csv',
+    rawSourceRowCount: 1,
+    usableSourceRowCount: 0,
+    usableSourceRatio: 0,
+    mappedFields: { source_id: ['Ticket ID'] },
+    ignoredPrivateFields: ['Internal Notes'],
+    populatedUnmappedFields: ['Conversation Text'],
+    fieldSampleLimit: 12,
+    admissionDecision: {
+      status: 'REJECT',
+      reason: 'no_usable_source_rows',
+      location: 'source_row_csv',
+      message: 'No usable support-ticket text was found in this file.',
+      howToFix: 'Re-export your tickets with customer text.',
+    },
+    coverageWarnings: [],
+  })
+})
+
 test('domain import request can opt into full source material', () => {
   assert.deepEqual(
     toWireIngestionImportRequest({
@@ -162,4 +214,16 @@ test('new run page renders parser issues from ingestion diagnostics', () => {
   assert.ok(newRunSource.includes('function IngestionParseErrorNotice'))
   assert.ok(newRunSource.includes('Parser issue'))
   assert.ok(newRunSource.includes('parseError.howToFix'))
+})
+
+test('new run page renders source-row admission guidance', () => {
+  assert.ok(newRunSource.includes('sourceRowAdmission?.admissionDecision'))
+  assert.ok(newRunSource.includes('function SourceRowAdmissionRejectNotice'))
+  assert.ok(newRunSource.includes('Upload guidance'))
+  assert.ok(newRunSource.includes('decision.howToFix'))
+  assert.ok(
+    newRunSource.includes(
+      'state.diagnostics.sourceRowAdmission?.admissionDecision?.status',
+    ),
+  )
 })

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -341,6 +341,27 @@ export interface ContentOpsIngestionParseErrorResponse {
   byte?: number
 }
 
+export interface ContentOpsSourceRowAdmissionDecisionResponse {
+  status: string
+  reason?: string
+  location?: string
+  message?: string
+  how_to_fix?: string
+}
+
+export interface ContentOpsSourceRowAdmissionResponse {
+  input_format: string
+  raw_source_row_count: number
+  usable_source_row_count: number
+  usable_source_ratio: number | null
+  mapped_fields: Record<string, string[]>
+  ignored_private_fields: string[]
+  populated_unmapped_fields: string[]
+  field_sample_limit: number
+  admission_decision?: ContentOpsSourceRowAdmissionDecisionResponse
+  coverage_warnings?: Array<Record<string, unknown>>
+}
+
 export interface ContentOpsIngestionDiagnosticsResponse {
   ok: boolean
   mode: 'opportunities' | 'source_rows'
@@ -353,6 +374,7 @@ export interface ContentOpsIngestionDiagnosticsResponse {
   samples: Array<Record<string, unknown>>
   source_material?: Array<Record<string, unknown>>
   warnings: ContentOpsIngestionWarning[]
+  source_row_admission?: ContentOpsSourceRowAdmissionResponse
   parse_error?: ContentOpsIngestionParseErrorResponse
 }
 

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -342,6 +342,32 @@ export function fromWireIngestionDiagnostics(
       rowIndex: warning.row_index,
       field: warning.field,
     })),
+    sourceRowAdmission: wire.source_row_admission
+      ? {
+          inputFormat: wire.source_row_admission.input_format,
+          rawSourceRowCount: wire.source_row_admission.raw_source_row_count,
+          usableSourceRowCount: wire.source_row_admission.usable_source_row_count,
+          usableSourceRatio: wire.source_row_admission.usable_source_ratio,
+          mappedFields: { ...wire.source_row_admission.mapped_fields },
+          ignoredPrivateFields: [...wire.source_row_admission.ignored_private_fields],
+          populatedUnmappedFields: [
+            ...wire.source_row_admission.populated_unmapped_fields,
+          ],
+          fieldSampleLimit: wire.source_row_admission.field_sample_limit,
+          admissionDecision: wire.source_row_admission.admission_decision
+            ? {
+                status: wire.source_row_admission.admission_decision.status,
+                reason: wire.source_row_admission.admission_decision.reason,
+                location: wire.source_row_admission.admission_decision.location,
+                message: wire.source_row_admission.admission_decision.message,
+                howToFix: wire.source_row_admission.admission_decision.how_to_fix,
+              }
+            : undefined,
+          coverageWarnings: (wire.source_row_admission.coverage_warnings ?? []).map(
+            (warning) => ({ ...warning }),
+          ),
+        }
+      : undefined,
     parseError: wire.parse_error
       ? {
           code: wire.parse_error.code,

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -231,6 +231,27 @@ export interface ContentOpsIngestionParseError {
   byte?: number
 }
 
+export interface ContentOpsSourceRowAdmissionDecision {
+  status: string
+  reason?: string
+  location?: string
+  message?: string
+  howToFix?: string
+}
+
+export interface ContentOpsSourceRowAdmission {
+  inputFormat: string
+  rawSourceRowCount: number
+  usableSourceRowCount: number
+  usableSourceRatio: number | null
+  mappedFields: Record<string, string[]>
+  ignoredPrivateFields: string[]
+  populatedUnmappedFields: string[]
+  fieldSampleLimit: number
+  admissionDecision?: ContentOpsSourceRowAdmissionDecision
+  coverageWarnings: Array<Record<string, unknown>>
+}
+
 export interface ContentOpsIngestionDiagnostics {
   ok: boolean
   mode: 'opportunities' | 'source_rows'
@@ -243,6 +264,7 @@ export interface ContentOpsIngestionDiagnostics {
   samples: Array<Record<string, unknown>>
   sourceMaterial: Array<Record<string, unknown>>
   warnings: ContentOpsIngestionWarning[]
+  sourceRowAdmission?: ContentOpsSourceRowAdmission
   parseError?: ContentOpsIngestionParseError
 }
 

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -2777,6 +2777,11 @@ function IngestionInspectResult({ state }: { state: IngestionInspectState }) {
       {diagnostics.parseError && (
         <IngestionParseErrorNotice parseError={diagnostics.parseError} />
       )}
+      {diagnostics.sourceRowAdmission?.admissionDecision?.status === 'REJECT' && (
+        <SourceRowAdmissionRejectNotice
+          decision={diagnostics.sourceRowAdmission.admissionDecision}
+        />
+      )}
       {diagnostics.warnings.length > 0 && (
         <Section label="Warnings">
           <ul className="ml-4 list-disc text-xs text-amber-100">
@@ -2796,6 +2801,28 @@ function IngestionInspectResult({ state }: { state: IngestionInspectState }) {
         </Section>
       )}
     </div>
+  )
+}
+
+function SourceRowAdmissionRejectNotice({
+  decision,
+}: {
+  decision: NonNullable<
+    NonNullable<ContentOpsIngestionDiagnostics['sourceRowAdmission']>['admissionDecision']
+  >
+}) {
+  return (
+    <Section label="Upload guidance">
+      <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+        <div className="font-medium">
+          {decision.reason ? `${decision.reason}: ` : ''}
+          {decision.message ?? 'No usable source rows were found.'}
+        </div>
+        {decision.howToFix && (
+          <div className="mt-1 text-amber-50/80">{decision.howToFix}</div>
+        )}
+      </div>
+    </Section>
   )
 }
 
@@ -3009,6 +3036,11 @@ function IngestionImportResult({
         </div>
         {state.diagnostics.parseError && (
           <IngestionParseErrorNotice parseError={state.diagnostics.parseError} />
+        )}
+        {state.diagnostics.sourceRowAdmission?.admissionDecision?.status === 'REJECT' && (
+          <SourceRowAdmissionRejectNotice
+            decision={state.diagnostics.sourceRowAdmission.admissionDecision}
+          />
         )}
         {state.diagnostics.warnings.length > 0 && (
           <Section label="Blocking diagnostics">

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -384,6 +384,13 @@ class SourceRowAdmissionDiagnostics:
                 "status": "REJECT",
                 "reason": "no_usable_source_rows",
                 "location": "source_row_csv",
+                "message": "No usable support-ticket text was found in this file.",
+                "how_to_fix": (
+                    "Re-export your tickets with the customer message or "
+                    "description column included, then upload again. Rows "
+                    "marked private or internal are skipped on purpose and "
+                    "do not count toward usable text."
+                ),
             }
         return {"status": "ACCEPT"}
 

--- a/plans/PR-Deflection-See-Something-Invariant.md
+++ b/plans/PR-Deflection-See-Something-Invariant.md
@@ -1,0 +1,120 @@
+# PR-Deflection-See-Something-Invariant
+
+## Why this slice exists
+
+#1467's remaining parser-admission question was whether low non-zero coverage
+should become a hard reject. The operator decided the product rule: **keep
+ACCEPT + warning** for partial coverage, because showing a warning and still
+producing the snapshot/report is preferable when at least some ticket text is
+usable.
+
+Root cause: the accept/reject boundary is behavior rather than a durable
+contract. The backend rejects zero-usable CSV uploads and warns on partial
+coverage, but a future threshold slice could change that accidentally. The
+zero-usable reject also carries only a machine reason code, so the one genuine
+"nothing usable" path does not tell a customer how to fix the upload.
+
+This PR fixes the root in safe scope by testing the boundary and adding
+customer-facing guidance to the existing zero-usable reject. It does not add a
+low-coverage reject threshold.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser
+Slice phase: Production hardening
+
+1. Add `message` and `how_to_fix` to the existing zero-usable
+   `source_row_admission.admission_decision` reject.
+2. Carry those fields through atlas-intel-ui and render them on operator
+   ingestion diagnostics.
+3. Add regressions proving partial coverage still accepts with a warning, while
+   zero-usable and parse-error paths give guidance without raw row echoes.
+
+### Review Contract
+
+Acceptance criteria:
+- Partial source-row CSV coverage remains `ACCEPT` and still returns
+  `ok: true` with at least one opportunity plus a
+  `partial_source_row_coverage` warning.
+- Zero usable source-row CSV coverage remains the only admission-level
+  `REJECT` in this slice and includes non-empty `message` and `how_to_fix`.
+- Reject guidance does not echo raw row content or private/internal sentinels.
+- atlas-intel-ui preserves and renders the admission reject guidance.
+- Parse-error guidance from #1675 remains intact and covered.
+
+Affected surfaces:
+- Extracted content pipeline ingestion diagnostics.
+- atlas-intel-ui operator content-ops upload/import diagnostics.
+
+Risk areas:
+- Accidentally changing the product boundary from ACCEPT+warning to hard reject
+  for low but non-zero coverage.
+- Echoing raw ticket/private text in guidance.
+- Frontend silently dropping new diagnostic fields.
+
+Reviewer rules triggered: R1, R2, R9, R10, R12, R13, R14.
+
+### Files touched
+
+- `atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
+- `atlas-intel-ui/src/domain/contentOps/types.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `plans/PR-Deflection-See-Something-Invariant.md`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+
+## Mechanism
+
+`SourceRowAdmissionDiagnostics.admission_decision` already centralizes the
+source-row CSV admission rule. The condition stays unchanged:
+
+- no decision for non-CSV/header-only inputs;
+- `REJECT` only when a non-empty CSV has zero usable source rows;
+- `ACCEPT` for any CSV with one or more usable source rows;
+- `coverage_warnings` reports partial coverage without blocking the report.
+
+The zero-usable reject gains static `message` and `how_to_fix` fields so it can
+guide the operator/customer without including row values.
+
+atlas-intel-ui types, maps, and renders the admission guidance beside the
+existing parse-error notice.
+
+## Intentional
+
+- Shape-preserving: this PR intentionally does not add a low non-zero coverage
+  reject threshold. The operator chose ACCEPT + warning for partial coverage.
+- Guidance is static and does not include raw CSV values, source ids, private
+  notes, or snippets from rejected rows.
+- Buyer-facing atlas-portfolio rendering is not touched in this Atlas PR.
+
+## Deferred
+
+- #1582 remains optional evidence gathering for provider calibration, but no
+  longer blocks the current ACCEPT + warning policy.
+- Buyer-facing atlas-portfolio rendering remains a separate repo/lane if needed.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_extracted_content_ingestion_diagnostics.py -q - 30 passed.
+- npm --prefix atlas-intel-ui run test:content-ops-upload-source-run-handoff - 7 passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py - OK, 185 matching tests enrolled.
+- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_content_ingestion_diagnostics.py - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - reasoning core 295 passed; extracted content pipeline 4638 passed, 10 skipped, 1 existing torch warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs` | 64 |
+| `atlas-intel-ui/src/api/contentOps.ts` | 22 |
+| `atlas-intel-ui/src/domain/contentOps/fromWire.ts` | 26 |
+| `atlas-intel-ui/src/domain/contentOps/types.ts` | 22 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 32 |
+| `extracted_content_pipeline/campaign_source_adapters.py` | 7 |
+| `plans/PR-Deflection-See-Something-Invariant.md` | 120 |
+| `tests/test_extracted_content_ingestion_diagnostics.py` | 106 |
+| **Total** | **399** |

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -13,6 +13,17 @@ from extracted_content_pipeline.ingestion_diagnostics import inspect_ingestion_f
 
 ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "scripts/inspect_extracted_content_ingestion.py"
+ZERO_USABLE_DECISION = {
+    "status": "REJECT",
+    "reason": "no_usable_source_rows",
+    "location": "source_row_csv",
+    "message": "No usable support-ticket text was found in this file.",
+    "how_to_fix": (
+        "Re-export your tickets with the customer message or description "
+        "column included, then upload again. Rows marked private or internal "
+        "are skipped on purpose and do not count toward usable text."
+    ),
+}
 
 
 def test_inspect_opportunity_json_reports_ready_rows(tmp_path: Path) -> None:
@@ -177,11 +188,12 @@ def test_inspect_source_csv_reports_unmapped_populated_text_column(tmp_path: Pat
     assert admission["usable_source_ratio"] == 0.0
     assert admission["mapped_fields"] == {"source_id": ["Ticket ID"]}
     assert admission["populated_unmapped_fields"] == ["Conversation Text"]
-    assert admission["admission_decision"] == {
-        "status": "REJECT",
-        "reason": "no_usable_source_rows",
-        "location": "source_row_csv",
-    }
+    assert admission["admission_decision"] == ZERO_USABLE_DECISION
+    assert "Customer cannot export" not in admission["admission_decision"]["message"]
+    assert (
+        "Customer cannot export"
+        not in admission["admission_decision"]["how_to_fix"]
+    )
     assert "coverage_warnings" not in admission
 
 
@@ -283,11 +295,7 @@ def test_inspect_source_csv_rejects_machine_json_message_payload(
         "source_id": ["Ticket ID"],
         "source_text": ["Message"],
     }
-    assert admission["admission_decision"] == {
-        "status": "REJECT",
-        "reason": "no_usable_source_rows",
-        "location": "source_row_csv",
-    }
+    assert admission["admission_decision"] == ZERO_USABLE_DECISION
 
 
 def test_inspect_source_csv_warns_when_partial_upload_has_machine_json_row(
@@ -325,6 +333,70 @@ def test_inspect_source_csv_warns_when_partial_upload_has_machine_json_row(
         "skipped_source_row_count": 1,
         "usable_source_ratio": 0.5,
     }]
+
+
+def test_partial_coverage_csv_still_produces_report(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "see-something.csv"
+    path.write_text(
+        "Ticket ID,Message,Internal Notes,Unused Column\n"
+        "T-1,Customer cannot export the weekly report.,,\n"
+        "T-2,,secret_ticket_text_private_note,\n"
+        "T-3,,,metadata only\n",
+        encoding="utf-8",
+    )
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=2,
+        default_fields={
+            "company_name": "Acme Logistics",
+            "vendor_name": "Atlas",
+            "contact_email": "ops@example.com",
+        },
+    ).as_dict()
+
+    admission = payload["source_row_admission"]
+    assert payload["ok"] is True
+    assert payload["opportunity_count"] >= 1
+    assert admission["admission_decision"] == {"status": "ACCEPT"}
+    assert admission["coverage_warnings"] == [{
+        "code": "partial_source_row_coverage",
+        "location": "source_row_csv",
+        "raw_source_row_count": 3,
+        "usable_source_row_count": 1,
+        "skipped_source_row_count": 2,
+        "usable_source_ratio": 0.333333,
+    }]
+
+
+def test_zero_usable_csv_rejects_with_guidance(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "zero-usable.csv"
+    path.write_text(
+        "Ticket ID,Internal Notes,Unused Column\n"
+        "T-1,secret_ticket_text_private_note,metadata only\n",
+        encoding="utf-8",
+    )
+
+    payload = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="csv",
+        sample_limit=1,
+    ).as_dict()
+
+    decision = payload["source_row_admission"]["admission_decision"]
+    assert payload["ok"] is False
+    assert decision == ZERO_USABLE_DECISION
+    assert decision["message"]
+    assert decision["how_to_fix"]
+    assert "secret_ticket_text_private_note" not in decision["message"]
+    assert "secret_ticket_text_private_note" not in decision["how_to_fix"]
 
 
 def test_inspect_source_csv_accepts_long_ticket_body_field(
@@ -441,11 +513,7 @@ def test_inspect_source_csv_rejects_observed_body_alias_when_row_is_private(
         "source_id": ["Ticket ID"],
         "source_text": ["actionbody"],
     }
-    assert admission["admission_decision"] == {
-        "status": "REJECT",
-        "reason": "no_usable_source_rows",
-        "location": "source_row_csv",
-    }
+    assert admission["admission_decision"] == ZERO_USABLE_DECISION
 
 
 def test_inspect_source_csv_sample_limit_does_not_make_known_aliases_unmapped(
@@ -814,11 +882,9 @@ def test_inspection_cli_emits_csv_source_row_admission(tmp_path: Path) -> None:
     assert payload["source_row_admission"]["populated_unmapped_fields"] == [
         "Conversation Text"
     ]
-    assert payload["source_row_admission"]["admission_decision"] == {
-        "status": "REJECT",
-        "reason": "no_usable_source_rows",
-        "location": "source_row_csv",
-    }
+    assert payload["source_row_admission"]["admission_decision"] == (
+        ZERO_USABLE_DECISION
+    )
 
 
 def test_inspection_cli_emits_structured_parse_error(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-See-Something-Invariant.md
Slice phase: Production hardening

#1467's remaining parser-admission policy is now explicit: low non-zero source-row coverage stays ACCEPT + warning, because showing a warning and still producing the snapshot/report is preferable when at least some ticket text is usable. This PR locks that boundary with tests and adds guidance to the existing zero-usable reject so the customer/operator knows how to fix an upload that genuinely contains no usable ticket text.

## Intentional
- Shape-preserving: this does not add a low non-zero coverage reject threshold.
- Zero-usable guidance is static and does not include raw CSV values, source ids, private notes, or snippets from rejected rows.
- Buyer-facing atlas-portfolio rendering is not touched in this Atlas PR.

## Deferred
- #1582 remains optional evidence gathering for provider calibration, but no longer blocks the current ACCEPT + warning policy.
- Buyer-facing atlas-portfolio rendering remains a separate repo/lane if needed.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_ingestion_diagnostics.py -q` - 30 passed.
- `npm --prefix atlas-intel-ui run test:content-ops-upload-source-run-handoff` - 7 passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - OK, 185 matching tests enrolled.
- `python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_content_ingestion_diagnostics.py` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - reasoning core 295 passed; extracted content pipeline 4638 passed, 10 skipped, 1 existing torch warning.
- `git diff --check` - passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-See-Something-Invariant.md --check` - passed.

## Diff size
8 files, +379 / -20; plan-estimated total 399 LOC.
