### PR TITLE
Measure two-letter deflection PII name recall

### DIFF
--- a/docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json
+++ b/docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json
@@ -8,24 +8,24 @@
   },
   "summary": {
     "cue_less_person_name_count": 1,
-    "cue_prefixed_person_name_count": 2,
-    "label_count": 10,
+    "cue_prefixed_person_name_count": 3,
+    "label_count": 11,
     "labels_by_class": {
       "dob": 1,
       "email": 1,
       "order_id": 1,
       "payment_card": 1,
-      "person_name": 3,
+      "person_name": 4,
       "phone": 1,
       "ssn": 1,
       "street_address": 1
     },
     "labels_by_severity": {
-      "high": 8,
+      "high": 9,
       "medium": 2
     },
     "must_survive_count": 3,
-    "ticket_count": 2
+    "ticket_count": 3
   },
   "tickets": [
     {
@@ -167,6 +167,28 @@
       ],
       "must_survive": [],
       "ticket_id": "pii-eval-002"
+    },
+    {
+      "fields": {
+        "agent_reply": "Customer Amy Rae Li Report plan was upgraded.",
+        "customer_message": "Can the Report plan stay active after an upgrade?",
+        "source_id": "ticket-eval-safe-003",
+        "subject": "Report plan upgrade"
+      },
+      "labels": [
+        {
+          "class": "person_name",
+          "end": 19,
+          "name_subtype": "cue_prefixed",
+          "origin_field": "agent_reply",
+          "severity": "high",
+          "span": "Amy Rae Li",
+          "start": 9,
+          "surrogate_id": "person_name-004"
+        }
+      ],
+      "must_survive": [],
+      "ticket_id": "pii-eval-003"
     }
   ]
 }

--- a/plans/PR-Deflection-PII-Two-Letter-Name-Recall.md
+++ b/plans/PR-Deflection-PII-Two-Letter-Name-Recall.md
@@ -1,0 +1,119 @@
+# PR-Deflection-PII-Two-Letter-Name-Recall
+
+## Why this slice exists
+
+#1742 requires the recall harness to make person-name recall visible rather than
+blend away known gaps. #1753 added partial person-name token measurement, but it
+parked a narrow scorer/corpus limitation: the partial-token detector ignored
+two-letter name tokens, so a residue such as `Mary Jane Li -> [redacted-name]
+Li` could look fully scrubbed even though the short surname survived.
+
+Root cause: the scorer's person-name token extractor used a global three-character
+minimum for all name tokens. That was safe against noisy short words, but it
+also excluded real two-letter non-initial surname tokens from the partial-leak
+detector.
+
+This change fixes the scorer root for the narrow class by admitting two-letter
+non-initial person-name tokens while filtering common two-letter words. It does
+not change scrubber behavior, thresholds, advisory-vs-gating policy, or the
+explicitly deferred cue-less/open-set name gap.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 5
+
+1. Add a surrogate-only tiny-corpus row for a cue-prefixed person name with a
+   two-letter surname so the harness exercises that shape end to end.
+2. Teach partial person-name leak scoring to count surviving two-letter
+   non-initial name tokens, with near-miss probes for common short words and
+   hyphenated/apostrophe compounds.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The tiny corpus includes a short-surname cue-prefixed person-name label
+        with no raw source data or real PII.
+  - [ ] The scorer still reports the current end-to-end corpus as clean for
+        gate-eligible free high-severity leaks and cue-prefixed name leaks.
+  - [ ] A direct scorer probe counts `[redacted-name] Li`-style residue as
+        `partial_name_token`.
+  - [ ] A near-miss common-word probe does not create a false partial-name leak.
+  - [ ] A near-miss hyphenated/apostrophe compound such as `Li-ion` or `Li's`
+        does not create a false partial-name leak.
+  - [ ] Existing cue-less/open-set name accounting stays deferred and visible.
+- Affected surfaces: extracted-checks advisory scorer JSON/markdown and the
+  committed surrogate-only tiny corpus fixture.
+- Risk areas: scorer precision, fixture accounting, CI enrollment, sanitized
+  advisory output.
+- Reviewer rules triggered: R1, R2, R10, R12, R14; boundary-probe required for
+  scorer leak-detection logic.
+
+### Files touched
+
+- `docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json`
+- `plans/PR-Deflection-PII-Two-Letter-Name-Recall.md`
+- `scripts/score_deflection_pii_recall.py`
+- `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+## Mechanism
+
+The fixture adds one more surrogate-only ticket whose agent reply contains a
+cue-prefixed synthetic person name with a two-letter surname. The scorer already
+runs the full deflection path for each ticket, so this increases the measured
+cue-prefixed denominator without changing production scrubber behavior.
+
+The scorer keeps the existing three-character token floor for ordinary
+person-name tokens, then allows exactly two-character non-initial tokens unless
+they are common short words. That makes a surviving short surname count as
+`partial_name_token` while keeping obvious short-word near-misses out of the
+leak count. After Codex review, the short-token match also treats hyphen and
+apostrophe as token-neighbor characters so unrelated compounds such as `Li-ion`
+and `Li's` do not count as a standalone leaked surname.
+
+## Intentional
+
+- No scrubber regex change: the current end-to-end short-surname fixture is
+  already fully redacted, and this slice is about making the measurement catch
+  the class if it regresses.
+- No threshold or gating flip: #1742 still says those are operator decisions
+  after the representative corpus is selected.
+- No model-based NER/open-set names: cue-less names remain measured and
+  deferred, not hidden.
+- Codex P2 on short-token matching inside hyphenated/apostrophe compounds is
+  fixed in the scorer boundary helper and covered by focused near-miss tests.
+
+## Deferred
+
+- Operator-derived representative corpus, corpus size/archetype mix, threshold
+  selection, labeling-quality process, and advisory-to-gating promotion remain
+  the #1742 open decisions.
+- Cue-less/open-set name recall remains the deferred NER/product decision; this
+  PR only improves deterministic scorer coverage for cue-prefixed short
+  surnames.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest `tests/test_score_deflection_pii_recall.py` -q -> 24 passed.
+- python -m pytest `tests/test_score_deflection_pii_recall.py` `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -q -> 36 passed.
+- python `scripts/score_deflection_pii_recall.py` --json -> status ok; `ticket_count=3`, `label_count=11`, `free_high_severity_gate_eligible_leak_count=0`, `cue_prefixed` expected 7 / leaks 0, deferred open-set name leaks 1.
+- python -m py_compile `scripts/score_deflection_pii_recall.py` `tests/test_score_deflection_pii_recall.py` `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -> passed.
+- python `scripts/audit_extracted_pipeline_ci_enrollment.py` -> OK, 188 matching tests enrolled.
+- bash `scripts/check_ascii_python.sh` -> passed.
+- bash `scripts/run_extracted_pipeline_checks.sh` -> reasoning core 295 passed; extracted content 4831 passed / 15 skipped.
+- Pending before push: bash `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json` | 32 |
+| `plans/PR-Deflection-PII-Two-Letter-Name-Recall.md` | 119 |
+| `scripts/score_deflection_pii_recall.py` | 64 |
+| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 22 |
+| `tests/test_score_deflection_pii_recall.py` | 58 |
+| **Total** | **295** |

