### PR TITLE
Split deflection PII headline gate counts

### DIFF
--- a/plans/PR-Deflection-PII-Headline-Gate-Split.md
+++ b/plans/PR-Deflection-PII-Headline-Gate-Split.md
@@ -1,0 +1,114 @@
+# PR-Deflection-PII-Headline-Gate-Split
+
+## Why this slice exists
+
+#1742 now has the deterministic tiny-corpus scrubber loop clean: email, phone,
+SSN, payment card, DOB, street address, order IDs, cue-prefixed names, and
+must-survive tokens all score clean after #1757. The remaining
+`free_high_severity_leak_count=1` is the explicitly deferred cue-less/open-set
+`person_name-001` gap that #1742 says must be reported but not gate on until a
+separate NER/open-set slice exists.
+
+Root cause: the scorer headline currently exposes only one all-in
+high-severity free-surface leak count. That count correctly keeps the open-set
+name gap visible, but it also makes the deterministic gate-eligible state
+ambiguous: the future advisory-to-gating decision cannot distinguish "the
+deterministic scrubber is clean" from "all high-severity PII is clean." This
+slice fixes the measurement root by adding an explicit gate-eligible headline
+split while keeping the all-in/deferred counts visible.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 3
+
+1. Add scorer headline fields for gate-eligible free high-severity leaks and
+   deferred cue-less/open-set name leaks.
+2. Keep the existing all-in `free_high_severity_leak_count` unchanged so the
+   residual open-set gap stays visible.
+3. Add focused tests proving cue-less names are excluded only from the
+   gate-eligible count, while any other high-severity free-surface leak still
+   blocks that gate-eligible count.
+
+### Review Contract
+
+Acceptance criteria:
+- Existing `headline.free_high_severity_leak_count` remains the all-in
+  diagnostic count and still reports `1` on the tiny corpus.
+- New gate-eligible headline fields report `0` leaks / pass true on the current
+  tiny corpus because the only residual is `person_name` with
+  `name_subtype=cue_less`.
+- A forced non-open-set high-severity free-surface leak increments both the
+  all-in and gate-eligible counts.
+- Leak samples remain surrogate-id only; no raw spans or tokens are added.
+- This PR does not flip CI/advisory behavior to a hard gate and does not attempt
+  cue-less/open-set NER.
+
+Affected surfaces:
+- `scripts/score_deflection_pii_recall.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+Risk areas:
+- Hiding the deferred cue-less name gap by filtering it out of the all-in
+  headline or leak samples.
+- Accidentally excluding non-name high-severity leaks from the gate-eligible
+  count.
+
+- Reviewer rules triggered: R1 Requirements match, R2 Test evidence, R10
+  Maintainability, R14 Codebase verification.
+
+### Files touched
+
+- `plans/PR-Deflection-PII-Headline-Gate-Split.md`
+- `scripts/score_deflection_pii_recall.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+## Mechanism
+
+The scorer already computes per-label leak scores with class, severity,
+name_subtype, surface, surrogate_id, and leak status. This slice replaces the
+single headline count helper with a headline summary helper that partitions
+unique free-surface high-severity leaked surrogate IDs into:
+
+- all high-severity leaked IDs;
+- deferred cue-less/open-set `person_name` leaked IDs;
+- gate-eligible leaked IDs, which are all leaked IDs minus the deferred cue-less
+  name IDs.
+
+The output remains additive. Existing consumers can keep reading
+`free_high_severity_leak_count`; future advisory/gating code can use the
+gate-eligible count without pretending the open-set name gap disappeared.
+
+## Intentional
+
+- No NER or cue-less name scrubber change; #1742 explicitly defers that to a
+  separate slice.
+- No CI gate flip. This only makes the scorer output unambiguous for the future
+  operator decision.
+- No raw leaked values in headline or samples.
+
+## Deferred
+
+- Operator-derived gold corpus, thresholds, and advisory-to-gating timing remain
+  open #1742 decisions.
+- Model-based NER for cue-less/open-set names remains separate.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_score_deflection_pii_recall.py -q` -- 17 passed.
+- `python scripts/score_deflection_pii_recall.py --json` -- status ok;
+  headline reports one all-in deferred open-set name leak and zero
+  gate-eligible leaks.
+- Python bytecode compile for the scorer script and scorer tests -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-PII-Headline-Gate-Split.md` | 114 |
+| `scripts/score_deflection_pii_recall.py` | 51 |
+| `tests/test_score_deflection_pii_recall.py` | 38 |
+| **Total** | **203** |

--- a/scripts/score_deflection_pii_recall.py
+++ b/scripts/score_deflection_pii_recall.py
@@ -146,7 +146,7 @@ def score_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
     )
     surface_summary = _surface_summary(label_scores)
     person_name_summary = _person_name_summary(label_scores)
-    headline_leak_count = _headline_free_high_severity_leak_count(label_scores)
+    headline_summary = _headline_summary(label_scores)
 
     return {
         "schema_version": SCORE_SCHEMA_VERSION,
@@ -158,10 +158,7 @@ def score_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
             "label_count": len(labels),
             "must_survive_count": len(must_survive),
         },
-        "headline": {
-            "free_high_severity_leak_count": headline_leak_count,
-            "free_high_severity_pass": headline_leak_count == 0,
-        },
+        "headline": headline_summary,
         "surfaces": surface_summary,
         "person_name": person_name_summary,
         "must_survive": must_survive_result,
