### PR TITLE
Remove query-token auth fallback

### DIFF
--- a/atlas_brain/auth/dependencies.py
+++ b/atlas_brain/auth/dependencies.py
@@ -52,14 +52,14 @@ def _effective_is_admin(role: str | None, is_admin_flag: bool | None) -> bool:
 
 
 def _extract_token(request: Request) -> Optional[str]:
-    """Extract JWT from Authorization header, cookie, or query param."""
+    """Extract JWT from Authorization header or cookie."""
     auth = request.headers.get("authorization", "")
     if auth.startswith("Bearer "):
         return auth[7:]
     cookie = request.cookies.get("atlas_token")
     if cookie:
         return cookie
-    return request.query_params.get("token")
+    return None
 
 
 async def require_auth(request: Request) -> AuthUser:

--- a/plans/PR-Remove-Query-Token-Auth.md
+++ b/plans/PR-Remove-Query-Token-Auth.md
@@ -1,0 +1,81 @@
+# PR-Remove-Query-Token-Auth
+
+## Why this slice exists
+
+Issue #1656 M4 verifies that `atlas_brain/auth/dependencies.py` accepts JWTs
+from `?token=` via the shared `_extract_token()` helper. URL-carried
+credentials can leak through access logs, browser history, analytics, and
+referrers, so auth must stay in the Authorization header or the existing
+`atlas_token` cookie.
+
+Root cause: the shared JWT extraction helper treated the query string as an
+equivalent credential source after checking the header and cookie. This PR
+fixes the root for every `require_auth()` and `optional_auth()` caller by
+removing the query-parameter source from the shared helper instead of patching
+one route.
+
+## Scope (this PR)
+
+Ownership lane: security/hardening-1656
+Slice phase: Production hardening
+
+1. Remove `request.query_params.get("token")` from the JWT extraction path.
+2. Add focused tests proving query-only auth is rejected while Bearer header
+   and `atlas_token` cookie auth are still admitted.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A request with only `?token=<jwt>` is treated as unauthenticated by
+        `require_auth()` and `optional_auth()`.
+  - [ ] `Authorization: Bearer <jwt>` still extracts the JWT.
+  - [ ] The `atlas_token` cookie still extracts the JWT.
+  - [ ] API-key auth remains header-only and is not broadened.
+- Affected surfaces: auth dependencies, SaaS JWT auth callers.
+- Risk areas: security, backward compatibility for any client still using URL
+  tokens.
+- Reviewer rules triggered: R1, R2, R3, R5, R14; boundary-probe required
+  before LGTM because this changes a security guard.
+
+### Files touched
+
+- `atlas_brain/auth/dependencies.py`
+- `plans/PR-Remove-Query-Token-Auth.md`
+- `tests/test_auth_dependencies.py`
+
+## Mechanism
+
+`_extract_token()` remains the single JWT source selector for `require_auth()`
+and `optional_auth()`, but it now returns only a Bearer token from the
+Authorization header or the `atlas_token` cookie. Query strings are ignored,
+so query-only requests fail at the normal missing-auth branch.
+
+## Intentional
+
+- This is a deliberate breaking change for URL-token clients. That
+  compatibility loss is the point of #1656 M4 because URL credentials are not a
+  safe auth transport.
+- No config flag or transition shim is added; keeping the query fallback alive
+  behind a flag would preserve the leak-prone path.
+
+## Deferred
+
+- #1656 M1 RLS, M2 JSONB encryption, M3 alert delivery, M6 incident response
+  docs, M8 disclosure policy/security.txt, M9 CVE SLA, and H3 provider-side
+  credential rotation remain separate slices.
+
+Parked hardening: none.
+
+## Verification
+
+- `tests/test_auth_dependencies.py` via `pytest` -- 30 passed.
+- `scripts/local_pr_review.sh` with the PR body file -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/auth/dependencies.py` | 4 |
+| `plans/PR-Remove-Query-Token-Auth.md` | 81 |
+| `tests/test_auth_dependencies.py` | 95 |
+| **Total** | **180** |

--- a/tests/test_auth_dependencies.py
+++ b/tests/test_auth_dependencies.py
@@ -10,6 +10,10 @@ from atlas_brain.auth.dependencies import (
     CONTENT_OPS_API_KEY_SCOPES,
     PLAN_ORDER,
     _effective_is_admin,
+    _extract_token,
+    optional_auth,
+    require_auth,
+    require_auth_or_api_key,
     require_b2b_plan,
     require_b2b_plan_or_api_key,
     require_plan,
@@ -17,8 +21,19 @@ from atlas_brain.auth.dependencies import (
 
 
 class _FakeRequest:
-    def __init__(self, token: str):
-        self.headers = {"authorization": f"Bearer {token}"}
+    def __init__(
+        self,
+        token: str | None = None,
+        *,
+        headers: dict[str, str] | None = None,
+        cookies: dict[str, str] | None = None,
+        query_params: dict[str, str] | None = None,
+    ):
+        self.headers = headers if headers is not None else {}
+        if token is not None and headers is None:
+            self.headers = {"authorization": f"Bearer {token}"}
+        self.cookies = cookies or {}
+        self.query_params = query_params or {}
         self.client = SimpleNamespace(host="127.0.0.1")
 
 
@@ -61,6 +76,82 @@ def test_auth_user_keeps_platform_admin_separate_from_account_admin():
 
     assert user.is_admin is True
     assert user.is_platform_admin is False
+
+
+def test_extract_token_prefers_authorization_header_over_cookie_and_query():
+    request = _FakeRequest(
+        headers={"authorization": "Bearer header-token"},
+        cookies={"atlas_token": "cookie-token"},
+        query_params={"token": "query-token"},
+    )
+
+    assert _extract_token(request) == "header-token"
+
+
+def test_extract_token_accepts_atlas_token_cookie():
+    request = _FakeRequest(
+        cookies={"atlas_token": "cookie-token"},
+        query_params={"token": "query-token"},
+    )
+
+    assert _extract_token(request) == "cookie-token"
+
+
+def test_extract_token_rejects_query_token_only():
+    request = _FakeRequest(query_params={"token": "query-token"})
+
+    assert _extract_token(request) is None
+
+
+@pytest.mark.asyncio
+async def test_require_auth_rejects_query_token_only(monkeypatch):
+    import atlas_brain.auth.dependencies as dependencies_mod
+
+    monkeypatch.setattr(
+        dependencies_mod,
+        "settings",
+        SimpleNamespace(saas_auth=SimpleNamespace(enabled=True)),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await require_auth(_FakeRequest(query_params={"token": "query-token"}))
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Authentication required"
+
+
+@pytest.mark.asyncio
+async def test_optional_auth_ignores_query_token_only(monkeypatch):
+    import atlas_brain.auth.dependencies as dependencies_mod
+
+    monkeypatch.setattr(
+        dependencies_mod,
+        "settings",
+        SimpleNamespace(saas_auth=SimpleNamespace(enabled=True)),
+    )
+
+    user = await optional_auth(_FakeRequest(query_params={"token": "query-token"}))
+
+    assert user is None
+
+
+@pytest.mark.asyncio
+async def test_require_auth_or_api_key_rejects_query_api_key_only(monkeypatch):
+    import atlas_brain.auth.dependencies as dependencies_mod
+
+    monkeypatch.setattr(
+        dependencies_mod,
+        "settings",
+        SimpleNamespace(saas_auth=SimpleNamespace(enabled=True)),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await require_auth_or_api_key(
+            _FakeRequest(query_params={"token": "atls_live_abcdefghijklmnopqrstuvwxyz"})
+        )
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Authentication required"
 
 
 def test_require_plan_rejects_unknown_consumer_tier():


### PR DESCRIPTION
Plan: plans/PR-Remove-Query-Token-Auth.md
Slice phase: Production hardening

Issue #1656 M4 identified that SaaS JWT auth still accepted `?token=` through the shared extractor. This removes the query-string credential source at the root helper so `require_auth()` and `optional_auth()` accept only `Authorization: Bearer` or the existing `atlas_token` cookie.

## Intentional
- This deliberately breaks URL-token clients because URL credentials are leak-prone.
- No transition flag or shim keeps the unsafe path alive.

## Deferred
- #1656 M1 RLS, M2 JSONB encryption, M3 alert delivery, M6 incident response docs, M8 disclosure policy/security.txt, M9 CVE SLA, and H3 provider-side credential rotation remain separate slices.

## Parked hardening
- None.

## Verification
- `pytest tests/test_auth_dependencies.py` -- 30 passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file .tmp/pr-remove-query-token-auth.md` -- passed.

## Diff size
3 files, +177 / -4
