### PR TITLE
Add deflection PII source intake summary

### DIFF
--- a/extracted_content_pipeline/deflection_pii_eval_corpus.py
+++ b/extracted_content_pipeline/deflection_pii_eval_corpus.py
@@ -18,6 +18,12 @@ from typing import Any
 SCHEMA_VERSION = "deflection_pii_eval_corpus.v1"
 INPUT_SCHEMA_VERSION = "deflection_pii_labeled_source.v1"
 SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION = "deflection_pii_labeled_source_intake_summary.v1"
+SAFE_MUST_SURVIVE_REASONS = frozenset({
+    "compliance_reference",
+    "must_survive",
+    "security_reference",
+    "tenant_source_id",
+})
 
 FIELD_KEYS = (
     "subject",
@@ -167,7 +173,11 @@ def build_surrogate_eval_corpus(source: Any) -> SurrogateEvalCorpusBuildResult:
     return SurrogateEvalCorpusBuildResult(artifact=artifact)
 
 
-def summarize_labeled_source(source: Any) -> dict[str, Any]:
+def summarize_labeled_source(
+    source: Any,
+    *,
+    build_result: SurrogateEvalCorpusBuildResult | None = None,
+) -> dict[str, Any]:
     """Return sanitized corpus-mix metadata for a labeled local source."""
 
     if not isinstance(source, Mapping):
@@ -176,17 +186,17 @@ def summarize_labeled_source(source: Any) -> dict[str, Any]:
     source_schema_version = _clean(source.get("schema_version"))
     if source_schema_version != INPUT_SCHEMA_VERSION:
         return _intake_error_summary(
-            source_schema_version,
+            _safe_schema_version_summary(source.get("schema_version")),
             (
                 _error(
                     "source_schema_version_mismatch",
                     expected=INPUT_SCHEMA_VERSION,
-                    actual=source_schema_version,
+                    actual=_safe_schema_version_summary(source.get("schema_version")),
                 ),
             ),
         )
 
-    result = build_surrogate_eval_corpus(source)
+    result = build_result if build_result is not None else build_surrogate_eval_corpus(source)
     if not result.ok:
         return _intake_error_summary(source_schema_version, result.errors)
 
@@ -210,7 +220,7 @@ def summarize_labeled_source(source: Any) -> dict[str, Any]:
         if isinstance(record, Mapping)
     )
     by_origin_field = Counter(_clean(label.get("origin_field")) for label in labels)
