### PR TITLE
Add deflection standard pricing terms contract

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -883,6 +883,13 @@ def create_content_ops_control_surface_router(
         return _deflection_report_process_contract_payload(resolved_config.prefix)
 
     @router.get(
+        "/deflection-reports/pricing/standard",
+        dependencies=public_deflection_dependencies,
+    )
+    async def deflection_report_standard_pricing_terms() -> dict[str, Any]:
+        return _deflection_standard_pricing_terms(resolved_config)
+
+    @router.get(
         "/deflection-reports/{request_id}/snapshot",
         dependencies=public_deflection_dependencies,
     )
@@ -2501,6 +2508,18 @@ def _deflection_checkout_terms(
         "amount_cents": amount_cents,
         "currency": currency,
         "price_id": price_id,
+    }
+
+
+def _deflection_standard_pricing_terms(
+    config: ContentOpsControlSurfaceApiConfig,
+) -> dict[str, Any]:
+    checkout = _deflection_checkout_terms(config)
+    return {
+        "variant": "standard",
+        "status": "configured",
+        "amount_cents": checkout["amount_cents"],
+        "currency": checkout["currency"],
     }
 
 

--- a/plans/PR-Deflection-Standard-Price-Terms.md
+++ b/plans/PR-Deflection-Standard-Price-Terms.md
@@ -1,0 +1,114 @@
+# PR-Deflection-Standard-Price-Terms
+
+## Why this slice exists
+
+atlas-portfolio issue #194 now targets an easier standard-price change path:
+ATLAS should remain the source of truth for the active deflection report charge,
+while portfolio stops carrying a separate public amount that can drift from the
+authorized checkout terms. The first ATLAS slice needs a small read contract the
+portfolio server can consume before any portfolio display or preflight work
+starts.
+
+## Scope (this PR)
+
+Ownership lane: deflection/stripe-monetization
+Slice phase: Vertical slice
+
+1. Add a standard deflection pricing terms endpoint on the existing Content Ops
+   control-surface router: `GET /content-ops/deflection-reports/pricing/standard`.
+2. Return only non-secret pricing terms: `variant`, `status`, `amount_cents`,
+   and `currency`. The existing checkout authorization remains the only response
+   that includes the Stripe `price_id` used for charge creation.
+3. Reuse the existing checkout-term validation so the public pricing terms fail
+   closed when amount, allowed amount set, currency, or price ID config is
+   invalid.
+4. Add extracted-router and Atlas host-mount tests proving the route contract,
+   fail-closed behavior, and dependency gates.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] `GET /content-ops/deflection-reports/pricing/standard` returns
+        `variant=standard`, `status=configured`, `amount_cents`, and
+        lower-case `currency` for valid standard checkout config.
+  - [ ] The terms response never exposes the Stripe `price_id`.
+  - [ ] Invalid amount, currency, allowed amount, or missing price ID config
+        fails closed with 503 before portfolio can display the terms.
+  - [ ] Existing checkout authorization remains request-specific and still
+        returns the Stripe `price_id` only after report-state checks pass.
+  - [ ] Atlas host-mount dependencies keep the pricing terms route behind the
+        public deflection auth/rate-limit gate.
+- Affected surfaces: API / auth / config / payments
+- Risk areas: backcompat / security / config drift / payment mismatch
+- Reviewer rules triggered: R1, R2, R3, R5, R10, R11, R14
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `plans/PR-Deflection-Standard-Price-Terms.md`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+- `tests/test_extracted_content_control_surface_api.py`
+
+## Mechanism
+
+The existing checkout terms helper already centralizes the standard checkout
+config guards: positive amount, configured currency, configured Stripe price ID,
+and exact allowed-amount membership. This slice keeps that as the authoritative
+validator, then projects the validated terms into a non-secret payload:
+
+```json
+{
+  "variant": "standard",
+  "status": "configured",
+  "amount_cents": 150000,
+  "currency": "usd"
+}
+```
+
+Because the projection calls the checkout validator first, a missing `price_id`
+or stale allowed amount makes the read endpoint return the same 503 class as
+checkout authorization instead of letting portfolio display a price ATLAS cannot
+charge or unlock.
+
+## Intentional
+
+- The endpoint does not expose `price_id`. Portfolio still has to ask for
+  request-specific checkout authorization before creating a Stripe Checkout
+  session, which keeps charge creation coupled to an existing report.
+- This slice adds only the standard variant path. Generic A/B, cohort routing,
+  and public partner checkout remain deferred until ATLAS has variant-aware
+  authorization.
+- The route uses the existing public deflection dependency set. It is
+  non-secret data, but the host mount still keeps the same authenticated
+  Content Ops account boundary and rate limit.
+
+## Deferred
+
+- ATLAS config consistency preflight/smoke proving the full `PRICE_ID`,
+  `AMOUNT_CENTS`, `ALLOWED_AMOUNT_CENTS`, `CURRENCY`, Stripe Checkout amount,
+  and webhook unlock loop agree.
+- Portfolio consumption of the ATLAS terms endpoint for standard price display.
+- Portfolio checkout/preflight mismatch refusal once display is sourced from
+  ATLAS.
+- Runbook documentation for the operator change-price procedure.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_content_control_surface_api.py -k "deflection_standard_pricing_terms or deflection_checkout_authorization or deflection_report_routes_use_public_and_trusted_dependencies"` -- passed, 21 selected.
+- `pytest tests/test_atlas_content_ops_generated_assets_api.py -k "public_deflection_routes_use_rate_limit_gate"` -- passed, 1 selected.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `python scripts/sync_pr_plan.py plans/PR-Deflection-Standard-Price-Terms.md` -- updated the plan from the real diff.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 19 |
+| `plans/PR-Deflection-Standard-Price-Terms.md` | 114 |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | 1 |
+| `tests/test_extracted_content_control_surface_api.py` | 105 |
+| **Total** | **239** |

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -488,6 +488,7 @@ def test_content_ops_public_deflection_routes_use_rate_limit_gate() -> None:
     api_pkg = _fresh_api_package()
     public_routes = [
         ("/content-ops/deflection-reports/submit", "POST"),
+        ("/content-ops/deflection-reports/pricing/standard", "GET"),
         ("/content-ops/deflection-reports/{request_id}/snapshot", "GET"),
         ("/content-ops/deflection-reports/{request_id}/artifact", "GET"),
         ("/content-ops/deflection-reports/{request_id}/report-model", "GET"),

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -76,6 +76,25 @@ def _checkout_authorization_route(
     )
 
 
+def _standard_pricing_terms_route(
+    *,
+    config_kwargs: dict[str, object] | None = None,
+):
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            **(config_kwargs or {"deflection_checkout_price_id": "price_report"}),
+        ),
+        scope_provider=lambda: {"account_id": "acct-gate", "user_id": "user-gate"},
+    )
+    return _route(
+        router,
+        "/ops/deflection-reports/pricing/standard",
+        "GET",
+    )
+
+
 class _UploadFile:
     def __init__(self, filename: str, content: bytes):
         self.filename = filename
@@ -2953,6 +2972,81 @@ async def test_deflection_report_delete_route_is_idempotent_and_scoped() -> None
 
 
 @pytest.mark.asyncio
+async def test_deflection_standard_pricing_terms_returns_public_contract_only():
+    route = _standard_pricing_terms_route(
+        config_kwargs={
+            "deflection_checkout_amount_cents": 150000,
+            "deflection_checkout_allowed_amount_cents": "149000,150000",
+            "deflection_checkout_currency": "USD",
+            "deflection_checkout_price_id": " price_deflection_report ",
+        },
+    )
+
+    payload = await route.endpoint()
+
+    assert payload == {
+        "variant": "standard",
+        "status": "configured",
+        "amount_cents": 150000,
+        "currency": "usd",
+    }
+    assert "price_id" not in payload
+    assert "price_deflection_report" not in str(payload)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_kwargs", "detail"),
+    [
+        (
+            {"deflection_checkout_price_id": ""},
+            "Deflection checkout price is not configured.",
+        ),
+        (
+            {
+                "deflection_checkout_amount_cents": 0,
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout amount is not configured.",
+        ),
+        (
+            {
+                "deflection_checkout_currency": "usdollar",
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout currency is not configured.",
+        ),
+        (
+            {
+                "deflection_checkout_amount_cents": 150000,
+                "deflection_checkout_allowed_amount_cents": "149000",
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout amount is not accepted by the payment gate.",
+        ),
+        (
+            {
+                "deflection_checkout_allowed_amount_cents": "not-cents",
+                "deflection_checkout_price_id": "price_deflection_report",
+            },
+            "Deflection checkout allowed amounts are not configured.",
+        ),
+    ],
+)
+async def test_deflection_standard_pricing_terms_fails_closed_when_config_invalid(
+    config_kwargs: dict[str, object],
+    detail: str,
+) -> None:
+    route = _standard_pricing_terms_route(config_kwargs=config_kwargs)
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint()
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == detail
+
+
+@pytest.mark.asyncio
 async def test_deflection_checkout_authorization_returns_canonical_terms_only():
     store = InMemoryDeflectionReportArtifactStore()
     await store.save_report(
@@ -3172,6 +3266,11 @@ def test_deflection_report_routes_use_public_and_trusted_dependencies() -> None:
 
     paid_route = _route(router, "/ops/deflection-reports/{request_id}/paid", "POST")
     submit_route = _route(router, "/ops/deflection-reports/submit", "POST")
+    standard_pricing_terms_route = _route(
+        router,
+        "/ops/deflection-reports/pricing/standard",
+        "GET",
+    )
     artifact_route = _route(
         router,
         "/ops/deflection-reports/{request_id}/artifact",
@@ -3197,12 +3296,18 @@ def test_deflection_report_routes_use_public_and_trusted_dependencies() -> None:
     assert "_trusted_paid_release" in _dependency_names(paid_route)
     assert "_public_deflection_gate" not in _dependency_names(paid_route)
     assert "_public_deflection_gate" in _dependency_names(submit_route)
+    assert "_public_deflection_gate" in _dependency_names(
+        standard_pricing_terms_route
+    )
     assert "_public_deflection_gate" in _dependency_names(artifact_route)
     assert "_public_deflection_gate" in _dependency_names(
         checkout_authorization_route
     )
     assert "_public_deflection_gate" in _dependency_names(snapshot_route)
     assert "_public_deflection_gate" in _dependency_names(delete_route)
+    assert "_trusted_paid_release" not in _dependency_names(
+        standard_pricing_terms_route
+    )
     assert "_trusted_paid_release" not in _dependency_names(artifact_route)
     assert "_trusted_paid_release" not in _dependency_names(
         checkout_authorization_route


### PR DESCRIPTION
Plan: plans/PR-Deflection-Standard-Price-Terms.md
Ownership lane: deflection/stripe-monetization
Slice phase: Vertical slice

Adds the first ATLAS-side contract for atlas-portfolio#194's easy standard price-change arc: `GET /content-ops/deflection-reports/pricing/standard` exposes only non-secret standard pricing terms (`variant`, `status`, `amount_cents`, `currency`) while checkout authorization remains the only source of the Stripe `price_id` used for charge creation.

## Intentional

- The endpoint does not expose `price_id`; portfolio must still request report-specific checkout authorization before creating Stripe Checkout.
- The route reuses the existing checkout terms validator so missing `PRICE_ID`, invalid amount/currency, or stale allowed amount config returns the same fail-closed 503 class checkout authorization would use.
- This is standard-only. Generic A/B, cohort routing, and partner checkout remain deferred until ATLAS has variant-aware authorization.

## Deferred

- ATLAS config consistency preflight/smoke proving `PRICE_ID`, `AMOUNT_CENTS`, `ALLOWED_AMOUNT_CENTS`, `CURRENCY`, Stripe Checkout amount, and webhook unlock agree.
- Portfolio consumption of the ATLAS terms endpoint for standard price display.
- Portfolio checkout/preflight mismatch refusal once display is sourced from ATLAS.
- Operator runbook for the standard price-change procedure.

## Parked hardening

None.

## Verification

- `pytest tests/test_extracted_content_control_surface_api.py -k "deflection_standard_pricing_terms or deflection_checkout_authorization or deflection_report_routes_use_public_and_trusted_dependencies"` -- passed, 21 selected.
- `pytest tests/test_atlas_content_ops_generated_assets_api.py -k "public_deflection_routes_use_rate_limit_gate"` -- passed, 1 selected.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Standard-Price-Terms.md` -- updated the plan from the real diff.
- `bash scripts/push_pr.sh /tmp/atlas-pr-deflection-standard-price-terms.md -u origin HEAD` -- passed local PR review and pushed.

## Diff size

| File | LOC |
|---|---:|
| `extracted_content_pipeline/api/control_surfaces.py` | 19 |
| `plans/PR-Deflection-Standard-Price-Terms.md` | 114 |
| `tests/test_atlas_content_ops_generated_assets_api.py` | 1 |
| `tests/test_extracted_content_control_surface_api.py` | 105 |
| **Total** | **239** |
