### PR TITLE
Deflection uploaded search admission gate

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -177,12 +177,15 @@ _DEFLECTION_REPORT_SEARCH_TEXT_FIELDS = (
     "when_to_contact_support",
     "answer_evidence_status",
 )
-_DEFLECTION_REPORT_SEARCH_SEQUENCE_FIELDS = (
+_DEFLECTION_REPORT_SEARCH_NUMBER_FIELDS = (
+    "ticket_count",
+    "opportunity_score",
+)
+_DEFLECTION_REPORT_SEARCH_STRING_ARRAY_FIELDS = (
     "steps",
     "action_items",
     "source_ids",
     "source_labels",
-    "term_mappings",
 )
 
 
@@ -3545,17 +3548,36 @@ def _deflection_report_artifact_items(
 
 def _deflection_report_full_item(item: Mapping[str, Any]) -> dict[str, Any] | None:
     for field in _DEFLECTION_REPORT_SEARCH_TEXT_FIELDS:
-        if not _clean(item.get(field)):
+        if not isinstance(item.get(field), str):
             return None
-    for field in _DEFLECTION_REPORT_SEARCH_SEQUENCE_FIELDS:
-        value = item.get(field)
-        if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+    for field in _DEFLECTION_REPORT_SEARCH_NUMBER_FIELDS:
+        if not _deflection_report_renderable_number(item.get(field)):
             return None
-    if _nonnegative_int(item.get("ticket_count")) <= 0 and _nonnegative_int(
-        item.get("frequency")
-    ) <= 0:
+    for field in _DEFLECTION_REPORT_SEARCH_STRING_ARRAY_FIELDS:
+        if not _deflection_report_string_array(item.get(field)):
+            return None
+    if not _deflection_report_term_mappings(item.get("term_mappings")):
         return None
     return dict(item)
+
+
+def _deflection_report_renderable_number(value: Any) -> bool:
+    return not isinstance(value, bool) and isinstance(value, (int, float))
+
+
+def _deflection_report_string_array(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _deflection_report_term_mappings(value: Any) -> bool:
+    if not isinstance(value, list):
+        return False
+    required_fields = ("customer_term", "documentation_term", "suggestion")
+    return all(
+        isinstance(mapping, Mapping)
+        and all(isinstance(mapping.get(field), str) for field in required_fields)
+        for mapping in value
+    )
 
 
 def _deflection_report_item_score(

--- a/plans/PR-Deflection-Uploaded-Search-Admission-Gate.md
+++ b/plans/PR-Deflection-Uploaded-Search-Admission-Gate.md
@@ -1,0 +1,97 @@
+# PR-Deflection-Uploaded-Search-Admission-Gate
+
+## Why this slice exists
+
+#1747 added the paid uploaded-report search endpoint that the portfolio can call
+after a CSV-backed report is unlocked. The reviewer found a non-blocking contract
+gap: ATLAS admitted some "full" FAQ rows with looser Python checks than the
+portfolio `isRenderableItem` parser, so the backend could return a search result
+that the UI would reject instead of rendering.
+
+Root cause: `_deflection_report_full_item` checked for broad sequences and
+coerced-ish counts instead of the exact render-facing `TicketFAQItem` fields the
+portfolio validates before showing an uploaded search match.
+
+## Scope (this PR)
+
+Ownership lane: deflection/uploaded-report-search
+Slice phase: Production hardening
+
+1. Tighten uploaded-report search admission so returned `item` payloads must have
+   the portfolio-rendered strings, numeric fields, string arrays, and
+   `term_mappings` object strings.
+2. Add focused route coverage proving malformed full-looking rows are skipped
+   while a valid stored paid artifact item still returns.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `POST /content-ops/deflection-reports/{request_id}/search` continues to
+    return a full paid uploaded report item for valid stored artifacts.
+  - Rows missing portfolio-rendered fields, with non-number `ticket_count` or
+    `opportunity_score`, with non-string array elements, or with malformed
+    `term_mappings` are skipped rather than returned.
+  - The change remains scoped to search-result admission and tests; no producer,
+    storage, auth, payment, or portfolio changes ride along.
+- Affected surfaces:
+  - `extracted_content_pipeline/api/control_surfaces.py`
+  - `tests/test_extracted_content_deflection_submit.py`
+- Risk areas:
+  - Accidentally rejecting valid producer output.
+  - Reintroducing compact search rows that the portfolio cannot render.
+- Reviewer rules triggered: R1, R2, R10, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Uploaded-Search-Admission-Gate.md`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+`_deflection_report_full_item` now mirrors the portfolio server parser's
+rendered-field contract before search scoring can return an item:
+
+- required rendered text fields must already be strings;
+- `ticket_count` and `opportunity_score` must be JSON-number-like Python
+  `int`/`float` values, not bools or digit strings;
+- `steps`, `action_items`, `source_ids`, and `source_labels` must be lists of
+  strings;
+- `term_mappings` must be a list whose entries expose string
+  `customer_term`, `documentation_term`, and `suggestion` fields.
+
+Malformed rows still fail closed by returning `None` from the helper, which keeps
+the existing search loop behavior: skip bad rows, score valid rows, and return the
+best matches from the stored paid artifact only.
+
+## Intentional
+
+- The helper intentionally remains local to uploaded-report search instead of
+  importing or generating a shared TypeScript/Python schema in this small slice.
+- Empty strings and empty arrays remain accepted when their types match the
+  portfolio parser; search scoring still controls whether a row matches the
+  user's query.
+- The search endpoint still skips malformed stored rows instead of failing the
+  whole request, preserving the #1747 behavior for mixed artifacts.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_extracted_content_deflection_submit.py::test_deflection_report_search_returns_full_paid_uploaded_item tests/test_extracted_content_deflection_submit.py::test_deflection_report_search_skips_compact_and_malformed_items tests/test_extracted_content_deflection_submit.py::test_deflection_report_search_only_returns_portfolio_renderable_items -q -- 3 passed.
+- pytest tests/test_extracted_content_deflection_submit.py -q -- 75 passed.
+- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py -- passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-deflection-uploaded-search-admission-gate.md -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 40 |
+| `plans/PR-Deflection-Uploaded-Search-Admission-Gate.md` | 97 |
+| `tests/test_extracted_content_deflection_submit.py` | 41 |
+| **Total** | **178** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -938,6 +938,47 @@ async def test_deflection_report_search_skips_compact_and_malformed_items() -> N
 
 
 @pytest.mark.asyncio
+async def test_deflection_report_search_only_returns_portfolio_renderable_items() -> None:
+    invalid_items = [
+        _search_item(when_to_contact_support=None),
+        _search_item(answer_evidence_status=None),
+        _search_item(ticket_count="2"),
+        _search_item(opportunity_score="6"),
+        _search_item(steps=["Open Analytics.", {"bad": "shape"}]),
+        _search_item(action_items=[1]),
+        _search_item(source_ids="ticket-export-1"),
+        _search_item(source_labels=["ticket-export-1", 1]),
+        _search_item(term_mappings=[None]),
+        _search_item(term_mappings=[{
+            "customer_term": "export",
+            "documentation_term": "download report",
+        }]),
+    ]
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="content-ops-search-renderable",
+        snapshot={"summary": {}},
+        artifact=_search_artifact([*invalid_items, _search_item()]),
+    )
+    await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="content-ops-search-renderable",
+        payment_reference="checkout-session:search",
+    )
+    router = _router(store)
+    search = _route(router, "/ops/deflection-reports/{request_id}/search", "POST")
+
+    payload = await search.endpoint(
+        payload=api_module.DeflectionReportSearchModel(q="export", limit=10),
+        request_id="content-ops-search-renderable",
+    )
+
+    assert payload["count"] == 1
+    assert payload["results"][0]["item"] == _search_item()
+
+
+@pytest.mark.asyncio
 async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     unsafe_artifact = {


### PR DESCRIPTION
Plan: plans/PR-Deflection-Uploaded-Search-Admission-Gate.md
Slice phase: Production hardening

This follow-up hardens the uploaded deflection report search endpoint from #1747 so ATLAS only returns full stored FAQ items that the portfolio `isRenderableItem` parser can render. The prior backend helper accepted broader Python sequence/coerced-count shapes, which could produce a paid search match that the UI rejects.

## Intentional
- Keep the renderable-item guard local to uploaded-report search instead of introducing a cross-language schema in this small follow-up.
- Preserve skip-malformed-row behavior for mixed stored artifacts.
- Accept empty strings and empty arrays when their types match the portfolio parser; search scoring still determines whether a row matches the query.

## Deferred
- None.

## Parked hardening
- None.

## AI reconciliation
- [chatgpt-codex-connector] Reject malformed generated item fields before returning hits: waived. The PR's target is the portfolio `isRenderableItem` render gate, not the full `TicketFAQItem` documentation contract; the reviewer verified the portfolio parser does not check the extra cited fields and the search-result render does not read them.
- [chatgpt-codex-connector] Validate the full term-mapping contract: waived. The portfolio `isTermMapping` gate only requires `customer_term`, `documentation_term`, and `suggestion` strings, so requiring the extra term-mapping counters would exceed the renderability contract this slice intentionally mirrors.
- [chatgpt-codex-connector] Require integer generated scores before returning hits: waived. The portfolio parser uses JavaScript `typeof === 'number'`, which accepts fractional numbers, and the renderer only calls `ticket_count.toLocaleString()` on a number; exact integer validation would be a stronger full-contract check outside this slice.

All findings fixed or waived: yes.

## Verification
- pytest tests/test_extracted_content_deflection_submit.py::test_deflection_report_search_returns_full_paid_uploaded_item tests/test_extracted_content_deflection_submit.py::test_deflection_report_search_skips_compact_and_malformed_items tests/test_extracted_content_deflection_submit.py::test_deflection_report_search_only_returns_portfolio_renderable_items -q -- 3 passed.
- pytest tests/test_extracted_content_deflection_submit.py -q -- 75 passed.
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py -- passed.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-deflection-uploaded-search-admission-gate.md -- passed.

## Diff size
3 files, +169 / -9.
