### PR TITLE
Add deflection PII source intake markdown

### DIFF
--- a/extracted_content_pipeline/deflection_pii_eval_corpus.py
+++ b/extracted_content_pipeline/deflection_pii_eval_corpus.py
@@ -24,6 +24,15 @@ SAFE_MUST_SURVIVE_REASONS = frozenset({
     "security_reference",
     "tenant_source_id",
 })
+SAFE_INTAKE_ERROR_DETAIL_KEYS = (
+    "record_index",
+    "label_index",
+    "must_survive_index",
+    "origin_field",
+    "detector",
+    "expected",
+    "actual",
+)
 
 FIELD_KEYS = (
     "subject",
@@ -244,6 +253,83 @@ def summarize_labeled_source(
         },
         "errors": [],
     }
+
+
+def format_labeled_source_intake_summary_markdown(summary: Mapping[str, Any]) -> str:
+    """Return a human-readable Markdown view of a sanitized intake summary."""
+
+    ok = bool(summary.get("ok"))
+    lines = [
+        "# Deflection PII Source Intake Summary",
+        "",
+        "## Status",
+        "",
+        _markdown_table(
+            ("Field", "Value"),
+            (
+                ("Status", "ok" if ok else "blocked"),
+                ("Schema", _clean(summary.get("schema_version"))),
+                ("Source schema", _clean(summary.get("source_schema_version"))),
+                ("Artifact schema", _clean(summary.get("artifact_schema_version"))),
+                ("Raw source persisted", _markdown_bool(summary.get("raw_source_persisted"))),
+                ("Raw label spans persisted", _markdown_bool(summary.get("raw_label_spans_persisted"))),
+                (
+                    "Surrogate positions are recall labels",
+                    _markdown_bool(summary.get("surrogate_positions_are_recall_labels")),
+                ),
+            ),
+        ),
+        "",
+    ]
+    if ok:
+        lines.extend([
+            "## Coverage",
+            "",
+            _markdown_table(
+                ("Field", "Count"),
+                (
+                    ("Tickets", _markdown_count(summary.get("ticket_count"))),
+                    ("Labels", _markdown_count(summary.get("label_count"))),
+                    (
+                        "Cue-prefixed person names",
+                        _markdown_count(_mapping(summary.get("person_name")).get("cue_prefixed")),
+                    ),
+                    (
+                        "Cue-less person names",
+                        _markdown_count(_mapping(summary.get("person_name")).get("cue_less")),
+                    ),
+                    (
+                        "Must-survive records",
+                        _markdown_count(_mapping(summary.get("must_survive")).get("count")),
+                    ),
+                ),
+            ),
+            "",
+            "## Labels By Class",
+            "",
+            _markdown_counter_table(summary.get("labels_by_class")),
+            "",
+            "## Labels By Severity",
+            "",
+            _markdown_counter_table(summary.get("labels_by_severity")),
+            "",
+            "## Labels By Origin Field",
+            "",
+            _markdown_counter_table(summary.get("labels_by_origin_field")),
+            "",
+            "## Must-Survive Reasons",
+            "",
+            _markdown_counter_table(_mapping(summary.get("must_survive")).get("by_reason")),
+            "",
+        ])
+    else:
+        lines.extend([
+            "## Errors",
+            "",
+            _markdown_error_table(summary.get("errors")),
+            "",
+        ])
+    return "\n".join(lines).rstrip() + "\n"
 
 
 @dataclass(frozen=True)
@@ -640,6 +726,86 @@ def _intake_error_summary(
     }
 
 
