### PR TITLE
Add deflection action identity foundation

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -4,10 +4,14 @@
       {
         "answer_evidence_status": "resolution_evidence",
         "answer_linkage": "publishable_answer",
+        "cluster_id": "repeat_b011111001111100011000011100110110000100100011010",
         "evidence_quote": "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\"",
+        "identity_basis": "question_topic",
+        "identity_confidence": "high",
         "question": "How do I export attribution reports?",
         "question_id": "q001",
         "rank": 1,
+        "repeat_key": "repeat_b011111001111100011000011100110110000100100011010",
         "resolution_evidence_scope": "scoped",
         "row_id": "q001-e001",
         "source_field": "evidence_quote",
@@ -16,10 +20,14 @@
       {
         "answer_evidence_status": "resolution_evidence",
         "answer_linkage": "publishable_answer",
+        "cluster_id": "repeat_b011111001111100011000011100110110000100100011010",
         "evidence_quote": "",
+        "identity_basis": "question_topic",
+        "identity_confidence": "high",
         "question": "How do I export attribution reports?",
         "question_id": "q001",
         "rank": 1,
+        "repeat_key": "repeat_b011111001111100011000011100110110000100100011010",
         "resolution_evidence_scope": "scoped",
         "row_id": "q001-e002",
         "source_field": "source_id",
@@ -28,10 +36,14 @@
       {
         "answer_evidence_status": "draft_needs_review",
         "answer_linkage": "needs_review",
+        "cluster_id": "repeat_b101110011101100010011111101110101110111101100011",
         "evidence_quote": "`ticket-sso-1` - SSO setup: \"How do I enable SSO for my team?\"",
+        "identity_basis": "question_topic",
+        "identity_confidence": "high",
         "question": "How do I enable SSO for my team?",
         "question_id": "q002",
         "rank": 2,
+        "repeat_key": "repeat_b101110011101100010011111101110101110111101100011",
         "resolution_evidence_scope": "not_applicable",
         "row_id": "q002-e001",
         "source_field": "evidence_quote",
@@ -40,10 +52,14 @@
       {
         "answer_evidence_status": "draft_needs_review",
         "answer_linkage": "needs_review",
+        "cluster_id": "repeat_b101110011101100010011111101110101110111101100011",
         "evidence_quote": "",
+        "identity_basis": "question_topic",
+        "identity_confidence": "high",
         "question": "How do I enable SSO for my team?",
         "question_id": "q002",
         "rank": 2,
+        "repeat_key": "repeat_b101110011101100010011111101110101110111101100011",
         "resolution_evidence_scope": "not_applicable",
         "row_id": "q002-e002",
         "source_field": "source_id",
@@ -55,13 +71,17 @@
         "answer": "To resolve this, open Analytics, choose Attribution, then click Download report.",
         "answer_evidence_status": "resolution_evidence",
         "answer_linkage": "publishable_answer",
+        "cluster_id": "repeat_b011111001111100011000011100110110000100100011010",
         "customer_wording": "",
         "evidence_quote_count": 1,
+        "identity_basis": "question_topic",
+        "identity_confidence": "high",
         "opportunity_score": 2,
         "outcome_diagnostics": {},
         "question": "How do I export attribution reports?",
         "question_id": "q001",
         "rank": 1,
+        "repeat_key": "repeat_b011111001111100011000011100110110000100100011010",
         "resolution_evidence_scope": "scoped",
         "source_ids": [
           "ticket-export-1",
@@ -103,13 +123,17 @@
         "answer": "No verified resolution evidence was found in 2 ticket sources; keep this FAQ in review before answering: How do I enable SSO for my team?",
         "answer_evidence_status": "draft_needs_review",
         "answer_linkage": "needs_review",
+        "cluster_id": "repeat_b101110011101100010011111101110101110111101100011",
         "customer_wording": "",
         "evidence_quote_count": 1,
+        "identity_basis": "question_topic",
+        "identity_confidence": "high",
         "opportunity_score": 2,
         "outcome_diagnostics": {},
         "question": "How do I enable SSO for my team?",
         "question_id": "q002",
         "rank": 2,
+        "repeat_key": "repeat_b101110011101100010011111101110101110111101100011",
         "resolution_evidence_scope": "not_applicable",
         "source_ids": [
           "ticket-sso-1",
@@ -462,6 +486,7 @@
           "backlog_limit": 25,
           "items": [
             {
+              "cluster_id": "repeat_b101110011101100010011111101110101110111101100011",
               "confidence": "medium",
               "csat_signal": {
                 "csat_present_count": 0,
@@ -471,6 +496,8 @@
               },
               "estimated_support_cost": 27.0,
               "fix_type": "create_missing_answer",
+              "identity_basis": "question_topic",
+              "identity_confidence": "high",
               "opportunity_score": 2,
               "owner_lane": "sso setup",
               "priority_drivers": [
@@ -483,6 +510,7 @@
               "rank": 2,
               "recommended_action": "Write and approve the missing answer for this repeated customer question.",
               "recommended_title": "How do I enable SSO for my team?",
+              "repeat_key": "repeat_b101110011101100010011111101110101110111101100011",
               "representative_phrasing": [
                 "How do I enable SSO for my team?",
                 "sso setup"
@@ -503,6 +531,7 @@
               ]
             },
             {
+              "cluster_id": "repeat_b011111001111100011000011100110110000100100011010",
               "confidence": "medium",
               "csat_signal": {
                 "csat_present_count": 0,
@@ -512,6 +541,8 @@
               },
               "estimated_support_cost": 27.0,
               "fix_type": "publish_help_center_answer",
+              "identity_basis": "question_topic",
+              "identity_confidence": "high",
               "opportunity_score": 2,
               "owner_lane": "reporting friction",
               "priority_drivers": [
@@ -524,6 +555,7 @@
               "rank": 1,
               "recommended_action": "Publish or adapt the drafted resolution into help-center or macro copy.",
               "recommended_title": "How do I export attribution reports?",
+              "repeat_key": "repeat_b011111001111100011000011100110110000100100011010",
               "representative_phrasing": [
                 "How do I export attribution reports?",
                 "reporting friction"
@@ -580,6 +612,7 @@
         "data": {
           "items": [
             {
+              "cluster_id": "repeat_b101110011101100010011111101110101110111101100011",
               "confidence": "medium",
               "csat_signal": {
                 "csat_present_count": 0,
@@ -589,6 +622,8 @@
               },
               "estimated_support_cost": 27.0,
               "fix_type": "create_missing_answer",
+              "identity_basis": "question_topic",
+              "identity_confidence": "high",
               "opportunity_score": 2,
               "owner_lane": "sso setup",
               "priority_drivers": [
@@ -601,6 +636,7 @@
               "rank": 2,
               "recommended_action": "Write and approve the missing answer for this repeated customer question.",
               "recommended_title": "How do I enable SSO for my team?",
+              "repeat_key": "repeat_b101110011101100010011111101110101110111101100011",
               "representative_phrasing": [
                 "How do I enable SSO for my team?",
                 "sso setup"
@@ -652,6 +688,7 @@
         "data": {
           "items": [
             {
+              "cluster_id": "repeat_b011111001111100011000011100110110000100100011010",
               "confidence": "medium",
               "csat_signal": {
                 "csat_present_count": 0,
@@ -661,6 +698,8 @@
               },
               "estimated_support_cost": 27.0,
               "fix_type": "publish_help_center_answer",
+              "identity_basis": "question_topic",
+              "identity_confidence": "high",
               "opportunity_score": 2,
               "owner_lane": "reporting friction",
               "priority_drivers": [
@@ -673,6 +712,7 @@
               "rank": 1,
               "recommended_action": "Publish or adapt the drafted resolution into help-center or macro copy.",
               "recommended_title": "How do I export attribution reports?",
+              "repeat_key": "repeat_b011111001111100011000011100110110000100100011010",
               "representative_phrasing": [
                 "How do I export attribution reports?",
                 "reporting friction"
@@ -742,6 +782,7 @@
           "default_limit": 25,
           "items": [
             {
+              "cluster_id": "repeat_b101110011101100010011111101110101110111101100011",
               "confidence": "medium",
               "csat_signal": {
                 "csat_present_count": 0,
@@ -751,6 +792,8 @@
               },
               "estimated_support_cost": 27.0,
               "fix_type": "create_missing_answer",
+              "identity_basis": "question_topic",
+              "identity_confidence": "high",
               "opportunity_score": 2,
               "owner_lane": "sso setup",
               "priority_drivers": [
@@ -763,6 +806,7 @@
               "rank": 2,
               "recommended_action": "Write and approve the missing answer for this repeated customer question.",
               "recommended_title": "How do I enable SSO for my team?",
+              "repeat_key": "repeat_b101110011101100010011111101110101110111101100011",
               "representative_phrasing": [
                 "How do I enable SSO for my team?",
                 "sso setup"
@@ -783,6 +827,7 @@
               ]
             },
             {
+              "cluster_id": "repeat_b011111001111100011000011100110110000100100011010",
               "confidence": "medium",
               "csat_signal": {
                 "csat_present_count": 0,
@@ -792,6 +837,8 @@
               },
               "estimated_support_cost": 27.0,
               "fix_type": "publish_help_center_answer",
+              "identity_basis": "question_topic",
+              "identity_confidence": "high",
               "opportunity_score": 2,
               "owner_lane": "reporting friction",
               "priority_drivers": [
@@ -804,6 +851,7 @@
               "rank": 1,
               "recommended_action": "Publish or adapt the drafted resolution into help-center or macro copy.",
               "recommended_title": "How do I export attribution reports?",
+              "repeat_key": "repeat_b011111001111100011000011100110110000100100011010",
               "representative_phrasing": [
                 "How do I export attribution reports?",
                 "reporting friction"

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -164,6 +164,10 @@ The action-oriented paid sections are a work queue, not a full ticket archive:
   `priority_drivers` enum labels. The score is based on repeat volume,
   benchmark support cost, answer evidence status, confidence, reopened-ticket
   signal, and CSAT signal; it is not produced by an LLM or cloud classifier.
+- Action rows also carry paid-only `repeat_key`, `cluster_id`,
+  `identity_basis`, and `identity_confidence` fields. Use those for
+  cross-run/monthly-delta matching; `rank` and evidence-export `question_id`
+  are display/run-local identifiers and can change when priority changes.
 - `top_unresolved_repeats` contains unresolved repeated questions only; one-off
   or low-confidence questions stay out of repeat accounting.
 - `drafted_resolutions` contains publishable or adaptable answer drafts.
@@ -187,6 +191,14 @@ type DeflectionEvidenceExport = {
   report_summary: FAQDeflectionReportSummary;
   questions: Array<{
     question_id: string;
+    repeat_key: string;
+    cluster_id: string;
+    identity_basis:
+  | "question_topic"
+  | "question"
+  | "source_ids"
+      | "insufficient_identity";
+    identity_confidence: "high" | "medium" | "low";
     rank: number;
     question: string;
     customer_wording: string;
@@ -207,6 +219,10 @@ type DeflectionEvidenceExport = {
   evidence_rows: Array<{
     row_id: string;
     question_id: string;
+    repeat_key: string;
+    cluster_id: string;
+    identity_basis: string;
+    identity_confidence: "high" | "medium" | "low";
     rank: number;
     question: string;
     source_id: string;

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -2358,8 +2359,10 @@ def _action_items(items: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
 def _action_item(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
     status = _action_status(item)
     ticket_count = _ticket_count(item)
+    identity = _action_identity(item)
     return {
         "rank": rank,
+        **identity,
         "question": _text(item.get("question")),
         "status": status,
         "owner_lane": _action_owner_lane(item),
@@ -2569,6 +2572,49 @@ def _action_status_counts(items: Sequence[Mapping[str, Any]]) -> dict[str, int]:
         status = _text(item.get("status")) or "Unknown"
         counts[status] = counts.get(status, 0) + 1
     return dict(sorted(counts.items()))
+
+
+def _action_identity(item: Mapping[str, Any]) -> dict[str, str]:
+    question = _identity_text(item.get("question"))
+    topic = _identity_text(item.get("topic"))
+    source_ids = tuple(
+        sorted(
+            _identity_text(source_id)
+            for source_id in _texts(item.get("source_ids"))
+        )
+    )
+    source_ids = tuple(source_id for source_id in source_ids if source_id)
+
+    if question and topic:
+        basis = "question_topic"
+        confidence = "high"
+        parts = ("question", question, "topic", topic)
+    elif question:
+        basis = "question_topic" if topic else "question"
+        confidence = "medium"
+        parts = ("question", question, "topic", topic)
+    elif source_ids:
+        basis = "source_ids"
+        confidence = "medium"
+        parts = ("sources", ",".join(source_ids))
+    else:
+        basis = "insufficient_identity"
+        confidence = "low"
+        parts = ("insufficient_identity",)
+
+    digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).digest()
+    digest_bits = f"{int.from_bytes(digest[:6], 'big'):048b}"
+    repeat_key = f"repeat_b{digest_bits}"
+    return {
+        "repeat_key": repeat_key,
+        "cluster_id": repeat_key,
+        "identity_basis": basis,
+        "identity_confidence": confidence,
+    }
+
+
+def _identity_text(value: Any) -> str:
+    return " ".join(_text(value).casefold().split())
 
 
 def _question_detail_rows(
@@ -2970,8 +3016,10 @@ def _complete_evidence_detail(item: Mapping[str, Any]) -> list[str]:
 
 def _evidence_export_question(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
     source_ids = _texts(item.get("source_ids"))
+    identity = _action_identity(item)
     return {
         "question_id": _evidence_question_id(rank),
+        **identity,
         "rank": rank,
         "question": _text(item.get("question")),
         "customer_wording": _text(item.get("customer_wording")),
@@ -2997,6 +3045,7 @@ def _evidence_export_question(rank: int, item: Mapping[str, Any]) -> dict[str, A
 
 def _evidence_export_rows(rank: int, item: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
     question_id = _evidence_question_id(rank)
+    identity = _action_identity(item)
     source_ids = _texts(item.get("source_ids"))
     quotes = _texts(item.get("evidence_quotes"))
     rows: list[dict[str, Any]] = []
@@ -3009,6 +3058,7 @@ def _evidence_export_rows(rank: int, item: Mapping[str, Any]) -> tuple[dict[str,
         rows.append(
             _evidence_row(
                 question_id=question_id,
+                identity=identity,
                 rank=rank,
                 item=item,
                 row_index=source_index,
@@ -3024,6 +3074,7 @@ def _evidence_export_rows(rank: int, item: Mapping[str, Any]) -> tuple[dict[str,
         rows.append(
             _evidence_row(
                 question_id=question_id,
+                identity=identity,
                 rank=rank,
                 item=item,
                 row_index=len(rows) + 1,
@@ -3038,6 +3089,7 @@ def _evidence_export_rows(rank: int, item: Mapping[str, Any]) -> tuple[dict[str,
 def _evidence_row(
     *,
     question_id: str,
+    identity: Mapping[str, str],
     rank: int,
     item: Mapping[str, Any],
     row_index: int,
@@ -3048,6 +3100,10 @@ def _evidence_row(
     return {
         "row_id": f"{question_id}-e{row_index:03d}",
         "question_id": question_id,
+        "repeat_key": identity["repeat_key"],
+        "cluster_id": identity["cluster_id"],
+        "identity_basis": identity["identity_basis"],
+        "identity_confidence": identity["identity_confidence"],
         "rank": rank,
         "question": _text(item.get("question")),
         "source_id": source_id,

--- a/plans/PR-Deflection-Action-Identity-Foundation.md
+++ b/plans/PR-Deflection-Action-Identity-Foundation.md
@@ -1,0 +1,133 @@
+# PR-Deflection-Action-Identity-Foundation
+
+## Why this slice exists
+
+#1612 and the linked #1316 delta-report plan both call out the same blocker:
+the paid `deflection.v1` action report has business signals for monthly deltas,
+but its evidence export only has rank-derived `question_id` values (`q001`,
+`q002`, ...). Those IDs can change when priority/rank changes, so they are not
+safe as month-over-month row identity.
+
+Root cause: action rows and evidence-export questions had display/run-local
+identity but no deterministic cross-run identity field. This PR fixes that root
+for the paid model/export by adding stable identity fields derived from the
+question/topic text, while keeping the free Snapshot projection fail-closed.
+
+## Scope (this PR)
+
+Ownership lane: issue-1612/deflection-full-report-delivery-actionability
+Slice phase: Vertical slice
+
+1. Add paid-only `repeat_key`, `cluster_id`, `identity_basis`, and
+   `identity_confidence` to action rows and evidence-export question/evidence
+   rows.
+2. Preserve existing rank-derived `question_id` as a run-local/export display
+   identifier for compatibility.
+3. Prove the new identity survives rank reorder and remains absent from the
+   free Snapshot projection.
+4. Refresh the frontend contract/example artifact so downstream report and
+   delta work sees the new fields.
+
+### Review Contract
+
+Acceptance criteria:
+- Paid action rows and evidence-export rows expose stable identity fields.
+- `repeat_key`/`cluster_id` are deterministic across rank reorder and ticket-ID
+  rollover for the same question/topic.
+- Low-confidence identity is explicit; this slice must not pretend rank is a
+  durable fallback.
+- Free Snapshot output remains allowlist-only; new paid identity fields do not
+  appear in the teaser.
+- Existing evidence-export `question_id`/`row_id` compatibility is preserved.
+
+Affected surfaces:
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+
+Risk areas:
+- Snapshot/privacy projection widening.
+- Evidence-export consumer compatibility.
+- Future delta matching accidentally relying on rank instead of paid identity.
+
+Reviewer rules triggered: R1, R10, R2, R3, R7, R13, R14.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Action-Identity-Foundation.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+
+## Mechanism
+
+`_action_identity` normalizes the source question/topic text, then hashes those
+deterministic parts into a `repeat_*` key. The digest is binary-encoded so the
+committed example fixtures do not resemble API keys to secret scanning while
+still carrying a deterministic non-PII identity. Source IDs do not participate
+when question text exists, so a fresh monthly ticket set does not make the same
+repeat look new. The basis and confidence are explicit:
+
+- `question_topic`: high confidence.
+- `question`: medium confidence.
+- `source_ids`: medium confidence fallback only when no question exists.
+- `insufficient_identity`: low confidence.
+
+Action-row builders and evidence-export builders call that same helper. The
+export keeps existing `question_id` and `row_id` values unchanged, but adds the
+stable identity fields alongside them. The Snapshot projection stays unchanged
+because no new `snapshot_safe_fields` are added.
+
+## Intentional
+
+- This is identity foundation only; it does not build the monthly delta report
+  or customer-facing delta UI.
+- `question_id` remains rank-derived for compatibility. New consumers should
+  use `repeat_key`/`cluster_id` for cross-run matching.
+- The helper uses deterministic lexical normalization, not source ticket IDs,
+  fuzzy matching, or LLM classification. Merge/split/fuzzy identity can be
+  layered later without making rank or evidence-set rollover the fallback.
+- Codex P2 was valid: ticket IDs must not feed durable monthly identity. This
+  update keeps source IDs only as a fallback when question text is absent.
+- The `repeat_key` suffix is binary-encoded to satisfy the Gitleaks PR scanner
+  on committed fixture values; it is still derived from SHA-256 digest bits and
+  is not customer text.
+
+## Deferred
+
+- #1316 D1 monthly delta core: compare persisted paid `deflection.v1` models
+  using these identity fields.
+- Fuzzy/merge/split identity matching and low-confidence adjudication remain
+  delta-lane follow-ups.
+- Snapshot-safe exposure of any identity field remains deferred; paid-only is
+  the boundary for this slice.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused identity/snapshot/doc pytest command -- 4 passed.
+- Affected report/doc pytest files -- 153 passed.
+- Python compile for touched Python files -- passed.
+- Git whitespace check -- passed.
+- Extracted content pipeline validation -- passed.
+- Extracted reasoning-import guard -- clean.
+- Extracted standalone audit -- Atlas runtime import findings: 0.
+- ASCII Python policy check -- passed.
+- Pending before push: local PR review.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_deflection_report_example.json` | 48 |
+| `docs/frontend/content_ops_faq_report_contract.md` | 16 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 56 |
+| `plans/PR-Deflection-Action-Identity-Foundation.md` | 133 |
+| `tests/test_content_ops_deflection_report.py` | 107 |
+| `tests/test_content_ops_faq_report_contract_docs.py` | 5 |
+| **Total** | **365** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -916,6 +916,105 @@ def test_deflection_action_evidence_quotes_match_source_ids() -> None:
     ]
 
 
+def test_deflection_action_identity_is_stable_when_rank_changes() -> None:
+    base = _structured_report_fixture_result()
+    reordered = TicketFAQMarkdownResult(
+        markdown=base.markdown,
+        source_count=base.source_count,
+        ticket_source_count=base.ticket_source_count,
+        output_checks=base.output_checks,
+        items=tuple(reversed(base.items)),
+    )
+
+    base_artifact = build_deflection_report_artifact(base)
+    reordered_artifact = build_deflection_report_artifact(reordered)
+    base_export = build_deflection_evidence_export(base_artifact)
+    reordered_export = build_deflection_evidence_export(reordered_artifact)
+
+    base_questions = {
+        question["question"]: question
+        for question in base_export["questions"]
+    }
+    reordered_questions = {
+        question["question"]: question
+        for question in reordered_export["questions"]
+    }
+
+    for question, base_row in base_questions.items():
+        reordered_row = reordered_questions[question]
+        assert reordered_row["repeat_key"] == base_row["repeat_key"]
+        assert reordered_row["cluster_id"] == base_row["cluster_id"]
+        assert reordered_row["identity_basis"] == "question_topic"
+        assert reordered_row["identity_confidence"] == "high"
+
+    assert (
+        base_questions["How do I export attribution reports?"]["question_id"]
+        != reordered_questions["How do I export attribution reports?"]["question_id"]
+    )
+
+    base_actions = {
+        item["question"]: item
+        for section in base_artifact.report_model.as_dict()["sections"]
+        if section["id"] == "backlog_table"
+        for item in section["data"]["items"]
+    }
+    reordered_actions = {
+        item["question"]: item
+        for section in reordered_artifact.report_model.as_dict()["sections"]
+        if section["id"] == "backlog_table"
+        for item in section["data"]["items"]
+    }
+    assert (
+        base_actions["How do I export attribution reports?"]["repeat_key"]
+        == reordered_actions["How do I export attribution reports?"]["repeat_key"]
+    )
+
+
+def test_deflection_action_identity_ignores_ticket_id_rollover() -> None:
+    base = _structured_report_fixture_result()
+    next_period_items: list[dict[str, object]] = []
+    for item in base.items:
+        updated = dict(item)
+        source_ids = item.get("source_ids")
+        source_count = len(source_ids) if isinstance(source_ids, tuple) else 0
+        updated["source_ids"] = tuple(
+            f"next-month-{index}"
+            for index in range(1, source_count + 1)
+        )
+        next_period_items.append(updated)
+    next_period = TicketFAQMarkdownResult(
+        markdown=base.markdown,
+        source_count=base.source_count,
+        ticket_source_count=base.ticket_source_count,
+        output_checks=base.output_checks,
+        items=tuple(next_period_items),
+    )
+
+    base_export = build_deflection_evidence_export(
+        build_deflection_report_artifact(base)
+    )
+    next_export = build_deflection_evidence_export(
+        build_deflection_report_artifact(next_period)
+    )
+
+    base_questions = {
+        question["question"]: question
+        for question in base_export["questions"]
+    }
+    next_questions = {
+        question["question"]: question
+        for question in next_export["questions"]
+    }
+
+    for question, base_row in base_questions.items():
+        next_row = next_questions[question]
+        assert next_row["repeat_key"] == base_row["repeat_key"]
+        assert next_row["cluster_id"] == base_row["cluster_id"]
+        assert next_row["identity_basis"] == "question_topic"
+        assert next_row["identity_confidence"] == "high"
+        assert next_row["source_ids"] != base_row["source_ids"]
+
+
 def test_deflection_snapshot_projection_is_allowlist_only() -> None:
     artifact = build_deflection_report_artifact(_structured_report_fixture_result())
     report_model = artifact.report_model.as_dict()
@@ -950,6 +1049,10 @@ def test_deflection_snapshot_projection_is_allowlist_only() -> None:
     assert "source_ids" not in encoded
     assert "ticket-export-1" not in encoded
     assert "priority_fix_queue" not in encoded
+    assert "repeat_key" not in encoded
+    assert "cluster_id" not in encoded
+    assert "identity_basis" not in encoded
+    assert "identity_confidence" not in encoded
     assert "hidden action detail" not in encoded
     assert "hidden unresolved action detail" not in encoded
     assert "hidden drafted action detail" not in encoded
@@ -1408,6 +1511,10 @@ def test_deflection_report_artifact_includes_complete_evidence_export() -> None:
     assert export["evidence_rows"][0] == {
         "row_id": "q001-e001",
         "question_id": "q001",
+        "repeat_key": "repeat_b110111100110011101111100111001111001111111111110",
+        "cluster_id": "repeat_b110111100110011101111100111001111001111111111110",
+        "identity_basis": "question_topic",
+        "identity_confidence": "high",
         "rank": 1,
         "question": "How do I export attribution reports?",
         "source_id": "ticket-1",

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -291,6 +291,11 @@ def test_content_ops_faq_report_contract_links_example() -> None:
     assert '"drafted_resolutions"' in doc
     assert '"already_covered_still_recurring"' in doc
     assert '"backlog_table"' in doc
+    assert "repeat_key: string" in doc
+    assert "cluster_id: string" in doc
+    assert "identity_basis:" in doc
+    assert "identity_confidence:" in doc
+    assert "cross-run/monthly-delta matching" in doc
     assert "required_data: string[]" in doc
     assert "snapshot_safe_fields: string[]" in doc
     assert "snapshot.teaser.full_answer" in doc


### PR DESCRIPTION
Plan: plans/PR-Deflection-Action-Identity-Foundation.md
Slice phase: Vertical slice

#1612/#1316 call out that the paid action-report model has useful delta signals, but only rank-derived export IDs. This slice adds paid-only stable action identity fields so future monthly deltas can compare persisted `deflection.v1` models without relying on `q001`/rank order.

## Intentional
- This is identity foundation only; it does not build monthly delta rendering or customer-facing delta UI.
- `question_id` and `row_id` stay compatible/run-local; new consumers should use `repeat_key`/`cluster_id`.
- Identity is deterministic lexical matching only. Source ticket IDs do not feed durable monthly identity when question text exists. Fuzzy merge/split handling remains a delta-lane follow-up.
- Codex P2 was valid: the first version hashed source IDs into `repeat_key`, which would make monthly ticket rollover look like a new action. Fixed by using source IDs only as a no-question fallback.
- The committed fixture `repeat_key` values use binary digest encoding so Gitleaks does not classify synthetic examples as API keys.

## Deferred
- #1316 D1 monthly delta core using these identity fields.
- Fuzzy/merge/split matching and low-confidence adjudication.
- Snapshot-safe exposure of identity fields; this slice keeps them paid/export only.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_action_identity_is_stable_when_rank_changes tests/test_content_ops_deflection_report.py::test_deflection_action_identity_ignores_ticket_id_rollover tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_is_allowlist_only tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_report_contract_links_example -q` -- 4 passed.
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -q` -- 153 passed.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py` -- passed.
- `git diff --check` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` -- passed.

## Diff size
6 files, +365 / -0.
