### PR TITLE
Add calibration library live DB verification

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -30,6 +30,7 @@ on:
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_content_ops_calibration_library.py"
+      - "tests/test_content_ops_calibration_library_live_db.py"
       - "tests/test_content_ops_calibration_library_api.py"
       - "tests/test_content_ops_claim_registry_api.py"
       - "tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py"
@@ -66,6 +67,7 @@ on:
       - "scripts/start_content_ops_marketer_verify_oauth_server.py"
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_content_ops_calibration_library.py"
+      - "tests/test_content_ops_calibration_library_live_db.py"
       - "tests/test_content_ops_calibration_library_api.py"
       - "tests/test_content_ops_claim_registry_api.py"
       - "tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py"
@@ -78,6 +80,22 @@ on:
 jobs:
   atlas-content-ops-review-workflow-checks:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16@sha256:081f1bc7bd5e143dbb6e487b710bbc27712cdcfaced4c071b8e47349aa1b4171
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas_migration_tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas -d atlas_migration_tests"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -99,6 +117,7 @@ jobs:
           python -m pytest \
             tests/test_atlas_content_ops_review_workflow.py \
             tests/test_content_ops_calibration_library.py \
+            tests/test_content_ops_calibration_library_live_db.py \
             tests/test_content_ops_calibration_library_api.py \
             tests/test_content_ops_claim_registry_api.py \
             tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py \

