### PR TITLE
Add incident response runbook

### DIFF
--- a/.github/workflows/atlas_security_policy_docs_checks.yml
+++ b/.github/workflows/atlas_security_policy_docs_checks.yml
@@ -1,0 +1,39 @@
+name: Atlas Security Policy Docs Checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_security_policy_docs_checks.yml"
+      - "SECURITY.md"
+      - "atlas_brain/api/billing.py"
+      - "atlas_brain/content_ops_deflection_delivery.py"
+      - "docs/INCIDENT_RESPONSE.md"
+      - "tests/test_security_policy_docs.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_security_policy_docs_checks.yml"
+      - "SECURITY.md"
+      - "atlas_brain/api/billing.py"
+      - "atlas_brain/content_ops_deflection_delivery.py"
+      - "docs/INCIDENT_RESPONSE.md"
+      - "tests/test_security_policy_docs.py"
+
+jobs:
+  atlas-security-policy-docs-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Run security policy docs contract
+        run: python -m unittest tests.test_security_policy_docs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,11 @@ Good-faith testing is welcome when it avoids harm:
 
 Reports that follow these guidelines are treated as authorized security research.
 
+## Incident Response
+
+Operational triage and response steps live in
+[docs/INCIDENT_RESPONSE.md](docs/INCIDENT_RESPONSE.md).
+
 ## Response Targets
 
 Atlas aims to acknowledge new vulnerability reports within five business days,

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -1,0 +1,143 @@
+# Incident Response
+
+This runbook covers security and money-path incidents for ATLAS. It is the
+operator companion to the public disclosure policy in `SECURITY.md`.
+
+## Severity Levels
+
+- SEV0 - Active compromise, exposed live secrets, unauthorized data access,
+  payment unlock abuse, or ongoing customer-impacting data loss.
+- SEV1 - Confirmed vulnerability with likely customer impact, failed paid report
+  delivery after payment, cross-account access risk, or disabled security gate.
+- SEV2 - Security control degraded without confirmed customer impact, repeated
+  paid-funnel incident alerts, or a high-risk dependency requiring coordinated
+  remediation.
+- SEV3 - Low-risk vulnerability report, scanner finding, suspicious but
+  unconfirmed activity, or documentation/process gap.
+
+## Roles and Ownership
+
+- Incident owner: the first responding Atlas operator. They keep the timeline,
+  assign tasks, and decide when the incident can close.
+- Technical lead: the engineer who owns the affected component or the smallest
+  safe fix path.
+- Communications owner: the operator who sends external updates and keeps
+  private vulnerability reporters informed.
+- Rotation owner: the person with provider access for Stripe, Anthropic,
+  OpenRouter, Resend, AWS SES, SignalWire, Google, or other affected services.
+
+If one person fills multiple roles, record that explicitly in the timeline.
+
+## Intake and Triage
+
+1. Open a private incident note with the report URL, reporter contact, received
+   time, affected systems, suspected data class, and initial severity.
+2. Confirm whether the issue affects ATLAS only, atlas-portfolio only, or a
+   cross-repo flow.
+3. Preserve evidence before changing state: relevant request IDs, account IDs,
+   provider event IDs, deployment SHAs, sanitized logs, and screenshots.
+4. Classify severity using the SEV table above. Raise severity if payment,
+   authentication, authorization, customer ticket content, or credential exposure
+   is involved.
+5. Assign the incident owner, technical lead, communications owner, and rotation
+   owner.
+
+## Communications
+
+- Acknowledge private vulnerability reports within five business days when
+  possible, matching `SECURITY.md`.
+- For SEV0 and SEV1, create an internal timeline immediately and update it at
+  least every hour while containment is active.
+- For SEV2, update the timeline at least once per business day until resolved or
+  explicitly accepted.
+- Keep public GitHub issues free of exploit details, secrets, customer data, and
+  provider event IDs.
+- If atlas-portfolio is involved, link the companion issue or incident note so
+  the two repositories share one timeline.
+
+## Paid Funnel Incident Types
+
+Paid deflection funnel incidents are emitted with the
+`DEFLECTION_PAID_FUNNEL_INCIDENT` marker. Treat these as payment-adjacent until
+triage proves otherwise:
+
+- `paid_report_checkout_terms_mismatch`
+- `paid_report_missing_after_payment`
+- `paid_report_revocation_missed_report`
+- `paid_report_restore_missed_report`
+- `paid_report_delivery_report_not_paid`
+- `paid_report_delivery_missing_email`
+- `paid_report_delivery_no_longer_sendable`
+- `paid_report_delivery_idempotent_replay`
+- `paid_report_delivery_send_failed`
+
+For these incidents, capture the Stripe event ID, checkout session ID, account
+ID, request ID, delivery ID when present, and the deployed commit SHA. Do not
+paste raw customer ticket content into the timeline.
+
+## Credential Rotation
+
+1. Treat credentials in git history, logs, screenshots, or third-party reports as
+   exposed until the provider confirms revocation.
+2. Create the replacement credential in the provider console or secret manager.
+3. Update deployed secret stores for every consumer before revoking the old value
+   when the provider requires overlap.
+4. Revoke the old credential and record the provider confirmation time.
+5. Run the narrow smoke check for the affected integration.
+6. Update the incident timeline with the old credential name, provider, rotation
+   time, verifier, and follow-up owner. Do not record secret values.
+
+Stripe and deflection funnel credentials may be shared with atlas-portfolio, so
+coordinate both repositories before revocation.
+
+## Containment and Recovery
+
+- Stop active abuse first: disable the affected route, revoke the credential,
+  pause the webhook, or turn off the feature flag if needed.
+- Prefer the smallest reversible mitigation while the root cause is still under
+  investigation.
+- Keep customer-facing claims truthful. If deletion, payment unlock, delivery,
+  or security copy is no longer true, update or disable it before announcing
+  closure.
+- After the fix lands, verify it on the deployed path or the closest available
+  local reproduction. Record the command, URL, provider event, or artifact used
+  as evidence.
+
+## Postmortem Template
+
+Use this template for SEV0, SEV1, repeated SEV2 incidents, or any incident where
+customer trust, payment integrity, or credential exposure was involved.
+
+```text
+Incident:
+Severity:
+Incident owner:
+Technical lead:
+Communications owner:
+Opened:
+Closed:
+
+Summary:
+
+Impact:
+
+Root cause:
+
+Timeline:
+- YYYY-MM-DD HH:MM TZ -
+
+Detection:
+
+Containment:
+
+Recovery verification:
+
+Customer or reporter communication:
+
+What worked:
+
+What failed:
+
+Follow-up actions:
+- [ ] Owner - action - due date
+```