-    by_reason = Counter(_clean(record.get("reason")) for record in must_survive)
+    by_reason = Counter(_safe_must_survive_reason(record.get("reason")) for record in must_survive)
     return {
         "schema_version": SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION,
         "ok": True,
@@ -630,6 +640,21 @@ def _intake_error_summary(
     }
 
 
+def _safe_schema_version_summary(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return "missing"
+    if value.strip() == INPUT_SCHEMA_VERSION:
+        return INPUT_SCHEMA_VERSION
+    return "invalid"
+
+
+def _safe_must_survive_reason(value: Any) -> str:
+    reason = _clean(value)
+    if reason in SAFE_MUST_SURVIVE_REASONS:
+        return reason
+    return "other"
+
+
 def _find_occurrence(text: str, span: str, occurrence: int) -> tuple[int, int] | None:
     start = -1
     for _ in range(max(1, occurrence)):
@@ -683,6 +708,7 @@ __all__ = [
     "PII_CLASSES",
     "SCHEMA_VERSION",
     "SEVERITY_BY_CLASS",
+    "SAFE_MUST_SURVIVE_REASONS",
     "SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION",
     "SurrogateEvalCorpusBuildResult",
     "build_surrogate_eval_corpus",

--- a/extracted_content_pipeline/deflection_pii_eval_corpus.py
+++ b/extracted_content_pipeline/deflection_pii_eval_corpus.py
@@ -17,6 +17,7 @@ from typing import Any
 
 SCHEMA_VERSION = "deflection_pii_eval_corpus.v1"
 INPUT_SCHEMA_VERSION = "deflection_pii_labeled_source.v1"
+SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION = "deflection_pii_labeled_source_intake_summary.v1"
 
 FIELD_KEYS = (
     "subject",
@@ -164,6 +165,75 @@ def build_surrogate_eval_corpus(source: Any) -> SurrogateEvalCorpusBuildResult:
         "tickets": tickets,
     }
     return SurrogateEvalCorpusBuildResult(artifact=artifact)
+
+
+def summarize_labeled_source(source: Any) -> dict[str, Any]:
+    """Return sanitized corpus-mix metadata for a labeled local source."""
+
+    if not isinstance(source, Mapping):
+        return _intake_error_summary("", (_error("source_invalid_shape"),))
+
+    source_schema_version = _clean(source.get("schema_version"))
+    if source_schema_version != INPUT_SCHEMA_VERSION:
+        return _intake_error_summary(
+            source_schema_version,
+            (
+                _error(
+                    "source_schema_version_mismatch",
+                    expected=INPUT_SCHEMA_VERSION,
+                    actual=source_schema_version,
+                ),
+            ),
+        )
+
+    result = build_surrogate_eval_corpus(source)
+    if not result.ok:
+        return _intake_error_summary(source_schema_version, result.errors)
+
+    assert result.artifact is not None
+    artifact = result.artifact
+    tickets = tuple(
+        ticket
+        for ticket in _sequence(artifact.get("tickets"))
+        if isinstance(ticket, Mapping)
+    )
+    labels = tuple(
+        label
+        for ticket in tickets
+        for label in _sequence(ticket.get("labels"))
+        if isinstance(label, Mapping)
+    )
+    must_survive = tuple(
+        record
+        for ticket in tickets
+        for record in _sequence(ticket.get("must_survive"))
+        if isinstance(record, Mapping)
+    )
+    by_origin_field = Counter(_clean(label.get("origin_field")) for label in labels)
+    by_reason = Counter(_clean(record.get("reason")) for record in must_survive)
+    return {
+        "schema_version": SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION,
+        "ok": True,
+        "source_schema_version": source_schema_version,
+        "artifact_schema_version": SCHEMA_VERSION,
+        "raw_source_persisted": False,
+        "raw_label_spans_persisted": False,
+        "surrogate_positions_are_recall_labels": True,
+        "ticket_count": len(tickets),
+        "label_count": len(labels),
+        "labels_by_class": dict(sorted(Counter(_clean(label.get("class")) for label in labels).items())),
+        "labels_by_severity": dict(sorted(Counter(_clean(label.get("severity")) for label in labels).items())),
+        "labels_by_origin_field": dict(sorted(by_origin_field.items())),
+        "person_name": {
+            "cue_less": sum(1 for label in labels if label.get("name_subtype") == "cue_less"),
+            "cue_prefixed": sum(1 for label in labels if label.get("name_subtype") == "cue_prefixed"),
+        },
+        "must_survive": {
+            "count": len(must_survive),
+            "by_reason": dict(sorted(by_reason.items())),
+        },
+        "errors": [],
+    }
 
 
 @dataclass(frozen=True)
@@ -544,6 +614,22 @@ def _summary(tickets: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _intake_error_summary(
+    source_schema_version: str,
+    errors: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION,
+        "ok": False,
+        "source_schema_version": source_schema_version,
+        "artifact_schema_version": SCHEMA_VERSION,
+        "raw_source_persisted": False,
+        "raw_label_spans_persisted": False,
+        "surrogate_positions_are_recall_labels": True,
+        "errors": [dict(error) for error in errors],
+    }
+
+
 def _find_occurrence(text: str, span: str, occurrence: int) -> tuple[int, int] | None:
     start = -1
     for _ in range(max(1, occurrence)):
@@ -597,6 +683,8 @@ __all__ = [
     "PII_CLASSES",
     "SCHEMA_VERSION",
     "SEVERITY_BY_CLASS",
+    "SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION",
     "SurrogateEvalCorpusBuildResult",
     "build_surrogate_eval_corpus",
+    "summarize_labeled_source",
 ]

--- a/plans/PR-Deflection-PII-Source-Intake-Summary.md
+++ b/plans/PR-Deflection-PII-Source-Intake-Summary.md
@@ -1,0 +1,128 @@
+# PR-Deflection-PII-Source-Intake-Summary
+
+## Why this slice exists
+
+#1742's remaining true work is the operator-derived corpus path: pick a real
+source, label it transiently, normalize/surrogate it, then use the scorer
+against that artifact. The current builder can already emit a surrogate artifact
+from labeled local JSON, but there is no safe intake summary that lets the
+operator/reviewer inspect corpus mix, class coverage, name subtype split, and
+labeling-quality errors without opening raw tickets or raw label spans.
+
+Root cause: the labeled-source handoff has only a build-artifact path. That is
+fine once the source is valid, but it leaves the pre-artifact review step
+implicit and tempts ad hoc inspection of raw source files. This slice fixes that
+handoff root by adding a sanitized summary output for the existing labeled-source
+input contract.
+
+This is a narrow corpus-first vertical slice. It does not choose the real source,
+label the real data, alter scrubber behavior, pick thresholds, or flip the
+advisory into a gate.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 4
+
+1. Add a sanitized labeled-source intake summary over the existing
+   `deflection_pii_labeled_source.v1` JSON envelope.
+2. Wire the corpus builder CLI to write that summary independently of the
+   surrogate artifact so a transient operator source can be reviewed without
+   persisting raw PII.
+3. Add focused tests proving valid summaries include only aggregate metadata and
+   invalid summaries return sanitized errors without raw spans.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The summary requires the explicit labeled-source schema version and
+        fails closed on mismatches.
+  - [ ] A valid source summary reports ticket count, label count, labels by
+        class/severity/origin field, person-name subtype counts, and
+        must-survive counts/reasons.
+  - [ ] The summary can be written without writing the surrogate artifact.
+  - [ ] Invalid input summaries include error codes/locations but do not echo
+        raw source text, raw label spans, or high-risk tokens.
+  - [ ] Existing artifact generation behavior remains compatible for the
+        current tiny fixture and existing tests.
+- Affected surfaces:
+  - `extracted_content_pipeline/deflection_pii_eval_corpus.py`
+  - `scripts/build_deflection_pii_surrogate_eval_corpus.py`
+  - `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+- Risk areas: accidental raw PII echo in summary/error output, schema drift,
+  CLI compatibility, and over-broad source validation.
+- Reviewer rules triggered: R1, R2, R3, R10, R13, R14; boundary-probe required
+  because this adds a validation/reporting gate over raw-source-adjacent input.
+
+### Files touched
+
+- `extracted_content_pipeline/deflection_pii_eval_corpus.py`
+- `plans/PR-Deflection-PII-Source-Intake-Summary.md`
+- `scripts/build_deflection_pii_surrogate_eval_corpus.py`
+- `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+
+## Mechanism
+
+The corpus module gets a pure summary helper for the labeled-source envelope. It
+first checks the source schema version, then reuses the existing
+`build_surrogate_eval_corpus` validation/surrogation path so summary readiness
+matches artifact readiness. On success, it derives aggregate counts only from
+the surrogate artifact labels and must-survive records. On failure, it returns
+the existing sanitized error records and does not include raw text or raw spans.
+
+The CLI gains `--summary-output`. Callers may pass only `--summary-output` for a
+pre-artifact intake check, or pass both `--summary-output` and `--output` to
+write the safe summary plus the surrogate eval artifact.
+
+## Intentional
+
+- No raw input persistence, no raw source excerpting, and no raw label-span
+  samples in the summary.
+- No threshold recommendation or advisory-to-gating flip; the summary is corpus
+  readiness evidence, not a policy decision.
+- No new detector/scrubber behavior. Existing artifact validation remains the
+  source of truth for what is safe to surrogate.
+
+## Deferred
+
+- Operator selection of the real transient source, corpus size/archetype mix,
+  labeling ownership, and labeling-quality review remain open #1742 decisions.
+- Building the larger derived surrogate artifact from that real source remains a
+  follow-up after the operator supplies/labels the source.
+- Threshold selection and advisory-to-gating promotion remain deferred.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest` on
+  `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -> 15
+  passed.
+- `python -m py_compile` on
+  `extracted_content_pipeline/deflection_pii_eval_corpus.py`,
+  `scripts/build_deflection_pii_surrogate_eval_corpus.py`, and
+  `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -> passed.
+- `python` `scripts/score_deflection_pii_recall.py` with JSON output -> status
+  ok; gate-eligible high-severity free leaks 0, deferred open-set name leaks 1.
+- `python` `scripts/audit_extracted_pipeline_ci_enrollment.py` -> OK, 188
+  matching tests enrolled.
+- `bash` `scripts/check_ascii_python.sh` -> passed.
+- `bash` `scripts/validate_extracted_content_pipeline.sh` -> passed.
+- `python` `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py`
+  `extracted_content_pipeline` -> clean.
+- `python` `scripts/audit_extracted_standalone.py` with fail-on-debt -> Atlas
+  runtime import findings: 0.
+- `bash` `scripts/run_extracted_pipeline_checks.sh` -> reasoning core 295
+  passed; extracted content 4839 passed / 15 skipped / 1 warning.
+- Pending before push: `bash` `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/deflection_pii_eval_corpus.py` | 88 |
+| `plans/PR-Deflection-PII-Source-Intake-Summary.md` | 128 |
+| `scripts/build_deflection_pii_surrogate_eval_corpus.py` | 58 |
+| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 112 |
+| **Total** | **386** |

--- a/plans/PR-Deflection-PII-Source-Intake-Summary.md
+++ b/plans/PR-Deflection-PII-Source-Intake-Summary.md
@@ -90,7 +90,9 @@ The CLI gains `--summary-output`. Callers may pass only `--summary-output` for a
 pre-artifact intake check, or pass both `--summary-output` and `--output` to
 write the safe summary plus the surrogate eval artifact. The CLI rejects
 identical resolved summary/artifact paths and reuses the already-built surrogate
-result when both outputs are requested.
+result when both outputs are requested. The CI-fix pass also replaces optimizer-
+removable artifact `assert` guards with explicit error handling so the CLI
+remains safe under optimized Python and stays below the maturity-sweep ratchet.
 
 ## Intentional
 
@@ -135,6 +137,15 @@ Parked hardening: none.
   runtime import findings: 0.
 - `bash` `scripts/run_extracted_pipeline_checks.sh` -> reasoning core 295
   passed; extracted content 4841 passed / 15 skipped / 1 warning.
+- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline
+  tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob
+  'scripts/**'` -> ratchet gate passed.
+- `python` `scripts/maturity_sweep_file_lane.py` over the 29 deflection files from
+  `find atlas_brain scripts extracted_content_pipeline -type f -name
+  '*deflection*.py'` with
+  `--tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json
+  --min-score 8` plus the workflow sensitive globs -> ratchet gate passed.
+- `python -m pytest tests/test_maturity_sweep.py --noconftest -q` -> 14 passed.
 - Pending before push: `bash` `scripts/push_pr.sh`.
 
 ## Estimated diff size
@@ -142,7 +153,7 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/deflection_pii_eval_corpus.py` | 114 |
-| `plans/PR-Deflection-PII-Source-Intake-Summary.md` | 148 |
-| `scripts/build_deflection_pii_surrogate_eval_corpus.py` | 70 |
+| `plans/PR-Deflection-PII-Source-Intake-Summary.md` | 159 |
+| `scripts/build_deflection_pii_surrogate_eval_corpus.py` | 87 |
 | `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 153 |
-| **Total** | **485** |
+| **Total** | **513** |

--- a/plans/PR-Deflection-PII-Source-Intake-Summary.md
+++ b/plans/PR-Deflection-PII-Source-Intake-Summary.md
@@ -19,6 +19,12 @@ This is a narrow corpus-first vertical slice. It does not choose the real source
 label the real data, alter scrubber behavior, pick thresholds, or flip the
 advisory into a gate.
 
+Diff-size note: the final diff is over the 400 LOC soft cap after review fixes
+because the safety contract needs negative no-echo fixtures for malformed schema
+values, unsafe must-survive reasons, and CLI path clobbering in the same PR as
+the summary code. Splitting those tests out would leave the blocker fixed
+without the guard that proves the class is closed.
+
 ## Scope (this PR)
 
 Ownership lane: deflection/pii-recall-precision-testing
@@ -44,6 +50,9 @@ Max files: 4
   - [ ] The summary can be written without writing the surrogate artifact.
   - [ ] Invalid input summaries include error codes/locations but do not echo
         raw source text, raw label spans, or high-risk tokens.
+  - [ ] Malformed schema-version values and free-form must-survive reasons are
+        not persisted verbatim in the summary or CLI stderr.
+  - [ ] Summary and artifact output paths cannot clobber each other.
   - [ ] Existing artifact generation behavior remains compatible for the
         current tiny fixture and existing tests.
 - Affected surfaces:
@@ -71,9 +80,17 @@ matches artifact readiness. On success, it derives aggregate counts only from
 the surrogate artifact labels and must-survive records. On failure, it returns
 the existing sanitized error records and does not include raw text or raw spans.
 
+The review-fix pass keeps untrusted metadata from becoming summary metadata:
+malformed schema-version values collapse to safe `missing`/`invalid` buckets,
+and must-survive reasons count only a fixed safe set
+(`security_reference`, `compliance_reference`, `tenant_source_id`, and
+`must_survive`), with everything else counted as `other`.
+
 The CLI gains `--summary-output`. Callers may pass only `--summary-output` for a
 pre-artifact intake check, or pass both `--summary-output` and `--output` to
-write the safe summary plus the surrogate eval artifact.
+write the safe summary plus the surrogate eval artifact. The CLI rejects
+identical resolved summary/artifact paths and reuses the already-built surrogate
+result when both outputs are requested.
 
 ## Intentional
 
@@ -83,6 +100,9 @@ write the safe summary plus the surrogate eval artifact.
   readiness evidence, not a policy decision.
 - No new detector/scrubber behavior. Existing artifact validation remains the
   source of truth for what is safe to surrogate.
+- Review fixes intentionally bucket unknown must-survive reasons instead of
+  trying to validate free-form rationale text, because the summary only needs a
+  safe aggregate readiness view.
 
 ## Deferred
 
@@ -97,7 +117,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest` on
-  `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -> 15
+  `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -> 17
   passed.
 - `python -m py_compile` on
   `extracted_content_pipeline/deflection_pii_eval_corpus.py`,
@@ -114,15 +134,15 @@ Parked hardening: none.
 - `python` `scripts/audit_extracted_standalone.py` with fail-on-debt -> Atlas
   runtime import findings: 0.
 - `bash` `scripts/run_extracted_pipeline_checks.sh` -> reasoning core 295
-  passed; extracted content 4839 passed / 15 skipped / 1 warning.
+  passed; extracted content 4841 passed / 15 skipped / 1 warning.
 - Pending before push: `bash` `scripts/push_pr.sh`.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/deflection_pii_eval_corpus.py` | 88 |
-| `plans/PR-Deflection-PII-Source-Intake-Summary.md` | 128 |
-| `scripts/build_deflection_pii_surrogate_eval_corpus.py` | 58 |
-| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 112 |
-| **Total** | **386** |
+| `extracted_content_pipeline/deflection_pii_eval_corpus.py` | 114 |
+| `plans/PR-Deflection-PII-Source-Intake-Summary.md` | 148 |
+| `scripts/build_deflection_pii_surrogate_eval_corpus.py` | 70 |
+| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 153 |
+| **Total** | **485** |

--- a/scripts/build_deflection_pii_surrogate_eval_corpus.py
+++ b/scripts/build_deflection_pii_surrogate_eval_corpus.py
@@ -16,6 +16,7 @@ if str(ROOT) not in sys.path:
 
 from extracted_content_pipeline.deflection_pii_eval_corpus import (  # noqa: E402
     SCHEMA_VERSION,
+    summarize_labeled_source,
     build_surrogate_eval_corpus,
 )
 
@@ -30,34 +31,67 @@ def main(argv: list[str] | None = None) -> int:
             "message": str(exc.__class__.__name__),
         }]})
         return 1
