### PR TITLE
Maturity sweep gate scope Phase B2c

### DIFF
--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -47,6 +47,9 @@ on:
       - "atlas_brain/skills/**"
       - "atlas_brain/vision/**"
       - "atlas_brain/voice/**"
+      - "atlas_brain/reasoning/**"
+      - "atlas_brain/security/**"
+      - "atlas_brain/storage/**"
   push:
     branches:
       - main
@@ -83,6 +86,9 @@ on:
       - "atlas_brain/skills/**"
       - "atlas_brain/vision/**"
       - "atlas_brain/voice/**"
+      - "atlas_brain/reasoning/**"
+      - "atlas_brain/security/**"
+      - "atlas_brain/storage/**"
 
 jobs:
   maturity-sweep:
@@ -256,6 +262,36 @@ jobs:
             python scripts/maturity_sweep.py "atlas_brain/${lane}" \
               --tests-root tests \
               --baseline "tests/maturity_sweep/baseline_atlas_brain_${slug}.json" \
+              --min-score 8 \
+              "${common_sensitive_args[@]}"
+            echo "::endgroup::"
+          done
+
+      - name: Maturity sweep atlas_brain B2c core-risk ratchet gates (blocking)
+        run: |
+          set -euo pipefail
+          common_sensitive_args=(
+            --sensitive-glob '**/billing/**'
+            --sensitive-glob '**/billing*'
+            --sensitive-glob '**/paid*'
+            --sensitive-glob '**/auth/**'
+            --sensitive-glob '**/auth*'
+            --sensitive-glob '**/webhook*'
+            --sensitive-glob '**/webhooks/**'
+            --sensitive-glob '**/*webhook*/**'
+            --sensitive-glob '**/payment*'
+            --sensitive-glob '**/invoicing/**'
+            --sensitive-glob '**/*invoice*'
+            --sensitive-glob '**/*deletion*'
+            --sensitive-glob '**/delete*/**'
+            --sensitive-glob 'atlas_brain/security/**'
+            --sensitive-glob 'atlas_brain/storage/**'
+          )
+          for lane in reasoning security storage; do
+            echo "::group::atlas_brain/${lane}"
+            python scripts/maturity_sweep.py "atlas_brain/${lane}" \
+              --tests-root tests \
+              --baseline "tests/maturity_sweep/baseline_atlas_brain_${lane}.json" \
               --min-score 8 \
               "${common_sensitive_args[@]}"
             echo "::endgroup::"

