### PR TITLE
Deflection priority status scoring

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -470,44 +470,15 @@
                 "status": "insufficient_data"
               },
               "estimated_support_cost": 27.0,
-              "fix_type": "publish_help_center_answer",
-              "opportunity_score": 2,
-              "owner_lane": "reporting friction",
-              "question": "How do I export attribution reports?",
-              "rank": 1,
-              "recommended_action": "Publish or adapt the drafted resolution into help-center or macro copy.",
-              "recommended_title": "How do I export attribution reports?",
-              "representative_phrasing": [
-                "How do I export attribution reports?",
-                "reporting friction"
-              ],
-              "status": "Draft ready",
-              "support_cost_formula": "ticket_count * assisted_contact_cost",
-              "support_cost_source": "default_assisted_contact_benchmark",
-              "ticket_count": 2,
-              "top_evidence": [
-                {
-                  "evidence_quote": "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\"",
-                  "source_id": "ticket-export-1"
-                },
-                {
-                  "evidence_quote": "",
-                  "source_id": "ticket-export-2"
-                }
-              ]
-            },
-            {
-              "confidence": "medium",
-              "csat_signal": {
-                "csat_present_count": 0,
-                "negative_csat_ticket_count": 0,
-                "numeric_average": null,
-                "status": "insufficient_data"
-              },
-              "estimated_support_cost": 27.0,
               "fix_type": "create_missing_answer",
               "opportunity_score": 2,
               "owner_lane": "sso setup",
+              "priority_drivers": [
+                "repeat_volume",
+                "missing_answer",
+                "benchmark_cost"
+              ],
+              "priority_score": 84,
               "question": "How do I enable SSO for my team?",
               "rank": 2,
               "recommended_action": "Write and approve the missing answer for this repeated customer question.",
@@ -528,6 +499,47 @@
                 {
                   "evidence_quote": "",
                   "source_id": "ticket-sso-2"
+                }
+              ]
+            },
+            {
+              "confidence": "medium",
+              "csat_signal": {
+                "csat_present_count": 0,
+                "negative_csat_ticket_count": 0,
+                "numeric_average": null,
+                "status": "insufficient_data"
+              },
+              "estimated_support_cost": 27.0,
+              "fix_type": "publish_help_center_answer",
+              "opportunity_score": 2,
+              "owner_lane": "reporting friction",
+              "priority_drivers": [
+                "repeat_volume",
+                "draft_ready",
+                "benchmark_cost"
+              ],
+              "priority_score": 59,
+              "question": "How do I export attribution reports?",
+              "rank": 1,
+              "recommended_action": "Publish or adapt the drafted resolution into help-center or macro copy.",
+              "recommended_title": "How do I export attribution reports?",
+              "representative_phrasing": [
+                "How do I export attribution reports?",
+                "reporting friction"
+              ],
+              "status": "Draft ready",
+              "support_cost_formula": "ticket_count * assisted_contact_cost",
+              "support_cost_source": "default_assisted_contact_benchmark",
+              "ticket_count": 2,
+              "top_evidence": [
+                {
+                  "evidence_quote": "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\"",
+                  "source_id": "ticket-export-1"
+                },
+                {
+                  "evidence_quote": "",
+                  "source_id": "ticket-export-2"
                 }
               ]
             }
@@ -579,6 +591,12 @@
               "fix_type": "create_missing_answer",
               "opportunity_score": 2,
               "owner_lane": "sso setup",
+              "priority_drivers": [
+                "repeat_volume",
+                "missing_answer",
+                "benchmark_cost"
+              ],
+              "priority_score": 84,
               "question": "How do I enable SSO for my team?",
               "rank": 2,
               "recommended_action": "Write and approve the missing answer for this repeated customer question.",
@@ -641,6 +659,12 @@
               "fix_type": "publish_help_center_answer",
               "opportunity_score": 2,
               "owner_lane": "reporting friction",
+              "priority_drivers": [
+                "repeat_volume",
+                "draft_ready",
+                "benchmark_cost"
+              ],
+              "priority_score": 59,
               "question": "How do I export attribution reports?",
               "rank": 1,
               "recommended_action": "Publish or adapt the drafted resolution into help-center or macro copy.",
