### PR TITLE
Add deflection PII review bundle manifest

### DIFF
--- a/plans/PR-Deflection-PII-Review-Bundle-Manifest.md
+++ b/plans/PR-Deflection-PII-Review-Bundle-Manifest.md
@@ -1,0 +1,161 @@
+# PR-Deflection-PII-Review-Bundle-Manifest
+
+## Why this slice exists
+
+#1742 now has the local operator handoff in two halves: #1769 creates a
+sanitized review-bundle directory from an operator-labeled source, and #1770
+scores that directory with predictable recall score artifacts. The remaining
+pre-source gap is artifact/versioning prep: a future real-source bundle should
+be self-describing without asking the reviewer to infer which fixed filenames,
+schema versions, counts, and score status belong together.
+
+Root cause: the bundle directory is deterministic by filename, but there is no
+single sanitized manifest that records the bundle's artifact inventory and score
+status. That makes the eventual "run locally, review, then version the
+surrogate-only eval artifact" step depend on convention rather than an explicit
+machine-readable contract.
+
+This slice fixes that handoff root by adding a sanitized review-bundle manifest
+that the builder writes and the scorer updates. It does not choose the real
+source, persist raw labels/text, set thresholds, change scrubber behavior, or
+promote the advisory score to a gate.
+
+Diff budget note: the synced LOC total is over 400 because the manifest contract
+must be proven on both halves of the bundle flow: builder valid/blocked output
+and scorer success/failure updates. The review fixes add same-class regression
+coverage for unreadable inputs, blocked manifests, and stale corpus inventory;
+splitting those would leave the review-bundle self-description contract only
+partly enforced.
+
+Review-fix root cause: the first manifest pass treated builder provenance as a
+mostly static record once scoring began, and it resolved bundle output paths only
+after the source JSON was readable. That left three self-description gaps:
+unreadable sources had no blocked manifest, scorer rewrites dropped blocked-build
+error codes, and score load failures could leave stale corpus-present inventory.
+This fix moves bundle path resolution before source reads, preserves sanitized
+build blocking codes during score updates, and clears stale corpus inventory when
+the bundle corpus cannot be loaded.
+
+## Scope (this PR)
+
+Ownership lane: deflection/pii-recall-precision-testing
+Slice phase: Vertical slice
+Max files: 5
+
+1. Add a predictable manifest filename, exposed as
+   `REVIEW_BUNDLE_MANIFEST_NAME`, to the bundle builder.
+2. Have valid and blocked bundle builds write a sanitized manifest with relative
+   artifact filenames, schema versions, status, and count metadata.
+3. Have `score_deflection_pii_recall.py --review-bundle-dir` update that
+   manifest with recall score JSON/Markdown entries after bundle scoring.
+4. Add focused tests proving the manifest is written/updated, remains sanitized,
+   and does not require the real operator source.
+5. Review update: keep manifests self-describing for unreadable sources,
+   blocked-source score attempts, and stale corpus inventory after score load
+   failures.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A valid review-bundle build writes the file named by
+        `REVIEW_BUNDLE_MANIFEST_NAME` beside the source summary, Markdown
+        summary, and surrogate eval corpus.
+  - [ ] A blocked/invalid source still writes a manifest that records the
+        blocked status, sanitized summaries, and absent surrogate artifact.
+  - [ ] Bundle scoring updates the same manifest with recall score artifact
+        filenames, score schema/status, and headline counts.
+  - [ ] Unreadable source input still writes a blocked manifest without
+        pretending source summary files or surrogate corpora exist.
+  - [ ] Scoring a blocked build manifest preserves the builder's sanitized
+        `blocking_error_codes`.
+  - [ ] Corpus load failures clear stale corpus-present inventory before the
+        score manifest is rewritten.
+  - [ ] Manifest paths are bundle-relative filenames only; no absolute paths,
+        raw source text, raw label spans, or high-risk raw tokens are emitted.
+  - [ ] Existing individual output flags and bundle filenames remain compatible.
+- Affected surfaces:
+  - `scripts/build_deflection_pii_surrogate_eval_corpus.py`
+  - `scripts/score_deflection_pii_recall.py`
+  - bundle/scorer tests
+- Risk areas: raw PII/path echo in manifest metadata, stale or contradictory
+  manifest state on invalid reruns, and scope creep into policy/gating.
+- Reviewer rules triggered: R1, R2, R3, R10, R14; boundary-probe required
+  because this writes raw-source-adjacent review metadata.
+
+### Files touched
+
+- `plans/PR-Deflection-PII-Review-Bundle-Manifest.md`
+- `scripts/build_deflection_pii_surrogate_eval_corpus.py`
+- `scripts/score_deflection_pii_recall.py`
+- `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py`
+- `tests/test_score_deflection_pii_recall.py`
+
+## Mechanism
+
+The builder gets manifest constants:
+
+- `REVIEW_BUNDLE_MANIFEST_NAME`
+- `REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION`
+
+When `--review-bundle-dir` is used, the builder writes the normal bundle files
+and then writes a manifest containing only sanitized metadata: relative
+filenames, source-summary schema/status, surrogate-corpus schema/counts when
+present, and a blocked/ok status. Invalid sources still remove stale surrogate
+artifacts before the manifest is written, so the manifest does not claim a
+present corpus when the source failed validation. Bundle paths are resolved
+before the source read, so malformed or non-UTF-8 source files can still write a
+blocked manifest whose source summary and surrogate corpus entries are marked
+absent.
+
+The scorer uses the same manifest filename/schema and, in `--review-bundle-dir`
+mode, reads any existing manifest, updates the recall-score JSON/Markdown
+entries, and rewrites the manifest. If scoring fails, the manifest records the
+sanitized score status/error codes; if scoring passes, it records the headline
+counts that reviewers need before versioning or threshold discussions. The
+scorer preserves sanitized build `blocking_error_codes` from blocked manifests
+and, on corpus load failures, clears stale corpus-present schema/count metadata
+before rewriting the manifest.
+
+## Intentional
+
+- No source selection or real-source run. The operator source remains transient
+  and out of repo scope.
+- No hashes or timestamps in this first manifest; stable count/schema/status
+  metadata is enough to make the handoff explicit without introducing
+  reproducibility churn.
+- No threshold recommendation and no advisory-to-gating flip.
+- No scrubber, detector, scorer math, or NER/open-set-name behavior change.
+
+## Deferred
+
+- Operator selection of the real transient source, corpus size/archetype mix,
+  labeling ownership, and labeling-quality review remain open #1742 decisions.
+- Running the full bundle plus scoring flow against the real source and
+  committing/versioning the surrogate-only eval artifact remains deferred until
+  that source is supplied and reviewed.
+- Threshold selection and advisory-to-gating promotion remain deferred.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py tests/test_score_deflection_pii_recall.py -q -- 62 passed.
+- python -m py_compile scripts/build_deflection_pii_surrogate_eval_corpus.py scripts/score_deflection_pii_recall.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py tests/test_score_deflection_pii_recall.py -- passed.
+- python scripts/score_deflection_pii_recall.py --json -- status ok; free_high_severity_gate_eligible_leak_count=0, deferred_open_set_name_leak_count=1.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
+- bash scripts/check_ascii_python.sh -- passed.
+- git diff --check -- passed.
+- python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
+- python scripts/maturity_sweep_file_lane.py scripts/build_deflection_pii_surrogate_eval_corpus.py scripts/score_deflection_pii_recall.py --tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-deflection-pii-review-bundle-manifest.md -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-PII-Review-Bundle-Manifest.md` | 161 |
+| `scripts/build_deflection_pii_surrogate_eval_corpus.py` | 155 |
+| `scripts/score_deflection_pii_recall.py` | 135 |
+| `tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py` | 88 |
+| `tests/test_score_deflection_pii_recall.py` | 169 |
+| **Total** | **708** |

--- a/scripts/build_deflection_pii_surrogate_eval_corpus.py
+++ b/scripts/build_deflection_pii_surrogate_eval_corpus.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping
 import json
 import sys
 from pathlib import Path
@@ -24,21 +25,16 @@ from extracted_content_pipeline.deflection_pii_eval_corpus import (  # noqa: E40
 REVIEW_BUNDLE_ARTIFACT_NAME = "deflection-pii-surrogate-eval-corpus.json"
 REVIEW_BUNDLE_SUMMARY_NAME = "source-intake-summary.json"
 REVIEW_BUNDLE_MARKDOWN_NAME = "source-intake-summary.md"
+REVIEW_BUNDLE_MANIFEST_NAME = "review-bundle-manifest.json"
+REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION = "deflection_pii_review_bundle_manifest.v1"
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    try:
-        source = json.loads(args.input.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        _write_error({"ok": False, "schema_version": SCHEMA_VERSION, "errors": [{
-            "code": "input_json_unreadable",
-            "message": str(exc.__class__.__name__),
-        }]})
-        return 1
     output_path = args.output
     summary_output = args.summary_output
     summary_markdown_output = args.summary_markdown_output
+    manifest_output: Path | None = None
     if args.review_bundle_dir is not None:
         bundle_paths = _review_bundle_paths(args.review_bundle_dir)
         if bundle_paths is None:
@@ -46,6 +42,24 @@ def main(argv: list[str] | None = None) -> int:
         output_path = bundle_paths["artifact"]
         summary_output = bundle_paths["summary"]
         summary_markdown_output = bundle_paths["markdown"]
+        manifest_output = bundle_paths["manifest"]
+
+    try:
+        source = json.loads(args.input.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        error_summary = _blocked_summary("input_json_unreadable", exc.__class__.__name__)
+        if manifest_output is not None:
+            if not _write_review_bundle_manifest(
+                manifest_output,
+                summary=error_summary,
+                artifact=None,
+                pretty=args.pretty,
+                source_summary_present=False,
+                source_markdown_present=False,
+            ):
+                return 1
+        _write_error(error_summary)
+        return 1
 
     result = build_surrogate_eval_corpus(source) if output_path else None
     summary: dict[str, Any] | None = None
@@ -73,6 +87,14 @@ def main(argv: list[str] | None = None) -> int:
         )
     if summary is not None:
         if not summary["ok"]:
+            if manifest_output is not None:
+                if not _write_review_bundle_manifest(
+                    manifest_output,
+                    summary=summary,
+                    artifact=None,
+                    pretty=args.pretty,
+                ):
+                    return 1
             _write_error({
                 "ok": False,
                 "schema_version": summary["schema_version"],
@@ -102,6 +124,14 @@ def main(argv: list[str] | None = None) -> int:
         text = json.dumps(artifact, indent=2 if args.pretty else None, sort_keys=True)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(text + "\n", encoding="utf-8")
+    if manifest_output is not None:
+        if not _write_review_bundle_manifest(
+            manifest_output,
+            summary=summary,
+            artifact=artifact,
+            pretty=args.pretty,
+        ):
+            return 1
     payload = {
         "ok": True,
         "schema_version": SCHEMA_VERSION,
@@ -120,6 +150,7 @@ def main(argv: list[str] | None = None) -> int:
         payload["summary_schema_version"] = str(summary["schema_version"])
     if args.review_bundle_dir is not None:
         payload["review_bundle_dir"] = str(args.review_bundle_dir)
+        payload["review_bundle_manifest"] = str(manifest_output)
     print(json.dumps(payload, sort_keys=True))
     return 0
 
@@ -180,6 +211,7 @@ def _review_bundle_paths(bundle_dir: Path) -> dict[str, Path] | None:
         "artifact": bundle_dir / REVIEW_BUNDLE_ARTIFACT_NAME,
         "summary": bundle_dir / REVIEW_BUNDLE_SUMMARY_NAME,
         "markdown": bundle_dir / REVIEW_BUNDLE_MARKDOWN_NAME,
+        "manifest": bundle_dir / REVIEW_BUNDLE_MANIFEST_NAME,
     }
 
 
@@ -212,6 +244,113 @@ def _reject_duplicate_output_paths(
         if existing is not None:
             parser.error(f"{existing} and {flag} must be different paths")
         seen[resolved] = flag
+
+
+def _write_review_bundle_manifest(
+    path: Path,
+    *,
+    summary: Mapping[str, Any] | None,
+    artifact: Mapping[str, Any] | None,
+    pretty: bool,
+    source_summary_present: bool | None = None,
+    source_markdown_present: bool | None = None,
+) -> bool:
+    try:
+        path.write_text(
+            json.dumps(
+                _review_bundle_manifest(
+                    summary=summary,
+                    artifact=artifact,
+                    source_summary_present=source_summary_present,
+                    source_markdown_present=source_markdown_present,
+                ),
+                indent=2 if pretty else None,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        _write_error({
+            "ok": False,
+            "schema_version": SCHEMA_VERSION,
+            "errors": [{
+                "code": "review_bundle_manifest_unwritable",
+                "message": exc.__class__.__name__,
+            }],
+        })
+        return False
+    return True
+
+
+def _review_bundle_manifest(
+    *,
+    summary: Mapping[str, Any] | None,
+    artifact: Mapping[str, Any] | None,
+    source_summary_present: bool | None = None,
+    source_markdown_present: bool | None = None,
+) -> dict[str, Any]:
+    summary_ok = bool(summary and summary.get("ok") is True)
+    summary_present = summary is not None if source_summary_present is None else source_summary_present
+    markdown_present = summary is not None if source_markdown_present is None else source_markdown_present
+    summary_file: dict[str, Any] = {
+        "path": REVIEW_BUNDLE_SUMMARY_NAME,
+        "present": summary_present,
+        "ok": summary_ok,
+    }
+    if summary_present and summary is not None:
+        summary_file["schema_version"] = _clean(summary.get("schema_version"))
+    manifest: dict[str, Any] = {
+        "schema_version": REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION,
+        "status": "ok" if summary_ok and artifact is not None else "blocked",
+        "files": {
+            "source_intake_summary": summary_file,
+            "source_intake_markdown": {
+                "path": REVIEW_BUNDLE_MARKDOWN_NAME,
+                "present": markdown_present,
+            },
+            "surrogate_eval_corpus": {
+                "path": REVIEW_BUNDLE_ARTIFACT_NAME,
+                "present": artifact is not None,
+            },
+        },
+    }
+    if summary is not None:
+        manifest["blocking_error_codes"] = [
+            _clean(error.get("code"))
+            for error in _sequence(summary.get("errors"))
+            if isinstance(error, Mapping) and _clean(error.get("code"))
+        ]
+    if artifact is not None:
+        corpus_file = manifest["files"]["surrogate_eval_corpus"]
+        artifact_summary = artifact.get("summary") if isinstance(artifact.get("summary"), Mapping) else {}
+        corpus_file.update({
+            "schema_version": _clean(artifact.get("schema_version")),
+            "ticket_count": int(artifact_summary.get("ticket_count", 0)),
+            "label_count": int(artifact_summary.get("label_count", 0)),
+        })
+    return manifest
+
+
+def _blocked_summary(code: str, message: str) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "schema_version": SCHEMA_VERSION,
+        "errors": [{
+            "code": code,
+            "message": message,
+        }],
+    }
+
+
+def _sequence(value: Any) -> tuple[Any, ...]:
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    return ()
+
+
+def _clean(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
 
 
 def _write_error(payload: dict[str, Any]) -> None:

--- a/scripts/score_deflection_pii_recall.py
+++ b/scripts/score_deflection_pii_recall.py
@@ -51,6 +51,13 @@ DEFAULT_CORPUS = (
 REVIEW_BUNDLE_CORPUS_NAME = "deflection-pii-surrogate-eval-corpus.json"
 REVIEW_BUNDLE_SCORE_NAME = "deflection-pii-recall-score.json"
 REVIEW_BUNDLE_SCORE_MARKDOWN_NAME = "deflection-pii-recall-score.md"
+REVIEW_BUNDLE_MANIFEST_NAME = "review-bundle-manifest.json"
+REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION = "deflection_pii_review_bundle_manifest.v1"
+REVIEW_BUNDLE_BUILD_FILE_KEYS = frozenset({
+    "source_intake_summary",
+    "source_intake_markdown",
+    "surrogate_eval_corpus",
+})
 SURFACES = ("free_snapshot", "free_teaser", "paid_artifact", "paid_pdf")
 FREE_SURFACES = frozenset({"free_snapshot", "free_teaser"})
 HIGH_SEVERITY_CLASSES = frozenset({
@@ -124,6 +131,9 @@ def main(argv: list[str] | None = None) -> int:
             _markdown_summary(summary),
             encoding="utf-8",
         )
+    if args.review_bundle_dir is not None:
+        if not _write_review_bundle_score_manifest(args.review_bundle_dir, summary):
+            return 1
     if args.json:
         print(json.dumps(summary, sort_keys=True))
     if summary["status"] != "ok":
@@ -425,6 +435,131 @@ def _load_corpus(path: Path) -> tuple[Mapping[str, Any], list[dict[str, Any]]]:
     if not isinstance(raw, Mapping):
         return {}, [_error("corpus_not_object")]
     return raw, []
+
+
+def _write_review_bundle_score_manifest(
+    bundle_dir: Path,
+    summary: Mapping[str, Any],
+) -> bool:
+    manifest_path = bundle_dir / REVIEW_BUNDLE_MANIFEST_NAME
+    manifest = _read_review_bundle_manifest(manifest_path)
+    files = manifest["files"]
+    status = _clean(summary.get("status"))
+    score_error_codes = _safe_error_codes(summary.get("blocking_error_codes"))
+    if "corpus_load_failed" in score_error_codes:
+        _clear_stale_corpus_manifest_entry(manifest)
+    files["recall_score"] = {
+        "path": REVIEW_BUNDLE_SCORE_NAME,
+        "present": True,
+        "schema_version": _clean(summary.get("schema_version")),
+        "status": status,
+        "blocking_error_codes": score_error_codes,
+    }
+    headline = summary.get("headline")
+    if isinstance(headline, Mapping):
+        files["recall_score"]["headline"] = {
+            "free_high_severity_gate_eligible_leak_count": int(
+                headline.get("free_high_severity_gate_eligible_leak_count", 0)
+            ),
+            "free_high_severity_leak_count": int(
+                headline.get("free_high_severity_leak_count", 0)
+            ),
+            "deferred_open_set_name_leak_count": int(
+                headline.get("deferred_open_set_name_leak_count", 0)
+            ),
+        }
+    files["recall_score_markdown"] = {
+        "path": REVIEW_BUNDLE_SCORE_MARKDOWN_NAME,
+        "present": True,
+    }
+    manifest["score_status"] = status
+    try:
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(
+            json.dumps({
+                "ok": False,
+                "schema_version": SCORE_SCHEMA_VERSION,
+                "errors": [{
+                    "code": "review_bundle_manifest_unwritable",
+                    "message": exc.__class__.__name__,
+                }],
+            }, sort_keys=True),
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _read_review_bundle_manifest(path: Path) -> dict[str, Any]:
+    raw: Any
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        raw = {}
+    status = _clean(raw.get("status")) if isinstance(raw, Mapping) else ""
+    if status not in {"ok", "blocked"}:
+        status = "unknown"
+    raw_files = raw.get("files") if isinstance(raw, Mapping) else {}
+    files: dict[str, Any] = {}
+    if isinstance(raw_files, Mapping):
+        for key in sorted(REVIEW_BUNDLE_BUILD_FILE_KEYS):
+            entry = raw_files.get(key)
+            if isinstance(entry, Mapping):
+                files[key] = _safe_manifest_file_entry(entry)
+    manifest = {
+        "schema_version": REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION,
+        "status": status or "unknown",
+        "files": files,
+    }
+    if isinstance(raw, Mapping) and "blocking_error_codes" in raw:
+        manifest["blocking_error_codes"] = _safe_error_codes(raw.get("blocking_error_codes"))
+    return manifest
+
+
+def _safe_manifest_file_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    path = _clean(entry.get("path"))
+    if path:
+        safe["path"] = Path(path).name
+    for key in ("present", "ok"):
+        value = entry.get(key)
+        if isinstance(value, bool):
+            safe[key] = value
+    schema_version = _clean(entry.get("schema_version"))
+    if schema_version:
+        safe["schema_version"] = schema_version
+    for key in ("ticket_count", "label_count"):
+        value = entry.get(key)
+        if isinstance(value, int):
+            safe[key] = value
+    return safe
+
+
+def _clear_stale_corpus_manifest_entry(manifest: dict[str, Any]) -> None:
+    if manifest.get("status") == "ok":
+        manifest["status"] = "blocked"
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        return
+    entry = files.get("surrogate_eval_corpus")
+    if not isinstance(entry, dict):
+        return
+    entry["present"] = False
+    for key in ("schema_version", "ticket_count", "label_count"):
+        entry.pop(key, None)
+
+
+def _safe_error_codes(value: Any) -> list[str]:
+    codes: list[str] = []
+    for code in _sequence(value):
+        text = _clean(code)
+        if re.fullmatch(r"[a-z0-9_:-]{1,80}", text):
+            codes.append(text)
+    return codes
 
 
 def _corpus_errors(corpus: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
+++ b/tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py
@@ -680,27 +680,56 @@ def test_cli_writes_review_bundle_with_artifact_and_summaries(
     artifact_output = bundle_dir / CLI.REVIEW_BUNDLE_ARTIFACT_NAME
     summary_output = bundle_dir / CLI.REVIEW_BUNDLE_SUMMARY_NAME
     markdown_output = bundle_dir / CLI.REVIEW_BUNDLE_MARKDOWN_NAME
+    manifest_output = bundle_dir / CLI.REVIEW_BUNDLE_MANIFEST_NAME
 
     assert payload["review_bundle_dir"] == str(bundle_dir)
     assert payload["output"] == str(artifact_output)
     assert payload["summary_output"] == str(summary_output)
     assert payload["summary_markdown_output"] == str(markdown_output)
+    assert payload["review_bundle_manifest"] == str(manifest_output)
     assert artifact_output.is_file()
     assert summary_output.is_file()
     assert markdown_output.is_file()
+    assert manifest_output.is_file()
     artifact = json.loads(artifact_output.read_text(encoding="utf-8"))
     summary = json.loads(summary_output.read_text(encoding="utf-8"))
     markdown = markdown_output.read_text(encoding="utf-8")
+    manifest = json.loads(manifest_output.read_text(encoding="utf-8"))
     rendered = (
         json.dumps(artifact, sort_keys=True)
         + json.dumps(summary, sort_keys=True)
         + markdown
+        + json.dumps(manifest, sort_keys=True)
         + captured.out
         + captured.err
     )
     assert artifact["summary"]["label_count"] == 9
     assert summary["ok"] is True
     assert "| Labels | 9 |" in markdown
+    assert manifest == {
+        "blocking_error_codes": [],
+        "files": {
+            "source_intake_markdown": {
+                "path": CLI.REVIEW_BUNDLE_MARKDOWN_NAME,
+                "present": True,
+            },
+            "source_intake_summary": {
+                "ok": True,
+                "path": CLI.REVIEW_BUNDLE_SUMMARY_NAME,
+                "present": True,
+                "schema_version": summary["schema_version"],
+            },
+            "surrogate_eval_corpus": {
+                "label_count": 9,
+                "path": CLI.REVIEW_BUNDLE_ARTIFACT_NAME,
+                "present": True,
+                "schema_version": artifact["schema_version"],
+                "ticket_count": 1,
+            },
+        },
+        "schema_version": CLI.REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION,
+        "status": "ok",
+    }
     for raw in (
         "Alice Baker",
         "alice.baker@example.com",
@@ -740,19 +769,76 @@ def test_cli_review_bundle_sanitizes_invalid_source_without_artifact(
     artifact_output = bundle_dir / CLI.REVIEW_BUNDLE_ARTIFACT_NAME
     summary_output = bundle_dir / CLI.REVIEW_BUNDLE_SUMMARY_NAME
     markdown_output = bundle_dir / CLI.REVIEW_BUNDLE_MARKDOWN_NAME
+    manifest_output = bundle_dir / CLI.REVIEW_BUNDLE_MANIFEST_NAME
 
     assert not artifact_output.exists()
     assert summary_output.is_file()
     assert markdown_output.is_file()
+    assert manifest_output.is_file()
     summary = json.loads(summary_output.read_text(encoding="utf-8"))
     markdown = markdown_output.read_text(encoding="utf-8")
-    rendered = json.dumps(summary, sort_keys=True) + markdown + captured.out + captured.err
+    manifest = json.loads(manifest_output.read_text(encoding="utf-8"))
+    rendered = (
+        json.dumps(summary, sort_keys=True)
+        + markdown
+        + json.dumps(manifest, sort_keys=True)
+        + captured.out
+        + captured.err
+    )
     assert summary["ok"] is False
+    assert manifest["status"] == "blocked"
+    assert manifest["blocking_error_codes"] == ["label_span_not_found"]
+    assert manifest["files"]["surrogate_eval_corpus"] == {
+        "path": CLI.REVIEW_BUNDLE_ARTIFACT_NAME,
+        "present": False,
+    }
     assert "| Status | blocked |" in markdown
     assert "label_span_not_found" in rendered
     assert "record_index=1, label_index=1, origin_field=customer_message" in rendered
     assert "raw.bad@example.com" not in rendered
     assert "missing.bad@example.com" not in rendered
+
+
+def test_cli_review_bundle_unreadable_source_writes_blocked_manifest(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = tmp_path / "alice.baker@example.com.json"
+    bundle_dir = tmp_path / "review-bundle"
+    source.write_bytes(b"\xff\xfe\x00")
+
+    assert CLI.main([str(source), "--review-bundle-dir", str(bundle_dir), "--pretty"]) == 1
+    captured = capsys.readouterr()
+    artifact_output = bundle_dir / CLI.REVIEW_BUNDLE_ARTIFACT_NAME
+    summary_output = bundle_dir / CLI.REVIEW_BUNDLE_SUMMARY_NAME
+    markdown_output = bundle_dir / CLI.REVIEW_BUNDLE_MARKDOWN_NAME
+    manifest_output = bundle_dir / CLI.REVIEW_BUNDLE_MANIFEST_NAME
+
+    assert not artifact_output.exists()
+    assert not summary_output.exists()
+    assert not markdown_output.exists()
+    assert manifest_output.is_file()
+    manifest = json.loads(manifest_output.read_text(encoding="utf-8"))
+    rendered = json.dumps(manifest, sort_keys=True) + captured.out + captured.err
+
+    assert manifest["status"] == "blocked"
+    assert manifest["blocking_error_codes"] == ["input_json_unreadable"]
+    assert manifest["files"]["source_intake_summary"] == {
+        "ok": False,
+        "path": CLI.REVIEW_BUNDLE_SUMMARY_NAME,
+        "present": False,
+    }
+    assert manifest["files"]["source_intake_markdown"] == {
+        "path": CLI.REVIEW_BUNDLE_MARKDOWN_NAME,
+        "present": False,
+    }
+    assert manifest["files"]["surrogate_eval_corpus"] == {
+        "path": CLI.REVIEW_BUNDLE_ARTIFACT_NAME,
+        "present": False,
+    }
+    assert "input_json_unreadable" in rendered
+    assert "alice.baker@example.com" not in rendered
+    assert str(source) not in rendered
 
 
 def test_cli_review_bundle_removes_stale_artifact_on_invalid_rebuild(

--- a/tests/test_score_deflection_pii_recall.py
+++ b/tests/test_score_deflection_pii_recall.py
@@ -38,6 +38,11 @@ def _tiny_corpus() -> dict:
 
 def test_review_bundle_corpus_filename_matches_builder_bundle_artifact() -> None:
     assert CLI.REVIEW_BUNDLE_CORPUS_NAME == BUILD_CLI.REVIEW_BUNDLE_ARTIFACT_NAME
+    assert CLI.REVIEW_BUNDLE_MANIFEST_NAME == BUILD_CLI.REVIEW_BUNDLE_MANIFEST_NAME
+    assert (
+        CLI.REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION
+        == BUILD_CLI.REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION
+    )
 
 
 def test_review_bundle_mode_writes_score_artifacts_without_span_echo(
@@ -49,6 +54,29 @@ def test_review_bundle_mode_writes_score_artifacts_without_span_echo(
         TINY_FIXTURE.read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+    manifest_path = bundle_dir / CLI.REVIEW_BUNDLE_MANIFEST_NAME
+    manifest_path.write_text(
+        json.dumps({
+            "schema_version": CLI.REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION,
+            "status": "ok",
+            "files": {
+                "source_intake_summary": {
+                    "path": BUILD_CLI.REVIEW_BUNDLE_SUMMARY_NAME,
+                    "present": True,
+                    "ok": True,
+                    "schema_version": "deflection_pii_source_intake_summary.v1",
+                },
+                "surrogate_eval_corpus": {
+                    "path": CLI.REVIEW_BUNDLE_CORPUS_NAME,
+                    "present": True,
+                    "schema_version": "deflection_pii_eval_corpus.v1",
+                    "ticket_count": 3,
+                    "label_count": 11,
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
 
     assert CLI.main(["--review-bundle-dir", str(bundle_dir)]) == 0
 
@@ -56,13 +84,34 @@ def test_review_bundle_mode_writes_score_artifacts_without_span_echo(
     markdown_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_MARKDOWN_NAME
     summary = json.loads(score_path.read_text(encoding="utf-8"))
     markdown = markdown_path.read_text(encoding="utf-8")
-    rendered = json.dumps(summary, sort_keys=True) + markdown
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rendered = json.dumps(summary, sort_keys=True) + markdown + json.dumps(manifest, sort_keys=True)
 
     assert summary["status"] == "ok"
     assert summary["schema_version"] == "deflection_pii_recall_score.v1"
     assert summary["input"]["ticket_count"] == 3
+    assert manifest["schema_version"] == CLI.REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION
+    assert manifest["status"] == "ok"
+    assert manifest["score_status"] == "ok"
+    assert manifest["files"]["surrogate_eval_corpus"]["path"] == CLI.REVIEW_BUNDLE_CORPUS_NAME
+    assert manifest["files"]["recall_score"] == {
+        "blocking_error_codes": [],
+        "headline": {
+            "deferred_open_set_name_leak_count": 1,
+            "free_high_severity_gate_eligible_leak_count": 0,
+            "free_high_severity_leak_count": 1,
+        },
+        "path": CLI.REVIEW_BUNDLE_SCORE_NAME,
+        "present": True,
+        "schema_version": CLI.SCORE_SCHEMA_VERSION,
+        "status": "ok",
+    }
+    assert manifest["files"]["recall_score_markdown"] == {
+        "path": CLI.REVIEW_BUNDLE_SCORE_MARKDOWN_NAME,
+        "present": True,
+    }
     assert "# Deflection PII Recall Advisory" in markdown
-    assert "deflection-pii-surrogate-eval-corpus.json" not in rendered
+    assert str(bundle_dir) not in rendered
     for raw in (
         "Maya Chen",
         "Jordan Lee",
@@ -112,15 +161,127 @@ def test_review_bundle_mode_missing_corpus_writes_sanitized_error(
     captured = capsys.readouterr()
     score_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_NAME
     markdown_path = bundle_dir / CLI.REVIEW_BUNDLE_SCORE_MARKDOWN_NAME
+    manifest_path = bundle_dir / CLI.REVIEW_BUNDLE_MANIFEST_NAME
     summary = json.loads(score_path.read_text(encoding="utf-8"))
     markdown = markdown_path.read_text(encoding="utf-8")
-    rendered = json.dumps(summary, sort_keys=True) + markdown + captured.err
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rendered = json.dumps(summary, sort_keys=True) + markdown + json.dumps(manifest, sort_keys=True) + captured.err
 
     assert summary["status"] == "failed"
     assert summary["blocking_error_codes"] == ["corpus_load_failed"]
+    assert manifest["status"] == "unknown"
+    assert manifest["score_status"] == "failed"
+    assert manifest["files"]["recall_score"]["blocking_error_codes"] == ["corpus_load_failed"]
+    assert manifest["files"]["recall_score_markdown"] == {
+        "path": CLI.REVIEW_BUNDLE_SCORE_MARKDOWN_NAME,
+        "present": True,
+    }
     assert "corpus_load_failed" in markdown
     assert str(bundle_dir) not in rendered
-    assert "deflection-pii-surrogate-eval-corpus.json" not in rendered
+    assert CLI.REVIEW_BUNDLE_CORPUS_NAME not in rendered
+
+
+def test_review_bundle_mode_preserves_blocked_build_errors_on_score_failure(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    manifest_path = bundle_dir / CLI.REVIEW_BUNDLE_MANIFEST_NAME
+    manifest_path.write_text(
+        json.dumps({
+            "schema_version": CLI.REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION,
+            "status": "blocked",
+            "blocking_error_codes": [
+                "label_span_not_found",
+                "alice.baker@example.com",
+            ],
+            "files": {
+                "source_intake_summary": {
+                    "path": BUILD_CLI.REVIEW_BUNDLE_SUMMARY_NAME,
+                    "present": True,
+                    "ok": False,
+                    "schema_version": "deflection_pii_source_intake_summary.v1",
+                },
+                "source_intake_markdown": {
+                    "path": BUILD_CLI.REVIEW_BUNDLE_MARKDOWN_NAME,
+                    "present": True,
+                },
+                "surrogate_eval_corpus": {
+                    "path": CLI.REVIEW_BUNDLE_CORPUS_NAME,
+                    "present": False,
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    assert CLI.main(["--review-bundle-dir", str(bundle_dir)]) == 1
+
+    captured = capsys.readouterr()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rendered = json.dumps(manifest, sort_keys=True) + captured.err
+
+    assert manifest["status"] == "blocked"
+    assert manifest["blocking_error_codes"] == ["label_span_not_found"]
+    assert manifest["files"]["surrogate_eval_corpus"] == {
+        "path": CLI.REVIEW_BUNDLE_CORPUS_NAME,
+        "present": False,
+    }
+    assert manifest["files"]["recall_score"]["blocking_error_codes"] == ["corpus_load_failed"]
+    assert "label_span_not_found" in rendered
+    assert "corpus_load_failed" in rendered
+    assert "alice.baker@example.com" not in rendered
+
+
+def test_review_bundle_mode_clears_stale_corpus_inventory_on_load_failure(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    manifest_path = bundle_dir / CLI.REVIEW_BUNDLE_MANIFEST_NAME
+    manifest_path.write_text(
+        json.dumps({
+            "schema_version": CLI.REVIEW_BUNDLE_MANIFEST_SCHEMA_VERSION,
+            "status": "ok",
+            "blocking_error_codes": [],
+            "files": {
+                "source_intake_summary": {
+                    "path": BUILD_CLI.REVIEW_BUNDLE_SUMMARY_NAME,
+                    "present": True,
+                    "ok": True,
+                    "schema_version": "deflection_pii_source_intake_summary.v1",
+                },
+                "surrogate_eval_corpus": {
+                    "path": CLI.REVIEW_BUNDLE_CORPUS_NAME,
+                    "present": True,
+                    "schema_version": "deflection_pii_eval_corpus.v1",
+                    "ticket_count": 3,
+                    "label_count": 11,
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    assert CLI.main(["--review-bundle-dir", str(bundle_dir)]) == 1
+
+    captured = capsys.readouterr()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rendered = json.dumps(manifest, sort_keys=True) + captured.err
+    corpus_entry = manifest["files"]["surrogate_eval_corpus"]
+
+    assert manifest["status"] == "blocked"
+    assert manifest["score_status"] == "failed"
+    assert corpus_entry == {
+        "path": CLI.REVIEW_BUNDLE_CORPUS_NAME,
+        "present": False,
+    }
+    assert manifest["files"]["recall_score"]["blocking_error_codes"] == ["corpus_load_failed"]
+    assert "ticket_count" not in corpus_entry
+    assert "label_count" not in corpus_entry
+    assert "corpus_load_failed" in rendered
 
 
 def test_review_bundle_mode_non_utf8_corpus_writes_sanitized_error(


### PR DESCRIPTION
Plan: plans/PR-Deflection-PII-Review-Bundle-Manifest.md
Slice phase: Vertical slice

#1742 now has a sanitized review-bundle builder and in-place recall scorer, but the bundle still lacked one machine-readable manifest tying fixed filenames, schema versions, counts, and score status together. This PR adds that sanitized manifest so a future real-source run can be reviewed and versioned without relying on convention.

## Intentional
- No source selection, real-source run, threshold recommendation, advisory-to-gating flip, scrubber change, scorer math change, or NER/open-set-name work.
- No timestamps or hashes in this first manifest; stable filenames, schemas, statuses, and counts are enough for the review-bundle contract.
- Review fixes keep blocked/unreadable/stale bundle states self-describing without widening into source selection or score policy.

## Deferred
- Operator source selection, corpus size/archetype mix, labeling ownership, labeling-quality review, real-source bundle run, surrogate artifact versioning, threshold selection, and gate promotion remain follow-ups.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py tests/test_score_deflection_pii_recall.py -q -- 62 passed.
- python -m py_compile scripts/build_deflection_pii_surrogate_eval_corpus.py scripts/score_deflection_pii_recall.py tests/test_content_ops_deflection_pii_surrogate_eval_corpus.py tests/test_score_deflection_pii_recall.py -- passed.
- python scripts/score_deflection_pii_recall.py --json -- status ok; free_high_severity_gate_eligible_leak_count=0, deferred_open_set_name_leak_count=1.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 188 matching tests are enrolled.
- bash scripts/check_ascii_python.sh -- passed.
- git diff --check -- passed.
- python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
- python scripts/maturity_sweep_file_lane.py scripts/build_deflection_pii_surrogate_eval_corpus.py scripts/score_deflection_pii_recall.py --tests-root tests --baseline tests/maturity_sweep/baseline_deflection_lane.json --min-score 8 --sensitive-glob 'scripts/**' -- ratchet gate passed.
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-deflection-pii-review-bundle-manifest.md -- passed.

## Diff size
5 files, +695 / -13
