### PR TITLE
Maturity sweep gate scope Phase B2d

### DIFF
--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -50,6 +50,9 @@ on:
       - "atlas_brain/reasoning/**"
       - "atlas_brain/security/**"
       - "atlas_brain/storage/**"
+      - "atlas_brain/agents/**"
+      - "atlas_brain/capabilities/**"
+      - "atlas_brain/tools/**"
   push:
     branches:
       - main
@@ -89,6 +92,9 @@ on:
       - "atlas_brain/reasoning/**"
       - "atlas_brain/security/**"
       - "atlas_brain/storage/**"
+      - "atlas_brain/agents/**"
+      - "atlas_brain/capabilities/**"
+      - "atlas_brain/tools/**"
 
 jobs:
   maturity-sweep:
@@ -288,6 +294,36 @@ jobs:
             --sensitive-glob 'atlas_brain/storage/**'
           )
           for lane in reasoning security storage; do
+            echo "::group::atlas_brain/${lane}"
+            python scripts/maturity_sweep.py "atlas_brain/${lane}" \
+              --tests-root tests \
+              --baseline "tests/maturity_sweep/baseline_atlas_brain_${lane}.json" \
+              --min-score 8 \
+              "${common_sensitive_args[@]}"
+            echo "::endgroup::"
+          done
+
+      - name: Maturity sweep atlas_brain B2d runtime-control ratchet gates (blocking)
+        run: |
+          set -euo pipefail
+          common_sensitive_args=(
+            --sensitive-glob '**/billing/**'
+            --sensitive-glob '**/billing*'
+            --sensitive-glob '**/paid*'
+            --sensitive-glob '**/auth/**'
+            --sensitive-glob '**/auth*'
+            --sensitive-glob '**/webhook*'
+            --sensitive-glob '**/webhooks/**'
+            --sensitive-glob '**/*webhook*/**'
+            --sensitive-glob '**/payment*'
+            --sensitive-glob '**/invoicing/**'
+            --sensitive-glob '**/*invoice*'
+            --sensitive-glob '**/*deletion*'
+            --sensitive-glob '**/delete*/**'
+            --sensitive-glob '**/security.py'
+            --sensitive-glob '**/security/**'
+          )
+          for lane in agents capabilities tools; do
             echo "::group::atlas_brain/${lane}"
             python scripts/maturity_sweep.py "atlas_brain/${lane}" \
               --tests-root tests \

