### PR TITLE
Fix deflection PII cued names and ISO precision

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -93,8 +93,9 @@ _DEFLECTION_REDACTION_ARTIFACT_RE = re.compile(
 _DEFLECTION_PERSON_NAME_RE = re.compile(
     rf"{_DEFLECTION_BOUNDARY_LEFT}"
     r"(?P<prefix>"
-    r"(?i:(?:customer|requester|contact|client|user|agent|member|person|name)"
-    r"(?:\s+name)?\s*(?:is|:|=|-)\s*)"
+    r"(?i:(?:customer|requester|contact|client|user|agent|member|person)"
+    r"(?:\s+name)?(?:\s*(?:is|:|=|-)\s*|\s+)"
+    r"|name\s*(?:is|:|=|-)\s*)"
     r")"
     r"(?P<name>"
     r"[A-Za-z][A-Za-z'-]+"
@@ -119,9 +120,13 @@ _DEFLECTION_PERSON_NAME_REJECT_TOKENS = frozenset(
         "export",
         "faq",
         "help",
+        "id",
+        "identifier",
         "invoice",
+        "is",
         "member",
         "name",
+        "number",
         "password",
         "person",
         "portal",
@@ -135,6 +140,27 @@ _DEFLECTION_PERSON_NAME_REJECT_TOKENS = frozenset(
         "ticket",
         "token",
         "user",
+        "was",
+        "were",
+        "will",
+    }
+)
+_DEFLECTION_ROLE_PHRASE_TOKENS = frozenset(
+    {
+        "annual",
+        "benefit",
+        "benefits",
+        "cycle",
+        "experience",
+        "feature",
+        "manager",
+        "plan",
+        "premium",
+        "program",
+        "research",
+        "subscription",
+        "success",
+        "team",
     }
 )
 _DEFLECTION_STREET_ADDRESS_RE = re.compile(
@@ -184,6 +210,20 @@ _DEFLECTION_CONTEXTUAL_OPAQUE_IDENTIFIER_RE = re.compile(
     rf"{_DEFLECTION_BOUNDARY_RIGHT}",
     re.IGNORECASE,
 )
+_DEFLECTION_STANDARD_PREFIXED_CONTEXTUAL_IDENTIFIER_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"(?P<prefix>"
+    r"(?i:(?:account|case|claim|contact|customer|member|order|profile|ref|"
+    r"reference|session|token|user)(?:\s+(?:code|id|identifier|token))?"
+    r"|(?:code|id|identifier|token))"
+    r"\s*(?:is|:|=|-)?\s*)"
+    r"(?P<identifier>"
+    r"(?:ISO|HIPAA)[-_ ]+"
+    r"(?:[A-Z0-9]{3,}(?:[-_][A-Z0-9]{3,})+|[A-Z0-9]{6,}|\d{4,})"
+    r")"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}",
+    re.IGNORECASE,
+)
 _DEFLECTION_OPAQUE_IDENTIFIER_RE = re.compile(
     rf"{_DEFLECTION_BOUNDARY_LEFT}"
     r"(?:[A-Z0-9]{8,}|[A-Z0-9]{3,}(?:[-_][A-Z0-9]{3,})+)"
@@ -216,6 +256,10 @@ _DEFLECTION_TECHNICAL_IDENTIFIER_RE = re.compile(
     r"|HIPAA[-_ ]?\d{2,4}"
     r"|SKU[-_ ]?\d{4,}"
     r")",
+    re.IGNORECASE,
+)
+_DEFLECTION_STANDARD_NUMBER_LABEL_RE = re.compile(
+    r"\s*\d{3,5}(?:\s+(?:certification|certifications|reference|references|standard|standards))?\s*",
     re.IGNORECASE,
 )
 _DEFLECTION_IDENTIFIER_KEYS = frozenset(
@@ -3436,6 +3480,10 @@ def _scrub_deflection_text(value: str) -> str:
     text = _DEFLECTION_PHONE_RE.sub("[redacted-phone]", text)
     text = _DEFLECTION_STREET_ADDRESS_RE.sub(_redact_deflection_street_address, text)
     text = _DEFLECTION_PERSON_NAME_RE.sub(_redact_deflection_person_name, text)
+    text = _DEFLECTION_STANDARD_PREFIXED_CONTEXTUAL_IDENTIFIER_RE.sub(
+        _redact_deflection_standard_prefixed_contextual_identifier,
+        text,
+    )
     text = _DEFLECTION_CONTEXTUAL_OPAQUE_IDENTIFIER_RE.sub(
         _redact_deflection_contextual_opaque_identifier,
         text,
@@ -3444,7 +3492,7 @@ def _scrub_deflection_text(value: str) -> str:
         _redact_deflection_opaque_identifier,
         text,
     )
-    return _DEFLECTION_IDENTIFIER_RE.sub("[redacted-identifier]", text)
+    return _DEFLECTION_IDENTIFIER_RE.sub(_redact_deflection_labeled_identifier, text)
 
 
 def _redact_deflection_street_address(match: re.Match[str]) -> str:
@@ -3482,9 +3530,16 @@ def _deflection_person_name_match_decision(
     match: re.Match[str],
 ) -> _DeflectionPersonNameDecision:
     candidate = match.group("name")
+    shortened = _shortest_deflection_person_name_candidate(candidate)
+    if _is_plain_role_deflection_person_name_cue(match.group("prefix")):
+        if shortened is not None:
+            _, trailing = shortened
+            return _DeflectionPersonNameDecision(redact=True, trailing_text=trailing)
+        if _looks_like_plain_role_deflection_person_name(candidate):
+            return _DeflectionPersonNameDecision(redact=True)
+        return _DeflectionPersonNameDecision(redact=False)
     if _looks_like_deflection_person_name(candidate):
         return _DeflectionPersonNameDecision(redact=True)
-    shortened = _shortest_deflection_person_name_candidate(candidate)
     if shortened is not None:
         _, trailing = shortened
         return _DeflectionPersonNameDecision(redact=True, trailing_text=trailing)
@@ -3495,6 +3550,36 @@ def _deflection_person_name_match_decision(
 
 def _deflection_person_name_match_is_pii(match: re.Match[str]) -> bool:
     return _deflection_person_name_match_decision(match).redact
+
+
+def _is_plain_role_deflection_person_name_cue(prefix: str) -> bool:
+    normalized = " ".join(prefix.strip().casefold().split())
+    return normalized in {
+        "agent",
+        "client",
+        "contact",
+        "customer",
+        "member",
+        "person",
+        "requester",
+        "user",
+    }
+
+
+def _looks_like_plain_role_deflection_person_name(value: str) -> bool:
+    tokens = [
+        token.strip(" .'-")
+        for token in value.split()
+        if token.strip(" .'-")
+    ]
+    if len(tokens) < 2 or len(tokens) > 3:
+        return False
+    lowered = [token.casefold() for token in tokens]
+    if any(token in _DEFLECTION_PERSON_NAME_REJECT_TOKENS for token in lowered):
+        return False
+    if _looks_like_deflection_role_phrase(tokens):
+        return False
+    return all(token[0].isupper() and len(token) >= 2 for token in tokens)
 
 
 def _looks_like_deflection_cued_person_name(value: str, prefix: str) -> bool:
@@ -3524,11 +3609,27 @@ def _shortest_deflection_person_name_candidate(value: str) -> tuple[str, str] | 
     first_two = " ".join(parts[:2])
     trailing = parts[2]
     if (
-        trailing.strip(" .'-").casefold() not in _DEFLECTION_PERSON_NAME_REJECT_TOKENS
-        or not _looks_like_deflection_person_name(first_two)
+        not _looks_like_deflection_person_name(first_two)
+        or _looks_like_deflection_role_phrase(parts[:2])
     ):
         return None
     return first_two, f" {trailing}"
+
+
+def _looks_like_deflection_role_phrase(tokens: Sequence[str]) -> bool:
+    return any(
+        token.strip(" .'-").casefold() in _DEFLECTION_ROLE_PHRASE_TOKENS
+        for token in tokens
+    )
+
+
+def _redact_deflection_standard_prefixed_contextual_identifier(
+    match: re.Match[str],
+) -> str:
+    identifier = match.group("identifier")
+    if _looks_like_deflection_technical_identifier(identifier):
+        return match.group(0)
+    return f"{match.group('prefix')}[redacted-identifier]"
 
 
 def _redact_deflection_contextual_opaque_identifier(match: re.Match[str]) -> str:
@@ -3536,6 +3637,19 @@ def _redact_deflection_contextual_opaque_identifier(match: re.Match[str]) -> str
     if not _looks_like_deflection_opaque_identifier(token, require_prefix=False):
         return match.group(0)
     return f"{match.group('prefix')}[redacted-identifier]"
+
+
+def _redact_deflection_labeled_identifier(match: re.Match[str]) -> str:
+    if _identifier_match_has_technical_standard_prefix(match):
+        return match.group(0)
+    return "[redacted-identifier]"
+
+
+def _identifier_match_has_technical_standard_prefix(match: re.Match[str]) -> bool:
+    prefix = match.string[max(0, match.start() - 16) : match.start()]
+    if not re.search(r"(?:ISO|HIPAA)[-_ ]?$", prefix, re.IGNORECASE):
+        return False
+    return bool(_DEFLECTION_STANDARD_NUMBER_LABEL_RE.fullmatch(match.group(0)))
 
 
 def _looks_like_deflection_person_name(value: str) -> bool:
@@ -3599,6 +3713,13 @@ def _has_deflection_source_link_pii(value: str) -> bool:
     if any(
         _deflection_person_name_match_is_pii(match)
         for match in _DEFLECTION_PERSON_NAME_RE.finditer(value)
+    ):
+        return True
+    if any(
+        not _looks_like_deflection_technical_identifier(match.group("identifier"))
+        for match in _DEFLECTION_STANDARD_PREFIXED_CONTEXTUAL_IDENTIFIER_RE.finditer(
+            value
+        )
     ):
         return True
     if any(

--- a/plans/PR-Deflection-PII-Cued-Name-ISO-Precision.md
+++ b/plans/PR-Deflection-PII-Cued-Name-ISO-Precision.md
@@ -1,0 +1,148 @@
+# PR-Deflection-PII-Cued-Name-ISO-Precision
+
+## Why this slice exists
+
+#1742 now has a merged recall/precision scorer and advisory artifact. The
+current tiny surrogate corpus exposes two deterministic scrubber gaps that are
+small enough to fix before the larger real-corpus and threshold decisions:
+
+- cue-prefixed customer names such as "Customer Jordan Lee" are not redacted
+  unless the cue uses "is", ":", "=", or "-";
+- "ISO 27001 references" is over-redacted because the generic identifier rule
+  treats "27001 references" as a customer/reference identifier.
+
+Root cause: the scrubber grammar is too narrow on customer-name cues and too
+broad on numeric identifier phrases near technical standards. This PR fixes the
+root at the shared deflection scrubber, not in the scorer, fixture, snapshot,
+PDF renderer, or report consumers.
+
+Review boundary probes showed the same root had second-side edges: plain role
+cues could reject a real name when followed by a title-cased label or arbitrary
+capitalized tier word, broad role cues could over-redact product/team phrases,
+and the ISO/HIPAA preserve hook could preserve arbitrary nearby identifiers.
+This update keeps the fix at the same shared scrubber root rather than patching
+individual report surfaces.
+
+This is deliberately not the open-set name solution. The cue-less name leak in
+the tiny corpus remains the deferred NER/open-set-name root called out in #1742.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+
+1. Broaden the deflection person-name cue grammar so plain role cues followed
+   by a plausible two- or three-token name are redacted, including
+   name-plus-label/tier shapes such as "Customer Jane Smith Account" and
+   "Customer Jane Smith Premium".
+2. Keep the weak plain-role path conservative so product/team phrases such as
+   Customer Success Manager, Premium Plan, Annual Subscription, and User
+   Experience Research remain readable.
+3. Preserve actual ISO-style technical standards before the generic numeric
+   identifier rule redacts trailing words such as "references", while still
+   scrubbing arbitrary ISO/HIPAA-prefixed identifiers near customer labels.
+4. Add behavior tests for the scrubber and scorer outcome:
+   - cue-prefixed names are removed from the measured surfaces;
+   - ISO 27001 survives as must-survive report content;
+   - arbitrary ISO/HIPAA-adjacent customer identifiers are scrubbed;
+   - existing near-misses such as Reset Password, product labels, CVE, SKU,
+     HIPAA, and tenant source ids still survive.
+5. Leave cue-less names, paid-only private-note residue, real corpus derivation,
+   and advisory-to-gating thresholds out of this PR.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-PII-Cued-Name-ISO-Precision.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The scorer reports zero cue-prefixed person-name leaks on the committed
+        tiny surrogate corpus.
+  - [ ] The scorer reports zero must-survive violations for ISO 27001 on the
+        committed tiny surrogate corpus.
+  - [ ] The cue-less name leak remains visible and is not blended away or
+        hidden by the fix.
+  - [ ] ISO/HIPAA-adjacent arbitrary customer identifiers are scrubbed while
+        ISO 27001 and ISO-27001 standard references survive.
+  - [ ] Plain role names followed by labels or arbitrary capitalized tier words
+        are shortened and redacted while common product/team phrases are not
+        redacted as names.
+  - [ ] Existing safe technical/product/reporting tokens remain unredacted.
+  - [ ] No corpus, scorer math, PDF rendering, snapshot structure, or threshold
+        gate changes land in this PR.
+- Affected surfaces: deterministic deflection report scrubber, paid artifact,
+  paid PDF text source, free snapshot/teaser, scorer tests.
+- Risk areas: PII leak recall, over-redaction of technical references, false
+  positives from broader name cues.
+- Reviewer rules triggered: R1, R2, R3, R10, R12, R13, R14.
+
+## Mechanism
+
+The scrubber already has one shared text path used by report artifacts,
+snapshots, source-link text, and the scorer. This PR adjusts that shared path:
+
+- the person-name regex admits plain role cues followed by a plausible name,
+  then routes those plain-role matches through a stricter title-case and
+  reject-token/role-phrase check so phrases like "member was reassigned",
+  Reset Password headings, Premium Plan, and Success Manager are not treated as
+  people;
+- the plain-role decision checks the existing shortest-candidate path before it
+  rejects a three-token candidate, so "Jane Smith Account" and
+  "Jane Smith Premium" redact Jane Smith while leaving the trailing text;
+- the identifier redaction path first scrubs labeled ISO/HIPAA-prefixed opaque
+  identifiers, then uses a narrowed callback so only actual standard-number
+  matches immediately preceded by a technical-standard prefix are preserved.
+
+The scorer remains a measurement tool. Its expected output changes only because
+the shared scrubber stops leaking the cued name and stops over-redacting ISO
+content.
+
+## Intentional
+
+- No cue-less-name solution. That requires the deferred open-set NER decision;
+  this PR only fixes names with explicit local cues.
+- No paid-only private-note fix. SSN/card residue in paid artifact is a
+  different evidence-ingestion/private-note root and should not be mixed into
+  this scrubber grammar slice.
+- No threshold or gating change. #1742 keeps the advisory-to-gating switch as
+  an operator decision after the larger eval corpus exists.
+- No dependency change. The fix is deterministic regex/callback logic inside
+  the existing scrubber.
+- Weak bare-role cues are intentionally narrower than explicit "name is" or
+  "customer is" cues. That trades off a little weak-cue recall to avoid
+  degrading report copy by redacting common product/team labels as names.
+
+## Deferred
+
+- Open-set/cue-less person-name detection and the NER decision.
+- Paid artifact private-note exclusion for SSN/card residue.
+- Operator-derived larger gold corpus and threshold selection.
+- Advisory-to-gating promotion for the headline KPI.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- 124 passed.
+- python scripts/score_deflection_pii_recall.py --json -- headline free high-severity leaks now 1, cue-prefixed person-name leaks 0, must-survive violations 0.
+- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- passed.
+- bash scripts/check_ascii_python.sh -- passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
+- bash scripts/local_pr_review.sh -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 133 |
+| `plans/PR-Deflection-PII-Cued-Name-ISO-Precision.md` | 148 |
+| `tests/test_content_ops_deflection_report.py` | 98 |
+| `tests/test_score_deflection_pii_recall.py` | 14 |
+| **Total** | **393** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -2231,6 +2231,93 @@ def test_deflection_report_payload_scrubs_local_entity_shapes() -> None:
     assert "[redacted-identifier]" in encoded
 
 
+@pytest.mark.parametrize(
+    ("raw_text", "expected_text"),
+    (
+        ("Customer Jordan Lee asked for help.", "Customer [redacted-name] asked for help."),
+        ("Requester Maria Garcia reopened it.", "Requester [redacted-name] reopened it."),
+        ("Client Priya Shah needs a refund.", "Client [redacted-name] needs a refund."),
+        ("User Alex Chen reported a bug.", "User [redacted-name] reported a bug."),
+        ("Agent Sam Rivera replied.", "Agent [redacted-name] replied."),
+        ("Member Pat Morgan updated billing.", "Member [redacted-name] updated billing."),
+        (
+            "Customer Jane Smith Account was closed.",
+            "Customer [redacted-name] Account was closed.",
+        ),
+        ("Customer Maya Chen Report", "Customer [redacted-name] Report"),
+        (
+            "Customer Jane Smith Premium plan was upgraded.",
+            "Customer [redacted-name] Premium plan was upgraded.",
+        ),
+        (
+            "Customer Taylor Morgan Platinum account was upgraded.",
+            "Customer [redacted-name] Platinum account was upgraded.",
+        ),
+    ),
+)
+def test_deflection_report_payload_scrubs_plain_role_cued_names(
+    raw_text: str,
+    expected_text: str,
+) -> None:
+    scrubbed = scrub_deflection_report_payload({"answer": raw_text})
+
+    assert scrubbed["answer"] == expected_text
+
+
+@pytest.mark.parametrize(
+    "raw_text",
+    (
+        "Customer Reset Password is a heading.",
+        "Customer Support Portal stayed online.",
+        "Agent Support Desk replied.",
+        "Customer Premium Plan upgrade stayed readable.",
+        "customer Annual Subscription stayed readable.",
+        "Customer Success Manager replied.",
+        "Member Benefits Team answered.",
+        "User Experience Research finished.",
+        "Customer Annual Subscription Premium stayed readable.",
+    ),
+)
+def test_deflection_report_payload_preserves_plain_role_cue_near_misses(
+    raw_text: str,
+) -> None:
+    scrubbed = scrub_deflection_report_payload({"answer": raw_text})
+
+    assert scrubbed["answer"] == raw_text
+    assert "[redacted-name]" not in scrubbed["answer"]
+
+
+def test_deflection_report_payload_scrubs_standard_prefixed_identifier_leaks() -> None:
+    scrubbed = scrub_deflection_report_payload(
+        {
+            "source_id": "ISO customer 123456 should be scrubbed.",
+            "answer": (
+                "customer id is ISO 9X4Q7ABCD12. "
+                "reference ISO ABC123XYZ7. "
+                "HIPAA 4829103 case. "
+                "ISO customer 123456 should be scrubbed. "
+                "ISO 27001 references and reference ISO-27001 stay readable."
+            ),
+        }
+    )
+
+    encoded = json.dumps(scrubbed, sort_keys=True)
+    for raw_fragment in (
+        "ISO 9X4Q7ABCD12",
+        "ISO ABC123XYZ7",
+        "HIPAA 4829103",
+        "customer 123456",
+    ):
+        assert raw_fragment not in encoded
+    assert scrubbed["source_id"] == "ISO [redacted-identifier] should be scrubbed."
+    assert "customer id is [redacted-identifier]" in scrubbed["answer"]
+    assert "reference [redacted-identifier]" in scrubbed["answer"]
+    assert "HIPAA [redacted-identifier]" in scrubbed["answer"]
+    assert "ISO [redacted-identifier] should be scrubbed" in scrubbed["answer"]
+    assert "ISO 27001 references" in scrubbed["answer"]
+    assert "reference ISO-27001" in scrubbed["answer"]
+
+
 def test_deflection_report_payload_scrubs_pii_regression_shapes() -> None:
     uuid_value = "123e4567-e89b-12d3-a456-426614174000"
     scrubbed = scrub_deflection_report_payload(
@@ -2250,7 +2337,8 @@ def test_deflection_report_payload_scrubs_pii_regression_shapes() -> None:
                 "customer id is ISO9X4Q7ABCD, session token is SKU90X4Q7AB, "
                 "and account id is HIPAA9X4Q7AB. "
                 "case CVE-2021-44228, order SKU-12345678, and "
-                "reference ISO-27001 should stay readable. HIPAA2026 too."
+                "reference ISO-27001 should stay readable. ISO 27001 references "
+                "should stay readable too. HIPAA2026 too."
             ),
             "steps": [
                 "agent is Alex Chen member was reassigned.",
@@ -2285,6 +2373,7 @@ def test_deflection_report_payload_scrubs_pii_regression_shapes() -> None:
     assert "case CVE-2021-44228" in answer
     assert "order SKU-12345678" in answer
     assert "reference ISO-27001" in answer
+    assert "ISO 27001 references" in answer
     assert "HIPAA2026" in answer
     assert scrubbed["source_id"] == "customer is [redacted-name] ticket"
     assert scrubbed["source_ids"] == [
@@ -2307,9 +2396,9 @@ def test_deflection_report_payload_preserves_local_entity_near_misses() -> None:
                 "price is $49, and ticket-source-a stays usable. "
                 "CVE-2021-44228 affected a dependency, SKU ABC12345 is active, "
                 "iPhone15Pro and Windows11 are supported, ISO27001 and HIPAA2026 "
-                "remain valid, Q4FY2026 is a reporting label, campaign2026 is a "
-                "campaign tag, 4 tickets are on the way, 4 invoices in one place, "
-                "and 4 cases in court."
+                "remain valid, ISO 27001 references remain valid, Q4FY2026 is a "
+                "reporting label, campaign2026 is a campaign tag, 4 tickets are "
+                "on the way, 4 invoices in one place, and 4 cases in court."
             ),
         }
     )
@@ -2327,6 +2416,7 @@ def test_deflection_report_payload_preserves_local_entity_near_misses() -> None:
     assert "iPhone15Pro" in answer
     assert "Windows11" in answer
     assert "ISO27001" in answer
+    assert "ISO 27001 references" in answer
     assert "HIPAA2026" in answer
     assert "Q4FY2026" in answer
     assert "campaign2026" in answer

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -57,8 +57,20 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     assert summary["surfaces"]["free_snapshot"]["email"]["expected"] == 1
     assert summary["surfaces"]["paid_artifact"]["ssn"]["expected"] == 1
     assert set(summary["person_name"]) == {"cue_less", "cue_prefixed"}
-    assert isinstance(summary["headline"]["free_high_severity_leak_count"], int)
+    assert summary["headline"] == {
+        "free_high_severity_leak_count": 1,
+        "free_high_severity_pass": False,
+    }
+    assert summary["person_name"]["cue_prefixed"]["expected"] > 0
+    assert summary["person_name"]["cue_prefixed"]["leaks"] == 0
+    assert summary["person_name"]["cue_prefixed"]["recall"] == 1.0
+    assert summary["person_name"]["cue_less"]["leaks"] > 0
+    assert summary["must_survive"]["violation_count"] == 0
     assert summary["leak_samples"]
+    assert all(
+        sample["surrogate_id"] != "person_name-002"
+        for sample in summary["leak_samples"]
+    )
     assert all("span" not in sample for sample in summary["leak_samples"])
 
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Cued-Name-ISO-Precision.md
Slice phase: Vertical slice

#1742's scorer exposed two small deterministic scrubber gaps: cue-prefixed names such as "Customer Jordan Lee" were leaking, and ISO 27001 references were being over-redacted as identifiers. Review boundary probes found the same weak-cue root had second-side edges, so this update fixes the shared scrubber root for trailing-label/tier names, product/team phrase near-misses, and arbitrary ISO/HIPAA-adjacent identifiers while leaving cue-less names, paid private-note residue, real corpus derivation, and threshold gating deferred.

## Intentional
- No cue-less-name solution; that remains the deferred open-set NER decision.
- No paid-only private-note fix; SSN/card residue in paid artifact is a different evidence-ingestion/private-note root.
- No scorer math, corpus, PDF renderer, snapshot structure, threshold, or gating change.
- The plain-role name path is stricter than separator cues, so headings and phrases like Reset Password, Premium Plan, Success Manager, Annual Subscription, or member was reassigned survive.
- ISO/HIPAA preservation is now limited to actual standard-number text; arbitrary nearby customer identifiers scrub.

## Deferred
- Open-set/cue-less person-name detection and the NER decision.
- Paid artifact private-note exclusion for SSN/card residue.
- Operator-derived larger gold corpus and threshold selection.
- Advisory-to-gating promotion for the headline KPI.

## Parked hardening
- None.

## AI reconciliation
- Codex P1, ISO/HIPAA precision exception leaked arbitrary identifiers: fixed by adding a standard-prefixed contextual identifier scrub pass and narrowing the standard preserve hook to standard-number labels only.
- Codex P1, trailing title-cased label left plain-role names unredacted: fixed by running the shortest-name candidate path before rejecting weak plain-role matches.
- Codex P2, role phrase over-redaction: fixed by adding weak-cue role phrase rejection for product/team noun phrases.
- Human MAJOR on trailing-label adjacent regression: fixed by redacting plausible first-two-token names regardless of the trailing capitalized word, while retaining role-phrase rejection for product phrases.
- All findings fixed or waived: yes.

## Verification
- pytest tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- 124 passed.
- python scripts/score_deflection_pii_recall.py --json -- headline free high-severity leaks now 1, cue-prefixed person-name leaks 0, must-survive violations 0.
- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- passed.
- bash scripts/check_ascii_python.sh -- passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
- bash scripts/validate_extracted_content_pipeline.sh -- passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
- bash scripts/local_pr_review.sh -- passed.

## Diff size
4 files, ~393 LOC.
