### PR TITLE
Add deflection snapshot projection contract

### DIFF
--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -108,6 +108,30 @@ type DeflectionReportSection = {
   snapshot_safe_fields: string[];
   data: Record<string, unknown>;
 };
+
+type DeflectionSnapshotProjectionContract = {
+  schema_version: "deflection.v1";
+  top_level_fields: [
+    "summary",
+    "top_questions",
+    "locked_questions",
+    "top_blind_spots",
+    "teaser"
+  ];
+  fields: DeflectionSnapshotProjectionField[];
+};
+
+type DeflectionSnapshotProjectionField = {
+  field: string;
+  source_section: string;
+  source_collection?: "rows" | "items";
+  snapshot_safe_fields: string[];
+  projected_fields: string[];
+  full_answer_fields?: string[];
+  preview_fields?: string[];
+  policy?: "scoped_resolution_evidence_only";
+  limit?: string;
+};
 ```
 
 Renderer rules:
@@ -120,6 +144,11 @@ Renderer rules:
   must be safe to emit for every projected row in that section; paid answer
   bodies and steps are not snapshot-safe section fields. The only free answer
   body is the separately gated `snapshot.teaser.full_answer`.
+- Treat the backend `snapshot_projection` contract as the source map from free
+  Snapshot fields to paid report sections. In particular, `top_blind_spots` is
+  sourced from `top_unresolved_repeats.items` and may project only `rank`,
+  `question`, and `ticket_count`. Use this contract before changing frontend
+  snapshot parsers; do not infer the projection from demo fixtures.
 - Treat `complete_evidence` as export-only. It summarizes export size and should
   not be inlined into web/PDF surfaces.
 - Breaking shape changes bump `schema_version`; additive sections should keep

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -729,6 +729,55 @@ _SNAPSHOT_REQUIRED_DETAIL_TEASER_FIELDS = frozenset({
     "answer",
     "steps",
 })
+DEFLECTION_SNAPSHOT_TOP_LEVEL_FIELDS = (
+    "summary",
+    "top_questions",
+    "locked_questions",
+    "top_blind_spots",
+    "teaser",
+)
+_SNAPSHOT_SUMMARY_FIELDS = (
+    "generated",
+    "drafted_answer_count",
+    "no_proven_answer_count",
+    "support_ticket_resolution_evidence_present",
+    "support_ticket_resolution_evidence_count",
+    "repeat_ticket_count",
+    "non_repeat_ticket_count",
+    "source_date_start",
+    "source_date_end",
+    "source_window_days",
+)
+_SNAPSHOT_TOP_QUESTION_FIELDS = (
+    "rank",
+    "question",
+    "ticket_count",
+    "weighted_frequency",
+    "customer_wording",
+)
+_SNAPSHOT_LOCKED_QUESTION_FIELDS = ("rank", "ticket_count")
+_SNAPSHOT_BLIND_SPOT_FIELDS = ("rank", "question", "ticket_count")
+_SNAPSHOT_TEASER_FIELDS = ("full_answer", "previews")
+_SNAPSHOT_TEASER_FULL_ANSWER_FIELDS = (
+    "rank",
+    "question",
+    "answer",
+    "steps",
+    "answer_evidence_status",
+    "resolution_evidence_scope",
+    "weighted_frequency",
+    "source_count",
+)
+_SNAPSHOT_TEASER_PREVIEW_FIELDS = (
+    "rank",
+    "question",
+    "answer_evidence_status",
+    "resolution_evidence_scope",
+    "weighted_frequency",
+    "step_count",
+    "source_count",
+    "body_withheld",
+)
 
 
 def deflection_report_model_contract_shape() -> dict[str, Any]:
@@ -738,6 +787,7 @@ def deflection_report_model_contract_shape() -> dict[str, Any]:
         "schema_version": DEFLECTION_REPORT_SCHEMA_VERSION,
         "model_fields": list(DEFLECTION_REPORT_MODEL_FIELDS),
         "section_fields": list(DEFLECTION_REPORT_SECTION_FIELDS),
+        "snapshot_projection": _deflection_snapshot_projection_contract_shape(),
         "sections": [
             {
                 "id": definition.id,
@@ -751,6 +801,80 @@ def deflection_report_model_contract_shape() -> dict[str, Any]:
             for definition in _DEFLECTION_REPORT_SECTION_DEFINITIONS
         ],
     }
+
+
+def _deflection_snapshot_projection_contract_shape() -> dict[str, Any]:
+    """Return the backend-owned free Snapshot projection contract."""
+
+    return {
+        "schema_version": DEFLECTION_REPORT_SCHEMA_VERSION,
+        "top_level_fields": list(DEFLECTION_SNAPSHOT_TOP_LEVEL_FIELDS),
+        "fields": [
+            _snapshot_projection_section_entry(
+                "summary",
+                source_section="support_tax",
+                projected_fields=_SNAPSHOT_SUMMARY_FIELDS,
+            ),
+            _snapshot_projection_section_entry(
+                "top_questions",
+                source_section="ranked_questions",
+                source_collection="rows",
+                projected_fields=_SNAPSHOT_TOP_QUESTION_FIELDS,
+                limit="top_n",
+            ),
+            _snapshot_projection_section_entry(
+                "locked_questions",
+                source_section="ranked_questions",
+                source_collection="rows",
+                projected_fields=_SNAPSHOT_LOCKED_QUESTION_FIELDS,
+                limit="remaining_after_top_n_and_teaser_full_answer",
+            ),
+            _snapshot_projection_section_entry(
+                "top_blind_spots",
+                source_section="top_unresolved_repeats",
+                source_collection="items",
+                projected_fields=_SNAPSHOT_BLIND_SPOT_FIELDS,
+                limit="top_unresolved_repeats.result_page_limit",
+            ),
+            {
+                "field": "teaser",
+                "source_section": "question_details",
+                "source_collection": "rows",
+                "policy": "scoped_resolution_evidence_only",
+                "snapshot_safe_fields": list(
+                    DEFLECTION_REPORT_SECTION_REGISTRY[
+                        "question_details"
+                    ].snapshot_safe_fields
+                ),
+                "projected_fields": list(_SNAPSHOT_TEASER_FIELDS),
+                "full_answer_fields": list(_SNAPSHOT_TEASER_FULL_ANSWER_FIELDS),
+                "preview_fields": list(_SNAPSHOT_TEASER_PREVIEW_FIELDS),
+                "limit": "teaser_preview_count_plus_optional_full_answer",
+            },
+        ],
+    }
+
+
+def _snapshot_projection_section_entry(
+    field: str,
+    *,
+    source_section: str,
+    projected_fields: Sequence[str],
+    source_collection: str | None = None,
+    limit: str | None = None,
+) -> dict[str, Any]:
+    definition = DEFLECTION_REPORT_SECTION_REGISTRY[source_section]
+    out: dict[str, Any] = {
+        "field": field,
+        "source_section": source_section,
+        "snapshot_safe_fields": list(definition.snapshot_safe_fields),
+        "projected_fields": list(projected_fields),
+    }
+    if source_collection is not None:
+        out["source_collection"] = source_collection
+    if limit is not None:
+        out["limit"] = limit
+    return out
 
 
 DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS: Mapping[str, Mapping[str, int]] = (

--- a/plans/PR-Deflection-Snapshot-Projection-Contract.md
+++ b/plans/PR-Deflection-Snapshot-Projection-Contract.md
@@ -1,0 +1,122 @@
+# PR-Deflection-Snapshot-Projection-Contract
+
+## Why this slice exists
+
+#1799/#1800 fixed the immediate phantom `top_blind_spots` field by emitting a
+real snapshot-safe projection from `top_unresolved_repeats`. The PR body
+explicitly deferred the broader structural hardening: the snapshot shape is
+still described across hand-synced backend model code, contract prose, example
+JSON, and frontend parser types. Tests catch some drift after the fact, but
+there is no backend-owned contract that tells consumers which free snapshot
+field is derived from which paid section and which allowlisted fields are safe.
+
+Root cause: the free Snapshot projection has runtime allowlist construction, but
+the projection contract itself is implicit and scattered. This slice fixes the
+root for the backend contract layer by adding a machine-readable snapshot
+projection contract derived from the report section registry and pinned in
+tests/docs. It does not codegen frontend types, change the snapshot payload, or
+alter which paid fields are exposed.
+
+## Scope (this PR)
+
+Ownership lane: deflection/full-report-actionability
+Slice phase: Production hardening
+
+1. Add a backend-owned `snapshot_projection` contract to
+   deflection_report_model_contract_shape, covering the five free snapshot
+   top-level fields and their source sections/field allowlists.
+2. Pin `top_blind_spots` to `top_unresolved_repeats.items.{rank,question,ticket_count}`
+   in the contract so future section changes cannot silently drift from the
+   free snapshot.
+3. Add focused tests proving the contract is derived from
+   `DEFLECTION_REPORT_SECTION_REGISTRY`, excludes paid action/evidence fields,
+   and matches the documented free snapshot shape.
+4. Update the frontend contract doc to name the machine-readable contract and
+   keep codegen/TS derivation deferred.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] deflection_report_model_contract_shape includes a
+        `snapshot_projection` object with `schema_version`, top-level snapshot
+        field order, and per-field source metadata.
+  - [ ] Snapshot section fields are copied from the section registry's
+        `snapshot_safe_fields`, not retyped literal allowlists.
+  - [ ] `top_blind_spots` is bound to `top_unresolved_repeats`, `items`, and
+        only `rank`/`question`/`ticket_count`.
+  - [ ] Paid action/evidence fields such as `source_ids`, `top_evidence`,
+        `representative_phrasing`, `priority_score`, and identity/delta fields
+        do not appear in the snapshot projection contract; `answer`/`steps`
+        appear only in the separately gated teaser full-answer contract.
+  - [ ] Runtime snapshot payload behavior is unchanged.
+- Affected surfaces:
+  - `extracted_content_pipeline/faq_deflection_report.py`
+  - `docs/frontend/content_ops_faq_report_contract.md`
+  - report contract tests
+- Risk areas: widening the free Snapshot boundary, changing the process
+  freshness contract accidentally, or creating a second hand-maintained
+  allowlist that drifts from the registry.
+- Reviewer rules triggered: R1, R2, R10, R14; boundary-probe required because
+  this exposes privacy-boundary contract metadata.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Snapshot-Projection-Contract.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+
+## Mechanism
+
+deflection_report_model_contract_shape already exposes the paid report
+section registry. This slice adds a sibling `snapshot_projection` block whose
+section-backed entries read `snapshot_safe_fields` directly from
+`DEFLECTION_REPORT_SECTION_REGISTRY`. Non-section-backed snapshot fields
+(`locked_questions` and `teaser`) declare their special projection policy, so
+the whole free Snapshot contract is discoverable from one backend-owned shape.
+
+The runtime build_deflection_snapshot payload is left alone. Tests compare
+the new contract to the registry and the documented `DeflectionSnapshot` shape
+so the contract fails before a free/paid projection drift ships.
+
+## Intentional
+
+- No frontend type generation or `atlas-portfolio` change in this slice. The
+  new contract is the backend source needed before a later codegen slice can be
+  useful.
+- No `schema_version` bump. This is additive metadata on the contract endpoint;
+  the persisted `deflection.v1` report model and snapshot payload are unchanged.
+- No change to which fields project into the free Snapshot.
+
+## Deferred
+
+- Generate frontend/portfolio types from the backend contract instead of
+  maintaining parallel TypeScript shapes.
+- Derive committed example JSON fixtures from the backend contract/generator
+  instead of hand-editing examples.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_model_contract_shape_requires_version_bump tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_contract_is_registry_derived tests/test_content_ops_faq_report_contract_docs.py -q -- 7 passed.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py tests/test_deflection_snapshot_report_drift.py tests/test_content_ops_faq_report_contract_docs.py -q -- 166 passed.
+- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -- passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
+- Command: bash scripts/check_ascii_python.sh -- passed.
+- Command: git diff --check -- passed.
+- Command: python scripts/sync_pr_plan.py plans/PR-Deflection-Snapshot-Projection-Contract.md --check -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_report_contract.md` | 29 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 124 |
+| `plans/PR-Deflection-Snapshot-Projection-Contract.md` | 122 |
+| `tests/test_content_ops_deflection_report.py` | 77 |
+| `tests/test_content_ops_faq_report_contract_docs.py` | 3 |
+| **Total** | **355** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -1309,6 +1309,83 @@ def test_deflection_report_model_contract_shape_requires_version_bump() -> None:
     ]
 
 
