### PR TITLE
Deflection PII recall advisory artifact

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -319,12 +319,13 @@ jobs:
         # pydantic-settings; this is purely the cross-boundary seam test.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings markdown 'fastapi<0.137' python-multipart slowapi
+          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings markdown 'fastapi<0.137' python-multipart slowapi 'fpdf2>=2.8.0'
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh
 
       - name: Write deflection PII recall advisory artifact
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p artifacts/deflection-pii-recall
           python scripts/score_deflection_pii_recall.py \
@@ -332,6 +333,7 @@ jobs:
             --json
 
       - name: Upload deflection PII recall advisory artifact
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: deflection-pii-recall-advisory

--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -72,6 +72,7 @@ on:
       - "scripts/build_deflection_pii_surrogate_eval_corpus.py"
       - "scripts/score_deflection_pii_recall.py"
       - "tests/test_score_deflection_pii_recall.py"
+      - "tests/test_extracted_pipeline_pii_recall_advisory_artifact.py"
       - "scripts/evaluate_zendesk_product_proof_corpus.py"
       - "scripts/probe_deflection_signal_spike.py"
       - "tests/test_probe_deflection_signal_spike.py"
@@ -214,6 +215,7 @@ on:
       - "scripts/build_deflection_pii_surrogate_eval_corpus.py"
       - "scripts/score_deflection_pii_recall.py"
       - "tests/test_score_deflection_pii_recall.py"
+      - "tests/test_extracted_pipeline_pii_recall_advisory_artifact.py"
       - "scripts/evaluate_zendesk_product_proof_corpus.py"
       - "scripts/probe_deflection_signal_spike.py"
       - "tests/test_probe_deflection_signal_spike.py"
@@ -321,3 +323,17 @@ jobs:
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh
+
+      - name: Write deflection PII recall advisory artifact
+        run: |
+          mkdir -p artifacts/deflection-pii-recall
+          python scripts/score_deflection_pii_recall.py \
+            --output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json \
+            --json
+
+      - name: Upload deflection PII recall advisory artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: deflection-pii-recall-advisory
+          path: artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json
+          if-no-files-found: error

