### PR TITLE
Add deflection report runtime contract tests

### DIFF
--- a/plans/PR-Deflection-Report-Runtime-Contract.md
+++ b/plans/PR-Deflection-Report-Runtime-Contract.md
@@ -42,8 +42,9 @@ Slice phase: Production hardening
    `outcome_diagnostics` is absent, and a fixture with both signals proves they
    are present with the declared fields.
 4. Add negative drift probes that mutate a real report model to prove missing
-   required fields, unexpected extra fields, and wrong conditional presence are
-   detected by the parity checker.
+   required fields, unexpected extra fields, wrong conditional presence,
+   envelope drift, record-field drift, and empty collections are detected by
+   the parity checker.
 
 ### Review Contract
 - Acceptance criteria:
@@ -52,10 +53,12 @@ Slice phase: Production hardening
         mirror.
   - [ ] Required section presence and conditional section absence/presence are
         both verified with real artifacts.
-  - [ ] Top-level section data, collection row/item fields, nested object
-        fields, and nested collection item fields are all covered.
+  - [ ] Top-level report envelopes, section envelopes, section data,
+        collection row/item fields, nested object fields, nested collection item
+        fields, and record fields are all covered.
   - [ ] At least one negative fixture proves each checker branch fails closed
-        for missing fields, extra fields, and presence drift.
+        for missing fields, extra fields, presence drift, duplicate/malformed
+        sections, record-field type drift, and empty collections.
   - [ ] No frontend codegen or portfolio consumer changes are included.
 - Affected surfaces: paid deflection report model contract tests; extracted
   content pipeline contract metadata if a real mismatch is found.
@@ -79,8 +82,10 @@ that:
 3. walk emitted sections by `id`;
 4. compare actual `data` key sets to declared projected fields, with optional
    fields allowed to be absent;
-5. recursively compare declared collection item fields, nested object fields,
-   nested collection item fields, and record-field mappings; and
+5. compare report and section envelope fields, duplicate/malformed sections,
+   declared collection item fields, nested object fields, nested collection
+   item fields, record-field mappings, and non-empty coverage for the rich
+   parity fixture; and
 6. return human-readable drift messages so negative tests can assert the
    failure mode.
 
@@ -111,10 +116,10 @@ Parked hardening: none.
 
 ## Verification
 
-- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_projection_fields_match_runtime_output tests/test_content_ops_deflection_report.py::test_deflection_report_projection_conditional_sections_match_runtime_output tests/test_content_ops_deflection_report.py::test_deflection_report_projection_checker_fails_on_field_drift tests/test_content_ops_deflection_report.py::test_deflection_report_projection_checker_fails_on_nested_drift tests/test_content_ops_deflection_report.py::test_deflection_report_projection_checker_fails_on_presence_drift -q
-  - 5 passed.
+- python -m pytest tests/test_content_ops_deflection_report.py -k projection -q
+  - 14 passed.
 - python -m pytest tests/test_content_ops_deflection_report.py -q
-  - 160 passed.
+  - 163 passed.
 - python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py
   - Passed.
 - git diff --check
