### PR TITLE
Bump Graphiti Python base image to 3.14

### DIFF
--- a/Dockerfile.graphiti
+++ b/Dockerfile.graphiti
@@ -1,7 +1,7 @@
 # Atlas Memory — Graphiti GraphRAG Server (local deployment)
 # Knowledge graph API with Neo4j backend, 100% local inference
 
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/plans/PR-Graphiti-Python-3-14-Base-Image.md
+++ b/plans/PR-Graphiti-Python-3-14-Base-Image.md
@@ -1,0 +1,88 @@
+# PR-Graphiti-Python-3-14-Base-Image
+
+## Why this slice exists
+
+Dependabot proposed moving the Graphiti local deployment image from
+`python:3.11-slim` to `python:3.14-slim`. This image installs Graphiti,
+FastAPI, sentence-transformers, PyTorch CPU, and Neo4j/Postgres clients at build
+time, so the base-image bump needs dependency-wheel evidence before it can be
+treated as a safe one-line Dockerfile change.
+
+## Scope (this PR)
+
+Ownership lane: graphiti/runtime-image
+Slice phase: Production hardening
+
+1. Update `Dockerfile.graphiti` from `python:3.11-slim` to `python:3.14-slim`.
+2. Verify the Graphiti Docker requirements can resolve CPython 3.14 Linux wheels,
+   including PyTorch CPU and compiled dependencies.
+3. Keep this slice limited to the Graphiti Docker base-image bump and plan doc.
+
+### Files touched
+
+- `Dockerfile.graphiti`
+- `plans/PR-Graphiti-Python-3-14-Base-Image.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- [ ] `Dockerfile.graphiti` uses `python:3.14-slim`.
+- [ ] The Graphiti Docker dependency stack has CPython 3.14 Linux wheel coverage
+      for the runtime-critical compiled dependencies: `torch`, `numpy`,
+      `pydantic-core`, `asyncpg`, `scipy`, and `scikit-learn`.
+- [ ] No Graphiti application code, runtime command, port, healthcheck, or
+      requirements file changes are included in this slice.
+- [ ] No workflow or repository-wide guardrail changes are included in this slice.
+
+Affected surfaces: Docker runtime image / local Graphiti deployment.
+
+Risk areas: dependency compatibility / runtime image build / deployment safety.
+
+Reviewer rules triggered: R1, R2, R11, R12, R14.
+
+## Mechanism
+
+`Dockerfile.graphiti` keeps the existing build flow: install system `git`/`curl`,
+install PyTorch CPU from the configured PyTorch CPU index, install the remaining
+`graphiti-wrapper/requirements.txt` entries from PyPI, copy the wrapper, switch
+to the non-root `atlas` user, and run `uvicorn`. Only the Python base image tag
+changes.
+
+The dependency-risk check is a wheel-resolution probe for the same requirements
+under CPython 3.14 Linux tags. It confirms the current resolver can obtain
+binary wheels for the compiled dependencies that would otherwise be likely build
+breakers.
+
+## Intentional
+
+- Docker base-image maintenance only; no Graphiti service code or dependency
+  pin changes.
+- Keeps the existing `TORCH_CPU_SPEC` and `TORCH_CPU_INDEX_URL` build arguments.
+- Does not add a Docker build workflow; this PR documents the local wheel probe
+  and leaves full image-build CI as a follow-up if the Graphiti image becomes a
+  release-blocking artifact.
+
+## Deferred
+
+- Add a dedicated Docker build smoke for `Dockerfile.graphiti` if/when the
+  Graphiti local image becomes a CI-enforced release artifact.
+- Parked hardening: none.
+
+## Verification
+
+- PyTorch CPU index probe confirmed releases are available for the resolver line.
+- CPython 3.14 Linux wheel probe passed for the PyTorch CPU package.
+- Mixed manylinux CPython 3.14 wheel-resolution probe passed for the Graphiti
+  Docker requirements, including `torch`, `numpy`, `pydantic-core`, `asyncpg`,
+  `scipy`, and `scikit-learn`.
+- Docker build was not run in this environment; validation is by dependency
+  wheel resolution plus CI.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `Dockerfile.graphiti` | ~1 |
+| `plans/PR-Graphiti-Python-3-14-Base-Image.md` | ~78 |
+| **Total** | **~79** |


### PR DESCRIPTION
Plan: plans/PR-Graphiti-Python-3-14-Base-Image.md
Slice phase: Production hardening

Supersedes #1635 after that Dependabot branch retained stale Security Guardrails carry-forward diffs from an older merge base. This replacement keeps the same Graphiti base-image maintenance goal on top of current `main`, limited to the Dockerfile bump and focused plan doc.

## Scope

Files touched:
- `Dockerfile.graphiti`
- `plans/PR-Graphiti-Python-3-14-Base-Image.md`

Review Contract:
- `Dockerfile.graphiti` uses `python:3.14-slim`.
- The Graphiti Docker dependency stack has CPython 3.14 Linux wheel coverage for `torch`, `numpy`, `pydantic-core`, `asyncpg`, `scipy`, and `scikit-learn`.
- No Graphiti application code, runtime command, port, healthcheck, requirements, workflow, or repository-wide guardrail changes are included in this slice.

Affected surfaces: Docker runtime image / local Graphiti deployment.

Risk areas: dependency compatibility / runtime image build / deployment safety.

Reviewer rules triggered: R1, R2, R11, R12, R14.

## Intentional

- Docker base-image maintenance only; no Graphiti service code or dependency pin changes.
- Keeps the existing `TORCH_CPU_SPEC` and `TORCH_CPU_INDEX_URL` build arguments.
- Does not add a Docker build workflow.

## Deferred

- Add a dedicated Docker build smoke for `Dockerfile.graphiti` if the Graphiti local image becomes a CI-enforced release artifact.

## Parked hardening

None.

## Verification

- PyTorch CPU index probe found CPython 3.14 CPU wheels for `torch`.
- Mixed manylinux CPython 3.14 wheel-resolution probe passed for `graphiti-wrapper/requirements.txt`, including `torch`, `numpy`, `pydantic-core`, `asyncpg`, `scipy`, and `scikit-learn`.
- Docker build was not run in this environment; validation is by dependency wheel resolution plus CI.

## Diff size

2 files, approximately +79 / -1.
