### PR TITLE
Add repo-wide unit backstop workflow

### DIFF
--- a/.github/workflows/repo_wide_unit_backstop.yml
+++ b/.github/workflows/repo_wide_unit_backstop.yml
@@ -1,0 +1,50 @@
+name: Repo-Wide Unit Backstop
+
+# The per-area checks are path-filtered and run explicit, hand-maintained test
+# lists, so a test file that no workflow enrolls can pass CI while never
+# executing. This catch-all runs the whole unit suite (no integration/e2e, which
+# need Postgres/Neo4j) so nothing hides indefinitely. It is intentionally NOT a
+# per-PR gate -- it runs on a schedule and on demand, separate from the fast
+# path-filtered checks. The pull_request trigger is scoped to this workflow file
+# only, so changes to the backstop itself are exercised immediately without
+# adding a slow full-suite run to every unrelated PR.
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # 06:00 UTC daily (~1:00am CDT). UTC<->Central: subtract 5h (CDT) / 6h (CST).
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/repo_wide_unit_backstop.yml"
+
+concurrency:
+  group: repo-wide-unit-backstop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repo-wide-unit-backstop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run repo-wide unit suite (no integration/e2e)
+        run: |
+          python -m pytest -m "not integration and not e2e" -q

--- a/.github/workflows/repo_wide_unit_backstop.yml
+++ b/.github/workflows/repo_wide_unit_backstop.yml
@@ -47,4 +47,8 @@ jobs:
 
       - name: Run repo-wide unit suite (no integration/e2e)
         run: |
-          python -m pytest -m "not integration and not e2e" -q
+          # --continue-on-collection-errors so one un-importable module (e.g. an
+          # optional-dependency MCP server) cannot abort the whole backstop at
+          # collection; import gaps are reported as errors alongside real results.
+          python -m pytest -m "not integration and not e2e" -q \
+            --continue-on-collection-errors

--- a/plans/PR-CI-Repo-Wide-Unit-Backstop.md
+++ b/plans/PR-CI-Repo-Wide-Unit-Backstop.md
@@ -59,11 +59,15 @@ Reviewer rules triggered: R1, R14.
 ## Mechanism
 
 A single job installs `requirements.txt` + pytest and runs
-`python -m pytest -m "not integration and not e2e" -q`. Because it does not
-path-filter the test set, a file that no per-area workflow enrolls is still
-executed here. The `pull_request` path filter is the workflow file itself, which
-makes the backstop self-exercising on this PR (immediate proof it runs) while
-keeping it off the critical path of normal PRs.
+`python -m pytest -m "not integration and not e2e" -q
+--continue-on-collection-errors`. Because it does not path-filter the test set, a
+file that no per-area workflow enrolls is still executed here.
+`--continue-on-collection-errors` keeps one un-importable module (e.g. an
+optional-dependency MCP server whose mock has drifted) from aborting the whole
+run at collection; import gaps surface as reported errors next to real results
+instead of zeroing out the signal. The `pull_request` path filter is the workflow
+file itself, which makes the backstop self-exercising on this PR (immediate proof
+it runs) while keeping it off the critical path of normal PRs.
 
 ## Intentional
 
@@ -78,6 +82,14 @@ keeping it off the critical path of normal PRs.
 
 ## Deferred
 
+- Resolve the import-gap modules the backstop's first run surfaced: ~11 test
+  modules cannot be collected in a base `requirements.txt` env -- mostly MCP
+  servers (`mcp.server.auth` absent; the `_MockFastMCP` fallback has drifted
+  behind `structured_output` / `custom_route`), plus an `asyncpg.__spec__`
+  import quirk and a few others. Decide per family whether to install the real
+  dependency in this job, refresh the mock, or mark them so the backstop can go
+  green. Until then this check stays red by design (it is reporting real gaps,
+  not a regression in this slice).
 - Broaden `audit_extracted_pipeline_ci_enrollment.py` (and make it
   workflow-aware) so deflection/content-ops test families are flagged for
   enrollment at PR time, not only caught nightly by this backstop.
