### PR TITLE
Deflection PDF action queue contract

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -621,6 +621,8 @@
               ]
             }
           ],
+          "pdf_limit": 10,
+          "result_page_limit": 3,
           "support_cost_basis": {
             "assisted_contact_cost": 13.5,
             "formula": "ticket_count * assisted_contact_cost",
@@ -635,6 +637,8 @@
         "required_data": [
           "items",
           "top_item_count",
+          "result_page_limit",
+          "pdf_limit",
           "support_cost_basis"
         ],
         "snapshot_safe_fields": [],
@@ -689,6 +693,8 @@
               ]
             }
           ],
+          "pdf_limit": 10,
+          "result_page_limit": 3,
           "top_item_count": 1
         },
         "default_limit": 3,
@@ -696,7 +702,9 @@
         "priority": 37,
         "required_data": [
           "items",
-          "top_item_count"
+          "top_item_count",
+          "result_page_limit",
+          "pdf_limit"
         ],
         "snapshot_safe_fields": [],
         "surfaces": [
@@ -709,6 +717,8 @@
       {
         "data": {
           "items": [],
+          "pdf_limit": 10,
+          "result_page_limit": 3,
           "top_item_count": 0
         },
         "default_limit": 3,
@@ -716,7 +726,9 @@
         "priority": 38,
         "required_data": [
           "items",
-          "top_item_count"
+          "top_item_count",
+          "result_page_limit",
+          "pdf_limit"
         ],
         "snapshot_safe_fields": [],
         "surfaces": [

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -496,6 +496,27 @@ class PostgresDeflectionReportArtifactStore:
         return parse_command_tag(result)
 
 
+_STORED_ACTION_SECTION_LIMIT_DEFAULTS = {
+    "priority_fix_queue": {
+        "result_page_limit": 3,
+        "pdf_limit": 10,
+        "backlog_limit": 25,
+    },
+    "top_unresolved_repeats": {
+        "result_page_limit": 3,
+        "pdf_limit": 10,
+    },
+    "drafted_resolutions": {
+        "result_page_limit": 3,
+        "pdf_limit": 10,
+    },
+    "already_covered_still_recurring": {
+        "result_page_limit": 3,
+        "pdf_limit": 10,
+    },
+}
+
+
 def _record_from_row(row: Mapping[str, Any]) -> DeflectionReportAccessRecord:
     snapshot = decode_jsonb_field(row.get("snapshot"), default={})
     artifact = decode_jsonb_field(row.get("artifact"), default={})
@@ -556,6 +577,11 @@ def _stored_report_model_section(value: Any) -> dict[str, Any] | None:
     raw_data = value.get("data")
     data = dict(raw_data) if isinstance(raw_data, Mapping) else {}
     required_data = _text_list(value.get("required_data"))
+    required_data, data = _normalize_stored_action_section_limits(
+        section_id,
+        required_data,
+        data,
+    )
     if any(key not in data for key in required_data):
         return None
     return {
@@ -568,6 +594,27 @@ def _stored_report_model_section(value: Any) -> dict[str, Any] | None:
         "snapshot_safe_fields": _text_list(value.get("snapshot_safe_fields")),
         "data": data,
     }
+
+
+def _normalize_stored_action_section_limits(
+    section_id: str,
+    required_data: list[str],
+    data: dict[str, Any],
+) -> tuple[list[str], dict[str, Any]]:
+    limit_defaults = _STORED_ACTION_SECTION_LIMIT_DEFAULTS.get(section_id)
+    if limit_defaults is None:
+        return required_data, data
+
+    normalized_data = dict(data)
+    for key, default in limit_defaults.items():
+        if _optional_int(normalized_data.get(key)) is None:
+            normalized_data[key] = default
+
+    normalized_required = list(required_data)
+    for key in limit_defaults:
+        if key not in normalized_required:
+            normalized_required.append(key)
+    return normalized_required, normalized_data
 
 
 def _list_record_from_row(row: Mapping[str, Any]) -> DeflectionReportListRecord:

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -572,6 +572,8 @@ _DEFLECTION_REPORT_SECTION_DEFINITIONS = (
         required_data=(
             "items",
             "top_item_count",
+            "result_page_limit",
+            "pdf_limit",
             "support_cost_basis",
         ),
     ),
@@ -584,6 +586,8 @@ _DEFLECTION_REPORT_SECTION_DEFINITIONS = (
         required_data=(
             "items",
             "top_item_count",
+            "result_page_limit",
+            "pdf_limit",
         ),
     ),
     DeflectionReportSectionDefinition(
@@ -595,6 +599,8 @@ _DEFLECTION_REPORT_SECTION_DEFINITIONS = (
         required_data=(
             "items",
             "top_item_count",
+            "result_page_limit",
+            "pdf_limit",
         ),
     ),
     DeflectionReportSectionDefinition(
@@ -2055,39 +2061,51 @@ def _priority_fix_queue_data(items: Sequence[Mapping[str, Any]]) -> dict[str, An
 
 def _top_unresolved_repeats_data(items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     unresolved = [
-        item for item in _action_items(items)
+        item
+        for item in _action_items(items)
         if item["status"] in {"Needs answer", "Needs review"}
         and _int(item.get("ticket_count")) >= 2
     ]
-    top_items = unresolved[:_ACTION_RESULT_PAGE_LIMIT]
+    model_limit = max(_ACTION_RESULT_PAGE_LIMIT, _ACTION_PDF_LIMIT)
+    top_items = unresolved[:model_limit]
     return {
         "items": top_items,
         "top_item_count": len(top_items),
+        "result_page_limit": _ACTION_RESULT_PAGE_LIMIT,
+        "pdf_limit": _ACTION_PDF_LIMIT,
         "support_cost_basis": _action_support_cost_basis(),
     }
 
 
 def _drafted_resolutions_data(items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    model_limit = max(_ACTION_RESULT_PAGE_LIMIT, _ACTION_PDF_LIMIT)
     drafted = [
-        item for item in _action_items(items)
+        item
+        for item in _action_items(items)
         if item["status"] == "Draft ready"
-    ][:_ACTION_RESULT_PAGE_LIMIT]
+    ][:model_limit]
     return {
         "items": drafted,
         "top_item_count": len(drafted),
+        "result_page_limit": _ACTION_RESULT_PAGE_LIMIT,
+        "pdf_limit": _ACTION_PDF_LIMIT,
     }
 
 
 def _already_covered_still_recurring_data(
     items: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
+    model_limit = max(_ACTION_RESULT_PAGE_LIMIT, _ACTION_PDF_LIMIT)
     recurring = [
-        item for item in _action_items(items)
+        item
+        for item in _action_items(items)
         if item["status"] == "Already covered but still recurring"
-    ][:_ACTION_RESULT_PAGE_LIMIT]
+    ][:model_limit]
     return {
         "items": recurring,
         "top_item_count": len(recurring),
+        "result_page_limit": _ACTION_RESULT_PAGE_LIMIT,
+        "pdf_limit": _ACTION_PDF_LIMIT,
     }
 
 

--- a/plans/PR-Deflection-PDF-Action-Queue-Contract.md
+++ b/plans/PR-Deflection-PDF-Action-Queue-Contract.md
@@ -1,0 +1,143 @@
+# PR-Deflection-PDF-Action-Queue-Contract
+
+## Why this slice exists
+
+#1612 shifted the paid deflection deliverable toward an actionable work queue:
+the buyer result page skims the top three fixes while the PDF/email lane needs
+a denser, curated view that is still bounded. The model already gives
+`priority_fix_queue` a result-page limit, PDF limit, and backlog limit, but the
+adjacent action sections still truncate to the result-page top three inside the
+producer. That forces later PDF rendering to either stay too thin or invent its
+own downstream selection rules.
+
+Root cause: the model contract only encoded multi-surface limits for
+`priority_fix_queue`; `top_unresolved_repeats`, `drafted_resolutions`, and
+`already_covered_still_recurring` were still result-page-shaped producer
+outputs despite being declared for both `web` and `pdf`.
+
+This change fixes the root for this contract layer by making the producer carry
+PDF-sized, bounded paid action sections with explicit web/PDF limits. It does
+not render the PDF; the renderer slice consumes this contract next.
+
+Diff-size note: this slice exceeds the 400 LOC soft cap because the review fix
+is inseparable from the contract change: historical stored `deflection.v1`
+reports need the same limit defaults before S4B can safely render from this
+contract. Splitting that compatibility guard would leave one pushed commit with
+two valid stored shapes under the same schema version.
+
+## Scope (this PR)
+
+Ownership lane: issue-1612/deflection-full-report-delivery-actionability
+Slice phase: Vertical slice
+
+1. Add explicit result-page/PDF action-section limits to the paid
+   `deflection.v1` model contract for unresolved repeats, drafted resolutions,
+   and already-covered-still-recurring callouts.
+2. Keep those sections bounded to the PDF limit in the model while preserving
+   result-page top-three metadata for downstream renderers.
+3. Prove Snapshot remains fail-closed: these paid action sections still have no
+   `snapshot_safe_fields`, so new paid payload is absent from free Snapshot.
+4. Normalize historical stored `deflection.v1` action sections so missing
+   limit fields are backfilled before renderer-facing routes consume them.
+5. Max files: 5.
+
+### Review Contract
+
+Acceptance criteria:
+- `priority_fix_queue` remains unchanged: result page limit 3, PDF limit 10,
+  backlog limit 25.
+- `top_unresolved_repeats`, `drafted_resolutions`, and
+  `already_covered_still_recurring` expose `result_page_limit` and `pdf_limit`
+  in `required_data` and `data`.
+- Those three sections keep up to `_ACTION_PDF_LIMIT` items in the paid model,
+  not only `_ACTION_RESULT_PAGE_LIMIT`.
+- Single-ticket unresolved rows remain excluded from unresolved repeats.
+- No action-section field is marked `snapshot_safe_fields`; free Snapshot does
+  not include the new paid section payload.
+- Historical stored models missing these action-section limit fields are
+  backfilled at the storage projection boundary without mutating the raw
+  artifact.
+
+Affected surfaces:
+- ATLAS deflection report-model producer only.
+- ATLAS stored report-model projection for paid/unlocked historical reports.
+- Tests that lock the report model contract.
+- The committed frontend contract example generated from the producer shape.
+
+Risk areas:
+- Accidentally widening the free Snapshot projection.
+- Breaking downstream consumers that rely on `top_item_count`.
+- Making renderer-specific choices in the producer.
+
+- Reviewer rules triggered: R1, R2, R3, R10, R13, R14.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-PDF-Action-Queue-Contract.md`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+The existing action constants stay canonical:
+
+```python
+_ACTION_RESULT_PAGE_LIMIT = 3
+_ACTION_PDF_LIMIT = 10
+_ACTION_BACKLOG_LIMIT = 25
+```
+
+This slice applies the same explicit limit pattern already used by
+`priority_fix_queue` to the three secondary action sections. The producer keeps
+up to `max(_ACTION_RESULT_PAGE_LIMIT, _ACTION_PDF_LIMIT)` rows for those paid
+sections and includes both limit values in section data. The section registry's
+`required_data` is updated so consumers can rely on those fields instead of
+hardcoding limits.
+
+Snapshot remains allowlist-only by construction. These paid action sections
+continue to define no `snapshot_safe_fields`, so `_snapshot_report_model_projection`
+drops them from the free projection.
+
+## Intentional
+
+- No PDF renderer changes in this PR. S4A defines the bounded contract; S4B
+  should render from it.
+- `top_item_count` remains the count of included model rows for compatibility.
+  Renderers use `result_page_limit` or `pdf_limit` to decide how many to show.
+- The evidence export/backlog table remains capped separately at the existing
+  default 25.
+- The slice does not add S6 delta/writeback identity fields.
+
+## Deferred
+
+- S4B: render the PDF action sections from these explicit limits.
+- S4C: add cross-surface PDF/result-page assertions that prove renderer output
+  agrees with the paid model while Snapshot stays closed.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 127 passed.
+- `python -m pytest tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_example_matches_producer_shape -q` -- 1 passed.
+- `python -m pytest tests/test_content_ops_faq_report_contract_docs.py -q` -- 5 passed.
+- `python -m pytest tests/test_content_ops_deflection_report.py::test_stored_deflection_report_model_backfills_legacy_action_limits tests/test_content_ops_deflection_report.py::test_stored_deflection_report_model_tolerates_legacy_and_schema_drift tests/test_content_ops_deflection_report.py::test_in_memory_deflection_report_store_round_trips_report_model -q` -- 3 passed.
+- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/deflection_report_access.py tests/test_content_ops_deflection_report.py` -- passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/PR-Deflection-PDF-Action-Queue-Contract.md` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_deflection_report_example.json` | 16 |
+| `extracted_content_pipeline/deflection_report_access.py` | 47 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 30 |
+| `plans/PR-Deflection-PDF-Action-Queue-Contract.md` | 143 |
+| `tests/test_content_ops_deflection_report.py` | 219 |
+| **Total** | **455** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -402,15 +402,21 @@ def test_deflection_report_artifact_exposes_structured_model_sections() -> None:
 
     unresolved = section_by_id["top_unresolved_repeats"]["data"]
     assert unresolved["top_item_count"] == 1
+    assert unresolved["result_page_limit"] == 3
+    assert unresolved["pdf_limit"] == 10
     assert unresolved["items"][0]["question"] == "Can I turn on SSO for all users?"
     assert unresolved["items"][0]["estimated_support_cost"] == 40.5
 
     drafted = section_by_id["drafted_resolutions"]["data"]
     assert drafted["top_item_count"] == 1
+    assert drafted["result_page_limit"] == 3
+    assert drafted["pdf_limit"] == 10
     assert drafted["items"][0]["question"] == "How do I export attribution reports?"
 
     recurring = section_by_id["already_covered_still_recurring"]["data"]
     assert recurring["top_item_count"] == 0
+    assert recurring["result_page_limit"] == 3
+    assert recurring["pdf_limit"] == 10
     assert recurring["items"] == []
 
     backlog = section_by_id["backlog_table"]["data"]
@@ -725,33 +731,39 @@ def test_deflection_priority_fix_queue_keeps_pdf_limit_items() -> None:
     assert priority["items"][0]["question"] == "How do I resolve repeat issue 12?"
 
 
-def test_deflection_top_unresolved_repeats_excludes_single_ticket_items() -> None:
+def test_deflection_top_unresolved_repeats_keeps_pdf_limit_items() -> None:
     result = TicketFAQMarkdownResult(
         markdown="# FAQ",
-        source_count=3,
-        ticket_source_count=3,
+        source_count=13,
+        ticket_source_count=13,
         output_checks={"condensed": True},
         items=(
             {
                 "question": "How do I handle a one-off invoice question?",
                 "customer_wording": "one-off invoice question",
                 "topic": "billing",
-                "weighted_frequency": 1,
+                "weighted_frequency": 99,
                 "ticket_count": 1,
-                "opportunity_score": 9,
+                "opportunity_score": 99,
                 "answer_evidence_status": "draft_needs_review",
                 "source_ids": ("ticket-singleton-1",),
             },
-            {
-                "question": "How do I handle repeated invoice questions?",
-                "customer_wording": "repeated invoice question",
-                "topic": "billing",
-                "weighted_frequency": 2,
-                "ticket_count": 2,
-                "opportunity_score": 8,
-                "answer_evidence_status": "draft_needs_review",
-                "source_ids": ("ticket-repeat-1", "ticket-repeat-2"),
-            },
+            *(
+                {
+                    "question": f"How do I resolve unresolved repeat {index}?",
+                    "customer_wording": f"unresolved repeat {index}",
+                    "topic": "billing",
+                    "weighted_frequency": index,
+                    "ticket_count": index,
+                    "opportunity_score": index,
+                    "answer_evidence_status": "draft_needs_review",
+                    "source_ids": tuple(
+                        f"ticket-unresolved-{index}-{source}"
+                        for source in range(1, index + 1)
+                    ),
+                }
+                for index in range(2, 14)
+            ),
         ),
     )
 
@@ -763,11 +775,102 @@ def test_deflection_top_unresolved_repeats_excludes_single_ticket_items() -> Non
     }
     unresolved = sections["top_unresolved_repeats"]["data"]
 
-    assert unresolved["top_item_count"] == 1
+    assert unresolved["result_page_limit"] == 3
+    assert unresolved["pdf_limit"] == 10
+    assert unresolved["top_item_count"] == 10
+    assert len(unresolved["items"]) == 10
     assert unresolved["items"][0]["question"] == (
-        "How do I handle repeated invoice questions?"
+        "How do I resolve unresolved repeat 13?"
     )
     assert "one-off" not in json.dumps(unresolved, sort_keys=True)
+
+
+def test_deflection_drafted_resolutions_keep_pdf_limit_items() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=12,
+        ticket_source_count=12,
+        output_checks={"condensed": True},
+        items=tuple(
+            {
+                "question": f"How do I publish drafted answer {index}?",
+                "customer_wording": f"drafted answer {index}",
+                "topic": "support",
+                "weighted_frequency": index,
+                "ticket_count": index,
+                "opportunity_score": index,
+                "answer": f"Use the drafted answer for issue {index}.",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "source_ids": tuple(
+                    f"ticket-drafted-{index}-{source}"
+                    for source in range(1, index + 1)
+                ),
+            }
+            for index in range(1, 13)
+        ),
+    )
+
+    sections = {
+        section["id"]: section
+        for section in build_deflection_report_artifact(result).as_dict()[
+            "report_model"
+        ]["sections"]
+    }
+    drafted = sections["drafted_resolutions"]["data"]
+
+    assert drafted["result_page_limit"] == 3
+    assert drafted["pdf_limit"] == 10
+    assert drafted["top_item_count"] == 10
+    assert len(drafted["items"]) == 10
+    assert drafted["items"][0]["question"] == "How do I publish drafted answer 12?"
+
+
+def test_deflection_already_covered_still_recurring_keeps_pdf_limit_items() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=12,
+        ticket_source_count=12,
+        output_checks={"condensed": True},
+        items=tuple(
+            {
+                "question": f"How do I find covered answer {index}?",
+                "customer_wording": f"covered answer {index}",
+                "topic": "support",
+                "weighted_frequency": index,
+                "ticket_count": index,
+                "opportunity_score": index,
+                "answer": f"Use the published answer for issue {index}.",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "outcome_diagnostics": {
+                    "diagnostic_ticket_count": index,
+                    "outcome_risk_ticket_count": 1,
+                    "reopened_ticket_count": 1,
+                    "negative_csat_ticket_count": 0,
+                },
+                "source_ids": tuple(
+                    f"ticket-covered-{index}-{source}"
+                    for source in range(1, index + 1)
+                ),
+            }
+            for index in range(1, 13)
+        ),
+    )
+
+    sections = {
+        section["id"]: section
+        for section in build_deflection_report_artifact(result).as_dict()[
+            "report_model"
+        ]["sections"]
+    }
+    recurring = sections["already_covered_still_recurring"]["data"]
+
+    assert recurring["result_page_limit"] == 3
+    assert recurring["pdf_limit"] == 10
+    assert recurring["top_item_count"] == 10
+    assert len(recurring["items"]) == 10
+    assert recurring["items"][0]["question"] == "How do I find covered answer 12?"
 
 
 def test_deflection_action_evidence_quotes_match_source_ids() -> None:
@@ -826,6 +929,12 @@ def test_deflection_snapshot_projection_is_allowlist_only() -> None:
     sections["priority_fix_queue"]["data"]["items"][0]["paid_only_note"] = (
         "hidden action detail"
     )
+    sections["top_unresolved_repeats"]["data"]["items"][0]["paid_only_note"] = (
+        "hidden unresolved action detail"
+    )
+    sections["drafted_resolutions"]["data"]["items"][0]["paid_only_note"] = (
+        "hidden drafted action detail"
+    )
     sections["question_details"]["data"]["rows"][1]["answer"] = (
         "LOCKED PAID ANSWER SHOULD NOT PROJECT"
     )
@@ -841,6 +950,8 @@ def test_deflection_snapshot_projection_is_allowlist_only() -> None:
     assert "ticket-export-1" not in encoded
     assert "priority_fix_queue" not in encoded
     assert "hidden action detail" not in encoded
+    assert "hidden unresolved action detail" not in encoded
+    assert "hidden drafted action detail" not in encoded
     assert "LOCKED PAID ANSWER SHOULD NOT PROJECT" not in encoded
     assert "LOCKED PAID STEP SHOULD NOT PROJECT" not in encoded
     assert snapshot["top_questions"][0] == {
@@ -983,7 +1094,13 @@ def test_deflection_report_model_contract_shape_requires_version_bump() -> None:
             36,
             ["web", "pdf"],
             3,
-            ["items", "top_item_count", "support_cost_basis"],
+            [
+                "items",
+                "top_item_count",
+                "result_page_limit",
+                "pdf_limit",
+                "support_cost_basis",
+            ],
             [],
         ),
         (
@@ -991,7 +1108,12 @@ def test_deflection_report_model_contract_shape_requires_version_bump() -> None:
             37,
             ["web", "pdf", "email_summary"],
             3,
-            ["items", "top_item_count"],
+            [
+                "items",
+                "top_item_count",
+                "result_page_limit",
+                "pdf_limit",
+            ],
             [],
         ),
         (
@@ -999,7 +1121,12 @@ def test_deflection_report_model_contract_shape_requires_version_bump() -> None:
             38,
             ["web", "pdf"],
             3,
-            ["items", "top_item_count"],
+            [
+                "items",
+                "top_item_count",
+                "result_page_limit",
+                "pdf_limit",
+            ],
             [],
         ),
         (
@@ -3435,6 +3562,58 @@ def test_stored_deflection_report_model_tolerates_legacy_and_schema_drift() -> N
             },
         ],
     }
+
+
+def test_stored_deflection_report_model_backfills_legacy_action_limits() -> None:
+    artifact = build_deflection_report_artifact(
+        _structured_report_fixture_result()
+    ).as_dict()
+    legacy_artifact = json.loads(json.dumps(artifact))
+    section_by_id = {
+        section["id"]: section
+        for section in legacy_artifact["report_model"]["sections"]
+    }
+    expected_limits = {
+        "priority_fix_queue": {
+            "result_page_limit": 3,
+            "pdf_limit": 10,
+            "backlog_limit": 25,
+        },
+        "top_unresolved_repeats": {
+            "result_page_limit": 3,
+            "pdf_limit": 10,
+        },
+        "drafted_resolutions": {
+            "result_page_limit": 3,
+            "pdf_limit": 10,
+        },
+        "already_covered_still_recurring": {
+            "result_page_limit": 3,
+            "pdf_limit": 10,
+        },
+    }
+    for section_id, limits in expected_limits.items():
+        section = section_by_id[section_id]
+        for key in limits:
+            section["data"].pop(key, None)
+            section["required_data"] = [
+                required for required in section["required_data"]
+                if required != key
+            ]
+
+    payload = stored_deflection_report_model(legacy_artifact)
+    assert payload is not None
+    normalized_sections = {
+        section["id"]: section
+        for section in payload["sections"]
+    }
+    for section_id, limits in expected_limits.items():
+        section = normalized_sections[section_id]
+        for key, expected in limits.items():
+            assert section["data"][key] == expected
+            assert key in section["required_data"]
+            assert key not in section_by_id[section_id]["data"]
+            assert key not in section_by_id[section_id]["required_data"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-PDF-Action-Queue-Contract.md
Slice phase: Vertical slice

#1612 shifted the paid deflection report toward an actionable work queue. This slice makes the ATLAS `deflection.v1` producer carry bounded PDF-sized paid action sections for unresolved repeats, drafted resolutions, and already-covered-still-recurring callouts, while preserving result-page top-three limits for downstream renderers. The committed frontend contract example is refreshed from the same producer shape, and stored historical models are normalized at the access boundary so old `deflection.v1` artifacts expose the same action-section limit defaults to renderer-facing routes.

## Intentional
- No PDF renderer changes in this PR. S4A defines the bounded model contract; S4B should render from it.
- `top_item_count` remains the count of included model rows for compatibility. Renderers use `result_page_limit` or `pdf_limit` to decide how many to show.
- Historical raw artifacts are not rewritten; `stored_deflection_report_model()` backfills only the safe exposed projection.
- The evidence export/backlog table remains capped separately at the existing default 25.
- The slice does not add S6 delta/writeback identity fields.

## Deferred
- S4B: render the PDF action sections from these explicit limits.
- S4C: add cross-surface PDF/result-page assertions that prove renderer output agrees with the paid model while Snapshot stays closed.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: frontend contract example now includes `result_page_limit` / `pdf_limit` in both `required_data` and section `data`.
- Fixed: historical stored `deflection.v1` action sections missing these limit fields are normalized before renderer-facing access.
- Waived: none.

## Verification
- `python -m pytest tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_example_matches_producer_shape -q` -- 1 passed.
- `python -m pytest tests/test_content_ops_faq_report_contract_docs.py -q` -- 5 passed.
- `python -m pytest tests/test_content_ops_deflection_report.py -q` -- 127 passed.
- `python -m pytest tests/test_content_ops_deflection_report.py::test_stored_deflection_report_model_backfills_legacy_action_limits tests/test_content_ops_deflection_report.py::test_stored_deflection_report_model_tolerates_legacy_and_schema_drift tests/test_content_ops_deflection_report.py::test_in_memory_deflection_report_store_round_trips_report_model -q` -- 3 passed.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/deflection_report_access.py tests/test_content_ops_deflection_report.py` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/PR-Deflection-PDF-Action-Queue-Contract.md` -- passed.

## Diff size
5 files, +455 / -28.
