### PR TITLE
Add CVE remediation SLA contract

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     labels:
       - dependencies
       - security
+      - cve-remediation-sla
 
   - package-ecosystem: "npm"
     directories:
@@ -27,6 +28,7 @@ updates:
     labels:
       - dependencies
       - security
+      - cve-remediation-sla
     groups:
       npm-security-and-patches:
         patterns:
@@ -51,6 +53,7 @@ updates:
     labels:
       - dependencies
       - security
+      - cve-remediation-sla
     groups:
       python-security-and-patches:
         patterns:
@@ -73,6 +76,7 @@ updates:
     labels:
       - dependencies
       - security
+      - cve-remediation-sla
 
   - package-ecosystem: "docker-compose"
     directories:
@@ -86,3 +90,4 @@ updates:
     labels:
       - dependencies
       - security
+      - cve-remediation-sla

--- a/.github/workflows/atlas_security_policy_docs_checks.yml
+++ b/.github/workflows/atlas_security_policy_docs_checks.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_security_policy_docs_checks.yml"
+      - ".github/dependabot.yml"
       - "SECURITY.md"
       - "atlas_brain/api/billing.py"
       - "atlas_brain/content_ops_deflection_delivery.py"
@@ -17,6 +18,7 @@ on:
       - main
     paths:
       - ".github/workflows/atlas_security_policy_docs_checks.yml"
+      - ".github/dependabot.yml"
       - "SECURITY.md"
       - "atlas_brain/api/billing.py"
       - "atlas_brain/content_ops_deflection_delivery.py"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,5 +53,18 @@ Atlas aims to acknowledge new vulnerability reports within five business days,
 confirm scope and impact after triage, and provide status updates for accepted
 reports until remediation or documented acceptance.
 
-Specific remediation deadlines and CVE handling are tracked separately from this
-initial disclosure policy.
+Accepted vulnerabilities, CVEs, and GitHub Security Advisories use these maximum
+remediation targets from the date Atlas confirms impact:
+
+- Critical: fix, mitigate, or document acceptance within 7 calendar days.
+- High: fix, mitigate, or document acceptance within 30 calendar days.
+- Moderate: fix, mitigate, or document acceptance within 90 calendar days.
+- Low: triage into the normal security backlog with an owner and rationale.
+
+Dependabot PRs carry the `dependencies`, `security`, and
+`cve-remediation-sla` labels. Those labels mark dependency and CVE updates as
+covered by this policy and keep triage separate from general feature work.
+
+For vulnerabilities that span ATLAS and atlas-portfolio, use the stricter
+affected-surface severity and track the remediation window across both
+repositories.

