### PR TITLE
Maturity sweep gate scope Phase B2b

### DIFF
--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -17,27 +17,7 @@ on:
     paths:
       - ".github/workflows/maturity_sweep_advisory.yml"
       - "scripts/maturity_sweep.py"
-      - "tests/test_maturity_sweep.py"
-      - "tests/maturity_sweep/baseline_extracted_content_pipeline.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_api.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_auth.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_autonomous.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_mcp.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_services_b2b.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_alerts.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_brand.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_discovery.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_escalation.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_events.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_jobs.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_memory.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_modes.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_orchestration.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_pipelines.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_presence.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_schemas.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_templates.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_utils.json"
+      - "tests/**"
       - "extracted_content_pipeline/**"
       - "atlas_brain/api/**"
       - "atlas_brain/auth/**"
@@ -58,69 +38,22 @@ on:
       - "atlas_brain/schemas/**"
       - "atlas_brain/templates/**"
       - "atlas_brain/utils/**"
-      - "tests/test_extracted_*.py"
-      - "tests/test_content_ops_*.py"
-      - "tests/test_atlas_*.py"
-      - "tests/test_b2b_*.py"
-      - "tests/test_mcp_*.py"
-      - "tests/test_auth*.py"
-      - "tests/test_*billing*.py"
-      - "tests/test_*webhook*.py"
-      - "tests/test_invoicing*.py"
-      - "tests/*alert*.py"
-      - "tests/*brand*.py"
-      - "tests/*discovery*.py"
-      - "tests/*escalation*.py"
-      - "tests/*event*.py"
-      - "tests/*job*.py"
-      - "tests/*memory*.py"
-      - "tests/*mode*.py"
-      - "tests/*orchestration*.py"
-      - "tests/*pipeline*.py"
-      - "tests/*presence*.py"
-      - "tests/*schema*.py"
-      - "tests/*template*.py"
-      - "tests/*util*.py"
-      - "tests/**/*alert*.py"
-      - "tests/**/*brand*.py"
-      - "tests/**/*discovery*.py"
-      - "tests/**/*escalation*.py"
-      - "tests/**/*event*.py"
-      - "tests/**/*job*.py"
-      - "tests/**/*memory*.py"
-      - "tests/**/*mode*.py"
-      - "tests/**/*orchestration*.py"
-      - "tests/**/*pipeline*.py"
-      - "tests/**/*presence*.py"
-      - "tests/**/*schema*.py"
-      - "tests/**/*template*.py"
-      - "tests/**/*util*.py"
+      - "atlas_brain/comms/**"
+      - "atlas_brain/services/email_webhooks/**"
+      - "atlas_brain/services/embedding/**"
+      - "atlas_brain/services/llm/**"
+      - "atlas_brain/services/personaplex/**"
+      - "atlas_brain/services/speaker_id/**"
+      - "atlas_brain/skills/**"
+      - "atlas_brain/vision/**"
+      - "atlas_brain/voice/**"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/maturity_sweep_advisory.yml"
       - "scripts/maturity_sweep.py"
-      - "tests/maturity_sweep/baseline_extracted_content_pipeline.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_api.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_auth.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_autonomous.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_mcp.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_services_b2b.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_alerts.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_brand.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_discovery.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_escalation.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_events.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_jobs.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_memory.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_modes.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_orchestration.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_pipelines.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_presence.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_schemas.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_templates.json"
-      - "tests/maturity_sweep/baseline_atlas_brain_utils.json"
+      - "tests/**"
       - "extracted_content_pipeline/**"
       - "atlas_brain/api/**"
       - "atlas_brain/auth/**"
@@ -141,34 +74,15 @@ on:
       - "atlas_brain/schemas/**"
       - "atlas_brain/templates/**"
       - "atlas_brain/utils/**"
