### PR TITLE
Add deflection delta monthly automation

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_report_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_report_checks.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_report_checks.yml"
       - "requirements.txt"
+      - "atlas_brain/autonomous/scheduler.py"
+      - "atlas_brain/autonomous/tasks/__init__.py"
+      - "atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py"
+      - "atlas_brain/config.py"
       - "atlas_brain/deflection_pdf_renderer.py"
       - "extracted_content_pipeline/**"
       - "extracted_content_pipeline/faq_deflection_report.py"
@@ -17,6 +21,7 @@ on:
       - "scripts/purge_content_ops_deflection_reports.py"
       - "scripts/run_deflection_full_report_qa_live_runner.py"
       - "tests/test_content_ops_deflection_report.py"
+      - "tests/test_deflection_delta_automation_task.py"
       - "tests/test_deflection_snapshot_report_drift.py"
       - "tests/test_extracted_content_ops_live_execute_harness.py"
       - "tests/test_extracted_ticket_faq_markdown.py"
@@ -28,6 +33,10 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_report_checks.yml"
       - "requirements.txt"
+      - "atlas_brain/autonomous/scheduler.py"
+      - "atlas_brain/autonomous/tasks/__init__.py"
+      - "atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py"
+      - "atlas_brain/config.py"
       - "atlas_brain/deflection_pdf_renderer.py"
       - "extracted_content_pipeline/**"
       - "extracted_content_pipeline/faq_deflection_report.py"
@@ -37,6 +46,7 @@ on:
       - "scripts/purge_content_ops_deflection_reports.py"
       - "scripts/run_deflection_full_report_qa_live_runner.py"
       - "tests/test_content_ops_deflection_report.py"
+      - "tests/test_deflection_delta_automation_task.py"
       - "tests/test_deflection_snapshot_report_drift.py"
       - "tests/test_extracted_content_ops_live_execute_harness.py"
       - "tests/test_extracted_ticket_faq_markdown.py"
@@ -80,6 +90,7 @@ jobs:
             tests/test_content_ops_deflection_report.py::test_retention_runner_resolves_database_url_from_non_argv_sources \
             tests/test_content_ops_deflection_report.py::test_retention_runner_preflights_output_before_opening_pool \
             tests/test_content_ops_deflection_report.py::test_retention_runner_output_failure_after_purge_falls_back_to_stdout \
+            tests/test_deflection_delta_automation_task.py \
             tests/test_deflection_snapshot_report_drift.py \
             tests/test_run_deflection_full_report_qa_live_runner.py \
             tests/test_smoke_content_ops_deflection_pdf_export_validators.py \

--- a/atlas_brain/autonomous/scheduler.py
+++ b/atlas_brain/autonomous/scheduler.py
@@ -755,6 +755,19 @@ class TaskScheduler:
             },
         },
         {
+            "name": "content_ops_deflection_delta_automation",
+            "description": "Generate persisted monthly deltas for paid Content Ops deflection reports",
+            "task_type": "builtin",
+            "schedule_type": "cron",
+            "cron_expression": None,  # resolved from settings.deflection_delta.cron_expression
+            "timeout_seconds": 300,
+            "enabled": False,  # opt-in via ATLAS_DEFLECTION_DELTA_ENABLED
+            "metadata": {
+                "builtin_handler": "content_ops_deflection_delta_automation",
+                "notify_tags": "chart_with_upwards_trend,content_ops,deflection",
+            },
+        },
+        {
             "name": "b2b_scrape_target_pruning",
             "description": "Disable low-yield scrape targets based on recent scrape outcomes",
             "task_type": "builtin",
@@ -989,12 +1002,14 @@ class TaskScheduler:
                     settings.b2b_campaign.content_ops_faq_macro_writeback_scheduled_enabled
                 ),
                 "content_ops_deflection_report_delivery": settings.deflection_delivery.enabled,
+                "content_ops_deflection_delta_automation": settings.deflection_delta.enabled,
             }
             _enabled_config_keys = {
                 "content_ops_faq_macro_writeback_scheduled_publish": (
                     "settings.b2b_campaign.content_ops_faq_macro_writeback_scheduled_enabled"
                 ),
                 "content_ops_deflection_report_delivery": "settings.deflection_delivery.enabled",
+                "content_ops_deflection_delta_automation": "settings.deflection_delta.enabled",
             }
 
             # Resolve configurable cron expressions at runtime
@@ -1004,6 +1019,7 @@ class TaskScheduler:
                 "amazon_seller_campaign_generation": settings.seller_campaign.schedule_cron,
                 "b2b_blog_post_generation": settings.b2b_churn.blog_post_cron,
                 "subcategory_intelligence": settings.subcategory_intelligence.schedule_cron,
+                "content_ops_deflection_delta_automation": settings.deflection_delta.cron_expression,
             }
 
             # Merge pipeline interval overrides from registry
@@ -1208,6 +1224,7 @@ class TaskScheduler:
                 "amazon_seller_campaign_generation": settings.seller_campaign.schedule_cron,
                 "b2b_blog_post_generation": settings.b2b_churn.blog_post_cron,
                 "subcategory_intelligence": settings.subcategory_intelligence.schedule_cron,
+                "content_ops_deflection_delta_automation": settings.deflection_delta.cron_expression,
             }
 
             # Merge pipeline cron overrides