--- a/plans/PR-Security-CVE-Remediation-SLA.md
+++ b/plans/PR-Security-CVE-Remediation-SLA.md
@@ -1,0 +1,104 @@
+# PR-Security-CVE-Remediation-SLA
+
+## Why this slice exists
+
+#1656 M9 asks for a severity-based CVE remediation SLA: Critical within 7 days,
+High within 30 days, and Moderate within 90 days, wired to Dependabot labels.
+The current `SECURITY.md` explicitly says remediation deadlines and CVE handling
+are tracked separately, while `.github/dependabot.yml` only applies generic
+`dependencies` and `security` labels. Root cause: the disclosure policy and
+Dependabot config do not share a durable contract for which dependency/CVE PRs
+fall under the remediation windows. This change fixes the root by documenting
+the SLA in the policy, labeling Dependabot updates as SLA-governed, and testing
+both the policy markers and label wiring in CI.
+
+## Scope (this PR)
+
+Ownership lane: security/cve-remediation-sla
+Slice phase: Production hardening
+
+1. Document the CVE/remediation severity windows in `SECURITY.md`.
+2. Add a `cve-remediation-sla` label to every Dependabot ecosystem block so
+   dependency security updates are visibly governed by the SLA.
+3. Create the repository label `cve-remediation-sla` so Dependabot can apply
+   the configured label instead of silently ignoring it.
+4. Extend the existing security policy docs contract so policy text,
+   Dependabot label wiring, and the workflow trigger stay in sync.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `SECURITY.md` names Critical 7-day, High 30-day, and Moderate 90-day
+        remediation targets for accepted vulnerabilities/CVEs.
+  - [ ] Every `.github/dependabot.yml` update block carries `dependencies`,
+        `security`, and `cve-remediation-sla` labels.
+  - [ ] The GitHub repository label `cve-remediation-sla` exists.
+  - [ ] The security policy docs workflow runs when `.github/dependabot.yml`
+        changes, so label drift cannot bypass the contract test.
+  - [ ] The focused docs/config test proves the positive contract plus
+        fail-closed fixtures for missing Dependabot update blocks, missing SLA
+        labels, and partial parser misses.
+- Affected surfaces: public security policy, Dependabot PR labeling, and
+  security policy docs CI.
+- Risk areas: security process drift, Dependabot triage visibility, and CI
+  trigger coverage.
+- Reviewer rules triggered: R1, R2, R5, R11, R12, R14.
+
+### Files touched
+
+- `.github/dependabot.yml`
+- `.github/workflows/atlas_security_policy_docs_checks.yml`
+- `SECURITY.md`
+- `plans/PR-Security-CVE-Remediation-SLA.md`
+- `tests/test_security_policy_docs.py`
+
+## Mechanism
+
+`SECURITY.md` replaces the placeholder response-target note with concrete
+remediation windows and names the Dependabot labels that mark dependency/CVE
+PRs as SLA-governed. `.github/dependabot.yml` adds the
+`cve-remediation-sla` label to every configured ecosystem, and the repository
+label was created in GitHub metadata so Dependabot can apply it. The existing
+security policy docs workflow adds `.github/dependabot.yml` to its path filters,
+and the `tests/test_security_policy_docs.py` contract checks the SLA text, all
+Dependabot label sets, a parser count cross-check, and that workflow trigger.
+
+## Intentional
+
+- This slice does not introduce auto-merge or severity-specific routing. The
+  durable first step is to make the SLA public and make every Dependabot PR
+  visibly subject to it; queue automation can build on the stable label later.
+- The Dependabot config test uses a small standard-library parser for the
+  repository's known subset of YAML instead of importing PyYAML, because this
+  docs-check job intentionally installs no third-party dependencies.
+
+## Deferred
+
+- Optional auto-merge for patch/minor Dependabot PRs that pass CI remains
+  deferred until the low-risk dependency class is separated from bucket-4
+  runtime bumps.
+- Severity-specific automation that maps GitHub advisory severity to labels is
+  deferred; this slice only establishes the public SLA and the Dependabot
+  governed-label contract.
+
+Parked hardening: none.
+
+## Verification
+
+- GitHub label metadata: `cve-remediation-sla` exists with description
+  "Dependabot/CVE remediation governed by SECURITY.md SLA".
+- `python -m unittest tests.test_security_policy_docs` -- passed (`9 tests`).
+- `scripts/local_pr_review.sh` with
+  `--current-pr-body-file tmp/pr-security-cve-remediation-sla-body.md` --
+  passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/dependabot.yml` | 5 |
+| `.github/workflows/atlas_security_policy_docs_checks.yml` | 2 |
+| `SECURITY.md` | 17 |
+| `plans/PR-Security-CVE-Remediation-SLA.md` | 104 |
+| `tests/test_security_policy_docs.py` | 132 |
+| **Total** | **260** |

--- a/tests/test_security_policy_docs.py
+++ b/tests/test_security_policy_docs.py
@@ -8,6 +8,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SECURITY_MD = REPO_ROOT / "SECURITY.md"
 INCIDENT_RESPONSE_MD = REPO_ROOT / "docs" / "INCIDENT_RESPONSE.md"
+DEPENDABOT_YML = REPO_ROOT / ".github" / "dependabot.yml"
+SECURITY_POLICY_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "atlas_security_policy_docs_checks.yml"
+)
 PAID_FUNNEL_EMITTERS = [
     REPO_ROOT / "atlas_brain" / "api" / "billing.py",
     REPO_ROOT / "atlas_brain" / "content_ops_deflection_delivery.py",
@@ -20,6 +24,71 @@ class SecurityPolicyDocsTest(unittest.TestCase):
 
         self.assertIn("## Incident Response", security_text)
         self.assertIn("[docs/INCIDENT_RESPONSE.md](docs/INCIDENT_RESPONSE.md)", security_text)
+
+    def test_security_policy_documents_cve_remediation_sla(self) -> None:
+        security_text = SECURITY_MD.read_text(encoding="utf-8")
+
+        required_markers = [
+            "Critical: fix, mitigate, or document acceptance within 7 calendar days.",
+            "High: fix, mitigate, or document acceptance within 30 calendar days.",
+            "Moderate: fix, mitigate, or document acceptance within 90 calendar days.",
+            "`dependencies`, `security`, and",
+            "`cve-remediation-sla` labels",
+            "Dependabot PRs",
+            "GitHub Security Advisories",
+        ]
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, security_text)
+
+    def test_dependabot_updates_carry_security_sla_labels(self) -> None:
+        config_text = DEPENDABOT_YML.read_text(encoding="utf-8")
+        update_labels = _dependabot_update_label_sets(config_text)
+
+        _assert_dependabot_security_sla_labels(
+            update_labels,
+            expected_update_count=_dependabot_package_ecosystem_count(config_text),
+        )
+
+    def test_dependabot_label_contract_fails_without_update_blocks(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "no Dependabot update blocks found"):
+            _dependabot_update_label_sets("version: 2\nupdates:\n")
+
+    def test_dependabot_label_contract_rejects_missing_sla_label(self) -> None:
+        update_labels = _dependabot_update_label_sets(
+            '\n'.join(
+                [
+                    "version: 2",
+                    "updates:",
+                    '  - package-ecosystem: "pip"',
+                    '    directory: "/"',
+                    "    labels:",
+                    "      - dependencies",
+                    "      - security",
+                ]
+            )
+        )
+
+        with self.assertRaisesRegex(AssertionError, "pip labels missing"):
+            _assert_dependabot_security_sla_labels(
+                update_labels,
+                expected_update_count=1,
+            )
+
+    def test_dependabot_label_contract_rejects_partial_parse(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            "parsed 1 Dependabot update block.*2 package-ecosystem markers",
+        ):
+            _assert_dependabot_security_sla_labels(
+                [("pip", {"dependencies", "security", "cve-remediation-sla"})],
+                expected_update_count=2,
+            )
+
+    def test_security_policy_docs_workflow_runs_on_dependabot_config_changes(self) -> None:
+        workflow = SECURITY_POLICY_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn('".github/dependabot.yml"', workflow)
 
     def test_incident_response_runbook_covers_required_sections(self) -> None:
         runbook = INCIDENT_RESPONSE_MD.read_text(encoding="utf-8")
@@ -74,6 +143,69 @@ def _paid_funnel_incident_types_from_emitters() -> set[str]:
     if not incident_types:
         raise AssertionError("no paid-funnel incident emitters found")
     return incident_types
+
+
+def _dependabot_update_label_sets(config_text: str) -> list[tuple[str, set[str]]]:
+    update_labels: list[tuple[str, set[str]]] = []
+    current_ecosystem: str | None = None
+    current_labels: set[str] = set()
+    in_labels = False
+
+    def flush_current() -> None:
+        nonlocal current_ecosystem, current_labels, in_labels
+        if current_ecosystem is not None:
+            update_labels.append((current_ecosystem, set(current_labels)))
+        current_ecosystem = None
+        current_labels = set()
+        in_labels = False
+
+    for raw_line in config_text.splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith("- package-ecosystem:"):
+            flush_current()
+            current_ecosystem = stripped.split(":", 1)[1].strip().strip('"')
+            continue
+        if current_ecosystem is None:
+            continue
+        if stripped == "labels:":
+            in_labels = True
+            continue
+        if in_labels and stripped.startswith("- "):
+            current_labels.add(stripped[2:].strip().strip('"'))
+            continue
+        if in_labels and stripped and not stripped.startswith("#"):
+            in_labels = False
+
+    flush_current()
+    if not update_labels:
+        raise AssertionError("no Dependabot update blocks found")
+    return update_labels
+
+
+def _assert_dependabot_security_sla_labels(
+    update_labels: list[tuple[str, set[str]]],
+    *,
+    expected_update_count: int,
+) -> None:
+    if len(update_labels) != expected_update_count:
+        raise AssertionError(
+            "parsed "
+            f"{len(update_labels)} Dependabot update block(s), but found "
+            f"{expected_update_count} package-ecosystem markers"
+        )
+    required_labels = {"dependencies", "security", "cve-remediation-sla"}
+    for ecosystem, labels in update_labels:
+        missing = required_labels - labels
+        if missing:
+            raise AssertionError(f"{ecosystem} labels missing {sorted(missing)}")
+
+
+def _dependabot_package_ecosystem_count(config_text: str) -> int:
+    return sum(
+        1
+        for line in config_text.splitlines()
+        if line.strip().startswith("- package-ecosystem:")
+    )
 
 
 def _call_name(func: ast.expr) -> str:


### PR DESCRIPTION
Plan: plans/PR-Security-CVE-Remediation-SLA.md
Slice phase: Production hardening

#1656 M9 needs a concrete CVE remediation SLA instead of the current
SECURITY.md placeholder. This documents Critical/High/Moderate remediation
windows, labels every Dependabot ecosystem as governed by the SLA, and extends
the security policy docs contract so the policy, Dependabot label wiring, and
workflow trigger cannot drift silently.

## Intentional
- No auto-merge or severity-specific routing in this slice; this establishes
  the public SLA and stable `cve-remediation-sla` Dependabot label contract.
- The docs/config test uses a small standard-library parser for the repo's
  Dependabot YAML subset so the docs-check workflow stays dependency-free.

## Deferred
- Optional auto-merge for low-risk patch/minor Dependabot PRs remains deferred.
- Severity-specific automation that maps GitHub advisory severity to labels is
  deferred; this slice makes every Dependabot PR visibly SLA-governed first.

## Parked hardening
- None.

## Verification
- GitHub label metadata: `cve-remediation-sla` exists with description
  "Dependabot/CVE remediation governed by SECURITY.md SLA"
- python -m unittest tests.test_security_policy_docs - 9 tests passed
- bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-security-cve-remediation-sla-body.md - passed

## AI reconciliation
- AI findings reviewed: yes.
- All fixed or waived: yes.
- Waivers justified: none.
- Fixed Codex: created the repository label `cve-remediation-sla` so Dependabot
  will apply the configured label instead of ignoring an undefined label.
- Fixed reviewer NIT: added an independent `package-ecosystem:` count
  cross-check and negative fixture so a partial Dependabot parser miss fails
  closed.

## Diff size
5 files, +258 / -2
