### PR TITLE
Add hosted-safe report projection parity test

### DIFF
--- a/plans/PR-Deflection-Report-Hosted-Safe-Parity.md
+++ b/plans/PR-Deflection-Report-Hosted-Safe-Parity.md
@@ -1,0 +1,156 @@
+# PR-Deflection-Report-Hosted-Safe-Parity
+
+## Why this slice exists
+
+#1828 made the public `/api/content-ops/deflection/report` response project the
+paid report model through generated hosted-safe field allowlists, but the
+reviewer flagged one remaining weak spot: the projection has to hand-classify a
+few non-scalar leaf shapes (`source_date_window`, `status_counts`,
+`status_mix`, `reason_counts`, `term_mappings`).
+
+Root cause: generated field-name parity is covered, but generated field-shape
+parity is not. A future backend contract could add a hosted-safe record or
+object-array field, the public projection could silently drop it, and the
+current tests would still pass if they only exercised the already-known fields.
+During review, that exact class turned up in current runtime behavior:
+`source_date_window` is produced by `_support_tax_data` as a scalar record, but
+the hosted proxy only preserved `status_counts` and `status_mix` records.
+After rebasing onto #1830, the same parity guard caught the new
+`suppressed_repeat_review_queue` section: `reason_counts` is a scalar record and
+`suppression_reason` / `suppression_reason_label` are scalar leaves that must be
+classified for the hosted projection to preserve them.
+
+This change fixes the test-gap root for the hosted-safe public boundary by
+building one report model fixture from every generated hosted-safe section
+field, classifying each current leaf shape, and asserting the public projection
+preserves every classified field. It also fixes the current upstream-proven
+runtime miss by preserving `source_date_window` as a hosted-safe scalar record.
+Unclassified future leaf fields become object fixtures by default, which the
+current projection intentionally drops; that makes a new shape fail test-time
+until the projection and classifier are updated together.
+
+The slice is slightly over the 400 LOC soft cap after review fixes because the
+`source_date_window` runtime repair, two-entry nested parity fixture, and
+section-metadata assertions are one coupled boundary proof. The extra #1830
+field classifications are also same-class parity coverage; splitting them would
+leave the hosted-safe projection green while part of the reviewed defect class
+remains unproven.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-contract-1805
+Slice phase: Production hardening
+
+1. Add a focused parity test to the existing `portfolio-ui` ATLAS proxy suite.
+2. Prove every generated hosted-safe report-model field survives
+   `publicHostedReportModel`, including nested rows/items, scalar arrays,
+   scalar records, and known object arrays.
+3. Preserve the real backend `source_date_window` record at the public hosted
+   paid report boundary.
+4. Strengthen the parity assertion to compare section metadata and every nested
+   row/item, not only the first item.
+5. Classify the #1830 suppressed-repeat review fields discovered by the
+   merge-commit CI run.
+
+### Review Contract
+
+Acceptance criteria:
+
+1. The test imports the generated report-model contract rather than duplicating
+   section IDs by hand.
+2. Every current hosted-safe leaf field is classified as scalar, scalar array,
+   scalar record, or object array.
+3. The fixture covers every generated hosted-safe section and nested item shape.
+4. The assertion checks preservation, not just absence of private fields,
+   including section metadata and multiple nested rows/items.
+5. Summary remains fail-closed (`summary: {}`), so the previous public payload
+   boundary is not widened.
+6. A real `source_date_window` scalar-record shape survives
+   `publicHostedReportModel`.
+
+Affected surfaces:
+
+- Public paid report JSON proxy projection.
+- Public paid report JSON proxy test coverage.
+
+Risk areas:
+
+- False-green projection coverage for future generated report-model shape
+  changes.
+- Privacy boundary regressions if a new scalar-record projection admits
+  non-scalar values or raw evidence fields.
+
+Reviewer rules triggered:
+
+- R2 Test evidence.
+- R5 Contract/API compatibility.
+- R13 Class-fix proof.
+- R14 Codebase verification.
+
+### Files touched
+
+- `plans/PR-Deflection-Report-Hosted-Safe-Parity.md`
+- `portfolio-ui/api/content-ops/deflection/report.js`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+
+## Mechanism
+
+The test walks `DEFLECTION_REPORT_SECTION_IDS` and each section's generated
+`*_HOSTED_CONSUMER_SAFE_FIELDS` constants. For nested generated field constants
+such as `*_ROWS_HOSTED_CONSUMER_SAFE_FIELDS` and
+`*_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS`, it builds a matching nested
+object or array fixture.
+
+Leaf fields are shape-classified in the test. Current scalar fields receive
+realistic scalar values, scalar arrays receive representative arrays, record
+fields receive scalar records, `source_date_window` receives the real
+`{source_date_start, source_date_end, source_window_days}` shape, and
+`term_mappings` receives an object-array fixture with a deliberately private
+extra key. The #1830 `suppression_reason` fields use scalar values, and
+`reason_counts` uses the scalar-record path. Unknown future leaves are
+intentionally emitted as object records, so the current projection drops them
+and the parity assertion fails until the new shape is explicitly handled.
+
+The assertion then runs the fixture through `publicHostedReportModel` and checks
+that each generated hosted-safe field path survives while the fail-closed
+summary remains empty and private marker values remain absent. Nested
+`rows`/`items` use two distinct entries and the assertion recurses over every
+entry, so later-row projection drift is covered.
+
+The runtime projection adds `source_date_window` and `reason_counts` to the
+hosted-safe scalar-record field set, reusing the existing `cloneScalarRecord`
+path so only scalar record members can cross the public boundary.
+
+## Intentional
+
+- Runtime behavior changes only for upstream-proven scalar records
+  (`source_date_window` and #1830 `reason_counts`); this does not add a broad
+  object passthrough.
+- The shape classifier is test-local because it is a guardrail for the
+  hand-coded projection bridge; a generated shape artifact would be better, but
+  that requires changing the contract generator and consumer runtime together.
+- The fixture uses realistic synthetic values instead of real ticket prose so
+  the test can safely live in the public repo without introducing customer data.
+
+## Deferred
+
+- Generate report-model field-shape metadata from the ATLAS projection contract
+  so `report.js` can project records/object arrays without test-local shape
+  classification.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: `npm --prefix portfolio-ui run test:deflection-atlas-proxy` (28 tests).
+- Pending before push: `bash scripts/push_pr.sh <body-file> -u origin HEAD`
+  (runs the local PR review bundle through the managed push path).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Report-Hosted-Safe-Parity.md` | 156 |
+| `portfolio-ui/api/content-ops/deflection/report.js` | 7 |
+| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 281 |
+| **Total** | **444** |

--- a/portfolio-ui/api/content-ops/deflection/report.js
+++ b/portfolio-ui/api/content-ops/deflection/report.js
@@ -2,7 +2,12 @@ import { clean, loadDeflectionReport, proxyErrorPublicPayload } from "./atlas-re
 import * as reportModelContract from "./report-model-contract.js";
 
 const DEFLECTION_REPORT_SECTION_ID_SET = new Set(reportModelContract.DEFLECTION_REPORT_SECTION_IDS);
-const HOSTED_SAFE_RECORD_FIELDS = new Set(["status_counts", "status_mix"]);
+const HOSTED_SAFE_RECORD_FIELDS = new Set([
+  "reason_counts",
+  "source_date_window",
+  "status_counts",
+  "status_mix",
+]);
 const HOSTED_SAFE_OBJECT_ARRAY_FIELDS = Object.freeze({
   term_mappings: Object.freeze([
     "customer_term",

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import evidenceExportHandler from "../api/content-ops/deflection/evidence-export.js";
-import reportHandler, { publicReportPayload } from "../api/content-ops/deflection/report.js";
+import reportHandler, {
+  publicHostedReportModel,
+  publicReportPayload,
+} from "../api/content-ops/deflection/report.js";
+import * as reportModelContract from "../api/content-ops/deflection/report-model-contract.js";
 import {
   atlasPath,
   fetchAtlasJson,
@@ -203,6 +207,249 @@ function withEnv(nextEnv, fn) {
         }
       }
     });
+}
+
+const HOSTED_SAFE_SCALAR_FIELDS = new Set([
+  "annualized_run_rate_support_cost",
+  "annualized_support_cost",
+  "answer",
+  "answer_evidence_status",
+  "answer_linkage",
+  "answer_status",
+  "assisted_contact_cost",
+  "backlog_limit",
+  "confidence",
+  "csat_present_count",
+  "customer_wording",
+  "default_limit",
+  "displayed_phrase_count",
+  "drafted_answer_count",
+  "estimated_support_cost",
+  "generated_question_count",
+  "guidance",
+  "limit",
+  "negative_csat_ticket_count",
+  "no_proven_answer_count",
+  "non_repeat_ticket_count",
+  "numeric_average",
+  "omitted_phrase_count",
+  "opportunity_score",
+  "outcome_diagnostic_ticket_count",
+  "outcome_risk_ticket_count",
+  "owner_lane",
+  "pdf_limit",
+  "priority_score",
+  "question",
+  "rank",
+  "recommended_action",
+  "reopened_ticket_count",
+  "repeat_ticket_count",
+  "resolution_evidence_scope",
+  "result_page_limit",
+  "source_count",
+  "source_proof",
+  "status",
+  "suppression_reason",
+  "suppression_reason_label",
+  "ticket_count",
+  "ticket_source_count",
+  "top_item_count",
+  "topic",
+  "total_item_count",
+  "total_phrase_count",
+  "weighted_frequency",
+]);
+
+const HOSTED_SAFE_SCALAR_ARRAY_FIELDS = new Set(["phrases", "priority_drivers", "steps"]);
+const HOSTED_SAFE_RECORD_FIELDS = new Set([
+  "reason_counts",
+  "source_date_window",
+  "status_counts",
+  "status_mix",
+]);
+const HOSTED_SAFE_OBJECT_ARRAY_FIELDS = Object.freeze({
+  term_mappings: Object.freeze([
+    "customer_term",
+    "documentation_term",
+    "suggestion",
+    "source_id_count",
+  ]),
+});
+const HOSTED_SAFE_OBJECT_CONTAINERS = new Set(["csat_signal", "support_cost_basis"]);
+const HOSTED_SAFE_ARRAY_CONTAINERS = new Set(["items", "rows"]);
+const HOSTED_SAFE_PRIVATE_MARKER = "hosted-safe-private-marker";
+
+function fieldConstToken(field) {
+  return String(field).toUpperCase().replace(/[^A-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function sectionConstPrefix(sectionId) {
+  return `DEFLECTION_REPORT_${fieldConstToken(sectionId)}`;
+}
+
+function generatedFields(name) {
+  const fields = reportModelContract[name];
+  return Array.isArray(fields) ? fields : [];
+}
+
+function scalarHostedValue(field, variant) {
+  if (
+    field === "rank" ||
+    field === "limit" ||
+    field.endsWith("_count") ||
+    field.endsWith("_cost") ||
+    field.endsWith("_frequency") ||
+    field.endsWith("_limit") ||
+    field.endsWith("_score") ||
+    field === "numeric_average"
+  ) {
+    return 7 + variant;
+  }
+  return `${field} value ${variant}`;
+}
+
+function hostedLeafValue(field, variant) {
+  if (HOSTED_SAFE_SCALAR_FIELDS.has(field)) return scalarHostedValue(field, variant);
+  if (HOSTED_SAFE_SCALAR_ARRAY_FIELDS.has(field)) {
+    return [`${field} value ${variant}`, `${field} follow-up ${variant}`];
+  }
+  if (field === "source_date_window") {
+    return {
+      source_date_start: "2026-06-01",
+      source_date_end: "2026-06-30",
+      source_window_days: 30 + variant,
+    };
+  }
+  if (HOSTED_SAFE_RECORD_FIELDS.has(field)) {
+    return { solved: 3 + variant, reopened: 1 + variant };
+  }
+  if (HOSTED_SAFE_OBJECT_ARRAY_FIELDS[field]) {
+    return [
+      {
+        customer_term: `billing reset ${variant}`,
+        documentation_term: `billing access reset ${variant}`,
+        suggestion: `Use customer wording in the help-center title ${variant}.`,
+        source_id_count: 2 + variant,
+        source_ids: [HOSTED_SAFE_PRIVATE_MARKER],
+      },
+      {
+        customer_term: `refund receipt ${variant}`,
+        documentation_term: `refund confirmation ${variant}`,
+        suggestion: `Mirror receipt language in the billing article ${variant}.`,
+        source_id_count: 4 + variant,
+        source_ids: [HOSTED_SAFE_PRIVATE_MARKER],
+      },
+    ];
+  }
+  return { unclassified_hosted_safe_shape: field };
+}
+
+function buildHostedRecord(fields, prefix, variant = 1) {
+  const record = {};
+  for (const field of fields) {
+    const nestedPrefix = `${prefix}_${fieldConstToken(field)}`;
+    const nestedFields = generatedFields(`${nestedPrefix}_HOSTED_CONSUMER_SAFE_FIELDS`);
+    if (nestedFields.length > 0) {
+      if (HOSTED_SAFE_ARRAY_CONTAINERS.has(field)) {
+        record[field] = [
+          buildHostedRecord(nestedFields, nestedPrefix, 1),
+          buildHostedRecord(nestedFields, nestedPrefix, 2),
+        ];
+      } else if (HOSTED_SAFE_OBJECT_CONTAINERS.has(field)) {
+        record[field] = buildHostedRecord(nestedFields, nestedPrefix, variant);
+      } else {
+        record[field] = { unclassified_hosted_safe_container: field };
+      }
+      continue;
+    }
+    record[field] = hostedLeafValue(field, variant);
+  }
+  return record;
+}
+
+function buildCompleteHostedReportModelFixture() {
+  return {
+    schema_version: reportModelContract.DEFLECTION_REPORT_MODEL_SCHEMA_VERSION,
+    title: "Complete hosted-safe paid report",
+    summary: {
+      generated: 99,
+      source_ids: [HOSTED_SAFE_PRIVATE_MARKER],
+      private_note: HOSTED_SAFE_PRIVATE_MARKER,
+    },
+    sections: reportModelContract.DEFLECTION_REPORT_SECTION_IDS.map((sectionId, index) => {
+      const prefix = sectionConstPrefix(sectionId);
+      return {
+        id: sectionId,
+        title: `${sectionId} section`,
+        priority: index + 1,
+        surfaces: ["result_page", "email_summary"],
+        default_limit: 5 + index,
+        required_data: ["fixture"],
+        snapshot_safe_fields: [],
+        data: buildHostedRecord(
+          generatedFields(`${prefix}_HOSTED_CONSUMER_SAFE_FIELDS`),
+          prefix,
+        ),
+      };
+    }),
+  };
+}
+
+function assertObjectArrayFieldSurvives(projectedValue, expectedValue, fields, path) {
+  assert.equal(Array.isArray(projectedValue), true, `${path} must stay an array`);
+  assert.equal(projectedValue.length, expectedValue.length, `${path} length`);
+  for (const [index, expectedItem] of expectedValue.entries()) {
+    const projectedItem = projectedValue[index];
+    for (const field of fields) {
+      assert.deepEqual(projectedItem[field], expectedItem[field], `${path}.${index}.${field}`);
+    }
+    assert.equal("source_ids" in projectedItem, false, `${path}.${index}.source_ids must stay private`);
+  }
+}
+
+function assertHostedFieldsSurvive(projected, expected, fields, prefix, path) {
+  for (const field of fields) {
+    const nestedPrefix = `${prefix}_${fieldConstToken(field)}`;
+    const nestedFields = generatedFields(`${nestedPrefix}_HOSTED_CONSUMER_SAFE_FIELDS`);
+    assert.equal(Object.prototype.hasOwnProperty.call(projected, field), true, `${path}.${field}`);
+
+    if (nestedFields.length > 0) {
+      if (HOSTED_SAFE_ARRAY_CONTAINERS.has(field)) {
+        assert.equal(Array.isArray(projected[field]), true, `${path}.${field} must stay an array`);
+        assert.equal(projected[field].length, expected[field].length, `${path}.${field} length`);
+        for (const [index, expectedItem] of expected[field].entries()) {
+          assertHostedFieldsSurvive(
+            projected[field][index],
+            expectedItem,
+            nestedFields,
+            nestedPrefix,
+            `${path}.${field}.${index}`,
+          );
+        }
+      } else {
+        assertHostedFieldsSurvive(
+          projected[field],
+          expected[field],
+          nestedFields,
+          nestedPrefix,
+          `${path}.${field}`,
+        );
+      }
+      continue;
+    }
+
+    if (HOSTED_SAFE_OBJECT_ARRAY_FIELDS[field]) {
+      assertObjectArrayFieldSurvives(
+        projected[field],
+        expected[field],
+        HOSTED_SAFE_OBJECT_ARRAY_FIELDS[field],
+        `${path}.${field}`,
+      );
+      continue;
+    }
+
+    assert.deepEqual(projected[field], expected[field], `${path}.${field}`);
+  }
 }
 
 await test("proxy rejects account mismatch before calling ATLAS", async () => {
@@ -431,6 +678,38 @@ await test("public report API returns sanitized locked envelope and never the to
     assert.equal(payload.artifact_status, "locked");
     assert.equal(JSON.stringify(payload).includes(ENV.ATLAS_B2B_JWT), false);
   });
+});
+
+await test("public hosted report projection preserves every generated hosted-safe field", () => {
+  const reportModel = buildCompleteHostedReportModelFixture();
+  const projected = publicHostedReportModel(reportModel);
+
+  assert.equal(projected.schema_version, reportModel.schema_version);
+  assert.equal(projected.title, reportModel.title);
+  assert.deepEqual(projected.summary, {});
+  assert.equal(projected.sections.length, reportModel.sections.length);
+
+  const projectedById = new Map(projected.sections.map((section) => [section.id, section]));
+  for (const expectedSection of reportModel.sections) {
+    const projectedSection = projectedById.get(expectedSection.id);
+    assert.ok(projectedSection, `${expectedSection.id} section`);
+    assert.equal(projectedSection.title, expectedSection.title);
+    assert.equal(projectedSection.priority, expectedSection.priority);
+    assert.equal(projectedSection.default_limit, expectedSection.default_limit);
+    assert.deepEqual(projectedSection.surfaces, expectedSection.surfaces);
+    assert.deepEqual(projectedSection.required_data, expectedSection.required_data);
+    assert.deepEqual(projectedSection.snapshot_safe_fields, expectedSection.snapshot_safe_fields);
+    const prefix = sectionConstPrefix(expectedSection.id);
+    assertHostedFieldsSurvive(
+      projectedSection.data,
+      expectedSection.data,
+      generatedFields(`${prefix}_HOSTED_CONSUMER_SAFE_FIELDS`),
+      prefix,
+      expectedSection.id,
+    );
+  }
+
+  assert.equal(JSON.stringify(projected).includes(HOSTED_SAFE_PRIVATE_MARKER), false);
 });
 
 await test("public report API returns only hosted-safe paid report model after unlock", async () => {


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-Hosted-Safe-Parity.md
Slice phase: Production hardening

Add parity coverage for the public hosted-safe paid report-model projection so every generated hosted-safe field is populated and proven to survive the public payload boundary. Review also exposed one real runtime miss: `source_date_window` is emitted by the backend as a scalar record, so this PR now preserves that record through `publicHostedReportModel`.

## Intentional
- Runtime behavior changes only for the upstream-proven `source_date_window` scalar record; this does not add broad object passthrough.
- Shape classification stays test-local for now because generated field-shape metadata is a follow-up contract-generator/runtime slice.
- The fixture uses synthetic support-report values and a private marker rather than real ticket content.

## Review update
- [chatgpt-codex-connector] Assert all section metadata parity: fixed in `5cab0c8` by asserting `title`, `priority`, and `default_limit` for every projected section.
- [chatgpt-codex-connector] Compare every nested array item: fixed in `5cab0c8` by building two distinct `rows`/`items` fixtures and recursing over every expected array element.
- [chatgpt-codex-connector] Model `source_date_window` with its real record shape: fixed in `5cab0c8` by moving the fixture to `{source_date_start, source_date_end, source_window_days}` and preserving `source_date_window` through the runtime scalar-record projection.
- CI merge-commit follow-up fixed in `660a895`: rebased onto #1830 and classified the new `suppressed_repeat_review_queue` hosted-safe fields (`suppression_reason`, `suppression_reason_label`, and `reason_counts`) so the parity test covers the current merged contract.

## AI reconciliation
- [chatgpt-codex-connector] Assert all section metadata parity: fixed in pushed head `660a895`.
- [chatgpt-codex-connector] Compare every nested array item: fixed in pushed head `660a895`.
- [chatgpt-codex-connector] Model `source_date_window` with its real record shape: fixed in pushed head `660a895`.

All findings fixed or waived: yes.

## Deferred
- Generate report-model field-shape metadata from the ATLAS projection contract so `report.js` can project records/object arrays without test-local shape classification.

## Parked hardening
- None.

## Verification
- `npm --prefix portfolio-ui run test:deflection-atlas-proxy` (28 tests)
- `bash scripts/push_pr.sh /tmp/deflection-report-hosted-safe-parity-pr-body.md --force-with-lease origin claude/pr-deflection-report-hosted-safe-parity` (local review passed in the managed push path)

## Diff size
3 files, +421 / -2