+    summary: dict[str, Any] | None = None
+    if args.summary_output:
+        summary = summarize_labeled_source(source)
+        args.summary_output.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_output.write_text(
+            json.dumps(summary, indent=2 if args.pretty else None, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if not summary["ok"]:
+            _write_error({
+                "ok": False,
+                "schema_version": summary["schema_version"],
+                "errors": list(summary["errors"]),
+            })
+            return 1
+
     result = build_surrogate_eval_corpus(source)
-    if not result.ok:
+    if args.output and not result.ok:
         _write_error({
             "ok": False,
             "schema_version": SCHEMA_VERSION,
             "errors": list(result.errors),
         })
         return 1
-    assert result.artifact is not None
-    text = json.dumps(result.artifact, indent=2 if args.pretty else None, sort_keys=True)
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(text + "\n", encoding="utf-8")
-    print(json.dumps({
+    if args.output:
+        assert result.artifact is not None
+        text = json.dumps(result.artifact, indent=2 if args.pretty else None, sort_keys=True)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    payload = {
         "ok": True,
         "schema_version": SCHEMA_VERSION,
-        "output": str(args.output),
-        "ticket_count": result.artifact["summary"]["ticket_count"],
-        "label_count": result.artifact["summary"]["label_count"],
-    }, sort_keys=True))
+    }
+    if args.output:
+        assert result.artifact is not None
+        payload.update({
+            "output": str(args.output),
+            "ticket_count": result.artifact["summary"]["ticket_count"],
+            "label_count": result.artifact["summary"]["label_count"],
+        })
+    if args.summary_output and summary is not None:
+        payload["summary_output"] = str(args.summary_output)
+        payload["summary_schema_version"] = str(summary["schema_version"])
+    print(json.dumps(payload, sort_keys=True))
     return 0
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("input", type=Path, help="Local labeled-source JSON.")
-    parser.add_argument("--output", required=True, type=Path, help="Surrogate artifact path.")
+    parser.add_argument("--output", type=Path, help="Surrogate artifact path.")
+    parser.add_argument(
+        "--summary-output",
+        type=Path,
+        help="Sanitized labeled-source intake summary path.",
+    )
     parser.add_argument("--pretty", action="store_true", help="Write pretty JSON.")
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.output is None and args.summary_output is None:
+        parser.error("at least one of --output or --summary-output is required")
+    return args
 
 
 def _write_error(payload: dict[str, Any]) -> None:

--- a/scripts/build_deflection_pii_surrogate_eval_corpus.py
+++ b/scripts/build_deflection_pii_surrogate_eval_corpus.py
@@ -48,32 +48,37 @@ def main(argv: list[str] | None = None) -> int:
             })
             return 1
 