@@ -714,44 +738,15 @@
                 "status": "insufficient_data"
               },
               "estimated_support_cost": 27.0,
-              "fix_type": "publish_help_center_answer",
-              "opportunity_score": 2,
-              "owner_lane": "reporting friction",
-              "question": "How do I export attribution reports?",
-              "rank": 1,
-              "recommended_action": "Publish or adapt the drafted resolution into help-center or macro copy.",
-              "recommended_title": "How do I export attribution reports?",
-              "representative_phrasing": [
-                "How do I export attribution reports?",
-                "reporting friction"
-              ],
-              "status": "Draft ready",
-              "support_cost_formula": "ticket_count * assisted_contact_cost",
-              "support_cost_source": "default_assisted_contact_benchmark",
-              "ticket_count": 2,
-              "top_evidence": [
-                {
-                  "evidence_quote": "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\"",
-                  "source_id": "ticket-export-1"
-                },
-                {
-                  "evidence_quote": "",
-                  "source_id": "ticket-export-2"
-                }
-              ]
-            },
-            {
-              "confidence": "medium",
-              "csat_signal": {
-                "csat_present_count": 0,
-                "negative_csat_ticket_count": 0,
-                "numeric_average": null,
-                "status": "insufficient_data"
-              },
-              "estimated_support_cost": 27.0,
               "fix_type": "create_missing_answer",
               "opportunity_score": 2,
               "owner_lane": "sso setup",
+              "priority_drivers": [
+                "repeat_volume",
+                "missing_answer",
+                "benchmark_cost"
+              ],
+              "priority_score": 84,
               "question": "How do I enable SSO for my team?",
               "rank": 2,
               "recommended_action": "Write and approve the missing answer for this repeated customer question.",
@@ -772,6 +767,47 @@
                 {
                   "evidence_quote": "",
                   "source_id": "ticket-sso-2"
+                }
+              ]
+            },
+            {
+              "confidence": "medium",
+              "csat_signal": {
+                "csat_present_count": 0,
+                "negative_csat_ticket_count": 0,
+                "numeric_average": null,
+                "status": "insufficient_data"
+              },
+              "estimated_support_cost": 27.0,
+              "fix_type": "publish_help_center_answer",
+              "opportunity_score": 2,
+              "owner_lane": "reporting friction",
+              "priority_drivers": [
+                "repeat_volume",
+                "draft_ready",
+                "benchmark_cost"
+              ],
+              "priority_score": 59,
+              "question": "How do I export attribution reports?",
+              "rank": 1,
+              "recommended_action": "Publish or adapt the drafted resolution into help-center or macro copy.",
+              "recommended_title": "How do I export attribution reports?",
+              "representative_phrasing": [
+                "How do I export attribution reports?",
+                "reporting friction"
+              ],
+              "status": "Draft ready",
+              "support_cost_formula": "ticket_count * assisted_contact_cost",
+              "support_cost_source": "default_assisted_contact_benchmark",
+              "ticket_count": 2,
+              "top_evidence": [
+                {
+                  "evidence_quote": "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\"",
+                  "source_id": "ticket-export-1"
+                },
+                {
+                  "evidence_quote": "",
+                  "source_id": "ticket-export-2"
                 }
               ]
             }

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -160,8 +160,12 @@ The action-oriented paid sections are a work queue, not a full ticket archive:
 - `priority_fix_queue` carries enough ranked items for the largest advertised
   bounded surface (`pdf_limit`, currently 10) while `result_page_limit` tells
   the result page to render only the top three.
+- Action rows include deterministic `priority_score` and bounded
+  `priority_drivers` enum labels. The score is based on repeat volume,
+  benchmark support cost, answer evidence status, confidence, reopened-ticket
+  signal, and CSAT signal; it is not produced by an LLM or cloud classifier.
 - `top_unresolved_repeats` contains unresolved repeated questions only; one-off
