### PR TITLE
Measure partial deflection person-name residue

### DIFF
--- a/docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json
+++ b/docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json
@@ -8,23 +8,23 @@
   },
   "summary": {
     "cue_less_person_name_count": 1,
-    "cue_prefixed_person_name_count": 1,
-    "label_count": 8,
+    "cue_prefixed_person_name_count": 2,
+    "label_count": 9,
     "labels_by_class": {
       "email": 1,
       "order_id": 1,
       "payment_card": 1,
-      "person_name": 2,
+      "person_name": 3,
       "phone": 1,
       "ssn": 1,
       "street_address": 1
     },
     "labels_by_severity": {
-      "high": 6,
+      "high": 7,
       "medium": 2
     },
     "must_survive_count": 3,
-    "ticket_count": 1
+    "ticket_count": 2
   },
   "tickets": [
     {
@@ -135,6 +135,28 @@
         }
       ],
       "ticket_id": "pii-eval-001"
+    },
+    {
+      "fields": {
+        "agent_reply": "Customer Mary Jane Watson Report plan was upgraded.",
+        "customer_message": "Can the Premium plan stay active after an upgrade?",
+        "source_id": "ticket-eval-safe-002",
+        "subject": "Premium plan upgrade"
+      },
+      "labels": [
+        {
+          "class": "person_name",
+          "end": 25,
+          "name_subtype": "cue_prefixed",
+          "origin_field": "agent_reply",
+          "severity": "high",
+          "span": "Mary Jane Watson",
+          "start": 9,
+          "surrogate_id": "person_name-003"
+        }
+      ],
+      "must_survive": [],
+      "ticket_id": "pii-eval-002"
     }
   ]
 }