-    if result is None and args.output:
-        result = build_surrogate_eval_corpus(source)
-    if args.output and not result.ok:
-        _write_error({
-            "ok": False,
-            "schema_version": SCHEMA_VERSION,
-            "errors": list(result.errors),
-        })
-        return 1
+    artifact: dict[str, Any] | None = None
     if args.output:
-        assert result is not None
-        assert result.artifact is not None
-        text = json.dumps(result.artifact, indent=2 if args.pretty else None, sort_keys=True)
+        if result is None:
+            result = build_surrogate_eval_corpus(source)
+        if not result.ok:
+            _write_error({
+                "ok": False,
+                "schema_version": SCHEMA_VERSION,
+                "errors": list(result.errors),
+            })
+            return 1
+        artifact = result.artifact
+        if artifact is None:
+            _write_error({
+                "ok": False,
+                "schema_version": SCHEMA_VERSION,
+                "errors": [{"code": "surrogate_artifact_missing"}],
+            })
+            return 1
+        text = json.dumps(artifact, indent=2 if args.pretty else None, sort_keys=True)
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(text + "\n", encoding="utf-8")
     payload = {
         "ok": True,
         "schema_version": SCHEMA_VERSION,
     }
-    if args.output:
-        assert result is not None
-        assert result.artifact is not None
+    if artifact is not None:
         payload.update({
             "output": str(args.output),
-            "ticket_count": result.artifact["summary"]["ticket_count"],
-            "label_count": result.artifact["summary"]["label_count"],
+            "ticket_count": artifact["summary"]["ticket_count"],
+            "label_count": artifact["summary"]["label_count"],
         })
     if args.summary_output and summary is not None:
         payload["summary_output"] = str(args.summary_output)

