### PR TITLE
Scrub partial deflection name token residue

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -165,12 +165,26 @@ _DEFLECTION_ROLE_PHRASE_TOKENS = frozenset(
         "feature",
         "manager",
         "plan",
+        "platinum",
         "premium",
         "program",
         "research",
         "subscription",
         "success",
         "team",
+    }
+)
+_DEFLECTION_TRAILING_LABEL_CONTEXT_TOKENS = frozenset(
+    {
+        "account",
+        "license",
+        "membership",
+        "package",
+        "plan",
+        "seat",
+        "status",
+        "subscription",
+        "tier",
     }
 )
 _DEFLECTION_STREET_ADDRESS_RE = re.compile(
@@ -3589,11 +3603,14 @@ def _deflection_person_name_match_decision(
     candidate = match.group("name")
     shortened = _shortest_deflection_person_name_candidate(candidate)
     if _is_plain_role_deflection_person_name_cue(match.group("prefix")):
-        if shortened is not None:
+        if shortened is not None and _has_deflection_trailing_label_context(match):
             _, trailing = shortened
             return _DeflectionPersonNameDecision(redact=True, trailing_text=trailing)
         if _looks_like_plain_role_deflection_person_name(candidate):
             return _DeflectionPersonNameDecision(redact=True)
+        if shortened is not None:
+            _, trailing = shortened
+            return _DeflectionPersonNameDecision(redact=True, trailing_text=trailing)
         return _DeflectionPersonNameDecision(redact=False)
     if _looks_like_deflection_person_name(candidate):
         return _DeflectionPersonNameDecision(redact=True)
@@ -3671,6 +3688,16 @@ def _shortest_deflection_person_name_candidate(value: str) -> tuple[str, str] | 
     ):
         return None
     return first_two, f" {trailing}"
+
+
+def _has_deflection_trailing_label_context(match: re.Match[str]) -> bool:
+    suffix = match.string[match.end() :]
+    next_token = re.match(r"\s+([A-Za-z][A-Za-z'-]*)", suffix)
+    return bool(
+        next_token
+        and next_token.group(1).strip(" .'-").casefold()
+        in _DEFLECTION_TRAILING_LABEL_CONTEXT_TOKENS
+    )
 
 
 def _looks_like_deflection_role_phrase(tokens: Sequence[str]) -> bool:

--- a/plans/PR-Deflection-PII-Partial-Name-Token-Scrub.md
+++ b/plans/PR-Deflection-PII-Partial-Name-Token-Scrub.md
@@ -1,0 +1,134 @@
+# PR-Deflection-PII-Partial-Name-Token-Scrub
+
+## Why this slice exists
+
+#1742 now measures the remaining scrubber failures on current `main`. After
+#1754, SSN/card leaks are closed and must-survive precision remains clean. The
+remaining fixable measured residue is `person_name-003`: a cue-prefixed
+three-token name where the scrubber redacts only the first two tokens and leaves
+the final token visible on paid artifact/PDF surfaces.
+
+Root cause: the cued-name scrubber tries to preserve trailing labels by
+shortening any three-token name candidate when the first two tokens look like a
+name. For a real three-token cue-prefixed name such as `Customer Mary Jane
+Watson Report`, that shortening runs before the full three-token plain-role
+name decision, so it emits `Customer [redacted-name] Watson Report` and leaves a
+meaningful name token behind. This change fixes the root in the shared
+name-scrub decision order: redact plausible full three-token plain-role names
+before falling back to the trailing-label shortening path.
+
+Review-update root cause: the first decision-order fix preserved only
+enumerated trailing labels, so an unknown product/status tier such as
+`Customer Jane Smith Gold plan` could be redacted as if `Gold` were a name
+token. The review update fixes that at the same shared scrubber boundary by
+using the word after the candidate (`plan`, `account`, `tier`, and similar
+context) to preserve unknown trailing labels without reintroducing the measured
+`Mary Jane Watson` residue.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 4
+
+1. Redact full three-token cue-prefixed person names when the whole candidate is
+   a plausible plain-role name.
+2. Preserve the existing trailing-label behavior for two-token names followed by
+   product/status labels, such as `Customer Jane Smith Premium`.
+3. Prove the #1742 scorer no longer reports `person_name-003` partial-name
+   token leaks while the explicitly deferred cue-less/open-set name gap remains
+   visible.
+
+### Review Contract
+
+Acceptance criteria:
+- `Customer Mary Jane Watson Report plan was upgraded.` redacts all of `Mary
+  Jane Watson` and does not leave `Watson` as partial residue.
+- Existing product/role phrase near-misses still survive, including `Customer
+  Jane Smith Premium` and `Customer Success Manager`.
+- Unknown trailing product/status labels survive when followed by label context,
+  such as `Customer Jane Smith Gold plan`.
+- The #1742 scorer reports no `partial_name_token` leak samples for
+  `person_name-003`.
+- The #1742 scorer still reports `person_name-001` cue-less/open-set leaks and
+  `free_high_severity_leak_count=1`; this PR must not hide that deferred gap.
+
+Affected surfaces:
+- Shared deflection report payload scrubber.
+- #1742 recall scorer outcome on the committed surrogate-only tiny corpus.
+
+Risk areas:
+- Over-redacting three-token product, role, plan, or team phrases as names.
+- Regressing the trailing-label behavior added for two-token names.
+- Treating the scorer as the fix instead of changing the shared scrubber.
+
+- Reviewer rules triggered: R1, R2, R3, R8, R10, R12, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-PII-Partial-Name-Token-Scrub.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+## Mechanism
+
+The shared person-name decision helper already has two useful predicates: one
+that recognizes plausible full plain-role names and one that shortens ambiguous
+three-token candidates to preserve trailing labels. This slice changes only
+their ordering for plain-role cues:
+
+1. If the full candidate is a plausible plain-role name, redact it as a whole.
+2. Before full-name redaction, preserve a shortened two-token name plus trailing
+   label when the word after the candidate has label context such as `plan`,
+   `account`, `subscription`, or `tier`.
+3. Otherwise, use the existing shortest-candidate path to preserve trailing
+   labels when the first two tokens are the name and the third token is a known
+   label.
+4. Keep role/product phrase rejection in the plain-role predicate so obvious
+   non-name phrases survive.
+
+The scorer remains a measurement surface. Its assertions update only because
+the shared scrubber now removes the measured residue.
+
+## Intentional
+
+- No cue-less/open-set name detector or NER; #1742 explicitly names that gap as
+  deferred and requires it to stay visible.
+- No scorer-side filtering of `person_name-003`; the leak must disappear because
+  the scrubbed output no longer contains the token.
+- No broad name dictionary or external NLP dependency in this vertical slice.
+
+## Deferred
+
+- Cue-less/open-set person-name detection or NER.
+- Larger operator-derived corpus and threshold selection.
+- Advisory-to-gating promotion after corpus/threshold decisions.
+- Broader name-shape hardening beyond the measured three-token cue-prefixed
+  residue if the larger corpus exposes new forms.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -q -- 140 passed.
+- python scripts/score_deflection_pii_recall.py --json -- no
+  `partial_name_token` samples, `person_name-003` absent from leak samples,
+  cue-prefixed recall 1.0, must-survive violations 0, and deferred
+  `person_name-001` cue-less leak remains with `free_high_severity_leak_count=1`.
+- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- passed.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
+- bash scripts/check_ascii_python.sh and python scripts/audit_extracted_pipeline_ci_enrollment.py -- ASCII passed; OK: 188 matching tests are enrolled.
+- Pending before push: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-deflection-pii-partial-name-token-scrub.md.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 29 |
+| `plans/PR-Deflection-PII-Partial-Name-Token-Scrub.md` | 134 |
+| `tests/test_content_ops_deflection_report.py` | 8 |
+| `tests/test_score_deflection_pii_recall.py` | 48 |
+| **Total** | **219** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -2342,12 +2342,20 @@ def test_deflection_report_payload_scrubs_card_before_adjacent_digits(
         ),
         ("Customer Maya Chen Report", "Customer [redacted-name] Report"),
         (
+            "Customer Mary Jane Watson Report plan was upgraded.",
+            "Customer [redacted-name] Report plan was upgraded.",
+        ),
+        (
             "Customer Jane Smith Premium plan was upgraded.",
             "Customer [redacted-name] Premium plan was upgraded.",
         ),
         (
             "Customer Taylor Morgan Platinum account was upgraded.",
             "Customer [redacted-name] Platinum account was upgraded.",
+        ),
+        (
+            "Customer Jane Smith Gold plan was upgraded.",
+            "Customer [redacted-name] Gold plan was upgraded.",
         ),
     ),
 )

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -75,16 +75,16 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     if paid_pdf["rendered"]:
         assert summary["person_name"]["cue_prefixed"] == {
             "expected": 5,
-            "redacted": 3,
-            "leaks": 2,
-            "recall": 0.6,
+            "redacted": 5,
+            "leaks": 0,
+            "recall": 1.0,
         }
     else:
         assert summary["person_name"]["cue_prefixed"] == {
             "expected": 3,
-            "redacted": 2,
-            "leaks": 1,
-            "recall": 0.6667,
+            "redacted": 3,
+            "leaks": 0,
+            "recall": 1.0,
         }
     assert summary["person_name"]["cue_less"]["leaks"] > 0
     assert summary["must_survive"]["violation_count"] == 0