-  questions stay out of repeat accounting.
+  or low-confidence questions stay out of repeat accounting.
 - `drafted_resolutions` contains publishable or adaptable answer drafts.
 - `already_covered_still_recurring` flags proven answers whose status/CSAT
   signals suggest discoverability or answer-quality work.

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -50,6 +50,13 @@ _ASSISTED_CONTACT_COST_LABEL = "$13.50"
 _ACTION_RESULT_PAGE_LIMIT = 3
 _ACTION_PDF_LIMIT = 10
 _ACTION_BACKLOG_LIMIT = 25
+_ACTION_STATUS_PRIORITY_WEIGHTS = MappingProxyType({
+    "Needs answer": 50,
+    "Already covered but still recurring": 45,
+    "Needs review": 35,
+    "Draft ready": 25,
+    "Low confidence": 0,
+})
 _SOURCE_EXAMPLE_LIMIT = 3
 _DEFLECTION_BOUNDARY_LEFT = r"(?<![A-Za-z0-9])"
 _DEFLECTION_BOUNDARY_RIGHT = r"(?![A-Za-z0-9])"
@@ -1981,7 +1988,7 @@ def _priority_fix_queue_data(items: Sequence[Mapping[str, Any]]) -> dict[str, An
 def _top_unresolved_repeats_data(items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     unresolved = [
         item for item in _action_items(items)
-        if item["status"] in {"Needs answer", "Needs review", "Low confidence"}
+        if item["status"] in {"Needs answer", "Needs review"}
         and _int(item.get("ticket_count")) >= 2
     ]
     top_items = unresolved[:_ACTION_RESULT_PAGE_LIMIT]
@@ -2033,6 +2040,7 @@ def _action_items(items: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     return sorted(
         rows,
         key=lambda row: (
+            -_int(row["priority_score"]),
             -float(row["estimated_support_cost"]),
             -_int(row["opportunity_score"]),
             _int(row["rank"]),
@@ -2051,6 +2059,8 @@ def _action_item(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
         "fix_type": _action_fix_type(status),
         "csat_signal": _action_csat_signal(item),
         "confidence": _action_confidence(item),
+        "priority_score": _action_priority_score(item, status),
+        "priority_drivers": _action_priority_drivers(item, status),
         "recommended_title": _action_recommended_title(item),
         "recommended_action": _action_recommended_action(status),
         "representative_phrasing": _action_representative_phrasing(item),
@@ -2064,17 +2074,26 @@ def _action_item(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _action_status(item: Mapping[str, Any]) -> str:
-    if _ticket_count(item) <= 0 or not _text(item.get("question")):
+    ticket_count = _ticket_count(item)
+    has_question = bool(_text(item.get("question")))
+    if ticket_count <= 0 or not has_question:
         return "Low confidence"
-    if _text(item.get("answer_evidence_status")) != _RESOLUTION_EVIDENCE_STATUS:
+    if ticket_count < 2 or _source_count(item) < 2:
+        return "Low confidence"
+    has_resolution_evidence = (
+        _text(item.get("answer_evidence_status")) == _RESOLUTION_EVIDENCE_STATUS
+    )
+    has_answer = bool(_text(item.get("answer")))
+    if not has_resolution_evidence:
         return "Needs answer"
     diagnostics = _item_outcome_diagnostics(item)
-    if (
+    has_pain_after_answer = (
         _int(diagnostics.get("reopened_ticket_count")) > 0
         or _int(diagnostics.get("negative_csat_ticket_count")) > 0
-    ):
+    )
+    if has_answer and has_pain_after_answer:
         return "Already covered but still recurring"
-    if _text(item.get("answer")):
+    if has_answer:
         return "Draft ready"
     return "Needs review"
 
@@ -2118,11 +2137,64 @@ def _action_csat_signal(item: Mapping[str, Any]) -> dict[str, Any]:
 
 def _action_confidence(item: Mapping[str, Any]) -> str:
     ticket_count = _ticket_count(item)
-    if ticket_count >= 5 and _source_count(item) >= 3:
+    source_count = _source_count(item)
+    if ticket_count < 2 or source_count < 2:
+        return "low"
+    if ticket_count >= 5 and source_count >= 3:
         return "high"
-    if ticket_count >= 2:
-        return "medium"
-    return "low"
+    return "medium"
+
+
+def _action_priority_score(item: Mapping[str, Any], status: str) -> int:
+    diagnostics = _item_outcome_diagnostics(item)
+    ticket_count = _ticket_count(item)
+    score = int(round(_support_cost(ticket_count)))
+    score += _int(item.get("opportunity_score"))
+    score += int(_ACTION_STATUS_PRIORITY_WEIGHTS.get(status, 0))
+    score += _int(diagnostics.get("negative_csat_ticket_count")) * 30
+    score += _int(diagnostics.get("reopened_ticket_count")) * 20
+    if ticket_count >= 5:
+        score += 15
+    elif ticket_count >= 2:
+        score += 5
+    average = diagnostics.get("csat_score_average")
+    present_count = _int(diagnostics.get("csat_present_count"))
+    if present_count >= 3 and average is not None:
+        try:
+            parsed_average = float(average)
+        except (TypeError, ValueError):
+            parsed_average = 0.0
+        if parsed_average < 3.0:
+            score += int(round((3.0 - parsed_average) * 10))
+    if _action_confidence(item) == "low":
+        score -= 25
+    return max(0, score)
+
+
+def _action_priority_drivers(item: Mapping[str, Any], status: str) -> list[str]:
+    diagnostics = _item_outcome_diagnostics(item)
+    drivers: list[str] = []
+    ticket_count = _ticket_count(item)
+    if ticket_count >= 5:
+        drivers.append("high_repeat_volume")
+    elif ticket_count >= 2:
+        drivers.append("repeat_volume")
+    drivers.append({
+        "Draft ready": "draft_ready",
+        "Needs answer": "missing_answer",
+        "Needs review": "review_resolution_evidence",
+        "Low confidence": "low_confidence",
+        "Already covered but still recurring": "already_covered_recurring",
+    }.get(status, "review_before_action"))
+    if _int(diagnostics.get("negative_csat_ticket_count")) > 0:
+        drivers.append("negative_csat")
+    if _int(diagnostics.get("reopened_ticket_count")) > 0:
+        drivers.append("reopened_after_answer")
+    if _action_confidence(item) == "low" and "low_confidence" not in drivers:
+        drivers.append("low_confidence")
+    if _support_cost(ticket_count) > 0:
+        drivers.append("benchmark_cost")
+    return drivers[:5]
 
 
 def _action_recommended_title(item: Mapping[str, Any]) -> str:

--- a/plans/PR-Deflection-Priority-Status-Scoring.md
+++ b/plans/PR-Deflection-Priority-Status-Scoring.md
@@ -1,0 +1,143 @@
+# PR-Deflection-Priority-Status-Scoring
+
+## Why this slice exists
+
+#1612's locked report-shape plan says the paid report should become a work
+queue, not a ticket archive. #1745 landed S1: the `deflection.v1` action
+sections and fail-closed Snapshot projection. That contract intentionally used
+a conservative deterministic baseline; it exposes action rows, but the priority
+queue still sorts mostly by estimated support cost and the status classifier
+does not yet prove the S2 cases from the plan.
+
+This slice implements S2's narrow behavior: deterministic priority scoring and
+status classification for the action sections. The goal is not a renderer
+refresh; it is to make the persisted model tell a support lead which repeat to
+fix first and why, using only repeat volume, benchmark support cost, answer
+evidence status, outcome/CSAT signal, and evidence confidence already present in
+the model.
+
+This slice exceeds the 400 LOC soft budget because the persisted model contract
+changes and the checked-in frontend example JSON is producer-synced. Splitting
+the example update from the classifier would make the code and documented
+contract disagree.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-actionability
+Slice phase: Functional validation
+
+1. Add an explicit deterministic `priority_score` and bounded
+   `priority_drivers` to paid action rows.
+2. Tune status classification so low-confidence/evidence-sparse rows are not
+   promoted as publishable work, unresolved repeats stay actionable, drafted
+   answers remain publish-ready, and already-covered-but-still-recurring rows
+   are called out when CSAT/reopen signals show unresolved customer pain.
+3. Sort the priority queue by the S2 score, then support cost/opportunity as
+   stable tie-breakers.
+4. Keep result-page/email/PDF rendering unchanged; S3/S4 consume this model
+   contract later.
+
+### Review Contract
+
+- Acceptance criteria:
+  - High-repeat rows with negative CSAT/reopen signal outrank otherwise similar
+    high-repeat rows with good/absent CSAT.
+  - Unresolved repeats with no proven answer receive `Needs answer` and a
+    missing-answer driver.
+  - Scoped resolution evidence with publishable answer copy receives
+    `Draft ready`.
+  - Scoped resolution evidence with customer pain after publication receives
+    `Already covered but still recurring`.
+  - Evidence-sparse or one-ticket rows receive `Low confidence` and do not enter
+    `top_unresolved_repeats`.
+  - Owner lane and fix type remain deterministic-only with `Unknown` fallback;
+    no LLM/cloud calls are introduced in report rendering.
+- Affected surfaces: paid `deflection.v1` report model action-section data,
+  frontend contract example/docs, focused report model tests, and this plan.
+- Risk areas: changing paid model shape, priority ordering regressions, and
+  accidentally implying CSAT/cost precision beyond the benchmark/source data.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+- boundary-probe: Required. This PR changes a classifier/ranking gate; review
+  should inspect the same-count CSAT ordering probe and low-confidence
+  rejection probe.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Priority-Status-Scoring.md`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+Action rows gain an internal scoring helper. The score starts from the existing
+opportunity/support-cost shape and adds deterministic weights for status,
+negative CSAT, reopened tickets, and confidence. The score is persisted as
+`priority_score` so later renderers can explain the queue without recomputing
+private heuristics.
+
+`priority_drivers` is a bounded list of safe enum strings such as
+`high_repeat_volume`, `missing_answer`, `negative_csat`, `reopened_after_answer`,
+`draft_ready`, and `low_confidence`. The labels describe why an item is ordered
+where it is without echoing raw customer text, ticket IDs, or evidence quotes.
+
+The classifier remains deterministic-only:
+
+- empty/one-ticket/evidence-sparse rows become `Low confidence`;
+- rows without scoped resolution evidence become `Needs answer`;
+- scoped answers with reopen/negative-CSAT signal become
+  `Already covered but still recurring`;
+- scoped answers with answer copy become `Draft ready`;
+- scoped evidence without answer copy remains `Needs review`.
+
+The queue sort key changes to `priority_score`, then estimated support cost,
+opportunity score, and original rank for stable ties.
+
+## Intentional
+
+- No renderer refresh. Result page, email, and PDF layout changes remain S3/S4.
+- No LLM, cloud classifier, or inferred product taxonomy. Owner lane stays
+  deterministic from existing topic data with `Unknown` fallback.
+- No source-cost precision. Support cost remains benchmark-only unless future
+  source data supplies a defensible cost basis.
+- No Snapshot expansion. These action sections remain paid-only and absent from
+  the free projection.
+
+## Deferred
+
+- S3 result-page actionable dashboard using the priority score/drivers.
+- S4 curated email/PDF refresh using the same model sections.
+- S5 cross-surface QA checks for action-section agreement.
+- S6 monthly delta and macro/writeback upsell fields.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused report and frontend contract-doc tests -- 95 passed.
+- Snapshot/report drift tests -- 10 passed.
+- Combined focused report, frontend contract-doc, and snapshot/report drift
+  tests -- 105 passed.
+- Sparse-evidence review regression covered in the focused report tests:
+  `ticket_count >= 2` with fewer than two sources now reports `Low confidence`,
+  `confidence: low`, and receives the low-confidence score penalty.
+- Python compile check for the report producer and focused report test module
+  -- passed.
+- Plan sync check for this plan against `origin/main` -- passed.
+- Extracted package gauntlet:
+  manifest validation, reasoning import audit, standalone audit, and ASCII
+  policy -- passed.
+- Full extracted pipeline check bundle -- passed; reasoning core 295 passed,
+  extracted content 4764 passed / 15 skipped.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_deflection_report_example.json` | 132 |
+| `docs/frontend/content_ops_faq_report_contract.md` | 6 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 92 |
+| `plans/PR-Deflection-Priority-Status-Scoring.md` | 143 |
+| `tests/test_content_ops_deflection_report.py` | 168 |
+| **Total** | **541** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -517,7 +517,175 @@ def test_deflection_action_sections_classify_recurring_covered_answers() -> None
         "negative_csat_ticket_count": 2,
         "numeric_average": 2.0,
     }
+    assert "negative_csat" in recurring["items"][0]["priority_drivers"]
+    assert "reopened_after_answer" in recurring["items"][0]["priority_drivers"]
     assert priority["status_counts"] == {"Already covered but still recurring": 1}
+
+
+def test_deflection_priority_queue_scores_status_and_csat_signals() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=22,
+        ticket_source_count=22,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "How do I find the saved analytics dashboard?",
+                "customer_wording": "dashboard answer still not helping",
+                "topic": "analytics",
+                "weighted_frequency": 12,
+                "ticket_count": 6,
+                "opportunity_score": 12,
+                "answer": "Open Analytics and choose Saved dashboards.",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "source_ids": tuple(f"ticket-risk-{index}" for index in range(6)),
+                "outcome_diagnostics": {
+                    "csat_present_count": 4,
+                    "csat_score_average": 1.5,
+                    "negative_csat_ticket_count": 3,
+                    "reopened_ticket_count": 1,
+                    "ticket_status_summary": {"reopened": 1, "resolved": 5},
+                },
+            },
+            {
+                "question": "How do I export attribution reports?",
+                "customer_wording": "export attribution reports",
+                "topic": "exports",
+                "weighted_frequency": 11,
+                "ticket_count": 6,
+                "opportunity_score": 12,
+                "answer": "Open Attribution and select Download report.",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "source_ids": tuple(f"ticket-good-{index}" for index in range(6)),
+                "outcome_diagnostics": {
+                    "csat_present_count": 4,
+                    "csat_score_average": 4.5,
+                    "negative_csat_ticket_count": 0,
+                    "reopened_ticket_count": 0,
+                    "ticket_status_summary": {"resolved": 6},
+                },
+            },
+            {
+                "question": "How do I configure SSO for contractors?",
+                "customer_wording": "contractor SSO setup",
+                "topic": "identity",
+                "weighted_frequency": 7,
+                "ticket_count": 4,
+                "opportunity_score": 9,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": tuple(f"ticket-missing-{index}" for index in range(4)),
+            },
+            {
+                "question": "How do I change invoice contacts?",
+                "customer_wording": "invoice contact change",
+                "topic": "billing",
+                "weighted_frequency": 6,
+                "ticket_count": 4,
+                "opportunity_score": 9,
+                "answer": "Open Billing, choose Contacts, and update the recipient.",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "source_ids": tuple(f"ticket-draft-{index}" for index in range(4)),
+            },
+            {
+                "question": "How do I review warehouse sync failures?",
+                "customer_wording": "warehouse sync failed",
+                "topic": "integrations",
+                "weighted_frequency": 5,
+                "ticket_count": 3,
+                "opportunity_score": 8,
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "source_ids": tuple(f"ticket-review-{index}" for index in range(3)),
+            },
+            {
+                "question": "Why did my imported contacts duplicate?",
+                "customer_wording": "contacts imported twice",
+                "topic": "imports",
+                "weighted_frequency": 5,
+                "ticket_count": 3,
+                "opportunity_score": 20,
+                "answer_evidence_status": "draft_needs_review",
+                "source_count": 1,
+                "source_ids": ("ticket-sparse-only",),
+            },
+            {
+                "question": "Can I rename one workspace?",
+                "customer_wording": "rename one workspace",
+                "topic": "workspace",
+                "weighted_frequency": 1,
+                "ticket_count": 1,
+                "opportunity_score": 20,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": ("ticket-one-off",),
+            },
+        ),
+    )
+
+    sections = {
+        section["id"]: section
+        for section in build_deflection_report_artifact(result).as_dict()[
+            "report_model"
+        ]["sections"]
+    }
+    priority = sections["priority_fix_queue"]["data"]
+    items = {item["question"]: item for item in priority["items"]}
+
+    assert priority["items"][0]["question"] == (
+        "How do I find the saved analytics dashboard?"
+    )
+    assert items["How do I find the saved analytics dashboard?"]["status"] == (
+        "Already covered but still recurring"
+    )
+    assert items["How do I export attribution reports?"]["status"] == "Draft ready"
+    assert (
+        items["How do I find the saved analytics dashboard?"]["priority_score"]
+        > items["How do I export attribution reports?"]["priority_score"]
+    )
+    assert items["How do I configure SSO for contractors?"]["status"] == (
+        "Needs answer"
+    )
+    assert "missing_answer" in items[
+        "How do I configure SSO for contractors?"
+    ]["priority_drivers"]
+    assert items["How do I change invoice contacts?"]["status"] == "Draft ready"
+    assert (
+        items["How do I configure SSO for contractors?"]["priority_score"]
+        > items["How do I change invoice contacts?"]["priority_score"]
+    )
+    assert items["How do I review warehouse sync failures?"]["status"] == (
+        "Needs review"
+    )
+    sparse = items["Why did my imported contacts duplicate?"]
+    assert sparse["status"] == "Low confidence"
+    assert sparse["confidence"] == "low"
+    assert sparse["priority_drivers"].count("low_confidence") == 1
+    sparse_score_without_low_penalty = (
+        int(round(sparse["estimated_support_cost"]))
+        + sparse["opportunity_score"]
+        + 5
+    )
+    assert sparse["priority_score"] == sparse_score_without_low_penalty - 25
+    assert items["Can I rename one workspace?"]["status"] == "Low confidence"
+    assert "low_confidence" in items["Can I rename one workspace?"][
+        "priority_drivers"
+    ]
+    assert priority["status_counts"] == {
+        "Already covered but still recurring": 1,
+        "Draft ready": 2,
+        "Low confidence": 2,
+        "Needs answer": 1,
+        "Needs review": 1,
+    }
+
+    unresolved = sections["top_unresolved_repeats"]["data"]
+    unresolved_questions = {item["question"] for item in unresolved["items"]}
+    assert "How do I configure SSO for contractors?" in unresolved_questions
+    assert "How do I review warehouse sync failures?" in unresolved_questions
+    assert "Why did my imported contacts duplicate?" not in unresolved_questions
+    assert "Can I rename one workspace?" not in unresolved_questions
 
 
 def test_deflection_priority_fix_queue_keeps_pdf_limit_items() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Priority-Status-Scoring.md
Slice phase: Functional validation

#1612 S2 after #1745: tune the paid `deflection.v1` action sections so the priority queue is ranked by deterministic status, repeat volume, benchmark support cost, CSAT/reopen risk, and evidence confidence rather than cost alone. This adds `priority_score` and bounded `priority_drivers` to paid action rows, keeps renderers unchanged, and keeps the free Snapshot projection closed.

## Intentional
- No renderer refresh; S3/S4 will consume the model fields.
- No LLM/cloud classifier; owner lane and fix type remain deterministic-only with `Unknown` fallback.
- Support cost remains benchmark-only until source data supplies a defensible basis.
- No Snapshot expansion; action sections remain paid-only.

## Deferred
- S3 result-page actionable dashboard.
- S4 curated email/PDF refresh.
- S5 cross-surface QA checks for action-section agreement.
- S6 monthly delta and macro/writeback fields.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -q` -- 95 passed.
- `python -m pytest tests/test_deflection_snapshot_report_drift.py -q` -- 10 passed.
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py tests/test_deflection_snapshot_report_drift.py -q` -- 105 passed.
- Sparse-evidence review regression covered: `ticket_count >= 2` with fewer than two sources now reports `Low confidence`, `confidence: low`, and receives the low-confidence score penalty.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py` -- passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Priority-Status-Scoring.md origin/main --check` -- passed.
- Extracted package gauntlet -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- passed; reasoning core 295 passed, extracted content 4764 passed / 15 skipped.

## AI reconciliation
- All findings fixed or waived: yes.
- Codex P2 sparse-evidence confidence mismatch: fixed by aligning `_action_confidence()` with the same `<2 sources` gate as `_action_status()` and adding the sparse-evidence status/confidence/score regression.

## Diff size
5 files, +482 / -59