--- a/scripts/build_deflection_pii_surrogate_eval_corpus.py
+++ b/scripts/build_deflection_pii_surrogate_eval_corpus.py
@@ -31,9 +31,10 @@ def main(argv: list[str] | None = None) -> int:
             "message": str(exc.__class__.__name__),
         }]})
         return 1
+    result = build_surrogate_eval_corpus(source) if args.output else None
     summary: dict[str, Any] | None = None
     if args.summary_output:
-        summary = summarize_labeled_source(source)
+        summary = summarize_labeled_source(source, build_result=result)
         args.summary_output.parent.mkdir(parents=True, exist_ok=True)
         args.summary_output.write_text(
             json.dumps(summary, indent=2 if args.pretty else None, sort_keys=True) + "\n",
@@ -47,7 +48,8 @@ def main(argv: list[str] | None = None) -> int:
             })
             return 1
 
-    result = build_surrogate_eval_corpus(source)
+    if result is None and args.output:
+        result = build_surrogate_eval_corpus(source)
     if args.output and not result.ok:
         _write_error({
             "ok": False,
@@ -56,6 +58,7 @@ def main(argv: list[str] | None = None) -> int:
         })
         return 1
     if args.output:
+        assert result is not None
         assert result.artifact is not None
         text = json.dumps(result.artifact, indent=2 if args.pretty else None, sort_keys=True)
         args.output.parent.mkdir(parents=True, exist_ok=True)
