### PR TITLE
Harden deflection scrub with local entity detector

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -75,9 +75,117 @@ _DEFLECTION_IDENTIFIER_RE = re.compile(
     re.IGNORECASE,
 )
 _DEFLECTION_REDACTION_ARTIFACT_RE = re.compile(
-    r"\[(?:redacted(?!-(?:email|identifier|phone|text)\])|removed|hidden)[^\]]*\]"
+    r"\[(?:redacted(?!-(?:address|email|identifier|name|phone|text)\])|removed|hidden)[^\]]*\]"
     r"|\bX{4,}\b",
     re.IGNORECASE,
+)
+_DEFLECTION_PERSON_NAME_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"(?P<prefix>"
+    r"(?i:(?:customer|requester|contact|client|user|agent|member|person|name)"
+    r"(?:\s+name)?\s*(?:is|:|=|-)\s*)"
+    r")"
+    r"(?P<name>"
+    r"[A-Za-z][A-Za-z'.-]+"
+    r"(?:\s+[A-Za-z][A-Za-z'.-]+){1,2}"
+    r")"
+    r"(?=$|[\s,.;:!?)]|</)",
+)
+_DEFLECTION_PERSON_NAME_REJECT_TOKENS = frozenset(
+    {
+        "account",
+        "analytics",
+        "api",
+        "billing",
+        "case",
+        "claim",
+        "dashboard",
+        "desk",
+        "export",
+        "faq",
+        "help",
+        "invoice",
+        "password",
+        "portal",
+        "report",
+        "reporting",
+        "reset",
+        "source",
+        "sso",
+        "support",
+        "ticket",
+        "token",
+    }
+)
+_DEFLECTION_STREET_ADDRESS_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"\d{1,6}\s+"
+    r"(?P<street_body>"
+    r"(?:[NSEW]\.?\s+)?"
+    r"(?:[A-Z0-9][A-Za-z0-9'.-]*\s+){0,6}"
+    r")"
+    r"(?P<street_suffix>"
+    r"Street|St\.?|Avenue|Ave\.?|Road|Rd\.?|Boulevard|Blvd\.?|"
+    r"Lane|Ln\.?|Drive|Dr\.?|Court|Ct\.?|Way|Place|Pl\.?|Terrace|Ter\.?|"
+    r"Circle|Cir\.?|Highway|Hwy\.?"
+    r")"
+    r"(?:\s+(?:Apt|Apartment|Suite|Ste\.?|Unit|#)\s*[A-Za-z0-9-]+)?"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}",
+    re.IGNORECASE,
+)
+_DEFLECTION_STREET_ADDRESS_REJECT_TOKENS = frozenset(
+    {
+        "are",
+        "case",
+        "cases",
+        "claim",
+        "claims",
+        "in",
+        "invoice",
+        "invoices",
+        "is",
+        "one",
+        "on",
+        "the",
+        "ticket",
+        "tickets",
+    }
+)
+_DEFLECTION_CONTEXTUAL_OPAQUE_IDENTIFIER_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"(?P<prefix>"
+    r"(?i:(?:account|case|claim|contact|customer|member|order|profile|ref|"
+    r"reference|session|token|user)(?:\s+(?:code|id|identifier|token))?"
+    r"|(?:code|id|identifier|token))"
+    r"\s*(?:is|:|=|-)?\s*)"
+    r"(?P<identifier>"
+    r"(?:[A-Z0-9]{8,}|[A-Z0-9]{3,}(?:[-_][A-Z0-9]{3,})+)"
+    r")"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}",
+    re.IGNORECASE,
+)
+_DEFLECTION_OPAQUE_IDENTIFIER_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"(?:[A-Z0-9]{8,}|[A-Z0-9]{3,}(?:[-_][A-Z0-9]{3,})+)"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}",
+    re.IGNORECASE,
+)
+_DEFLECTION_OPAQUE_IDENTIFIER_PREFIXES = (
+    "acct",
+    "account",
+    "case",
+    "claim",
+    "contact",
+    "cust",
+    "customer",
+    "member",
+    "ord",
+    "order",
+    "profile",
+    "ref",
+    "session",
+    "user",
+    "usr",
 )
 _DEFLECTION_IDENTIFIER_KEYS = frozenset(
     {
@@ -2524,11 +2632,7 @@ def _should_preserve_source_link(value: str) -> bool:
     text = _text(value)
     if not text:
         return False
-    return not (
-        _DEFLECTION_EMAIL_RE.search(text)
-        or _DEFLECTION_PHONE_RE.search(text)
-        or _DEFLECTION_REDACTION_ARTIFACT_RE.search(text)
-    )
+    return not _has_deflection_source_link_pii(text)
 
 
 def _protect_source_link_mentions(
@@ -2635,7 +2739,119 @@ def _scrub_deflection_text(value: str) -> str:
     text = _DEFLECTION_REDACTION_ARTIFACT_RE.sub("[redacted-text]", value)
     text = _DEFLECTION_EMAIL_RE.sub("[redacted-email]", text)
     text = _DEFLECTION_PHONE_RE.sub("[redacted-phone]", text)
+    text = _DEFLECTION_STREET_ADDRESS_RE.sub(_redact_deflection_street_address, text)
+    text = _DEFLECTION_PERSON_NAME_RE.sub(_redact_deflection_person_name, text)
+    text = _DEFLECTION_CONTEXTUAL_OPAQUE_IDENTIFIER_RE.sub(
+        _redact_deflection_contextual_opaque_identifier,
+        text,
+    )
+    text = _DEFLECTION_OPAQUE_IDENTIFIER_RE.sub(
+        _redact_deflection_opaque_identifier,
+        text,
+    )
     return _DEFLECTION_IDENTIFIER_RE.sub("[redacted-identifier]", text)
+
+
+def _redact_deflection_street_address(match: re.Match[str]) -> str:
+    if not _looks_like_deflection_street_address(match):
+        return match.group(0)
+    return "[redacted-address]"
+
+
+def _looks_like_deflection_street_address(match: re.Match[str]) -> bool:
+    body = match.group("street_body")
+    tokens = [
+        token.casefold()
+        for token in re.findall(r"[A-Za-z]+", body)
+        if token.casefold() not in {"n", "s", "e", "w"}
+    ]
+    if any(token in _DEFLECTION_STREET_ADDRESS_REJECT_TOKENS for token in tokens):
+        return False
+    return bool(tokens or re.search(r"\d", body))
+
+
+def _redact_deflection_person_name(match: re.Match[str]) -> str:
+    candidate = match.group("name")
+    if not _looks_like_deflection_person_name(candidate):
+        return match.group(0)
+    return f"{match.group('prefix')}[redacted-name]"
+
+
+def _looks_like_deflection_person_name(value: str) -> bool:
+    tokens = [
+        token.strip(" .'-").casefold()
+        for token in value.split()
+        if token.strip(" .'-")
+    ]
+    if len(tokens) < 2 or len(tokens) > 3:
+        return False
+    if any(token in _DEFLECTION_PERSON_NAME_REJECT_TOKENS for token in tokens):
+        return False
+    return all(len(token) >= 2 for token in tokens)
+
+
+def _redact_deflection_contextual_opaque_identifier(match: re.Match[str]) -> str:
+    token = match.group("identifier")
+    if not _looks_like_deflection_opaque_identifier(token, require_prefix=False):
+        return match.group(0)
+    return f"{match.group('prefix')}[redacted-identifier]"
+
+
+def _redact_deflection_opaque_identifier(match: re.Match[str]) -> str:
+    token = match.group(0)
+    if not _looks_like_deflection_opaque_identifier(token, require_prefix=True):
+        return token
+    return "[redacted-identifier]"
+
+
+def _looks_like_deflection_opaque_identifier(
+    value: str,
+    *,
+    require_prefix: bool,
+) -> bool:
+    compact = re.sub(r"[-_]", "", value)
+    if len(compact) < 8:
+        return False
+    if not any(char.isalpha() for char in compact):
+        return False
+    digit_count = sum(1 for char in compact if char.isdigit())
+    if digit_count < 1:
+        return False
+    lowered = value.casefold()
+    if require_prefix and not lowered.startswith(_DEFLECTION_OPAQUE_IDENTIFIER_PREFIXES):
+        return False
+    return digit_count >= 1
+
+
+def _has_deflection_source_link_pii(value: str) -> bool:
+    if (
+        _DEFLECTION_EMAIL_RE.search(value)
+        or _DEFLECTION_PHONE_RE.search(value)
+        or _DEFLECTION_REDACTION_ARTIFACT_RE.search(value)
+    ):
+        return True
+    if any(
+        _looks_like_deflection_street_address(match)
+        for match in _DEFLECTION_STREET_ADDRESS_RE.finditer(value)
+    ):
+        return True
+    if any(
+        _looks_like_deflection_person_name(match.group("name"))
+        for match in _DEFLECTION_PERSON_NAME_RE.finditer(value)
+    ):
+        return True
+    if any(
+        _looks_like_deflection_opaque_identifier(
+            match.group("identifier"),
+            require_prefix=False,
+        )
+        for match in _DEFLECTION_CONTEXTUAL_OPAQUE_IDENTIFIER_RE.finditer(value)
+    ):
+        return True
+    return any(
+        _looks_like_deflection_opaque_identifier(match.group(0), require_prefix=True)
+        for match in _DEFLECTION_OPAQUE_IDENTIFIER_RE.finditer(value)
+    )
 
 
 def _json_ready(value: Any) -> Any:

--- a/plans/PR-Deflection-Local-NER-Scrub.md
+++ b/plans/PR-Deflection-Local-NER-Scrub.md
@@ -1,0 +1,139 @@
+# PR-Deflection-Local-NER-Scrub
+
+## Why this slice exists
+
+Issue #1734 closed the highest-risk live leak with #1730: the report storage
+gate now runs a structural scrub over the paid artifact and free Snapshot before
+persistence. That scrub is still regex-only. The root cause for the remaining
+privacy gap is that the single report-text scrub seam only detects patterned
+PII classes: emails, phone numbers, labeled identifiers, and prior redaction
+artifacts. Names, street addresses, and high-entropy opaque customer identifiers
+can still pass through answer/steps prose because they do not always carry a
+stable label or delimiter.
+
+This PR fixes the root within safe scope by widening the local detector behind
+the existing report-payload scrub seam. It does not add cloud DLP, does not
+change report shape, does not change paid source-ID policy, and does not touch
+retention/deletion. The heavier local-model option from #1734 remains
+replaceable behind the same seam if we later decide a spaCy/Presidio dependency
+is worth the operational cost.
+
+The diff is over the 400 LOC soft cap because the review-fix pass added
+same-class negative fixtures for the detector branches, source-link parity, and
+buyer-facing near-misses; splitting those probes away would weaken the guard
+that makes this privacy hardening safe to merge.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-privacy
+Slice phase: Production hardening
+
+1. Add a dependency-free local entity-style detector to the existing
+   deflection report scrub path for:
+   - context-labeled person names;
+   - street-address shapes;
+   - high-entropy opaque customer/system IDs with an explicit ID cue or known
+     customer/system prefix.
+2. Keep the detector conservative with explicit near-miss coverage for product
+   names, ordinary numerics, ISO-style references, and paid source-link values.
+3. Prove the detector runs before both stored paid artifact and free Snapshot
+   persistence through the existing scrubber and storage-gate tests.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Local-NER-Scrub.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+### Review Contract
+
+Acceptance criteria:
+- Names in explicit customer/requester/contact/user contexts redact to
+  `[redacted-name]`.
+- Street-address shaped text redacts to `[redacted-address]`.
+- Opaque mixed letter/digit customer IDs with explicit ID context or a known
+  customer/system prefix redact to `[redacted-identifier]`.
+- Paid `source_id` / `source_ids` linkage values remain governed by #1730:
+  non-PII source IDs are preserved in source-link fields, while PII-shaped
+  source ID values are still scrubbed.
+- Near-misses remain intact: product names, ordinary counts, prices, years,
+  ISO-like standards, and low-entropy ticket labels.
+- The persisted paid artifact and free Snapshot are both built from the widened
+  scrubbed payload.
+
+Affected surfaces:
+- Deflection paid report artifact JSON stored by the control-surface report
+  gate.
+- Free Snapshot JSON derived from the same artifact before persistence.
+
+Risk areas:
+- Over-redacting product/company names in buyer-facing answers.
+- Accidentally changing the #1730 paid source-ID traceability contract.
+- Adding broad regexes that catch legitimate numeric metrics.
+
+Reviewer rules triggered: R1, R2, R10, R14
+
+## Mechanism
+
+The current recursive payload scrubber already funnels free text through one
+local text scrub seam after source-link protection and known identifier token
+replacement. This PR extends that seam with three deterministic detectors:
+
+1. Context-labeled person names are redacted only when introduced by person
+   context such as customer, requester, contact, user, client, or name labels.
+   This intentionally avoids broad title-case matching.
+2. Street-address shapes redact street numbers plus common street suffixes and
+   optional unit markers.
+3. Opaque IDs redact mixed letter/digit tokens only when they carry explicit ID
+   context or a known customer/system prefix, while allowing common low-risk
+   standards, CVEs, SKUs, product versions, count phrases, and ticket labels.
+
+The implementation stays pure and local inside
+`extracted_content_pipeline/faq_deflection_report.py`. Tests exercise both the
+new detection branches and the false-positive side of each branch.
+
+## Intentional
+
+- This is a conservative local detector, not a full NLP model. It catches clear
+  high-confidence leak shapes without introducing a large runtime dependency or
+  cloud processing surface.
+- The slice does not try to redact every title-cased human name in prose. Broad
+  title-case matching would over-redact product names and report headings.
+- Bare CVEs, SKUs, product-version labels, ISO-like labels, and count phrases
+  are intentionally preserved unless they carry explicit customer/system ID
+  context.
+- Retention/deletion for `content_ops_deflection_reports` stays deferred as the
+  next separate #1734 item.
+- Paid source IDs remain visible as buyer linkage metadata per #1730.
+
+## Deferred
+
+- #1734 retention/deletion slice for `content_ops_deflection_reports`.
+- Optional heavier local NLP backend behind the same scrub seam if conservative
+  deterministic detection is not enough after live artifact review.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_local_entity_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q -
+  5 passed.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_local_entity_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q -
+  3 passed.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_deflection_submit.py -q -
+  142 passed.
+- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_deflection_submit.py -
+  passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-deflection-local-ner-scrub.md -
+  passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 228 |
+| `plans/PR-Deflection-Local-NER-Scrub.md` | 139 |
+| `tests/test_content_ops_deflection_report.py` | 89 |
+| `tests/test_extracted_content_deflection_submit.py` | 21 |
+| **Total** | **477** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -1617,6 +1617,95 @@ def test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys() 
     assert "[redacted-identifier]" in encoded
 
 
+def test_deflection_report_payload_scrubs_local_entity_shapes() -> None:
+    scrubbed = scrub_deflection_report_payload(
+        {
+            "source_id": "ticket-source-a",
+            "source_ids": [
+                "ticket-source-a",
+                "owner@example.com",
+                "123 Maple Street",
+                "customer: jane doe",
+            ],
+            "answer": (
+                "Customer: Jane Doe asked us to ship the replacement to "
+                "123 Maple Street Apt 4B. Their migration token is "
+                "CUST-9XQ7-ABCD."
+            ),
+            "steps": [
+                "Requester name is Maria Garcia.",
+                "requester name is maria garcia.",
+                "Mail the label to 44 W 9th St Unit 12.",
+                "Search for profile code A9X4Q7Z2 before replying.",
+            ],
+        }
+    )
+
+    encoded = json.dumps(scrubbed, sort_keys=True)
+
+    for raw_fragment in (
+        "Jane Doe",
+        "123 Maple",
+        "CUST-9XQ7-ABCD",
+        "Maria Garcia",
+        "maria garcia",
+        "44 W 9th",
+        "A9X4Q7Z2",
+    ):
+        assert raw_fragment not in encoded
+    assert scrubbed["source_id"] == "ticket-source-a"
+    assert scrubbed["source_ids"] == [
+        "ticket-source-a",
+        "[redacted-email]",
+        "[redacted-address]",
+        "customer: [redacted-name]",
+    ]
+    assert "[redacted-name]" in encoded
+    assert "[redacted-address]" in encoded
+    assert "[redacted-identifier]" in encoded
+
+
+def test_deflection_report_payload_preserves_local_entity_near_misses() -> None:
+    scrubbed = scrub_deflection_report_payload(
+        {
+            "source_id": "ticket-source-a",
+            "answer": (
+                "Northstar Analytics follows ISO-9001. Customer: Reset Password "
+                "is a heading, not a person. The 2026 count is 1234567, the "
+                "price is $49, and ticket-source-a stays usable. "
+                "CVE-2021-44228 affected a dependency, SKU ABC12345 is active, "
+                "iPhone15Pro and Windows11 are supported, ISO27001 and HIPAA2026 "
+                "remain valid, Q4FY2026 is a reporting label, campaign2026 is a "
+                "campaign tag, 4 tickets are on the way, 4 invoices in one place, "
+                "and 4 cases in court."
+            ),
+        }
+    )
+
+    answer = scrubbed["answer"]
+    assert "Northstar Analytics" in answer
+    assert "ISO-9001" in answer
+    assert "Customer: Reset Password" in answer
+    assert "2026" in answer
+    assert "1234567" in answer
+    assert "$49" in answer
+    assert "ticket-source-a" in answer
+    assert "CVE-2021-44228" in answer
+    assert "SKU ABC12345" in answer
+    assert "iPhone15Pro" in answer
+    assert "Windows11" in answer
+    assert "ISO27001" in answer
+    assert "HIPAA2026" in answer
+    assert "Q4FY2026" in answer
+    assert "campaign2026" in answer
+    assert "4 tickets are on the way" in answer
+    assert "4 invoices in one place" in answer
+    assert "4 cases in court" in answer
+    assert "[redacted-name]" not in answer
+    assert "[redacted-address]" not in answer
+    assert "[redacted-identifier]" not in answer
+
+
 def test_deflection_snapshot_marks_question_only_exports_absent_resolution_evidence() -> None:
     result = TicketFAQMarkdownResult(
         markdown="# FAQ",

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -712,6 +712,7 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
             "# Report\n\n"
             "How do I reset access for jane.doe@acme.com?\n"
             "Call _555-123-4567_ and confirm account 4829103.\n"
+            "Customer: Jane Doe moved to 123 Maple Street Apt 4B.\n"
         ),
         "summary": {
             "generated": 1,
@@ -726,10 +727,16 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
                     "customer_wording": "Call 555-123-4567 for account 4829103.",
                     "weighted_frequency": 2,
                     "ticket_count": 2,
-                    "answer": "Reset _jane.doe@acme.com_ after confirming account 4829103.",
+                    "answer": (
+                        "Reset _jane.doe@acme.com_ after confirming account 4829103 "
+                        "for customer: Jane Doe at 123 Maple Street Apt 4B."
+                    ),
                     "steps": [
                         "Remove XXXXX before publishing.",
                         "Escalate case 999999 if the reset still fails.",
+                        "Check opaque migration token CUST-9XQ7-ABCD.",
+                        "Requester name is Jane Doe.",
+                        "Mail a label to 123 Maple Street Apt 4B.",
                     ],
                     "source_ids": ["4829103", "777777"],
                     "evidence_quotes": [
@@ -758,6 +765,7 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
                                 "question": "How do I reset jane.doe@acme.com?",
                                 "answer": (
                                     "Confirm account 4829103 for jane.doe@acme.com."
+                                    " Requester name is Jane Doe at 123 Maple Street."
                                 ),
                             }
                         ]
@@ -813,6 +821,9 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
         "4829103",
         "777777",
         "999999",
+        "jane doe",
+        "123 maple",
+        "cust-9xq7-abcd",
         "xxxxx",
     ):
         assert raw_fragment not in encoded
@@ -822,6 +833,9 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
     assert teaser_answer["steps"] == [
         "Remove [redacted-text] before publishing.",
         "Escalate [redacted-identifier] if the reset still fails.",
+        "Check opaque migration token [redacted-identifier].",
+        "Requester name is [redacted-name]",
+        "Mail a label to [redacted-address].",
     ]
     artifact_sources = record.artifact["faq_result"]["items"][0]["source_ids"]
     assert artifact_sources == ["4829103", "777777"]
@@ -834,6 +848,9 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
         "acme.com",
         "555-123-4567",
         "999999",
+        "jane doe",
+        "123 maple",
+        "cust-9xq7-abcd",
         "xxxxx",
     ):
         assert raw_fragment not in artifact_encoded
@@ -842,6 +859,8 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
     assert "[redacted-email]" in encoded
     assert "[redacted-phone]" in encoded
     assert "[redacted-identifier]" in encoded
+    assert "[redacted-name]" in encoded
+    assert "[redacted-address]" in encoded
     assert "[redacted-text]" in encoded
 
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-Local-NER-Scrub.md
Slice phase: Production hardening

Issue #1734 left one privacy gap after #1730: the structural scrub boundary is in the right place, but the detector behind it is still regex-only, so clear names, street addresses, and opaque customer/system identifiers can survive answer/steps prose. This PR widens that local detector behind the same report-payload scrub seam without adding cloud DLP, changing report shape, changing paid source-ID policy, or touching retention/deletion.

## Intentional
- Conservative deterministic detection only; no cloud DLP or new NLP runtime dependency.
- Broad title-case name detection remains out of scope to avoid product/company false positives.
- Paid source IDs remain visible as buyer linkage metadata per #1730.

## Deferred
- #1734 retention/deletion for `content_ops_deflection_reports`.
- Optional heavier local NLP backend behind the same seam after live artifact review.

## AI reconciliation
- [chatgpt-codex-connector] P1: source-link fields preserved address/name-shaped values - fixed by running the new supported PII detector set before preserving source-link values; non-PII source IDs remain preserved per #1730.
- [chatgpt-codex-connector] P2: ordinary alphanumeric labels were over-redacted - fixed by requiring explicit ID context or a known customer/system prefix for opaque identifier redaction; near-misses now cover CVE IDs, SKUs, product versions, ISO/HIPAA labels, campaign labels, and quarter/year labels.
- [chatgpt-codex-connector] P2: lowercase labeled names survived - fixed by allowing lowercase name tokens in explicit customer/requester/contact/user contexts.
- [chatgpt-codex-connector] P2: count phrases were treated as addresses - fixed by validating address matches and preserving phrases such as "4 tickets are on the way", "4 invoices in one place", and "4 cases in court".
- [canfieldjuan] MAJOR: opaque-id detector over-redacted buyer-facing CVE/SKU/product-version content - fixed with the same context/prefix gate and near-miss tests.
- [canfieldjuan] NIT: cue-less names remain out of scope - waived/deferred as already documented; broad title-case matching is intentionally avoided until a heavier local NLP backend is chosen.

All findings fixed or waived: yes.

## Parked hardening
- None.

## Verification
- Command: python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_supported_pii_before_snapshot_projection tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_local_entity_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q - 5 passed.
- Command: python -m pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_deflection_submit.py -q - 142 passed.
- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_deflection_submit.py - passed.
- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-deflection-local-ner-scrub.md - passed.

## Diff size
4 files, +470 / -7.
