### PR TITLE
Test-hygiene cleanup + repo-wide unit backstop (advisory)

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -9,10 +9,19 @@ on:
       - ".github/workflows/atlas_invoicing_checks.yml"
       - "requirements.txt"
       - "atlas_brain/mcp/invoicing_server.py"
+      - "atlas_brain/mcp/invoicing_readonly_server.py"
+      - "atlas_brain/mcp/invoicing_draft_writer_server.py"
+      - "atlas_brain/mcp/invoicing_readonly_oauth.py"
+      - "atlas_brain/mcp/invoicing_draft_writer_oauth.py"
+      - "atlas_brain/mcp/auth.py"
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "tests/test_monthly_invoice_generation.py"
+      - "tests/test_invoicing_readonly_mcp.py"
+      - "tests/test_invoicing_readonly_oauth.py"
+      - "tests/test_invoicing_draft_writer_mcp.py"
+      - "tests/test_invoicing_draft_writer_oauth.py"
   push:
     branches:
       - main
@@ -20,10 +29,19 @@ on:
       - ".github/workflows/atlas_invoicing_checks.yml"
       - "requirements.txt"
       - "atlas_brain/mcp/invoicing_server.py"
+      - "atlas_brain/mcp/invoicing_readonly_server.py"
+      - "atlas_brain/mcp/invoicing_draft_writer_server.py"
+      - "atlas_brain/mcp/invoicing_readonly_oauth.py"
+      - "atlas_brain/mcp/invoicing_draft_writer_oauth.py"
+      - "atlas_brain/mcp/auth.py"
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "tests/test_monthly_invoice_generation.py"
+      - "tests/test_invoicing_readonly_mcp.py"
+      - "tests/test_invoicing_readonly_oauth.py"
+      - "tests/test_invoicing_draft_writer_mcp.py"
+      - "tests/test_invoicing_draft_writer_oauth.py"
 
 jobs:
   atlas-invoicing-checks:
@@ -49,4 +67,13 @@ jobs:
           python -m pytest \
             tests/test_monthly_invoice_generation.py \
             -k "update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities" \
+            -q
+
+      - name: Run invoicing MCP + OAuth surface tests
+        run: |
+          python -m pytest \
+            tests/test_invoicing_readonly_mcp.py \
+            tests/test_invoicing_readonly_oauth.py \
+            tests/test_invoicing_draft_writer_mcp.py \
+            tests/test_invoicing_draft_writer_oauth.py \
             -q

--- a/.github/workflows/repo_wide_unit_backstop.yml
+++ b/.github/workflows/repo_wide_unit_backstop.yml
@@ -1,0 +1,54 @@
+name: Repo-Wide Unit Backstop
+
+# The per-area checks are path-filtered and run explicit, hand-maintained test
+# lists, so a test file that no workflow enrolls can pass CI while never
+# executing. This catch-all runs the whole unit suite (no integration/e2e, which
+# need Postgres/Neo4j) so nothing hides indefinitely. It is intentionally NOT a
+# per-PR gate -- it runs on a schedule and on demand, separate from the fast
+# path-filtered checks. The pull_request trigger is scoped to this workflow file
+# only, so changes to the backstop itself are exercised immediately without
+# adding a slow full-suite run to every unrelated PR.
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # 06:00 UTC daily (~1:00am CDT). UTC<->Central: subtract 5h (CDT) / 6h (CST).
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/repo_wide_unit_backstop.yml"
+
+concurrency:
+  group: repo-wide-unit-backstop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repo-wide-unit-backstop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run repo-wide unit suite (no integration/e2e)
+        run: |
+          # --continue-on-collection-errors so one un-importable module (e.g. an
+          # optional-dependency MCP server) cannot abort the whole backstop at
+          # collection; import gaps are reported as errors alongside real results.
+          python -m pytest -m "not integration and not e2e" -q \
+            --continue-on-collection-errors

