### PR TITLE
Add Claude Code pre-edit fix-mode enforcement (PreToolUse deny + baton)

### DIFF
--- a/.claude/hooks/check_edit_budget.py
+++ b/.claude/hooks/check_edit_budget.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: confine edits to the fix-mode allowed-files set.
+
+Reads the PreToolUse payload on stdin. When an active fix-mode baton
+(.claude/fix-mode-state.json) is present, it denies an Edit/Write/MultiEdit
+whose target path is outside the baton's `allowed` globs, surfacing the reason
+to the model via `permissionDecision: "deny"`.
+
+Fail-open by construction: no baton, an inactive/empty/malformed baton, or any
+unexpected error exits 0 with no output, so normal (non-fix-mode) sessions and
+any committed-but-unarmed checkout are never blocked. The companion push-time
+gate (scripts/audit_plan_doc_files_touched.py --max-files / `Max files:`)
+enforces the file-count budget; this hook only enforces the allowed *set*.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import sys
+
+
+def _project_dir() -> str:
+    return os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+
+def _targets(tool_input: dict) -> list[str]:
+    targets: list[str] = []
+    fp = tool_input.get("file_path")
+    if isinstance(fp, str) and fp:
+        targets.append(fp)
+    for edit in tool_input.get("edits") or []:
+        if isinstance(edit, dict):
+            efp = edit.get("file_path")
+            if isinstance(efp, str) and efp:
+                targets.append(efp)
+    return targets
+
+
+def _relativize(path: str, project_dir: str) -> str:
+    try:
+        if os.path.isabs(path):
+            return os.path.relpath(path, project_dir)
+    except ValueError:
+        return path
+    return path
+
+
+def _deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # cannot parse input -> do not block
+
+    try:
+        project_dir = _project_dir()
+        baton_path = os.path.join(project_dir, ".claude", "fix-mode-state.json")
+        if not os.path.isfile(baton_path):
+            return 0
+
+        with open(baton_path, encoding="utf-8") as fh:
+            baton = json.load(fh)
+        if not isinstance(baton, dict) or not baton.get("active"):
+            return 0
+
+        allowed = baton.get("allowed")
+        if not isinstance(allowed, list) or not allowed:
+            return 0  # active but no constraint declared -> do not block
+
+        tool_input = payload.get("tool_input")
+        if not isinstance(tool_input, dict):
+            return 0
+
+        for target in _targets(tool_input):
+            rel = _relativize(target, project_dir)
+            if not any(fnmatch.fnmatch(rel, str(pat)) for pat in allowed):
+                _deny(
+                    f"{rel} is outside the fix-mode allowed set "
+                    f"({', '.join(str(p) for p in allowed)}). Widen the baton's "
+                    "allowed list with the upstream reason (AGENTS.md 3k/3l) "
+                    "before editing it."
+                )
+                return 0
+        return 0
+    except Exception:
+        return 0  # never block on an unexpected hook error
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/check_edit_budget.py
+++ b/.claude/hooks/check_edit_budget.py
@@ -38,13 +38,26 @@ def _targets(tool_input: dict) -> list[str]:
     return targets
 
 
+# Control files the armed session must always be able to edit, regardless of the
+# allowed set -- so `/fix-mode off`, widening the baton, and updating the human
+# state file are never locked out.
+_ALWAYS_ALLOWED = {".claude/fix-mode-state.json", "SESSION_STATE.local.md"}
+
+
 def _relativize(path: str, project_dir: str) -> str:
+    """Repo-relative, normalized POSIX path (collapses '..'/'.', unifies seps).
+
+    Normalizing before glob matching closes the `scripts/../tests/foo.py` bypass
+    (it resolves to `tests/foo.py`, which no longer matches `scripts/*`) and
+    makes Windows `\\` separators match `/`-based globs.
+    """
     try:
-        if os.path.isabs(path):
-            return os.path.relpath(path, project_dir)
+        candidate = path.replace("\\", "/")
+        if os.path.isabs(path) or os.path.isabs(candidate):
+            candidate = os.path.relpath(path, project_dir)
+        return os.path.normpath(candidate).replace("\\", "/")
     except ValueError:
         return path
-    return path
 
 
 def _deny(reason: str) -> None:
