### PR TITLE
Add deflection report delete endpoint

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1046,6 +1046,22 @@ def create_content_ops_control_surface_router(
             raise HTTPException(status_code=404, detail="Deflection report not found.")
         return {"request_id": request_id, "paid": True}
 
+    @router.delete(
+        "/deflection-reports/{request_id}",
+        dependencies=public_deflection_dependencies,
+        status_code=204,
+    )
+    async def delete_deflection_report(
+        request_id: str = PathParam(..., min_length=1, max_length=200),
+    ) -> None:
+        store = await _resolve_deflection_report_store(deflection_report_store_provider)
+        scope = await _resolve_scope(scope_provider)
+        await store.delete_report(
+            account_id=_required_scope_account_id(scope),
+            request_id=request_id,
+        )
+        return None
+
     @router.post("/preview")
     async def preview_generation(
         payload: ContentOpsRequestModel = Body(...),
@@ -2991,6 +3007,7 @@ def _deflection_report_process_contract_payload(prefix: str) -> dict[str, Any]:
             "snapshot": f"{route_base}/{{request_id}}/snapshot",
             "artifact": f"{route_base}/{{request_id}}/artifact",
             "report_model": f"{route_base}/{{request_id}}/report-model",
+            "delete": f"{route_base}/{{request_id}}",
         },
     }
 

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -126,6 +126,14 @@ class DeflectionReportArtifactStore(Protocol):
     ) -> bool:
         """Relock a paid report. Returns False when no matching row exists."""
 
