### PR TITLE
Render deflection PDF action sections

### DIFF
--- a/atlas_brain/deflection_pdf_renderer.py
+++ b/atlas_brain/deflection_pdf_renderer.py
@@ -36,6 +36,34 @@ _QUESTION_DETAIL_CAP_NOTE = (
     "for PDF readability; download the complete evidence export for the full "
     "uncapped evidence archive."
 )
+_ACTION_SECTION_INTROS = {
+    "priority_fix_queue": (
+        "Use this queue as the first-pass work plan for the help center or macro "
+        "backlog. Items are ranked by repeat volume, benchmark support cost, "
+        "answer status, confidence, and available outcome signals."
+    ),
+    "top_unresolved_repeats": (
+        "These repeated customer questions still need an approved answer. The "
+        "support-cost estimate sizes the repeated assisted-contact work that "
+        "stays unresolved for each question."
+    ),
+    "drafted_resolutions": (
+        "These repeated questions have drafted or adaptable resolution copy. "
+        "Review, approve, and publish the answer where it belongs."
+    ),
+    "already_covered_still_recurring": (
+        "These questions appear to have a covered answer but still recur. Treat "
+        "them as discoverability, clarity, or answer-quality follow-ups."
+    ),
+}
+_ACTION_SECTION_EMPTY_MESSAGES = {
+    "priority_fix_queue": "No priority action items were generated for this run.",
+    "top_unresolved_repeats": "No unresolved repeated questions were generated for this run.",
+    "drafted_resolutions": "No drafted resolutions were generated for this run.",
+    "already_covered_still_recurring": (
+        "No covered-but-still-recurring questions were generated for this run."
+    ),
+}
 
 _UNICODE_MAP = str.maketrans({
     "\u2014": "--",
@@ -225,6 +253,8 @@ def _report_model_section_pdf_lines(section: Mapping[str, Any]) -> list[str]:
         return _ranked_questions_model_pdf_lines(section)
     if section_id == "outcome_diagnostics":
         return _outcome_diagnostics_model_pdf_lines(section)
+    if section_id in _ACTION_SECTION_INTROS:
+        return _action_section_model_pdf_lines(section, section_id=section_id)
     if section_id == "question_details":
         return _question_details_model_pdf_lines(section)
     return []
@@ -476,6 +506,70 @@ def _question_details_model_pdf_lines(section: Mapping[str, Any]) -> list[str]:
     if len(rows) > PDF_QUESTION_DETAIL_LIMIT:
         lines.extend(["", _QUESTION_DETAIL_CAP_NOTE, ""])
     return lines
+
+
+def _action_section_model_pdf_lines(
+    section: Mapping[str, Any],
+    *,
+    section_id: str,
+) -> list[str]:
+    data = _section_data(section)
+    rows = _model_rows(data.get("items"))
+    title = _model_text(section.get("title")) or _action_section_title(section_id)
+    lines = [
+        f"## {title}",
+        "",
+        _ACTION_SECTION_INTROS[section_id],
+        "",
+        (
+            "Complete source IDs and raw evidence quotes stay in the complete "
+            "evidence export, not this curated PDF."
+        ),
+        "",
+    ]
+    if not rows:
+        return [*lines, _ACTION_SECTION_EMPTY_MESSAGES[section_id], ""]
+
+    limit = _action_section_pdf_limit(data, row_count=len(rows))
+    lines.extend([
+        (
+            "| Rank | Question | Status | Tickets | Support cost | Priority | "
+            "Owner lane | Recommended action |"
+        ),
+        "|---:|---|---|---:|---:|---:|---|---|",
+    ])
+    for index, row in enumerate(rows[:limit], start=1):
+        rank = _model_int(row.get("rank")) or index
+        lines.append(
+            "| "
+            f"{rank} | "
+            f"{_model_cell(row.get('question'))} | "
+            f"{_model_cell(row.get('status'))} | "
+            f"{_model_count(_model_int(row.get('ticket_count')))} | "
+            f"{_model_money(row.get('estimated_support_cost'))} | "
+            f"{_model_int(row.get('priority_score'))} | "
+            f"{_model_cell(row.get('owner_lane'))} | "
+            f"{_model_cell(row.get('recommended_action'))} |"
+        )
+    if len(rows) > limit:
+        lines.extend([
+            "",
+            (
+                f"{title} capped at {_model_count(limit)} items for PDF readability; "
+                "download the complete evidence export for the full evidence archive."
+            ),
+        ])
+    lines.append("")
+    return lines
+
+
+def _action_section_pdf_limit(data: Mapping[str, Any], *, row_count: int) -> int:
+    limit = _model_int(data.get("pdf_limit")) or row_count
+    return max(1, min(limit, row_count))
+
+
+def _action_section_title(section_id: str) -> str:
+    return section_id.replace("_", " ").title()
 
 
 def _publishable_answer_model_pdf_lines(

--- a/plans/PR-Deflection-PDF-Action-Sections.md
+++ b/plans/PR-Deflection-PDF-Action-Sections.md
@@ -1,0 +1,124 @@
+# PR-Deflection-PDF-Action-Sections
+
+## Why this slice exists
+
+Issue #1612 is turning the paid deflection report into an actionable support
+ops deliverable. PR #1758/S4A added explicit `pdf_limit` / `result_page_limit`
+contract fields for the action-oriented report-model sections, but the PDF
+renderer still allowlists only the older section IDs. As a result, the paid PDF
+can include ranked questions and details while silently dropping the work queue
+sections that tell a help-center owner what to fix first.
+
+Root cause: `atlas_brain.deflection_pdf_renderer._report_model_section_pdf_lines`
+admits PDF sections by explicit section ID, and the S4A action-section IDs have
+no renderer branch yet. This slice fixes the root at the PDF render boundary by
+adding allowlist construction for those action sections instead of widening the
+renderer to dump arbitrary section payloads.
+
+## Scope (this PR)
+
+Ownership lane: issue-1612/deflection-full-report-delivery-actionability
+Slice phase: Vertical slice
+
+1. Render the S4A action sections in the paid PDF from their existing
+   report-model payloads: `priority_fix_queue`, `top_unresolved_repeats`,
+   `drafted_resolutions`, and `already_covered_still_recurring`.
+2. Use each section's `data.pdf_limit` as the PDF row cap, while keeping the
+   result-page limit and broader report-model contract unchanged.
+3. Add renderer tests proving the PDF markdown includes only allowlisted
+   action-item fields, caps at `pdf_limit`, and does not expose raw evidence,
+   source IDs, or representative phrasing payloads.
+
+### Review Contract
+
+Acceptance criteria:
+
+- Paid report-model PDFs render all four action-section IDs when their
+  `surfaces` include `pdf`.
+- Action-section rendering is allowlist construction: no `top_evidence`,
+  `source_ids`, `representative_phrasing`, or raw quote fields are emitted.
+- The renderer honors `data.pdf_limit`; it does not reuse the smaller
+  `result_page_limit` and does not invent a new backend contract.
+- Existing ranked-question, question-detail, and curated-markdown PDF behavior
+  remains unchanged.
+
+Affected surfaces:
+
+- `atlas_brain/deflection_pdf_renderer.py`
+- `tests/test_deflection_pdf_renderer.py`
+
+Risk areas:
+
+- Privacy/export boundary: action items can carry raw evidence fields in the
+  stored model, but the PDF must be a curated surface.
+- Report-actionability contract: the PDF should show the top paid queue items,
+  not only the web teaser count.
+
+Triggered reviewer rules:
+
+- R1 Requirements match
+- R2 Test evidence
+- R3 Security/auth/privacy
+- R5 Boundary/contract preservation
+- R8 Thin-slice scope
+- R13 Review-finding class coverage
+- R14 Codebase verification
+
+Max files: 3
+
+### Files touched
+
+- `atlas_brain/deflection_pdf_renderer.py`
+- `plans/PR-Deflection-PDF-Action-Sections.md`
+- `tests/test_deflection_pdf_renderer.py`
+
+## Mechanism
+
+Add explicit action-section branches to `_report_model_section_pdf_lines`.
+Those branches call a shared helper that:
+
+- reads `items` and `pdf_limit` from `section.data`;
+- emits a short section intro plus an allowlisted table of rank, question,
+  status, tickets, estimated support cost, priority score, owner lane, and
+  recommended action;
+- appends a cap note when more model items exist than the PDF renders;
+- ignores raw evidence/source fields even when they are present in the stored
+  report model.
+
+This keeps the PDF renderer fail-closed: a new section ID still renders only
+after it gets an explicit renderer branch.
+
+## Intentional
+
+- This PR does not change the report-model producer, stored-model normalizer,
+  frontend result page, email summary, or complete evidence export. S4A already
+  created the contract; this slice consumes it in the PDF only.
+- The action-section helper emits compact tables rather than full per-item
+  narrative blocks. The PDF should be dense enough to hand to a support lead
+  without becoming the complete ticket archive.
+- The renderer does not include `top_evidence`, `source_id`, `source_ids`, or
+  `representative_phrasing` in action sections. Complete evidence remains in
+  the export JSON.
+
+## Deferred
+
+- Full PDF layout polish, richer grouping, and any browser/portfolio result-page
+  changes remain later #1612 slices.
+- Email attachment/body delivery wiring remains a separate delivery slice.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_deflection_pdf_renderer.py -q -- 13 passed.
+- Command: python -m py_compile atlas_brain/deflection_pdf_renderer.py tests/test_deflection_pdf_renderer.py -- passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_pdf_action_sections.md -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/deflection_pdf_renderer.py` | 94 |
+| `plans/PR-Deflection-PDF-Action-Sections.md` | 124 |
+| `tests/test_deflection_pdf_renderer.py` | 83 |
+| **Total** | **301** |

--- a/tests/test_deflection_pdf_renderer.py
+++ b/tests/test_deflection_pdf_renderer.py
@@ -254,6 +254,89 @@ def test_report_model_pdf_markdown_caps_rows_and_skips_non_pdf_sections() -> Non
     assert "complete evidence export" in model_markdown
 
 
+def test_report_model_pdf_markdown_renders_action_sections_with_pdf_limit() -> None:
+    section_ids = (
+        "priority_fix_queue",
+        "top_unresolved_repeats",
+        "drafted_resolutions",
+        "already_covered_still_recurring",
+    )
+    sections = []
+    for priority, section_id in enumerate(section_ids, start=35):
+        sections.append(
+            {
+                "id": section_id,
+                "title": section_id.replace("_", " ").title(),
+                "priority": priority,
+                "surfaces": ["web", "pdf"],
+                "default_limit": 3,
+                "required_data": ["items", "result_page_limit", "pdf_limit"],
+                "data": {
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                    "items": [
+                        {
+                            "rank": index,
+                            "question": f"Action question {section_id} {index}",
+                            "status": "Needs answer",
+                            "ticket_count": index,
+                            "estimated_support_cost": index * 13.5,
+                            "priority_score": 100 - index,
+                            "owner_lane": f"Lane {index}",
+                            "recommended_action": (
+                                f"Fix action {section_id} {index}"
+                            ),
+                            "representative_phrasing": [
+                                f"RAW_REPRESENTATIVE_PHRASE_{section_id}_{index}"
+                            ],
+                            "source_ids": (
+                                f"RAW_SOURCE_ID_{section_id}_{index}",
+                            ),
+                            "top_evidence": [
+                                {
+                                    "source_id": (
+                                        f"RAW_TOP_EVIDENCE_SOURCE_{section_id}_{index}"
+                                    ),
+                                    "evidence_quote": (
+                                        f"RAW_TOP_EVIDENCE_QUOTE_{section_id}_{index}"
+                                    ),
+                                }
+                            ],
+                        }
+                        for index in range(1, 13)
+                    ],
+                },
+            }
+        )
+    artifact = {
+        "report_model": {
+            "schema_version": "deflection.v1",
+            "title": "Action PDF",
+            "sections": sections,
+        }
+    }
+
+    model_markdown = _artifact_report_model_pdf_markdown(artifact)
+
+    for section_id in section_ids:
+        assert f"## {section_id.replace('_', ' ').title()}" in model_markdown
+        assert f"Action question {section_id} 3" in model_markdown
+        assert f"Action question {section_id} 10" in model_markdown
+        assert f"Action question {section_id} 11" not in model_markdown
+        assert f"Fix action {section_id} 10" in model_markdown
+        assert f"RAW_REPRESENTATIVE_PHRASE_{section_id}_1" not in model_markdown
+        assert f"RAW_SOURCE_ID_{section_id}_1" not in model_markdown
+        assert f"RAW_TOP_EVIDENCE_SOURCE_{section_id}_1" not in model_markdown
+        assert f"RAW_TOP_EVIDENCE_QUOTE_{section_id}_1" not in model_markdown
+    assert "Complete source IDs and raw evidence quotes stay" in model_markdown
+    assert "capped at 10 items for PDF readability" in model_markdown
+
+    pdf_bytes = render_deflection_full_report_pdf(artifact)
+
+    assert pdf_bytes[:5] == b"%PDF-"
+    assert len(pdf_bytes) > 1000
+
+
 def test_curated_pdf_markdown_caps_ranked_table_and_question_details() -> None:
     curated = _curate_markdown_for_pdf(_large_markdown())
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-PDF-Action-Sections.md
Slice phase: Vertical slice

Issue #1612 is making the paid deflection report actionable enough for support teams to use immediately. S4A added bounded action-section contract fields; this PR consumes that contract in the paid PDF by rendering the four action-oriented sections from `pdf_limit` while keeping raw source/evidence payloads in the complete evidence export.

## Intentional
- This PR does not change the report-model producer, stored-model normalizer, frontend result page, email summary, or complete evidence export. S4A already created the contract; this slice consumes it in the PDF only.
- The action-section helper emits compact tables rather than full per-item narrative blocks so the PDF stays usable as a work plan, not a ticket archive.
- The renderer does not include `top_evidence`, `source_id`, `source_ids`, or `representative_phrasing` in action sections. Complete evidence remains in the export JSON.

## Deferred
- Full PDF layout polish, richer grouping, and any browser/portfolio result-page changes remain later #1612 slices.
- Email attachment/body delivery wiring remains a separate delivery slice.

## Parked hardening
- None.

## Verification
- Command: python -m pytest tests/test_deflection_pdf_renderer.py -q -- 13 passed.
- Command: python -m py_compile atlas_brain/deflection_pdf_renderer.py tests/test_deflection_pdf_renderer.py -- passed.
- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_pdf_action_sections.md -- passed.

## Diff size
3 files, +296 / -0