--- a/plans/PR-Content-Ops-Calibration-Live-DB-Verification.md
+++ b/plans/PR-Content-Ops-Calibration-Live-DB-Verification.md
@@ -1,0 +1,139 @@
+# PR-Content-Ops-Calibration-Live-DB-Verification
+
+## Why this slice exists
+
+Issue #1497 says the Content Ops calibration library shipped through slices
+#1494/#1495/#1496 with SQL-text assertions, fake asyncpg pools, TestClient
+router fakes, and GitHub CI, but no local or CI path applied migration 335 to a
+real Postgres database and exercised the constraints and repository behavior
+that only Postgres can prove.
+
+Root cause: the calibration-library persistence tests stopped at parser/fake
+pool boundaries. That verified SQL intent and router mapping, but never
+verified the live database contract: foreign keys, CHECK constraints, partial
+unique indexes, cascade delete, asyncpg exception types, and repo round-trips.
+
+This fixes the root for the migration/repository half of #1497 by adding a
+real-Postgres verification test and enrolling it in CI with a disposable
+Postgres service. It also runs locally against a disposable Docker Postgres, so
+the issue's "not just GitHub CI" gap is closed for this slice.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/calibration-live-verification
+Slice phase: Robust testing
+
+1. Add an env-gated real-Postgres test for the calibration-library chain:
+   minimal `saas_accounts` dependency, migration 334, then migration 335.
+2. Prove migration 335's live constraints:
+   - invalid `label` is rejected;
+   - blank `excerpt` and `reasoning` are rejected;
+   - duplicate active `example_id` per account raises asyncpg
+     `UniqueViolationError`;
+   - archiving the active row allows the same `example_id` to be reused;
+   - deleting the tenant account cascades calibration rows.
+3. Prove repository round-trip behavior against the live database:
+   `create_calibration_example`, `list_calibration_examples`,
+   `update_calibration_example`, `archive_calibration_example`, and
+   `list_calibration_example_records`.
+4. Enroll the live DB test in the Content Ops review workflow with a Postgres
+   service and in the extracted pipeline local runner.
+5. Keep the existing fake-pool tests; this adds coverage for database behavior,
+   not a replacement for lightweight unit tests.
+
+### Review Contract
+
+Acceptance criteria:
+- The new test skips cleanly when `ATLAS_MIGRATION_TEST_DATABASE_URL` is unset.
+- Against a real Postgres, 334 then 335 apply in order after the minimal
+  `saas_accounts` dependency exists.
+- The test exercises the named CHECK, partial unique, archive/reuse, and cascade
+  behaviors using real SQL errors from Postgres.
+- The repo functions operate against asyncpg directly and surface the expected
+  active rows after create/update/archive.
+- The CI workflow provides `ATLAS_MIGRATION_TEST_DATABASE_URL` through a
+  disposable Postgres service, so the live test runs in CI instead of skipping.
+- Existing fake-pool unit tests remain enrolled and unchanged.
+
+Affected surfaces:
+- Content Ops calibration-library persistence verification.
+- Content Ops review workflow CI enrollment.
+- Extracted pipeline local runner enrollment.
+
+Risk areas:
+- Accidentally depending on a full fresh Atlas migration chain, which is known
+  to have unrelated fresh-apply debt.
+- Test data leaking across runs in the shared CI service database.
+- Over-broad CI path triggers that slow unrelated PRs.
+
+- Reviewer rules triggered: R2, R10, R12, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+- `plans/PR-Content-Ops-Calibration-Live-DB-Verification.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_content_ops_calibration_library_live_db.py`
+
+## Mechanism
+
+The new test mirrors the existing deflection migration apply pattern: it is
+guarded by `ATLAS_MIGRATION_TEST_DATABASE_URL`, uses asyncpg directly, creates a
+throwaway schema per test, applies only the dependency chain needed for this
+feature, and drops the schema in `finally`.
+
+The test creates a minimal `saas_accounts` table in that throwaway schema
+instead of applying the full migration set, because the full fresh chain has
+unrelated historical dependencies. It then applies migrations 334 and 335 in
+order and probes the database contract with real inserts/updates/deletes plus
+the repository's async functions.
+
+The Content Ops review workflow gets a Postgres service and runs this test in
+the same job as the existing calibration fake-pool and router tests. The local
+extracted pipeline runner includes the new test so a full local runner with
+`ATLAS_MIGRATION_TEST_DATABASE_URL` exercises the live DB path.
+
+## Intentional
+
+- This slice does not attempt a full repo migration-chain fresh apply. That is
+  explicitly outside #1497's calibration-library dependency chain and remains
+  blocked by unrelated historical migration debt.
+- The live test creates only the minimal `saas_accounts` table needed to prove
+  the 334 -> 335 chain and cascade behavior.
+- Router reachability against a running app is deferred because the immediate
+  unverified database contract can be closed with a smaller, deterministic DB
+  slice first.
+
+## Deferred
+
+- Running-app calibration admin router smoke: auth + admin gate + tenant
+  scoping against a live app remains a separate #1497 follow-up.
+- Full `bash scripts/run_extracted_pipeline_checks.sh` with all runtime deps is
+  run in this slice if the local environment permits; any unrelated preexisting
+  dependency/runtime failure will be reported rather than fixed here.
+- Full migration-chain fresh apply remains separate migration debt.
+
+Parked hardening: none.
+
+## Verification
+
+- Py compile for the new live DB test - pass.
+- Live DB test with no DSN configured - pass, skipped cleanly.
+- Local Docker-backed Postgres run of the new live calibration DB test - pass,
+  4 tests.
+- Content Ops review workflow pytest subset with the same local Postgres DSN -
+  pass, 189 tests.
+- Workflow YAML parse for the edited Content Ops review workflow - pass.
+- Full extracted pipeline runner with the local Postgres DSN - pass, 4704
+  passed, 10 skipped, 1 torch/pynvml warning.
+- Pending before push: local PR review bundle through `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_review_workflow_checks.yml` | 19 |
+| `plans/PR-Content-Ops-Calibration-Live-DB-Verification.md` | 139 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_content_ops_calibration_library_live_db.py` | 227 |
+| **Total** | **386** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -147,6 +147,7 @@ pytest \
   tests/test_mcp_content_ops_marketer_verify.py \
   tests/test_content_ops_claim_registry.py \
   tests/test_content_ops_calibration_library.py \
+  tests/test_content_ops_calibration_library_live_db.py \
   tests/test_content_ops_calibration_library_api.py \
   tests/test_content_ops_claim_registry_api.py \
   tests/test_atlas_content_ops_generated_assets_api.py \

--- a/tests/test_content_ops_calibration_library_live_db.py
+++ b/tests/test_content_ops_calibration_library_live_db.py
@@ -1,0 +1,227 @@
+"""Real-Postgres verification for the Content Ops calibration library (#1497).
+
+These tests prove the migration/repository contract that fake asyncpg pools
+cannot: migration 334 -> 335 applies against Postgres, CHECK constraints and the
+partial unique index fire, cascade delete works, and the repo functions
+round-trip through asyncpg.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import uuid
+
+import pytest
+
+from atlas_brain import _content_ops_calibration_library as calib
+from extracted_content_pipeline.calibration_library import CalibrationLabel
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = ROOT / "atlas_brain" / "storage" / "migrations"
+DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+
+
+def _database_url() -> str | None:
+    return os.environ.get(DATABASE_URL_ENV)
+
+
+def _migration(name: str) -> str:
+    return (MIGRATIONS_DIR / name).read_text(encoding="utf-8")
+
+
+def _quote_ident(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+async def _apply_calibration_chain(conn) -> None:
+    await conn.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+    await conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS saas_accounts (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid()
+        )
+        """
+    )
+    await conn.execute(_migration("334_content_ops_claim_registry.sql"))
+    await conn.execute(_migration("335_content_ops_calibration_library.sql"))
+
+
+async def _new_schema(conn) -> str:
+    schema_name = f"atlas_calibration_live_{uuid.uuid4().hex}"
+    quoted = _quote_ident(schema_name)
+    await conn.execute(f"CREATE SCHEMA {quoted}")
+    await conn.execute(f"SET search_path TO {quoted}, public")
+    return schema_name
+
+
+@pytest.mark.asyncio
+async def test_calibration_library_migration_and_repo_round_trip_live_db() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = _database_url()
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+
+    conn = await asyncpg.connect(database_url)
+    schema_name = await _new_schema(conn)
+    try:
+        await _apply_calibration_chain(conn)
+
+        account_id = await conn.fetchval("INSERT INTO saas_accounts DEFAULT VALUES RETURNING id")
+        other_account_id = await conn.fetchval(
+            "INSERT INTO saas_accounts DEFAULT VALUES RETURNING id"
+        )
+        pool = conn
+
+        created = await calib.create_calibration_example(
+            pool,
+            account_id=account_id,
+            payload={
+                "example_id": " Overclaim-001 ",
+                "label": CalibrationLabel.OVERCLAIM.value,
+                "excerpt": "Guaranteed 99.99% uptime.",
+                "reasoning": "No published SLA supports that claim.",
+                "source": "live-db-test",
+                "metadata": {"case": "create"},
+            },
+        )
+        assert created.example_id == "Overclaim-001"
+        assert created.metadata == {"case": "create"}
+
+        reader = calib.ContentOpsCalibrationLibraryRepository(pool)
+        examples = await reader.list_calibration_examples(
+            scope=TenantScope(account_id=str(account_id))
+        )
+        assert tuple(item.example_id for item in examples) == ("Overclaim-001",)
+        assert examples[0].label is CalibrationLabel.OVERCLAIM
+
+        records = await calib.list_calibration_example_records(pool, account_id=account_id)
+        assert [record.id for record in records] == [created.id]
+
+        updated = await calib.update_calibration_example(
+            pool,
+            account_id=account_id,
+            example_row_id=created.id,
+            payload={
+                "example_id": "Voice-001",
+                "label": CalibrationLabel.VOICE_DRIFT.value,
+                "excerpt": "Crush your quota instantly.",
+                "reasoning": "Tone does not match the brand voice.",
+                "metadata": {"case": "update"},
+            },
+        )
+        assert updated is not None
+        assert updated.example_id == "Voice-001"
+        assert updated.label == CalibrationLabel.VOICE_DRIFT.value
+
+        same_id_other_tenant = await calib.create_calibration_example(
+            pool,
+            account_id=other_account_id,
+            payload={
+                "example_id": "voice-001",
+                "label": CalibrationLabel.VOICE_DRIFT.value,
+                "excerpt": "Other tenant can reuse the same logical id.",
+                "reasoning": "The unique index is tenant scoped.",
+            },
+        )
+        assert same_id_other_tenant.account_id == other_account_id
+
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await calib.create_calibration_example(
+                pool,
+                account_id=account_id,
+                payload={
+                    "example_id": " voice-001 ",
+                    "label": CalibrationLabel.VOICE_DRIFT.value,
+                    "excerpt": "Duplicate active id.",
+                    "reasoning": "Should violate lower/btrim partial unique index.",
+                },
+            )
+
+        assert await calib.archive_calibration_example(
+            pool, account_id=account_id, example_row_id=created.id
+        )
+        assert await reader.list_calibration_examples(
+            scope=TenantScope(account_id=str(account_id))
+        ) == ()
+
+        reused = await calib.create_calibration_example(
+            pool,
+            account_id=account_id,
+            payload={
+                "example_id": "voice-001",
+                "label": CalibrationLabel.GOOD_VOICE.value,
+                "excerpt": "Clear, specific, and on brand.",
+                "reasoning": "Archived rows do not participate in the active unique index.",
+            },
+        )
+        assert reused.id != created.id
+
+        await conn.execute("DELETE FROM saas_accounts WHERE id = $1", account_id)
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM content_ops_calibration_library WHERE account_id = $1",
+                account_id,
+            )
+            == 0
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM content_ops_calibration_library WHERE account_id = $1",
+                other_account_id,
+            )
+            == 1
+        )
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {_quote_ident(schema_name)} CASCADE")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("column", "value", "message"),
+    (
+        ("label", "not_a_label", "label"),
+        ("excerpt", "   ", "excerpt"),
+        ("reasoning", "", "reasoning"),
+    ),
+)
+async def test_calibration_library_live_db_constraints_reject_bad_rows(
+    column: str, value: str, message: str
+) -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = _database_url()
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+
+    conn = await asyncpg.connect(database_url)
+    schema_name = await _new_schema(conn)
+    try:
+        await _apply_calibration_chain(conn)
+        account_id = await conn.fetchval("INSERT INTO saas_accounts DEFAULT VALUES RETURNING id")
+        row = {
+            "example_id": "constraint-001",
+            "label": CalibrationLabel.OVERCLAIM.value,
+            "excerpt": "Example excerpt.",
+            "reasoning": "Example reasoning.",
+        }
+        row[column] = value
+
+        with pytest.raises(asyncpg.CheckViolationError, match=message):
+            await conn.execute(
+                """
+                INSERT INTO content_ops_calibration_library
+                    (account_id, example_id, label, excerpt, reasoning)
+                VALUES ($1, $2, $3, $4, $5)
+                """,
+                account_id,
+                row["example_id"],
+                row["label"],
+                row["excerpt"],
+                row["reasoning"],
+            )
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {_quote_ident(schema_name)} CASCADE")
+        await conn.close()


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Calibration-Live-DB-Verification.md
Slice phase: Robust testing

Closes the real-Postgres verification gap from issue #1497 for the Content Ops calibration library migration/repository path. The new env-gated test applies the 334 -> 335 dependency chain against a disposable Postgres schema, proves CHECK/unique/cascade behavior with real SQL errors, and round-trips through the repository CRUD/read functions. The Content Ops review workflow now provides a Postgres service so the live test runs in CI instead of skipping.

## Intentional
- This does not attempt a full fresh Atlas migration-chain apply; that remains unrelated migration debt.
- The live test creates the minimal `saas_accounts` dependency needed to prove the 334 -> 335 calibration-library chain.
- Running-app calibration admin router smoke is deferred; this slice closes the database/repository half of #1497 first.

## Deferred
- Running-app calibration admin router smoke: auth + admin gate + tenant scoping against a live app.
- Full migration-chain fresh apply remains separate migration debt.

## Parked hardening
- None.

## Verification
- Py compile for the new live DB test - pass.
- Live DB test with no DSN configured - pass, 4 skipped.
- Local Docker-backed Postgres run of the new live calibration DB test - pass, 4 tests.
- Content Ops review workflow pytest subset with the same local Postgres DSN - pass, 189 tests.
- Workflow YAML parse for the edited Content Ops review workflow - pass.
- Full extracted pipeline runner with the local Postgres DSN - pass, 4704 passed, 10 skipped, 1 torch/pynvml warning.

## Diff size
4 files, +386 / -0