+    async def delete_report(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> bool:
+        """Delete one tenant/request report row. Returns False when absent."""
+
     async def count_reports_older_than(self, *, cutoff: datetime) -> int:
         """Count report rows older than the retention cutoff."""
 
@@ -375,6 +383,7 @@ class InMemoryDeflectionReportArtifactStore:
         for key in keys:
             self._rows.pop(key, None)
             self._created_at_by_key.pop(key, None)
+            self._delete_referencing_deltas(key)
         return len(keys)
 
     async def mark_unpaid(
@@ -405,6 +414,32 @@ class InMemoryDeflectionReportArtifactStore:
             delivery_email=row.delivery_email,
         )
         return True
+
+    async def delete_report(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> bool:
+        key = (
+            _required_text(account_id, "account_id"),
+            _required_text(request_id, "request_id"),
+        )
+        existed = key in self._rows
+        self._rows.pop(key, None)
+        self._created_at_by_key.pop(key, None)
+        self._delete_referencing_deltas(key)
+        return existed
+
+    def _delete_referencing_deltas(self, report_key: tuple[str, str]) -> None:
+        account_id, request_id = report_key
+        for delta_key in list(self._deltas):
+            delta_account, current_request_id, baseline_request_id = delta_key
+            if (
+                delta_account == account_id
+                and request_id in {current_request_id, baseline_request_id}
+            ):
+                self._deltas.pop(delta_key, None)
 
     async def select_previous_paid_report(
         self,
@@ -680,6 +715,22 @@ class PostgresDeflectionReportArtifactStore:
                 resolved_limit,
             )
         return _parse_command_count(result)
+
+    async def delete_report(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            DELETE FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            _required_text(account_id, "account_id"),
+            _required_text(request_id, "request_id"),
+        )
+        return parse_command_tag(result)
 
     async def mark_unpaid(
         self,

--- a/plans/PR-Deflection-Report-Delete-Endpoint.md
+++ b/plans/PR-Deflection-Report-Delete-Endpoint.md
@@ -1,0 +1,129 @@
+# PR-Deflection-Report-Delete-Endpoint
+
+## Why this slice exists
+
+Issue #1656 H1 says the portfolio cleanup can delete uploaded blobs and Neon
+rows, but the ATLAS-derived deflection report row still has no request-scoped
+delete path. The existing ATLAS retention helper deletes old rows by age, which
+is useful for a future TTL job, but it does not let the portfolio cleanup delete
+the specific derived report for a completed 30-day purge.
+
+Root cause: `DeflectionReportArtifactStore` exposes read, paid-state, and
+age-retention operations, but not the product cleanup operation keyed by the
+authenticated service-token account plus `request_id`. The companion freshness
+checker also validates the process contract shape without validating advertised
+routes, so it could greenlight a stale hosted process that lacks the DELETE
+capability. This PR fixes those roots for the backend half by adding an
+idempotent same-account delete operation, a matching DELETE route, and
+checker coverage that fails closed when that route is absent or stale.
+
+## Scope (this PR)
+
+Ownership lane: security/hardening-1656
+Slice phase: Production hardening
+Max files: 8
+
+1. Add `delete_report(account_id, request_id)` to the deflection report store
+   protocol and both in-memory/Postgres implementations.
+2. Add `DELETE /api/v1/content-ops/deflection-reports/{request_id}` through the
+   same public deflection dependencies and scope account resolution used by
+   submit/read routes.
+3. Expose the delete route in the deflection process contract so the portfolio
+   cleanup side can discover the backend purge URL.
+4. Prove same-account delete removes the report, repeated/missing deletes return
+   the same 204-shaped result, and cross-account delete does not remove another
+   account's report.
+5. Teach the process-contract freshness checker to require the advertised route
+   map, including `routes.delete`, so hosted stale builds fail preflight.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Deleting by the authenticated scope account plus `request_id` removes
+        the stored snapshot/artifact row.
+  - [ ] Deleting a missing report is idempotent and returns the same no-body
+        success shape as deleting an existing report.
+  - [ ] A cross-account delete attempt cannot remove another tenant's report.
+  - [ ] The Postgres adapter issues a bounded
+        `DELETE FROM content_ops_deflection_reports WHERE account_id = $1 AND request_id = $2`.
+  - [ ] The route uses the same deflection public dependency lane as submit and
+        snapshot/artifact reads.
+- Affected surfaces: extracted deflection-report store, Content Ops control
+  surface API, process contract metadata, process-contract freshness checker,
+  tests.
+- Risk areas: data deletion, tenant isolation, retry/idempotency, API
+  backcompat.
+- Reviewer rules triggered: R1, R2, R3, R5, R8, R10, R12, R14. Boundary-probe
+  required because this is a data-deletion guard.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `plans/PR-Deflection-Report-Delete-Endpoint.md`
+- `scripts/check_deflection_process_contract.py`
+- `tests/test_check_deflection_process_contract.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_run_deflection_full_report_qa_live_runner.py`
+
+## Mechanism
+
+The store protocol gets a request-scoped `delete_report` method. The in-memory
+implementation deletes the `(account_id, request_id)` row and removes any
+in-memory delta rows that reference it, mirroring the Postgres `ON DELETE
+CASCADE` foreign keys. The Postgres implementation issues a single tenant-bound
+`DELETE` and parses the command count for tests/diagnostics. The FastAPI router
+exposes a 204 DELETE endpoint that resolves scope with
+`_required_scope_account_id(scope)`, calls the store, and intentionally ignores
+the bool result so existing and missing rows are indistinguishable.
+The freshness checker validates the hosted process contract's route map against
+the current required paths; missing or stale route capabilities fail preflight
+before the companion cleanup job can rely on them.
+
+## Intentional
+
+- This slice does not purge existing rows or add a scheduler. Issue #1656's
+  deletion spec explicitly says not to purge a backlog; a TTL/cron job remains
+  defense-in-depth after the request-scoped API exists.
+- The endpoint returns 204 for both existing and missing rows to avoid existence
+  leaks and to make portfolio cleanup retries safe.
+- The process-contract checker validates literal route templates rather than
+  probing every route method because the endpoint's job is a cheap freshness
+  preflight; route behavior is covered by the API/store tests in this slice.
+
+## Deferred
+
+- ATLAS-side scheduled 30-day TTL purge, likely by wiring the existing
+  retention helper into a production job after this endpoint lands.
+- Portfolio cleanup integration in the companion atlas-portfolio issue so its
+  cron calls this ATLAS delete route after Blob/Neon cleanup.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_deflection_report.py::test_in_memory_report_retention_deletes_only_old_rows_with_limit tests/test_content_ops_deflection_report.py::test_postgres_report_retention_uses_cutoff_and_limited_delete tests/test_content_ops_deflection_report.py::test_in_memory_deflection_report_store_deletes_report_and_referencing_deltas tests/test_content_ops_deflection_report.py::test_postgres_delete_report_scopes_to_account_and_request_id tests/test_extracted_content_control_surface_api.py::test_deflection_process_contract_route_advertises_paid_artifact_contract tests/test_extracted_content_control_surface_api.py::test_deflection_report_delete_route_is_idempotent_and_scoped tests/test_extracted_content_control_surface_api.py::test_deflection_report_routes_use_public_and_trusted_dependencies -q` -- 7 passed.
+- `python -m pytest tests/test_check_deflection_process_contract.py -q` -- 10 passed.
+- `python -m pytest tests/test_run_deflection_full_report_qa_live_runner.py::test_live_runner_extracts_pdf_text_from_renderer_bytes_by_default tests/test_run_deflection_full_report_qa_live_runner.py::test_process_contract_drift_fails_before_paid_artifact_fetches -q` -- 2 passed.
+- `python -m pytest tests/test_run_deflection_full_report_qa_live_runner.py -q` -- 17 passed.
+- Python compile check for the changed implementation, checker, runner, and
+  test modules -- passed.
+- `git diff --check` -- passed.
+- `python scripts/sync_pr_plan.py plans/PR-Deflection-Report-Delete-Endpoint.md --check` -- passed.
+- Pending before push:
+  - `bash scripts/push_pr.sh /tmp/PR-Deflection-Report-Delete-Endpoint.md -u origin HEAD`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 17 |
+| `extracted_content_pipeline/deflection_report_access.py` | 51 |
+| `plans/PR-Deflection-Report-Delete-Endpoint.md` | 129 |
+| `scripts/check_deflection_process_contract.py` | 32 |
+| `tests/test_check_deflection_process_contract.py` | 51 |
+| `tests/test_content_ops_deflection_report.py` | 66 |
+| `tests/test_extracted_content_control_surface_api.py` | 44 |
+| `tests/test_run_deflection_full_report_qa_live_runner.py` | 1 |
+| **Total** | **391** |

--- a/scripts/check_deflection_process_contract.py
+++ b/scripts/check_deflection_process_contract.py
@@ -28,6 +28,13 @@ DEFAULT_CONTRACT_PATH = (
     "/api/v1/content-ops/deflection-reports/process-contract"
 )
 LOCAL_HOSTS = frozenset({"localhost", "0.0.0.0", "::1"})
+REQUIRED_ROUTE_SUFFIXES = {
+    "process_contract": "/process-contract",
+    "snapshot": "/{request_id}/snapshot",
+    "artifact": "/{request_id}/artifact",
+    "report_model": "/{request_id}/report-model",
+    "delete": "/{request_id}",
+}
 
 
 @dataclass(frozen=True)
@@ -115,7 +122,19 @@ def _fetch_json(url: str, *, token: str, timeout: float) -> HttpResult:
     return HttpResult(status=status, payload=dict(payload))
 
 
-def _validate_contract(payload: Any) -> list[str]:
+def _expected_routes(process_contract_path: str) -> dict[str, str]:
+    base = _clean(process_contract_path)
+    if base.endswith("/process-contract"):
+        base = base[: -len("/process-contract")]
+    else:
+        base = base.rstrip("/")
+    return {
+        key: f"{base}{suffix}"
+        for key, suffix in REQUIRED_ROUTE_SUFFIXES.items()
+    }
+
+
+def _validate_contract(payload: Any, *, process_contract_path: str) -> list[str]:
     if not isinstance(payload, Mapping):
         return ["process contract endpoint response must be a JSON object"]
     errors: list[str] = []
@@ -129,6 +148,13 @@ def _validate_contract(payload: Any) -> list[str]:
     contract = payload.get("contract")
     if not isinstance(contract, Mapping):
         return [*errors, "contract must be an object"]
+    routes = payload.get("routes")
+    if not isinstance(routes, Mapping):
+        errors.append("routes must be an object")
+    else:
+        for key, expected in _expected_routes(process_contract_path).items():
+            if _clean(routes.get(key)) != expected:
+                errors.append(f"routes.{key} must be {expected}")
     if (
         _clean(contract.get("report_model_schema_version"))
         != EXPECTED_REPORT_MODEL_SCHEMA_VERSION
@@ -170,7 +196,7 @@ def check_process_contract(args: argparse.Namespace) -> tuple[int, dict[str, Any
         payload = result.payload
         errors.extend(result.errors)
         if not result.errors:
-            errors.extend(_validate_contract(payload))
+            errors.extend(_validate_contract(payload, process_contract_path=args.path))
     output = {
         "schema_version": SCHEMA_VERSION,
         "ok": not errors,
@@ -189,6 +215,7 @@ def _safe_observed_contract(payload: Any) -> dict[str, Any]:
         return {}
     contract = payload.get("contract")
     required = contract.get("paid_artifact_requires") if isinstance(contract, Mapping) else {}
+    routes = payload.get("routes")
     return {
         "schema_version": _clean(payload.get("schema_version")),
         "service": _clean(payload.get("service")),
@@ -211,6 +238,7 @@ def _safe_observed_contract(payload: Any) -> dict[str, Any]:
             else ""
         ),
         "paid_artifact_requires": dict(required) if isinstance(required, Mapping) else {},
+        "routes": dict(routes) if isinstance(routes, Mapping) else {},
     }
 
 

--- a/tests/test_check_deflection_process_contract.py
+++ b/tests/test_check_deflection_process_contract.py
@@ -53,9 +53,22 @@ def _contract(**overrides: Any) -> dict[str, Any]:
                 "evidence_export": "object",
             },
         },
+        "routes": _routes(),
     }
     payload.update(overrides)
     return payload
+
+
+def _routes(**overrides: str) -> dict[str, str]:
+    routes = {
+        "process_contract": "/api/v1/content-ops/deflection-reports/process-contract",
+        "snapshot": "/api/v1/content-ops/deflection-reports/{request_id}/snapshot",
+        "artifact": "/api/v1/content-ops/deflection-reports/{request_id}/artifact",
+        "report_model": "/api/v1/content-ops/deflection-reports/{request_id}/report-model",
+        "delete": "/api/v1/content-ops/deflection-reports/{request_id}",
+    }
+    routes.update(overrides)
+    return routes
 
 
 def _run(monkeypatch, body: Any, tmp_path: Path, *, status: int = 200):
@@ -96,6 +109,7 @@ def test_process_contract_checker_accepts_current_contract(monkeypatch, tmp_path
             "report_model": "object",
             "evidence_export": "object",
         },
+        "routes": _routes(),
     }
     assert seen["url"] == (
         "https://atlas.example.com/api/v1/content-ops/"
@@ -123,6 +137,43 @@ def test_process_contract_checker_fails_on_missing_route(monkeypatch, tmp_path):
     assert payload["ok"] is False
     assert payload["errors"] == [
         "process contract endpoint must return 200, got 404"
+    ]
+
+
+def test_process_contract_checker_fails_on_missing_delete_route(
+    monkeypatch,
+    tmp_path,
+):
+    routes = _routes()
+    del routes["delete"]
+    code, payload, _seen = _run(
+        monkeypatch,
+        _contract(routes=routes),
+        tmp_path,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["errors"] == [
+        "routes.delete must be /api/v1/content-ops/deflection-reports/{request_id}"
+    ]
+    assert payload["observed"]["routes"] == routes
+
+
+def test_process_contract_checker_fails_on_stale_delete_route(
+    monkeypatch,
+    tmp_path,
+):
+    code, payload, _seen = _run(
+        monkeypatch,
+        _contract(routes=_routes(delete="/api/v1/content-ops/deflection-reports")),
+        tmp_path,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["errors"] == [
+        "routes.delete must be /api/v1/content-ops/deflection-reports/{request_id}"
     ]
 
 

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -4183,6 +4183,45 @@ async def test_in_memory_list_reports_filters_tenant_paid_state_and_orders_newes
 
 
 @pytest.mark.asyncio
+async def test_in_memory_deflection_report_store_deletes_report_and_referencing_deltas() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    for account_id, request_id, question in (
+        ("acct-1", "current", "Delete me"),
+        ("acct-1", "baseline", "Baseline"),
+        ("acct-2", "current", "Keep me"),
+    ):
+        await store.save_report(
+            account_id=account_id,
+            request_id=request_id,
+            snapshot=_report_access_snapshot(question),
+            artifact={},
+        )
+    await store.save_deflection_delta(
+        account_id="acct-1",
+        current_request_id="current",
+        baseline_request_id="baseline",
+        delta={"summary": {"matched_item_count": 1}},
+    )
+
+    assert await store.delete_report(account_id="acct-1", request_id="current") is True
+
+    assert await store.get_artifact_record(
+        account_id="acct-1",
+        request_id="current",
+    ) is None
+    assert await store.get_artifact_record(
+        account_id="acct-2",
+        request_id="current",
+    ) is not None
+    assert await store.get_deflection_delta(
+        account_id="acct-1",
+        current_request_id="current",
+        baseline_request_id="baseline",
+    ) is None
+    assert await store.delete_report(account_id="acct-1", request_id="current") is False
+
+
+@pytest.mark.asyncio
 async def test_postgres_list_reports_uses_account_scope_optional_paid_filter_and_unbounded_limit() -> None:
     class _Pool:
         def __init__(self) -> None:
@@ -4224,6 +4263,33 @@ async def test_postgres_list_reports_uses_account_scope_optional_paid_filter_and
     assert pool.calls[2][1] == ("acct-1",)
     assert "ORDER BY created_at DESC" in pool.calls[2][0]
     assert "LIMIT $" not in pool.calls[2][0]
+
+
+@pytest.mark.asyncio
+async def test_postgres_delete_report_scopes_to_account_and_request_id() -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+            self.execute_result = "DELETE 1"
+
+        async def execute(self, query: str, *args: object) -> str:
+            self.execute_calls.append((query, args))
+            return self.execute_result
+
+    pool = _Pool()
+    store = PostgresDeflectionReportArtifactStore(pool=pool)
+
+    assert await store.delete_report(
+        account_id=" acct-1 ",
+        request_id=" request-delete ",
+    ) is True
+    query, args = pool.execute_calls[0]
+    assert args == ("acct-1", "request-delete")
+    assert "DELETE FROM content_ops_deflection_reports" in query
+    assert "WHERE account_id = $1 AND request_id = $2" in query
+
+    pool.execute_result = "DELETE 0"
+    assert await store.delete_report(account_id="acct-1", request_id="missing") is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -370,6 +370,7 @@ async def test_deflection_process_contract_route_advertises_paid_artifact_contra
             "snapshot": "/ops/deflection-reports/{request_id}/snapshot",
             "artifact": "/ops/deflection-reports/{request_id}/artifact",
             "report_model": "/ops/deflection-reports/{request_id}/report-model",
+            "delete": "/ops/deflection-reports/{request_id}",
         },
     }
 
@@ -2916,6 +2917,42 @@ async def test_deflection_report_artifact_route_is_locked_until_marked_paid():
 
 
 @pytest.mark.asyncio
+async def test_deflection_report_delete_route_is_idempotent_and_scoped() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-gate",
+        request_id="request-delete",
+        snapshot={"summary": {"generated": 1}},
+        artifact={"markdown": "# Delete me"},
+    )
+    await store.save_report(
+        account_id="acct-other",
+        request_id="request-delete",
+        snapshot={"summary": {"generated": 2}},
+        artifact={"markdown": "# Keep me"},
+    )
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-gate", "user_id": "user-gate"},
+        deflection_report_store_provider=lambda: store,
+    )
+
+    delete_route = _route(router, "/ops/deflection-reports/{request_id}", "DELETE")
+
+    assert delete_route.status_code == 204
+    assert await delete_route.endpoint(request_id="request-delete") is None
+    assert await store.get_artifact_record(
+        account_id="acct-gate",
+        request_id="request-delete",
+    ) is None
+    assert await store.get_artifact_record(
+        account_id="acct-other",
+        request_id="request-delete",
+    ) is not None
+    assert await delete_route.endpoint(request_id="request-delete") is None
+
+
+@pytest.mark.asyncio
 async def test_deflection_checkout_authorization_returns_canonical_terms_only():
     store = InMemoryDeflectionReportArtifactStore()
     await store.save_report(
@@ -3100,6 +3137,11 @@ def test_deflection_report_routes_use_public_and_trusted_dependencies() -> None:
         "/ops/deflection-reports/{request_id}/snapshot",
         "GET",
     )
+    delete_route = _route(
+        router,
+        "/ops/deflection-reports/{request_id}",
+        "DELETE",
+    )
 
     assert "_tenant_user" in _dependency_names(paid_route)
     assert "_trusted_paid_release" in _dependency_names(paid_route)
@@ -3110,11 +3152,13 @@ def test_deflection_report_routes_use_public_and_trusted_dependencies() -> None:
         checkout_authorization_route
     )
     assert "_public_deflection_gate" in _dependency_names(snapshot_route)
+    assert "_public_deflection_gate" in _dependency_names(delete_route)
     assert "_trusted_paid_release" not in _dependency_names(artifact_route)
     assert "_trusted_paid_release" not in _dependency_names(
         checkout_authorization_route
     )
     assert "_trusted_paid_release" not in _dependency_names(snapshot_route)
+    assert "_trusted_paid_release" not in _dependency_names(delete_route)
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_deflection_full_report_qa_live_runner.py
+++ b/tests/test_run_deflection_full_report_qa_live_runner.py
@@ -211,6 +211,7 @@ def _process_contract(**contract_overrides: Any) -> dict[str, Any]:
             "snapshot": "/api/v1/content-ops/deflection-reports/{request_id}/snapshot",
             "artifact": "/api/v1/content-ops/deflection-reports/{request_id}/artifact",
             "report_model": "/api/v1/content-ops/deflection-reports/{request_id}/report-model",
+            "delete": "/api/v1/content-ops/deflection-reports/{request_id}",
         },
     }
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-Delete-Endpoint.md
Slice phase: Production hardening

Issue #1656 H1 needs the ATLAS-side half of end-to-end 30-day deletion: portfolio cleanup can delete its own Blob/Neon data, but ATLAS still lacked a request-scoped delete path for the derived deflection report row. This PR adds that backend delete operation, an authenticated idempotent DELETE route scoped to the service-token account plus `request_id`, and process-contract checker coverage so stale hosted builds fail preflight when that DELETE capability is absent.

## Intentional
- DELETE returns 204 for existing and missing rows so cleanup retries are safe and request IDs cannot be probed for existence.
- This does not purge existing rows or add a TTL scheduler; #1656 explicitly separates the request-scoped backend path from the optional TTL fast-follow.
- The process-contract checker validates literal route templates rather than probing every route method because the endpoint's job is a cheap freshness preflight; route behavior is covered by API/store tests in this slice.

## Deferred
- Wire an ATLAS-side scheduled 30-day TTL purge using the existing retention helper.
- Integrate the companion portfolio cleanup cron so it calls this ATLAS route after Blob/Neon cleanup.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: Codex P2 on `scripts/check_deflection_process_contract.py` noted that the process-contract checker did not require the new advertised `routes.delete` capability. This update validates the hosted route map, adds missing/stale DELETE-route negative fixtures, and updates the live-runner process-contract fixture.
- Waived: none.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py::test_in_memory_report_retention_deletes_only_old_rows_with_limit tests/test_content_ops_deflection_report.py::test_postgres_report_retention_uses_cutoff_and_limited_delete tests/test_content_ops_deflection_report.py::test_in_memory_deflection_report_store_deletes_report_and_referencing_deltas tests/test_content_ops_deflection_report.py::test_postgres_delete_report_scopes_to_account_and_request_id tests/test_extracted_content_control_surface_api.py::test_deflection_process_contract_route_advertises_paid_artifact_contract tests/test_extracted_content_control_surface_api.py::test_deflection_report_delete_route_is_idempotent_and_scoped tests/test_extracted_content_control_surface_api.py::test_deflection_report_routes_use_public_and_trusted_dependencies -q` -- 7 passed.
- `python -m pytest tests/test_check_deflection_process_contract.py -q` -- 10 passed.
- `python -m pytest tests/test_run_deflection_full_report_qa_live_runner.py::test_live_runner_extracts_pdf_text_from_renderer_bytes_by_default tests/test_run_deflection_full_report_qa_live_runner.py::test_process_contract_drift_fails_before_paid_artifact_fetches -q` -- 2 passed.
- `python -m pytest tests/test_run_deflection_full_report_qa_live_runner.py -q` -- 17 passed.
- Python compile check for the changed implementation, checker, runner, and test modules -- passed.
- `git diff --check` -- passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Report-Delete-Endpoint.md --check` -- passed.

## Diff size
8 files, +391 / -0
