### PR TITLE
Redact deflection HTTP error source id values

### DIFF
--- a/plans/PR-Deflection-HTTP-Error-Source-ID-Values.md
+++ b/plans/PR-Deflection-HTTP-Error-Source-ID-Values.md
@@ -1,0 +1,118 @@
+# PR-Deflection-HTTP-Error-Source-ID-Values
+
+## Why this slice exists
+
+#1728 closed the shared HTTP error-body redaction gap, but its LGTM left a
+non-blocking NIT: submit-handoff can still persist an opaque
+`source_id` / `source_ids` JSON value when the value has no vendor prefix, row
+prefix, ticket prefix, or long numeric run. That means an error response like
+`{"source_id": "opaque7key"}` is sanitized for tokens and URLs but can still
+store the opaque source id in proof output.
+
+Root cause: the shared HTTP helper's structural JSON redaction is value-only
+and context-free. The submit caller can redact string values by pattern, but it
+cannot know that a short opaque string is sensitive when it appears under the
+`source_id` or `source_ids` keys. Adding more denylist regexes would either
+miss the next opaque shape or over-redact unrelated short strings.
+
+This PR fixes the root for operator proof output by adding an optional
+key-path-aware JSON value redaction hook at the shared helper seam, then using
+it only in submit-handoff's HTTP error-body path. It intentionally does not
+change backend paid artifact storage or buyer report source-id policy; #1730 is
+already carrying that separate backend PII/source-id tradeoff.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/report-delivery-live-funnel
+Slice phase: Production hardening
+
+1. Add an optional key-path-aware JSON value redaction hook for HTTP error
+   bodies in the deflection HTTP helper.
+2. Wire submit-handoff to redact scalar values under `source_id` and
+   `source_ids` in HTTP error JSON payloads, including short opaque values and
+   numeric source IDs.
+3. Add focused negative and near-miss tests proving keyed source-id values are
+   redacted without broad regex overreach.
+
+### Files touched
+
+- `plans/PR-Deflection-HTTP-Error-Source-ID-Values.md`
+- `scripts/_deflection_http.py`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_deflection_http_helpers.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Submit-handoff HTTP error JSON redacts scalar values under `source_id`
+        and `source_ids`, even when they are opaque short strings or numeric
+        IDs.
+  - [ ] Non-source-id short strings in the same payload are not redacted solely
+        because they are short or opaque.
+  - [ ] Existing token, content-ops id, email, signed URL, and numeric JSON
+        preservation behavior from #1728 remains intact.
+  - [ ] The change is limited to HTTP error-body proof output and does not
+        change backend paid artifact persistence or buyer-facing source-id
+        semantics.
+- Affected surfaces: deflection operator HTTP helper, submit-handoff proof
+  output, extracted pipeline CI enrollment.
+- Risk areas: over-redacting unrelated diagnostics, changing successful
+  response payloads, colliding with #1730 backend source-id policy, JSON type
+  corruption.
+- Reviewer rules triggered: R1, R2, R3, R8, R10, R12, R14.
+
+## Mechanism
+
+Extend the helper's HTTP error-body JSON redaction path with an optional
+JSON-value callback that receives the current key path and value. The default
+is absent, so existing callers keep the #1728 behavior: recurse through JSON,
+redact string values with the plain text redactor, and preserve non-string
+values.
+
+Submit-handoff passes a small key-aware callback that replaces scalar values
+under `source_id` and `source_ids` with `[source-id-redacted]`. The normal text
+redactor still handles bearer tokens, content-ops request ids, emails,
+source-id shaped strings, signed URL query strings, and long numeric string
+values.
+
+Tests mock the HTTP boundary and assert both sides of the guard: opaque keyed
+source-id values are removed from `payload` and `raw_text`, while a same-shaped
+short diagnostic value under an unrelated key survives.
+
+## Intentional
+
+- This is operator-output-only. It does not touch `content_ops_deflection_reports`
+  persistence, report artifacts, snapshots, or buyer report traceability.
+- The fix is key-aware instead of another broad regex. Opaque source ids are
+  sensitive because of their field context; unrelated short diagnostics are not.
+- Successful submit responses remain unchanged so request ids still support the
+  same-request snapshot/artifact probes.
+
+## Deferred
+
+- Backend paid-artifact source-id policy remains with #1730. This slice does
+  not decide whether buyer-visible paid artifacts should redact, pseudonymize,
+  or preserve source IDs.
+
+Parked hardening: none.
+
+## Verification
+
+- Command passed: python -m py_compile scripts/_deflection_http.py scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_deflection_http_helpers.py tests/test_smoke_content_ops_deflection_submit_handoff.py.
+- Command passed: pytest tests/test_deflection_http_helpers.py tests/test_smoke_content_ops_deflection_submit_handoff.py -q -- 59 passed.
+- Command passed: python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 185 matching tests are enrolled.
+- Command passed: exact maturity-sweep-deflection-content-ops workflow command -- 14 + 8 maturity tests passed; product surface manifest ok; deflection and AI content ops ratchet gates passed with no new brittleness above baseline.
+- Command passed: bash scripts/run_extracted_pipeline_checks.sh -- 4702 passed, 10 skipped.
+- Pending before push: scripts/push_pr.sh.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-HTTP-Error-Source-ID-Values.md` | 118 |
+| `scripts/_deflection_http.py` | 41 |
+| `scripts/smoke_content_ops_deflection_submit_handoff.py` | 11 |
+| `tests/test_deflection_http_helpers.py` | 42 |
+| `tests/test_smoke_content_ops_deflection_submit_handoff.py` | 34 |
+| **Total** | **246** |

--- a/scripts/_deflection_http.py
+++ b/scripts/_deflection_http.py
@@ -13,6 +13,7 @@ import urllib.request
 
 Redactor = Callable[[Any], str]
 TextRedactor = Callable[[str], str]
+JsonValueRedactor = Callable[[tuple[str, ...], Any], Any | None]
 Opener = Callable[[urllib.request.Request], Any]
 _KEEP_STATUS = object()
 
@@ -58,22 +59,47 @@ def _encoded_body(
     return json.dumps(body, separators=(",", ":")).encode("utf-8")
 
 
-def _redact_json_string_values(value: Any, redactor: TextRedactor) -> Any:
+def _redact_json_string_values(
+    value: Any,
+    redactor: TextRedactor,
+    json_value_redactor: JsonValueRedactor | None = None,
+    path: tuple[str, ...] = (),
+) -> Any:
+    if json_value_redactor is not None:
+        replacement = json_value_redactor(path, value)
+        if replacement is not None:
+            return replacement
     if isinstance(value, str):
         return redactor(value)
     if isinstance(value, list):
-        return [_redact_json_string_values(item, redactor) for item in value]
+        return [
+            _redact_json_string_values(item, redactor, json_value_redactor, path)
+            for item in value
+        ]
     if isinstance(value, dict):
-        return {key: _redact_json_string_values(item, redactor) for key, item in value.items()}
+        return {
+            key: _redact_json_string_values(
+                item,
+                redactor,
+                json_value_redactor,
+                path + (str(key),),
+            )
+            for key, item in value.items()
+        }
     return value
 
 
-def _redact_error_body(raw: str, redactor: TextRedactor) -> str:
+def _redact_error_body(
+    raw: str,
+    redactor: TextRedactor,
+    json_value_redactor: JsonValueRedactor | None = None,
+) -> str:
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
         return redactor(raw)
-    return json.dumps(_redact_json_string_values(payload, redactor), separators=(",", ":"))
+    redacted = _redact_json_string_values(payload, redactor, json_value_redactor)
+    return json.dumps(redacted, separators=(",", ":"))
 
 
 def json_request(
@@ -93,6 +119,7 @@ def json_request(
     invalid_json_template: str = "{method} {url} returned invalid JSON: {error}",
     invalid_json_status: int | None | object = _KEEP_STATUS,
     error_body_redactor: TextRedactor | None = None,
+    error_body_json_value_redactor: JsonValueRedactor | None = None,
     truncate_text: int | None = None,
 ) -> HttpResponse:
     encoded_body = _encoded_body(body, data)
@@ -118,6 +145,7 @@ def json_request(
         invalid_json_template=invalid_json_template,
         invalid_json_status=invalid_json_status,
         error_body_redactor=error_body_redactor,
+        error_body_json_value_redactor=error_body_json_value_redactor,
         truncate_text=truncate_text,
     )
 
@@ -135,6 +163,7 @@ def json_response_from_request(
     invalid_json_template: str = "{method} {url} returned invalid JSON: {error}",
     invalid_json_status: int | None | object = _KEEP_STATUS,
     error_body_redactor: TextRedactor | None = None,
+    error_body_json_value_redactor: JsonValueRedactor | None = None,
     truncate_text: int | None = None,
 ) -> HttpResponse:
     http_errors: tuple[str, ...] = ()
@@ -157,7 +186,7 @@ def json_response_from_request(
         )
 
     if error_body_redactor is not None and status >= 400:
-        raw = _redact_error_body(raw, error_body_redactor)
+        raw = _redact_error_body(raw, error_body_redactor, error_body_json_value_redactor)
     stored_raw = raw if truncate_text is None else raw[:truncate_text]
     if not raw.strip():
         return HttpResponse(

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -90,6 +90,7 @@ _HTTP_ERROR_BODY_REDACTIONS = (
     ),
     (re.compile(r"\b\d{6,}\b"), "[id-redacted]"),
 )
+_HTTP_ERROR_SOURCE_ID_KEYS = frozenset({"source_id", "source_ids"})
 
 try:
     from dotenv import load_dotenv
@@ -314,6 +315,14 @@ def _redact_http_error_body(value: str) -> str:
     return text
 
 
+def _redact_http_error_json_value(path: tuple[str, ...], value: Any) -> Any | None:
+    if not path or path[-1] not in _HTTP_ERROR_SOURCE_ID_KEYS:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        return None
+    return "[source-id-redacted]"
+
+
 def _submit_body(args: argparse.Namespace) -> dict[str, Any]:
     body: dict[str, Any] = {
         "blob_url": _clean(args.blob_url),
@@ -351,6 +360,7 @@ def _parse_http_json_response(
         timeout=timeout,
         opener=_open_http_request,
         error_body_redactor=_redact_http_error_body,
+        error_body_json_value_redactor=_redact_http_error_json_value,
         truncate_text=2000,
     )
 
@@ -371,6 +381,7 @@ def _json_request(
         body=body,
         opener=_open_http_request,
         error_body_redactor=_redact_http_error_body,
+        error_body_json_value_redactor=_redact_http_error_json_value,
         truncate_text=2000,
     )
 

--- a/tests/test_deflection_http_helpers.py
+++ b/tests/test_deflection_http_helpers.py
@@ -138,6 +138,48 @@ def test_json_request_structural_redaction_preserves_numeric_json_fields(monkeyp
     assert result.errors == ("HTTP 422",)
 
 
+def test_json_request_keyed_error_redaction_preserves_unrelated_opaque_strings(monkeypatch) -> None:
+    def _urlopen(request, *, timeout):
+        assert timeout == 7
+        raise _http_error(
+            request.full_url,
+            422,
+            {
+                "source_id": "opaque-source-A",
+                "trace_id": "opaque-trace-B",
+                "source_ids": ["shortA", 12345],
+                "received_count": 1500000,
+            },
+        )
+
+    def _redact_keyed_value(path: tuple[str, ...], value: Any) -> Any | None:
+        if path and path[-1] in {"source_id", "source_ids"} and isinstance(value, (str, int)):
+            return "[source-id-redacted]"
+        return None
+
+    monkeypatch.setattr(http.urllib.request, "urlopen", _urlopen)
+
+    result = http.json_request(
+        "POST",
+        "https://atlas.example.com/proof",
+        timeout=7,
+        http_error_template="HTTP {status}",
+        error_body_redactor=lambda raw: raw,
+        error_body_json_value_redactor=_redact_keyed_value,
+    )
+
+    assert result.status == 422
+    assert result.payload == {
+        "source_id": "[source-id-redacted]",
+        "trace_id": "opaque-trace-B",
+        "source_ids": ["[source-id-redacted]", "[source-id-redacted]"],
+        "received_count": 1500000,
+    }
+    assert "opaque-source-A" not in result.raw_text
+    assert "shortA" not in result.raw_text
+    assert "opaque-trace-B" in result.raw_text
+
+
 def test_json_request_redacts_transport_error(monkeypatch) -> None:
     def _urlopen(_request, *, timeout):
         assert timeout == 3

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -1332,6 +1332,40 @@ def test_json_request_redacts_escaped_url_and_source_id_values_without_corruptin
     assert "https://blob.example.com/tickets.csv?[redacted]" in serialized
 
 
+def test_json_request_redacts_opaque_source_id_values_by_key_without_broadening_regex(monkeypatch):
+    raw_body = (
+        b'{"detail":"validation failed",'
+        b'"source_id":"opaque-src-A",'
+        b'"source_ids":["tinyAlpha",321],'
+        b'"trace_id":"opaque-trace-B",'
+        b'"received_count":1500000}'
+    )
+
+    monkeypatch.setattr(
+        smoke,
+        "_open_http_request",
+        _fake_open([(422, raw_body)], []),
+    )
+
+    response = smoke._json_request(
+        "GET",
+        "https://atlas.example.com/probe",
+        token="secret",
+        timeout=1.0,
+    )
+
+    serialized = json.dumps(response.payload, sort_keys=True) + response.raw_text
+    assert response.status == 422
+    assert response.payload["source_id"] == "[source-id-redacted]"
+    assert response.payload["source_ids"] == ["[source-id-redacted]", "[source-id-redacted]"]
+    assert response.payload["trace_id"] == "opaque-trace-B"
+    assert response.payload["received_count"] == 1500000
+    assert "opaque-src-A" not in serialized
+    assert "tinyAlpha" not in serialized
+    assert "321" not in serialized
+    assert "opaque-trace-B" in serialized
+
+
 def test_json_request_preserves_success_request_id(monkeypatch):
     monkeypatch.setattr(
         smoke,


### PR DESCRIPTION
Plan: plans/PR-Deflection-HTTP-Error-Source-ID-Values.md
Slice phase: Production hardening

#1728 fixed HTTP error-body redaction but left one optional source-id completeness NIT: opaque `source_id` / `source_ids` JSON values without vendor prefixes, row prefixes, ticket prefixes, or long numeric runs could still persist in submit-handoff proof output. This slice fixes that operator-output root with a key-path-aware JSON value redaction hook while leaving #1730's backend paid-artifact source-id policy untouched.

## Intentional
- Operator-output-only: no `content_ops_deflection_reports` persistence, report artifact, snapshot, or buyer report semantics change.
- Key-aware redaction instead of another broad regex; source-id sensitivity comes from field context.
- Successful submit responses remain unchanged for same-request snapshot/artifact probes.

## Deferred
- Backend paid-artifact source-id policy remains with #1730.

## Parked hardening
- None.

## Verification
- Command passed: python -m py_compile scripts/_deflection_http.py scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_deflection_http_helpers.py tests/test_smoke_content_ops_deflection_submit_handoff.py.
- Command passed: pytest tests/test_deflection_http_helpers.py tests/test_smoke_content_ops_deflection_submit_handoff.py -q -- 59 passed.
- Command passed: python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 185 matching tests are enrolled.
- Command passed: exact maturity-sweep-deflection-content-ops workflow command -- 14 + 8 maturity tests passed; product surface manifest ok; deflection and AI content ops ratchet gates passed with no new brittleness above baseline.
- Command passed: bash scripts/run_extracted_pipeline_checks.sh -- 4702 passed, 10 skipped.

## Diff size
5 files, +246 / -0
