### PR TITLE
Scrub DOB in deflection PII recall path

### DIFF
--- a/docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json
+++ b/docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json
@@ -9,8 +9,9 @@
   "summary": {
     "cue_less_person_name_count": 1,
     "cue_prefixed_person_name_count": 2,
-    "label_count": 9,
+    "label_count": 10,
     "labels_by_class": {
+      "dob": 1,
       "email": 1,
       "order_id": 1,
       "payment_card": 1,
@@ -20,7 +21,7 @@
       "street_address": 1
     },
     "labels_by_severity": {
-      "high": 7,
+      "high": 8,
       "medium": 2
     },
     "must_survive_count": 3,
@@ -29,7 +30,7 @@
   "tickets": [
     {
       "fields": {
-        "agent_reply": "Customer Jordan Lee can keep CVE-2021-44228 and ISO 27001 references in the report.",
+        "agent_reply": "Customer Jordan Lee can keep CVE-2021-44228 and ISO 27001 references in the report. DOB 1990-04-17 was removed.",
         "customer_message": "Email alex.rivera@example.test or call 555-010-4301. Order order_SYNTH_2001 ships to 1842 Pine Street.",
         "private_note": "SSN 123-45-6789 and card 4111 1111 1111 1111.",
         "source_id": "ticket-eval-safe-001",
@@ -45,6 +46,15 @@
           "span": "Jordan Lee",
           "start": 9,
           "surrogate_id": "person_name-002"
+        },
+        {
+          "class": "dob",
+          "end": 98,
+          "origin_field": "agent_reply",
+          "severity": "high",
+          "span": "1990-04-17",
+          "start": 88,
+          "surrogate_id": "dob-001"
         },
         {
           "class": "email",

--- a/extracted_content_pipeline/deflection_pii_eval_corpus.py
+++ b/extracted_content_pipeline/deflection_pii_eval_corpus.py
@@ -69,6 +69,17 @@ _SURROGATES = {
 
 _BOUNDARY_LEFT = r"(?<![A-Za-z0-9])"
 _BOUNDARY_RIGHT = r"(?![A-Za-z0-9])"
+_MONTH_RE_FRAGMENT = (
+    r"(?i:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|"
+    r"jul(?:y)?|aug(?:ust)?|sep(?:tember)?|sept(?:ember)?|oct(?:ober)?|"
+    r"nov(?:ember)?|dec(?:ember)?)"
+)
+_DOB_DATE_RE_FRAGMENT = (
+    r"(?:\d{4}[-/]\d{1,2}[-/]\d{1,2}"
+    r"|\d{1,2}[-/]\d{1,2}[-/]\d{2,4}"
+    rf"|{_MONTH_RE_FRAGMENT}\s+\d{{1,2}},?\s+\d{{4}}"
+    rf"|\d{{1,2}}\s+{_MONTH_RE_FRAGMENT}\s+\d{{4}})"
+)
 _LEAK_DETECTORS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("email", re.compile(
         rf"{_BOUNDARY_LEFT}[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{{2,}}{_BOUNDARY_RIGHT}"
@@ -78,6 +89,12 @@ _LEAK_DETECTORS: tuple[tuple[str, re.Pattern[str]], ...] = (
     )),
     ("ssn", re.compile(rf"{_BOUNDARY_LEFT}\d{{3}}-\d{{2}}-\d{{4}}{_BOUNDARY_RIGHT}")),
     ("payment_card", re.compile(rf"{_BOUNDARY_LEFT}(?:\d[ -]?){{13,19}}{_BOUNDARY_RIGHT}")),
+    ("dob", re.compile(
+        rf"{_BOUNDARY_LEFT}"
+        r"(?i:(?:date\s+of\s+birth|birth\s*date|birthday|dob|d\.o\.b\.|born(?:\s+on)?)"
+        r"\s*(?:is|:|=|-)?\s*)"
+        rf"(?P<dob>{_DOB_DATE_RE_FRAGMENT}){_BOUNDARY_RIGHT}"
+    )),
     ("street_address", re.compile(
         rf"{_BOUNDARY_LEFT}"
         r"\d{1,6}\s+"
@@ -433,7 +450,12 @@ def _output_leak_errors(
             continue
         for detector_name, pattern in _LEAK_DETECTORS:
             for match in pattern.finditer(text):
-                start, end = match.span("name") if detector_name == "person_name" else match.span()
+                if detector_name == "person_name":
+                    start, end = match.span("name")
+                elif detector_name == "dob":
+                    start, end = match.span("dob")
+                else:
+                    start, end = match.span()
                 if _is_recorded_surrogate_span(output_labels, origin_field, start, end):
                     continue
                 errors.append(_error(

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -75,6 +75,26 @@ _DEFLECTION_SSN_RE = re.compile(
     r"\d{3}-\d{2}-\d{4}"
     rf"{_DEFLECTION_BOUNDARY_RIGHT}"
 )
+_DEFLECTION_MONTH_RE_FRAGMENT = (
+    r"(?i:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|"
+    r"jul(?:y)?|aug(?:ust)?|sep(?:tember)?|sept(?:ember)?|oct(?:ober)?|"
+    r"nov(?:ember)?|dec(?:ember)?)"
+)
+_DEFLECTION_DOB_DATE_RE_FRAGMENT = (
+    r"(?:\d{4}[-/]\d{1,2}[-/]\d{1,2}"
+    r"|\d{1,2}[-/]\d{1,2}[-/]\d{2,4}"
+    rf"|{_DEFLECTION_MONTH_RE_FRAGMENT}\s+\d{{1,2}},?\s+\d{{4}}"
+    rf"|\d{{1,2}}\s+{_DEFLECTION_MONTH_RE_FRAGMENT}\s+\d{{4}})"
+)
+_DEFLECTION_DOB_RE = re.compile(
+    rf"{_DEFLECTION_BOUNDARY_LEFT}"
+    r"(?P<prefix>"
+    r"(?i:(?:date\s+of\s+birth|birth\s*date|birthday|dob|d\.o\.b\.|born(?:\s+on)?)"
+    r"\s*(?:is|:|=|-)?\s*)"
+    r")"
+    rf"(?P<dob>{_DEFLECTION_DOB_DATE_RE_FRAGMENT})"
+    rf"{_DEFLECTION_BOUNDARY_RIGHT}"
+)
 _DEFLECTION_PAYMENT_CARD_RE = re.compile(
     r"(?<![A-Za-z0-9@])"
     r"\d(?:[\s-]?\d){12,63}"
@@ -3500,6 +3520,7 @@ def _should_scrub_identifier_inside_text(value: str) -> bool:
 
 def _scrub_deflection_text(value: str) -> str:
     text = _DEFLECTION_REDACTION_ARTIFACT_RE.sub("[redacted-text]", value)
+    text = _DEFLECTION_DOB_RE.sub(_redact_deflection_dob, text)
     text = _DEFLECTION_SSN_RE.sub("[redacted-ssn]", text)
     text = _DEFLECTION_EMAIL_RE.sub("[redacted-email]", text)
     text = _DEFLECTION_PAYMENT_CARD_RE.sub(_redact_deflection_payment_card, text)
@@ -3519,6 +3540,10 @@ def _scrub_deflection_text(value: str) -> str:
         text,
     )
     return _DEFLECTION_IDENTIFIER_RE.sub(_redact_deflection_labeled_identifier, text)
+
+
+def _redact_deflection_dob(match: re.Match[str]) -> str:
+    return f"{match.group('prefix')}[redacted-dob]"
 
 
 def _redact_deflection_payment_card(match: re.Match[str]) -> str:
@@ -3786,6 +3811,7 @@ def _has_deflection_source_link_pii(value: str) -> bool:
         _DEFLECTION_EMAIL_RE.search(value)
         or _DEFLECTION_PHONE_RE.search(value)
         or _DEFLECTION_SSN_RE.search(value)
+        or _DEFLECTION_DOB_RE.search(value)
         or _DEFLECTION_REDACTION_ARTIFACT_RE.search(value)
         or _has_deflection_labeled_identifier_pii(value)
     ):

--- a/plans/PR-Deflection-PII-DOB-Scrub.md
+++ b/plans/PR-Deflection-PII-DOB-Scrub.md
@@ -1,0 +1,129 @@
+# PR-Deflection-PII-DOB-Scrub
+
+## Why this slice exists
+
+#1742 defines DOB as high-severity PII for the deflection recall/precision arc,
+and `deflection_pii_eval_corpus.py` already accepts and surrogates `dob` labels.
+The root cause is that the production report scrub boundary and the committed
+tiny corpus never exercised a DOB label, so a high-severity class could remain
+unproved by the end-to-end scorer. This slice fixes the root for the currently
+supported DOB shape by adding context-cued DOB detection/redaction at the shared
+deflection scrub boundary and locking it into the surrogate corpus/scorer proof.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 7
+
+1. Redact context-cued DOB values before deflection report payloads project into
+   snapshot, teaser, paid artifact, and PDF surfaces.
+2. Add the first DOB surrogate label to the committed tiny eval corpus so the
+   scorer proves this high-severity class through the real production path.
+3. Add focused positive and near-miss tests for cued DOB shapes, ordinary dates,
+   existing compliance/security date-like tokens, corpus surrogation, and scorer
+   leak reporting.
+4. Review update: include `birthday` and bare `born` as common DOB cues while
+   preserving non-date phrases such as "born to lead" and birthday reminders.
+
+### Review Contract
+
+Acceptance criteria:
+- `dob` remains a high-severity corpus/scorer class and the tiny fixture includes
+  one DOB label.
+- Context-cued DOB values such as `DOB 1990-04-17` redact to
+  `[redacted-dob]` anywhere the deflection scrubber processes text.
+- The scorer reports the tiny DOB label as expected and redacted on the paid
+  artifact path, with no DOB leak sample.
+- Ordinary date-like report content remains readable unless it is DOB-cued.
+- The existing deferred cue-less/open-set person-name leak remains unchanged and
+  explicitly out of scope.
+
+Affected surfaces:
+- Deflection report payload scrubber.
+- Surrogate eval corpus fixture and corpus builder tests.
+- PII recall scorer tests and default tiny fixture.
+
+Risk areas:
+- Over-redacting non-PII dates, CVEs, ISO/SOC references, years, prices, and
+  ticket counts.
+- Under-proving DOB by adding only a fixture without exercising the shared
+  scrub boundary.
+
+- Reviewer rules triggered: R1 Requirements match, R2 Test evidence, R3
+  Security/privacy, R8 Scope, R10 Maintainability, R13 Fix-the-class, R14
+  Codebase verification.
+
+### Files touched
+
+- `docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json`
+- `extracted_content_pipeline/deflection_pii_eval_corpus.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-PII-DOB-Scrub.md`
+- `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+## Mechanism
+
+The shared deflection scrubber gets a DOB regex that requires a DOB/birth-date
+cue before redacting a date-shaped value, including common support text cues
+such as `birthday` and bare `born`. The replacement preserves the cue and
+replaces only the date value with `[redacted-dob]`, so ordinary dates do not get
+treated as PII.
+
+The surrogate corpus builder gets the same context-cued DOB detector for its
+fail-closed unlabeled-PII pass. The committed tiny fixture adds one DOB label in
+agent reply text, which projects into the free and paid surfaces. The scorer then
+uses the existing class/severity machinery to prove the label reaches surfaces
+and is redacted by the production scrubber.
+
+## Intentional
+
+- This is context-cued DOB redaction only. Broad date redaction is intentionally
+  avoided because the report has legitimate dates, years, CVE IDs, ISO/SOC
+  references, prices, and counts that must survive for precision.
+- Cue-less/open-set person names remain deferred per #1742. This slice should
+  not change the existing `person_name-001` leak sample.
+
+## Deferred
+
+- Operator-derived gold corpus, thresholds, and gate flip decisions remain open
+  #1742 inputs.
+- Model-based NER for cue-less/open-set names remains a separate deferred slice
+  under #1734/#1742.
+- Additional DOB locales/formats beyond the context-cued shapes covered here can
+  be expanded once the real corpus shows they occur.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py tests/test_score_deflection_pii_recall.py -q -- 167 passed after the review update.
+- python scripts/score_deflection_pii_recall.py --json -- status ok,
+  label_count 10, paid_artifact/paid_pdf `dob` leaks 0 / recall 1.0,
+  must-survive violations 0, and only the deferred cue-less `person_name-001`
+  leak remains with `free_high_severity_leak_count=1`.
+- python -m py_compile extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/deflection_pii_eval_corpus.py tests/test_content_ops_deflection_report.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py tests/test_score_deflection_pii_recall.py -- passed.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas
+  runtime import findings: 0.
+- bash scripts/check_ascii_python.sh -- ASCII passed for
+  extracted_content_pipeline Python files.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188
+  matching tests are enrolled.
+- Pending before push: bash scripts/push_pr.sh <pr-body-file> -u origin HEAD.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json` | 16 |
+| `extracted_content_pipeline/deflection_pii_eval_corpus.py` | 24 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 26 |
+| `plans/PR-Deflection-PII-DOB-Scrub.md` | 129 |
+| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 46 |
+| `tests/test_content_ops_deflection_report.py` | 43 |
+| `tests/test_score_deflection_pii_recall.py` | 14 |
+| **Total** | **298** |

--- a/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
+++ b/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
@@ -41,7 +41,7 @@ def _valid_source() -> dict:
                     ),
                     "agent_reply": (
                         "Customer Alice Baker can keep CVE-2021-44228 and ISO 27001 "
-                        "references in the report."
+                        "references in the report. DOB 1977-06-05 was removed."
                     ),
                     "private_note": "SSN 111-22-3333 and card 4242 4242 4242 4242.",
                     "source_id": "ticket-eval-safe-001",
@@ -78,6 +78,11 @@ def _valid_source() -> dict:
                         "class": "person_name",
                         "origin_field": "agent_reply",
                         "name_subtype": "cue_prefixed",
+                    },
+                    {
+                        "span": "1977-06-05",
+                        "class": "dob",
+                        "origin_field": "agent_reply",
                     },
                     {
                         "span": "111-22-3333",
@@ -132,6 +137,7 @@ def test_surrogate_artifact_rewrites_labels_and_drops_raw_pii() -> None:
         "202-555-0188",
         "ORD-98765",
         "99 Real Street",
+        "1977-06-05",
         "111-22-3333",
         "4242 4242 4242 4242",
     ):
@@ -144,7 +150,7 @@ def test_surrogate_artifact_rewrites_labels_and_drops_raw_pii() -> None:
         text = fields[label["origin_field"]]
         assert text[label["start"]:label["end"]] == label["span"]
     assert artifact["summary"]["labels_by_severity"] == {
-        "high": 6,
+        "high": 7,
         "medium": 2,
     }
     assert artifact["summary"]["cue_less_person_name_count"] == 1
@@ -211,7 +217,8 @@ def test_unlabeled_pii_in_rendered_output_fails_closed_without_raw_echo() -> Non
                     "customer_message": (
                         "Customer is John Doe. Email leak.real@gmail.com, "
                         "call 212-555-7788, SSN 987-65-4321, card "
-                        "4000 0000 0000 0002, ship to 44 Cedar Street."
+                        "4000 0000 0000 0002, DOB 1977-06-05, ship to "
+                        "44 Cedar Street."
                     )
                 },
                 "labels": [
@@ -233,13 +240,41 @@ def test_unlabeled_pii_in_rendered_output_fails_closed_without_raw_echo() -> Non
         "212-555-7788",
         "987-65-4321",
         "4000 0000 0000 0002",
+        "1977-06-05",
         "44 Cedar Street",
     ):
         assert raw not in rendered
     assert {error["code"] for error in result.errors} == {"unlabeled_pii_detected"}
-    assert {"email", "phone", "ssn", "payment_card", "street_address"} <= {
+    assert {"email", "phone", "ssn", "payment_card", "dob", "street_address"} <= {
         error["detector"] for error in result.errors
     }
+
+
+def test_unlabeled_dob_common_cues_fail_closed_without_raw_echo() -> None:
+    for text, raw_dob in (
+        ("Customer is John Doe. Birthday is 1977-06-05.", "1977-06-05"),
+        ("Customer is John Doe. Born 06/05/1977.", "06/05/1977"),
+    ):
+        result = build_surrogate_eval_corpus({
+            "records": [
+                {
+                    "fields": {"customer_message": text},
+                    "labels": [
+                        {
+                            "span": "John Doe",
+                            "class": "person_name",
+                            "origin_field": "customer_message",
+                            "name_subtype": "cue_prefixed",
+                        }
+                    ],
+                }
+            ]
+        })
+
+        assert not result.ok
+        rendered = json.dumps({"errors": result.errors}, sort_keys=True)
+        assert raw_dob not in rendered
+        assert {error["detector"] for error in result.errors} == {"dob"}
 
 
 def test_surrogate_never_reuses_matching_raw_span() -> None:
@@ -426,10 +461,13 @@ def test_committed_tiny_fixture_is_surrogate_only() -> None:
         "202-555-0188",
         "ORD-98765",
         "99 Real Street",
+        "1977-06-05",
         "111-22-3333",
         "4242 4242 4242 4242",
     ):
         assert raw not in rendered
+    assert artifact["summary"]["labels_by_class"]["dob"] == 1
+    assert artifact["summary"]["labels_by_severity"]["high"] == 8
     residual_ticket = artifact["tickets"][1]
     assert residual_ticket["fields"]["agent_reply"] == (
         "Customer Mary Jane Watson Report plan was upgraded."

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -2287,6 +2287,49 @@ def test_deflection_report_payload_scrubs_ssn_and_payment_card_shapes(
     assert expected_token in encoded
 
 
+@pytest.mark.parametrize(
+    ("raw_text", "raw_fragment"),
+    (
+        ("DOB 1990-04-17 was pasted.", "1990-04-17"),
+        ("dob: 1984/11/02 was pasted.", "1984/11/02"),
+        ("Date of birth is 04/17/1990.", "04/17/1990"),
+        ("Birthdate=11-02-1984 appeared.", "11-02-1984"),
+        ("Customer was born on April 17, 1990.", "April 17, 1990"),
+        ("Customer was born on 17 April 1990.", "17 April 1990"),
+        ("birthday is 1990-05-03.", "1990-05-03"),
+        ("Customer was born 05/03/1990.", "05/03/1990"),
+    ),
+)
+def test_deflection_report_payload_scrubs_context_cued_dob_shapes(
+    raw_text: str,
+    raw_fragment: str,
+) -> None:
+    scrubbed = scrub_deflection_report_payload({raw_text: raw_text})
+
+    encoded = json.dumps(scrubbed, sort_keys=True)
+    assert raw_fragment not in encoded
+    assert "[redacted-dob]" in encoded
+
+
+@pytest.mark.parametrize(
+    "raw_text",
+    (
+        "Report date 1990-04-17 stayed readable.",
+        "The launch happened on April 17, 1990.",
+        "CVE-2021-44228 and ISO 27001 stayed readable.",
+        "The 2026 count is 1234567 and the price is $49.",
+        "DOB policy changed in 2026 without listing a birth date.",
+        "Born to lead in 2024 stayed readable.",
+        "The birthday reminder for 2026-01-15 stayed readable.",
+    ),
+)
+def test_deflection_report_payload_preserves_dob_near_misses(raw_text: str) -> None:
+    scrubbed = scrub_deflection_report_payload({"answer": raw_text})
+
+    assert scrubbed["answer"] == raw_text
+    assert "[redacted-dob]" not in scrubbed["answer"]
+
+
 def test_deflection_report_payload_preserves_card_number_near_misses() -> None:
     raw_text = (
         "CVE-2021-44228, ISO 27001, SKU-12345678, price $49, "

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -33,7 +33,7 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     assert summary["input"] == {
         "schema_version": "deflection_pii_eval_corpus.v1",
         "ticket_count": 2,
-        "label_count": 9,
+        "label_count": 10,
         "must_survive_count": 3,
     }
     paid_pdf = summary["surface_generation"]["paid_pdf"]
@@ -62,6 +62,12 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
         "recall": 1.0,
     }
     assert summary["surfaces"]["paid_artifact"]["payment_card"] == {
+        "expected": 1,
+        "redacted": 1,
+        "leaks": 0,
+        "recall": 1.0,
+    }
+    assert summary["surfaces"]["paid_artifact"]["dob"] == {
         "expected": 1,
         "redacted": 1,
         "leaks": 0,
@@ -99,6 +105,10 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     )
     assert all(
         sample["surrogate_id"] != "person_name-003"
+        for sample in summary["leak_samples"]
+    )
+    assert all(
+        sample["surrogate_id"] != "dob-001"
         for sample in summary["leak_samples"]
     )
     assert all(
@@ -278,7 +288,7 @@ def test_malformed_label_span_fails_closed_without_scoring(
         {
             "code": error_code,
             "ticket_index": 1,
-            "label_index": 9,
+            "label_index": 10,
         }
     ]
     assert "email-bad" not in json.dumps(summary, sort_keys=True)


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-DOB-Scrub.md
Slice phase: Vertical slice

#1742 defines DOB as high-severity PII, and the corpus/scorer already know the `dob` class, but the shared deflection scrub boundary and committed tiny fixture did not prove or redact DOB. This slice fixes that root for context-cued DOB values by adding shared DOB redaction, a fail-closed corpus DOB detector, and one DOB label in the tiny end-to-end scorer fixture. Review update: `birthday` and bare `born` are now covered as DOB cues while non-date phrases like "born to lead" and birthday reminders stay readable.

## Intentional
- Context-cued DOB redaction only; ordinary report dates, years, CVEs, ISO/SOC references, prices, and counts are preserved for precision.
- Cue-less/open-set person names remain deferred and the existing `person_name-001` leak sample is expected to remain visible.

## Deferred
- Operator-derived gold corpus, thresholds, and gate flip decisions remain open #1742 inputs.
- Model-based NER for cue-less/open-set names remains deferred under #1734/#1742.
- Additional DOB locales/formats beyond the context-cued shapes covered here can expand once the real corpus shows they occur.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py tests/test_score_deflection_pii_recall.py -q` -- 167 passed.
- `python scripts/score_deflection_pii_recall.py --json` -- status ok, label_count 10, paid_artifact/paid_pdf `dob` leaks 0 / recall 1.0, must-survive violations 0, and only deferred cue-less `person_name-001` remains with `free_high_severity_leak_count=1`.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/deflection_pii_eval_corpus.py tests/test_content_ops_deflection_report.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py tests/test_score_deflection_pii_recall.py` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` -- ASCII passed for extracted_content_pipeline Python files.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- OK: 188 matching tests are enrolled.

## Diff size
7 files, +288 / -10 (`git diff origin/main --stat`); 298 LOC estimated by `python scripts/sync_pr_plan.py`.
