### PR TITLE
Enforce deflection snapshot projected fields at runtime

### DIFF
--- a/plans/PR-Deflection-Snapshot-Runtime-Contract.md
+++ b/plans/PR-Deflection-Snapshot-Runtime-Contract.md
@@ -1,0 +1,86 @@
+# PR-Deflection-Snapshot-Runtime-Contract
+
+## Why this slice exists
+
+The #1804 sequencing review called out the remaining high-value gap in the
+snapshot chain: the contract now documents `projected_fields`, but the test
+still checks hardcoded expected lists instead of the real runtime output from
+`build_deflection_snapshot`. A projection implementation change can drift away
+from the contract while the contract test stays green.
+
+Root cause: the contract assertion is anchored to duplicated literals rather
+than to the runtime projection boundary. This PR fixes the root for
+`projected_fields` by building a representative snapshot and comparing the
+actual emitted field sets to the contract.
+
+## Scope (this PR)
+
+Ownership lane: deflection/full-report-actionability
+Slice phase: Production hardening
+
+1. Add a runtime-backed contract test for snapshot projection fields.
+2. Keep the existing registry-derived assertions for source section metadata and
+   snapshot-safe allowlists.
+3. Prove summary, top questions, locked questions, top blind spots, teaser full
+   answer, and teaser previews match the contract's projected field lists.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The representative runtime snapshot contains rows for every contract
+        field that declares `projected_fields`, including locked questions and
+        teaser preview rows.
+  - [ ] The test compares actual snapshot key sets to
+        `deflection_report_model_contract_shape()["snapshot_projection"]`.
+  - [ ] The old hardcoded expected lists are not the only proof for runtime
+        projected field shape.
+- Affected surfaces: deflection report contract tests.
+- Risk areas: false-green snapshot contract, frontend type generation
+  preconditions, free snapshot privacy boundary.
+- Reviewer rules triggered: R1, R2, R10, R14. Boundary-probe required because
+  this is a contract checker.
+
+### Files touched
+
+- `plans/PR-Deflection-Snapshot-Runtime-Contract.md`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+The test uses the existing structured deflection report fixture, adds one extra
+scoped resolved repeat with complete source-date metadata, and calls
+`build_deflection_snapshot` with `top_n=1`. That forces the runtime path to emit
+a top question, locked question, top blind spot, teaser full answer, and teaser
+preview. The assertion indexes the contract by field name and compares actual
+snapshot key sets to the contract's projected field lists.
+
+## Intentional
+
+- This slice changes test enforcement only. The runtime projection already emits
+  the intended shape; the defect is the contract test's proof source.
+- It reuses the deterministic structured report fixture instead of creating a
+  new fixture corpus.
+
+## Deferred
+
+- Generate frontend/portfolio types from the enforced contract in the next
+  slice.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projected_fields_match_runtime_output -q -- 2 passed.
+- python -m py_compile tests/test_content_ops_deflection_report.py -- passed.
+- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_model_contract_shape_requires_version_bump tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projected_fields_match_runtime_output tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_report_contract_links_example -q -- 4 passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- passed.
+- bash scripts/check_ascii_python.sh -- passed.
+- git diff --check -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Snapshot-Runtime-Contract.md` | 86 |
+| `tests/test_content_ops_deflection_report.py` | 59 |
+| **Total** | **145** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import importlib.util
 import json
@@ -1384,6 +1385,64 @@ def test_deflection_snapshot_projection_contract_is_registry_derived() -> None:
         "identity_confidence",
     ):
         assert forbidden not in encoded
+
+
+def test_deflection_snapshot_projected_fields_match_runtime_output() -> None:
+    fixture = _structured_report_fixture_result()
+    fixture = replace(
+        fixture,
+        source_count=fixture.source_count + 2,
+        ticket_source_count=fixture.ticket_source_count + 2,
+        items=fixture.items
+        + (
+            {
+                "question": "How do I resend an invoice receipt?",
+                "customer_wording": "resend invoice receipt",
+                "topic": "billing",
+                "weighted_frequency": 2,
+                "ticket_count": 2,
+                "opportunity_score": 8,
+                "answer": "Open Billing, choose Receipts, then resend the receipt.",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "steps": ["Open Billing and select Resend receipt."],
+                "source_ids": ("ticket-receipt-1", "ticket-receipt-2"),
+                "source_date_span": {
+                    "start": "2026-05-16",
+                    "end": "2026-05-17",
+                    "missing_source_count": 0,
+                },
+            },
+        ),
+    )
+    artifact = build_deflection_report_artifact(fixture)
+    snapshot = build_deflection_snapshot(artifact, top_n=1).as_dict()
+    projection = deflection_report_model_contract_shape()["snapshot_projection"]
+    fields = {field["field"]: field for field in projection["fields"]}
+
+    assert snapshot["top_questions"]
+    assert snapshot["locked_questions"]
+    assert snapshot["top_blind_spots"]
+    assert snapshot["teaser"]["full_answer"] is not None
+    assert snapshot["teaser"]["previews"]
+
+    assert set(snapshot["summary"]) == set(fields["summary"]["projected_fields"])
+    assert set(snapshot["top_questions"][0]) == set(
+        fields["top_questions"]["projected_fields"]
+    )
+    assert set(snapshot["locked_questions"][0]) == set(
+        fields["locked_questions"]["projected_fields"]
+    )
+    assert set(snapshot["top_blind_spots"][0]) == set(
+        fields["top_blind_spots"]["projected_fields"]
+    )
+    assert set(snapshot["teaser"]) == set(fields["teaser"]["projected_fields"])
+    assert set(snapshot["teaser"]["full_answer"]) == set(
+        fields["teaser"]["full_answer_fields"]
+    )
+    assert set(snapshot["teaser"]["previews"][0]) == set(
+        fields["teaser"]["preview_fields"]
+    )
 
 
 def test_deflection_report_section_registry_drives_section_metadata() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Snapshot-Runtime-Contract.md
Slice phase: Production hardening

The #1804 sequencing review called out that the snapshot projection contract still documented `projected_fields` without proving those fields against real `build_deflection_snapshot` output. This PR adds a runtime-backed contract test so summary, top questions, locked questions, top blind spots, teaser full answer, and teaser previews must match the contract.

## Intentional
- Test-only enforcement: runtime projection already emits the intended shape; the gap was the proof source.
- Reuses the deterministic structured report fixture with one extra scoped resolved repeat instead of adding a new fixture corpus.

## Deferred
- Generate frontend/portfolio types from the enforced contract in the next slice.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projected_fields_match_runtime_output -q -- 2 passed.
- python -m py_compile tests/test_content_ops_deflection_report.py -- passed.
- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_model_contract_shape_requires_version_bump tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projected_fields_match_runtime_output tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_report_contract_links_example -q -- 4 passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- passed.
- bash scripts/check_ascii_python.sh -- passed.
- git diff --check -- passed.

## Diff size
2 files, +143 / -0