@@ -133,6 +138,6 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Deflection-Report-Runtime-Contract.md` | 138 |
-| `tests/test_content_ops_deflection_report.py` | 361 |
-| **Total** | **499** |
+| `plans/PR-Deflection-Report-Runtime-Contract.md` | 143 |
+| `tests/test_content_ops_deflection_report.py` | 489 |
+| **Total** | **632** |

--- a/plans/PR-Deflection-Report-Runtime-Contract.md
+++ b/plans/PR-Deflection-Report-Runtime-Contract.md
@@ -1,0 +1,138 @@
+# PR-Deflection-Report-Runtime-Contract
+
+## Why this slice exists
+
+#1805's paid report-model contract arc now has an ATLAS-owned
+`report_projection` artifact, but #1815 intentionally stopped before proving
+that contract against the runtime producer. The #1815 reviewer called this out
+as the hard gate before report-model codegen: `projected_fields` and the new
+section `presence` metadata are still hand-written claims until
+the build_deflection_report_artifact output is reconciled against them.
+
+Root cause: the report projection contract and the runtime
+`DeflectionStructuredReport` producer are currently parallel shapes. The
+contract can drift by adding/removing a field, mislabeling a conditional section
+as required, or modeling nested rows incorrectly without any test comparing the
+contract to a real emitted artifact. This slice fixes that root at the ATLAS
+producer/contract boundary by adding runtime parity tests over real report
+artifacts. It does not generate TypeScript yet; codegen is deferred until this
+runtime proof is load-bearing.
+
+This slice is over the usual 400 LOC soft budget because the parity checker has
+to cover top-level fields, conditional presence, collections, nested objects,
+nested collections, and negative drift probes in one coherent test harness. If
+those proofs are split, slice 3 could still generate from a partially verified
+contract.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-contract-1805
+Slice phase: Production hardening
+
+1. Add a runtime parity test that builds a real paid deflection report artifact
+   and asserts each emitted section's top-level `data` keys match that
+   section's `report_projection.projected_fields`, allowing only fields marked
+   `optional_projected_fields` to be absent.
+2. Assert collection item contracts from real emitted rows/items, including
+   action-section `items`, `csat_signal` nested objects, `top_evidence` nested
+   collections, ranked/question/detail rows, outcome diagnostic rows, and string
+   phrase collections.
+3. Add omit-case coverage for conditional section presence: no `source_label`
+   means `source_file` is absent, no rendered outcome diagnostics means
+   `outcome_diagnostics` is absent, and a fixture with both signals proves they
+   are present with the declared fields.
+4. Add negative drift probes that mutate a real report model to prove missing
+   required fields, unexpected extra fields, and wrong conditional presence are
+   detected by the parity checker.
+
+### Review Contract
+- Acceptance criteria:
+  - [ ] The test suite compares `report_projection` to
+   build_deflection_report_artifact output, not to another hand-written
+        mirror.
+  - [ ] Required section presence and conditional section absence/presence are
+        both verified with real artifacts.
+  - [ ] Top-level section data, collection row/item fields, nested object
+        fields, and nested collection item fields are all covered.
+  - [ ] At least one negative fixture proves each checker branch fails closed
+        for missing fields, extra fields, and presence drift.
+  - [ ] No frontend codegen or portfolio consumer changes are included.
+- Affected surfaces: paid deflection report model contract tests; extracted
+  content pipeline contract metadata if a real mismatch is found.
+- Risk areas: schema/contract drift, future frontend codegen correctness,
+  report payload privacy boundary.
+- Reviewer rules triggered: R1, R2, R10, R14; boundary-probe required because
+  this adds a contract checker.
+
+### Files touched
+
+- `plans/PR-Deflection-Report-Runtime-Contract.md`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+Add small test-local helpers in `tests/test_content_ops_deflection_report.py`
+that:
+
+1. read `deflection_report_model_contract_shape()["report_projection"]`;
+2. build real build_deflection_report_artifact payloads;
+3. walk emitted sections by `id`;
+4. compare actual `data` key sets to declared projected fields, with optional
+   fields allowed to be absent;
+5. recursively compare declared collection item fields, nested object fields,
+   nested collection item fields, and record-field mappings; and
+6. return human-readable drift messages so negative tests can assert the
+   failure mode.
+
+The positive test uses a rich fixture with `source_label` and outcome
+diagnostics so every section can be checked. A second sparse fixture omits
+`source_label` and outcome diagnostics to prove the two conditional sections
+are legitimately absent while required sections remain present.
+
+## Intentional
+
+- This is test-enforced runtime parity, not a production runtime validator. The
+  goal is to make CI fail before a drifted contract can feed report-model
+  codegen; adding request-time validation would add cost to report generation
+  without changing the emitted payload.
+- The checker lives beside the existing report tests rather than in a new
+  script because the codegen step does not exist yet. A standalone
+  `scripts/check_*` gate can consume this same contract after slice 3 publishes
+  generated artifacts.
+
+## Deferred
+
+- Slice 3: generate the report-model frontend artifact from the ATLAS-owned
+  report projection after this runtime enforcement lands.
+- Cross-repo portfolio/proxy consumption remains deferred until ATLAS publishes
+  that generated artifact.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_report_projection_fields_match_runtime_output tests/test_content_ops_deflection_report.py::test_deflection_report_projection_conditional_sections_match_runtime_output tests/test_content_ops_deflection_report.py::test_deflection_report_projection_checker_fails_on_field_drift tests/test_content_ops_deflection_report.py::test_deflection_report_projection_checker_fails_on_nested_drift tests/test_content_ops_deflection_report.py::test_deflection_report_projection_checker_fails_on_presence_drift -q
+  - 5 passed.
+- python -m pytest tests/test_content_ops_deflection_report.py -q
+  - 160 passed.
+- python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py
+  - Passed.
+- git diff --check
+  - Passed.
+- bash scripts/validate_extracted_content_pipeline.sh
+  - Passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed.
+- bash scripts/check_ascii_python.sh
+  - Passed.
+- Pending before push: bash scripts/push_pr.sh /tmp/atlas-pr-body-deflection-report-runtime-contract.md
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Report-Runtime-Contract.md` | 138 |
+| `tests/test_content_ops_deflection_report.py` | 361 |
+| **Total** | **499** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -161,6 +161,58 @@ def _structured_report_fixture_result() -> TicketFAQMarkdownResult:
     )
 
 
