### PR TITLE
Project public deflection report payloads safely

### DIFF
--- a/plans/PR-Deflection-Report-Hosted-Safe-Proxy.md
+++ b/plans/PR-Deflection-Report-Hosted-Safe-Proxy.md
@@ -15,9 +15,10 @@ from the generated report-model contract. This fixes the root at that boundary:
 locked/free responses stay snapshot-only, and unlocked responses expose only a
 hosted-safe report model constructed from generated allowlists.
 
-Diff-size note: this is just over the 400 LOC soft cap because the boundary
-test needs a representative unlocked report model with nested safe and raw
-fields. The production change is limited to the public JSON proxy.
+Diff-size note: this is over the 400 LOC soft cap because the privacy-boundary
+fix needs representative unlocked report fixtures for summary leaks, records,
+object arrays, nested safe fields, and raw-field rejection. The production
+change is still limited to the public JSON proxy.
 
 ## Scope (this PR)
 
@@ -32,6 +33,8 @@ Slice phase: Production hardening
 3. Add tests proving locked/free JSON has no `answer`/`steps`, while unlocked
    JSON can include paid web-render `answer`/`steps` but strips export-only raw
    fields.
+4. Fix-loop scope: Max files: 3. The Codex P1/P2 follow-up is limited to the
+   public proxy, its focused test, and this plan.
 
 ### Review Contract
 
@@ -65,8 +68,11 @@ field constants when unlocked.
 
 The projection is recursive for object fields and object-array fields when a
 matching nested generated allowlist exists. Fields without a generated
-allowlist are copied only as scalar or scalar-array values; object payloads
-without explicit nested allowlists are omitted.
+allowlist are copied only as scalar or scalar-array values, except for the
+contract-owned hosted-safe record and object-array fields that have explicit
+field readers (`status_counts`, `status_mix`, and `term_mappings`). The report
+model summary has no generated hosted-safe allowlist yet, so the public payload
+emits an empty summary instead of self-allowlisting backend keys.
 
 ## Intentional
 
@@ -75,6 +81,8 @@ without explicit nested allowlists are omitted.
   server side; this PR constrains only the browser-facing JSON API boundary.
 - `answer` and `steps` remain allowed only in unlocked hosted-safe report-model
   rows. The locked/free path still returns no artifact and no paid answer body.
+- Summary fields are omitted from the public hosted report model until ATLAS
+  publishes a generated summary allowlist. This is fail-closed on purpose.
 
 ## Deferred
 
@@ -86,14 +94,14 @@ Parked hardening: none.
 ## Verification
 
 - Portfolio proxy test: package `portfolio-ui`, script