@@ -88,6 +101,8 @@ def main() -> int:
 
         for target in _targets(tool_input):
             rel = _relativize(target, project_dir)
+            if rel in _ALWAYS_ALLOWED:
+                continue  # control files stay editable so /fix-mode off + widen work
             if not any(fnmatch.fnmatch(rel, str(pat)) for pat in allowed):
                 _deny(
                     f"{rel} is outside the fix-mode allowed set "

--- a/.claude/hooks/inject_fix_mode.py
+++ b/.claude/hooks/inject_fix_mode.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""SessionStart hook: re-inject the fix-mode baton after start/resume/compact.
+
+When an active fix-mode baton (.claude/fix-mode-state.json) exists, emits its
+key fields as `additionalContext` so a session -- especially one resuming after
+auto-compaction -- continues the fix loop instead of re-exploring. No baton, an
+inactive/malformed baton, or any error produces no output and exits 0.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _project_dir() -> str:
+    return os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+
+def _summary(baton: dict) -> str:
+    lines = ["PR Fix Mode is ACTIVE -- stay inside the allowed set:"]
+    fields = [
+        ("PR", baton.get("pr")),
+        ("Branch", baton.get("branch")),
+        ("Latest commit", baton.get("latest_commit")),
+        ("Allowed files", baton.get("allowed")),
+        ("Max files", baton.get("max_files")),
+        ("Current failing check", baton.get("failing_check")),
+        ("Last useful finding", baton.get("last_finding")),
+        ("Next exact action", baton.get("next_action")),
+        ("Do-NOT-redo", baton.get("do_not_redo")),
+    ]
+    for label, value in fields:
+        if value:
+            lines.append(f"- {label}: {value}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass  # SessionStart payload is unused; never fail on it
+
+    try:
+        baton_path = os.path.join(_project_dir(), ".claude", "fix-mode-state.json")
+        if not os.path.isfile(baton_path):
+            return 0
+        with open(baton_path, encoding="utf-8") as fh:
+            baton = json.load(fh)
+        if not isinstance(baton, dict) or not baton.get("active"):
+            return 0
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "SessionStart",
+                        "additionalContext": _summary(baton),
+                    }
+                }
+            )
+        )
+        return 0
+    except Exception:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/check_edit_budget.py\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/inject_fix_mode.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/fix-mode/SKILL.md
+++ b/.claude/skills/fix-mode/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: fix-mode
+description: Arm or clear PR fix mode -- confine edits to an allowed-files set and a max-files budget during a red-CI / review-comment fix loop. Operator-invoked.
+disable-model-invocation: true
+argument-hint: "[allowed-glob,allowed-glob,...] [max-files] | off"
+---
+
+# /fix-mode -- constrain a PR fix loop
+
+Writes the machine-readable baton `.claude/fix-mode-state.json` (gitignored) that
+the committed `PreToolUse` and `SessionStart` hooks read. When active, edits to
+files outside the allowed set are denied before they happen, and the baton is
+re-injected after compaction. See AGENTS.md 3l.
+
+## Arm
+
+`/fix-mode "scripts/*,tests/test_x.py" 3`
+
+Write `.claude/fix-mode-state.json` with:
+
+```json
+{
+  "active": true,
+  "pr": "<#number from the open PR>",
+  "branch": "<git rev-parse --abbrev-ref HEAD>",
+  "latest_commit": "<git rev-parse --short HEAD>",
+  "allowed": ["scripts/*", "tests/test_x.py"],
+  "max_files": 3,
+  "failing_check": "<the red check / review thread>",
+  "last_finding": "<the line that localized it>",
+  "next_action": "<one sentence>",
+  "do_not_redo": "<paths ruled out, checks already green, dead ends>"
+}
+```
+
+`allowed` entries are `fnmatch` globs against repo-relative paths. Set them to the
+failure source only, not "everything the symptom touches." Also mirror these
+fields into the `## PR Fix Mode` block of `SESSION_STATE.local.md` (the human
+baton).
+
+## Widen (root-cause decision)
+
+If the fix genuinely needs an upstream file, add it to `allowed` **and** record
+the upstream reason in the baton and the plan first (AGENTS.md 3k). Do not grow
+the set silently.
+
+## Clear
+
+`/fix-mode off` -> set `"active": false` (or delete the file). The hooks then
+fail open and stop constraining edits.