--- a/plans/PR-Incident-Response-Runbook.md
+++ b/plans/PR-Incident-Response-Runbook.md
@@ -1,0 +1,94 @@
+# PR-Incident-Response-Runbook
+
+## Why this slice exists
+
+Issue #1656 M6 calls for an incident-response playbook covering severity
+definitions, ownership, communications, credential rotation, money-path incident
+types, and postmortems. #1812 added the public disclosure path, but reports still
+land in a policy vacuum: `SECURITY.md` tells researchers where to report without
+linking to an operator runbook for triage and response.
+
+Root cause: Atlas had disclosure intake metadata but no first-party incident
+response operating document. This PR fixes that root for the Atlas repo by adding
+the runbook, linking it from the security policy, and testing the expected doc
+contract in CI.
+
+## Scope (this PR)
+
+Ownership lane: security/hardening-1656
+Slice phase: Production hardening
+
+1. Add `docs/INCIDENT_RESPONSE.md` with SEV0-SEV3 definitions, ownership,
+   communications cadence, credential-rotation flow, paid-funnel incident types,
+   and a postmortem template.
+2. Link the runbook from `SECURITY.md` so the disclosure policy points operators
+   to the response process.
+3. Add a focused docs contract test and enroll it in a small GitHub Actions
+   workflow.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `docs/INCIDENT_RESPONSE.md` exists and covers SEV0-SEV3, owners,
+        communications, credential rotation, paid-funnel incident types, and a
+        postmortem template.
+  - [ ] `SECURITY.md` links to the incident-response runbook.
+  - [ ] The docs contract test fails if the link or required runbook sections
+        disappear.
+  - [ ] The new docs contract test is CI-enrolled.
+- Affected surfaces: security policy docs, incident-response runbook, docs-only
+  CI check.
+- Risk areas: overpromising operational SLAs, drift between emitted incident
+  names and the runbook.
+- Reviewer rules triggered: R1, R2, R5, R11, R12, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_security_policy_docs_checks.yml`
+- `SECURITY.md`
+- `docs/INCIDENT_RESPONSE.md`
+- `plans/PR-Incident-Response-Runbook.md`
+- `tests/test_security_policy_docs.py`
+
+## Mechanism
+
+The runbook is a repo-local markdown document. `SECURITY.md` links to it from
+the response-targets section, keeping public disclosure intake and internal
+operator response connected. The docs test reads both markdown files and asserts
+the link, required headings, SEV labels, paid-funnel incident names from the
+current code, and postmortem template markers. The GitHub Actions workflow runs
+for the security policy, runbook, test, workflow itself, and paid-funnel emitter
+paths that can add or rename incident types.
+
+## Intentional
+
+- This PR does not implement real alert delivery (M3), CVE remediation labels
+  (M9), or provider-side credential rotation (H3). The runbook names those flows
+  without claiming they are fully automated.
+- This PR stays Atlas-only; the portfolio companion issue can mirror or link to
+  the same response process separately.
+
+## Deferred
+
+- #1656 M3 real alert delivery, M9 CVE remediation SLA and labels, H3 provider
+  credential rotation, M1 RLS, M2 JSONB encryption, M5 scanner ratcheting, M7
+  structured logging, and H5 blog-admin authz remain separate slices.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m unittest tests.test_security_policy_docs - 3 tests passed
+- bash scripts/local_pr_review.sh --current-pr-body-file
+  tmp/pr-incident-response-runbook-body.md - passed
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_security_policy_docs_checks.yml` | 39 |
+| `SECURITY.md` | 5 |
+| `docs/INCIDENT_RESPONSE.md` | 143 |
+| `plans/PR-Incident-Response-Runbook.md` | 94 |
+| `tests/test_security_policy_docs.py` | 99 |
+| **Total** | **380** |

