### PR TITLE
Add uploaded deflection report search endpoint

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -7,6 +7,7 @@ import http.client
 import json
 import logging
 import math
+import re
 import ssl
 import tempfile
 import ipaddress
@@ -165,6 +166,24 @@ _DEFLECTION_SUBMIT_PLATFORMS = frozenset({
     "other",
 })
 _DEFLECTION_SUBMIT_IMPORTER_MODES = frozenset({"csv", "full_thread"})
+_DEFLECTION_REPORT_SEARCH_DEFAULT_LIMIT = 5
+_DEFLECTION_REPORT_SEARCH_MAX_LIMIT = 10
+_DEFLECTION_REPORT_SEARCH_MAX_QUERY_CHARS = 300
+_DEFLECTION_REPORT_SEARCH_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_DEFLECTION_REPORT_SEARCH_TEXT_FIELDS = (
+    "topic",
+    "question",
+    "answer",
+    "when_to_contact_support",
+    "answer_evidence_status",
+)
+_DEFLECTION_REPORT_SEARCH_SEQUENCE_FIELDS = (
+    "steps",
+    "action_items",
+    "source_ids",
+    "source_labels",
+    "term_mappings",
+)
 
 
 @dataclass(frozen=True)
@@ -649,6 +668,26 @@ if BaseModel is not None:
 
         payment_reference: str | None = Field(default=None, max_length=200)
 
+    class DeflectionReportSearchModel(BaseModel):
+        """Request-scoped uploaded report search body."""
+
+        model_config = ConfigDict(extra="forbid")
+
+        q: str = Field(
+            ...,
+            min_length=1,
+            max_length=_DEFLECTION_REPORT_SEARCH_MAX_QUERY_CHARS,
+        )
+        limit: int | None = Field(default=None, ge=1)
+
+        @field_validator("q")
+        @classmethod
+        def _validate_query(cls, value: Any) -> str:
+            text = _clean(value)
+            if not text:
+                raise ValueError("q is required")
+            return str(text)
+
     class _DeflectionReportSubmitFieldsModel(BaseModel):
         """Shared portfolio submit metadata fields."""
 
@@ -714,6 +753,7 @@ else:  # pragma: no cover - module import fallback when FastAPI is unavailable.
     ContentOpsIngestionInspectModel = Any
     ContentOpsIngestionImportModel = Any
     DeflectionReportPaidModel = Any
+    DeflectionReportSearchModel = Any
     DeflectionReportSubmitModel = Any
     DeflectionReportSubmitFieldsModel = Any
 
@@ -890,6 +930,32 @@ def create_content_ops_control_surface_router(
                 detail="Deflection report model is not available.",
             )
         return model