--- a/plans/PR-Deflection-PII-Recall-Advisory-Artifact.md
+++ b/plans/PR-Deflection-PII-Recall-Advisory-Artifact.md
@@ -1,0 +1,109 @@
+# PR-Deflection-PII-Recall-Advisory-Artifact
+
+## Why this slice exists
+
+#1742 Phase 2 calls for the recall/precision harness output to be wired as an
+advisory CI artifact before any headline KPI becomes gating. PR #1746 merged the
+scorer and CI-enrolled tests, but CI still only proves the scorer can run via
+pytest; it does not publish the scorer's JSON result for reviewers/operators to
+inspect.
+
+Root cause: the measurement tool is available, but the CI workflow does not
+produce a durable measurement artifact. This PR fixes that wiring gap by running
+the merged scorer in extracted-checks and uploading its JSON summary as an
+artifact. It intentionally leaves the leak KPI advisory, because the larger
+operator-derived corpus and threshold decision are still open in #1742.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+
+1. Add an extracted-checks step that runs the merged
+   `scripts/score_deflection_pii_recall.py` against the committed tiny surrogate
+   fixture and writes a JSON summary under a CI artifact directory.
+2. Upload that JSON summary with a pinned `actions/upload-artifact` action so
+   every extracted-checks run has a reviewer-visible advisory output.
+3. Keep the scorer command failure-detecting, but do not fail the workflow on
+   the measured headline KPI being nonzero. The current tiny fixture is expected
+   to report leaks; that is the point of the advisory artifact.
+4. Add a small workflow-contract test so the pinned upload step and scorer
+   command cannot disappear while tests stay green.
+
+### Files touched
+
+- `.github/workflows/extracted_pipeline_checks.yml`
+- `plans/PR-Deflection-PII-Recall-Advisory-Artifact.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_pipeline_pii_recall_advisory_artifact.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The extracted-checks workflow runs the merged scorer as a standalone CI
+        command and writes deflection-pii-recall-advisory.json.
+  - [ ] The JSON is uploaded as an artifact using a pinned upload-artifact SHA,
+        not a floating action tag.
+  - [ ] The artifact is advisory: the command may fail on script/runtime errors,
+        but a nonzero `free_high_severity_leak_count` in the tiny fixture does
+        not fail CI.
+  - [ ] A CI-facing test verifies the workflow still contains the scorer run,
+        artifact path/name, pinned upload action, and no threshold-gating flag.
+  - [ ] No scrubber, detector, scorer math, real corpus, or threshold change
+        lands in this PR.
+- Affected surfaces: one workflow, one workflow-contract test, and this plan.
+- Risk areas: accidentally turning the current known leaks into a CI failure,
+  using an unpinned action, or creating an artifact step that can silently drift
+  away from the scorer.
+- Reviewer rules triggered: R1, R2, R6, R10, R12, R14.
+
+## Mechanism
+
+The workflow creates `artifacts/deflection-pii-recall`, runs the existing scorer
+with `--output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json`,
+then uploads that directory with `actions/upload-artifact` pinned to the current
+v4.6.2 SHA. The scorer still exits nonzero for malformed inputs or runtime
+failures, so CI detects broken measurement plumbing. The current measured leak
+counts remain data inside the uploaded JSON; the workflow does not parse or gate
+on those counts.
+
+The test reads `.github/workflows/extracted_pipeline_checks.yml` as text and
+checks the contract markers that matter for this workflow slice: scorer command,
+output filename, artifact name, pinned upload action, and absence of a
+threshold/gating flag.
+
+## Intentional
+
+- No threshold gate yet. #1742 explicitly keeps threshold values and the
+  advisory-to-gating switch as operator decisions.
+- No new wrapper script. The merged scorer already owns JSON output and
+  structured failure; the workflow should call it directly.
+- No real corpus artifact. This uses the committed tiny surrogate fixture until
+  the operator-derived corpus is supplied.
+
+## Deferred
+
+- Operator-supplied larger gold corpus and corpus-size/archetype decision.
+- Threshold configuration and advisory-to-gating switch.
+- Follow-up scrubber/precision fixes for the current tiny-corpus measured gaps.
+
+Parked hardening: none.
+
+## Verification
+
+- git ls-remote https://github.com/actions/upload-artifact.git refs/tags/v4 refs/tags/v4.6.2 -- both resolve to `ea165f8d65b6e75b540449e92b4886f43607fa02`.
+- python -m py_compile tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
+- pytest tests/test_extracted_pipeline_pii_recall_advisory_artifact.py -- 3 passed.
+- python scripts/score_deflection_pii_recall.py --output /tmp/deflection-pii-recall-artifact-test/deflection-pii-recall-advisory.json --json -- status ok and wrote a non-empty JSON artifact.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/extracted_pipeline_checks.yml` | 16 |
+| `plans/PR-Deflection-PII-Recall-Advisory-Artifact.md` | 109 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_pipeline_pii_recall_advisory_artifact.py` | 44 |
+| **Total** | **170** |

--- a/plans/PR-Deflection-PII-Recall-Advisory-Artifact.md
+++ b/plans/PR-Deflection-PII-Recall-Advisory-Artifact.md
@@ -14,6 +14,12 @@ the merged scorer in extracted-checks and uploading its JSON summary as an
 artifact. It intentionally leaves the leak KPI advisory, because the larger
 operator-derived corpus and threshold decision are still open in #1742.
 
+Review update root cause: the first workflow wiring placed the advisory writer
+after the extracted test bundle without an explicit step condition and did not
+install the PDF renderer dependency. That meant a red test bundle could suppress
+the advisory output, and a clean runner could produce an advisory result with
+the paid-PDF surface skipped. This PR fixes both at the workflow boundary.
+
 ## Scope (this PR)
 
 Ownership lane: deflection/pii-recall-precision-testing
@@ -29,6 +35,9 @@ Slice phase: Vertical slice
    to report leaks; that is the point of the advisory artifact.
 4. Add a small workflow-contract test so the pinned upload step and scorer
    command cannot disappear while tests stay green.
+5. Install the PDF renderer dependency in this workflow and keep the write/upload
+   steps running when prior checks fail, so red extracted checks still preserve
+   the advisory JSON when the job is not cancelled.
 
 ### Files touched
 
@@ -47,6 +56,10 @@ Slice phase: Vertical slice
   - [ ] The artifact is advisory: the command may fail on script/runtime errors,
         but a nonzero `free_high_severity_leak_count` in the tiny fixture does
         not fail CI.
+  - [ ] Red extracted checks do not suppress the advisory write/upload steps
+        when the job is not cancelled.
+  - [ ] The workflow installs the PDF renderer dependency so the paid-PDF surface
+        is scored on clean CI runners.
   - [ ] A CI-facing test verifies the workflow still contains the scorer run,
         artifact path/name, pinned upload action, and no threshold-gating flag.
   - [ ] No scrubber, detector, scorer math, real corpus, or threshold change
@@ -59,18 +72,21 @@ Slice phase: Vertical slice
 
 ## Mechanism
 
-The workflow creates `artifacts/deflection-pii-recall`, runs the existing scorer
-with `--output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json`,
+The workflow installs `fpdf2>=2.8.0`, creates `artifacts/deflection-pii-recall`,
+runs the existing scorer with
+`--output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json`,
 then uploads that directory with `actions/upload-artifact` pinned to the current
-v4.6.2 SHA. The scorer still exits nonzero for malformed inputs or runtime
-failures, so CI detects broken measurement plumbing. The current measured leak
-counts remain data inside the uploaded JSON; the workflow does not parse or gate
-on those counts.
+v4.6.2 SHA. The write and upload steps use GitHub's not-cancelled condition so a
+red test bundle does not suppress the advisory output. The scorer still exits
+nonzero for malformed inputs or runtime failures, so CI detects broken
+measurement plumbing; when the scorer can write its structured error summary,
+the upload step still preserves it. The current measured leak counts remain data
+inside the uploaded JSON; the workflow does not parse or gate on those counts.
 
 The test reads `.github/workflows/extracted_pipeline_checks.yml` as text and
 checks the contract markers that matter for this workflow slice: scorer command,
-output filename, artifact name, pinned upload action, and absence of a
-threshold/gating flag.
+output filename, artifact name, pinned upload action, PDF dependency, non-cancelled
+step conditions, and absence of a threshold/gating flag.
 
 ## Intentional
 
@@ -93,8 +109,8 @@ Parked hardening: none.
 
 - git ls-remote https://github.com/actions/upload-artifact.git refs/tags/v4 refs/tags/v4.6.2 -- both resolve to `ea165f8d65b6e75b540449e92b4886f43607fa02`.
 - python -m py_compile tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
-- pytest tests/test_extracted_pipeline_pii_recall_advisory_artifact.py -- 3 passed.
-- python scripts/score_deflection_pii_recall.py --output /tmp/deflection-pii-recall-artifact-test/deflection-pii-recall-advisory.json --json -- status ok and wrote a non-empty JSON artifact.
+- pytest tests/test_extracted_pipeline_pii_recall_advisory_artifact.py -- 4 passed.
+- python scripts/score_deflection_pii_recall.py --output /tmp/deflection-pii-recall-artifact-test/deflection-pii-recall-advisory.json --json -- status ok, wrote a non-empty JSON artifact, and reported paid_pdf skipped=false.
 - python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
 - bash scripts/check_ascii_python.sh -- passed.
 
@@ -102,8 +118,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/extracted_pipeline_checks.yml` | 16 |
-| `plans/PR-Deflection-PII-Recall-Advisory-Artifact.md` | 109 |
+| `.github/workflows/extracted_pipeline_checks.yml` | 20 |
+| `plans/PR-Deflection-PII-Recall-Advisory-Artifact.md` | 125 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_extracted_pipeline_pii_recall_advisory_artifact.py` | 44 |
-| **Total** | **170** |
+| `tests/test_extracted_pipeline_pii_recall_advisory_artifact.py` | 69 |
+| **Total** | **215** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -221,6 +221,7 @@ pytest \
   tests/test_audit_ui_test_enrollment.py \
   tests/test_archive_plans.py \
   tests/test_drain_hardening.py \
+  tests/test_extracted_pipeline_pii_recall_advisory_artifact.py \
   tests/test_extracted_pipeline_route_ci_contract.py \
   tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_content_pipeline_reasoning_archetypes.py \

--- a/tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
+++ b/tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "extracted_pipeline_checks.yml"
+CHECKS = ROOT / "scripts" / "run_extracted_pipeline_checks.sh"
+
+
+def test_extracted_checks_uploads_deflection_pii_recall_advisory_artifact() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Write deflection PII recall advisory artifact" in workflow
+    assert "python scripts/score_deflection_pii_recall.py" in workflow
+    assert (
+        "--output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json"
+        in workflow
+    )
+    assert "Upload deflection PII recall advisory artifact" in workflow
+    assert (
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+        in workflow
+    )
+    assert "name: deflection-pii-recall-advisory" in workflow
+    assert (
+        "path: artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json"
+        in workflow
+    )
+    assert "if-no-files-found: error" in workflow
+
+
+def test_deflection_pii_recall_artifact_stays_advisory_not_gating() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "--require-free-high-severity-pass" not in workflow
+    assert "free_high_severity_pass" not in workflow
+    assert "free_high_severity_leak_count" not in workflow
+
+
+def test_advisory_artifact_contract_test_is_ci_enrolled() -> None:
+    checks = CHECKS.read_text(encoding="utf-8")
+
+    assert "tests/test_extracted_pipeline_pii_recall_advisory_artifact.py" in checks

--- a/tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
+++ b/tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
@@ -8,8 +8,25 @@ WORKFLOW = ROOT / ".github" / "workflows" / "extracted_pipeline_checks.yml"
 CHECKS = ROOT / "scripts" / "run_extracted_pipeline_checks.sh"
 
 
+def _workflow_step_block(workflow: str, name: str) -> str:
+    marker = f"      - name: {name}"
+    start = workflow.index(marker)
+    next_step = workflow.find("\n      - name:", start + len(marker))
+    if next_step == -1:
+        return workflow[start:]
+    return workflow[start:next_step]
+
+
 def test_extracted_checks_uploads_deflection_pii_recall_advisory_artifact() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
+    write_step = _workflow_step_block(
+        workflow,
+        "Write deflection PII recall advisory artifact",
+    )
+    upload_step = _workflow_step_block(
+        workflow,
+        "Upload deflection PII recall advisory artifact",
+    )
 
     assert "Write deflection PII recall advisory artifact" in workflow
     assert "python scripts/score_deflection_pii_recall.py" in workflow
@@ -17,17 +34,25 @@ def test_extracted_checks_uploads_deflection_pii_recall_advisory_artifact() -> N
         "--output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json"
         in workflow
     )
+    assert "if: ${{ !cancelled() }}" in write_step
     assert "Upload deflection PII recall advisory artifact" in workflow
     assert (
         "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
         in workflow
     )
+    assert "if: ${{ !cancelled() }}" in upload_step
     assert "name: deflection-pii-recall-advisory" in workflow
     assert (
         "path: artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json"
         in workflow
     )
     assert "if-no-files-found: error" in workflow
+
+
+def test_deflection_pii_recall_artifact_scores_paid_pdf_surface_in_ci() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "'fpdf2>=2.8.0'" in workflow
 
 
 def test_deflection_pii_recall_artifact_stays_advisory_not_gating() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Recall-Advisory-Artifact.md
Slice phase: Vertical slice

#1742 now has a merged scorer, but extracted-checks only proves the scorer through tests; it does not publish the measurement output for reviewers/operators. This PR runs the scorer in CI, writes the JSON summary, and uploads it as an advisory artifact while keeping the current headline KPI non-gating.

## Intentional
- No threshold gate yet; #1742 keeps threshold values and the advisory-to-gating switch as operator decisions.
- No scorer, scrubber, detector, real corpus, or report-surface logic changes in this slice.
- The workflow calls the existing scorer directly because it already owns JSON output and structured failures.
- The upload action is pinned to `ea165f8d65b6e75b540449e92b4886f43607fa02` (`actions/upload-artifact` v4.6.2).
- The write/upload steps now run under the workflow's not-cancelled condition so red extracted checks do not suppress the advisory artifact path.

## Deferred
- Operator-supplied larger gold corpus and corpus-size/archetype decision.
- Threshold configuration and advisory-to-gating switch.
- Follow-up scrubber/precision fixes for the current tiny-corpus measured gaps.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Codex P2: keep publishing the advisory artifact on red extracted checks -- fixed by running both write and upload under the workflow's not-cancelled condition.
- Codex P2: install PDF dependency before writing the recall artifact -- fixed by installing `fpdf2>=2.8.0` in extracted-checks and adding a contract test.

## Verification
- git ls-remote https://github.com/actions/upload-artifact.git refs/tags/v4 refs/tags/v4.6.2 -- both resolve to `ea165f8d65b6e75b540449e92b4886f43607fa02`.
- python -m py_compile tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
- pytest tests/test_extracted_pipeline_pii_recall_advisory_artifact.py -- 4 passed.
- python scripts/score_deflection_pii_recall.py --output /tmp/deflection-pii-recall-artifact-test/deflection-pii-recall-advisory.json --json -- status ok, wrote a non-empty JSON artifact, and reported paid_pdf skipped=false.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
- bash scripts/check_ascii_python.sh -- passed.

## Diff size
4 files, +215 / -0
