### PR TITLE
Deflection semantic question detection

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -314,6 +314,40 @@ _RESOLUTION_ACTION_TERMS = {
     "update",
     "verify",
 }
+_SEMANTIC_SUPPORT_REQUEST_ACTION_TERMS = frozenset(
+    (
+        _RESOLUTION_ACTION_TERMS
+        | {
+            "access",
+            "invite",
+            "login",
+        }
+    )
+    - {
+        "ask",
+        "check",
+        "contact",
+        "open",
+        "review",
+        "send",
+    }
+)
+_SEMANTIC_SUPPORT_SUBJECT_TERMS = frozenset(
+    _SEMANTIC_SUPPORT_REQUEST_ACTION_TERMS
+    | {
+        "billing",
+        "dashboard",
+        "email",
+        "export",
+        "invoice",
+        "login",
+        "password",
+        "payment",
+        "profile",
+        "report",
+        "setting",
+    }
+)
 _RESOLUTION_ACTION_IRREGULAR_PAST_TERMS = {
     "chose": "choose",
     "ran": "run",
@@ -2569,11 +2603,17 @@ def _question_text_matching(
                 normalized = _first_person_issue_question_text(tail, predicate=predicate)
                 if normalized:
                     return normalized
+                normalized = _semantic_support_issue_question_text(tail, predicate=predicate)
+                if normalized:
+                    return normalized
             continue
         normalized = _question_start_text(text, predicate=predicate)
         if normalized:
             return normalized
         normalized = _first_person_issue_question_text(text, predicate=predicate)
+        if normalized:
+            return normalized
+        normalized = _semantic_support_issue_question_text(text, predicate=predicate)
         if normalized:
             return normalized
     return ""
@@ -2655,6 +2695,8 @@ def _question_start_text(
         "como ",
     )
     lowered = text.lower()
+    if lowered.startswith("can not "):
+        return ""
     if lowered.startswith(question_starts):
         normalized = _normalize_question_text(text)
         if resolved_predicate(normalized):
@@ -2713,6 +2755,82 @@ def _first_person_issue_question_text(
             if resolved_predicate(normalized):
                 return normalized
     return ""
+
+
+def _semantic_support_issue_question_text(
+    text: str,
+    *,
+    predicate: Callable[[str], bool] | None = None,
+) -> str:
+    resolved_predicate = predicate or _usable_question
+    sentence = _first_sentence(text)
+    if not sentence:
+        return ""
+    lowered = sentence.lower()
+    unable_patterns = (
+        ("unable to ", "How do I "),
+        ("cannot ", "How do I "),
+        ("can't ", "How do I "),
+        ("can not ", "How do I "),
+    )
+    for prefix, question_prefix in unable_patterns:
+        if lowered.startswith(prefix):
+            remainder = sentence[len(prefix):].strip()
+            if not _starts_with_semantic_support_action(remainder):
+                return ""
+            normalized = _normalize_question_text(f"{question_prefix}{remainder}")
+            if resolved_predicate(normalized):
+                return normalized
+
+    for prefix in ("please ", "pls "):
+        if lowered.startswith(prefix):
+            remainder = sentence[len(prefix):].strip()
+            if not _starts_with_semantic_support_action(remainder):
+                return ""
+            normalized = _normalize_question_text(f"How do I {remainder}")
+            if resolved_predicate(normalized):
+                return normalized
+
+    if _is_semantic_support_keep_failing_issue(sentence):
+        normalized = _normalize_question_text(
+            f"What should I do if {sentence[0].lower()}{sentence[1:]}"
+        )
+        if resolved_predicate(normalized):
+            return normalized
+    return ""
+
+
+def _starts_with_semantic_support_action(value: str) -> bool:
+    lowered = value.lower().strip()
+    if re.match(r"^(?:log|logging)\s+in\b", lowered):
+        return True
+    tokens = re.findall(r"[a-z0-9]+", lowered)
+    return (
+        bool(tokens)
+        and _semantic_support_token(tokens[0]) in _SEMANTIC_SUPPORT_REQUEST_ACTION_TERMS
+    )
+
+
+def _is_semantic_support_keep_failing_issue(value: str) -> bool:
+    match = re.match(r"^(?P<subject>.+?)\s+keeps?\s+failing\b", value.lower().strip())
+    if match is None:
+        return False
+    subject = re.sub(r"^(?:a|an|the)\s+", "", match.group("subject").strip())
+    tokens = re.findall(r"[a-z0-9]+", subject)
+    return any(
+        _semantic_support_token(token) in _SEMANTIC_SUPPORT_SUBJECT_TERMS
+        for token in tokens
+    )
+
+
+def _semantic_support_token(value: str) -> str:
+    if value == "logging":
+        return "login"
+    if value.endswith("ies") and len(value) > 3:
+        return f"{value[:-3]}y"
+    if value.endswith("s") and not value.endswith(("ss", "us", "is", "as")):
+        return value[:-1]
+    return value
 
 
 def _first_sentence(text: str) -> str:

--- a/plans/PR-Deflection-Semantic-Question-Detection.md
+++ b/plans/PR-Deflection-Semantic-Question-Detection.md
@@ -1,0 +1,102 @@
+# PR-Deflection-Semantic-Question-Detection
+
+## Why this slice exists
+
+#1463's remaining concrete P2 parser item is semantic question detection. The
+issue names three customer phrasings that still reproduce on current `main`:
+`Unable to reset password`, `The export keeps failing`, and `please reset my
+password` all return no question from `_question_text(...)`, so they fall back
+to weaker generated labels even though they clearly express a support question.
+
+Root cause: `_question_text_matching(...)` only recognizes explicit
+question-starts and first-person issue forms. It does not have a conservative
+template for short support-action complaints without "I/we", so useful customer
+phrasing is dropped before FAQ labels are selected.
+
+This PR fixes the root in the question extraction layer, not downstream in
+rendering. It adds a bounded semantic support-issue template for the exact class
+and tests both cited cases and allowed near-misses.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-parser
+Slice phase: Product polish
+
+1. Add a conservative semantic support-issue question helper in
+   `ticket_faq_markdown.py`.
+2. Recognize support-action variants of:
+   - `Unable to ...` / `Cannot ...`
+   - `please <support action> ...`
+   - `<thing> keeps failing`
+3. Add focused tests for the #1463 cited examples plus same-class held-out
+   variants and near-misses that must stay unrecognized.
+
+### Review Contract
+
+Acceptance criteria:
+- The three #1463 examples become usable questions.
+- Same-class held-out support examples become usable questions.
+- Near-misses such as generic "please see attached logs" do not become FAQ
+  questions.
+- Existing explicit question and first-person behavior remains unchanged.
+
+Affected surfaces:
+- Extracted support-ticket FAQ question-label extraction.
+
+Risk areas:
+- Over-capturing generic statements into buyer-facing FAQ questions.
+- Fixing only the cited examples rather than the class.
+
+Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Semantic-Question-Detection.md`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+## Mechanism
+
+`_question_text_matching(...)` already routes through explicit question starts
+and first-person issue templates. This PR adds one more helper after those
+existing branches: `_semantic_support_issue_question_text(...)`.
+
+The helper is intentionally small. It only templates support-action terms such
+as reset/export/update/download/access/login/invite/payment/billing, and it has
+separate shapes for `unable/cannot`, `please <action>`, and `keeps failing`.
+Everything still passes through the existing `_normalize_question_text(...)` and
+predicate check before it can become a label.
+
+## Intentional
+
+- This is not a broad NLP parser or LLM repair. It is a deterministic template
+  for a known support-ticket phrasing class.
+- Generic polite statements remain unrecognized unless they contain a supported
+  action term.
+- The stemmer/synonym-map and HTML bullets in #1463 are left for reconciliation
+  or separate slices; this PR only takes the proven semantic-question residual.
+
+## Deferred
+
+- Reconcile the remaining #1463 bullets after this PR: some are already landed,
+  some are intentionally superseded, and any true residual should get its own
+  narrow slice.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py -q -- 418 passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 185 matching
+  tests are enrolled.
+- bash scripts/run_extracted_pipeline_checks.sh -- extracted reasoning core 295
+  passed; extracted content pipeline 4659 passed, 10 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 118 |
+| `plans/PR-Deflection-Semantic-Question-Detection.md` | 102 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 51 |
+| **Total** | **271** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -27,6 +27,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownService,
     _RESOLUTION_ACTION_TERMS,
     _output_checks,
+    _question_text,
     _resolution_advisory_signals,
     _resolution_signal_token,
     _resolution_signal_tokens,
@@ -1902,6 +1903,56 @@ def test_build_ticket_faq_markdown_cleans_committed_zendesk_product_corpus_label
     assert not any(question.startswith("Localized support question ") for question in questions)
     assert "What should I do about atla?" not in questions
     assert cluster_labels.isdisjoint({"atla", "atlas"})
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_question"),
+    (
+        ("Unable to reset password", "How do I reset password?"),
+        ("The export keeps failing", "What should I do if the export keeps failing?"),
+        ("please reset my password", "How do I reset my password?"),
+        ("Cannot download invoice", "How do I download invoice?"),
+        ("can't access billing settings", "How do I access billing settings?"),
+        ("The report keeps failing", "What should I do if the report keeps failing?"),
+        ("please update billing email", "How do I update billing email?"),
+        ("Unable to invite teammates", "How do I invite teammates?"),
+        ("Unable to log in", "How do I log in?"),
+        ("please log in", "How do I log in?"),
+        ("Payments keep failing", "What should I do if payments keep failing?"),
+        ("The exports keep failing", "What should I do if the exports keep failing?"),
+        ("can not reset password", "How do I reset password?"),
+    ),
+)
+def test_question_text_recognizes_semantic_support_issue_phrasing(
+    text: str,
+    expected_question: str,
+) -> None:
+    assert _question_text(text) == expected_question
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "Please see attached logs",
+        "Unable to attend the webinar",
+        "Unable to attend billing webinar",
+        "The office keeps moving",
+        "Please review when you have time",
+        "Please billing team can ignore this",
+        "Please password is included in the screenshot",
+    ),
+)
+def test_question_text_rejects_semantic_support_issue_near_misses(text: str) -> None:
+    assert _question_text(text) == ""
+
+
+def test_question_text_preserves_existing_question_and_first_person_templates() -> None:
+    assert _question_text("How do I change my email address?") == (
+        "How do I change my email address?"
+    )
+    assert _question_text("I cannot update the email address.") == (
+        "How do I update the email address?"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Plan: plans/PR-Deflection-Semantic-Question-Detection.md
Slice phase: Product polish

#1463's remaining concrete parser residual is semantic question detection: short support-ticket phrasings such as `Unable to reset password`, `The export keeps failing`, and `please reset my password` still dropped out of `_question_text(...)` and fell back to weaker generated labels. This fixes the root in the question extraction layer by adding a bounded support-action template after the existing explicit-question and first-person issue templates, with held-out and near-miss tests so the matcher recognizes the class without turning generic polite prose into FAQ questions.

## Intentional
- This is deterministic parser polish, not a broad NLP parser or LLM repair.
- Generic polite statements remain unrecognized unless they start with a real support request verb.
- Keep-failing complaints may match support subjects such as exports/payments, but cannot match unrelated subjects.
- The other #1463 backlog bullets remain outside this slice unless reconciliation proves a true residual needs its own narrow PR.

## Deferred
- Reconcile the remaining #1463 bullets after this PR: some are already landed, some are intentionally superseded, and any true residual should get its own narrow slice.

## Parked hardening
- None.

## AI Reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Codex #2801 fixed: `unable`/`cannot` complaints now require the support action at the matched action position, so `Unable to attend billing webinar` stays unrecognized.
- Codex #334 fixed: `please <...>` requests use a request-verb set instead of support nouns, so `Please billing team can ignore this` and `Please password is included in the screenshot` stay unrecognized.
- Codex #2765 fixed: `can not ...` no longer exits through the generic `can ` question-start path; it normalizes through the semantic complaint template.
- Codex #325 fixed: phrase-level `log in` / `logging in` support-action detection covers `Unable to log in` and `please log in`.
- Codex #2785 fixed: `keep failing` plural variants are recognized for support subjects, including `Payments keep failing` and `The exports keep failing`.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py -q -- 418 passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 185 matching tests are enrolled.
- bash scripts/run_extracted_pipeline_checks.sh -- extracted reasoning core 295 passed; extracted content pipeline 4659 passed, 10 skipped, 1 warning.

## Diff size
3 files, +271 / -0