--- a/atlas_brain/autonomous/tasks/__init__.py
+++ b/atlas_brain/autonomous/tasks/__init__.py
@@ -44,6 +44,7 @@ _BUILTIN_TASKS = [
     ("b2b_report_subscription_delivery", "run", "b2b_report_subscription_delivery"),
     ("b2b_watchlist_alert_delivery", "run", "b2b_watchlist_alert_delivery"),
     ("content_ops_deflection_report_delivery", "run", "content_ops_deflection_report_delivery"),
+    ("content_ops_deflection_delta_automation", "run", "content_ops_deflection_delta_automation"),
     ("consumer_weekly_digest", "run", "consumer_weekly_digest"),
     ("consumer_signal_alerts", "run", "consumer_signal_alerts"),
     ("trial_nurture", "run", "trial_nurture"),

--- a/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
+++ b/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
@@ -1,0 +1,74 @@
+"""Scheduled generation for paid Content Ops deflection report deltas."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from extracted_content_pipeline.deflection_report_access import (
+    PostgresDeflectionReportArtifactStore,
+    compute_and_save_recent_deflection_deltas,
+)
+
+from ...config import settings
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+
+logger = logging.getLogger("atlas.tasks.content_ops_deflection_delta_automation")
+
+
+def _task_metadata(task: ScheduledTask | Any) -> dict[str, Any]:
+    metadata = getattr(task, "metadata", None)
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _metadata_int(task: ScheduledTask | Any, key: str, default: int) -> int:
+    value = _task_metadata(task).get(key, default)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(parsed, 100))
+
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Generate persisted deltas for recent paid deflection reports."""
+
+    cfg = settings.deflection_delta
+    if not cfg.enabled:
+        return {"_skip_synthesis": "Deflection delta automation disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    try:
+        summary = await compute_and_save_recent_deflection_deltas(
+            PostgresDeflectionReportArtifactStore(pool=pool),
+            account_limit=_metadata_int(task, "account_limit", int(cfg.account_limit)),
+            reports_per_account=_metadata_int(
+                task,
+                "reports_per_account",
+                int(cfg.reports_per_account),
+            ),
+        )
+    except Exception as exc:
+        logger.exception("Deflection delta automation failed")
+        return {
+            "_skip_synthesis": "Deflection delta automation failed",
+            "error": str(exc)[:500],
+        }
+
+    payload = {
+        "accounts_scanned": summary.accounts_scanned,
+        "reports_scanned": summary.reports_scanned,
+        "deltas_saved": summary.deltas_saved,
+        "skipped_no_delta": summary.skipped_no_delta,
+        "failed": summary.failed,
+    }
+    if summary.reports_scanned == 0:
+        return {
+            "_skip_synthesis": "No paid deflection reports found for delta automation",
+            **payload,
+        }
+    return {"_skip_synthesis": "Deflection delta automation complete", **payload}

--- a/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
+++ b/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
@@ -52,12 +52,9 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 int(cfg.reports_per_account),
             ),
         )
-    except Exception as exc:
+    except Exception:
         logger.exception("Deflection delta automation failed")
-        return {
-            "_skip_synthesis": "Deflection delta automation failed",
-            "error": str(exc)[:500],
-        }
+        raise
 
     payload = {
         "accounts_scanned": summary.accounts_scanned,

--- a/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
+++ b/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
@@ -68,4 +68,8 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             "_skip_synthesis": "No paid deflection reports found for delta automation",
             **payload,
         }
+    if summary.failed >= summary.reports_scanned:
+        raise RuntimeError("Deflection delta automation failed for all scanned reports")
+    if summary.failed:
+        return {"_skip_synthesis": "Deflection delta automation degraded", **payload}
     return {"_skip_synthesis": "Deflection delta automation complete", **payload}

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4038,6 +4038,19 @@ class DeflectionDeliveryConfig(BaseSettings):
     resend_timeout_seconds: float = Field(default=30.0, ge=1.0, le=300.0, description="Timeout for Resend email send requests")
 
 
+class DeflectionDeltaConfig(BaseSettings):
+    """Paid Content Ops deflection delta automation configuration."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_DEFLECTION_DELTA_", env_file=ENV_FILES, extra="ignore"
+    )
+
+    enabled: bool = Field(default=False, description="Enable scheduled paid deflection delta generation")
+    cron_expression: str = Field(default="0 8 1 * *", description="Cron expression for monthly deflection delta generation")
+    account_limit: int = Field(default=100, ge=1, le=100, description="Maximum paid-report accounts scanned per run")
+    reports_per_account: int = Field(default=25, ge=1, le=100, description="Maximum recent paid reports scanned per account")
+
+
 class B2BWebhookConfig(BaseSettings):
     """B2B outbound webhook delivery configuration."""
 
@@ -5761,6 +5774,7 @@ class Settings(BaseSettings):
     b2b_watchlist_delivery: B2BWatchlistDeliveryConfig = Field(default_factory=B2BWatchlistDeliveryConfig)
     b2b_report_delivery: B2BReportDeliveryConfig = Field(default_factory=B2BReportDeliveryConfig)
     deflection_delivery: DeflectionDeliveryConfig = Field(default_factory=DeflectionDeliveryConfig)
+    deflection_delta: DeflectionDeltaConfig = Field(default_factory=DeflectionDeltaConfig)
     b2b_webhook: B2BWebhookConfig = Field(default_factory=B2BWebhookConfig)
     crm_event: CRMEventConfig = Field(default_factory=CRMEventConfig)
     b2b_scrape: B2BScrapeConfig = Field(default_factory=B2BScrapeConfig)

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -251,6 +251,7 @@ class InMemoryDeflectionReportArtifactStore:
     def __init__(self) -> None:
         self._rows: dict[tuple[str, str], DeflectionReportAccessRecord] = {}
         self._created_at_by_key: dict[tuple[str, str], datetime] = {}
+        self._paid_at_by_key: dict[tuple[str, str], datetime] = {}
         self._deltas: dict[
             tuple[str, str, str],
             DeflectionDeltaAccessRecord,
@@ -334,14 +335,15 @@ class InMemoryDeflectionReportArtifactStore:
             account_id, _request_id = key
             if not row.paid:
                 continue
-            created_at = self._created_at_by_key.get(key, fallback)
-            if created_at > newest_by_account.get(account_id, fallback):
-                newest_by_account[account_id] = created_at
-        ordered = sorted(
-            newest_by_account,
-            key=lambda account_id: newest_by_account[account_id],
-            reverse=True,
-        )
+            paid_activity_at = self._paid_at_by_key.get(
+                key,
+                self._created_at_by_key.get(key, fallback),
+            )
+            if paid_activity_at > newest_by_account.get(account_id, fallback):
+                newest_by_account[account_id] = paid_activity_at
+        ordered_items = sorted(newest_by_account.items(), key=lambda item: item[0])
+        ordered_items.sort(key=lambda item: item[1], reverse=True)
+        ordered = [account_id for account_id, _activity_at in ordered_items]
         if limit is None:
             return tuple(ordered)
         return tuple(ordered[:_bounded_limit(limit)])
@@ -385,6 +387,7 @@ class InMemoryDeflectionReportArtifactStore:
             payment_reference=_clean(payment_reference) or row.payment_reference,
             delivery_email=row.delivery_email,
         )
+        self._paid_at_by_key.setdefault(key, datetime.now(timezone.utc))
         return True
 
     async def count_reports_older_than(self, *, cutoff: datetime) -> int:
@@ -445,6 +448,7 @@ class InMemoryDeflectionReportArtifactStore:
             payment_reference=row.payment_reference,
             delivery_email=row.delivery_email,
         )
+        self._paid_at_by_key.pop(key, None)
         return True
 
     async def select_previous_paid_report(
@@ -650,7 +654,7 @@ class PostgresDeflectionReportArtifactStore:
             FROM content_ops_deflection_reports
             WHERE paid = true
             GROUP BY account_id
-            ORDER BY MAX(created_at) DESC, account_id ASC
+            ORDER BY MAX(COALESCE(paid_at, updated_at, created_at)) DESC, account_id ASC
             {limit_clause}
             """,
             *args,

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -60,6 +60,17 @@ class DeflectionDeltaAccessRecord:
     updated_at: Any = None
 
 