--- a/docs/backstop_test_hygiene_scope.md
+++ b/docs/backstop_test_hygiene_scope.md
@@ -1,0 +1,108 @@
+# Scope: Test-Hygiene Cleanup to Re-enable the Repo-Wide Backstop
+
+Goal: make the unit suite runnable as a whole so the held repo-wide backstop
+(`claude/pr-ci-repo-wide-unit-backstop`, closed PR #1707) can return and go
+green. The backstop excludes `integration`/`e2e` markers and runs everything
+else; its first run could not run the suite because some tests cannot be
+collected and others silently need services. This breaks that into ordered,
+independent slices. Counts are from the actual #1707 backstop run + local audit.
+
+## What the backstop surfaced (root causes, not "missing dependency")
+
+`mcp>=1.26.0` IS in `requirements.txt` (installed in CI). The failures are
+labeling, a real production API mismatch, and stale test mocks -- not an absent
+dep.
+
+---
+
+## Slice A -- Mark mislabeled DB-backed tests as `integration`
+
+~8 test files use the `db_pool` fixture (a real Postgres pool) but carry no
+`integration` marker, so `not integration and not e2e` runs them against a
+database that isn't there. They are integration tests; mark them so.
+
+Candidates (verify each genuinely needs a live DB vs a mocked pool first):
+- `tests/test_b2b_enrichment_batch_integration.py`  (name says integration, not marked)
+- `tests/test_b2b_enrichment_repair_batch_integration.py`  (same)
+- `tests/test_campaign_recipient_dedup.py`
+- `tests/test_evidence_gate.py`
+- `tests/test_session_id_normalization.py`
+- `tests/test_default_task_seeding.py`
+- `tests/test_voice_session_reuse.py`
+- `tests/test_entity_context.py`
+
+Fix: module-level `pytestmark = pytest.mark.integration` (or per-test). Risk:
+low/mechanical. Size: small.
+
+## Slice B -- Fix the never-run invoicing MCP/OAuth tests (highest value)
+
+`test_invoicing_readonly_mcp`, `test_invoicing_readonly_oauth`,
+`test_invoicing_draft_writer_mcp`, `test_invoicing_draft_writer_oauth` are
+enrolled in **zero** workflows -- they never run in CI today. They fail to
+import because production code
+(`atlas_brain/mcp/invoicing_readonly_oauth.py:19`) does
+`from mcp.server.auth.provider import ...`, but the installed `mcp>=1.26.0`
+has no `mcp.server.auth` (`'mcp.server' is not a package`). This is a real,
+untested production import.
+
+Fix: determine which `mcp` version exposes `mcp.server.auth` (or what it was
+renamed to) and either pin/upgrade `mcp` or update the import to the current
+API; then enroll these tests in `atlas_invoicing_checks.yml` so they actually
+run. Risk: touches production OAuth server code + a dependency pin. Size:
+medium (the meatiest slice; do not bundle with the others).
+
+## Slice C -- Fix stale/leaky MCP test mocks (content-ops MCP tests)
+
+`test_mcp_content_ops_deflection_readonly` (enrolled in 1 workflow) and
+`test_mcp_content_ops_marketer_verify` (2) DO run today, yet failed in the
+full-suite collection with `_MockFastMCP.tool() got an unexpected keyword
+argument 'structured_output'` and `'_MockFastMCP' object has no attribute
+'custom_route'`. The `_MockFastMCP` stand-ins are defined inside the test files
+and have drifted behind the server code.
+
+Investigate first: do they pass in isolation (their own workflow) but break
+under whole-suite collection because a mock / `sys.modules` patch from another
+`*_mcp.py` test leaks across files? If so the fix is isolation; if the mock is
+simply stale, update it to match the FastMCP API (`structured_output`,
+`custom_route`). Risk: test-only. Size: small-medium.
+
+## Slice D -- Categorize and handle the remaining collection errors
+
+Per-file, ~5 files:
+- `tests/test_cloud_latency.py` -- imports `openai`; it is an external-API
+  latency test. Mark `e2e` (or skip-if-no-key). 
+- `tests/test_graphiti_wrapper_health.py` -- exercises the Graphiti service;
+  mark `e2e`.
+- `tests/test_atlas_content_ops_input_provider.py` -- `asyncpg.__spec__ is not
+  set` (an import/mocking quirk); fix the import or guard.
+- `tests/test_competitive_intelligence.py`, `tests/test_b2b_phase4_causality_gate.py`
+  -- need a per-file look (likely import-time service/dep dependence).
+
+Risk: low per file. Size: small.
+
+## Slice E -- Reintroduce the backstop
+
+Restore the backstop workflow + plan from
+`claude/pr-ci-repo-wide-unit-backstop` (branched fresh off `main`), confirm the
+suite now collects and runs with only intended `integration`/`e2e` skips, and
+decide advisory vs. gating. Keep `--continue-on-collection-errors` as a
+belt-and-suspenders. Size: small (the workflow already exists). Gated on A-D.
+
+---
+
+## Sequencing
+
+- A, C, D are independent test-file changes -- parallelizable.
+- B is the substantive one (production + dependency); isolate it.
+- E is last, gated on A-D landing.
+
+## Meta note
+
+That four invoicing MCP/OAuth test files are enrolled in zero workflows is
+itself the exact problem the backstop exists to catch: tests that pass review
+and ship while never running. Slice B both fixes them and enrolls them; the
+backstop (slice E) is the standing guard so it cannot recur silently.
+
+Related but separate: broaden `audit_extracted_pipeline_ci_enrollment.py`
+(make it workflow-aware) so un-enrolled files are flagged at PR time, not only
+caught by the nightly backstop.

--- a/docs/backstop_test_hygiene_scope.md
+++ b/docs/backstop_test_hygiene_scope.md
@@ -64,7 +64,24 @@ touch production OAuth code and do not re-pin `mcp`. The enrollment must land
 *together with* the Slice C isolation fix, or the leak will make them fail.
 Risk: CI-config only. Size: small.
 
-## Slice C -- Stop the global `mcp` MagicMock leak (the real root cause)
+## Slice C -- Stop the global `mcp` MagicMock leak (the real root cause)  [DONE]
+
+Landed via `tests/_mcp_stub.py` (`stub_mcp` context manager: save -> plant
+fake -> import server -> restore `sys.modules`) applied to all eight files.
+The `mcp` setdefault blocks are gone; each test plants its fake only for its
+own server import, so nothing survives to poison sibling collection. Verified
+the helper's save/restore semantics directly, including the exact
+invoicing-poison scenario (a real `mcp.server.auth.provider` is no longer
+shadowed after a stub block). Full collection is CI-verified (this sandbox
+lacks `torch`/`mcp`).
+
+Confirmed root cause along the way: the b2b tool submodules only ever call
+`@mcp.tool()` (no kwargs) and `b2b/server.py` is the *sole* importer of
+`mcp.server.fastmcp`. So the `tool() got unexpected keyword 'structured_output'`
+/ missing `custom_route` errors were never "stale mocks" -- they were the
+content-ops server inheriting the b2b passthrough fake because `setdefault`
+let whichever module collected first win. Fixing isolation fixes both that and
+the `'mcp.server' is not a package` failure; no fake signature changes needed.
 
 This is the linchpin, not a side issue. Eight tests
 (`test_b2b_churn_mcp`, `test_b2b_products_mcp`, `test_b2b_signals_mcp_inputs`,
@@ -139,3 +156,11 @@ guard so it cannot recur silently.
 Related but separate: broaden `audit_extracted_pipeline_ci_enrollment.py`
 (make it workflow-aware) so un-enrolled files are flagged at PR time, not only
 caught by the nightly backstop.
+
+Deferred (same bug class as Slice C, not the backstop blocker): the same eight
+tests still stub heavy deps (`torch`, `asyncpg`, `numpy`, ...) into
+`sys.modules` with `setdefault` and no teardown. Those fakes can leak across
+modules too, but they did not cause the invoicing collection failure and a
+fake `torch` is mostly inert in the unit backstop. Fold them into the same
+save/restore window (or a shared autouse fixture) in a follow-up once Slice E
+confirms which, if any, still bite.

--- a/docs/backstop_test_hygiene_scope.md
+++ b/docs/backstop_test_hygiene_scope.md
@@ -126,19 +126,55 @@ Two distinct test-only problems to fix:
 
 Risk: test-only. Size: small-medium.
 
-## Slice D -- Categorize and handle the remaining collection errors
+## Slice D -- Categorize and handle the remaining collection errors  [DONE]
 
-Per-file, ~5 files:
-- `tests/test_cloud_latency.py` -- imports `openai`; it is an external-API
-  latency test. Mark `e2e` (or skip-if-no-key). 
-- `tests/test_graphiti_wrapper_health.py` -- exercises the Graphiti service;
-  mark `e2e`.
-- `tests/test_atlas_content_ops_input_provider.py` -- `asyncpg.__spec__ is not
-  set` (an import/mocking quirk); fix the import or guard.
-- `tests/test_competitive_intelligence.py`, `tests/test_b2b_phase4_causality_gate.py`
-  -- need a per-file look (likely import-time service/dep dependence).
+Investigation split the five into two genuinely-external tests (fixed here)
+and three heavy-dep **leak victims** (legit unit tests; do NOT mislabel them
+e2e -- they need Slice F below).
 
-Risk: low per file. Size: small.
+Fixed here:
+- `tests/test_cloud_latency.py` -- external Fireworks/Together latency
+  benchmark; `openai` is not a brain runtime dep. Added module-level
+  `pytest.importorskip("openai")` + `pytestmark = pytest.mark.e2e`. Verified:
+  collects as a clean skip under the backstop filter, no error.
+- `tests/test_graphiti_wrapper_health.py` -- loads the standalone
+  graphiti-wrapper `main.py` (deps `graphiti_core`, `neo4j` are not brain
+  deps). Added `pytestmark = pytest.mark.e2e` and a module-level
+  `pytest.skip(allow_module_level=True)` guard around `exec_module` so an
+  absent service dep skips cleanly instead of erroring collection.
+
+Re-classified as heavy-dep leak victims (NOT fixed here; see Slice F):
+- `tests/test_atlas_content_ops_input_provider.py` -- its **collection-time**
+  `@pytest.mark.skipif(importlib.util.find_spec("asyncpg") is None, ...)`
+  raises `asyncpg.__spec__ is not set` when a sibling has planted a bare
+  `types.ModuleType("asyncpg")` (no `__spec__`). It is a legitimate unit test
+  that skips correctly when asyncpg is genuinely absent.
+- `tests/test_competitive_intelligence.py`,
+  `tests/test_b2b_phase4_causality_gate.py` -- stub nothing themselves; they
+  just `from atlas_brain.autonomous.tasks... import`. Under whole-suite
+  collection a sibling's `sys.modules["asyncpg"] = <bare module>` (direct
+  assignment, overrides real asyncpg) breaks their import chain.
+
+Risk: low. Size: small (two marker/guard edits).
+
+## Slice F -- Stop the heavy-dep (`asyncpg`/`torch`/...) sys.modules leak
+
+Promoted from the Slice C deferred note once Slice D showed it is actively
+breaking three otherwise-green unit tests (incl. a content-ops lane file).
+Same bug class as Slice C, wider blast radius: many b2b/backfill tests plant
+fake heavy deps into `sys.modules` and never restore -- two shapes, both
+leaky:
+- `sys.modules.setdefault("asyncpg", MagicMock())` (collection-order
+  dependent: wins only if asyncpg not yet imported, but then persists).
+- `sys.modules["asyncpg"] = types.ModuleType("asyncpg")` (direct assignment:
+  unconditionally overrides real asyncpg; the bare module has `__spec__=None`,
+  which is what makes `find_spec` raise).
+
+Fix: generalize the Slice C `stub_mcp` save/restore into a `stub_modules`
+helper (or shared autouse fixture) and route every heavy-dep stub through it
+so nothing outlives its own module import. Then the three Slice D victims
+collect under the full suite with no change to themselves. Risk: test-only but
+broad (audit every planter). Size: medium. Gates a fully-clean Slice E.
 
 ## Slice E -- Reintroduce the backstop
 
@@ -152,9 +188,13 @@ belt-and-suspenders. Size: small (the workflow already exists). Gated on A-D.
 
 ## Sequencing
 
-- A, C, D are independent test-file changes -- parallelizable.
-- B is the substantive one (production + dependency); isolate it.
-- E is last, gated on A-D landing.
+- A, C, D are independent test-file changes -- parallelizable. [all DONE]
+- B is enrollment-only (no production change after the Slice B correction).
+  [DONE]
+- F (heavy-dep leak) surfaced during D; it is the last substantive cleanup
+  and gates a fully-clean E.
+- E is last, gated on A-D landing and F (or E ships with
+  `--continue-on-collection-errors` tolerating the F victims until F lands).
 
 ## Meta note
 

--- a/docs/backstop_test_hygiene_scope.md
+++ b/docs/backstop_test_hygiene_scope.md
@@ -157,24 +157,40 @@ Re-classified as heavy-dep leak victims (NOT fixed here; see Slice F):
 
 Risk: low. Size: small (two marker/guard edits).
 
-## Slice F -- Stop the heavy-dep (`asyncpg`/`torch`/...) sys.modules leak
+## Slice F -- Stop the heavy-dep (`asyncpg`/`torch`/...) sys.modules leak  [DONE]
 
-Promoted from the Slice C deferred note once Slice D showed it is actively
-breaking three otherwise-green unit tests (incl. a content-ops lane file).
-Same bug class as Slice C, wider blast radius: many b2b/backfill tests plant
-fake heavy deps into `sys.modules` and never restore -- two shapes, both
-leaky:
-- `sys.modules.setdefault("asyncpg", MagicMock())` (collection-order
-  dependent: wins only if asyncpg not yet imported, but then persists).
-- `sys.modules["asyncpg"] = types.ModuleType("asyncpg")` (direct assignment:
-  unconditionally overrides real asyncpg; the bare module has `__spec__=None`,
-  which is what makes `find_spec` raise).
+Audit found 111 test files plant into `sys.modules`, but the *confirmed*
+backstop breakage is `asyncpg`, and only **5** files used the dangerous shape:
 
-Fix: generalize the Slice C `stub_mcp` save/restore into a `stub_modules`
-helper (or shared autouse fixture) and route every heavy-dep stub through it
-so nothing outlives its own module import. Then the three Slice D victims
-collect under the full suite with no change to themselves. Risk: test-only but
-broad (audit every planter). Size: medium. Gates a fully-clean Slice E.
+```
+if "asyncpg" not in sys.modules:
+    sys.modules["asyncpg"] = types.ModuleType("asyncpg")   # bare: __spec__=None
+```
+
+(`test_backfill_g2_reviewer_company_cleanup`,
+`test_backfill_trustpilot_jsonld_company_cleanup`,
+`test_backfill_low_substance_enriched_reviews`,
+`test_plan_parser_upgrade_rescrape_targets`,
+`test_b2b_parser_upgrade_maintenance`.) The bare `ModuleType` both
+unconditionally overrides real asyncpg and carries `__spec__=None`, which is
+exactly the `find_spec` landmine that broke the three Slice D victims.
+
+Landed `tests/_module_stub.py::stub_missing_module(name, attributes=...)` and
+routed all 5 through it. It stubs only when the dep is genuinely not
+importable (so CI, where asyncpg is installed, imports the real module and
+nothing is shadowed) and gives any stub it creates a real `__spec__` (so
+`find_spec` never raises). Verified directly: an installed module is never
+shadowed; an absent one is stubbed with a valid spec; the `'__spec__ is not
+set'` landmine is gone. Collecting a converted file now passes the asyncpg
+boundary (fails only on an unrelated sandbox-missing dep).
+
+Deliberately scoped OUT (not the confirmed breakage; converting blind is
+reckless): the ~37 `setdefault("asyncpg", MagicMock())` planters. `setdefault`
+no-ops once real asyncpg is imported (very likely early under the full suite),
+and a `MagicMock` has a truthy `__spec__` so it does not trip `find_spec`. If
+Slice E shows any still biting, convert those specific files to
+`stub_missing_module` the same way. The inert `torch`/`numpy`/etc. stubs are
+likewise left until proven to matter.
 
 ## Slice E -- Reintroduce the backstop
 

--- a/docs/backstop_test_hygiene_scope.md
+++ b/docs/backstop_test_hygiene_scope.md
@@ -39,37 +39,64 @@ Risk: low/mechanical. Size: small. Landed: module markers on 3 files,
 per-test markers on 5 tests in `test_evidence_gate`; the 6 pure-unit tests
 there stay in the backstop.
 
-## Slice B -- Fix the never-run invoicing MCP/OAuth tests (highest value)
+## Slice B -- Enroll the never-run invoicing MCP/OAuth tests (NOT a prod fix)
 
 `test_invoicing_readonly_mcp`, `test_invoicing_readonly_oauth`,
 `test_invoicing_draft_writer_mcp`, `test_invoicing_draft_writer_oauth` are
-enrolled in **zero** workflows -- they never run in CI today. They fail to
-import because production code
-(`atlas_brain/mcp/invoicing_readonly_oauth.py:19`) does
-`from mcp.server.auth.provider import ...`, but the installed `mcp>=1.26.0`
-has no `mcp.server.auth` (`'mcp.server' is not a package`). This is a real,
-untested production import.
+enrolled in **zero** workflows -- they never run in CI today. That part of
+the finding stands.
 
-Fix: determine which `mcp` version exposes `mcp.server.auth` (or what it was
-renamed to) and either pin/upgrade `mcp` or update the import to the current
-API; then enroll these tests in `atlas_invoicing_checks.yml` so they actually
-run. Risk: touches production OAuth server code + a dependency pin. Size:
-medium (the meatiest slice; do not bundle with the others).
+**Correction (the earlier framing was wrong):** the production import is
+NOT broken. `atlas_brain/mcp/invoicing_readonly_oauth.py:19` does
+`from mcp.server.auth.provider import OAuthAuthorizationServerProvider, ...`,
+which are real symbols in the official `mcp>=1.26.0` SDK. That module is
+live -- it is imported by the live `invoicing_readonly_server.py:24` and is
+the shipped OAuth connector pattern (Claude/Codex connect through it; see
+`docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`). It is neither dead code nor a
+version mismatch. The `'mcp.server' is not a package` error seen in the
+full-suite run was **not** a real import failure -- it was caused by sibling
+tests poisoning `sys.modules` (see Slice C), plus this sandbox simply not
+having `mcp` installed (`No module named 'mcp'`; CI installs it via
+`requirements.txt`).
 
-## Slice C -- Fix stale/leaky MCP test mocks (content-ops MCP tests)
+Fix: just enroll these four files in `atlas_invoicing_checks.yml`. Do not
+touch production OAuth code and do not re-pin `mcp`. The enrollment must land
+*together with* the Slice C isolation fix, or the leak will make them fail.
+Risk: CI-config only. Size: small.
 
-`test_mcp_content_ops_deflection_readonly` (enrolled in 1 workflow) and
-`test_mcp_content_ops_marketer_verify` (2) DO run today, yet failed in the
-full-suite collection with `_MockFastMCP.tool() got an unexpected keyword
-argument 'structured_output'` and `'_MockFastMCP' object has no attribute
-'custom_route'`. The `_MockFastMCP` stand-ins are defined inside the test files
-and have drifted behind the server code.
+## Slice C -- Stop the global `mcp` MagicMock leak (the real root cause)
 
-Investigate first: do they pass in isolation (their own workflow) but break
-under whole-suite collection because a mock / `sys.modules` patch from another
-`*_mcp.py` test leaks across files? If so the fix is isolation; if the mock is
-simply stale, update it to match the FastMCP API (`structured_output`,
-`custom_route`). Risk: test-only. Size: small-medium.
+This is the linchpin, not a side issue. Eight tests
+(`test_b2b_churn_mcp`, `test_b2b_products_mcp`, `test_b2b_signals_mcp_inputs`,
+`test_b2b_vendor_registry_mcp`, `test_b2b_scrape_targets_mcp_inputs`,
+`test_b2b_evidence_mcp`, `test_b2b_source_impact`,
+`test_mcp_content_ops_marketer_verify`) do, at **module top level with no
+teardown**, e.g.:
+
+```
+sys.modules.setdefault("mcp", MagicMock())
+sys.modules.setdefault("mcp.server", MagicMock())
+sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)  # _fastmcp_mod.FastMCP = _MockFastMCP
+```
+
+`setdefault` plants the fake whenever `mcp` has not been imported *yet* --
+true even when real `mcp` is installed, if no earlier test imported it. Once
+planted, `mcp` is a MagicMock for the rest of the pytest session, so any
+later test importing real `mcp.server.auth.provider` (the invoicing OAuth
+tests) gets `'mcp.server' is not a package`. In their own single-file
+workflows these b2b tests pass; under whole-suite collection they poison
+everything downstream. This is exactly why the backstop choked on `mcp`.
+
+Two distinct test-only problems to fix:
+1. **Isolation/leak:** make the stub session-safe -- use a `conftest`
+   fixture with proper teardown, or only stub when real `mcp` is genuinely
+   absent and restore `sys.modules` after, so real-`mcp` tests are unaffected.
+2. **Stale fakes:** the hand-rolled `_MockFastMCP` has drifted behind the
+   real FastMCP API (`tool(... structured_output=...)`, `custom_route`).
+   Where the stub exists only to dodge a heavy import, prefer importing real
+   `mcp` (it is in `requirements.txt`) over maintaining a divergent fake.
+
+Risk: test-only. Size: small-medium.
 
 ## Slice D -- Categorize and handle the remaining collection errors
 
@@ -105,8 +132,9 @@ belt-and-suspenders. Size: small (the workflow already exists). Gated on A-D.
 
 That four invoicing MCP/OAuth test files are enrolled in zero workflows is
 itself the exact problem the backstop exists to catch: tests that pass review
-and ship while never running. Slice B both fixes them and enrolls them; the
-backstop (slice E) is the standing guard so it cannot recur silently.
+and ship while never running. Slice B enrolls them (production is fine -- the
+OAuth server is live via Claude/Codex); the backstop (slice E) is the standing
+guard so it cannot recur silently.
 
 Related but separate: broaden `audit_extracted_pipeline_ci_enrollment.py`
 (make it workflow-aware) so un-enrolled files are flagged at PR time, not only

--- a/docs/backstop_test_hygiene_scope.md
+++ b/docs/backstop_test_hygiene_scope.md
@@ -39,12 +39,23 @@ Risk: low/mechanical. Size: small. Landed: module markers on 3 files,
 per-test markers on 5 tests in `test_evidence_gate`; the 6 pure-unit tests
 there stay in the backstop.
 
-## Slice B -- Enroll the never-run invoicing MCP/OAuth tests (NOT a prod fix)
+## Slice B -- Enroll the never-run invoicing MCP/OAuth tests (NOT a prod fix)  [DONE]
 
 `test_invoicing_readonly_mcp`, `test_invoicing_readonly_oauth`,
 `test_invoicing_draft_writer_mcp`, `test_invoicing_draft_writer_oauth` are
 enrolled in **zero** workflows -- they never run in CI today. That part of
 the finding stands.
+
+Landed: added all four files to `atlas_invoicing_checks.yml` as a dedicated
+`Run invoicing MCP + OAuth surface tests` step, plus path triggers for the
+production modules they exercise (`invoicing_readonly_server.py`,
+`invoicing_draft_writer_server.py`, `invoicing_readonly_oauth.py`,
+`invoicing_draft_writer_oauth.py`, `mcp/auth.py`) and the four test files
+themselves. All four are unit tests (no `integration`/`e2e` markers, no
+`db_pool`); the two `_oauth` files import real `mcp.server.auth.provider`,
+which resolves because the dedicated workflow installs `requirements.txt`
+(`mcp>=1.26.0`) and -- thanks to Slice C -- no sibling test poisons `mcp`
+first. No production OAuth code touched; no `mcp` re-pin.
 
 **Correction (the earlier framing was wrong):** the production import is
 NOT broken. `atlas_brain/mcp/invoicing_readonly_oauth.py:19` does

--- a/docs/backstop_test_hygiene_scope.md
+++ b/docs/backstop_test_hygiene_scope.md
@@ -192,13 +192,20 @@ Slice E shows any still biting, convert those specific files to
 `stub_missing_module` the same way. The inert `torch`/`numpy`/etc. stubs are
 likewise left until proven to matter.
 
-## Slice E -- Reintroduce the backstop
+## Slice E -- Reintroduce the backstop  [DONE]
 
-Restore the backstop workflow + plan from
-`claude/pr-ci-repo-wide-unit-backstop` (branched fresh off `main`), confirm the
-suite now collects and runs with only intended `integration`/`e2e` skips, and
-decide advisory vs. gating. Keep `--continue-on-collection-errors` as a
-belt-and-suspenders. Size: small (the workflow already exists). Gated on A-D.
+Restored `.github/workflows/repo_wide_unit_backstop.yml` +
+`plans/PR-CI-Repo-Wide-Unit-Backstop.md` from the closed
+`claude/pr-ci-repo-wide-unit-backstop` branch onto this effort's branch (which
+carries A-F), so the backstop ships together with the fixes that let it run
+clean. Workflow unchanged from its resilient final state: schedule + manual
+dispatch + a `pull_request` trigger scoped to the workflow file only, running
+`pytest -m "not integration and not e2e" -q --continue-on-collection-errors`.
+YAML validated; `scripts/audit_workflow_security_posture.py` passes. Introduced
+**advisory** (not a merge gate) for its debut so its runtime/flake profile and
+any residual gaps (the 37 `setdefault` planters) are observed first. The
+self-scoped `pull_request` trigger makes the backstop run on this PR -- its CI
+result is the live proof the suite now collects.
 
 ---
 

