### PR TITLE
Add deflection PII review bundle scoring

### DIFF
--- a/plans/PR-Deflection-PII-Review-Bundle-Score.md
+++ b/plans/PR-Deflection-PII-Review-Bundle-Score.md
@@ -1,0 +1,135 @@
+# PR-Deflection-PII-Review-Bundle-Score
+
+## Why this slice exists
+
+#1742 has moved from the tiny-corpus scrubber loop into the operator-derived
+corpus handoff. #1769 added a single review-bundle directory that can hold the
+sanitized source intake JSON summary, sanitized Markdown summary, and
+surrogate-only eval corpus artifact. The remaining handoff gap is that scoring
+that bundle still requires a separate ad hoc command with two output paths.
+
+Root cause: the review bundle has predictable source-review and corpus filenames,
+but `score_deflection_pii_recall.py` only knows about a corpus path plus
+individual score-output paths. That makes the "review this derived corpus before
+versioning it" handoff less reproducible than the bundle creation step.
+
+This slice fixes the handoff root by adding a bundle scoring mode that reads the
+known review-bundle corpus filename and writes predictable recall-score JSON and
+Markdown files in the same directory. It does not choose the real operator
+source, select thresholds, promote advisory output to a gate, change scrubber
+behavior, or close the deferred cue-less/open-set name gap.
+
+Review-fix root cause: the first bundle-scoring pass derived child paths before
+validating that `--review-bundle-dir` was actually a directory, and `_load_corpus`
+caught file/JSON errors but not decode errors. This change fixes those roots by
+rejecting existing non-directory bundle paths during argument parsing and routing
+non-UTF-8 corpus files through the same sanitized `corpus_load_failed` path as
+missing or malformed JSON corpora.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 3
+
+1. Add a scorer `--review-bundle-dir` mode for the bundle produced by
+   `scripts/build_deflection_pii_surrogate_eval_corpus.py`.
+2. Write predictable bundle score filenames for recall JSON and recall Markdown.
+3. Keep existing `--corpus`, `--output`, `--markdown-output`, and `--json`
+   behavior compatible.
+4. Add focused tests proving bundle scoring writes the expected artifacts,
+   rejects split output flags, fails closed on missing bundle corpus, and does
+   not echo raw spans/tokens in score artifacts.
+5. Review update: reject existing non-directory bundle paths before deriving
+   child paths and treat non-UTF-8 corpus files as sanitized load failures.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Given a review bundle containing the builder artifact filename recorded
+        by `REVIEW_BUNDLE_CORPUS_NAME`, the scorer writes the score JSON and
+        Markdown filenames recorded by `REVIEW_BUNDLE_SCORE_NAME` and
+        `REVIEW_BUNDLE_SCORE_MARKDOWN_NAME` in the same directory.
+  - [ ] Bundle score artifacts use the existing recall-score schema and Markdown
+        formatter.
+  - [ ] `--review-bundle-dir` cannot be combined with individual corpus/output
+        flags, so operators do not accidentally score one corpus while writing
+        into another bundle.
+  - [ ] A missing bundle corpus fails closed with the existing sanitized
+        `corpus_load_failed` error path.
+  - [ ] Existing non-directory bundle paths are rejected without echoing the
+        local path.
+  - [ ] Non-UTF-8 bundle corpora fail closed with sanitized score artifacts
+        instead of surfacing decoder exceptions.
+  - [ ] Score JSON/Markdown do not include raw spans or person-name tokens.
+- Affected surfaces:
+  - `scripts/score_deflection_pii_recall.py`
+  - `tests/test_score_deflection_pii_recall.py`
+- Risk areas: bundle/file mismatch, accidental raw PII echo in score artifacts,
+  and scope creep into policy or scrubber behavior.
+- Reviewer rules triggered: R1, R2, R3, R10, R14; boundary-probe required
+  because this writes raw-source-adjacent review artifacts.
+
+### Files touched
+
+- `plans/PR-Deflection-PII-Review-Bundle-Score.md`
+- `scripts/score_deflection_pii_recall.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+## Mechanism
+
+The scorer gets a `--review-bundle-dir` option. When present, argument parsing
+rejects `--corpus`, `--output`, and `--markdown-output`, then derives the fixed
+bundle paths from these constants:
+
+- `REVIEW_BUNDLE_CORPUS_NAME`
+- `REVIEW_BUNDLE_SCORE_NAME`
+- `REVIEW_BUNDLE_SCORE_MARKDOWN_NAME`
+
+The scoring itself stays unchanged: the command loads the derived corpus,
+passes it to `score_corpus`, and writes the existing JSON and Markdown summary
+formats. Missing or unreadable corpus input uses the current sanitized
+`corpus_load_failed` error path and returns non-zero. Existing non-directory
+bundle paths are rejected before derived children are assigned, and decoded-input
+failures such as non-UTF-8 corpus files are caught with the same sanitized load
+failure envelope.
+
+## Intentional
+
+- No threshold recommendation and no advisory-to-gating flip. This only makes
+  the review-bundle measurement handoff reproducible.
+- No source selection, no raw-source persistence, and no raw-label persistence.
+- No scrubber, detector, scorer math, or NER/open-set-name behavior change.
+- The bundle scorer rejects split output flags instead of allowing partial
+  bundle writes because #1769 made the bundle path intentionally predictable.
+
+## Deferred
+
+- Operator selection of the real transient source, corpus size/archetype mix,
+  labeling ownership, and labeling-quality review remain open #1742 decisions.
+- Running the full bundle plus scoring flow against that real source and
+  committing/versioning the resulting surrogate-only eval artifact remains a
+  follow-up once the source is supplied and reviewed.
+- Threshold selection and advisory-to-gating promotion remain deferred.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_score_deflection_pii_recall.py -q -- 30 passed.
+- python -m py_compile scripts/score_deflection_pii_recall.py tests/test_score_deflection_pii_recall.py -- passed.
+- python scripts/score_deflection_pii_recall.py --json -- status ok; free_high_severity_gate_eligible_leak_count=0, deferred_open_set_name_leak_count=1.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh -- passed.
+- git diff --check -- passed.
+- python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
+- python scripts/maturity_sweep_file_lane.py <deflection lane files> --tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json --min-score 8 ... -- ratchet gate passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-PII-Review-Bundle-Score.md` | 135 |
+| `scripts/score_deflection_pii_recall.py` | 32 |
+| `tests/test_score_deflection_pii_recall.py` | 122 |
+| **Total** | **289** |