+@dataclass(frozen=True)
+class DeflectionDeltaBatchSummary:
+    """Result of a tenant-scoped batch delta generation run."""
+
+    accounts_scanned: int
+    reports_scanned: int
+    deltas_saved: int
+    skipped_no_delta: int
+    failed: int = 0
+
+
 class DeflectionDeltaReadError(ValueError):
     """Raised when a persisted delta is unavailable to a paid read surface."""
 
@@ -99,6 +110,13 @@ class DeflectionReportArtifactStore(Protocol):
         paid: bool | None = None,
     ) -> tuple[DeflectionReportListRecord, ...]:
         """List free report snapshots for one tenant, newest first."""
+
+    async def list_paid_report_accounts(
+        self,
+        *,
+        limit: int | None = 100,
+    ) -> tuple[str, ...]:
+        """List tenants with paid reports, newest paid activity first."""
 
     async def get_artifact_record(
         self,
@@ -304,6 +322,29 @@ class InMemoryDeflectionReportArtifactStore:
                 )
             )
         return tuple(out)
+
+    async def list_paid_report_accounts(
+        self,
+        *,
+        limit: int | None = 100,
+    ) -> tuple[str, ...]:
+        newest_by_account: dict[str, datetime] = {}
+        fallback = datetime.min.replace(tzinfo=timezone.utc)
+        for key, row in self._rows.items():
+            account_id, _request_id = key
+            if not row.paid:
+                continue
+            created_at = self._created_at_by_key.get(key, fallback)
+            if created_at > newest_by_account.get(account_id, fallback):
+                newest_by_account[account_id] = created_at
+        ordered = sorted(
+            newest_by_account,
+            key=lambda account_id: newest_by_account[account_id],
+            reverse=True,
+        )
+        if limit is None:
+            return tuple(ordered)
+        return tuple(ordered[:_bounded_limit(limit)])
 
     async def get_artifact_record(
         self,
@@ -592,6 +633,33 @@ class PostgresDeflectionReportArtifactStore:
             *args,
         )
         return tuple(_list_record_from_row(row_to_dict(row)) for row in rows)