--- a/docs/backstop_test_hygiene_scope.md
+++ b/docs/backstop_test_hygiene_scope.md
@@ -15,24 +15,29 @@ dep.
 
 ---
 
-## Slice A -- Mark mislabeled DB-backed tests as `integration`
+## Slice A -- Mark mislabeled DB-backed tests as `integration`  [DONE]
 
-~8 test files use the `db_pool` fixture (a real Postgres pool) but carry no
-`integration` marker, so `not integration and not e2e` runs them against a
+Tests that use the `db_pool` fixture (a real Postgres pool) but carry no
+`integration` marker get run by `not integration and not e2e` against a
 database that isn't there. They are integration tests; mark them so.
 
-Candidates (verify each genuinely needs a live DB vs a mocked pool first):
-- `tests/test_b2b_enrichment_batch_integration.py`  (name says integration, not marked)
-- `tests/test_b2b_enrichment_repair_batch_integration.py`  (same)
-- `tests/test_campaign_recipient_dedup.py`
-- `tests/test_evidence_gate.py`
-- `tests/test_session_id_normalization.py`
-- `tests/test_default_task_seeding.py`
-- `tests/test_voice_session_reuse.py`
-- `tests/test_entity_context.py`
+Auditing the original candidate list corrected it (verify-before-marking
+paid off):
 