+def test_deflection_snapshot_projection_contract_is_registry_derived() -> None:
+    shape = deflection_report_model_contract_shape()
+    projection = shape["snapshot_projection"]
+    fields = {field["field"]: field for field in projection["fields"]}
+    encoded = json.dumps(projection, sort_keys=True)
+
+    assert projection["schema_version"] == DEFLECTION_REPORT_SCHEMA_VERSION
+    assert projection["top_level_fields"] == [
+        "summary",
+        "top_questions",
+        "locked_questions",
+        "top_blind_spots",
+        "teaser",
+    ]
+    assert list(fields) == projection["top_level_fields"]
+    assert fields["summary"]["source_section"] == "support_tax"
+    assert fields["summary"]["snapshot_safe_fields"] == list(
+        DEFLECTION_REPORT_SECTION_REGISTRY["support_tax"].snapshot_safe_fields
+    )
+    assert fields["top_questions"] == {
+        "field": "top_questions",
+        "source_section": "ranked_questions",
+        "snapshot_safe_fields": list(
+            DEFLECTION_REPORT_SECTION_REGISTRY[
+                "ranked_questions"
+            ].snapshot_safe_fields
+        ),
+        "projected_fields": [
+            "rank",
+            "question",
+            "ticket_count",
+            "weighted_frequency",
+            "customer_wording",
+        ],
+        "source_collection": "rows",
+        "limit": "top_n",
+    }
+    assert fields["top_blind_spots"] == {
+        "field": "top_blind_spots",
+        "source_section": "top_unresolved_repeats",
+        "snapshot_safe_fields": list(
+            DEFLECTION_REPORT_SECTION_REGISTRY[
+                "top_unresolved_repeats"
+            ].snapshot_safe_fields
+        ),
+        "projected_fields": ["rank", "question", "ticket_count"],
+        "source_collection": "items",
+        "limit": "top_unresolved_repeats.result_page_limit",
+    }
+    assert fields["teaser"]["source_section"] == "question_details"
+    assert fields["teaser"]["policy"] == "scoped_resolution_evidence_only"
+    assert fields["teaser"]["snapshot_safe_fields"] == list(
+        DEFLECTION_REPORT_SECTION_REGISTRY["question_details"].snapshot_safe_fields
+    )
+    assert fields["teaser"]["full_answer_fields"] == [
+        "rank",
+        "question",
+        "answer",
+        "steps",
+        "answer_evidence_status",
+        "resolution_evidence_scope",
+        "weighted_frequency",
+        "source_count",
+    ]
+    for forbidden in (
+        "source_ids",
+        "top_evidence",
+        "representative_phrasing",
+        "priority_score",
+        "repeat_key",
+        "cluster_id",
+        "identity_basis",
+        "identity_confidence",
+    ):
+        assert forbidden not in encoded
+
+
 def test_deflection_report_section_registry_drives_section_metadata() -> None:
     artifact = build_deflection_report_artifact(
         _structured_report_fixture_result(),

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -303,6 +303,9 @@ def test_content_ops_faq_report_contract_links_example() -> None:
     assert "cross-run/monthly-delta matching" in doc
     assert "required_data: string[]" in doc
     assert "snapshot_safe_fields: string[]" in doc
+    assert "DeflectionSnapshotProjectionContract" in doc
+    assert "snapshot_projection" in doc
+    assert "top_unresolved_repeats.items" in doc
     assert "snapshot.teaser.full_answer" in doc
     assert "Skip unknown section IDs" in doc
     assert "Treat `complete_evidence` as export-only" in doc


### PR DESCRIPTION
Plan: plans/PR-Deflection-Snapshot-Projection-Contract.md
Slice phase: Production hardening

#1799/#1800 fixed the immediate phantom `top_blind_spots` field. This PR adds the small backend-owned contract that was deferred there: `deflection_report_model_contract_shape()` now exposes the free Snapshot projection map, including which paid section each snapshot field comes from and which registry allowlist fields are safe.

## Intentional
- No frontend type generation or `atlas-portfolio` change in this slice.
- No `schema_version` bump; this is additive contract metadata and does not change persisted report or snapshot payload behavior.
- No change to which fields project into the free Snapshot.

## Deferred
- Generate frontend/portfolio types from the backend contract instead of maintaining parallel TypeScript shapes.
- Derive committed example JSON fixtures from the backend contract/generator instead of hand-editing examples.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_model_contract_shape_requires_version_bump tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_contract_is_registry_derived tests/test_content_ops_faq_report_contract_docs.py -q` -- 7 passed.
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_deflection_snapshot_report_drift.py tests/test_content_ops_faq_report_contract_docs.py -q` -- 166 passed.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` -- passed.
- `git diff --check` -- passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Snapshot-Projection-Contract.md --check` -- passed.

## AI reconciliation
- No AI findings yet. All fixed or waived: yes.

## Diff size
5 files, +355 / -0
