### PR TITLE
Bump Atlas video Kafka compose image to 8.2.1

### DIFF
--- a/atlas_video-processing/docker-compose.yml
+++ b/atlas_video-processing/docker-compose.yml
@@ -1,30 +1,27 @@
 version: '3.8'
 
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:latest
-    container_name: zookeeper
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    ports:
-      - "2181:2181"
-
   kafka:
-    image: confluentinc/cp-kafka:5.5.3
+    image: confluentinc/cp-kafka:8.2.1
     container_name: kafka
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
       - "9093:9093"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      # Confluent Platform 8.x uses KRaft mode; ZooKeeper settings are unsupported.
+      KAFKA_CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:29093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093,CONTROLLER://0.0.0.0:29093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ingest-drone:
     build:

--- a/plans/PR-Atlas-Video-Processing-Kafka-8.md
+++ b/plans/PR-Atlas-Video-Processing-Kafka-8.md
@@ -1,0 +1,89 @@
+# PR-Atlas-Video-Processing-Kafka-8
+
+## Why this slice exists
+
+Dependabot proposed moving the `atlas_video-processing` compose Kafka image from
+Confluent Platform 5.5.3 to 8.2.1. Confluent Platform 8.x Kafka containers no
+longer support the old ZooKeeper-mode settings, so this slice keeps the image
+bump while moving the local compose broker to single-node KRaft and preserving
+the client listener surfaces used by the rest of the stack.
+
+## Scope (this PR)
+
+Ownership lane: atlas-video-processing/kafka-infra
+Slice phase: Production hardening
+
+1. Update the compose Kafka image from `confluentinc/cp-kafka:5.5.3` to
+   `confluentinc/cp-kafka:8.2.1`.
+2. Remove the local ZooKeeper service and ZooKeeper broker wiring.
+3. Configure a single-node KRaft broker/controller with `KAFKA_CLUSTER_ID`, node
+   ID, controller quorum, controller listener, and listener map.
+4. Preserve existing local client endpoints as `kafka:9092` for compose services
+   and `localhost:9093` for host access.
+
+### Files touched
+
+- `atlas_video-processing/docker-compose.yml`
+- `plans/PR-Atlas-Video-Processing-Kafka-8.md`
+
+### Review Contract
+
+Acceptance criteria:
+
+- [ ] The Kafka service uses the Confluent 8.2.1 image.
+- [ ] The compose file no longer configures Kafka through ZooKeeper settings.
+- [ ] The Kafka service has the required single-node KRaft roles, node ID,
+      controller quorum, controller listener, listener map, and Kafka cluster ID.
+- [ ] Existing local client endpoints remain available as `kafka:9092` for
+      compose services and `localhost:9093` for host access.
+- [ ] No ingest, processing, control, LLM service, Postgres image, runtime
+      application code, workflow, or repository-wide guardrail changes are
+      included in this slice.
+
+Affected surfaces: config / local compose Kafka.
+
+Risk areas: backcompat / config correctness / deployment safety.
+
+Reviewer rules triggered: R1, R2, R11, R12, R14.
+
+## Mechanism
+
+The `zookeeper` service and `KAFKA_ZOOKEEPER_CONNECT` wiring are removed. The
+`kafka` service now runs as a combined KRaft broker/controller with a stable
+local `KAFKA_CLUSTER_ID`, node ID, controller quorum, listener map, and
+controller listener. Compose services still use `kafka:9092`, and host tools
+still use `localhost:9093`.
+
+## Intentional
+
+- Compose-only dependency upgrade; application code and service build contexts
+  are unchanged.
+- The Postgres service remains on the already-merged `postgres:18` setup from
+  the separate Postgres slice.
+- No Kafka data volume is added in this slice, matching the existing ephemeral
+  local compose behavior.
+
+## Deferred
+
+- Add a container healthcheck or smoke test for the compose Kafka bootstrap path
+  if this stack becomes a CI-exercised integration target.
+- Parked hardening: none.
+
+## Verification
+
+- Inspected the existing #1632 compose diff and review threads.
+- Updated `atlas_video-processing/docker-compose.yml` to remove ZooKeeper wiring
+  and configure single-node KRaft while preserving `kafka:9092` and
+  `localhost:9093` listener surfaces.
+- Used `KAFKA_CLUSTER_ID` for the KRaft cluster ID to address the Copilot review
+  finding on the stale Dependabot branch.
+- Docker compose was not run in this environment; validation is by compose-file
+  inspection plus CI.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_video-processing/docker-compose.yml` | ~30 |
+| `plans/PR-Atlas-Video-Processing-Kafka-8.md` | ~88 |
+| **Total** | **~118** |


### PR DESCRIPTION
Plan: plans/PR-Atlas-Video-Processing-Kafka-8.md
Slice phase: Production hardening

Supersedes #1632 after that Dependabot branch retained stale Security Guardrails carry-forward diffs from an older merge base. This replacement keeps the same Kafka 8 compose maintenance goal on top of current `main`, preserves the merged Postgres 18 setup, and fixes the KRaft cluster-id review finding by using `KAFKA_CLUSTER_ID`.

## Scope

Files touched:
- `atlas_video-processing/docker-compose.yml`
- `plans/PR-Atlas-Video-Processing-Kafka-8.md`

Review Contract:
- The Kafka service uses `confluentinc/cp-kafka:8.2.1`.
- ZooKeeper service/wiring is removed because Confluent Platform 8.x uses KRaft.
- The Kafka service has single-node KRaft roles, node ID, controller quorum, controller listener, listener map, and `KAFKA_CLUSTER_ID`.
- Existing local client endpoints remain available as `kafka:9092` for compose services and `localhost:9093` for host access.
- No ingest, processing, control, LLM service, Postgres image, runtime application code, workflow, or repository-wide guardrail changes are included in this slice.

Affected surfaces: config / local compose Kafka.

Risk areas: backcompat / config correctness / deployment safety.

Reviewer rules triggered: R1, R2, R11, R12, R14.

## Intentional

- Compose-only dependency upgrade; application code and service build contexts are unchanged.
- The Postgres service remains on the already-merged `postgres:18` setup from the separate Postgres slice.
- No Kafka data volume is added in this slice, matching the existing ephemeral local compose behavior.

## Deferred

- Add a container healthcheck or smoke test for the compose Kafka bootstrap path if this stack becomes a CI-exercised integration target.

## Parked hardening

None.

## Verification

- Inspected the existing #1632 compose diff and review threads.
- Updated `atlas_video-processing/docker-compose.yml` to remove ZooKeeper wiring and configure single-node KRaft while preserving `kafka:9092` and `localhost:9093` listener surfaces.
- Used `KAFKA_CLUSTER_ID` for the KRaft cluster ID to address the Copilot review finding on the stale Dependabot branch.
- Docker compose was not run in this environment; validation is by compose-file inspection plus CI.

## Diff size

2 files, approximately +118 / -13.
