### PR TITLE
Redact deflection HTTP error bodies

### DIFF
--- a/plans/PR-Deflection-HTTP-Error-Body-Redaction.md
+++ b/plans/PR-Deflection-HTTP-Error-Body-Redaction.md
@@ -1,0 +1,122 @@
+# PR-Deflection-HTTP-Error-Body-Redaction
+
+## Why this slice exists
+
+#1727 centralized the deflection operator-script HTTP boundary, and its review
+flagged a pre-existing sanitizer gap: HTTP error-response bodies can be stored
+into `text`, `raw_text`, and parsed `payload` without passing through any
+redaction hook. `smoke_content_ops_deflection_submit_handoff.py` is the risky
+persisting caller because it writes result JSON and currently depends on the
+response layer returning already-safe details.
+
+Root cause: the shared HTTP helper only applies the caller-provided redactor to
+transport exceptions. HTTP status errors travel a different branch, so their
+response body is read, truncated, parsed, and returned before any shared
+redaction boundary can run. That leaves each caller responsible for remembering
+a separate whole-payload sanitizer.
+
+This PR fixes the root within the report-delivery lane by adding a shared
+HTTP-error body redaction hook at the helper seam and wiring submit-handoff to
+use it. The fix is intentionally limited to HTTP error bodies so successful
+submit responses still expose the request id internally for snapshot/artifact
+polling.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/report-delivery-live-funnel
+Slice phase: Production hardening
+
+1. Add an optional shared redaction hook for HTTP error-response bodies in the
+   deflection HTTP helper.
+2. Wire submit-handoff's JSON and multipart response parsing through that
+   redaction hook before error bodies can reach `raw_text` or parsed `payload`.
+3. Add focused failure-branch tests proving sensitive HTTP error body values
+   are redacted while successful submit responses still preserve request ids.
+
+### Files touched
+
+- `plans/PR-Deflection-HTTP-Error-Body-Redaction.md`
+- `scripts/_deflection_http.py`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_deflection_http_helpers.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] HTTP error bodies can be redacted before they are stored in `text` or
+        `raw_text`.
+  - [ ] JSON HTTP error bodies are redacted structurally, so string values are
+        sanitized without corrupting numeric/count fields before the payload is
+        returned.
+  - [ ] Successful submit responses are not redacted and still preserve the
+        request id needed for same-request snapshot/artifact probes.
+  - [ ] Existing raw Stripe webhook byte handling and Mapping request-body
+        encoding remain unchanged.
+  - [ ] New failure-branch tests run in extracted checks.
+- Affected surfaces: deflection operator HTTP helper, submit-handoff proof
+  output, extracted pipeline CI enrollment.
+- Risk areas: over-redacting successful submit payloads, malformed JSON after
+  redaction, sanitizer false negatives, payment/report proof output safety.
+- Reviewer rules triggered: R1, R2, R3, R8, R10, R12, R14.
+
+## Mechanism
+
+Extend `scripts/_deflection_http.py` with an optional error-body redactor
+callback. When an HTTP error is caught, the helper first tries to parse JSON
+error bodies, recursively redacts only string values, then serializes the
+redacted payload for the existing response path. Non-JSON bodies still fall back
+to whole-text redaction. Existing callers that do not pass the hook keep their
+current behavior.
+
+Add a submit-handoff redactor for persisted HTTP error bodies. It redacts the
+same identifier classes that are unsafe in committed proof artifacts: bearer
+tokens, content-ops request ids, source-id shaped values, emails, and signed
+URL query strings. The submit-handoff wrapper passes that hook to both the JSON
+request path and the multipart response parser.
+
+Tests mock the transport boundary below the helper. Helper tests prove the
+shared hook redacts HTTP error bodies and keeps numeric JSON fields intact.
+Submit tests prove escaped signed URLs and source-id shaped values are redacted
+from persisted failure responses while the success response still keeps the
+request id.
+
+## Intentional
+
+- The hook applies only to HTTP error bodies, not all successful response
+  bodies. Submit-handoff needs the successful request id for follow-up probes,
+  and globally redacting success payloads would break the smoke's real flow.
+- This does not add a generic artifact sanitizer framework. The narrow root is
+  the shared HTTP error branch introduced by #1727, and a helper-level hook
+  fixes that class without widening the slice into every proof artifact.
+- Existing callers keep their behavior unless they opt into the new hook. That
+  keeps this PR focused on the known persisting caller rather than silently
+  changing every operator script's diagnostics.
+
+## Deferred
+
+- A broader proof-output sanitizer framework remains deferred until another
+  caller demonstrates the same persistence risk. This slice fixes the current
+  HTTP error branch and the known persisting caller.
+
+Parked hardening: none.
+
+## Verification
+
+- Command passed: python -m py_compile scripts/_deflection_http.py scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_deflection_http_helpers.py tests/test_smoke_content_ops_deflection_submit_handoff.py.
+- Command passed: pytest tests/test_deflection_http_helpers.py tests/test_smoke_content_ops_deflection_submit_handoff.py -q -- 57 passed.
+- Command passed: python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 185 matching tests are enrolled.
+- Command passed: deflection maturity ratchet command from .github/workflows/maturity_sweep_deflection_content_ops.yml -- ratchet gate passed; no new brittleness above baseline.
+- Command passed: bash scripts/run_extracted_pipeline_checks.sh -- 4700 passed, 10 skipped.
+- Pending before push: scripts/push_pr.sh.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-HTTP-Error-Body-Redaction.md` | 122 |
+| `scripts/_deflection_http.py` | 24 |
+| `scripts/smoke_content_ops_deflection_submit_handoff.py` | 26 |
+| `tests/test_deflection_http_helpers.py` | 76 |
+| `tests/test_smoke_content_ops_deflection_submit_handoff.py` | 88 |
+| **Total** | **336** |

--- a/scripts/_deflection_http.py
+++ b/scripts/_deflection_http.py
@@ -12,6 +12,7 @@ import urllib.request
 
 
 Redactor = Callable[[Any], str]
+TextRedactor = Callable[[str], str]
 Opener = Callable[[urllib.request.Request], Any]
 _KEEP_STATUS = object()
 
@@ -57,6 +58,24 @@ def _encoded_body(
     return json.dumps(body, separators=(",", ":")).encode("utf-8")
 
 
+def _redact_json_string_values(value: Any, redactor: TextRedactor) -> Any:
+    if isinstance(value, str):
+        return redactor(value)
+    if isinstance(value, list):
+        return [_redact_json_string_values(item, redactor) for item in value]
+    if isinstance(value, dict):
+        return {key: _redact_json_string_values(item, redactor) for key, item in value.items()}
+    return value
+
+
+def _redact_error_body(raw: str, redactor: TextRedactor) -> str:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return redactor(raw)
+    return json.dumps(_redact_json_string_values(payload, redactor), separators=(",", ":"))
+
+
 def json_request(
     method: str,
     url: str,
@@ -73,6 +92,7 @@ def json_request(
     transport_error_template: str = "{method} {url} transport failed: {error}",
     invalid_json_template: str = "{method} {url} returned invalid JSON: {error}",
     invalid_json_status: int | None | object = _KEEP_STATUS,
+    error_body_redactor: TextRedactor | None = None,
     truncate_text: int | None = None,
 ) -> HttpResponse:
     encoded_body = _encoded_body(body, data)
@@ -97,6 +117,7 @@ def json_request(
         transport_error_template=transport_error_template,
         invalid_json_template=invalid_json_template,
         invalid_json_status=invalid_json_status,
+        error_body_redactor=error_body_redactor,
         truncate_text=truncate_text,
     )
 
@@ -113,6 +134,7 @@ def json_response_from_request(
     transport_error_template: str = "{method} {url} transport failed: {error}",
     invalid_json_template: str = "{method} {url} returned invalid JSON: {error}",
     invalid_json_status: int | None | object = _KEEP_STATUS,
+    error_body_redactor: TextRedactor | None = None,
     truncate_text: int | None = None,
 ) -> HttpResponse:
     http_errors: tuple[str, ...] = ()
@@ -134,6 +156,8 @@ def json_response_from_request(
             errors=(transport_error_template.format(method=method, url=url, error=detail),),
         )
 
+    if error_body_redactor is not None and status >= 400:
+        raw = _redact_error_body(raw, error_body_redactor)
     stored_raw = raw if truncate_text is None else raw[:truncate_text]
     if not raw.strip():
         return HttpResponse(

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import math
 import os
+import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 import sys
@@ -74,6 +75,21 @@ VOLUME_GATE_PROFILES: dict[str, dict[str, int]] = {
         "top_question_count": 5,
     },
 }
+_SIGNED_URL_QUERY_RE = re.compile(r"(https?://[^\s\"'<>?]+)\?[^\s\"'<>]+")
+_HTTP_ERROR_BODY_REDACTIONS = (
+    (re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE), "Bearer [redacted]"),
+    (re.compile(r"content-ops-[A-Za-z0-9_-]+"), "content-ops-[redacted]"),
+    (re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE), "[email-redacted]"),
+    (
+        re.compile(
+            r"\b(?:zendesk|freshdesk|intercom|helpscout|ticket|row|zd|source)[-_:]"
+            r"[A-Za-z0-9][A-Za-z0-9._-]*\b",
+            re.IGNORECASE,
+        ),
+        "[source-id-redacted]",
+    ),
+    (re.compile(r"\b\d{6,}\b"), "[id-redacted]"),
+)
 
 try:
     from dotenv import load_dotenv
@@ -290,6 +306,14 @@ def _redacted_blob_host(blob_url: str) -> str:
     return parsed.hostname or ""
 
 
+def _redact_http_error_body(value: str) -> str:
+    text = "" if value is None else str(value)
+    text = _SIGNED_URL_QUERY_RE.sub(r"\1?[redacted]", text)
+    for pattern, replacement in _HTTP_ERROR_BODY_REDACTIONS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
 def _submit_body(args: argparse.Namespace) -> dict[str, Any]:
     body: dict[str, Any] = {
         "blob_url": _clean(args.blob_url),
@@ -326,6 +350,7 @@ def _parse_http_json_response(
         request=request,
         timeout=timeout,
         opener=_open_http_request,
+        error_body_redactor=_redact_http_error_body,
         truncate_text=2000,
     )
 
@@ -345,6 +370,7 @@ def _json_request(
         timeout=timeout,
         body=body,
         opener=_open_http_request,
+        error_body_redactor=_redact_http_error_body,
         truncate_text=2000,
     )
 

--- a/tests/test_deflection_http_helpers.py
+++ b/tests/test_deflection_http_helpers.py
@@ -63,6 +63,81 @@ def test_json_request_preserves_http_error_status(monkeypatch) -> None:
     assert result.errors == ("HTTP 409",)
 
 
+def test_json_request_redacts_http_error_body_before_payload_parse(monkeypatch) -> None:
+    def _urlopen(request, *, timeout):
+        assert timeout == 7
+        raise _http_error(
+            request.full_url,
+            422,
+            {
+                "detail": (
+                    "Bearer sk_test_secret for content-ops-proof-123 "
+                    "buyer@example.com at https://blob.example.com/file.csv?sig=secret"
+                )
+            },
+        )
+
+    def _redact_body(raw: str) -> str:
+        return (
+            raw.replace("sk_test_secret", "[stripe-redacted]")
+            .replace("content-ops-proof-123", "content-ops-[redacted]")
+            .replace("buyer@example.com", "[email-redacted]")
+            .replace("sig=secret", "sig=[redacted]")
+        )
+
+    monkeypatch.setattr(http.urllib.request, "urlopen", _urlopen)
+
+    result = http.json_request(
+        "POST",
+        "https://atlas.example.com/proof",
+        timeout=7,
+        http_error_template="HTTP {status}",
+        error_body_redactor=_redact_body,
+    )
+
+    assert result.status == 422
+    assert result.errors == ("HTTP 422",)
+    serialized = json.dumps(result.payload, sort_keys=True) + result.raw_text
+    assert "sk_test_secret" not in serialized
+    assert "content-ops-proof-123" not in serialized
+    assert "buyer@example.com" not in serialized
+    assert "sig=secret" not in serialized
+    assert "[stripe-redacted]" in serialized
+
+
+def test_json_request_structural_redaction_preserves_numeric_json_fields(monkeypatch) -> None:
+    def _urlopen(request, *, timeout):
+        assert timeout == 7
+        raise _http_error(
+            request.full_url,
+            422,
+            {
+                "detail": "Bearer sk_test_secret for batch 1500000",
+                "received_count": 1500000,
+            },
+        )
+
+    def _redact_body(raw: str) -> str:
+        return raw.replace("sk_test_secret", "[stripe-redacted]").replace("1500000", "[id-redacted]")
+
+    monkeypatch.setattr(http.urllib.request, "urlopen", _urlopen)
+
+    result = http.json_request(
+        "POST",
+        "https://atlas.example.com/proof",
+        timeout=7,
+        http_error_template="HTTP {status}",
+        error_body_redactor=_redact_body,
+    )
+
+    assert result.status == 422
+    assert result.payload == {
+        "detail": "Bearer [stripe-redacted] for batch [id-redacted]",
+        "received_count": 1500000,
+    }
+    assert result.errors == ("HTTP 422",)
+
+
 def test_json_request_redacts_transport_error(monkeypatch) -> None:
     def _urlopen(_request, *, timeout):
         assert timeout == 3
@@ -157,4 +232,3 @@ def test_json_request_rejects_ambiguous_body_inputs() -> None:
             body={"ok": True},
             data=b"raw",
         )
-

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -1263,6 +1263,94 @@ def test_json_request_preserves_http_error_status(monkeypatch):
     assert response.errors == ()
 
 
+def test_json_request_redacts_sensitive_http_error_body(monkeypatch):
+    def _return_http_error_response(_request, *, timeout):
+        assert timeout == 1.0
+        return FakeResponse(
+            422,
+            {
+                "detail": (
+                    "Bearer token-secret failed for content-ops-sensitive-123 "
+                    "lead@example.com source zendesk:123456 "
+                    "https://blob.example.com/tickets.csv?sig=signed-secret"
+                )
+            },
+        )
+
+    monkeypatch.setattr(smoke, "_open_http_request", _return_http_error_response)
+
+    response = smoke._json_request(
+        "GET",
+        "https://atlas.example.com/probe",
+        token="secret",
+        timeout=1.0,
+    )
+
+    serialized = json.dumps(response.payload, sort_keys=True) + response.raw_text
+    assert response.status == 422
+    assert "token-secret" not in serialized
+    assert "content-ops-sensitive-123" not in serialized
+    assert "lead@example.com" not in serialized
+    assert "zendesk:123456" not in serialized
+    assert "sig=signed-secret" not in serialized
+    assert "Bearer [redacted]" in serialized
+    assert "content-ops-[redacted]" in serialized
+
+
+def test_json_request_redacts_escaped_url_and_source_id_values_without_corrupting_numbers(monkeypatch):
+    raw_body = (
+        b'{"detail":"Bearer token-secret failed for content-ops-sensitive-123",'
+        b'"source_id":"ticket-1",'
+        b'"source_ids":["row:1","zendesk:123456"],'
+        b'"received_count":1500000,'
+        b'"signed_url":"https:\\/\\/blob.example.com\\/tickets.csv?sig=signed-secret"}'
+    )
+
+    monkeypatch.setattr(
+        smoke,
+        "_open_http_request",
+        _fake_open([(422, raw_body)], []),
+    )
+
+    response = smoke._json_request(
+        "GET",
+        "https://atlas.example.com/probe",
+        token="secret",
+        timeout=1.0,
+    )
+
+    serialized = json.dumps(response.payload, sort_keys=True) + response.raw_text
+    assert response.status == 422
+    assert response.payload["received_count"] == 1500000
+    assert "token-secret" not in serialized
+    assert "content-ops-sensitive-123" not in serialized
+    assert "ticket-1" not in serialized
+    assert "row:1" not in serialized
+    assert "zendesk:123456" not in serialized
+    assert "sig=signed-secret" not in serialized
+    assert "[source-id-redacted]" in serialized
+    assert "https://blob.example.com/tickets.csv?[redacted]" in serialized
+
+
+def test_json_request_preserves_success_request_id(monkeypatch):
+    monkeypatch.setattr(
+        smoke,
+        "_open_http_request",
+        _fake_open([(200, _submit_payload(request_id="content-ops-keep-123"))], []),
+    )
+
+    response = smoke._json_request(
+        "POST",
+        "https://atlas.example.com/probe",
+        token="secret",
+        timeout=1.0,
+        body={"ok": True},
+    )
+
+    assert response.status == 200
+    assert response.payload["request_id"] == "content-ops-keep-123"
+
+
 def test_main_preflight_writes_redacted_result(tmp_path, capsys):
     result_path = tmp_path / "preflight.json"
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-HTTP-Error-Body-Redaction.md
Slice phase: Production hardening

#1727 centralized deflection operator-script HTTP handling, and its review surfaced a pre-existing sanitizer gap: HTTP error-response bodies could be read, truncated, parsed, and returned before any shared redaction boundary ran. This slice fixes that root at the shared helper seam and wires submit-handoff into it, while leaving successful submit payloads untouched so same-request snapshot/artifact probes still receive the request id they need.

## Intentional
- Redact only HTTP error bodies, not successful response bodies.
- Redact JSON error bodies structurally: string values are sanitized recursively, while numeric/count fields remain typed and parseable.
- Keep broader proof-output sanitizer framework deferred until another persisting caller shows the same risk.
- Existing callers keep behavior unless they opt into the new hook.

## Deferred
- Broader proof-output sanitizer framework remains deferred.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Human MAJOR fixed: HTTP error-body JSON is now parsed structurally, with recursive string-value redaction and non-JSON fallback text redaction.
- Codex P2 fixed: source-id values such as `ticket-1`, `row:1`, and `zendesk:123456` are covered by the submit error-body redactor.
- Codex P2 fixed: JSON-escaped signed URLs are redacted after JSON parsing, so escaped slashes normalize before URL-query redaction.
- Codex P2 fixed: numeric JSON fields remain numeric; focused tests assert `received_count` survives as an integer.

## Verification
- Command passed: python -m py_compile scripts/_deflection_http.py scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_deflection_http_helpers.py tests/test_smoke_content_ops_deflection_submit_handoff.py.
- Command passed: pytest tests/test_deflection_http_helpers.py tests/test_smoke_content_ops_deflection_submit_handoff.py -q -- 57 passed.
- Command passed: python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 185 matching tests are enrolled.
- Command passed: deflection maturity ratchet command from .github/workflows/maturity_sweep_deflection_content_ops.yml -- ratchet gate passed; no new brittleness above baseline.
- Command passed: bash scripts/run_extracted_pipeline_checks.sh -- 4700 passed, 10 skipped.

## Diff size
5 files, +335 / -1
