### PR TITLE
Fix deflection PII scrub regression

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -64,7 +64,7 @@ _DEFLECTION_IDENTIFIER_RE = re.compile(
     r"(?:account|accounts|acct|case|cases|claim|claims|confirmation|"
     r"confirmations|customer|customers|id|ids|invoice|invoices|member|"
     r"members|order|orders|ref|refs|reference|references|ticket|tickets)"
-    r"\s*(?:#|number|no\.?)?\s*[:#-]?\s*\d{4,}"
+    r"\s*(?:#|number|no\.?|is)?\s*[:#-]?\s*\d{4,}"
     rf"{_DEFLECTION_BOUNDARY_RIGHT}"
     r"|"
     rf"{_DEFLECTION_BOUNDARY_LEFT}"
@@ -86,8 +86,9 @@ _DEFLECTION_PERSON_NAME_RE = re.compile(
     r"(?:\s+name)?\s*(?:is|:|=|-)\s*)"
     r")"
     r"(?P<name>"
-    r"[A-Za-z][A-Za-z'.-]+"
-    r"(?:\s+[A-Za-z][A-Za-z'.-]+){1,2}"
+    r"[A-Za-z][A-Za-z'-]+"
+    r"\s+[A-Za-z][A-Za-z'-]+"
+    r"(?:\s+[A-Z][A-Za-z'-]+)?"
     r")"
     r"(?=$|[\s,.;:!?)]|</)",
 )
@@ -99,22 +100,30 @@ _DEFLECTION_PERSON_NAME_REJECT_TOKENS = frozenset(
         "billing",
         "case",
         "claim",
+        "client",
+        "contact",
+        "customer",
         "dashboard",
         "desk",
         "export",
         "faq",
         "help",
         "invoice",
+        "member",
+        "name",
         "password",
+        "person",
         "portal",
         "report",
         "reporting",
+        "requester",
         "reset",
         "source",
         "sso",
         "support",
         "ticket",
         "token",
+        "user",
     }
 )
 _DEFLECTION_STREET_ADDRESS_RE = re.compile(
@@ -159,7 +168,7 @@ _DEFLECTION_CONTEXTUAL_OPAQUE_IDENTIFIER_RE = re.compile(
     r"|(?:code|id|identifier|token))"
     r"\s*(?:is|:|=|-)?\s*)"
     r"(?P<identifier>"
-    r"(?:[A-Z0-9]{8,}|[A-Z0-9]{3,}(?:[-_][A-Z0-9]{3,})+)"
+    r"(?:[A-Z0-9]{3,}(?:[-_][A-Z0-9]{3,})+|[A-Z0-9]{8,}|\d{4,})"
     r")"
     rf"{_DEFLECTION_BOUNDARY_RIGHT}",
     re.IGNORECASE,
@@ -186,6 +195,17 @@ _DEFLECTION_OPAQUE_IDENTIFIER_PREFIXES = (
     "session",
     "user",
     "usr",
+)
+_DEFLECTION_TECHNICAL_IDENTIFIER_RE = re.compile(
+    r"(?:"
+    r"CVE-\d{4}-\d{4,}"
+    r"|CWE-\d{1,6}"
+    r"|GHSA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}"
+    r"|ISO[-_ ]?\d{3,5}"
+    r"|HIPAA[-_ ]?\d{2,4}"
+    r"|SKU[-_ ]?\d{4,}"
+    r")",
+    re.IGNORECASE,
 )
 _DEFLECTION_IDENTIFIER_KEYS = frozenset(
     {
@@ -2771,10 +2791,76 @@ def _looks_like_deflection_street_address(match: re.Match[str]) -> bool:
 
 
 def _redact_deflection_person_name(match: re.Match[str]) -> str:
-    candidate = match.group("name")
-    if not _looks_like_deflection_person_name(candidate):
+    decision = _deflection_person_name_match_decision(match)
+    if not decision.redact:
         return match.group(0)
-    return f"{match.group('prefix')}[redacted-name]"
+    return f"{match.group('prefix')}[redacted-name]{decision.trailing_text}"
+
+
+@dataclass(frozen=True)
+class _DeflectionPersonNameDecision:
+    redact: bool
+    trailing_text: str = ""
+
+
+def _deflection_person_name_match_decision(
+    match: re.Match[str],
+) -> _DeflectionPersonNameDecision:
+    candidate = match.group("name")
+    if _looks_like_deflection_person_name(candidate):
+        return _DeflectionPersonNameDecision(redact=True)
+    shortened = _shortest_deflection_person_name_candidate(candidate)
+    if shortened is not None:
+        _, trailing = shortened
+        return _DeflectionPersonNameDecision(redact=True, trailing_text=trailing)
+    if _looks_like_deflection_cued_person_name(candidate, match.group("prefix")):
+        return _DeflectionPersonNameDecision(redact=True)
+    return _DeflectionPersonNameDecision(redact=False)
+
+
+def _deflection_person_name_match_is_pii(match: re.Match[str]) -> bool:
+    return _deflection_person_name_match_decision(match).redact
+
+
+def _looks_like_deflection_cued_person_name(value: str, prefix: str) -> bool:
+    if not _is_strong_deflection_person_name_cue(prefix):
+        return False
+    tokens = [
+        token.strip(" .'-").casefold()
+        for token in value.split()
+        if token.strip(" .'-")
+    ]
+    if len(tokens) < 2 or len(tokens) > 3:
+        return False
+    if all(token in _DEFLECTION_PERSON_NAME_REJECT_TOKENS for token in tokens):
+        return False
+    return all(len(token) >= 2 for token in tokens)
+
+
+def _is_strong_deflection_person_name_cue(prefix: str) -> bool:
+    normalized = " ".join(prefix.strip().casefold().split())
+    return " name" in f" {normalized}" or normalized.endswith(" is")
+
+
+def _shortest_deflection_person_name_candidate(value: str) -> tuple[str, str] | None:
+    parts = value.split()
+    if len(parts) != 3:
+        return None
+    first_two = " ".join(parts[:2])
+    trailing = parts[2]
+    if (
+        trailing.strip(" .'-").casefold() not in _DEFLECTION_PERSON_NAME_REJECT_TOKENS
+        or not _looks_like_deflection_person_name(first_two)
+    ):
+        return None
+    return first_two, f" {trailing}"
+
+
+def _redact_deflection_contextual_opaque_identifier(match: re.Match[str]) -> str:
+    token = match.group("identifier")
+    if not _looks_like_deflection_opaque_identifier(token, require_prefix=False):
+        return match.group(0)
+    return f"{match.group('prefix')}[redacted-identifier]"
 
 
 def _looks_like_deflection_person_name(value: str) -> bool:
@@ -2788,13 +2874,6 @@ def _looks_like_deflection_person_name(value: str) -> bool:
     if any(token in _DEFLECTION_PERSON_NAME_REJECT_TOKENS for token in tokens):
         return False
     return all(len(token) >= 2 for token in tokens)
-
-
-def _redact_deflection_contextual_opaque_identifier(match: re.Match[str]) -> str:
-    token = match.group("identifier")
-    if not _looks_like_deflection_opaque_identifier(token, require_prefix=False):
-        return match.group(0)
-    return f"{match.group('prefix')}[redacted-identifier]"
 
 
 def _redact_deflection_opaque_identifier(match: re.Match[str]) -> str:
@@ -2812,8 +2891,10 @@ def _looks_like_deflection_opaque_identifier(
     compact = re.sub(r"[-_]", "", value)
     if len(compact) < 8:
         return False
-    if not any(char.isalpha() for char in compact):
+    if _looks_like_deflection_technical_identifier(value):
         return False
+    if not any(char.isalpha() for char in compact):
+        return not require_prefix
     digit_count = sum(1 for char in compact if char.isdigit())
     if digit_count < 1:
         return False
@@ -2823,11 +2904,16 @@ def _looks_like_deflection_opaque_identifier(
     return digit_count >= 1
 
 
+def _looks_like_deflection_technical_identifier(value: str) -> bool:
+    return bool(_DEFLECTION_TECHNICAL_IDENTIFIER_RE.fullmatch(value.strip()))
+
+
 def _has_deflection_source_link_pii(value: str) -> bool:
     if (
         _DEFLECTION_EMAIL_RE.search(value)
         or _DEFLECTION_PHONE_RE.search(value)
         or _DEFLECTION_REDACTION_ARTIFACT_RE.search(value)
+        or _has_deflection_labeled_identifier_pii(value)
     ):
         return True
     if any(
@@ -2836,7 +2922,7 @@ def _has_deflection_source_link_pii(value: str) -> bool:
     ):
         return True
     if any(
-        _looks_like_deflection_person_name(match.group("name"))
+        _deflection_person_name_match_is_pii(match)
         for match in _DEFLECTION_PERSON_NAME_RE.finditer(value)
     ):
         return True
@@ -2852,6 +2938,18 @@ def _has_deflection_source_link_pii(value: str) -> bool:
         _looks_like_deflection_opaque_identifier(match.group(0), require_prefix=True)
         for match in _DEFLECTION_OPAQUE_IDENTIFIER_RE.finditer(value)
     )
+
+
+def _has_deflection_labeled_identifier_pii(value: str) -> bool:
+    return bool(
+        _DEFLECTION_IDENTIFIER_RE.search(value)
+        and not _looks_like_deflection_source_link_identifier(value)
+    )
+
+
+def _looks_like_deflection_source_link_identifier(value: str) -> bool:
+    text = _text(value).strip().casefold()
+    return bool(re.fullmatch(r"(?:ticket|source)-[a-z0-9][a-z0-9_-]*", text))
 
 
 def _json_ready(value: Any) -> Any:

--- a/plans/PR-Deflection-Scrub-Regression.md
+++ b/plans/PR-Deflection-Scrub-Regression.md
@@ -1,0 +1,146 @@
+# PR-Deflection-Scrub-Regression
+
+## Why this slice exists
+
+Issue #1740 tracks a live regression in the paid deflection report privacy
+boundary after #1738: the deterministic scrubber is invoked before storing the
+paid artifact and free Snapshot, but several regex branches can still leak or
+mis-shape PII in answer/steps prose.
+
+Root cause: the scrubber's text patterns do not encode the intended precedence
+and contextual grammar. The person-name pattern greedily admits 2-3 capitalized
+tokens after a cue, so trailing support words can be swallowed or turn a valid
+name into a rejected 3-token candidate. The contextual opaque-id pattern lists
+the compact `{8,}` form before the segmented UUID/token form, so a dashed token
+can be partially matched. The contextual identifier separator made `is`
+optional but did not cover the all-digit `id is 12345678` shape safely. This
+change fixes the root in the shared scrub helper rather than patching one
+downstream report field.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-privacy
+Slice phase: Production hardening
+
+1. Fix the shared deflection text scrubber so cued names, contextual dashed
+   UUID/opaque identifiers, and contextual all-digit identifiers redact
+   deterministically before persisted artifact/Snapshot projection.
+2. Preserve safe technical references such as CVE/SKU/ISO-style tokens and
+   support nouns that follow a redacted name.
+3. Add regression tests for the direct scrub helper and the stored
+   artifact/Snapshot gate.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Cued two-token names redact while trailing support words remain visible.
+  - [ ] Cued three-token names redact without consuming the next support noun.
+  - [ ] Contextual dashed UUID/opaque identifiers redact as a whole, not as a
+        partial compact prefix.
+  - [ ] Contextual `account/customer/id is <digits>` phrases redact the digit
+        payload.
+  - [ ] CVE/SKU/ISO-like technical references and ordinary non-contextual
+        counts remain visible.
+  - [ ] The stored artifact/Snapshot gate exercises at least one new regression
+        shape so downstream persistence uses the fixed scrubber.
+- Affected surfaces: extracted_content_pipeline deflection report scrubber;
+  content-ops deflection report artifact/Snapshot persistence.
+- Risk areas: security/privacy under-redaction; customer-visible report
+  over-redaction; backcompat for source-link preservation.
+- Reviewer rules triggered: R1, R2, R3, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Scrub-Regression.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+The scrubber remains deterministic and local. This slice keeps the invocation
+points unchanged:
+
+1. `scrub_deflection_report_payload(...)` cleans the completed paid artifact.
+2. `build_deflection_snapshot(...)` projects the free Snapshot from that
+   scrubbed artifact.
+3. The Snapshot is scrubbed again before persistence as defense in depth.
+
+Inside `_scrub_deflection_text`, the regexes are tightened rather than
+replaced. The contextual opaque identifier pattern admits the dashed/segmented
+form before the compact form, so UUID-like values are consumed as one token.
+The contextual branch admits all-digit IDs only when there is an explicit
+identifier cue. The name branch redacts the shortest valid name candidate after
+a cue and leaves subsequent support words in place. Strong name cues (`name is`
+or `<role> is`) can override the reject-token list so `Jane Client` and
+`John Member` do not leak just because the surname is also a support noun.
+Source-link preservation uses the same supported-PII detector family as the
+text scrubber, with an explicit safe-source-link exception for internal
+`ticket-*`/`source-*` IDs, so source links cannot bypass labeled numeric IDs
+that the text path redacts. Tests lock both the redaction cases and near-miss
+preservation cases.
+
+## Intentional
+
+- No external NER dependency. The regression is in deterministic post-processing
+  and should stay dependency-light for extracted-checks CI.
+- Bare all-digit strings remain preserved unless they are already covered by an
+  identifier/key context. The product still reports ordinary counts and years.
+- Source-link preservation remains unchanged; source IDs are preserved unless
+  they are PII-shaped by existing policy.
+
+## Deferred
+
+- Broader final-report action-section restructuring remains in #1612 after the
+  scrub boundary is green.
+- Bare UUID-without-prefix policy remains explicit but conservative here:
+  contextual UUIDs redact, while unrelated bare technical tokens stay governed
+  by the existing opaque-token near-miss policy.
+
+Parked hardening: none.
+
+## Verification
+
+- Command passed: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_local_entity_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 4 passed.
+- Command passed: `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 83 passed after rebasing over #1739.
+- Command passed: `python -m pytest tests/test_extracted_content_deflection_submit.py -q` -- 70 passed.
+- Command passed: `bash` `scripts/validate_extracted_content_pipeline.sh` -- validation passed; `forbid_hard_atlas_imports` clean.
+- Command passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean.
+- Command passed: `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
+- Command passed: `bash` `scripts/check_ascii_python.sh` -- ASCII check passed for extracted_content_pipeline Python files.
+- Command passed: `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` -- refreshed mapped files; post-sync focused regression tests still passed.
+- Command passed: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 2 passed.
+- Command passed after local reviewer BLOCKER fix: `python - <<'PY' ... scrub_deflection_report_payload({'source_id': 'customer is Jane Smith ticket'}) ... PY` -- returned `customer is [redacted-name] ticket`.
+- Command passed after local reviewer BLOCKER fix: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 3 passed.
+- Command passed after local reviewer BLOCKER fix: `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 83 passed after rebasing over #1739.
+- Command passed after local reviewer BLOCKER fix: `python -m pytest tests/test_extracted_content_deflection_submit.py -q` -- 70 passed.
+- Command passed after GitHub BLOCKER fix: direct review repros show `customer id is ISO9X4Q7ABCD`, `session token is SKU90X4Q7AB`, and `account id is HIPAA9X4Q7AB` redact, while `CVE-2021-44228`, `SKU-12345678`, `ISO-27001`, and `HIPAA2026` remain readable.
+- Command passed after GitHub BLOCKER fix: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes -q` -- 1 passed.
+- Command passed after GitHub BLOCKER fix: `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 83 passed.
+- Command passed after GitHub BLOCKER fix: `python -m pytest tests/test_extracted_content_deflection_submit.py -q` -- 70 passed.
+- Command passed after GitHub BLOCKER fix: `bash` `scripts/validate_extracted_content_pipeline.sh` -- validation passed; `forbid_hard_atlas_imports` clean.
+- Command passed after GitHub BLOCKER fix: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean.
+- Command passed after GitHub BLOCKER fix: `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
+- Command passed after GitHub BLOCKER fix: `bash` `scripts/check_ascii_python.sh` -- ASCII check passed for extracted_content_pipeline Python files.
+- Command passed after GitHub BLOCKER fix: `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` -- refreshed mapped files.
+- Command passed after GitHub BLOCKER fix: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 2 passed after sync.
+- Command passed after GitHub BLOCKER round 2 fix: direct repros show `source_id: "account is 1234567"` now redacts, `Requester name is Jane Client` and `customer is John Member` redact, `Customer: Reset Password` stays readable, and `ticket-4829103` stays preserved as a source link.
+- Command passed after GitHub BLOCKER round 2 fix: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses -q` -- 3 passed.
+- Command passed after GitHub BLOCKER round 2 fix: `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 83 passed.
+- Command passed after GitHub BLOCKER round 2 fix: `python -m pytest tests/test_extracted_content_deflection_submit.py -q` -- 70 passed.
+- Command passed after GitHub BLOCKER round 2 fix: `bash` `scripts/validate_extracted_content_pipeline.sh` -- validation passed; `forbid_hard_atlas_imports` clean.
+- Command passed after GitHub BLOCKER round 2 fix: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean.
+- Command passed after GitHub BLOCKER round 2 fix: `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
+- Command passed after GitHub BLOCKER round 2 fix: `bash` `scripts/check_ascii_python.sh` -- ASCII check passed for extracted_content_pipeline Python files.
+- Command passed after GitHub BLOCKER round 2 fix: `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` -- refreshed mapped files.
+- Command passed after GitHub BLOCKER round 2 fix: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 3 passed after sync.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 120 |
+| `plans/PR-Deflection-Scrub-Regression.md` | 146 |
+| `tests/test_content_ops_deflection_report.py` | 66 |
+| `tests/test_extracted_content_deflection_submit.py` | 15 |
+| **Total** | **347** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -1677,6 +1677,72 @@ def test_deflection_report_payload_scrubs_local_entity_shapes() -> None:
     assert "[redacted-identifier]" in encoded
 
 
+def test_deflection_report_payload_scrubs_pii_regression_shapes() -> None:
+    uuid_value = "123e4567-e89b-12d3-a456-426614174000"
+    scrubbed = scrub_deflection_report_payload(
+        {
+            "source_id": "customer is Jane Smith ticket",
+            "source_ids": [
+                "account is 1234567",
+                "customer is John Member",
+                "ticket-source-a",
+            ],
+            "answer": (
+                "The customer is Jane Smith ticket was closed. "
+                "Requester name is Maria Elena Garcia account is active. "
+                "Requester name is Jane Client. "
+                f"The customer id is {uuid_value}. "
+                "customer id is 12345678 and the ordinary count is 12345678. "
+                "customer id is ISO9X4Q7ABCD, session token is SKU90X4Q7AB, "
+                "and account id is HIPAA9X4Q7AB. "
+                "case CVE-2021-44228, order SKU-12345678, and "
+                "reference ISO-27001 should stay readable. HIPAA2026 too."
+            ),
+            "steps": [
+                "agent is Alex Chen member was reassigned.",
+                "session token is CUST-9XQ7-ABCD.",
+                "reference ISO27001 remains a standard.",
+            ],
+        }
+    )
+
+    answer = scrubbed["answer"]
+    encoded = json.dumps(scrubbed, sort_keys=True)
+    for raw_fragment in (
+        "Jane Smith",
+        "Maria Elena Garcia",
+        "Jane Client",
+        "John Member",
+        uuid_value,
+        "customer id is 12345678",
+        "account is 1234567",
+        "ISO9X4Q7ABCD",
+        "SKU90X4Q7AB",
+        "HIPAA9X4Q7AB",
+        "Alex Chen",
+        "CUST-9XQ7-ABCD",
+    ):
+        assert raw_fragment not in encoded
+    assert "customer is [redacted-name] ticket was closed" in answer
+    assert "Requester name is [redacted-name] account is active" in answer
+    assert "Requester name is [redacted-name]" in answer
+    assert "customer id is [redacted-identifier]" in answer
+    assert "ordinary count is 12345678" in answer
+    assert "case CVE-2021-44228" in answer
+    assert "order SKU-12345678" in answer
+    assert "reference ISO-27001" in answer
+    assert "HIPAA2026" in answer
+    assert scrubbed["source_id"] == "customer is [redacted-name] ticket"
+    assert scrubbed["source_ids"] == [
+        "[redacted-identifier]",
+        "customer is [redacted-name]",
+        "ticket-source-a",
+    ]
+    assert scrubbed["steps"][0] == "agent is [redacted-name] member was reassigned."
+    assert scrubbed["steps"][1] == "session token is [redacted-identifier]."
+    assert scrubbed["steps"][2] == "reference ISO27001 remains a standard."
+
+
 def test_deflection_report_payload_preserves_local_entity_near_misses() -> None:
     scrubbed = scrub_deflection_report_payload(
         {

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -729,7 +729,9 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
                     "ticket_count": 2,
                     "answer": (
                         "Reset _jane.doe@acme.com_ after confirming account 4829103 "
-                        "for customer: Jane Doe at 123 Maple Street Apt 4B."
+                        "for customer: Jane Doe at 123 Maple Street Apt 4B. "
+                        "The customer is Jane Smith ticket was closed. "
+                        "The customer id is 123e4567-e89b-12d3-a456-426614174000."
                     ),
                     "steps": [
                         "Remove XXXXX before publishing.",
@@ -737,6 +739,8 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
                         "Check opaque migration token CUST-9XQ7-ABCD.",
                         "Requester name is Jane Doe.",
                         "Mail a label to 123 Maple Street Apt 4B.",
+                        "customer id is 12345678.",
+                        "case CVE-2021-44228 should remain diagnostic context.",
                     ],
                     "source_ids": ["4829103", "777777"],
                     "evidence_quotes": [
@@ -822,11 +826,16 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
         "777777",
         "999999",
         "jane doe",
+        "jane smith",
         "123 maple",
         "cust-9xq7-abcd",
+        "123e4567-e89b-12d3-a456-426614174000",
+        "customer id is 12345678",
         "xxxxx",
     ):
         assert raw_fragment not in encoded
+    assert "cve-2021-44228" in encoded
+    assert "ticket was closed" in encoded
     teaser_answer = record.snapshot["teaser"]["full_answer"]
     assert "[redacted-email]" in teaser_answer["answer"]
     assert "[redacted-identifier]" in teaser_answer["answer"]
@@ -834,8 +843,10 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
         "Remove [redacted-text] before publishing.",
         "Escalate [redacted-identifier] if the reset still fails.",
         "Check opaque migration token [redacted-identifier].",
-        "Requester name is [redacted-name]",
+        "Requester name is [redacted-name].",
         "Mail a label to [redacted-address].",
+        "customer id is [redacted-identifier].",
+        "case CVE-2021-44228 should remain diagnostic context.",
     ]
     artifact_sources = record.artifact["faq_result"]["items"][0]["source_ids"]
     assert artifact_sources == ["4829103", "777777"]


### PR DESCRIPTION
Plan: plans/PR-Deflection-Scrub-Regression.md
Slice phase: Production hardening

Fixes #1740.

The deflection report scrubber already runs before persisted paid artifacts and free Snapshots, but the text scrub grammar let several #1740 regression shapes slip or mis-redact: cued two-token names followed by support nouns, contextual dashed UUIDs that were only partially redacted, contextual all-digit `id is` payloads, and CVE/SKU/ISO technical references that should stay readable.

## Intentional
- No external NER dependency; this remains deterministic and extracted-checks friendly.
- Bare all-digit strings remain visible unless an identifier context marks them sensitive.
- Source-link preservation stays unchanged.

## Deferred
- Broader final-report action-section restructuring remains in #1612 after the scrub boundary is green.
- Bare UUID-without-prefix policy remains conservative: contextual UUIDs redact, unrelated bare technical tokens stay under the existing opaque-token near-miss policy.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_local_entity_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 4 passed.
- `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 83 passed after rebasing over #1739.
- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` -- 70 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` -- refreshed mapped files.
- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 2 passed after sync.
- Local reviewer BLOCKER follow-up: direct source-id probe for `customer is Jane Smith ticket` returned `customer is [redacted-name] ticket`.
- Local reviewer BLOCKER follow-up: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses tests/test_extracted_content_deflection_submit.py::test_deflection_report_storage_gate_scrubs_supported_pii -q` -- 3 passed.
- Rebase follow-up: `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 83 passed.
- GitHub BLOCKER follow-up: direct review repros show `customer id is ISO9X4Q7ABCD`, `session token is SKU90X4Q7AB`, and `account id is HIPAA9X4Q7AB` redact, while `CVE-2021-44228`, `SKU-12345678`, `ISO-27001`, and `HIPAA2026` remain readable.
- GitHub BLOCKER follow-up: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes -q` -- 1 passed.
- GitHub BLOCKER follow-up: `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 83 passed.
- GitHub BLOCKER follow-up: `python -m pytest tests/test_extracted_content_deflection_submit.py -q` -- 70 passed.
- GitHub BLOCKER follow-up: extracted_content_pipeline validation/import/ascii/sync checks passed, then focused report/storage tests passed after sync.
- GitHub BLOCKER round 2 follow-up: direct repros show `source_id: "account is 1234567"` now redacts, `Requester name is Jane Client` and `customer is John Member` redact, `Customer: Reset Password` stays readable, and `ticket-4829103` stays preserved as a source link.
- GitHub BLOCKER round 2 follow-up: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys tests/test_content_ops_deflection_report.py::test_deflection_report_payload_scrubs_pii_regression_shapes tests/test_content_ops_deflection_report.py::test_deflection_report_payload_preserves_local_entity_near_misses -q` -- 3 passed.
- GitHub BLOCKER round 2 follow-up: `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 83 passed.
- GitHub BLOCKER round 2 follow-up: `python -m pytest tests/test_extracted_content_deflection_submit.py -q` -- 70 passed.
- GitHub BLOCKER round 2 follow-up: extracted_content_pipeline validation/import/ascii/sync checks passed, then focused source-link/report/storage tests passed after sync.

## AI reconciliation
- All automated-review findings fixed or waived: Yes.
- Fixed: Codex P1 SKU-prefixed cued identifiers, P1 short digit identifiers in source-link fields, and P2 cued names with support-word surnames.
- Waived: none.

## Diff size
4 files, +334 / -13