+def _markdown_table(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[Any]],
+) -> str:
+    header = "| " + " | ".join(_markdown_cell(value) for value in headers) + " |"
+    separator = "| " + " | ".join("---" for _ in headers) + " |"
+    body = [
+        "| " + " | ".join(_markdown_cell(value) for value in row) + " |"
+        for row in rows
+    ]
+    return "\n".join((header, separator, *body))
+
+
+def _markdown_counter_table(value: Any) -> str:
+    counter = _mapping(value)
+    if not counter:
+        return "_None._"
+    rows = tuple((key, _markdown_count(counter[key])) for key in sorted(counter))
+    return _markdown_table(("Item", "Count"), rows)
+
+
+def _markdown_error_table(value: Any) -> str:
+    errors = tuple(error for error in _sequence(value) if isinstance(error, Mapping))
+    if not errors:
+        return "_None._"
+    return _markdown_table(
+        ("Code", "Location", "Details"),
+        tuple(
+            (
+                _clean(error.get("code")),
+                _error_location(error),
+                _error_details(error),
+            )
+            for error in errors
+        ),
+    )
+
+
+def _error_location(error: Mapping[str, Any]) -> str:
+    parts = []
+    for key in ("record_index", "label_index", "must_survive_index", "origin_field"):
+        value = error.get(key)
+        if isinstance(value, (int, str)) and value != "":
+            parts.append(f"{key}={value}")
+    return ", ".join(parts) if parts else "-"
+
+
+def _error_details(error: Mapping[str, Any]) -> str:
+    parts = []
+    for key in SAFE_INTAKE_ERROR_DETAIL_KEYS:
+        if key in {"record_index", "label_index", "must_survive_index", "origin_field"}:
+            continue
+        value = error.get(key)
+        if isinstance(value, (int, str)) and value not in ("", 0):
+            parts.append(f"{key}={value}")
+    return ", ".join(parts) if parts else "-"
+
+
+def _markdown_cell(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _markdown_bool(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return "unknown"
+
+
+def _markdown_count(value: Any) -> str:
+    if isinstance(value, bool):
+        return "0"
+    if isinstance(value, int):
+        return str(value)
+    return "0"
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
 def _safe_schema_version_summary(value: Any) -> str:
     if not isinstance(value, str) or not value.strip():
         return "missing"
@@ -712,5 +878,6 @@ __all__ = [
     "SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION",
     "SurrogateEvalCorpusBuildResult",
     "build_surrogate_eval_corpus",
+    "format_labeled_source_intake_summary_markdown",
     "summarize_labeled_source",
 ]

--- a/plans/PR-Deflection-PII-Source-Intake-Markdown.md
+++ b/plans/PR-Deflection-PII-Source-Intake-Markdown.md
@@ -1,0 +1,132 @@
+# PR-Deflection-PII-Source-Intake-Markdown
+
+## Why this slice exists
+
+#1742 has now closed the fixable tiny-corpus scrubber residue loop: the current
+scorer reports zero gate-eligible free high-severity leaks, with only the
+explicitly deferred cue-less/open-set name gap still visible. The next true
+corpus-first work is the operator-derived labeled source, but the source cannot
+be reviewed by passing raw tickets around.
+
+#1765 added a sanitized JSON intake summary for
+`deflection_pii_labeled_source.v1`. That is safe, but it is still a machine JSON
+artifact. This slice adds the thinnest human-reviewable companion: a Markdown
+summary generated from the already-sanitized intake summary, so an operator or
+reviewer can inspect corpus mix, class coverage, name subtype split,
+must-survive coverage, and sanitized errors without opening raw source files or
+raw label spans.
+
+This is a vertical slice because it adds the end-to-end operator-facing artifact
+path: labeled local source -> sanitized intake summary -> sanitized Markdown
+review artifact. It does not select the real source, label real data, choose
+thresholds, turn the advisory into a gate, or close the deferred open-set name
+gap.
+
+Diff budget note: the synced LOC total is over 400 because it includes this
+plan. The implementation plus tests are 321 net LOC, and the formatter, CLI
+path, clobber guard, and raw-echo boundary tests are the indivisible proof for
+the review artifact path.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 4
+
+1. Add a Markdown formatter for the existing sanitized labeled-source intake
+   summary.
+2. Wire the corpus builder CLI to write the Markdown review artifact alongside,
+   or independently of, the JSON summary.
+3. Add focused tests proving the Markdown includes useful aggregate coverage and
+   sanitized error codes, while excluding raw source text, raw label spans, and
+   high-risk tokens.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The Markdown is derived only from the sanitized intake summary, not raw
+        source records.
+  - [ ] Valid-source Markdown reports ticket/label counts, class/severity
+        coverage, origin-field coverage, person-name subtype counts, and
+        must-survive reason counts.
+  - [ ] Invalid-source Markdown reports sanitized error codes/locations without
+        echoing raw source text or raw label spans.
+  - [ ] The Markdown can be written without writing the surrogate artifact.
+  - [ ] JSON summary, Markdown summary, and surrogate artifact output paths
+        cannot clobber each other.
+  - [ ] Existing JSON summary and artifact behavior remains compatible.
+- Affected surfaces:
+  - `extracted_content_pipeline/deflection_pii_eval_corpus.py`
+  - `scripts/build_deflection_pii_surrogate_eval_corpus.py`
+  - `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+- Risk areas: accidental raw PII echo in Markdown, CLI path clobbering, and
+  broadening the slice into source-selection or threshold policy.
+- Reviewer rules triggered: R1, R2, R3, R10, R13, R14; boundary-probe required
+  because this renders a raw-source-adjacent validation artifact.
+
+### Files touched
+
+- `extracted_content_pipeline/deflection_pii_eval_corpus.py`
+- `plans/PR-Deflection-PII-Source-Intake-Markdown.md`
+- `scripts/build_deflection_pii_surrogate_eval_corpus.py`
+- `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+
+## Mechanism
+
+`deflection_pii_eval_corpus.py` gets a small Markdown formatter that accepts the
+already-sanitized summary dictionary returned by `summarize_labeled_source`.
+The formatter renders compact tables/lists for counts and errors, using only
+safe keys, numeric counts, schema/version labels, and sanitized error metadata.
+
+The CLI gains `--summary-markdown-output`. When present, it builds or reuses the
+same sanitized summary used by `--summary-output`, writes the Markdown, and keeps
+the existing failure behavior: invalid labeled sources return exit 1 after the
+sanitized review artifacts are written. The parser rejects duplicate resolved
+output paths across `--output`, `--summary-output`, and
+`--summary-markdown-output` so an operator typo cannot overwrite the review
+artifact.
+
+## Intentional
+
+- No raw input persistence, no raw source excerpting, and no raw label-span
+  samples in Markdown.
+- No threshold recommendation or advisory-to-gating flip; the Markdown is a
+  review artifact, not policy.
+- No new detector/scrubber behavior and no NER/open-set-name work.
+- No corpus-size or class-mix gate. The Markdown exposes coverage so the
+  operator can make those decisions explicitly.
+
+## Deferred
+
+- Operator selection of the real transient source, corpus size/archetype mix,
+  labeling ownership, and labeling-quality review remain open #1742 decisions.
+- Building the larger derived surrogate artifact from that real source remains a
+  follow-up after the operator supplies/labels the source.
+- Threshold selection and advisory-to-gating promotion remain deferred.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -q -- 22 passed.
+- python -m py_compile extracted_content_pipeline/deflection_pii_eval_corpus.py scripts/build_deflection_pii_surrogate_eval_corpus.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -- passed.
+- git diff --check -- passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh -- passed.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
+- python scripts/score_deflection_pii_recall.py --json -- status ok; free_high_severity_gate_eligible_leak_count=0, deferred_open_set_name_leak_count=1.
+- python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
+- python scripts/maturity_sweep_file_lane.py <deflection lane files> --tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json --min-score 8 ... -- ratchet gate passed.
+- bash scripts/run_extracted_pipeline_checks.sh -- reasoning core: 295 passed; extracted content pipeline: 4849 passed, 15 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/deflection_pii_eval_corpus.py` | 167 |
+| `plans/PR-Deflection-PII-Source-Intake-Markdown.md` | 132 |
+| `scripts/build_deflection_pii_surrogate_eval_corpus.py` | 53 |
+| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 102 |
+| **Total** | **454** |

--- a/scripts/build_deflection_pii_surrogate_eval_corpus.py
+++ b/scripts/build_deflection_pii_surrogate_eval_corpus.py
@@ -16,6 +16,7 @@ if str(ROOT) not in sys.path:
 
 from extracted_content_pipeline.deflection_pii_eval_corpus import (  # noqa: E402
     SCHEMA_VERSION,
+    format_labeled_source_intake_summary_markdown,
     summarize_labeled_source,
     build_surrogate_eval_corpus,
 )
@@ -33,13 +34,21 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     result = build_surrogate_eval_corpus(source) if args.output else None
     summary: dict[str, Any] | None = None
-    if args.summary_output:
+    if args.summary_output or args.summary_markdown_output:
         summary = summarize_labeled_source(source, build_result=result)
+    if args.summary_output:
         args.summary_output.parent.mkdir(parents=True, exist_ok=True)
         args.summary_output.write_text(
             json.dumps(summary, indent=2 if args.pretty else None, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+    if args.summary_markdown_output:
+        args.summary_markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_markdown_output.write_text(
+            format_labeled_source_intake_summary_markdown(summary),
+            encoding="utf-8",
+        )
+    if summary is not None:
         if not summary["ok"]:
             _write_error({
                 "ok": False,
@@ -83,6 +92,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.summary_output and summary is not None:
         payload["summary_output"] = str(args.summary_output)
         payload["summary_schema_version"] = str(summary["schema_version"])
+    if args.summary_markdown_output and summary is not None:
+        payload["summary_markdown_output"] = str(args.summary_markdown_output)
+        payload["summary_schema_version"] = str(summary["schema_version"])
     print(json.dumps(payload, sort_keys=True))
     return 0
 
@@ -96,17 +108,40 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         type=Path,
         help="Sanitized labeled-source intake summary path.",
     )
+    parser.add_argument(
+        "--summary-markdown-output",
+        type=Path,
+        help="Sanitized Markdown intake summary path.",
+    )
     parser.add_argument("--pretty", action="store_true", help="Write pretty JSON.")
     args = parser.parse_args(argv)
-    if args.output is None and args.summary_output is None:
-        parser.error("at least one of --output or --summary-output is required")
-    if (
-        args.output is not None
-        and args.summary_output is not None
-        and args.output.expanduser().resolve() == args.summary_output.expanduser().resolve()
-    ):
-        parser.error("--output and --summary-output must be different paths")
+    outputs = (
+        ("--output", args.output),
+        ("--summary-output", args.summary_output),
+        ("--summary-markdown-output", args.summary_markdown_output),
+    )
+    if not any(path is not None for _, path in outputs):
+        parser.error(
+            "at least one of --output, --summary-output, or "
+            "--summary-markdown-output is required"
+        )
+    _reject_duplicate_output_paths(parser, outputs)
     return args
+
+
+def _reject_duplicate_output_paths(
+    parser: argparse.ArgumentParser,
+    outputs: tuple[tuple[str, Path | None], ...],
+) -> None:
+    seen: dict[Path, str] = {}
+    for flag, path in outputs:
+        if path is None:
+            continue
+        resolved = path.expanduser().resolve()
+        existing = seen.get(resolved)
+        if existing is not None:
+            parser.error(f"{existing} and {flag} must be different paths")
+        seen[resolved] = flag
 
 
 def _write_error(payload: dict[str, Any]) -> None:

--- a/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
+++ b/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
@@ -11,6 +11,7 @@ from extracted_content_pipeline.deflection_pii_eval_corpus import (
     SCHEMA_VERSION,
     SOURCE_INTAKE_SUMMARY_SCHEMA_VERSION,
     build_surrogate_eval_corpus,
+    format_labeled_source_intake_summary_markdown,
     summarize_labeled_source,
 )
 
@@ -249,6 +250,46 @@ def test_labeled_source_intake_summary_buckets_unsafe_must_survive_reasons() -> 
         },
     }
     assert "alice@example.com" not in rendered
+
+
+def test_labeled_source_intake_markdown_reports_mix_without_raw_echo() -> None:
+    summary = summarize_labeled_source(_valid_source())
+
+    markdown = format_labeled_source_intake_summary_markdown(summary)
+
+    assert "# Deflection PII Source Intake Summary" in markdown
+    assert "| Status | ok |" in markdown
+    assert "| Tickets | 1 |" in markdown
+    assert "| Labels | 9 |" in markdown
+    assert "| person_name | 2 |" in markdown
+    assert "| high | 7 |" in markdown
+    assert "| customer_message | 4 |" in markdown
+    assert "| security_reference | 1 |" in markdown
+    for raw in (
+        "Alice Baker",
+        "alice.baker@example.com",
+        "202-555-0188",
+        "ORD-98765",
+        "99 Real Street",
+        "1977-06-05",
+        "111-22-3333",
+        "4242 4242 4242 4242",
+    ):
+        assert raw not in markdown
+
+
+def test_labeled_source_intake_markdown_sanitizes_invalid_source() -> None:
+    source = _valid_source()
+    source["schema_version"] = "alice@example.com"
+
+    summary = summarize_labeled_source(source)
+    markdown = format_labeled_source_intake_summary_markdown(summary)
+
+    assert "| Status | blocked |" in markdown
+    assert "source_schema_version_mismatch" in markdown
+    assert "actual=invalid" in markdown
+    assert "alice@example.com" not in markdown
+    assert "Alice Baker" not in markdown
 
 
 def test_must_survive_tokens_are_preserved_for_precision_scoring() -> None:
@@ -582,7 +623,62 @@ def test_cli_writes_summary_without_artifact_and_sanitizes_invalid_summary(
     assert "missing.bad@example.com" not in rendered
 
 
-def test_cli_rejects_colliding_summary_and_artifact_paths(tmp_path: Path) -> None:
+def test_cli_writes_markdown_summary_without_artifact_and_sanitizes_invalid_summary(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "source.json"
+    markdown_output = tmp_path / "summary.md"
+    artifact_output = tmp_path / "artifact.json"
+    source.write_text(json.dumps(_valid_source()), encoding="utf-8")
+
+    assert CLI.main([str(source), "--summary-markdown-output", str(markdown_output)]) == 0
+    assert markdown_output.is_file()
+    assert not artifact_output.exists()
+    markdown = markdown_output.read_text(encoding="utf-8")
+    assert "| Labels | 9 |" in markdown
+    assert "| payment_card | 1 |" in markdown
+    assert "Alice Baker" not in markdown
+
+    bad_source = tmp_path / "bad-source.json"
+    bad_source.write_text(
+        json.dumps({
+            "schema_version": "deflection_pii_labeled_source.v1",
+            "records": [{
+                "fields": {"customer_message": "Email raw.bad@example.com"},
+                "labels": [{
+                    "span": "missing.bad@example.com",
+                    "class": "email",
+                    "origin_field": "customer_message",
+                }],
+            }],
+        }),
+        encoding="utf-8",
+    )
+    assert CLI.main([str(bad_source), "--summary-markdown-output", str(markdown_output)]) == 1
+    markdown = markdown_output.read_text(encoding="utf-8")
+    captured = capsys.readouterr()
+    rendered = markdown + captured.err
+    assert "| Status | blocked |" in rendered
+    assert "label_span_not_found" in rendered
+    assert "record_index=1, label_index=1, origin_field=customer_message" in rendered
+    assert "raw.bad@example.com" not in rendered
+    assert "missing.bad@example.com" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("first_flag", "second_flag"),
+    (
+        ("--summary-output", "--output"),
+        ("--summary-markdown-output", "--output"),
+        ("--summary-output", "--summary-markdown-output"),
+    ),
+)
+def test_cli_rejects_colliding_output_paths(
+    tmp_path: Path,
+    first_flag: str,
+    second_flag: str,
+) -> None:
     source = tmp_path / "source.json"
     shared_output = tmp_path / "pii-output.json"
     source.write_text(json.dumps(_valid_source()), encoding="utf-8")
@@ -590,9 +686,9 @@ def test_cli_rejects_colliding_summary_and_artifact_paths(tmp_path: Path) -> Non
     with pytest.raises(SystemExit) as exc:
         CLI.main([
             str(source),
-            "--summary-output",
+            first_flag,
             str(shared_output),
-            "--output",
+            second_flag,
             str(shared_output),
         ])
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Source-Intake-Markdown.md
Slice phase: Vertical slice

#1742 has closed the fixable tiny-corpus scrubber residue loop, but the operator-derived labeled source still needs a human-reviewable, sanitized intake artifact before real raw support tickets can enter the corpus workflow. This PR adds a Markdown companion generated from the already-sanitized `deflection_pii_labeled_source.v1` intake summary, so corpus mix, class/severity coverage, person-name subtype split, must-survive coverage, and sanitized validation errors can be reviewed without echoing raw source text or raw label spans.

## Intentional
- No raw input persistence, raw source excerpting, or raw label-span samples in Markdown.
- No threshold recommendation, advisory-to-gating flip, detector/scrubber change, NER/open-set-name work, or corpus-size/class-mix gate.
- The Markdown exposes aggregate coverage only; operator source selection and policy decisions remain explicit follow-ups.

## Deferred
- Operator selection of the real transient source, corpus size/archetype mix, labeling ownership, and labeling-quality review remain open #1742 decisions.
- Building the larger derived surrogate artifact from that real source remains a follow-up after the operator supplies/labels the source.
- Threshold selection and advisory-to-gating promotion remain deferred.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -q -- 22 passed.
- python -m py_compile extracted_content_pipeline/deflection_pii_eval_corpus.py scripts/build_deflection_pii_surrogate_eval_corpus.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -- passed.
- git diff --check -- passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
- bash scripts/check_ascii_python.sh -- passed.
- bash scripts/validate_extracted_content_pipeline.sh -- passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
- python scripts/score_deflection_pii_recall.py --json -- status ok; free_high_severity_gate_eligible_leak_count=0, deferred_open_set_name_leak_count=1.
- python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
- python scripts/maturity_sweep_file_lane.py <deflection lane files> --tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json --min-score 8 ... -- ratchet gate passed.
- bash scripts/run_extracted_pipeline_checks.sh -- reasoning core: 295 passed; extracted content pipeline: 4849 passed, 15 skipped, 1 warning.

## Diff size
4 files, +442 / -12. Synced plan total is 454 LOC because the plan doc is included; implementation plus tests are 321 net LOC.