--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -61,7 +61,7 @@ jobs:
       - name: PR-review tooling unit tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio pyyaml
-          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_check_gitleaks_baseline_rotation.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_claude_workflow_security.py -q
+          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_check_gitleaks_baseline_rotation.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_claude_workflow_security.py tests/test_fix_mode_hook.py -q
 
       - name: Workflow security posture audit
         run: python scripts/audit_workflow_security_posture.py .github/workflows

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,14 @@ requirements.freeze.bak
 *.crt
 *.key
 *.pem
-.claude/
+# .claude/: keep everything ignored by default, then re-include only the shared,
+# scrubbed fix-mode config. Personal overrides and the local baton stay ignored.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/skills/
+.claude/settings.local.json
+.claude/fix-mode-state.json
 .vercel
 .env*.local
 .playwright-mcp/

--- a/plans/PR-Fix-Mode-Claude-Code-Enforcement.md
+++ b/plans/PR-Fix-Mode-Claude-Code-Enforcement.md
@@ -10,7 +10,7 @@ re-injects the fix baton after compaction, and a `/fix-mode` skill to arm it.
 The push-time audit only catches strays after the work is done; this stops them
 at the edit.
 
-This PR is over the 400-LOC soft cap (~513). The overage is intentional and
+This PR is over the 400-LOC soft cap (~566). The overage is intentional and
 indivisible: the gitignore enablement, the two hooks, the `/fix-mode` skill, and
 the fail-open test matrix are one unit -- a half-wired hook set (e.g. a deny hook
 with no skill to arm it, or a skill writing a baton no hook reads) would be worse
@@ -21,7 +21,7 @@ fail-open/deny test coverage, not new behavior.
 
 Ownership lane: process/agent-guidance
 Slice phase: Production hardening
-Max files: 7
+Max files: 8
 
 The hooks are committed and active in `.claude/settings.json` (team-wide) but
 **fail open**: they do nothing unless a gitignored fix-mode baton exists, and any
@@ -36,6 +36,7 @@ unarmed checkout are never blocked.
 - `.claude/hooks/inject_fix_mode.py`
 - `.claude/skills/fix-mode/SKILL.md`
 - `tests/test_fix_mode_hook.py`
+- `.github/workflows/pre_push_audit.yml`
 - `plans/PR-Fix-Mode-Claude-Code-Enforcement.md`
 
 ### Review Contract
@@ -88,9 +89,22 @@ tracked.
   ASCII-only.
 - The allowed-set lives in the hook; the count budget stays in the #1716
   pre-push audit -- two composable layers, no stateful counting in the hook.
+- Targets are normalized (collapse `..`/`.`, unify separators) before glob
+  matching so `scripts/../tests/foo.py` cannot bypass `scripts/*`, and the
+  control files (`.claude/fix-mode-state.json`, `SESSION_STATE.local.md`) are
+  always editable so `/fix-mode off` / widen are never locked out.
+- `tests/test_fix_mode_hook.py` is enrolled in the
+  `.github/workflows/pre_push_audit.yml` PR-review tooling test list so the hook
+  is PR-gated, not only covered by the scheduled backstop.
 
 ## Deferred
 
