### PR TITLE
Scrub deflection SSN and card residue

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -70,6 +70,16 @@ _DEFLECTION_PHONE_RE = re.compile(
     r"(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}"
     rf"{_DEFLECTION_BOUNDARY_RIGHT}"
 )
+_DEFLECTION_SSN_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"\d{3}-\d{2}-\d{4}"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}"
+)
+_DEFLECTION_PAYMENT_CARD_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"(?:\d[\s-]?){12,18}\d"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}"
+)
 _DEFLECTION_IDENTIFIER_RE = re.compile(
     rf"{_DEFLECTION_BOUNDARY_LEFT}"
     r"(?:account|accounts|acct|case|cases|claim|claims|confirmation|"
@@ -3476,6 +3486,8 @@ def _should_scrub_identifier_inside_text(value: str) -> bool:
 
 def _scrub_deflection_text(value: str) -> str:
     text = _DEFLECTION_REDACTION_ARTIFACT_RE.sub("[redacted-text]", value)
+    text = _DEFLECTION_SSN_RE.sub("[redacted-ssn]", text)
+    text = _DEFLECTION_PAYMENT_CARD_RE.sub(_redact_deflection_payment_card, text)
     text = _DEFLECTION_EMAIL_RE.sub("[redacted-email]", text)
     text = _DEFLECTION_PHONE_RE.sub("[redacted-phone]", text)
     text = _DEFLECTION_STREET_ADDRESS_RE.sub(_redact_deflection_street_address, text)
@@ -3493,6 +3505,31 @@ def _scrub_deflection_text(value: str) -> str:
         text,
     )
     return _DEFLECTION_IDENTIFIER_RE.sub(_redact_deflection_labeled_identifier, text)