-Fix: module-level `pytestmark = pytest.mark.integration` (or per-test). Risk:
-low/mechanical. Size: small.
+- Already correctly marked (class-level `@pytest.mark.integration`), no
+  change needed: `test_session_id_normalization`, `test_default_task_seeding`,
+  `test_voice_session_reuse`, `test_entity_context`.
+- Wholly DB-bound -> module-level `pytestmark = pytest.mark.integration`:
+  `test_b2b_enrichment_batch_integration`,
+  `test_b2b_enrichment_repair_batch_integration`,
+  `test_campaign_recipient_dedup`.
+- **Mixed** file -> per-test markers on the five `db_pool` tests only,
+  leaving the pure-function tests (which use an in-test `_NullPool` stub) in
+  the backstop: `test_evidence_gate`.
+
+Risk: low/mechanical. Size: small. Landed: module markers on 3 files,
+per-test markers on 5 tests in `test_evidence_gate`; the 6 pure-unit tests
+there stay in the backstop.
 
 ## Slice B -- Fix the never-run invoicing MCP/OAuth tests (highest value)
 

--- a/plans/PR-CI-Repo-Wide-Unit-Backstop.md
+++ b/plans/PR-CI-Repo-Wide-Unit-Backstop.md
@@ -1,0 +1,129 @@
+# PR-CI-Repo-Wide-Unit-Backstop
+
+## Why this slice exists
+
+CI runs no repo-wide test suite. Every `*_checks.yml` workflow is path-filtered
+and executes an explicit, hand-maintained list of test files, and the one safety
+net (`scripts/audit_extracted_pipeline_ci_enrollment.py`) only audits files whose
+names match a fixed allowlist (`test_extracted_content*`, `test_extracted_ticket_faq*`,
+...). A test file named outside those patterns -- e.g. the recently added
+`tests/test_deflection_snapshot_report_drift.py` -- can therefore pass all of CI
+while never running until someone manually enrolls it. That is a silent-coverage
+hole: a brand-new test, or a regression in a file enrolled only under another
+lane's path filter, can ship green.
+
+This slice adds the missing catch-all: a scheduled, on-demand full unit run so
+nothing hides indefinitely. It does not touch the fast path-filtered per-PR
+checks, which stay as the quick first line.
+
+This re-introduction ships atop the test-hygiene slices A-F documented in
+`docs/backstop_test_hygiene_scope.md`, which resolve the collection gaps the
+backstop's first (closed PR #1707) run surfaced -- mislabeled DB-backed tests,
+the global `mcp` MagicMock leak, the never-run invoicing tests, the two
+external/cross-service tests, and the `asyncpg` `__spec__` leak. With those in
+place the backstop can run the suite cleanly rather than report a wall of
+collection errors.
+
+## Scope (this PR)
+
+Ownership lane: ci/coverage
+Slice phase: Production hardening
+
+1. Add `.github/workflows/repo_wide_unit_backstop.yml` running
+   `pytest -m "not integration and not e2e"` over the whole `tests/` tree
+   (integration/e2e need Postgres/Neo4j and are out of scope for a no-services
+   runner).
+2. Triggers: `schedule` (daily, single commented cron with a UTC<->Central
+   note), `workflow_dispatch` for on-demand, and a `pull_request` trigger
+   **scoped to this workflow file only** so the backstop is exercised on changes
+   to itself without becoming a slow gate on every unrelated PR.
+3. `permissions: contents: read`, a `concurrency` group, and a per-job
+   `timeout-minutes` cap, matching repo workflow conventions.
+
+### Files touched
+
+- `.github/workflows/repo_wide_unit_backstop.yml`
+- `plans/PR-CI-Repo-Wide-Unit-Backstop.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- [ ] The workflow runs the unit suite repo-wide (no per-file allowlist) and
+      excludes integration/e2e markers.
+- [ ] It is not a per-PR gate: only schedule, manual dispatch, and self-file
+      changes trigger it.
+- [ ] Actions and permissions follow the repo's workflow-security posture
+      (`scripts/audit_workflow_security_posture.py` passes).
+
+Affected surfaces: CI only; no application code.
+
+Risk areas: a long full-suite runtime; surfacing pre-existing failures that the
+path-filtered lanes never ran (that is the intended signal, not a regression in
+this change).
+
+Reviewer rules triggered: R1, R14.
+
+## Mechanism
+
+A single job installs `requirements.txt` + pytest and runs
+`python -m pytest -m "not integration and not e2e" -q
+--continue-on-collection-errors`. Because it does not path-filter the test set, a
+file that no per-area workflow enrolls is still executed here.
+`--continue-on-collection-errors` keeps one un-importable module (e.g. an
+optional-dependency MCP server whose mock has drifted) from aborting the whole
+run at collection; import gaps surface as reported errors next to real results
+instead of zeroing out the signal. The `pull_request` path filter is the workflow
+file itself, which makes the backstop self-exercising on this PR (immediate proof
+it runs) while keeping it off the critical path of normal PRs.
+
+## Intentional
+
+- Not a per-PR gate. The per-area path-filtered checks remain the fast layer;
+  this is the nightly/on-demand backstop, so it does not slow every PR.
+- No change to the enrollment auditor in this slice. Broadening the auditor's
+  name-pattern allowlist (so non-conforming files are flagged at PR time) is a
+  separate slice because that auditor is scoped to one workflow + runner and
+  would red-fail until cross-workflow enrollment is taught to it.
+- Integration/e2e excluded; those need Postgres/Neo4j and belong to their own
+  service-backed jobs.
+
+## Deferred
+
+- The import gaps and unmarked DB-backed tests the backstop's first run
+  surfaced (the `mcp` MagicMock leak / `_MockFastMCP` drift, the
+  `asyncpg.__spec__` leak, and the `db_pool` tests marked only
+  `@pytest.mark.asyncio`) are **resolved in this same effort** by Slices
+  A/C/D/F in `docs/backstop_test_hygiene_scope.md` -- not deferred. The
+  backstop is still introduced **advisory** (informational, not a merge gate)
+  for its debut run so its runtime/flake profile and any residual gaps are
+  observed before it gates anything.
+- Residual heavy-dep leak: ~37 tests still stub `asyncpg` via
+  `setdefault("asyncpg", MagicMock())`. These no-op once real asyncpg is
+  imported (very likely early under the full suite) and a `MagicMock` carries a
+  truthy `__spec__`, so they were not the confirmed breakage and are left until
+  the backstop's first run shows whether any still bite (Slice F note).
+- Broaden `audit_extracted_pipeline_ci_enrollment.py` (and make it
+  workflow-aware) so deflection/content-ops test families are flagged for
+  enrollment at PR time, not only caught nightly by this backstop.
+- Optionally gate merges on a green backstop once its runtime/flake profile is
+  known.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -c "import yaml; yaml.safe_load(open('.github/workflows/repo_wide_unit_backstop.yml'))"`
+  -- valid.
+- `python scripts/audit_workflow_security_posture.py` -- workflow security
+  posture audit passed.
+- The backstop runs on this PR via the self-scoped `pull_request` trigger; its
+  CI result is the live proof of repo-wide execution.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/repo_wide_unit_backstop.yml` | 54 |
+| `plans/PR-CI-Repo-Wide-Unit-Backstop.md` | 116 |
+| **Total** | **170** |

--- a/tests/_mcp_stub.py
+++ b/tests/_mcp_stub.py
@@ -1,0 +1,63 @@
+"""Session-safe ``mcp`` stubbing for MCP-server unit tests.
+
+Several MCP-server unit tests import a server module that constructs a
+``mcp.server.fastmcp.FastMCP`` at import time. Historically each test planted a
+fake ``mcp`` package into ``sys.modules`` at module top level with
+``setdefault`` and never removed it. Under whole-suite collection that fake
+survived for the rest of the session, with two failure modes:
+
+* It poisoned sibling tests that need the real ``mcp`` package -- notably the
+  invoicing OAuth tests, which import ``mcp.server.auth.provider`` and then
+  saw ``'mcp.server' is not a package``.
+* Because ``setdefault`` plants only when the key is absent, whichever test
+  was collected first won, and later tests inherited the *wrong* fake -- e.g.
+  a content-ops server built against a b2b passthrough ``FastMCP`` whose
+  ``tool()`` rejected ``structured_output`` and lacked ``custom_route``.
+
+``stub_mcp`` plants the fake only for the duration of the caller's server
+import, then restores ``sys.modules``. The imported server module keeps its
+reference to the fake ``FastMCP`` instance, so the tests behave exactly as
+before, while collection of every other module sees the real ``mcp`` (CI) or
+a clean absence (local sandbox).
+"""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from typing import Iterator, Mapping
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def stub_mcp(
+    fastmcp_cls: type,
+    *,
+    extra_modules: Mapping[str, object] | None = None,
+) -> Iterator[None]:
+    """Temporarily install a fake ``mcp`` package, restoring afterward.
+
+    ``fastmcp_cls`` is installed as ``mcp.server.fastmcp.FastMCP``. Any
+    ``extra_modules`` (e.g. ``{"mcp.server.auth.provider": <stub>}``) are
+    installed and restored alongside the defaults. Import the server module(s)
+    under test inside the ``with`` block; their bound reference to the fake
+    survives after ``sys.modules`` is restored.
+    """
+    fastmcp_mod = MagicMock(name="mcp.server.fastmcp")
+    fastmcp_mod.FastMCP = fastmcp_cls
+    planted: dict[str, object] = {
+        "mcp": MagicMock(name="mcp"),
+        "mcp.server": MagicMock(name="mcp.server"),
+        "mcp.server.fastmcp": fastmcp_mod,
+    }
+    planted.update(extra_modules or {})
+    saved = {name: sys.modules.get(name) for name in planted}
+    try:
+        sys.modules.update(planted)
+        yield
+    finally:
+        for name, prior in saved.items():
+            if prior is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prior

--- a/tests/_module_stub.py
+++ b/tests/_module_stub.py
@@ -1,0 +1,57 @@
+"""Importability-guarded stand-ins for optional heavy dependencies.
+
+Several tests stub a dependency (notably ``asyncpg``) into ``sys.modules`` so
+the production module they import does not require the real package. The
+historic idiom --
+
+    if "asyncpg" not in sys.modules:
+        sys.modules["asyncpg"] = types.ModuleType("asyncpg")   # or setdefault
+
+plants the fake whenever the dependency is not *currently imported*. In CI,
+where the dependency IS installed, that shadows the real module for the rest
+of the session and poisons sibling tests that need it. Worse, a bare
+``ModuleType`` has ``__spec__ = None``, so a later
+``importlib.util.find_spec(name)`` raises ``'<name>.__spec__ is not set'`` at
+collection (this is exactly what broke test_atlas_content_ops_input_provider,
+test_competitive_intelligence, and test_b2b_phase4_causality_gate under the
+repo-wide unit backstop).
+
+``stub_missing_module`` stubs only when the dependency genuinely cannot be
+imported, and gives any stub it creates a real ``__spec__`` -- so it never
+shadows an installed package and never trips ``find_spec``.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from typing import Mapping, Optional
+
+
+def stub_missing_module(
+    name: str,
+    *,
+    attributes: Optional[Mapping[str, object]] = None,
+) -> Optional[types.ModuleType]:
+    """Ensure ``name`` is importable, stubbing a stand-in only if it is not.
+
+    Returns the freshly-created stub module, or ``None`` when no stub was
+    needed (the dependency is already present or genuinely importable). The
+    ``None`` return lets callers stub a submodule (e.g. ``asyncpg.exceptions``)
+    only in the same branch where the parent was stubbed.
+    """
+    if name in sys.modules:
+        return None  # already present (real import or a prior stub); leave it
+    try:
+        if importlib.util.find_spec(name) is not None:
+            return None  # real package importable; let the caller import it
+    except (ImportError, ValueError):
+        pass  # parent missing / unset spec -> treat as absent and stub it
+    module = types.ModuleType(name)
+    module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+    for attr, value in (attributes or {}).items():
+        setattr(module, attr, value)
+    sys.modules[name] = module
+    return module

--- a/tests/test_b2b_churn_mcp.py
+++ b/tests/test_b2b_churn_mcp.py
@@ -44,13 +44,16 @@ class _MockFastMCP:
         pass
 
 
-_mcp_mod = MagicMock()
-_mcp_server_mod = MagicMock()
-_fastmcp_mod = MagicMock()
-_fastmcp_mod.FastMCP = _MockFastMCP
-sys.modules.setdefault("mcp", _mcp_mod)
-sys.modules.setdefault("mcp.server", _mcp_server_mod)
-sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
+from tests._mcp_stub import stub_mcp
+
+# The b2b tool submodules this test imports inline (inside test bodies) all
+# obtain their FastMCP via `from .server import mcp`, and b2b/server.py is the
+# only module that imports `mcp.server.fastmcp`. Import it here under the fake
+# `mcp` so the shared FastMCP instance is cached; the inline imports then hit
+# the module cache and need no `mcp` package. Restoring sys.modules afterward
+# keeps the fake from poisoning sibling tests that need the real `mcp`.
+with stub_mcp(_MockFastMCP):
+    import atlas_brain.mcp.b2b.server  # noqa: F401
 
 import json
 from datetime import date, datetime, timezone

--- a/tests/test_b2b_enrichment_batch_integration.py
+++ b/tests/test_b2b_enrichment_batch_integration.py
@@ -17,6 +17,11 @@ from atlas_brain.services.b2b.cache_runner import (
 from atlas_brain.services.b2b.llm_exact_cache import compute_cache_key
 from atlas_brain.skills import get_skill_registry
 
+# Every test in this module exercises real SQL via the db_pool fixture
+# (live Postgres). Mark the module integration so the unit backstop
+# (`not integration and not e2e`) does not run it without a database.
+pytestmark = pytest.mark.integration
+
 
 def _configure_batch_settings(monkeypatch, *, tier2_model: str | None = None) -> None:
     monkeypatch.setattr(settings.b2b_churn, "enabled", True, raising=False)

--- a/tests/test_b2b_enrichment_repair_batch_integration.py
+++ b/tests/test_b2b_enrichment_repair_batch_integration.py
@@ -10,6 +10,11 @@ from atlas_brain.autonomous.tasks import b2b_enrichment_repair as repair_mod
 from atlas_brain.autonomous.tasks.b2b_scrape_intake import _INSERT_SQL
 from atlas_brain.config import settings
 
+# Every test in this module exercises real SQL via the db_pool fixture
+# (live Postgres). Mark the module integration so the unit backstop
+# (`not integration and not e2e`) does not run it without a database.
+pytestmark = pytest.mark.integration
+
 
 def _configure_repair_batch_settings(monkeypatch) -> None:
     monkeypatch.setattr(settings.b2b_churn, "enabled", True, raising=False)

--- a/tests/test_b2b_evidence_mcp.py
+++ b/tests/test_b2b_evidence_mcp.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tests._mcp_stub import stub_mcp
+
 
 class _MockFastMCP:
     def __init__(self, *args, **kwargs):
@@ -21,13 +23,11 @@ class _MockFastMCP:
 
 sys.modules.setdefault("asyncpg", MagicMock())
 sys.modules.setdefault("asyncpg.exceptions", MagicMock())
-sys.modules.setdefault("mcp", MagicMock())
-sys.modules.setdefault("mcp.server", MagicMock())
-_fastmcp_mod = MagicMock()
-_fastmcp_mod.FastMCP = _MockFastMCP
-sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
 
-import atlas_brain.mcp.b2b.evidence as evidence_mcp
+# Plant the fake `mcp` only while the server module imports, then restore
+# sys.modules so sibling tests that need the real `mcp` are not poisoned.
+with stub_mcp(_MockFastMCP):
+    import atlas_brain.mcp.b2b.evidence as evidence_mcp
 
 
 @pytest.mark.asyncio

--- a/tests/test_b2b_parser_upgrade_maintenance.py
+++ b/tests/test_b2b_parser_upgrade_maintenance.py
@@ -1,15 +1,17 @@
-import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tests._module_stub import stub_missing_module
 
-if "asyncpg" not in __import__("sys").modules:
-    asyncpg_module = types.ModuleType("asyncpg")
-    asyncpg_module.connect = object
-    asyncpg_module.Connection = object
-    asyncpg_module.Record = dict
-    __import__("sys").modules["asyncpg"] = asyncpg_module
+# Stub asyncpg only when it is genuinely not importable, so CI (where asyncpg
+# is installed) imports the real module and no sibling test is poisoned. The
+# production task module is imported inline in each test below; this top-level
+# stub guarantees asyncpg is resolvable before those imports run.
+stub_missing_module(
+    "asyncpg",
+    attributes={"connect": object, "Connection": object, "Record": dict},
+)
 
 
 @pytest.mark.asyncio

--- a/tests/test_b2b_products_mcp.py
+++ b/tests/test_b2b_products_mcp.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tests._mcp_stub import stub_mcp
+
 
 class _MockFastMCP:
     def __init__(self, *args, **kwargs):
@@ -21,13 +23,11 @@ class _MockFastMCP:
 
 sys.modules.setdefault("asyncpg", MagicMock())
 sys.modules.setdefault("asyncpg.exceptions", MagicMock())
-sys.modules.setdefault("mcp", MagicMock())
-sys.modules.setdefault("mcp.server", MagicMock())
-_fastmcp_mod = MagicMock()
-_fastmcp_mod.FastMCP = _MockFastMCP
-sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
 
-import atlas_brain.mcp.b2b.products as products_mcp
+# Plant the fake `mcp` only while the server module imports, then restore
+# sys.modules so sibling tests that need the real `mcp` are not poisoned.
+with stub_mcp(_MockFastMCP):
+    import atlas_brain.mcp.b2b.products as products_mcp
 
 
 def _install_product_matching_service(monkeypatch, **kwargs):

--- a/tests/test_b2b_scrape_targets_mcp_inputs.py
+++ b/tests/test_b2b_scrape_targets_mcp_inputs.py
@@ -5,12 +5,12 @@ from uuid import uuid4
 
 import pytest
 
+from tests._mcp_stub import stub_mcp
+
 
 for _heavy_mod in [
     "asyncpg",
     "asyncpg.exceptions",
-    "mcp",
-    "mcp.server",
 ]:
     sys.modules.setdefault(_heavy_mod, MagicMock())
 
@@ -28,11 +28,10 @@ class _MockFastMCP:
         return None
 
 
-_fastmcp_mod = MagicMock()
-_fastmcp_mod.FastMCP = _MockFastMCP
-sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
-
-import atlas_brain.mcp.b2b.scrape_targets as scrape_targets_mcp
+# Plant the fake `mcp` only while the server module imports, then restore
+# sys.modules so sibling tests that need the real `mcp` are not poisoned.
+with stub_mcp(_MockFastMCP):
+    import atlas_brain.mcp.b2b.scrape_targets as scrape_targets_mcp
 
 
 def _mock_pool():

--- a/tests/test_b2b_signals_mcp_inputs.py
+++ b/tests/test_b2b_signals_mcp_inputs.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 
 import pytest
 
+from tests._mcp_stub import stub_mcp
+
 
 for _heavy_mod in [
     "PIL", "PIL.Image",
@@ -41,15 +43,10 @@ class _MockFastMCP:
         return None
 
 
-_mcp_mod = MagicMock()
-_mcp_server_mod = MagicMock()
-_fastmcp_mod = MagicMock()
-_fastmcp_mod.FastMCP = _MockFastMCP
-sys.modules.setdefault("mcp", _mcp_mod)
-sys.modules.setdefault("mcp.server", _mcp_server_mod)
-sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
-
-import atlas_brain.mcp.b2b.signals as signals_mcp
+# Plant the fake `mcp` only while the server module imports, then restore
+# sys.modules so sibling tests that need the real `mcp` are not poisoned.
+with stub_mcp(_MockFastMCP):
+    import atlas_brain.mcp.b2b.signals as signals_mcp
 
 
 def _mock_pool():

--- a/tests/test_b2b_source_impact.py
+++ b/tests/test_b2b_source_impact.py
@@ -11,6 +11,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests._mcp_stub import stub_mcp
+
 
 _asyncpg_mock = MagicMock()
 _asyncpg_exceptions = MagicMock()
@@ -62,14 +64,6 @@ class _MockFastMCP:
         return None
 
 
-_mcp_mod = MagicMock()
-_mcp_server_mod = MagicMock()
-_fastmcp_mod = MagicMock()
-_fastmcp_mod.FastMCP = _MockFastMCP
-sys.modules.setdefault("mcp", _mcp_mod)
-sys.modules.setdefault("mcp.server", _mcp_server_mod)
-sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
-
 import atlas_brain
 
 from atlas_brain.services.b2b.source_impact import (
@@ -94,7 +88,10 @@ b2b_dashboard = importlib.util.module_from_spec(_dashboard_spec)
 sys.modules["atlas_brain.api.b2b_dashboard"] = b2b_dashboard
 _dashboard_spec.loader.exec_module(b2b_dashboard)
 
-from atlas_brain.mcp.b2b import pipeline as mcp_pipeline
+# Plant the fake `mcp` only while the server module imports, then restore
+# sys.modules so sibling tests that need the real `mcp` are not poisoned.
+with stub_mcp(_MockFastMCP):
+    from atlas_brain.mcp.b2b import pipeline as mcp_pipeline
 
 
 def _mock_pool(fetch_return=None):

--- a/tests/test_b2b_vendor_registry_mcp.py
+++ b/tests/test_b2b_vendor_registry_mcp.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tests._mcp_stub import stub_mcp
+
 
 class _MockFastMCP:
     def __init__(self, *args, **kwargs):
@@ -21,13 +23,11 @@ class _MockFastMCP:
 
 sys.modules.setdefault("asyncpg", MagicMock())
 sys.modules.setdefault("asyncpg.exceptions", MagicMock())
-sys.modules.setdefault("mcp", MagicMock())
-sys.modules.setdefault("mcp.server", MagicMock())
-_fastmcp_mod = MagicMock()
-_fastmcp_mod.FastMCP = _MockFastMCP
-sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
 
-import atlas_brain.mcp.b2b.vendor_registry as vendor_registry_mcp
+# Plant the fake `mcp` only while the server module imports, then restore
+# sys.modules so sibling tests that need the real `mcp` are not poisoned.
+with stub_mcp(_MockFastMCP):
+    import atlas_brain.mcp.b2b.vendor_registry as vendor_registry_mcp
 
 
 def _install_vendor_registry_service(monkeypatch, **kwargs):

--- a/tests/test_backfill_g2_reviewer_company_cleanup.py
+++ b/tests/test_backfill_g2_reviewer_company_cleanup.py
@@ -1,15 +1,15 @@
 import sys
-import types
 from pathlib import Path
 from uuid import uuid4
 
+from tests._module_stub import stub_missing_module
 
-if "asyncpg" not in sys.modules:
-    asyncpg_module = types.ModuleType("asyncpg")
-    asyncpg_module.connect = object
-    asyncpg_module.Connection = object
-    asyncpg_module.Record = dict
-    sys.modules["asyncpg"] = asyncpg_module
+# Stub asyncpg only when it is genuinely not importable, so CI (where asyncpg
+# is installed) imports the real module and no sibling test is poisoned.
+stub_missing_module(
+    "asyncpg",
+    attributes={"connect": object, "Connection": object, "Record": dict},
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT / "scripts") not in sys.path:

--- a/tests/test_backfill_low_substance_enriched_reviews.py
+++ b/tests/test_backfill_low_substance_enriched_reviews.py
@@ -1,21 +1,24 @@
 import sys
-import types
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+from tests._module_stub import stub_missing_module
 
-if "asyncpg" not in sys.modules:
-    asyncpg_module = types.ModuleType("asyncpg")
-    asyncpg_module.connect = MagicMock()
-    asyncpg_module.Connection = object
-    asyncpg_module.Record = dict
-    asyncpg_exceptions = types.ModuleType("asyncpg.exceptions")
-    asyncpg_exceptions.UndefinedTableError = Exception
-    asyncpg_module.exceptions = asyncpg_exceptions
-    sys.modules["asyncpg"] = asyncpg_module
-    sys.modules["asyncpg.exceptions"] = asyncpg_exceptions
+# Stub asyncpg (+ asyncpg.exceptions) only when it is genuinely not importable,
+# so CI (where asyncpg is installed) imports the real module and no sibling
+# test is poisoned.
+_asyncpg_stub = stub_missing_module(
+    "asyncpg",
+    attributes={"connect": MagicMock(), "Connection": object, "Record": dict},
+)
+if _asyncpg_stub is not None:
+    _asyncpg_exceptions_stub = stub_missing_module(
+        "asyncpg.exceptions",
+        attributes={"UndefinedTableError": Exception},
+    )
+    _asyncpg_stub.exceptions = _asyncpg_exceptions_stub
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT / "scripts") not in sys.path:

--- a/tests/test_backfill_trustpilot_jsonld_company_cleanup.py
+++ b/tests/test_backfill_trustpilot_jsonld_company_cleanup.py
@@ -1,16 +1,16 @@
 import sys
-import types
 from pathlib import Path
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+from tests._module_stub import stub_missing_module
 
-if "asyncpg" not in sys.modules:
-    asyncpg_module = types.ModuleType("asyncpg")
-    asyncpg_module.connect = MagicMock()
-    asyncpg_module.Connection = object
-    asyncpg_module.Record = dict
-    sys.modules["asyncpg"] = asyncpg_module
+# Stub asyncpg only when it is genuinely not importable, so CI (where asyncpg
+# is installed) imports the real module and no sibling test is poisoned.
+stub_missing_module(
+    "asyncpg",
+    attributes={"connect": MagicMock(), "Connection": object, "Record": dict},
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT / "scripts") not in sys.path:

--- a/tests/test_campaign_recipient_dedup.py
+++ b/tests/test_campaign_recipient_dedup.py
@@ -22,6 +22,11 @@ from atlas_brain.autonomous.tasks.campaign_suppression import (
     attach_recipient_strict,
 )
 
+# Every test in this module exercises real SQL via the db_pool fixture
+# (live Postgres). Mark the module integration so the unit backstop
+# (`not integration and not e2e`) does not run it without a database.
+pytestmark = pytest.mark.integration
+
 
 @pytest_asyncio.fixture
 async def cleanup_sequences(db_pool):

--- a/tests/test_cloud_latency.py
+++ b/tests/test_cloud_latency.py
@@ -8,7 +8,14 @@ import os
 import time
 
 import pytest
-from openai import OpenAI
+
+# External cloud-latency benchmark: needs live Fireworks/Together API keys and
+# the `openai` SDK, which is not a brain runtime dependency. Mark e2e and skip
+# cleanly at collection when the SDK is absent so the unit backstop
+# (`not integration and not e2e`) does not error collecting it.
+pytestmark = pytest.mark.e2e
+pytest.importorskip("openai")
+from openai import OpenAI  # noqa: E402
 
 # API Keys from environment
 FIREWORKS_API_KEY = os.environ.get("FIREWORKS_API_KEY", "")

--- a/tests/test_evidence_gate.py
+++ b/tests/test_evidence_gate.py
@@ -37,6 +37,7 @@ def test_rank_floor_case_insensitive():
     assert _rank_floor("Weak") == 1
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_audit_returns_zero_for_empty_review_ids(db_pool):
     result = await audit_witness_evidence_coverage(
@@ -50,6 +51,7 @@ async def test_audit_returns_zero_for_empty_review_ids(db_pool):
     assert result["coverage_ratio"] == 1.0
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_audit_returns_zero_for_empty_vendor(db_pool):
     result = await audit_witness_evidence_coverage(
@@ -133,6 +135,7 @@ async def _seed_claim(
     )
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_audit_counts_strong_backed_review_ids(db_pool, cleanup_claims):
     vendor = f"vendor-{uuid4().hex[:8]}"
@@ -160,6 +163,7 @@ async def test_audit_counts_strong_backed_review_ids(db_pool, cleanup_claims):
     assert result["coverage_ratio"] == round(1 / 3, 3)
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_audit_loosened_to_weak_includes_weak_claims(db_pool, cleanup_claims):
     vendor = f"vendor-{uuid4().hex[:8]}"
@@ -184,6 +188,7 @@ async def test_audit_loosened_to_weak_includes_weak_claims(db_pool, cleanup_clai
     assert str(unbacked_rid) not in result["covered_review_ids"]
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_audit_ignores_invalid_status_rows(db_pool, cleanup_claims):
     vendor = f"vendor-{uuid4().hex[:8]}"

--- a/tests/test_graphiti_wrapper_health.py
+++ b/tests/test_graphiti_wrapper_health.py
@@ -7,6 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+# This exercises the standalone graphiti-wrapper service by loading its
+# main.py, whose deps (graphiti_core, neo4j) are not brain runtime deps. Mark
+# e2e and skip cleanly at module load when those deps are absent so the unit
+# backstop (`not integration and not e2e`) does not error collecting it.
+pytestmark = pytest.mark.e2e
 
 _ROOT = Path(__file__).resolve().parents[1]
 _WRAPPER_DIR = _ROOT / "graphiti-wrapper"
@@ -18,7 +23,13 @@ if str(_WRAPPER_DIR) not in sys.path:
 _SPEC = importlib.util.spec_from_file_location("graphiti_wrapper_main", _MODULE_PATH)
 assert _SPEC is not None and _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)
-_SPEC.loader.exec_module(_MODULE)
+try:
+    _SPEC.loader.exec_module(_MODULE)
+except Exception as exc:  # graphiti-wrapper service deps not installed here
+    pytest.skip(
+        f"graphiti-wrapper service deps unavailable: {exc}",
+        allow_module_level=True,
+    )
 
 
 def _make_settings():

--- a/tests/test_mcp_content_ops_marketer_verify.py
+++ b/tests/test_mcp_content_ops_marketer_verify.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests._mcp_stub import stub_mcp
+
 
 class _MockToolManager:
     def __init__(self) -> None:
@@ -80,11 +82,6 @@ class _TransportSecuritySettings:
         self.__dict__.update(kwargs)
 
 
-sys.modules.setdefault("mcp", MagicMock())
-sys.modules.setdefault("mcp.server", MagicMock())
-_fastmcp_mod = MagicMock()
-_fastmcp_mod.FastMCP = _MockFastMCP
-sys.modules.setdefault("mcp.server.fastmcp", _fastmcp_mod)
 _auth_provider_mod = MagicMock()
 _auth_provider_mod.AccessToken = _OAuthRecord
 _auth_provider_mod.AuthorizationCode = _OAuthRecord
@@ -95,28 +92,37 @@ _auth_provider_mod.ProviderTokenVerifier = _ProviderTokenVerifier
 _auth_provider_mod.RefreshToken = _OAuthRecord
 _auth_provider_mod.TokenError = _OAuthException
 _auth_provider_mod.construct_redirect_uri = lambda redirect_uri, **params: redirect_uri
-sys.modules.setdefault("mcp.server.auth.provider", _auth_provider_mod)
 _auth_settings_mod = MagicMock()
 _auth_settings_mod.AuthSettings = _AuthSettings
 _auth_settings_mod.ClientRegistrationOptions = _ClientRegistrationOptions
-sys.modules.setdefault("mcp.server.auth.settings", _auth_settings_mod)
 _transport_security_mod = MagicMock()
 _transport_security_mod.TransportSecuritySettings = _TransportSecuritySettings
-sys.modules.setdefault("mcp.server.transport_security", _transport_security_mod)
 _shared_auth_mod = MagicMock()
 _shared_auth_mod.OAuthClientInformationFull = _OAuthRecord
 _shared_auth_mod.OAuthToken = _OAuthRecord
-sys.modules.setdefault("mcp.shared.auth", _shared_auth_mod)
 
-from atlas_brain.config import settings
-from atlas_brain.mcp import content_ops_marketer_verify_chatgpt_adapter_server as adapter
-from atlas_brain.mcp import content_ops_marketer_verify_server as verify
-from atlas_brain.mcp.auth import BearerAuthMiddleware
-from atlas_brain.mcp.content_ops_marketer_verify_oauth import (
-    ContentOpsMarketerVerifyOAuthProvider,
-    DEFAULT_CONTENT_OPS_VERIFY_SCOPE,
-    validate_oauth_settings,
-)
+# Plant the fake `mcp` -- including the OAuth submodules this server imports --
+# only while the server modules import, then restore sys.modules so sibling
+# tests that need the real `mcp` (notably the invoicing OAuth tests, which
+# import `mcp.server.auth.provider`) are not poisoned during collection.
+with stub_mcp(
+    _MockFastMCP,
+    extra_modules={
+        "mcp.server.auth.provider": _auth_provider_mod,
+        "mcp.server.auth.settings": _auth_settings_mod,
+        "mcp.server.transport_security": _transport_security_mod,
+        "mcp.shared.auth": _shared_auth_mod,
+    },
+):
+    from atlas_brain.config import settings
+    from atlas_brain.mcp import content_ops_marketer_verify_chatgpt_adapter_server as adapter
+    from atlas_brain.mcp import content_ops_marketer_verify_server as verify
+    from atlas_brain.mcp.auth import BearerAuthMiddleware
+    from atlas_brain.mcp.content_ops_marketer_verify_oauth import (
+        ContentOpsMarketerVerifyOAuthProvider,
+        DEFAULT_CONTENT_OPS_VERIFY_SCOPE,
+        validate_oauth_settings,
+    )
 from extracted_content_pipeline.adversarial_pass import AdversarialFindingCategory
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.claims_map import RegistryClaim

--- a/tests/test_plan_parser_upgrade_rescrape_targets.py
+++ b/tests/test_plan_parser_upgrade_rescrape_targets.py
@@ -1,5 +1,4 @@
 import sys
-import types
 import argparse
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -7,13 +6,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests._module_stub import stub_missing_module
 
-if "asyncpg" not in sys.modules:
-    asyncpg_module = types.ModuleType("asyncpg")
-    asyncpg_module.connect = object
-    asyncpg_module.Connection = object
-    asyncpg_module.Record = dict
-    sys.modules["asyncpg"] = asyncpg_module
+# Stub asyncpg only when it is genuinely not importable, so CI (where asyncpg
+# is installed) imports the real module and no sibling test is poisoned.
+stub_missing_module(
+    "asyncpg",
+    attributes={"connect": object, "Connection": object, "Record": dict},
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT / "scripts") not in sys.path:


### PR DESCRIPTION
Plan: plans/PR-CI-Repo-Wide-Unit-Backstop.md
Umbrella scope: docs/backstop_test_hygiene_scope.md

Ownership lane: ci/coverage
Slice phase: Production hardening

## Why this slice exists

The repo has no repo-wide test suite — every `*_checks.yml` workflow is path-filtered and runs a hand-maintained file list, so a test file no workflow enrolls can pass CI while never executing. The first attempt at a catch-all backstop (closed PR #1707) couldn't go green because the full suite couldn't even be *collected*: some tests were unmarked DB tests, others were poisoned by cross-test `sys.modules` leaks, and four invoicing test files were enrolled in **zero** workflows. This effort fixes those collection gaps at the root and then re-introduces the backstop on top, so it can run the suite cleanly instead of reporting a wall of errors.

Over the 400-LOC soft cap (+725/−110, 25 files): justified as one coherent "make the repo-wide backstop able to run green" effort, sliced into independently-reviewable commits and almost entirely test-isolation + CI config. The umbrella scope doc explains the slicing.

## Mechanism (slices A–F + E)

- **A** — mark mislabeled DB-backed tests `integration` (module-level on 3 wholly-`db_pool` files; per-test on the 5 `db_pool` tests in the mixed `test_evidence_gate`, leaving its `_NullPool` unit tests in the backstop).
- **C** — stop the global `mcp` MagicMock leak. New `tests/_mcp_stub.py::stub_mcp` (save → plant fake → import server → restore `sys.modules`) applied to 8 MCP-server tests. Root cause confirmed: `setdefault` let whichever test collected first win, so the content-ops server inherited the b2b passthrough `FastMCP` (hence the `structured_output`/`custom_route` errors) and the invoicing OAuth tests saw `'mcp.server' is not a package`. No fake signatures changed — isolation alone fixes both.
- **B** — enroll the four never-run invoicing MCP/OAuth tests in `atlas_invoicing_checks.yml` with path triggers. The OAuth server is live (Claude/Codex connect through it); the import was never broken, only unrun and (under the full suite) poisoned — so this is CI-config only, no production OAuth code or `mcp` re-pin.
- **D** — classify the 5 remaining collection errors: fix the 2 genuinely-external (`test_cloud_latency` → `importorskip("openai")` + `e2e`; `test_graphiti_wrapper_health` → `e2e` + guarded cross-service load); re-classify the other 3 as heavy-dep leak victims (not mislabeled `e2e`).
- **F** — stop the `asyncpg` `sys.modules` leak. New `tests/_module_stub.py::stub_missing_module` (importability-guarded; never shadows installed asyncpg, gives any stub a valid `__spec__`) applied to the 5 bare-`ModuleType` planters that caused `asyncpg.__spec__ is not set` at collection.
- **E** — reintroduce `repo_wide_unit_backstop.yml` (schedule + manual dispatch + self-scoped `pull_request`, `--continue-on-collection-errors`), **advisory** for its debut run.

## Intentional

- Backstop is advisory (not a per-PR merge gate) for the debut so its runtime/flake profile and any residual gaps are observed first. Fast path-filtered per-PR checks are untouched.
- Helper logic verified in isolation; full-suite verification is by CI (the dev sandbox lacks `torch`/`mcp`/`fastapi`/`asyncpg`). The self-scoped `pull_request` trigger makes the backstop run on this PR — its result is the live proof the suite now collects.

## Deferred

- ~37 tests still stub `asyncpg` via `setdefault(MagicMock())`. These no-op once real asyncpg is imported and a `MagicMock` carries a truthy `__spec__`, so they weren't the confirmed breakage — left until the backstop's first run shows whether any still bite.
- Inert `torch`/`numpy` `sys.modules` stubs, same bug class, left until proven to matter.
- Broaden `audit_extracted_pipeline_ci_enrollment.py` (make it workflow-aware) so un-enrolled files are flagged at PR time, not only caught nightly.
- Optionally gate merges on a green backstop once its runtime/flake profile is known.

## Parked hardening

None.

## Verification

- `python -c "import yaml; yaml.safe_load(...)"` on both workflows — valid.
- `scripts/audit_workflow_security_posture.py` — passes.
- `stub_mcp` save/restore unit-checked (incl. the invoicing-poison scenario); `stub_missing_module` unit-checked (installed module never shadowed, absent one gets a valid `__spec__`, no `find_spec` landmine).
- `test_cloud_latency` collects as a clean skip under the backstop filter; a Slice-F-converted file now collects past the `asyncpg` boundary.
- Full-suite collection is CI-verified via the self-scoped backstop run on this PR.

## Diff size

25 files, +725/−110 (over the 400-LOC soft cap; justified in *Why this slice exists*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)