### PR TITLE
Require platform admin for blog admin routes

### DIFF
--- a/atlas_brain/api/blog_admin.py
+++ b/atlas_brain/api/blog_admin.py
@@ -37,6 +37,12 @@ _REVIEW_BASIS_CANONICAL = "canonical_reviews"
 router = APIRouter(prefix="/admin/blog", tags=["blog-admin"])
 
 
+async def require_blog_admin_user(user: AuthUser = Depends(require_auth)) -> AuthUser:
+    if bool(getattr(user, "is_platform_admin", False)):
+        return user
+    raise HTTPException(status_code=403, detail="Platform admin access required")
+
+
 def _unwrap_param_default(value: object | None) -> object | None:
     if isinstance(value, Param):
         return value.default
@@ -271,7 +277,7 @@ def _publish_revalidation_report(row) -> dict:
 async def list_drafts(
     status: Optional[str] = Query(None, description="Filter by status"),
     limit: int = Query(50, ge=1, le=200),
-    _user: AuthUser = Depends(require_auth),
+    _user: AuthUser = Depends(require_blog_admin_user),
 ):
     """List blog post drafts, optionally filtered by status."""
     status = _clean_optional_text(status)
@@ -325,7 +331,7 @@ async def list_drafts(
 
 
 @router.get("/drafts/summary")
-async def draft_summary(_user: AuthUser = Depends(require_auth)):
+async def draft_summary(_user: AuthUser = Depends(require_blog_admin_user)):
     """Roll up current blog draft quality and status counts."""
     pool = get_db_pool()
     if not pool.is_initialized:
@@ -425,7 +431,7 @@ async def draft_summary(_user: AuthUser = Depends(require_auth)):
 async def blog_quality_trends(
     days: int = Query(14, ge=1, le=90),
     top_n: int = Query(5, ge=1, le=20),
-    _user: AuthUser = Depends(require_auth),
+    _user: AuthUser = Depends(require_blog_admin_user),
 ):
     pool = get_db_pool()
     if not pool.is_initialized:
@@ -510,7 +516,7 @@ async def blog_quality_trends(
 async def blog_quality_diagnostics(
     days: int = Query(14, ge=1, le=90),
     top_n: int = Query(10, ge=1, le=50),
-    _user: AuthUser = Depends(require_auth),
+    _user: AuthUser = Depends(require_blog_admin_user),
 ):
     from ..autonomous.tasks.b2b_blog_post_generation import _blog_slug_block_reason
 
@@ -716,7 +722,7 @@ async def blog_quality_diagnostics(
 @router.get("/drafts/{draft_id}")
 async def get_draft(
     draft_id: UUID,
-    _user: AuthUser = Depends(require_auth),
+    _user: AuthUser = Depends(require_blog_admin_user),
 ):
     """Get a single blog draft with full content and charts."""
     pool = get_db_pool()
@@ -748,7 +754,7 @@ async def get_draft(
 async def get_draft_evidence(
     draft_id: UUID,
     limit: int = Query(20, ge=1, le=100),
-    _user: AuthUser = Depends(require_auth),
+    _user: AuthUser = Depends(require_blog_admin_user),
 ):
     """Return matching b2b_reviews that back the claims in a blog draft."""
     limit = _clean_int_query(limit, default=20)
@@ -856,7 +862,7 @@ async def get_draft_evidence(
 async def update_draft(
     draft_id: UUID,
     patch: BlogDraftPatch,
-    _user: AuthUser = Depends(require_auth),
+    _user: AuthUser = Depends(require_blog_admin_user),
 ):
     """Edit draft title, content, charts, tags, status, or reviewer notes."""
     pool = get_db_pool()
@@ -912,7 +918,7 @@ async def update_draft(
 @router.post("/drafts/{draft_id}/publish")
 async def publish_draft(
     draft_id: UUID,
-    _user: AuthUser = Depends(require_auth),
+    _user: AuthUser = Depends(require_blog_admin_user),
 ):
     """Publish a draft: set status=published, set published_at, optionally write TS file."""
     pool = get_db_pool()
@@ -1094,7 +1100,7 @@ async def publish_draft(
 @router.post("/generate")
 async def generate_post(
     req: ManualGenerateRequest,
-    _user: AuthUser = Depends(require_auth),
+    _user: AuthUser = Depends(require_blog_admin_user),
 ):
     """Manually trigger blog post generation for a specific vendor + topic type."""
     from ..autonomous.tasks.b2b_blog_post_generation import (

--- a/plans/PR-Security-Blog-Admin-Authz.md
+++ b/plans/PR-Security-Blog-Admin-Authz.md
@@ -1,0 +1,73 @@
+# PR-Security-Blog-Admin-Authz
+
+## Why this slice exists
+
+Security issue #1656 calls out `/admin/blog/*` as authenticated but not
+administrator-authorized. The router exposes platform blog draft, quality, edit,
+publish, and generation controls; regular authenticated account users should not
+be able to operate that console.
+
+## Scope (this PR)
+
+Ownership lane: security/rbac-blog-admin
+Slice phase: Production hardening
+
+1. Require platform-admin authorization for every `/admin/blog/*` endpoint.
+2. Add route-level proof that account owners/admins without platform-admin
+   authority receive `403`, while the existing blog admin route coverage uses a
+   platform-admin test principal.
+
+### Files touched
+
+- `atlas_brain/api/blog_admin.py`
+- `plans/PR-Security-Blog-Admin-Authz.md`
+- `tests/test_truthful_artifact_routes.py`
+
+## Mechanism
+
+`blog_admin.py` keeps composing through the existing `require_auth` dependency so
+the session/token contract remains unchanged. A local `require_blog_admin_user`
+dependency then checks `AuthUser.is_platform_admin` and raises
+`403 Platform admin access required` for authenticated users who are only account
+owners/admins. Every router endpoint depends on that helper instead of depending
+on `require_auth` directly.
+
+The route tests assert that each `/admin/blog/*` operation is wired to the new
+dependency, exercise every route method with a non-platform-admin user, and keep
+the existing success-path route tests on a platform-admin fixture.
+
+## Intentional
+
+- This slice does not import `require_admin_user` from `admin_costs.py`; that
+  helper permits account owners/admins and pulls in unrelated cost telemetry
+  imports. Blog administration is a platform operation, so the gate is local and
+  checks `is_platform_admin`.
+- This slice does not change token validation, plan checks, database access, or
+  route response shapes. It only tightens authorization for the existing admin
+  surface.
+
+## Deferred
+
+The remaining #1656 work is still deferred to its own slices or operational
+tasks: provider credential rotation, backend report deletion/TTL, report RLS,
+encryption at rest, alert delivery channel setup, `?token=` link removal,
+scanner ratchets, IR/security docs, CVE SLA docs, and structured
+logging/error-tracking hardening.
+
+Parked hardening: none.
+
+## Verification
+
+- Reviewer rules triggered: R1, R2, R5.
+- `python -m pytest tests/test_truthful_artifact_routes.py -k "blog_admin or blog_quality or blog_draft_evidence or blog_publish or manual_blog_generate" -q` — passed (`21 passed, 32 deselected`, one existing `pynvml` deprecation warning).
+- `python -m pytest tests/test_truthful_artifact_routes.py tests/test_blog_admin_inputs.py -q` — passed (`56 passed`, one existing `pynvml` deprecation warning).
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-security-blog-admin-authz-pr-body.md` — passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/blog_admin.py` | 24 |
+| `plans/PR-Security-Blog-Admin-Authz.md` | 73 |
+| `tests/test_truthful_artifact_routes.py` | 90 |
+| **Total** | **187** |

--- a/plans/PR-Security-Blog-Admin-Authz.md
+++ b/plans/PR-Security-Blog-Admin-Authz.md
@@ -17,6 +17,20 @@ Slice phase: Production hardening
    authority receive `403`, while the existing blog admin route coverage uses a
    platform-admin test principal.
 
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Every `/admin/blog/*` route depends on `require_blog_admin_user`
+        instead of depending on `require_auth` directly.
+  - [ ] An authenticated account owner/admin without `is_platform_admin` gets
+        `403` before blog admin route handler or database work can run.
+  - [ ] A platform-admin principal retains access to the existing blog admin
+        route behaviors covered by the route tests.
+- Affected surfaces: FastAPI blog admin API authorization and route tests.
+- Risk areas: security, backward compatibility, accidental platform-admin
+  lockout.
+- Reviewer rules triggered: R1, R2, R3, R5, R14.
+
 ### Files touched
 
 - `atlas_brain/api/blog_admin.py`
@@ -58,7 +72,7 @@ Parked hardening: none.
 
 ## Verification
 
-- Reviewer rules triggered: R1, R2, R5.
+- Reviewer rules triggered: R1, R2, R3, R5, R14.
 - `python -m pytest tests/test_truthful_artifact_routes.py -k "blog_admin or blog_quality or blog_draft_evidence or blog_publish or manual_blog_generate" -q` — passed (`21 passed, 32 deselected`, one existing `pynvml` deprecation warning).
 - `python -m pytest tests/test_truthful_artifact_routes.py tests/test_blog_admin_inputs.py -q` — passed (`56 passed`, one existing `pynvml` deprecation warning).
 - `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-security-blog-admin-authz-pr-body.md` — passed.
@@ -68,6 +82,6 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/api/blog_admin.py` | 24 |
-| `plans/PR-Security-Blog-Admin-Authz.md` | 73 |
+| `plans/PR-Security-Blog-Admin-Authz.md` | 87 |
 | `tests/test_truthful_artifact_routes.py` | 90 |
-| **Total** | **187** |
+| **Total** | **201** |

--- a/tests/test_truthful_artifact_routes.py
+++ b/tests/test_truthful_artifact_routes.py
@@ -21,7 +21,7 @@ from atlas_brain.auth.dependencies import AuthUser, require_auth
 from atlas_brain.autonomous.tasks.b2b_blog_post_generation import PostBlueprint
 
 
-def _auth_user(plan: str = "b2b_pro") -> AuthUser:
+def _auth_user(plan: str = "b2b_pro", *, is_platform_admin: bool = False) -> AuthUser:
     return AuthUser(
         user_id=str(uuid4()),
         account_id=str(uuid4()),
@@ -30,13 +30,75 @@ def _auth_user(plan: str = "b2b_pro") -> AuthUser:
         role="owner",
         product="b2b_retention",
         is_admin=True,
+        is_platform_admin=is_platform_admin,
     )
+
+
+def _blog_admin_user(plan: str = "b2b_pro") -> AuthUser:
+    return _auth_user(plan=plan, is_platform_admin=True)
+
+
+def test_blog_admin_routes_require_platform_admin_dependency():
+    routes = [
+        route
+        for route in blog_admin_api.router.routes
+        if getattr(route, "path", "").startswith("/admin/blog")
+    ]
+
+    assert len(routes) == 9
+    for route in routes:
+        dependency_names = [
+            getattr(dependency.call, "__name__", "")
+            for dependency in route.dependant.dependencies
+        ]
+        assert "require_blog_admin_user" in dependency_names, route.path
+        assert "require_auth" not in dependency_names, route.path
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        ("get", "/admin/blog/drafts", {}),
+        ("get", "/admin/blog/drafts/summary", {}),
+        ("get", "/admin/blog/quality-trends", {}),
+        ("get", "/admin/blog/quality-diagnostics", {}),
+        ("get", "/admin/blog/drafts/11111111-1111-1111-1111-111111111111", {}),
+        ("get", "/admin/blog/drafts/11111111-1111-1111-1111-111111111111/evidence", {}),
+        ("patch", "/admin/blog/drafts/11111111-1111-1111-1111-111111111111", {"json": {"title": "Updated"}}),
+        ("post", "/admin/blog/drafts/11111111-1111-1111-1111-111111111111/publish", {}),
+        (
+            "post",
+            "/admin/blog/generate",
+            {"json": {"vendor_name": "Acme", "topic_type": "migration_guide"}},
+        ),
+    ],
+)
+def test_blog_admin_routes_reject_account_admin_without_platform_admin(
+    monkeypatch,
+    method,
+    path,
+    kwargs,
+):
+    app = FastAPI()
+    app.include_router(blog_admin_api.router)
+    app.dependency_overrides[require_auth] = _auth_user
+
+    def fail_get_db_pool():
+        pytest.fail("blog admin route handler ran before platform-admin authz")
+
+    monkeypatch.setattr(blog_admin_api, "get_db_pool", fail_get_db_pool)
+
+    client = TestClient(app)
+    response = getattr(client, method)(path, **kwargs)
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Platform admin access required"}
 
 
 def test_blog_admin_routes_return_truth_fields(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     created_at = datetime(2026, 3, 30, 18, 0, tzinfo=timezone.utc)
     draft_id = uuid4()
@@ -156,7 +218,7 @@ def test_blog_admin_routes_return_truth_fields(monkeypatch):
 def test_blog_admin_summary_returns_quality_rollup(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True
@@ -200,7 +262,7 @@ def test_blog_admin_summary_returns_quality_rollup(monkeypatch):
 def test_blog_quality_trends_returns_daily_rollups(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True
@@ -1694,7 +1756,7 @@ def test_upsert_report_subscription_library_view_persists_filter_payload(monkeyp
 def test_blog_quality_diagnostics_returns_grouped_failures(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True
@@ -1757,7 +1819,7 @@ def test_blog_quality_diagnostics_returns_grouped_failures(monkeypatch):
 def test_blog_quality_diagnostics_status_counts_ignore_top_n_limit(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True
@@ -1814,7 +1876,7 @@ def test_blog_quality_diagnostics_status_counts_ignore_top_n_limit(monkeypatch):
 def test_blog_draft_evidence_uses_canonical_review_basis(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     captured = {}
 
@@ -1862,7 +1924,7 @@ def test_blog_draft_evidence_uses_canonical_review_basis(monkeypatch):
 def test_blog_publish_route_blocks_failed_revalidation(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     draft_id = uuid4()
     created_at = datetime(2026, 3, 30, 18, 0, tzinfo=timezone.utc)
@@ -1949,7 +2011,7 @@ def test_blog_publish_route_blocks_failed_revalidation(monkeypatch):
 def test_blog_publish_route_blocks_unresolved_critical_warnings(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     draft_id = uuid4()
     created_at = datetime(2026, 3, 30, 18, 0, tzinfo=timezone.utc)
@@ -2110,7 +2172,7 @@ def test_tenant_report_routes_return_truth_fields(monkeypatch):
 def test_blog_manual_generate_persists_first_pass_audit(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True
@@ -2264,7 +2326,7 @@ def test_blog_manual_generate_persists_first_pass_audit(monkeypatch):
 def test_blog_manual_generate_backfills_missing_length_fields(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True
@@ -2423,7 +2485,7 @@ def test_blog_manual_generate_backfills_missing_length_fields(monkeypatch):
 def test_manual_blog_generate_blocks_recent_rejected_slug(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True
@@ -2491,7 +2553,7 @@ def test_manual_blog_generate_blocks_recent_rejected_slug(monkeypatch):
 def test_manual_blog_generate_persists_quality_rejection(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True
@@ -2571,7 +2633,7 @@ def test_manual_blog_generate_persists_quality_rejection(monkeypatch):
 def test_manual_blog_generate_blocks_insufficient_blueprint(monkeypatch):
     app = FastAPI()
     app.include_router(blog_admin_api.router)
-    app.dependency_overrides[require_auth] = _auth_user
+    app.dependency_overrides[require_auth] = _blog_admin_user
 
     class Pool:
         is_initialized = True


### PR DESCRIPTION
Plan: plans/PR-Security-Blog-Admin-Authz.md
Ownership lane: security/rbac-blog-admin
Slice phase: Production hardening

Security issue #1656 calls out `/admin/blog/*` as authenticated but not administrator-authorized. This slice makes the platform blog admin console platform-admin-only while preserving the existing session/token contract and route response shapes.

## Intentional

- Uses a local `require_blog_admin_user` dependency instead of importing `require_admin_user` from `admin_costs.py`; the cost helper permits account owners/admins, while blog administration is a platform operation.
- Keeps token validation, plan checks, database access, and handler behavior unchanged outside the authorization dependency.

## Deferred

The remaining #1656 work is deferred to separate slices or operational tasks: provider credential rotation, backend report deletion/TTL, report RLS, encryption at rest, alert delivery channel setup, `?token=` link removal, scanner ratchets, IR/security docs, CVE SLA docs, and structured logging/error-tracking hardening.

## Parked hardening

None.

## Verification

- Reviewer rules triggered: R1, R2, R3, R5, R14.
- `python -m pytest tests/test_truthful_artifact_routes.py -k "blog_admin or blog_quality or blog_draft_evidence or blog_publish or manual_blog_generate" -q` — passed (`21 passed, 32 deselected`, one existing `pynvml` deprecation warning).
- `python -m pytest tests/test_truthful_artifact_routes.py tests/test_blog_admin_inputs.py -q` — passed (`56 passed`, one existing `pynvml` deprecation warning).
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-security-blog-admin-authz-pr-body.md` — passed.

## AI reconciliation

All fixed or waived: yes.

- Fixed Codex P1: added the missing `### Review Contract` block to `plans/PR-Security-Blog-Admin-Authz.md`, including acceptance criteria, affected surfaces, risk areas, and reviewer rules.

## Diff size

| File | LOC |
|---|---:|
| `atlas_brain/api/blog_admin.py` | 24 |
| `plans/PR-Security-Blog-Admin-Authz.md` | 87 |
| `tests/test_truthful_artifact_routes.py` | 90 |
| **Total** | **201** |
