### PR TITLE
Add deflection action-section QA scorecard coverage

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -753,6 +753,10 @@ DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS: Mapping[str, Mapping[str, int]] = (
         "pdf": MappingProxyType({
             "ranked_questions": 25,
             "question_details": 10,
+            "priority_fix_queue": _ACTION_PDF_LIMIT,
+            "top_unresolved_repeats": _ACTION_PDF_LIMIT,
+            "drafted_resolutions": _ACTION_PDF_LIMIT,
+            "already_covered_still_recurring": _ACTION_PDF_LIMIT,
         }),
     })
 )
@@ -825,6 +829,10 @@ _SCORECARD_COUNT_KEYS = frozenset({
     "seo_omitted_phrase_count",
     "outcome_diagnostic_row_count",
     "question_detail_count",
+    "priority_fix_queue_count",
+    "top_unresolved_repeats_count",
+    "drafted_resolutions_count",
+    "already_covered_still_recurring_count",
 })
 _SCORECARD_SURFACE_KEYS = frozenset({
     "email",
@@ -835,6 +843,17 @@ _SCORECARD_SURFACE_KEYS = frozenset({
     "result_page",
     "web",
 })
+_FULL_REPORT_QA_REQUIRED_MODEL_SECTION_IDS = (
+    "support_tax",
+    "seo_targets",
+    "ranked_questions",
+    "priority_fix_queue",
+    "top_unresolved_repeats",
+    "drafted_resolutions",
+    "already_covered_still_recurring",
+    "question_details",
+    "complete_evidence",
+)
 
 
 class FAQDeflectionReportService:
@@ -982,13 +1001,7 @@ def build_deflection_full_report_qa_scorecard(
         expected=DEFLECTION_REPORT_SCHEMA_VERSION,
         actual=_text(model.get("schema_version")),
     )
-    for section_id in (
-        "support_tax",
-        "seo_targets",
-        "ranked_questions",
-        "question_details",
-        "complete_evidence",
-    ):
+    for section_id in _FULL_REPORT_QA_REQUIRED_MODEL_SECTION_IDS:
         add(
             f"model.section.{section_id}.present",
             section_id in sections,
@@ -1078,6 +1091,7 @@ def build_deflection_full_report_qa_deterministic_harness(
                 surface_id=surface_id,
                 observation=observation,
                 surface_caps=caps,
+                counts=counts,
             )
 
     result = dict(scorecard)
@@ -1111,6 +1125,7 @@ def _add_full_report_qa_required_metric_assertions(
     surface_id: str,
     observation: Mapping[str, Any],
     surface_caps: Mapping[str, Mapping[str, int]],
+    counts: Mapping[str, Any],
 ) -> None:
     observed_counts = (
         observation.get("counts")
@@ -1146,6 +1161,8 @@ def _add_full_report_qa_required_metric_assertions(
             allowed=frozenset(DEFLECTION_REPORT_SECTION_REGISTRY),
             fallback=f"section_{section_index}",
         )
+        if _scorecard_section_total(str(section_id), counts) == 0:
+            continue
         assertions.append({
             "id": (
                 f"harness.surface.{surface_id}.displayed_rows."
@@ -1214,6 +1231,13 @@ def _scorecard_rows_count(data: Mapping[str, Any]) -> int:
     return len([row for row in rows if isinstance(row, Mapping)])
 
 
+def _scorecard_items_count(data: Mapping[str, Any]) -> int:
+    items = data.get("items")
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
+        return 0
+    return len([item for item in items if isinstance(item, Mapping)])
+
+
 def _scorecard_float(value: Any) -> float:
     try:
         return float(value)
@@ -1228,6 +1252,13 @@ def _scorecard_counts(sections: Mapping[str, Mapping[str, Any]]) -> dict[str, An
     diagnostics = _scorecard_section_data(sections, "outcome_diagnostics")
     question_details = _scorecard_section_data(sections, "question_details")
     complete_evidence = _scorecard_section_data(sections, "complete_evidence")
+    priority_fix_queue = _scorecard_section_data(sections, "priority_fix_queue")
+    unresolved_repeats = _scorecard_section_data(sections, "top_unresolved_repeats")
+    drafted_resolutions = _scorecard_section_data(sections, "drafted_resolutions")
+    already_covered_recurring = _scorecard_section_data(
+        sections,
+        "already_covered_still_recurring",
+    )
     return {
         "repeat_ticket_count": _int(support_tax.get("repeat_ticket_count")),
         "generated_question_count": _int(
@@ -1250,6 +1281,12 @@ def _scorecard_counts(sections: Mapping[str, Mapping[str, Any]]) -> dict[str, An
         "seo_omitted_phrase_count": _int(seo_targets.get("omitted_phrase_count")),
         "outcome_diagnostic_row_count": _scorecard_rows_count(diagnostics),
         "question_detail_count": _scorecard_rows_count(question_details),
+        "priority_fix_queue_count": _scorecard_items_count(priority_fix_queue),
+        "top_unresolved_repeats_count": _scorecard_items_count(unresolved_repeats),
+        "drafted_resolutions_count": _scorecard_items_count(drafted_resolutions),
+        "already_covered_still_recurring_count": _scorecard_items_count(
+            already_covered_recurring,
+        ),
     }
 
 
@@ -1333,6 +1370,12 @@ def _scorecard_section_total(section_id: str, counts: Mapping[str, Any]) -> int:
         "outcome_diagnostics": _int(counts.get("outcome_diagnostic_row_count")),
         "question_details": _int(counts.get("question_detail_count")),
         "complete_evidence": _int(counts.get("evidence_row_count")),
+        "priority_fix_queue": _int(counts.get("priority_fix_queue_count")),
+        "top_unresolved_repeats": _int(counts.get("top_unresolved_repeats_count")),
+        "drafted_resolutions": _int(counts.get("drafted_resolutions_count")),
+        "already_covered_still_recurring": _int(
+            counts.get("already_covered_still_recurring_count")
+        ),
     }.get(section_id, 0)
 
 

--- a/plans/PR-Deflection-Action-Section-QA-Scorecard.md
+++ b/plans/PR-Deflection-Action-Section-QA-Scorecard.md
@@ -1,0 +1,167 @@
+# PR-Deflection-Action-Section-QA-Scorecard
+
+## Why this slice exists
+
+#1612's current report-actionability arc has landed the model contract
+and the PDF renderer for the new action sections. PR #1758 explicitly deferred
+S4C: add cross-surface assertions proving renderer output agrees with the paid
+model while Snapshot stays closed. PR #1760 made the PDF render the action
+sections, but the shared QA scorecard still only counts/caps the older ranked
+question, question-detail, SEO, and diagnostic sections.
+
+Root cause: `_scorecard_counts`, `_scorecard_section_total`, and the PDF/export
+artifact observer do not know the action-section row totals, and the PDF
+validator previously treated action headings as unconditional document markers
+instead of model-driven sections. That can either miss a PDF that drops
+`priority_fix_queue`, `top_unresolved_repeats`, `drafted_resolutions`, or
+`already_covered_still_recurring`, or falsely fail older/live artifacts whose
+model has action sections with no rows.
+
+This slice fixes the root in the QA contract, not the renderer: the scorecard
+requires the action sections in the paid model, learns their totals/caps for
+PDF, and the PDF/export validator observes action-section rows from rendered
+PDF text only when the model has rows for that section.
+
+Diff budget note: this slice is over the 400 LOC soft cap because the review
+fix has to keep the scorecard contract, PDF artifact checker, regression tests,
+and plan/body reconciliation in one PR. Splitting the checker from the tests
+would leave the privacy/report-delivery gate under-proven.
+
+## Scope (this PR)
+
+Ownership lane: issue-1612/deflection-full-report-delivery-actionability
+Slice phase: Functional validation
+
+1. Add action-section row totals to the shared full-report QA scorecard counts
+   and require the action sections in the paid report model.
+2. Teach the PDF/export artifact validator to observe visible action-section
+   rows in the rendered PDF text without requiring empty action sections.
+3. Add focused regression tests proving missing action-section rows fail the
+   scorecard/validator, action rows do not inflate ranked-row observations, and
+   result-page action-row assertions stay deferred until the hosted observer
+   lands.
+4. Refresh the live-runner fixtures to the current S4 model shape with empty
+   action sections instead of preserving the pre-action-section model.
+5. Refresh hosted-smoke fixtures to the same current S4 model shape so the
+   shared scorecard contract is consistent across live and hosted runners.
+
+### Review Contract
+
+Acceptance criteria:
+
+- `priority_fix_queue`, `top_unresolved_repeats`, `drafted_resolutions`, and
+  `already_covered_still_recurring` have model-derived row totals in the
+  scorecard counts.
+- The four action sections are required model sections, so a producer
+  regression that drops the paid action queue cannot false-green as zero rows.
+- Default surface caps include action-section caps for `pdf` using each
+  section's existing PDF contract limit: 10.
+- `build_deflection_full_report_qa_scorecard` fails when a surface observation
+  reports fewer displayed action rows than the paid model requires for that
+  surface cap.
+- `check_deflection_full_report_pdf_export_artifacts.py` extracts action-section
+  displayed rows from PDF text and feeds them into the shared scorecard when
+  the model has rows for the section.
+- Ranked-question PDF row extraction stops at action-section headings so action
+  rows cannot hide a missing ranked row.
+- The slice does not add buyer hosted-page automation in ATLAS; the buyer
+  result page lives in `atlas-portfolio`, so result-page action-row caps remain
+  deferred here.
+- `tests/test_run_deflection_full_report_qa_live_runner.py` uses current-shape
+  fixtures with present action sections, including the valid empty-section
+  case.
+- `tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py` uses the
+  same current-shape fixture contract for hosted result-page observations.
+- Snapshot remains fail-closed by the existing model projection; this slice
+  does not make action sections snapshot-safe.
+
+Affected surfaces:
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `scripts/check_deflection_full_report_pdf_export_artifacts.py`
+- scorecard, live-runner, hosted-smoke, and PDF/export validator tests
+
+Risk areas:
+
+- False-green QA if action sections are omitted from rendered PDF text.
+- False-positive QA if a section with zero model rows is required to display
+  rows.
+- Privacy boundary drift if the QA slice tries to project paid action sections
+  into Snapshot.
+
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R13, R14.
+
+Max files: 7
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Action-Section-QA-Scorecard.md`
+- `scripts/check_deflection_full_report_pdf_export_artifacts.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_run_deflection_full_report_qa_live_runner.py`
+- `tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py`
+- `tests/test_smoke_content_ops_deflection_pdf_export_validators.py`
+
+## Mechanism
+
+The shared scorecard requires the four action-section model sections, counts
+`items` for each action section, and adds those counts to
+`_scorecard_section_total`. Default PDF caps gain action-section entries
+matching the model's `pdf_limit`; default result-page caps stay on the
+currently observed hosted sections until `atlas-portfolio` ships action-section
+row extraction.
+
+The PDF/export validator will split PDF text by the action-section headings and
+count visible action questions in each section, using the same question-text
+matching helper used by ranked questions and question details. Those
+observations feed the existing displayed-row scorecard assertions. Action
+headings are model-gated markers, so a model with zero rows for an action
+section does not force a heading into every artifact.
+
+## Intentional
+
+- This PR does not change the PDF renderer, report-model producer, delivery
+  email, evidence export, or portfolio buyer result page.
+- Result-page observations remain limited to the sections the hosted observer
+  can currently report. Action-section result-page caps are deferred to the
+  `atlas-portfolio` observer slice so this PR does not create an immediate
+  false-red gate.
+- The checker counts visible action questions, not raw source/evidence fields.
+  Complete evidence remains export-only.
+
+## Deferred
+
+- Hosted buyer result-page action-section observation and the corresponding
+  result-page action caps remain in `atlas-portfolio`.
+- Email summary action-section rendering, if desired, remains a later delivery
+  slice.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_run_deflection_full_report_qa_live_runner.py::test_live_runner_extracts_pdf_text_from_renderer_bytes_by_default tests/test_run_deflection_full_report_qa_live_runner.py::test_live_runner_fetches_live_json_and_writes_redacted_scorecard -q -- 2 passed.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py -q -- 145 passed.
+- Command: python -m pytest tests/test_run_deflection_full_report_qa_live_runner.py -q -- 17 passed.
+- Command: python -m pytest tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py -q -- 3 passed.
+- Command: python -m pytest tests/test_smoke_content_ops_deflection_pdf_export_validators.py -q -- 18 passed.
+- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py scripts/check_deflection_full_report_pdf_export_artifacts.py tests/test_content_ops_deflection_report.py tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py tests/test_smoke_content_ops_deflection_pdf_export_validators.py tests/test_run_deflection_full_report_qa_live_runner.py -- passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
+- Command: bash scripts/check_ascii_python.sh -- passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_action_section_qa_scorecard.md -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 57 |
+| `plans/PR-Deflection-Action-Section-QA-Scorecard.md` | 167 |
+| `scripts/check_deflection_full_report_pdf_export_artifacts.py` | 56 |
+| `tests/test_content_ops_deflection_report.py` | 155 |
+| `tests/test_run_deflection_full_report_qa_live_runner.py` | 43 |
+| `tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py` | 39 |
+| `tests/test_smoke_content_ops_deflection_pdf_export_validators.py` | 144 |
+| **Total** | **661** |

--- a/scripts/check_deflection_full_report_pdf_export_artifacts.py
+++ b/scripts/check_deflection_full_report_pdf_export_artifacts.py
@@ -38,6 +38,12 @@ REQUIRED_PDF_MARKERS = (
     "Question Details and Evidence",
     "complete evidence export",
 )
+ACTION_SECTION_TITLES = {
+    "priority_fix_queue": "Priority Fix Queue",
+    "top_unresolved_repeats": "Top Unresolved Repeats",
+    "drafted_resolutions": "Drafted Resolutions Ready to Publish",
+    "already_covered_still_recurring": "Already Covered but Still Recurring",
+}
 PDF_COUNT_PATTERNS = {
     "repeat_ticket_count": (
         r"\b{value}\s+question-level\s+repeat tickets\b",
@@ -156,6 +162,13 @@ def _rows(data: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes, bytearray)):
         return []
     return [row for row in rows if isinstance(row, Mapping)]
+
+
+def _items(data: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    items = data.get("items")
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
+        return []
+    return [item for item in items if isinstance(item, Mapping)]
 
 
 def _sequence(value: Any) -> list[Any]:
@@ -368,10 +381,15 @@ def _visible_question_rows(section_text: str, rows: Sequence[Mapping[str, Any]])
 
 
 def _pdf_displayed_rows(report_model: Mapping[str, Any], pdf_text: str) -> dict[str, int]:
+    action_section_end_markers = tuple(ACTION_SECTION_TITLES.values())
     ranked_section = _section_text(
         pdf_text,
         "Ranked Question Opportunities",
-        ("Resolution Outcome Diagnostics", "Question Details and Evidence"),
+        (
+            *action_section_end_markers,
+            "Resolution Outcome Diagnostics",
+            "Question Details and Evidence",
+        ),
     )
     detail_section = _section_text(
         pdf_text,
@@ -383,7 +401,7 @@ def _pdf_displayed_rows(report_model: Mapping[str, Any], pdf_text: str) -> dict[
     caps = DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS.get("pdf", {})
     ranked_cap = _int(caps.get("ranked_questions")) if isinstance(caps, Mapping) else 0
     detail_cap = _int(caps.get("question_details")) if isinstance(caps, Mapping) else 0
-    return {
+    displayed = {
         "ranked_questions": _visible_question_rows(
             ranked_section,
             ranked_rows[:ranked_cap] if ranked_cap else ranked_rows,
@@ -393,9 +411,32 @@ def _pdf_displayed_rows(report_model: Mapping[str, Any], pdf_text: str) -> dict[
             detail_rows[:detail_cap] if detail_cap else detail_rows,
         ),
     }
+    section_end_markers = (
+        *action_section_end_markers,
+        "Resolution Outcome Diagnostics",
+        "Question Details and Evidence",
+        "Complete Evidence",
+    )
+    for section_id, title in ACTION_SECTION_TITLES.items():
+        rows = _items(_section_data(report_model, section_id))
+        if not rows:
+            continue
+        section_text = _section_text(
+            pdf_text,
+            title,
+            tuple(marker for marker in section_end_markers if marker != title),
+        )
+        section_cap = _int(caps.get(section_id)) if isinstance(caps, Mapping) else 0
+        displayed[section_id] = _visible_question_rows(
+            section_text,
+            rows[:section_cap] if section_cap else rows,
+        )
+    return displayed
+
 
 def _pdf_artifact_assertions(
     *,
+    report_model: Mapping[str, Any],
     pdf_bytes: bytes,
     pdf_text: str,
     counts: Mapping[str, Any],
@@ -418,6 +459,16 @@ def _pdf_artifact_assertions(
     ]
     normalized_text = _normal_text(pdf_text).casefold()
     for marker in REQUIRED_PDF_MARKERS:
+        marker_id = re.sub(r"[^a-z0-9]+", "_", marker.casefold()).strip("_")
+        assertions.append(_assertion(
+            f"artifact.pdf.text.marker.{marker_id}",
+            marker.casefold() in normalized_text,
+            expected="present",
+            actual="present" if marker.casefold() in normalized_text else "missing",
+        ))
+    for section_id, marker in ACTION_SECTION_TITLES.items():
+        if not _items(_section_data(report_model, section_id)):
+            continue
         marker_id = re.sub(r"[^a-z0-9]+", "_", marker.casefold()).strip("_")
         assertions.append(_assertion(
             f"artifact.pdf.text.marker.{marker_id}",
@@ -525,6 +576,7 @@ def build_pdf_export_scorecard(
         | _source_ids_from_model(report_payload)
     )
     artifact_assertions = _pdf_artifact_assertions(
+        report_model=report_payload,
         pdf_bytes=pdf_bytes,
         pdf_text=pdf_text,
         counts=counts,

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -1551,6 +1551,161 @@ def test_deflection_full_report_qa_scorecard_checks_surface_caps_behaviorally() 
     assert "surface.result_page.displayed_rows.ranked_questions" in failed
 
 
+def test_deflection_full_report_qa_scorecard_checks_action_section_caps() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    export = build_deflection_evidence_export(artifact)
+    model = json.loads(json.dumps(artifact.report_model.as_dict()))
+    sections = {section["id"]: section for section in model["sections"]}
+    priority_rows = sections["priority_fix_queue"]["data"]["items"]
+    expected_pdf_rows = min(len(priority_rows), 10)
+
+    assert expected_pdf_rows > 0
+
+    scorecard = build_deflection_full_report_qa_scorecard(
+        model,
+        evidence_export=export,
+        surface_observations={
+            "pdf": {"displayed_rows": {"priority_fix_queue": expected_pdf_rows}},
+        },
+    )
+    bad_scorecard = build_deflection_full_report_qa_scorecard(
+        model,
+        evidence_export=export,
+        surface_observations={
+            "pdf": {"displayed_rows": {"priority_fix_queue": expected_pdf_rows - 1}},
+        },
+    )
+    harness = build_deflection_full_report_qa_deterministic_harness(
+        model,
+        evidence_export=export,
+    )
+
+    assert scorecard["ok"] is True
+    assert bad_scorecard["ok"] is False
+    failed = {
+        assertion["id"]
+        for assertion in bad_scorecard["assertions"]
+        if not assertion["ok"]
+    }
+    assert "surface.pdf.displayed_rows.priority_fix_queue" in failed
+    assert harness["counts"]["priority_fix_queue_count"] == len(priority_rows)
+    assert any(
+        assertion["id"] == "harness.surface.pdf.displayed_rows.priority_fix_queue.present"
+        and assertion["ok"] is True
+        for assertion in harness["assertions"]
+    )
+
+
+def test_deflection_full_report_qa_scorecard_requires_action_sections() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    model = json.loads(json.dumps(artifact.report_model.as_dict()))
+    model["sections"] = [
+        section
+        for section in model["sections"]
+        if section["id"]
+        not in {
+            "priority_fix_queue",
+            "top_unresolved_repeats",
+            "drafted_resolutions",
+            "already_covered_still_recurring",
+        }
+    ]
+
+    scorecard = build_deflection_full_report_qa_deterministic_harness(model)
+
+    assert scorecard["ok"] is False
+    failed = {
+        assertion["id"]
+        for assertion in scorecard["assertions"]
+        if not assertion["ok"]
+    }
+    assert "model.section.priority_fix_queue.present" in failed
+    assert "model.section.top_unresolved_repeats.present" in failed
+    assert "model.section.drafted_resolutions.present" in failed
+    assert "model.section.already_covered_still_recurring.present" in failed
+
+
+def test_deflection_full_report_qa_harness_defers_result_page_action_row_observer() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    export = build_deflection_evidence_export(artifact)
+    model = artifact.report_model.as_dict()
+    sections = {section["id"]: section for section in model["sections"]}
+    priority_rows = sections["priority_fix_queue"]["data"]["items"]
+    unresolved_rows = sections["top_unresolved_repeats"]["data"]["items"]
+    drafted_rows = sections["drafted_resolutions"]["data"]["items"]
+    counts = build_deflection_full_report_qa_scorecard(model)["counts"]
+
+    scorecard = build_deflection_full_report_qa_deterministic_harness(
+        model,
+        evidence_export=export,
+        surface_observations={
+            "result_page": {
+                "counts": {
+                    "repeat_ticket_count": counts["repeat_ticket_count"],
+                    "generated_question_count": counts["generated_question_count"],
+                    "ranked_question_count": counts["ranked_question_count"],
+                    "drafted_answer_count": counts["drafted_answer_count"],
+                    "no_proven_answer_count": counts["no_proven_answer_count"],
+                    "ticket_source_count": counts["ticket_source_count"],
+                    "estimated_support_cost": counts["estimated_support_cost"],
+                    "evidence_row_count": len(export["evidence_rows"]),
+                    "source_id_count": export["summary"]["source_id_count"],
+                },
+                "displayed_rows": {
+                    "ranked_questions": counts["ranked_question_count"],
+                    "question_details": counts["question_detail_count"],
+                    "seo_targets": counts["seo_total_phrase_count"],
+                    "outcome_diagnostics": counts["outcome_diagnostic_row_count"],
+                },
+            },
+            "email": {
+                "counts": {
+                    "repeat_ticket_count": counts["repeat_ticket_count"],
+                    "generated_question_count": counts["generated_question_count"],
+                    "drafted_answer_count": counts["drafted_answer_count"],
+                    "no_proven_answer_count": counts["no_proven_answer_count"],
+                    "ticket_source_count": counts["ticket_source_count"],
+                    "estimated_support_cost": counts["estimated_support_cost"],
+                },
+            },
+            "pdf": {
+                "counts": {
+                    "repeat_ticket_count": counts["repeat_ticket_count"],
+                    "generated_question_count": counts["generated_question_count"],
+                    "ranked_question_count": counts["ranked_question_count"],
+                    "drafted_answer_count": counts["drafted_answer_count"],
+                    "no_proven_answer_count": counts["no_proven_answer_count"],
+                    "ticket_source_count": counts["ticket_source_count"],
+                    "estimated_support_cost": counts["estimated_support_cost"],
+                },
+                "displayed_rows": {
+                    "ranked_questions": counts["ranked_question_count"],
+                    "question_details": counts["question_detail_count"],
+                    "priority_fix_queue": len(priority_rows),
+                    "top_unresolved_repeats": len(unresolved_rows),
+                    "drafted_resolutions": len(drafted_rows),
+                },
+            },
+            "evidence_export": {
+                "counts": {
+                    "evidence_question_count": len(export["questions"]),
+                    "evidence_row_count": len(export["evidence_rows"]),
+                    "source_id_count": export["summary"]["source_id_count"],
+                    "drafted_answer_count": counts["drafted_answer_count"],
+                    "no_proven_answer_count": counts["no_proven_answer_count"],
+                },
+            },
+        },
+    )
+
+    assert scorecard["ok"] is True
+    assert not any(
+        assertion["id"]
+        == "harness.surface.result_page.displayed_rows.priority_fix_queue.present"
+        for assertion in scorecard["assertions"]
+    )
+
+
 def test_deflection_full_report_qa_scorecard_honors_zero_row_surface_caps() -> None:
     artifact = build_deflection_report_artifact(_structured_report_fixture_result())
     export = build_deflection_evidence_export(artifact)

--- a/tests/test_run_deflection_full_report_qa_live_runner.py
+++ b/tests/test_run_deflection_full_report_qa_live_runner.py
@@ -93,6 +93,49 @@ def _report_model() -> dict[str, object]:
                 },
             },
             {
+                "id": "priority_fix_queue",
+                "priority": 35,
+                "data": {
+                    "items": [],
+                    "status_counts": {},
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                    "backlog_limit": 25,
+                    "support_cost_basis": "assisted_contact_cost",
+                },
+            },
+            {
+                "id": "top_unresolved_repeats",
+                "priority": 36,
+                "data": {
+                    "items": [],
+                    "top_item_count": 0,
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                    "support_cost_basis": "assisted_contact_cost",
+                },
+            },
+            {
+                "id": "drafted_resolutions",
+                "priority": 37,
+                "data": {
+                    "items": [],
+                    "top_item_count": 0,
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                },
+            },
+            {
+                "id": "already_covered_still_recurring",
+                "priority": 38,
+                "data": {
+                    "items": [],
+                    "top_item_count": 0,
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                },
+            },
+            {
                 "id": "question_details",
                 "priority": 50,
                 "data": {

--- a/tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py
+++ b/tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py
@@ -53,6 +53,45 @@ def _report_model() -> dict[str, object]:
                 "data": {"rows": [{"rank": 1}, {"rank": 2}]},
             },
             {
+                "id": "priority_fix_queue",
+                "data": {
+                    "items": [],
+                    "status_counts": {},
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                    "backlog_limit": 25,
+                    "support_cost_basis": "assisted_contact_cost",
+                },
+            },
+            {
+                "id": "top_unresolved_repeats",
+                "data": {
+                    "items": [],
+                    "top_item_count": 0,
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                    "support_cost_basis": "assisted_contact_cost",
+                },
+            },
+            {
+                "id": "drafted_resolutions",
+                "data": {
+                    "items": [],
+                    "top_item_count": 0,
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                },
+            },
+            {
+                "id": "already_covered_still_recurring",
+                "data": {
+                    "items": [],
+                    "top_item_count": 0,
+                    "result_page_limit": 3,
+                    "pdf_limit": 10,
+                },
+            },
+            {
                 "id": "question_details",
                 "data": {"rows": [{"rank": 1}, {"rank": 2}]},
             },

--- a/tests/test_smoke_content_ops_deflection_pdf_export_validators.py
+++ b/tests/test_smoke_content_ops_deflection_pdf_export_validators.py
@@ -19,6 +19,32 @@ SPEC.loader.exec_module(checker)
 
 
 def _report_model() -> dict[str, object]:
+    action_sections = [
+        (
+            "priority_fix_queue",
+            "Priority Fix Queue",
+            "How do I export attribution reports?",
+            "Publish the drafted export answer.",
+        ),
+        (
+            "top_unresolved_repeats",
+            "Top Unresolved Repeats",
+            "How do I invite teammates?",
+            "Write and approve the missing teammate answer.",
+        ),
+        (
+            "drafted_resolutions",
+            "Drafted Resolutions Ready to Publish",
+            "How do I export attribution reports?",
+            "Publish or adapt the drafted resolution.",
+        ),
+        (
+            "already_covered_still_recurring",
+            "Already Covered but Still Recurring",
+            "How do I invite teammates?",
+            "Improve discoverability for the teammate answer.",
+        ),
+    ]
     return {
         "schema_version": "deflection.v1",
         "title": "Support Ticket Deflection Report",
@@ -83,6 +109,65 @@ def _report_model() -> dict[str, object]:
                     "surfaces": ["export"],
                 },
             },
+            *[
+                {
+                    "id": section_id,
+                    "title": title,
+                    "data": {
+                        "result_page_limit": 3,
+                        "pdf_limit": 10,
+                        **(
+                            {
+                                "backlog_limit": 25,
+                                "status_counts": {"Needs answer": 1},
+                                "support_cost_basis": {
+                                    "status": "benchmark_only",
+                                    "source": "default_assisted_contact_benchmark",
+                                    "formula": "ticket_count * assisted_contact_cost",
+                                    "assisted_contact_cost": 13.5,
+                                },
+                            }
+                            if section_id == "priority_fix_queue"
+                            else {}
+                        ),
+                        **(
+                            {
+                                "top_item_count": 1,
+                                "support_cost_basis": {
+                                    "status": "benchmark_only",
+                                    "source": "default_assisted_contact_benchmark",
+                                    "formula": "ticket_count * assisted_contact_cost",
+                                    "assisted_contact_cost": 13.5,
+                                },
+                            }
+                            if section_id == "top_unresolved_repeats"
+                            else {}
+                        ),
+                        **(
+                            {"top_item_count": 1}
+                            if section_id
+                            in {
+                                "drafted_resolutions",
+                                "already_covered_still_recurring",
+                            }
+                            else {}
+                        ),
+                        "items": [
+                            {
+                                "rank": 1,
+                                "question": question,
+                                "status": "Needs answer",
+                                "ticket_count": 2,
+                                "estimated_support_cost": 27,
+                                "priority_score": 80,
+                                "owner_lane": "Support docs",
+                                "recommended_action": action,
+                            }
+                        ],
+                    },
+                }
+                for section_id, title, question, action in action_sections
+            ],
         ],
     }
 
@@ -128,6 +213,18 @@ def _pdf_text() -> str:
     Ranked Question Opportunities
     2 ranked questions appear in the curated PDF.
     How do I export attribution reports?
+    How do I invite teammates?
+
+    Priority Fix Queue
+    How do I export attribution reports?
+
+    Top Unresolved Repeats
+    How do I invite teammates?
+
+    Drafted Resolutions Ready to Publish
+    How do I export attribution reports?
+
+    Already Covered but Still Recurring
     How do I invite teammates?
 
     Question Details and Evidence
@@ -406,6 +503,41 @@ def test_pdf_export_validator_keeps_pdf_row_cap_observations_enabled() -> None:
     assert "surface.pdf.displayed_rows.question_details" in failed
 
 
+def test_pdf_export_validator_does_not_count_action_rows_as_ranked_rows() -> None:
+    pdf_text = _pdf_text().replace(
+        "How do I invite teammates?\n\n    Priority Fix Queue",
+        "Priority Fix Queue",
+    )
+
+    scorecard = checker.build_pdf_export_scorecard(
+        report_model=_report_model(),
+        evidence_export=_evidence_export(),
+        pdf_bytes=_pdf_bytes(),
+        pdf_text=pdf_text,
+    )
+
+    assert scorecard["ok"] is False
+    failed = _failed_ids(scorecard)
+    assert "surface.pdf.displayed_rows.ranked_questions" in failed
+    assert "surface.pdf.displayed_rows.top_unresolved_repeats" not in failed
+
+
+def test_pdf_export_validator_keeps_action_section_row_cap_observations_enabled() -> None:
+    scorecard = checker.build_pdf_export_scorecard(
+        report_model=_report_model(),
+        evidence_export=_evidence_export(),
+        pdf_bytes=_pdf_bytes(),
+        pdf_text=_pdf_text().replace(
+            "Top Unresolved Repeats\n    How do I invite teammates?",
+            "Top Unresolved Repeats",
+        ),
+    )
+
+    assert scorecard["ok"] is False
+    failed = _failed_ids(scorecard)
+    assert "surface.pdf.displayed_rows.top_unresolved_repeats" in failed
+
+
 def test_pdf_export_validator_does_not_treat_body_copy_as_section_end() -> None:
     text = """
     Support Ticket Deflection Report
@@ -420,6 +552,18 @@ def test_pdf_export_validator_does_not_treat_body_copy_as_section_end() -> None:
     Ranked Question Opportunities
     1 | How do I export attribution reports? | 0 | $0 | 0
     2 | How do I invite teammates? | 0 | $0 | 0
+
+    Priority Fix Queue
+    How do I export attribution reports?
+
+    Top Unresolved Repeats
+    How do I invite teammates?
+
+    Drafted Resolutions Ready to Publish
+    How do I export attribution reports?
+
+    Already Covered but Still Recurring
+    How do I invite teammates?
 
     Question Details and Evidence
     How do I export attribution reports?


### PR DESCRIPTION
Plan: plans/PR-Deflection-Action-Section-QA-Scorecard.md
Slice phase: Functional validation

#1612's action-report arc now has the model contract and PDF renderer for the paid action sections. This PR closes the S4C validation gap by making the shared QA scorecard require the paid action sections and making the PDF/export validator count model-backed PDF action-section rows, so a rendered PDF cannot drop the work queue while the model still looks valid.

## Intentional
- This PR does not change the PDF renderer, report-model producer, delivery email, evidence export, or portfolio buyer result page.
- Result-page action-row caps remain deferred until the hosted buyer-page observer lands in `atlas-portfolio`; this avoids making ATLAS require data the page observer cannot currently produce.
- The checker counts visible action questions, not raw source/evidence fields. Complete evidence remains export-only.
- PDF action-section heading checks are row-driven, not unconditional; current-shape models with present-but-empty action sections should not fail only because those headings are absent.

## Deferred
- Hosted buyer result-page action-section observation and corresponding result-page action caps remain in `atlas-portfolio`.
- Email summary action-section rendering, if desired, remains a later delivery slice.

## Parked hardening
- None.

## AI reconciliation
- Reviewer BLOCKER: fixed. Action-section PDF marker/displayed-row requirements now depend on model rows, so live-runner fixtures without action sections no longer fail.
- Codex P2, action rows counted as ranked rows: fixed. Ranked PDF extraction stops at action-section headings, with a regression proving an action row cannot mask a missing ranked row.
- Codex P2, result-page action caps before hosted observer ships: fixed. Default result-page action caps were removed until `atlas-portfolio` can observe those rows.
- Codex P2, requiring action sections globally before deriving zero counts: fixed. The scorecard now requires the four action sections, and the live-runner fixtures use the current S4-era shape with present empty action sections.

All findings fixed or waived: yes.

## Verification
- Command: python -m pytest tests/test_run_deflection_full_report_qa_live_runner.py::test_live_runner_extracts_pdf_text_from_renderer_bytes_by_default tests/test_run_deflection_full_report_qa_live_runner.py::test_live_runner_fetches_live_json_and_writes_redacted_scorecard -q -- 2 passed.
- Command: python -m pytest tests/test_content_ops_deflection_report.py -q -- 145 passed.
- Command: python -m pytest tests/test_run_deflection_full_report_qa_live_runner.py -q -- 17 passed.
- Command: python -m pytest tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py -q -- 3 passed.
- Command: python -m pytest tests/test_smoke_content_ops_deflection_pdf_export_validators.py -q -- 18 passed.
- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py scripts/check_deflection_full_report_pdf_export_artifacts.py tests/test_content_ops_deflection_report.py tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py tests/test_smoke_content_ops_deflection_pdf_export_validators.py tests/test_run_deflection_full_report_qa_live_runner.py -- passed.
- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
- Command: bash scripts/check_ascii_python.sh -- passed.
- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_action_section_qa_scorecard.md -- passed.

## Diff size
7 files, +652 / -9