-      - "tests/*alert*.py"
-      - "tests/*brand*.py"
-      - "tests/*discovery*.py"
-      - "tests/*escalation*.py"
-      - "tests/*event*.py"
-      - "tests/*job*.py"
-      - "tests/*memory*.py"
-      - "tests/*mode*.py"
-      - "tests/*orchestration*.py"
-      - "tests/*pipeline*.py"
-      - "tests/*presence*.py"
-      - "tests/*schema*.py"
-      - "tests/*template*.py"
-      - "tests/*util*.py"
-      - "tests/**/*alert*.py"
-      - "tests/**/*brand*.py"
-      - "tests/**/*discovery*.py"
-      - "tests/**/*escalation*.py"
-      - "tests/**/*event*.py"
-      - "tests/**/*job*.py"
-      - "tests/**/*memory*.py"
-      - "tests/**/*mode*.py"
-      - "tests/**/*orchestration*.py"
-      - "tests/**/*pipeline*.py"
-      - "tests/**/*presence*.py"
-      - "tests/**/*schema*.py"
-      - "tests/**/*template*.py"
-      - "tests/**/*util*.py"
+      - "atlas_brain/comms/**"
+      - "atlas_brain/services/email_webhooks/**"
+      - "atlas_brain/services/embedding/**"
+      - "atlas_brain/services/llm/**"
+      - "atlas_brain/services/personaplex/**"
+      - "atlas_brain/services/speaker_id/**"
+      - "atlas_brain/skills/**"
+      - "atlas_brain/vision/**"
+      - "atlas_brain/voice/**"
 
 jobs:
   maturity-sweep:
@@ -292,6 +206,7 @@ jobs:
             --sensitive-glob '**/auth*'
             --sensitive-glob '**/webhook*'
             --sensitive-glob '**/webhooks/**'
+            --sensitive-glob '**/*webhook*/**'
             --sensitive-glob '**/payment*'
             --sensitive-glob '**/invoicing/**'
             --sensitive-glob '**/*invoice*'
@@ -302,6 +217,45 @@ jobs:
             python scripts/maturity_sweep.py "atlas_brain/${lane}" \
               --tests-root tests \
               --baseline "tests/maturity_sweep/baseline_atlas_brain_${lane}.json" \
+              --min-score 8 \
+              "${common_sensitive_args[@]}"
+            echo "::endgroup::"
+          done
+
+      - name: Maturity sweep atlas_brain B2b service/comms ratchet gates (blocking)
+        run: |
+          set -euo pipefail
+          common_sensitive_args=(
+            --sensitive-glob '**/billing/**'
+            --sensitive-glob '**/billing*'
+            --sensitive-glob '**/paid*'
+            --sensitive-glob '**/auth/**'
+            --sensitive-glob '**/auth*'
+            --sensitive-glob '**/webhook*'
+            --sensitive-glob '**/webhooks/**'
+            --sensitive-glob '**/*webhook*/**'
+            --sensitive-glob '**/payment*'
+            --sensitive-glob '**/invoicing/**'
+            --sensitive-glob '**/*invoice*'
+            --sensitive-glob '**/*deletion*'
+          )
+          lanes=(
+            comms
+            services/email_webhooks
+            services/embedding
+            services/llm
+            services/personaplex
+            services/speaker_id
+            skills
+            vision
+            voice
+          )
+          for lane in "${lanes[@]}"; do
+            slug="${lane//\//_}"
+            echo "::group::atlas_brain/${lane}"
+            python scripts/maturity_sweep.py "atlas_brain/${lane}" \
+              --tests-root tests \
+              --baseline "tests/maturity_sweep/baseline_atlas_brain_${slug}.json" \
               --min-score 8 \
               "${common_sensitive_args[@]}"
             echo "::endgroup::"

