### PR TITLE
Add deflection PII markdown advisory summary

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -330,6 +330,7 @@ jobs:
           mkdir -p artifacts/deflection-pii-recall
           python scripts/score_deflection_pii_recall.py \
             --output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json \
+            --markdown-output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.md \
             --json
 
       - name: Upload deflection PII recall advisory artifact
@@ -337,5 +338,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: deflection-pii-recall-advisory
-          path: artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json
+          path: artifacts/deflection-pii-recall
           if-no-files-found: error

--- a/plans/PR-Deflection-PII-Markdown-Advisory-Summary.md
+++ b/plans/PR-Deflection-PII-Markdown-Advisory-Summary.md
@@ -1,0 +1,116 @@
+# PR-Deflection-PII-Markdown-Advisory-Summary
+
+## Why this slice exists
+
+#1742 section 8 defines the recall/precision harness output as a report
+artifact with JSON plus a markdown summary. The merged advisory CI slice
+currently writes and uploads only the JSON advisory file, so the measurement is
+machine-readable but not reviewer-friendly in the artifact bundle.
+
+Root cause: the scorer CLI only has a JSON `--output` path, and the extracted
+checks workflow points the upload at that single JSON file. This slice fixes the
+artifact-shape root by adding a redacted markdown summary output and uploading
+the artifact directory, while preserving the existing advisory/non-gating
+behavior.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 5
+
+1. Add a scorer CLI option that writes a redacted markdown summary beside the
+   existing JSON summary.
+2. Wire extracted-checks to emit and upload both JSON and markdown advisory
+   artifacts.
+3. Add focused tests proving the markdown summary contains the headline,
+   per-surface/person-name/must-survive facts needed for review without raw PII
+   spans or tokens.
+
+### Review Contract
+
+Acceptance criteria:
+- `scripts/score_deflection_pii_recall.py --markdown-output <path>` writes a
+  markdown file for the existing tiny corpus without changing JSON output.
+- The markdown summary includes the all-in headline, gate-eligible headline,
+  deferred open-set name count, person-name split, must-survive violation count,
+  per-surface recall table, and bounded leak sample metadata.
+- The markdown summary does not include raw label spans, must-survive spans, or
+  synthetic high-risk tokens from the corpus.
+- `.github/workflows/extracted_pipeline_checks.yml` writes both
+  the JSON advisory file and the markdown advisory file, then uploads the
+  artifact directory.
+- This PR does not flip advisory output into a gate and does not change scrubber
+  behavior, thresholds, or the cue-less/open-set name deferral.
+
+Affected surfaces:
+- `scripts/score_deflection_pii_recall.py`
+- `.github/workflows/extracted_pipeline_checks.yml`
+- `tests/test_score_deflection_pii_recall.py`
+- `tests/test_extracted_pipeline_pii_recall_advisory_artifact.py`
+
+Risk areas:
+- Accidentally echoing PII/surrogate spans into the markdown report.
+- Weakening the existing JSON artifact or advisory/non-gating workflow contract.
+- Making the markdown summary inconsistent with the JSON summary.
+
+- Reviewer rules triggered: R1 Requirements match, R2 Test evidence, R10
+  Maintainability, R12 CI test enrollment, R14 Codebase verification.
+
+### Files touched
+
+- `.github/workflows/extracted_pipeline_checks.yml`
+- `plans/PR-Deflection-PII-Markdown-Advisory-Summary.md`
+- `scripts/score_deflection_pii_recall.py`
+- `tests/test_extracted_pipeline_pii_recall_advisory_artifact.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+## Mechanism
+
+The scorer already builds a sanitized summary dictionary: headline counts,
+per-surface/class counts, person-name subtype counts, must-survive violation
+metadata, and leak samples that carry only surrogate IDs and metadata. This
+slice adds a pure renderer that formats that summary into markdown tables. The
+renderer consumes the existing sanitized summary rather than raw corpus records,
+so it cannot access label spans or must-survive spans.
+
+The CLI gains `--markdown-output`, independent from `--output` and `--json`.
+The extracted-checks workflow passes both output paths and uploads the containing
+directory so reviewers can inspect either artifact.
+
+## Intentional
+
+- No advisory-to-gating flip. #1742 still leaves threshold and gate timing as
+  operator decisions.
+- No scrubber or corpus change. The current tiny-corpus result remains:
+  deterministic/gate-eligible leaks are clean; the cue-less/open-set
+  `person_name-001` gap stays visible.
+- The markdown leak table is metadata-only; no spans, raw tokens, or source text.
+
+## Deferred
+
+- Operator-derived gold corpus, thresholds, and advisory-to-gating timing remain
+  open #1742 decisions.
+- Model-based NER for cue-less/open-set names remains separate.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_score_deflection_pii_recall.py tests/test_extracted_pipeline_pii_recall_advisory_artifact.py -q`
+  -- 22 passed.
+- `python scripts/score_deflection_pii_recall.py --output tmp/deflection-pii-markdown-advisory/deflection-pii-recall-advisory.json --markdown-output tmp/deflection-pii-markdown-advisory/deflection-pii-recall-advisory.md --json`
+  -- status ok; wrote both advisory artifacts.
+- Python bytecode compile for the scorer script and focused tests -- passed.
+- `git diff --check` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/extracted_pipeline_checks.yml` | 3 |
+| `plans/PR-Deflection-PII-Markdown-Advisory-Summary.md` | 116 |
+| `scripts/score_deflection_pii_recall.py` | 187 |
+| `tests/test_extracted_pipeline_pii_recall_advisory_artifact.py` | 9 |
+| `tests/test_score_deflection_pii_recall.py` | 46 |
+| **Total** | **361** |

--- a/scripts/score_deflection_pii_recall.py
+++ b/scripts/score_deflection_pii_recall.py
@@ -88,6 +88,12 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(summary, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+    if args.markdown_output:
+        args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_output.write_text(
+            _markdown_summary(summary),
+            encoding="utf-8",
+        )
     if args.json:
         print(json.dumps(summary, sort_keys=True))
     if summary["status"] != "ok":
@@ -173,8 +179,189 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
     parser.add_argument("--output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
+
+
+def _markdown_summary(summary: Mapping[str, Any]) -> str:
+    lines = [
+        "# Deflection PII Recall Advisory",
+        "",
+        _markdown_table(
+            ("Field", "Value"),
+            (
+                ("Status", _clean(summary.get("status"))),
+                ("Schema", _clean(summary.get("schema_version"))),
+            ),
+        ),
+        "",
+    ]
+    if _clean(summary.get("status")) != "ok":
+        lines.extend([
+            "## Blocking Errors",
+            "",
+            _markdown_table(
+                ("Code",),
+                ((code,) for code in _sequence(summary.get("blocking_error_codes"))),
+            ),
+            "",
+        ])
+        return "\n".join(lines).rstrip() + "\n"
+
+    input_summary = summary.get("input")
+    if not isinstance(input_summary, Mapping):
+        input_summary = {}
+    headline = summary.get("headline")
+    if not isinstance(headline, Mapping):
+        headline = {}
+    lines.extend([
+        "## Input",
+        "",
+        _markdown_table(
+            ("Metric", "Value"),
+            (
+                ("Corpus schema", _clean(input_summary.get("schema_version"))),
+                ("Tickets", input_summary.get("ticket_count", 0)),
+                ("Labels", input_summary.get("label_count", 0)),
+                ("Must-survive records", input_summary.get("must_survive_count", 0)),
+            ),
+        ),
+        "",
+        "## Headline",
+        "",
+        _markdown_table(
+            ("Metric", "Value"),
+            (
+                ("Free high-severity leaks (all-in)", headline.get("free_high_severity_leak_count", 0)),
+                ("Free high-severity pass (all-in)", headline.get("free_high_severity_pass", False)),
+                ("Gate-eligible free high-severity leaks", headline.get("free_high_severity_gate_eligible_leak_count", 0)),
+                ("Gate-eligible pass", headline.get("free_high_severity_gate_eligible_pass", False)),
+                ("Deferred open-set name leaks", headline.get("deferred_open_set_name_leak_count", 0)),
+            ),
+        ),
+        "",
+        "## Person Name Split",
+        "",
+        _class_rows_table(summary.get("person_name"), first_header="Subtype"),
+        "",
+        "## Surface Recall",
+        "",
+        _surface_rows_table(summary.get("surfaces")),
+        "",
+        "## Must-Survive Precision",
+        "",
+        _must_survive_table(summary.get("must_survive")),
+        "",
+        "## Leak Samples",
+        "",
+        _leak_samples_table(summary.get("leak_samples")),
+        "",
+    ])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _class_rows_table(value: Any, *, first_header: str) -> str:
+    if not isinstance(value, Mapping):
+        return _markdown_table((first_header, "Expected", "Redacted", "Leaks", "Recall"), ())
+    return _markdown_table(
+        (first_header, "Expected", "Redacted", "Leaks", "Recall"),
+        (
+            (
+                key,
+                counts.get("expected", 0),
+                counts.get("redacted", 0),
+                counts.get("leaks", 0),
+                _format_recall(counts.get("recall")),
+            )
+            for key, counts in sorted(value.items())
+            if isinstance(counts, Mapping)
+        ),
+    )
+
+
+def _surface_rows_table(value: Any) -> str:
+    rows: list[tuple[Any, ...]] = []
+    if isinstance(value, Mapping):
+        for surface, class_counts in sorted(value.items()):
+            if not isinstance(class_counts, Mapping):
+                continue
+            for pii_class, counts in sorted(class_counts.items()):
+                if not isinstance(counts, Mapping):
+                    continue
+                rows.append((
+                    surface,
+                    pii_class,
+                    counts.get("expected", 0),
+                    counts.get("redacted", 0),
+                    counts.get("leaks", 0),
+                    _format_recall(counts.get("recall")),
+                ))
+    return _markdown_table(
+        ("Surface", "Class", "Expected", "Redacted", "Leaks", "Recall"),
+        rows,
+    )
+
+
+def _must_survive_table(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return _markdown_table(("Metric", "Value"), ())
+    rows: list[tuple[Any, ...]] = [
+        ("Violation count", value.get("violation_count", 0)),
+    ]
+    surface_counts = value.get("surface_counts")
+    if isinstance(surface_counts, Mapping):
+        for surface, counts in sorted(surface_counts.items()):
+            if not isinstance(counts, Mapping):
+                continue
+            rows.append((
+                f"{surface} reached/total",
+                f"{counts.get('reached_surface', 0)}/{counts.get('total_tokens', 0)}",
+            ))
+    return _markdown_table(("Metric", "Value"), rows)
+
+
+def _leak_samples_table(value: Any) -> str:
+    rows: list[tuple[Any, ...]] = []
+    for sample in _sequence(value):
+        if not isinstance(sample, Mapping):
+            continue
+        rows.append((
+            _clean(sample.get("surrogate_id")),
+            _clean(sample.get("class")),
+            _clean(sample.get("name_subtype")),
+            _clean(sample.get("severity")),
+            _clean(sample.get("surface")),
+            _clean(sample.get("leak_kind")),
+        ))
+    return _markdown_table(
+        ("Surrogate ID", "Class", "Name subtype", "Severity", "Surface", "Leak kind"),
+        rows,
+    )
+
+
+def _markdown_table(headers: Sequence[Any], rows: Sequence[Sequence[Any]]) -> str:
+    row_list = list(rows)
+    header_line = "| " + " | ".join(_markdown_cell(header) for header in headers) + " |"
+    separator = "| " + " | ".join("---" for _ in headers) + " |"
+    body = [
+        "| " + " | ".join(_markdown_cell(cell) for cell in row) + " |"
+        for row in row_list
+    ]
+    if not body:
+        body = ["| " + " | ".join("None" for _ in headers) + " |"]
+    return "\n".join([header_line, separator, *body])
+
+
+def _markdown_cell(value: Any) -> str:
+    text = str(value)
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _format_recall(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{value:.4f}".rstrip("0").rstrip(".")
+    return "n/a"
 
 
 def _load_corpus(path: Path) -> tuple[Mapping[str, Any], list[dict[str, Any]]]:

--- a/tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
+++ b/tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
@@ -34,6 +34,10 @@ def test_extracted_checks_uploads_deflection_pii_recall_advisory_artifact() -> N
         "--output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json"
         in workflow
     )
+    assert (
+        "--markdown-output artifacts/deflection-pii-recall/deflection-pii-recall-advisory.md"
+        in workflow
+    )
     assert "if: ${{ !cancelled() }}" in write_step
     assert "Upload deflection PII recall advisory artifact" in workflow
     assert (
@@ -42,10 +46,7 @@ def test_extracted_checks_uploads_deflection_pii_recall_advisory_artifact() -> N
     )
     assert "if: ${{ !cancelled() }}" in upload_step
     assert "name: deflection-pii-recall-advisory" in workflow
-    assert (
-        "path: artifacts/deflection-pii-recall/deflection-pii-recall-advisory.json"
-        in workflow
-    )
+    assert "\n          path: artifacts/deflection-pii-recall\n" in workflow
     assert "if-no-files-found: error" in workflow
 
 

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -402,9 +402,50 @@ def test_missing_pdf_dependency_skips_paid_pdf_scoring(monkeypatch) -> None:
     assert summary["surfaces"]["paid_pdf"] == {}
 
 
+def test_cli_writes_markdown_summary_without_raw_spans(tmp_path: Path) -> None:
+    json_path = tmp_path / "summary.json"
+    markdown_path = tmp_path / "summary.md"
+
+    exit_code = CLI.main([
+        "--output",
+        str(json_path),
+        "--markdown-output",
+        str(markdown_path),
+    ])
+
+    assert exit_code == 0
+    written = json.loads(json_path.read_text(encoding="utf-8"))
+    markdown = markdown_path.read_text(encoding="utf-8")
+    assert written["headline"]["free_high_severity_gate_eligible_leak_count"] == 0
+    assert "# Deflection PII Recall Advisory" in markdown
+    assert "| Gate-eligible free high-severity leaks | 0 |" in markdown
+    assert "| Deferred open-set name leaks | 1 |" in markdown
+    cue_less_expected = (
+        4 if written["surface_generation"]["paid_pdf"]["rendered"] else 3
+    )
+    assert f"| cue_less | {cue_less_expected} | 0 | {cue_less_expected} | 0 |" in markdown
+    assert "| Violation count | 0 |" in markdown
+    assert "person_name-001" in markdown
+    for raw_value in (
+        "Maya Chen",
+        "Jordan Lee",
+        "Mary Jane Watson",
+        "alex.rivera@example.test",
+        "555-010-4301",
+        "1990-04-17",
+        "123-45-6789",
+        "4111 1111 1111 1111",
+        "CVE-2021-44228",
+        "ISO 27001",
+        "ticket-eval-safe-001",
+    ):
+        assert raw_value not in markdown
+
+
 def test_cli_writes_failure_summary_and_returns_nonzero(tmp_path: Path) -> None:
     corpus_path = tmp_path / "bad.json"
     output_path = tmp_path / "summary.json"
+    markdown_path = tmp_path / "summary.md"
     corpus_path.write_text('{"schema_version": "wrong", "tickets": []}', encoding="utf-8")
 
     exit_code = CLI.main([
@@ -412,9 +453,14 @@ def test_cli_writes_failure_summary_and_returns_nonzero(tmp_path: Path) -> None:
         str(corpus_path),
         "--output",
         str(output_path),
+        "--markdown-output",
+        str(markdown_path),
     ])
 
     assert exit_code == 1
     written = json.loads(output_path.read_text(encoding="utf-8"))
     assert written["status"] == "failed"
     assert written["blocking_error_codes"]
+    markdown = markdown_path.read_text(encoding="utf-8")
+    assert "## Blocking Errors" in markdown
+    assert "corpus_empty_tickets" in markdown


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Markdown-Advisory-Summary.md
Slice phase: Vertical slice

#1742 defines the recall/precision advisory artifact as JSON plus a markdown summary, but extracted-checks currently uploads only the JSON scorer output. This slice adds a redacted markdown summary companion and uploads the advisory artifact directory, making the measurement reviewer-readable without changing the existing advisory/non-gating contract.

## Intentional
- No advisory-to-gating flip. #1742 still leaves threshold and gate timing as operator decisions.
- No scrubber or corpus change. The current tiny-corpus result remains: deterministic/gate-eligible leaks are clean; the cue-less/open-set `person_name-001` gap stays visible.
- The markdown leak table is metadata-only; no spans, raw tokens, or source text.

## Deferred
- Operator-derived gold corpus, thresholds, and advisory-to-gating timing remain open #1742 decisions.
- Model-based NER for cue-less/open-set names remains separate.

## Parked hardening
- None.

## Verification
- `pytest tests/test_score_deflection_pii_recall.py tests/test_extracted_pipeline_pii_recall_advisory_artifact.py -q` -- 22 passed.
- `python scripts/score_deflection_pii_recall.py --output tmp/deflection-pii-markdown-advisory/deflection-pii-recall-advisory.json --markdown-output tmp/deflection-pii-markdown-advisory/deflection-pii-recall-advisory.md --json` -- status ok; wrote both advisory artifacts.
- Python bytecode compile for the scorer script and focused tests -- passed.
- `python scripts/sync_pr_plan.py --check plans/PR-Deflection-PII-Markdown-Advisory-Summary.md` -- plan already in sync.
- `python scripts/audit_plan_code_consistency.py plans/PR-Deflection-PII-Markdown-Advisory-Summary.md` -- all path/function claims resolve.
- `git diff --check` -- passed.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: Codex P2 on `tests/test_score_deflection_pii_recall.py` now branches the cue-less markdown row expectation on whether the optional paid-PDF renderer is available.
- Waived: None.

## Diff size
5 files, +356 / -5