@@ -97,19 +97,14 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
         sample["surrogate_id"] not in {"ssn-001", "payment_card-001"}
         for sample in summary["leak_samples"]
     )
-    partial_name_leaks = [
-        sample
+    assert all(
+        sample["surrogate_id"] != "person_name-003"
         for sample in summary["leak_samples"]
-        if sample["surrogate_id"] == "person_name-003"
-    ]
-    expected_partial_surfaces = {"paid_artifact"}
-    if summary["surface_generation"]["paid_pdf"]["rendered"]:
-        expected_partial_surfaces.add("paid_pdf")
-    assert {
-        sample["surface"]
-        for sample in partial_name_leaks
-        if sample["leak_kind"] == "partial_name_token"
-    } == expected_partial_surfaces
+    )
+    assert all(
+        sample["leak_kind"] != "partial_name_token"
+        for sample in summary["leak_samples"]
+    )
     assert all("span" not in sample for sample in summary["leak_samples"])
     assert all("token" not in sample for sample in summary["leak_samples"])
     rendered_samples = json.dumps(summary["leak_samples"], sort_keys=True)
@@ -118,7 +113,17 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     assert "Watson" not in rendered_samples
 
 
-def test_partial_name_token_detection_is_scoped_to_own_ticket() -> None:
+def test_partial_name_token_detection_reports_token_residue() -> None:
+    leak_kind = CLI._label_leak_kind(
+        label={"class": "person_name", "span": "Mary Jane Watson"},
+        baseline_text="Customer Mary Jane Watson Report plan was upgraded.",
+        scrubbed_text="Customer [redacted-name] Watson Report plan was upgraded.",
+    )
+
+    assert leak_kind == "partial_name_token"
+
+
+def test_resolved_partial_name_token_does_not_cross_contaminate_tickets() -> None:
     corpus = _tiny_corpus()
     corpus["tickets"].append(
         {
@@ -151,9 +156,8 @@ def test_partial_name_token_detection_is_scoped_to_own_ticket() -> None:
         for sample in summary["leak_samples"]
         if sample["surrogate_id"] == "person_name-004"
     ] == []
-    assert any(
-        sample["surrogate_id"] == "person_name-003"
-        and sample["leak_kind"] == "partial_name_token"
+    assert all(
+        sample["surrogate_id"] != "person_name-003"
         for sample in summary["leak_samples"]
     )
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Partial-Name-Token-Scrub.md
Slice phase: Vertical slice

#1742 now measures one remaining fixable scrubber residue after #1754: the paid-only `person_name-003` partial token leak. The root is the shared cued-name scrubber shortening every plausible three-token candidate before checking whether the full candidate is itself a plain-role name. This PR changes that decision order so `Customer Mary Jane Watson Report...` redacts the full name while the deferred cue-less/open-set name gap stays visible. The review update also preserves unknown trailing product/status labels when the following word provides label context, such as `Customer Jane Smith Gold plan...`.

## Intentional
- No cue-less/open-set name detector or NER; #1742 explicitly keeps that gap deferred and visible.
- No scorer-side filtering of `person_name-003`; the scorer changes only because the shared scrubber removes the residue.
- No broad name dictionary or external NLP dependency in this vertical slice.

## Deferred
- Cue-less/open-set person-name detection or NER.
- Larger operator-derived corpus and threshold selection.
- Advisory-to-gating promotion after corpus/threshold decisions.
- Broader name-shape hardening beyond the measured three-token cue-prefixed residue if the larger corpus exposes new forms.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Fixed: Codex trailing-label finding by preserving a shortened two-token name plus unknown trailing label when the candidate is followed by label context such as `plan`, `account`, `subscription`, or `tier`.

## Verification
- pytest tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -q -- 140 passed.
- python scripts/score_deflection_pii_recall.py --json -- no partial_name_token samples, person_name-003 absent from leak samples, cue-prefixed recall 1.0, must-survive violations 0, deferred person_name-001 cue-less leak remains with free_high_severity_leak_count=1.
- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_score_deflection_pii_recall.py -- passed.
- bash scripts/validate_extracted_content_pipeline.sh -- passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
- bash scripts/check_ascii_python.sh and python scripts/audit_extracted_pipeline_ci_enrollment.py -- ASCII passed; OK: 188 matching tests are enrolled.

## Diff size
4 files, ~219 LOC.
