### PR TITLE
Add deflection report projection contract

### DIFF
--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -109,6 +109,62 @@ type DeflectionReportSection = {
   data: Record<string, unknown>;
 };
 
+type DeflectionReportProjectionContract = {
+  schema_version: "deflection.v1";
+  model_fields: ["schema_version", "title", "summary", "sections"];
+  section_fields: [
+    "id",
+    "title",
+    "priority",
+    "surfaces",
+    "default_limit",
+    "required_data",
+    "snapshot_safe_fields",
+    "data"
+  ];
+  sections: DeflectionReportProjectionSection[];
+};
+
+type DeflectionReportProjectionSection = {
+  id: string;
+  title: string;
+  priority: number;
+  surfaces: string[];
+  default_limit: number | null;
+  required_data: string[];
+  snapshot_safe_fields: string[];
+  presence:
+    | { mode: "required" }
+    | { mode: "conditional"; condition: string };
+  projected_fields: string[];
+  optional_projected_fields?: string[];
+  hosted_consumer_safe_fields: string[];
+  collection?: {
+    field: "rows" | "items" | "phrases" | string;
+    item_type: "object" | "string" | string;
+    projected_fields?: string[];
+    hosted_consumer_safe_fields?: string[];
+    nested_object_fields?: DeflectionReportProjectionNestedField[];
+    nested_collection_fields?: DeflectionReportProjectionNestedCollection[];
+  };
+  nested_object_fields?: DeflectionReportProjectionNestedField[];
+  nested_collection_fields?: DeflectionReportProjectionNestedCollection[];
+  record_fields?: string[];
+};
+
+type DeflectionReportProjectionNestedField = {
+  field: string;
+  projected_fields: string[];
+  hosted_consumer_safe_fields: string[];
+};
+
+type DeflectionReportProjectionNestedCollection = {
+  field: string;
+  item_type: "object" | "string" | string;
+  projected_fields: string[];
+  hosted_consumer_safe_fields: string[];
+};
+
 type DeflectionSnapshotProjectionContract = {
   schema_version: "deflection.v1";
   top_level_fields: [
@@ -138,8 +194,23 @@ Renderer rules:
 
 - Sort sections by `priority`; do not rely on array position alone.
 - Skip unknown section IDs or unsupported `surfaces` values rather than failing.
-- Use `required_data` as the section's top-level data contract. A listed key is
-  expected to be present in `data`; nested shapes stay section-specific.
+- Use `report_projection` as the paid structured-report source for future
+  frontend type generation. `projected_fields` describes the full paid backend
+  model; `hosted_consumer_safe_fields` is the smaller allowlist for URL/token
+  hosted result-page payload construction.
+- Use `presence.mode` before treating a section as required. `source_file`
+  appears only when a source label exists, and `outcome_diagnostics` appears
+  only when diagnostics render.
+- Action section `items` include identity/delta and evidence fields in the full
+  paid projection, but hosted result pages must allowlist-construct their item
+  payload from `hosted_consumer_safe_fields` rather than validate-and-pass
+  through raw rows.
+- Treat nested arrays such as action-item `top_evidence` as
+  `nested_collection_fields`; apply their item allowlist per row, not as a
+  single nested object.
+- `source_file.source_label` is not hosted-consumer-safe because it can contain
+  a local/customer filename. Hosted pages should omit it unless a later slice
+  normalizes it to a safe display label.
 - Treat `snapshot_safe_fields` as the free Snapshot allowlist. A listed field
   must be safe to emit for every projected row in that section; paid answer
   bodies and steps are not snapshot-safe section fields. The only free answer
@@ -150,7 +221,7 @@ Renderer rules:
   `question`, and `ticket_count`. Use this contract before changing frontend
   snapshot parsers; do not infer the projection from demo fixtures.
 - Treat `complete_evidence` as export-only. It summarizes export size and should
-  not be inlined into web/PDF surfaces.
+  not be inlined into web/PDF surfaces or hosted result-page payloads.
 - Breaking shape changes bump `schema_version`; additive sections should keep
   `schema_version: "deflection.v1"` and remain skippable by older renderers.
 

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -783,6 +783,296 @@ _SNAPSHOT_TEASER_PREVIEW_FIELDS = (
     "source_count",
     "body_withheld",
 )
+_REPORT_SUPPORT_TAX_FIELDS = (
+    "repeat_ticket_count",
+    "non_repeat_ticket_count",
+    "generated_question_count",
+    "assisted_contact_cost",
+    "estimated_support_cost",
+    "source_date_window",
+    "drafted_answer_count",
+    "no_proven_answer_count",
+    "ticket_source_count",
+    "annualized_support_cost",
+    "annualized_run_rate_support_cost",
+)
+_REPORT_SUPPORT_TAX_OPTIONAL_FIELDS = (
+    "annualized_support_cost",
+    "annualized_run_rate_support_cost",
+)
+_REPORT_SOURCE_FILE_FIELDS = ("source_label",)
+_REPORT_SEO_TARGET_FIELDS = (
+    "phrases",
+    "total_phrase_count",
+    "displayed_phrase_count",
+    "omitted_phrase_count",
+    "limit",
+)
+_REPORT_RANKED_QUESTION_FIELDS = ("rows",)
+_REPORT_RANKED_QUESTION_ROW_FIELDS = (
+    "rank",
+    "question",
+    "ticket_count",
+    "weighted_frequency",
+    "customer_wording",
+    "estimated_support_cost",
+    "opportunity_score",
+    "answer_status",
+    "source_proof",
+)
+_REPORT_ACTION_ITEM_FIELDS = (
+    "rank",
+    "repeat_key",
+    "cluster_id",
+    "identity_basis",
+    "identity_confidence",
+    "question",
+    "status",
+    "owner_lane",
+    "fix_type",
+    "csat_signal",
+    "confidence",
+    "priority_score",
+    "priority_drivers",
+    "recommended_title",
+    "recommended_action",
+    "representative_phrasing",
+    "ticket_count",
+    "estimated_support_cost",
+    "support_cost_formula",
+    "support_cost_source",
+    "opportunity_score",
+    "top_evidence",
+)
+_REPORT_ACTION_ITEM_HOSTED_SAFE_FIELDS = (
+    "rank",
+    "question",
+    "status",
+    "owner_lane",
+    "confidence",
+    "recommended_action",
+    "ticket_count",
+    "estimated_support_cost",
+    "priority_score",
+    "priority_drivers",
+    "csat_signal",
+)
+_REPORT_ACTION_CSAT_SIGNAL_FIELDS = (
+    "status",
+    "csat_present_count",
+    "negative_csat_ticket_count",
+    "numeric_average",
+)
+_REPORT_ACTION_TOP_EVIDENCE_FIELDS = ("source_id", "evidence_quote")
+_REPORT_ACTION_SUPPORT_COST_BASIS_FIELDS = (
+    "status",
+    "assisted_contact_cost",
+    "formula",
+    "source",
+)
+_REPORT_ACTION_SUPPORT_COST_BASIS_HOSTED_SAFE_FIELDS = ("status",)
+_REPORT_ACTION_ITEM_NESTED_FIELDS = (
+    MappingProxyType({
+        "field": "csat_signal",
+        "projected_fields": _REPORT_ACTION_CSAT_SIGNAL_FIELDS,
+        "hosted_consumer_safe_fields": _REPORT_ACTION_CSAT_SIGNAL_FIELDS,
+    }),
+)
+_REPORT_ACTION_ITEM_NESTED_COLLECTIONS = (
+    MappingProxyType({
+        "field": "top_evidence",
+        "item_type": "object",
+        "projected_fields": _REPORT_ACTION_TOP_EVIDENCE_FIELDS,
+        "hosted_consumer_safe_fields": (),
+    }),
+)
+_REPORT_ACTION_ITEM_COLLECTION = MappingProxyType({
+    "field": "items",
+    "item_type": "object",
+    "projected_fields": _REPORT_ACTION_ITEM_FIELDS,
+    "hosted_consumer_safe_fields": _REPORT_ACTION_ITEM_HOSTED_SAFE_FIELDS,
+    "nested_object_fields": _REPORT_ACTION_ITEM_NESTED_FIELDS,
+    "nested_collection_fields": _REPORT_ACTION_ITEM_NESTED_COLLECTIONS,
+})
+_REPORT_ACTION_SUPPORT_COST_BASIS_NESTED_FIELD = MappingProxyType({
+    "field": "support_cost_basis",
+    "projected_fields": _REPORT_ACTION_SUPPORT_COST_BASIS_FIELDS,
+    "hosted_consumer_safe_fields": _REPORT_ACTION_SUPPORT_COST_BASIS_HOSTED_SAFE_FIELDS,
+})
+_REPORT_PRIORITY_FIX_QUEUE_FIELDS = (
+    "items",
+    "status_counts",
+    "result_page_limit",
+    "pdf_limit",
+    "backlog_limit",
+    "support_cost_basis",
+)
+_REPORT_TOP_UNRESOLVED_REPEATS_FIELDS = (
+    "items",
+    "top_item_count",
+    "result_page_limit",
+    "pdf_limit",
+    "support_cost_basis",
+)
+_REPORT_TOP_UNRESOLVED_REPEATS_HOSTED_SAFE_FIELDS = (
+    "items",
+    "top_item_count",
+    "support_cost_basis",
+)
+_REPORT_ACTION_TOP_ITEMS_FIELDS = (
+    "items",
+    "top_item_count",
+    "result_page_limit",
+    "pdf_limit",
+)
+_REPORT_ACTION_TOP_ITEMS_HOSTED_SAFE_FIELDS = ("items", "top_item_count")
+_REPORT_BACKLOG_FIELDS = ("items", "total_item_count", "default_limit")
+_REPORT_OUTCOME_DIAGNOSTIC_FIELDS = (
+    "outcome_diagnostic_ticket_count",
+    "outcome_risk_ticket_count",
+    "reopened_ticket_count",
+    "negative_csat_ticket_count",
+    "rows",
+)
+_REPORT_OUTCOME_DIAGNOSTIC_ROW_FIELDS = (
+    "question",
+    "status_mix",
+    "reopened_ticket_count",
+    "negative_csat_ticket_count",
+    "guidance",
+)
+_REPORT_QUESTION_DETAIL_FIELDS = ("rows",)
+_REPORT_QUESTION_DETAIL_ROW_FIELDS = (
+    "rank",
+    "question",
+    "customer_wording",
+    "topic",
+    "ticket_count",
+    "weighted_frequency",
+    "source_count",
+    "estimated_support_cost",
+    "answer_status",
+    "answer_evidence_status",
+    "resolution_evidence_scope",
+    "answer_linkage",
+    "answer",
+    "steps",
+    "term_mappings",
+    "source_ids",
+    "evidence_quotes",
+    "outcome_diagnostics",
+)
+_REPORT_QUESTION_DETAIL_ROW_HOSTED_SAFE_FIELDS = (
+    "rank",
+    "question",
+    "customer_wording",
+    "topic",
+    "ticket_count",
+    "weighted_frequency",
+    "source_count",
+    "estimated_support_cost",
+    "answer_status",
+    "answer_evidence_status",
+    "resolution_evidence_scope",
+    "answer_linkage",
+    "answer",
+    "steps",
+    "term_mappings",
+)
+_REPORT_COMPLETE_EVIDENCE_FIELDS = (
+    "question_count",
+    "evidence_row_count",
+    "source_id_count",
+    "surfaces",
+)
+_REPORT_SECTION_PROJECTION_METADATA: Mapping[str, Mapping[str, Any]] = MappingProxyType({
+    "support_tax": MappingProxyType({
+        "projected_fields": _REPORT_SUPPORT_TAX_FIELDS,
+        "optional_projected_fields": _REPORT_SUPPORT_TAX_OPTIONAL_FIELDS,
+    }),
+    "source_file": MappingProxyType({
+        "projected_fields": _REPORT_SOURCE_FILE_FIELDS,
+        "hosted_consumer_safe_fields": (),
+        "presence": MappingProxyType({
+            "mode": "conditional",
+            "condition": "source_label_present",
+        }),
+    }),
+    "seo_targets": MappingProxyType({
+        "projected_fields": _REPORT_SEO_TARGET_FIELDS,
+        "collection": MappingProxyType({
+            "field": "phrases",
+            "item_type": "string",
+        }),
+    }),
+    "ranked_questions": MappingProxyType({
+        "projected_fields": _REPORT_RANKED_QUESTION_FIELDS,
+        "collection": MappingProxyType({
+            "field": "rows",
+            "item_type": "object",
+            "projected_fields": _REPORT_RANKED_QUESTION_ROW_FIELDS,
+            "hosted_consumer_safe_fields": _REPORT_RANKED_QUESTION_ROW_FIELDS,
+        }),
+    }),
+    "priority_fix_queue": MappingProxyType({
+        "projected_fields": _REPORT_PRIORITY_FIX_QUEUE_FIELDS,
+        "hosted_consumer_safe_fields": _REPORT_PRIORITY_FIX_QUEUE_FIELDS,
+        "collection": _REPORT_ACTION_ITEM_COLLECTION,
+        "nested_object_fields": (_REPORT_ACTION_SUPPORT_COST_BASIS_NESTED_FIELD,),
+        "record_fields": ("status_counts",),
+    }),
+    "top_unresolved_repeats": MappingProxyType({
+        "projected_fields": _REPORT_TOP_UNRESOLVED_REPEATS_FIELDS,
+        "hosted_consumer_safe_fields": _REPORT_TOP_UNRESOLVED_REPEATS_HOSTED_SAFE_FIELDS,
+        "collection": _REPORT_ACTION_ITEM_COLLECTION,
+        "nested_object_fields": (_REPORT_ACTION_SUPPORT_COST_BASIS_NESTED_FIELD,),
+    }),
+    "drafted_resolutions": MappingProxyType({
+        "projected_fields": _REPORT_ACTION_TOP_ITEMS_FIELDS,
+        "hosted_consumer_safe_fields": _REPORT_ACTION_TOP_ITEMS_HOSTED_SAFE_FIELDS,
+        "collection": _REPORT_ACTION_ITEM_COLLECTION,
+    }),
+    "already_covered_still_recurring": MappingProxyType({
+        "projected_fields": _REPORT_ACTION_TOP_ITEMS_FIELDS,
+        "hosted_consumer_safe_fields": _REPORT_ACTION_TOP_ITEMS_HOSTED_SAFE_FIELDS,
+        "collection": _REPORT_ACTION_ITEM_COLLECTION,
+    }),
+    "backlog_table": MappingProxyType({
+        "projected_fields": _REPORT_BACKLOG_FIELDS,
+        "hosted_consumer_safe_fields": _REPORT_BACKLOG_FIELDS,
+        "collection": _REPORT_ACTION_ITEM_COLLECTION,
+    }),
+    "outcome_diagnostics": MappingProxyType({
+        "projected_fields": _REPORT_OUTCOME_DIAGNOSTIC_FIELDS,
+        "hosted_consumer_safe_fields": _REPORT_OUTCOME_DIAGNOSTIC_FIELDS,
+        "presence": MappingProxyType({
+            "mode": "conditional",
+            "condition": "outcome_diagnostics_rendered",
+        }),
+        "collection": MappingProxyType({
+            "field": "rows",
+            "item_type": "object",
+            "projected_fields": _REPORT_OUTCOME_DIAGNOSTIC_ROW_FIELDS,
+            "hosted_consumer_safe_fields": _REPORT_OUTCOME_DIAGNOSTIC_ROW_FIELDS,
+        }),
+    }),
+    "question_details": MappingProxyType({
+        "projected_fields": _REPORT_QUESTION_DETAIL_FIELDS,
+        "hosted_consumer_safe_fields": _REPORT_QUESTION_DETAIL_FIELDS,
+        "collection": MappingProxyType({
+            "field": "rows",
+            "item_type": "object",
+            "projected_fields": _REPORT_QUESTION_DETAIL_ROW_FIELDS,
+            "hosted_consumer_safe_fields": (
+                _REPORT_QUESTION_DETAIL_ROW_HOSTED_SAFE_FIELDS
+            ),
+        }),
+    }),
+    "complete_evidence": MappingProxyType({
+        "projected_fields": _REPORT_COMPLETE_EVIDENCE_FIELDS,
+        "hosted_consumer_safe_fields": (),
+    }),
+})
 
 
 def deflection_report_model_contract_shape() -> dict[str, Any]:
@@ -793,6 +1083,7 @@ def deflection_report_model_contract_shape() -> dict[str, Any]:
         "model_fields": list(DEFLECTION_REPORT_MODEL_FIELDS),
         "section_fields": list(DEFLECTION_REPORT_SECTION_FIELDS),
         "snapshot_projection": _deflection_snapshot_projection_contract_shape(),
+        "report_projection": _deflection_report_projection_contract_shape(),
         "sections": [
             {
                 "id": definition.id,
@@ -806,6 +1097,171 @@ def deflection_report_model_contract_shape() -> dict[str, Any]:
             for definition in _DEFLECTION_REPORT_SECTION_DEFINITIONS
         ],
     }
+
+
+def _deflection_report_projection_contract_shape() -> dict[str, Any]:
+    """Return the backend-owned paid report projection contract."""
+
+    return {
+        "schema_version": DEFLECTION_REPORT_SCHEMA_VERSION,
+        "model_fields": list(DEFLECTION_REPORT_MODEL_FIELDS),
+        "section_fields": list(DEFLECTION_REPORT_SECTION_FIELDS),
+        "sections": [
+            _report_projection_section_entry(definition)
+            for definition in _DEFLECTION_REPORT_SECTION_DEFINITIONS
+        ],
+    }
+
+
+def _report_projection_section_entry(
+    definition: DeflectionReportSectionDefinition,
+) -> dict[str, Any]:
+    metadata = _REPORT_SECTION_PROJECTION_METADATA.get(definition.id)
+    if metadata is None:
+        raise ValueError(f"report projection missing section: {definition.id}")
+    projected_fields = _field_tuple(metadata, "projected_fields")
+    out: dict[str, Any] = {
+        "id": definition.id,
+        "title": definition.title,
+        "priority": definition.priority,
+        "surfaces": list(definition.surfaces),
+        "default_limit": definition.default_limit,
+        "required_data": list(definition.required_data),
+        "snapshot_safe_fields": list(definition.snapshot_safe_fields),
+        "presence": _presence_entry(metadata),
+        "projected_fields": list(projected_fields),
+        "hosted_consumer_safe_fields": list(
+            _field_tuple(
+                metadata,
+                "hosted_consumer_safe_fields",
+                default=projected_fields,
+            )
+        ),
+    }
+    optional_fields = _field_tuple(metadata, "optional_projected_fields")
+    if optional_fields:
+        out["optional_projected_fields"] = list(optional_fields)
+    if "collection" in metadata:
+        collection = metadata["collection"]
+        if isinstance(collection, Mapping):
+            out["collection"] = _report_projection_collection_entry(collection)
+    nested_fields = _nested_field_entries(metadata)
+    if nested_fields:
+        out["nested_object_fields"] = nested_fields
+    nested_collections = _nested_collection_entries(metadata)
+    if nested_collections:
+        out["nested_collection_fields"] = nested_collections
+    record_fields = _field_tuple(metadata, "record_fields")
+    if record_fields:
+        out["record_fields"] = list(record_fields)
+    return out
+
+
+def _report_projection_collection_entry(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    field = _text(metadata.get("field"))
+    item_type = _text(metadata.get("item_type")) or "object"
+    if not field:
+        raise ValueError("report projection collection missing field")
+    out: dict[str, Any] = {
+        "field": field,
+        "item_type": item_type,
+    }
+    projected_fields = _field_tuple(metadata, "projected_fields")
+    if projected_fields:
+        out["projected_fields"] = list(projected_fields)
+        out["hosted_consumer_safe_fields"] = list(
+            _field_tuple(
+                metadata,
+                "hosted_consumer_safe_fields",
+                default=projected_fields,
+            )
+        )
+    nested_fields = _nested_field_entries(metadata)
+    if nested_fields:
+        out["nested_object_fields"] = nested_fields
+    nested_collections = _nested_collection_entries(metadata)
+    if nested_collections:
+        out["nested_collection_fields"] = nested_collections
+    return out
+
+
+def _presence_entry(metadata: Mapping[str, Any]) -> dict[str, str]:
+    presence = metadata.get("presence")
+    if presence is None:
+        return {"mode": "required"}
+    if not isinstance(presence, Mapping):
+        raise ValueError("report projection presence must be a mapping")
+    mode = _text(presence.get("mode"))
+    if mode not in {"required", "conditional"}:
+        raise ValueError("report projection presence mode must be required or conditional")
+    out = {"mode": mode}
+    condition = _text(presence.get("condition"))
+    if condition:
+        out["condition"] = condition
+    if mode == "conditional" and not condition:
+        raise ValueError("conditional report projection presence needs a condition")
+    return out
+
+
+def _nested_field_entries(metadata: Mapping[str, Any]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for raw_entry in metadata.get("nested_object_fields") or ():
+        if not isinstance(raw_entry, Mapping):
+            raise ValueError("report projection nested field entry must be a mapping")
+        field = _text(raw_entry.get("field"))
+        if not field:
+            raise ValueError("report projection nested field missing field")
+        projected_fields = _field_tuple(raw_entry, "projected_fields")
+        entries.append({
+            "field": field,
+            "projected_fields": list(projected_fields),
+            "hosted_consumer_safe_fields": list(
+                _field_tuple(
+                    raw_entry,
+                    "hosted_consumer_safe_fields",
+                    default=projected_fields,
+                )
+            ),
+        })
+    return entries
+
+
+def _nested_collection_entries(metadata: Mapping[str, Any]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for raw_entry in metadata.get("nested_collection_fields") or ():
+        if not isinstance(raw_entry, Mapping):
+            raise ValueError("report projection nested collection entry must be a mapping")
+        field = _text(raw_entry.get("field"))
+        if not field:
+            raise ValueError("report projection nested collection missing field")
+        projected_fields = _field_tuple(raw_entry, "projected_fields")
+        entries.append({
+            "field": field,
+            "item_type": _text(raw_entry.get("item_type")) or "object",
+            "projected_fields": list(projected_fields),
+            "hosted_consumer_safe_fields": list(
+                _field_tuple(
+                    raw_entry,
+                    "hosted_consumer_safe_fields",
+                    default=projected_fields,
+                )
+            ),
+        })
+    return entries
+
+
+def _field_tuple(
+    metadata: Mapping[str, Any],
+    key: str,
+    *,
+    default: Sequence[str] = (),
+) -> tuple[str, ...]:
+    value = metadata.get(key, default)
+    if value is None:
+        return ()
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise ValueError(f"report projection {key} must be a string sequence")
+    return tuple(_text(item) for item in value if _text(item))
 
 
 def _deflection_snapshot_projection_contract_shape() -> dict[str, Any]:

--- a/plans/PR-Deflection-Report-Projection-Contract.md
+++ b/plans/PR-Deflection-Report-Projection-Contract.md
@@ -1,0 +1,163 @@
+# PR-Deflection-Report-Projection-Contract
+
+## Why this slice exists
+
+#1805 is the remaining report-contract half after the snapshot contract
+derivation finished. The snapshot arc now has a backend-owned projection
+contract, runtime drift proof, generated frontend types, and proxy/portfolio
+consumers. The paid `DeflectionStructuredReport` does not: frontend/report
+consumers still infer section `data` fields from examples, docs, or local
+validators, which recreates the hand-sync pattern that caused the
+`top_blind_spots` phantom.
+
+Root cause: `deflection_report_model_contract_shape()` exposes paid section
+metadata (`id`, surfaces, limits, `required_data`, and snapshot-safe fields) but
+does not publish the paid section data projection or the hosted-consumer-safe
+allowlist. This slice fixes the root for the backend contract-definition layer
+by adding an ATLAS-owned `report_projection` sibling to `snapshot_projection`.
+It does not enforce runtime parity or generate TypeScript yet; those need the
+published contract this slice creates.
+
+This slice is over the usual 400 LOC soft budget because the contract is only
+useful if it names every paid section, every nested action/question row field,
+and the separate hosted-consumer-safe allowlist in the same source shape.
+Splitting the field lists from the contract helper would leave the next runtime
+enforcement slice comparing against an incomplete source of truth.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-contract-1805
+Slice phase: Production hardening
+
+1. Add a backend-owned `report_projection` contract to
+   `deflection_report_model_contract_shape()` for the paid structured report.
+2. Describe each paid section's top-level `data.projected_fields`,
+   optional projected fields where the producer has branch-dependent output,
+   conditional section presence, nested collection item fields for
+   `rows`/`items`/`phrases`, and the hosted-consumer-safe allowlist.
+3. Pin the action-section contract to both full paid action row fields
+   (`repeat_key`, `cluster_id`, scoring, evidence metadata) and the smaller
+   hosted result-page allowlist so later consumers do not confuse backend
+   availability with safe page payload construction.
+4. Add focused contract tests proving the projection is registry-derived where
+   possible, covers all sections, includes identity/delta fields in the paid
+   projection, and keeps raw evidence fields out of the hosted-consumer-safe
+   allowlist.
+5. Update the frontend handoff doc to name `report_projection` as the source
+   for the future report-model type generator.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `deflection_report_model_contract_shape()` includes a
+        `report_projection` object with the current report schema version,
+        model fields, section fields, and one projection entry per paid section.
+  - [ ] Every `report_projection.sections[]` entry is tied to
+        `DEFLECTION_REPORT_SECTION_REGISTRY` metadata and the section order
+        matches the registry/report priority order.
+  - [ ] Action sections declare full paid item projected fields including
+        `repeat_key`, `cluster_id`, `identity_basis`, `identity_confidence`,
+        `representative_phrasing`, and `top_evidence`.
+  - [ ] Action sections separately declare hosted-consumer-safe item fields
+        that exclude raw evidence/phrasing and identity/delta fields until a
+        consumer explicitly opts into an export/delta surface.
+  - [ ] Branch-dependent `support_tax` annualized cost fields are modeled as
+        optional projected fields rather than required fields.
+  - [ ] Conditionally-emitted sections (`source_file`, `outcome_diagnostics`)
+        carry presence metadata so runtime enforcement/codegen does not treat
+        them as always required.
+  - [ ] Nested arrays inside action items, including `top_evidence`, are marked
+        as nested collections rather than nested objects.
+  - [ ] `source_file.source_label` is not hosted-consumer-safe.
+  - [ ] Runtime report behavior is unchanged.
+- Affected surfaces:
+  - `extracted_content_pipeline/faq_deflection_report.py`
+  - `docs/frontend/content_ops_faq_report_contract.md`
+  - deflection report contract tests
+- Risk areas: accidentally widening the hosted result-page payload contract,
+  creating a second section registry, or generating report-model types from a
+  contract that still omits real runtime fields.
+- Reviewer rules triggered: R1, R2, R10, R14; boundary-probe required because
+  this publishes allowlist metadata for a privacy/safety boundary.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Report-Projection-Contract.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+
+## Mechanism
+
+The existing section registry remains the source for paid section identity,
+titles, priorities, surfaces, default limits, `required_data`, and
+`snapshot_safe_fields`. This slice adds a report projection helper that walks
+that registry and attaches section-specific data field metadata.
+
+For simple sections, `projected_fields` names the section `data` keys emitted
+by the producer. Every section also carries `presence` metadata so generators
+can distinguish always-emitted sections from conditional sections. For
+collection sections, the entry also carries a `collection` object naming the
+collection field, item type, nested object fields, nested collection fields, and
+the hosted-consumer-safe nested fields. Action-oriented sections share one full
+paid item field list and a separate `hosted_consumer_safe_fields` list. That
+separation is deliberate: the backend paid model can carry export/delta/evidence
+material, while hosted result pages must construct a smaller payload rather than
+validating and passing through raw fields.
+
+The next slice can compare `build_deflection_report_artifact(...).report_model`
+runtime output against this contract. The following generator slice can emit
+the frontend report-model artifact from the same shape.
+
+## Intentional
+
+- No runtime enforcement in this slice. This PR creates the backend-owned
+  contract so the next slice can enforce it against
+  `build_deflection_report_artifact()` without mixing contract definition and
+  runtime drift logic.
+- No frontend TypeScript generation or `atlas-portfolio` change yet. Starting
+  there would recreate the #370 wait-on-ATLAS-artifact problem.
+- Hosted-consumer-safe fields intentionally exclude action identity/delta
+  fields for now even though the paid backend projection includes them. Monthly
+  deltas can consume the full paid model or a dedicated delta artifact later;
+  the hosted page should stay allowlist-constructed.
+- `source_file.source_label` remains paid-only because the current CLI can pass
+  a local/customer path label. A future display-label normalization slice can
+  opt it into hosted payloads deliberately.
+
+## Deferred
+
+- ATLAS runtime enforcement: compare representative
+  `build_deflection_report_artifact()` report-model output to
+  `report_projection`.
+- ATLAS generated frontend report-model artifact under `portfolio-ui/src/types`
+  once the runtime enforcement is in place.
+- Cross-repo/proxy consumption: update `atlas-portfolio` and any proxy contract
+  generator to consume the ATLAS-owned paid report-model artifact.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_report_projection_separates_paid_and_hosted_action_fields tests/test_content_ops_deflection_report.py::test_deflection_report_projection_marks_raw_question_evidence_export_only tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projected_fields_match_runtime_output tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_report_contract_links_example -q -- 6 passed.
+- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_report_projection_separates_paid_and_hosted_action_fields tests/test_content_ops_deflection_report.py::test_deflection_report_projection_marks_raw_question_evidence_export_only tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_report_contract_links_example -q -- 4 passed after Codex P2 fixes.
+- python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -q -- 160 passed.
+- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -- passed.
+- git diff --check -- passed.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
+- bash scripts/check_ascii_python.sh -- passed.
+- Pending before push: bash scripts/local_pr_review.sh via scripts/push_pr.sh.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_report_contract.md` | 77 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 456 |
+| `plans/PR-Deflection-Report-Projection-Contract.md` | 163 |
+| `tests/test_content_ops_deflection_report.py` | 162 |
+| `tests/test_content_ops_faq_report_contract_docs.py` | 7 |
+| **Total** | **865** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -1392,6 +1392,168 @@ def test_deflection_snapshot_projection_contract_is_registry_derived() -> None:
         assert forbidden not in encoded
 
 
+def test_deflection_report_projection_contract_is_registry_derived() -> None:
+    shape = deflection_report_model_contract_shape()
+    projection = shape["report_projection"]
+    sections = {section["id"]: section for section in projection["sections"]}
+
+    assert projection["schema_version"] == DEFLECTION_REPORT_SCHEMA_VERSION
+    assert projection["model_fields"] == [
+        "schema_version",
+        "title",
+        "summary",
+        "sections",
+    ]
+    assert projection["section_fields"] == [
+        "id",
+        "title",
+        "priority",
+        "surfaces",
+        "default_limit",
+        "required_data",
+        "snapshot_safe_fields",
+        "data",
+    ]
+    assert list(sections) == list(DEFLECTION_REPORT_SECTION_REGISTRY)
+
+    for section_id, definition in DEFLECTION_REPORT_SECTION_REGISTRY.items():
+        section = sections[section_id]
+        assert section["title"] == definition.title
+        assert section["priority"] == definition.priority
+        assert section["surfaces"] == list(definition.surfaces)
+        assert section["default_limit"] == definition.default_limit
+        assert section["required_data"] == list(definition.required_data)
+        assert section["snapshot_safe_fields"] == list(definition.snapshot_safe_fields)
+        assert set(definition.required_data) <= set(section["projected_fields"])
+
+    support_tax = sections["support_tax"]
+    assert support_tax["optional_projected_fields"] == [
+        "annualized_support_cost",
+        "annualized_run_rate_support_cost",
+    ]
+    assert set(support_tax["required_data"]).isdisjoint(
+        support_tax["optional_projected_fields"]
+    )
+    assert set(support_tax["optional_projected_fields"]) <= set(
+        support_tax["projected_fields"]
+    )
+
+    source_file = sections["source_file"]
+    assert source_file["presence"] == {
+        "mode": "conditional",
+        "condition": "source_label_present",
+    }
+    assert source_file["hosted_consumer_safe_fields"] == []
+
+    outcome_diagnostics = sections["outcome_diagnostics"]
+    assert outcome_diagnostics["presence"] == {
+        "mode": "conditional",
+        "condition": "outcome_diagnostics_rendered",
+    }
+
+    assert sections["support_tax"]["presence"] == {"mode": "required"}
+    top_unresolved = sections["top_unresolved_repeats"]
+    assert top_unresolved["hosted_consumer_safe_fields"] == [
+        "items",
+        "top_item_count",
+        "support_cost_basis",
+    ]
+    support_cost_basis = {
+        entry["field"]: entry
+        for entry in top_unresolved["nested_object_fields"]
+    }["support_cost_basis"]
+    assert support_cost_basis["projected_fields"] == [
+        "status",
+        "assisted_contact_cost",
+        "formula",
+        "source",
+    ]
+    assert support_cost_basis["hosted_consumer_safe_fields"] == ["status"]
+
+
+def test_deflection_report_projection_separates_paid_and_hosted_action_fields() -> None:
+    projection = deflection_report_model_contract_shape()["report_projection"]
+    sections = {section["id"]: section for section in projection["sections"]}
+    action_section_ids = [
+        "priority_fix_queue",
+        "top_unresolved_repeats",
+        "drafted_resolutions",
+        "already_covered_still_recurring",
+        "backlog_table",
+    ]
+    paid_only_action_fields = {
+        "repeat_key",
+        "cluster_id",
+        "identity_basis",
+        "identity_confidence",
+        "fix_type",
+        "recommended_title",
+        "representative_phrasing",
+        "support_cost_formula",
+        "support_cost_source",
+        "opportunity_score",
+        "top_evidence",
+    }
+
+    for section_id in action_section_ids:
+        collection = sections[section_id]["collection"]
+        projected = set(collection["projected_fields"])
+        hosted_safe = set(collection["hosted_consumer_safe_fields"])
+        nested = {entry["field"]: entry for entry in collection["nested_object_fields"]}
+        nested_collections = {
+            entry["field"]: entry
+            for entry in collection["nested_collection_fields"]
+        }
+
+        assert collection["field"] == "items"
+        assert paid_only_action_fields <= projected
+        assert hosted_safe < projected
+        assert paid_only_action_fields.isdisjoint(hosted_safe)
+        assert nested["csat_signal"]["hosted_consumer_safe_fields"] == [
+            "status",
+            "csat_present_count",
+            "negative_csat_ticket_count",
+            "numeric_average",
+        ]
+        assert "top_evidence" not in nested
+        assert nested_collections["top_evidence"]["item_type"] == "object"
+        assert nested_collections["top_evidence"]["projected_fields"] == [
+            "source_id",
+            "evidence_quote",
+        ]
+        assert nested_collections["top_evidence"]["hosted_consumer_safe_fields"] == []
+
+    priority = sections["priority_fix_queue"]
+    assert priority["record_fields"] == ["status_counts"]
+
+
+def test_deflection_report_projection_marks_raw_question_evidence_export_only() -> None:
+    projection = deflection_report_model_contract_shape()["report_projection"]
+    sections = {section["id"]: section for section in projection["sections"]}
+    question_details = sections["question_details"]["collection"]
+    complete_evidence = sections["complete_evidence"]
+
+    assert question_details["field"] == "rows"
+    assert {
+        "source_ids",
+        "evidence_quotes",
+        "outcome_diagnostics",
+    } <= set(question_details["projected_fields"])
+    assert {
+        "source_ids",
+        "evidence_quotes",
+        "outcome_diagnostics",
+    }.isdisjoint(question_details["hosted_consumer_safe_fields"])
+    assert "source_count" in question_details["hosted_consumer_safe_fields"]
+    assert complete_evidence["projected_fields"] == [
+        "question_count",
+        "evidence_row_count",
+        "source_id_count",
+        "surfaces",
+    ]
+    assert complete_evidence["hosted_consumer_safe_fields"] == []
+
+
 def test_deflection_snapshot_projected_fields_match_runtime_output() -> None:
     fixture = _structured_report_fixture_result()
     fixture = replace(

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -248,6 +248,13 @@ def test_content_ops_faq_report_contract_links_example() -> None:
     assert "cross-run/monthly-delta matching" in doc
     assert "required_data: string[]" in doc
     assert "snapshot_safe_fields: string[]" in doc
+    assert "DeflectionReportProjectionContract" in doc
+    assert "report_projection" in doc
+    assert "hosted_consumer_safe_fields" in doc
+    assert "presence.mode" in doc
+    assert "nested_collection_fields" in doc
+    assert "source_file.source_label" in doc
+    assert "validate-and-pass" in doc
     assert "DeflectionSnapshotProjectionContract" in doc
     assert "snapshot_projection" in doc
     assert "top_unresolved_repeats.items" in doc


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-Projection-Contract.md
Slice phase: Production hardening

Adds the ATLAS-owned paid report_projection contract for DeflectionStructuredReport so #1805 can proceed from backend contract definition to runtime enforcement, generated frontend artifact, and then cross-repo consumption.

## Intentional
- No runtime enforcement in this slice; the next #1805 slice compares build_deflection_report_artifact() output to report_projection.
- No frontend TypeScript generation or atlas-portfolio change yet; this publishes the missing ATLAS-owned artifact precondition.
- Hosted-consumer-safe fields intentionally stay smaller than the full paid projection.
- source_file.source_label remains paid-only because the current CLI can pass a local/customer path label.

## Deferred
- Runtime enforcement against build_deflection_report_artifact().
- Generated portfolio-ui report-model artifact.
- Cross-repo/proxy consumers after the ATLAS artifact exists.

## Parked hardening
- None.

## AI reconciliation
- All findings fixed or waived: yes.
- Fixed: Codex P2 top_evidence nested collection metadata; report_projection now emits top_evidence under nested_collection_fields with item_type and per-row projected fields.
- Fixed: Codex P2 optional section semantics; source_file and outcome_diagnostics now carry conditional presence metadata.
- Fixed: Codex P2 source_label hosted-safe leak; source_file hosted_consumer_safe_fields is empty.

## Verification
- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_report_projection_separates_paid_and_hosted_action_fields tests/test_content_ops_deflection_report.py::test_deflection_report_projection_marks_raw_question_evidence_export_only tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_snapshot_projected_fields_match_runtime_output tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_report_contract_links_example -q -- 6 passed.
- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_projection_contract_is_registry_derived tests/test_content_ops_deflection_report.py::test_deflection_report_projection_separates_paid_and_hosted_action_fields tests/test_content_ops_deflection_report.py::test_deflection_report_projection_marks_raw_question_evidence_export_only tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_report_contract_links_example -q -- 4 passed after Codex P2 fixes.
- python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -q -- 160 passed.
- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py -- passed.
- git diff --check -- passed.
- bash scripts/validate_extracted_content_pipeline.sh -- passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -- Atlas runtime import findings: 0.
- bash scripts/check_ascii_python.sh -- passed.

## Diff size
5 files, +865 / -3
