### PR TITLE
Add max-files budget to plan files-touched audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -662,7 +662,9 @@ the **allowed-files set**, and a **max-files budget**.
 
 - **Stay inside the allowed set.** The allowed files are the failure source you
   identified, not "everything the symptom touches." Touching a file outside the
-  set is presumed scope creep.
+  set is presumed scope creep. Declare `Max files: N` in the plan's *Scope* to
+  have the files-touched audit (`scripts/audit_plan_doc_files_touched.py`)
+  enforce the budget at pre-push/CI -- the PR fails if more than N files change.
 - **Widening the set is a root-cause decision.** If the fix genuinely needs an
   upstream file, name the upstream reason in the baton and the plan **before**
   editing it (this is the §3k trace, not a drive-by). Do not silently grow the

--- a/plans/PR-Codex-Max-Files-Budget.md
+++ b/plans/PR-Codex-Max-Files-Budget.md
@@ -52,9 +52,11 @@ Reviewer rules triggered: R1, R10, R2.
 
 ## Mechanism
 
-`declared_max_files()` parses an optional `Max files: N` line from the plan text
-(mirroring how `scripts/audit_plan_doc_diff_size.py` reads its Total from the
-plan). `main()` moves to argparse -- positional `plan`, optional `base_ref`
+`declared_max_files()` reads an optional `Max files: N` line from the plan's
+*Scope* section only -- so a digit-only mention in other prose or an example
+does not arm the gate -- and fails closed (raising `PlanBudgetError`, exit 2) on
+a present-but-malformed value so a typo cannot silently disable the budget. This
+mirrors how `scripts/audit_plan_doc_diff_size.py` reads its Total from the plan. `main()` moves to argparse -- positional `plan`, optional `base_ref`
 (default `origin/main`), and `--max-files` -- which preserves the existing
 two-positional call in `scripts/pre_push_audit.sh`. The budget resolves to the
 flag if given, else the declared value; when set and the actual changed-file
@@ -102,8 +104,8 @@ None.
 
 | File | LOC |
 |---|---:|
-| `scripts/audit_plan_doc_files_touched.py` | 34 |
-| `tests/test_audit_plan_doc_files_touched.py` | 84 |
+| `scripts/audit_plan_doc_files_touched.py` | 74 |
+| `tests/test_audit_plan_doc_files_touched.py` | 118 |
 | `AGENTS.md` | 3 |
 | `plans/PR-Codex-Max-Files-Budget.md` | ~109 |
-| **Total** | **~230** |
+| **Total** | **~304** |