--- a/plans/PR-Maturity-Sweep-Atlas-Brain-B2c.md
+++ b/plans/PR-Maturity-Sweep-Atlas-Brain-B2c.md
@@ -1,0 +1,148 @@
+# PR-Maturity-Sweep-Atlas-Brain-B2c
+
+## Why this slice exists
+
+Issue #1689 extends the robust maturity-sweep ratchet from
+`extracted_content_pipeline` across the rest of `atlas_brain/**` and the
+remaining packages. Phase B1 covered high-blast-radius API/auth/MCP/B2B lanes;
+B2a covered support lanes; B2b covered service/comms edge lanes and replaced
+fragile per-lane test triggers with `tests/**`.
+
+The remaining `atlas_brain` lanes are the larger/riskier core runtime areas.
+This slice takes the highest-severity-per-review-effort subset: reasoning,
+security, and storage. These lanes hold decision logic, security monitoring, and
+persistence boundaries, so a new swallowed exception or brittle parser in these
+paths can hide production failures even though the workflow is green today.
+
+This is intentionally narrower than "all remaining B2" because the
+`services/scraping` baseline is parser-heavy and the
+`agents`/`capabilities`/`tools` set is another coherent runtime-control group.
+Splitting them keeps the generated baselines reviewable, as issue #1689 allows
+when a phase gets large.
+
+## Scope (this PR)
+
+Ownership lane: ci/maturity-sweep
+Slice phase: Production hardening
+
+1. Add baseline-backed blocking maturity-sweep gates for these Phase B2c lanes:
+   `atlas_brain/reasoning`, `atlas_brain/security`, and
+   `atlas_brain/storage`.
+2. Add one committed ratchet baseline per lane under `tests/maturity_sweep/`
+   so the workflow starts green and blocks only new debt.
+3. Extend the maturity-sweep workflow source triggers for the three lanes.
+   Existing `tests/**` coverage from B2b continues to trigger the sweep for any
+   test-only change.
+4. Prove the gates pass against their committed baselines and that a new
+   sensitive-path swallowed exception fails in a scratch copy.
+
+### Review Contract
+
+Acceptance criteria:
+- Each B2c lane has a committed lane-specific baseline under
+  `tests/maturity_sweep/`.
+- `.github/workflows/maturity_sweep_advisory.yml` runs blocking ratchet gates
+  for reasoning, security, and storage with no `continue-on-error`.
+- The workflow `pull_request` and `push` path filters include every B2c source
+  lane; `tests/**` remains present for all test-only changes.
+- Existing B1, B2a, and B2b gates and baselines remain intact.
+- No `scripts/maturity_sweep.py` detector or ratchet logic changes in this
+  slice.
+
+Affected surfaces:
+- Maturity sweep GitHub Actions workflow.
+- Generated maturity-sweep baseline artifacts for reasoning, security, and
+  storage.
+
+Risk areas:
+- Workflow path filters that omit a source change or remove the broad
+  `tests/**` trigger.
+- Baseline paths mismatched to lane paths.
+- Sensitive globs missing obvious auth/webhook/billing/payment/invoice/delete
+  filenames in reasoning/security/storage paths.
+
+Triggered reviewer rules:
+- R1 Requirements match.
+- R2 Test evidence.
+- R3 Security/auth for sensitive-path gate coverage.
+- R6 CI/workflow correctness.
+- R9 Generated artifacts/baseline review.
+- R14 Codebase verification.
+
+### Files touched
+
+- `.github/workflows/maturity_sweep_advisory.yml`
+- `plans/PR-Maturity-Sweep-Atlas-Brain-B2c.md`
+- `tests/maturity_sweep/baseline_atlas_brain_reasoning.json`
+- `tests/maturity_sweep/baseline_atlas_brain_security.json`
+- `tests/maturity_sweep/baseline_atlas_brain_storage.json`
+
+## Mechanism
+
+The workflow reuses the existing robust maturity-sweep gate from #1690/#1692
+and the B2a/B2b rollout. Each B2c lane gets a committed baseline via
+`--update-baseline`, then CI runs the same command without `--update-baseline`:
+
+```bash
+python scripts/maturity_sweep.py <lane> \
+  --tests-root tests \
+  --baseline <that lane's committed baseline> \
+  --min-score 8 \
+  --sensitive-glob ...
+```
+
+Existing debt is recorded in the baseline. New files above threshold, score
+regressions, or new swallowed/bare exceptions in sensitive paths fail the gate.
+The B2c workflow step follows the existing loop pattern with `set -euo pipefail`.
+The `security` and `storage` lanes are whole-lane sensitive for new
+swallowed/bare exceptions; reasoning keeps the shared sensitive filename globs.
+
+## Intentional
+
+- This is B2c core-risk, not all remaining `atlas_brain/**`. The
+  `agents`/`capabilities`/`tools` runtime-control group and
+  `services/scraping` parser-heavy group stay deferred so their baselines are
+  readable and reviewable.
+- No detector changes. This slice only expands workflow coverage and baseline
+  artifacts for existing logic.
+- Existing debt remains baselined. This PR prevents new brittleness; it does
+  not burn down grandfathered entries.
+
+## Deferred
+
+- Issue #1689 B2d: remaining `atlas_brain` runtime-control lanes:
+  `agents`, `capabilities`, and `tools`.
+- Issue #1689 B2e: parser-heavy `atlas_brain/services/scraping`.
+- Issue #1689 Phase C: remaining `extracted_*` packages and `scripts/**`.
+- Baseline debt burndown/trend reporting across lanes remains a later
+  observability slice.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_maturity_sweep.py --noconftest -q` -- 14
+  passed.
+- `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`.
+- B2c ratchet loop over `reasoning security storage` -- each lane printed
+  `ratchet gate passed: no new brittleness above baseline`.
+- Path-filter spot check: `atlas_brain/reasoning/context_aggregator.py`,
+  `atlas_brain/security/monitor.py`,
+  `atlas_brain/storage/repositories/session.py`, and
+  `tests/test_reasoning_context_aggregator.py` are covered by both PR and push
+  triggers.
+- Scratch sensitive-path proof: temporarily added a swallowed exception to
+  `atlas_brain/security/monitor.py`; the security gate exited 1 with
+  `score increased (10 -> 15)` and `new sensitive-path SWALLOWED_EXCEPT
+  (0 -> 1)`, then the scratch function was removed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/maturity_sweep_advisory.yml` | 36 |
+| `plans/PR-Maturity-Sweep-Atlas-Brain-B2c.md` | 148 |
+| `tests/maturity_sweep/baseline_atlas_brain_reasoning.json` | 189 |
+| `tests/maturity_sweep/baseline_atlas_brain_security.json` | 63 |
+| `tests/maturity_sweep/baseline_atlas_brain_storage.json` | 142 |
+| **Total** | **578** |

