### PR TITLE
Add deflection delta read surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ atlas_brain/
 | Calendar                | 8059 | 8     | `atlas_brain.mcp.calendar_server`     |
 | Invoicing               | 8060 | 18    | `atlas_brain.mcp.invoicing_server`    |
 | Invoicing Readonly      | 8065 | 8     | `atlas_brain.mcp.invoicing_readonly_server` |
-| Content Ops Deflection Readonly | 8067 | 2 | `atlas_brain.mcp.content_ops_deflection_readonly_server` |
+| Content Ops Deflection Readonly | 8067 | 3 | `atlas_brain.mcp.content_ops_deflection_readonly_server` |
 | Content Ops Marketer Verify | 8068 | 1 | `atlas_brain.mcp.content_ops_marketer_verify_server` |
 | Intelligence            | 8061 | 33    | `atlas_brain.mcp.intelligence_server` |
 | B2B Churn Intelligence  | 8062 | 83    | `atlas_brain.mcp.b2b_churn_server` (split across 17 modules in `mcp/b2b/`) |
@@ -609,7 +609,7 @@ startup instead of shell-sourcing `.env` manually. The launcher loads `.env` and
 token length, starts the read-only server in the foreground, and prints the
 discovery/e2e smoke commands. It masks bearer and approval tokens in output.
 
-### Content Ops Deflection Readonly MCP Server (2 tools)
+### Content Ops Deflection Readonly MCP Server (3 tools)
 ```bash
 # stdio mode
 python -m atlas_brain.mcp.content_ops_deflection_readonly_server
@@ -618,11 +618,12 @@ python -m atlas_brain.mcp.content_ops_deflection_readonly_server
 ATLAS_MCP_AUTH_TOKEN=<token> python -m atlas_brain.mcp.content_ops_deflection_readonly_server --sse
 ```
 
-Tools: `search`, `fetch`
+Tools: `search`, `fetch`, `fetch_delta`
 
 This local read-only surface returns unpaid-safe FAQ deflection report snapshots
-for one configured tenant binding. It deliberately omits generation, publishing,
-checkout, paid unlock mutation, full report markdown, answers, and evidence.
+and paid-gated persisted deltas for one configured tenant binding. It
+deliberately omits generation, publishing, checkout, paid unlock mutation, full
+report markdown, answers, and evidence.
 OAuth connector binding and public route smokes are deferred to the rollout
 slice.
 

--- a/atlas_brain/mcp/content_ops_deflection_readonly_server.py
+++ b/atlas_brain/mcp/content_ops_deflection_readonly_server.py
@@ -19,9 +19,12 @@ from urllib.parse import quote
 from mcp.server.fastmcp import FastMCP
 
 from extracted_content_pipeline.deflection_report_access import (
+    DeflectionDeltaReadError,
     DeflectionReportArtifactStore,
     DeflectionReportListRecord,
     PostgresDeflectionReportArtifactStore,
+    deflection_delta_read_payload,
+    fetch_paid_deflection_delta,
 )
 from extracted_content_pipeline.faq_deflection_report import (
     DEFAULT_DEFLECTION_SNAPSHOT_TOP_N,
@@ -210,6 +213,50 @@ async def fetch(id: str) -> dict[str, Any]:
     }
 
 
+@mcp.tool(structured_output=True)
+async def fetch_delta(id: str, baseline_id: str = "") -> dict[str, Any]:
+    """Fetch one paid persisted deflection delta by current report ID."""
+    account_id = await _resolve_account_id()
+    if account_id is None:
+        return _failure_payload(
+            "account_binding_required",
+            "A single Content Ops account binding is required before report deltas can be fetched.",
+        )
+
+    request_id = _clean(id)
+    if not request_id:
+        return _failure_payload(
+            "request_id_required",
+            "fetch_delta requires a current deflection report request ID.",
+        )
+
+    try:
+        record = await fetch_paid_deflection_delta(
+            _get_store(),
+            account_id=account_id,
+            current_request_id=request_id,
+            baseline_request_id=_clean(baseline_id) or None,
+        )
+    except DeflectionDeltaReadError as exc:
+        return _failure_payload(exc.code, exc.message)
+
+    payload = deflection_delta_read_payload(record)
+    return {
+        "id": record.current_request_id,
+        "title": (
+            "Deflection delta: "
+            f"{record.current_request_id} vs {record.baseline_request_id}"
+        ),
+        "text": _delta_document_text(payload),
+        "url": _report_url(record.current_request_id),
+        "metadata": {
+            "ok": True,
+            "found": True,
+            "delta_report": payload,
+        },
+    }
+
+
 def _streamable_http_app():
     """Build the authenticated streamable HTTP app for read-only tools."""
     from .auth import BearerAuthMiddleware
@@ -378,6 +425,26 @@ def _document_text(
         "- Full report is available after unlock." if paid else "- Full report remains locked.",
     ])
     return "\n".join(lines)
+
+
+def _delta_document_text(payload: Mapping[str, Any]) -> str:
+    delta = payload.get("delta") if isinstance(payload.get("delta"), Mapping) else {}
+    summary = delta.get("summary") if isinstance(delta.get("summary"), Mapping) else {}
+    current = _clean(payload.get("current_request_id"))
+    baseline = _clean(payload.get("baseline_request_id"))
+    return "\n".join(
+        [
+            f"Deflection delta: {current} vs {baseline}",
+            "",
+            "Summary",
+            f"- New repeats: {_int(summary.get('new_count'))}",
+            f"- Resolved repeats: {_int(summary.get('resolved_count'))}",
+            f"- Growing repeats: {_int(summary.get('growing_count'))}",
+            f"- Shrinking repeats: {_int(summary.get('shrinking_count'))}",
+            f"- Still unresolved repeats: {_int(summary.get('still_unresolved_count'))}",
+            f"- Support cost delta: {summary.get('support_cost_delta') or 0}",
+        ]
+    )
 
 
 def _question_texts(snapshot: Mapping[str, Any]) -> list[str]:

--- a/atlas_brain/mcp/content_ops_deflection_readonly_server.py
+++ b/atlas_brain/mcp/content_ops_deflection_readonly_server.py
@@ -1,9 +1,10 @@
 """
 Read-only Content Ops FAQ deflection MCP server.
 
-This server exposes only ChatGPT-compatible search/fetch tools for free
-deflection report snapshots. It never accepts an account ID as a tool argument;
-every tool resolves the tenant binding before touching storage.
+This server exposes ChatGPT-compatible search/fetch tools for free deflection
+report snapshots plus a paid-gated persisted-delta fetch tool. It never accepts
+an account ID as a tool argument; every tool resolves the tenant binding before
+touching storage.
 """
 
 from __future__ import annotations

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -958,8 +958,14 @@ def create_content_ops_control_surface_router(
             )
         except DeflectionDeltaReadError as exc:
             status = 403 if exc.code.endswith("_locked") else 404