--- a/plans/PR-Codex-Max-Files-Budget.md
+++ b/plans/PR-Codex-Max-Files-Budget.md
@@ -1,0 +1,109 @@
+# PR-Codex-Max-Files-Budget
+
+## Why this slice exists
+
+The PR fix-mode doc layer (merged in #1715: AGENTS.md 3l + baton +
+compact instructions) is advisory only. This slice lands the first
+**enforcement** piece from issue #1714: a max-files budget on the plan-doc
+files-touched audit. A fix loop that strays beyond its declared file count now
+fails a cheap, early gate -- the audit already runs in `scripts/pre_push_audit.sh`
+before any test or long CI lane -- instead of being caught late or not at all.
+This is the Codex-side enforcement (deterministic at push/CI time); the Claude
+Code pre-edit-hook track is a separate later slice under #1714.
+
+## Scope (this PR)
+
+Ownership lane: ci/coverage
+Slice phase: Production hardening
+Max files: 4
+
+The files-touched audit gains an optional, opt-in budget. A plan declaring
+`Max files: N` in its *Scope* has the budget enforced automatically; a
+`--max-files N` flag overrides it for manual fix-session runs. When neither is
+set the audit behaves exactly as before, so non-fix PRs are unaffected. This PR
+dogfoods the field on its own plan (`Max files: 4`).
+
+### Files touched
+
+- `scripts/audit_plan_doc_files_touched.py`
+- `tests/test_audit_plan_doc_files_touched.py`
+- `AGENTS.md`
+- `plans/PR-Codex-Max-Files-Budget.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- [ ] A plan with `Max files: N` fails the audit when the diff changes more than
+      N files, with `OVER BUDGET` in output and exit 1.
+- [ ] `--max-files N` overrides/supplies the budget for manual runs.
+- [ ] With no budget declared and no flag, behavior is unchanged (no cap); the
+      existing MISSING/EXTRA logic and exit codes are preserved.
+- [ ] No change to how `scripts/pre_push_audit.sh` invokes the audit.
+
+Affected surfaces: the plan-doc files-touched auditor (a gate predicate) + its
+tests + one AGENTS.md sentence. No application code.
+
+Risk areas: a budget gate that misfires could block legitimate PRs -- mitigated
+by making it strictly opt-in (off unless a plan/flag sets it) and counting the
+same `actual` diff set the existing EXTRA/MISSING check already uses.
+
+Reviewer rules triggered: R1, R10, R2.
+
+## Mechanism
+
+`declared_max_files()` parses an optional `Max files: N` line from the plan text
+(mirroring how `scripts/audit_plan_doc_diff_size.py` reads its Total from the
+plan). `main()` moves to argparse -- positional `plan`, optional `base_ref`
+(default `origin/main`), and `--max-files` -- which preserves the existing
+two-positional call in `scripts/pre_push_audit.sh`. The budget resolves to the
+flag if given, else the declared value; when set and the actual changed-file
+count exceeds it, the audit prints `OVER BUDGET` and returns exit 1 alongside the
+unchanged MISSING/EXTRA reporting. The budget counts every file in
+`git diff --name-only base...HEAD`, including the plan doc, so authors set N to
+include it.
+
+## Intentional
+
+- Opt-in only: no budget declared and no flag means the cap is off and the audit
+  is byte-for-byte the prior behavior, so existing PRs are untouched.
+- Budget sourced from the tracked plan doc (not the gitignored baton) so it is
+  enforceable at pre-push/CI; the `--max-files` flag covers manual fix-session
+  runs.
+- No invocation wiring change -- `scripts/pre_push_audit.sh` already passes the
+  plan doc, so declaring the field is enough to enforce it.
+
+## Deferred
+
+Tracked in issue #1714 (not this PR):
+
+- Claude Code pre-edit enforcement (`.claude/` PreToolUse deny +
+  SessionStart/PreCompact baton re-hydration hooks) and the `/fix-mode` skill.
+- `.gitignore` narrowing to make the Claude Code config shareable.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Run the files-touched audit tests in `tests/test_audit_plan_doc_files_touched.py`
+  -- existing plus new budget cases pass.
+- Dogfood: with `Max files: 4` in this plan and exactly four changed files, the
+  audit prints the budget line and exits 0; lowering the field to 3 exits 1 with
+  `OVER BUDGET` (reverted before commit).
+- Run `scripts/audit_plan_code_consistency.py` on this plan -- all path and
+  function claims resolve (`declared_max_files` resolves to its def; the
+  `Max files: 4` line has no backticks and is not a claim).
+- Run `scripts/local_pr_review.sh` -- full local bundle green, including this
+  plan passing its own files-touched budget.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `scripts/audit_plan_doc_files_touched.py` | 34 |
+| `tests/test_audit_plan_doc_files_touched.py` | 84 |
+| `AGENTS.md` | 3 |
+| `plans/PR-Codex-Max-Files-Budget.md` | ~109 |
+| **Total** | **~230** |

--- a/plans/PR-Codex-Max-Files-Budget.md
+++ b/plans/PR-Codex-Max-Files-Budget.md
@@ -13,7 +13,7 @@ Code pre-edit-hook track is a separate later slice under #1714.
 
 ## Scope (this PR)
 
-Ownership lane: ci/coverage
+Ownership lane: process/agent-guidance
 Slice phase: Production hardening
 Max files: 4
 

--- a/scripts/audit_plan_doc_files_touched.py
+++ b/scripts/audit_plan_doc_files_touched.py
@@ -11,8 +11,16 @@ from dataclasses import dataclass
 from pathlib import Path
 
 PATH_PATTERN = re.compile(r"`([^`\n]+)`")
-# Optional fix-mode budget declared in the plan Scope, e.g. "Max files: 3".
-MAX_FILES_PATTERN = re.compile(r"(?im)^\s*Max files:\s*(\d+)\b")
+# Optional fix-mode budget declared in the plan *Scope*, e.g. "Max files: 3".
+# Read only from the Scope section (so digit-only mentions in other prose do not
+# trigger the gate) and fail closed on a malformed value (so a typo cannot
+# silently disable the gate).
+SCOPE_HEADING_PATTERN = re.compile(r"^##\s+Scope\b")
+MAX_FILES_LINE_PATTERN = re.compile(r"(?im)^\s*Max files:\s*(\S.*?)\s*$")
+
+
+class PlanBudgetError(ValueError):
+    """A `Max files:` declaration is present in Scope but is not an integer."""
 
 
 @dataclass(frozen=True)
@@ -63,10 +71,37 @@ def claimed_files_touched(text: str) -> set[str]:
     return claimed
 
 
+def _scope_section(text: str) -> str:
+    """The plan's `## Scope` section body (up to the next `## ` heading)."""
+    out: list[str] = []
+    in_scope = False
+    for line in text.splitlines():
+        if line.startswith("## "):
+            if SCOPE_HEADING_PATTERN.match(line):
+                in_scope = True
+                continue
+            if in_scope:
+                break
+        if in_scope:
+            out.append(line)
+    return "\n".join(out)
+
+
 def declared_max_files(text: str) -> int | None:
-    """The optional `Max files: N` budget declared in the plan, or None."""
-    match = MAX_FILES_PATTERN.search(text)
-    return int(match.group(1)) if match else None
+    """The `Max files: N` budget from the plan's Scope, or None if absent.
+
+    Reads only the Scope section, so a digit-only `Max files:` mention in other
+    prose or an example does not trigger the budget. Fails closed: a present but
+    non-integer value raises `PlanBudgetError` rather than silently disabling the
+    gate.
+    """
+    match = MAX_FILES_LINE_PATTERN.search(_scope_section(text))
+    if match is None:
+        return None
+    raw = match.group(1).strip()
+    if not raw.isdigit():
+        raise PlanBudgetError(f"malformed 'Max files:' value in Scope: {raw!r}")
+    return int(raw)
 
 
 def actual_diff_files(base_ref: str) -> set[str]:
@@ -117,7 +152,12 @@ def main(argv: list[str] | None = None) -> int:
 
     plan_text = plan_path.read_text(encoding="utf-8")
     audit = audit_files_touched(plan_text, actual)
-    budget = args.max_files if args.max_files is not None else declared_max_files(plan_text)
+    try:
+        plan_budget = declared_max_files(plan_text)
+    except PlanBudgetError as exc:
+        print(f"plan budget error: {exc}", file=sys.stderr)
+        return 2
+    budget = args.max_files if args.max_files is not None else plan_budget
     over_budget = budget is not None and len(audit.actual) > budget
 
     print(f"plan doc: {plan_path}")

--- a/scripts/audit_plan_doc_files_touched.py
+++ b/scripts/audit_plan_doc_files_touched.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import re
 import subprocess
 import sys
@@ -10,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 PATH_PATTERN = re.compile(r"`([^`\n]+)`")
+# Optional fix-mode budget declared in the plan Scope, e.g. "Max files: 3".
+MAX_FILES_PATTERN = re.compile(r"(?im)^\s*Max files:\s*(\d+)\b")
 
 
 @dataclass(frozen=True)
@@ -60,6 +63,12 @@ def claimed_files_touched(text: str) -> set[str]:
     return claimed
 
 
+def declared_max_files(text: str) -> int | None:
+    """The optional `Max files: N` budget declared in the plan, or None."""
+    match = MAX_FILES_PATTERN.search(text)
+    return int(match.group(1)) if match else None
+
+
 def actual_diff_files(base_ref: str) -> set[str]:
     result = subprocess.run(
         ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
@@ -81,37 +90,52 @@ def _print_paths(label: str, paths: set[str]) -> None:
         print(f"{label:<15} {path}")
 
 
-def main() -> int:
-    if len(sys.argv) not in (2, 3):
-        print("usage: audit_plan_doc_files_touched.py PLAN [BASE_REF]", file=sys.stderr)
-        return 2
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare a plan doc's declared files against the git diff."
+    )
+    parser.add_argument("plan", help="path to the plan doc")
+    parser.add_argument("base_ref", nargs="?", default="origin/main")
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="override the plan's `Max files: N` budget (fix-mode budget cap)",
+    )
+    args = parser.parse_args(argv)
 
-    plan_path = Path(sys.argv[1])
-    base_ref = sys.argv[2] if len(sys.argv) == 3 else "origin/main"
+    plan_path = Path(args.plan)
     if not plan_path.exists():
         print(f"plan doc not found: {plan_path}", file=sys.stderr)
         return 2
 
     try:
-        actual = actual_diff_files(base_ref)
+        actual = actual_diff_files(args.base_ref)
     except RuntimeError as exc:
         print(f"failed to read git diff: {exc}", file=sys.stderr)
         return 2
 
-    audit = audit_files_touched(plan_path.read_text(encoding="utf-8"), actual)
+    plan_text = plan_path.read_text(encoding="utf-8")
+    audit = audit_files_touched(plan_text, actual)
+    budget = args.max_files if args.max_files is not None else declared_max_files(plan_text)
+    over_budget = budget is not None and len(audit.actual) > budget
 
     print(f"plan doc: {plan_path}")
-    print(f"base ref: {base_ref}")
+    print(f"base ref: {args.base_ref}")
     print(f"claimed files: {len(audit.claimed)}")
     print(f"actual files: {len(audit.actual)}")
+    if budget is not None:
+        print(f"max files: {budget}")
     print("-" * 60)
 
-    if audit.ok:
+    if audit.ok and not over_budget:
         print("OK             plan files match git diff")
         return 0
 
     _print_paths("MISSING", audit.missing_in_plan)
     _print_paths("EXTRA", audit.extra_in_plan)
+    if over_budget:
+        print(f"OVER BUDGET     {len(audit.actual)} files changed, max {budget}")
     return 1
 
 

--- a/tests/test_audit_plan_doc_files_touched.py
+++ b/tests/test_audit_plan_doc_files_touched.py
@@ -6,6 +6,8 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "audit_plan_doc_files_touched.py"
 
@@ -28,7 +30,7 @@ def load_auditor():
     return module
 
 
-def _plan(files_section: str, max_files: int | None = None) -> str:
+def _plan(files_section: str, max_files: object | None = None) -> str:
     budget_line = f"\n        Max files: {max_files}\n" if max_files is not None else ""
     return textwrap.dedent(
         f"""\
@@ -104,6 +106,23 @@ def test_declared_max_files_absent_is_none():
     assert auditor.declared_max_files(_plan("- `a.py`")) is None
 
 
+def test_declared_max_files_ignores_mentions_outside_scope():
+    auditor = load_auditor()
+    # A digit-only mention in a later section must not arm the budget.
+    text = (
+        "# Plan\n\n## Scope\n\n### Files touched\n\n- `a.py`\n\n"
+        "## Deferred\n\nMax files: 9\n"
+    )
+    assert auditor.declared_max_files(text) is None
+
+
+def test_declared_max_files_malformed_raises():
+    auditor = load_auditor()
+    for bad in ("four", "4.5", "-1"):
+        with pytest.raises(auditor.PlanBudgetError):
+            auditor.declared_max_files(_plan("- `a.py`", max_files=bad))
+
+
 def test_cli_accepts_matching_plan_against_real_git_diff(tmp_path):
     repo = _git_repo_with_base_commit(tmp_path)
     plan = repo / "plans" / "slice.md"
@@ -159,7 +178,7 @@ def test_cli_rejects_plan_that_omits_changed_file(tmp_path):
     assert "src/app.py" in result.stdout
 
 
-def _two_file_repo(tmp_path: Path, max_files: int | None) -> tuple[Path, Path]:
+def _two_file_repo(tmp_path: Path, max_files: object | None) -> tuple[Path, Path]:
     """Repo whose diff vs HEAD~1 touches exactly two files, both listed in the
     plan, so MISSING/EXTRA is clean and only the budget can fail."""
     repo = _git_repo_with_base_commit(tmp_path)
@@ -213,6 +232,21 @@ def test_cli_flag_overrides_plan_budget(tmp_path):
 
     assert result.returncode == 1
     assert "OVER BUDGET" in result.stdout
+
+
+def test_cli_malformed_budget_fails_closed(tmp_path):
+    repo, plan = _two_file_repo(tmp_path, max_files="four")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "malformed" in result.stderr.lower()
 
 
 def test_cli_no_budget_is_unbounded(tmp_path):

--- a/tests/test_audit_plan_doc_files_touched.py
+++ b/tests/test_audit_plan_doc_files_touched.py
@@ -28,13 +28,14 @@ def load_auditor():
     return module
 
 
-def _plan(files_section: str) -> str:
+def _plan(files_section: str, max_files: int | None = None) -> str:
+    budget_line = f"\n        Max files: {max_files}\n" if max_files is not None else ""
     return textwrap.dedent(
         f"""\
         # Plan
 
         ## Scope
-
+        {budget_line}
         Backticks here, like `not-a-file.py`, are not file claims.
 
         ### Files touched
@@ -93,6 +94,16 @@ def test_extra_claimed_file_is_reported_as_extra_in_plan():
     assert not audit.ok
 
 
+def test_declared_max_files_parses_budget():
+    auditor = load_auditor()
+    assert auditor.declared_max_files(_plan("- `a.py`", max_files=3)) == 3
+
+
+def test_declared_max_files_absent_is_none():
+    auditor = load_auditor()
+    assert auditor.declared_max_files(_plan("- `a.py`")) is None
+
+
 def test_cli_accepts_matching_plan_against_real_git_diff(tmp_path):
     repo = _git_repo_with_base_commit(tmp_path)
     plan = repo / "plans" / "slice.md"
@@ -146,6 +157,77 @@ def test_cli_rejects_plan_that_omits_changed_file(tmp_path):
     assert result.returncode == 1
     assert "MISSING" in result.stdout
     assert "src/app.py" in result.stdout
+
+
+def _two_file_repo(tmp_path: Path, max_files: int | None) -> tuple[Path, Path]:
+    """Repo whose diff vs HEAD~1 touches exactly two files, both listed in the
+    plan, so MISSING/EXTRA is clean and only the budget can fail."""
+    repo = _git_repo_with_base_commit(tmp_path)
+    plan = repo / "plans" / "slice.md"
+    plan.parent.mkdir()
+    plan.write_text(
+        _plan(
+            """\
+            - `plans/slice.md`
+            - `src/app.py`
+            """,
+            max_files=max_files,
+        ),
+        encoding="utf-8",
+    )
+    source = repo / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("print('ok')\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "change")
+    return repo, plan
+
+
+def test_cli_rejects_over_budget(tmp_path):
+    repo, plan = _two_file_repo(tmp_path, max_files=1)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "OVER BUDGET" in result.stdout
+    # Budget is the only failing dimension: both files are listed in the plan.
+    assert "MISSING" not in result.stdout.replace("OVER BUDGET", "")
+
+
+def test_cli_flag_overrides_plan_budget(tmp_path):
+    repo, plan = _two_file_repo(tmp_path, max_files=None)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1", "--max-files", "1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "OVER BUDGET" in result.stdout
+
+
+def test_cli_no_budget_is_unbounded(tmp_path):
+    repo, plan = _two_file_repo(tmp_path, max_files=None)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "OK" in result.stdout
 
 
 def _git_repo_with_base_commit(tmp_path: Path) -> Path:


### PR DESCRIPTION
Plan: plans/PR-Codex-Max-Files-Budget.md

Slice phase: Production hardening

First enforcement piece of PR fix mode (issue #1714). The PR fix-mode doc layer
(#1715) is advisory; this adds a deterministic, opt-in **max-files budget** to
the plan-doc files-touched audit so a fix loop that strays beyond its declared
file count fails a cheap, early gate (the audit already runs in
`scripts/pre_push_audit.sh`, before any test/long CI lane).

## Intentional

- Opt-in only. A plan declaring `Max files: N` in its *Scope* has the budget
  enforced automatically via the existing `scripts/pre_push_audit.sh` call (no
  caller change); a `--max-files N` flag overrides it for manual fix-session
  runs. With neither set, the audit is byte-for-byte its prior behavior, so
  non-fix PRs are unaffected.
- Budget sourced from the tracked plan doc (not the gitignored baton) so it is
  enforceable at pre-push/CI. `main()` moves to argparse, preserving the
  two-positional `PLAN [BASE_REF]` call.
- The budget counts the same `git diff --name-only base...HEAD` set the existing
  EXTRA/MISSING check uses (includes the plan doc; set N accordingly).
- `AGENTS.md` §3l gains a one-line pointer to the field. This PR dogfoods it
  (`Max files: 4`, exactly 4 files changed).

## Deferred

Tracked in #1714: Claude Code pre-edit enforcement (`.claude/` PreToolUse deny +
SessionStart/PreCompact hooks), the `/fix-mode` skill, and the `.gitignore`
narrowing to make that config shareable.

## Parked hardening

None.

## Verification

- `tests/test_audit_plan_doc_files_touched.py` -- 10 pass (added `declared_max_files`
  unit cases + CLI over-budget, flag-override, and unbounded cases).
- Dogfood: budget 4 against this PR's 4-file diff exits 0; `--max-files 3` prints
  `OVER BUDGET     4 files changed, max 3` and exits 1.
- `scripts/local_pr_review.sh` -- full bundle green, including this plan passing
  its own files-touched budget.

## Diff size

4 files, ~230 added lines: the audit script (34), its tests (84), AGENTS.md (3),
and the plan doc (~109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Bwpk9YWN2xGaE1jmNPYLP

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bwpk9YWN2xGaE1jmNPYLP)_