-  `test:deflection-atlas-proxy` -- 27 tests passed.
+  `test:deflection-atlas-proxy` -- 27 tests passed after the Codex P1/P2 fixes.
 - Local PR review bundle -- passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Deflection-Report-Hosted-Safe-Proxy.md` | 99 |
-| `portfolio-ui/api/content-ops/deflection/report.js` | 127 |
-| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 181 |
-| **Total** | **407** |
+| `plans/PR-Deflection-Report-Hosted-Safe-Proxy.md` | 107 |
+| `portfolio-ui/api/content-ops/deflection/report.js` | 165 |
+| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 219 |
+| **Total** | **491** |

--- a/plans/PR-Deflection-Report-Hosted-Safe-Proxy.md
+++ b/plans/PR-Deflection-Report-Hosted-Safe-Proxy.md
@@ -1,0 +1,99 @@
+# PR-Deflection-Report-Hosted-Safe-Proxy
+
+## Why this slice exists
+
+#1805's hosted-safe artifact is now published, and the #1826 review carried the
+consumer requirement forward: `hosted_consumer_safe_fields` is a paid web-render
+allowlist, not a free-surface allowlist. The public report API currently returns the full unlocked
+ATLAS artifact, which can carry raw paid/export-only fields such as markdown,
+`faq_result`, `evidence_export`, `source_ids`, `evidence_quotes`, and
+`top_evidence`.
+
+Root cause: the public browser JSON boundary is still validate-and-pass for
+unlocked artifacts instead of allowlist-constructing the hosted report payload
+from the generated report-model contract. This fixes the root at that boundary:
+locked/free responses stay snapshot-only, and unlocked responses expose only a
+hosted-safe report model constructed from generated allowlists.
+
+Diff-size note: this is just over the 400 LOC soft cap because the boundary
+test needs a representative unlocked report model with nested safe and raw
+fields. The production change is limited to the public JSON proxy.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-contract-1805
+Slice phase: Production hardening
+
+1. Add a public-report payload constructor that returns no artifact unless the
+   artifact status is unlocked.
+2. For unlocked reports, project `artifact.report_model` through the generated
+   hosted-consumer-safe field constants and return that as the only public
+   artifact payload.
+3. Add tests proving locked/free JSON has no `answer`/`steps`, while unlocked
+   JSON can include paid web-render `answer`/`steps` but strips export-only raw
+   fields.
+
+### Review Contract
+
+- Acceptance criteria: public report API responses are snapshot-only when
+  locked, hosted-safe report-model-only when unlocked, and never expose raw
+  `faq_result`, `evidence_export`, markdown, source ids, evidence quotes,
+  `top_evidence`, `recommended_title`, or `representative_phrasing`.
+- Affected surfaces: `portfolio-ui/api/content-ops/deflection/report.js` and
+  `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`.
+- Risk areas: do not break server-side result-page rendering or evidence export
+  download, both of which need the raw server-only artifact after unlock; do not
+  treat hosted-safe fields as free-safe.
+- Reviewer rules triggered: R1 requirements match, R2 test evidence, R3
+  security/privacy boundary, R6 generated contract consumption, R9 checker
+  failure branches, R13 class fix, R14 codebase verification.
+
+### Files touched
+
+- `plans/PR-Deflection-Report-Hosted-Safe-Proxy.md`
+- `portfolio-ui/api/content-ops/deflection/report.js`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+
+## Mechanism
+
+The public `report.js` handler continues to call `loadDeflectionReport`, but it
+serializes a new public payload instead of dumping the returned object. The
+constructor keeps the snapshot envelope for all successful responses, includes
+no artifact unless ATLAS returned `artifact_status: "unlocked"`, and projects
+`artifact.report_model.sections[].data` through generated hosted-consumer-safe
+field constants when unlocked.
+
+The projection is recursive for object fields and object-array fields when a
+matching nested generated allowlist exists. Fields without a generated
+allowlist are copied only as scalar or scalar-array values; object payloads
+without explicit nested allowlists are omitted.
+
+## Intentional
+
+- `loadDeflectionReport` remains raw/server-only. The result-page HTML renderer
+  and evidence-export download still need the full unlocked artifact on the
+  server side; this PR constrains only the browser-facing JSON API boundary.
+- `answer` and `steps` remain allowed only in unlocked hosted-safe report-model
+  rows. The locked/free path still returns no artifact and no paid answer body.
+
+## Deferred
+
+- atlas-portfolio cross-repo consumption should mirror this pattern once it
+  consumes the generated ATLAS report-model artifact.
+
+Parked hardening: none.
+
+## Verification
+
+- Portfolio proxy test: package `portfolio-ui`, script
+  `test:deflection-atlas-proxy` -- 27 tests passed.
+- Local PR review bundle -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Report-Hosted-Safe-Proxy.md` | 99 |
+| `portfolio-ui/api/content-ops/deflection/report.js` | 127 |
+| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 181 |
+| **Total** | **407** |

--- a/portfolio-ui/api/content-ops/deflection/report.js
+++ b/portfolio-ui/api/content-ops/deflection/report.js
@@ -2,6 +2,15 @@ import { clean, loadDeflectionReport, proxyErrorPublicPayload } from "./atlas-re
 import * as reportModelContract from "./report-model-contract.js";
 
 const DEFLECTION_REPORT_SECTION_ID_SET = new Set(reportModelContract.DEFLECTION_REPORT_SECTION_IDS);