--- a/tests/maturity_sweep/baseline_atlas_brain_reasoning.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_reasoning.json
@@ -1,0 +1,189 @@
+{
+  "atlas_brain/reasoning/agent.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/reasoning/call_transcript.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "atlas_brain/reasoning/config.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/reasoning/consumer.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "atlas_brain/reasoning/context_aggregator.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 18
+  },
+  "atlas_brain/reasoning/cross_vendor_selection.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 13
+  },
+  "atlas_brain/reasoning/ecosystem.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "atlas_brain/reasoning/entity_locks.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/reasoning/event_bus.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 3
+    },
+    "score": 21
+  },
+  "atlas_brain/reasoning/events.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "atlas_brain/reasoning/evidence_engine.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 12
+  },
+  "atlas_brain/reasoning/knowledge_graph.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 12
+  },
+  "atlas_brain/reasoning/llm_utils.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 11
+  },
+  "atlas_brain/reasoning/lock_integration.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 3
+    },
+    "score": 21
+  },
+  "atlas_brain/reasoning/market_pulse.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/reasoning/narrative.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 10
+  },
+  "atlas_brain/reasoning/patterns.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "atlas_brain/reasoning/phrase_metadata.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 8
+  },
+  "atlas_brain/reasoning/semantic_cache.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "atlas_brain/reasoning/single_pass_prompts/battle_card_reasoning.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1
+    },
+    "score": 1
+  },
+  "atlas_brain/reasoning/single_pass_prompts/category_council_synthesis.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 3
+    },
+    "score": 3
+  },
+  "atlas_brain/reasoning/single_pass_prompts/cross_vendor_battle.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 2
+    },
+    "score": 2
+  },
+  "atlas_brain/reasoning/single_pass_prompts/cross_vendor_battle_synthesis.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 3
+    },
+    "score": 3
+  },
+  "atlas_brain/reasoning/single_pass_prompts/resource_asymmetry_synthesis.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1
+    },
+    "score": 1
+  },
+  "atlas_brain/reasoning/single_pass_prompts/vendor_classify.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1
+    },
+    "score": 1
+  },
+  "atlas_brain/reasoning/state.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/reasoning/trigger_events.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "atlas_brain/reasoning/vendor_pressure.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_security.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_security.json
@@ -1,0 +1,63 @@
+{
+  "atlas_brain/security/assets/drone_tracker.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/security/assets/sensor_network.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/security/assets/vehicle_tracker.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/security/monitor.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "WEAK_CONTRACT": 6
+    },
+    "score": 10
+  },
+  "atlas_brain/security/network/arp_monitor.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/security/network/port_scan_detector.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 8
+  },
+  "atlas_brain/security/network/traffic_analyzer.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 10
+  },
+  "atlas_brain/security/wireless/deauth_detector.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "atlas_brain/security/wireless/monitor.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 14
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_storage.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_storage.json
@@ -1,0 +1,142 @@
+{
+  "atlas_brain/storage/config.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/storage/database.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1
+    },
+    "score": 4
+  },
+  "atlas_brain/storage/models.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 11
+  },
+  "atlas_brain/storage/repositories/appointment.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 11
+  },
+  "atlas_brain/storage/repositories/call_transcript.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "atlas_brain/storage/repositories/competitive_set.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 10
+  },
+  "atlas_brain/storage/repositories/conversation.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 17
+  },
+  "atlas_brain/storage/repositories/device.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/storage/repositories/email.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 11
+  },
+  "atlas_brain/storage/repositories/feedback.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "atlas_brain/storage/repositories/identity.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 2,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 8
+  },
+  "atlas_brain/storage/repositories/invoice.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 12
+  },
+  "atlas_brain/storage/repositories/reminder.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 11
+  },
+  "atlas_brain/storage/repositories/scheduled_task.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 20
+  },
+  "atlas_brain/storage/repositories/session.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 3
+    },
+    "score": 17
+  },
+  "atlas_brain/storage/repositories/sms_message.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/storage/repositories/unified_alerts.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "NO_TEST_FILE": 1,
+      "UNGUARDED_INDEX": 2,
+      "UNGUARDED_INPUT": 2
+    },
+    "score": 19
+  },
+  "atlas_brain/storage/repositories/vector.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/storage/repositories/vision.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 2,
+      "UNGUARDED_INDEX": 1,
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 8
+  }
+}