+- Constraining **Bash** writes during fix mode (shell redirection / `python -c` /
+  `sed` writing outside the allowed set bypass the `Edit|Write|MultiEdit` hook).
+  Out of scope here: this hook is a cooperative guardrail for the agent's own
+  Edit/Write path, not an adversarial sandbox, and intercepting arbitrary
+  write-capable shell commands is a separate, heuristic-heavy slice. (Tracked in
+  #1714.)
 - A `PreCompact` snapshot hook: `SessionStart` `matcher: compact` already
   re-injects the on-disk baton after auto-compaction, so PreCompact adds little;
   revisit if volatile in-context findings need snapshotting first. (Tracked in
@@ -123,9 +137,10 @@ None.
 |---|---:|
 | `.gitignore` | 8 |
 | `.claude/settings.json` | 26 |
-| `.claude/hooks/check_edit_budget.py` | 105 |
+| `.claude/hooks/check_edit_budget.py` | 120 |
 | `.claude/hooks/inject_fix_mode.py` | 70 |
 | `.claude/skills/fix-mode/SKILL.md` | 50 |
-| `tests/test_fix_mode_hook.py` | 130 |
-| `plans/PR-Fix-Mode-Claude-Code-Enforcement.md` | ~124 |
-| **Total** | **~513** |
+| `.github/workflows/pre_push_audit.yml` | 1 |
+| `tests/test_fix_mode_hook.py` | 153 |
+| `plans/PR-Fix-Mode-Claude-Code-Enforcement.md` | ~138 |
+| **Total** | **~566** |

--- a/plans/PR-Fix-Mode-Claude-Code-Enforcement.md
+++ b/plans/PR-Fix-Mode-Claude-Code-Enforcement.md
@@ -1,0 +1,131 @@
+# PR-Fix-Mode-Claude-Code-Enforcement
+
+## Why this slice exists
+
+The PR fix-mode doc layer (#1715) and the Codex push-time `Max files:` budget
+(#1716) are merged. This slice adds the Claude Code *pre-edit* half from issue
+#1714: a `PreToolUse` hook that denies an edit to a file outside the declared
+failure source **before tokens are spent**, a `SessionStart` hook that
+re-injects the fix baton after compaction, and a `/fix-mode` skill to arm it.
+The push-time audit only catches strays after the work is done; this stops them
+at the edit.
+
+This PR is over the 400-LOC soft cap (~513). The overage is intentional and
+indivisible: the gitignore enablement, the two hooks, the `/fix-mode` skill, and
+the fail-open test matrix are one unit -- a half-wired hook set (e.g. a deny hook
+with no skill to arm it, or a skill writing a baton no hook reads) would be worse
+than one coherent slice. Roughly half the diff is the plan doc plus the
+fail-open/deny test coverage, not new behavior.
+
+## Scope (this PR)
+
+Ownership lane: process/agent-guidance
+Slice phase: Production hardening
+Max files: 7
+
+The hooks are committed and active in `.claude/settings.json` (team-wide) but
+**fail open**: they do nothing unless a gitignored fix-mode baton exists, and any
+error / missing / malformed input exits 0 (allow). Normal sessions and any
+unarmed checkout are never blocked.
+
+### Files touched
+
+- `.gitignore`
+- `.claude/settings.json`
+- `.claude/hooks/check_edit_budget.py`
+- `.claude/hooks/inject_fix_mode.py`
+- `.claude/skills/fix-mode/SKILL.md`
+- `tests/test_fix_mode_hook.py`
+- `plans/PR-Fix-Mode-Claude-Code-Enforcement.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- [ ] With no / inactive / malformed / empty-allowed baton, `.claude/hooks/check_edit_budget.py`
+      exits 0 and emits no deny -- the committed hook is inert for normal sessions.
+- [ ] With an active baton, an edit outside the `allowed` globs returns
+      `permissionDecision: "deny"` with a reason; an edit inside is allowed;
+      MultiEdit denies if any target is outside; absolute paths are relativized
+      before matching.
+- [ ] `.claude/hooks/inject_fix_mode.py` emits the baton as `additionalContext` when active and
+      nothing otherwise.
+- [ ] `.gitignore` tracks only `.claude/settings.json`, `.claude/hooks/`, and
+      `.claude/skills/`; `.claude/settings.local.json` and the baton stay ignored.
+- [ ] No secrets or absolute/home paths in any committed `.claude/` file.
+
+Affected surfaces: Claude Code session tooling only; no application code.
+
+Risk areas: a committed active `PreToolUse` hook can block edits for everyone who
+pulls the repo. Mitigated by exhaustive fail-open (every error path exits 0) and
+tests covering the missing / inactive / malformed / empty-allowed baton paths.
+
+Reviewer rules triggered: R1, R14, R2.
+
+## Mechanism
+
+`.claude/hooks/check_edit_budget.py` reads the PreToolUse payload from stdin, collects target
+paths (`file_path` for Edit/Write, `edits[].file_path` for MultiEdit), and reads
+`.claude/fix-mode-state.json` under `CLAUDE_PROJECT_DIR`. If the baton is absent,
+inactive, malformed, or has no `allowed` globs, it returns 0 with no output. With
+an active baton it relativizes each target and denies (via `permissionDecision`)
+any that no `allowed` glob matches (`fnmatch`). Every error path exits 0, so the
+hook cannot wedge a session. It enforces the allowed *set* only; the merged
+`scripts/audit_plan_doc_files_touched.py` budget enforces the file *count* at
+pre-push. `.claude/hooks/inject_fix_mode.py` re-emits the baton fields as `additionalContext`
+on `SessionStart` (`startup|resume|compact`). The `/fix-mode` skill writes the
+baton; `.gitignore` uses an allowlist so only the shared, scrubbed config is
+tracked.
+
+## Intentional
+
+- Committed and active, but fail-open, so enforcement only bites inside an armed
+  fix loop and normal work is untouched.
+- Dedicated machine-readable baton `.claude/fix-mode-state.json` for the hooks,
+  alongside the human `## PR Fix Mode` block already in `SESSION_STATE.local.md`
+  (#1715); the skill writes both.
+- Hooks in `python3` (repo convention for JSON in scripts; no `jq` dependency),
+  ASCII-only.
+- The allowed-set lives in the hook; the count budget stays in the #1716
+  pre-push audit -- two composable layers, no stateful counting in the hook.
+
+## Deferred
+
+- A `PreCompact` snapshot hook: `SessionStart` `matcher: compact` already
+  re-injects the on-disk baton after auto-compaction, so PreCompact adds little;
+  revisit if volatile in-context findings need snapshotting first. (Tracked in
+  #1714.)
+- An optional pre-commit secret-scan over staged `.claude/` files. (Tracked in
+  #1714.)
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Run the hook tests in `tests/test_fix_mode_hook.py` -- 10 cases pass (fail-open
+  for no/inactive/malformed/empty baton; allow inside; deny outside; MultiEdit;
+  absolute-path relativization; SessionStart inject present/absent).
+- Validate `.claude/settings.json` parses as JSON.
+- Fail-open proof: with no baton, pipe an Edit payload to
+  `.claude/hooks/check_edit_budget.py` -- exit 0, no output.
+- Deny proof: with an active baton `allowed: ["scripts/*"]`, pipe an Edit to a
+  `tests/` path -- deny JSON.
+- Confirm `git check-ignore` keeps `.claude/settings.local.json` and the baton
+  ignored while the four shared files are trackable.
+- Run `scripts/local_pr_review.sh` -- full bundle green, including this plan
+  passing its own `Max files: 7` budget.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.gitignore` | 8 |
+| `.claude/settings.json` | 26 |
+| `.claude/hooks/check_edit_budget.py` | 105 |
+| `.claude/hooks/inject_fix_mode.py` | 70 |
+| `.claude/skills/fix-mode/SKILL.md` | 50 |
+| `tests/test_fix_mode_hook.py` | 130 |
+| `plans/PR-Fix-Mode-Claude-Code-Enforcement.md` | ~124 |
+| **Total** | **~513** |

--- a/tests/test_fix_mode_hook.py
+++ b/tests/test_fix_mode_hook.py
@@ -1,0 +1,130 @@
+"""Tests for the Claude Code fix-mode hooks.
+
+The hooks are deny/inject scripts driven by stdin JSON. These tests subprocess
+them with a tmp CLAUDE_PROJECT_DIR and crafted payloads, mirroring the
+subprocess style of test_install_local_pr_hook.py. The load-bearing property is
+fail-open: with no/inactive/malformed baton the PreToolUse hook never blocks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECK_HOOK = REPO_ROOT / ".claude" / "hooks" / "check_edit_budget.py"
+INJECT_HOOK = REPO_ROOT / ".claude" / "hooks" / "inject_fix_mode.py"
+
+
+def _run(hook: Path, payload: dict, project_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(hook)],
+        input=json.dumps(payload),
+        cwd=str(project_dir),
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CLAUDE_PROJECT_DIR": str(project_dir)},
+    )
+
+
+def _write_baton(project_dir: Path, baton: dict) -> None:
+    state_dir = project_dir / ".claude"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "fix-mode-state.json").write_text(json.dumps(baton), encoding="utf-8")
+
+
+def _edit(file_path: str) -> dict:
+    return {"tool_name": "Edit", "tool_input": {"file_path": file_path}}
+
+
+def _decision(stdout: str) -> str | None:
+    if not stdout.strip():
+        return None
+    return json.loads(stdout)["hookSpecificOutput"]["permissionDecision"]
+
+
+def test_no_baton_allows(tmp_path):
+    result = _run(CHECK_HOOK, _edit("anything.py"), tmp_path)
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_inactive_baton_allows(tmp_path):
+    _write_baton(tmp_path, {"active": False, "allowed": ["scripts/*"]})
+    result = _run(CHECK_HOOK, _edit("tests/foo.py"), tmp_path)
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_malformed_baton_allows(tmp_path):
+    (tmp_path / ".claude").mkdir(parents=True)
+    (tmp_path / ".claude" / "fix-mode-state.json").write_text("{not json", encoding="utf-8")
+    result = _run(CHECK_HOOK, _edit("tests/foo.py"), tmp_path)
+    assert result.returncode == 0
+    assert _decision(result.stdout) is None
+
+
+def test_active_empty_allowed_does_not_block(tmp_path):
+    _write_baton(tmp_path, {"active": True, "allowed": []})
+    result = _run(CHECK_HOOK, _edit("tests/foo.py"), tmp_path)
+    assert result.returncode == 0
+    assert _decision(result.stdout) is None
+
+
+def test_edit_inside_allowed_is_allowed(tmp_path):
+    _write_baton(tmp_path, {"active": True, "allowed": ["scripts/*"]})
+    result = _run(CHECK_HOOK, _edit("scripts/audit_x.py"), tmp_path)
+    assert result.returncode == 0
+    assert _decision(result.stdout) is None
+
+
+def test_edit_outside_allowed_is_denied(tmp_path):
+    _write_baton(tmp_path, {"active": True, "allowed": ["scripts/*"]})
+    result = _run(CHECK_HOOK, _edit("tests/foo.py"), tmp_path)
+    assert result.returncode == 0
+    assert _decision(result.stdout) == "deny"
+    assert "allowed set" in result.stdout
+
+
+def test_multiedit_any_outside_target_is_denied(tmp_path):
+    _write_baton(tmp_path, {"active": True, "allowed": ["scripts/*"]})
+    payload = {
+        "tool_name": "MultiEdit",
+        "tool_input": {
+            "edits": [
+                {"file_path": "scripts/ok.py"},
+                {"file_path": "tests/bad.py"},
+            ]
+        },
+    }
+    result = _run(CHECK_HOOK, payload, tmp_path)
+    assert _decision(result.stdout) == "deny"
+
+
+def test_absolute_path_is_relativized_before_match(tmp_path):
+    _write_baton(tmp_path, {"active": True, "allowed": ["scripts/*"]})
+    abs_target = str(tmp_path / "scripts" / "audit_x.py")
+    result = _run(CHECK_HOOK, _edit(abs_target), tmp_path)
+    assert _decision(result.stdout) is None
+
+
+def test_inject_emits_context_when_active(tmp_path):
+    _write_baton(
+        tmp_path,
+        {"active": True, "pr": "#42", "allowed": ["scripts/*"], "next_action": "fix foo"},
+    )
+    result = _run(INJECT_HOOK, {"hook_event_name": "SessionStart", "source": "compact"}, tmp_path)
+    assert result.returncode == 0
+    ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert "PR Fix Mode is ACTIVE" in ctx
+    assert "#42" in ctx
+
+
+def test_inject_silent_when_no_baton(tmp_path):
+    result = _run(INJECT_HOOK, {"hook_event_name": "SessionStart", "source": "startup"}, tmp_path)
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""

--- a/tests/test_fix_mode_hook.py
+++ b/tests/test_fix_mode_hook.py
@@ -112,6 +112,29 @@ def test_absolute_path_is_relativized_before_match(tmp_path):
     assert _decision(result.stdout) is None
 
 
+def test_traversal_path_cannot_bypass_allowed_set(tmp_path):
+    # `scripts/../tests/foo.py` matches `scripts/*` by raw fnmatch but resolves
+    # to `tests/foo.py`; normalization must catch the escape and deny it.
+    _write_baton(tmp_path, {"active": True, "allowed": ["scripts/*"]})
+    result = _run(CHECK_HOOK, _edit("scripts/../tests/foo.py"), tmp_path)
+    assert _decision(result.stdout) == "deny"
+
+
+def test_baton_control_file_is_always_editable(tmp_path):
+    # Even with an allowed set that omits it, the baton must stay editable so
+    # `/fix-mode off` / widen are never locked out.
+    _write_baton(tmp_path, {"active": True, "allowed": ["scripts/*"]})
+    result = _run(CHECK_HOOK, _edit(".claude/fix-mode-state.json"), tmp_path)
+    assert result.returncode == 0
+    assert _decision(result.stdout) is None
+
+
+def test_session_state_file_is_always_editable(tmp_path):
+    _write_baton(tmp_path, {"active": True, "allowed": ["scripts/*"]})
+    result = _run(CHECK_HOOK, _edit("SESSION_STATE.local.md"), tmp_path)
+    assert _decision(result.stdout) is None
+
+
 def test_inject_emits_context_when_active(tmp_path):
     _write_baton(
         tmp_path,


### PR DESCRIPTION
Plan: plans/PR-Fix-Mode-Claude-Code-Enforcement.md

Slice phase: Production hardening

Final piece of PR fix mode (issue #1714): the Claude Code **pre-edit** half. A
`PreToolUse` hook denies an edit to a file outside the declared failure source
*before tokens are spent*; a `SessionStart` hook re-injects the baton after
compaction; a `/fix-mode` skill arms it. The merged #1716 push-time `Max files:`
audit only catches strays after the work is done — this stops them at the edit.

Over the 400-LOC soft cap (~566) and intentionally indivisible: the gitignore
enablement, both hooks, the skill, and the fail-open test matrix are one unit.

## Intentional

- Committed and **active** in `.claude/settings.json` (team-wide) but **fail
  open**: the hooks do nothing unless a gitignored `.claude/fix-mode-state.json`
  baton exists, and any error / missing / malformed / empty-allowed input exits 0.
- Edit targets are **normalized** (collapse `..`/`.`, unify separators) before
  glob matching, so `scripts/../tests/foo.py` cannot bypass `scripts/*`; the
  control files (`.claude/fix-mode-state.json`, `SESSION_STATE.local.md`) are
  always editable so `/fix-mode off` / widen are never locked out.
- The allowed **set** is enforced here pre-edit; the file **count** budget stays
  in the #1716 pre-push audit. Hooks are `python3`, ASCII-only, no secrets.
- `tests/test_fix_mode_hook.py` is enrolled in the pre-push-audit PR-review
  tooling test list so the hook is PR-gated, not only in the scheduled backstop.
- `.gitignore` allowlist: only `.claude/settings.json`, `.claude/hooks/`, and
  `.claude/skills/` are trackable; `settings.local.json` and the baton stay
  ignored. Dogfoods #1716 via `Max files: 8`.

## Deferred

- **Constraining Bash writes during fix mode** (shell redirection / `python -c` /
  `sed` writing outside the allowed set bypass the `Edit|Write|MultiEdit` hook).
  Waived for this slice: the hook is a cooperative guardrail for the agent's own
  Edit/Write path, not an adversarial shell sandbox, and intercepting arbitrary
  write-capable shell commands is a separate, heuristic-heavy slice. Tracked in
  #1714.
- A `PreCompact` snapshot hook (SessionStart `matcher: compact` already
  re-injects the on-disk baton) and an optional pre-commit secret-scan over
  staged `.claude/` files. Tracked in #1714.

## Parked hardening

None.

## Verification

- `tests/test_fix_mode_hook.py` — 13 cases pass (fail-open for
  no/inactive/malformed/empty baton; allow inside; deny outside; MultiEdit;
  absolute-path + traversal normalization; control-file always-editable;
  SessionStart inject present/absent).
- `.claude/settings.json` parses as JSON; `git check-ignore` keeps
  `settings.local.json` and the baton ignored while the shared files are tracked.
- `scripts/local_pr_review.sh` — full bundle green, incl. this plan passing its
  own `Max files: 8` budget.

## Diff size

8 files, ~566 added: hooks (120 + 70), settings (26), skill (50), gitignore (8),
workflow (1), tests (153), plan doc (~138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Bwpk9YWN2xGaE1jmNPYLP