### PR TITLE
Deflection paid unlock metadata guard

### DIFF
--- a/plans/PR-Deflection-Paid-Unlock-Metadata-Guard.md
+++ b/plans/PR-Deflection-Paid-Unlock-Metadata-Guard.md
@@ -1,0 +1,116 @@
+# PR-Deflection-Paid-Unlock-Metadata-Guard
+
+## Why this slice exists
+
+#1612 is now proven end to end via Stripe test mode: a no-live-charge Checkout
+completed, the hosted ATLAS webhook unlocked the report, the buyer page rendered
+the full report, and the buyer report email arrived. The manual proof exposed a
+tooling defect first: the paid-unlock smoke trusted caller-supplied
+`account_id` metadata even though the persisted report row already had the
+authoritative account. That allowed a valid test payment to be signed for the
+wrong tenant and fail later as `paid_report_missing_after_payment`.
+
+Root cause: the proof runner accepts account/report metadata from the operator
+instead of verifying it against the stored `content_ops_deflection_reports`
+record before posting a signed Stripe-shaped webhook.
+
+This change fixes the root for the existing signed-webhook proof path by adding
+an opt-in persisted-row guard that derives or verifies the account id from the
+report store before the webhook is sent. It does not build the future hosted
+Stripe test Checkout helper; that remains the next #1440 proof tooling slice.
+
+Diff-size note: this is over the 400 LOC soft cap because guard-shaped billing
+proof code needs both sides of the boundary covered: derived success,
+explicit-mismatch rejection, missing-row rejection, env-default handling, and
+existing unguarded compatibility.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/report-delivery-live-funnel
+Slice phase: Production hardening
+
+1. Extend the existing paid-unlock smoke with an opt-in persisted-report
+   metadata guard.
+2. When the guard is enabled, require an explicit Postgres DSN, look up the
+   report by request id, and either derive the account id or fail if the
+   supplied account id disagrees.
+3. Keep the existing no-DB signed-webhook mode for deterministic CI tests and
+   older runbooks.
+4. Add focused regression tests for derived metadata, mismatched metadata,
+   missing report row, and sanitized result output.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Guarded mode posts webhook metadata using the persisted report row's
+        account id when the caller omits account id.
+  - [ ] Guarded mode fails before posting a webhook when caller account id
+        differs from the persisted report row.
+  - [ ] Guarded mode fails clearly when the requested report row is missing.
+  - [ ] Existing unguarded signed-webhook smoke behavior remains compatible.
+  - [ ] Result artifacts do not expose token or webhook secret values.
+- Affected surfaces: operator smoke script, smoke tests, #1612/#1440 proof
+  tooling.
+- Risk areas: billing proof correctness, tenant isolation, webhook
+  idempotency, CI enrollment.
+- Reviewer rules triggered: R2, R3, R6, R8, R10, R12, R14.
+
+### Files touched
+
+- `plans/PR-Deflection-Paid-Unlock-Metadata-Guard.md`
+- `scripts/smoke_content_ops_deflection_stripe_paid_unlock.py`
+- `tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py`
+
+## Mechanism
+
+Add a guarded metadata resolution step before the script performs its locked
+artifact check and webhook post. In guarded mode the script reads the report
+row from `content_ops_deflection_reports` by request id, expects exactly one
+row, and uses that row's account id as the Stripe metadata account. If the
+operator also supplied an account id, it must match the persisted row.
+
+The lookup is isolated behind a small injectable helper so tests can exercise
+the behavior without a real Postgres connection. The helper uses an explicit
+DSN supplied to the smoke command; it does not introduce a new Atlas config
+field or depend on the app's already-initialized DB pool.
+
+The result payload records whether persisted metadata was used, whether the
+caller supplied an account id, and whether the account id was derived, but it
+continues to avoid secrets and does not add raw webhook bodies to output.
+
+## Intentional
+
+- No hosted Stripe Checkout creation in this slice. The existing script signs a
+  Stripe-shaped webhook for deterministic paid-gate proof; the next slice can
+  add a separate operator-run Checkout helper for live Stripe test mode.
+- No required DB lookup in the default path. CI and older runbooks can keep
+  using the current explicit account id flow.
+- The Postgres lookup is by request id and fails if zero or multiple rows are
+  returned. Guessing on ambiguity would recreate the tenant-metadata problem.
+
+## Deferred
+
+- #1440 follow-up: add an operator-run Stripe test-mode Checkout helper that
+  creates the hosted Checkout Session from the persisted report row, waits for
+  webhook unlock, and emits sanitized proof.
+- #1440 follow-up: run the full-volume funnel using the hardened paid-unlock
+  proof path.
+
+Parked hardening: none.
+
+## Verification
+
+- Compile check for the paid-unlock smoke script and focused test file -
+  passed.
+- Focused paid-unlock smoke tests - 16 passed.
+- Extracted pipeline checks - 4665 passed, 10 skipped, 1 warning.
+- Pending before push: local PR review via the push wrapper.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Paid-Unlock-Metadata-Guard.md` | 116 |
+| `scripts/smoke_content_ops_deflection_stripe_paid_unlock.py` | 153 |
+| `tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py` | 217 |
+| **Total** | **486** |

--- a/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import hashlib
 import hmac
 import json
@@ -51,6 +52,14 @@ class HttpResult:
     errors: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class MetadataResolution:
+    account_id: str
+    account_id_source: str
+    account_id_supplied: bool
+    report_row_checked: bool
+
+
 def _load_dotenv_files() -> None:
     if load_dotenv is not None:
         load_dotenv(ROOT / ".env")
@@ -74,6 +83,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--token", default=_env("ATLAS_B2B_JWT", "ATLAS_TOKEN"))
     parser.add_argument("--webhook-secret", default=_env("ATLAS_SAAS_STRIPE_WEBHOOK_SECRET", "STRIPE_WEBHOOK_SECRET"))
     parser.add_argument("--account-id", default=_env("ATLAS_ACCOUNT_ID", "ATLAS_FAQ_SEARCH_ACCOUNT_ID"))
+    parser.add_argument("--database-url", default="")
+    parser.add_argument(
+        "--derive-account-id-from-report",
+        action="store_true",
+        help="Look up the report row and use its account_id for Stripe metadata.",
+    )
     parser.add_argument("--request-id", default=_env("ATLAS_DEFLECTION_REQUEST_ID"))
     parser.add_argument("--event-id", default=_env("ATLAS_DEFLECTION_STRIPE_EVENT_ID"))
     parser.add_argument("--session-id", default=_env("ATLAS_DEFLECTION_STRIPE_SESSION_ID"))
@@ -118,14 +133,18 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required")
     if not _clean(args.webhook_secret):
         errors.append("ATLAS_SAAS_STRIPE_WEBHOOK_SECRET, STRIPE_WEBHOOK_SECRET, or --webhook-secret is required")
+    derive_account_id = bool(getattr(args, "derive_account_id_from_report", False))
     account_id = _clean(args.account_id)
     if not account_id:
-        errors.append("ATLAS_ACCOUNT_ID, ATLAS_FAQ_SEARCH_ACCOUNT_ID, or --account-id is required")
+        if not derive_account_id:
+            errors.append("ATLAS_ACCOUNT_ID, ATLAS_FAQ_SEARCH_ACCOUNT_ID, or --account-id is required")
     else:
         try:
             uuid.UUID(account_id)
         except ValueError:
             errors.append("--account-id must be a UUID for the Stripe metadata contract")
+    if derive_account_id and not _clean(getattr(args, "database_url", "")):
+        errors.append("--database-url is required with --derive-account-id-from-report")
     if not _clean(args.request_id):
         errors.append("ATLAS_DEFLECTION_REQUEST_ID or --request-id is required")
     if int(args.amount_total) <= 0:
@@ -152,6 +171,89 @@ def _join_url(base_url: str, path: str) -> str:
 
 def _open_http_request(request: urllib.request.Request, *, timeout: float) -> Any:
     return urllib.request.urlopen(request, timeout=timeout)
+
+
+async def _fetch_report_account_ids(database_url: str, request_id: str) -> list[str]:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError("asyncpg is required to derive account_id from the report row") from exc
+
+    pool = await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=1)
+    try:
+        rows = await pool.fetch(
+            """
+            SELECT account_id::text AS account_id
+            FROM content_ops_deflection_reports
+            WHERE request_id = $1
+            ORDER BY created_at DESC
+            LIMIT 2
+            """,
+            request_id,
+        )
+    finally:
+        await pool.close()
+    return [_clean(row["account_id"]) for row in rows if _clean(row["account_id"])]
+
+
+def _lookup_report_account_id(database_url: str, request_id: str) -> str:
+    account_ids = asyncio.run(_fetch_report_account_ids(database_url, request_id))
+    if not account_ids:
+        raise RuntimeError("persisted deflection report row was not found")
+    if len(account_ids) > 1:
+        raise RuntimeError("persisted deflection report request_id is ambiguous")
+    account_id = account_ids[0]
+    try:
+        uuid.UUID(account_id)
+    except ValueError as exc:
+        raise RuntimeError("persisted report account_id is not a UUID") from exc
+    return account_id
+
+
+def _resolve_metadata(args: argparse.Namespace) -> tuple[MetadataResolution | None, list[str]]:
+    supplied_account_id = _clean(args.account_id)
+    account_id_explicit = bool(
+        getattr(args, "account_id_explicit", bool(supplied_account_id))
+    )
+    if not bool(getattr(args, "derive_account_id_from_report", False)):
+        return (
+            MetadataResolution(
+                account_id=supplied_account_id,
+                account_id_source="supplied",
+                account_id_supplied=bool(supplied_account_id),
+                report_row_checked=False,
+            ),
+            [],
+        )
+
+    try:
+        persisted_account_id = _lookup_report_account_id(
+            _clean(args.database_url),
+            _clean(args.request_id),
+        )
+    except RuntimeError as exc:
+        return (None, [str(exc)])
+
+    if account_id_explicit and supplied_account_id and supplied_account_id != persisted_account_id:
+        return (
+            MetadataResolution(
+                account_id=persisted_account_id,
+                account_id_source="persisted_report",
+                account_id_supplied=True,
+                report_row_checked=True,
+            ),
+            ["--account-id does not match the persisted deflection report row"],
+        )
+
+    return (
+        MetadataResolution(
+            account_id=persisted_account_id,
+            account_id_source="persisted_report",
+            account_id_supplied=account_id_explicit and bool(supplied_account_id),
+            report_row_checked=True,
+        ),
+        [],
+    )
 
 
 def _read_http_error(exc: urllib.error.HTTPError) -> str:
@@ -295,7 +397,13 @@ def _result_payload(
     replay_webhook: HttpResult | None = None,
     after_artifact: HttpResult | None = None,
     errors: Sequence[str] = (),
+    metadata_resolution: MetadataResolution | None = None,
 ) -> dict[str, Any]:
+    resolved_account_id = (
+        metadata_resolution.account_id
+        if metadata_resolution is not None
+        else _clean(args.account_id)
+    )
     return {
         "ok": not preflight_errors and not errors,
         "preflight_errors": list(preflight_errors),
@@ -303,11 +411,25 @@ def _result_payload(
         "inputs": {
             "base_url": _clean(args.base_url),
             "request_id": _clean(args.request_id),
-            "account_id": _clean(args.account_id),
+            "account_id": resolved_account_id,
             "event_id": event_id,
             "session_id": session_id,
             "token_present": bool(_clean(args.token)),
             "webhook_secret_present": bool(_clean(args.webhook_secret)),
+            "database_url_present": bool(_clean(getattr(args, "database_url", ""))),
+            "metadata_resolution": (
+                {
+                    "account_id_source": metadata_resolution.account_id_source,
+                    "account_id_supplied": metadata_resolution.account_id_supplied,
+                    "report_row_checked": metadata_resolution.report_row_checked,
+                }
+                if metadata_resolution is not None
+                else {
+                    "account_id_source": "unresolved",
+                    "account_id_supplied": bool(_clean(args.account_id)),
+                    "report_row_checked": False,
+                }
+            ),
         },
         "before_artifact": _http_summary(
             before_artifact,
@@ -333,7 +455,9 @@ def _write_result(path: Path | None, payload: Mapping[str, Any]) -> None:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = _build_parser().parse_args(argv)
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    args = _build_parser().parse_args(raw_argv)
+    args.account_id_explicit = "--account-id" in raw_argv
     preflight_errors = _validate_args(args)
     event_id = _clean(args.event_id) or _generated_id("evt_content_ops_deflection_paid")
     session_id = _clean(args.session_id) or _generated_id("cs_content_ops_deflection")
@@ -350,6 +474,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             print("preflight failed" if preflight_errors else "preflight passed")
         return 2 if preflight_errors else 0
+
+    metadata_resolution, metadata_errors = _resolve_metadata(args)
+    if metadata_errors:
+        payload = _result_payload(
+            args=args,
+            preflight_errors=(),
+            event_id=event_id,
+            session_id=session_id,
+            metadata_resolution=metadata_resolution,
+            errors=metadata_errors,
+        )
+        _write_result(args.output_result, payload)
+        if args.json:
+            print(json.dumps(payload, sort_keys=True))
+        else:
+            print("stripe paid-unlock smoke failed")
+        return 1
+    if metadata_resolution is None:
+        raise AssertionError("metadata resolution unexpectedly missing")
 
     request_id = _clean(args.request_id)
     artifact_path = _clean(args.artifact_path_template).format(
@@ -372,6 +515,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             session_id=session_id,
             before_artifact=before_artifact,
             errors=errors,
+            metadata_resolution=metadata_resolution,
         )
         _write_result(args.output_result, payload)
         if args.json:
@@ -383,7 +527,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     event = _stripe_event_payload(
         event_id=event_id,
         session_id=session_id,
-        account_id=_clean(args.account_id),
+        account_id=metadata_resolution.account_id,
         request_id=request_id,
         amount_total=int(args.amount_total),
         currency=_clean(args.currency).lower(),
@@ -448,6 +592,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         replay_webhook=replay_webhook,
         after_artifact=after_artifact,
         errors=errors,
+        metadata_resolution=metadata_resolution,
     )
     _write_result(args.output_result, payload)
     if args.json:

--- a/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -225,7 +225,7 @@ def _lookup_report_account_id(database_url: str, request_id: str) -> str:
         raise RuntimeError("persisted deflection report row was not found")
     if len(account_ids) > 1:
         raise RuntimeError("persisted deflection report request_id is ambiguous")
-    account_id = account_ids[0]
+    account_id = next(iter(account_ids))
     try:
         uuid.UUID(account_id)
     except ValueError as exc:

--- a/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -176,31 +176,51 @@ def _open_http_request(request: urllib.request.Request, *, timeout: float) -> An
     return urllib.request.urlopen(request, timeout=timeout)
 
 
+def _report_lookup_error(exc: BaseException) -> RuntimeError:
+    detail = _redact_error_detail(exc)
+    message = "persisted report lookup failed"
+    if detail:
+        message = f"{message}: {detail}"
+    return RuntimeError(message)
+
+
 async def _fetch_report_account_ids(database_url: str, request_id: str) -> list[str]:
     try:
         import asyncpg  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover - host dependency
         raise RuntimeError("asyncpg is required to derive account_id from the report row") from exc
 
-    pool = await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=1)
     try:
-        rows = await pool.fetch(
-            """
-            SELECT account_id::text AS account_id
-            FROM content_ops_deflection_reports
-            WHERE request_id = $1
-            ORDER BY created_at DESC
-            LIMIT 2
-            """,
-            request_id,
-        )
-    finally:
-        await pool.close()
+        pool = await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=1)
+        try:
+            rows = await pool.fetch(
+                """
+                SELECT account_id::text AS account_id
+                FROM content_ops_deflection_reports
+                WHERE request_id = $1
+                ORDER BY created_at DESC
+                LIMIT 2
+                """,
+                request_id,
+            )
+        finally:
+            await pool.close()
+    except (
+        OSError,
+        TimeoutError,
+        ValueError,
+        asyncio.TimeoutError,
+        asyncpg.PostgresError,
+    ) as exc:
+        raise _report_lookup_error(exc) from exc
     return [_clean(row["account_id"]) for row in rows if _clean(row["account_id"])]
 
 
 def _lookup_report_account_id(database_url: str, request_id: str) -> str:
-    account_ids = asyncio.run(_fetch_report_account_ids(database_url, request_id))
+    try:
+        account_ids = asyncio.run(_fetch_report_account_ids(database_url, request_id))
+    except (OSError, TimeoutError, ValueError, asyncio.TimeoutError) as exc:
+        raise _report_lookup_error(exc) from exc
     if not account_ids:
         raise RuntimeError("persisted deflection report row was not found")
     if len(account_ids) > 1:
@@ -236,12 +256,6 @@ def _resolve_metadata(args: argparse.Namespace) -> tuple[MetadataResolution | No
         )
     except RuntimeError as exc:
         return (None, [str(exc)])
-    except Exception as exc:
-        detail = _redact_error_detail(exc)
-        error = "persisted report lookup failed"
-        if detail:
-            error = f"{error}: {detail}"
-        return (None, [error])
 
     if account_id_explicit and supplied_account_id and supplied_account_id != persisted_account_id:
         return (

--- a/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -135,10 +135,13 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("ATLAS_SAAS_STRIPE_WEBHOOK_SECRET, STRIPE_WEBHOOK_SECRET, or --webhook-secret is required")
     derive_account_id = bool(getattr(args, "derive_account_id_from_report", False))
     account_id = _clean(args.account_id)
+    account_id_explicit = bool(
+        getattr(args, "account_id_explicit", bool(account_id))
+    )
     if not account_id:
         if not derive_account_id:
             errors.append("ATLAS_ACCOUNT_ID, ATLAS_FAQ_SEARCH_ACCOUNT_ID, or --account-id is required")
-    else:
+    elif not derive_account_id or account_id_explicit:
         try:
             uuid.UUID(account_id)
         except ValueError:
@@ -233,6 +236,12 @@ def _resolve_metadata(args: argparse.Namespace) -> tuple[MetadataResolution | No
         )
     except RuntimeError as exc:
         return (None, [str(exc)])
+    except Exception as exc:
+        detail = _redact_error_detail(exc)
+        error = "persisted report lookup failed"
+        if detail:
+            error = f"{error}: {detail}"
+        return (None, [error])
 
     if account_id_explicit and supplied_account_id and supplied_account_id != persisted_account_id:
         return (
@@ -457,7 +466,10 @@ def _write_result(path: Path | None, payload: Mapping[str, Any]) -> None:
 def main(argv: Sequence[str] | None = None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     args = _build_parser().parse_args(raw_argv)
-    args.account_id_explicit = "--account-id" in raw_argv
+    args.account_id_explicit = any(
+        value == "--account-id" or value.startswith("--account-id=")
+        for value in raw_argv
+    )
     preflight_errors = _validate_args(args)
     event_id = _clean(args.event_id) or _generated_id("evt_content_ops_deflection_paid")
     session_id = _clean(args.session_id) or _generated_id("cs_content_ops_deflection")

--- a/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -203,6 +203,33 @@ def test_metadata_resolution_ignores_env_default_account_when_deriving(
     )
 
 
+def test_validate_args_ignores_non_explicit_env_account_when_deriving() -> None:
+    args = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "secret-token",
+        "--webhook-secret",
+        "whsec_test",
+        "--account-id",
+        "acct-123",
+        "--request-id",
+        "content-ops-123",
+        "--database-url",
+        "postgres://example",
+        "--derive-account-id-from-report",
+    ])
+    args.account_id_explicit = False
+
+    assert smoke._validate_args(args) == []
+
+    args.account_id_explicit = True
+
+    assert smoke._validate_args(args) == [
+        "--account-id must be a UUID for the Stripe metadata contract"
+    ]
+
+
 def test_preflight_only_writes_redacted_inputs_without_network(monkeypatch, tmp_path, capsys) -> None:
     def _unexpected(*_args, **_kwargs):
         raise AssertionError("preflight must not call network")
@@ -380,6 +407,37 @@ def test_main_rejects_mismatched_persisted_account_before_network(
     }
 
 
+def test_main_treats_equals_form_account_id_as_explicit(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    def _unexpected_network(*_args, **_kwargs):
+        raise AssertionError("mismatched account must stop before network")
+
+    monkeypatch.setattr(smoke, "_lookup_report_account_id", lambda *_args: ACCOUNT_ID)
+    monkeypatch.setattr(smoke, "_open_http_request", _unexpected_network)
+
+    code = smoke.main([
+        *_without_account_id(_base_args(tmp_path)),
+        f"--account-id={OTHER_ACCOUNT_ID}",
+        "--database-url",
+        "postgres://example",
+        "--derive-account-id-from-report",
+    ])
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["errors"] == [
+        "--account-id does not match the persisted deflection report row"
+    ]
+    assert payload["inputs"]["metadata_resolution"] == {
+        "account_id_source": "persisted_report",
+        "account_id_supplied": True,
+        "report_row_checked": True,
+    }
+
+
 def test_main_reports_missing_persisted_report_before_network(
     monkeypatch,
     tmp_path,
@@ -406,6 +464,42 @@ def test_main_reports_missing_persisted_report_before_network(
     assert code == 1
     assert payload["ok"] is False
     assert payload["errors"] == ["persisted deflection report row was not found"]
+    assert payload["inputs"]["metadata_resolution"] == {
+        "account_id_source": "unresolved",
+        "account_id_supplied": False,
+        "report_row_checked": False,
+    }
+    assert "postgres://example" not in json.dumps(payload)
+
+
+def test_main_reports_database_lookup_failure_before_network(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    def _lookup_failure(*_args):
+        raise OSError("database connection failed")
+
+    def _unexpected_network(*_args, **_kwargs):
+        raise AssertionError("database lookup failure must stop before network")
+
+    monkeypatch.setattr(smoke, "_lookup_report_account_id", _lookup_failure)
+    monkeypatch.setattr(smoke, "_open_http_request", _unexpected_network)
+
+    code = smoke.main([
+        *_without_account_id(_base_args(tmp_path)),
+        "--account-id",
+        "",
+        "--database-url",
+        "postgres://example",
+        "--derive-account-id-from-report",
+    ])
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["errors"] == [
+        "persisted report lookup failed: database connection failed"
+    ]
     assert payload["inputs"]["metadata_resolution"] == {
         "account_id_source": "unresolved",
         "account_id_supplied": False,

--- a/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -23,6 +23,7 @@ SPEC.loader.exec_module(smoke)
 
 
 ACCOUNT_ID = "11111111-1111-4111-8111-111111111111"
+OTHER_ACCOUNT_ID = "22222222-2222-4222-8222-222222222222"
 ARTIFACT = {
     "summary": {"source_count": 2},
     "markdown": "# Paid report",
@@ -71,6 +72,20 @@ def _base_args(tmp_path: Path) -> list[str]:
     ]
 
 
+def _without_account_id(args: list[str]) -> list[str]:
+    out: list[str] = []
+    skip_next = False
+    for value in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if value == "--account-id":
+            skip_next = True
+            continue
+        out.append(value)
+    return out
+
+
 def _http_error(url: str, status: int, body: dict[str, Any] | None = None) -> urllib.error.HTTPError:
     fp = None
     if body is not None:
@@ -114,6 +129,78 @@ def test_validate_args_fails_closed_for_missing_and_unsafe_inputs() -> None:
         "--webhook-path must start with /",
         "--artifact-path-template must include {request_id}",
     ]
+
+
+def test_validate_args_requires_database_url_when_deriving_account_id() -> None:
+    args = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "secret-token",
+        "--webhook-secret",
+        "whsec_test",
+        "--account-id",
+        "",
+        "--request-id",
+        "content-ops-123",
+        "--derive-account-id-from-report",
+    ])
+
+    assert smoke._validate_args(args) == [
+        "--database-url is required with --derive-account-id-from-report",
+    ]
+
+
+def test_validate_args_allows_missing_account_id_when_report_lookup_is_enabled() -> None:
+    args = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "secret-token",
+        "--webhook-secret",
+        "whsec_test",
+        "--account-id",
+        "",
+        "--request-id",
+        "content-ops-123",
+        "--database-url",
+        "postgres://example",
+        "--derive-account-id-from-report",
+    ])
+
+    assert smoke._validate_args(args) == []
+
+
+def test_metadata_resolution_ignores_env_default_account_when_deriving(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(smoke, "_lookup_report_account_id", lambda *_args: ACCOUNT_ID)
+    args = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "secret-token",
+        "--webhook-secret",
+        "whsec_test",
+        "--account-id",
+        OTHER_ACCOUNT_ID,
+        "--request-id",
+        "content-ops-123",
+        "--database-url",
+        "postgres://example",
+        "--derive-account-id-from-report",
+    ])
+    args.account_id_explicit = False
+
+    metadata_resolution, errors = smoke._resolve_metadata(args)
+
+    assert errors == []
+    assert metadata_resolution == smoke.MetadataResolution(
+        account_id=ACCOUNT_ID,
+        account_id_source="persisted_report",
+        account_id_supplied=False,
+        report_row_checked=True,
+    )
 
 
 def test_preflight_only_writes_redacted_inputs_without_network(monkeypatch, tmp_path, capsys) -> None:
@@ -195,6 +282,136 @@ def test_main_posts_signed_webhook_and_unlocks_artifact(monkeypatch, tmp_path, c
         "account_id": ACCOUNT_ID,
         "request_id": "content-ops-123",
     }
+
+
+def test_main_derives_account_id_from_persisted_report_before_webhook(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _lookup(database_url: str, request_id: str) -> str:
+        assert database_url == "postgres://example"
+        assert request_id == "content-ops-123"
+        return ACCOUNT_ID
+
+    def _open(request, *, timeout):
+        body = request.data or b""
+        calls.append({
+            "url": request.full_url,
+            "method": request.get_method(),
+            "headers": dict(request.header_items()),
+            "body": body.decode("utf-8"),
+            "timeout": timeout,
+        })
+        if request.get_method() == "GET" and len([c for c in calls if c["method"] == "GET"]) == 1:
+            raise _http_error(request.full_url, 403, {"detail": "payment_required"})
+        if request.get_method() == "POST":
+            return FakeResponse(200, {"status": "ok"})
+        return FakeResponse(200, ARTIFACT)
+
+    monkeypatch.setattr(smoke, "_lookup_report_account_id", _lookup)
+    monkeypatch.setattr(smoke, "_open_http_request", _open)
+    monkeypatch.setattr(smoke.time, "time", lambda: 1700000000)
+
+    code = smoke.main([
+        *_without_account_id(_base_args(tmp_path)),
+        "--account-id",
+        "",
+        "--database-url",
+        "postgres://example",
+        "--derive-account-id-from-report",
+        "--json",
+    ])
+
+    assert code == 0
+    printed = json.loads(capsys.readouterr().out)
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    assert printed == payload
+    assert payload["ok"] is True
+    assert payload["inputs"]["account_id"] == ACCOUNT_ID
+    assert payload["inputs"]["database_url_present"] is True
+    assert payload["inputs"]["metadata_resolution"] == {
+        "account_id_source": "persisted_report",
+        "account_id_supplied": False,
+        "report_row_checked": True,
+    }
+    assert "postgres://example" not in json.dumps(payload)
+
+    event = json.loads(calls[1]["body"])
+    assert event["data"]["object"]["metadata"] == {
+        "source": "content_ops_deflection_report",
+        "account_id": ACCOUNT_ID,
+        "request_id": "content-ops-123",
+    }
+
+
+def test_main_rejects_mismatched_persisted_account_before_network(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    def _unexpected_network(*_args, **_kwargs):
+        raise AssertionError("mismatched account must stop before network")
+
+    monkeypatch.setattr(smoke, "_lookup_report_account_id", lambda *_args: ACCOUNT_ID)
+    monkeypatch.setattr(smoke, "_open_http_request", _unexpected_network)
+
+    args = _base_args(tmp_path)
+    args[args.index("--account-id") + 1] = OTHER_ACCOUNT_ID
+    code = smoke.main([
+        *args,
+        "--database-url",
+        "postgres://example",
+        "--derive-account-id-from-report",
+    ])
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["errors"] == [
+        "--account-id does not match the persisted deflection report row"
+    ]
+    assert payload["inputs"]["account_id"] == ACCOUNT_ID
+    assert payload["inputs"]["metadata_resolution"] == {
+        "account_id_source": "persisted_report",
+        "account_id_supplied": True,
+        "report_row_checked": True,
+    }
+
+
+def test_main_reports_missing_persisted_report_before_network(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    def _missing(*_args):
+        raise RuntimeError("persisted deflection report row was not found")
+
+    def _unexpected_network(*_args, **_kwargs):
+        raise AssertionError("missing report must stop before network")
+
+    monkeypatch.setattr(smoke, "_lookup_report_account_id", _missing)
+    monkeypatch.setattr(smoke, "_open_http_request", _unexpected_network)
+
+    code = smoke.main([
+        *_without_account_id(_base_args(tmp_path)),
+        "--account-id",
+        "",
+        "--database-url",
+        "postgres://example",
+        "--derive-account-id-from-report",
+    ])
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["errors"] == ["persisted deflection report row was not found"]
+    assert payload["inputs"]["metadata_resolution"] == {
+        "account_id_source": "unresolved",
+        "account_id_supplied": False,
+        "report_row_checked": False,
+    }
+    assert "postgres://example" not in json.dumps(payload)
 
 
 def test_main_replays_signed_webhook_and_requires_idempotent_response(

--- a/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -476,13 +476,13 @@ def test_main_reports_database_lookup_failure_before_network(
     monkeypatch,
     tmp_path,
 ) -> None:
-    def _lookup_failure(*_args):
+    async def _lookup_failure(*_args):
         raise OSError("database connection failed")
 
     def _unexpected_network(*_args, **_kwargs):
         raise AssertionError("database lookup failure must stop before network")
 
-    monkeypatch.setattr(smoke, "_lookup_report_account_id", _lookup_failure)
+    monkeypatch.setattr(smoke, "_fetch_report_account_ids", _lookup_failure)
     monkeypatch.setattr(smoke, "_open_http_request", _unexpected_network)
 
     code = smoke.main([


### PR DESCRIPTION
Plan: plans/PR-Deflection-Paid-Unlock-Metadata-Guard.md
Slice phase: Production hardening

#1612 is now proven end to end via Stripe test mode, but the manual proof exposed a tooling defect first: the paid-unlock smoke trusted caller-supplied account metadata even when the persisted report row already held the authoritative tenant. This PR hardens the existing signed-webhook proof path so guarded runs derive or verify Stripe metadata from the stored report before posting a paid event.

## Intentional
- No hosted Stripe Checkout creation in this slice; that operator-run test-mode helper remains the next #1440 proof tooling slice.
- Guarded mode is opt-in, so existing deterministic CI/runbook usage stays compatible.
- The Postgres lookup fails on zero or multiple matching rows rather than guessing.

## Deferred
- #1440 follow-up: add an operator-run Stripe test-mode Checkout helper that creates Checkout from the persisted report row, waits for webhook unlock, and emits sanitized proof.
- #1440 follow-up: run the full-volume funnel using the hardened paid-unlock proof path.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/smoke_content_ops_deflection_stripe_paid_unlock.py tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py` - passed.
- `pytest tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py -q` - 16 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 4665 passed, 10 skipped, 1 warning.

## Diff size
3 files, +482 / -4