-            if exc.code == "invalid_report_pair":
+            if exc.code in {
+                "account_id_required",
+                "current_request_id_required",
+                "invalid_report_pair",
+            }:
                 status = 400
+            if exc.code == "unsupported_delta_schema":
+                status = 409
             raise HTTPException(status_code=status, detail=exc.message) from exc
         return deflection_delta_read_payload(record)
 

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -58,7 +58,12 @@ from ..content_ops_input_provider import (
     merge_content_ops_input_package,
 )
 from ..content_ops_cache_policy import normalize_content_ops_cache_policy
-from ..deflection_report_access import DeflectionReportArtifactStore
+from ..deflection_report_access import (
+    DeflectionDeltaReadError,
+    DeflectionReportArtifactStore,
+    deflection_delta_read_payload,
+    fetch_paid_deflection_delta,
+)
 from ..control_surfaces import (
     OUTPUT_CATALOG,
     PRESETS,
@@ -933,6 +938,30 @@ def create_content_ops_control_surface_router(
                 detail="Deflection report model is not available.",
             )
         return model
+
+    @router.get(
+        "/deflection-reports/{request_id}/delta",
+        dependencies=public_deflection_dependencies,
+    )
+    async def deflection_report_delta(
+        request_id: str = PathParam(..., min_length=1, max_length=200),
+        baseline_request_id: str | None = Query(default=None, max_length=200),
+    ) -> dict[str, Any]:
+        store = await _resolve_deflection_report_store(deflection_report_store_provider)
+        scope = await _resolve_scope(scope_provider)
+        try:
+            record = await fetch_paid_deflection_delta(
+                store,
+                account_id=_required_scope_account_id(scope),
+                current_request_id=request_id,
+                baseline_request_id=baseline_request_id,
+            )
+        except DeflectionDeltaReadError as exc:
+            status = 403 if exc.code.endswith("_locked") else 404
+            if exc.code == "invalid_report_pair":
+                status = 400
+            raise HTTPException(status_code=status, detail=exc.message) from exc
+        return deflection_delta_read_payload(record)
 
     @router.post(
         "/deflection-reports/{request_id}/search",

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -164,6 +164,15 @@ class DeflectionReportArtifactStore(Protocol):
     ) -> DeflectionDeltaAccessRecord | None:
         """Return one persisted deflection delta for a report pair."""
 
+    async def get_paid_deflection_delta(
+        self,
+        *,
+        account_id: str,
+        current_request_id: str,
+        baseline_request_id: str,
+    ) -> DeflectionDeltaAccessRecord | None:
+        """Return one persisted delta only while both source reports are paid."""
+
 
 _DEFLECTION_DELTA_METADATA_FIELDS = (
     "schema_version",
@@ -475,6 +484,25 @@ class InMemoryDeflectionReportArtifactStore:
             updated_at=row.updated_at,
         )
 
+    async def get_paid_deflection_delta(
+        self,
+        *,
+        account_id: str,
+        current_request_id: str,
+        baseline_request_id: str,
+    ) -> DeflectionDeltaAccessRecord | None:
+        key = _delta_key(account_id, current_request_id, baseline_request_id)
+        resolved_account, resolved_current, resolved_baseline = key
+        current = self._rows.get((resolved_account, resolved_current))
+        baseline = self._rows.get((resolved_account, resolved_baseline))
+        if current is None or baseline is None or not current.paid or not baseline.paid:
+            return None
+        return await self.get_deflection_delta(
+            account_id=resolved_account,
+            current_request_id=resolved_current,
+            baseline_request_id=resolved_baseline,
+        )
+
 
 @dataclass(frozen=True)
 class PostgresDeflectionReportArtifactStore:
@@ -775,6 +803,42 @@ class PostgresDeflectionReportArtifactStore:
         )
         return _delta_record_from_row(row_to_dict(row)) if row is not None else None
 
