### PR TITLE
Add deflection report TTL purge workflow

### DIFF
--- a/.github/workflows/content_ops_deflection_report_ttl_purge.yml
+++ b/.github/workflows/content_ops_deflection_report_ttl_purge.yml
@@ -1,0 +1,70 @@
+name: Content Ops Deflection Report TTL Purge
+
+on:
+  schedule:
+    - cron: "23 8 * * *"
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: "Delete reports older than this many days."
+        required: false
+        default: "30"
+      limit:
+        description: "Maximum rows to delete in one run."
+        required: false
+        default: "1000"
+      dry_run:
+        description: "Count eligible rows without deleting them."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: content-ops-deflection-report-ttl-purge
+  cancel-in-progress: false
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install purge dependencies
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install asyncpg
+
+      - name: Purge expired deflection reports
+        env:
+          EXTRACTED_DATABASE_URL: ${{ secrets.EXTRACTED_DATABASE_URL }}
+          RETENTION_DAYS: ${{ inputs.retention_days }}
+          DELETE_LIMIT: ${{ inputs.limit }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          retention_days="${RETENTION_DAYS:-30}"
+          delete_limit="${DELETE_LIMIT:-1000}"
+          dry_run="${DRY_RUN:-false}"
+          args=(
+            --database-url-env EXTRACTED_DATABASE_URL
+            --retention-days "$retention_days"
+            --limit "$delete_limit"
+            --json
+          )
+          if [ "$dry_run" != "true" ]; then
+            args+=(--confirm-delete)
+          fi
+          python scripts/purge_content_ops_deflection_reports.py "${args[@]}"

--- a/.github/workflows/content_ops_deflection_report_ttl_purge.yml
+++ b/.github/workflows/content_ops_deflection_report_ttl_purge.yml
@@ -28,11 +28,14 @@ concurrency:
 
 jobs:
   purge:
+    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/content_ops_deflection_report_ttl_purge.yml
+++ b/.github/workflows/content_ops_deflection_report_ttl_purge.yml
@@ -52,13 +52,13 @@ jobs:
 
       - name: Purge expired deflection reports
         env:
-          EXTRACTED_DATABASE_URL: ${{ secrets.EXTRACTED_DATABASE_URL }}
+          EXTRACTED_DATABASE_URL: ${{ secrets.EXTRACTED_DATABASE_URL }} # exposed only after main/default-branch guards
           RETENTION_DAYS: ${{ inputs.retention_days }}
           DELETE_LIMIT: ${{ inputs.limit }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          retention_days="${RETENTION_DAYS:-30}"
+          retention_days="${RETENTION_DAYS:-30}" # checkout closes 24h before this cutoff
           delete_limit="${DELETE_LIMIT:-1000}"
           dry_run="${DRY_RUN:-false}"
           args=(
@@ -70,4 +70,4 @@ jobs:
           if [ "$dry_run" != "true" ]; then
             args+=(--confirm-delete)
           fi
-          python scripts/purge_content_ops_deflection_reports.py "${args[@]}"
+          python scripts/purge_content_ops_deflection_reports.py "${args[@]}" # store deletes companion delivery metadata first

--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -61,7 +61,7 @@ jobs:
       - name: PR-review tooling unit tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio pyyaml
-          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_check_gitleaks_baseline_rotation.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_claude_workflow_security.py tests/test_fix_mode_hook.py -q
+          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_check_gitleaks_baseline_rotation.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_claude_workflow_security.py tests/test_deflection_report_ttl_workflow.py tests/test_fix_mode_hook.py -q
 
       - name: Workflow security posture audit
         run: python scripts/audit_workflow_security_posture.py .github/workflows

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -2553,18 +2553,11 @@ def _deflection_report_checkout_inside_retention_window(
 
 
 def _coerce_aware_datetime(value: Any) -> datetime | None:
-    if isinstance(value, datetime):
-        resolved = value
-    elif isinstance(value, str) and value.strip():
-        try:
-            resolved = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
-        except ValueError:
-            return None
-    else:
+    if not isinstance(value, datetime):
         return None
-    if resolved.tzinfo is None or resolved.utcoffset() is None:
+    if value.tzinfo is None or value.utcoffset() is None:
         return None
-    return resolved.astimezone(timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _with_deflection_submit_diagnostics(

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -16,6 +16,7 @@ import urllib.error
 import urllib.parse
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
@@ -119,6 +120,9 @@ ReasoningContextProvider = Callable[
     [],
     Any | Awaitable[Any],
 ]
+
+_DEFLECTION_REPORT_RETENTION_DAYS = 30
+_DEFLECTION_CHECKOUT_OPEN_SESSION_GRACE = timedelta(hours=24)
 ReasoningStatusProvider = Callable[
     [],
     Mapping[str, Any] | None | Awaitable[Mapping[str, Any] | None],
@@ -1020,6 +1024,11 @@ def create_content_ops_control_surface_router(
             raise HTTPException(
                 status_code=409,
                 detail="Deflection report artifact is not available.",
+            )
+        if not _deflection_report_checkout_inside_retention_window(record.created_at):
+            raise HTTPException(
+                status_code=409,
+                detail="Deflection report checkout window expired.",
             )
         return {
             "request_id": request_id,
@@ -2524,6 +2533,38 @@ def _deflection_checkout_allowed_amounts(
             )
         amounts.append(amount_cents)
     return tuple(dict.fromkeys(amounts))
+
+
+def _deflection_report_checkout_inside_retention_window(
+    created_at: Any,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    resolved_created_at = _coerce_aware_datetime(created_at)
+    if resolved_created_at is None:
+        return False
+    checkout_deadline = (
+        resolved_created_at
+        + timedelta(days=_DEFLECTION_REPORT_RETENTION_DAYS)
+        - _DEFLECTION_CHECKOUT_OPEN_SESSION_GRACE
+    )
+    resolved_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return resolved_now < checkout_deadline
+
+
+def _coerce_aware_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        resolved = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            resolved = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if resolved.tzinfo is None or resolved.utcoffset() is None:
+        return None
+    return resolved.astimezone(timezone.utc)
 
 
 def _with_deflection_submit_diagnostics(

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -28,6 +28,7 @@ class DeflectionReportAccessRecord:
     paid: bool
     payment_reference: str | None = None
     delivery_email: str | None = None
+    created_at: Any = None
 
     def report_model(self) -> dict[str, Any] | None:
         """Return the supported persisted structured report model, if present."""
@@ -272,6 +273,7 @@ class InMemoryDeflectionReportArtifactStore:
             payment_reference=existing.payment_reference if existing else None,
             delivery_email=cleaned_delivery_email
             or (existing.delivery_email if existing else None),
+            created_at=self._created_at_by_key.get(key),
         )
 
     async def get_snapshot(
@@ -330,6 +332,7 @@ class InMemoryDeflectionReportArtifactStore:
             paid=row.paid,
             payment_reference=row.payment_reference,
             delivery_email=row.delivery_email,
+            created_at=self._created_at_by_key.get((row.account_id, row.request_id)),
         )
 
     async def mark_paid(
@@ -351,6 +354,7 @@ class InMemoryDeflectionReportArtifactStore:
             paid=True,
             payment_reference=_clean(payment_reference) or row.payment_reference,
             delivery_email=row.delivery_email,
+            created_at=row.created_at,
         )
         return True
 
@@ -412,6 +416,7 @@ class InMemoryDeflectionReportArtifactStore:
             paid=False,
             payment_reference=row.payment_reference,
             delivery_email=row.delivery_email,
+            created_at=row.created_at,
         )
         return True
 
@@ -636,7 +641,7 @@ class PostgresDeflectionReportArtifactStore:
     ) -> DeflectionReportAccessRecord | None:
         row = await self.pool.fetchrow(
             """
-            SELECT account_id, request_id, snapshot, artifact, paid, payment_reference, delivery_email
+            SELECT account_id, request_id, snapshot, artifact, paid, payment_reference, delivery_email, created_at
             FROM content_ops_deflection_reports
             WHERE account_id = $1 AND request_id = $2
             """,
@@ -688,33 +693,40 @@ class PostgresDeflectionReportArtifactStore:
     ) -> int:
         resolved_cutoff = _required_cutoff(cutoff)
         resolved_limit = _optional_positive_limit(limit)
-        if resolved_limit is None:
-            result = await self.pool.execute(
-                """
-                DELETE FROM content_ops_deflection_reports
+        limit_clause = "" if resolved_limit is None else "LIMIT $2"
+        args: tuple[Any, ...] = (
+            (resolved_cutoff,)
+            if resolved_limit is None
+            else (resolved_cutoff, resolved_limit)
+        )
+        deleted = await self.pool.fetchval(
+            f"""
+            WITH doomed AS (
+                SELECT account_id, request_id
+                FROM content_ops_deflection_reports
                 WHERE created_at < $1
-                """,
-                resolved_cutoff,
-            )
-        else:
-            result = await self.pool.execute(
-                """
-                WITH doomed AS (
-                    SELECT account_id, request_id
-                    FROM content_ops_deflection_reports
-                    WHERE created_at < $1
-                    ORDER BY created_at ASC
-                    LIMIT $2
-                )
+                ORDER BY created_at ASC
+                {limit_clause}
+            ),
+            deleted_deliveries AS (
+                DELETE FROM content_ops_deflection_report_deliveries deliveries
+                USING doomed
+                WHERE deliveries.account_id = doomed.account_id
+                  AND deliveries.request_id = doomed.request_id
+                RETURNING 1
+            ),
+            deleted_reports AS (
                 DELETE FROM content_ops_deflection_reports reports
                 USING doomed
                 WHERE reports.account_id = doomed.account_id
                   AND reports.request_id = doomed.request_id
-                """,
-                resolved_cutoff,
-                resolved_limit,
+                RETURNING 1
             )
-        return _parse_command_count(result)
+            SELECT COUNT(*) FROM deleted_reports
+            """,
+            *args,
+        )
+        return int(deleted or 0)
 
     async def delete_report(
         self,
@@ -722,15 +734,33 @@ class PostgresDeflectionReportArtifactStore:
         account_id: str,
         request_id: str,
     ) -> bool:
-        result = await self.pool.execute(
+        deleted = await self.pool.fetchval(
             """
-            DELETE FROM content_ops_deflection_reports
-            WHERE account_id = $1 AND request_id = $2
+            WITH target AS (
+                SELECT account_id, request_id
+                FROM content_ops_deflection_reports
+                WHERE account_id = $1 AND request_id = $2
+            ),
+            deleted_deliveries AS (
+                DELETE FROM content_ops_deflection_report_deliveries deliveries
+                USING target
+                WHERE deliveries.account_id = target.account_id
+                  AND deliveries.request_id = target.request_id
+                RETURNING 1
+            ),
+            deleted_reports AS (
+                DELETE FROM content_ops_deflection_reports reports
+                USING target
+                WHERE reports.account_id = target.account_id
+                  AND reports.request_id = target.request_id
+                RETURNING 1
+            )
+            SELECT COUNT(*) FROM deleted_reports
             """,
             _required_text(account_id, "account_id"),
             _required_text(request_id, "request_id"),
         )
-        return parse_command_tag(result)
+        return int(deleted or 0) > 0
 
     async def mark_unpaid(
         self,
@@ -923,6 +953,7 @@ def _record_from_row(row: Mapping[str, Any]) -> DeflectionReportAccessRecord:
         paid=bool(row.get("paid")),
         payment_reference=_clean(row.get("payment_reference")),
         delivery_email=_clean(row.get("delivery_email")) or None,
+        created_at=row.get("created_at"),
     )
 
 

--- a/plans/PR-Deflection-Report-TTL-Purge.md
+++ b/plans/PR-Deflection-Report-TTL-Purge.md
@@ -162,10 +162,10 @@ Parked hardening: none.
 
 - Command: python -m py_compile extracted_content_pipeline/deflection_report_access.py extracted_content_pipeline/api/control_surfaces.py tests/test_deflection_report_ttl_workflow.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py
   -- passed.
-- Command: python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_content_ops_deflection_report.py::test_postgres_delete_report_scopes_to_account_and_request_id tests/test_content_ops_deflection_report.py::test_postgres_report_retention_uses_cutoff_and_limited_delete tests/test_content_ops_deflection_report.py::test_postgres_report_retention_fails_closed_on_unparseable_delete_count tests/test_content_ops_deflection_report.py::test_retention_runner_requires_confirm_delete_and_valid_bounds tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_returns_canonical_terms_only tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_rejects_reports_inside_retention_grace_window tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_closed_without_report_created_at -q
-  -- 13 passed.
+- Command: python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_content_ops_deflection_report.py::test_postgres_delete_report_scopes_to_account_and_request_id tests/test_content_ops_deflection_report.py::test_postgres_report_retention_uses_cutoff_and_limited_delete tests/test_content_ops_deflection_report.py::test_postgres_report_retention_fails_closed_on_unparseable_delete_count tests/test_content_ops_deflection_report.py::test_retention_runner_requires_confirm_delete_and_valid_bounds tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_returns_canonical_terms_only tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_rejects_reports_inside_retention_grace_window tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_closed_without_usable_report_age -q
+  -- 14 passed.
 - Command: python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_pre_push_audit_workflow.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py -q
-  -- 314 passed, 1 skipped.
+  -- 315 passed, 1 skipped.
 - Command: bash scripts/validate_extracted_content_pipeline.sh
   -- passed.
 - Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
@@ -176,6 +176,8 @@ Parked hardening: none.
   -- passed.
 - Command: python scripts/audit_workflow_security_posture.py .github/workflows
   -- passed with existing repository-wide WARN findings only.
+- Command: python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --top 25
+  -- passed; ratchet gate reported no new brittleness above baseline.
 - Command: git diff --check -- passed.
 - Command: python scripts/sync_pr_plan.py plans/PR-Deflection-Report-TTL-Purge.md --check
   -- passed.
@@ -186,11 +188,11 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/content_ops_deflection_report_ttl_purge.yml` | 73 |
 | `.github/workflows/pre_push_audit.yml` | 2 |
-| `extracted_content_pipeline/api/control_surfaces.py` | 41 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 34 |
 | `extracted_content_pipeline/deflection_report_access.py` | 83 |
-| `plans/PR-Deflection-Report-TTL-Purge.md` | 196 |
+| `plans/PR-Deflection-Report-TTL-Purge.md` | 198 |
 | `tests/test_content_ops_deflection_report.py` | 41 |
 | `tests/test_deflection_report_ttl_workflow.py` | 77 |
-| `tests/test_extracted_content_control_surface_api.py` | 43 |
+| `tests/test_extracted_content_control_surface_api.py` | 50 |
 | `tests/test_pre_push_audit_workflow.py` | 6 |
-| **Total** | **562** |
+| **Total** | **564** |

--- a/plans/PR-Deflection-Report-TTL-Purge.md
+++ b/plans/PR-Deflection-Report-TTL-Purge.md
@@ -1,0 +1,138 @@
+# PR-Deflection-Report-TTL-Purge
+
+## Why this slice exists
+
+Issue #1656's deletion-path spec made the Atlas delete endpoint the blocking
+backend half for the public 30-day deletion claim, then explicitly called out
+an optional fast-follow: Atlas should also own a 30-day TTL so report expiry
+does not depend on a single portfolio-side cron.
+
+The root cause is not missing row-deletion mechanics anymore: #1806 added the
+request-scoped delete endpoint, and the retention CLI/store already support
+guarded cut-off deletion. The remaining root is that no production owner invokes
+that Atlas retention path on a schedule. This slice fixes that root by adding an
+Atlas-owned scheduled/manual workflow that calls the existing guarded purge
+script with a 30-day window and bounded batches, without adding paid
+infrastructure or new database deletion logic.
+
+## Scope (this PR)
+
+Ownership lane: security/hardening-1656
+Slice phase: Production hardening
+
+1. Add a scheduled/manual GitHub Actions workflow for
+   `content_ops_deflection_reports` TTL purge.
+2. Run the existing `scripts/purge_content_ops_deflection_reports.py` with a
+   default 30-day retention window, default 1,000-row batch limit, JSON output,
+   and confirmed deletion on scheduled runs.
+3. Keep the database URL out of argv by passing only the secret-backed
+   environment variable name to the purge script.
+4. Add workflow-contract tests and enroll them in the pre-push audit workflow.
+5. Leave the existing purge script, access store, and API endpoint behavior
+   unchanged.
+
+### Files touched
+
+- `.github/workflows/content_ops_deflection_report_ttl_purge.yml`
+- `.github/workflows/pre_push_audit.yml`
+- `plans/PR-Deflection-Report-TTL-Purge.md`
+- `tests/test_deflection_report_ttl_workflow.py`
+- `tests/test_pre_push_audit_workflow.py`
+
+### Review Contract
+
+Acceptance criteria:
+
+- The TTL purge workflow runs only on `schedule` and manual
+  `workflow_dispatch`, not on PR or push events.
+- The scheduled path deletes reports older than 30 days by default and bounds
+  each run to a default 1,000-row batch.
+- Manual dispatch can opt into a dry run that omits `--confirm-delete`.
+- The workflow passes `--database-url-env EXTRACTED_DATABASE_URL`, not a raw
+  database URL on argv.
+- Workflow permissions are minimal and external Actions are SHA-pinned.
+- The workflow-contract test is enrolled in pre-push audit CI.
+
+Affected surfaces:
+
+- GitHub Actions workflow config.
+- Existing Atlas deflection report purge CLI invocation.
+- PR-review tooling test enrollment.
+
+Risk areas:
+
+- Data deletion from an accidentally broad or unbounded scheduled job.
+- Secret exposure through command-line arguments or logs.
+- CI drift if the workflow-contract tests are not enrolled.
+
+Reviewer rules triggered: R1, R2, R3, R6, R7, R8, R11, R12, R14.
+
+## Mechanism
+
+The new workflow runs daily at 08:23 UTC and can also be started manually. It
+installs the repo runtime dependencies plus `asyncpg`, then invokes:
+
+```bash
+python scripts/purge_content_ops_deflection_reports.py \
+  --database-url-env EXTRACTED_DATABASE_URL \
+  --retention-days "$retention_days" \
+  --limit "$delete_limit" \
+  --json \
+  --confirm-delete
+```
+
+For scheduled runs, the workflow falls back to `retention_days=30`,
+`delete_limit=1000`, and `dry_run=false`, so `--confirm-delete` is appended. For
+manual dispatch, `dry_run=true` leaves `--confirm-delete` out and the existing
+purge runner reports the eligible count without deleting rows.
+
+The workflow relies on the retention runner's existing fail-closed checks:
+exactly one database URL source, positive retention, positive limit, preflighted
+output, and no payload exposure in JSON output. This PR adds tests around the
+workflow wrapper rather than duplicating those purge mechanics.
+
+## Intentional
+
+- No new purge code. The retention logic is already covered in
+  `tests/test_content_ops_deflection_report.py`; this slice wires the
+  production invoker and tests that wrapper contract.
+- No paid infrastructure. GitHub Actions is already used by this public repo
+  and satisfies #1656's zero-paid-dependency constraint.
+- No portfolio copy or cron changes. The companion repo still needs its own
+  coordination, but Atlas now has an independent expiry backstop.
+- No database URL on argv. The workflow passes the name of the secret-backed
+  environment variable so process arguments and command logs do not carry the
+  DSN.
+
+## Deferred
+
+- #1656 / atlas-portfolio#313: keep the portfolio cleanup path coordinated
+  with the Atlas delete endpoint and public security copy.
+- #1656 medium-tier follow-ups remain separate: RLS, app-level encryption,
+  alert delivery, token-auth removal, scanner ratchets, IR docs, structured
+  logging, security.txt, and CVE SLA.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_pre_push_audit_workflow.py -q
+  -- 14 passed.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py::test_retention_runner_requires_confirm_delete_and_valid_bounds tests/test_content_ops_deflection_report.py::test_retention_runner_resolves_database_url_from_non_argv_sources tests/test_content_ops_deflection_report.py::test_retention_runner_dry_run_counts_without_deleting_or_exposing_payload -q
+  -- 3 passed.
+- Command: python scripts/audit_workflow_security_posture.py .github/workflows
+  -- passed with existing repository-wide WARN findings only.
+- Command: git diff --check -- passed.
+- Command: python scripts/sync_pr_plan.py plans/PR-Deflection-Report-TTL-Purge.md --check
+  -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/content_ops_deflection_report_ttl_purge.yml` | 70 |
+| `.github/workflows/pre_push_audit.yml` | 2 |
+| `plans/PR-Deflection-Report-TTL-Purge.md` | 138 |
+| `tests/test_deflection_report_ttl_workflow.py` | 67 |
+| `tests/test_pre_push_audit_workflow.py` | 6 |
+| **Total** | **283** |

--- a/plans/PR-Deflection-Report-TTL-Purge.md
+++ b/plans/PR-Deflection-Report-TTL-Purge.md
@@ -13,12 +13,25 @@ guarded cut-off deletion. The remaining root is that no production owner invokes
 that Atlas retention path on a schedule. This slice fixes that root by adding an
 Atlas-owned scheduled/manual workflow that calls the existing guarded purge
 script with a 30-day window and bounded batches, without adding paid
-infrastructure or new database deletion logic.
+infrastructure.
+
+Review on #1809 exposed three cross-path gaps around that orchestrator:
+manual-dispatch refs could run branch code with the production DB secret, the
+report retention delete did not remove companion delivery metadata, and checkout
+authorization could start a new Stripe session inside the final 24 hours before
+the scheduled 30-day purge. The upstream fix is in the Atlas workflow,
+retention store, and checkout-authorization guard, not in a downstream waiver.
+This is over the 400-line soft cap because the review fix spans the scheduled
+workflow, the shared storage boundary, checkout authorization, and their
+regression tests; splitting those would leave at least one deletion-safety
+thread unresolved on an open PR.
 
 ## Scope (this PR)
 
 Ownership lane: security/hardening-1656
 Slice phase: Production hardening
+
+Max files: 9
 
 1. Add a scheduled/manual GitHub Actions workflow for
    `content_ops_deflection_reports` TTL purge.
@@ -27,16 +40,25 @@ Slice phase: Production hardening
    and confirmed deletion on scheduled runs.
 3. Keep the database URL out of argv by passing only the secret-backed
    environment variable name to the purge script.
-4. Add workflow-contract tests and enroll them in the pre-push audit workflow.
-5. Leave the existing purge script, access store, and API endpoint behavior
-   unchanged.
+4. Reject non-main manual workflow refs before the purge job reaches the DB
+   secret, and explicitly check out the default branch for the script.
+5. Delete matching `content_ops_deflection_report_deliveries` rows whenever the
+   retention path or request-scoped delete removes report rows.
+6. Reject checkout authorization when a report is already inside the final
+   24-hour open-session grace window before 30-day retention expiry.
+7. Add workflow/store/control-surface tests and enroll the workflow-contract
+   test in the pre-push audit workflow.
 
 ### Files touched
 
 - `.github/workflows/content_ops_deflection_report_ttl_purge.yml`
 - `.github/workflows/pre_push_audit.yml`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/deflection_report_access.py`
 - `plans/PR-Deflection-Report-TTL-Purge.md`
+- `tests/test_content_ops_deflection_report.py`
 - `tests/test_deflection_report_ttl_workflow.py`
+- `tests/test_extracted_content_control_surface_api.py`
 - `tests/test_pre_push_audit_workflow.py`
 
 ### Review Contract
@@ -50,22 +72,32 @@ Acceptance criteria:
 - Manual dispatch can opt into a dry run that omits `--confirm-delete`.
 - The workflow passes `--database-url-env EXTRACTED_DATABASE_URL`, not a raw
   database URL on argv.
+- Manual workflow dispatches on non-main refs do not reach the secret-bearing
+  purge step, and checkout uses the default-branch script.
 - Workflow permissions are minimal and external Actions are SHA-pinned.
+- Report retention deletes matching delivery rows so payment/delivery metadata
+  is not orphaned after the report row expires.
+- Checkout authorization rejects reports inside the final 24-hour grace window
+  before the 30-day purge cutoff, and fails closed when report age is unknown.
 - The workflow-contract test is enrolled in pre-push audit CI.
 
 Affected surfaces:
 
 - GitHub Actions workflow config.
-- Existing Atlas deflection report purge CLI invocation.
+- Atlas deflection report purge/delete storage boundary.
+- Atlas deflection report checkout-authorization control surface.
 - PR-review tooling test enrollment.
 
 Risk areas:
 
 - Data deletion from an accidentally broad or unbounded scheduled job.
 - Secret exposure through command-line arguments or logs.
+- Paid-but-missing reports when a checkout session is opened too close to the
+  retention cutoff.
+- Orphaned paid delivery metadata after report expiry.
 - CI drift if the workflow-contract tests are not enrolled.
 
-Reviewer rules triggered: R1, R2, R3, R6, R7, R8, R11, R12, R14.
+Reviewer rules triggered: R1, R2, R3, R6, R7, R8, R10, R11, R12, R14.
 
 ## Mechanism
 
@@ -86,16 +118,25 @@ For scheduled runs, the workflow falls back to `retention_days=30`,
 manual dispatch, `dry_run=true` leaves `--confirm-delete` out and the existing
 purge runner reports the eligible count without deleting rows.
 
+The purge job is restricted to scheduled runs and manual runs on `refs/heads/main`.
+The checkout action also pins `ref` to the repository default branch, so the
+secret-bearing purge step runs the merged purge script rather than branch code.
+
 The workflow relies on the retention runner's existing fail-closed checks:
 exactly one database URL source, positive retention, positive limit, preflighted
-output, and no payload exposure in JSON output. This PR adds tests around the
-workflow wrapper rather than duplicating those purge mechanics.
+output, and no payload exposure in JSON output. The Postgres retention delete
+now builds a `doomed` report set, deletes matching delivery rows first, then
+deletes the report rows and returns the report deletion count. The
+request-scoped delete path uses the same target-then-delivery-then-report
+shape.
+
+Checkout authorization reads `created_at` from the artifact record and rejects a
+new checkout when `created_at + 30 days - 24 hours` has passed. That leaves room
+for Stripe's default open-session window before the scheduled purge can remove
+the row.
 
 ## Intentional
 
-- No new purge code. The retention logic is already covered in
-  `tests/test_content_ops_deflection_report.py`; this slice wires the
-  production invoker and tests that wrapper contract.
 - No paid infrastructure. GitHub Actions is already used by this public repo
   and satisfies #1656's zero-paid-dependency constraint.
 - No portfolio copy or cron changes. The companion repo still needs its own
@@ -103,6 +144,9 @@ workflow wrapper rather than duplicating those purge mechanics.
 - No database URL on argv. The workflow passes the name of the secret-backed
   environment variable so process arguments and command logs do not carry the
   DSN.
+- No schema migration in this slice. Delivery rows do not currently have a
+  foreign key, so the narrow safe fix is an explicit delete in the existing
+  retention/delete paths.
 
 ## Deferred
 
@@ -116,10 +160,20 @@ Parked hardening: none.
 
 ## Verification
 
-- Command: python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_pre_push_audit_workflow.py -q
-  -- 14 passed.
-- Command: python -m pytest tests/test_content_ops_deflection_report.py::test_retention_runner_requires_confirm_delete_and_valid_bounds tests/test_content_ops_deflection_report.py::test_retention_runner_resolves_database_url_from_non_argv_sources tests/test_content_ops_deflection_report.py::test_retention_runner_dry_run_counts_without_deleting_or_exposing_payload -q
-  -- 3 passed.
+- Command: python -m py_compile extracted_content_pipeline/deflection_report_access.py extracted_content_pipeline/api/control_surfaces.py tests/test_deflection_report_ttl_workflow.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py
+  -- passed.
+- Command: python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_content_ops_deflection_report.py::test_postgres_delete_report_scopes_to_account_and_request_id tests/test_content_ops_deflection_report.py::test_postgres_report_retention_uses_cutoff_and_limited_delete tests/test_content_ops_deflection_report.py::test_postgres_report_retention_fails_closed_on_unparseable_delete_count tests/test_content_ops_deflection_report.py::test_retention_runner_requires_confirm_delete_and_valid_bounds tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_returns_canonical_terms_only tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_rejects_reports_inside_retention_grace_window tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_closed_without_report_created_at -q
+  -- 13 passed.
+- Command: python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_pre_push_audit_workflow.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py -q
+  -- 314 passed, 1 skipped.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  -- passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  -- passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  -- passed.
+- Command: bash scripts/check_ascii_python.sh
+  -- passed.
 - Command: python scripts/audit_workflow_security_posture.py .github/workflows
   -- passed with existing repository-wide WARN findings only.
 - Command: git diff --check -- passed.
@@ -130,9 +184,13 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/content_ops_deflection_report_ttl_purge.yml` | 70 |
+| `.github/workflows/content_ops_deflection_report_ttl_purge.yml` | 73 |
 | `.github/workflows/pre_push_audit.yml` | 2 |
-| `plans/PR-Deflection-Report-TTL-Purge.md` | 138 |
-| `tests/test_deflection_report_ttl_workflow.py` | 67 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 41 |
+| `extracted_content_pipeline/deflection_report_access.py` | 83 |
+| `plans/PR-Deflection-Report-TTL-Purge.md` | 196 |
+| `tests/test_content_ops_deflection_report.py` | 41 |
+| `tests/test_deflection_report_ttl_workflow.py` | 77 |
+| `tests/test_extracted_content_control_surface_api.py` | 43 |
 | `tests/test_pre_push_audit_workflow.py` | 6 |
-| **Total** | **283** |
+| **Total** | **562** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -4356,12 +4356,12 @@ async def test_postgres_list_reports_uses_account_scope_optional_paid_filter_and
 async def test_postgres_delete_report_scopes_to_account_and_request_id() -> None:
     class _Pool:
         def __init__(self) -> None:
-            self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
-            self.execute_result = "DELETE 1"
+            self.fetchval_calls: list[tuple[str, tuple[object, ...]]] = []
+            self.fetchval_result = 1
 
-        async def execute(self, query: str, *args: object) -> str:
-            self.execute_calls.append((query, args))
-            return self.execute_result
+        async def fetchval(self, query: str, *args: object) -> int:
+            self.fetchval_calls.append((query, args))
+            return self.fetchval_result
 
     pool = _Pool()
     store = PostgresDeflectionReportArtifactStore(pool=pool)
@@ -4370,12 +4370,14 @@ async def test_postgres_delete_report_scopes_to_account_and_request_id() -> None
         account_id=" acct-1 ",
         request_id=" request-delete ",
     ) is True
-    query, args = pool.execute_calls[0]
+    query, args = pool.fetchval_calls[0]
     assert args == ("acct-1", "request-delete")
+    assert "WITH target AS" in query
+    assert "DELETE FROM content_ops_deflection_report_deliveries" in query
     assert "DELETE FROM content_ops_deflection_reports" in query
     assert "WHERE account_id = $1 AND request_id = $2" in query
 
-    pool.execute_result = "DELETE 0"
+    pool.fetchval_result = 0
     assert await store.delete_report(account_id="acct-1", request_id="missing") is False
 
 
@@ -4424,16 +4426,13 @@ async def test_postgres_report_retention_uses_cutoff_and_limited_delete() -> Non
     class _Pool:
         def __init__(self) -> None:
             self.fetchval_calls: list[tuple[str, tuple[object, ...]]] = []
-            self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
-            self.execute_result = "DELETE 2"
+            self.delete_result = 2
 
         async def fetchval(self, query: str, *args: object) -> int:
             self.fetchval_calls.append((query, args))
-            return 3
-
-        async def execute(self, query: str, *args: object) -> str:
-            self.execute_calls.append((query, args))
-            return self.execute_result
+            if "SELECT COUNT(*)\n            FROM content_ops_deflection_reports" in query:
+                return 3
+            return self.delete_result
 
     pool = _Pool()
     store = PostgresDeflectionReportArtifactStore(pool=pool)
@@ -4443,13 +4442,15 @@ async def test_postgres_report_retention_uses_cutoff_and_limited_delete() -> Non
     assert pool.fetchval_calls[0][1] == (cutoff,)
     assert "created_at < $1" in pool.fetchval_calls[0][0]
     assert await store.delete_reports_older_than(cutoff=cutoff, limit=25) == 2
-    limited_query, limited_args = pool.execute_calls[0]
+    limited_query, limited_args = pool.fetchval_calls[1]
     assert limited_args == (cutoff, 25)
     assert "WITH doomed AS" in limited_query
+    assert "DELETE FROM content_ops_deflection_report_deliveries" in limited_query
+    assert "DELETE FROM content_ops_deflection_reports" in limited_query
     assert "LIMIT $2" in limited_query
-    pool.execute_result = "DELETE 4"
+    pool.delete_result = 4
     assert await store.delete_reports_older_than(cutoff=cutoff) == 4
-    unbounded_query, unbounded_args = pool.execute_calls[1]
+    unbounded_query, unbounded_args = pool.fetchval_calls[2]
     assert unbounded_args == (cutoff,)
     assert "DELETE FROM content_ops_deflection_reports" in unbounded_query
     assert "LIMIT" not in unbounded_query
@@ -4458,13 +4459,13 @@ async def test_postgres_report_retention_uses_cutoff_and_limited_delete() -> Non
 @pytest.mark.asyncio
 async def test_postgres_report_retention_fails_closed_on_unparseable_delete_count() -> None:
     class _Pool:
-        async def execute(self, _query: str, *_args: object) -> str:
-            return "DELETE unknown"
+        async def fetchval(self, _query: str, *_args: object) -> str:
+            return "unknown"
 
     store = PostgresDeflectionReportArtifactStore(pool=_Pool())
     cutoff = datetime(2026, 5, 1, tzinfo=timezone.utc)
 
-    with pytest.raises(ValueError, match="could not parse database command count"):
+    with pytest.raises(ValueError, match="invalid literal"):
         await store.delete_reports_older_than(cutoff=cutoff)
 
 

--- a/tests/test_deflection_report_ttl_workflow.py
+++ b/tests/test_deflection_report_ttl_workflow.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "content_ops_deflection_report_ttl_purge.yml"
+)
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_ttl_purge_workflow_runs_only_on_schedule_or_manual_dispatch() -> None:
+    text = _workflow_text()
+
+    assert "  schedule:" in text
+    assert '    - cron: "23 8 * * *"' in text
+    assert "  workflow_dispatch:" in text
+    assert "  pull_request:" not in text
+    assert "  push:" not in text
+
+
+def test_ttl_purge_workflow_defaults_to_30_days_and_bounded_batches() -> None:
+    text = _workflow_text()
+
+    assert "      retention_days:" in text
+    assert '        default: "30"' in text
+    assert "      limit:" in text
+    assert '        default: "1000"' in text
+    assert 'retention_days="${RETENTION_DAYS:-30}"' in text
+    assert 'delete_limit="${DELETE_LIMIT:-1000}"' in text
+
+
+def test_ttl_purge_workflow_keeps_database_url_out_of_argv() -> None:
+    text = _workflow_text()
+
+    assert "EXTRACTED_DATABASE_URL: ${{ secrets.EXTRACTED_DATABASE_URL }}" in text
+    assert "--database-url-env EXTRACTED_DATABASE_URL" in text
+    assert re.search(r"--database-url(?!-env)\b", text) is None
+
+
+def test_ttl_purge_workflow_deletes_by_default_but_manual_dispatch_can_dry_run() -> None:
+    text = _workflow_text()
+
+    assert "      dry_run:" in text
+    assert "        type: boolean" in text
+    assert "        default: false" in text
+    assert 'dry_run="${DRY_RUN:-false}"' in text
+    assert 'if [ "$dry_run" != "true" ]; then' in text
+    assert "args+=(--confirm-delete)" in text
+
+
+def test_ttl_purge_workflow_has_minimal_permissions_and_pinned_actions() -> None:
+    text = _workflow_text()
+
+    assert "permissions:\n  contents: read" in text
+    assert "pull-requests: write" not in text
+    assert re.search(r"uses: actions/checkout@[0-9a-f]{40}", text)
+    assert re.search(r"uses: actions/setup-python@[0-9a-f]{40}", text)
+    assert "uses: actions/checkout@v" not in text
+    assert "uses: actions/setup-python@v" not in text

--- a/tests/test_deflection_report_ttl_workflow.py
+++ b/tests/test_deflection_report_ttl_workflow.py
@@ -45,6 +45,16 @@ def test_ttl_purge_workflow_keeps_database_url_out_of_argv() -> None:
     assert re.search(r"--database-url(?!-env)\b", text) is None
 
 
+def test_ttl_purge_workflow_rejects_non_main_manual_refs_before_secret_use() -> None:
+    text = _workflow_text()
+    secret_index = text.index("EXTRACTED_DATABASE_URL: ${{ secrets.EXTRACTED_DATABASE_URL }}")
+
+    assert "if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'" in text
+    assert "ref: ${{ github.event.repository.default_branch }}" in text
+    assert text.index("if: github.event_name == 'schedule'") < secret_index
+    assert text.index("ref: ${{ github.event.repository.default_branch }}") < secret_index
+
+
 def test_ttl_purge_workflow_deletes_by_default_but_manual_dispatch_can_dry_run() -> None:
     text = _workflow_text()
 

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -3031,6 +3031,49 @@ async def test_deflection_checkout_authorization_fails_closed_for_report_state(
 
 
 @pytest.mark.asyncio
+async def test_deflection_checkout_authorization_rejects_reports_inside_retention_grace_window():
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-gate",
+        request_id="request-expiring",
+        snapshot={"summary": {"generated": 1}},
+        artifact={"markdown": "# Full"},
+    )
+    store._created_at_by_key[("acct-gate", "request-expiring")] = datetime(
+        2020,
+        1,
+        1,
+        tzinfo=timezone.utc,
+    )
+
+    route = _checkout_authorization_route(store)
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(request_id="request-expiring")
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "Deflection report checkout window expired."
+
+
+@pytest.mark.asyncio
+async def test_deflection_checkout_authorization_fails_closed_without_report_created_at():
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.save_report(
+        account_id="acct-gate",
+        request_id="request-unknown-age",
+        snapshot={"summary": {"generated": 1}},
+        artifact={"markdown": "# Full"},
+    )
+    store._created_at_by_key.pop(("acct-gate", "request-unknown-age"))
+
+    route = _checkout_authorization_route(store)
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(request_id="request-unknown-age")
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "Deflection report checkout window expired."
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("config_kwargs", "detail"),
     [

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -3055,7 +3055,10 @@ async def test_deflection_checkout_authorization_rejects_reports_inside_retentio
 
 
 @pytest.mark.asyncio
-async def test_deflection_checkout_authorization_fails_closed_without_report_created_at():
+@pytest.mark.parametrize("created_at", [None, "2026-05-01T12:00:00Z"])
+async def test_deflection_checkout_authorization_fails_closed_without_usable_report_age(
+    created_at: object,
+):
     store = InMemoryDeflectionReportArtifactStore()
     await store.save_report(
         account_id="acct-gate",
@@ -3063,7 +3066,11 @@ async def test_deflection_checkout_authorization_fails_closed_without_report_cre
         snapshot={"summary": {"generated": 1}},
         artifact={"markdown": "# Full"},
     )
-    store._created_at_by_key.pop(("acct-gate", "request-unknown-age"))
+    key = ("acct-gate", "request-unknown-age")
+    if created_at is None:
+        store._created_at_by_key.pop(key)
+    else:
+        store._created_at_by_key[key] = created_at
 
     route = _checkout_authorization_route(store)
     with pytest.raises(api_module.HTTPException) as exc:

--- a/tests/test_pre_push_audit_workflow.py
+++ b/tests/test_pre_push_audit_workflow.py
@@ -59,3 +59,9 @@ def test_pre_push_audit_workflow_enrolls_claude_workflow_security_tests() -> Non
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "tests/test_claude_workflow_security.py" in text
+
+
+def test_pre_push_audit_workflow_enrolls_deflection_report_ttl_workflow_tests() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "tests/test_deflection_report_ttl_workflow.py" in text


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-TTL-Purge.md
Slice phase: Production hardening

Issue #1656's deletion item now has the request-scoped delete endpoint, but Atlas still needed its own production retention owner so 30-day expiry does not depend only on a downstream portfolio cron. This adds a scheduled/manual TTL purge workflow and addresses the review-discovered cross-path safety gaps: non-main manual dispatch cannot reach the DB secret, the purge/delete paths remove companion delivery metadata, and checkout authorization rejects reports already inside the final 24-hour grace window before 30-day expiry.

## Intentional
- No paid infrastructure; the slice uses existing GitHub Actions and repo secrets.
- No raw database URL on argv; the workflow passes only `--database-url-env EXTRACTED_DATABASE_URL`.
- No portfolio copy or cron changes in this Atlas slice.
- No schema migration here; delivery rows currently have no foreign key cascade, so the narrow fix explicitly deletes matching delivery rows in the existing retention/delete paths.

## Deferred
- #1656 / atlas-portfolio#313: keep the portfolio cleanup path coordinated with the Atlas delete endpoint and public security copy.
- #1656 medium-tier RLS, encryption, alerting, auth, scanner, IR, logging, security.txt, and CVE SLA items remain separate.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: yes.

- Resolved Codex P1: manual workflow dispatch is restricted to `refs/heads/main`, and checkout uses the repository default branch before the secret-bearing purge step.
- Resolved Codex P2: checkout authorization now fails closed during the final 24-hour open-session grace window before the 30-day purge cutoff.
- Resolved Codex P2: report retention/delete now removes matching `content_ops_deflection_report_deliveries` rows with the report rows.

## Verification
- `python -m py_compile extracted_content_pipeline/deflection_report_access.py extracted_content_pipeline/api/control_surfaces.py tests/test_deflection_report_ttl_workflow.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py` -- passed.
- `python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_content_ops_deflection_report.py::test_postgres_delete_report_scopes_to_account_and_request_id tests/test_content_ops_deflection_report.py::test_postgres_report_retention_uses_cutoff_and_limited_delete tests/test_content_ops_deflection_report.py::test_postgres_report_retention_fails_closed_on_unparseable_delete_count tests/test_content_ops_deflection_report.py::test_retention_runner_requires_confirm_delete_and_valid_bounds tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_returns_canonical_terms_only tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_rejects_reports_inside_retention_grace_window tests/test_extracted_content_control_surface_api.py::test_deflection_checkout_authorization_fails_closed_without_usable_report_age -q` -- 14 passed.
- `python -m pytest tests/test_deflection_report_ttl_workflow.py tests/test_pre_push_audit_workflow.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py -q` -- 315 passed, 1 skipped.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `python scripts/audit_workflow_security_posture.py .github/workflows` -- passed with existing repository-wide WARN findings only.
- `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --top 25` -- passed; ratchet gate reported no new brittleness above baseline.
- `git diff --check` -- passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Report-TTL-Purge.md --check` -- passed.

## Diff size
9 files, +517 / -47.
