### PR TITLE
Add calibration admin live app smoke

### DIFF
--- a/.github/workflows/atlas_content_ops_review_workflow_checks.yml
+++ b/.github/workflows/atlas_content_ops_review_workflow_checks.yml
@@ -13,8 +13,11 @@ on:
       - "atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py"
       - "atlas_brain/mcp/content_ops_marketer_verify_server.py"
       - "atlas_brain/_content_ops_calibration_library.py"
+      - "atlas_brain/api/__init__.py"
+      - "atlas_brain/auth/**"
       - "atlas_brain/api/content_ops_calibration_library.py"
       - "atlas_brain/storage/migrations/335_content_ops_calibration_library.sql"
+      - "atlas_brain/storage/migrations/338_saas_users_is_admin.sql"
       - "atlas_brain/_content_ops_claim_registry.py"
       - "atlas_brain/api/content_ops_claim_registry.py"
       - "atlas_brain/storage/migrations/334_content_ops_claim_registry.sql"
@@ -31,6 +34,7 @@ on:
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_content_ops_calibration_library.py"
       - "tests/test_content_ops_calibration_library_live_db.py"
+      - "tests/test_content_ops_calibration_library_live_app.py"
       - "tests/test_content_ops_calibration_library_api.py"
       - "tests/test_content_ops_claim_registry_api.py"
       - "tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py"
@@ -50,8 +54,11 @@ on:
       - "atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py"
       - "atlas_brain/mcp/content_ops_marketer_verify_server.py"
       - "atlas_brain/_content_ops_calibration_library.py"
+      - "atlas_brain/api/__init__.py"
+      - "atlas_brain/auth/**"
       - "atlas_brain/api/content_ops_calibration_library.py"
       - "atlas_brain/storage/migrations/335_content_ops_calibration_library.sql"
+      - "atlas_brain/storage/migrations/338_saas_users_is_admin.sql"
       - "atlas_brain/_content_ops_claim_registry.py"
       - "atlas_brain/api/content_ops_claim_registry.py"
       - "atlas_brain/storage/migrations/334_content_ops_claim_registry.sql"
@@ -68,6 +75,7 @@ on:
       - "tests/test_atlas_content_ops_review_workflow.py"
       - "tests/test_content_ops_calibration_library.py"
       - "tests/test_content_ops_calibration_library_live_db.py"
+      - "tests/test_content_ops_calibration_library_live_app.py"
       - "tests/test_content_ops_calibration_library_api.py"
       - "tests/test_content_ops_claim_registry_api.py"
       - "tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py"
@@ -118,6 +126,7 @@ jobs:
             tests/test_atlas_content_ops_review_workflow.py \
             tests/test_content_ops_calibration_library.py \
             tests/test_content_ops_calibration_library_live_db.py \
+            tests/test_content_ops_calibration_library_live_app.py \
             tests/test_content_ops_calibration_library_api.py \
             tests/test_content_ops_claim_registry_api.py \
             tests/test_check_content_ops_marketer_verify_claude_hosted_oauth.py \

--- a/atlas_brain/storage/migrations/338_saas_users_is_admin.sql
+++ b/atlas_brain/storage/migrations/338_saas_users_is_admin.sql
@@ -1,0 +1,9 @@
+-- Effective account/platform admin flag used by SaaS auth dependencies.
+--
+-- `atlas_brain.auth.dependencies.require_auth` reads this column for every
+-- authenticated request. Older databases may already have it from manual or
+-- out-of-band setup; fresh repo-managed databases need the migration so auth
+-- does not fail with a missing-column SQL error.
+
+ALTER TABLE saas_users
+    ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE;