+const HOSTED_SAFE_RECORD_FIELDS = new Set(["status_counts", "status_mix"]);
+const HOSTED_SAFE_OBJECT_ARRAY_FIELDS = Object.freeze({
+  term_mappings: Object.freeze([
+    "customer_term",
+    "documentation_term",
+    "suggestion",
+    "source_id_count",
+  ]),
+});
 
 function isObjectRecord(value) {
   return value && typeof value === "object" && !Array.isArray(value);
@@ -43,6 +52,25 @@ function cloneScalarArray(value) {
   return cloned;
 }
 
+function cloneScalarRecord(value) {
+  if (!isObjectRecord(value)) return undefined;
+  const cloned = {};
+  for (const [key, item] of Object.entries(value)) {
+    const scalar = cloneScalar(item);
+    if (scalar === undefined) return undefined;
+    cloned[key] = scalar;
+  }
+  return cloned;
+}
+
+function projectKnownObjectArray(field, value) {
+  const fields = HOSTED_SAFE_OBJECT_ARRAY_FIELDS[field];
+  if (!fields || !Array.isArray(value)) return undefined;
+  return value
+    .filter(isObjectRecord)
+    .map((item) => projectHostedFields(item, fields, `${fieldConstToken(field)}_ITEM`));
+}
+
 function projectHostedFields(record, fields, prefix) {
   if (!isObjectRecord(record)) return {};
   const projected = {};
@@ -70,6 +98,16 @@ function projectHostedFields(record, fields, prefix) {
     const scalarArray = cloneScalarArray(value);
     if (scalarArray !== undefined) {
       projected[field] = scalarArray;
+      continue;
+    }
+    if (HOSTED_SAFE_RECORD_FIELDS.has(field)) {
+      const scalarRecord = cloneScalarRecord(value);
+      if (scalarRecord !== undefined) projected[field] = scalarRecord;
+      continue;
+    }
+    const objectArray = projectKnownObjectArray(field, value);
+    if (objectArray !== undefined) {
+      projected[field] = objectArray;
     }
   }
   return projected;
@@ -102,7 +140,7 @@ function publicHostedReportModel(model) {
   return {
     schema_version: clean(model.schema_version),
     title: clean(model.title),
-    summary: projectHostedFields(model.summary, Object.keys(model.summary || {}), "DEFLECTION_REPORT_SUMMARY"),
+    summary: {},
     sections,
   };
 }

--- a/portfolio-ui/api/content-ops/deflection/report.js
+++ b/portfolio-ui/api/content-ops/deflection/report.js
@@ -1,4 +1,127 @@
 import { clean, loadDeflectionReport, proxyErrorPublicPayload } from "./atlas-report.js";
+import * as reportModelContract from "./report-model-contract.js";
+
+const DEFLECTION_REPORT_SECTION_ID_SET = new Set(reportModelContract.DEFLECTION_REPORT_SECTION_IDS);
+
+function isObjectRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function fieldConstToken(field) {
+  return String(field).toUpperCase().replace(/[^A-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function sectionConstPrefix(sectionId) {
+  return `DEFLECTION_REPORT_${fieldConstToken(sectionId)}`;
+}
+
+function generatedFields(name) {
+  const fields = reportModelContract[name];
+  return Array.isArray(fields) ? fields : [];
+}
+
+function cloneScalar(value) {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+function cloneScalarArray(value) {
+  if (!Array.isArray(value)) return undefined;
+  const cloned = [];
+  for (const item of value) {
+    const scalar = cloneScalar(item);
+    if (scalar === undefined) return undefined;
+    cloned.push(scalar);
+  }
+  return cloned;
+}
+
+function projectHostedFields(record, fields, prefix) {
+  if (!isObjectRecord(record)) return {};
+  const projected = {};
+  for (const field of fields) {
+    if (!Object.prototype.hasOwnProperty.call(record, field)) continue;
+    const value = record[field];
+    const nestedPrefix = `${prefix}_${fieldConstToken(field)}`;
+    const nestedFields = generatedFields(`${nestedPrefix}_HOSTED_CONSUMER_SAFE_FIELDS`);
+    if (nestedFields.length > 0) {
+      if (Array.isArray(value)) {
+        projected[field] = value
+          .filter(isObjectRecord)
+          .map((item) => projectHostedFields(item, nestedFields, nestedPrefix));
+      } else if (isObjectRecord(value)) {
+        projected[field] = projectHostedFields(value, nestedFields, nestedPrefix);
+      }
+      continue;
+    }
+
+    const scalar = cloneScalar(value);
+    if (scalar !== undefined) {
+      projected[field] = scalar;
+      continue;
+    }
+    const scalarArray = cloneScalarArray(value);
+    if (scalarArray !== undefined) {
+      projected[field] = scalarArray;
+    }
+  }
+  return projected;
+}
+
+function publicHostedReportModel(model) {
+  if (!isObjectRecord(model) || !Array.isArray(model.sections)) return null;
+  const sections = [];
+  for (const section of model.sections) {
+    if (!isObjectRecord(section)) continue;
+    const sectionId = clean(section.id);
+    if (!DEFLECTION_REPORT_SECTION_ID_SET.has(sectionId)) continue;
+    const prefix = sectionConstPrefix(sectionId);
+    const hostedFields = generatedFields(`${prefix}_HOSTED_CONSUMER_SAFE_FIELDS`);
+    sections.push({
+      id: sectionId,
+      title: clean(section.title),
+      priority: typeof section.priority === "number" && Number.isFinite(section.priority)
+        ? section.priority
+        : 0,
+      surfaces: cloneScalarArray(section.surfaces) || [],
+      default_limit: typeof section.default_limit === "number" && Number.isFinite(section.default_limit)
+        ? section.default_limit
+        : null,
+      required_data: cloneScalarArray(section.required_data) || [],
+      snapshot_safe_fields: cloneScalarArray(section.snapshot_safe_fields) || [],
+      data: projectHostedFields(section.data, hostedFields, prefix),
+    });
+  }
+  return {
+    schema_version: clean(model.schema_version),
+    title: clean(model.title),
+    summary: projectHostedFields(model.summary, Object.keys(model.summary || {}), "DEFLECTION_REPORT_SUMMARY"),
+    sections,
+  };
+}
+
+function publicReportPayload(report) {
+  const payload = {
+    ok: true,
+    request_id: clean(report.request_id),
+    snapshot: report.snapshot,
+    artifact_status: clean(report.artifact_status),
+  };
+  if (payload.artifact_status !== "unlocked") return payload;
+
+  const reportModel = publicHostedReportModel(report.artifact?.report_model);
+  if (reportModel) {
+    payload.artifact = { report_model: reportModel };
+  }
+  return payload;
+}
 
 function json(res, statusCode, payload) {
   res.statusCode = statusCode;
@@ -29,5 +152,7 @@ export default async function handler(req, res) {
     json(res, report.statusCode || 502, proxyErrorPublicPayload(report));
     return;
   }
-  json(res, 200, report);
+  json(res, 200, publicReportPayload(report));
 }
+
+export { publicHostedReportModel, publicReportPayload };

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import evidenceExportHandler from "../api/content-ops/deflection/evidence-export.js";
-import reportHandler from "../api/content-ops/deflection/report.js";
+import reportHandler, { publicReportPayload } from "../api/content-ops/deflection/report.js";
 import {
   atlasPath,
   fetchAtlasJson,
@@ -431,6 +431,185 @@ await test("public report API returns sanitized locked envelope and never the to
     assert.equal(payload.artifact_status, "locked");
     assert.equal(JSON.stringify(payload).includes(ENV.ATLAS_B2B_JWT), false);
   });
+});
+
+await test("public report API returns only hosted-safe paid report model after unlock", async () => {
+  const paidArtifact = {
+    markdown: "# raw markdown must not reach browser JSON",
+    faq_result: {
+      items: [
+        {
+          question: "Raw item question",
+          representative_phrasing: "private representative phrase",
+          recommended_title: "private title",
+          top_evidence: [
+            {
+              source_id: "zendesk:raw-source",
+              evidence_quote: "private raw evidence",
+            },
+          ],
+        },
+      ],
+    },
+    evidence_export: EVIDENCE_EXPORT,
+    report_model: {
+      schema_version: "deflection.v1",
+      title: "Paid deflection report",
+      summary: {
+        generated: 1,
+        raw_internal_note: { source_ids: ["ticket-hidden"] },
+      },
+      sections: [
+        {
+          id: "question_details",
+          title: "Question details",
+          priority: 10,
+          surfaces: ["result_page"],
+          default_limit: 5,
+          required_data: ["rows"],
+          snapshot_safe_fields: [],
+          data: {
+            rows: [
+              {
+                rank: 1,
+                question: "How do I reset billing access?",
+                customer_wording: "billing reset access",
+                topic: "Billing",
+                ticket_count: 12,
+                weighted_frequency: 12,
+                source_count: 2,
+                estimated_support_cost: 162,
+                answer_status: "resolution_evidence",
+                answer_evidence_status: "resolution_evidence",
+                resolution_evidence_scope: "uploaded_ticket_reply",
+                answer_linkage: "publishable_answer",
+                answer: "Open Billing > Users.",
+                steps: ["Open Billing.", "Choose Users."],
+                term_mappings: [
+                  {
+                    customer_term: "billing reset",
+                    source_ids: ["term-source-hidden"],
+                  },
+                ],
+                source_ids: ["ticket-hidden"],
+                evidence_quotes: ["private quote"],
+                outcome_diagnostics: { source_ids: ["diagnostic-hidden"] },
+              },
+            ],
+          },
+        },
+        {
+          id: "priority_fix_queue",
+          title: "Priority fix queue",
+          priority: 20,
+          surfaces: ["result_page"],
+          default_limit: 3,
+          required_data: ["items"],
+          snapshot_safe_fields: [],
+          data: {
+            items: [
+              {
+                rank: 1,
+                question: "How do I reset billing access?",
+                status: "Needs answer",
+                owner_lane: "docs",
+                confidence: "high",
+                recommended_action: "Draft help article",
+                ticket_count: 12,
+                estimated_support_cost: 162,
+                priority_score: 91,
+                priority_drivers: ["repeat volume"],
+                csat_signal: {
+                  status: "negative",
+                  csat_present_count: 3,
+                  negative_csat_ticket_count: 2,
+                  numeric_average: 2.5,
+                  source_ids: ["csat-hidden"],
+                },
+                repeat_key: "repeat-hidden",
+                cluster_id: "cluster-hidden",
+                representative_phrasing: "private representative phrase",
+                recommended_title: "private title",
+                top_evidence: [
+                  {
+                    source_id: "zendesk:raw-source",
+                    evidence_quote: "private raw evidence",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+  const previousFetch = globalThis.fetch;
+  const { fetchImpl } = mockFetch([response(SNAPSHOT, 200), response(paidArtifact, 200)]);
+  globalThis.fetch = fetchImpl;
+  await withEnv(ENV, async () => {
+    const req = {
+      method: "GET",
+      headers: { host: "portfolio.example.com", "x-forwarded-proto": "https" },
+      query: { request_id: REQUEST_ID },
+      url: `/api/content-ops/deflection/report?request_id=${REQUEST_ID}`,
+    };
+    const res = mockResponse();
+    try {
+      await reportHandler(req, res);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+    assert.equal(res.statusCode, 200);
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.artifact_status, "unlocked");
+    assert.equal(payload.artifact.report_model.title, "Paid deflection report");
+    const encoded = JSON.stringify(payload);
+    assert.match(encoded, /Open Billing > Users/);
+    assert.match(encoded, /Choose Users/);
+    for (const forbidden of [
+      "raw markdown must not reach browser JSON",
+      "faq_result",
+      "evidence_export",
+      "source_ids",
+      "evidence_quotes",
+      "outcome_diagnostics",
+      "representative_phrasing",
+      "recommended_title",
+      "top_evidence",
+      "zendesk:raw-source",
+      "private raw evidence",
+      "private representative phrase",
+      "term-source-hidden",
+      ENV.ATLAS_B2B_JWT,
+      ACCOUNT_ID,
+    ]) {
+      assert.equal(encoded.includes(forbidden), false, forbidden);
+    }
+  });
+});
+
+await test("public payload keeps paid answers gated behind unlocked status", async () => {
+  const locked = publicReportPayload({
+    ok: true,
+    request_id: REQUEST_ID,
+    snapshot: PROJECTED_SNAPSHOT,
+    artifact_status: "locked",
+    artifact: {
+      report_model: {
+        sections: [
+          {
+            id: "question_details",
+            data: { rows: [{ answer: "Hidden paid answer", steps: ["Hidden paid step"] }] },
+          },
+        ],
+      },
+    },
+  });
+
+  assert.equal(locked.artifact_status, "locked");
+  assert.equal("artifact" in locked, false);
+  assert.equal(JSON.stringify(locked).includes("Hidden paid answer"), false);
+  assert.equal(JSON.stringify(locked).includes("Hidden paid step"), false);
 });
 
 await test("evidence export API downloads only unlocked v1 export", async () => {

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -457,6 +457,8 @@ await test("public report API returns only hosted-safe paid report model after u
       title: "Paid deflection report",
       summary: {
         generated: 1,
+        source_ids: ["summary-ticket-hidden"],
+        private_scalar_note: "private summary note",
         raw_internal_note: { source_ids: ["ticket-hidden"] },
       },
       sections: [
@@ -488,6 +490,9 @@ await test("public report API returns only hosted-safe paid report model after u
                 term_mappings: [
                   {
                     customer_term: "billing reset",
+                    documentation_term: "billing access reset",
+                    suggestion: "Use customer wording in the help-center title.",
+                    source_id_count: 1,
                     source_ids: ["term-source-hidden"],
                   },
                 ],
@@ -507,6 +512,9 @@ await test("public report API returns only hosted-safe paid report model after u
           required_data: ["items"],
           snapshot_safe_fields: [],
           data: {
+            status_counts: {
+              "Needs answer": 1,
+            },
             items: [
               {
                 rank: 1,
@@ -540,6 +548,29 @@ await test("public report API returns only hosted-safe paid report model after u
             ],
           },
         },
+        {
+          id: "outcome_diagnostics",
+          title: "Outcome diagnostics",
+          priority: 30,
+          surfaces: ["result_page"],
+          default_limit: 3,
+          required_data: ["rows"],
+          snapshot_safe_fields: [],
+          data: {
+            rows: [
+              {
+                question: "How do I reset billing access?",
+                status_mix: {
+                  reopened: 2,
+                  solved: 3,
+                },
+                reopened_ticket_count: 2,
+                negative_csat_ticket_count: 1,
+                guidance: "Review billing reset workflow.",
+              },
+            ],
+          },
+        },
       ],
     },
   };
@@ -563,22 +594,29 @@ await test("public report API returns only hosted-safe paid report model after u
     const payload = JSON.parse(res.body);
     assert.equal(payload.artifact_status, "unlocked");
     assert.equal(payload.artifact.report_model.title, "Paid deflection report");
+    assert.deepEqual(payload.artifact.report_model.summary, {});
     const encoded = JSON.stringify(payload);
     assert.match(encoded, /Open Billing > Users/);
     assert.match(encoded, /Choose Users/);
+    assert.match(encoded, /billing access reset/);
+    assert.match(encoded, /Use customer wording in the help-center title/);
+    assert.match(encoded, /"status_counts":\{"Needs answer":1\}/);
+    assert.match(encoded, /"status_mix":\{"reopened":2,"solved":3\}/);
     for (const forbidden of [
       "raw markdown must not reach browser JSON",
       "faq_result",
       "evidence_export",
       "source_ids",
       "evidence_quotes",
-      "outcome_diagnostics",
       "representative_phrasing",
       "recommended_title",
       "top_evidence",
       "zendesk:raw-source",
       "private raw evidence",
       "private representative phrase",
+      "diagnostic-hidden",
+      "summary-ticket-hidden",
+      "private summary note",
       "term-source-hidden",
       ENV.ATLAS_B2B_JWT,
       ACCOUNT_ID,


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-Hosted-Safe-Proxy.md
Slice phase: Production hardening

Constrain the public deflection report JSON proxy so locked/free responses remain snapshot-only, and unlocked responses expose only a hosted-safe paid report model constructed from generated allowlists.

## Intentional
- `loadDeflectionReport` remains raw/server-only so result-page rendering and evidence-export downloads can still use the full unlocked artifact on the server.
- `answer` and `steps` remain paid fields: they appear only in the unlocked hosted-safe report-model payload, never in locked/free responses.
- Codex P1/P2 addressed: report-model summary is fail-closed to `{}` until a generated summary allowlist exists, and hosted-safe `status_counts`, `status_mix`, and `term_mappings` are preserved through explicit readers.

## Deferred
- atlas-portfolio cross-repo consumption should mirror this pattern once it consumes the generated ATLAS report-model artifact.

## Parked hardening
- None.

## Verification
- Portfolio proxy test: package `portfolio-ui`, script `test:deflection-atlas-proxy` -- 27 tests passed after Codex P1/P2 fixes.
- Local PR review bundle -- pending in push wrapper for the review-fix commit.

## Diff size
3 files, +490 / -21