--- a/plans/PR-Maturity-Sweep-Atlas-Brain-B2b.md
+++ b/plans/PR-Maturity-Sweep-Atlas-Brain-B2b.md
@@ -1,0 +1,167 @@
+# PR-Maturity-Sweep-Atlas-Brain-B2b
+
+## Why this slice exists
+
+Issue #1689 extends the robust maturity-sweep ratchet from
+`extracted_content_pipeline` across the rest of `atlas_brain/**` and the
+remaining packages. Phase B1 covered the high-blast-radius API/auth/MCP/B2B
+lanes, and Phase B2a covered smaller support lanes. The remaining
+service/comms edge lanes still have no baseline-backed gate, so a new brittle
+file or a new swallowed exception in those paths can merge without this ratchet
+running.
+
+This slice continues Phase B2 with the remaining communication/service edge
+lanes that are cohesive enough to review together. It leaves the larger graph,
+storage, security, and scraping-heavy lanes for the next slice so their
+baselines are not buried in an oversized PR.
+
+The diff is expected to be above the 400 LOC soft cap because this slice adds
+generated baseline JSON files plus explicit source/test workflow triggers.
+Keeping these edge lanes together gives the reviewer a coherent coverage
+boundary while still deferring the largest remaining lanes.
+
+## Scope (this PR)
+
+Ownership lane: ci/maturity-sweep
+Slice phase: Production hardening
+
+1. Add baseline-backed blocking maturity-sweep gates for these Phase B2b lanes:
+   `atlas_brain/comms`, `atlas_brain/services/email_webhooks`,
+   `atlas_brain/services/embedding`, `atlas_brain/services/llm`,
+   `atlas_brain/services/personaplex`, `atlas_brain/services/speaker_id`,
+   `atlas_brain/skills`, `atlas_brain/vision`, and `atlas_brain/voice`.
+2. Add one committed ratchet baseline per lane under `tests/maturity_sweep/`
+   so the workflow starts green and blocks only new debt.
+3. Extend the maturity-sweep workflow triggers to run when those lanes or any
+   `tests/**` file changes, so module/provider-named tests cannot bypass the
+   gate.
+4. Prove the gates pass against their committed baselines and that a new
+   sensitive-path swallowed exception fails in a scratch copy.
+
+### Review Contract
+
+Acceptance criteria:
+- Each B2b lane has a committed lane-specific baseline under
+  `tests/maturity_sweep/`.
+- `.github/workflows/maturity_sweep_advisory.yml` runs blocking ratchet gates
+  for every B2b lane with no `continue-on-error`.
+- The workflow `pull_request` and `push` path filters include every B2b source
+  lane and `tests/**` so the gates fire on relevant source changes and all
+  test-only changes.
+- Existing B1 and B2a gates and baselines remain intact.
+- No `scripts/maturity_sweep.py` detector or ratchet logic changes in this
+  slice.
+
+Affected surfaces:
+- Maturity sweep GitHub Actions workflow.
+- Generated maturity-sweep baseline artifacts for B2b edge lanes.
+
+Risk areas:
+- Workflow path filters that omit a source change or any test-only change.
+- Baseline paths mismatched to lane paths, especially nested
+  `atlas_brain/services/*` lanes.
+- Sensitive globs missing obvious auth/webhook/billing/payment/invoice/delete
+  filenames in service/comms paths.
+
+Triggered reviewer rules:
+- R1 Requirements match.
+- R2 Test evidence.
+- R3 Security/auth for sensitive-path gate coverage.
+- R6 CI/workflow correctness.
+- R9 Generated artifacts/baseline review.
+- R14 Codebase verification.
+
+### Files touched
+
+- `.github/workflows/maturity_sweep_advisory.yml`
+- `plans/PR-Maturity-Sweep-Atlas-Brain-B2b.md`
+- `tests/maturity_sweep/baseline_atlas_brain_comms.json`
+- `tests/maturity_sweep/baseline_atlas_brain_services_email_webhooks.json`
+- `tests/maturity_sweep/baseline_atlas_brain_services_embedding.json`
+- `tests/maturity_sweep/baseline_atlas_brain_services_llm.json`
+- `tests/maturity_sweep/baseline_atlas_brain_services_personaplex.json`
+- `tests/maturity_sweep/baseline_atlas_brain_services_speaker_id.json`
+- `tests/maturity_sweep/baseline_atlas_brain_skills.json`
+- `tests/maturity_sweep/baseline_atlas_brain_vision.json`
+- `tests/maturity_sweep/baseline_atlas_brain_voice.json`
+
+## Mechanism
+
+The workflow reuses the existing robust maturity-sweep gate from #1690, #1692,
+and #1694. Each B2b lane gets a committed baseline via `--update-baseline`, then
+CI runs the same command without `--update-baseline`:
+
+```bash
+python scripts/maturity_sweep.py <lane> \
+  --tests-root tests \
+  --baseline <that lane's committed baseline> \
+  --min-score 8 \
+  --sensitive-glob ...
+```
+
+Existing debt is recorded in the baseline. New files above threshold, score
+regressions, or new swallowed/bare exceptions in sensitive paths fail the gate.
+The B2b workflow step uses the same explicit `set -euo pipefail` pattern added
+in B2a.
+
+## Intentional
+
+- This is B2b, not all remaining `atlas_brain/**`. The largest/riskier
+  directories (`agents`, `capabilities`, `security`, `storage`, `tools`,
+  `reasoning`, and `services/scraping`) stay deferred so their baselines are
+  readable and reviewable.
+- No detector changes. This slice only expands workflow coverage and baseline
+  artifacts for existing logic.
+- Existing debt remains baselined. This PR prevents new brittleness; it does
+  not burn down grandfathered entries.
+
+## Deferred
+
+- Issue #1689 B2c: remaining large/riskier `atlas_brain` lanes, including
+  agents, capabilities, security, storage, tools, reasoning, and
+  services/scraping.
+- Issue #1689 Phase C: remaining `extracted_*` packages and `scripts/**`.
+- Baseline debt burndown/trend reporting across lanes remains a later
+  observability slice.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_maturity_sweep.py --noconftest -q` -- 14
+  passed.
+- `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`.
+- B2b ratchet loop over `comms services/email_webhooks services/embedding
+  services/llm services/personaplex services/speaker_id skills vision voice`
+  -- each lane printed `ratchet gate passed: no new brittleness above
+  baseline`.
+- Path-filter spot checks: `tests/test_call_intelligence.py`,
+  `tests/test_anthropic_convert_messages.py`,
+  `tests/test_openrouter_structured_output.py`, `tests/test_cloud_latency.py`,
+  `tests/test_email_webhooks.py`, `tests/test_voice.py`, and
+  `tests/test_skill_registry.py` are covered by `tests/**` in both PR and push
+  filters. This closes the recurring class where module/provider-named tests
+  bypassed lane-name globs.
+- Scratch sensitive-path proof: temporarily added a swallowed exception to
+  `atlas_brain/services/email_webhooks/__init__.py`; the email-webhooks gate
+  exited 1 with `new sensitive-path SWALLOWED_EXCEPT (0 -> 1)`, then the
+  scratch function was removed. This proof also tightened the B2b sensitive
+  globs with `**/*webhook*/**` so `email_webhooks` directory segments are
+  actually sensitive.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/maturity_sweep_advisory.yml` | 166 |
+| `plans/PR-Maturity-Sweep-Atlas-Brain-B2b.md` | 167 |
+| `tests/maturity_sweep/baseline_atlas_brain_comms.json` | 42 |
+| `tests/maturity_sweep/baseline_atlas_brain_services_email_webhooks.json` | 9 |
+| `tests/maturity_sweep/baseline_atlas_brain_services_embedding.json` | 8 |
+| `tests/maturity_sweep/baseline_atlas_brain_services_llm.json` | 71 |
+| `tests/maturity_sweep/baseline_atlas_brain_services_personaplex.json` | 18 |
+| `tests/maturity_sweep/baseline_atlas_brain_services_speaker_id.json` | 16 |
+| `tests/maturity_sweep/baseline_atlas_brain_skills.json` | 9 |
+| `tests/maturity_sweep/baseline_atlas_brain_vision.json` | 17 |
+| `tests/maturity_sweep/baseline_atlas_brain_voice.json` | 75 |
+| **Total** | **598** |

--- a/tests/maturity_sweep/baseline_atlas_brain_comms.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_comms.json
@@ -1,0 +1,42 @@
+{
+  "atlas_brain/comms/action_planner.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 10
+  },
+  "atlas_brain/comms/call_intelligence.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 4
+    },
+    "score": 16
+  },
+  "atlas_brain/comms/invoice_detector.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/comms/real_services.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/comms/sms_intelligence.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 3
+    },
+    "score": 21
+  },
+  "atlas_brain/comms/tool_bridge.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 8
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_services_email_webhooks.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_services_email_webhooks.json
@@ -1,0 +1,9 @@
+{
+  "atlas_brain/services/email_webhooks/resend.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 16
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_services_embedding.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_services_embedding.json
@@ -1,0 +1,8 @@
+{
+  "atlas_brain/services/embedding/sentence_transformer.py": {
+    "counts": {
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 8
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_services_llm.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_services_llm.json
@@ -1,0 +1,71 @@
+{
+  "atlas_brain/services/llm/anthropic.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 14
+  },
+  "atlas_brain/services/llm/cloud.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "atlas_brain/services/llm/groq.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 6
+  },
+  "atlas_brain/services/llm/llama_cpp.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 6
+    },
+    "score": 17
+  },
+  "atlas_brain/services/llm/model_manager.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/services/llm/ollama.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "atlas_brain/services/llm/openrouter.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 23
+  },
+  "atlas_brain/services/llm/together.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 6
+  },
+  "atlas_brain/services/llm/transformers_flash.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 7
+    },
+    "score": 22
+  },
+  "atlas_brain/services/llm/vllm.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 4
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_services_personaplex.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_services_personaplex.json
@@ -1,0 +1,18 @@
+{
+  "atlas_brain/services/personaplex/config.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/services/personaplex/service.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 4
+    },
+    "score": 18
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_services_speaker_id.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_services_speaker_id.json
@@ -1,0 +1,16 @@
+{
+  "atlas_brain/services/speaker_id/embedder.py": {
+    "counts": {
+      "WEAK_CONTRACT": 1
+    },
+    "score": 1
+  },
+  "atlas_brain/services/speaker_id/service.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 4
+    },
+    "score": 13
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_skills.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_skills.json
@@ -1,0 +1,9 @@
+{
+  "atlas_brain/skills/registry.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 10
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_vision.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_vision.json
@@ -1,0 +1,17 @@
+{
+  "atlas_brain/vision/models.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 15
+  },
+  "atlas_brain/vision/subscriber.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 9
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_voice.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_voice.json
@@ -1,0 +1,75 @@
+{
+  "atlas_brain/voice/audio_capture.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1,
+      "WEAK_CONTRACT": 1
+    },
+    "score": 15
+  },
+  "atlas_brain/voice/command_executor.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "WEAK_CONTRACT": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/voice/frame_processor.py": {
+    "counts": {
+      "WEAK_CONTRACT": 1
+    },
+    "score": 1
+  },
+  "atlas_brain/voice/free_mode.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/voice/launcher.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 4
+    },
+    "score": 24
+  },
+  "atlas_brain/voice/pipeline.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 2,
+      "SWALLOWED_EXCEPT": 5,
+      "UNGUARDED_INDEX": 20,
+      "UNGUARDED_INPUT": 1,
+      "WEAK_CONTRACT": 6
+    },
+    "score": 40
+  },
+  "atlas_brain/voice/playback.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "WEAK_CONTRACT": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/voice/segmenter.py": {
+    "counts": {
+      "WEAK_CONTRACT": 1
+    },
+    "score": 1
+  },
+  "atlas_brain/voice/tts_kokoro.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "WEAK_CONTRACT": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/voice/vad/silero.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 10
+  }
+}


### PR DESCRIPTION
Plan: plans/PR-Maturity-Sweep-Atlas-Brain-B2b.md
Slice phase: Production hardening

Extends the robust maturity-sweep ratchet from #1690/#1692/#1694 to Phase B2b `atlas_brain` service/comms edge lanes: comms, services/email_webhooks, services/embedding, services/llm, services/personaplex, services/speaker_id, skills, vision, and voice. Each lane gets a committed baseline and a blocking gate, so existing debt is tracked while new brittleness or new sensitive-path swallowed exceptions fail CI.

## Intentional
- B2b covers service/comms edge lanes only; larger/riskier remaining `atlas_brain` lanes stay deferred for B2c so their baselines are reviewable.
- No detector or ratchet logic changes; this slice only expands workflow coverage and baseline artifacts.
- Existing debt remains baselined. This PR prevents new debt rather than burning down grandfathered entries.

## Deferred
- Issue #1689 B2c: remaining large/riskier `atlas_brain` lanes, including agents, capabilities, security, storage, tools, reasoning, and services/scraping.
- Issue #1689 Phase C: remaining `extracted_*` packages and `scripts/**`.
- Baseline debt burndown/trend reporting across lanes remains a later observability slice.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_maturity_sweep.py --noconftest -q` -- 14 passed.
- `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- B2b ratchet loop over `comms services/email_webhooks services/embedding services/llm services/personaplex services/speaker_id skills vision voice` -- each lane printed `ratchet gate passed: no new brittleness above baseline`.
- Path-filter spot checks: `tests/test_call_intelligence.py`, `tests/test_anthropic_convert_messages.py`, `tests/test_openrouter_structured_output.py`, `tests/test_cloud_latency.py`, `tests/test_email_webhooks.py`, `tests/test_voice.py`, and `tests/test_skill_registry.py` are covered by `tests/**` in both PR and push filters. This closes the recurring class where module/provider-named tests bypassed lane-name globs.
- Scratch sensitive-path proof: temporarily added a swallowed exception to `atlas_brain/services/email_webhooks/__init__.py`; the email-webhooks gate exited 1 with `new sensitive-path SWALLOWED_EXCEPT (0 -> 1)`, then the scratch function was removed. This proof also tightened the B2b sensitive globs with `**/*webhook*/**` so `email_webhooks` directory segments are actually sensitive.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: Codex P2 on `services/llm` test-only path coverage. Replaced the hand-curated test-path enumeration with `tests/**` in both PR and push filters so every test-only change triggers the sweep, including provider/module-named tests such as `anthropic`, `openrouter`, and `cloud`.

## Diff size
11 files, +492 / -106