--- a/tests/test_security_policy_docs.py
+++ b/tests/test_security_policy_docs.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SECURITY_MD = REPO_ROOT / "SECURITY.md"
+INCIDENT_RESPONSE_MD = REPO_ROOT / "docs" / "INCIDENT_RESPONSE.md"
+PAID_FUNNEL_EMITTERS = [
+    REPO_ROOT / "atlas_brain" / "api" / "billing.py",
+    REPO_ROOT / "atlas_brain" / "content_ops_deflection_delivery.py",
+]
+
+
+class SecurityPolicyDocsTest(unittest.TestCase):
+    def test_security_policy_links_incident_response_runbook(self) -> None:
+        security_text = SECURITY_MD.read_text(encoding="utf-8")
+
+        self.assertIn("## Incident Response", security_text)
+        self.assertIn("[docs/INCIDENT_RESPONSE.md](docs/INCIDENT_RESPONSE.md)", security_text)
+
+    def test_incident_response_runbook_covers_required_sections(self) -> None:
+        runbook = INCIDENT_RESPONSE_MD.read_text(encoding="utf-8")
+
+        required_markers = [
+            "# Incident Response",
+            "## Severity Levels",
+            "SEV0",
+            "SEV1",
+            "SEV2",
+            "SEV3",
+            "## Roles and Ownership",
+            "## Intake and Triage",
+            "## Communications",
+            "## Paid Funnel Incident Types",
+            "## Credential Rotation",
+            "## Containment and Recovery",
+            "## Postmortem Template",
+            "Incident:",
+            "Root cause:",
+            "Timeline:",
+            "Follow-up actions:",
+        ]
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, runbook)
+
+    def test_incident_response_names_current_paid_funnel_incidents(self) -> None:
+        runbook = INCIDENT_RESPONSE_MD.read_text(encoding="utf-8")
+
+        incident_types = sorted(_paid_funnel_incident_types_from_emitters())
+        for incident_type in incident_types:
+            with self.subTest(incident_type=incident_type):
+                self.assertIn(incident_type, runbook)
+
+
+def _paid_funnel_incident_types_from_emitters() -> set[str]:
+    incident_types: set[str] = set()
+    for emitter_path in PAID_FUNNEL_EMITTERS:
+        tree = ast.parse(emitter_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if _call_name(node.func) not in {
+                "_emit_delivery_incident",
+                "emit_deflection_paid_funnel_incident_alert",
+            }:
+                continue
+            incident_type = _literal_incident_type(node)
+            if incident_type:
+                incident_types.add(incident_type)
+    if not incident_types:
+        raise AssertionError("no paid-funnel incident emitters found")
+    return incident_types
+
+
+def _call_name(func: ast.expr) -> str:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _literal_incident_type(node: ast.Call) -> str | None:
+    for keyword in node.keywords:
+        if keyword.arg == "incident_type" and isinstance(keyword.value, ast.Constant):
+            value = keyword.value.value
+            return value if isinstance(value, str) else None
+    if node.args and isinstance(node.args[0], ast.Constant):
+        value = node.args[0].value
+        return value if isinstance(value, str) else None
+    return None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Plan: plans/PR-Incident-Response-Runbook.md
Slice phase: Production hardening

Issue #1656 M6 needs an operator incident-response process now that the public
disclosure path exists. This adds the Atlas runbook, links it from SECURITY.md,
and enrolls a focused docs contract check so the link, required sections, and
paid-funnel incident names do not drift silently.

## Intentional
- This documents the response process without implementing M3 alert delivery,
  M9 CVE labels, or H3 provider-side rotation.
- Scope stays in ATLAS; atlas-portfolio can mirror or link to the same process
  separately.

## Deferred
- #1656 M3 real alert delivery, M9 CVE remediation SLA and labels, H3 provider
  credential rotation, M1 RLS, M2 JSONB encryption, M5 scanner ratcheting, M7
  structured logging, and H5 blog-admin authz remain separate slices.

## Parked hardening
- None.

## Verification
- python -m unittest tests.test_security_policy_docs - 3 tests passed
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-incident-response-runbook-body.md - passed

## AI reconciliation
- AI findings reviewed: yes.
- All fixed or waived: yes.
- Waivers justified: none.
- Fixed Codex: derive paid-funnel incident names from `atlas_brain/api/billing.py`
  and `atlas_brain/content_ops_deflection_delivery.py` instead of hardcoding a
  second copy in the docs test.
- Fixed Codex: run the docs contract workflow when paid-funnel emitter files
  change.
- Fixed Codex: assert postmortem template body markers, not only the heading.

## Diff size
5 files, +380 / -0
