### PR TITLE
Publish deflection report hosted-safe artifact

### DIFF
--- a/plans/PR-Deflection-Report-Hosted-Safe-Artifact.md
+++ b/plans/PR-Deflection-Report-Hosted-Safe-Artifact.md
@@ -1,0 +1,109 @@
+# PR-Deflection-Report-Hosted-Safe-Artifact
+
+## Why this slice exists
+
+#1805's report-contract arc has now landed the paid report contract, runtime
+enforcement, generated paid frontend artifact, and in-repo paid consumer. The
+remaining boundary gap named by the prior slices is hosted-safe construction:
+the backend `report_projection` contract already carries
+`hosted_consumer_safe_fields`, but the generated frontend artifacts currently
+drop that metadata. A consumer cannot construct hosted/token page payloads from
+the contract until ATLAS publishes those allowlists.
+
+Root cause: the generator validated hosted-safe metadata inside
+`report_projection` but only emitted paid runtime fields and
+`snapshot_safe_fields`. This fixes the root for the ATLAS-owned artifact by
+publishing hosted-safe allowlist constants from the backend contract; it does
+not yet consume those constants in a hosted result page.
+
+Diff-size note: this lands slightly above the 400 LOC soft cap because half of
+the diff is generated constants plus the negative fixtures required for the
+privacy-boundary checker. The hand-written implementation remains narrow.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-contract-1805
+Slice phase: Production hardening
+
+1. Emit generated `*_HOSTED_CONSUMER_SAFE_FIELDS` constants for report sections,
+   object collections, nested objects, and nested collections in both the
+   TypeScript and JS report-model artifacts.
+2. Keep runtime paid model types unchanged: `hosted_consumer_safe_fields` is
+   contract metadata, not a field on `DeflectionStructuredReport` sections.
+3. Add generator tests proving hosted-safe metadata is emitted, and fails closed
+   when hosted-safe metadata references a field outside the paid projection.
+
+### Review Contract
+
+- Acceptance criteria: generated artifacts publish hosted-safe allowlists for
+  top-level sections, action `items`, nested `csat_signal`, and raw
+  `top_evidence` as an empty hosted-safe allowlist.
+- Affected surfaces: `scripts/generate_deflection_frontend_contract_types.py`,
+  `portfolio-ui/src/types/deflectionReportModel.ts`,
+  `portfolio-ui/api/content-ops/deflection/report-model-contract.js`, and the
+  generator tests.
+- Risk areas: do not widen the runtime paid report model shape; do not add
+  hosted-safe metadata to free snapshot output; fail closed on invalid
+  hosted-safe fields.
+- Reviewer rules triggered: R1 requirements match, R2 test evidence, R3
+  security/privacy boundary, R6 generated artifact drift, R9 checker failure
+  branches, R13 class fix, R14 codebase verification.
+
+### Files touched
+
+- `plans/PR-Deflection-Report-Hosted-Safe-Artifact.md`
+- `portfolio-ui/api/content-ops/deflection/report-model-contract.js`
+- `portfolio-ui/src/types/deflectionReportModel.ts`
+- `scripts/generate_deflection_frontend_contract_types.py`
+- `tests/test_generate_deflection_frontend_contract_types.py`
+
+## Mechanism
+
+The generator already reads `report_projection` and validates the section,
+collection, nested-object, and nested-collection metadata. This slice teaches
+that metadata pass to validate `hosted_consumer_safe_fields` as subsets of the
+same object's projected fields, then renders stable constants in the generated
+TS/JS artifacts.
+
+The runtime `DeflectionStructuredReport` types remain paid-shape types. Hosted
+allowlists are emitted only as sidecar constants for future consumers to use
+when allowlist-constructing hosted result-page payloads.
+
+## Intentional
+
+- No hosted result-page consumer change in this PR. Publishing the ATLAS-owned
+  artifact first keeps the next consumer slice small and prevents repeating the
+  atlas-portfolio "waiting on ATLAS artifact" problem.
+- No `hosted_consumer_safe_fields` property is added to
+  `DeflectionReportSection`. The runtime report model does not carry that
+  metadata; adding it to the type would make valid paid report output look
+  invalid.
+
+## Deferred
+
+- Hosted result-page construction must consume these generated allowlists in a
+  follow-up slice before any hosted/free paid report payload uses the paid
+  model. That slice should allowlist-construct from the constants rather than
+  validate-and-pass raw report rows.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused generator pytest: `python -m pytest`, target
+  `tests/test_generate_deflection_frontend_contract_types.py` -- 19 passed.
+- Generator drift check: `python`, target
+  `scripts/generate_deflection_frontend_contract_types.py`, with `--check` --
+  all four generated frontend contract outputs are current.
+- Local PR review bundle -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Report-Hosted-Safe-Artifact.md` | 109 |
+| `portfolio-ui/api/content-ops/deflection/report-model-contract.js` | 64 |
+| `portfolio-ui/src/types/deflectionReportModel.ts` | 64 |
+| `scripts/generate_deflection_frontend_contract_types.py` | 88 |
+| `tests/test_generate_deflection_frontend_contract_types.py` | 108 |
+| **Total** | **433** |

--- a/portfolio-ui/api/content-ops/deflection/report-model-contract.js
+++ b/portfolio-ui/api/content-ops/deflection/report-model-contract.js
@@ -21,11 +21,15 @@ export const DEFLECTION_REPORT_SUPPORT_TAX_REQUIRED_DATA = Object.freeze(["repea
 
 export const DEFLECTION_REPORT_SUPPORT_TAX_SNAPSHOT_SAFE_FIELDS = Object.freeze(["repeat_ticket_count", "non_repeat_ticket_count", "generated_question_count", "drafted_answer_count", "no_proven_answer_count", "ticket_source_count", "source_date_window"]);
 
+export const DEFLECTION_REPORT_SUPPORT_TAX_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["repeat_ticket_count", "non_repeat_ticket_count", "generated_question_count", "assisted_contact_cost", "estimated_support_cost", "source_date_window", "drafted_answer_count", "no_proven_answer_count", "ticket_source_count", "annualized_support_cost", "annualized_run_rate_support_cost"]);
+
 export const DEFLECTION_REPORT_SOURCE_FILE_FIELDS = Object.freeze(["source_label"]);
 
 export const DEFLECTION_REPORT_SOURCE_FILE_REQUIRED_DATA = Object.freeze(["source_label"]);
 
 export const DEFLECTION_REPORT_SOURCE_FILE_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
+
+export const DEFLECTION_REPORT_SOURCE_FILE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
 export const DEFLECTION_REPORT_SEO_TARGETS_FIELDS = Object.freeze(["phrases", "total_phrase_count", "displayed_phrase_count", "omitted_phrase_count", "limit"]);
 
@@ -33,11 +37,17 @@ export const DEFLECTION_REPORT_SEO_TARGETS_REQUIRED_DATA = Object.freeze(["phras
 
 export const DEFLECTION_REPORT_SEO_TARGETS_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
 
+export const DEFLECTION_REPORT_SEO_TARGETS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["phrases", "total_phrase_count", "displayed_phrase_count", "omitted_phrase_count", "limit"]);
+
 export const DEFLECTION_REPORT_RANKED_QUESTIONS_FIELDS = Object.freeze(["rows"]);
 
 export const DEFLECTION_REPORT_RANKED_QUESTIONS_REQUIRED_DATA = Object.freeze(["rows"]);
 
 export const DEFLECTION_REPORT_RANKED_QUESTIONS_SNAPSHOT_SAFE_FIELDS = Object.freeze(["rows.rank", "rows.question", "rows.ticket_count", "rows.weighted_frequency", "rows.customer_wording"]);
+
+export const DEFLECTION_REPORT_RANKED_QUESTIONS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rows"]);
+
+export const DEFLECTION_REPORT_RANKED_QUESTIONS_ROWS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "ticket_count", "weighted_frequency", "customer_wording", "estimated_support_cost", "opportunity_score", "answer_status", "source_proof"]);
 
 export const DEFLECTION_REPORT_RANKED_QUESTIONS_ROWS_FIELDS = Object.freeze(["rank", "question", "ticket_count", "weighted_frequency", "customer_wording", "estimated_support_cost", "opportunity_score", "answer_status", "source_proof"]);
 
@@ -47,6 +57,16 @@ export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_REQUIRED_DATA = Object.freeze(
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
 
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "status_counts", "result_page_limit", "pdf_limit", "backlog_limit", "support_cost_basis"]);
+
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_SUPPORT_COST_BASIS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status"]);
+
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
+
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
+
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_FIELDS = Object.freeze(["items", "top_item_count", "result_page_limit", "pdf_limit", "support_cost_basis"]);
@@ -54,6 +74,16 @@ export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_FIELDS = Object.freeze(["i
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_REQUIRED_DATA = Object.freeze(["items", "top_item_count", "result_page_limit", "pdf_limit", "support_cost_basis"]);
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_SNAPSHOT_SAFE_FIELDS = Object.freeze(["items.rank", "items.question", "items.ticket_count"]);
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "top_item_count", "support_cost_basis"]);
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_SUPPORT_COST_BASIS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status"]);
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
@@ -63,6 +93,14 @@ export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_REQUIRED_DATA = Object.freeze
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
 
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "top_item_count"]);
+
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
+
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
+
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_FIELDS = Object.freeze(["items", "top_item_count", "result_page_limit", "pdf_limit"]);
@@ -70,6 +108,14 @@ export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_FIELDS = Object.f
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_REQUIRED_DATA = Object.freeze(["items", "top_item_count", "result_page_limit", "pdf_limit"]);
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
+
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "top_item_count"]);
+
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
+
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
@@ -79,6 +125,14 @@ export const DEFLECTION_REPORT_BACKLOG_TABLE_REQUIRED_DATA = Object.freeze(["ite
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
 
+export const DEFLECTION_REPORT_BACKLOG_TABLE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "total_item_count", "default_limit"]);
+
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
+
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
+
 export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_FIELDS = Object.freeze(["outcome_diagnostic_ticket_count", "outcome_risk_ticket_count", "reopened_ticket_count", "negative_csat_ticket_count", "rows"]);
@@ -86,6 +140,10 @@ export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_FIELDS = Object.freeze(["outc
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_REQUIRED_DATA = Object.freeze(["outcome_diagnostic_ticket_count", "outcome_risk_ticket_count", "reopened_ticket_count", "negative_csat_ticket_count", "rows"]);
 
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
+
+export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["outcome_diagnostic_ticket_count", "outcome_risk_ticket_count", "reopened_ticket_count", "negative_csat_ticket_count", "rows"]);
+
+export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_ROWS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["question", "status_mix", "reopened_ticket_count", "negative_csat_ticket_count", "guidance"]);
 
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_ROWS_FIELDS = Object.freeze(["question", "status_mix", "reopened_ticket_count", "negative_csat_ticket_count", "guidance"]);
 
@@ -95,6 +153,10 @@ export const DEFLECTION_REPORT_QUESTION_DETAILS_REQUIRED_DATA = Object.freeze(["
 
 export const DEFLECTION_REPORT_QUESTION_DETAILS_SNAPSHOT_SAFE_FIELDS = Object.freeze(["rows.rank", "rows.question", "rows.answer_evidence_status", "rows.resolution_evidence_scope", "rows.weighted_frequency", "rows.source_count"]);
 
+export const DEFLECTION_REPORT_QUESTION_DETAILS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rows"]);
+
+export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "customer_wording", "topic", "ticket_count", "weighted_frequency", "source_count", "estimated_support_cost", "answer_status", "answer_evidence_status", "resolution_evidence_scope", "answer_linkage", "answer", "steps", "term_mappings"]);
+
 export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_FIELDS = Object.freeze(["rank", "question", "customer_wording", "topic", "ticket_count", "weighted_frequency", "source_count", "estimated_support_cost", "answer_status", "answer_evidence_status", "resolution_evidence_scope", "answer_linkage", "answer", "steps", "term_mappings", "source_ids", "evidence_quotes", "outcome_diagnostics"]);
 
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_FIELDS = Object.freeze(["question_count", "evidence_row_count", "source_id_count", "surfaces"]);
@@ -102,3 +164,5 @@ export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_FIELDS = Object.freeze(["questi
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_REQUIRED_DATA = Object.freeze(["question_count", "evidence_row_count", "source_id_count", "surfaces"]);
 
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
+
+export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);

--- a/portfolio-ui/src/types/deflectionReportModel.ts
+++ b/portfolio-ui/src/types/deflectionReportModel.ts
@@ -21,11 +21,15 @@ export const DEFLECTION_REPORT_SUPPORT_TAX_REQUIRED_DATA = ["repeat_ticket_count
 
 export const DEFLECTION_REPORT_SUPPORT_TAX_SNAPSHOT_SAFE_FIELDS = ["repeat_ticket_count", "non_repeat_ticket_count", "generated_question_count", "drafted_answer_count", "no_proven_answer_count", "ticket_source_count", "source_date_window"] as const;
 
+export const DEFLECTION_REPORT_SUPPORT_TAX_HOSTED_CONSUMER_SAFE_FIELDS = ["repeat_ticket_count", "non_repeat_ticket_count", "generated_question_count", "assisted_contact_cost", "estimated_support_cost", "source_date_window", "drafted_answer_count", "no_proven_answer_count", "ticket_source_count", "annualized_support_cost", "annualized_run_rate_support_cost"] as const;
+
 export const DEFLECTION_REPORT_SOURCE_FILE_FIELDS = ["source_label"] as const;
 
 export const DEFLECTION_REPORT_SOURCE_FILE_REQUIRED_DATA = ["source_label"] as const;
 
 export const DEFLECTION_REPORT_SOURCE_FILE_SNAPSHOT_SAFE_FIELDS = [] as const;
+
+export const DEFLECTION_REPORT_SOURCE_FILE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
 export const DEFLECTION_REPORT_SEO_TARGETS_FIELDS = ["phrases", "total_phrase_count", "displayed_phrase_count", "omitted_phrase_count", "limit"] as const;
 
@@ -33,11 +37,17 @@ export const DEFLECTION_REPORT_SEO_TARGETS_REQUIRED_DATA = ["phrases", "total_ph
 
 export const DEFLECTION_REPORT_SEO_TARGETS_SNAPSHOT_SAFE_FIELDS = [] as const;
 
+export const DEFLECTION_REPORT_SEO_TARGETS_HOSTED_CONSUMER_SAFE_FIELDS = ["phrases", "total_phrase_count", "displayed_phrase_count", "omitted_phrase_count", "limit"] as const;
+
 export const DEFLECTION_REPORT_RANKED_QUESTIONS_FIELDS = ["rows"] as const;
 
 export const DEFLECTION_REPORT_RANKED_QUESTIONS_REQUIRED_DATA = ["rows"] as const;
 
 export const DEFLECTION_REPORT_RANKED_QUESTIONS_SNAPSHOT_SAFE_FIELDS = ["rows.rank", "rows.question", "rows.ticket_count", "rows.weighted_frequency", "rows.customer_wording"] as const;
+
+export const DEFLECTION_REPORT_RANKED_QUESTIONS_HOSTED_CONSUMER_SAFE_FIELDS = ["rows"] as const;
+
+export const DEFLECTION_REPORT_RANKED_QUESTIONS_ROWS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "ticket_count", "weighted_frequency", "customer_wording", "estimated_support_cost", "opportunity_score", "answer_status", "source_proof"] as const;
 
 export const DEFLECTION_REPORT_RANKED_QUESTIONS_ROWS_FIELDS = ["rank", "question", "ticket_count", "weighted_frequency", "customer_wording", "estimated_support_cost", "opportunity_score", "answer_status", "source_proof"] as const;
 
@@ -47,6 +57,16 @@ export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_REQUIRED_DATA = ["items", "sta
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_SNAPSHOT_SAFE_FIELDS = [] as const;
 
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "status_counts", "result_page_limit", "pdf_limit", "backlog_limit", "support_cost_basis"] as const;
+
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_SUPPORT_COST_BASIS_HOSTED_CONSUMER_SAFE_FIELDS = ["status"] as const;
+
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
+
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
+
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_FIELDS = ["items", "top_item_count", "result_page_limit", "pdf_limit", "support_cost_basis"] as const;
@@ -54,6 +74,16 @@ export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_FIELDS = ["items", "top_it
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_REQUIRED_DATA = ["items", "top_item_count", "result_page_limit", "pdf_limit", "support_cost_basis"] as const;
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_SNAPSHOT_SAFE_FIELDS = ["items.rank", "items.question", "items.ticket_count"] as const;
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "top_item_count", "support_cost_basis"] as const;
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_SUPPORT_COST_BASIS_HOSTED_CONSUMER_SAFE_FIELDS = ["status"] as const;
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
+
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
@@ -63,6 +93,14 @@ export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_REQUIRED_DATA = ["items", "to
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_SNAPSHOT_SAFE_FIELDS = [] as const;
 
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "top_item_count"] as const;
+
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
+
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
+
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_FIELDS = ["items", "top_item_count", "result_page_limit", "pdf_limit"] as const;
@@ -70,6 +108,14 @@ export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_FIELDS = ["items"
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_REQUIRED_DATA = ["items", "top_item_count", "result_page_limit", "pdf_limit"] as const;
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_SNAPSHOT_SAFE_FIELDS = [] as const;
+
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "top_item_count"] as const;
+
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
+
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
@@ -79,6 +125,14 @@ export const DEFLECTION_REPORT_BACKLOG_TABLE_REQUIRED_DATA = ["items", "total_it
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_SNAPSHOT_SAFE_FIELDS = [] as const;
 
+export const DEFLECTION_REPORT_BACKLOG_TABLE_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "total_item_count", "default_limit"] as const;
+
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
+
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
+
 export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_FIELDS = ["outcome_diagnostic_ticket_count", "outcome_risk_ticket_count", "reopened_ticket_count", "negative_csat_ticket_count", "rows"] as const;
@@ -86,6 +140,10 @@ export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_FIELDS = ["outcome_diagnostic
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_REQUIRED_DATA = ["outcome_diagnostic_ticket_count", "outcome_risk_ticket_count", "reopened_ticket_count", "negative_csat_ticket_count", "rows"] as const;
 
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_SNAPSHOT_SAFE_FIELDS = [] as const;
+
+export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_HOSTED_CONSUMER_SAFE_FIELDS = ["outcome_diagnostic_ticket_count", "outcome_risk_ticket_count", "reopened_ticket_count", "negative_csat_ticket_count", "rows"] as const;
+
+export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_ROWS_HOSTED_CONSUMER_SAFE_FIELDS = ["question", "status_mix", "reopened_ticket_count", "negative_csat_ticket_count", "guidance"] as const;
 
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_ROWS_FIELDS = ["question", "status_mix", "reopened_ticket_count", "negative_csat_ticket_count", "guidance"] as const;
 
@@ -95,6 +153,10 @@ export const DEFLECTION_REPORT_QUESTION_DETAILS_REQUIRED_DATA = ["rows"] as cons
 
 export const DEFLECTION_REPORT_QUESTION_DETAILS_SNAPSHOT_SAFE_FIELDS = ["rows.rank", "rows.question", "rows.answer_evidence_status", "rows.resolution_evidence_scope", "rows.weighted_frequency", "rows.source_count"] as const;
 
+export const DEFLECTION_REPORT_QUESTION_DETAILS_HOSTED_CONSUMER_SAFE_FIELDS = ["rows"] as const;
+
+export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "customer_wording", "topic", "ticket_count", "weighted_frequency", "source_count", "estimated_support_cost", "answer_status", "answer_evidence_status", "resolution_evidence_scope", "answer_linkage", "answer", "steps", "term_mappings"] as const;
+
 export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_FIELDS = ["rank", "question", "customer_wording", "topic", "ticket_count", "weighted_frequency", "source_count", "estimated_support_cost", "answer_status", "answer_evidence_status", "resolution_evidence_scope", "answer_linkage", "answer", "steps", "term_mappings", "source_ids", "evidence_quotes", "outcome_diagnostics"] as const;
 
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_FIELDS = ["question_count", "evidence_row_count", "source_id_count", "surfaces"] as const;
@@ -102,6 +164,8 @@ export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_FIELDS = ["question_count", "ev
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_REQUIRED_DATA = ["question_count", "evidence_row_count", "source_id_count", "surfaces"] as const;
 
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_SNAPSHOT_SAFE_FIELDS = [] as const;
+
+export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
 export type DeflectionReportSourceDateWindow = {
   source_date_start: string | null;

--- a/scripts/generate_deflection_frontend_contract_types.py
+++ b/scripts/generate_deflection_frontend_contract_types.py
@@ -188,6 +188,22 @@ def _optional_projected_fields(entry: Mapping[str, Any]) -> list[str]:
     return fields
 
 
+def _hosted_consumer_safe_fields(entry: Mapping[str, Any], owner: str) -> list[str]:
+    fields = entry.get("hosted_consumer_safe_fields")
+    if not isinstance(fields, list) or not all(isinstance(field, str) for field in fields):
+        raise ValueError(
+            f"report_projection {owner} has invalid hosted_consumer_safe_fields"
+        )
+    projected = set(_projected_fields(entry))
+    unknown = [field for field in fields if field not in projected]
+    if unknown:
+        raise ValueError(
+            f"hosted consumer safe fields are not projected for {owner}: "
+            + ", ".join(unknown)
+        )
+    return fields
+
+
 def _render_field_tuple(name: str, fields: Sequence[str]) -> list[str]:
     quoted = ", ".join(f'"{field}"' for field in fields)
     return [f"export const {name} = [{quoted}] as const;"]
@@ -454,6 +470,7 @@ def _report_projection_metadata(contract: Mapping[str, Any] | None = None) -> di
             record_fields,
             structural_fields,
         )
+        _hosted_consumer_safe_fields(section, section_id)
 
         if collection is not None:
             if not isinstance(collection, Mapping):
@@ -483,6 +500,10 @@ def _report_projection_metadata(contract: Mapping[str, Any] | None = None) -> di
                     [],
                     [],
                     collection_structural_fields,
+                )
+                _hosted_consumer_safe_fields(
+                    collection,
+                    f"{section_id}.{collection_field}",
                 )
                 _validate_nested_fields(section_id, collection, item_fields)
 
@@ -538,6 +559,71 @@ def _validate_nested_fields(
                 )
             nested_fields = _projected_fields(entry)
             _validate_report_fields(section_id, nested_fields, [], [])
+            _hosted_consumer_safe_fields(entry, f"{section_id}.{field}")
+
+
+def _field_const_token(field: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "_", field.upper()).strip("_")
+
+
+def _render_report_hosted_safe_constants(
+    section: Mapping[str, Any],
+    render_fields,
+) -> list[str]:
+    section_id = str(section["id"])
+    const_prefix = f"DEFLECTION_REPORT_{section_id.upper()}"
+    generated: list[str] = []
+
+    generated.extend(
+        render_fields(
+            f"{const_prefix}_HOSTED_CONSUMER_SAFE_FIELDS",
+            _hosted_consumer_safe_fields(section, section_id),
+        )
+    )
+    generated.append("")
+
+    def add_nested_constants(
+        owner: Mapping[str, Any],
+        owner_prefix: str,
+    ) -> None:
+        for nested in owner.get("nested_object_fields", []):
+            field = str(nested["field"])
+            generated.extend(
+                render_fields(
+                    f"{owner_prefix}_{_field_const_token(field)}_HOSTED_CONSUMER_SAFE_FIELDS",
+                    _hosted_consumer_safe_fields(nested, f"{section_id}.{field}"),
+                )
+            )
+            generated.append("")
+        for nested in owner.get("nested_collection_fields", []):
+            field = str(nested["field"])
+            generated.extend(
+                render_fields(
+                    f"{owner_prefix}_{_field_const_token(field)}_HOSTED_CONSUMER_SAFE_FIELDS",
+                    _hosted_consumer_safe_fields(nested, f"{section_id}.{field}"),
+                )
+            )
+            generated.append("")
+
+    add_nested_constants(section, const_prefix)
+
+    collection = section.get("collection")
+    if isinstance(collection, Mapping) and collection.get("item_type") == "object":
+        collection_field = str(collection["field"])
+        collection_prefix = f"{const_prefix}_{_field_const_token(collection_field)}"
+        generated.extend(
+            render_fields(
+                f"{collection_prefix}_HOSTED_CONSUMER_SAFE_FIELDS",
+                _hosted_consumer_safe_fields(
+                    collection,
+                    f"{section_id}.{collection_field}",
+                ),
+            )
+        )
+        generated.append("")
+        add_nested_constants(collection, collection_prefix)
+
+    return generated
 
 
 def _object_type_with_overrides(
@@ -694,6 +780,7 @@ def render_report_model_types(contract: Mapping[str, Any] | None = None) -> str:
             _render_field_tuple(f"{const_prefix}_SNAPSHOT_SAFE_FIELDS", section["snapshot_safe_fields"])
         )
         generated.append("")
+        generated.extend(_render_report_hosted_safe_constants(section, _render_field_tuple))
 
         collection = section.get("collection")
         if isinstance(collection, Mapping) and collection.get("item_type") == "object":
@@ -823,6 +910,7 @@ def render_report_model_api_contract(contract: Mapping[str, Any] | None = None) 
             _render_field_array(f"{const_prefix}_SNAPSHOT_SAFE_FIELDS", section["snapshot_safe_fields"])
         )
         generated.append("")
+        generated.extend(_render_report_hosted_safe_constants(section, _render_field_array))
         collection = section.get("collection")
         if isinstance(collection, Mapping) and collection.get("item_type") == "object":
             generated.extend(

--- a/tests/test_generate_deflection_frontend_contract_types.py
+++ b/tests/test_generate_deflection_frontend_contract_types.py
@@ -83,6 +83,30 @@ def test_deflection_report_model_types_include_backend_projection_fields() -> No
     assert "any" not in rendered
 
 
+def test_deflection_report_model_types_publish_hosted_safe_allowlists() -> None:
+    rendered = MOD["render_report_model_types"]()
+
+    assert (
+        'DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_HOSTED_CONSUMER_SAFE_FIELDS = '
+        '["items", "top_item_count", "support_cost_basis"]'
+    ) in rendered
+    assert (
+        'DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = '
+        '["rank", "question", "status", "owner_lane", "confidence", '
+        '"recommended_action", "ticket_count", "estimated_support_cost", '
+        '"priority_score", "priority_drivers", "csat_signal"]'
+    ) in rendered
+    assert (
+        'DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = '
+        '["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]'
+    ) in rendered
+    assert (
+        "DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = "
+        "[]"
+    ) in rendered
+    assert "hosted_consumer_safe_fields: string[];" not in rendered
+
+
 def test_deflection_report_model_api_contract_includes_backend_projection_fields() -> None:
     rendered = MOD["render_report_model_api_contract"]()
 
@@ -107,6 +131,30 @@ def test_deflection_report_model_api_contract_includes_backend_projection_fields
     assert '"source_ids"' in rendered
     assert '"evidence_quotes"' in rendered
     assert "as const" not in rendered
+
+
+def test_deflection_report_model_api_contract_publishes_hosted_safe_allowlists() -> None:
+    rendered = MOD["render_report_model_api_contract"]()
+
+    assert (
+        'DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_HOSTED_CONSUMER_SAFE_FIELDS = '
+        'Object.freeze(["items", "top_item_count", "support_cost_basis"])'
+    ) in rendered
+    assert (
+        'DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = '
+        'Object.freeze(["rank", "question", "status", "owner_lane", "confidence", '
+        '"recommended_action", "ticket_count", "estimated_support_cost", '
+        '"priority_score", "priority_drivers", "csat_signal"])'
+    ) in rendered
+    assert (
+        'DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = '
+        'Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", '
+        '"numeric_average"])'
+    ) in rendered
+    assert (
+        "DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = "
+        "Object.freeze([])"
+    ) in rendered
 
 
 def test_generated_deflection_api_contracts_are_enrolled_in_product_surface_manifest() -> None:
@@ -317,3 +365,63 @@ def test_deflection_report_model_types_reject_unknown_optional_field() -> None:
         assert "not_actually_projected" in str(exc)
     else:
         raise AssertionError("optional report fields must also be projected")
+
+
+def test_deflection_report_model_types_reject_unknown_hosted_safe_section_field() -> None:
+    contract = MOD["deflection_report_model_contract_shape"]()
+    section = contract["report_projection"]["sections"][0]
+    section["hosted_consumer_safe_fields"] = [
+        *section["hosted_consumer_safe_fields"],
+        "raw_unprojected_hosted_field",
+    ]
+
+    try:
+        MOD["render_report_model_types"](contract)
+    except ValueError as exc:
+        assert "raw_unprojected_hosted_field" in str(exc)
+    else:
+        raise AssertionError("hosted-safe section fields must also be projected")
+
+
+def test_deflection_report_model_types_reject_unknown_hosted_safe_collection_field() -> None:
+    contract = MOD["deflection_report_model_contract_shape"]()
+    sections = {
+        section["id"]: section
+        for section in contract["report_projection"]["sections"]
+    }
+    collection = sections["priority_fix_queue"]["collection"]
+    collection["hosted_consumer_safe_fields"] = [
+        *collection["hosted_consumer_safe_fields"],
+        "raw_unprojected_hosted_field",
+    ]
+
+    try:
+        MOD["render_report_model_types"](contract)
+    except ValueError as exc:
+        assert "raw_unprojected_hosted_field" in str(exc)
+    else:
+        raise AssertionError("hosted-safe collection fields must also be projected")
+
+
+def test_deflection_report_model_types_reject_unknown_hosted_safe_nested_field() -> None:
+    contract = MOD["deflection_report_model_contract_shape"]()
+    sections = {
+        section["id"]: section
+        for section in contract["report_projection"]["sections"]
+    }
+    collection = sections["priority_fix_queue"]["collection"]
+    nested = {
+        entry["field"]: entry
+        for entry in collection["nested_object_fields"]
+    }["csat_signal"]
+    nested["hosted_consumer_safe_fields"] = [
+        *nested["hosted_consumer_safe_fields"],
+        "raw_unprojected_hosted_field",
+    ]
+
+    try:
+        MOD["render_report_model_types"](contract)
+    except ValueError as exc:
+        assert "raw_unprojected_hosted_field" in str(exc)
+    else:
+        raise AssertionError("hosted-safe nested fields must also be projected")


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-Hosted-Safe-Artifact.md
Slice phase: Production hardening

Publish the backend-owned hosted-safe report-model allowlists in the generated frontend artifacts, closing the artifact side of the hosted result-page boundary gap without widening the paid runtime report model shape.

## Intentional
- Emit hosted-safe metadata as generated sidecar constants, not as `DeflectionReportSection` fields. Runtime paid report sections do not carry this metadata.
- No hosted result-page consumer change in this PR; the next boundary slice should consume these constants for allowlist construction.

## Deferred
- Hosted result-page construction must consume these generated allowlists in a follow-up slice before any hosted/free paid report payload uses the paid model.

## Parked hardening
- None.

## Verification
- Focused generator pytest: `python -m pytest`, target `tests/test_generate_deflection_frontend_contract_types.py` -- 19 passed.
- Generator drift check: `python`, target `scripts/generate_deflection_frontend_contract_types.py`, with `--check` -- all four generated frontend contract outputs are current.
- Local PR review bundle -- passed.

## Diff size
5 files, +432 / -0