@@ -65,6 +68,7 @@ def main(argv: list[str] | None = None) -> int:
         "schema_version": SCHEMA_VERSION,
     }
     if args.output:
+        assert result is not None
         assert result.artifact is not None
         payload.update({
             "output": str(args.output),
@@ -91,6 +95,12 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.output is None and args.summary_output is None:
         parser.error("at least one of --output or --summary-output is required")
+    if (
+        args.output is not None
+        and args.summary_output is not None
+        and args.output.expanduser().resolve() == args.summary_output.expanduser().resolve()
+    ):
+        parser.error("--output and --summary-output must be different paths")
     return args
 
 

--- a/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
+++ b/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 from extracted_content_pipeline.deflection_pii_eval_corpus import (
     SCHEMA_VERSION,
+    SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION,
     build_surrogate_eval_corpus,
+    summarize_labeled_source,
 )
 
 
@@ -155,6 +157,75 @@ def test_surrogate_artifact_rewrites_labels_and_drops_raw_pii() -> None:
     }
     assert artifact["summary"]["cue_less_person_name_count"] == 1
     assert artifact["summary"]["cue_prefixed_person_name_count"] == 1
+
+
+def test_labeled_source_intake_summary_reports_mix_without_raw_echo() -> None:
+    summary = summarize_labeled_source(_valid_source())
+    rendered = json.dumps(summary, sort_keys=True)
+
+    assert summary["ok"] is True
+    assert summary["schema_version"] == SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION
+    assert summary["source_schema_version"] == "deflection_pii_labeled_source.v1"
+    assert summary["artifact_schema_version"] == SCHEMA_VERSION
+    assert summary["raw_source_persisted"] is False
+    assert summary["raw_label_spans_persisted"] is False
+    assert summary["ticket_count"] == 1
+    assert summary["label_count"] == 9
+    assert summary["labels_by_class"] == {
+        "dob": 1,
+        "email": 1,
+        "order_id": 1,
+        "payment_card": 1,
+        "person_name": 2,
+        "phone": 1,
+        "ssn": 1,
+        "street_address": 1,
+    }
+    assert summary["labels_by_origin_field"] == {
+        "agent_reply": 2,
+        "customer_message": 4,
+        "private_note": 2,
+        "subject": 1,
+    }
+    assert summary["person_name"] == {"cue_less": 1, "cue_prefixed": 1}
+    assert summary["must_survive"] == {
+        "count": 3,
+        "by_reason": {
+            "compliance_reference": 1,
+            "security_reference": 1,
+            "tenant_source_id": 1,
+        },
+    }
+    for raw in (
+        "Alice Baker",
+        "alice.baker@example.com",
+        "202-555-0188",
+        "ORD-98765",
+        "99 Real Street",
+        "1977-06-05",
+        "111-22-3333",
+        "4242 4242 4242 4242",
+    ):
+        assert raw not in rendered
+
+
+def test_labeled_source_intake_summary_requires_schema_without_raw_echo() -> None:
+    source = _valid_source()
+    source["schema_version"] = "wrong.version"
+
+    summary = summarize_labeled_source(source)
+    rendered = json.dumps(summary, sort_keys=True)
+
+    assert summary["ok"] is False
+    assert summary["errors"] == [
+        {
+            "code": "source_schema_version_mismatch",
+            "expected": "deflection_pii_labeled_source.v1",
+            "actual": "wrong.version",
+        }
+    ]
+    assert "Alice Baker" not in rendered
+    assert "alice.baker@example.com" not in rendered
 
 
 def test_must_survive_tokens_are_preserved_for_precision_scoring() -> None:
@@ -445,6 +516,47 @@ def test_cli_writes_artifact_and_rejects_invalid_input_without_raw_echo(
     assert "raw.bad@example.com" not in captured.err
     assert "missing.bad@example.com" not in captured.err
     assert "label_span_not_found" in captured.err
+
+
+def test_cli_writes_summary_without_artifact_and_sanitizes_invalid_summary(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "source.json"
+    summary_output = tmp_path / "summary.json"
+    artifact_output = tmp_path / "artifact.json"
+    source.write_text(json.dumps(_valid_source()), encoding="utf-8")
+
+    assert CLI.main([str(source), "--summary-output", str(summary_output), "--pretty"]) == 0
+    assert summary_output.is_file()
+    assert not artifact_output.exists()
+    summary = json.loads(summary_output.read_text(encoding="utf-8"))
+    assert summary["ok"] is True
+    assert summary["label_count"] == 9
+
+    bad_source = tmp_path / "bad-source.json"
+    bad_source.write_text(
+        json.dumps({
+            "schema_version": "deflection_pii_labeled_source.v1",
+            "records": [{
+                "fields": {"customer_message": "Email raw.bad@example.com"},
+                "labels": [{
+                    "span": "missing.bad@example.com",
+                    "class": "email",
+                    "origin_field": "customer_message",
+                }],
+            }],
+        }),
+        encoding="utf-8",
+    )
+    assert CLI.main([str(bad_source), "--summary-output", str(summary_output)]) == 1
+    summary = json.loads(summary_output.read_text(encoding="utf-8"))
+    captured = capsys.readouterr()
+    rendered = json.dumps(summary, sort_keys=True) + captured.err
+    assert summary["ok"] is False
+    assert "label_span_not_found" in rendered
+    assert "raw.bad@example.com" not in rendered
+    assert "missing.bad@example.com" not in rendered
 
 
 def test_committed_tiny_fixture_is_surrogate_only() -> None:

--- a/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
+++ b/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from extracted_content_pipeline.deflection_pii_eval_corpus import (
     SCHEMA_VERSION,
     SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION,
@@ -211,21 +213,42 @@ def test_labeled_source_intake_summary_reports_mix_without_raw_echo() -> None:
 
 def test_labeled_source_intake_summary_requires_schema_without_raw_echo() -> None:
     source = _valid_source()
-    source["schema_version"] = "wrong.version"
+    source["schema_version"] = "alice@example.com"
 
     summary = summarize_labeled_source(source)
     rendered = json.dumps(summary, sort_keys=True)
 
     assert summary["ok"] is False
+    assert summary["source_schema_version"] == "invalid"
     assert summary["errors"] == [
         {
             "code": "source_schema_version_mismatch",
             "expected": "deflection_pii_labeled_source.v1",
-            "actual": "wrong.version",
+            "actual": "invalid",
         }
     ]
     assert "Alice Baker" not in rendered
     assert "alice.baker@example.com" not in rendered
+    assert "alice@example.com" not in rendered
+
+
+def test_labeled_source_intake_summary_buckets_unsafe_must_survive_reasons() -> None:
+    source = _valid_source()
+    source["records"][0]["must_survive"][0]["reason"] = "alice@example.com"
+
+    summary = summarize_labeled_source(source)
+    rendered = json.dumps(summary, sort_keys=True)
+
+    assert summary["ok"] is True
+    assert summary["must_survive"] == {
+        "count": 3,
+        "by_reason": {
+            "compliance_reference": 1,
+            "other": 1,
+            "tenant_source_id": 1,
+        },
+    }
+    assert "alice@example.com" not in rendered
 
 
 def test_must_survive_tokens_are_preserved_for_precision_scoring() -> None:
@@ -557,6 +580,24 @@ def test_cli_writes_summary_without_artifact_and_sanitizes_invalid_summary(
     assert "label_span_not_found" in rendered
     assert "raw.bad@example.com" not in rendered
     assert "missing.bad@example.com" not in rendered
+
+
+def test_cli_rejects_colliding_summary_and_artifact_paths(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    shared_output = tmp_path / "pii-output.json"
+    source.write_text(json.dumps(_valid_source()), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        CLI.main([
+            str(source),
+            "--summary-output",
+            str(shared_output),
+            "--output",
+            str(shared_output),
+        ])
+
+    assert exc.value.code == 2
+    assert not shared_output.exists()
 
 
 def test_committed_tiny_fixture_is_surrogate_only() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Source-Intake-Summary.md
Slice phase: Vertical slice

#1742's remaining corpus-first work needs a safe handoff step before a real operator-derived source becomes a versioned surrogate artifact. This PR adds a sanitized labeled-source intake summary for the existing `deflection_pii_labeled_source.v1` input contract so corpus mix, class coverage, name subtype split, must-survive coverage, and labeling errors can be reviewed without persisting or echoing raw tickets or raw label spans.

## Intentional
- No raw input persistence, raw source excerpts, or raw label-span samples in the summary.
- No threshold recommendation or advisory-to-gating flip; this is corpus readiness evidence only.
- No detector/scrubber behavior change; existing artifact validation remains the source of truth for what is safe to surrogate.
- Unknown must-survive reasons are bucketed as `other` instead of persisted verbatim.

## AI reconciliation
- AI findings reviewed: yes.
- All fixed or waived: yes.
- Fixed Codex P1 raw schema-version echo by reporting safe `missing`/`invalid` buckets instead of the untrusted value.
- Fixed Codex P1 raw must-survive reason echo by counting only safe enum reasons and bucketing unknown reasons as `other`.
- Fixed Codex P2 summary/artifact path clobber by rejecting identical resolved output paths.
- Fixed Codex P2 duplicate build by reusing the already-built surrogate result when both outputs are requested.
- Fixed maturity-sweep ratchet failure by replacing optimizer-removable artifact `assert` guards with explicit CLI error handling.

## Deferred
- Operator selection of the real transient source, corpus size/archetype mix, labeling ownership, and labeling-quality review remain open #1742 decisions.
- Building the larger derived surrogate artifact from that real source remains a follow-up after the operator supplies/labels the source.
- Threshold selection and advisory-to-gating promotion remain deferred.

## Parked hardening
- None.

## Verification
- `python -m pytest` on `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -> 17 passed.
- `python -m py_compile` on `extracted_content_pipeline/deflection_pii_eval_corpus.py`, `scripts/build_deflection_pii_surrogate_eval_corpus.py`, and `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` -> passed.
- `python` `scripts/score_deflection_pii_recall.py` with JSON output -> status ok; gate-eligible high-severity free leaks 0, deferred open-set name leaks 1.
- `python` `scripts/audit_extracted_pipeline_ci_enrollment.py` -> OK, 188 matching tests enrolled.
- `bash` `scripts/check_ascii_python.sh` -> passed.
- `bash` `scripts/validate_extracted_content_pipeline.sh` -> passed.
- `python` `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` `extracted_content_pipeline` -> clean.
- `python` `scripts/audit_extracted_standalone.py` with fail-on-debt -> Atlas runtime import findings: 0.
- `bash` `scripts/run_extracted_pipeline_checks.sh` -> reasoning core 295 passed; extracted content 4841 passed / 15 skipped / 1 warning.
- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` -> ratchet gate passed.
- `python` `scripts/maturity_sweep_file_lane.py` over the 29 deflection files from `find atlas_brain scripts extracted_content_pipeline -type f -name '*deflection*.py'` with the workflow baseline/min-score/sensitive globs -> ratchet gate passed.
- `python -m pytest tests/test_maturity_sweep.py --noconftest -q` -> 14 passed.

## Diff size
4 files, +494 / -19