+
+
+def _redact_deflection_payment_card(match: re.Match[str]) -> str:
+    digits = re.sub(r"\D", "", match.group(0))
+    if not _looks_like_payment_card_number(digits):
+        return match.group(0)
+    return "[redacted-payment-card]"
+
+
+def _looks_like_payment_card_number(digits: str) -> bool:
+    if not 13 <= len(digits) <= 19:
+        return False
+    if len(set(digits)) == 1:
+        return False
+    total = 0
+    should_double = False
+    for char in reversed(digits):
+        value = int(char)
+        if should_double:
+            value *= 2
+            if value > 9:
+                value -= 9
+        total += value
+        should_double = not should_double
+    return total % 10 == 0
 
 
 def _redact_deflection_street_address(match: re.Match[str]) -> str:

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -76,9 +76,9 @@ _DEFLECTION_SSN_RE = re.compile(
     rf"{_DEFLECTION_BOUNDARY_RIGHT}"
 )
 _DEFLECTION_PAYMENT_CARD_RE = re.compile(
-    rf"{_DEFLECTION_BOUNDARY_LEFT}"
-    r"(?:\d[\s-]?){12,18}\d"
-    rf"{_DEFLECTION_BOUNDARY_RIGHT}"
+    r"(?<![A-Za-z0-9@])"
+    r"\d(?:[\s-]?\d){12,63}"
+    r"(?![A-Za-z0-9@])"
 )
 _DEFLECTION_IDENTIFIER_RE = re.compile(
     rf"{_DEFLECTION_BOUNDARY_LEFT}"
@@ -3487,8 +3487,8 @@ def _should_scrub_identifier_inside_text(value: str) -> bool:
 def _scrub_deflection_text(value: str) -> str:
     text = _DEFLECTION_REDACTION_ARTIFACT_RE.sub("[redacted-text]", value)
     text = _DEFLECTION_SSN_RE.sub("[redacted-ssn]", text)
-    text = _DEFLECTION_PAYMENT_CARD_RE.sub(_redact_deflection_payment_card, text)
     text = _DEFLECTION_EMAIL_RE.sub("[redacted-email]", text)
+    text = _DEFLECTION_PAYMENT_CARD_RE.sub(_redact_deflection_payment_card, text)
     text = _DEFLECTION_PHONE_RE.sub("[redacted-phone]", text)
     text = _DEFLECTION_STREET_ADDRESS_RE.sub(_redact_deflection_street_address, text)
     text = _DEFLECTION_PERSON_NAME_RE.sub(_redact_deflection_person_name, text)
@@ -3508,10 +3508,30 @@ def _scrub_deflection_text(value: str) -> str:
 
 
 def _redact_deflection_payment_card(match: re.Match[str]) -> str:
-    digits = re.sub(r"\D", "", match.group(0))
-    if not _looks_like_payment_card_number(digits):
+    replacement = _deflection_payment_card_replacement(match.group(0))
+    if replacement is None:
         return match.group(0)
-    return "[redacted-payment-card]"
+    return replacement
+
+
+def _deflection_payment_card_replacement(value: str) -> str | None:
+    digit_positions = [index for index, char in enumerate(value) if char.isdigit()]
+    digits = "".join(value[index] for index in digit_positions)
+    if _looks_like_payment_card_number(digits):
+        return "[redacted-payment-card]"
+
+    for digit_count in range(min(19, len(digits) - 1), 12, -1):
+        prefix_digits = digits[:digit_count]
+        if not _looks_like_payment_card_number(prefix_digits):
+            continue
+        suffix = value[digit_positions[digit_count - 1] + 1 :]
+        if suffix.startswith("-"):
+            continue
+        if suffix and not suffix[0].isspace():
+            continue
+        return f"[redacted-payment-card]{suffix}"
+
+    return None
 
 
 def _looks_like_payment_card_number(digits: str) -> bool:
@@ -3738,8 +3758,14 @@ def _has_deflection_source_link_pii(value: str) -> bool:
     if (
         _DEFLECTION_EMAIL_RE.search(value)
         or _DEFLECTION_PHONE_RE.search(value)
+        or _DEFLECTION_SSN_RE.search(value)
         or _DEFLECTION_REDACTION_ARTIFACT_RE.search(value)
         or _has_deflection_labeled_identifier_pii(value)
+    ):
+        return True
+    if any(
+        _deflection_payment_card_replacement(match.group(0)) is not None
+        for match in _DEFLECTION_PAYMENT_CARD_RE.finditer(value)
     ):
         return True
     if any(

--- a/plans/PR-Deflection-PII-SSN-Card-Scrub.md
+++ b/plans/PR-Deflection-PII-SSN-Card-Scrub.md
@@ -15,16 +15,28 @@ in paid artifact fields remains full-span residue after the shared deflection
 payload scrub. This change fixes the root for those classes by adding SSN/card
 redaction to the shared scrubber, not by hiding them in the scorer.
 
+Review-update root cause: source-link preservation and card candidate matching
+were separate admission paths around the shared text scrub. The first pass
+taught only the normal text path about SSN/card values, so `source_id`/
+`source_ids` could still preserve those values. The first card candidate also
+ran before email redaction and used a greedy bounded candidate, so numeric email
+local parts, longer hyphenated identifiers, and adjacent expiry/CVV digits could
+be handled incorrectly. The update fixes those roots in the shared scrubber
+boundary logic rather than adding scorer exceptions.
+
 ## Scope (this PR)
 
 Ownership lane: deflection/pii-recall-precision-testing
 Slice phase: Vertical slice
+Max files: 4
 
 1. Add SSN and payment-card redaction to the shared deflection payload scrubber.
 2. Prove the tiny #1742 scorer no longer reports paid-artifact SSN/card leaks
    while the intentionally deferred cue-less name headline gap remains visible.
 3. Keep precision probes for near-miss technical/commercial numbers that should
    survive.
+4. Close the Codex review findings for source-link preservation, numeric-email
+   ordering, longer hyphenated identifiers, and card-plus-expiry/CVV adjacency.
 
 ### Review Contract
 
@@ -38,6 +50,13 @@ Acceptance criteria:
   open-set/NER names are deferred.
 - Existing source-id preservation, ISO/CVE/SKU precision, and ordinary numeric
   near-misses still pass.
+- SSN/card values in source-link fields are scrubbed while ordinary ticket/source
+  IDs remain preserved.
+- Numeric email addresses are redacted as complete emails before card matching.
+- Longer hyphenated numeric identifiers are not split into partial card
+  redactions.
+- Cards followed by adjacent expiry/CVV-style digit tokens still redact the card
+  prefix.
 
 Affected surfaces:
 - Shared deflection paid artifact payload scrub.
@@ -64,9 +83,17 @@ scrub helper. This slice adds two detector branches there:
 
 - SSN shape detection for bounded `###-##-####` values, emitted as
   `[redacted-ssn]`.
-- Payment-card candidate detection for bounded 13-19 digit values with spaces
-  or hyphens, guarded by digit normalization and a Luhn check before emitting
+- Payment-card candidate detection for digit values with spaces or hyphens,
+  guarded by 13-19 digit normalization and a Luhn check before emitting
   `[redacted-payment-card]`.
+
+The review fix reuses those same detectors in source-link preservation before a
+`source_id`/`source_ids` value is allowed through unchanged. It also redacts
+emails before card candidates, broadens card candidate collection enough to see
+adjacent digit tokens, and redacts only a Luhn-valid prefix when the continuation
+is whitespace-separated. Hyphen continuations remain unredacted unless the whole
+candidate is a valid card number, which avoids splitting longer hyphenated
+identifiers.
 
 The scorer remains unchanged except for its assertions: it should observe the
 existing payload scrubber behavior becoming safer. That keeps the measurement
@@ -80,6 +107,8 @@ honest and prevents a false-green scorer-only fix.
   artifact text that survives source selection is scrubbed for SSN/card classes.
 - No raw PII in scorer leak samples; the existing surrogate-id-only reporting
   stays intact.
+- No GitHub self-resolution of bot threads; the code and PR body record the
+  fixes, and the next review/live-reconciliation pass can verify thread state.
 
 ## Deferred
 
@@ -93,7 +122,7 @@ Parked hardening: none.
 
 ## Verification
 
-- pytest tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -q -- 134 passed.
+- pytest tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -q -- 137 passed.
 - python scripts/score_deflection_pii_recall.py --json -- reports paid_artifact `ssn` leaks 0 / recall 1.0, paid_artifact `payment_card` leaks 0 / recall 1.0, leak samples limited to `person_name-001` and `person_name-003`, and the deferred free headline cue-less name failure remains `free_high_severity_leak_count=1`.
 - python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- passed.
 - bash scripts/validate_extracted_content_pipeline.sh -- passed.
@@ -106,8 +135,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/faq_deflection_report.py` | 37 |
-| `plans/PR-Deflection-PII-SSN-Card-Scrub.md` | 113 |
-| `tests/test_content_ops_deflection_report.py` | 58 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 63 |
+| `plans/PR-Deflection-PII-SSN-Card-Scrub.md` | 142 |
+| `tests/test_content_ops_deflection_report.py` | 98 |
 | `tests/test_score_deflection_pii_recall.py` | 17 |
-| **Total** | **225** |
+| **Total** | **320** |

--- a/plans/PR-Deflection-PII-SSN-Card-Scrub.md
+++ b/plans/PR-Deflection-PII-SSN-Card-Scrub.md
@@ -1,0 +1,113 @@
+# PR-Deflection-PII-SSN-Card-Scrub
+
+## Why this slice exists
+
+#1742 now has a CI-visible recall scorer and the current main baseline is
+measured: the free headline still fails on a cue-less person name, and the paid
+artifact still leaks the tiny corpus private-note SSN/card labels. The cue-less
+name gap is explicitly an open-set/NER follow-up in #1742, so this slice takes
+the next narrow fixable root.
+
+Root cause: the deflection report payload scrubber has detectors for email,
+phone, addresses, role-cued names, and contextual identifiers, but it has no
+SSN or payment-card detector. As a result, high-severity SSN/card text carried
+in paid artifact fields remains full-span residue after the shared deflection
+payload scrub. This change fixes the root for those classes by adding SSN/card
+redaction to the shared scrubber, not by hiding them in the scorer.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+
+1. Add SSN and payment-card redaction to the shared deflection payload scrubber.
+2. Prove the tiny #1742 scorer no longer reports paid-artifact SSN/card leaks
+   while the intentionally deferred cue-less name headline gap remains visible.
+3. Keep precision probes for near-miss technical/commercial numbers that should
+   survive.
+
+### Review Contract
+
+Acceptance criteria:
+- SSN-shaped text such as `123-45-6789` is redacted from nested report payloads
+  and keys as `[redacted-ssn]`.
+- Payment-card-shaped text that passes the detector is redacted as
+  `[redacted-payment-card]`.
+- The #1742 scorer reports `ssn-001` and `payment_card-001` absent from
+  `leak_samples`; `person_name-001` remains the free headline leak because
+  open-set/NER names are deferred.
+- Existing source-id preservation, ISO/CVE/SKU precision, and ordinary numeric
+  near-misses still pass.
+
+Affected surfaces:
+- Shared deflection paid artifact payload scrub.
+- #1742 recall scorer outcome on the committed surrogate-only tiny corpus.
+
+Risk areas:
+- Over-redacting ordinary long numeric identifiers as payment cards.
+- Accidentally changing source-id preservation or the already-measured
+  person-name outcomes.
+
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-PII-SSN-Card-Scrub.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+## Mechanism
+
+The shared deflection scrubber routes every string through its central text
+scrub helper. This slice adds two detector branches there:
+
+- SSN shape detection for bounded `###-##-####` values, emitted as
+  `[redacted-ssn]`.
+- Payment-card candidate detection for bounded 13-19 digit values with spaces
+  or hyphens, guarded by digit normalization and a Luhn check before emitting
+  `[redacted-payment-card]`.
+
+The scorer remains unchanged except for its assertions: it should observe the
+existing payload scrubber behavior becoming safer. That keeps the measurement
+honest and prevents a false-green scorer-only fix.
+
+## Intentional
+
+- No cue-less/open-set name fix; #1742 explicitly treats that as the measured
+  NER/open-set gap.
+- No private-note source-exclusion policy change; this slice ensures any paid
+  artifact text that survives source selection is scrubbed for SSN/card classes.
+- No raw PII in scorer leak samples; the existing surrogate-id-only reporting
+  stays intact.
+
+## Deferred
+
+- Cue-less/open-set person-name detection or NER.
+- Larger operator-derived corpus and threshold selection.
+- Advisory-to-gating promotion after corpus/threshold decisions.
+- Broader private-note/evidence-source policy if product decides private notes
+  should be excluded rather than scrubbed.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -q -- 134 passed.
+- python scripts/score_deflection_pii_recall.py --json -- reports paid_artifact `ssn` leaks 0 / recall 1.0, paid_artifact `payment_card` leaks 0 / recall 1.0, leak samples limited to `person_name-001` and `person_name-003`, and the deferred free headline cue-less name failure remains `free_high_severity_leak_count=1`.
+- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- passed.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
+- bash scripts/check_ascii_python.sh and python scripts/audit_extracted_pipeline_ci_enrollment.py -- ASCII passed; OK: 188 matching tests are enrolled.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-deflection-pii-ssn-card-scrub.md -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 37 |
+| `plans/PR-Deflection-PII-SSN-Card-Scrub.md` | 113 |
+| `tests/test_content_ops_deflection_report.py` | 58 |
+| `tests/test_score_deflection_pii_recall.py` | 17 |
+| **Total** | **225** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -2232,6 +2232,64 @@ def test_deflection_report_payload_scrubs_local_entity_shapes() -> None:
 
 
 @pytest.mark.parametrize(
+    ("raw_text", "raw_fragment", "expected_token"),
+    (
+        ("SSN 123-45-6789 was in the note.", "123-45-6789", "[redacted-ssn]"),
+        ("Social security 987-65-4321 appeared.", "987-65-4321", "[redacted-ssn]"),
+        ("Customer record had 212-55-0199.", "212-55-0199", "[redacted-ssn]"),
+        (
+            "Card 4111 1111 1111 1111 was pasted.",
+            "4111 1111 1111 1111",
+            "[redacted-payment-card]",
+        ),
+        (
+            "Card 5555-5555-5555-4444 was pasted.",
+            "5555-5555-5555-4444",
+            "[redacted-payment-card]",
+        ),
+        (
+            "Amex 378282246310005 was pasted.",
+            "378282246310005",
+            "[redacted-payment-card]",
+        ),
+        (
+            "Discover 6011 1111 1111 1117 was pasted.",
+            "6011 1111 1111 1117",
+            "[redacted-payment-card]",
+        ),
+        (
+            "Diners 30569309025904 was pasted.",
+            "30569309025904",
+            "[redacted-payment-card]",
+        ),
+    ),
+)
+def test_deflection_report_payload_scrubs_ssn_and_payment_card_shapes(
+    raw_text: str,
+    raw_fragment: str,
+    expected_token: str,
+) -> None:
+    scrubbed = scrub_deflection_report_payload({raw_text: raw_text})
+
+    encoded = json.dumps(scrubbed, sort_keys=True)
+    assert raw_fragment not in encoded
+    assert expected_token in encoded
+
+
+def test_deflection_report_payload_preserves_card_number_near_misses() -> None:
+    raw_text = (
+        "CVE-2021-44228, ISO 27001, SKU-12345678, price $49, "
+        "and batch number 1234 5678 9012 3456 stayed readable."
+    )
+
+    scrubbed = scrub_deflection_report_payload({"answer": raw_text})
+
+    assert scrubbed["answer"] == raw_text
+    assert "[redacted-payment-card]" not in scrubbed["answer"]
+    assert "[redacted-ssn]" not in scrubbed["answer"]
+
+
+@pytest.mark.parametrize(
     ("raw_text", "expected_text"),
     (
         ("Customer Jordan Lee asked for help.", "Customer [redacted-name] asked for help."),

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -2145,7 +2145,13 @@ def test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys() 
     scrubbed = scrub_deflection_report_payload(
         {
             "source_id": "4829103",
-            "source_ids": ["777777", "ticket-4829103", "owner@example.com"],
+            "source_ids": [
+                "777777",
+                "ticket-4829103",
+                "owner@example.com",
+                "123-45-6789",
+                "4111 1111 1111 1111",
+            ],
             "first_source_id": "888888",
             "account_id": 5550000,
             "id": "question_details",
@@ -2164,6 +2170,9 @@ def test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys() 
         "999999",
         "jane.doe",
         "acme.com",
+        "owner@example.com",
+        "123-45-6789",
+        "4111 1111 1111 1111",
         "555-123-4567",
     ):
         assert raw_fragment not in encoded
@@ -2172,6 +2181,8 @@ def test_deflection_report_payload_scrubs_identifier_fields_markdown_and_keys() 
         "777777",
         "ticket-4829103",
         "[redacted-email]",
+        "[redacted-ssn]",
+        "[redacted-payment-card]",
     ]
     assert scrubbed["first_source_id"] == "888888"
     assert scrubbed["account_id"].startswith("deflection-ref-")
@@ -2279,7 +2290,8 @@ def test_deflection_report_payload_scrubs_ssn_and_payment_card_shapes(
 def test_deflection_report_payload_preserves_card_number_near_misses() -> None:
     raw_text = (
         "CVE-2021-44228, ISO 27001, SKU-12345678, price $49, "
-        "and batch number 1234 5678 9012 3456 stayed readable."
+        "batch number 1234 5678 9012 3456, and identifier "
+        "11111111-1111-4111-8111-111111111111 stayed readable."
     )
 
     scrubbed = scrub_deflection_report_payload({"answer": raw_text})
@@ -2287,6 +2299,32 @@ def test_deflection_report_payload_preserves_card_number_near_misses() -> None:
     assert scrubbed["answer"] == raw_text
     assert "[redacted-payment-card]" not in scrubbed["answer"]
     assert "[redacted-ssn]" not in scrubbed["answer"]
+
+
+def test_deflection_report_payload_scrubs_numeric_email_as_email() -> None:
+    scrubbed = scrub_deflection_report_payload(
+        {"answer": "Reply to 4111111111111111@example.com about the ticket."}
+    )
+
+    assert scrubbed["answer"] == "Reply to [redacted-email] about the ticket."
+    assert "@example.com" not in scrubbed["answer"]
+    assert "[redacted-payment-card]" not in scrubbed["answer"]
+
+
+@pytest.mark.parametrize(
+    "raw_text",
+    (
+        "Card 4111 1111 1111 1111 05/26 was pasted.",
+        "Card 4111 1111 1111 1111 123 was pasted.",
+    ),
+)
+def test_deflection_report_payload_scrubs_card_before_adjacent_digits(
+    raw_text: str,
+) -> None:
+    scrubbed = scrub_deflection_report_payload({"answer": raw_text})
+
+    assert "4111 1111 1111 1111" not in scrubbed["answer"]
+    assert "[redacted-payment-card]" in scrubbed["answer"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -55,7 +55,18 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
         "paid_pdf",
     }
     assert summary["surfaces"]["free_snapshot"]["email"]["expected"] == 1
-    assert summary["surfaces"]["paid_artifact"]["ssn"]["expected"] == 1
+    assert summary["surfaces"]["paid_artifact"]["ssn"] == {
+        "expected": 1,
+        "redacted": 1,
+        "leaks": 0,
+        "recall": 1.0,
+    }
+    assert summary["surfaces"]["paid_artifact"]["payment_card"] == {
+        "expected": 1,
+        "redacted": 1,
+        "leaks": 0,
+        "recall": 1.0,
+    }
     assert set(summary["person_name"]) == {"cue_less", "cue_prefixed"}
     assert summary["headline"] == {
         "free_high_severity_leak_count": 1,
@@ -80,6 +91,10 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     assert summary["leak_samples"]
     assert all(
         sample["surrogate_id"] != "person_name-002"
+        for sample in summary["leak_samples"]
+    )
+    assert all(
+        sample["surrogate_id"] not in {"ssn-001", "payment_card-001"}
         for sample in summary["leak_samples"]
     )
     partial_name_leaks = [


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-SSN-Card-Scrub.md
Slice phase: Vertical slice

#1742 now measures the remaining deflection PII gaps. The current tiny-corpus baseline still showed paid-artifact full-span SSN/card residue because the shared deflection payload scrubber had no SSN or payment-card detector. This PR fixes that root by adding those redaction classes to the shared scrubber and proving the scorer no longer reports `ssn-001` or `payment_card-001` leaks, while the intentionally deferred cue-less/open-set name headline gap remains visible. The review update also fixes the source-link preservation and card-candidate boundary paths that could bypass or misapply the new classes.

## Intentional
- No cue-less/open-set name fix; #1742 treats that as the measured NER/open-set gap.
- No private-note source-exclusion policy change; this slice ensures paid artifact text that survives source selection is scrubbed for SSN/card classes.
- No scorer-only hiding of leaks.
- No GitHub self-resolution of bot threads; the code and PR body record the fixes, and the next review/live-reconciliation pass can verify thread state.

## Deferred
- Cue-less/open-set person-name detection or NER.
- Larger operator-derived corpus and threshold selection.
- Advisory-to-gating promotion after corpus/threshold decisions.
- Broader private-note/evidence-source policy if product decides private notes should be excluded rather than scrubbed.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed: Codex source-link preservation finding by teaching `_has_deflection_source_link_pii` the SSN/payment-card detectors before preserving source-link fields.
- Fixed: Codex hyphenated identifier finding by rejecting hyphen continuations unless the whole candidate is a valid card number.
- Fixed: Codex numeric-email ordering finding by redacting emails before payment-card candidates.
- Fixed: Codex adjacent expiry/CVV finding by broadening candidate collection and redacting a Luhn-valid card prefix before whitespace-separated adjacent digit tokens.

## Verification
- pytest tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -q -- 137 passed.
- python scripts/score_deflection_pii_recall.py --json -- paid_artifact ssn leaks 0 / recall 1.0, paid_artifact payment_card leaks 0 / recall 1.0, leak samples limited to person_name-001 and person_name-003, deferred free headline cue-less name failure remains free_high_severity_leak_count=1.
- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- passed.
- bash scripts/validate_extracted_content_pipeline.sh -- passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
- bash scripts/check_ascii_python.sh and python scripts/audit_extracted_pipeline_ci_enrollment.py -- ASCII passed; OK: 188 matching tests are enrolled.

## Diff size
4 files, ~320 LOC.