+    async def get_paid_deflection_delta(
+        self,
+        *,
+        account_id: str,
+        current_request_id: str,
+        baseline_request_id: str,
+    ) -> DeflectionDeltaAccessRecord | None:
+        key = _delta_key(account_id, current_request_id, baseline_request_id)
+        resolved_account, resolved_current, resolved_baseline = key
+        row = await self.pool.fetchrow(
+            """
+            SELECT deltas.account_id,
+                   deltas.current_request_id,
+                   deltas.baseline_request_id,
+                   deltas.delta,
+                   deltas.created_at,
+                   deltas.updated_at
+            FROM content_ops_deflection_deltas deltas
+            JOIN content_ops_deflection_reports current_report
+              ON current_report.account_id = deltas.account_id
+             AND current_report.request_id = deltas.current_request_id
+             AND current_report.paid = true
+            JOIN content_ops_deflection_reports baseline_report
+              ON baseline_report.account_id = deltas.account_id
+             AND baseline_report.request_id = deltas.baseline_request_id
+             AND baseline_report.paid = true
+            WHERE deltas.account_id = $1
+              AND deltas.current_request_id = $2
+              AND deltas.baseline_request_id = $3
+            """,
+            resolved_account,
+            resolved_current,
+            resolved_baseline,
+        )
+        return _delta_record_from_row(row_to_dict(row)) if row is not None else None
+
 
 _STORED_ACTION_SECTION_LIMIT_DEFAULTS = {
     "priority_fix_queue": {
@@ -939,6 +1003,14 @@ def deflection_delta_read_payload(
     }
 
 
+def _require_supported_delta_schema(delta: Mapping[str, Any]) -> None:
+    if _clean(delta.get("schema_version")) != "deflection_delta.v1":
+        raise DeflectionDeltaReadError(
+            "unsupported_delta_schema",
+            "Persisted deflection delta uses an unsupported schema.",
+        )
+
+
 def _bounded_limit(value: Any) -> int:
     try:
         parsed = int(value)
@@ -1044,8 +1116,7 @@ def _timestamp(value: Any) -> str | None:
 
 
 def _allowlisted_deflection_delta(delta: Mapping[str, Any]) -> dict[str, Any]:
-    if _clean(delta.get("schema_version")) != "deflection_delta.v1":
-        return {"schema_version": _clean(delta.get("schema_version"))}
+    _require_supported_delta_schema(delta)
     return {
         "schema_version": "deflection_delta.v1",
         "current": _allowlisted_mapping(
@@ -1139,8 +1210,18 @@ async def fetch_paid_deflection_delta(
 ) -> DeflectionDeltaAccessRecord:
     """Fetch a stored delta only while both source reports remain paid."""
 
-    resolved_account = _required_text(account_id, "account_id")
-    resolved_current = _required_text(current_request_id, "current_request_id")
+    resolved_account = _clean(account_id)
+    if not resolved_account:
+        raise DeflectionDeltaReadError(
+            "account_id_required",
+            "Content Ops account ID is required.",
+        )
+    resolved_current = _clean(current_request_id)
+    if not resolved_current:
+        raise DeflectionDeltaReadError(
+            "current_request_id_required",
+            "Current deflection report request ID is required.",
+        )
     current = await store.get_artifact_record(
         account_id=resolved_account,
         request_id=resolved_current,
@@ -1188,7 +1269,7 @@ async def fetch_paid_deflection_delta(
                 "No paid baseline deflection report is available.",
             )
 
-    record = await store.get_deflection_delta(
+    record = await store.get_paid_deflection_delta(
         account_id=resolved_account,
         current_request_id=current.request_id,
         baseline_request_id=baseline.request_id,
@@ -1198,6 +1279,7 @@ async def fetch_paid_deflection_delta(
             "delta_not_found",
             "Persisted deflection delta was not found for this report pair.",
         )
+    _require_supported_delta_schema(record.delta)
     return record
 
 

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -60,6 +60,15 @@ class DeflectionDeltaAccessRecord:
     updated_at: Any = None
 
 
+class DeflectionDeltaReadError(ValueError):
+    """Raised when a persisted delta is unavailable to a paid read surface."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
 class DeflectionReportArtifactStore(Protocol):
     """Host-owned persistence for snapshots, full artifacts, and paid flags."""
 
@@ -154,6 +163,59 @@ class DeflectionReportArtifactStore(Protocol):
         baseline_request_id: str,
     ) -> DeflectionDeltaAccessRecord | None:
         """Return one persisted deflection delta for a report pair."""
+
+
+_DEFLECTION_DELTA_METADATA_FIELDS = (
+    "schema_version",
+    "title",
+    "source_date_start",
+    "source_date_end",
+    "source_window_days",
+)
+_DEFLECTION_DELTA_SUMMARY_FIELDS = (
+    "current_item_count",
+    "baseline_item_count",
+    "matched_item_count",
+    "support_cost_delta",
+    "new_count",
+    "resolved_count",
+    "resurfaced_count",
+    "growing_count",
+    "shrinking_count",
+    "still_unresolved_count",
+    "status_changed_count",
+    "cost_changed_count",
+    "csat_changed_count",
+    "low_confidence_identity_count",
+    "stable_count",
+)
+_DEFLECTION_DELTA_ITEM_FIELDS = (
+    "identity_key",
+    "repeat_key",
+    "cluster_id",
+    "identity_basis",
+    "identity_confidence",
+    "question",
+    "owner_lane",
+    "fix_type",
+    "current_status",
+    "baseline_status",
+    "current_ticket_count",
+    "baseline_ticket_count",
+    "ticket_count_delta",
+    "current_estimated_support_cost",
+    "baseline_estimated_support_cost",
+    "support_cost_delta",
+    "current_csat_signal",
+    "baseline_csat_signal",
+    "change_types",
+)
+_DEFLECTION_DELTA_CSAT_FIELDS = (
+    "status",
+    "csat_present_count",
+    "negative_csat_ticket_count",
+    "numeric_average",
+)
 
 
 class InMemoryDeflectionReportArtifactStore:
@@ -860,6 +922,23 @@ def _delta_record_from_row(row: Mapping[str, Any]) -> DeflectionDeltaAccessRecor
     )
 
 
+def deflection_delta_read_payload(
+    record: DeflectionDeltaAccessRecord,
+) -> dict[str, Any]:
+    """Return the allowlisted customer-facing payload for a persisted delta."""
+
+    return {
+        "schema_version": "deflection_delta_read.v1",
+        "current_request_id": record.current_request_id,
+        "baseline_request_id": record.baseline_request_id,
+        "delta": _allowlisted_deflection_delta(record.delta),
+        "metadata": {
+            "created_at": _timestamp(record.created_at),
+            "updated_at": _timestamp(record.updated_at),
+        },
+    }
+
+
 def _bounded_limit(value: Any) -> int:
     try:
         parsed = int(value)
@@ -956,6 +1035,63 @@ def _clean(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _timestamp(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _allowlisted_deflection_delta(delta: Mapping[str, Any]) -> dict[str, Any]:
+    if _clean(delta.get("schema_version")) != "deflection_delta.v1":
+        return {"schema_version": _clean(delta.get("schema_version"))}
+    return {
+        "schema_version": "deflection_delta.v1",
+        "current": _allowlisted_mapping(
+            delta.get("current"),
+            _DEFLECTION_DELTA_METADATA_FIELDS,
+        ),
+        "baseline": _allowlisted_mapping(
+            delta.get("baseline"),
+            _DEFLECTION_DELTA_METADATA_FIELDS,
+        ),
+        "summary": _allowlisted_mapping(
+            delta.get("summary"),
+            _DEFLECTION_DELTA_SUMMARY_FIELDS,
+        ),
+        "items": _allowlisted_delta_items(delta.get("items")),
+    }
+
+
+def _allowlisted_mapping(value: Any, fields: Sequence[str]) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {field: value.get(field) for field in fields if field in value}
+
+
+def _allowlisted_delta_items(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        projected = _allowlisted_mapping(item, _DEFLECTION_DELTA_ITEM_FIELDS)
+        if isinstance(projected.get("current_csat_signal"), Mapping):
+            projected["current_csat_signal"] = _allowlisted_mapping(
+                projected["current_csat_signal"],
+                _DEFLECTION_DELTA_CSAT_FIELDS,
+            )
+        if isinstance(projected.get("baseline_csat_signal"), Mapping):
+            projected["baseline_csat_signal"] = _allowlisted_mapping(
+                projected["baseline_csat_signal"],
+                _DEFLECTION_DELTA_CSAT_FIELDS,
+            )
+        out.append(projected)
+    return out
+
+
 async def compute_and_save_previous_deflection_delta(
     store: DeflectionReportArtifactStore,
     *,
@@ -994,13 +1130,87 @@ async def compute_and_save_previous_deflection_delta(
     )
 
 
+async def fetch_paid_deflection_delta(
+    store: DeflectionReportArtifactStore,
+    *,
+    account_id: str,
+    current_request_id: str,
+    baseline_request_id: str | None = None,
+) -> DeflectionDeltaAccessRecord:
+    """Fetch a stored delta only while both source reports remain paid."""
+
+    resolved_account = _required_text(account_id, "account_id")
+    resolved_current = _required_text(current_request_id, "current_request_id")
+    current = await store.get_artifact_record(
+        account_id=resolved_account,
+        request_id=resolved_current,
+    )
+    if current is None:
+        raise DeflectionDeltaReadError(
+            "current_report_not_found",
+            "Current deflection report was not found.",
+        )
+    if not current.paid:
+        raise DeflectionDeltaReadError(
+            "current_report_locked",
+            "Current deflection report is locked.",
+        )
+
+    requested_baseline = _clean(baseline_request_id)
+    if requested_baseline:
+        if requested_baseline == resolved_current:
+            raise DeflectionDeltaReadError(
+                "invalid_report_pair",
+                "Current and baseline deflection reports must differ.",
+            )
+        baseline = await store.get_artifact_record(
+            account_id=resolved_account,
+            request_id=requested_baseline,
+        )
+        if baseline is None:
+            raise DeflectionDeltaReadError(
+                "baseline_report_not_found",
+                "Baseline deflection report was not found.",
+            )
+        if not baseline.paid:
+            raise DeflectionDeltaReadError(
+                "baseline_report_locked",
+                "Baseline deflection report is locked.",
+            )
+    else:
+        baseline = await store.select_previous_paid_report(
+            account_id=resolved_account,
+            current_request_id=resolved_current,
+        )
+        if baseline is None:
+            raise DeflectionDeltaReadError(
+                "baseline_report_not_found",
+                "No paid baseline deflection report is available.",
+            )
+
+    record = await store.get_deflection_delta(
+        account_id=resolved_account,
+        current_request_id=current.request_id,
+        baseline_request_id=baseline.request_id,
+    )
+    if record is None:
+        raise DeflectionDeltaReadError(
+            "delta_not_found",
+            "Persisted deflection delta was not found for this report pair.",
+        )
+    return record
+
+
 __all__ = [
     "DeflectionDeltaAccessRecord",
+    "DeflectionDeltaReadError",
     "DeflectionReportAccessRecord",
     "DeflectionReportListRecord",
     "DeflectionReportArtifactStore",
     "InMemoryDeflectionReportArtifactStore",
     "PostgresDeflectionReportArtifactStore",
     "compute_and_save_previous_deflection_delta",
+    "deflection_delta_read_payload",
+    "fetch_paid_deflection_delta",
     "stored_deflection_report_model",
 ]

--- a/plans/PR-Deflection-Delta-Read-Surface.md
+++ b/plans/PR-Deflection-Delta-Read-Surface.md
@@ -1,0 +1,159 @@
+# PR-Deflection-Delta-Read-Surface
+
+## Why this slice exists
+
+#1316's next delta-report step is a paid-gated read surface for the persisted
+`deflection_delta.v1` artifact. #1771 added the pure comparator and #1795 added
+tenant-scoped persistence, but the stored delta is still only reachable from
+tests/internal store methods. A monthly subscription cannot use it until the
+existing report read surfaces can fetch it safely.
+
+Root cause: persisted deflection deltas exist behind the
+`DeflectionReportArtifactStore` boundary, but there is no shared paid/read
+constructor that gates source reports and returns a customer-facing delta
+payload. This PR fixes that root for read-only HTTP and MCP surfaces. Monthly
+automation, delivery email, and result-page rendering remain separate slices.
+
+Diff-size note: this exceeds the 400 LOC target because the smallest useful read
+surface needs the shared paid gate, HTTP route, MCP tool, allowlist projection,
+MCP inventory docs/fixtures, and source-report relock tests in one PR. Splitting
+the docs/tests from the tool would leave the new surface under-audited.
+
+## Scope (this PR)
+
+Ownership lane: issue-1316/deflection-delta-read-surface
+Slice phase: Vertical slice
+
+1. Add a shared access-layer helper for fetching a persisted delta by current
+   report and optional baseline report while requiring both source reports to
+   remain paid for the same tenant.
+2. Add a paid-gated HTTP read endpoint under the existing deflection report
+   control surface.
+3. Add a read-only MCP tool that returns the same allowlisted delta payload for
+   the bound tenant.
+4. Update MCP tool-count/docs fixtures because the read-only server grows from
+   two tools to three.
+5. Add focused tests for tenant scoping, unpaid/relocked source reports,
+   missing baselines/deltas, raw-artifact exclusion, and MCP no-account
+   fail-closed behavior.
+
+### Review Contract
+
+Acceptance criteria:
+- The read surface returns only a persisted `deflection_delta.v1` payload and
+  pair metadata; it does not compute deltas on demand and does not expose raw
+  report artifacts, markdown, evidence export rows, source IDs, or ticket text.
+- Both current and baseline reports must exist, belong to the resolved tenant,
+  and still be paid at read time; relocking/refunding either source report makes
+  the delta unavailable.
+- When no baseline is supplied, the read surface uses the existing
+  `select_previous_paid_report(...)` store boundary rather than guessing across
+  tenants or unpaid reports.
+- When a baseline is supplied, the read surface verifies that exact report pair
+  is still paid and tenant-scoped before reading the stored delta.
+- The MCP tool fails closed before touching storage when no tenant binding is
+  configured, and the server remains read-only with no generation/unlock
+  mutation tools.
+- MCP docs, audited tool counts, and fixtures are updated in the same PR as the
+  new tool.
+
+Affected surfaces:
+- `extracted_content_pipeline/deflection_report_access.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `atlas_brain/mcp/content_ops_deflection_readonly_server.py`
+- `tests/test_content_ops_deflection_delta_persistence.py`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_mcp_content_ops_deflection_readonly.py`
+- MCP docs/tool-count audit fixtures
+
+Risk areas:
+- Treating a previously persisted delta as paid forever after source reports are
+  relocked.
+- Returning raw stored report payloads through a buyer-facing read endpoint.
+- Diverging HTTP and MCP behavior by implementing separate payload rules.
+- Forgetting MCP tool inventory docs, which makes local review fail late.
+
+Reviewer rules triggered: R1, R2, R3, R4, R5, R8, R10, R13, R14.
+
+### Files touched
+
+- `CLAUDE.md`
+- `atlas_brain/mcp/content_ops_deflection_readonly_server.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `plans/PR-Deflection-Delta-Read-Surface.md`
+- `tests/test_audit_mcp_tool_names_match_docs.py`
+- `tests/test_content_ops_deflection_delta_persistence.py`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_mcp_content_ops_deflection_readonly.py`
+- `tests/test_pre_push_audit.py`
+
+## Mechanism
+
+The access helper resolves the current report through
+`DeflectionReportArtifactStore.get_artifact_record(...)` and requires `paid` to
+still be true. If the caller supplies `baseline_request_id`, the helper loads
+that exact baseline report through the same tenant-scoped store boundary and
+requires it to still be paid. If the caller omits a baseline, the helper uses
+`select_previous_paid_report(...)`, which already anchors selection to the paid
+current report's `created_at`.
+
+Only after both source reports pass that paid/tenant gate does the helper call
+`get_deflection_delta(...)` for the exact `(account_id, current_request_id,
+baseline_request_id)` pair. A small payload constructor then allowlists the
+pair IDs, timestamps, and known `deflection_delta.v1` top-level/item/CSAT fields.
+HTTP and MCP both call that shared path, so one contract controls both read
+surfaces.
+
+## Intentional
+
+- No on-demand compute from the read endpoint. If the delta was not generated
+  and stored by #1795's helper, the read surface returns unavailable instead of
+  silently doing work on a GET/MCP read path.
+- No free snapshot delta surface. Deltas compare paid full report models and
+  stay behind paid/source-report gates.
+- No delivery email, result-page UI, autonomous monthly job, calendar-window
+  baseline resolver, or explicit recompute endpoint in this slice.
+- The MCP tool is added to the existing read-only server instead of creating a
+  new MCP server because it shares the same tenant binding, auth mode, and
+  deflection report store boundary.
+
+## Deferred
+
+- #1316 monthly automation and delivery/upsell email.
+- Result-page rendering for paid delta reports.
+- Calendar/source-window baseline resolver and explicit recompute/override
+  workflow.
+- Multi-version recompute audit history for the same current/baseline pair.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused read-surface pytest -- 33 passed.
+- MCP tool-name docs audit -- passed.
+- MCP tool-count docs audit -- passed.
+- Python compile for touched Python files -- passed.
+- Extracted content pipeline validation -- passed.
+- Extracted reasoning-import guard -- clean.
+- Extracted standalone audit -- Atlas runtime import findings: 0.
+- ASCII Python policy check -- passed.
+- Full extracted pipeline bundle -- reasoning core 295 passed; extracted
+  content 4882 passed, 15 skipped, 1 existing torch warning.
+- Pending before push: local PR review.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `CLAUDE.md` | 11 |
+| `atlas_brain/mcp/content_ops_deflection_readonly_server.py` | 67 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 31 |
+| `extracted_content_pipeline/deflection_report_access.py` | 210 |
+| `plans/PR-Deflection-Delta-Read-Surface.md` | 159 |
+| `tests/test_audit_mcp_tool_names_match_docs.py` | 10 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 96 |
+| `tests/test_extracted_content_deflection_submit.py` | 118 |
+| `tests/test_mcp_content_ops_deflection_readonly.py` | 115 |
+| `tests/test_pre_push_audit.py` | 6 |
+| **Total** | **823** |

--- a/plans/PR-Deflection-Delta-Read-Surface.md
+++ b/plans/PR-Deflection-Delta-Read-Surface.md
@@ -15,9 +15,10 @@ payload. This PR fixes that root for read-only HTTP and MCP surfaces. Monthly
 automation, delivery email, and result-page rendering remain separate slices.
 
 Diff-size note: this exceeds the 400 LOC target because the smallest useful read
-surface needs the shared paid gate, HTTP route, MCP tool, allowlist projection,
-MCP inventory docs/fixtures, and source-report relock tests in one PR. Splitting
-the docs/tests from the tool would leave the new surface under-audited.
+surface needs the shared paid gate, atomic Postgres paid-pair read, HTTP route,
+MCP tool, allowlist projection, MCP inventory docs/fixtures, and source-report
+relock tests in one PR. Splitting the docs/tests from the tool would leave the
+new surface under-audited.
 
 ## Scope (this PR)
 
@@ -99,11 +100,13 @@ requires it to still be paid. If the caller omits a baseline, the helper uses
 current report's `created_at`.
 
 Only after both source reports pass that paid/tenant gate does the helper call
-`get_deflection_delta(...)` for the exact `(account_id, current_request_id,
-baseline_request_id)` pair. A small payload constructor then allowlists the
-pair IDs, timestamps, and known `deflection_delta.v1` top-level/item/CSAT fields.
-HTTP and MCP both call that shared path, so one contract controls both read
-surfaces.
+`get_paid_deflection_delta(...)` for the exact `(account_id,
+current_request_id, baseline_request_id)` pair. The Postgres implementation
+joins both source report rows with `paid = true` in the same query that returns
+the delta, so a relock/refund racing the read cannot return a stale paid delta.
+A small payload constructor then allowlists the pair IDs, timestamps, and known
+`deflection_delta.v1` top-level/item/CSAT fields. HTTP and MCP both call that
+shared path, so one contract controls both read surfaces.
 
 ## Intentional
 
@@ -131,6 +134,7 @@ Parked hardening: none.
 ## Verification
 
 - Focused read-surface pytest -- 33 passed.
+- Focused review-fix pytest -- 27 passed.
 - MCP tool-name docs audit -- passed.
 - MCP tool-count docs audit -- passed.
 - Python compile for touched Python files -- passed.
@@ -139,7 +143,7 @@ Parked hardening: none.
 - Extracted standalone audit -- Atlas runtime import findings: 0.
 - ASCII Python policy check -- passed.
 - Full extracted pipeline bundle -- reasoning core 295 passed; extracted
-  content 4882 passed, 15 skipped, 1 existing torch warning.
+  content 4885 passed, 15 skipped, 1 existing torch warning.
 - Pending before push: local PR review.
 
 ## Estimated diff size
@@ -147,13 +151,13 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `CLAUDE.md` | 11 |
-| `atlas_brain/mcp/content_ops_deflection_readonly_server.py` | 67 |
-| `extracted_content_pipeline/api/control_surfaces.py` | 31 |
-| `extracted_content_pipeline/deflection_report_access.py` | 210 |
-| `plans/PR-Deflection-Delta-Read-Surface.md` | 159 |
+| `atlas_brain/mcp/content_ops_deflection_readonly_server.py` | 74 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 37 |
+| `extracted_content_pipeline/deflection_report_access.py` | 292 |
+| `plans/PR-Deflection-Delta-Read-Surface.md` | 163 |
 | `tests/test_audit_mcp_tool_names_match_docs.py` | 10 |
-| `tests/test_content_ops_deflection_delta_persistence.py` | 96 |
-| `tests/test_extracted_content_deflection_submit.py` | 118 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 140 |
+| `tests/test_extracted_content_deflection_submit.py` | 173 |
 | `tests/test_mcp_content_ops_deflection_readonly.py` | 115 |
 | `tests/test_pre_push_audit.py` | 6 |
-| **Total** | **823** |
+| **Total** | **1021** |

--- a/tests/test_audit_mcp_tool_names_match_docs.py
+++ b/tests/test_audit_mcp_tool_names_match_docs.py
@@ -47,15 +47,19 @@ def test_known_server_header_lands_in_claims(auditor):
 
 def test_content_ops_deflection_readonly_header_is_known(auditor):
     text = textwrap.dedent("""\
-        ### Content Ops Deflection Readonly MCP Server (2 tools)
+        ### Content Ops Deflection Readonly MCP Server (3 tools)
 
-        Tools: `search`, `fetch`
+        Tools: `search`, `fetch`, `fetch_delta`
     """)
 
     claims, unknown = auditor.doc_claims(text)
 
     assert "Content Ops Deflection Readonly" in claims
-    assert claims["Content Ops Deflection Readonly"] == {"search", "fetch"}
+    assert claims["Content Ops Deflection Readonly"] == {
+        "search",
+        "fetch",
+        "fetch_delta",
+    }
     assert unknown == []
 
 

--- a/tests/test_content_ops_deflection_delta_persistence.py
+++ b/tests/test_content_ops_deflection_delta_persistence.py
@@ -4,9 +4,12 @@ from datetime import datetime, timezone
 import pytest
 
 from extracted_content_pipeline.deflection_report_access import (
+    DeflectionDeltaReadError,
     InMemoryDeflectionReportArtifactStore,
     PostgresDeflectionReportArtifactStore,
     compute_and_save_previous_deflection_delta,
+    deflection_delta_read_payload,
+    fetch_paid_deflection_delta,
 )
 
 
@@ -181,6 +184,99 @@ async def test_compute_and_save_previous_delta_persists_pair_payload() -> None:
     )
     assert stored is not None
     assert json.loads(json.dumps(stored.delta)) == stored.delta
+
+
+@pytest.mark.asyncio
+async def test_fetch_paid_delta_requires_paid_source_reports() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await _save(
+        store,
+        request_id="baseline",
+        model=_model(_row("repeat_1", ticket_count=2, cost=27.0)),
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        request_id="current",
+        model=_model(_row("repeat_1", ticket_count=5, cost=67.5)),
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    saved = await compute_and_save_previous_deflection_delta(
+        store,
+        account_id="acct-1",
+        current_request_id="current",
+    )
+    assert saved is not None
+
+    fetched = await fetch_paid_deflection_delta(
+        store,
+        account_id="acct-1",
+        current_request_id="current",
+    )
+    payload = deflection_delta_read_payload(fetched)
+    assert payload["schema_version"] == "deflection_delta_read.v1"
+    assert payload["current_request_id"] == "current"
+    assert payload["baseline_request_id"] == "baseline"
+    assert payload["delta"]["schema_version"] == "deflection_delta.v1"
+
+    assert await store.mark_unpaid(account_id="acct-1", request_id="baseline")
+    with pytest.raises(DeflectionDeltaReadError) as baseline_locked:
+        await fetch_paid_deflection_delta(
+            store,
+            account_id="acct-1",
+            current_request_id="current",
+            baseline_request_id="baseline",
+        )
+    assert baseline_locked.value.code == "baseline_report_locked"
+
+    assert await store.mark_paid(account_id="acct-1", request_id="baseline")
+    assert await store.mark_unpaid(account_id="acct-1", request_id="current")
+    with pytest.raises(DeflectionDeltaReadError) as current_locked:
+        await fetch_paid_deflection_delta(
+            store,
+            account_id="acct-1",
+            current_request_id="current",
+        )
+    assert current_locked.value.code == "current_report_locked"
+
+
+@pytest.mark.asyncio
+async def test_fetch_paid_delta_requires_stored_pair_for_bound_tenant() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await _save(
+        store,
+        request_id="baseline",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        request_id="current",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-2",
+        request_id="baseline",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(DeflectionDeltaReadError) as missing_delta:
+        await fetch_paid_deflection_delta(
+            store,
+            account_id="acct-1",
+            current_request_id="current",
+            baseline_request_id="baseline",
+        )
+    assert missing_delta.value.code == "delta_not_found"
+
+    with pytest.raises(DeflectionDeltaReadError) as missing_baseline:
+        await fetch_paid_deflection_delta(
+            store,
+            account_id="acct-1",
+            current_request_id="current",
+            baseline_request_id="other-tenant-baseline",
+        )
+    assert missing_baseline.value.code == "baseline_report_not_found"
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_ops_deflection_delta_persistence.py
+++ b/tests/test_content_ops_deflection_delta_persistence.py
@@ -280,6 +280,37 @@ async def test_fetch_paid_delta_requires_stored_pair_for_bound_tenant() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_paid_delta_rejects_unsupported_delta_schema() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await _save(
+        store,
+        request_id="baseline",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        request_id="current",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    await store.save_deflection_delta(
+        account_id="acct-1",
+        current_request_id="current",
+        baseline_request_id="baseline",
+        delta={"schema_version": "future_delta.v2", "items": [{"raw": "nope"}]},
+    )
+
+    with pytest.raises(DeflectionDeltaReadError) as exc:
+        await fetch_paid_deflection_delta(
+            store,
+            account_id="acct-1",
+            current_request_id="current",
+            baseline_request_id="baseline",
+        )
+
+    assert exc.value.code == "unsupported_delta_schema"
+
+
+@pytest.mark.asyncio
 async def test_compute_and_save_previous_delta_fails_closed_without_paid_models() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     await _save(
@@ -376,6 +407,11 @@ async def test_postgres_delta_methods_are_account_scoped_and_jsonb_encoded() -> 
         current_request_id="current",
         baseline_request_id="baseline",
     )
+    paid_stored = await store.get_paid_deflection_delta(
+        account_id="acct-1",
+        current_request_id="current",
+        baseline_request_id="baseline",
+    )
 
     assert selected is not None
     select_query, select_args = pool.fetchrow_calls[0]
@@ -391,3 +427,11 @@ async def test_postgres_delta_methods_are_account_scoped_and_jsonb_encoded() -> 
     assert json.loads(str(insert_args[3])) == {"schema_version": "deflection_delta.v1"}
     assert stored is not None
     assert stored.delta == {"schema_version": "deflection_delta.v1"}
+    assert paid_stored is not None
+    paid_query, paid_args = pool.fetchrow_calls[2]
+    assert paid_args == ("acct-1", "current", "baseline")
+    assert "FROM content_ops_deflection_deltas deltas" in paid_query
+    assert "JOIN content_ops_deflection_reports current_report" in paid_query
+    assert "JOIN content_ops_deflection_reports baseline_report" in paid_query
+    assert "current_report.paid = true" in paid_query
+    assert "baseline_report.paid = true" in paid_query

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -831,6 +831,124 @@ async def test_deflection_report_search_returns_full_paid_uploaded_item() -> Non
 
 
 @pytest.mark.asyncio
+async def test_deflection_report_delta_returns_paid_allowlisted_payload() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="baseline",
+        snapshot={"summary": {}},
+        artifact=_search_artifact(),
+    )
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="current",
+        snapshot={"summary": {}},
+        artifact=_search_artifact(),
+    )
+    assert await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="baseline",
+    )
+    assert await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="current",
+    )
+    await store.save_deflection_delta(
+        account_id="acct-portfolio-submit",
+        current_request_id="current",
+        baseline_request_id="baseline",
+        delta={
+            "schema_version": "deflection_delta.v1",
+            "raw_artifact": {"markdown": "# must not leak"},
+            "current": {"schema_version": "deflection.v1", "source_ids": ["ticket-1"]},
+            "baseline": {"schema_version": "deflection.v1"},
+            "summary": {"growing_count": 1, "support_cost_delta": 40.5},
+            "items": [
+                {
+                    "identity_key": "repeat_1",
+                    "question": "Question repeat_1",
+                    "source_ids": ["ticket-1"],
+                    "change_types": ["GROWING"],
+                }
+            ],
+        },
+    )
+    router = _router(store)
+
+    delta_route = _route(router, "/ops/deflection-reports/{request_id}/delta", "GET")
+    payload = await delta_route.endpoint(
+        request_id="current",
+        baseline_request_id=None,
+    )
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert payload["schema_version"] == "deflection_delta_read.v1"
+    assert payload["current_request_id"] == "current"
+    assert payload["baseline_request_id"] == "baseline"
+    assert payload["delta"]["summary"] == {
+        "support_cost_delta": 40.5,
+        "growing_count": 1,
+    }
+    assert payload["delta"]["items"] == [
+        {
+            "identity_key": "repeat_1",
+            "question": "Question repeat_1",
+            "change_types": ["GROWING"],
+        }
+    ]
+    assert "raw_artifact" not in encoded
+    assert "markdown" not in encoded
+    assert "source_ids" not in encoded
+    assert "ticket-1" not in encoded
+
+
+@pytest.mark.asyncio
+async def test_deflection_report_delta_blocks_after_source_report_relock() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="baseline",
+        snapshot={"summary": {}},
+        artifact=_search_artifact(),
+    )
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="current",
+        snapshot={"summary": {}},
+        artifact=_search_artifact(),
+    )
+    assert await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="baseline",
+    )
+    assert await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="current",
+    )
+    await store.save_deflection_delta(
+        account_id="acct-portfolio-submit",
+        current_request_id="current",
+        baseline_request_id="baseline",
+        delta={"schema_version": "deflection_delta.v1"},
+    )
+    assert await store.mark_unpaid(
+        account_id="acct-portfolio-submit",
+        request_id="current",
+    )
+    router = _router(store)
+
+    delta_route = _route(router, "/ops/deflection-reports/{request_id}/delta", "GET")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await delta_route.endpoint(
+            request_id="current",
+            baseline_request_id="baseline",
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Current deflection report is locked."
+
+
+@pytest.mark.asyncio
 async def test_deflection_report_search_keeps_scope_and_paid_gate() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     await store.save_report(

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -949,6 +949,61 @@ async def test_deflection_report_delta_blocks_after_source_report_relock() -> No
 
 
 @pytest.mark.asyncio
+async def test_deflection_report_delta_rejects_blank_request_id() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    router = _router(store)
+
+    delta_route = _route(router, "/ops/deflection-reports/{request_id}/delta", "GET")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await delta_route.endpoint(request_id="  ", baseline_request_id=None)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Current deflection report request ID is required."
+
+
+@pytest.mark.asyncio
+async def test_deflection_report_delta_rejects_unsupported_delta_schema() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="baseline",
+        snapshot={"summary": {}},
+        artifact=_search_artifact(),
+    )
+    await store.save_report(
+        account_id="acct-portfolio-submit",
+        request_id="current",
+        snapshot={"summary": {}},
+        artifact=_search_artifact(),
+    )
+    assert await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="baseline",
+    )
+    assert await store.mark_paid(
+        account_id="acct-portfolio-submit",
+        request_id="current",
+    )
+    await store.save_deflection_delta(
+        account_id="acct-portfolio-submit",
+        current_request_id="current",
+        baseline_request_id="baseline",
+        delta={"schema_version": "future_delta.v2"},
+    )
+    router = _router(store)
+
+    delta_route = _route(router, "/ops/deflection-reports/{request_id}/delta", "GET")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await delta_route.endpoint(
+            request_id="current",
+            baseline_request_id="baseline",
+        )
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "Persisted deflection delta uses an unsupported schema."
+
+
+@pytest.mark.asyncio
 async def test_deflection_report_search_keeps_scope_and_paid_gate() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     await store.save_report(

--- a/tests/test_mcp_content_ops_deflection_readonly.py
+++ b/tests/test_mcp_content_ops_deflection_readonly.py
@@ -13,7 +13,7 @@ from extracted_content_pipeline.deflection_report_access import (
 )
 
 
-READONLY_TOOLS = {"search", "fetch"}
+READONLY_TOOLS = {"search", "fetch", "fetch_delta"}
 MUTATING_TOOLS = {
     "generate",
     "generate_blog_post",
@@ -54,6 +54,50 @@ def _snapshot(question: str, *, generated: int = 1) -> dict[str, Any]:
                 "evidence_quotes": ["ticket-1 says export is blocked"],
             }
         ],
+    }
+
+
+def _row(key: str, ticket_count: int = 2, cost: float = 27.0) -> dict[str, Any]:
+    return {
+        "repeat_key": key,
+        "cluster_id": key,
+        "identity_basis": "question_topic",
+        "identity_confidence": "high",
+        "question": f"Question {key}",
+        "status": "Needs answer",
+        "owner_lane": "help_center",
+        "fix_type": "create_missing_answer",
+        "ticket_count": ticket_count,
+        "estimated_support_cost": cost,
+        "csat_signal": {
+            "status": "insufficient_data",
+            "csat_present_count": 0,
+            "negative_csat_ticket_count": 0,
+            "numeric_average": None,
+        },
+    }
+
+
+def _model(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": "deflection.v1",
+        "title": "Support Ticket Deflection Report",
+        "summary": {"source_window_days": 31},
+        "sections": [
+            {
+                "id": "backlog_table",
+                "title": "Backlog",
+                "data": {"items": [row]},
+            }
+        ],
+    }
+
+
+def _artifact(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "markdown": "# Raw paid report",
+        "evidence_export": {"evidence_rows": [{"source_id": "ticket-1"}]},
+        "report_model": _model(row),
     }
 
 
@@ -100,6 +144,27 @@ async def test_fetch_fails_closed_without_account_binding(
     )
 
     payload = await readonly.fetch(id="request-1")
+
+    assert payload["metadata"]["ok"] is False
+    assert payload["metadata"]["error"] == "account_binding_required"
+
+
+@pytest.mark.asyncio
+async def test_fetch_delta_fails_closed_without_account_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingStore:
+        async def get_artifact_record(self, **kwargs: Any) -> object:
+            raise AssertionError("store must not be called without account binding")
+
+    monkeypatch.setattr(readonly, "_store_override", _FailingStore())
+    monkeypatch.setattr(
+        readonly,
+        "_account_resolver_override",
+        readonly.StaticContentOpsDeflectionAccountResolver(""),
+    )
+
+    payload = await readonly.fetch_delta(id="current")
 
     assert payload["metadata"]["ok"] is False
     assert payload["metadata"]["error"] == "account_binding_required"
@@ -250,6 +315,54 @@ async def test_fetch_uses_bound_account_and_excludes_paid_artifact_fields(
     assert "faq_result" not in encoded
     assert "source_ids" not in encoded
     assert "evidence_quotes" not in encoded
+
+
+@pytest.mark.asyncio
+async def test_fetch_delta_returns_paid_allowlisted_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-1",
+        request_id="baseline",
+        snapshot=_snapshot("Baseline"),
+        artifact=_artifact(_row("repeat_1", ticket_count=2, cost=27.0)),
+    )
+    await store.save_report(
+        account_id="acct-1",
+        request_id="current",
+        snapshot=_snapshot("Current"),
+        artifact=_artifact(_row("repeat_1", ticket_count=5, cost=67.5)),
+    )
+    assert await store.mark_paid(account_id="acct-1", request_id="baseline")
+    assert await store.mark_paid(account_id="acct-1", request_id="current")
+    await store.save_deflection_delta(
+        account_id="acct-1",
+        current_request_id="current",
+        baseline_request_id="baseline",
+        delta={
+            "schema_version": "deflection_delta.v1",
+            "summary": {"growing_count": 1, "support_cost_delta": 40.5},
+            "items": [{"identity_key": "repeat_1"}],
+        },
+    )
+    monkeypatch.setattr(readonly, "_store_override", store)
+    monkeypatch.setattr(
+        readonly,
+        "_account_resolver_override",
+        readonly.StaticContentOpsDeflectionAccountResolver("acct-1"),
+    )
+
+    payload = await readonly.fetch_delta(id="current")
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert payload["metadata"]["ok"] is True
+    assert payload["metadata"]["delta_report"]["current_request_id"] == "current"
+    assert payload["metadata"]["delta_report"]["baseline_request_id"] == "baseline"
+    assert "Growing repeats: 1" in payload["text"]
+    assert "markdown" not in encoded
+    assert "evidence_export" not in encoded
+    assert "ticket-1" not in encoded
 
 
 def test_content_ops_deflection_readonly_http_requires_bearer_token(

--- a/tests/test_pre_push_audit.py
+++ b/tests/test_pre_push_audit.py
@@ -173,7 +173,7 @@ python -m atlas_brain.mcp.invoicing_server --sse
 # SSE HTTP mode (port 8065)
 python -m atlas_brain.mcp.invoicing_readonly_server --sse
 {invoicing_readonly_tools}
-### Content Ops Deflection Readonly MCP Server (2 tools)
+### Content Ops Deflection Readonly MCP Server (3 tools)
 # SSE HTTP mode (port 8067)
 python -m atlas_brain.mcp.content_ops_deflection_readonly_server --sse
 {content_ops_deflection_readonly_tools}
@@ -204,7 +204,7 @@ python -m atlas_brain.mcp.memory_server --sse
         calendar_tools=_tool_list(8),
         invoicing_tools=_tool_list(18),
         invoicing_readonly_tools=_tool_list(8),
-        content_ops_deflection_readonly_tools=_tool_list(2),
+        content_ops_deflection_readonly_tools=_tool_list(3),
         content_ops_marketer_verify_tools=_tool_list(1),
         intelligence_tools=_tool_list(33),
         b2b_tools=_tool_list(83),
@@ -246,7 +246,7 @@ def _write_mcp_servers(mcp_dir: Path) -> None:
         "calendar_server.py": 8,
         "invoicing_server.py": 18,
         "invoicing_readonly_server.py": 8,
-        "content_ops_deflection_readonly_server.py": 2,
+        "content_ops_deflection_readonly_server.py": 3,
         "content_ops_marketer_verify_server.py": 1,
         "intelligence_server.py": 33,
         "scraper_server.py": 5,


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delta-Read-Surface.md
Slice phase: Vertical slice

#1316 now has persisted `deflection_delta.v1` records from #1795, but no paid-gated read surface. This PR adds the shared paid read helper, an HTTP endpoint, and a read-only MCP tool that expose only the allowlisted persisted delta payload while requiring both source reports to remain paid for the resolved tenant, including an atomic Postgres paid-pair read.

## Intentional
- No on-demand compute from the read endpoint; missing persisted deltas stay unavailable.
- No free snapshot delta surface; deltas compare paid full report models.
- No delivery email, result-page UI, autonomous monthly job, calendar-window baseline resolver, or explicit recompute endpoint in this slice.
- The MCP tool is added to the existing read-only server because it shares the same tenant binding, auth mode, and store boundary.

## Deferred
- #1316 monthly automation and delivery/upsell email.
- Result-page rendering for paid delta reports.
- Calendar/source-window baseline resolver and explicit recompute/override workflow.
- Multi-version recompute audit history for the same current/baseline pair.

## Parked hardening
- None.

## AI reconciliation
- [chatgpt-codex-connector] Reject unsupported delta schemas: fixed by making `fetch_paid_deflection_delta(...)` reject non-`deflection_delta.v1` rows with `unsupported_delta_schema`, mapped to HTTP 409 and structured MCP failure.
- [chatgpt-codex-connector] Make paid delta reads atomic: fixed by adding `get_paid_deflection_delta(...)`; the Postgres implementation joins both source report rows with `paid = true` in the same query that returns the delta.
- [chatgpt-codex-connector] Return 4xx for blank delta IDs: fixed by converting blank current request IDs into a handled `current_request_id_required` read error mapped to HTTP 400.
- Human reviewer NIT: fixed the read-only MCP module docstring so it names the third paid-gated `fetch_delta` tool.

All findings fixed or waived: yes.

## Verification
- `python -m pytest tests/test_content_ops_deflection_delta_persistence.py tests/test_extracted_content_deflection_submit.py::test_deflection_report_delta_returns_paid_allowlisted_payload tests/test_extracted_content_deflection_submit.py::test_deflection_report_delta_blocks_after_source_report_relock tests/test_mcp_content_ops_deflection_readonly.py tests/test_audit_mcp_tool_names_match_docs.py tests/test_pre_push_audit.py -q` -- 33 passed.
- `python -m pytest tests/test_content_ops_deflection_delta_persistence.py tests/test_extracted_content_deflection_submit.py::test_deflection_report_delta_returns_paid_allowlisted_payload tests/test_extracted_content_deflection_submit.py::test_deflection_report_delta_blocks_after_source_report_relock tests/test_extracted_content_deflection_submit.py::test_deflection_report_delta_rejects_blank_request_id tests/test_extracted_content_deflection_submit.py::test_deflection_report_delta_rejects_unsupported_delta_schema tests/test_mcp_content_ops_deflection_readonly.py -q` -- 27 passed.
- `python scripts/audit_mcp_tool_names_match_docs.py` -- passed.
- `python scripts/audit_claude_md_claims.py` -- passed.
- `python -m py_compile extracted_content_pipeline/deflection_report_access.py extracted_content_pipeline/api/control_surfaces.py atlas_brain/mcp/content_ops_deflection_readonly_server.py` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- reasoning core 295 passed; extracted content 4885 passed, 15 skipped, 1 existing torch warning.

## Diff size
10 files, +1021 / -13.