@@ -99,6 +111,6 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/repo_wide_unit_backstop.yml` | 52 |
-| `plans/PR-CI-Repo-Wide-Unit-Backstop.md` | 95 |
-| **Total** | **147** |
+| `.github/workflows/repo_wide_unit_backstop.yml` | 54 |
+| `plans/PR-CI-Repo-Wide-Unit-Backstop.md` | 116 |
+| **Total** | **170** |

--- a/plans/PR-CI-Repo-Wide-Unit-Backstop.md
+++ b/plans/PR-CI-Repo-Wide-Unit-Backstop.md
@@ -90,6 +90,14 @@ it runs) while keeping it off the critical path of normal PRs.
   dependency in this job, refresh the mock, or mark them so the backstop can go
   green. Until then this check stays red by design (it is reporting real gaps,
   not a regression in this slice).
+- Resolve the unmarked DB-backed tests the backstop surfaced (review comment):
+  tests using the `db_pool` fixture marked only `@pytest.mark.asyncio` (e.g.
+  `tests/test_session_id_normalization.py`) are not excluded by
+  `not integration and not e2e`, so they fail against no Postgres. Either add a
+  Postgres service to this job or mark those tests `integration`. This, with the
+  import gaps above, is why the backstop is **advisory** (informational, not a
+  merge gate) at debut: a green backstop requires the repo's service-dependent
+  tests to be marked/provisioned, which is the larger test-hygiene follow-up.
 - Broaden `audit_extracted_pipeline_ci_enrollment.py` (and make it
   workflow-aware) so deflection/content-ops test families are flagged for
   enrollment at PR time, not only caught nightly by this backstop.

--- a/plans/PR-CI-Repo-Wide-Unit-Backstop.md
+++ b/plans/PR-CI-Repo-Wide-Unit-Backstop.md
@@ -1,0 +1,104 @@
+# PR-CI-Repo-Wide-Unit-Backstop
+
+## Why this slice exists
+
+CI runs no repo-wide test suite. Every `*_checks.yml` workflow is path-filtered
+and executes an explicit, hand-maintained list of test files, and the one safety
+net (`scripts/audit_extracted_pipeline_ci_enrollment.py`) only audits files whose
+names match a fixed allowlist (`test_extracted_content*`, `test_extracted_ticket_faq*`,
+...). A test file named outside those patterns -- e.g. the recently added
+`tests/test_deflection_snapshot_report_drift.py` -- can therefore pass all of CI
+while never running until someone manually enrolls it. That is a silent-coverage
+hole: a brand-new test, or a regression in a file enrolled only under another
+lane's path filter, can ship green.
+
+This slice adds the missing catch-all: a scheduled, on-demand full unit run so
+nothing hides indefinitely. It does not touch the fast path-filtered per-PR
+checks, which stay as the quick first line.
+
+## Scope (this PR)
+
+Ownership lane: ci/coverage
+Slice phase: Production hardening
+
+1. Add `.github/workflows/repo_wide_unit_backstop.yml` running
+   `pytest -m "not integration and not e2e"` over the whole `tests/` tree
+   (integration/e2e need Postgres/Neo4j and are out of scope for a no-services
+   runner).
+2. Triggers: `schedule` (daily, single commented cron with a UTC<->Central
+   note), `workflow_dispatch` for on-demand, and a `pull_request` trigger
+   **scoped to this workflow file only** so the backstop is exercised on changes
+   to itself without becoming a slow gate on every unrelated PR.
+3. `permissions: contents: read`, a `concurrency` group, and a per-job
+   `timeout-minutes` cap, matching repo workflow conventions.
+
+### Files touched
+
+- `.github/workflows/repo_wide_unit_backstop.yml`
+- `plans/PR-CI-Repo-Wide-Unit-Backstop.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- [ ] The workflow runs the unit suite repo-wide (no per-file allowlist) and
+      excludes integration/e2e markers.
+- [ ] It is not a per-PR gate: only schedule, manual dispatch, and self-file
+      changes trigger it.
+- [ ] Actions and permissions follow the repo's workflow-security posture
+      (`scripts/audit_workflow_security_posture.py` passes).
+
+Affected surfaces: CI only; no application code.
+
+Risk areas: a long full-suite runtime; surfacing pre-existing failures that the
+path-filtered lanes never ran (that is the intended signal, not a regression in
+this change).
+
+Reviewer rules triggered: R1, R14.
+
+## Mechanism
+
+A single job installs `requirements.txt` + pytest and runs
+`python -m pytest -m "not integration and not e2e" -q`. Because it does not
+path-filter the test set, a file that no per-area workflow enrolls is still
+executed here. The `pull_request` path filter is the workflow file itself, which
+makes the backstop self-exercising on this PR (immediate proof it runs) while
+keeping it off the critical path of normal PRs.
+
+## Intentional
+
+- Not a per-PR gate. The per-area path-filtered checks remain the fast layer;
+  this is the nightly/on-demand backstop, so it does not slow every PR.
+- No change to the enrollment auditor in this slice. Broadening the auditor's
+  name-pattern allowlist (so non-conforming files are flagged at PR time) is a
+  separate slice because that auditor is scoped to one workflow + runner and
+  would red-fail until cross-workflow enrollment is taught to it.
+- Integration/e2e excluded; those need Postgres/Neo4j and belong to their own
+  service-backed jobs.
+
+## Deferred
+
+- Broaden `audit_extracted_pipeline_ci_enrollment.py` (and make it
+  workflow-aware) so deflection/content-ops test families are flagged for
+  enrollment at PR time, not only caught nightly by this backstop.
+- Optionally gate merges on a green backstop once its runtime/flake profile is
+  known.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -c "import yaml; yaml.safe_load(open('.github/workflows/repo_wide_unit_backstop.yml'))"`
+  -- valid.
+- `python scripts/audit_workflow_security_posture.py` -- workflow security
+  posture audit passed.
+- The backstop runs on this PR via the self-scoped `pull_request` trigger; its
+  CI result is the live proof of repo-wide execution.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/repo_wide_unit_backstop.yml` | 52 |
+| `plans/PR-CI-Repo-Wide-Unit-Backstop.md` | 95 |
+| **Total** | **147** |