--- a/plans/PR-Maturity-Sweep-Atlas-Brain-B2d.md
+++ b/plans/PR-Maturity-Sweep-Atlas-Brain-B2d.md
@@ -1,0 +1,144 @@
+# PR-Maturity-Sweep-Atlas-Brain-B2d
+
+## Why this slice exists
+
+Issue #1689 is rolling the maturity-sweep ratchet across Atlas lane by lane so
+new structural brittleness is blocked without making existing debt a big-bang
+failure. B2a covered support lanes, B2b covered service/comms lanes, and B2c
+covered reasoning/security/storage. This slice extends the same baseline
+ratchet to the remaining `atlas_brain` runtime-control surfaces:
+`agents`, `capabilities`, and `tools`.
+
+Root cause: these runtime-control lanes contain orchestration, Home Assistant
+actions, and tool execution code, but they are not yet included in the
+blocking maturity-sweep baseline gate. That means a PR can add new high-score
+or sensitive swallowed-exception debt there without tripping the ratchet. This
+change fixes the root for these three lanes by enrolling them directly in the
+workflow and committing their current baselines.
+
+This approaches the 400 LOC soft cap because the workflow loop needs all three
+current baselines to land green; splitting the baselines from the gate would
+ship a red or ineffective CI change.
+
+## Scope (this PR)
+
+Ownership lane: ci/maturity-sweep
+Slice phase: Production hardening
+
+1. Add blocking maturity-sweep ratchet gates for `atlas_brain/agents`,
+   `atlas_brain/capabilities`, and `atlas_brain/tools`.
+2. Add committed baselines for those lanes so CI fails only on new debt or
+   explicit baseline changes.
+3. Add path triggers so PRs touching those runtime-control source lanes run
+   the maturity-sweep workflow.
+
+### Review Contract
+
+Acceptance criteria:
+- `pull_request` and `push` path filters include `atlas_brain/agents/**`,
+  `atlas_brain/capabilities/**`, and `atlas_brain/tools/**`.
+- CI has one blocking B2d loop that runs `scripts/maturity_sweep.py` for all
+  three lanes with the committed baselines and `--min-score 8`.
+- The B2d loop carries the same common sensitive globs as prior B2 lanes and
+  also marks security-named files/directories sensitive, because this scope
+  includes `atlas_brain/agents/graphs/security.py` and
+  `atlas_brain/tools/security.py`.
+- The new baselines are generated from the current tree with
+  `--update-baseline`.
+- Existing maturity-sweep tests still pass.
+- A scratch negative proof shows the shipped B2d command fails when new
+  sensitive swallowed-exception debt is added under a security-named B2d file.
+
+Affected surfaces:
+- `.github/workflows/maturity_sweep_advisory.yml`
+- `tests/maturity_sweep/baseline_atlas_brain_agents.json`
+- `tests/maturity_sweep/baseline_atlas_brain_capabilities.json`
+- `tests/maturity_sweep/baseline_atlas_brain_tools.json`
+
+Risk areas:
+- CI enrollment/path-filter drift.
+- False-green sensitive-path coverage for security-named runtime-control code.
+- Baseline churn that could accept unrelated debt.
+
+Reviewer rules triggered:
+- R2 Test evidence.
+- R12 Deployment safety and CI enrollment.
+- R14 Codebase verification.
+
+### Files touched
+
+- `.github/workflows/maturity_sweep_advisory.yml`
+- `plans/PR-Maturity-Sweep-Atlas-Brain-B2d.md`
+- `tests/maturity_sweep/baseline_atlas_brain_agents.json`
+- `tests/maturity_sweep/baseline_atlas_brain_capabilities.json`
+- `tests/maturity_sweep/baseline_atlas_brain_tools.json`
+
+## Mechanism
+
+The workflow adds the three B2d directories to both PR and main-push path
+filters, then runs a grouped Bash loop:
+
+```bash
+for lane in agents capabilities tools; do
+  python scripts/maturity_sweep.py "atlas_brain/${lane}" \
+    --tests-root tests \
+    --baseline "tests/maturity_sweep/baseline_atlas_brain_${lane}.json" \
+    --min-score 8 \
+    "${common_sensitive_args[@]}"
+done
+```
+
+The committed baselines snapshot the current per-file counts for each lane.
+That keeps current debt visible but non-blocking, while any file whose score
+increases, any new file over the threshold, or any new sensitive-path bare or
+swallowed exception fails the gate.
+
+## Intentional
+
+- This does not fix existing brittle files in `agents`, `capabilities`, or
+  `tools`; it ratchets them so new brittleness cannot land silently.
+- This does not broaden `tests/**`; the broad test trigger already exists from
+  earlier maturity-sweep phases so test-side baseline or detector changes keep
+  running the workflow.
+- Security-named files/directories are treated as sensitive for B2d. The common
+  billing/auth/webhook/payment/delete globs do not catch
+  `atlas_brain/agents/graphs/security.py` or `atlas_brain/tools/security.py`,
+  and those are runtime control surfaces where silent failure should be
+  zero-tolerance.
+
+## Deferred
+
+- B2e: enroll `atlas_brain/services/scraping`.
+- Phase C: enroll the remaining `extracted_*` packages and `scripts/**` with
+  lane-specific baselines.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` - pass.
+- `python -m pytest tests/test_maturity_sweep.py --noconftest -q` - pass,
+  14 passed.
+- B2d ratchet loop over `agents capabilities tools` with the shipped
+  sensitive globs - pass, all three lanes reported `ratchet gate passed: no
+  new brittleness above baseline`.
+- Path-filter spot check for `atlas_brain/agents/**`,
+  `atlas_brain/capabilities/**`, `atlas_brain/tools/**`, and retained
+  `tests/**` - pass.
+- Scratch sensitive-path negative proof in `atlas_brain/tools/security.py` -
+  pass. A temporary swallowed-exception probe made the shipped tools command
+  fail with `score increased (8 -> 13)` and
+  `new sensitive-path SWALLOWED_EXCEPT (0 -> 1)`; the scratch code was removed
+  and the clean B2d loop was rerun successfully.
+- `python scripts/sync_pr_plan.py plans/PR-Maturity-Sweep-Atlas-Brain-B2d.md --check` - pass.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/maturity_sweep_advisory.yml` | 36 |
+| `plans/PR-Maturity-Sweep-Atlas-Brain-B2d.md` | 144 |
+| `tests/maturity_sweep/baseline_atlas_brain_agents.json` | 83 |
+| `tests/maturity_sweep/baseline_atlas_brain_capabilities.json` | 69 |
+| `tests/maturity_sweep/baseline_atlas_brain_tools.json` | 80 |
+| **Total** | **412** |

--- a/tests/maturity_sweep/baseline_atlas_brain_agents.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_agents.json
@@ -1,0 +1,83 @@
+{
+  "atlas_brain/agents/entity_tracker.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 8
+  },
+  "atlas_brain/agents/graphs/atlas.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 6,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 32
+  },
+  "atlas_brain/agents/graphs/email_query.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/agents/graphs/home.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 4
+  },
+  "atlas_brain/agents/graphs/presence.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "atlas_brain/agents/graphs/receptionist.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 3
+  },
+  "atlas_brain/agents/graphs/security.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/agents/graphs/state.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/agents/graphs/workflow_state.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 11
+  },
+  "atlas_brain/agents/interface.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 4
+    },
+    "score": 20
+  },
+  "atlas_brain/agents/memory.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/agents/tools.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 12
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_capabilities.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_capabilities.json
@@ -1,0 +1,69 @@
+{
+  "atlas_brain/capabilities/actions.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 9
+  },
+  "atlas_brain/capabilities/backends/homeassistant.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1
+    },
+    "score": 5
+  },
+  "atlas_brain/capabilities/backends/homeassistant_ws.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2
+    },
+    "score": 10
+  },
+  "atlas_brain/capabilities/backends/mqtt.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  },
+  "atlas_brain/capabilities/device_resolver.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 4
+    },
+    "score": 17
+  },
+  "atlas_brain/capabilities/devices/media.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 7
+  },
+  "atlas_brain/capabilities/devices/switches.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "atlas_brain/capabilities/homeassistant.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 9
+  },
+  "atlas_brain/capabilities/intent_parser.py": {
+    "counts": {
+      "NO_TEST_FILE": 1,
+      "SWALLOWED_EXCEPT": 3,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 23
+  },
+  "atlas_brain/capabilities/state_cache.py": {
+    "counts": {
+      "NO_TEST_FILE": 1
+    },
+    "score": 6
+  }
+}

--- a/tests/maturity_sweep/baseline_atlas_brain_tools.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_tools.json
@@ -1,0 +1,80 @@
+{
+  "atlas_brain/tools/calendar.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 2,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 12
+  },
+  "atlas_brain/tools/display.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "atlas_brain/tools/email.py": {
+    "counts": {
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 9
+  },
+  "atlas_brain/tools/notify.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "atlas_brain/tools/presence.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 4
+  },
+  "atlas_brain/tools/reminder.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "atlas_brain/tools/risk_sensors.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 5
+  },
+  "atlas_brain/tools/scheduling.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 6
+    },
+    "score": 6
+  },
+  "atlas_brain/tools/security.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "WEAK_CONTRACT": 1
+    },
+    "score": 8
+  },
+  "atlas_brain/tools/time.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "atlas_brain/tools/traffic.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "atlas_brain/tools/weather.py": {
+    "counts": {
+      "HEURISTIC_COMMENT": 2
+    },
+    "score": 2
+  }
+}


### PR DESCRIPTION
Plan: plans/PR-Maturity-Sweep-Atlas-Brain-B2d.md
Slice phase: Production hardening

Issue #1689 is rolling the maturity-sweep ratchet across Atlas lane by lane. This slice enrolls the remaining `atlas_brain` runtime-control surfaces (`agents`, `capabilities`, and `tools`) in the blocking baseline gate so new high-score or sensitive swallowed-exception debt cannot land silently in those lanes.

## Intentional
- This does not fix existing brittle files in `agents`, `capabilities`, or `tools`; it snapshots current debt and blocks new debt.
- This does not broaden `tests/**`; that broad trigger already exists from earlier maturity-sweep phases.
- Security-named files/directories are sensitive in B2d because this scope includes `atlas_brain/agents/graphs/security.py` and `atlas_brain/tools/security.py`, which the common billing/auth/webhook/payment/delete globs do not catch.

## Deferred
- B2e: enroll `atlas_brain/services/scraping`.
- Phase C: enroll the remaining `extracted_*` packages and `scripts/**` with lane-specific baselines.

## Parked hardening
- None.

## Verification
- `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` - pass.
- `python -m pytest tests/test_maturity_sweep.py --noconftest -q` - pass, 14 passed.
- B2d ratchet loop over `agents capabilities tools` with the shipped sensitive globs - pass.
- Path-filter spot check for `atlas_brain/agents/**`, `atlas_brain/capabilities/**`, `atlas_brain/tools/**`, and retained `tests/**` - pass.
- Scratch sensitive-path negative proof in `atlas_brain/tools/security.py` - pass. Temporary probe failed with `score increased (8 -> 13)` and `new sensitive-path SWALLOWED_EXCEPT (0 -> 1)`; scratch code was removed and the clean loop reran successfully.
- `python scripts/sync_pr_plan.py plans/PR-Maturity-Sweep-Atlas-Brain-B2d.md --check` - pass.

## Diff size
5 files, +412 / -0. Over the 400 LOC soft cap because the workflow loop needs all three current baselines to land green; splitting the baselines from the gate would ship a red or ineffective CI change.