+
+    @router.post(
+        "/deflection-reports/{request_id}/search",
+        dependencies=public_deflection_dependencies,
+    )
+    async def search_deflection_report(
+        payload: DeflectionReportSearchModel = Body(...),
+        request_id: str = PathParam(..., min_length=1, max_length=200),
+    ) -> dict[str, Any]:
+        query = _deflection_report_search_query(payload.q)
+        limit = _deflection_report_search_limit(payload.limit)
+        store = await _resolve_deflection_report_store(deflection_report_store_provider)
+        scope = await _resolve_scope(scope_provider)
+        record = await store.get_artifact_record(
+            account_id=_required_scope_account_id(scope),
+            request_id=request_id,
+        )
+        if record is None:
+            raise HTTPException(status_code=404, detail="Deflection report not found.")
+        if not record.paid:
+            raise HTTPException(status_code=403, detail="Deflection report is locked.")
+        return _search_deflection_report_artifact(
+            record.artifact,
+            query=query,
+            limit=limit,
+        )
 
     @router.post(
         "/deflection-reports/{request_id}/checkout-authorization",
@@ -3397,6 +3463,145 @@ def _deflection_resolution_preview_summary(
         "support_ticket_resolution_evidence_present": bool(present),
         "support_ticket_resolution_evidence_count": count,
     }
+
+
+def _deflection_report_search_query(value: Any) -> str:
+    query = _clean(value)
+    if not query:
+        raise HTTPException(status_code=400, detail="q is required")
+    if len(query) > _DEFLECTION_REPORT_SEARCH_MAX_QUERY_CHARS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "q must be "
+                f"{_DEFLECTION_REPORT_SEARCH_MAX_QUERY_CHARS} characters or fewer"
+            ),
+        )
+    return str(query)
+
+
+def _deflection_report_search_limit(value: Any) -> int:
+    if value is None:
+        return _DEFLECTION_REPORT_SEARCH_DEFAULT_LIMIT
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="limit must be positive") from exc
+    if parsed <= 0:
+        raise HTTPException(status_code=400, detail="limit must be positive")
+    return min(parsed, _DEFLECTION_REPORT_SEARCH_MAX_LIMIT)
+
+
+def _search_deflection_report_artifact(
+    artifact: Mapping[str, Any] | None,
+    *,
+    query: str,
+    limit: int,
+) -> dict[str, Any]:
+    normalized_query = _deflection_report_search_query(query)
+    query_tokens = _deflection_report_search_tokens(normalized_query)
+    if not isinstance(artifact, Mapping) or not query_tokens or limit <= 0:
+        return {"query": normalized_query, "count": 0, "results": []}
+
+    matches: list[dict[str, Any]] = []
+    for rank, item in enumerate(_deflection_report_artifact_items(artifact), start=1):
+        full_item = _deflection_report_full_item(item)
+        if full_item is None:
+            continue
+        score = _deflection_report_item_score(full_item, query_tokens)
+        if score <= 0:
+            continue
+        matches.append({
+            "item": full_item,
+            "score": score,
+            "rank": _nonnegative_int(full_item.get("rank")) or rank,
+        })
+    matches.sort(
+        key=lambda result: (
+            -int(result["score"]),
+            int(result["rank"]),
+            str(result["item"].get("question") or ""),
+        )
+    )
+    selected = matches[:limit]
+    return {
+        "query": normalized_query,
+        "count": len(selected),
+        "results": selected,
+    }
+
+
+def _deflection_report_artifact_items(
+    artifact: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    faq_result = artifact.get("faq_result")
+    if not isinstance(faq_result, Mapping):
+        return ()
+    items = faq_result.get("items")
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
+        return ()
+    return tuple(item for item in items if isinstance(item, Mapping))
+
+
+def _deflection_report_full_item(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    for field in _DEFLECTION_REPORT_SEARCH_TEXT_FIELDS:
+        if not _clean(item.get(field)):
+            return None
+    for field in _DEFLECTION_REPORT_SEARCH_SEQUENCE_FIELDS:
+        value = item.get(field)
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+            return None
+    if _nonnegative_int(item.get("ticket_count")) <= 0 and _nonnegative_int(
+        item.get("frequency")
+    ) <= 0:
+        return None
+    return dict(item)
+
+
+def _deflection_report_item_score(
+    item: Mapping[str, Any],
+    query_tokens: Sequence[str],
+) -> int:
+    question_tokens = set(_deflection_report_search_tokens(item.get("question")))
+    topic_tokens = set(_deflection_report_search_tokens(item.get("topic")))
+    text_tokens = _deflection_report_search_tokens(_deflection_report_item_search_text(item))
+    score = 0
+    for token in query_tokens:
+        if token in question_tokens:
+            score += 6
+        if token in topic_tokens:
+            score += 3
+        score += min(text_tokens.count(token), 4)
+    return score
+
+
+def _deflection_report_item_search_text(item: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    for field in ("topic", "question", "answer", "when_to_contact_support"):
+        text = _clean(item.get(field))
+        if text:
+            parts.append(str(text))
+    for field in ("steps", "action_items", "source_labels"):
+        for value in _text_sequence(item.get(field)):
+            parts.append(value)
+    for mapping in item.get("term_mappings") or ():
+        if not isinstance(mapping, Mapping):
+            continue
+        for field in ("customer_term", "documentation_term", "suggestion"):
+            text = _clean(mapping.get(field))
+            if text:
+                parts.append(str(text))
+    return " ".join(parts)
+
+
+def _deflection_report_search_tokens(value: Any) -> list[str]:
+    return _DEFLECTION_REPORT_SEARCH_TOKEN_RE.findall(str(value or "").lower())
+
+
+def _text_sequence(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(str(item) for item in value if _clean(item))
 
 
 def _nonnegative_int(value: Any) -> int:

--- a/plans/PR-Deflection-Uploaded-Report-Search.md
+++ b/plans/PR-Deflection-Uploaded-Report-Search.md
@@ -1,0 +1,157 @@
+# PR-Deflection-Uploaded-Report-Search
+
+## Why this slice exists
+
+atlas-portfolio #341 now ships the paid uploaded-report search workbench dark
+behind `DEFLECTION_UPLOADED_SEARCH_ENABLED=true`. That portfolio path is honest
+and paid-gated, but it cannot run end to end until ATLAS serves the matching
+request-scoped search endpoint. The root cause is that ATLAS currently exposes
+only tenant-scoped compact FAQ search at
+`GET /api/v1/content-ops/faq-deflection-search`; there is no
+`POST /api/v1/content-ops/deflection-reports/{request_id}/search` contract that
+searches a buyer's uploaded report and returns full report items.
+
+This slice closes the ATLAS side of that contract without faking shape from the
+existing compact projection.
+
+The diff is over the 400 LOC soft cap because the route is small but the
+review contract requires guard-shaped tests for paid access, request scoping,
+validation-before-store, limit capping, and compact-row rejection in the same
+slice. Splitting the tests from the endpoint would ship an unproven paid-data
+gate.
+
+## Scope (this PR)
+
+Ownership lane: deflection/uploaded-report-search
+Slice phase: Vertical slice
+
+1. Add `POST /deflection-reports/{request_id}/search` beside the existing
+   deflection report snapshot/artifact/report-model routes.
+2. Accept JSON `{ q, limit }`, validate the query before store access, cap the
+   limit, and keep customer ticket phrases out of URLs.
+3. Scope lookup by the current tenant/account and `request_id`, require the
+   existing paid/unlocked report state, and return 404/403 with the same
+   semantics as artifact/report-model access.
+4. Search only the stored, scrubbed full artifact's `faq_result.items`, and
+   return full item payloads under an envelope shape the portfolio parser can
+   accept: `{ query, count, results: [{ item, score, rank }] }`.
+5. Add focused route tests for happy path, empty result, locked/missing reports,
+   malformed/overlong query, limit capping, malformed artifact rows, and no
+   compact-row fabrication.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The route path and method match the portfolio contract:
+  `POST /api/v1/content-ops/deflection-reports/{request_id}/search` once the
+  control-surface router is mounted at `/api/v1/content-ops`.
+- Search is request-scoped, not tenant-corpus scoped: no call to the existing
+  `ticket_faq_search_documents` projection is used for uploaded report search.
+- A report must exist and be paid before any full `faq_result.items` payload can
+  be returned.
+- The route returns full stored report items only; malformed or compact rows are
+  skipped, not inflated into fake `TicketFAQItem` objects.
+- Query text is accepted only in the POST body and is validated before store
+  access on blank/overlong input.
+
+Affected surfaces:
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+Risk areas:
+
+- Paid-gate leakage of full report items.
+- Cross-tenant/request leakage.
+- Compact-row shape adaptation that would violate portfolio's "real, not fake"
+  requirement.
+- Search behavior over scrubbed artifact JSON after the PII scrub slices.
+
+Reviewer rules triggered: R1, R2, R3, R5, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Uploaded-Report-Search.md`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+The new route reuses the existing control-surface dependencies:
+`_resolve_deflection_report_store` for the persisted report store and
+`_resolve_scope` / `_required_scope_account_id` for account isolation. It reads
+the same `DeflectionReportAccessRecord` used by `/artifact` and
+`/report-model`; missing reports return 404 and unpaid reports return 403.
+
+After paid access passes, the route searches the stored artifact's
+`faq_result.items`. Each candidate must already be a full item mapping with the
+fields the paid report workbench needs (`topic`, `question`, `answer`,
+`when_to_contact_support`, `steps`, `action_items`, `source_ids`,
+`source_labels`, `term_mappings`, count/evidence fields). Candidates that do
+not meet that minimum are skipped. The matcher tokenizes the query and scores
+matches across question, topic, answer, customer term mappings, steps, action
+items, and source labels. Results are sorted deterministically by score, rank,
+and question, capped by the configured API limit, and returned as:
+
+```json
+{
+  "query": "export reports",
+  "count": 1,
+  "results": [
+    { "item": { "...": "full stored TicketFAQItem fields" }, "score": 12, "rank": 1 }
+  ]
+}
+```
+
+The route does not touch the tenant-scoped compact FAQ search projection. That
+projection remains useful for approved FAQ corpus search, but uploaded report
+search needs the exact report artifact generated from the buyer's CSV.
+
+## Intentional
+
+- Keep this as a local artifact search instead of adding a new search table in
+  the first ATLAS companion slice; the stored report artifact already contains
+  the scrubbed full items the paid workbench must render.
+- Do not hydrate compact `ticket_faq_search_documents` rows through
+  `/faq-deflection-search/{faq_id}`. Those rows are tenant-corpus scoped and can
+  mismatch the uploaded request.
+- Skip malformed full-item candidates instead of fabricating required fields.
+- Reuse the existing paid report gate rather than adding a separate unlock
+  concept for search.
+
+## Deferred
+
+- Live portfolio enablement remains a follow-up: after this PR lands and live
+  upload-search verification passes, set
+  `DEFLECTION_UPLOADED_SEARCH_ENABLED=true` in the portfolio deployment.
+- A future scale hardening slice can add a persisted request-scoped FTS index if
+  artifact-local search becomes too slow for larger paid reports.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_content_deflection_submit.py -k "deflection_report_search" -q`
+  -- 4 passed, 70 deselected.
+- `pytest tests/test_extracted_content_deflection_submit.py -q` -- 74 passed.
+- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py`
+  -- passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` -- 4742 passed, 15 skipped,
+  1 existing torch warning.
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_uploaded_report_search.md`
+  -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 205 |
+| `plans/PR-Deflection-Uploaded-Report-Search.md` | 157 |
+| `tests/test_extracted_content_deflection_submit.py` | 233 |
+| **Total** | **595** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -592,6 +592,101 @@ def _router(
     )
 
 
+def _router_with_store_provider(
+    store_provider: Any,
+    *,
+    account_id: str = "acct-portfolio-submit",
+):
+    return create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            deflection_snapshot_top_n=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        deflection_report_store_provider=store_provider,
+        scope_provider=lambda: {"account_id": account_id},
+    )
+
+
+def _search_item(**overrides: Any) -> dict[str, Any]:
+    item = {
+        "rank": 1,
+        "topic": "Reporting exports",
+        "question": "How do I export attribution reports?",
+        "question_source": "customer_wording",
+        "summary": "Customers ask how to export attribution reports.",
+        "frequency": 2,
+        "weighted_frequency": 2,
+        "ticket_count": 2,
+        "opportunity_score": 6,
+        "failure_risk_score": 1,
+        "failure_risk_signals": ["failed_workflow"],
+        "answer": "Open Analytics and click Download report.",
+        "steps": [
+            "Open Analytics.",
+            "Choose the attribution report.",
+            "Click Download report.",
+        ],
+        "action_items": ["Add export wording"],
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_source_count": 2,
+        "when_to_contact_support": "Contact support if export is unavailable.",
+        "evidence_quotes": ["`ticket-export-1`: customer asked about exports"],
+        "source_ids": ["ticket-export-1", "ticket-export-2"],
+        "source_labels": [
+            "ticket-export-1 - How do I export attribution reports?",
+            "ticket-export-2 - Where is the report download?",
+        ],
+        "source_type_counts": {"support_ticket": 2},
+        "weighted_source_volume_by_type": {"support_ticket": 2},
+        "term_mappings": [
+            {
+                "customer_term": "export",
+                "documentation_term": "download report",
+                "suggestion": "Use export wording near download steps.",
+                "source_id_count": 2,
+                "zero_result_source_count": 0,
+                "failure_risk_score": 1,
+                "failure_risk_signals": ["failed_workflow"],
+                "opportunity_score": 6,
+                "first_source_id": "ticket-export-1",
+            }
+        ],
+        "evidence_count": 1,
+        "displayed_evidence_count": 1,
+    }
+    item.update(overrides)
+    return item
+
+
+def _search_artifact(items: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "markdown": "# Report",
+        "summary": {"drafted_answer_count": 1},
+        "faq_result": {
+            "items": list(items if items is not None else [_search_item()]),
+        },
+        "report_model": {
+            "schema_version": DEFLECTION_REPORT_SCHEMA_VERSION,
+            "title": "Support Ticket Deflection Report",
+            "summary": {"drafted_answer_count": 1},
+            "sections": [
+                {
+                    "id": "ranked_questions",
+                    "title": "Ranked questions",
+                    "priority": 30,
+                    "surfaces": ["web"],
+                    "required_data": ["rows"],
+                    "data": {"rows": []},
+                }
+            ],
+        },
+    }
+
+
 @pytest.mark.asyncio
 async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     monkeypatch: pytest.MonkeyPatch,
@@ -702,6 +797,144 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     ) == {"request_id": payload["request_id"], "paid": True}
     artifact_payload = await artifact.endpoint(request_id=payload["request_id"])
     assert "lead@acme.example" not in str(artifact_payload)
+
+
+@pytest.mark.asyncio
+async def test_deflection_report_search_returns_full_paid_uploaded_item() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="content-ops-search-1",
+        snapshot={"summary": {}},
+        artifact=_search_artifact(),
+    )
+    await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="content-ops-search-1",
+        payment_reference="checkout-session:search",
+    )
+    router = _router(store)
+
+    search = _route(router, "/ops/deflection-reports/{request_id}/search", "POST")
+    payload = await search.endpoint(
+        payload=api_module.DeflectionReportSearchModel(q="export report", limit=5),
+        request_id="content-ops-search-1",
+    )
+
+    assert payload["query"] == "export report"
+    assert payload["count"] == 1
+    result = payload["results"][0]
+    assert result["score"] > 0
+    assert result["rank"] == 1
+    assert result["item"] == _search_item()
+    assert "answer_summary" not in result
+
+
+@pytest.mark.asyncio
+async def test_deflection_report_search_keeps_scope_and_paid_gate() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="content-ops-search-locked",
+        snapshot={"summary": {}},
+        artifact=_search_artifact(),
+    )
+    router = _router(store)
+    search = _route(router, "/ops/deflection-reports/{request_id}/search", "POST")
+
+    with pytest.raises(api_module.HTTPException) as locked:
+        await search.endpoint(
+            payload=api_module.DeflectionReportSearchModel(q="export", limit=5),
+            request_id="content-ops-search-locked",
+        )
+    assert locked.value.status_code == 403
+    assert locked.value.detail == "Deflection report is locked."
+
+    other_scope = _router_with_store_provider(lambda: store, account_id="acct-other")
+    other_scope_search = _route(
+        other_scope,
+        "/ops/deflection-reports/{request_id}/search",
+        "POST",
+    )
+    with pytest.raises(api_module.HTTPException) as missing_for_other_account:
+        await other_scope_search.endpoint(
+            payload=api_module.DeflectionReportSearchModel(q="export", limit=5),
+            request_id="content-ops-search-locked",
+        )
+    assert missing_for_other_account.value.status_code == 404
+    assert missing_for_other_account.value.detail == "Deflection report not found."
+
+
+@pytest.mark.asyncio
+async def test_deflection_report_search_validates_query_before_store_access() -> None:
+    def _store_provider() -> InMemoryDeflectionReportArtifactStore:
+        raise AssertionError("store should not be resolved for invalid search")
+
+    router = _router_with_store_provider(_store_provider)
+    search = _route(router, "/ops/deflection-reports/{request_id}/search", "POST")
+
+    with pytest.raises(api_module.HTTPException) as blank:
+        await search.endpoint(
+            payload=api_module.DeflectionReportSearchModel.model_construct(
+                q="   ",
+                limit=5,
+            ),
+            request_id="content-ops-search-invalid",
+        )
+    assert blank.value.status_code == 400
+    assert blank.value.detail == "q is required"
+
+    with pytest.raises(api_module.HTTPException) as too_long:
+        await search.endpoint(
+            payload=api_module.DeflectionReportSearchModel.model_construct(
+                q="x" * (api_module._DEFLECTION_REPORT_SEARCH_MAX_QUERY_CHARS + 1),
+                limit=5,
+            ),
+            request_id="content-ops-search-invalid",
+        )
+    assert too_long.value.status_code == 400
+    assert too_long.value.detail == "q must be 300 characters or fewer"
+
+
+@pytest.mark.asyncio
+async def test_deflection_report_search_skips_compact_and_malformed_items() -> None:
+    compact_row = {
+        "topic": "Billing",
+        "question": "Where is the refund export?",
+        "answer_summary": "Compact search row only.",
+        "ticket_count": 3,
+    }
+    malformed_full_item = _search_item(
+        question="How do I download refund data?",
+        source_labels="ticket-refund-1",
+    )
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="content-ops-search-compact",
+        snapshot={"summary": {}},
+        artifact=_search_artifact([compact_row, malformed_full_item, _search_item()]),
+    )
+    await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="content-ops-search-compact",
+        payment_reference="checkout-session:search",
+    )
+    router = _router(store)
+    search = _route(router, "/ops/deflection-reports/{request_id}/search", "POST")
+
+    compact_only = await search.endpoint(
+        payload=api_module.DeflectionReportSearchModel(q="refund", limit=5),
+        request_id="content-ops-search-compact",
+    )
+    assert compact_only == {"query": "refund", "count": 0, "results": []}
+
+    full_item = await search.endpoint(
+        payload=api_module.DeflectionReportSearchModel(q="attribution export", limit=99),
+        request_id="content-ops-search-compact",
+    )
+    assert full_item["count"] == 1
+    assert full_item["results"][0]["item"] == _search_item()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Uploaded-Report-Search.md
Slice phase: Vertical slice

atlas-portfolio #341 now has the paid uploaded-report search workbench ready but dark by default. This PR adds the matching ATLAS request-scoped search endpoint so the workbench can search the paid, stored report generated from that buyer's upload, without falling back to tenant-scoped compact FAQ rows or fabricating full item shape.

## Intentional

- Keep search local to the paid stored artifact for this first companion slice; no new search table or migration is needed to prove the real flow.
- Do not hydrate compact `ticket_faq_search_documents` rows through `/faq-deflection-search/{faq_id}` because those rows are tenant-corpus scoped and not tied to the uploaded request.
- Skip malformed full-item candidates instead of inventing required `TicketFAQItem` fields.
- Reuse the existing paid report gate rather than adding a separate unlock concept for search.

## Deferred

- Live portfolio enablement remains a follow-up: after this PR lands and live upload-search verification passes, set `DEFLECTION_UPLOADED_SEARCH_ENABLED=true` in the portfolio deployment.
- A future scale hardening slice can add a persisted request-scoped FTS index if artifact-local search becomes too slow for larger paid reports.

## Parked hardening

None.

## Verification

- `pytest tests/test_extracted_content_deflection_submit.py -k "deflection_report_search" -q` -- 4 passed, 70 deselected.
- `pytest tests/test_extracted_content_deflection_submit.py -q` -- 74 passed.
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 4742 passed, 15 skipped, 1 existing torch warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_uploaded_report_search.md` -- passed.

## Diff size

3 files, +595 / -0.
