### PR TITLE
Add deflection PII source review bundle

### DIFF
--- a/plans/PR-Deflection-PII-Source-Review-Bundle.md
+++ b/plans/PR-Deflection-PII-Source-Review-Bundle.md
@@ -1,0 +1,138 @@
+# PR-Deflection-PII-Source-Review-Bundle
+
+## Why this slice exists
+
+#1742 has the corpus-first measurement path in place: the surrogate eval schema,
+the recall scorer, the advisory artifact, the sanitized labeled-source intake
+JSON summary (#1765), and the sanitized Markdown intake summary (#1767). The
+remaining true work needs an operator-supplied labeled source, but the current
+CLI still asks the operator to coordinate three separate output paths by hand.
+
+This slice adds the thinnest handoff artifact path for that operator source: a
+single review-bundle directory that writes the sanitized JSON intake summary,
+the sanitized Markdown summary, and the surrogate eval artifact with predictable
+filenames. Invalid labeled sources still write only the sanitized review
+summaries and do not persist a surrogate artifact.
+
+This is a vertical slice because it exercises the real local handoff flow:
+operator-labeled local source -> sanitized intake summaries -> surrogate eval
+artifact bundle. It does not choose the real source, set corpus-mix targets,
+select thresholds, promote advisory output to a gate, or address the deferred
+cue-less/open-set name gap.
+
+Review-fix root cause: bundle mode assigned a stable artifact path before
+validation, but the invalid-summary return path exited before overwriting or
+removing a prior artifact in that directory. This change fixes the root for
+bundle mode by making a blocked source clear the bundle artifact path before it
+writes blocked summaries, so a reused bundle cannot contain summaries for one
+source and a surrogate corpus from another.
+
+Diff budget note: the synced LOC total is over 400 because it includes this
+plan plus the review-fix root-cause/verification record. The code and tests are
+the narrow bundle CLI path and the stale-artifact regression required to close
+the review finding.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 3
+
+1. Add a `--review-bundle-dir` CLI option for
+   `scripts/build_deflection_pii_surrogate_eval_corpus.py`.
+2. Write predictable sanitized bundle filenames for summary JSON, summary
+   Markdown, and the surrogate eval artifact on valid sources.
+3. Preserve the fail-closed invalid-source path: sanitized summaries are written,
+   stderr is sanitized, and no surrogate artifact is written.
+4. Remove any prior bundle artifact before writing blocked summaries for an
+   invalid source rerun.
+5. Add focused CLI tests for valid bundles, invalid bundles, stale-artifact
+   invalid reruns, and flag-shape rejection.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A valid labeled source can be converted into a review bundle directory
+        containing sanitized JSON summary, sanitized Markdown summary, and a
+        surrogate-only eval artifact.
+  - [ ] An invalid labeled source writes sanitized review summaries, returns a
+        non-zero exit, and does not write the eval artifact.
+  - [ ] `--review-bundle-dir` cannot be combined with the individual output
+        flags, so operators do not accidentally split or clobber the bundle.
+  - [ ] Existing individual output flags remain compatible.
+  - [ ] No raw source text, raw label spans, or high-risk raw tokens are echoed
+        in bundle files, stdout, or stderr.
+- Affected surfaces:
+  - `scripts/build_deflection_pii_surrogate_eval_corpus.py`
+  - `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+- Risk areas: raw PII echo in bundle artifacts, stale artifact creation on
+  invalid sources, and scope creep into corpus policy or scrubber behavior.
+- Reviewer rules triggered: R1, R2, R3, R10, R13, R14; boundary-probe required
+  because this writes raw-source-adjacent validation artifacts.
+
+### Files touched
+
+- `plans/PR-Deflection-PII-Source-Review-Bundle.md`
+- `scripts/build_deflection_pii_surrogate_eval_corpus.py`
+- `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+
+## Mechanism
+
+The CLI gains `--review-bundle-dir`. When present, the parser rejects any
+individual output flags and the command uses fixed filenames inside the bundle
+directory:
+
+- source intake summary JSON
+- source intake summary Markdown
+- deflection PII surrogate eval corpus JSON
+
+The command uses the same sanitized summary and Markdown formatter already
+landed by #1765/#1767. Because the bundle includes an artifact path, the CLI
+builds the surrogate corpus once and passes that result into
+`summarize_labeled_source`. If validation fails, the sanitized summaries are
+written after any existing bundle artifact is removed, the command returns exit
+1 with sanitized errors, and the surrogate artifact is not written.
+
+## Intentional
+
+- No raw-source persistence and no raw-label persistence.
+- No operator source choice, corpus-size target, threshold recommendation, or
+  advisory-to-gating flip.
+- No detector/scrubber behavior change and no NER/open-set-name work.
+- The bundle option is mutually exclusive with individual output flags to keep
+  this handoff predictable and avoid inventing partial-bundle semantics.
+
+## Deferred
+
+- Operator selection of the real transient source, corpus size/archetype mix,
+  labeling ownership, and labeling-quality review remain open #1742 decisions.
+- Running the bundle against that real source and committing/versioning the
+  resulting surrogate-only eval artifact remains a follow-up once the source is
+  supplied and reviewed.
+- Threshold selection and advisory-to-gating promotion remain deferred.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -q -- 29 passed.
+- python -m py_compile scripts/build_deflection_pii_surrogate_eval_corpus.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -- passed.
+- git diff --check -- passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh -- passed.
+- python scripts/score_deflection_pii_recall.py --json -- status ok; free_high_severity_gate_eligible_leak_count=0, deferred_open_set_name_leak_count=1.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
+- python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
+- python scripts/maturity_sweep_file_lane.py <deflection lane files> --tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json --min-score 8 ... -- ratchet gate passed.
+- bash scripts/run_extracted_pipeline_checks.sh -- reasoning core: 295 passed; extracted content pipeline: 4857 passed, 15 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-PII-Source-Review-Bundle.md` | 138 |
+| `scripts/build_deflection_pii_surrogate_eval_corpus.py` | 106 |
+| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 182 |
+| **Total** | **426** |

--- a/scripts/build_deflection_pii_surrogate_eval_corpus.py
+++ b/scripts/build_deflection_pii_surrogate_eval_corpus.py
@@ -21,6 +21,10 @@ from extracted_content_pipeline.deflection_pii_eval_corpus import (  # noqa: E40
     build_surrogate_eval_corpus,
 )
 
+REVIEW_BUNDLE_ARTIFACT_NAME = "deflection-pii-surrogate-eval-corpus.json"
+REVIEW_BUNDLE_SUMMARY_NAME = "source-intake-summary.json"
+REVIEW_BUNDLE_MARKDOWN_NAME = "source-intake-summary.md"
+
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
@@ -32,19 +36,38 @@ def main(argv: list[str] | None = None) -> int:
             "message": str(exc.__class__.__name__),
         }]})
         return 1
-    result = build_surrogate_eval_corpus(source) if args.output else None
+    output_path = args.output
+    summary_output = args.summary_output
+    summary_markdown_output = args.summary_markdown_output
+    if args.review_bundle_dir is not None:
+        bundle_paths = _review_bundle_paths(args.review_bundle_dir)
+        if bundle_paths is None:
+            return 1
+        output_path = bundle_paths["artifact"]
+        summary_output = bundle_paths["summary"]
+        summary_markdown_output = bundle_paths["markdown"]
+
+    result = build_surrogate_eval_corpus(source) if output_path else None
     summary: dict[str, Any] | None = None
-    if args.summary_output or args.summary_markdown_output:
+    if summary_output or summary_markdown_output:
         summary = summarize_labeled_source(source, build_result=result)
-    if args.summary_output:
-        args.summary_output.parent.mkdir(parents=True, exist_ok=True)
-        args.summary_output.write_text(
+    if (
+        args.review_bundle_dir is not None
+        and summary is not None
+        and not summary["ok"]
+        and output_path is not None
+    ):
+        if not _remove_existing_review_bundle_artifact(output_path):
+            return 1
+    if summary_output:
+        summary_output.parent.mkdir(parents=True, exist_ok=True)
+        summary_output.write_text(
             json.dumps(summary, indent=2 if args.pretty else None, sort_keys=True) + "\n",
             encoding="utf-8",
         )
-    if args.summary_markdown_output:
-        args.summary_markdown_output.parent.mkdir(parents=True, exist_ok=True)
-        args.summary_markdown_output.write_text(
+    if summary_markdown_output:
+        summary_markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        summary_markdown_output.write_text(
             format_labeled_source_intake_summary_markdown(summary),
             encoding="utf-8",
         )
@@ -58,7 +81,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     artifact: dict[str, Any] | None = None
-    if args.output:
+    if output_path:
         if result is None:
             result = build_surrogate_eval_corpus(source)
         if not result.ok:
@@ -77,24 +100,26 @@ def main(argv: list[str] | None = None) -> int:
             })
             return 1
         text = json.dumps(artifact, indent=2 if args.pretty else None, sort_keys=True)
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(text + "\n", encoding="utf-8")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(text + "\n", encoding="utf-8")
     payload = {
         "ok": True,
         "schema_version": SCHEMA_VERSION,
     }
     if artifact is not None:
         payload.update({
-            "output": str(args.output),
+            "output": str(output_path),
             "ticket_count": artifact["summary"]["ticket_count"],
             "label_count": artifact["summary"]["label_count"],
         })
-    if args.summary_output and summary is not None:
-        payload["summary_output"] = str(args.summary_output)
+    if summary_output and summary is not None:
+        payload["summary_output"] = str(summary_output)
         payload["summary_schema_version"] = str(summary["schema_version"])
-    if args.summary_markdown_output and summary is not None:
-        payload["summary_markdown_output"] = str(args.summary_markdown_output)
+    if summary_markdown_output and summary is not None:
+        payload["summary_markdown_output"] = str(summary_markdown_output)
         payload["summary_schema_version"] = str(summary["schema_version"])
+    if args.review_bundle_dir is not None:
+        payload["review_bundle_dir"] = str(args.review_bundle_dir)
     print(json.dumps(payload, sort_keys=True))
     return 0
 
@@ -113,6 +138,14 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         type=Path,
         help="Sanitized Markdown intake summary path.",
     )
+    parser.add_argument(
+        "--review-bundle-dir",
+        type=Path,
+        help=(
+            "Directory for a sanitized review bundle containing the source "
+            "intake JSON summary, Markdown summary, and surrogate artifact."
+        ),
+    )
     parser.add_argument("--pretty", action="store_true", help="Write pretty JSON.")
     args = parser.parse_args(argv)
     outputs = (
@@ -120,13 +153,50 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         ("--summary-output", args.summary_output),
         ("--summary-markdown-output", args.summary_markdown_output),
     )
-    if not any(path is not None for _, path in outputs):
+    if args.review_bundle_dir is not None and any(path is not None for _, path in outputs):
+        parser.error(
+            "--review-bundle-dir cannot be combined with --output, "
+            "--summary-output, or --summary-markdown-output"
+        )
+    if args.review_bundle_dir is None and not any(path is not None for _, path in outputs):
         parser.error(
             "at least one of --output, --summary-output, or "
-            "--summary-markdown-output is required"
+            "--summary-markdown-output is required unless --review-bundle-dir is set"
         )
     _reject_duplicate_output_paths(parser, outputs)
     return args
+
+
+def _review_bundle_paths(bundle_dir: Path) -> dict[str, Path] | None:
+    if bundle_dir.exists() and not bundle_dir.is_dir():
+        _write_error({
+            "ok": False,
+            "schema_version": SCHEMA_VERSION,
+            "errors": [{"code": "review_bundle_dir_not_directory"}],
+        })
+        return None
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    return {
+        "artifact": bundle_dir / REVIEW_BUNDLE_ARTIFACT_NAME,
+        "summary": bundle_dir / REVIEW_BUNDLE_SUMMARY_NAME,
+        "markdown": bundle_dir / REVIEW_BUNDLE_MARKDOWN_NAME,
+    }
+
+
+def _remove_existing_review_bundle_artifact(output_path: Path) -> bool:
+    try:
+        output_path.unlink(missing_ok=True)
+    except OSError as exc:
+        _write_error({
+            "ok": False,
+            "schema_version": SCHEMA_VERSION,
+            "errors": [{
+                "code": "review_bundle_artifact_unremovable",
+                "message": exc.__class__.__name__,
+            }],
+        })
+        return False
+    return True
 
 
 def _reject_duplicate_output_paths(

--- a/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
+++ b/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
@@ -666,6 +666,188 @@ def test_cli_writes_markdown_summary_without_artifact_and_sanitizes_invalid_summ
     assert "missing.bad@example.com" not in rendered
 
 
+def test_cli_writes_review_bundle_with_artifact_and_summaries(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "source.json"
+    bundle_dir = tmp_path / "review-bundle"
+    source.write_text(json.dumps(_valid_source()), encoding="utf-8")
+
+    assert CLI.main([str(source), "--review-bundle-dir", str(bundle_dir), "--pretty"]) == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    artifact_output = bundle_dir / CLI.REVIEW_BUNDLE_ARTIFACT_NAME
+    summary_output = bundle_dir / CLI.REVIEW_BUNDLE_SUMMARY_NAME
+    markdown_output = bundle_dir / CLI.REVIEW_BUNDLE_MARKDOWN_NAME
+
+    assert payload["review_bundle_dir"] == str(bundle_dir)
+    assert payload["output"] == str(artifact_output)
+    assert payload["summary_output"] == str(summary_output)
+    assert payload["summary_markdown_output"] == str(markdown_output)
+    assert artifact_output.is_file()
+    assert summary_output.is_file()
+    assert markdown_output.is_file()
+    artifact = json.loads(artifact_output.read_text(encoding="utf-8"))
+    summary = json.loads(summary_output.read_text(encoding="utf-8"))
+    markdown = markdown_output.read_text(encoding="utf-8")
+    rendered = (
+        json.dumps(artifact, sort_keys=True)
+        + json.dumps(summary, sort_keys=True)
+        + markdown
+        + captured.out
+        + captured.err
+    )
+    assert artifact["summary"]["label_count"] == 9
+    assert summary["ok"] is True
+    assert "| Labels | 9 |" in markdown
+    for raw in (
+        "Alice Baker",
+        "alice.baker@example.com",
+        "202-555-0188",
+        "ORD-98765",
+        "99 Real Street",
+        "1977-06-05",
+        "111-22-3333",
+        "4242 4242 4242 4242",
+    ):
+        assert raw not in rendered
+
+
+def test_cli_review_bundle_sanitizes_invalid_source_without_artifact(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "bad-source.json"
+    bundle_dir = tmp_path / "review-bundle"
+    source.write_text(
+        json.dumps({
+            "schema_version": "deflection_pii_labeled_source.v1",
+            "records": [{
+                "fields": {"customer_message": "Email raw.bad@example.com"},
+                "labels": [{
+                    "span": "missing.bad@example.com",
+                    "class": "email",
+                    "origin_field": "customer_message",
+                }],
+            }],
+        }),
+        encoding="utf-8",
+    )
+
+    assert CLI.main([str(source), "--review-bundle-dir", str(bundle_dir), "--pretty"]) == 1
+    captured = capsys.readouterr()
+    artifact_output = bundle_dir / CLI.REVIEW_BUNDLE_ARTIFACT_NAME
+    summary_output = bundle_dir / CLI.REVIEW_BUNDLE_SUMMARY_NAME
+    markdown_output = bundle_dir / CLI.REVIEW_BUNDLE_MARKDOWN_NAME
+
+    assert not artifact_output.exists()
+    assert summary_output.is_file()
+    assert markdown_output.is_file()
+    summary = json.loads(summary_output.read_text(encoding="utf-8"))
+    markdown = markdown_output.read_text(encoding="utf-8")
+    rendered = json.dumps(summary, sort_keys=True) + markdown + captured.out + captured.err
+    assert summary["ok"] is False
+    assert "| Status | blocked |" in markdown
+    assert "label_span_not_found" in rendered
+    assert "record_index=1, label_index=1, origin_field=customer_message" in rendered
+    assert "raw.bad@example.com" not in rendered
+    assert "missing.bad@example.com" not in rendered
+
+
+def test_cli_review_bundle_removes_stale_artifact_on_invalid_rebuild(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "source.json"
+    bad_source = tmp_path / "bad-source.json"
+    bundle_dir = tmp_path / "review-bundle"
+    source.write_text(json.dumps(_valid_source()), encoding="utf-8")
+    bad_source.write_text(
+        json.dumps({
+            "schema_version": "alice@example.com",
+            "records": [{
+                "fields": {"customer_message": "Email raw.bad@example.com"},
+                "labels": [{
+                    "span": "missing.bad@example.com",
+                    "class": "email",
+                    "origin_field": "customer_message",
+                }],
+            }],
+        }),
+        encoding="utf-8",
+    )
+
+    assert CLI.main([str(source), "--review-bundle-dir", str(bundle_dir)]) == 0
+    artifact_output = bundle_dir / CLI.REVIEW_BUNDLE_ARTIFACT_NAME
+    assert artifact_output.is_file()
+    valid_artifact = json.loads(artifact_output.read_text(encoding="utf-8"))
+    assert valid_artifact["summary"]["label_count"] == 9
+    capsys.readouterr()
+
+    assert CLI.main([str(bad_source), "--review-bundle-dir", str(bundle_dir)]) == 1
+    captured = capsys.readouterr()
+    summary_output = bundle_dir / CLI.REVIEW_BUNDLE_SUMMARY_NAME
+    markdown_output = bundle_dir / CLI.REVIEW_BUNDLE_MARKDOWN_NAME
+
+    assert not artifact_output.exists()
+    assert summary_output.is_file()
+    assert markdown_output.is_file()
+    summary = json.loads(summary_output.read_text(encoding="utf-8"))
+    markdown = markdown_output.read_text(encoding="utf-8")
+    rendered = json.dumps(summary, sort_keys=True) + markdown + captured.out + captured.err
+    assert summary["ok"] is False
+    assert "source_schema_version_mismatch" in rendered
+    assert "| Status | blocked |" in markdown
+    assert "alice@example.com" not in rendered
+    assert "raw.bad@example.com" not in rendered
+    assert "missing.bad@example.com" not in rendered
+
+
+@pytest.mark.parametrize(
+    "output_flag",
+    ("--output", "--summary-output", "--summary-markdown-output"),
+)
+def test_cli_rejects_review_bundle_with_individual_outputs(
+    tmp_path: Path,
+    output_flag: str,
+) -> None:
+    source = tmp_path / "source.json"
+    bundle_dir = tmp_path / "review-bundle"
+    explicit_output = tmp_path / "explicit-output"
+    source.write_text(json.dumps(_valid_source()), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        CLI.main([
+            str(source),
+            "--review-bundle-dir",
+            str(bundle_dir),
+            output_flag,
+            str(explicit_output),
+        ])
+
+    assert exc.value.code == 2
+    assert not bundle_dir.exists()
+    assert not explicit_output.exists()
+
+
+def test_cli_rejects_review_bundle_file_path_without_raw_echo(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "source.json"
+    bundle_path = tmp_path / "review-bundle"
+    source.write_text(json.dumps(_valid_source()), encoding="utf-8")
+    bundle_path.write_text("not a directory", encoding="utf-8")
+
+    assert CLI.main([str(source), "--review-bundle-dir", str(bundle_path)]) == 1
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err
+    assert "review_bundle_dir_not_directory" in rendered
+    assert "Alice Baker" not in rendered
+    assert "alice.baker@example.com" not in rendered
+
+
 @pytest.mark.parametrize(
     ("first_flag", "second_flag"),
     (


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Source-Review-Bundle.md
Slice phase: Vertical slice

#1742 has the corpus-first measurement path in place, including the surrogate eval schema, recall scorer, advisory artifact, sanitized JSON intake summary, and sanitized Markdown intake summary. This PR adds the next handoff slice: a single sanitized review-bundle directory for an operator-labeled local source, with predictable summary JSON, summary Markdown, and surrogate eval artifact filenames.

## Intentional
- No raw-source persistence and no raw-label persistence.
- No operator source choice, corpus-size target, threshold recommendation, advisory-to-gating flip, detector/scrubber change, or NER/open-set-name work.
- Bundle mode is mutually exclusive with individual output flags so the handoff stays predictable and does not invent partial-bundle semantics.

## Deferred
- Operator selection of the real transient source, corpus size/archetype mix, labeling ownership, and labeling-quality review remain open #1742 decisions.
- Running the bundle against that real source and committing/versioning the resulting surrogate-only eval artifact remains a follow-up once the source is supplied and reviewed.
- Threshold selection and advisory-to-gating promotion remain deferred.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -q -- 29 passed.
- python -m py_compile scripts/build_deflection_pii_surrogate_eval_corpus.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py -- passed.
- git diff --check -- passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
- bash scripts/check_ascii_python.sh -- passed.
- python scripts/score_deflection_pii_recall.py --json -- status ok; free_high_severity_gate_eligible_leak_count=0, deferred_open_set_name_leak_count=1.
- bash scripts/validate_extracted_content_pipeline.sh -- passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
- python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
- python scripts/maturity_sweep_file_lane.py <deflection lane files> --tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json --min-score 8 ... -- ratchet gate passed.
- bash scripts/run_extracted_pipeline_checks.sh -- reasoning core: 295 passed; extracted content pipeline: 4857 passed, 15 skipped, 1 warning.

## Diff size
3 files, +408 / -18. Synced plan total is 426 LOC; the overage is the plan plus the review-fix root-cause/verification record.
