### PR TITLE
Make security labels code-owned

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "dependencies",
+    "color": "0366d6",
+    "description": "Dependency updates and dependency-maintenance work"
+  },
+  {
+    "name": "security",
+    "color": "b60205",
+    "description": "Security-relevant dependency or vulnerability work"
+  },
+  {
+    "name": "cve-remediation-sla",
+    "color": "5319e7",
+    "description": "Dependabot/CVE remediation governed by SECURITY.md SLA"
+  },
+  {
+    "name": "security-rotation",
+    "color": "d93f0b",
+    "description": "Controlled credential or security-baseline rotation"
+  }
+]

--- a/.github/workflows/atlas_security_policy_docs_checks.yml
+++ b/.github/workflows/atlas_security_policy_docs_checks.yml
@@ -7,22 +7,32 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_security_policy_docs_checks.yml"
+      - ".github/workflows/repo_labels.yml"
       - ".github/dependabot.yml"
+      - ".github/labels.json"
       - "SECURITY.md"
       - "atlas_brain/api/billing.py"
       - "atlas_brain/content_ops_deflection_delivery.py"
       - "docs/INCIDENT_RESPONSE.md"
+      - "docs/SECURITY_GUARDRAILS.md"
+      - "scripts/check_gitleaks_baseline_rotation.py"
+      - "scripts/sync_github_labels.py"
       - "tests/test_security_policy_docs.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/atlas_security_policy_docs_checks.yml"
+      - ".github/workflows/repo_labels.yml"
       - ".github/dependabot.yml"
+      - ".github/labels.json"
       - "SECURITY.md"
       - "atlas_brain/api/billing.py"
       - "atlas_brain/content_ops_deflection_delivery.py"
       - "docs/INCIDENT_RESPONSE.md"
+      - "docs/SECURITY_GUARDRAILS.md"
+      - "scripts/check_gitleaks_baseline_rotation.py"
+      - "scripts/sync_github_labels.py"
       - "tests/test_security_policy_docs.py"
 
 jobs:

--- a/.github/workflows/repo_labels.yml
+++ b/.github/workflows/repo_labels.yml
@@ -1,0 +1,40 @@
+name: Repo Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/labels.json"
+      - ".github/workflows/repo_labels.yml"
+      - "scripts/sync_github_labels.py"
+  workflow_dispatch:
+  schedule:
+    - cron: "37 10 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  sync-repo-labels:
+    name: Sync repository labels
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Apply label manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/sync_github_labels.py --manifest .github/labels.json --apply

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -65,6 +65,13 @@ SHA and pin the Gitleaks container image by digest. The rest of the repository's
 older workflow actions are intentionally left to a follow-up fleet-wide pinning
 and OIDC review so this slice stays focused on the new guardrails.
 
+Security-critical GitHub labels used by Dependabot SLA tracking and controlled
+Gitleaks baseline rotations are code-owned in `.github/labels.json`. The
+`Repo Labels` workflow reconciles that manifest through
+`scripts/sync_github_labels.py` on trusted `main` updates and manual dispatch,
+so deleting one of those labels becomes manifest drift instead of silent policy
+loss.
+
 Workflow supply-chain posture is checked by
 `scripts/audit_workflow_security_posture.py`. It fails unapproved
 `pull_request_target` jobs and unapproved `id-token: write` / `write-all`

