### PR TITLE
Scrub deflection report artifacts before storage

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -76,6 +76,7 @@ from ..faq_deflection_report import (
     DEFLECTION_REPORT_SCHEMA_VERSION,
     build_deflection_snapshot,
     deflection_report_model_contract_shape,
+    scrub_deflection_report_payload,
 )
 from ..landing_page_input_contract import landing_page_seo_geo_aeo_input_contracts
 from ..ingestion_diagnostics import inspect_ingestion_file, inspect_ingestion_rows
@@ -3324,8 +3325,9 @@ async def _gate_deflection_report_artifacts(
                 detail="Deflection report artifact is malformed.",
             )
         try:
+            scrubbed_artifact = scrub_deflection_report_payload(artifact)
             snapshot = build_deflection_snapshot(
-                artifact,
+                scrubbed_artifact,
                 top_n=top_n,
                 teaser_preview_count=teaser_preview_count,
             ).as_dict()
@@ -3333,11 +3335,12 @@ async def _gate_deflection_report_artifacts(
                 snapshot_summary = dict(snapshot.get("summary") or {})
                 snapshot_summary.update(dict(preview_summary_metadata))
                 snapshot["summary"] = snapshot_summary
+            snapshot = scrub_deflection_report_payload(snapshot)
             await store.save_report(
                 account_id=account_id,
                 request_id=request_id,
                 snapshot=snapshot,
-                artifact=dict(artifact),
+                artifact=scrubbed_artifact,
                 delivery_email=delivery_email,
             )
         except ValueError as exc:

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date
@@ -46,6 +47,115 @@ _UNCAPPED_REPORT_MAX_ITEMS = 0
 _ASSISTED_CONTACT_COST = 13.50
 _ASSISTED_CONTACT_COST_LABEL = "$13.50"
 _SOURCE_EXAMPLE_LIMIT = 3
+_DEFLECTION_BOUNDARY_LEFT = r"(?<![A-Za-z0-9])"
+_DEFLECTION_BOUNDARY_RIGHT = r"(?![A-Za-z0-9])"
+_DEFLECTION_EMAIL_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}"
+)
+_DEFLECTION_PHONE_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}"
+)
+_DEFLECTION_IDENTIFIER_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"(?:account|accounts|acct|case|cases|claim|claims|confirmation|"
+    r"confirmations|customer|customers|id|ids|invoice|invoices|member|"
+    r"members|order|orders|ref|refs|reference|references|ticket|tickets)"
+    r"\s*(?:#|number|no\.?)?\s*[:#-]?\s*\d{4,}"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}"
+    r"|"
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"\d{4,}\s*(?:account|accounts|acct|case|cases|claim|claims|customer|"
+    r"customers|invoice|invoices|member|members|order|orders|ref|refs|"
+    r"reference|references|ticket|tickets)"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}",
+    re.IGNORECASE,
+)
+_DEFLECTION_REDACTION_ARTIFACT_RE = re.compile(
+    r"\[(?:redacted(?!-(?:email|identifier|phone|text)\])|removed|hidden)[^\]]*\]"
+    r"|\bX{4,}\b",
+    re.IGNORECASE,
+)
+_DEFLECTION_IDENTIFIER_KEYS = frozenset(
+    {
+        "account",
+        "account_id",
+        "account_ids",
+        "acct",
+        "acct_id",
+        "acct_ids",
+        "case",
+        "case_id",
+        "case_ids",
+        "claim",
+        "claim_id",
+        "claim_ids",
+        "confirmation",
+        "confirmation_id",
+        "confirmation_ids",
+        "customer",
+        "customer_id",
+        "customer_ids",
+        "invoice",
+        "invoice_id",
+        "invoice_ids",
+        "member",
+        "member_id",
+        "member_ids",
+        "order",
+        "order_id",
+        "order_ids",
+        "ref",
+        "ref_id",
+        "ref_ids",
+        "reference",
+        "reference_id",
+        "reference_ids",
+        "ticket",
+    }
+)
+_DEFLECTION_SOURCE_LINK_KEYS = frozenset(
+    {
+        "source_id",
+        "source_ids",
+        "ticket_id",
+        "ticket_ids",
+    }
+)
+_DEFLECTION_IDENTIFIER_KEY_SUFFIXES = (
+    "_account_id",
+    "_account_ids",
+    "_acct_id",
+    "_acct_ids",
+    "_case_id",
+    "_case_ids",
+    "_claim_id",
+    "_claim_ids",
+    "_confirmation_id",
+    "_confirmation_ids",
+    "_customer_id",
+    "_customer_ids",
+    "_invoice_id",
+    "_invoice_ids",
+    "_member_id",
+    "_member_ids",
+    "_order_id",
+    "_order_ids",
+    "_ref_id",
+    "_ref_ids",
+    "_reference_id",
+    "_reference_ids",
+)
+_DEFLECTION_SOURCE_LINK_KEY_SUFFIXES = (
+    "_source_id",
+    "_source_ids",
+    "_ticket_id",
+    "_ticket_ids",
+)
+_DEFLECTION_IDENTIFIER_TOKEN_PREFIX = "deflection-ref"
 
 
 @dataclass(frozen=True)