### PR DESCRIPTION
Plan: plans/PR-Maturity-Sweep-Atlas-Brain-B2c.md
Slice phase: Production hardening

Extends the maturity-sweep ratchet from #1690/#1692/#1694/#1696 to the next highest-risk `atlas_brain` core lanes: reasoning, security, and storage. Each lane gets a committed baseline and a blocking gate so existing debt is tracked while new brittleness or new sensitive-path swallowed exceptions fail CI.

## Intentional
- B2c covers reasoning/security/storage only; agents/capabilities/tools and services/scraping stay deferred so their baselines remain reviewable.
- No detector or ratchet logic changes; this slice only expands workflow coverage and baseline artifacts.
- Existing debt remains baselined. This PR prevents new debt rather than burning down grandfathered entries.

## Deferred
- Issue #1689 B2d: `atlas_brain/agents`, `atlas_brain/capabilities`, and `atlas_brain/tools`.
- Issue #1689 B2e: parser-heavy `atlas_brain/services/scraping`.
- Issue #1689 Phase C: remaining `extracted_*` packages and `scripts/**`.
- Baseline debt burndown/trend reporting across lanes remains a later observability slice.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_maturity_sweep.py --noconftest -q` -- 14 passed.
- `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- B2c ratchet loop over `reasoning security storage` -- each lane printed `ratchet gate passed: no new brittleness above baseline`.
- Path-filter spot check: `atlas_brain/reasoning/context_aggregator.py`, `atlas_brain/security/monitor.py`, `atlas_brain/storage/repositories/session.py`, and `tests/test_reasoning_context_aggregator.py` are covered by both PR and push triggers.
- Scratch sensitive-path proof: temporarily added a swallowed exception to `atlas_brain/security/monitor.py`; the security gate exited 1 with `score increased (10 -> 15)` and `new sensitive-path SWALLOWED_EXCEPT (0 -> 1)`, then the scratch function was removed.

## Diff size
5 files, +578 / -0