--- a/plans/PR-Security-Labels-As-Code.md
+++ b/plans/PR-Security-Labels-As-Code.md
@@ -1,0 +1,187 @@
+# PR-Security-Labels-As-Code
+
+## Why this slice exists
+
+Issue #1656 now has a CVE remediation SLA path, but the labels that make the
+path observable are still mutable GitHub metadata. PR #1814 created
+`cve-remediation-sla` manually, while `.github/dependabot.yml`, `SECURITY.md`,
+and the Gitleaks baseline rotation guard also rely on `dependencies`,
+`security`, and `security-rotation`. Live repo state proves the drift: a new
+Dependabot PR only received `cve-remediation-sla` because the other configured
+labels do not exist.
+
+Root cause: security-critical label names were referenced independently from
+docs, Dependabot config, and guard scripts without a committed repo-label
+contract or any automation that restores those labels when GitHub metadata
+drifts.
+
+This change fixes the root for the security label set by making those labels
+code-owned in a manifest, adding a main/manual sync workflow, and testing that
+every security policy label reference is covered by the manifest.
+
+Diff budget note: this is over the 400 LOC soft cap because the root fix is
+indivisible across manifest, trusted sync workflow, stdlib sync helper, and
+negative tests. Splitting those pieces would recreate the original failure
+mode: labels could be documented without being reconciled, or reconciled
+without a tested contract that catches drift. The post-review Codex P2 fixes
+kept the same PR over the soft cap because they close the same label-as-code
+failure class: source-reference drift, live-metadata drift, case-only drift,
+and invalid label metadata reaching the trusted sync job.
+
+## Scope (this PR)
+
+Ownership lane: security/labels-as-code
+Slice phase: Workflow/process
+Max files: 7
+
+Post-review fix budget: the local fix-mode baton limits the
+workflow-dispatch guard change to the label workflow, the security policy docs
+test, and this plan. The plan-level budget covers the whole PR diff.
+
+1. Add a committed repo-label manifest for the security/Dependabot labels
+   used by the current #1656 security guardrails.
+2. Add a stdlib label-sync helper and a main/manual GitHub Actions workflow
+   that reconciles the manifest into repository labels and repairs live drift
+   on a weekly schedule.
+3. Extend the security policy docs contract tests so Dependabot labels,
+   labels documented in `SECURITY.md`, the Gitleaks rotation label, the
+   manifest, and the label-sync workflow stay aligned.
+
+### Review Contract
+
+Acceptance criteria:
+- `.github/labels.json` defines every label referenced by
+  `.github/dependabot.yml`, `SECURITY.md`, and the Gitleaks rotation guard.
+- The sync helper plans create/update operations for missing or stale live
+  labels, handles case-only live label drift as an update/rename, and refuses
+  malformed manifests.
+- The label workflow only syncs from trusted `main`/manual execution, not from
+  untrusted PR code.
+- The security policy docs workflow runs when the manifest, sync workflow, or
+  sync helper changes.
+
+Affected surfaces:
+- Repository label metadata contract for Dependabot/CVE SLA and controlled
+  Gitleaks baseline rotations.
+- Security policy docs checks.
+
+Risk areas:
+- Over-broad workflow write permissions.
+- Manifest drift from the actual label names consumed by Dependabot or guard
+  scripts.
+- A sync script that silently accepts duplicate or malformed labels.
+
+Triggered reviewer rules:
+- R1 Requirements match.
+- R2 Test evidence.
+- R3 Security/auth.
+- R8 CI/workflow enrollment.
+- R13 Fix class, not example.
+- R14 Codebase verification.
+
+### Files touched
+
+- `.github/labels.json`
+- `.github/workflows/atlas_security_policy_docs_checks.yml`
+- `.github/workflows/repo_labels.yml`
+- `docs/SECURITY_GUARDRAILS.md`
+- `plans/PR-Security-Labels-As-Code.md`
+- `scripts/sync_github_labels.py`
+- `tests/test_security_policy_docs.py`
+
+## Mechanism
+
+`.github/labels.json` is the code-owned label manifest. The sync helper reads
+that manifest, reads live labels from `gh label list --json
+name,description,color`, computes missing/stale labels, and either reports
+drift (`--check`) or applies it (`--apply`) with `gh label create/edit`.
+
+`.github/workflows/repo_labels.yml` runs the helper on pushes to `main` that
+change the manifest/helper/workflow, on manual dispatch, and on a weekly
+schedule. The workflow grants `issues: write` only to the sync job because
+GitHub labels are issue/PR metadata; it does not run on `pull_request`. Manual
+dispatches are guarded to the `main` ref and the checkout pins to the
+repository default branch before running the token-backed repo script.
+
+`tests/test_security_policy_docs.py` stays the CI-facing contract for the
+security policy documents. It now also imports the sync helper directly and
+proves malformed manifests, missing referenced labels, missing live labels, and
+stale live labels fail the relevant checks. It derives the documented
+Dependabot labels from `SECURITY.md`, imports the Gitleaks rotation label from
+the guard script, and ensures the security docs workflow runs when those source
+files change.
+
+The sync helper keys live labels case-insensitively and emits `gh label edit
+<current-name> --name <manifest-name>` for case-only drift. Manifest loading
+also enforces GitHub's 100-character label description limit so invalid label
+metadata fails before merge instead of in the trusted main sync job.
+
+## Intentional
+
+- The manifest is scoped to security-critical labels, not every default repo
+  label. This slice closes the #1656 label drift; a full repo taxonomy cleanup
+  can happen separately if needed.
+- The sync workflow runs only from trusted `main` or manual dispatch. PRs prove
+  the contract through tests instead of letting untrusted branch code mutate
+  repository metadata; the manual path is branch-guarded and checks out the
+  default branch before running the sync script.
+- The helper shells out to `gh` rather than adding a GitHub REST dependency.
+  The workflow image already includes `gh`, and the helper remains stdlib-only
+  for local and CI use.
+
+## Deferred
+
+- Full repository label taxonomy cleanup is deferred; this PR only owns labels
+  that current security policy and guardrail code consume.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m unittest tests.test_security_policy_docs` -- 18 tests passed.
+- `python scripts/audit_workflow_security_posture.py .github/workflows` --
+  passed; existing mutable-action warnings are unrelated parked debt.
+- `python -m py_compile` against `scripts/sync_github_labels.py` -- passed.
+- `scripts/check_ascii_python.sh` through `bash` -- passed.
+- `python scripts/sync_github_labels.py --manifest .github/labels.json --apply`
+  -- created `dependencies`, `security`, and `security-rotation` live labels
+  from the manifest.
+- `python scripts/sync_github_labels.py --manifest .github/labels.json --check`
+  -- passed after sync.
+- `scripts/push_pr.sh` with the prepared PR body and `-u origin HEAD` --
+  local review passed and branch pushed.
+- Review-fix verification: `python -m unittest tests.test_security_policy_docs`
+  -- 18 tests passed with the workflow-dispatch guard assertions.
+- Review-fix verification:
+  `python scripts/audit_workflow_security_posture.py .github/workflows` --
+  passed; existing mutable-action warnings are unrelated parked debt.
+- Review-fix verification:
+  `python scripts/sync_github_labels.py --manifest .github/labels.json --check`
+  -- passed.
+- Codex P2 review-fix verification:
+  `python -m unittest tests.test_security_policy_docs` -- 20 tests passed with
+  path-filter, `SECURITY.md` label extraction, schedule, case-only drift, and
+  overlong-description coverage.
+- Codex P2 review-fix verification:
+  `python scripts/audit_workflow_security_posture.py .github/workflows` --
+  passed; existing mutable-action warnings are unrelated parked debt.
+- Codex P2 review-fix verification:
+  `python -m py_compile` against `scripts/sync_github_labels.py` -- passed.
+- Codex P2 review-fix verification:
+  `python scripts/sync_github_labels.py --manifest .github/labels.json --check`
+  -- passed.
+- Pending review-fix push: `scripts/push_pr.sh` with the updated PR body and
+  `--force-with-lease origin HEAD`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/labels.json` | 22 |
+| `.github/workflows/atlas_security_policy_docs_checks.yml` | 10 |
+| `.github/workflows/repo_labels.yml` | 40 |
+| `docs/SECURITY_GUARDRAILS.md` | 7 |
+| `plans/PR-Security-Labels-As-Code.md` | 187 |
+| `scripts/sync_github_labels.py` | 234 |
+| `tests/test_security_policy_docs.py` | 206 |
+| **Total** | **706** |