--- a/scripts/score_deflection_pii_recall.py
+++ b/scripts/score_deflection_pii_recall.py
@@ -58,9 +58,8 @@ HIGH_SEVERITY_CLASSES = frozenset({
     "person_name",
     "dob",
 })
-# Keep the curated surrogate corpus on 3+ character name tokens; two-letter
-# surnames need an explicit scorer/corpus follow-up before they are reliable.
 PERSON_NAME_TOKEN_MIN_LENGTH = 3
+PERSON_NAME_SHORT_TOKEN_LENGTH = 2
 PERSON_NAME_TOKEN_STOPWORDS = frozenset({
     "agent",
     "client",
@@ -71,6 +70,34 @@ PERSON_NAME_TOKEN_STOPWORDS = frozenset({
     "person",
     "requester",
     "user",
+})
+PERSON_NAME_TOKEN_BOUNDARY_CHARS = r"A-Za-z0-9"
+PERSON_NAME_SHORT_TOKEN_BOUNDARY_CHARS = r"A-Za-z0-9'\-"
+PERSON_NAME_SHORT_TOKEN_STOPWORDS = frozenset({
+    "am",
+    "an",
+    "as",
+    "at",
+    "be",
+    "by",
+    "do",
+    "go",
+    "he",
+    "if",
+    "in",
+    "is",
+    "it",
+    "me",
+    "my",
+    "no",
+    "of",
+    "on",
+    "or",
+    "so",
+    "to",
+    "up",
+    "us",
+    "we",
 })
 
 
@@ -634,18 +661,37 @@ def _label_leak_kind(
 
 def _person_name_token_survives(span: str, scrubbed_text: str) -> bool:
     for token in _person_name_tokens(span):
-        if re.search(rf"(?<![A-Za-z0-9]){re.escape(token)}(?![A-Za-z0-9])", scrubbed_text):
+        if re.search(_person_name_token_pattern(token), scrubbed_text):
             return True
     return False
 
 
-def _person_name_tokens(span: str) -> tuple[str, ...]:
-    return tuple(
-        token
-        for token in re.findall(r"[A-Za-z][A-Za-z'-]+", span)
-        if len(token) >= PERSON_NAME_TOKEN_MIN_LENGTH
-        and token.casefold() not in PERSON_NAME_TOKEN_STOPWORDS
+def _person_name_token_pattern(token: str) -> str:
+    boundary_chars = (
+        PERSON_NAME_SHORT_TOKEN_BOUNDARY_CHARS
+        if len(token) == PERSON_NAME_SHORT_TOKEN_LENGTH
+        else PERSON_NAME_TOKEN_BOUNDARY_CHARS
     )
+    return rf"(?<![{boundary_chars}]){re.escape(token)}(?![{boundary_chars}])"
+
+
+def _person_name_tokens(span: str) -> tuple[str, ...]:
+    tokens = re.findall(r"[A-Za-z][A-Za-z'-]+", span)
+    filtered: list[str] = []
+    for index, token in enumerate(tokens):
+        normalized = token.casefold()
+        if normalized in PERSON_NAME_TOKEN_STOPWORDS:
+            continue
+        if len(token) >= PERSON_NAME_TOKEN_MIN_LENGTH:
+            filtered.append(token)
+            continue
+        if (
+            len(token) == PERSON_NAME_SHORT_TOKEN_LENGTH
+            and index > 0
+            and normalized not in PERSON_NAME_SHORT_TOKEN_STOPWORDS
+        ):
+            filtered.append(token)
+    return tuple(filtered)
 
 
 def _score_must_survive(

--- a/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
+++ b/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
@@ -452,9 +452,9 @@ def test_committed_tiny_fixture_is_surrogate_only() -> None:
     rendered = json.dumps(artifact, sort_keys=True)
 
     assert artifact["schema_version"] == SCHEMA_VERSION
-    assert artifact["summary"]["ticket_count"] == 2
+    assert artifact["summary"]["ticket_count"] == 3
     assert artifact["summary"]["cue_less_person_name_count"] == 1
-    assert artifact["summary"]["cue_prefixed_person_name_count"] == 2
+    assert artifact["summary"]["cue_prefixed_person_name_count"] == 3
     for raw in (
         "Alice Baker",
         "alice.baker@example.com",
@@ -467,7 +467,7 @@ def test_committed_tiny_fixture_is_surrogate_only() -> None:
     ):
         assert raw not in rendered
     assert artifact["summary"]["labels_by_class"]["dob"] == 1
-    assert artifact["summary"]["labels_by_severity"]["high"] == 8
+    assert artifact["summary"]["labels_by_severity"]["high"] == 9
     residual_ticket = artifact["tickets"][1]
     assert residual_ticket["fields"]["agent_reply"] == (
         "Customer Mary Jane Watson Report plan was upgraded."
@@ -482,5 +482,21 @@ def test_committed_tiny_fixture_is_surrogate_only() -> None:
             "span": "Mary Jane Watson",
             "start": 9,
             "surrogate_id": "person_name-003",
+        }
+    ]
+    short_surname_ticket = artifact["tickets"][2]
+    assert short_surname_ticket["fields"]["agent_reply"] == (
+        "Customer Amy Rae Li Report plan was upgraded."
+    )
+    assert short_surname_ticket["labels"] == [
+        {
+            "class": "person_name",
+            "end": 19,
+            "name_subtype": "cue_prefixed",
+            "origin_field": "agent_reply",
+            "severity": "high",
+            "span": "Amy Rae Li",
+            "start": 9,
+            "surrogate_id": "person_name-004",
         }
     ]

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -32,8 +32,8 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     assert summary["status"] == "ok"
     assert summary["input"] == {
         "schema_version": "deflection_pii_eval_corpus.v1",
-        "ticket_count": 2,
-        "label_count": 10,
+        "ticket_count": 3,
+        "label_count": 11,
         "must_survive_count": 3,
     }
     paid_pdf = summary["surface_generation"]["paid_pdf"]
@@ -83,15 +83,15 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     }
     if paid_pdf["rendered"]:
         assert summary["person_name"]["cue_prefixed"] == {
-            "expected": 5,
-            "redacted": 5,
+            "expected": 7,
+            "redacted": 7,
             "leaks": 0,
             "recall": 1.0,
         }
     else:
         assert summary["person_name"]["cue_prefixed"] == {
-            "expected": 3,
-            "redacted": 3,
+            "expected": 4,
+            "redacted": 4,
             "leaks": 0,
             "recall": 1.0,
         }
@@ -108,6 +108,10 @@ def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:
     )
     assert all(
         sample["surrogate_id"] != "person_name-003"
+        for sample in summary["leak_samples"]
+    )
+    assert all(
+        sample["surrogate_id"] != "person_name-004"
         for sample in summary["leak_samples"]
     )
     assert all(
@@ -134,6 +138,47 @@ def test_partial_name_token_detection_reports_token_residue() -> None:
     )
 
     assert leak_kind == "partial_name_token"
+
+
+def test_partial_name_token_detection_reports_two_letter_surname_residue() -> None:
+    leak_kind = CLI._label_leak_kind(
+        label={"class": "person_name", "span": "Amy Rae Li"},
+        baseline_text="Customer Amy Rae Li Report plan was upgraded.",
+        scrubbed_text="Customer [redacted-name] Li Report plan was upgraded.",
+    )
+
+    assert leak_kind == "partial_name_token"
+
+
+def test_partial_name_token_detection_ignores_common_two_letter_words() -> None:
+    leak_kind = CLI._label_leak_kind(
+        label={"class": "person_name", "span": "Amy Rae To"},
+        baseline_text="Customer Amy Rae To Report plan was upgraded.",
+        scrubbed_text="Customer [redacted-name] To Report plan was upgraded.",
+    )
+
+    assert leak_kind == ""
+
+
+@pytest.mark.parametrize(
+    "scrubbed_text",
+    (
+        "Customer [redacted-name] Li-ion battery plan was upgraded.",
+        "Customer [redacted-name] Li's plan was upgraded.",
+        "Customer [redacted-name] O'Li plan was upgraded.",
+        "Customer [redacted-name] Link plan was upgraded.",
+    ),
+)
+def test_partial_name_token_detection_ignores_short_token_compounds(
+    scrubbed_text: str,
+) -> None:
+    leak_kind = CLI._label_leak_kind(
+        label={"class": "person_name", "span": "Amy Rae Li"},
+        baseline_text="Customer Amy Rae Li Report plan was upgraded.",
+        scrubbed_text=scrubbed_text,
+    )
+
+    assert leak_kind == ""
 
 
 def test_resolved_partial_name_token_does_not_cross_contaminate_tickets() -> None:
@@ -430,6 +475,7 @@ def test_cli_writes_markdown_summary_without_raw_spans(tmp_path: Path) -> None:
         "Maya Chen",
         "Jordan Lee",
         "Mary Jane Watson",
+        "Amy Rae Li",
         "alex.rivera@example.test",
         "555-010-4301",
         "1990-04-17",


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Two-Letter-Name-Recall.md
Slice phase: Vertical slice

This #1742 slice closes the parked two-letter surname scorer/corpus follow-up from the partial person-name measurement work: the tiny surrogate corpus now exercises a cue-prefixed short-surname name, and the scorer counts surviving two-letter non-initial name tokens as partial person-name residue without changing scrubber behavior, thresholds, gating, or the deferred cue-less/open-set name gap.

## Intentional
- No scrubber regex change; the current end-to-end short-surname fixture is already fully redacted, and this slice makes the measurement catch the class if it regresses.
- No threshold or advisory-to-gating change.
- No model-based NER/open-set name change.

## AI reconciliation
- AI findings reviewed: yes.
- All fixed or waived: yes.
- Fixed Codex P2 about two-letter tokens matching inside hyphenated/apostrophe compounds. Short-token matching now treats hyphen and apostrophe as token-neighbor characters, and tests cover `Li-ion`, `Li's`, `O'Li`, and `Link` near-misses.

## Deferred
- Operator-derived representative corpus, corpus size/archetype mix, threshold selection, labeling-quality process, and advisory-to-gating promotion remain #1742 decisions.
- Cue-less/open-set names remain measured and deferred.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_score_deflection_pii_recall.py -q` -> 24 passed.
- `python -m pytest tests/test_score_deflection_pii_recall.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -q` -> 36 passed.
- `python scripts/score_deflection_pii_recall.py --json` -> status ok; `ticket_count=3`, `label_count=11`, `free_high_severity_gate_eligible_leak_count=0`, `cue_prefixed` expected 7 / leaks 0, deferred open-set name leaks 1.
- `python -m py_compile scripts/score_deflection_pii_recall.py tests/test_score_deflection_pii_recall.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -> passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -> OK, 188 matching tests enrolled.
- `bash scripts/check_ascii_python.sh` -> passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -> reasoning core 295 passed; extracted content 4831 passed / 15 skipped.

## Diff size
5 files, +272 / -23