--- a/plans/PR-Content-Ops-Calibration-Admin-Live-App-Smoke.md
+++ b/plans/PR-Content-Ops-Calibration-Admin-Live-App-Smoke.md
@@ -1,0 +1,107 @@
+# PR-Content-Ops-Calibration-Admin-Live-App-Smoke
+
+## Why this slice exists
+
+Issue #1497 says the calibration-library persistence and admin router shipped
+without proof against a real local machine/app surface. PR #1735 fixed the root
+for the migration/repository half by applying migrations 334 -> 335 against
+Postgres and round-tripping the repository. The remaining root gap is that the
+admin router has still only been exercised as a direct router with fake auth and
+fake pools; nothing proves the production-mounted Content Ops API route reaches
+the calibration router with the real JWT/B2B plan gate, admin role check, tenant
+scope, and Postgres pool wired together.
+
+This change fixes that root for the running-app/router half by adding an
+env-gated live ASGI smoke that imports the production aggregate API router,
+mounts it under the same `/api/v1` prefix as `atlas_brain.main`, seeds real
+SaaS account/user rows, signs real JWTs, and drives the calibration endpoints
+over HTTP against the same Postgres service used by the live migration test.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/calibration-live-verification
+Slice phase: Functional validation
+
+1. Add one live-app calibration admin router smoke test for issue #1497.
+2. Enroll that test in the Content Ops review workflow and extracted pipeline
+   check list so it remains continuous when a Postgres DSN is available.
+3. Add the missing `saas_users.is_admin` migration required by the real auth
+   dependency used by this route.
+
+### Review Contract
+
+Acceptance criteria: the smoke mounts production `atlas_brain.api.router` at
+`/api/v1`, uses real JWT auth through `require_b2b_plan_or_api_key`, skips
+without `ATLAS_MIGRATION_TEST_DATABASE_URL`, and proves 401 unauthenticated,
+403 below-plan, 403 non-admin write, 201 admin create, 409 duplicate, tenant
+isolation, and DB-backed delete/archive. Fresh migrations must include
+`saas_users.is_admin`, and workflow filters must cover aggregate router/auth
+paths that can break this proof.
+
+Affected surfaces: Content Ops review workflow enrollment, extracted pipeline
+aggregate enrollment, aggregate API/auth path filters, SaaS auth schema, and
+calibration-library live verification tests only.
+
+Risk areas: restore mutated global DB/auth settings, avoid fake auth/pools, and
+clean seeded tenant rows even when assertions fail.
+
+Reviewer rules triggered: R1, R2, R4, R9, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_review_workflow_checks.yml`
+- `atlas_brain/storage/migrations/338_saas_users_is_admin.sql`
+- `plans/PR-Content-Ops-Calibration-Admin-Live-App-Smoke.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_content_ops_calibration_library_live_app.py`
+
+## Mechanism
+
+The test points Atlas' DB settings at `ATLAS_MIGRATION_TEST_DATABASE_URL`,
+initializes the real `DatabasePool`, applies migrations 076, 079, 338, 334, and
+335, then seeds passing owner/member tenants, a second tenant, and a below-plan
+tenant. It signs JWTs with `create_access_token` and sends HTTP requests through
+`httpx.ASGITransport` to a FastAPI app containing the production aggregate API
+router. Migration 338 fixes the auth-schema root cause surfaced by this smoke:
+`require_auth` reads `saas_users.is_admin` on every authenticated request.
+
+## Intentional
+
+- The smoke mounts the production aggregate API router rather than importing
+  `atlas_brain.main.app`. The main app lifespan starts unrelated services
+  (ASR, discovery, reminders, MCP clients, voice, LLM warmups) that would make
+  this verification slow and flaky. The router mount still exercises the real
+  production route/dependency/DB wiring that #1497 asks about.
+- The test uses the same workflow Postgres service as the migration live test
+  and cleans up seeded account rows by ID. A separate temporary schema is not
+  used because the production `DatabasePool` does not set `search_path` per
+  pooled connection.
+
+## Deferred
+
+- Full `atlas_brain.main` lifespan smoke remains out of scope unless we add a
+  dedicated startup profile that disables unrelated background services.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: python -m py_compile tests/test_content_ops_calibration_library_live_app.py.
+- Passed: no-asyncpg collection probe for tests/test_content_ops_calibration_library_live_app.py -- module import succeeds when `asyncpg` is blocked.
+- Passed: env -u ATLAS_MIGRATION_TEST_DATABASE_URL python -m pytest tests/test_content_ops_calibration_library_live_app.py -q -- 1 skipped.
+- Passed: python -m pytest tests/test_migrations_runner.py -q -- 4 passed.
+- Passed: ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_content_ops_calibration_library_live_app.py -q -- 1 passed, 1 warning.
+- Passed: Content Ops review workflow subset with the same `ATLAS_MIGRATION_TEST_DATABASE_URL` -- 190 passed, 1 warning.
+- Passed: ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas bash scripts/run_extracted_pipeline_checks.sh -- 4707 passed, 10 skipped, 1 warning.
+- Passed: bash scripts/push_pr.sh tmp/pr-body-content-ops-calibration-admin-live-app-smoke.md --force-with-lease origin HEAD:claude/pr-content-ops-calibration-admin-live-app-smoke -- local PR review passed and branch pushed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_review_workflow_checks.yml` | 9 |
+| `atlas_brain/storage/migrations/338_saas_users_is_admin.sql` | 9 |
+| `plans/PR-Content-Ops-Calibration-Admin-Live-App-Smoke.md` | 107 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_content_ops_calibration_library_live_app.py` | 258 |
+| **Total** | **384** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -148,6 +148,7 @@ pytest \
   tests/test_content_ops_claim_registry.py \
   tests/test_content_ops_calibration_library.py \
   tests/test_content_ops_calibration_library_live_db.py \
+  tests/test_content_ops_calibration_library_live_app.py \
   tests/test_content_ops_calibration_library_api.py \
   tests/test_content_ops_claim_registry_api.py \
   tests/test_atlas_content_ops_generated_assets_api.py \

--- a/tests/test_content_ops_calibration_library_live_app.py
+++ b/tests/test_content_ops_calibration_library_live_app.py
@@ -1,0 +1,258 @@
+"""Production-mounted live-app smoke for calibration-library admin routes (#1497)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = ROOT / "atlas_brain" / "storage" / "migrations"
+DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+JWT_SECRET = "test-jwt-secret-not-for-prod"
+
+
+def _database_url() -> str | None:
+    return os.environ.get(DATABASE_URL_ENV)
+
+
+def _migration(name: str) -> str:
+    return (MIGRATIONS_DIR / name).read_text(encoding="utf-8")
+
+
+def _point_atlas_db_settings_at(database_url: str, *, storage_config, database_module) -> None:
+    parsed = urlparse(database_url)
+    storage_config.db_settings.enabled = True
+    storage_config.db_settings.host = parsed.hostname or "localhost"
+    storage_config.db_settings.port = parsed.port or 5432
+    storage_config.db_settings.database = parsed.path.lstrip("/")
+    storage_config.db_settings.user = parsed.username or ""
+    storage_config.db_settings.password = parsed.password or ""
+    storage_config.db_settings.socket_path = None
+    database_module.db_settings = storage_config.db_settings
+
+
+async def _apply_required_migrations(conn) -> None:
+    await conn.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+    for name in (
+        "076_saas_accounts.sql",
+        "079_b2b_saas.sql",
+        "338_saas_users_is_admin.sql",
+        "334_content_ops_claim_registry.sql",
+        "335_content_ops_calibration_library.sql",
+    ):
+        await conn.execute(_migration(name))
+
+
+async def _seed_user(conn, *, role: str, account_id: uuid.UUID) -> uuid.UUID:
+    user_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO saas_users
+            (id, account_id, email, password_hash, role, is_active)
+        VALUES ($1, $2, $3, 'not-used-in-jwt-smoke', $4, TRUE)
+        """,
+        user_id,
+        account_id,
+        f"{user_id}@example.test",
+        role,
+    )
+    return user_id
+
+
+async def _seed_account(
+    conn,
+    *,
+    name: str,
+    plan: str = "b2b_growth",
+    product: str = "b2b_challenger",
+) -> uuid.UUID:
+    account_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO saas_accounts
+            (id, name, plan, plan_status, product)
+        VALUES ($1, $2, $3, 'active', $4)
+        """,
+        account_id,
+        name,
+        plan,
+        product,
+    )
+    return account_id
+
+
+def _auth_header(user_id: uuid.UUID, account_id: uuid.UUID) -> dict[str, str]:
+    from atlas_brain.auth.jwt import create_access_token
+
+    token = create_access_token(
+        str(user_id),
+        str(account_id),
+        "b2b_growth",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _calibration_body(example_id: str = "voice-001") -> dict[str, object]:
+    return {
+        "example_id": example_id,
+        "label": "voice_drift",
+        "excerpt": "Crush your quota instantly.",
+        "reasoning": "The phrasing is too aggressive for this brand voice.",
+        "source": "live-app-smoke",
+        "metadata": {"suite": "content-ops-calibration-live-app"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_calibration_library_admin_router_live_app_auth_tenant_and_db_smoke() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = _database_url()
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+
+    from atlas_brain.config import settings
+    from atlas_brain.storage import config as storage_config
+    from atlas_brain.storage import database as database_module
+
+    original_saas_auth = {
+        "enabled": settings.saas_auth.enabled,
+        "jwt_secret": settings.saas_auth.jwt_secret,
+        "api_key_pepper": settings.saas_auth.api_key_pepper,
+        "byok_encryption_kek": settings.saas_auth.byok_encryption_kek,
+    }
+    original_db_settings = {
+        "enabled": storage_config.db_settings.enabled,
+        "host": storage_config.db_settings.host,
+        "port": storage_config.db_settings.port,
+        "database": storage_config.db_settings.database,
+        "user": storage_config.db_settings.user,
+        "password": storage_config.db_settings.password,
+        "socket_path": storage_config.db_settings.socket_path,
+    }
+
+    _point_atlas_db_settings_at(
+        database_url,
+        storage_config=storage_config,
+        database_module=database_module,
+    )
+    settings.saas_auth.enabled = True
+    settings.saas_auth.jwt_secret = JWT_SECRET
+    settings.saas_auth.api_key_pepper = "test-api-key-pepper-not-for-prod"
+    settings.saas_auth.byok_encryption_kek = "test:DEj0-fNH6mOs5JYXn3Uv6ejEfP4PQ6XIqWla36eIR_U="
+    database_module._db_pool = None
+
+    conn = await asyncpg.connect(database_url)
+    seeded_account_ids: list[uuid.UUID] = []
+    try:
+        await _apply_required_migrations(conn)
+        owner_account_id = await _seed_account(conn, name="Calibration smoke owner")
+        other_account_id = await _seed_account(conn, name="Calibration smoke other")
+        trial_account_id = await _seed_account(
+            conn, name="Calibration smoke trial", plan="b2b_trial"
+        )
+        seeded_account_ids.extend([owner_account_id, other_account_id, trial_account_id])
+        owner_user_id = await _seed_user(conn, role="owner", account_id=owner_account_id)
+        member_user_id = await _seed_user(conn, role="member", account_id=owner_account_id)
+        other_owner_user_id = await _seed_user(
+            conn, role="owner", account_id=other_account_id
+        )
+        trial_owner_user_id = await _seed_user(
+            conn, role="owner", account_id=trial_account_id
+        )
+
+        await database_module.init_database()
+
+        from atlas_brain.api import router as api_router
+
+        app = FastAPI()
+        app.include_router(api_router, prefix="/api/v1")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            route = "/api/v1/content-ops/calibration-library"
+
+            unauthenticated = await client.get(route)
+            assert unauthenticated.status_code == 401
+
+            below_plan = await client.get(
+                route,
+                headers=_auth_header(trial_owner_user_id, trial_account_id),
+            )
+            assert below_plan.status_code == 403
+
+            member_write = await client.post(
+                route,
+                headers=_auth_header(member_user_id, owner_account_id),
+                json=_calibration_body(),
+            )
+            assert member_write.status_code == 403
+
+            created = await client.post(
+                route,
+                headers=_auth_header(owner_user_id, owner_account_id),
+                json=_calibration_body(),
+            )
+            assert created.status_code == 201
+            created_body = created.json()
+            assert created_body["account_id"] == str(owner_account_id)
+            assert created_body["example_id"] == "voice-001"
+
+            duplicate = await client.post(
+                route,
+                headers=_auth_header(owner_user_id, owner_account_id),
+                json=_calibration_body(" voice-001 "),
+            )
+            assert duplicate.status_code == 409
+
+            owner_list = await client.get(
+                route,
+                headers=_auth_header(owner_user_id, owner_account_id),
+            )
+            assert owner_list.status_code == 200
+            assert [row["example_id"] for row in owner_list.json()] == ["voice-001"]
+
+            other_tenant_list = await client.get(
+                route,
+                headers=_auth_header(other_owner_user_id, other_account_id),
+            )
+            assert other_tenant_list.status_code == 200
+            assert other_tenant_list.json() == []
+
+            deleted = await client.delete(
+                f"{route}/{created_body['id']}",
+                headers=_auth_header(owner_user_id, owner_account_id),
+            )
+            assert deleted.status_code == 204
+
+        archived_at = await conn.fetchval(
+            """
+            SELECT archived_at
+            FROM content_ops_calibration_library
+            WHERE id = $1 AND account_id = $2
+            """,
+            uuid.UUID(created_body["id"]),
+            owner_account_id,
+        )
+        assert archived_at is not None
+    finally:
+        try:
+            await database_module.close_database()
+            database_module._db_pool = None
+            for account_id in seeded_account_ids:
+                await conn.execute("DELETE FROM saas_accounts WHERE id = $1", account_id)
+            await conn.close()
+        finally:
+            for key, value in original_saas_auth.items():
+                setattr(settings.saas_auth, key, value)
+            for key, value in original_db_settings.items():
+                setattr(storage_config.db_settings, key, value)
+            database_module.db_settings = storage_config.db_settings


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Calibration-Admin-Live-App-Smoke.md
Slice phase: Functional validation

Issue #1497 still lacked proof that the calibration-library admin router works through the production-mounted Content Ops API route with real auth, B2B plan gating, admin gating, tenant scoping, and a real Postgres pool. This slice adds an env-gated live ASGI smoke that mounts `atlas_brain.api.router` under `/api/v1`, seeds real SaaS account/user rows, signs real JWTs, drives the calibration endpoints over HTTP, and adds the missing `saas_users.is_admin` migration required by the real auth dependency.

## Intentional
- The smoke mounts the production aggregate API router instead of `atlas_brain.main.app`; the main lifespan starts unrelated background services that would make this route verification slow and flaky.
- The smoke imports asyncpg-bound storage modules only after the `asyncpg` and DSN skip guards, so asyncpg-free environments skip instead of failing during collection.

## Deferred
- Full `atlas_brain.main` lifespan smoke remains out of scope unless we add a dedicated startup profile that disables unrelated background services.

## Parked hardening
- None.

## AI reconciliation
- [chatgpt-codex-connector] Add a negative B2B plan-gate probe: fixed by seeding a `b2b_trial` tenant and asserting the mounted route returns 403 before the admin happy path.
- [chatgpt-codex-connector] Extend workflow trigger coverage for aggregate router/auth changes: fixed by adding `atlas_brain/api/__init__.py` and `atlas_brain/auth/**` to both pull_request and push filters.
- All fixed or waived: Yes.

## Verification
- python -m py_compile tests/test_content_ops_calibration_library_live_app.py -- passed.
- no-asyncpg collection probe for tests/test_content_ops_calibration_library_live_app.py -- module import succeeds when `asyncpg` is blocked.
- env -u ATLAS_MIGRATION_TEST_DATABASE_URL python -m pytest tests/test_content_ops_calibration_library_live_app.py -q -- 1 skipped.
- python -m pytest tests/test_migrations_runner.py -q -- 4 passed.
- ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_content_ops_calibration_library_live_app.py -q -- 1 passed, 1 warning.
- Content Ops review workflow subset with the same `ATLAS_MIGRATION_TEST_DATABASE_URL` -- 190 passed, 1 warning.
- ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas bash scripts/run_extracted_pipeline_checks.sh -- 4707 passed, 10 skipped, 1 warning.
- bash scripts/push_pr.sh tmp/pr-body-content-ops-calibration-admin-live-app-smoke.md --force-with-lease origin HEAD:claude/pr-content-ops-calibration-admin-live-app-smoke -- local PR review passed and branch pushed.

## Diff size
5 files, +384 / -0