--- a/plans/PR-Deflection-PII-Partial-Name-Recall.md
+++ b/plans/PR-Deflection-PII-Partial-Name-Recall.md
@@ -1,0 +1,132 @@
+# PR-Deflection-PII-Partial-Name-Recall
+
+## Why this slice exists
+
+#1751 closed the measured cued-name and ISO precision scrubber loop, but its
+LGTM review found a residual measurement gap:
+
+- "Customer Mary Jane Watson Report" renders as "Customer [redacted-name] Watson
+  Report";
+- the surname token is still visible;
+- the current scorer only checks whether the full surrogate span survives, so
+  it would mark "Mary Jane Watson" as redacted and hide the partial leak.
+
+Root cause: the recall scorer is span-exact for all classes. That is correct
+for emails, phone numbers, cards, and identifiers, but it is too coarse for
+multi-token person names because a surviving name token can still identify the
+customer even when the full name string is gone. This PR fixes the measurement
+root by making person-name scoring detect residual name-token leaks and by
+adding the residual three-token-name-plus-label shape to the committed tiny
+corpus. It does not change the scrubber.
+
+Review found one deeper measurement root: token residue must be attributed only
+inside the owning ticket's rendered context, not the aggregate report text,
+otherwise shared surnames can create false leaks for unrelated labels. This PR
+fixes that attribution root in the scorer.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+
+1. Add a committed surrogate-only tiny-corpus row for a cue-prefixed
+   three-token name followed by a title-cased label/tier word.
+2. Teach the scorer to count a person-name label as leaked when any meaningful
+   token from the surrogate name survives on a surface where the full name
+   reached the baseline surface, scoped to the label's own ticket context.
+3. Mark the leak sample as partial person-name residue without echoing the
+   leaked token or full surrogate span.
+4. Update tests to prove:
+   - the new tiny-corpus row is counted;
+   - the scorer reports the partial cue-prefixed leak;
+   - leak samples remain redacted and do not contain spans or tokens;
+   - the #1751 ISO and must-survive precision wins remain intact.
+
+### Files touched
+
+- `docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json`
+- `plans/PR-Deflection-PII-Partial-Name-Recall.md`
+- `scripts/score_deflection_pii_recall.py`
+- `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The tiny corpus includes a surrogate-only three-token cue-prefixed
+        person name followed by a title-cased trailing word.
+  - [ ] The scorer reports partial person-name residue as a leak when a
+        meaningful name token survives after full-name redaction.
+  - [ ] Shared surnames in another ticket do not create false partial leaks for
+        a fully redacted label.
+  - [ ] Leak samples identify the class/surface/subtype and partial-leak kind
+        without echoing the leaked token or full span.
+  - [ ] The scorer continues to report zero must-survive violations.
+  - [ ] The scrubber behavior is unchanged in this PR.
+- Affected surfaces: #1742 scorer, committed tiny eval corpus, scorer tests.
+- Risk areas: false-positive partial-token matching, leak-sample safety,
+  misleading recall math, accidental scrubber scope creep.
+- Reviewer rules triggered: R1, R2, R3, R10, R12, R13, R14.
+
+## Mechanism
+
+The scorer already builds baseline and scrubbed surface text for each label.
+This PR keeps that flow and changes only the label leak predicate:
+
+- non-name labels still use exact full-span matching;
+- person-name labels first use exact full-span matching, then check meaningful
+  name tokens with word boundaries inside that label's own scrubbed ticket
+  surface when the full span reached the aggregate baseline surface;
+- partial-token hits are recorded as a leak with a leak-kind marker, not with
+  the sensitive token.
+
+The fixture adds a second tiny-corpus ticket whose answer contains a
+three-token cue-prefixed surrogate name followed by a trailing title-cased word.
+That makes the residual detector ceiling visible in the advisory artifact while
+leaving the deferred NER/open-set decision untouched.
+
+## Intentional
+
+- No scrubber change. The #1751 reviewer explicitly called out this shape as
+  the deterministic-name ceiling; this slice measures it instead of chasing
+  another regex round.
+- No threshold or gate change. The advisory artifact is allowed to become more
+  honestly red while the corpus is still tiny and the operator thresholds are
+  deferred.
+- No raw PII. The added corpus row uses surrogate-only text and labels.
+- Two-character name tokens are intentionally not counted by the partial-token
+  detector yet. The current curated surrogate corpus uses longer tokens; short
+  surnames need a future scorer/corpus follow-up before they are reliable.
+
+## Deferred
+
+- NER/open-set person-name detection.
+- Operator-derived larger gold corpus and threshold selection.
+- Paid artifact private-note exclusion for SSN/card residue.
+- Advisory-to-gating promotion.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_score_deflection_pii_recall.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -q -- 26 passed.
+- python scripts/score_deflection_pii_recall.py --json -- reports ticket_count 2, label_count 9, cue-prefixed person-name expected 5/leaks 2/recall 0.6, partial_name_token samples for person_name-003, and must-survive violations 0.
+- simulated no-fpdf scorer run -- reports paid_pdf skipped and cue-prefixed expected 3/leaks 1/recall 0.6667.
+- python -m py_compile scripts/score_deflection_pii_recall.py tests/test_score_deflection_pii_recall.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -- passed.
+- bash scripts/check_ascii_python.sh -- passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
+- bash scripts/local_pr_review.sh -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json` | 32 |
+| `plans/PR-Deflection-PII-Partial-Name-Recall.md` | 132 |
+| `scripts/score_deflection_pii_recall.py` | 110 |
+| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 20 |
+| `tests/test_score_deflection_pii_recall.py` | 79 |
+| **Total** | **373** |

--- a/scripts/score_deflection_pii_recall.py
+++ b/scripts/score_deflection_pii_recall.py
@@ -8,6 +8,7 @@ from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 import json
 from pathlib import Path
+import re
 import sys
 from typing import Any
 
@@ -56,6 +57,20 @@ HIGH_SEVERITY_CLASSES = frozenset({
     "payment_card",
     "person_name",
     "dob",
+})
+# Keep the curated surrogate corpus on 3+ character name tokens; two-letter
+# surnames need an explicit scorer/corpus follow-up before they are reliable.
+PERSON_NAME_TOKEN_MIN_LENGTH = 3
+PERSON_NAME_TOKEN_STOPWORDS = frozenset({
+    "agent",
+    "client",
+    "contact",
+    "customer",
+    "member",
+    "name",
+    "person",
+    "requester",
+    "user",
 })
 
 
@@ -114,6 +129,7 @@ def score_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
         snapshot=scrubbed_snapshot,
         pdf_text=scrubbed_pdf_text,
     )
+    scrubbed_surfaces_by_ticket = _scrubbed_surface_texts_by_ticket(tickets)
 
     labels = _labels(tickets)
     must_survive = _must_survive(tickets)
@@ -121,6 +137,7 @@ def score_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
         labels=labels,
         baseline_surfaces=baseline_surfaces,
         scrubbed_surfaces=scrubbed_surfaces,