--- a/scripts/sync_github_labels.py
+++ b/scripts/sync_github_labels.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Sync repository labels from the committed Atlas label manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+COLOR_RE = re.compile(r"^[0-9a-f]{6}$")
+MAX_DESCRIPTION_LENGTH = 100
+
+
+@dataclass(frozen=True)
+class LabelSpec:
+    name: str
+    color: str
+    description: str
+
+
+@dataclass(frozen=True)
+class LabelUpdate:
+    current_name: str
+    wanted: LabelSpec
+
+
+@dataclass(frozen=True)
+class SyncPlan:
+    create: tuple[LabelSpec, ...]
+    update: tuple[LabelUpdate, ...]
+    unchanged: tuple[str, ...]
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.create or self.update)
+
+
+def normalize_color(value: object, *, label_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label_name}: color must be a string")
+    color = value.strip().lstrip("#").lower()
+    if not COLOR_RE.fullmatch(color):
+        raise ValueError(f"{label_name}: color must be a 6-digit hex value")
+    return color
+
+
+def label_spec_from_mapping(raw: object, *, source: str) -> LabelSpec:
+    if not isinstance(raw, dict):
+        raise ValueError(f"{source}: label entries must be objects")
+    name = raw.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(f"{source}: label name must be a non-empty string")
+    label_name = name.strip()
+    description = raw.get("description", "")
+    if description is None:
+        description = ""
+    if not isinstance(description, str):
+        raise ValueError(f"{label_name}: description must be a string")
+    label_description = description.strip()
+    if len(label_description) > MAX_DESCRIPTION_LENGTH:
+        raise ValueError(
+            f"{label_name}: description must be {MAX_DESCRIPTION_LENGTH} characters or fewer"
+        )
+    return LabelSpec(
+        name=label_name,
+        color=normalize_color(raw.get("color"), label_name=label_name),
+        description=label_description,
+    )
+
+
+def load_manifest_text(text: str) -> tuple[LabelSpec, ...]:
+    parsed = json.loads(text)
+    if not isinstance(parsed, list):
+        raise ValueError("label manifest must be a JSON array")
+
+    labels = tuple(
+        label_spec_from_mapping(entry, source=f"label manifest entry {index}")
+        for index, entry in enumerate(parsed, start=1)
+    )
+    if not labels:
+        raise ValueError("label manifest must define at least one label")
+
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for label in labels:
+        key = label.name.lower()
+        if key in seen:
+            duplicates.append(label.name)
+        seen.add(key)
+    if duplicates:
+        raise ValueError(f"duplicate repo label definitions: {', '.join(sorted(set(duplicates)))}")
+    return labels
+
+
+def load_manifest(path: Path) -> tuple[LabelSpec, ...]:
+    return load_manifest_text(path.read_text(encoding="utf-8"))
+
+
+def load_repo_labels_text(text: str) -> dict[str, LabelSpec]:
+    parsed = json.loads(text)
+    if not isinstance(parsed, list):
+        raise ValueError("repo labels JSON must be an array")
+
+    labels: dict[str, LabelSpec] = {}
+    for index, entry in enumerate(parsed, start=1):
+        label = label_spec_from_mapping(entry, source=f"repo label entry {index}")
+        labels[label.name.lower()] = label
+    return labels
+
+
+def plan_label_sync(
+    manifest_labels: tuple[LabelSpec, ...],
+    repo_labels: dict[str, LabelSpec],
+) -> SyncPlan:
+    create: list[LabelSpec] = []
+    update: list[LabelSpec] = []
+    unchanged: list[str] = []
+    for wanted in manifest_labels:
+        current = repo_labels.get(wanted.name.lower())
+        if current is None:
+            create.append(wanted)
+            continue
+        if (
+            current.name != wanted.name
+            or current.color != wanted.color
+            or current.description != wanted.description
+        ):
+            update.append(LabelUpdate(current.name, wanted))
+            continue
+        unchanged.append(wanted.name)
+    return SyncPlan(tuple(create), tuple(update), tuple(unchanged))
+
+
+def run_gh_json(args: list[str]) -> str:
+    proc = subprocess.run(["gh", *args], check=False, capture_output=True, text=True)
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "gh command failed"
+        raise RuntimeError(detail)
+    return proc.stdout
+
+
+def load_live_repo_labels(repo_labels_json: Path | None) -> dict[str, LabelSpec]:
+    if repo_labels_json is not None:
+        return load_repo_labels_text(repo_labels_json.read_text(encoding="utf-8"))
+    return load_repo_labels_text(
+        run_gh_json(["label", "list", "--limit", "1000", "--json", "name,description,color"])
+    )
+
+
+def apply_plan(plan: SyncPlan) -> None:
+    for label in plan.create:
+        run_gh_json(
+            [
+                "label",
+                "create",
+                label.name,
+                "--color",
+                label.color,
+                "--description",
+                label.description,
+            ]
+        )
+    for update in plan.update:
+        label = update.wanted
+        run_gh_json(
+            [
+                "label",
+                "edit",
+                update.current_name,
+                "--name",
+                label.name,
+                "--color",
+                label.color,
+                "--description",
+                label.description,
+            ]
+        )
+
+
+def print_plan(plan: SyncPlan) -> None:
+    if not plan.has_changes:
+        print("GitHub labels already match .github/labels.json.")
+        return
+    if plan.create:
+        print("Labels to create:")
+        for label in plan.create:
+            print(f"- {label.name}")
+    if plan.update:
+        print("Labels to update:")
+        for update in plan.update:
+            if update.current_name == update.wanted.name:
+                print(f"- {update.wanted.name}")
+            else:
+                print(f"- {update.current_name} -> {update.wanted.name}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=Path(".github/labels.json"))
+    parser.add_argument(
+        "--repo-labels-json",
+        type=Path,
+        default=None,
+        help="Optional gh label list JSON fixture. Defaults to live gh label list.",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="Fail if live labels drift from the manifest.")
+    mode.add_argument("--apply", action="store_true", help="Create or update live labels to match the manifest.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        manifest_labels = load_manifest(args.manifest)
+        repo_labels = load_live_repo_labels(args.repo_labels_json)
+        plan = plan_label_sync(manifest_labels, repo_labels)
+        print_plan(plan)
+        if args.check:
+            return 1 if plan.has_changes else 0
+        apply_plan(plan)
+        return 0
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_security_policy_docs.py
+++ b/tests/test_security_policy_docs.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import ast
+import importlib.util
+import re
+import sys
 import unittest
 from pathlib import Path
 
@@ -8,10 +11,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SECURITY_MD = REPO_ROOT / "SECURITY.md"
 INCIDENT_RESPONSE_MD = REPO_ROOT / "docs" / "INCIDENT_RESPONSE.md"
+SECURITY_GUARDRAILS_MD = REPO_ROOT / "docs" / "SECURITY_GUARDRAILS.md"
 DEPENDABOT_YML = REPO_ROOT / ".github" / "dependabot.yml"
 SECURITY_POLICY_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "atlas_security_policy_docs_checks.yml"
 )
+REPO_LABELS_JSON = REPO_ROOT / ".github" / "labels.json"
+REPO_LABELS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "repo_labels.yml"
+LABEL_SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync_github_labels.py"
+GITLEAKS_ROTATION_SCRIPT = REPO_ROOT / "scripts" / "check_gitleaks_baseline_rotation.py"
 PAID_FUNNEL_EMITTERS = [
     REPO_ROOT / "atlas_brain" / "api" / "billing.py",
     REPO_ROOT / "atlas_brain" / "content_ops_deflection_delivery.py",
@@ -90,6 +98,151 @@ class SecurityPolicyDocsTest(unittest.TestCase):
 
         self.assertIn('".github/dependabot.yml"', workflow)
 
+    def test_security_policy_docs_workflow_runs_on_label_contract_changes(self) -> None:
+        workflow = SECURITY_POLICY_WORKFLOW.read_text(encoding="utf-8")
+
+        required_paths = [
+            '".github/labels.json"',
+            '".github/workflows/repo_labels.yml"',
+            '"docs/SECURITY_GUARDRAILS.md"',
+            '"scripts/check_gitleaks_baseline_rotation.py"',
+            '"scripts/sync_github_labels.py"',
+        ]
+        for path in required_paths:
+            with self.subTest(path=path):
+                self.assertIn(path, workflow)
+
+    def test_repo_label_manifest_covers_security_policy_references(self) -> None:
+        manifest_labels = _repo_label_manifest_names()
+        dependabot_labels = set().union(
+            *[labels for _, labels in _dependabot_update_label_sets(DEPENDABOT_YML.read_text(encoding="utf-8"))]
+        )
+        required_labels = (
+            dependabot_labels
+            | _security_policy_label_references(SECURITY_MD.read_text(encoding="utf-8"))
+            | {_gitleaks_rotation_label()}
+        )
+
+        _assert_repo_label_manifest_covers(required_labels, manifest_labels)
+
+    def test_repo_label_manifest_rejects_missing_referenced_label(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "missing repo label definitions.*security"):
+            _assert_repo_label_manifest_covers({"security"}, {"dependencies"})
+
+    def test_repo_label_manifest_rejects_duplicate_names(self) -> None:
+        syncer = _load_label_syncer()
+
+        with self.assertRaisesRegex(ValueError, "duplicate repo label definitions: security"):
+            syncer.load_manifest_text(
+                """
+                [
+                  {"name": "security", "color": "b60205", "description": "one"},
+                  {"name": "security", "color": "d73a4a", "description": "two"}
+                ]
+                """
+            )
+
+    def test_repo_label_manifest_rejects_bad_color(self) -> None:
+        syncer = _load_label_syncer()
+
+        with self.assertRaisesRegex(ValueError, "security: color must be a 6-digit hex value"):
+            syncer.load_manifest_text(
+                '[{"name": "security", "color": "red", "description": "bad"}]'
+            )
+
+    def test_repo_label_manifest_rejects_overlong_description(self) -> None:
+        syncer = _load_label_syncer()
+        overlong = "x" * 101
+
+        with self.assertRaisesRegex(ValueError, "description must be 100 characters or fewer"):
+            syncer.load_manifest_text(
+                f'[{{"name": "security", "color": "b60205", "description": "{overlong}"}}]'
+            )
+
+    def test_repo_label_sync_plans_missing_and_stale_live_labels(self) -> None:
+        syncer = _load_label_syncer()
+        manifest = (
+            syncer.LabelSpec("security", "b60205", "Security-relevant dependency or vulnerability work"),
+            syncer.LabelSpec("security-rotation", "d93f0b", "Controlled credential or security-baseline rotation"),
+        )
+        live = {
+            "security": syncer.LabelSpec("security", "ededed", "Old description"),
+        }
+
+        plan = syncer.plan_label_sync(manifest, live)
+
+        self.assertEqual([label.name for label in plan.create], ["security-rotation"])
+        self.assertEqual([update.wanted.name for update in plan.update], ["security"])
+        self.assertEqual([update.current_name for update in plan.update], ["security"])
+        self.assertEqual(plan.unchanged, ())
+
+    def test_repo_label_sync_plans_case_only_label_drift_as_update(self) -> None:
+        syncer = _load_label_syncer()
+        manifest = (
+            syncer.LabelSpec("security", "b60205", "Security-relevant dependency or vulnerability work"),
+        )
+        live = syncer.load_repo_labels_text(
+            """
+            [
+              {
+                "name": "Security",
+                "color": "b60205",
+                "description": "Security-relevant dependency or vulnerability work"
+              }
+            ]
+            """
+        )
+
+        plan = syncer.plan_label_sync(manifest, live)
+
+        self.assertEqual(plan.create, ())
+        self.assertEqual(plan.update[0].current_name, "Security")
+        self.assertEqual(plan.update[0].wanted.name, "security")
+
+    def test_repo_label_sync_plans_noop_when_live_labels_match(self) -> None:
+        syncer = _load_label_syncer()
+        manifest = (
+            syncer.LabelSpec("cve-remediation-sla", "5319e7", "Dependabot/CVE remediation governed by SECURITY.md SLA"),
+        )
+        live = {
+            "cve-remediation-sla": syncer.LabelSpec(
+                "cve-remediation-sla",
+                "5319e7",
+                "Dependabot/CVE remediation governed by SECURITY.md SLA",
+            )
+        }
+
+        plan = syncer.plan_label_sync(manifest, live)
+
+        self.assertFalse(plan.has_changes)
+        self.assertEqual(plan.unchanged, ("cve-remediation-sla",))
+
+    def test_repo_labels_workflow_syncs_manifest_from_trusted_events_only(self) -> None:
+        workflow = REPO_LABELS_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("push:", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("schedule:", workflow)
+        self.assertIn('cron: "37 10 * * 1"', workflow)
+        self.assertNotIn("pull_request:", workflow)
+        self.assertIn("if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'", workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
+        self.assertIn("issues: write", workflow)
+        self.assertIn("python scripts/sync_github_labels.py --manifest .github/labels.json --apply", workflow)
+
+    def test_security_guardrails_documents_repo_label_manifest(self) -> None:
+        guardrails = SECURITY_GUARDRAILS_MD.read_text(encoding="utf-8")
+
+        required_markers = [
+            ".github/labels.json",
+            "`Repo Labels` workflow",
+            "`scripts/sync_github_labels.py`",
+            "trusted `main` updates and manual dispatch",
+        ]
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, guardrails)
+
     def test_incident_response_runbook_covers_required_sections(self) -> None:
         runbook = INCIDENT_RESPONSE_MD.read_text(encoding="utf-8")
 
@@ -123,6 +276,59 @@ class SecurityPolicyDocsTest(unittest.TestCase):
         for incident_type in incident_types:
             with self.subTest(incident_type=incident_type):
                 self.assertIn(incident_type, runbook)
+
+
+def _load_script_module(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _load_label_syncer():
+    return _load_script_module("sync_github_labels", LABEL_SYNC_SCRIPT)
+
+
+def _load_gitleaks_checker():
+    return _load_script_module("check_gitleaks_baseline_rotation", GITLEAKS_ROTATION_SCRIPT)
+
+
+def _repo_label_manifest_names() -> set[str]:
+    syncer = _load_label_syncer()
+    labels = syncer.load_manifest(REPO_LABELS_JSON)
+    return {label.name for label in labels}
+
+
+def _gitleaks_rotation_label() -> str:
+    return _load_gitleaks_checker().DEFAULT_ROTATION_LABEL
+
+
+def _security_policy_label_references(security_text: str) -> set[str]:
+    match = re.search(r"Dependabot PRs carry the (?P<labels>.*?) labels\.", security_text, re.S)
+    if not match:
+        raise AssertionError("SECURITY.md does not document Dependabot PR labels")
+    labels = set(re.findall(r"`([^`]+)`", match.group("labels")))
+    if not labels:
+        raise AssertionError("SECURITY.md Dependabot label sentence has no backtick labels")
+    return labels
+
+
+def _assert_repo_label_manifest_covers(
+    required_labels: set[str],
+    manifest_labels: set[str],
+) -> None:
+    missing = sorted(required_labels - manifest_labels)
+    if missing:
+        raise AssertionError(f"missing repo label definitions: {missing}")
 
 
 def _paid_funnel_incident_types_from_emitters() -> set[str]:


### PR DESCRIPTION
Plan: plans/PR-Security-Labels-As-Code.md
Slice phase: Workflow/process

Issue #1656 now has CVE remediation SLA tracking, but the labels that make the policy observable were still mutable GitHub metadata. This PR code-owns the security label set with a committed manifest, a trusted main/manual/scheduled sync workflow, and tests that keep Dependabot labels, `SECURITY.md` label references, the Gitleaks rotation label, the manifest, and the workflow aligned.

## Intentional
- The manifest is scoped to security-critical labels, not the full repository label taxonomy.
- The sync workflow does not run on `pull_request`; PRs prove the contract through tests while repository label mutation stays on trusted `main` or manual dispatch. The manual path is branch-guarded and checks out the default branch before running the sync script.
- The helper shells out to `gh` instead of adding a GitHub REST dependency.
- The helper handles case-only live label drift as an update/rename and validates GitHub's 100-character label description limit before merge.
- Existing open Dependabot PRs were not relabeled. A new Dependabot PR opened after the live manifest sync (#1819) received `dependencies`, `security`, and `cve-remediation-sla`.

## Deferred
- Full repository label taxonomy cleanup remains deferred.

## Parked hardening
- None.

## Verification
- `python -m unittest tests.test_security_policy_docs` -- 18 tests passed.
- `python scripts/audit_workflow_security_posture.py .github/workflows` -- passed; existing mutable-action warnings are unrelated parked debt.
- `python -m py_compile` against `scripts/sync_github_labels.py` -- passed.
- `scripts/check_ascii_python.sh` through `bash` -- passed.
- `python scripts/sync_github_labels.py --manifest .github/labels.json --apply` -- created `dependencies`, `security`, and `security-rotation` live labels from the manifest.
- `python scripts/sync_github_labels.py --manifest .github/labels.json --check` -- passed after sync.
- `scripts/push_pr.sh` with the prepared PR body and `-u origin HEAD` -- local review passed and branch pushed.
- Review-fix verification: `python -m unittest tests.test_security_policy_docs` -- 18 tests passed with the workflow-dispatch guard assertions.
- Review-fix verification: `python scripts/audit_workflow_security_posture.py .github/workflows` -- passed; existing mutable-action warnings are unrelated parked debt.
- Review-fix verification: `python scripts/sync_github_labels.py --manifest .github/labels.json --check` -- passed.
- Codex P2 review-fix verification: `python -m unittest tests.test_security_policy_docs` -- 20 tests passed with path-filter, `SECURITY.md` label extraction, schedule, case-only drift, and overlong-description coverage.
- Codex P2 review-fix verification: `python scripts/audit_workflow_security_posture.py .github/workflows` -- passed; existing mutable-action warnings are unrelated parked debt.
- Codex P2 review-fix verification: `python -m py_compile` against `scripts/sync_github_labels.py` -- passed.
- Codex P2 review-fix verification: `python scripts/sync_github_labels.py --manifest .github/labels.json --check` -- passed.

## Diff size
7 files, +706 / -0