### PR DESCRIPTION
Plan: plans/PR-CI-Repo-Wide-Unit-Backstop.md
Slice phase: Production hardening

CI runs no repo-wide test suite: every `*_checks.yml` is path-filtered and runs an explicit, hand-maintained list of test files, and the enrollment auditor only covers files matching a fixed name-pattern allowlist. So a test file named outside those patterns can pass all of CI while never running until someone manually enrolls it. This adds the missing catch-all: a scheduled, on-demand full unit run so nothing hides indefinitely, without touching the fast path-filtered per-PR checks. It is an advisory (non-gating) check at debut: its first run surfaced real test-hygiene debt (import-gap modules + unmarked DB-backed tests), so a green backstop requires marking/provisioning the repo's service-dependent tests, which is the larger follow-up.

## Intentional

- Not a per-PR gate. The per-area path-filtered checks remain the fast layer; this is the nightly/on-demand backstop. The `pull_request` trigger is scoped to this workflow file only, so it self-exercises on this PR without slowing every unrelated PR.
- `--continue-on-collection-errors` so one un-importable module cannot abort the whole run at collection; import gaps are reported, not silently zeroing the signal.
- No enrollment-auditor change in this slice (that auditor is scoped to one workflow + runner and would red-fail until taught cross-workflow enrollment) -- deferred.
- Integration/e2e excluded; they need Postgres/Neo4j and belong to service-backed jobs.

## Deferred

- Resolve the import-gap modules and unmarked DB-backed tests the backstop surfaced (install optional deps / refresh mocks / mark service-dependent tests) so it can go green.
- Broaden `audit_extracted_pipeline_ci_enrollment.py` (and make it workflow-aware) so deflection/content-ops test families are flagged for enrollment at PR time.
- Optionally gate merges on a green backstop once its runtime/flake profile is known.

## Parked hardening

none

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/repo_wide_unit_backstop.yml'))"` -- valid.
- `python scripts/audit_workflow_security_posture.py` -- workflow security posture audit passed.
- The backstop runs on this PR via the self-scoped `pull_request` trigger; its CI result is the live proof of repo-wide execution (advisory; red at debut is the surfaced debt, see Deferred).

## Diff size

| File | LOC |
|---|---:|
| `.github/workflows/repo_wide_unit_backstop.yml` | 54 |
| `plans/PR-CI-Repo-Wide-Unit-Backstop.md` | 116 |
| **Total** | **170** |

## AI reconciliation

AI findings reviewed: Yes. All fixed or waived: Yes.

- Copilot scope-mismatch (`plans/...:39`) -- fixed: this PR was rebuilt off `main` to contain only the backstop workflow + plan (the CSAT/drift/PII changes were stacked in by a branching error and live on their own branches).
- Codex backstop unmarked-DB-tests (`repo_wide_unit_backstop.yml:50`) -- acknowledged/deferred: real test-hygiene debt the backstop is meant to surface; the check is advisory and the marking/provisioning follow-up is documented in the plan's Deferred.
- Codex CSAT fractional cutoff (`ticket_faq_markdown.py:1601`), percent parsing (`:496`), and submit-field-not-preserved (`control_surfaces.py:1397`), plus Copilot's fractional-cutoff note -- waived here (those files are not in this PR's diff after the rebuild). They are valid and are tracked on the CSAT slice (`PR-Deflection-CSAT-Scale-Hardening`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Bwpk9YWN2xGaE1jmNPYLP