+        scrubbed_surfaces_by_ticket=scrubbed_surfaces_by_ticket,
     )
     must_survive_result = _score_must_survive(
         records=must_survive,
@@ -340,11 +357,35 @@ def _surface_texts(
     }
 
 
+def _scrubbed_surface_texts_by_ticket(
+    tickets: Sequence[Mapping[str, Any]],
+) -> dict[str, dict[str, str]]:
+    surfaces: dict[str, dict[str, str]] = {}
+    for index, ticket in enumerate(tickets, start=1):
+        artifact = build_deflection_report_artifact(
+            _faq_result_from_corpus((ticket,)),
+            source_label="deflection_pii_eval_corpus",
+        )
+        scrubbed_artifact = scrub_deflection_report_payload(artifact.as_dict())
+        scrubbed_snapshot = build_deflection_snapshot(scrubbed_artifact).as_dict()
+        _, scrubbed_pdf_text, _ = _paid_pdf_surfaces(
+            baseline_artifact=artifact.as_dict(),
+            scrubbed_artifact=scrubbed_artifact,
+        )
+        surfaces[_ticket_key(ticket, index)] = _surface_texts(
+            artifact=scrubbed_artifact,
+            snapshot=scrubbed_snapshot,
+            pdf_text=scrubbed_pdf_text,
+        )
+    return surfaces
+
+
 def _score_labels(
     *,
     labels: Sequence[Mapping[str, Any]],
     baseline_surfaces: Mapping[str, str],
     scrubbed_surfaces: Mapping[str, str],
+    scrubbed_surfaces_by_ticket: Mapping[str, Mapping[str, str]],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     scores: list[dict[str, Any]] = []
     leaks: list[dict[str, Any]] = []
@@ -353,8 +394,19 @@ def _score_labels(
         if not span:
             continue
         for surface in SURFACES:
-            reaches = span in baseline_surfaces.get(surface, "")
-            leaked = reaches and span in scrubbed_surfaces.get(surface, "")
+            baseline_text = baseline_surfaces.get(surface, "")
+            scrubbed_text = scrubbed_surfaces.get(surface, "")
+            reaches = span in baseline_text
+            label_scrubbed_text = scrubbed_surfaces_by_ticket.get(
+                _clean(label.get("_ticket_key")),
+                {},
+            ).get(surface, scrubbed_text)
+            leak_kind = _label_leak_kind(
+                label=label,
+                baseline_text=baseline_text,
+                scrubbed_text=label_scrubbed_text,
+            )
+            leaked = bool(leak_kind)
             score = {
                 "surrogate_id": _clean(label.get("surrogate_id")),
                 "class": _clean(label.get("class")),
@@ -363,6 +415,7 @@ def _score_labels(
                 "surface": surface,
                 "reaches_surface": reaches,
                 "leaked": leaked,
+                "leak_kind": leak_kind,
             }
             scores.append(score)
             if leaked:
@@ -372,8 +425,43 @@ def _score_labels(
                     "severity": score["severity"],
                     "surface": surface,
                     "name_subtype": score["name_subtype"],
+                    "leak_kind": leak_kind,
                 })
     return scores, leaks
+
+
+def _label_leak_kind(
+    *,
+    label: Mapping[str, Any],
+    baseline_text: str,
+    scrubbed_text: str,
+) -> str:
+    span = _clean(label.get("span"))
+    if not span or span not in baseline_text:
+        return ""
+    if span in scrubbed_text:
+        return "full_span"
+    if _clean(label.get("class")) != "person_name":
+        return ""
+    if _person_name_token_survives(span, scrubbed_text):
+        return "partial_name_token"
+    return ""
+
+
+def _person_name_token_survives(span: str, scrubbed_text: str) -> bool:
+    for token in _person_name_tokens(span):
+        if re.search(rf"(?<![A-Za-z0-9]){re.escape(token)}(?![A-Za-z0-9])", scrubbed_text):
+            return True
+    return False
+
+
+def _person_name_tokens(span: str) -> tuple[str, ...]:
+    return tuple(
+        token
+        for token in re.findall(r"[A-Za-z][A-Za-z'-]+", span)
+        if len(token) >= PERSON_NAME_TOKEN_MIN_LENGTH
+        and token.casefold() not in PERSON_NAME_TOKEN_STOPWORDS
+    )
 
 
 def _score_must_survive(
@@ -479,12 +567,14 @@ def _class_summary(counts: Mapping[str, int]) -> dict[str, Any]:
 
 
 def _labels(tickets: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
-    return [
-        label
-        for ticket in tickets
-        for label in _sequence(ticket.get("labels"))
-        if isinstance(label, Mapping)
-    ]
+    labels: list[Mapping[str, Any]] = []
+    for index, ticket in enumerate(tickets, start=1):
+        ticket_key = _ticket_key(ticket, index)
+        for label in _sequence(ticket.get("labels")):
+            if not isinstance(label, Mapping):
+                continue
+            labels.append({**label, "_ticket_key": ticket_key})
+    return labels
 
 
 def _must_survive(tickets: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
@@ -494,6 +584,10 @@ def _must_survive(tickets: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any
         for record in _sequence(ticket.get("must_survive"))
         if isinstance(record, Mapping)
     ]
+
+
+def _ticket_key(ticket: Mapping[str, Any], index: int) -> str:
+    return _clean(ticket.get("ticket_id")) or f"ticket-{index:03d}"
 
 
 def _surface_text(value: Any) -> str:

--- a/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
+++ b/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
@@ -417,9 +417,9 @@ def test_committed_tiny_fixture_is_surrogate_only() -> None:
     rendered = json.dumps(artifact, sort_keys=True)
 
     assert artifact["schema_version"] == SCHEMA_VERSION
-    assert artifact["summary"]["ticket_count"] == 1
+    assert artifact["summary"]["ticket_count"] == 2
     assert artifact["summary"]["cue_less_person_name_count"] == 1
-    assert artifact["summary"]["cue_prefixed_person_name_count"] == 1
+    assert artifact["summary"]["cue_prefixed_person_name_count"] == 2
     for raw in (
         "Alice Baker",
         "alice.baker@example.com",
@@ -430,3 +430,19 @@ def test_committed_tiny_fixture_is_surrogate_only() -> None:
         "4242 4242 4242 4242",
     ):
         assert raw not in rendered
+    residual_ticket = artifact["tickets"][1]
+    assert residual_ticket["fields"]["agent_reply"] == (
+        "Customer Mary Jane Watson Report plan was upgraded."
+    )
+    assert residual_ticket["labels"] == [
+        {
+            "class": "person_name",
+            "end": 25,
+            "name_subtype": "cue_prefixed",
+            "origin_field": "agent_reply",
+            "severity": "high",
+            "span": "Mary Jane Watson",
+            "start": 9,
+            "surrogate_id": "person_name-003",
+        }
+    ]

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -32,8 +32,8 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     assert summary["status"] == "ok"
     assert summary["input"] == {
         "schema_version": "deflection_pii_eval_corpus.v1",
-        "ticket_count": 1,
-        "label_count": 8,
+        "ticket_count": 2,
+        "label_count": 9,
         "must_survive_count": 3,
     }
     paid_pdf = summary["surface_generation"]["paid_pdf"]
@@ -61,9 +61,20 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
         "free_high_severity_leak_count": 1,
         "free_high_severity_pass": False,
     }
-    assert summary["person_name"]["cue_prefixed"]["expected"] > 0
-    assert summary["person_name"]["cue_prefixed"]["leaks"] == 0
-    assert summary["person_name"]["cue_prefixed"]["recall"] == 1.0
+    if paid_pdf["rendered"]:
+        assert summary["person_name"]["cue_prefixed"] == {
+            "expected": 5,
+            "redacted": 3,
+            "leaks": 2,
+            "recall": 0.6,
+        }
+    else:
+        assert summary["person_name"]["cue_prefixed"] == {
+            "expected": 3,
+            "redacted": 2,
+            "leaks": 1,
+            "recall": 0.6667,
+        }
     assert summary["person_name"]["cue_less"]["leaks"] > 0
     assert summary["must_survive"]["violation_count"] == 0
     assert summary["leak_samples"]
@@ -71,7 +82,65 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
         sample["surrogate_id"] != "person_name-002"
         for sample in summary["leak_samples"]
     )
+    partial_name_leaks = [
+        sample
+        for sample in summary["leak_samples"]
+        if sample["surrogate_id"] == "person_name-003"
+    ]
+    expected_partial_surfaces = {"paid_artifact"}
+    if summary["surface_generation"]["paid_pdf"]["rendered"]:
+        expected_partial_surfaces.add("paid_pdf")
+    assert {
+        sample["surface"]
+        for sample in partial_name_leaks
+        if sample["leak_kind"] == "partial_name_token"
+    } == expected_partial_surfaces
     assert all("span" not in sample for sample in summary["leak_samples"])
+    assert all("token" not in sample for sample in summary["leak_samples"])
+    rendered_samples = json.dumps(summary["leak_samples"], sort_keys=True)
+    assert "Mary" not in rendered_samples
+    assert "Jane" not in rendered_samples
+    assert "Watson" not in rendered_samples
+
+
+def test_partial_name_token_detection_is_scoped_to_own_ticket() -> None:
+    corpus = _tiny_corpus()
+    corpus["tickets"].append(
+        {
+            "fields": {
+                "agent_reply": "Customer Alice Watson Premium was upgraded.",
+                "customer_message": "Premium update completed.",
+                "source_id": "ticket-eval-safe-003",
+                "subject": "Premium update",
+            },
+            "labels": [
+                {
+                    "class": "person_name",
+                    "name_subtype": "cue_prefixed",
+                    "origin_field": "agent_reply",
+                    "severity": "high",
+                    "span": "Alice Watson",
+                    "surrogate_id": "person_name-004",
+                }
+            ],
+            "must_survive": [],
+            "ticket_id": "pii-eval-003",
+        }
+    )
+
+    summary = CLI.score_corpus(corpus)
+
+    assert summary["status"] == "ok"
+    assert [
+        sample
+        for sample in summary["leak_samples"]
+        if sample["surrogate_id"] == "person_name-004"
+    ] == []
+    assert any(
+        sample["surrogate_id"] == "person_name-003"
+        and sample["leak_kind"] == "partial_name_token"
+        for sample in summary["leak_samples"]
+    )
 
 
 def test_forced_leak_reports_surface_and_surrogate_without_span() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Partial-Name-Recall.md
Slice phase: Vertical slice

#1751 closed the measured cued-name and ISO precision scrubber loop, but its LGTM review exposed a scorer blind spot: a three-token name can be partially redacted while a surname token survives, and the scorer's full-span matching would mark that as clean. This PR fixes the measurement root by adding the residual surrogate-only corpus row and counting meaningful surviving person-name tokens as partial leaks without echoing spans or tokens; the review follow-up scopes token attribution to the owning ticket context so shared surnames in other tickets do not create false leaks.

## Intentional
- No scrubber change; this measures the deterministic-name ceiling instead of chasing another regex round.
- No threshold or gate change; the advisory artifact is allowed to become more honestly red while corpus and threshold decisions are still open.
- No raw PII; the added corpus row is surrogate-only.
- Two-character name tokens remain a documented limitation for a future scorer/corpus follow-up; the current surrogate corpus uses 3+ character name tokens.

## Deferred
- NER/open-set person-name detection.
- Operator-derived larger gold corpus and threshold selection.
- Paid artifact private-note exclusion for SSN/card residue.
- Advisory-to-gating promotion.

## Parked hardening
- None.

## AI reconciliation
- Codex P2, partial-name token checks used aggregate rendered surfaces and could cross-contaminate shared surnames: fixed by scoring partial tokens against the label's own scrubbed ticket surface while preserving aggregate reach accounting.
- Codex P2, cue-prefixed totals assumed paid PDF rendered despite the supported no-fpdf path: fixed by making expected totals conditional on paid_pdf.rendered and adding a no-fpdf verification.
- NIT, two-character surnames are undercounted: documented as a current curated-corpus limitation and deferred to a future scorer/corpus follow-up.
- All findings fixed or waived: yes.

## Verification
- pytest tests/test_score_deflection_pii_recall.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -q -- 26 passed.
- python scripts/score_deflection_pii_recall.py --json -- reports ticket_count 2, label_count 9, cue-prefixed person-name expected 5/leaks 2/recall 0.6, partial_name_token samples for person_name-003, and must-survive violations 0.
- simulated no-fpdf scorer run -- reports paid_pdf skipped and cue-prefixed expected 3/leaks 1/recall 0.6667.
- python -m py_compile scripts/score_deflection_pii_recall.py tests/test_score_deflection_pii_recall.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -- passed.
- bash scripts/check_ascii_python.sh -- passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
- bash scripts/validate_extracted_content_pipeline.sh -- passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
- bash scripts/local_pr_review.sh -- passed.

## Diff size
5 files, ~373 LOC.
