### PR TITLE
Fix two external/cross-service test collection errors

### DIFF
--- a/plans/PR-Test-Collection-Fixes.md
+++ b/plans/PR-Test-Collection-Fixes.md
@@ -81,8 +81,7 @@ None.
 
 - `python -m pytest tests/test_cloud_latency.py -m "not integration and not e2e"`
   -- collects as a clean skip (no `openai`), no collection error.
-- `python -m py_compile tests/test_cloud_latency.py tests/test_graphiti_wrapper_health.py`
-  -- both compile.
+- Both test modules pass `py_compile`.
 
 ## Estimated diff size
 

--- a/plans/PR-Test-Collection-Fixes.md
+++ b/plans/PR-Test-Collection-Fixes.md
@@ -1,0 +1,94 @@
+# PR-Test-Collection-Fixes
+
+## Why this slice exists
+
+Two test modules cannot be collected in a base `requirements.txt` environment,
+which aborts any whole-suite run (e.g. a repo-wide unit sweep) at collection
+time rather than reporting a clean skip:
+
+- `tests/test_cloud_latency.py` does a module-level `from openai import OpenAI`,
+  but `openai` is not a brain runtime dependency -- it is an external
+  Fireworks/Together latency benchmark that also needs live API keys.
+- `tests/test_graphiti_wrapper_health.py` `exec_module`s the standalone
+  `graphiti-wrapper/main.py` at import time, whose deps (`graphiti_core`,
+  `neo4j`) are not brain runtime deps.
+
+Both are legitimately external/cross-service tests; they should be marked `e2e`
+and skip cleanly when their optional deps are absent, instead of erroring
+collection.
+
+## Scope (this PR)
+
+Ownership lane: ci/coverage
+Slice phase: Production hardening
+
+1. `tests/test_cloud_latency.py`: add module-level `pytest.importorskip("openai")`
+   and `pytestmark = pytest.mark.e2e` so it skips cleanly without the SDK/keys.
+2. `tests/test_graphiti_wrapper_health.py`: add `pytestmark = pytest.mark.e2e`
+   and guard the cross-service `exec_module` with a module-level
+   `pytest.skip(allow_module_level=True)` narrowed to `ImportError`, so an
+   absent service dep skips but a real syntax/runtime regression still fails.
+
+### Files touched
+
+- `tests/test_cloud_latency.py`
+- `tests/test_graphiti_wrapper_health.py`
+- `plans/PR-Test-Collection-Fixes.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- [ ] Both modules collect as clean skips under `not integration and not e2e`
+      when their optional deps are absent.
+- [ ] The graphiti guard only skips on `ImportError`, not arbitrary exceptions.
+- [ ] No production code changes; test classification only.
+
+Affected surfaces: tests only.
+
+Risk areas: over-broad skip masking a real failure -- mitigated by narrowing
+the graphiti guard to `ImportError`.
+
+Reviewer rules triggered: R1.
+
+## Mechanism
+
+`pytest.importorskip("openai")` raises `Skipped` at module import when `openai`
+is not installed, so collection records a skip instead of an `ImportError`. The
+`e2e` marker keeps both modules out of the unit lane (`not integration and not
+e2e`). For graphiti, `exec_module` is wrapped so that an `ImportError` (the
+wrapper's `graphiti_core`/`neo4j` deps missing in a brain-only env) becomes a
+module-level skip, while any other exception (a real regression in
+`graphiti-wrapper/main.py`) propagates and fails the e2e test.
+
+## Intentional
+
+- Test classification only; the test bodies and assertions are unchanged.
+- The graphiti guard is deliberately `ImportError`-only (not `except
+  Exception`) so startup-breaking regressions in the wrapper are not silently
+  skipped in the environment where the e2e test should run.
+
+## Deferred
+
+- A repo-wide unit backstop (separate slice) that benefits from these clean
+  skips at whole-suite collection.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- `python -m pytest tests/test_cloud_latency.py -m "not integration and not e2e"`
+  -- collects as a clean skip (no `openai`), no collection error.
+- `python -m py_compile tests/test_cloud_latency.py tests/test_graphiti_wrapper_health.py`
+  -- both compile.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `tests/test_cloud_latency.py` | ~7 |
+| `tests/test_graphiti_wrapper_health.py` | ~12 |
+| `plans/PR-Test-Collection-Fixes.md` | ~80 |
+| **Total** | **~99** |

--- a/plans/PR-Test-Collection-Fixes.md
+++ b/plans/PR-Test-Collection-Fixes.md
@@ -13,9 +13,11 @@ time rather than reporting a clean skip:
   `graphiti-wrapper/main.py` at import time, whose deps (`graphiti_core`,
   `neo4j`) are not brain runtime deps.
 
-Both are legitimately external/cross-service tests; they should be marked `e2e`
-and skip cleanly when their optional deps are absent, instead of erroring
-collection.
+They should skip cleanly when their optional deps are absent instead of
+erroring collection. `test_cloud_latency` genuinely calls live external APIs,
+so it is `e2e`; `test_graphiti_wrapper_health`'s tests are fully mocked, so
+they stay in the unit lane and only the cross-service module load is gated on
+the optional deps.
 
 ## Scope (this PR)
 
@@ -23,11 +25,14 @@ Ownership lane: ci/coverage
 Slice phase: Production hardening
 
 1. `tests/test_cloud_latency.py`: add module-level `pytest.importorskip("openai")`
-   and `pytestmark = pytest.mark.e2e` so it skips cleanly without the SDK/keys.
-2. `tests/test_graphiti_wrapper_health.py`: add `pytestmark = pytest.mark.e2e`
-   and guard the cross-service `exec_module` with a module-level
-   `pytest.skip(allow_module_level=True)` narrowed to `ImportError`, so an
-   absent service dep skips but a real syntax/runtime regression still fails.
+   and `pytestmark = pytest.mark.e2e` so it skips cleanly without the SDK/keys
+   (it is an external live-API benchmark).
+2. `tests/test_graphiti_wrapper_health.py`: preflight the named optional service
+   deps with `pytest.importorskip("neo4j")` / `pytest.importorskip("graphiti_core")`
+   before `exec_module`, and run `exec_module` unguarded. No `e2e` marker: the
+   health/readiness tests are fully mocked, so when the deps are present they
+   run in the unit lane, and a real import regression in `main.py` or its local
+   modules still fails (only the named absent deps skip).
 
 ### Files touched
 
@@ -39,34 +44,45 @@ Slice phase: Production hardening
 
 Acceptance criteria:
 
-- [ ] Both modules collect as clean skips under `not integration and not e2e`
-      when their optional deps are absent.
-- [ ] The graphiti guard only skips on `ImportError`, not arbitrary exceptions.
+- [ ] Both modules collect as clean skips in a brain-only env (no `openai`,
+      no `neo4j`/`graphiti_core`) instead of erroring collection.
+- [ ] `test_graphiti_wrapper_health` skips only on the named absent optional
+      deps; a real import regression in `main.py` or its local modules fails.
+- [ ] `test_graphiti_wrapper_health` carries no `e2e` marker, so its mocked
+      tests run in the unit lane when the deps are present.
 - [ ] No production code changes; test classification only.
 
 Affected surfaces: tests only.
 
-Risk areas: over-broad skip masking a real failure -- mitigated by narrowing
-the graphiti guard to `ImportError`.
+Risk areas: a skip masking a real failure -- mitigated by preflighting only the
+named optional deps (`neo4j`, `graphiti_core`) and running `exec_module`
+unguarded so other import regressions propagate.
 
 Reviewer rules triggered: R1.
 
 ## Mechanism
 
-`pytest.importorskip("openai")` raises `Skipped` at module import when `openai`
-is not installed, so collection records a skip instead of an `ImportError`. The
-`e2e` marker keeps both modules out of the unit lane (`not integration and not
-e2e`). For graphiti, `exec_module` is wrapped so that an `ImportError` (the
-wrapper's `graphiti_core`/`neo4j` deps missing in a brain-only env) becomes a
-module-level skip, while any other exception (a real regression in
-`graphiti-wrapper/main.py`) propagates and fails the e2e test.
+`pytest.importorskip(name)` raises `Skipped` at module import when `name` is not
+installed, recording a clean skip instead of an `ImportError`. `test_cloud_latency`
+preflights `openai` and is marked `e2e` (it makes live Fireworks/Together
+calls). `test_graphiti_wrapper_health` preflights the named service deps
+`neo4j` and `graphiti_core`, then `exec_module`s `graphiti-wrapper/main.py`
+**unguarded**: in a brain-only env the preflight skips before the load is
+attempted, while if those deps are present a genuine import regression in
+`main.py` or one of its local modules (e.g. `embedder_factory`) propagates as a
+failure rather than a silent skip. The module is not marked `e2e` because its
+health/readiness tests patch `AsyncGraphDatabase`, the embedder preload, and
+the readiness gate -- they need no live services and belong in the unit lane.
 
 ## Intentional
 
 - Test classification only; the test bodies and assertions are unchanged.
-- The graphiti guard is deliberately `ImportError`-only (not `except
-  Exception`) so startup-breaking regressions in the wrapper are not silently
-  skipped in the environment where the e2e test should run.
+- The graphiti skip is preflight-on-named-deps (not a broad `except`) so
+  regressions in the wrapper's own modules still fail in the environment where
+  the test can run -- per reviewer feedback (Codex + Copilot) on the prior
+  combined PR.
+- No `e2e` marker on the mocked graphiti tests, so they execute in the
+  repo-wide unit lane when `neo4j`/`graphiti_core` are installed.
 
 ## Deferred
 

--- a/tests/test_cloud_latency.py
+++ b/tests/test_cloud_latency.py
@@ -8,7 +8,14 @@ import os
 import time
 
 import pytest
-from openai import OpenAI
+
+# External cloud-latency benchmark: needs live Fireworks/Together API keys and
+# the `openai` SDK, which is not a brain runtime dependency. Mark e2e and skip
+# cleanly at collection when the SDK is absent so the unit backstop
+# (`not integration and not e2e`) does not error collecting it.
+pytestmark = pytest.mark.e2e
+pytest.importorskip("openai")
+from openai import OpenAI  # noqa: E402
 
 # API Keys from environment
 FIREWORKS_API_KEY = os.environ.get("FIREWORKS_API_KEY", "")

--- a/tests/test_graphiti_wrapper_health.py
+++ b/tests/test_graphiti_wrapper_health.py
@@ -7,11 +7,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-# This exercises the standalone graphiti-wrapper service by loading its
-# main.py, whose deps (graphiti_core, neo4j) are not brain runtime deps. Mark
-# e2e and skip cleanly at module load when those deps are absent so the unit
-# backstop (`not integration and not e2e`) does not error collecting it.
-pytestmark = pytest.mark.e2e
+# main.py belongs to the standalone graphiti-wrapper service; its service deps
+# (neo4j, graphiti_core) are not brain runtime deps. Skip the whole module only
+# when those named optional deps are absent (e.g. a brain-only env). When they
+# are present the health/readiness tests below are fully mocked (no live
+# services), so they stay in the normal unit lane -- no e2e marker -- and a real
+# import regression in main.py or its local modules still fails because
+# exec_module is not wrapped in a broad guard.
+pytest.importorskip("neo4j")
+pytest.importorskip("graphiti_core")
 
 _ROOT = Path(__file__).resolve().parents[1]
 _WRAPPER_DIR = _ROOT / "graphiti-wrapper"
@@ -23,15 +27,7 @@ if str(_WRAPPER_DIR) not in sys.path:
 _SPEC = importlib.util.spec_from_file_location("graphiti_wrapper_main", _MODULE_PATH)
 assert _SPEC is not None and _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)
-try:
-    _SPEC.loader.exec_module(_MODULE)
-except ImportError as exc:  # only skip when the wrapper's service deps are absent
-    # Narrow to ImportError so a real syntax/runtime regression in the
-    # graphiti-wrapper module surfaces as a failure instead of a silent skip.
-    pytest.skip(
-        f"graphiti-wrapper service deps unavailable: {exc}",
-        allow_module_level=True,
-    )
+_SPEC.loader.exec_module(_MODULE)
 
 
 def _make_settings():

--- a/tests/test_graphiti_wrapper_health.py
+++ b/tests/test_graphiti_wrapper_health.py
@@ -7,6 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+# This exercises the standalone graphiti-wrapper service by loading its
+# main.py, whose deps (graphiti_core, neo4j) are not brain runtime deps. Mark
+# e2e and skip cleanly at module load when those deps are absent so the unit
+# backstop (`not integration and not e2e`) does not error collecting it.
+pytestmark = pytest.mark.e2e
 
 _ROOT = Path(__file__).resolve().parents[1]
 _WRAPPER_DIR = _ROOT / "graphiti-wrapper"
@@ -18,7 +23,15 @@ if str(_WRAPPER_DIR) not in sys.path:
 _SPEC = importlib.util.spec_from_file_location("graphiti_wrapper_main", _MODULE_PATH)
 assert _SPEC is not None and _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)
-_SPEC.loader.exec_module(_MODULE)
+try:
+    _SPEC.loader.exec_module(_MODULE)
+except ImportError as exc:  # only skip when the wrapper's service deps are absent
+    # Narrow to ImportError so a real syntax/runtime regression in the
+    # graphiti-wrapper module surfaces as a failure instead of a silent skip.
+    pytest.skip(
+        f"graphiti-wrapper service deps unavailable: {exc}",
+        allow_module_level=True,
+    )
 
 
 def _make_settings():


### PR DESCRIPTION
Plan: plans/PR-Test-Collection-Fixes.md

Ownership lane: ci/coverage
Slice phase: Production hardening

## Why this slice exists

Two test modules can't be collected in a base `requirements.txt` env, which aborts any whole-suite run at collection time instead of skipping cleanly:
- `tests/test_cloud_latency.py` — module-level `from openai import OpenAI`, but `openai` isn't a brain dep (it's an external Fireworks/Together latency benchmark needing live API keys).
- `tests/test_graphiti_wrapper_health.py` — `exec_module`s the standalone `graphiti-wrapper/main.py` (service deps `neo4j`/`graphiti_core` aren't brain deps).

`test_cloud_latency` genuinely makes live external calls → `e2e`. `test_graphiti_wrapper_health`'s tests are **fully mocked** → they stay in the unit lane; only the cross-service module load is gated on the optional deps. Second slice of the split test-hygiene effort (umbrella: `docs/backstop_test_hygiene_scope.md`); slice B merged in #1710.

## Mechanism

`pytest.importorskip(name)` raises `Skipped` at module import when `name` isn't installed, recording a clean skip instead of an `ImportError`.

- `test_cloud_latency`: `pytest.importorskip("openai")` + `pytestmark = pytest.mark.e2e` (it makes live Fireworks/Together calls).
- `test_graphiti_wrapper_health`: `pytest.importorskip("neo4j")` + `pytest.importorskip("graphiti_core")` before an **unguarded** `exec_module`. In a brain-only env the preflight skips before the load is attempted; when those deps are present, a genuine import regression in `main.py` or a local module (e.g. `embedder_factory`) propagates as a failure rather than a silent skip. **No `e2e` marker** — the health/readiness tests patch `AsyncGraphDatabase`, the embedder preload, and the readiness gate, so they need no live services and belong in the unit lane.

## Intentional

- Test classification only; test bodies/assertions unchanged.
- Graphiti skip is preflight-on-named-deps (not a broad `except`), so regressions in the wrapper's own modules still fail where the test can run — per Codex + Copilot review on the prior combined PR.
- No `e2e` marker on the mocked graphiti tests, so they run in the repo-wide unit lane when `neo4j`/`graphiti_core` are installed.

## Deferred

- The repo-wide unit backstop (separate slice) that benefits from these clean skips at whole-suite collection.

## Parked hardening

None.

## Verification

- `python -m pytest tests/test_cloud_latency.py -m "not integration and not e2e"` → clean skip (no `openai`), no collection error (verified locally).
- `py_compile` on both modules → compile.

## Review reconciliation

All review threads resolved.

- Codex + Copilot (graphiti broad `ImportError` masks real regressions; `e2e` marker excludes mocked tests from the unit lane): **fixed** — switched to `importorskip("neo4j")`/`importorskip("graphiti_core")` + unguarded `exec_module`, dropped the `e2e` marker.
- Codex (plan/code-consistency: backtick `py_compile` parsed as a path claim): **fixed** — reworded as prose.
- Copilot (PR description out of sync with the implemented approach): **fixed** — this description matches the `importorskip` design.

## Diff size

3 files, ~120 LOC (under the 400-LOC soft cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)