### PR TITLE
Add deflection email action summary

### DIFF
--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 from typing import Any, Literal, Mapping, Protocol
 from urllib.parse import quote
@@ -23,6 +23,7 @@ from extracted_content_pipeline.storage._jsonb_helpers import decode_jsonb_field
 DEFAULT_DEFLECTION_DELIVERY_SUBJECT = "Your FAQ deflection report is ready"
 DELIVERY_CLAIM_STALE_AFTER = "15 minutes"
 MAX_DELIVERY_ERROR_CHARS = 500
+EMAIL_ACTION_SECTION_LIMIT = 3
 
 logger = logging.getLogger("atlas.content_ops_deflection_delivery")
 
@@ -52,6 +53,15 @@ class DeflectionReportDeliverySummary:
 
 
 @dataclass(frozen=True)
+class _DeliveryEmailActionItem:
+    question: str
+    ticket_count: int
+    estimated_support_cost: float | None
+    status: str
+    recommended_action: str
+
+
+@dataclass(frozen=True)
 class _DeliveryEmailSummary:
     repeat_ticket_count: int
     generated_question_count: int
@@ -59,6 +69,8 @@ class _DeliveryEmailSummary:
     drafted_answer_count: int
     no_proven_answer_count: int
     ticket_source_count: int
+    priority_fix_items: tuple[_DeliveryEmailActionItem, ...] = ()
+    drafted_resolution_items: tuple[_DeliveryEmailActionItem, ...] = ()
 
 
 async def send_pending_deflection_report_deliveries(
@@ -337,6 +349,7 @@ def _render_model_summary_html(
         "approved resolution evidence.</li>"
         f"<li>{_html_count(summary.ticket_source_count)} ticket sources represented.</li>"
         "</ul>"
+        f"{_render_action_summary_html(summary)}"
         f"{attachment_copy}"
         "<p>The secure results page has the consolidated report, PDF, and complete "
         "evidence export.</p>"
@@ -367,6 +380,7 @@ def _render_model_summary_text(
         f"- {_email_count(summary.no_proven_answer_count)} questions still need approved "
         "resolution evidence.\n"
         f"- {_email_count(summary.ticket_source_count)} ticket sources represented.\n\n"
+        f"{_render_action_summary_text(summary)}"
         f"{attachment_copy}"
         "The secure results page has the consolidated report, PDF, and complete "
         "evidence export:\n\n"
@@ -380,12 +394,29 @@ def _delivery_email_summary(artifact: Any) -> _DeliveryEmailSummary | None:
     )
     if model is None:
         return None
-    for section in _model_sections(model, "email_summary"):
+    sections = _model_sections(model, "email_summary")
+    for section in sections:
         if _clean(section.get("id")) != "support_tax":
             continue
         summary = _support_tax_email_summary(section)
         if summary is not None:
-            return summary
+            drafted_resolution_items = _section_action_items(
+                sections,
+                "drafted_resolutions",
+            )
+            drafted_questions = {
+                item.question.casefold() for item in drafted_resolution_items
+            }
+            return replace(
+                summary,
+                priority_fix_items=_section_action_items(
+                    sections,
+                    "priority_fix_queue",
+                    excluded_questions=drafted_questions,
+                    excluded_statuses={"draft ready"},
+                ),
+                drafted_resolution_items=drafted_resolution_items,
+            )
     return None
 
 
@@ -434,6 +465,117 @@ def _support_tax_email_summary(
     )
 
 
+def _section_action_items(
+    sections: tuple[dict[str, Any], ...],
+    section_id: str,
+    *,
+    excluded_questions: set[str] | None = None,
+    excluded_statuses: set[str] | None = None,
+) -> tuple[_DeliveryEmailActionItem, ...]:
+    excluded_questions = excluded_questions or set()
+    excluded_statuses = excluded_statuses or set()
+    for section in sections:
+        if _clean(section.get("id")) != section_id:
+            continue
+        data = section.get("data")
+        if not isinstance(data, Mapping):
+            return ()
+        rows = data.get("items")
+        if not isinstance(rows, list):
+            return ()
+        limit = _email_action_limit(data)
+        if limit <= 0:
+            return ()
+        items: list[_DeliveryEmailActionItem] = []
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            item = _email_action_item(row)
+            if item is None:
+                continue
+            if item.question.casefold() in excluded_questions:
+                continue
+            if item.status.casefold() in excluded_statuses:
+                continue
+            items.append(item)
+            if len(items) >= limit:
+                break
+        return tuple(items)
+    return ()
+
+
+def _email_action_limit(data: Mapping[str, Any]) -> int:
+    limit = _strict_int(data.get("result_page_limit"))
+    if limit is None:
+        return EMAIL_ACTION_SECTION_LIMIT
+    if limit <= 0:
+        return 0
+    return min(limit, EMAIL_ACTION_SECTION_LIMIT)
+
+
+def _email_action_item(row: Mapping[str, Any]) -> _DeliveryEmailActionItem | None:
+    question = _strict_text(row.get("question"))
+    ticket_count = _strict_int(row.get("ticket_count"))
+    if not question or ticket_count is None:
+        return None
+    estimated_support_cost = _strict_number(row.get("estimated_support_cost"))
+    return _DeliveryEmailActionItem(
+        question=question,
+        ticket_count=ticket_count,
+        estimated_support_cost=estimated_support_cost,
+        status=_strict_text(row.get("status")) or "",
+        recommended_action=_strict_text(row.get("recommended_action")) or "",
+    )
+
+
+def _render_action_summary_html(summary: _DeliveryEmailSummary) -> str:
+    blocks: list[str] = []
+    if summary.priority_fix_items:
+        blocks.append("<h2>Next actions</h2><ul>")
+        for item in summary.priority_fix_items:
+            blocks.append(f"<li>{_html_action_item(item, include_action=True)}</li>")
+        blocks.append("</ul>")
+    if summary.drafted_resolution_items:
+        blocks.append("<h2>Ready to publish</h2><ul>")
+        for item in summary.drafted_resolution_items:
+            blocks.append(f"<li>{_html_action_item(item, include_action=False)}</li>")
+        blocks.append("</ul>")
+    return "".join(blocks)
+
+
+def _render_action_summary_text(summary: _DeliveryEmailSummary) -> str:
+    blocks: list[str] = []
+    if summary.priority_fix_items:
+        blocks.append("Next actions:\n")
+        for item in summary.priority_fix_items:
+            blocks.append(f"- {_text_action_item(item, include_action=True)}\n")
+        blocks.append("\n")
+    if summary.drafted_resolution_items:
+        blocks.append("Ready to publish:\n")
+        for item in summary.drafted_resolution_items:
+            blocks.append(f"- {_text_action_item(item, include_action=False)}\n")
+        blocks.append("\n")
+    return "".join(blocks)
+
+
+def _html_action_item(item: _DeliveryEmailActionItem, *, include_action: bool) -> str:
+    return _escape(_text_action_item(item, include_action=include_action))
+
+
+def _text_action_item(item: _DeliveryEmailActionItem, *, include_action: bool) -> str:
+    parts = [
+        item.question,
+        f"{_email_count(item.ticket_count)} repeat tickets",
+    ]
+    if item.estimated_support_cost is not None:
+        parts.append(f"{_email_money(item.estimated_support_cost)} estimated handling")
+    if item.status:
+        parts.append(item.status)
+    if include_action and item.recommended_action:
+        parts.append(item.recommended_action)
+    return " - ".join(parts)
+
+
 def _strict_int(value: Any) -> int | None:
     if isinstance(value, bool):
         return None
@@ -457,6 +599,13 @@ def _strict_number(value: Any) -> float | None:
         except ValueError:
             return None
     return None
+
+
+def _strict_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
 
 
 def _decoded_artifact(artifact: Any) -> Any:

--- a/plans/PR-Deflection-Email-Action-Summary.md
+++ b/plans/PR-Deflection-Email-Action-Summary.md
@@ -1,0 +1,140 @@
+# PR-Deflection-Email-Action-Summary
+
+## Why this slice exists
+
+Issue #1612 split the paid deflection deliverable into multiple customer
+surfaces: the hosted result page, curated PDF, delivery email, and complete
+evidence export. Recent slices added action-section model contracts, rendered
+those sections in the PDF, and made the QA scorecard verify the PDF rows. The
+paid delivery email still summarizes only legacy top-line metrics, so a buyer
+can receive the report email without seeing the first actionable work queue
+that the report now exists to deliver.
+
+Root cause: `atlas_brain.content_ops_deflection_delivery._DeliveryEmailSummary`
+only extracts the `support_tax` email-summary section. The report model already
+marks `priority_fix_queue` and `drafted_resolutions` as `email_summary`
+surfaces, but the email renderer ignores those sections and therefore cannot
+name the highest-value fixes or publish-ready drafts.
+
+This PR fixes the root at the email projection boundary by allowlist-building a
+small action summary from those two email-eligible sections. It does not widen
+email to dump arbitrary action-section fields or raw evidence payloads.
+
+Review follow-up root cause: the first projection allowed `_clean()` to
+stringify nested action-row containers, treated draft-ready priority rows as a
+separate email action, and treated explicit zero row limits as unset. This
+update keeps the fix at the projection boundary by accepting only scalar text
+for row copy, de-duping draft-ready questions from the priority block, and
+honoring zero as "show no rows."
+
+Diff budget note: this slice is over the 400 LOC soft cap because the review
+fix touches a privacy/export boundary and ships the same-class negative probes
+with the fix. The added size is concentrated in regression fixtures for
+non-scalar required text, non-scalar optional text, draft de-dupe, and explicit
+zero limits rather than a broader product surface.
+
+## Scope (this PR)
+
+Ownership lane: issue-1612/deflection-full-report-delivery-actionability
+Slice phase: Vertical slice
+
+1. Extend the paid report delivery email summary with an allowlisted action
+   summary from `priority_fix_queue` and `drafted_resolutions`.
+2. Render only compact, customer-safe fields in HTML/text: question, ticket
+   count, estimated handling cost, status/recommended action for priority
+   fixes, and question/count/cost for publish-ready drafts.
+3. Keep raw evidence, source IDs, representative phrasing, and full backlog
+   details out of the email body.
+4. Preserve fallback behavior for legacy/future/malformed report models.
+5. Max files: 3.
+
+### Review Contract
+
+Acceptance criteria:
+- A `deflection.v1` report model with email-summary action sections produces an
+  email containing "Next actions" and "Ready to publish" sections.
+- Email action rows are capped to the section's `result_page_limit` when
+  present, falling back to a small fixed cap only when the limit is missing;
+  an explicit zero suppresses that email block.
+- The email summary is allowlist construction; it must not include
+  `top_evidence`, `source_ids`, `representative_phrasing`, raw evidence quotes,
+  or complete evidence rows.
+- Action row text is scalar-only: malformed object/list questions are skipped,
+  and malformed object/list status or recommended-action values are omitted
+  rather than stringified.
+- Draft-ready questions already shown in "Ready to publish" do not consume
+  "Next actions" slots.
+- Missing or malformed action-section data does not fail delivery and does not
+  synthesize misleading zero-action copy.
+- Existing support-tax email metrics, PDF attachment behavior, result URL, and
+  legacy fallback email copy remain unchanged.
+
+Affected surfaces:
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+
+Risk areas:
+- Privacy/export boundary: action items carry raw evidence fields in the paid
+  model, but delivery email must remain a bounded summary.
+- Report actionability: email should point the buyer at what to fix first
+  without becoming a second full report or complete ticket archive.
+
+Reviewer rules triggered: R1, R2, R3, R5, R8, R13, R14.
+
+### Files touched
+
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `plans/PR-Deflection-Email-Action-Summary.md`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+
+## Mechanism
+
+Add a small internal action-summary type to the delivery email module. The
+summary extractor continues to require valid `support_tax` metrics for the
+model-backed email path, then scans `email_summary` sections for:
+
+- `priority_fix_queue`: top N `items`, capped by `result_page_limit`;
+- `drafted_resolutions`: top N `items`, capped by `result_page_limit`.
+
+Each row is built from an explicit allowlist. The renderers add short HTML and
+plain-text blocks after the key numbers. Malformed action rows are skipped; if
+no safe rows remain, that block is omitted. Optional row copy is admitted only
+when it is already scalar text, so nested evidence/source containers cannot
+become email text through stringification. Drafted-resolution rows are collected
+first and their questions/statuses are filtered out of the priority block, so a
+publish-ready answer is not duplicated as a next action.
+
+## Intentional
+
+- No report-model producer changes. The sections already advertise
+  `email_summary`; this PR consumes that contract in the delivery email only.
+- No unresolved-repeats or already-covered recurring email block. Those
+  sections are `web`/`pdf` today, not `email_summary`, and adding them to email
+  would be a model-contract change.
+- No raw customer wording/phrasing/snippet fields in email. The email should
+  orient the buyer and link to the report, not become another high-risk content
+  surface.
+
+## Deferred
+
+- Hosted buyer result-page action-section observation remains in
+  `atlas-portfolio`.
+- Richer email design/layout polish remains later product polish after the
+  functional delivery surface is correct.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q -- 21 passed.
+- Command: python -m py_compile atlas_brain/content_ops_deflection_delivery.py tests/test_atlas_content_ops_deflection_delivery.py -- passed.
+- Pending before push: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_email_action_summary.md
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/content_ops_deflection_delivery.py` | 155 |
+| `plans/PR-Deflection-Email-Action-Summary.md` | 140 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 234 |
+| **Total** | **529** |

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -156,6 +156,90 @@ def _delivery_report_model_artifact(
                         ]
                     },
                 },
+                {
+                    "id": "priority_fix_queue",
+                    "title": "Priority Fix Queue",
+                    "priority": 35,
+                    "surfaces": ["web", "pdf", "email_summary"],
+                    "default_limit": 3,
+                    "required_data": ["items", "result_page_limit", "pdf_limit"],
+                    "data": {
+                        "result_page_limit": 2,
+                        "pdf_limit": 10,
+                        "items": [
+                            {
+                                "question": "How do I enable SSO?",
+                                "ticket_count": 6,
+                                "estimated_support_cost": 81.0,
+                                "status": "Draft ready",
+                                "recommended_action": "Review and publish",
+                                "source_ids": ["ticket-secret-priority-draft"],
+                            },
+                            {
+                                "question": "How do I export attribution reports?",
+                                "ticket_count": 9,
+                                "estimated_support_cost": 121.5,
+                                "status": "Needs answer",
+                                "recommended_action": "Create a help-center answer",
+                                "representative_phrasing": [
+                                    "RAW_REPRESENTATIVE_PHRASE_SHOULD_STAY_OUT",
+                                ],
+                                "source_ids": ["ticket-secret-action-1"],
+                                "top_evidence": [
+                                    {
+                                        "source_id": "ticket-secret-action-2",
+                                        "evidence_quote": (
+                                            "raw action evidence should stay out"
+                                        ),
+                                    },
+                                ],
+                            },
+                            {
+                                "question": "How do I update invoice contacts?",
+                                "ticket_count": 4,
+                                "estimated_support_cost": 54.0,
+                                "status": "Needs review",
+                                "recommended_action": "Approve the billing macro",
+                            },
+                            {
+                                "question": "How do I invite an auditor?",
+                                "ticket_count": 3,
+                                "estimated_support_cost": 40.5,
+                                "status": "Needs answer",
+                                "recommended_action": "Create an admin answer",
+                            },
+                        ],
+                    },
+                },
+                {
+                    "id": "drafted_resolutions",
+                    "title": "Drafted Resolutions Ready to Publish",
+                    "priority": 37,
+                    "surfaces": ["web", "pdf", "email_summary"],
+                    "default_limit": 3,
+                    "required_data": ["items", "result_page_limit", "pdf_limit"],
+                    "data": {
+                        "result_page_limit": 1,
+                        "pdf_limit": 10,
+                        "items": [
+                            {
+                                "question": "How do I enable SSO?",
+                                "ticket_count": 6,
+                                "estimated_support_cost": 81.0,
+                                "status": "Draft ready",
+                                "recommended_action": "Review and publish",
+                                "source_ids": ["ticket-secret-draft-1"],
+                            },
+                            {
+                                "question": "How do I change workspace owners?",
+                                "ticket_count": 2,
+                                "estimated_support_cost": 27.0,
+                                "status": "Draft ready",
+                                "recommended_action": "Publish ownership FAQ",
+                            },
+                        ],
+                    },
+                },
             ],
         },
     }
@@ -257,20 +341,170 @@ async def test_delivery_worker_renders_model_backed_email_summary(
     assert "3 publishable answers drafted" in request.html_body
     assert "5 questions still need approved resolution evidence" in request.html_body
     assert "42 ticket sources represented" in request.html_body
+    assert "Next actions" in request.html_body
+    assert "How do I export attribution reports?" in request.html_body
+    assert "9 repeat tickets" in request.html_body
+    assert "$122 estimated handling" in request.html_body
+    assert "Create a help-center answer" in request.html_body
+    assert "How do I update invoice contacts?" in request.html_body
+    assert "How do I invite an auditor?" not in request.html_body
+    assert "Ready to publish" in request.html_body
+    assert "How do I enable SSO?" in request.html_body
+    assert request.html_body.count("How do I enable SSO?") == 1
+    assert "How do I change workspace owners?" not in request.html_body
     assert "curated report PDF is attached" in request.html_body
     assert "full report PDF is attached" not in request.html_body
     assert "The secure results page has the consolidated report" in request.html_body
     assert "RAW MARKDOWN BODY" not in request.html_body
     assert "private evidence quote" not in request.html_body
     assert "ticket-secret-123" not in request.html_body
+    assert "RAW_REPRESENTATIVE_PHRASE_SHOULD_STAY_OUT" not in request.html_body
+    assert "ticket-secret-action-1" not in request.html_body
+    assert "raw action evidence should stay out" not in request.html_body
+    assert "ticket-secret-priority-draft" not in request.html_body
+    assert "ticket-secret-draft-1" not in request.html_body
     assert "resolution_evidence" not in request.html_body
     assert request.text_body is not None
     assert "1,234 repeat tickets across 8 ranked questions" in request.text_body
     assert "$16,659 estimated assisted-contact handling" in request.text_body
+    assert "Next actions" in request.text_body
+    assert "How do I export attribution reports?" in request.text_body
+    assert "How do I update invoice contacts?" in request.text_body
+    assert "How do I invite an auditor?" not in request.text_body
+    assert "Ready to publish" in request.text_body
+    assert "How do I enable SSO?" in request.text_body
+    assert request.text_body.count("How do I enable SSO?") == 1
+    assert "How do I change workspace owners?" not in request.text_body
     assert "curated report PDF is attached" in request.text_body
     assert "RAW MARKDOWN BODY" not in request.text_body
     assert "private evidence quote" not in request.text_body
     assert "ticket-secret-123" not in request.text_body
+    assert "ticket-secret-action-1" not in request.text_body
+    assert "raw action evidence should stay out" not in request.text_body
+    assert "ticket-secret-priority-draft" not in request.text_body
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_omits_malformed_action_summary_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _delivery_report_model_artifact()
+    sections = artifact["report_model"]["sections"]
+    for section in sections:
+        if section["id"] == "priority_fix_queue":
+            section["data"]["items"] = [
+                {"question": "Missing ticket count"},
+                {"ticket_count": 3},
+                {
+                    "question": {
+                        "source_ids": ["ticket-object-leak"],
+                        "evidence_quote": "object evidence leak",
+                    },
+                    "ticket_count": 3,
+                    "estimated_support_cost": 30.0,
+                },
+                "not-a-row",
+            ]
+        if section["id"] == "drafted_resolutions":
+            section["data"]["items"] = "not-a-list"
+    pool = _Pool([_row(artifact=json.dumps(artifact))])
+    sender = _Sender()
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-model-bytes")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.sent == 1
+    request = sender.requests[0]
+    assert "Key numbers" in request.html_body
+    assert "Next actions" not in request.html_body
+    assert "Ready to publish" not in request.html_body
+    assert "Missing ticket count" not in request.html_body
+    assert "ticket-object-leak" not in request.html_body
+    assert "object evidence leak" not in request.html_body
+    assert "not-a-list" not in request.html_body
+    assert request.text_body is not None
+    assert "Next actions" not in request.text_body
+    assert "Ready to publish" not in request.text_body
+    assert "ticket-object-leak" not in request.text_body
+    assert "object evidence leak" not in request.text_body
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_omits_non_scalar_action_optional_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _delivery_report_model_artifact()
+    sections = artifact["report_model"]["sections"]
+    for section in sections:
+        if section["id"] == "priority_fix_queue":
+            section["data"]["items"] = [
+                {
+                    "question": "How do I update audit exports?",
+                    "ticket_count": 5,
+                    "estimated_support_cost": 67.5,
+                    "status": ["status evidence leak"],
+                    "recommended_action": {
+                        "evidence_quote": "action evidence leak",
+                    },
+                },
+            ]
+        if section["id"] == "drafted_resolutions":
+            section["data"]["items"] = []
+    pool = _Pool([_row(artifact=json.dumps(artifact))])
+    sender = _Sender()
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-model-bytes")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.sent == 1
+    request = sender.requests[0]
+    assert "Next actions" in request.html_body
+    assert "How do I update audit exports?" in request.html_body
+    assert "status evidence leak" not in request.html_body
+    assert "action evidence leak" not in request.html_body
+    assert request.text_body is not None
+    assert "How do I update audit exports?" in request.text_body
+    assert "status evidence leak" not in request.text_body
+    assert "action evidence leak" not in request.text_body
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_honors_zero_action_summary_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _delivery_report_model_artifact()
+    sections = artifact["report_model"]["sections"]
+    for section in sections:
+        if section["id"] in {"priority_fix_queue", "drafted_resolutions"}:
+            section["data"]["result_page_limit"] = 0
+    pool = _Pool([_row(artifact=json.dumps(artifact))])
+    sender = _Sender()
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-model-bytes")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.sent == 1
+    request = sender.requests[0]
+    assert "Key numbers" in request.html_body
+    assert "Next actions" not in request.html_body
+    assert "Ready to publish" not in request.html_body
+    assert "How do I export attribution reports?" not in request.html_body
+    assert "How do I enable SSO?" not in request.html_body
+    assert request.text_body is not None
+    assert "Next actions" not in request.text_body
+    assert "Ready to publish" not in request.text_body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Email-Action-Summary.md
Slice phase: Vertical slice

#1612's paid report now has action-section model/PDF coverage. This slice makes the paid delivery email consume the existing `email_summary` action sections so the buyer sees the first fixes and publish-ready drafts directly in the email without exposing raw evidence payloads.

## Intentional
- No report-model producer changes; this consumes the existing `email_summary` section contract.
- No unresolved-repeats or already-covered recurring email block; those sections are not `email_summary` surfaces today.
- No raw customer wording, evidence quotes, representative phrasing, or source IDs in email.
- Action-row text is scalar-only at the email projection boundary; object/list values are skipped or omitted instead of stringified.

## Deferred
- Hosted buyer result-page action-section observation remains in `atlas-portfolio`.
- Richer email layout polish remains later product polish.

## Parked hardening
- None.

## AI reconciliation
- Codex P1 non-scalar action-row text -- fixed by scalar-only row construction plus malformed object/list regression coverage.
- Codex P2 drafted rows in Next actions -- fixed by collecting drafted rows first and excluding draft-ready/duplicate questions from the priority block.
- Codex P2 explicit zero action limits -- fixed by treating `result_page_limit: 0` as suppressing the email block.
- All findings fixed or waived: yes.

## Verification
- Command: `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q` -- 21 passed.
- Command: `python -m py_compile atlas_brain/content_ops_deflection_delivery.py tests/test_atlas_content_ops_deflection_delivery.py` -- passed.
- Pending before push: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_email_action_summary.md`

## Diff size
3 files, +523 / -17
