### PR TITLE
Add maturity sweep baseline debt report

### DIFF
--- a/plans/PR-Maturity-Sweep-Baseline-Report.md
+++ b/plans/PR-Maturity-Sweep-Baseline-Report.md
@@ -1,0 +1,101 @@
+# PR-Maturity-Sweep-Baseline-Report
+
+## Why this slice exists
+
+Issue #1689 deferred "baseline debt burndown/trend reporting across lanes"
+after the maturity-sweep ratchet finished rolling out. Phase C4 completed the
+last explicit enrollment lane (`scripts/**`); the repo now has many committed
+baselines but no quick way to see which lanes carry the most debt or which
+finding classes dominate.
+
+Root cause: maturity-sweep baselines are stored as per-lane JSON artifacts, but
+there is no deterministic report that summarizes total score, file count, and
+finding counts across those baselines. This change treats observability, not
+gate behavior: it adds a read-only report over existing baselines so operators
+can prioritize burndown without reverse-engineering JSON files.
+
+## Scope (this PR)
+
+Ownership lane: ci/maturity-sweep
+Slice phase: Production hardening
+
+1. Add a read-only baseline summary script for maturity-sweep baseline JSON
+   files.
+2. Add focused unit tests for deterministic aggregation, sorting, and malformed
+   baseline rejection.
+3. Keep CI gate behavior unchanged.
+
+### Review Contract
+
+Acceptance criteria:
+- The helper reads maturity-sweep baseline JSON files and summarizes per-lane
+  file count, total score, top score, and finding counts.
+- Output is deterministic and useful in text by default, with JSON output
+  available for later automation.
+- Malformed baseline JSON fails closed with a non-zero exit.
+- Tests cover aggregation, ordering, JSON output, and malformed input.
+
+Affected surfaces:
+- `scripts/summarize_maturity_sweep_baselines.py`
+- `tests/test_summarize_maturity_sweep_baselines.py`
+
+Risk areas:
+- Misleading totals from malformed baseline entries.
+- Report nondeterminism that makes trend diffs noisy.
+
+Reviewer rules triggered: R1, R2, R10, R14.
+
+### Files touched
+
+- `plans/PR-Maturity-Sweep-Baseline-Report.md`
+- `scripts/summarize_maturity_sweep_baselines.py`
+- `tests/test_summarize_maturity_sweep_baselines.py`
+
+## Mechanism
+
+The script scans a baseline glob, validates each baseline object, and aggregates
+only numeric `score` and `counts` fields. Lanes are sorted by total score
+descending, then lane name ascending for stable output. Text output is compact
+for humans; `--json` emits the same computed summaries for future trend tooling.
+
+## Intentional
+
+- No workflow enrollment in this slice. This is an operator/reporting helper,
+  not a new gate.
+- No historical trend storage yet. This produces the current snapshot that a
+  later scheduled artifact or trend slice can consume.
+
+## Deferred
+
+- Scheduled trend artifact publishing remains deferred.
+- Threshold tightening remains deferred until operators use the report to pick
+  lanes for burndown.
+
+Parked hardening: none.
+
+## Verification
+
+- Command passed: python -m py_compile for
+  `scripts/summarize_maturity_sweep_baselines.py` and
+  `tests/test_summarize_maturity_sweep_baselines.py`.
+- Command passed: pytest for `tests/test_summarize_maturity_sweep_baselines.py`
+  and `tests/test_maturity_sweep.py` with `--noconftest -q`; 19 passed.
+- Command passed: scripts-lane maturity-sweep ratchet for
+  `tests/maturity_sweep/baseline_scripts.json`; 262 files scanned and no new
+  brittleness above baseline.
+- Command passed: summary report for `tests/maturity_sweep/baseline_scripts.json`
+  with top three finding counts; reports `scripts 260 2385 63`.
+- Command passed: full summary report over all maturity-sweep baselines; reports
+  `scripts`, `extracted_content_pipeline`, and `atlas_brain_autonomous` as the
+  top three total-score lanes.
+- Command passed: plan sync for
+  `plans/PR-Maturity-Sweep-Baseline-Report.md`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Maturity-Sweep-Baseline-Report.md` | 101 |
+| `scripts/summarize_maturity_sweep_baselines.py` | 129 |
+| `tests/test_summarize_maturity_sweep_baselines.py` | 106 |
+| **Total** | **336** |

--- a/scripts/summarize_maturity_sweep_baselines.py
+++ b/scripts/summarize_maturity_sweep_baselines.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Summarize maturity-sweep baseline debt across lanes."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class LaneSummary:
+    lane: str
+    path: str
+    files: int
+    total_score: int
+    top_score: int
+    counts: dict[str, int]
+
+
+class BaselineError(ValueError):
+    """Raised when a baseline cannot be summarized safely."""
+
+
+def lane_name(path: Path) -> str:
+    stem = path.stem
+    return stem.removeprefix("baseline_")
+
+
+def _int_field(value: object, *, path: Path, field: str) -> int:
+    if not isinstance(value, int):
+        raise BaselineError(f"{path}: {field} must be an integer")
+    return value
+
+
+def summarize_baseline(path: Path) -> LaneSummary:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BaselineError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise BaselineError(f"{path}: baseline must be a JSON object")
+
+    total_score = 0
+    top_score = 0
+    counts: dict[str, int] = {}
+    for file_path, entry in payload.items():
+        if not isinstance(file_path, str):
+            raise BaselineError(f"{path}: baseline file keys must be strings")
+        if not isinstance(entry, dict):
+            raise BaselineError(f"{path}: {file_path} entry must be an object")
+        score = _int_field(entry.get("score", 0), path=path, field=f"{file_path}.score")
+        total_score += score
+        top_score = max(top_score, score)
+        raw_counts = entry.get("counts", {})
+        if not isinstance(raw_counts, dict):
+            raise BaselineError(f"{path}: {file_path}.counts must be an object")
+        for code, count in raw_counts.items():
+            if not isinstance(code, str):
+                raise BaselineError(f"{path}: {file_path}.counts keys must be strings")
+            counts[code] = counts.get(code, 0) + _int_field(
+                count, path=path, field=f"{file_path}.counts.{code}"
+            )
+
+    return LaneSummary(
+        lane=lane_name(path),
+        path=str(path),
+        files=len(payload),
+        total_score=total_score,
+        top_score=top_score,
+        counts=dict(sorted(counts.items())),
+    )
+
+
+def collect_summaries(patterns: Iterable[str]) -> list[LaneSummary]:
+    paths = sorted({Path(match) for pattern in patterns for match in glob.glob(pattern)})
+    if not paths:
+        raise BaselineError("no baseline files matched")
+    summaries = [summarize_baseline(path) for path in paths]
+    return sorted(summaries, key=lambda item: (-item.total_score, item.lane))
+
+
+def render_text(summaries: list[LaneSummary], *, top_counts: int) -> str:
+    lines = ["lane files total_score top_score top_findings"]
+    for item in summaries:
+        top = sorted(item.counts.items(), key=lambda pair: (-pair[1], pair[0]))[:top_counts]
+        findings = ",".join(f"{code}:{count}" for code, count in top) or "-"
+        lines.append(
+            f"{item.lane} {item.files} {item.total_score} {item.top_score} {findings}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "patterns",
+        nargs="*",
+        default=["tests/maturity_sweep/baseline_*.json"],
+        help="baseline JSON glob(s) to summarize",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON summaries")
+    parser.add_argument(
+        "--top-counts",
+        type=int,
+        default=5,
+        help="number of finding classes to show in text output",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        summaries = collect_summaries(args.patterns)
+    except BaselineError as exc:
+        print(f"maturity baseline summary: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps([asdict(item) for item in summaries], indent=2, sort_keys=True))
+    else:
+        print(render_text(summaries, top_counts=max(args.top_counts, 0)), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_summarize_maturity_sweep_baselines.py
+++ b/tests/test_summarize_maturity_sweep_baselines.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "summarize_maturity_sweep_baselines.py"
+
+SPEC = importlib.util.spec_from_file_location("summarize_maturity_sweep_baselines", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_collect_summaries_orders_by_total_score_then_lane(tmp_path: Path) -> None:
+    write_json(
+        tmp_path / "baseline_beta.json",
+        {
+            "beta/a.py": {"score": 5, "counts": {"SWALLOWED_EXCEPT": 1}},
+            "beta/b.py": {"score": 3, "counts": {"NO_TEST_FILE": 1}},
+        },
+    )
+    write_json(
+        tmp_path / "baseline_alpha.json",
+        {"alpha/a.py": {"score": 8, "counts": {"NO_TEST_FILE": 1}}},
+    )
+    write_json(
+        tmp_path / "baseline_gamma.json",
+        {"gamma/a.py": {"score": 2, "counts": {"WEAK_CONTRACT": 2}}},
+    )
+
+    summaries = MOD.collect_summaries([str(tmp_path / "baseline_*.json")])
+
+    assert [item.lane for item in summaries] == ["alpha", "beta", "gamma"]
+    assert summaries[1].files == 2
+    assert summaries[1].total_score == 8
+    assert summaries[1].top_score == 5
+    assert summaries[1].counts == {"NO_TEST_FILE": 1, "SWALLOWED_EXCEPT": 1}
+
+
+def test_render_text_is_deterministic_and_limits_top_counts(tmp_path: Path) -> None:
+    write_json(
+        tmp_path / "baseline_lane.json",
+        {
+            "lane/a.py": {
+                "score": 11,
+                "counts": {"ZZZ": 2, "AAA": 2, "MID": 1},
+            }
+        },
+    )
+
+    output = MOD.render_text(
+        MOD.collect_summaries([str(tmp_path / "baseline_*.json")]),
+        top_counts=2,
+    )
+
+    assert output.splitlines() == [
+        "lane files total_score top_score top_findings",
+        "lane 1 11 11 AAA:2,ZZZ:2",
+    ]
+
+
+def test_json_output_uses_same_summary_shape(tmp_path: Path, capsys) -> None:
+    write_json(
+        tmp_path / "baseline_lane.json",
+        {"lane/a.py": {"score": 4, "counts": {"NO_TEST_FILE": 1}}},
+    )
+
+    assert MOD.main([str(tmp_path / "baseline_*.json"), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == [
+        {
+            "counts": {"NO_TEST_FILE": 1},
+            "files": 1,
+            "lane": "lane",
+            "path": str(tmp_path / "baseline_lane.json"),
+            "top_score": 4,
+            "total_score": 4,
+        }
+    ]
+
+
+def test_malformed_count_fails_closed(tmp_path: Path, capsys) -> None:
+    write_json(
+        tmp_path / "baseline_bad.json",
+        {"bad/a.py": {"score": 4, "counts": {"NO_TEST_FILE": "one"}}},
+    )
+
+    assert MOD.main([str(tmp_path / "baseline_*.json")]) == 1
+
+    assert "counts.NO_TEST_FILE must be an integer" in capsys.readouterr().err
+
+
+def test_no_matching_baselines_fails_closed(tmp_path: Path, capsys) -> None:
+    assert MOD.main([str(tmp_path / "missing_*.json")]) == 1
+
+    assert "no baseline files matched" in capsys.readouterr().err


### PR DESCRIPTION
Plan: plans/PR-Maturity-Sweep-Baseline-Report.md
Slice phase: Production hardening

Issue #1689 deferred baseline debt burndown/trend reporting after maturity-sweep rollout. This slice adds a read-only report over committed maturity-sweep baselines so operators can see which lanes carry the most debt and which finding classes dominate.

## Intentional
- No workflow enrollment in this slice; this is an operator/reporting helper, not a new gate.
- No historical trend storage yet; this produces the current snapshot that a later scheduled artifact or trend slice can consume.

## Deferred
- Scheduled trend artifact publishing remains deferred.
- Threshold tightening remains deferred until operators use the report to pick lanes for burndown.

## Parked hardening
- None.

## Verification
- Command passed: python -m py_compile for `scripts/summarize_maturity_sweep_baselines.py` and `tests/test_summarize_maturity_sweep_baselines.py`.
- Command passed: pytest for `tests/test_summarize_maturity_sweep_baselines.py` and `tests/test_maturity_sweep.py` with `--noconftest -q`; 19 passed.
- Command passed: scripts-lane maturity-sweep ratchet for `tests/maturity_sweep/baseline_scripts.json`; 262 files scanned and no new brittleness above baseline.
- Command passed: summary report for `tests/maturity_sweep/baseline_scripts.json` with top three finding counts; reports `scripts 260 2385 63`.
- Command passed: full summary report over all maturity-sweep baselines; reports `scripts`, `extracted_content_pipeline`, and `atlas_brain_autonomous` as the top three total-score lanes.
- Command passed: plan sync for `plans/PR-Maturity-Sweep-Baseline-Report.md`.

## Diff size
3 files, +336 / -0
