### PR TITLE
Add deflection email action scorecard

### DIFF
--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -17,6 +17,9 @@ from extracted_content_pipeline.campaign_ports import (
 from extracted_content_pipeline.deflection_report_access import (
     stored_deflection_report_model,
 )
+from extracted_content_pipeline.faq_deflection_report import (
+    deflection_report_email_action_rows,
+)
 from extracted_content_pipeline.storage._jsonb_helpers import decode_jsonb_field
 
 
@@ -71,6 +74,36 @@ class _DeliveryEmailSummary:
     ticket_source_count: int
     priority_fix_items: tuple[_DeliveryEmailActionItem, ...] = ()
     drafted_resolution_items: tuple[_DeliveryEmailActionItem, ...] = ()
+
+
+def deflection_delivery_email_surface_observation(
+    text_body: str | None,
+) -> dict[str, dict[str, int]]:
+    """Return sanitized scorecard observations from a rendered delivery email."""
+
+    return {"displayed_rows": _delivery_email_displayed_rows(text_body or "")}
+
+
+def _delivery_email_displayed_rows(text_body: str) -> dict[str, int]:
+    rows = {
+        "priority_fix_queue": 0,
+        "drafted_resolutions": 0,
+    }
+    active_section: str | None = None
+    for raw_line in text_body.splitlines():
+        line = raw_line.strip()
+        if line == "Next actions:":
+            active_section = "priority_fix_queue"
+            continue
+        if line == "Ready to publish:":
+            active_section = "drafted_resolutions"
+            continue
+        if not line:
+            active_section = None
+            continue
+        if active_section is not None and line.startswith("- "):
+            rows[active_section] += 1
+    return rows
 
 
 async def send_pending_deflection_report_deliveries(
@@ -400,22 +433,18 @@ def _delivery_email_summary(artifact: Any) -> _DeliveryEmailSummary | None:
             continue
         summary = _support_tax_email_summary(section)
         if summary is not None:
-            drafted_resolution_items = _section_action_items(
-                sections,
-                "drafted_resolutions",
+            selected_rows = deflection_report_email_action_rows(
+                model,
+                cap=EMAIL_ACTION_SECTION_LIMIT,
             )
-            drafted_questions = {
-                item.question.casefold() for item in drafted_resolution_items
-            }
             return replace(
                 summary,
-                priority_fix_items=_section_action_items(
-                    sections,
-                    "priority_fix_queue",
-                    excluded_questions=drafted_questions,
-                    excluded_statuses={"draft ready"},
+                priority_fix_items=_email_action_items(
+                    selected_rows.get("priority_fix_queue", ()),
                 ),
-                drafted_resolution_items=drafted_resolution_items,
+                drafted_resolution_items=_email_action_items(
+                    selected_rows.get("drafted_resolutions", ()),
+                ),
             )
     return None
 
@@ -465,52 +494,14 @@ def _support_tax_email_summary(
     )
 
 
-def _section_action_items(
-    sections: tuple[dict[str, Any], ...],
-    section_id: str,
-    *,
-    excluded_questions: set[str] | None = None,
-    excluded_statuses: set[str] | None = None,
+def _email_action_items(
+    rows: tuple[Mapping[str, Any], ...],
 ) -> tuple[_DeliveryEmailActionItem, ...]:
-    excluded_questions = excluded_questions or set()
-    excluded_statuses = excluded_statuses or set()
-    for section in sections:
-        if _clean(section.get("id")) != section_id:
-            continue
-        data = section.get("data")
-        if not isinstance(data, Mapping):
-            return ()
-        rows = data.get("items")
-        if not isinstance(rows, list):
-            return ()
-        limit = _email_action_limit(data)
-        if limit <= 0:
-            return ()
-        items: list[_DeliveryEmailActionItem] = []
-        for row in rows:
-            if not isinstance(row, Mapping):
-                continue
-            item = _email_action_item(row)
-            if item is None:
-                continue
-            if item.question.casefold() in excluded_questions:
-                continue
-            if item.status.casefold() in excluded_statuses:
-                continue
-            items.append(item)
-            if len(items) >= limit:
-                break
-        return tuple(items)
-    return ()
-
-
-def _email_action_limit(data: Mapping[str, Any]) -> int:
-    limit = _strict_int(data.get("result_page_limit"))
-    if limit is None:
-        return EMAIL_ACTION_SECTION_LIMIT
-    if limit <= 0:
-        return 0
-    return min(limit, EMAIL_ACTION_SECTION_LIMIT)
+    return tuple(
+        item
+        for row in rows
+        if (item := _email_action_item(row)) is not None
+    )
 
 
 def _email_action_item(row: Mapping[str, Any]) -> _DeliveryEmailActionItem | None:

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -48,6 +48,7 @@ _UNCAPPED_REPORT_MAX_ITEMS = 0
 _ASSISTED_CONTACT_COST = 13.50
 _ASSISTED_CONTACT_COST_LABEL = "$13.50"
 _ACTION_RESULT_PAGE_LIMIT = 3
+_ACTION_EMAIL_LIMIT = 3
 _ACTION_PDF_LIMIT = 10
 _ACTION_BACKLOG_LIMIT = 25
 _ACTION_STATUS_PRIORITY_WEIGHTS = MappingProxyType({
@@ -744,6 +745,10 @@ def deflection_report_model_contract_shape() -> dict[str, Any]:
 
 DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS: Mapping[str, Mapping[str, int]] = (
     MappingProxyType({
+        "email": MappingProxyType({
+            "priority_fix_queue": _ACTION_EMAIL_LIMIT,
+            "drafted_resolutions": _ACTION_EMAIL_LIMIT,
+        }),
         "result_page": MappingProxyType({
             "ranked_questions": 25,
             "question_details": 10,
@@ -1025,6 +1030,7 @@ def build_deflection_full_report_qa_scorecard(
     _add_surface_observation_assertions(
         add,
         counts,
+        sections,
         surface_observations or {},
         surface_caps or DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS,
     )
@@ -1054,11 +1060,12 @@ def build_deflection_full_report_qa_deterministic_harness(
     if not isinstance(model, Mapping):
         model = {}
     caps = surface_caps or DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS
-    counts = _scorecard_counts(_scorecard_sections(model))
+    sections = _scorecard_sections(model)
+    counts = _scorecard_counts(sections)
     observations = (
         surface_observations
         if surface_observations is not None
-        else _full_report_qa_surface_observations(counts, caps)
+        else _full_report_qa_surface_observations(counts, caps, sections)
     )
     observations = observations if isinstance(observations, Mapping) else {}
 
@@ -1092,6 +1099,7 @@ def build_deflection_full_report_qa_deterministic_harness(
                 observation=observation,
                 surface_caps=caps,
                 counts=counts,
+                sections=sections,
             )
 
     result = dict(scorecard)
@@ -1118,6 +1126,26 @@ def build_deflection_full_report_qa_deterministic_harness(
     return result
 
 
+def deflection_report_email_action_rows(
+    report_model: DeflectionStructuredReport | Mapping[str, Any],
+    *,
+    cap: int = _ACTION_EMAIL_LIMIT,
+) -> dict[str, tuple[Mapping[str, Any], ...]]:
+    """Return action rows selected for the compact delivery email."""
+
+    model = (
+        report_model.as_dict()
+        if isinstance(report_model, DeflectionStructuredReport)
+        else report_model
+    )
+    if not isinstance(model, Mapping):
+        model = {}
+    return _deflection_email_action_rows_from_sections(
+        _scorecard_sections(model),
+        cap=cap,
+    )
+
+
 def _add_full_report_qa_required_metric_assertions(
     assertions: list[dict[str, Any]],
     *,
@@ -1126,6 +1154,7 @@ def _add_full_report_qa_required_metric_assertions(
     observation: Mapping[str, Any],
     surface_caps: Mapping[str, Mapping[str, int]],
     counts: Mapping[str, Any],
+    sections: Mapping[str, Mapping[str, Any]],
 ) -> None:
     observed_counts = (
         observation.get("counts")
@@ -1177,6 +1206,7 @@ def _add_full_report_qa_required_metric_assertions(
 def _full_report_qa_surface_observations(
     counts: Mapping[str, Any],
     surface_caps: Mapping[str, Mapping[str, int]],
+    sections: Mapping[str, Mapping[str, Any]],
 ) -> dict[str, dict[str, Any]]:
     observations: dict[str, dict[str, Any]] = {}
     for surface, keys in _FULL_REPORT_QA_SURFACE_COUNT_KEYS.items():
@@ -1186,9 +1216,12 @@ def _full_report_qa_surface_observations(
         caps = surface_caps.get(surface)
         if isinstance(caps, Mapping) and caps:
             observation["displayed_rows"] = {
-                section_id: min(
-                    _scorecard_section_total(section_id, counts),
-                    max(0, _int(cap)),
+                section_id: _scorecard_expected_displayed_rows(
+                    surface,
+                    section_id,
+                    counts,
+                    sections,
+                    cap,
                 )
                 for section_id, cap in sorted(caps.items())
             }
@@ -1379,9 +1412,128 @@ def _scorecard_section_total(section_id: str, counts: Mapping[str, Any]) -> int:
     }.get(section_id, 0)
 
 
+def _scorecard_expected_displayed_rows(
+    surface: str,
+    section_id: str,
+    counts: Mapping[str, Any],
+    sections: Mapping[str, Mapping[str, Any]],
+    cap: Any,
+) -> int:
+    cap_int = max(0, _int(cap))
+    if surface == "email" and section_id in {
+        "priority_fix_queue",
+        "drafted_resolutions",
+    }:
+        return len(
+            _deflection_email_action_rows_from_sections(
+                sections,
+                cap=cap_int,
+            ).get(section_id, ())
+        )
+    return min(_scorecard_section_total(section_id, counts), cap_int)
+
+
+def _deflection_email_action_rows_from_sections(
+    sections: Mapping[str, Mapping[str, Any]],
+    *,
+    cap: int,
+) -> dict[str, tuple[Mapping[str, Any], ...]]:
+    if cap <= 0:
+        return {
+            "priority_fix_queue": (),
+            "drafted_resolutions": (),
+        }
+    drafted_rows = _deflection_email_action_items(
+        sections,
+        "drafted_resolutions",
+        cap=cap,
+    )
+    drafted_questions = {
+        _scorecard_strict_text(item.get("question")).casefold()
+        for item in drafted_rows
+    }
+    priority_rows = _deflection_email_action_items(
+        sections,
+        "priority_fix_queue",
+        cap=cap,
+        excluded_questions=drafted_questions,
+        excluded_statuses=frozenset({"draft ready"}),
+    )
+    return {
+        "priority_fix_queue": priority_rows,
+        "drafted_resolutions": drafted_rows,
+    }
+
+
+def _deflection_email_action_items(
+    sections: Mapping[str, Mapping[str, Any]],
+    section_id: str,
+    *,
+    cap: int,
+    excluded_questions: frozenset[str] | set[str] = frozenset(),
+    excluded_statuses: frozenset[str] | set[str] = frozenset(),
+) -> tuple[Mapping[str, Any], ...]:
+    section = sections.get(section_id)
+    if not isinstance(section, Mapping):
+        return ()
+    data = section.get("data")
+    if not isinstance(data, Mapping):
+        return ()
+    rows = data.get("items")
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes, bytearray)):
+        return ()
+    limit = _deflection_email_action_limit(data, cap=cap)
+    if limit <= 0:
+        return ()
+
+    items: list[Mapping[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        question = _scorecard_strict_text(row.get("question"))
+        ticket_count = _scorecard_strict_int(row.get("ticket_count"))
+        if not question or ticket_count is None:
+            continue
+        status = _scorecard_strict_text(row.get("status")).casefold()
+        if question.casefold() in excluded_questions:
+            continue
+        if status in excluded_statuses:
+            continue
+        items.append(dict(row))
+        if len(items) >= limit:
+            break
+    return tuple(items)
+
+
+def _deflection_email_action_limit(data: Mapping[str, Any], *, cap: int) -> int:
+    limit = _scorecard_strict_int(data.get("result_page_limit"))
+    if limit is None:
+        return cap
+    if limit <= 0:
+        return 0
+    return min(limit, cap)
+
+
+def _scorecard_strict_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _scorecard_strict_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
 def _add_surface_observation_assertions(
     add: Any,
     counts: Mapping[str, Any],
+    sections: Mapping[str, Mapping[str, Any]],
     surface_observations: Mapping[str, Mapping[str, Any]],
     surface_caps: Mapping[str, Mapping[str, int]],
 ) -> None:
@@ -1460,7 +1612,13 @@ def _add_surface_observation_assertions(
                 if section_text in caps
                 else total
             )
-            expected = min(total, cap)
+            expected = _scorecard_expected_displayed_rows(
+                surface,
+                section_text,
+                counts,
+                sections,
+                cap,
+            )
             observed = _scorecard_observed_int(actual)
             add(
                 f"surface.{surface_id}.displayed_rows.{section_safe_id}",
@@ -3963,6 +4121,7 @@ __all__ = [
     "build_deflection_report_artifact",
     "build_deflection_full_report_qa_deterministic_harness",
     "build_deflection_full_report_qa_scorecard",
+    "deflection_report_email_action_rows",
     "deflection_report_summary",
     "deflection_report_model_contract_shape",
     "deflection_snapshot_content_opportunities",

--- a/plans/PR-Deflection-Email-Action-Scorecard.md
+++ b/plans/PR-Deflection-Email-Action-Scorecard.md
@@ -1,0 +1,156 @@
+# PR-Deflection-Email-Action-Scorecard
+
+## Why this slice exists
+
+Issue #1612's QA harness is supposed to prove the paid deliverable surfaces
+agree with the persisted `deflection.v1` model. #1764 made the delivery email
+actionable by rendering compact `priority_fix_queue` and `drafted_resolutions`
+rows, but the shared scorecard still treats email as a counts-only surface.
+
+Root cause: `DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS` had row caps for the
+result page and PDF, but no email caps. The deterministic harness could
+therefore stay green even if the delivery email stopped rendering its action
+rows, because there was no required `email.displayed_rows.*` observation to
+check. The first implementation also treated email displayed rows as
+`min(section_total, 3)`, which was still a symptom fix: the delivery email
+filters action rows by item validity, `result_page_limit`, drafted-question
+deduplication, and `Draft ready` priority exclusion before rendering.
+
+This PR fixes the root in the shared scorecard contract by making email action
+rows an observed, capped surface, moving email action-row selection into one
+shared extracted-package helper, and feeding actual rendered delivery-email row
+counts into the scorecard. It turns the #1764 behavior into a reusable,
+load-bearing QA invariant instead of a duplicated renderer mirror.
+
+This exceeds the 400 LOC soft cap because the re-review root fix is indivisible:
+landing only the scorecard contract duplicated renderer rules, while landing
+only the shared selector left no live consumer. The coherent fix needs the
+shared selector, renderer rewiring, rendered-email observer, and tests together.
+
+## Scope (this PR)
+
+Ownership lane: issue-1612/deflection-full-report-delivery-actionability
+Slice phase: Vertical slice
+
+1. Add email action-section row caps to the shared full-report QA scorecard
+   surface-cap defaults.
+2. Move delivery-email action row selection into a shared lower-layer helper
+   consumed by both the scorecard and the delivery renderer.
+3. Add a rendered delivery-email observer that feeds sanitized action row
+   counts into the scorecard.
+4. Add focused scorecard/harness and delivery-renderer tests proving email
+   action rows are required, capped, fail closed when mismatched, and reflect
+   the actually rendered email.
+5. Max files: 5.
+
+### Review Contract
+
+Acceptance criteria:
+- The shared deterministic full-report QA harness requires the `email` surface
+  to observe `priority_fix_queue` and `drafted_resolutions` displayed rows when
+  the model contains those sections.
+- Email expected rows mirror the delivery renderer's action selection:
+  section-level `result_page_limit`, three-row email cap, invalid-row skips,
+  drafted-question removal from priority rows, and `Draft ready` priority
+  exclusion.
+- The delivery renderer consumes the same shared action-row selector as the
+  scorecard; it does not carry a second copy of the selection loop.
+- A rendered delivery email can be observed as sanitized row counts and those
+  counts pass/fail the scorecard.
+- A missing email action-row observation fails the harness instead of silently
+  passing counts-only email coverage.
+- Existing PDF/result-page/evidence-export assertions remain unchanged.
+
+Affected surfaces:
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_content_ops_deflection_report.py`
+
+Risk areas:
+- QA false-green risk: the harness must fail on missing email action rows
+  without requiring raw evidence, source IDs, or email-body content.
+- Cross-surface contract drift: email rows should be bounded independently from
+  PDF rows, should not inherit the larger PDF cap, and should not use raw
+  section totals when the email renderer would display fewer rows.
+- Renderer/scorecard drift: action-row selection must live in one shared helper
+  so the scorecard does not duplicate the renderer's private rules.
+
+Reviewer rules triggered: R1, R2, R5, R8, R10, R14.
+
+### Files touched
+
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Email-Action-Scorecard.md`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+Add email-specific action-section caps to
+`DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS`:
+
+- `priority_fix_queue`: 3
+- `drafted_resolutions`: 3
+
+The scorecard and delivery renderer now share an extracted-package email
+action-row selector, which selects the rows eligible for compact delivery email
+rendering. Result page and PDF sections keep the
+existing aggregate `min(total, cap)` scorecard behavior. Email action sections
+use the shared selected rows: malformed action rows are skipped, each section's
+`result_page_limit` can lower the three-row email cap, drafted-resolution
+questions are removed from priority rows, and `Draft ready` priority rows are
+excluded.
+
+The delivery email surface observer parses the rendered text email into
+sanitized `displayed_rows` counts. The delivery test renders the actual
+email through the worker, feeds those counts into the scorecard, and proves a
+wrong rendered row count fails.
+
+## Intentional
+
+- Delivery email output is unchanged; the renderer now consumes the shared row
+  selector instead of selecting rows privately.
+- No email checks for `top_unresolved_repeats` or
+  `already_covered_still_recurring`; those sections are not `email_summary`
+  surfaces today.
+- Email body observation returns sanitized counts only; source IDs, quotes, and
+  email text stay out of scorecards.
+- Codex P2 on the first push was valid. This PR fixes it by deriving email
+  expected rows from renderer-equivalent item selection instead of raw section
+  counts.
+- Human re-review MAJOR was valid. This update removes the duplicated
+  renderer-rule mirror and proves the scorecard against actual rendered email
+  counts.
+
+## Deferred
+
+- Hosted/live runner wiring for real inbox delivery remains deferred. This PR
+  adds the reusable rendered-email observation helper and proves it against the
+  worker-rendered email in tests.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_full_report_qa_scorecard_checks_action_section_caps tests/test_content_ops_deflection_report.py::test_deflection_full_report_qa_scorecard_mirrors_email_action_limits tests/test_atlas_content_ops_deflection_delivery.py::test_delivery_worker_renders_model_backed_email_summary -q -- 3 passed.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py tests/test_atlas_content_ops_deflection_delivery.py -q -- 167 passed.
+- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py atlas_brain/content_ops_deflection_delivery.py tests/test_content_ops_deflection_report.py tests/test_atlas_content_ops_deflection_delivery.py -- passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
+- Command: bash scripts/check_ascii_python.sh -- passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_email_action_scorecard.md -- failed before push because the plan missed R10 for a checker/gate change; fixed in this commit.
+- Pending before push: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_email_action_scorecard.md -- rerun via push wrapper.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/content_ops_deflection_delivery.py` | 105 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 171 |
+| `plans/PR-Deflection-Email-Action-Scorecard.md` | 156 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 44 |
+| `tests/test_content_ops_deflection_report.py` | 126 |
+| **Total** | **602** |

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -11,6 +11,7 @@ import pytest
 from atlas_brain.content_ops_deflection_delivery import (
     DELIVERY_CLAIM_STALE_AFTER,
     DeflectionReportDeliveryConfig,
+    deflection_delivery_email_surface_observation,
     deflection_report_result_url,
     send_pending_deflection_report_deliveries,
 )
@@ -19,6 +20,9 @@ from extracted_content_pipeline.campaign_ports import (
     IdempotentReplayConflict,
     SendRequest,
     SendResult,
+)
+from extracted_content_pipeline.faq_deflection_report import (
+    build_deflection_full_report_qa_scorecard,
 )
 
 
@@ -323,7 +327,8 @@ async def test_delivery_worker_sends_pending_paid_report_link(
 async def test_delivery_worker_renders_model_backed_email_summary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    pool = _Pool([_row(artifact=json.dumps(_delivery_report_model_artifact()))])
+    artifact = _delivery_report_model_artifact()
+    pool = _Pool([_row(artifact=json.dumps(artifact))])
     sender = _Sender()
     _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-model-bytes")
 
@@ -382,6 +387,43 @@ async def test_delivery_worker_renders_model_backed_email_summary(
     assert "ticket-secret-action-1" not in request.text_body
     assert "raw action evidence should stay out" not in request.text_body
     assert "ticket-secret-priority-draft" not in request.text_body
+
+    observation = deflection_delivery_email_surface_observation(request.text_body)
+    scorecard = build_deflection_full_report_qa_scorecard(
+        artifact["report_model"],
+        surface_observations={"email": observation},
+    )
+    bad_scorecard = build_deflection_full_report_qa_scorecard(
+        artifact["report_model"],
+        surface_observations={
+            "email": {
+                "displayed_rows": {
+                    "priority_fix_queue": 3,
+                    "drafted_resolutions": 1,
+                },
+            },
+        },
+    )
+
+    assert observation == {
+        "displayed_rows": {
+            "priority_fix_queue": 2,
+            "drafted_resolutions": 1,
+        },
+    }
+    failed = {
+        assertion["id"]
+        for assertion in scorecard["assertions"]
+        if not assertion["ok"]
+    }
+    bad_failed = {
+        assertion["id"]
+        for assertion in bad_scorecard["assertions"]
+        if not assertion["ok"]
+    }
+    assert "surface.email.displayed_rows.priority_fix_queue" not in failed
+    assert "surface.email.displayed_rows.drafted_resolutions" not in failed
+    assert "surface.email.displayed_rows.priority_fix_queue" in bad_failed
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -21,6 +21,7 @@ from extracted_content_pipeline.faq_deflection_report import (
     build_deflection_report_model,
     build_deflection_snapshot,
     build_deflection_report_artifact,
+    deflection_report_email_action_rows,
     deflection_report_model_contract_shape,
     deflection_snapshot_content_opportunities,
     render_deflection_report_model,
@@ -1557,14 +1558,32 @@ def test_deflection_full_report_qa_scorecard_checks_action_section_caps() -> Non
     model = json.loads(json.dumps(artifact.report_model.as_dict()))
     sections = {section["id"]: section for section in model["sections"]}
     priority_rows = sections["priority_fix_queue"]["data"]["items"]
+    selected_email_rows = deflection_report_email_action_rows(model)
+    expected_email_priority_rows = len(selected_email_rows["priority_fix_queue"])
+    expected_email_drafted_rows = len(selected_email_rows["drafted_resolutions"])
     expected_pdf_rows = min(len(priority_rows), 10)
 
     assert expected_pdf_rows > 0
+    assert expected_email_priority_rows > 0
+    assert expected_email_drafted_rows > 0
+    assert expected_email_priority_rows < min(len(priority_rows), 3)
+    assert [
+        row["question"] for row in selected_email_rows["priority_fix_queue"]
+    ] == ["Can I turn on SSO for all users?"]
+    assert [
+        row["question"] for row in selected_email_rows["drafted_resolutions"]
+    ] == ["How do I export attribution reports?"]
 
     scorecard = build_deflection_full_report_qa_scorecard(
         model,
         evidence_export=export,
         surface_observations={
+            "email": {
+                "displayed_rows": {
+                    "priority_fix_queue": expected_email_priority_rows,
+                    "drafted_resolutions": expected_email_drafted_rows,
+                },
+            },
             "pdf": {"displayed_rows": {"priority_fix_queue": expected_pdf_rows}},
         },
     )
@@ -1572,7 +1591,26 @@ def test_deflection_full_report_qa_scorecard_checks_action_section_caps() -> Non
         model,
         evidence_export=export,
         surface_observations={
-            "pdf": {"displayed_rows": {"priority_fix_queue": expected_pdf_rows - 1}},
+            "email": {
+                "displayed_rows": {
+                    "priority_fix_queue": expected_email_priority_rows - 1,
+                    "drafted_resolutions": expected_email_drafted_rows,
+                },
+            },
+            "pdf": {"displayed_rows": {"priority_fix_queue": expected_pdf_rows}},
+        },
+    )
+    raw_min_scorecard = build_deflection_full_report_qa_scorecard(
+        model,
+        evidence_export=export,
+        surface_observations={
+            "email": {
+                "displayed_rows": {
+                    "priority_fix_queue": min(len(priority_rows), 3),
+                    "drafted_resolutions": expected_email_drafted_rows,
+                },
+            },
+            "pdf": {"displayed_rows": {"priority_fix_queue": expected_pdf_rows}},
         },
     )
     harness = build_deflection_full_report_qa_deterministic_harness(
@@ -1587,13 +1625,81 @@ def test_deflection_full_report_qa_scorecard_checks_action_section_caps() -> Non
         for assertion in bad_scorecard["assertions"]
         if not assertion["ok"]
     }
-    assert "surface.pdf.displayed_rows.priority_fix_queue" in failed
+    assert "surface.email.displayed_rows.priority_fix_queue" in failed
+    raw_min_failed = {
+        assertion["id"]
+        for assertion in raw_min_scorecard["assertions"]
+        if not assertion["ok"]
+    }
+    assert raw_min_scorecard["ok"] is False
+    assert "surface.email.displayed_rows.priority_fix_queue" in raw_min_failed
     assert harness["counts"]["priority_fix_queue_count"] == len(priority_rows)
+    email_priority_assertion = next(
+        assertion
+        for assertion in harness["assertions"]
+        if assertion["id"] == "surface.email.displayed_rows.priority_fix_queue"
+    )
+    assert email_priority_assertion["expected"] == expected_email_priority_rows
+    assert email_priority_assertion["actual"] == expected_email_priority_rows
     assert any(
         assertion["id"] == "harness.surface.pdf.displayed_rows.priority_fix_queue.present"
         and assertion["ok"] is True
         for assertion in harness["assertions"]
     )
+    assert any(
+        assertion["id"] == "harness.surface.email.displayed_rows.priority_fix_queue.present"
+        and assertion["ok"] is True
+        for assertion in harness["assertions"]
+    )
+    assert any(
+        assertion["id"] == "harness.surface.email.displayed_rows.drafted_resolutions.present"
+        and assertion["ok"] is True
+        for assertion in harness["assertions"]
+    )
+
+
+def test_deflection_full_report_qa_scorecard_mirrors_email_action_limits() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    export = build_deflection_evidence_export(artifact)
+    model = json.loads(json.dumps(artifact.report_model.as_dict()))
+    sections = {section["id"]: section for section in model["sections"]}
+    sections["priority_fix_queue"]["data"]["result_page_limit"] = 0
+    sections["drafted_resolutions"]["data"]["result_page_limit"] = 0
+
+    scorecard = build_deflection_full_report_qa_scorecard(
+        model,
+        evidence_export=export,
+        surface_observations={
+            "email": {
+                "displayed_rows": {
+                    "priority_fix_queue": 0,
+                    "drafted_resolutions": 0,
+                },
+            },
+        },
+    )
+    bad_scorecard = build_deflection_full_report_qa_scorecard(
+        model,
+        evidence_export=export,
+        surface_observations={
+            "email": {
+                "displayed_rows": {
+                    "priority_fix_queue": 1,
+                    "drafted_resolutions": 1,
+                },
+            },
+        },
+    )
+
+    assert scorecard["ok"] is True
+    assert bad_scorecard["ok"] is False
+    failed = {
+        assertion["id"]
+        for assertion in bad_scorecard["assertions"]
+        if not assertion["ok"]
+    }
+    assert "surface.email.displayed_rows.priority_fix_queue" in failed
+    assert "surface.email.displayed_rows.drafted_resolutions" in failed
 
 
 def test_deflection_full_report_qa_scorecard_requires_action_sections() -> None:
@@ -1666,6 +1772,10 @@ def test_deflection_full_report_qa_harness_defers_result_page_action_row_observe
                     "no_proven_answer_count": counts["no_proven_answer_count"],
                     "ticket_source_count": counts["ticket_source_count"],
                     "estimated_support_cost": counts["estimated_support_cost"],
+                },
+                "displayed_rows": {
+                    "priority_fix_queue": 1,
+                    "drafted_resolutions": min(len(drafted_rows), 3),
                 },
             },
             "pdf": {
@@ -1841,6 +1951,10 @@ def test_deflection_full_report_qa_deterministic_harness_composes_all_surfaces()
     assert "harness.surface.pdf.present" in assertion_ids
     assert "harness.surface.evidence_export.present" in assertion_ids
     assert "surface.email.count.repeat_ticket_count" in assertion_ids
+    assert "surface.email.displayed_rows.priority_fix_queue" in assertion_ids
+    assert "surface.email.displayed_rows.drafted_resolutions" in assertion_ids
+    assert "harness.surface.email.displayed_rows.priority_fix_queue.present" in assertion_ids
+    assert "harness.surface.email.displayed_rows.drafted_resolutions.present" in assertion_ids
     assert "surface.result_page.displayed_rows.seo_targets" in assertion_ids
     assert "surface.pdf.displayed_rows.ranked_questions" in assertion_ids
     assert "surface.evidence_export.count.evidence_row_count" in assertion_ids
@@ -1898,6 +2012,14 @@ def test_deflection_full_report_qa_deterministic_harness_requires_surface_metric
         if not assertion["ok"]
     }
     assert "harness.surface.email.count.generated_question_count.present" in failed
+    assert (
+        "harness.surface.email.displayed_rows.priority_fix_queue.present"
+        in failed
+    )
+    assert (
+        "harness.surface.email.displayed_rows.drafted_resolutions.present"
+        in failed
+    )
     assert "harness.surface.result_page.count.evidence_row_count.present" in failed
     assert (
         "harness.surface.result_page.displayed_rows.question_details.present"


### PR DESCRIPTION
Plan: plans/PR-Deflection-Email-Action-Scorecard.md
Slice phase: Vertical slice

#1612's shared QA harness now treats the paid delivery email as an action surface, matching #1764. Email observations must prove `priority_fix_queue` and `drafted_resolutions` row counts from the actual rendered delivery email instead of passing on top-line metrics only.

## Intentional
- Delivery email output is unchanged; the renderer now consumes the shared extracted-package action-row selector instead of selecting rows privately.
- No email checks for `top_unresolved_repeats` or `already_covered_still_recurring`; those are not `email_summary` surfaces today.
- The rendered email observer returns sanitized row counts only; raw email body text, source IDs, quotes, and evidence stay out of the scorecard.
- Codex P2 on the first push was valid; this update fixes it by deriving expected email rows from renderer-equivalent item selection instead of raw section totals.
- Human re-review MAJOR was valid; this update removes duplicated renderer-rule selection and proves the scorecard against worker-rendered email counts.

## Deferred
- Hosted/live runner wiring for real inbox delivery remains deferred; this slice adds the reusable rendered-email observer and proves it against the worker-rendered delivery email.

## Parked hardening
- None.

## Verification
- Command: `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_full_report_qa_scorecard_checks_action_section_caps tests/test_content_ops_deflection_report.py::test_deflection_full_report_qa_scorecard_mirrors_email_action_limits tests/test_atlas_content_ops_deflection_delivery.py::test_delivery_worker_renders_model_backed_email_summary -q` -- 3 passed.
- Command: `python -m pytest tests/test_content_ops_deflection_report.py tests/test_atlas_content_ops_deflection_delivery.py -q` -- 167 passed.
- Command: `python -m py_compile extracted_content_pipeline/faq_deflection_report.py atlas_brain/content_ops_deflection_delivery.py tests/test_content_ops_deflection_report.py tests/test_atlas_content_ops_deflection_delivery.py` -- passed.
- Command: `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- Command: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- Command: `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- Command: `bash scripts/check_ascii_python.sh` -- passed.
- Command: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_email_action_scorecard.md` -- failed before push because the plan missed R10 for a checker/gate change; fixed in this commit.
- Pending before push: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_email_action_scorecard.md` -- rerun via push wrapper.

## Diff size
5 files, +536 / -66
