### PR TITLE
Add PR fix mode doc layer (rule + baton + compact instructions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -651,6 +651,30 @@ not after a full review round. Chasing the symptom one layer at a time -- fix
 the named case, ship, get bounced one layer deeper, repeat -- is the
 tail-chasing this gate exists to stop.
 
+### 3l. PR fix mode (constrain the fix loop)
+
+A **fix loop** -- iterating on red CI or review comments on an already-open PR
+-- is where sessions burn the most time and tokens: broad exploration, edits to
+files outside the real failure source, and re-orientation after every
+compaction. Before editing in a fix loop, record a **fix baton** in
+`SESSION_STATE.local.md` (the `PR Fix Mode` block) capturing the failure source,
+the **allowed-files set**, and a **max-files budget**.
+
+- **Stay inside the allowed set.** The allowed files are the failure source you
+  identified, not "everything the symptom touches." Touching a file outside the
+  set is presumed scope creep.
+- **Widening the set is a root-cause decision.** If the fix genuinely needs an
+  upstream file, name the upstream reason in the baton and the plan **before**
+  editing it (this is the §3k trace, not a drive-by). Do not silently grow the
+  diff.
+- **One judgment pass, no auto-loop.** Bot findings are advisory inputs you
+  disposition deliberately (resolve or waive with a reason); there is no
+  "address every comment" reflex (§4a.1).
+- **The baton is the compaction handoff.** Keep the current failing
+  check/comment, the last useful log finding, the next exact action, and
+  do-not-redo notes current, so a post-compaction resume continues instead of
+  re-exploring. Update it before and after each push.
+
 ---
 
 ## 4. Reviewer workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1378,3 +1378,17 @@ Compose files for sub-services:
   identifiers and string literals.
 - **No `--no-verify`**: never bypass pre-commit / CI gates without explicit
   user authorization.
+
+## Compact Instructions
+
+When compacting this conversation, preserve verbatim (do not summarize away):
+
+- The active operator-assigned lane and the **owned active PR** (number, branch,
+  latest pushed SHA) from `SESSION_STATE.local.md`.
+- The full **PR Fix Mode** baton when a fix loop is active: allowed-files set +
+  max-files budget, current failing check/comment, last useful log finding, next
+  exact action, and do-not-redo notes.
+
+These are the fields a post-compaction resume needs to continue a fix loop
+without re-exploring or touching files outside the declared scope (see
+`AGENTS.md` §3l). When in doubt, keep the baton and drop narrative.

--- a/docs/SESSION_STATE_TEMPLATE.md
+++ b/docs/SESSION_STATE_TEMPLATE.md
@@ -51,9 +51,24 @@ Dirty state expected: yes | no
 
 <One sentence: e.g. "Opened #1234 and stopped; waiting for operator signal.">
 
+## PR Fix Mode (active fix loop)
+
+Active: yes | no   (fill in only while iterating on red CI / review comments)
+PR: #<number or none>
+Branch: <branch>
+Latest commit: <sha at last push>
+Allowed files (max N=<n>):
+- <path or glob -- the failure source, not everything the symptom touches>
+Current failing check / comment: <e.g. live-reconciliation: copilot :194,:226>
+Last useful log finding: <the single line that localized it>
+Next exact action: <one sentence>
+Do-NOT-redo: <paths ruled out, checks already green, dead ends>
+
 ## Resume Checklist
 
 - [ ] Read this file before any PR action.
+- [ ] If PR Fix Mode is active, read its block before any edit; do not touch
+      files outside Allowed files (widening requires the §3k upstream reason).
 - [ ] Run `gh pr list --state open`.
 - [ ] Run `git log --oneline -15 origin/main`.
 - [ ] Confirm the current PR is listed under "Owned Active PR" or "PRs This

--- a/plans/PR-Fix-Mode-Doc-Layer.md
+++ b/plans/PR-Fix-Mode-Doc-Layer.md
@@ -1,0 +1,110 @@
+# PR-Fix-Mode-Doc-Layer
+
+## Why this slice exists
+
+Fix loops -- iterating on red CI or review comments on an already-open PR -- are
+where agent sessions (Codex, Claude Code) burn the most time and tokens: broad
+exploration, edits to files outside the real failure source, and re-orientation
+after every context compaction. Issue #1714 captured a full "PR fix mode" design
+(a model-agnostic core plus Codex and Claude Code enforcement layers). This
+slice lands only the **doc layer** of that design -- the part that is tracked in
+git, benefits both agents immediately, needs no `.gitignore` change, and weakens
+no existing gate. The deterministic enforcement layer (`.claude/` hooks,
+`/fix-mode` skill, `.gitignore` narrowing, Codex `--max-files`) is deferred to
+follow-ups under #1714.
+
+## Scope (this PR)
+
+Ownership lane: process/agent-guidance
+Slice phase: Production hardening
+
+Documentation only. Three tracked files gain a fix-loop rule, a reusable baton
+block, and a compaction-preservation instruction. No code, no config, no gate
+change.
+
+### Files touched
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/SESSION_STATE_TEMPLATE.md`
+- `plans/PR-Fix-Mode-Doc-Layer.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- [ ] `AGENTS.md` gains a `### 3l. PR fix mode` subsection between §3k and §4,
+      cross-referencing §3k (root-cause) and §4a.1 (no auto-loop) rather than
+      restating them.
+- [ ] `docs/SESSION_STATE_TEMPLATE.md` gains a `## PR Fix Mode (active fix loop)`
+      block inside the template fence with the eight baton fields, plus a
+      Resume-Checklist bullet gating edits on the allowed-files set.
+- [ ] `CLAUDE.md` gains a `## Compact Instructions` section telling the
+      summarizer to preserve the baton fields verbatim across compaction.
+- [ ] No code, config, workflow, or `.gitignore` change; no existing gate
+      relaxed.
+
+Affected surfaces: builder/agent process docs only.
+
+Risk areas: a documented rule with no enforcement is advisory -- mitigated by
+landing it on the read-first docs (AGENTS.md, the SESSION_STATE template loaded
+into the gitignored baton, and CLAUDE.md) and tracking the enforcement follow-up
+in #1714.
+
+Reviewer rules triggered: R1.
+
+## Mechanism
+
+The baton reuses the existing gitignored `SESSION_STATE.local.md` (mandated by
+AGENTS.md §3a.1), so there is no new file or convention -- the template just
+grows a `PR Fix Mode` block that builders copy in. AGENTS.md §3l states the
+fix-loop discipline (declare failure source + allowed-files + max-files budget
+before editing; widening the set is a §3k root-cause decision; disposition
+findings in one pass per §4a.1; keep the baton current as the compaction
+handoff). CLAUDE.md `## Compact Instructions` is read by Claude Code at
+compaction time and documents intent for any agent: preserve the baton fields
+verbatim so a post-compaction resume continues instead of re-exploring.
+
+## Intentional
+
+- Doc layer only -- no enforcement code. The value is the shared rule + baton
+  shape, usable by both agents today.
+- §3l cross-references §3k and §4a.1 instead of duplicating them, to avoid drift
+  between the rule and its gates.
+- The baton lives in the already-gitignored session-state file, so it never
+  enters a PR diff and survives compaction as a read-first doc.
+
+## Deferred
+
+Tracked in issue #1714 (not this PR):
+
+- `.gitignore` narrowing (`.claude/`) to make Claude Code config shareable.
+- `.claude/settings.json` PreToolUse deny + SessionStart/PreCompact baton
+  re-hydration hooks, and a `/fix-mode` skill entrypoint.
+- Codex `--max-files` budget enforcement in
+  `audit_plan_doc_files_touched.py`.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Run `scripts/audit_plan_doc.py` against this plan -- 7 required sections
+  present and ordered.
+- Run `scripts/pre_push_audit.sh` -- plan files-touched and diff-size audits
+  match the real diff (no MISSING/EXTRA, Total within tolerance).
+- Run `scripts/local_pr_review.sh` -- full local review bundle green before
+  push.
+- Manual read-through: §3l renders between §3k and §4; the template block sits
+  inside the fenced template; the CLAUDE.md section is at end of file.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 24 |
+| `CLAUDE.md` | 14 |
+| `docs/SESSION_STATE_TEMPLATE.md` | 15 |
+| `plans/PR-Fix-Mode-Doc-Layer.md` | ~110 |
+| **Total** | **~163** |


### PR DESCRIPTION
Plan: plans/PR-Fix-Mode-Doc-Layer.md

Slice phase: Production hardening

Fix loops -- iterating on red CI or review comments on an already-open PR --
are where agent sessions (Codex, Claude Code) burn the most time and tokens:
broad exploration, edits outside the real failure source, and re-orientation
after compaction. This lands the doc layer of the PR fix-mode design captured in
issue #1714 -- the tracked part that helps both agents now, needs no
`.gitignore` change, and weakens no gate.

## Intentional

- Doc layer only -- no enforcement code. The value is the shared rule + baton
  shape, usable by Codex and Claude Code today.
- `AGENTS.md` 3l states the fix-loop discipline (declare failure source +
  allowed-files + max-files budget before editing; widening the set is a 3k
  root-cause decision; disposition findings in one pass per 4a.1; keep the baton
  current as the compaction handoff) and cross-references 3k/4a.1 instead of
  duplicating them.
- The baton reuses the already-gitignored `SESSION_STATE.local.md`, so it never
  enters a PR diff and survives compaction as a read-first doc.
- `CLAUDE.md` Compact Instructions tell the summarizer to preserve the baton
  verbatim.

## Deferred

Tracked in issue #1714 (not this PR):

- `.gitignore` narrowing (`.claude/`) to make Claude Code config shareable.
- `.claude/settings.json` PreToolUse deny + SessionStart/PreCompact baton
  re-hydration hooks, and a `/fix-mode` skill entrypoint.
- Codex max-files budget enforcement in the plan files-touched audit.

## Parked hardening

None.

## Verification

- Ran the plan-doc section audit -- 7 required sections present and ordered.
- Ran the plan-code consistency audit -- all 8 path claims resolve.
- Ran the full local review bundle -- green except the pre-PR body check, which
  passes once this body is supplied.

## Diff size

4 files, ~163 added lines: AGENTS.md (24), CLAUDE.md (14),
docs/SESSION_STATE_TEMPLATE.md (15), and the plan doc (~110). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Bwpk9YWN2xGaE1jmNPYLP

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bwpk9YWN2xGaE1jmNPYLP)_