@@ -540,18 +537,46 @@ def _person_name_summary(scores: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _headline_free_high_severity_leak_count(scores: Sequence[Mapping[str, Any]]) -> int:
-    leaked_ids = {
-        _clean(score.get("surrogate_id"))
+def _headline_summary(scores: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    leaked_ids = _free_high_severity_leaked_ids(scores)
+    deferred_open_set_name_ids = {
+        _score_surrogate_id(score)
+        for score in scores
+        if _score_surrogate_id(score) in leaked_ids
+        and _clean(score.get("class")) == "person_name"
+        and _clean(score.get("name_subtype")) == "cue_less"
+    }
+    gate_eligible_ids = leaked_ids - deferred_open_set_name_ids
+    return {
+        "free_high_severity_leak_count": len(leaked_ids),
+        "free_high_severity_pass": len(leaked_ids) == 0,
+        "free_high_severity_gate_eligible_leak_count": len(gate_eligible_ids),
+        "free_high_severity_gate_eligible_pass": len(gate_eligible_ids) == 0,
+        "deferred_open_set_name_leak_count": len(deferred_open_set_name_ids),
+    }
+
+
+def _free_high_severity_leaked_ids(scores: Sequence[Mapping[str, Any]]) -> set[str]:
+    return {
+        leaked_id
         for score in scores
         if score.get("leaked") is True
         and _clean(score.get("surface")) in FREE_SURFACES
-        and (
-            _clean(score.get("severity")) == "high"
-            or _clean(score.get("class")) in HIGH_SEVERITY_CLASSES
-        )
+        and _score_is_high_severity(score)
+        for leaked_id in (_score_surrogate_id(score),)
+        if leaked_id
     }
-    return len({value for value in leaked_ids if value})
+
+
+def _score_is_high_severity(score: Mapping[str, Any]) -> bool:
+    return (
+        _clean(score.get("severity")) == "high"
+        or _clean(score.get("class")) in HIGH_SEVERITY_CLASSES
+    )
+
+
+def _score_surrogate_id(score: Mapping[str, Any]) -> str:
+    return _clean(score.get("surrogate_id"))
 
 
 def _class_summary(counts: Mapping[str, int]) -> dict[str, Any]:

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -75,6 +75,9 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     }
     assert set(summary["person_name"]) == {"cue_less", "cue_prefixed"}
     assert summary["headline"] == {
+        "deferred_open_set_name_leak_count": 1,
+        "free_high_severity_gate_eligible_leak_count": 0,
+        "free_high_severity_gate_eligible_pass": True,
         "free_high_severity_leak_count": 1,
         "free_high_severity_pass": False,
     }
@@ -202,6 +205,41 @@ def test_forced_leak_reports_surface_and_surrogate_without_span() -> None:
     assert {sample["surface"] for sample in matching} >= expected_surfaces
     assert all("span" not in sample for sample in matching)
     assert "UNSCRUBBED_SENTINEL" not in json.dumps(
+        summary["leak_samples"],
+        sort_keys=True,
+    )
+
+
+def test_gate_eligible_headline_excludes_only_deferred_open_set_names() -> None:
+    corpus = _tiny_corpus()
+    ticket = corpus["tickets"][0]
+    ticket["fields"]["subject"] = (
+        f"{ticket['fields']['subject']} UNSCRUBBED_HIGH_SEV"
+    )
+    ticket["labels"].append(
+        {
+            "class": "custom_token",
+            "origin_field": "subject",
+            "severity": "high",
+            "span": "UNSCRUBBED_HIGH_SEV",
+            "surrogate_id": "custom-high-sev-001",
+        }
+    )
+
+    summary = CLI.score_corpus(corpus)
+
+    assert summary["headline"] == {
+        "deferred_open_set_name_leak_count": 1,
+        "free_high_severity_gate_eligible_leak_count": 1,
+        "free_high_severity_gate_eligible_pass": False,
+        "free_high_severity_leak_count": 2,
+        "free_high_severity_pass": False,
+    }
+    assert {
+        sample["surrogate_id"]
+        for sample in summary["leak_samples"]
+    } >= {"custom-high-sev-001", "person_name-001"}
+    assert "UNSCRUBBED_HIGH_SEV" not in json.dumps(
         summary["leak_samples"],
         sort_keys=True,
     )


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Headline-Gate-Split.md
Slice phase: Vertical slice

#1742 now has deterministic tiny-corpus PII leaks clean except the explicitly deferred cue-less/open-set `person_name-001` gap. This slice fixes the scorer measurement root by splitting the headline into the existing all-in free high-severity leak count plus a gate-eligible count that excludes only deferred cue-less/open-set names, so future advisory/gating decisions can see that deterministic scrubber classes are clean without hiding the open-set residual.

## Intentional
- No NER or cue-less name scrubber change; #1742 explicitly defers that to a separate slice.
- No CI gate flip. This only makes the scorer output unambiguous for the future operator decision.
- No raw leaked values in headline or samples.

## Deferred
- Operator-derived gold corpus, thresholds, and advisory-to-gating timing remain open #1742 decisions.
- Model-based NER for cue-less/open-set names remains separate.

## Parked hardening
- None.

## Verification
- `pytest tests/test_score_deflection_pii_recall.py -q` -- 17 passed.
- `python scripts/score_deflection_pii_recall.py --json` -- status ok; headline reports one all-in deferred open-set name leak and zero gate-eligible leaks.
- Python bytecode compile for the scorer script and scorer tests -- passed.
- `python scripts/sync_pr_plan.py --check plans/PR-Deflection-PII-Headline-Gate-Split.md` -- plan already in sync.
- `git diff --check` -- passed.

## Diff size
3 files, +190 / -13