--- a/scripts/score_deflection_pii_recall.py
+++ b/scripts/score_deflection_pii_recall.py
@@ -48,6 +48,9 @@ DEFAULT_CORPUS = (
     ROOT
     / "docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json"
 )
+REVIEW_BUNDLE_CORPUS_NAME = "deflection-pii-surrogate-eval-corpus.json"
+REVIEW_BUNDLE_SCORE_NAME = "deflection-pii-recall-score.json"
+REVIEW_BUNDLE_SCORE_MARKDOWN_NAME = "deflection-pii-recall-score.md"
 SURFACES = ("free_snapshot", "free_teaser", "paid_artifact", "paid_pdf")
 FREE_SURFACES = frozenset({"free_snapshot", "free_teaser"})
 HIGH_SEVERITY_CLASSES = frozenset({
@@ -204,11 +207,34 @@ def score_corpus(corpus: Mapping[str, Any]) -> dict[str, Any]:
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--corpus", type=Path)
     parser.add_argument("--output", type=Path)
     parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument(
+        "--review-bundle-dir",
+        type=Path,
+        help=(
+            "Directory produced by build_deflection_pii_surrogate_eval_corpus.py "
+            "--review-bundle-dir. Writes predictable recall score JSON/Markdown "
+            "files in that directory."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.review_bundle_dir is not None:
+        if args.corpus is not None or args.output is not None or args.markdown_output is not None:
+            parser.error(
+                "--review-bundle-dir cannot be combined with --corpus, "
+                "--output, or --markdown-output"
+            )
+        if args.review_bundle_dir.exists() and not args.review_bundle_dir.is_dir():
+            parser.error("--review-bundle-dir must be a directory")
+        args.corpus = args.review_bundle_dir / REVIEW_BUNDLE_CORPUS_NAME
+        args.output = args.review_bundle_dir / REVIEW_BUNDLE_SCORE_NAME
+        args.markdown_output = args.review_bundle_dir / REVIEW_BUNDLE_SCORE_MARKDOWN_NAME
+    elif args.corpus is None:
+        args.corpus = DEFAULT_CORPUS
+    return args
 
 
 def _markdown_summary(summary: Mapping[str, Any]) -> str:
@@ -394,7 +420,7 @@ def _format_recall(value: Any) -> str:
 def _load_corpus(path: Path) -> tuple[Mapping[str, Any], list[dict[str, Any]]]:
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return {}, [_error("corpus_load_failed")]
     if not isinstance(raw, Mapping):
         return {}, [_error("corpus_not_object")]

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -10,6 +10,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "score_deflection_pii_recall.py"
+BUILD_SCRIPT = ROOT / "scripts" / "build_deflection_pii_surrogate_eval_corpus.py"
 TINY_FIXTURE = (
     ROOT
     / "docs/extraction/validation/fixtures/deflection_pii_surrogate_eval_tiny.json"
@@ -20,10 +21,131 @@ assert SPEC.loader is not None
 CLI = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = CLI
 SPEC.loader.exec_module(CLI)
+BUILD_SPEC = importlib.util.spec_from_file_location(
+    "build_deflection_pii_surrogate_eval_corpus_for_score_tests",
+    BUILD_SCRIPT,
+)
+assert BUILD_SPEC is not None
+assert BUILD_SPEC.loader is not None
+BUILD_CLI = importlib.util.module_from_spec(BUILD_SPEC)
+sys.modules[BUILD_SPEC.name] = BUILD_CLI
+BUILD_SPEC.loader.exec_module(BUILD_CLI)
 
 
 def _tiny_corpus() -> dict:
     return json.loads(TINY_FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_review_bundle_corpus_filename_matches_builder_bundle_artifact() -> None:
+    assert CLI.REVIEW_BUNDLE_CORPUS_NAME == BUILD_CLI.REVIEW_BUNDLE_ARTIFACT_NAME
+
+
+def test_review_bundle_mode_writes_score_artifacts_without_span_echo(
+    tmp_path: Path,
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / CLI.REVIEW_BUNDLE_CORPUS_NAME).write_text(
+        TINY_FIXTURE.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    assert CLI.main(["--review-bundle-dir", str(bundle_dir)]) == 0
+
+    score_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_NAME
+    markdown_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_MARKDOWN_NAME
+    summary = json.loads(score_path.read_text(encoding="utf-8"))
+    markdown = markdown_path.read_text(encoding="utf-8")
+    rendered = json.dumps(summary, sort_keys=True) + markdown
+
+    assert summary["status"] == "ok"
+    assert summary["schema_version"] == "deflection_pii_recall_score.v1"
+    assert summary["input"]["ticket_count"] == 3
+    assert "# Deflection PII Recall Advisory" in markdown
+    assert "deflection-pii-surrogate-eval-corpus.json" not in rendered
+    for raw in (
+        "Maya Chen",
+        "Jordan Lee",
+        "Taylor Brooks",
+        "Mary Jane Watson",
+        "Watson",
+    ):
+        assert raw not in rendered
+
+
+def test_review_bundle_mode_rejects_split_output_flags(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc:
+        CLI._parse_args([
+            "--review-bundle-dir",
+            str(tmp_path / "bundle"),
+            "--output",
+            str(tmp_path / "score.json"),
+        ])
+
+    assert exc.value.code == 2
+
+
+def test_review_bundle_mode_rejects_existing_file_path_without_echo(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle_path = tmp_path / "bundle-file"
+    bundle_path.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        CLI._parse_args(["--review-bundle-dir", str(bundle_path)])
+
+    captured = capsys.readouterr()
+    assert exc.value.code == 2
+    assert "--review-bundle-dir must be a directory" in captured.err
+    assert str(bundle_path) not in captured.err
+
+
+def test_review_bundle_mode_missing_corpus_writes_sanitized_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+
+    assert CLI.main(["--review-bundle-dir", str(bundle_dir)]) == 1
+
+    captured = capsys.readouterr()
+    score_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_NAME
+    markdown_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_MARKDOWN_NAME
+    summary = json.loads(score_path.read_text(encoding="utf-8"))
+    markdown = markdown_path.read_text(encoding="utf-8")
+    rendered = json.dumps(summary, sort_keys=True) + markdown + captured.err
+
+    assert summary["status"] == "failed"
+    assert summary["blocking_error_codes"] == ["corpus_load_failed"]
+    assert "corpus_load_failed" in markdown
+    assert str(bundle_dir) not in rendered
+    assert "deflection-pii-surrogate-eval-corpus.json" not in rendered
+
+
+def test_review_bundle_mode_non_utf8_corpus_writes_sanitized_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / CLI.REVIEW_BUNDLE_CORPUS_NAME).write_bytes(b"\xff\xfe\x00")
+
+    assert CLI.main(["--review-bundle-dir", str(bundle_dir)]) == 1
+
+    captured = capsys.readouterr()
+    score_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_NAME
+    markdown_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_MARKDOWN_NAME
+    summary = json.loads(score_path.read_text(encoding="utf-8"))
+    markdown = markdown_path.read_text(encoding="utf-8")
+    rendered = json.dumps(summary, sort_keys=True) + markdown + captured.err
+
+    assert summary["status"] == "failed"
+    assert summary["blocking_error_codes"] == ["corpus_load_failed"]
+    assert "corpus_load_failed" in markdown
+    assert "UnicodeDecodeError" not in rendered
+    assert str(bundle_dir) not in rendered
+    assert "deflection-pii-surrogate-eval-corpus.json" not in rendered
 
 
 def test_tiny_fixture_scores_all_surfaces_without_echoing_spans() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Review-Bundle-Score.md
Slice phase: Vertical slice

#1742 now has a safe review-bundle directory for operator-derived PII corpus handoff, but scoring that bundle still required a separate ad hoc corpus/output command. This PR adds a scorer `--review-bundle-dir` mode that reads the known bundle corpus filename and writes predictable recall score JSON/Markdown files beside it.

## Intentional
- No source selection, threshold recommendation, advisory-to-gating flip, scrubber change, or NER/open-set-name behavior change.
- Bundle scoring rejects split corpus/output flags to keep the handoff deterministic.
- Review fixes reject existing non-directory bundle paths and route non-UTF-8 corpus files through the sanitized `corpus_load_failed` path.

## Deferred
- Operator source selection, corpus size/archetype mix, labeling-quality review, real-source bundle run, artifact versioning, threshold selection, and gate promotion remain #1742 follow-ups.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_score_deflection_pii_recall.py -q -- 30 passed.
- python -m py_compile scripts/score_deflection_pii_recall.py tests/test_score_deflection_pii_recall.py -- passed.
- python scripts/score_deflection_pii_recall.py --json -- status ok; free_high_severity_gate_eligible_leak_count=0, deferred_open_set_name_leak_count=1.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
- bash scripts/check_ascii_python.sh -- passed.
- git diff --check -- passed.
- python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
- python scripts/maturity_sweep_file_lane.py <deflection lane files> --tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json --min-score 8 ... -- ratchet gate passed.

## Diff size
3 files, +226 / -2