+
+    async def list_paid_report_accounts(
+        self,
+        *,
+        limit: int | None = 100,
+    ) -> tuple[str, ...]:
+        args: list[Any] = []
+        limit_clause = ""
+        if limit is not None:
+            args.append(_bounded_limit(limit))
+            limit_clause = "LIMIT $1"
+        rows = await self.pool.fetch(
+            f"""
+            SELECT account_id
+            FROM content_ops_deflection_reports
+            WHERE paid = true
+            GROUP BY account_id
+            ORDER BY MAX(created_at) DESC, account_id ASC
+            {limit_clause}
+            """,
+            *args,
+        )
+        return tuple(
+            account_id
+            for row in rows
+            if (account_id := _clean(row_to_dict(row).get("account_id")))
+        )
 
     async def get_artifact_record(
         self,
@@ -1201,6 +1269,51 @@ async def compute_and_save_previous_deflection_delta(
     )
 
 
+async def compute_and_save_recent_deflection_deltas(
+    store: DeflectionReportArtifactStore,
+    *,
+    account_limit: int | None = 100,
+    reports_per_account: int | None = 25,
+) -> DeflectionDeltaBatchSummary:
+    """Persist previous-paid-report deltas for recent paid reports."""
+
+    accounts = await store.list_paid_report_accounts(limit=account_limit)
+    reports_scanned = 0
+    deltas_saved = 0
+    skipped_no_delta = 0
+    failed = 0
+
+    for account_id in accounts:
+        reports = await store.list_reports(
+            account_id=account_id,
+            limit=reports_per_account,
+            paid=True,
+        )
+        for report in reports:
+            reports_scanned += 1
+            try:
+                record = await compute_and_save_previous_deflection_delta(
+                    store,
+                    account_id=account_id,
+                    current_request_id=report.request_id,
+                )
+            except Exception:
+                failed += 1
+                continue
+            if record is None:
+                skipped_no_delta += 1
+                continue
+            deltas_saved += 1
+
+    return DeflectionDeltaBatchSummary(
+        accounts_scanned=len(accounts),
+        reports_scanned=reports_scanned,
+        deltas_saved=deltas_saved,
+        skipped_no_delta=skipped_no_delta,
+        failed=failed,
+    )
+
+
 async def fetch_paid_deflection_delta(
     store: DeflectionReportArtifactStore,
     *,
@@ -1285,6 +1398,7 @@ async def fetch_paid_deflection_delta(
 
 __all__ = [
     "DeflectionDeltaAccessRecord",
+    "DeflectionDeltaBatchSummary",
     "DeflectionDeltaReadError",
     "DeflectionReportAccessRecord",
     "DeflectionReportListRecord",
@@ -1292,6 +1406,7 @@ __all__ = [
     "InMemoryDeflectionReportArtifactStore",
     "PostgresDeflectionReportArtifactStore",
     "compute_and_save_previous_deflection_delta",
+    "compute_and_save_recent_deflection_deltas",
     "deflection_delta_read_payload",
     "fetch_paid_deflection_delta",
     "stored_deflection_report_model",

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -15,6 +16,9 @@ from .storage._jsonb_helpers import (
     parse_command_tag,
     row_to_dict,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -1302,6 +1306,12 @@ async def compute_and_save_recent_deflection_deltas(
                     current_request_id=report.request_id,
                 )
             except Exception:
+                logger.warning(
+                    "Deflection delta generation failed for account=%s report=%s",
+                    account_id,
+                    report.request_id,
+                    exc_info=True,
+                )
                 failed += 1
                 continue
             if record is None:

--- a/plans/PR-Deflection-Delta-Monthly-Automation.md
+++ b/plans/PR-Deflection-Delta-Monthly-Automation.md
@@ -33,6 +33,9 @@ Slice phase: Vertical slice
    the batch helper when `ATLAS_DEFLECTION_DELTA_*` config enables it.
 4. Prove registration, scheduler seed/config behavior, disabled/DB-not-ready
    task exits, tenant scoping, idempotent generation, and no-baseline skips.
+5. Review follow-up: let real batch exceptions fail the scheduled task, rank
+   paid account discovery by paid activity instead of report creation time, and
+   enroll the automation task tests in PR CI.
 
 ### Review Contract
 
@@ -65,6 +68,7 @@ Reviewer rules triggered: R1, R6, R8, R10, R11, R12, R14.
 - `atlas_brain/autonomous/tasks/__init__.py`
 - `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py`
 - `atlas_brain/config.py`
+- `.github/workflows/atlas_content_ops_deflection_report_checks.yml`
 - `extracted_content_pipeline/deflection_report_access.py`
 - `plans/PR-Deflection-Delta-Monthly-Automation.md`
 - `tests/test_content_ops_deflection_delta_persistence.py`
@@ -83,10 +87,17 @@ Reviewer rules triggered: R1, R6, R8, R10, R11, R12, R14.
 - Add `atlas_brain.autonomous.tasks.content_ops_deflection_delta_automation`.
   The task exits before touching DB when disabled, exits safely when the DB pool
   is not initialized, and otherwise constructs the Postgres store and delegates
-  to the batch helper.
+  to the batch helper. Real batch exceptions are logged and re-raised so the
+  scheduler records a failed run instead of a false success.
 - Seed and register `content_ops_deflection_delta_automation` as an opt-in
   monthly cron task, with cron/account/report limits resolved from typed
   `settings.deflection_delta`.
+- Order paid account discovery by paid activity (`paid_at` with updated/created
+  fallback) so newly unlocked older reports are eligible under the account
+  limit.
+- Enroll the automation task test in the content-ops deflection report workflow
+  because it imports atlas autonomous/storage modules and should not run in the
+  extracted pipeline's lighter dependency environment.
 
 ## Intentional
 
@@ -103,6 +114,9 @@ Reviewer rules triggered: R1, R6, R8, R10, R11, R12, R14.
 - Subscription-plan entitlement checks for which accounts should receive
   monthly deltas.
 - Live production cron enablement and operator runbook.
+- The D0 stable identity foundation called out in #1316 remains the gate before
+  any customer-facing delta delivery. This slice only keeps persisted pair
+  deltas warm through the existing access boundary.
 
 Parked hardening: none.
 
@@ -118,6 +132,9 @@ Parked hardening: none.
 - Pending before push: Plan sync check.
 - Pending before push: Atlas push wrapper with the PR body file
   which runs the local PR review bundle once.
+- Review follow-up verification is GitHub Actions only in this recovery
+  session because the current Codex workspace has no local repo checkout,
+  Python, `git`, or `gh`.
 
 ## Estimated diff size
 
@@ -127,8 +144,9 @@ Parked hardening: none.
 | `atlas_brain/autonomous/tasks/__init__.py` | 1 |
 | `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 74 |
 | `atlas_brain/config.py` | 14 |
+| `.github/workflows/atlas_content_ops_deflection_report_checks.yml` | 9 |
 | `extracted_content_pipeline/deflection_report_access.py` | 115 |
 | `plans/PR-Deflection-Delta-Monthly-Automation.md` | 134 |
 | `tests/test_content_ops_deflection_delta_persistence.py` | 85 |
 | `tests/test_deflection_delta_automation_task.py` | 201 |
-| **Total** | **641** |
+| **Total** | **650** |

--- a/plans/PR-Deflection-Delta-Monthly-Automation.md
+++ b/plans/PR-Deflection-Delta-Monthly-Automation.md
@@ -36,6 +36,8 @@ Slice phase: Vertical slice
 5. Review follow-up: let real batch exceptions fail the scheduled task, rank
    paid account discovery by paid activity instead of report creation time, and
    enroll the automation task tests in PR CI.
+6. Review follow-up: surface partial per-report failures as a degraded task
+   result and fail the task when every scanned report failed.
 
 ### Review Contract
 
@@ -88,7 +90,9 @@ Reviewer rules triggered: R1, R6, R8, R10, R11, R12, R14.
   The task exits before touching DB when disabled, exits safely when the DB pool
   is not initialized, and otherwise constructs the Postgres store and delegates
   to the batch helper. Real batch exceptions are logged and re-raised so the
-  scheduler records a failed run instead of a false success.
+  scheduler records a failed run instead of a false success. Per-report
+  exceptions are logged with account/request context; partial failures return a
+  degraded result, and all-report failures raise.
 - Seed and register `content_ops_deflection_delta_automation` as an opt-in
   monthly cron task, with cron/account/report limits resolved from typed
   `settings.deflection_delta`.
@@ -117,6 +121,9 @@ Reviewer rules triggered: R1, R6, R8, R10, R11, R12, R14.
 - The D0 stable identity foundation called out in #1316 remains the gate before
   any customer-facing delta delivery. This slice only keeps persisted pair
   deltas warm through the existing access boundary.
+- Before live cron enablement, add pagination or cap-saturation alerting for
+  `account_limit` and `reports_per_account` so monthly coverage cannot silently
+  skip least-recently-paid tenants or older reports.
 
 Parked hardening: none.
 
@@ -143,10 +150,10 @@ Parked hardening: none.
 | `atlas_brain/autonomous/scheduler.py` | 17 |
 | `atlas_brain/autonomous/tasks/__init__.py` | 1 |
 | `.github/workflows/atlas_content_ops_deflection_report_checks.yml` | 11 |
-| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 71 |
+| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 74 |
 | `atlas_brain/config.py` | 14 |
-| `extracted_content_pipeline/deflection_report_access.py` | 119 |
-| `plans/PR-Deflection-Delta-Monthly-Automation.md` | 152 |
-| `tests/test_content_ops_deflection_delta_persistence.py` | 122 |
-| `tests/test_deflection_delta_automation_task.py` | 216 |
-| **Total** | **723** |
+| `extracted_content_pipeline/deflection_report_access.py` | 127 |
+| `plans/PR-Deflection-Delta-Monthly-Automation.md` | 164 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 163 |
+| `tests/test_deflection_delta_automation_task.py` | 264 |
+| **Total** | **835** |

--- a/plans/PR-Deflection-Delta-Monthly-Automation.md
+++ b/plans/PR-Deflection-Delta-Monthly-Automation.md
@@ -142,11 +142,11 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/autonomous/scheduler.py` | 17 |
 | `atlas_brain/autonomous/tasks/__init__.py` | 1 |
-| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 74 |
+| `.github/workflows/atlas_content_ops_deflection_report_checks.yml` | 11 |
+| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 71 |
 | `atlas_brain/config.py` | 14 |
-| `.github/workflows/atlas_content_ops_deflection_report_checks.yml` | 9 |
-| `extracted_content_pipeline/deflection_report_access.py` | 115 |
-| `plans/PR-Deflection-Delta-Monthly-Automation.md` | 134 |
-| `tests/test_content_ops_deflection_delta_persistence.py` | 85 |
-| `tests/test_deflection_delta_automation_task.py` | 201 |
-| **Total** | **650** |
+| `extracted_content_pipeline/deflection_report_access.py` | 119 |
+| `plans/PR-Deflection-Delta-Monthly-Automation.md` | 152 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 122 |
+| `tests/test_deflection_delta_automation_task.py` | 216 |
+| **Total** | **723** |

--- a/plans/PR-Deflection-Delta-Monthly-Automation.md
+++ b/plans/PR-Deflection-Delta-Monthly-Automation.md
@@ -1,0 +1,134 @@
+# PR-Deflection-Delta-Monthly-Automation
+
+## Why this slice exists
+
+Issue #1316 has the paid report delta path split into small slices. #1795
+persisted report-pair deltas and #1796 exposed the paid read surface, but the
+system still has no scheduled entrypoint that keeps those deltas populated for
+new paid reports. That leaves Report Deltas dependent on a one-off caller
+remembering to run `compute_and_save_previous_deflection_delta`.
+
+Root cause: the delta persistence primitive is scoped to one current report,
+while the autonomous layer has no tenant-scoped batch worker that discovers
+paid report accounts/reports and invokes the primitive on a schedule. This PR
+fixes that root for generation only; customer-facing delivery/email copy stays
+deferred.
+
+Diff budget note: this is over the 400 LOC target because the slice crosses the
+store contract, Postgres implementation, scheduler seed, task registration,
+task handler, and focused tests that prove each boundary. Splitting the tests
+from the wiring would leave an unprotected monthly task seed.
+
+## Scope (this PR)
+
+Ownership lane: issue-1316/deflection-delta-monthly-automation
+Slice phase: Vertical slice
+
+1. Add tenant/account discovery for paid deflection reports to the report
+   artifact store contract and implementations.
+2. Add a deterministic batch helper that walks paid reports per account and
+   persists current-vs-previous deltas through the existing idempotent delta
+   save path.
+3. Register a disabled-by-default monthly autonomous builtin task that calls
+   the batch helper when `ATLAS_DEFLECTION_DELTA_*` config enables it.
+4. Prove registration, scheduler seed/config behavior, disabled/DB-not-ready
+   task exits, tenant scoping, idempotent generation, and no-baseline skips.
+
+### Review Contract
+
+Acceptance criteria:
+- The worker never scans reports cross-tenant; every report list and delta
+  compute call is scoped by one discovered `account_id`.
+- Existing paid/current report access rules remain the boundary: unpaid
+  reports, missing baselines, and missing models do not create deltas.
+- The autonomous task is disabled by default and uses typed settings, not raw
+  environment reads.
+- Re-running the worker is safe because it reuses the existing persisted-delta
+  upsert path.
+
+Affected surfaces:
+- `extracted_content_pipeline.deflection_report_access`
+- `atlas_brain.autonomous.scheduler`
+- `atlas_brain.autonomous.tasks`
+- `atlas_brain.config`
+
+Risk areas:
+- Store protocol drift between in-memory and Postgres implementations.
+- Accidentally enabling a monthly task in seeded installs.
+- Batch automation that silently ignores tenants or crosses tenant boundaries.
+
+Reviewer rules triggered: R1, R6, R8, R10, R11, R12, R14.
+
+### Files touched
+
+- `atlas_brain/autonomous/scheduler.py`
+- `atlas_brain/autonomous/tasks/__init__.py`
+- `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py`
+- `atlas_brain/config.py`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `plans/PR-Deflection-Delta-Monthly-Automation.md`
+- `tests/test_content_ops_deflection_delta_persistence.py`
+- `tests/test_deflection_delta_automation_task.py`
+
+## Mechanism
+
+- Extend the deflection report artifact store with a `list_paid_report_accounts`
+  method. In-memory derives distinct paid-account IDs from stored records;
+  Postgres reads distinct paid account IDs from `content_ops_deflection_reports`
+  with a deterministic limit.
+- Add `compute_and_save_recent_deflection_deltas`, which obtains paid accounts,
+  lists recent paid reports for each account, and calls
+  `compute_and_save_previous_deflection_delta` for each current report. It
+  returns a summary with account/report/delta/skip/error counts.
+- Add `atlas_brain.autonomous.tasks.content_ops_deflection_delta_automation`.
+  The task exits before touching DB when disabled, exits safely when the DB pool
+  is not initialized, and otherwise constructs the Postgres store and delegates
+  to the batch helper.
+- Seed and register `content_ops_deflection_delta_automation` as an opt-in
+  monthly cron task, with cron/account/report limits resolved from typed
+  `settings.deflection_delta`.
+
+## Intentional
+
+- No email delivery, customer-visible monthly digest copy, or subscription
+  billing change in this slice. This only keeps persisted deltas ready for the
+  later delivery/report-delta surfaces.
+- The batch worker recomputes/upserts recent deltas instead of trying to detect
+  a missing row first. That keeps the slice small and leans on the already
+  idempotent persistence path.
+
+## Deferred
+
+- Monthly Report Delta delivery email and customer-facing copy.
+- Subscription-plan entitlement checks for which accounts should receive
+  monthly deltas.
+- Live production cron enablement and operator runbook.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused delta pytest command for the persistence and automation task tests -- 17 passed, 1 torch CUDA warning.
+- Scheduler trigger pytest command plus the automation task tests -- 16 passed, 1 torch CUDA warning.
+- Python compile check for the changed delta access, automation task, scheduler, and config modules -- passed.
+- Extracted content pipeline validation script -- passed.
+- Extracted reasoning-import audit -- passed.
+- Extracted standalone-debt audit -- passed.
+- Extracted ASCII policy check -- passed.
+- Pending before push: Plan sync check.
+- Pending before push: Atlas push wrapper with the PR body file
+  which runs the local PR review bundle once.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/autonomous/scheduler.py` | 17 |
+| `atlas_brain/autonomous/tasks/__init__.py` | 1 |
+| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 74 |
+| `atlas_brain/config.py` | 14 |
+| `extracted_content_pipeline/deflection_report_access.py` | 115 |
+| `plans/PR-Deflection-Delta-Monthly-Automation.md` | 134 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 85 |
+| `tests/test_deflection_delta_automation_task.py` | 201 |
+| **Total** | **641** |

--- a/plans/PR-Deflection-Delta-Monthly-Automation.md
+++ b/plans/PR-Deflection-Delta-Monthly-Automation.md
@@ -147,13 +147,13 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
+| `.github/workflows/atlas_content_ops_deflection_report_checks.yml` | 11 |
 | `atlas_brain/autonomous/scheduler.py` | 17 |
 | `atlas_brain/autonomous/tasks/__init__.py` | 1 |
-| `.github/workflows/atlas_content_ops_deflection_report_checks.yml` | 11 |
-| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 74 |
+| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 75 |
 | `atlas_brain/config.py` | 14 |
-| `extracted_content_pipeline/deflection_report_access.py` | 127 |
-| `plans/PR-Deflection-Delta-Monthly-Automation.md` | 164 |
-| `tests/test_content_ops_deflection_delta_persistence.py` | 163 |
-| `tests/test_deflection_delta_automation_task.py` | 264 |
-| **Total** | **835** |
+| `extracted_content_pipeline/deflection_report_access.py` | 129 |
+| `plans/PR-Deflection-Delta-Monthly-Automation.md` | 159 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 166 |
+| `tests/test_deflection_delta_automation_task.py` | 270 |
+| **Total** | **842** |

--- a/tests/test_content_ops_deflection_delta_persistence.py
+++ b/tests/test_content_ops_deflection_delta_persistence.py
@@ -6,6 +6,7 @@ import pytest
 from extracted_content_pipeline.deflection_report_access import (
     DeflectionDeltaBatchSummary,
     DeflectionDeltaReadError,
+    DeflectionReportListRecord,
     InMemoryDeflectionReportArtifactStore,
     PostgresDeflectionReportArtifactStore,
     compute_and_save_previous_deflection_delta,
@@ -279,6 +280,49 @@ async def test_recent_delta_batch_discovers_paid_accounts_and_stays_tenant_scope
         current_request_id="acct-2-current",
         baseline_request_id="acct-1-current",
     ) is None
+
+
+@pytest.mark.asyncio
+async def test_recent_delta_batch_logs_per_report_failures(caplog) -> None:
+    class _FailingStore:
+        async def list_paid_report_accounts(self, *, limit: int | None = 100) -> tuple[str, ...]:
+            return ("acct-1",)
+
+        async def list_reports(
+            self,
+            *,
+            account_id: str,
+            limit: int | None = 25,
+            paid: bool | None = None,
+        ) -> tuple[DeflectionReportListRecord, ...]:
+            return (
+                DeflectionReportListRecord(
+                    account_id=account_id,
+                    request_id="broken-report",
+                    snapshot={},
+                    paid=True,
+                ),
+            )
+
+        async def get_artifact_record(self, *, account_id: str, request_id: str) -> None:
+            raise RuntimeError("delta source exploded")
+
+    caplog.set_level("WARNING", logger="extracted_content_pipeline.deflection_report_access")
+
+    summary = await compute_and_save_recent_deflection_deltas(
+        _FailingStore(),
+        account_limit=10,
+        reports_per_account=10,
+    )
+
+    assert summary == DeflectionDeltaBatchSummary(
+        accounts_scanned=1,
+        reports_scanned=1,
+        deltas_saved=0,
+        skipped_no_delta=0,
+        failed=1,
+    )
+    assert "account=acct-1 report=broken-report" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_ops_deflection_delta_persistence.py
+++ b/tests/test_content_ops_deflection_delta_persistence.py
@@ -4,10 +4,12 @@ from datetime import datetime, timezone
 import pytest
 
 from extracted_content_pipeline.deflection_report_access import (
+    DeflectionDeltaBatchSummary,
     DeflectionDeltaReadError,
     InMemoryDeflectionReportArtifactStore,
     PostgresDeflectionReportArtifactStore,
     compute_and_save_previous_deflection_delta,
+    compute_and_save_recent_deflection_deltas,
     deflection_delta_read_payload,
     fetch_paid_deflection_delta,
 )
@@ -184,6 +186,65 @@ async def test_compute_and_save_previous_delta_persists_pair_payload() -> None:
     )
     assert stored is not None
     assert json.loads(json.dumps(stored.delta)) == stored.delta
+
+
+@pytest.mark.asyncio
+async def test_recent_delta_batch_discovers_paid_accounts_and_stays_tenant_scoped() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await _save(
+        store,
+        account_id="acct-1",
+        request_id="acct-1-baseline",
+        model=_model(_row("repeat_1", ticket_count=2, cost=27.0)),
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-1",
+        request_id="acct-1-current",
+        model=_model(_row("repeat_1", ticket_count=5, cost=67.5)),
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-2",
+        request_id="acct-2-current",
+        model=_model(_row("repeat_2", ticket_count=4, cost=54.0)),
+        created_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-3",
+        request_id="acct-3-unpaid",
+        paid=False,
+        created_at=datetime(2026, 6, 3, tzinfo=timezone.utc),
+    )
+
+    accounts = await store.list_paid_report_accounts(limit=10)
+    summary = await compute_and_save_recent_deflection_deltas(
+        store,
+        account_limit=10,
+        reports_per_account=10,
+    )
+
+    assert accounts == ("acct-2", "acct-1")
+    assert summary == DeflectionDeltaBatchSummary(
+        accounts_scanned=2,
+        reports_scanned=3,
+        deltas_saved=1,
+        skipped_no_delta=2,
+        failed=0,
+    )
+    assert await store.get_deflection_delta(
+        account_id="acct-1",
+        current_request_id="acct-1-current",
+        baseline_request_id="acct-1-baseline",
+    )
+    assert await store.get_deflection_delta(
+        account_id="acct-2",
+        current_request_id="acct-2-current",
+        baseline_request_id="acct-1-current",
+    ) is None
 
 
 @pytest.mark.asyncio
@@ -435,3 +496,27 @@ async def test_postgres_delta_methods_are_account_scoped_and_jsonb_encoded() -> 
     assert "JOIN content_ops_deflection_reports baseline_report" in paid_query
     assert "current_report.paid = true" in paid_query
     assert "baseline_report.paid = true" in paid_query
+
+
+@pytest.mark.asyncio
+async def test_postgres_paid_account_discovery_is_paid_scoped_ordered_and_bounded() -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+
+        async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
+            self.fetch_calls.append((query, args))
+            return [{"account_id": "acct-2"}, {"account_id": "acct-1"}]
+
+    pool = _Pool()
+    store = PostgresDeflectionReportArtifactStore(pool=pool)
+
+    accounts = await store.list_paid_report_accounts(limit=7)
+
+    assert accounts == ("acct-2", "acct-1")
+    query, args = pool.fetch_calls[0]
+    assert args == (7,)
+    assert "WHERE paid = true" in query
+    assert "GROUP BY account_id" in query
+    assert "ORDER BY MAX(created_at) DESC, account_id ASC" in query
+    assert "LIMIT $1" in query

--- a/tests/test_content_ops_deflection_delta_persistence.py
+++ b/tests/test_content_ops_deflection_delta_persistence.py
@@ -82,6 +82,7 @@ async def _save(
     model: dict[str, object] | None = None,
     paid: bool = True,
     created_at: datetime,
+    paid_at: datetime | None = None,
 ) -> None:
     await store.save_report(
         account_id=account_id,
@@ -92,6 +93,8 @@ async def _save(
     store._created_at_by_key[(account_id, request_id)] = created_at
     if paid:
         assert await store.mark_paid(account_id=account_id, request_id=request_id)
+        if paid_at is not None:
+            store._paid_at_by_key[(account_id, request_id)] = paid_at
 
 
 @pytest.mark.asyncio
@@ -146,6 +149,37 @@ async def test_in_memory_select_previous_paid_report_is_scoped_paid_and_ordered(
         account_id="acct-1",
         current_request_id="current",
     ) is None
+
+
+@pytest.mark.asyncio
+async def test_in_memory_paid_account_discovery_orders_by_paid_activity() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await _save(
+        store,
+        account_id="acct-old-report-recent-pay",
+        request_id="old-report",
+        created_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 10, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-new-report-old-pay",
+        request_id="new-report",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 5, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-unpaid",
+        request_id="newer-unpaid",
+        paid=False,
+        created_at=datetime(2026, 6, 15, tzinfo=timezone.utc),
+    )
+
+    assert await store.list_paid_report_accounts(limit=10) == (
+        "acct-old-report-recent-pay",
+        "acct-new-report-old-pay",
+    )
 
 
 @pytest.mark.asyncio
@@ -518,5 +552,8 @@ async def test_postgres_paid_account_discovery_is_paid_scoped_ordered_and_bounde
     assert args == (7,)
     assert "WHERE paid = true" in query
     assert "GROUP BY account_id" in query
-    assert "ORDER BY MAX(created_at) DESC, account_id ASC" in query
+    assert (
+        "ORDER BY MAX(COALESCE(paid_at, updated_at, created_at)) DESC, account_id ASC"
+        in query
+    )
     assert "LIMIT $1" in query

--- a/tests/test_deflection_delta_automation_task.py
+++ b/tests/test_deflection_delta_automation_task.py
@@ -98,6 +98,21 @@ async def test_run_skips_when_db_not_ready(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_run_raises_when_batch_worker_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_delta_settings(monkeypatch)
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def _raise_batch_failure(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("delta table missing")
+
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", _raise_batch_failure)
+
+    with pytest.raises(RuntimeError, match="delta table missing"):
+        await mod.run(SimpleNamespace(metadata={}))
+
+
+@pytest.mark.asyncio
 async def test_run_delegates_to_batch_worker_with_typed_and_metadata_limits(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_deflection_delta_automation_task.py
+++ b/tests/test_deflection_delta_automation_task.py
@@ -163,6 +163,60 @@ async def test_run_delegates_to_batch_worker_with_typed_and_metadata_limits(
 
 
 @pytest.mark.asyncio
+async def test_run_reports_degraded_when_some_reports_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch)
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+        return DeflectionDeltaBatchSummary(
+            accounts_scanned=2,
+            reports_scanned=3,
+            deltas_saved=1,
+            skipped_no_delta=1,
+            failed=1,
+        )
+
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", _compute)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result == {
+        "_skip_synthesis": "Deflection delta automation degraded",
+        "accounts_scanned": 2,
+        "reports_scanned": 3,
+        "deltas_saved": 1,
+        "skipped_no_delta": 1,
+        "failed": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_raises_when_all_scanned_reports_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch)
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+        return DeflectionDeltaBatchSummary(
+            accounts_scanned=2,
+            reports_scanned=3,
+            deltas_saved=0,
+            skipped_no_delta=0,
+            failed=3,
+        )
+
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", _compute)
+
+    with pytest.raises(RuntimeError, match="failed for all scanned reports"):
+        await mod.run(SimpleNamespace(metadata={}))
+
+
+@pytest.mark.asyncio
 async def test_scheduler_seed_uses_typed_delta_cron_and_opt_in(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_deflection_delta_automation_task.py
+++ b/tests/test_deflection_delta_automation_task.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+import atlas_brain.autonomous.tasks.content_ops_deflection_delta_automation as mod
+from extracted_content_pipeline.deflection_report_access import DeflectionDeltaBatchSummary
+
+
+def _set_delta_settings(monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> None:
+    values = {
+        "enabled": True,
+        "cron_expression": "15 8 1 * *",
+        "account_limit": 11,
+        "reports_per_account": 9,
+    }
+    values.update(overrides)
+    for name, value in values.items():
+        monkeypatch.setattr(mod.settings.deflection_delta, name, value, raising=False)
+
+
+def test_deflection_delta_automation_task_is_registered_builtin() -> None:
+    from atlas_brain.autonomous.tasks import _BUILTIN_TASKS
+
+    assert (
+        "content_ops_deflection_delta_automation",
+        "run",
+        "content_ops_deflection_delta_automation",
+    ) in _BUILTIN_TASKS
+
+
+def test_deflection_delta_automation_default_task_seed_is_disabled_monthly_cron() -> None:
+    from atlas_brain.autonomous.scheduler import TaskScheduler
+
+    seed = next(
+        (
+            task
+            for task in TaskScheduler._DEFAULT_TASKS
+            if task.get("name") == "content_ops_deflection_delta_automation"
+        ),
+        None,
+    )
+
+    assert seed is not None
+    assert seed["task_type"] == "builtin"
+    assert seed["schedule_type"] == "cron"
+    assert seed["cron_expression"] is None
+    assert seed["enabled"] is False
+    assert seed["timeout_seconds"] == 300
+    assert seed["metadata"]["builtin_handler"] == "content_ops_deflection_delta_automation"
+    assert seed["metadata"]["notify_tags"] == "chart_with_upwards_trend,content_ops,deflection"
+
+
+def test_deflection_delta_automation_registers_on_runner() -> None:
+    class _Recorder:
+        def __init__(self) -> None:
+            self.registered: dict[str, object] = {}
+
+        def register_builtin(self, name: str, handler: object) -> None:
+            self.registered[name] = handler
+
+    from atlas_brain.autonomous.tasks import register_builtin_tasks
+
+    runner = _Recorder()
+    register_builtin_tasks(runner)
+
+    handler = runner.registered["content_ops_deflection_delta_automation"]
+    assert callable(handler)
+    assert getattr(handler, "__name__", "") == "run"
+    assert handler.__module__.endswith("content_ops_deflection_delta_automation")
+
+
+@pytest.mark.asyncio
+async def test_run_skips_when_delta_automation_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_delta_settings(monkeypatch, enabled=False)
+    get_pool = AsyncMock()
+    monkeypatch.setattr(mod, "get_db_pool", get_pool)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result == {"_skip_synthesis": "Deflection delta automation disabled"}
+    get_pool.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_skips_when_db_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_delta_settings(monkeypatch)
+    pool = SimpleNamespace(is_initialized=False)
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result == {"_skip_synthesis": "DB not ready"}
+
+
+@pytest.mark.asyncio
+async def test_run_delegates_to_batch_worker_with_typed_and_metadata_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch, account_limit=5, reports_per_account=4)
+    pool = SimpleNamespace(is_initialized=True)
+    calls: list[dict[str, Any]] = []
+
+    async def _compute(store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+        calls.append(
+            {
+                "store_type": type(store).__name__,
+                "store_pool": getattr(store, "pool", None),
+                "account_limit": account_limit,
+                "reports_per_account": reports_per_account,
+            }
+        )
+        return DeflectionDeltaBatchSummary(
+            accounts_scanned=2,
+            reports_scanned=3,
+            deltas_saved=1,
+            skipped_no_delta=2,
+            failed=0,
+        )
+
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", _compute)
+
+    result = await mod.run(
+        SimpleNamespace(metadata={"account_limit": "7", "reports_per_account": "6"})
+    )
+
+    assert calls == [
+        {
+            "store_type": "PostgresDeflectionReportArtifactStore",
+            "store_pool": pool,
+            "account_limit": 7,
+            "reports_per_account": 6,
+        }
+    ]
+    assert result == {
+        "_skip_synthesis": "Deflection delta automation complete",
+        "accounts_scanned": 2,
+        "reports_scanned": 3,
+        "deltas_saved": 1,
+        "skipped_no_delta": 2,
+        "failed": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_scheduler_seed_uses_typed_delta_cron_and_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain.autonomous.scheduler import TaskScheduler
+    from atlas_brain.storage.models import ScheduledTask
+
+    _set_delta_settings(monkeypatch, enabled=True, cron_expression="45 9 1 * *")
+    scheduler = TaskScheduler()
+    scheduler._DEFAULT_TASKS = [
+        {
+            "name": "content_ops_deflection_delta_automation",
+            "task_type": "builtin",
+            "schedule_type": "cron",
+            "cron_expression": None,
+            "timeout_seconds": 300,
+            "enabled": False,
+            "metadata": {"builtin_handler": "content_ops_deflection_delta_automation"},
+        },
+    ]
+    repo = AsyncMock()
+    repo.get_by_name = AsyncMock(return_value=None)
+    repo.create = AsyncMock(
+        return_value=ScheduledTask(
+            id=uuid4(),
+            name="content_ops_deflection_delta_automation",
+            task_type="builtin",
+            schedule_type="cron",
+            cron_expression="45 9 1 * *",
+            timeout_seconds=300,
+            enabled=True,
+            metadata={"builtin_handler": "content_ops_deflection_delta_automation"},
+        )
+    )
+    monkeypatch.setattr(
+        "atlas_brain.storage.repositories.scheduled_task.get_scheduled_task_repo",
+        lambda: repo,
+    )
+    monkeypatch.setattr(scheduler, "register_and_schedule", AsyncMock())
+    monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_interval_overrides", lambda: {})
+    monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_default_tasks", lambda: [])
+
+    await scheduler._ensure_default_tasks()
+
+    create_kwargs = repo.create.await_args.kwargs
+    assert create_kwargs["enabled"] is True
+    assert create_kwargs["cron_expression"] == "45 9 1 * *"
+    assert create_kwargs["metadata"]["enabled_config_key"] == "settings.deflection_delta.enabled"
+    assert create_kwargs["metadata"]["enabled_config_value"] is True
+    assert scheduler.register_and_schedule.await_args.args[0].name == (
+        "content_ops_deflection_delta_automation"
+    )


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delta-Monthly-Automation.md
Slice phase: Vertical slice

Issue #1316 already has persisted report-pair deltas and a paid read surface, but nothing keeps deltas populated over time. This slice adds tenant-scoped paid report discovery, a deterministic recent-delta batch helper, and an opt-in monthly autonomous builtin task that generates persisted deltas through the existing idempotent save path.

## Intentional
- No customer-facing monthly email or subscription entitlement changes in this slice.
- Recompute/upsert recent deltas through the existing idempotent persistence path instead of adding a preflight missing-row query.
- Diff is over the soft 400 LOC target because the slice crosses store contract, Postgres implementation, scheduler seed, task registration, task handler, workflow enrollment, and focused tests for each boundary.

## Deferred
- Monthly Report Delta delivery email and customer-facing copy.
- Subscription-plan entitlement checks for eligible accounts.
- Live production cron enablement and operator runbook.
- D0 stable identity foundation from #1316 remains the gate before customer-facing delta delivery; this slice only keeps existing persisted pair deltas warm through the access boundary.
- Before live cron enablement, add pagination, paid-activity ordering, or cap-saturation alerting for `account_limit` and `reports_per_account` so monthly coverage cannot silently skip least-recently-paid tenants or older reports.

## Parked hardening
- None.

## AI Reconciliation
all fixed or waived: yes.

- Fixed: `content_ops_deflection_delta_automation.py` now logs and re-raises real batch exceptions so scheduled runs fail/retry/alert instead of being recorded as successful no-op results.
- Fixed: `list_paid_report_accounts` now ranks tenants by paid activity using `paid_at` with `updated_at`/`created_at` fallback; in-memory parity and Postgres SQL assertions cover newly unlocked older reports.
- Fixed: `tests/test_deflection_delta_automation_task.py` is now enrolled in the Content Ops deflection report workflow with autonomous/config path filters.
- Fixed: per-report delta failures now log account/report context, partial failures return a degraded task result, and all scanned reports failing raises so the scheduler records failure.
- Deferred: `account_limit`/`reports_per_account` cap saturation needs pagination or alerting before live cron enablement; this is recorded in the plan because the monthly task remains opt-in/deferred.
- Waived/deferred: Copilot's per-account paid report listing concern is the same `reports_per_account` window issue at report scope: a newly paid older report can be outside the created-date window. This PR does not enable live cron; before live enablement, the follow-up must paginate or order per-account paid report scans by paid activity so older newly paid reports cannot be silently skipped.

## Verification
- `python -m pytest tests/test_content_ops_deflection_delta_persistence.py tests/test_deflection_delta_automation_task.py -q` -- 17 passed, 1 torch CUDA warning.
- `python -m pytest tests/test_scheduler.py::TestBuildTrigger tests/test_deflection_delta_automation_task.py -q` -- 16 passed, 1 torch CUDA warning.
- `python -m py_compile extracted_content_pipeline/deflection_report_access.py atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py atlas_brain/autonomous/scheduler.py atlas_brain/config.py` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Delta-Monthly-Automation.md --check` -- passed.
- `bash scripts/push_pr.sh <body-file> -u origin HEAD` -- local PR review passed before push.
- Review follow-up verification is GitHub Actions only in this recovery session because the current Codex workspace has no local repo checkout, Python, `git`, or `gh`.

## Diff size
9 files, +842 / -0