@@ -154,6 +264,13 @@ class DeflectionReportArtifact:
 
     def snapshot(self, *, top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N) -> DeflectionSnapshot:
         return build_deflection_snapshot(self, top_n=top_n)
+
+
+def scrub_deflection_report_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a JSON payload with supported customer PII classes redacted."""
+
+    scrubber = _DeflectionPayloadScrubber(payload)
+    return scrubber.scrub_payload(payload)
 
 
 _DEFLECTION_REPORT_SECTION_DEFINITIONS = (
@@ -2280,6 +2397,247 @@ def _positive_limit(value: Any) -> int:
     return max(1, min(parsed, 25))
 
 
+class _DeflectionPayloadScrubber:
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        self._tokens_by_normalized_identifier: dict[str, str] = {}
+        self._tokens_by_raw_identifier: dict[str, str] = {}
+        self._source_links: set[str] = set()
+        self._collect_identifier_tokens(payload)
+
+    def scrub_payload(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        scrubbed = self._scrub_value(value)
+        if not isinstance(scrubbed, dict):
+            return {}
+        return scrubbed
+
+    def _collect_identifier_tokens(self, value: Any, *, identifier_field: bool = False) -> None:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if _is_deflection_source_link_key(key):
+                    self._collect_source_links(item)
+                    continue
+                self._collect_identifier_tokens(
+                    item,
+                    identifier_field=_is_deflection_identifier_key(key),
+                )
+            return
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            for item in value:
+                self._collect_identifier_tokens(
+                    item,
+                    identifier_field=identifier_field,
+                )
+            return
+        if identifier_field:
+            self._token_for_identifier(value)
+
+    def _collect_source_links(self, value: Any) -> None:
+        if isinstance(value, Mapping):
+            for item in value.values():
+                self._collect_source_links(item)
+            return
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            for item in value:
+                self._collect_source_links(item)
+            return
+        if isinstance(value, str) and _should_preserve_source_link(value):
+            self._source_links.add(value)
+
+    def _scrub_value(
+        self,
+        value: Any,
+        *,
+        identifier_field: bool = False,
+        source_link_field: bool = False,
+    ) -> Any:
+        if source_link_field:
+            return self._scrub_source_link_value(value)
+        if isinstance(value, Mapping):
+            return {
+                self._scrub_key(key): self._scrub_value(
+                    item,
+                    identifier_field=_is_deflection_identifier_key(key),
+                    source_link_field=_is_deflection_source_link_key(key),
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return [
+                self._scrub_value(item, identifier_field=identifier_field)
+                for item in value
+            ]
+        if identifier_field:
+            return self._token_for_identifier(value)
+        if isinstance(value, str):
+            return self._scrub_text(value)
+        return value
+
+    def _scrub_source_link_value(self, value: Any) -> Any:
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return [self._scrub_source_link_value(item) for item in value]
+        if isinstance(value, str):
+            return _scrub_source_link_text(value)
+        return value
+
+    def _scrub_key(self, key: Any) -> str:
+        return self._scrub_text(str(key))
+
+    def _token_for_identifier(self, value: Any) -> str:
+        text = _text(value)
+        if not text:
+            return ""
+        existing = self._tokens_by_raw_identifier.get(text)
+        if existing:
+            return existing
+        normalized = _normalize_deflection_identifier(text)
+        token = self._tokens_by_normalized_identifier.get(normalized)
+        if token is None:
+            token = (
+                f"{_DEFLECTION_IDENTIFIER_TOKEN_PREFIX}-"
+                f"{_alpha_index(len(self._tokens_by_normalized_identifier))}"
+            )
+            self._tokens_by_normalized_identifier[normalized] = token
+        self._tokens_by_raw_identifier[text] = token
+        return token
+
+    def _scrub_text(self, value: str) -> str:
+        protected_text, source_link_placeholders = _protect_source_link_mentions(
+            value,
+            self._source_links,
+        )
+        scrubbed = _scrub_deflection_text(
+            _scrub_known_identifier_text(
+                protected_text,
+                self._tokens_by_raw_identifier,
+            )
+        )
+        return _restore_source_link_mentions(scrubbed, source_link_placeholders)
+
+
+def _scrub_source_link_text(value: str) -> str:
+    if _should_preserve_source_link(value):
+        return value
+    return _scrub_deflection_text(value)
+
+
+def _should_preserve_source_link(value: str) -> bool:
+    text = _text(value)
+    if not text:
+        return False
+    return not (
+        _DEFLECTION_EMAIL_RE.search(text)
+        or _DEFLECTION_PHONE_RE.search(text)
+        or _DEFLECTION_REDACTION_ARTIFACT_RE.search(text)
+    )
+
+
+def _protect_source_link_mentions(
+    value: str,
+    source_links: set[str],
+) -> tuple[str, dict[str, str]]:
+    if not source_links:
+        return value, {}
+    placeholders: dict[str, str] = {}
+    out_lines: list[str] = []
+    for line in value.splitlines(keepends=True):
+        if not _line_preserves_source_links(line):
+            out_lines.append(line)
+            continue
+        protected = line
+        for source_link in sorted(source_links, key=len, reverse=True):
+            placeholder = f"DEFLECTIONSOURCELINK{_alpha_index(len(placeholders))}"
+            pattern = re.compile(re.escape(source_link), re.IGNORECASE)
+            if not pattern.search(protected):
+                continue
+            protected = pattern.sub(placeholder, protected)
+            placeholders[placeholder] = source_link
+        out_lines.append(protected)
+    return "".join(out_lines), placeholders
+
+
+def _line_preserves_source_links(value: str) -> bool:
+    text = value.strip().casefold()
+    return (
+        text.startswith("`")
+        or "source id" in text
+        or "source ids" in text
+        or text.startswith("**sources:**")
+        or text.startswith("sources:")
+    )
+
+
+def _restore_source_link_mentions(
+    value: str,
+    placeholders: Mapping[str, str],
+) -> str:
+    text = value
+    for placeholder, source_link in placeholders.items():
+        text = text.replace(placeholder, source_link)
+    return text
+
+
+def _is_deflection_identifier_key(key: Any) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(key).strip().casefold()).strip("_")
+    return normalized in _DEFLECTION_IDENTIFIER_KEYS or normalized.endswith(
+        _DEFLECTION_IDENTIFIER_KEY_SUFFIXES
+    )
+
+
+def _is_deflection_source_link_key(key: Any) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(key).strip().casefold()).strip("_")
+    return normalized in _DEFLECTION_SOURCE_LINK_KEYS or normalized.endswith(
+        _DEFLECTION_SOURCE_LINK_KEY_SUFFIXES
+    )
+
+
+def _normalize_deflection_identifier(value: str) -> str:
+    digit_groups = re.findall(r"\d{4,}", value)
+    if digit_groups:
+        return "|".join(digit_groups)
+    return re.sub(r"\s+", " ", value.strip().casefold())
+
+
+def _alpha_index(index: int) -> str:
+    letters = "abcdefghijklmnopqrstuvwxyz"
+    value = index + 1
+    chars: list[str] = []
+    while value:
+        value, remainder = divmod(value - 1, len(letters))
+        chars.append(letters[remainder])
+    return "".join(reversed(chars))
+
+
+def _scrub_known_identifier_text(
+    value: str,
+    tokens_by_raw_identifier: Mapping[str, str],
+) -> str:
+    text = value
+    for raw_identifier, token in sorted(
+        tokens_by_raw_identifier.items(),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    ):
+        if not _should_scrub_identifier_inside_text(raw_identifier):
+            continue
+        pattern = re.compile(
+            rf"{_DEFLECTION_BOUNDARY_LEFT}{re.escape(raw_identifier)}{_DEFLECTION_BOUNDARY_RIGHT}",
+            re.IGNORECASE,
+        )
+        text = pattern.sub(token, text)
+    return text
+
+
+def _should_scrub_identifier_inside_text(value: str) -> bool:
+    return bool(re.search(r"\d{4,}", value) or re.search(r"[^A-Za-z0-9]", value))
+
+
+def _scrub_deflection_text(value: str) -> str:
+    text = _DEFLECTION_REDACTION_ARTIFACT_RE.sub("[redacted-text]", value)
+    text = _DEFLECTION_EMAIL_RE.sub("[redacted-email]", text)
+    text = _DEFLECTION_PHONE_RE.sub("[redacted-phone]", text)
+    return _DEFLECTION_IDENTIFIER_RE.sub("[redacted-identifier]", text)
+
+
 def _json_ready(value: Any) -> Any:
     if isinstance(value, Mapping):
         return {str(key): _json_ready(item) for key, item in value.items()}
@@ -2323,4 +2681,5 @@ __all__ = [
     "deflection_snapshot_content_opportunities",
     "render_deflection_report",
     "render_deflection_report_model",
+    "scrub_deflection_report_payload",
 ]

--- a/plans/PR-Deflection-Backend-PII-Scrub.md
+++ b/plans/PR-Deflection-Backend-PII-Scrub.md
@@ -1,0 +1,163 @@
+# PR-Deflection-Backend-PII-Scrub
+
+## Why this slice exists
+
+Portfolio copy cannot honestly claim trustworthy PII scrubbing while ATLAS only
+has narrow FAQ-heading/evidence privacy filters. The hosted deflection backend
+persists a free Snapshot and paid report artifact in
+`content_ops_deflection_reports`; those payloads can include customer-facing
+question text, customer wording, teaser answers, Markdown, raw FAQ items,
+structured report-model rows, and evidence-export rows. This slice adds the
+backend scrub boundary before those payloads are stored or served.
+
+Review found the first implementation still treated identifiers as plain text:
+prefixed IDs were over-redacted to one flat token, while bare numeric IDs under
+identifier keys could leak because the scrubber ignored field context. The root
+cause was context-blind recursive value scrubbing, plus word-boundary regexes
+that treated Markdown underscores as part of a token. This update fixes the
+root in the backend scrub boundary by tokenizing non-source identifier fields,
+preserving paid source-link fields for buyer traceability, and making the text
+patterns delimiter-aware.
+
+This PR is over the 400 LOC soft cap because it combines the existing storage
+boundary, the field-context scrubber fix required by review, and the negative
+tests that prove both sides of the privacy guard. Splitting after the review
+findings would leave the backend guarantee knowingly incomplete.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-privacy
+Slice phase: Production hardening
+
+1. Scrub supported PII classes from completed deflection report artifact
+   payloads before the host stores them.
+2. Build the free Snapshot from the scrubbed artifact so pre-checkout and paid
+   surfaces share the same backend privacy boundary.
+3. Preserve paid-report source IDs as buyer traceability/linkage keys while
+   scrubbing supported PII classes from answer, step, quote, and structured
+   report text.
+4. Treat Markdown emphasis characters as delimiters for supported email, phone,
+   and labeled-identifier detection.
+5. Add focused tests proving raw email, phone, account/reference identifiers,
+   and redaction-token artifacts do not survive in the Snapshot, paid artifact,
+   structured report model, Markdown, FAQ payload, or evidence export.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Completed `faq_deflection_report` artifacts are scrubbed before the report
+    store receives them.
+  - The free Snapshot is derived from the scrubbed artifact, not the raw one.
+  - Bare numeric account/case/reference values under known identifier keys are
+    replaced with stable per-report refs.
+  - Paid-artifact `source_id` / `source_ids` values stay available for buyer
+    helpdesk cross-reference, while free Snapshot/gated output still omits
+    source IDs.
+  - Markdown-wrapped email and phone values are redacted.
+  - Tests prove the covered PII classes are absent from persisted Snapshot and
+    paid report payloads.
+- Affected surfaces: hosted deflection submit, stored free Snapshot, paid
+  artifact/report-model payload, report Markdown, FAQ payload, and evidence
+  export.
+- Risk areas: over-redacting safe support terms, under-redacting supported PII
+  classes, breaking the paid-report model shape, or scrubbing delivery metadata
+  that the mailer needs.
+- Reviewer rules triggered: R1 (requirements match), R2 (failure-class tests),
+  R10 (maintainability), R14 (codebase verification).
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Backend-PII-Scrub.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+`faq_deflection_report` gets a small deterministic scrubber for supported
+customer PII classes:
+
+- email-like tokens;
+- phone-shaped numbers;
+- long identifier/account/case/reference numbers in identifier context;
+- existing redaction-token artifacts such as `XXXXX` and bracketed redactions.
+
+The scrubber walks Mapping/Sequence payloads recursively and rewrites strings
+with typed redaction labels. Before the recursive rewrite, it collects values
+from known identifier fields such as `account_id`, `case_id`, `reference_id`,
+and safe suffix variants. Each distinct non-source identifier gets a
+deterministic `deflection-ref-*` token for that scrub pass; prefixed and bare
+forms sharing the same long numeric body map to the same token. That closes the
+bare-ID leak for account/case/reference fields without changing the paid
+report's existing source-ID cross-reference contract.
+
+Source-link keys such as `source_id`, `source_ids`, `ticket_id`, and
+`first_source_id` are treated as paid-report linkage metadata: normal source IDs
+are preserved in the paid artifact so buyers can cross-reference their own
+helpdesk, while email/phone-shaped source IDs are still scrubbed as supported
+PII. The free Snapshot remains source-free.
+
+Text matching uses delimiter-aware boundaries instead of `\b`/`\w`, so
+Markdown-wrapped values like `_jane.doe@acme.com_` and `_555-123-4567_` are
+redacted. Dict keys are scrubbed as well as values, and the scrubber preserves
+its own typed redaction tokens when the Snapshot gets a second defense-in-depth
+scrub pass.
+
+`_gate_deflection_report_artifacts` converts the completed report step into a
+scrubbed artifact payload before persistence, then calls
+`build_deflection_snapshot` on that scrubbed payload and stores both scrubbed
+objects. The public Snapshot/artifact/report-model routes continue to read from
+the same store, so they inherit the backend boundary instead of depending on
+client-side upload behavior.
+
+## Intentional
+
+- The slice backs a deterministic server-side guarantee for the PII classes
+  listed above. It does not claim arbitrary human-name detection; that needs a
+  separate classifier/metadata-backed path before the portfolio copy can say
+  broader things.
+- The scrubber rewrites rather than fails the whole report so support-cost and
+  opportunity counts remain usable when a few labels contain identifiers.
+- `deflection-ref-*` tokens are stable only inside one scrubbed report payload.
+  They are for non-source account/case/reference identifiers, not cross-report
+  correlation.
+- Paid-report source IDs remain visible for buyer traceability. PII-bearing
+  source-ID values such as emails are scrubbed, but a broader source-ID policy
+  can be revisited separately if the product chooses privacy over direct
+  helpdesk cross-reference later.
+- `delivery_email` is not scrubbed by this slice because it is operational
+  delivery metadata, not part of the customer-facing report artifact.
+
+## Deferred
+
+Portfolio claim/copy upgrades remain deferred until this backend slice is
+merged and the portfolio issue can point at the supported scrub classes.
+Local NER for names/addresses and retention/deletion controls for stored
+`content_ops_deflection_reports` remain follow-up work under the #1734 privacy
+arc.
+
+Parked hardening: none.
+
+## Verification
+
+- Command passed: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` -- 4 passed.
+- Command passed: `python -m pytest tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` -- 5 passed.
+- Command passed: Python compile check for the touched Python modules and test files.
+- Command passed: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 3 passed.
+- Command passed: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_strips_answers_evidence_and_sources tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection -q` -- 2 passed.
+- Command passed: `python -m pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_fetches_blob_and_returns_locked_report tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 2 passed.
+- Command passed: repository ASCII Python policy script.
+- Recurring value/copy sweep: not applicable; this slice adds a backend scrub
+  boundary and tests, not a repeated user-facing copy/string replacement.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 7 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 359 |
+| `plans/PR-Deflection-Backend-PII-Scrub.md` | 163 |
+| `tests/test_content_ops_deflection_report.py` | 113 |
+| `tests/test_extracted_content_deflection_submit.py` | 149 |
+| **Total** | **791** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -21,6 +21,7 @@ from extracted_content_pipeline.faq_deflection_report import (
     deflection_report_model_contract_shape,
     deflection_snapshot_content_opportunities,
     render_deflection_report_model,
+    scrub_deflection_report_payload,
     _report_section,
 )
 from extracted_content_pipeline.deflection_report_access import (
@@ -1502,6 +1503,118 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
     assert "ticket-export-1" not in encoded
     assert "evidence_quotes" not in encoded
     assert "source_ids" not in encoded
+
+
+def test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=2,
+        ticket_source_count=2,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "How do I reset access for jane.doe@acme.com?",
+                "question_source": "customer_wording",
+                "customer_wording": (
+                    "Jane can be reached at 555-123-4567 for account 4829103."
+                ),
+                "topic": "Password reset for jane.doe@acme.com",
+                "weighted_frequency": 4,
+                "ticket_count": 2,
+                "answer": "Send jane.doe@acme.com a reset link.",
+                "steps": [
+                    "Confirm account 4829103 before resetting access.",
+                    "Call (555) 123-4567 if the customer is locked out.",
+                    "Escalate claim 999999 if the reset still fails.",
+                ],
+                "term_mappings": [
+                    {
+                        "customer_term": "Jane's account 4829103",
+                        "documentation_term": "password reset",
+                        "suggestion": "Remove XXXXX before publishing.",
+                        "source_id_count": 2,
+                    }
+                ],
+                "source_ids": ("ticket-source-a", "ticket-source-b"),
+                "evidence_quotes": (
+                    "`ticket-source-a`: jane.doe@acme.com mentioned XXXXX.",
+                    "`ticket-source-b`: Call 555-123-4567 for ref 777777.",
+                ),
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+            },
+        ),
+    )
+    artifact = build_deflection_report_artifact(result).as_dict()
+
+    scrubbed_artifact = scrub_deflection_report_payload(artifact)
+    snapshot = build_deflection_snapshot(scrubbed_artifact).as_dict()
+    encoded = json.dumps(
+        {"artifact": scrubbed_artifact, "snapshot": snapshot},
+        sort_keys=True,
+    ).lower()
+
+    for raw_fragment in (
+        "jane.doe",
+        "acme.com",
+        "555-123-4567",
+        "(555) 123-4567",
+        "4829103",
+        "777777",
+        "999999",
+        "xxxxx",
+    ):
+        assert raw_fragment not in encoded
+    assert scrubbed_artifact["faq_result"]["items"][0]["source_ids"] == [
+        "ticket-source-a",
+        "ticket-source-b",
+    ]
+    assert "[redacted-email]" in encoded
+    assert "[redacted-phone]" in encoded
+    assert "[redacted-identifier]" in encoded
+    assert "[redacted-text]" in encoded
+
+
+def test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys() -> None:
+    scrubbed = scrub_deflection_report_payload(
+        {
+            "source_id": "4829103",
+            "source_ids": ["777777", "ticket-4829103", "owner@example.com"],
+            "first_source_id": "888888",
+            "account_id": 5550000,
+            "id": "question_details",
+            "note": (
+                "Sources 4829103 and ticket-4829103 reached "
+                "_jane.doe@acme.com_ at _555-123-4567_ about case 999999."
+            ),
+            "jane.doe@acme.com": {"_555-123-4567_": "visible"},
+        }
+    )
+
+    encoded = json.dumps(scrubbed, sort_keys=True).lower()
+
+    for raw_fragment in (
+        "5550000",
+        "999999",
+        "jane.doe",
+        "acme.com",
+        "555-123-4567",
+    ):
+        assert raw_fragment not in encoded
+    assert scrubbed["source_id"] == "4829103"
+    assert scrubbed["source_ids"] == [
+        "777777",
+        "ticket-4829103",
+        "[redacted-email]",
+    ]
+    assert scrubbed["first_source_id"] == "888888"
+    assert scrubbed["account_id"].startswith("deflection-ref-")
+    assert scrubbed["id"] == "question_details"
+    assert "[redacted-email]" in scrubbed
+    assert any("[redacted-phone]" in key for key in scrubbed["[redacted-email]"])
+    assert "[redacted-email]" in encoded
+    assert "[redacted-phone]" in encoded
+    assert "[redacted-identifier]" in encoded
 
 
 def test_deflection_snapshot_marks_question_only_exports_absent_resolution_evidence() -> None:

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -19,6 +19,7 @@ from extracted_content_pipeline.api.control_surfaces import (
     ContentOpsControlSurfaceApiConfig,
     create_content_ops_control_surface_router,
 )
+from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
 from extracted_content_pipeline.deflection_report_access import (
     InMemoryDeflectionReportArtifactStore,
@@ -704,6 +705,147 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
 
 
 @pytest.mark.asyncio
+async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    unsafe_artifact = {
+        "markdown": (
+            "# Report\n\n"
+            "How do I reset access for jane.doe@acme.com?\n"
+            "Call _555-123-4567_ and confirm account 4829103.\n"
+        ),
+        "summary": {
+            "generated": 1,
+            "drafted_answer_count": 1,
+            "no_proven_answer_count": 0,
+        },
+        "faq_result": {
+            "items": [
+                {
+                    "question": "How do I reset access for jane.doe@acme.com?",
+                    "question_source": "customer_wording",
+                    "customer_wording": "Call 555-123-4567 for account 4829103.",
+                    "weighted_frequency": 2,
+                    "ticket_count": 2,
+                    "answer": "Reset _jane.doe@acme.com_ after confirming account 4829103.",
+                    "steps": [
+                        "Remove XXXXX before publishing.",
+                        "Escalate case 999999 if the reset still fails.",
+                    ],
+                    "source_ids": ["4829103", "777777"],
+                    "evidence_quotes": [
+                        "`4829103`: jane.doe@acme.com called _555-123-4567_."
+                    ],
+                    "answer_evidence_status": "resolution_evidence",
+                    "resolution_evidence_scope": "scoped",
+                }
+            ]
+        },
+        "report_model": {
+            "schema_version": DEFLECTION_REPORT_SCHEMA_VERSION,
+            "title": "Support Ticket Deflection Report",
+            "summary": {"generated": 1},
+            "sections": [
+                {
+                    "id": "question_details",
+                    "title": "Question Details and Evidence",
+                    "priority": 40,
+                    "surfaces": ["web"],
+                    "default_limit": None,
+                    "required_data": ["rows"],
+                    "data": {
+                        "rows": [
+                            {
+                                "question": "How do I reset jane.doe@acme.com?",
+                                "answer": (
+                                    "Confirm account 4829103 for jane.doe@acme.com."
+                                ),
+                            }
+                        ]
+                    },
+                }
+            ],
+        },
+        "evidence_export": {
+            "schema_version": DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION,
+            "evidence_rows": [
+                {
+                    "source_id": "4829103",
+                    "evidence_quote": "jane.doe@acme.com called 555-123-4567.",
+                }
+            ],
+        },
+    }
+
+    gated = await api_module._gate_deflection_report_artifacts(
+        {
+            "status": "completed",
+            "steps": [
+                {
+                    "output": "faq_deflection_report",
+                    "status": "completed",
+                    "result": unsafe_artifact,
+                }
+            ],
+        },
+        store_provider=lambda: store,
+        scope=TenantScope(account_id="acct-pii"),
+        request_id="request-pii",
+        top_n=1,
+        teaser_preview_count=1,
+    )
+
+    record = await store.get_artifact_record(
+        account_id="acct-pii",
+        request_id="request-pii",
+    )
+    assert record is not None
+    encoded = json.dumps(
+        {
+            "gated": gated["steps"][0]["result"],
+            "snapshot": record.snapshot,
+        },
+        sort_keys=True,
+    ).lower()
+    for raw_fragment in (
+        "jane.doe",
+        "acme.com",
+        "555-123-4567",
+        "4829103",
+        "777777",
+        "999999",
+        "xxxxx",
+    ):
+        assert raw_fragment not in encoded
+    teaser_answer = record.snapshot["teaser"]["full_answer"]
+    assert "[redacted-email]" in teaser_answer["answer"]
+    assert "[redacted-identifier]" in teaser_answer["answer"]
+    assert teaser_answer["steps"] == [
+        "Remove [redacted-text] before publishing.",
+        "Escalate [redacted-identifier] if the reset still fails.",
+    ]
+    artifact_sources = record.artifact["faq_result"]["items"][0]["source_ids"]
+    assert artifact_sources == ["4829103", "777777"]
+    assert record.artifact["evidence_export"]["evidence_rows"][0]["source_id"] == (
+        "4829103"
+    )
+    artifact_encoded = json.dumps(record.artifact, sort_keys=True).lower()
+    for raw_fragment in (
+        "jane.doe",
+        "acme.com",
+        "555-123-4567",
+        "999999",
+        "xxxxx",
+    ):
+        assert raw_fragment not in artifact_encoded
+    assert "4829103" in artifact_encoded
+    assert "777777" in artifact_encoded
+    assert "[redacted-email]" in encoded
+    assert "[redacted-phone]" in encoded
+    assert "[redacted-identifier]" in encoded
+    assert "[redacted-text]" in encoded
+
+
+@pytest.mark.asyncio
 async def test_deflection_submit_accepts_zendesk_full_thread_blob(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -792,11 +934,14 @@ async def test_deflection_submit_accepts_zendesk_full_thread_blob(
     assert artifact_payload["faq_result"]["items"][0]["resolution_evidence_scope"] == (
         "missing_question_scope"
     )
-    assert list(artifact_payload["faq_result"]["items"][0]["source_ids"]) == ["41"]
+    first_source_ids = list(artifact_payload["faq_result"]["items"][0]["source_ids"])
+    assert first_source_ids == ["41"]
     assert artifact_payload["faq_result"]["items"][1]["answer_evidence_status"] == (
         "resolution_evidence"
     )
-    assert list(artifact_payload["faq_result"]["items"][1]["source_ids"]) == ["2"]
+    second_source_ids = list(artifact_payload["faq_result"]["items"][1]["source_ids"])
+    assert second_source_ids == ["2"]
+    assert first_source_ids[0] != second_source_ids[0]
     assert "duplicate billing event and refunded the extra charge" in (
         artifact_payload["markdown"]
     )


### PR DESCRIPTION
Plan: plans/PR-Deflection-Backend-PII-Scrub.md
Slice phase: Production hardening

This slice adds the backend privacy boundary for hosted deflection reports and fixes the review-discovered root cause: identifier scrubbing was context-blind, so bare numeric account/case/reference IDs could leak, paid source IDs were accidentally pseudonymized, and Markdown underscore delimiters could hide emails/phones from the regex boundary.

## Intentional

- The backend guarantee covers deterministic email-like tokens, phone-shaped numbers, account/case/reference values in known non-source identifier-field context, labeled identifier text, and redaction-token artifacts.
- Paid artifact `source_id` / `source_ids` values are preserved as buyer traceability/linkage keys; the free Snapshot and gated output still omit source IDs.
- Non-source identifier fields are rewritten to stable per-report `deflection-ref-*` tokens.
- The scrubber does not claim arbitrary human-name or street-address detection; local NER remains a follow-up before broader portfolio copy.
- `delivery_email` remains operational delivery metadata and is not scrubbed from the delivery field.

## Deferred

- Portfolio claim/copy upgrades remain deferred until this backend slice is merged and the portfolio issue can point at the supported scrub classes.
- Local NER for names/addresses and retention/deletion controls for stored `content_ops_deflection_reports` remain follow-up work under the #1734 privacy arc.

## Parked hardening

- None.

## AI Reconciliation

All findings fixed or waived: Yes.

- Codex P1 `faq_deflection_report.py:2314` bare numeric identifier values under identifier keys leaked: fixed for non-source account/case/reference identifier keys with field-context-aware tokenization; source ID keys are intentionally preserved as paid-report linkage metadata, with email/phone-shaped source IDs still scrubbed.
- Codex P2 `faq_deflection_report.py:54` Markdown underscore-wrapped PII evaded matching: fixed with delimiter-aware email/phone/identifier boundaries and regression coverage.
- Reviewer BLOCKER paid-artifact source-ID contract break: fixed by preserving paid artifact source IDs and restoring the existing execute-harness expectation.
- Reviewer MAJOR source-id traceability collapse: fixed by treating source IDs as buyer linkage metadata instead of pseudonymizing them.
- Reviewer MINOR dict keys not scrubbed: fixed by scrubbing mapping keys as well as values, with key-level regression coverage.

## Verification

- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` -- 4 passed.
- `python -m pytest tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii tests/test_extracted_content_deflection_submit.py::test_deflection_submit_accepts_zendesk_full_thread_blob -q` -- 5 passed.
- `python -m compileall -q extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/api/control_surfaces.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_deflection_submit.py` -- passed.
- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 3 passed.
- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_strips_answers_evidence_and_sources tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection -q` -- 2 passed.
- `python -m pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_fetches_blob_and_returns_locked_report tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 2 passed.
- `bash scripts/check_ascii_python.sh` -- passed.

## Diff size

5 files, +787 / -4. Over the 400 LOC soft cap because this includes the storage boundary, the field-context review fix, the paid-source-ID contract repair, and the negative privacy-guard tests in one indivisible hardening slice.