+def _report_projection_runtime_fixture_result() -> TicketFAQMarkdownResult:
+    base = _structured_report_fixture_result()
+    recurring_item = {
+        "question": "How do I fix a stale dashboard?",
+        "customer_wording": "dashboard is stale again",
+        "topic": "analytics",
+        "weighted_frequency": 8,
+        "ticket_count": 4,
+        "opportunity_score": 19,
+        "answer": "Refresh the dashboard cache from Analytics settings.",
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
+        "source_ids": (
+            "ticket-dashboard-1",
+            "ticket-dashboard-2",
+            "ticket-dashboard-3",
+            "ticket-dashboard-4",
+        ),
+        "evidence_quotes": ("`ticket-dashboard-1` - Dashboard stale again",),
+        "outcome_diagnostics": {
+            "csat_present_count": 4,
+            "csat_score_average": 2.0,
+            "diagnostic_ticket_count": 4,
+            "negative_csat_ticket_count": 2,
+            "outcome_risk_ticket_count": 2,
+            "reopened_ticket_count": 1,
+            "ticket_status_summary": {"reopened": 1, "resolved": 3},
+        },
+    }
+    return replace(
+        base,
+        source_count=base.source_count + 4,
+        ticket_source_count=base.ticket_source_count + 4,
+        items=base.items + (recurring_item,),
+    )
+
+
+def _report_projection_no_conditionals_fixture_result() -> TicketFAQMarkdownResult:
+    base = _structured_report_fixture_result()
+    return replace(
+        base,
+        items=tuple(
+            {
+                key: value
+                for key, value in item.items()
+                if key != "outcome_diagnostics"
+            }
+            for item in base.items
+        ),
+    )
+
+
 _STRUCTURED_REPORT_GOLDEN_MARKDOWN = """# Support Ticket Deflection Report
 
 ## Support Tax Confirmation
@@ -1552,6 +1604,315 @@ def test_deflection_report_projection_marks_raw_question_evidence_export_only() 
         "surfaces",
     ]
     assert complete_evidence["hosted_consumer_safe_fields"] == []
+
+
+def _report_projection_drift_errors(
+    report_model: Mapping[str, object],
+    *,
+    expected_present: set[str] | None = None,
+    expected_absent: set[str] | None = None,
+) -> list[str]:
+    projection = deflection_report_model_contract_shape()["report_projection"]
+    contract_sections = {
+        str(section["id"]): section
+        for section in projection["sections"]
+        if isinstance(section, Mapping)
+    }
+    raw_sections = report_model.get("sections")
+    if not isinstance(raw_sections, list):
+        return ["report_model.sections is not a list"]
+    actual_sections = {
+        str(section.get("id")): section
+        for section in raw_sections
+        if isinstance(section, Mapping)
+    }
+    errors: list[str] = []
+    expected_present = expected_present or set()
+    expected_absent = expected_absent or set()
+
+    for section_id in sorted(set(actual_sections) - set(contract_sections)):
+        errors.append(f"unknown section emitted: {section_id}")
+    for section_id, contract in contract_sections.items():
+        presence = contract.get("presence")
+        mode = (
+            str(presence.get("mode"))
+            if isinstance(presence, Mapping)
+            else "required"
+        )
+        is_present = section_id in actual_sections
+        if section_id in expected_absent and is_present:
+            errors.append(f"section {section_id} should be absent")
+        if (mode == "required" or section_id in expected_present) and not is_present:
+            errors.append(f"section {section_id} missing")
+        if not is_present:
+            continue
+
+        section = actual_sections[section_id]
+        data = section.get("data")
+        if not isinstance(data, Mapping):
+            errors.append(f"section {section_id} data is not an object")
+            continue
+        errors.extend(_report_projection_data_errors(section_id, data, contract))
+    return errors
+
+
+def _report_projection_data_errors(
+    section_id: str,
+    data: Mapping[str, object],
+    contract: Mapping[str, object],
+) -> list[str]:
+    expected = set(_string_list(contract.get("projected_fields")))
+    optional = set(_string_list(contract.get("optional_projected_fields")))
+    actual = set(data)
+    errors = _field_set_errors(
+        f"section {section_id} data",
+        actual,
+        expected,
+        optional=optional,
+    )
+    collection = contract.get("collection")
+    if isinstance(collection, Mapping):
+        errors.extend(
+            _report_projection_collection_errors(
+                f"section {section_id}",
+                data,
+                collection,
+            )
+        )
+    errors.extend(
+        _report_projection_nested_object_errors(
+            f"section {section_id} data",
+            data,
+            contract.get("nested_object_fields"),
+        )
+    )
+    return errors
+
+
+def _report_projection_collection_errors(
+    label: str,
+    container: Mapping[str, object],
+    contract: Mapping[str, object],
+) -> list[str]:
+    field = str(contract.get("field"))
+    item_type = str(contract.get("item_type") or "object")
+    value = container.get(field)
+    if not isinstance(value, list):
+        return [f"{label}.{field} is not a list"]
+    errors: list[str] = []
+    if item_type == "string":
+        for index, item in enumerate(value):
+            if not isinstance(item, str):
+                errors.append(f"{label}.{field}[{index}] is not a string")
+        return errors
+
+    expected = set(_string_list(contract.get("projected_fields")))
+    for index, item in enumerate(value):
+        item_label = f"{label}.{field}[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{item_label} is not an object")
+            continue
+        errors.extend(_field_set_errors(item_label, set(item), expected))
+        errors.extend(
+            _report_projection_nested_object_errors(
+                item_label,
+                item,
+                contract.get("nested_object_fields"),
+            )
+        )
+        errors.extend(
+            _report_projection_nested_collection_errors(
+                item_label,
+                item,
+                contract.get("nested_collection_fields"),
+            )
+        )
+    return errors
+
+
+def _report_projection_nested_object_errors(
+    label: str,
+    container: Mapping[str, object],
+    entries: object,
+) -> list[str]:
+    errors: list[str] = []
+    for entry in entries if isinstance(entries, list) else []:
+        if not isinstance(entry, Mapping):
+            continue
+        field = str(entry.get("field"))
+        value = container.get(field)
+        if not isinstance(value, Mapping):
+            errors.append(f"{label}.{field} is not an object")
+            continue
+        errors.extend(
+            _field_set_errors(
+                f"{label}.{field}",
+                set(value),
+                set(_string_list(entry.get("projected_fields"))),
+            )
+        )
+    return errors
+
+
+def _report_projection_nested_collection_errors(
+    label: str,
+    container: Mapping[str, object],
+    entries: object,
+) -> list[str]:
+    errors: list[str] = []
+    for entry in entries if isinstance(entries, list) else []:
+        if not isinstance(entry, Mapping):
+            continue
+        field = str(entry.get("field"))
+        value = container.get(field)
+        if not isinstance(value, list):
+            errors.append(f"{label}.{field} is not a list")
+            continue
+        expected = set(_string_list(entry.get("projected_fields")))
+        for index, item in enumerate(value):
+            item_label = f"{label}.{field}[{index}]"
+            if not isinstance(item, Mapping):
+                errors.append(f"{item_label} is not an object")
+                continue
+            errors.extend(_field_set_errors(item_label, set(item), expected))
+    return errors
+
+
+def _field_set_errors(
+    label: str,
+    actual: set[str],
+    expected: set[str],
+    *,
+    optional: set[str] | None = None,
+) -> list[str]:
+    optional = optional or set()
+    missing = sorted((expected - optional) - actual)
+    extra = sorted(actual - expected)
+    errors: list[str] = []
+    if missing:
+        errors.append(f"{label} missing fields: {', '.join(missing)}")
+    if extra:
+        errors.append(f"{label} has unexpected fields: {', '.join(extra)}")
+    return errors
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def test_deflection_report_projection_fields_match_runtime_output() -> None:
+    artifact = build_deflection_report_artifact(
+        _report_projection_runtime_fixture_result(),
+        source_label="zendesk-trial-export.json",
+    ).as_dict()
+
+    errors = _report_projection_drift_errors(
+        artifact["report_model"],
+        expected_present={"source_file", "outcome_diagnostics"},
+    )
+
+    assert errors == []
+
+
+def test_deflection_report_projection_conditional_sections_match_runtime_output() -> None:
+    artifact = build_deflection_report_artifact(
+        _report_projection_no_conditionals_fixture_result()
+    ).as_dict()
+
+    errors = _report_projection_drift_errors(
+        artifact["report_model"],
+        expected_absent={"source_file", "outcome_diagnostics"},
+    )
+
+    assert errors == []
+
+
+def test_deflection_report_projection_checker_fails_on_field_drift() -> None:
+    artifact = build_deflection_report_artifact(
+        _report_projection_runtime_fixture_result(),
+        source_label="zendesk-trial-export.json",
+    ).as_dict()
+    sections = {
+        section["id"]: section
+        for section in artifact["report_model"]["sections"]
+    }
+    sections["priority_fix_queue"]["data"]["items"][0].pop("top_evidence")
+    sections["question_details"]["data"]["rows"][0]["surprise_raw_payload"] = {
+        "ticket": "raw"
+    }
+
+    errors = _report_projection_drift_errors(
+        artifact["report_model"],
+        expected_present={"source_file", "outcome_diagnostics"},
+    )
+
+    assert (
+        "section priority_fix_queue.items[0] missing fields: top_evidence"
+        in errors
+    )
+    assert (
+        "section question_details.rows[0] has unexpected fields: "
+        "surprise_raw_payload"
+    ) in errors
+
+
+def test_deflection_report_projection_checker_fails_on_nested_drift() -> None:
+    artifact = build_deflection_report_artifact(
+        _report_projection_runtime_fixture_result(),
+        source_label="zendesk-trial-export.json",
+    ).as_dict()
+    sections = {
+        section["id"]: section
+        for section in artifact["report_model"]["sections"]
+    }
+    item = sections["priority_fix_queue"]["data"]["items"][0]
+    item["csat_signal"].pop("numeric_average")
+    item["top_evidence"][0]["raw_ticket_body"] = "do not project"
+
+    errors = _report_projection_drift_errors(
+        artifact["report_model"],
+        expected_present={"source_file", "outcome_diagnostics"},
+    )
+
+    assert (
+        "section priority_fix_queue.items[0].csat_signal missing fields: "
+        "numeric_average"
+    ) in errors
+    assert (
+        "section priority_fix_queue.items[0].top_evidence[0] has unexpected "
+        "fields: raw_ticket_body"
+    ) in errors
+
+
+def test_deflection_report_projection_checker_fails_on_presence_drift() -> None:
+    artifact = build_deflection_report_artifact(
+        _report_projection_no_conditionals_fixture_result()
+    ).as_dict()
+    artifact["report_model"]["sections"].append({
+        "id": "outcome_diagnostics",
+        "title": "Outcome Diagnostics",
+        "priority": 90,
+        "surfaces": ["web", "pdf", "markdown"],
+        "default_limit": None,
+        "required_data": [],
+        "snapshot_safe_fields": [],
+        "data": {
+            "outcome_diagnostic_ticket_count": 0,
+            "outcome_risk_ticket_count": 0,
+            "reopened_ticket_count": 0,
+            "negative_csat_ticket_count": 0,
+            "rows": [],
+        },
+    })
+
+    errors = _report_projection_drift_errors(
+        artifact["report_model"],
+        expected_absent={"source_file", "outcome_diagnostics"},
+    )
+
+    assert "section outcome_diagnostics should be absent" in errors
 
 
 def test_deflection_snapshot_projected_fields_match_runtime_output() -> None:

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -1611,22 +1611,44 @@ def _report_projection_drift_errors(
     *,
     expected_present: set[str] | None = None,
     expected_absent: set[str] | None = None,
+    require_non_empty_collections: bool = True,
 ) -> list[str]:
     projection = deflection_report_model_contract_shape()["report_projection"]
+    errors = _field_set_errors(
+        "report_model",
+        set(report_model),
+        set(_string_list(projection.get("model_fields"))),
+    )
     contract_sections = {
         str(section["id"]): section
         for section in projection["sections"]
         if isinstance(section, Mapping)
     }
+    section_fields = set(_string_list(projection.get("section_fields")))
     raw_sections = report_model.get("sections")
     if not isinstance(raw_sections, list):
-        return ["report_model.sections is not a list"]
-    actual_sections = {
-        str(section.get("id")): section
-        for section in raw_sections
-        if isinstance(section, Mapping)
-    }
-    errors: list[str] = []
+        errors.append("report_model.sections is not a list")
+        return errors
+    actual_sections: dict[str, Mapping[str, object]] = {}
+    for index, section in enumerate(raw_sections):
+        if not isinstance(section, Mapping):
+            errors.append(f"report_model.sections[{index}] is not an object")
+            continue
+        section_id = section.get("id")
+        if not isinstance(section_id, str) or not section_id:
+            errors.append(f"report_model.sections[{index}] missing string id")
+            continue
+        if section_id in actual_sections:
+            errors.append(f"duplicate section emitted: {section_id}")
+            continue
+        actual_sections[section_id] = section
+        errors.extend(
+            _field_set_errors(
+                f"section {section_id} envelope",
+                set(section),
+                section_fields,
+            )
+        )
     expected_present = expected_present or set()
     expected_absent = expected_absent or set()
 
@@ -1652,7 +1674,14 @@ def _report_projection_drift_errors(
         if not isinstance(data, Mapping):
             errors.append(f"section {section_id} data is not an object")
             continue
-        errors.extend(_report_projection_data_errors(section_id, data, contract))
+        errors.extend(
+            _report_projection_data_errors(
+                section_id,
+                data,
+                contract,
+                require_non_empty_collections=require_non_empty_collections,
+            )
+        )
     return errors
 
 
@@ -1660,6 +1689,8 @@ def _report_projection_data_errors(
     section_id: str,
     data: Mapping[str, object],
     contract: Mapping[str, object],
+    *,
+    require_non_empty_collections: bool,
 ) -> list[str]:
     expected = set(_string_list(contract.get("projected_fields")))
     optional = set(_string_list(contract.get("optional_projected_fields")))
@@ -1677,6 +1708,7 @@ def _report_projection_data_errors(
                 f"section {section_id}",
                 data,
                 collection,
+                require_non_empty=require_non_empty_collections,
             )
         )
     errors.extend(
@@ -1686,6 +1718,7 @@ def _report_projection_data_errors(
             contract.get("nested_object_fields"),
         )
     )
+    errors.extend(_report_projection_record_field_errors(section_id, data, contract))
     return errors
 
 
@@ -1693,6 +1726,8 @@ def _report_projection_collection_errors(
     label: str,
     container: Mapping[str, object],
     contract: Mapping[str, object],
+    *,
+    require_non_empty: bool,
 ) -> list[str]:
     field = str(contract.get("field"))
     item_type = str(contract.get("item_type") or "object")
@@ -1700,6 +1735,8 @@ def _report_projection_collection_errors(
     if not isinstance(value, list):
         return [f"{label}.{field} is not a list"]
     errors: list[str] = []
+    if require_non_empty and not value:
+        errors.append(f"{label}.{field} is empty")
     if item_type == "string":
         for index, item in enumerate(value):
             if not isinstance(item, str):
@@ -1725,6 +1762,7 @@ def _report_projection_collection_errors(
                 item_label,
                 item,
                 contract.get("nested_collection_fields"),
+                require_non_empty=require_non_empty,
             )
         )
     return errors
@@ -1758,6 +1796,8 @@ def _report_projection_nested_collection_errors(
     label: str,
     container: Mapping[str, object],
     entries: object,
+    *,
+    require_non_empty: bool,
 ) -> list[str]:
     errors: list[str] = []
     for entry in entries if isinstance(entries, list) else []:
@@ -1768,6 +1808,8 @@ def _report_projection_nested_collection_errors(
         if not isinstance(value, list):
             errors.append(f"{label}.{field} is not a list")
             continue
+        if require_non_empty and not value:
+            errors.append(f"{label}.{field} is empty")
         expected = set(_string_list(entry.get("projected_fields")))
         for index, item in enumerate(value):
             item_label = f"{label}.{field}[{index}]"
@@ -1775,6 +1817,19 @@ def _report_projection_nested_collection_errors(
                 errors.append(f"{item_label} is not an object")
                 continue
             errors.extend(_field_set_errors(item_label, set(item), expected))
+    return errors
+
+
+def _report_projection_record_field_errors(
+    section_id: str,
+    data: Mapping[str, object],
+    contract: Mapping[str, object],
+) -> list[str]:
+    errors: list[str] = []
+    for field in _string_list(contract.get("record_fields")):
+        value = data.get(field)
+        if not isinstance(value, Mapping):
+            errors.append(f"section {section_id} data.{field} is not an object")
     return errors
 
 
@@ -1824,6 +1879,7 @@ def test_deflection_report_projection_conditional_sections_match_runtime_output(
     errors = _report_projection_drift_errors(
         artifact["report_model"],
         expected_absent={"source_file", "outcome_diagnostics"},
+        require_non_empty_collections=False,
     )
 
     assert errors == []
@@ -1913,6 +1969,78 @@ def test_deflection_report_projection_checker_fails_on_presence_drift() -> None:
     )
 
     assert "section outcome_diagnostics should be absent" in errors
+
+
+def test_deflection_report_projection_checker_fails_on_envelope_drift() -> None:
+    artifact = build_deflection_report_artifact(
+        _report_projection_runtime_fixture_result(),
+        source_label="zendesk-trial-export.json",
+    ).as_dict()
+    report_model = artifact["report_model"]
+    report_model.pop("title")
+    report_model["debug_payload"] = {"raw": "do not project"}
+    sections = report_model["sections"]
+    first_section = sections[0]
+    first_section["debug_payload"] = {"raw": "do not project"}
+    sections.append(dict(first_section))
+    sections.append("not-a-section")
+
+    errors = _report_projection_drift_errors(
+        report_model,
+        expected_present={"source_file", "outcome_diagnostics"},
+    )
+
+    assert "report_model missing fields: title" in errors
+    assert "report_model has unexpected fields: debug_payload" in errors
+    assert (
+        f"section {first_section['id']} envelope has unexpected fields: "
+        "debug_payload"
+    ) in errors
+    assert f"duplicate section emitted: {first_section['id']}" in errors
+    assert "report_model.sections[13] is not an object" in errors
+
+
+def test_deflection_report_projection_checker_fails_on_record_field_drift() -> None:
+    artifact = build_deflection_report_artifact(
+        _report_projection_runtime_fixture_result(),
+        source_label="zendesk-trial-export.json",
+    ).as_dict()
+    sections = {
+        section["id"]: section
+        for section in artifact["report_model"]["sections"]
+    }
+    sections["priority_fix_queue"]["data"]["status_counts"] = [
+        "Draft ready",
+        "Needs answer",
+    ]
+
+    errors = _report_projection_drift_errors(
+        artifact["report_model"],
+        expected_present={"source_file", "outcome_diagnostics"},
+    )
+
+    assert "section priority_fix_queue data.status_counts is not an object" in errors
+
+
+def test_deflection_report_projection_checker_fails_on_empty_collections() -> None:
+    artifact = build_deflection_report_artifact(
+        _report_projection_runtime_fixture_result(),
+        source_label="zendesk-trial-export.json",
+    ).as_dict()
+    sections = {
+        section["id"]: section
+        for section in artifact["report_model"]["sections"]
+    }
+    sections["ranked_questions"]["data"]["rows"] = []
+    sections["priority_fix_queue"]["data"]["items"][0]["top_evidence"] = []
+
+    errors = _report_projection_drift_errors(
+        artifact["report_model"],
+        expected_present={"source_file", "outcome_diagnostics"},
+    )
+
+    assert "section ranked_questions.rows is empty" in errors
+    assert "section priority_fix_queue.items[0].top_evidence is empty" in errors
 
 
 def test_deflection_snapshot_projected_fields_match_runtime_output() -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-Runtime-Contract.md
Slice phase: Production hardening

Adds runtime parity tests that reconcile the paid `report_projection` contract with real `build_deflection_report_artifact()` output before report-model codegen uses the contract. This closes the #1815 carry-forward: section `presence`, model/section envelopes, projected fields, collection rows/items, nested objects, nested collections, record fields, and non-empty collection coverage are now verified against emitted artifacts instead of another hand-written mirror.

## Intentional
- This is CI/test-time contract enforcement, not request-time validation.
- The checker stays test-local until the generated report-model artifact exists.
- The sparse conditional-section fixture disables non-empty collection proof because it exists to prove conditional absence only; the rich parity fixture remains strict.
- The slice is over the 400 LOC soft budget because the checker and negative probes need to cover top-level fields, conditional presence, envelopes, records, collections, nested objects, and nested collections together before codegen.

## Deferred
- Slice 3 generates the report-model frontend artifact from the ATLAS-owned report projection.
- Cross-repo portfolio/proxy consumption waits until ATLAS publishes that artifact.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py -k projection -q` — 14 passed.
- `python -m pytest tests/test_content_ops_deflection_report.py -q` — 163 passed.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py` — passed.
- `git diff --check` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.

## Diff size
2 files, +632 / -0
