### PR TITLE
Add suppressed repeat review keys

### DIFF
--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import hashlib
 from typing import Any, Protocol
 
 from .deflection_delta import compute_deflection_delta
@@ -1008,6 +1009,7 @@ def _stored_report_model_section(value: Any) -> dict[str, Any] | None:
         required_data,
         data,
     )
+    data = _normalize_stored_suppressed_review_keys(section_id, data)
     if any(key not in data for key in required_data):
         return None
     return {
@@ -1041,6 +1043,57 @@ def _normalize_stored_action_section_limits(
         if key not in normalized_required:
             normalized_required.append(key)
     return normalized_required, normalized_data
+
+
+def _normalize_stored_suppressed_review_keys(
+    section_id: str,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    if section_id != "suppressed_repeat_review_queue":
+        return data
+    raw_items = data.get("items")
+    if not _is_sequence(raw_items):
+        return data
+
+    normalized_items: list[Any] = []
+    changed = False
+    for index, item in enumerate(raw_items, start=1):
+        if not isinstance(item, Mapping):
+            normalized_items.append(item)
+            continue
+        row = dict(item)
+        if not _clean(row.get("review_key")):
+            row["review_key"] = _stored_suppressed_repeat_review_key(row, index)
+            changed = True
+        normalized_items.append(row)
+
+    if not changed:
+        return data
+    normalized_data = dict(data)
+    normalized_data["items"] = normalized_items
+    return normalized_data
+
+
+def _stored_suppressed_repeat_review_key(
+    row: Mapping[str, Any],
+    index: int,
+) -> str:
+    identity = (
+        _clean(row.get("repeat_key"))
+        or _clean(row.get("cluster_id"))
+        or _identity_text(row.get("question"))
+    )
+    reason = _clean(row.get("suppression_reason")) or "insufficient_source_support"
+    parts = ["suppressed_repeat_review_queue", identity, reason]
+    if _clean(row.get("identity_basis")) == "insufficient_identity":
+        rank = _parse_int(row.get("rank")) or index
+        parts.append(f"row_{rank}")
+    digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+    return f"review_{digest[:24]}"
+
+
+def _identity_text(value: Any) -> str:
+    return " ".join(_clean(value).casefold().split())
 
 
 def _list_record_from_row(row: Mapping[str, Any]) -> DeflectionReportListRecord:

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -3060,7 +3060,15 @@ def _suppressed_repeat_review_queue_data(
         reason = _suppression_reason(item)
         review_items.append({
             **action_item,
-            "review_key": _suppressed_repeat_review_key(action_item, reason),
+            "review_key": _suppressed_repeat_review_key(
+                action_item,
+                reason,
+                row_discriminator=(
+                    f"row_{rank}"
+                    if action_item["identity_basis"] == "insufficient_identity"
+                    else ""
+                ),
+            ),
             "suppression_reason": reason,
             "suppression_reason_label": _suppression_reason_label(reason),
         })
@@ -3093,16 +3101,19 @@ def _suppression_reason(item: Mapping[str, Any]) -> str:
 def _suppressed_repeat_review_key(
     action_item: Mapping[str, Any],
     reason: str,
+    *,
+    row_discriminator: str = "",
 ) -> str:
     identity = (
         _text(action_item.get("repeat_key"))
         or _text(action_item.get("cluster_id"))
         or _identity_text(action_item.get("question"))
     )
+    parts = ["suppressed_repeat_review_queue", identity, reason]
+    if row_discriminator:
+        parts.append(row_discriminator)
     digest = hashlib.sha256(
-        "\x1f".join(("suppressed_repeat_review_queue", identity, reason)).encode(
-            "utf-8"
-        )
+        "\x1f".join(parts).encode("utf-8")
     ).hexdigest()
     return f"review_{digest[:24]}"
 

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -872,11 +872,13 @@ _REPORT_ACTION_ITEM_HOSTED_SAFE_FIELDS = (
 )
 _REPORT_SUPPRESSED_REPEAT_REVIEW_ITEM_FIELDS = (
     *_REPORT_ACTION_ITEM_FIELDS,
+    "review_key",
     "suppression_reason",
     "suppression_reason_label",
 )
 _REPORT_SUPPRESSED_REPEAT_REVIEW_ITEM_HOSTED_SAFE_FIELDS = (
     *_REPORT_ACTION_ITEM_HOSTED_SAFE_FIELDS,
+    "review_key",
     "suppression_reason",
     "suppression_reason_label",
 )
@@ -3058,6 +3060,7 @@ def _suppressed_repeat_review_queue_data(
         reason = _suppression_reason(item)
         review_items.append({
             **action_item,
+            "review_key": _suppressed_repeat_review_key(action_item, reason),
             "suppression_reason": reason,
             "suppression_reason_label": _suppression_reason_label(reason),
         })
@@ -3085,6 +3088,23 @@ def _suppression_reason(item: Mapping[str, Any]) -> str:
     if _source_count(item) < 2:
         return "insufficient_source_support"
     raise ValueError("low-confidence item has no supported suppression reason")
+
+
+def _suppressed_repeat_review_key(
+    action_item: Mapping[str, Any],
+    reason: str,
+) -> str:
+    identity = (
+        _text(action_item.get("repeat_key"))
+        or _text(action_item.get("cluster_id"))
+        or _identity_text(action_item.get("question"))
+    )
+    digest = hashlib.sha256(
+        "\x1f".join(("suppressed_repeat_review_queue", identity, reason)).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    return f"review_{digest[:24]}"
 
 
 def _suppression_reason_label(reason: str) -> str:

--- a/plans/PR-Deflection-Suppressed-Review-Key.md
+++ b/plans/PR-Deflection-Suppressed-Review-Key.md
@@ -1,0 +1,76 @@
+# PR-Deflection-Suppressed-Review-Key
+
+## Why this slice exists
+
+The next #324 follow-up is a real reviewer override workflow for suppressed repeat rows. Portfolio can display suppressed rows after atlas-portfolio#378, but it cannot persist reviewer decisions safely yet because the hosted-safe payload strips `repeat_key` and `cluster_id`, and keying overrides by rank or question text would be brittle and would store customer wording unnecessarily.
+
+Root cause: the paid report model has no hosted-safe stable identifier for suppressed review rows. This change fixes the root prerequisite by adding a deterministic `review_key` to suppressed repeat review items and publishing that field in the hosted-consumer-safe allowlist.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-review-overrides
+Slice phase: Vertical slice
+
+1. Add a stable, non-raw `review_key` to each `suppressed_repeat_review_queue.items[]` row.
+2. Keep `repeat_key`, `cluster_id`, source IDs, and evidence quotes paid/export-only; hosted consumers receive only `review_key` plus the existing safe row fields and suppression reason labels.
+3. Regenerate the Portfolio contract artifacts so atlas-portfolio can consume the key in the next UI/API slice.
+4. Add focused tests proving `review_key` is present, deterministic, hosted-safe, and does not expose raw repeat identity fields.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `suppressed_repeat_review_queue.items[]` includes `review_key` for every emitted row.
+  - [ ] `review_key` is stable across repeated builds of the same input and does not change when row rank/order changes.
+  - [ ] Hosted-safe projection includes `review_key` but still excludes `repeat_key`, `cluster_id`, `top_evidence`, source IDs, and evidence quotes.
+  - [ ] Generated `portfolio-ui` TypeScript and API contract artifacts expose the new field.
+- Affected surfaces: report model contract / hosted projection / generated frontend artifacts / tests.
+- Risk areas: backcompat, privacy, contract drift.
+- Reviewer rules triggered: R1, R2, R5, R10, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Suppressed-Review-Key.md`
+- `portfolio-ui/api/content-ops/deflection/report-model-contract.js`
+- `portfolio-ui/src/types/deflectionReportModel.ts`
+- `scripts/generate_deflection_frontend_contract_types.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_generate_deflection_frontend_contract_types.py`
+
+## Mechanism
+
+The suppressed review queue builds from action items that already carry deterministic internal identity (`repeat_key` / `cluster_id`). This PR derives `review_key` from the section name, raw repeat identity, and suppression reason using SHA-256, then exposes a prefixed short digest such as `review_abcd...`. The key is deterministic for the same suppressed finding but does not reveal the raw repeat identity or question text.
+
+Only the suppressed review item schema gets the key. The hosted-safe allowlist for that collection includes `review_key`; the shared action-item hosted allowlist remains unchanged so other report sections do not accidentally expose raw or new identifiers.
+
+## Intentional
+
+- `repeat_key` and `cluster_id` remain paid/export-only. They are already hashes, but exposing a new purpose-specific review key keeps the browser contract narrow and prevents Portfolio from depending on internal report identity fields.
+- This does not add an override endpoint or persisted decision store. It only creates the safe row key needed for that next Portfolio slice.
+
+## Deferred
+
+- Portfolio follow-up: persist reviewer decisions keyed by `(request_id, review_key)` and render reviewed/promoted/suppressed states.
+- Future ATLAS follow-up: accept reviewer decisions back into the report generation flow if we want overrides to regenerate exports, not just annotate the hosted report.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_deflection_report.py -k "suppressed_repeat_review_queue or suppressed_review_key or projection_separates_paid_and_hosted_action_fields"` - passed, 3 selected.
+- `python -m pytest tests/test_generate_deflection_frontend_contract_types.py -k "report_model"` - passed, 11 selected.
+- `python scripts/generate_deflection_frontend_contract_types.py --check` - passed.
+- `ATLAS_CURRENT_PR_BODY_FILE=/tmp/deflection-suppressed-review-key-pr-body.md bash scripts/local_pr_review.sh` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 20 |
+| `plans/PR-Deflection-Suppressed-Review-Key.md` | 76 |
+| `portfolio-ui/api/content-ops/deflection/report-model-contract.js` | 4 |
+| `portfolio-ui/src/types/deflectionReportModel.ts` | 5 |
+| `scripts/generate_deflection_frontend_contract_types.py` | 1 |
+| `tests/test_content_ops_deflection_report.py` | 58 |
+| `tests/test_generate_deflection_frontend_contract_types.py` | 10 |
+| **Total** | **174** |

--- a/plans/PR-Deflection-Suppressed-Review-Key.md
+++ b/plans/PR-Deflection-Suppressed-Review-Key.md
@@ -15,12 +15,15 @@ Slice phase: Vertical slice
 2. Keep `repeat_key`, `cluster_id`, source IDs, and evidence quotes paid/export-only; hosted consumers receive only `review_key` plus the existing safe row fields and suppression reason labels.
 3. Regenerate the Portfolio contract artifacts so atlas-portfolio can consume the key in the next UI/API slice.
 4. Add focused tests proving `review_key` is present, deterministic, hosted-safe, and does not expose raw repeat identity fields.
+5. Backfill missing `review_key` values when reading legacy stored `deflection.v1` artifacts so the field can remain required without a schema bump.
 
 ### Review Contract
 
 - Acceptance criteria:
   - [ ] `suppressed_repeat_review_queue.items[]` includes `review_key` for every emitted row.
-  - [ ] `review_key` is stable across repeated builds of the same input and does not change when row rank/order changes.
+  - [ ] `review_key` is stable across repeated builds of rows with usable identity and does not change when row rank/order changes.
+  - [ ] Identity-less suppressed rows receive distinct review keys instead of colliding on `insufficient_identity`.
+  - [ ] Stored legacy `deflection.v1` report models without `review_key` backfill the field at read time.
   - [ ] Hosted-safe projection includes `review_key` but still excludes `repeat_key`, `cluster_id`, `top_evidence`, source IDs, and evidence quotes.
   - [ ] Generated `portfolio-ui` TypeScript and API contract artifacts expose the new field.
 - Affected surfaces: report model contract / hosted projection / generated frontend artifacts / tests.
@@ -30,8 +33,10 @@ Slice phase: Vertical slice
 ### Files touched
 
 - `extracted_content_pipeline/faq_deflection_report.py`
+- `extracted_content_pipeline/deflection_report_access.py`
 - `plans/PR-Deflection-Suppressed-Review-Key.md`
 - `portfolio-ui/api/content-ops/deflection/report-model-contract.js`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
 - `portfolio-ui/src/types/deflectionReportModel.ts`
 - `scripts/generate_deflection_frontend_contract_types.py`
 - `tests/test_content_ops_deflection_report.py`
@@ -41,7 +46,11 @@ Slice phase: Vertical slice
 
 The suppressed review queue builds from action items that already carry deterministic internal identity (`repeat_key` / `cluster_id`). This PR derives `review_key` from the section name, raw repeat identity, and suppression reason using SHA-256, then exposes a prefixed short digest such as `review_abcd...`. The key is deterministic for the same suppressed finding but does not reveal the raw repeat identity or question text.
 
+Rows that genuinely lack usable identity carry the existing `insufficient_identity` marker, so this PR adds the report rank as a discriminator only for that low-confidence class. Normal identified rows stay identity-derived and stable across ordering changes; identity-less rows stay row-specific so reviewer decisions cannot collide.
+
 Only the suppressed review item schema gets the key. The hosted-safe allowlist for that collection includes `review_key`; the shared action-item hosted allowlist remains unchanged so other report sections do not accidentally expose raw or new identifiers.
+
+Persisted `deflection.v1` artifacts are normalized at the stored report model access boundary. If a legacy suppressed review row lacks `review_key`, the access layer derives the same key shape from stored row fields, preferring the stored rank as the identity-less discriminator. This keeps the field required under the existing schema without mutating the stored artifact.
 
 ## Intentional
 
@@ -57,7 +66,8 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_content_ops_deflection_report.py -k "suppressed_repeat_review_queue or suppressed_review_key or projection_separates_paid_and_hosted_action_fields"` - passed, 3 selected.
+- `python -m pytest tests/test_content_ops_deflection_report.py -k "suppressed_repeat_review_queue or suppressed_review_key or stored_deflection_report_model_backfills_legacy_suppressed_review_keys or projection_separates_paid_and_hosted_action_fields"` - passed, 5 selected.
+- `npm --prefix portfolio-ui run test:deflection-atlas-proxy` - passed.
 - `python -m pytest tests/test_generate_deflection_frontend_contract_types.py -k "report_model"` - passed, 11 selected.
 - `python scripts/generate_deflection_frontend_contract_types.py --check` - passed.
 - `ATLAS_CURRENT_PR_BODY_FILE=/tmp/deflection-suppressed-review-key-pr-body.md bash scripts/local_pr_review.sh` - passed.
@@ -66,11 +76,13 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/faq_deflection_report.py` | 20 |
-| `plans/PR-Deflection-Suppressed-Review-Key.md` | 76 |
+| `extracted_content_pipeline/deflection_report_access.py` | 53 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 31 |
+| `plans/PR-Deflection-Suppressed-Review-Key.md` | 86 |
 | `portfolio-ui/api/content-ops/deflection/report-model-contract.js` | 4 |
+| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 1 |
 | `portfolio-ui/src/types/deflectionReportModel.ts` | 5 |
 | `scripts/generate_deflection_frontend_contract_types.py` | 1 |
-| `tests/test_content_ops_deflection_report.py` | 58 |
+| `tests/test_content_ops_deflection_report.py` | 181 |
 | `tests/test_generate_deflection_frontend_contract_types.py` | 10 |
-| **Total** | **174** |
+| **Total** | **372** |

--- a/portfolio-ui/api/content-ops/deflection/report-model-contract.js
+++ b/portfolio-ui/api/content-ops/deflection/report-model-contract.js
@@ -155,13 +155,13 @@ export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_SNAPSHOT_SAFE_FIEL
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "total_item_count", "default_limit", "reason_counts"]);
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal", "suppression_reason", "suppression_reason_label"]);
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal", "review_key", "suppression_reason", "suppression_reason_label"]);
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence", "suppression_reason", "suppression_reason_label"]);
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence", "review_key", "suppression_reason", "suppression_reason_label"]);
 
 export const DEFLECTION_REPORT_QUESTION_DETAILS_FIELDS = Object.freeze(["rows"]);
 

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -244,6 +244,7 @@ const HOSTED_SAFE_SCALAR_FIELDS = new Set([
   "recommended_action",
   "reopened_ticket_count",
   "repeat_ticket_count",
+  "review_key",
   "resolution_evidence_scope",
   "result_page_limit",
   "source_count",

--- a/portfolio-ui/src/types/deflectionReportModel.ts
+++ b/portfolio-ui/src/types/deflectionReportModel.ts
@@ -155,13 +155,13 @@ export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_SNAPSHOT_SAFE_FIEL
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "total_item_count", "default_limit", "reason_counts"] as const;
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal", "suppression_reason", "suppression_reason_label"] as const;
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal", "review_key", "suppression_reason", "suppression_reason_label"] as const;
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence", "suppression_reason", "suppression_reason_label"] as const;
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence", "review_key", "suppression_reason", "suppression_reason_label"] as const;
 
 export const DEFLECTION_REPORT_QUESTION_DETAILS_FIELDS = ["rows"] as const;
 
@@ -645,6 +645,7 @@ export type DeflectionReportSuppressedRepeatReviewQueueItem = {
   support_cost_source: string;
   opportunity_score: number;
   top_evidence: DeflectionReportSuppressedRepeatReviewQueueTopEvidence[];
+  review_key: string;
   suppression_reason: string;
   suppression_reason_label: string;
 };

--- a/scripts/generate_deflection_frontend_contract_types.py
+++ b/scripts/generate_deflection_frontend_contract_types.py
@@ -78,6 +78,7 @@ TYPE_BY_FIELD = {
     "repeat_ticket_count": "number",
     "repeat_key": "string",
     "representative_phrasing": "string",
+    "review_key": "string",
     "resolution_evidence_scope": "string",
     "result_page_limit": "number",
     "source": "string",

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -860,6 +860,7 @@ def test_deflection_suppressed_repeat_review_queue_explains_hidden_rows() -> Non
         item["suppression_reason"]: item
         for item in queue["items"]
     }
+    review_keys = {item["review_key"] for item in queue["items"]}
 
     assert unresolved_questions == {"How do I configure SCIM groups?"}
     assert queue["total_item_count"] == 3
@@ -869,6 +870,8 @@ def test_deflection_suppressed_repeat_review_queue_explains_hidden_rows() -> Non
         "too_low_volume": 1,
     }
     assert set(by_reason) == set(queue["reason_counts"])
+    assert len(review_keys) == 3
+    assert all(key.startswith("review_") and len(key) == 31 for key in review_keys)
     assert by_reason["missing_question"]["question"] == ""
     assert by_reason["missing_question"]["status"] == "Low confidence"
     assert "No normalized customer question" in by_reason[
@@ -1165,6 +1168,59 @@ def test_deflection_action_identity_is_stable_when_rank_changes() -> None:
         base_actions["How do I export attribution reports?"]["repeat_key"]
         == reordered_actions["How do I export attribution reports?"]["repeat_key"]
     )
+
+
+def test_deflection_suppressed_review_key_is_stable_when_rank_changes() -> None:
+    base = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=6,
+        ticket_source_count=6,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "Can I rename one workspace?",
+                "customer_wording": "rename one workspace",
+                "topic": "workspace",
+                "weighted_frequency": 1,
+                "ticket_count": 1,
+                "opportunity_score": 20,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": ("ticket-one-off",),
+            },
+            {
+                "question": "Why did my imported contacts duplicate?",
+                "customer_wording": "contacts imported twice",
+                "topic": "imports",
+                "weighted_frequency": 5,
+                "ticket_count": 4,
+                "opportunity_score": 20,
+                "answer_evidence_status": "draft_needs_review",
+                "source_count": 1,
+                "source_ids": ("ticket-sparse-only",),
+            },
+        ),
+    )
+    reordered = TicketFAQMarkdownResult(
+        markdown=base.markdown,
+        source_count=base.source_count,
+        ticket_source_count=base.ticket_source_count,
+        output_checks=base.output_checks,
+        items=tuple(reversed(base.items)),
+    )
+
+    def review_keys_by_question(result: TicketFAQMarkdownResult) -> dict[str, str]:
+        sections = {
+            section["id"]: section
+            for section in build_deflection_report_artifact(result).report_model.as_dict()[
+                "sections"
+            ]
+        }
+        return {
+            item["question"]: item["review_key"]
+            for item in sections["suppressed_repeat_review_queue"]["data"]["items"]
+        }
+
+    assert review_keys_by_question(base) == review_keys_by_question(reordered)
 
 
 def test_deflection_action_identity_ignores_ticket_id_rollover() -> None:
@@ -1723,10 +1779,12 @@ def test_deflection_report_projection_separates_paid_and_hosted_action_fields() 
     suppressed_collection = suppressed["collection"]
     assert suppressed["record_fields"] == ["reason_counts"]
     assert {
+        "review_key",
         "suppression_reason",
         "suppression_reason_label",
     } <= set(suppressed_collection["projected_fields"])
     assert {
+        "review_key",
         "suppression_reason",
         "suppression_reason_label",
     } <= set(suppressed_collection["hosted_consumer_safe_fields"])

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -1223,6 +1223,57 @@ def test_deflection_suppressed_review_key_is_stable_when_rank_changes() -> None:
     assert review_keys_by_question(base) == review_keys_by_question(reordered)
 
 
+def test_deflection_suppressed_review_key_disambiguates_identityless_rows() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=4,
+        ticket_source_count=4,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "",
+                "customer_wording": "",
+                "topic": "",
+                "weighted_frequency": 3,
+                "ticket_count": 3,
+                "opportunity_score": 30,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": (),
+            },
+            {
+                "question": "",
+                "customer_wording": "",
+                "topic": "",
+                "weighted_frequency": 3,
+                "ticket_count": 3,
+                "opportunity_score": 25,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": (),
+            },
+        ),
+    )
+
+    sections = {
+        section["id"]: section
+        for section in build_deflection_report_artifact(result).report_model.as_dict()[
+            "sections"
+        ]
+    }
+    items = sections["suppressed_repeat_review_queue"]["data"]["items"]
+    review_keys = [item["review_key"] for item in items]
+
+    assert len(items) == 2
+    assert [item["identity_basis"] for item in items] == [
+        "insufficient_identity",
+        "insufficient_identity",
+    ]
+    assert [item["suppression_reason"] for item in items] == [
+        "missing_question",
+        "missing_question",
+    ]
+    assert len(set(review_keys)) == len(review_keys)
+
+
 def test_deflection_action_identity_ignores_ticket_id_rollover() -> None:
     base = _structured_report_fixture_result()
     next_period_items: list[dict[str, object]] = []
@@ -5094,6 +5145,78 @@ def test_stored_deflection_report_model_backfills_legacy_action_limits() -> None
             assert key in section["required_data"]
             assert key not in section_by_id[section_id]["data"]
             assert key not in section_by_id[section_id]["required_data"]
+
+
+def test_stored_deflection_report_model_backfills_legacy_suppressed_review_keys() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=4,
+        ticket_source_count=4,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "",
+                "customer_wording": "",
+                "topic": "",
+                "weighted_frequency": 3,
+                "ticket_count": 3,
+                "opportunity_score": 30,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": (),
+            },
+            {
+                "question": "",
+                "customer_wording": "",
+                "topic": "",
+                "weighted_frequency": 3,
+                "ticket_count": 3,
+                "opportunity_score": 25,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": (),
+            },
+            {
+                "question": "Can I rename one workspace?",
+                "customer_wording": "rename one workspace",
+                "topic": "workspace",
+                "weighted_frequency": 1,
+                "ticket_count": 1,
+                "opportunity_score": 20,
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": ("ticket-one-off",),
+            },
+        ),
+    )
+    artifact = build_deflection_report_artifact(result).as_dict()
+    legacy_artifact = json.loads(json.dumps(artifact))
+    expected_keys_by_rank: dict[int, str] = {}
+    legacy_section = next(
+        section
+        for section in legacy_artifact["report_model"]["sections"]
+        if section["id"] == "suppressed_repeat_review_queue"
+    )
+    original_section = next(
+        section
+        for section in artifact["report_model"]["sections"]
+        if section["id"] == "suppressed_repeat_review_queue"
+    )
+    for item in original_section["data"]["items"]:
+        expected_keys_by_rank[item["rank"]] = item["review_key"]
+    for item in legacy_section["data"]["items"]:
+        item.pop("review_key", None)
+
+    payload = stored_deflection_report_model(legacy_artifact)
+    assert payload is not None
+    section = next(
+        section
+        for section in payload["sections"]
+        if section["id"] == "suppressed_repeat_review_queue"
+    )
+    items = section["data"]["items"]
+    review_keys = [item["review_key"] for item in items]
+
+    assert review_keys == [expected_keys_by_rank[item["rank"]] for item in items]
+    assert len(set(review_keys)) == len(review_keys)
+    assert "review_key" not in legacy_section["data"]["items"][0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_generate_deflection_frontend_contract_types.py
+++ b/tests/test_generate_deflection_frontend_contract_types.py
@@ -75,6 +75,7 @@ def test_deflection_report_model_types_include_backend_projection_fields() -> No
     assert "support_cost_basis: DeflectionReportPriorityFixQueueSupportCostBasis;" in rendered
     assert "csat_signal: DeflectionReportPriorityFixQueueCsatSignal;" in rendered
     assert "top_evidence: DeflectionReportPriorityFixQueueTopEvidence[];" in rendered
+    assert "review_key: string;" in rendered
     assert "suppression_reason: string;" in rendered
     assert "suppression_reason_label: string;" in rendered
     assert "term_mappings: DeflectionReportTermMapping[];" in rendered
@@ -106,6 +107,7 @@ def test_deflection_report_model_types_publish_hosted_safe_allowlists() -> None:
         "DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = "
         "[]"
     ) in rendered
+    assert '"review_key", "suppression_reason", "suppression_reason_label"' in rendered
     assert "hosted_consumer_safe_fields: string[];" not in rendered
 
 
@@ -129,6 +131,7 @@ def test_deflection_report_model_api_contract_includes_backend_projection_fields
         'DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = '
         'Object.freeze(["rank", "repeat_key", "cluster_id"'
     ) in rendered
+    assert '"review_key"' in rendered
     assert '"suppression_reason"' in rendered
     assert '"suppression_reason_label"' in rendered
     assert '"top_evidence"' in rendered
@@ -162,6 +165,13 @@ def test_deflection_report_model_api_contract_publishes_hosted_safe_allowlists()
     assert (
         "DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = "
         "Object.freeze([])"
+    ) in rendered
+    assert (
+        'DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = '
+        'Object.freeze(["rank", "question", "status", "owner_lane", "confidence", '
+        '"recommended_action", "ticket_count", "estimated_support_cost", '
+        '"priority_score", "priority_drivers", "csat_signal", "review_key", '
+        '"suppression_reason", "suppression_reason_label"])'
     ) in rendered
 
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-Suppressed-Review-Key.md
Slice phase: Vertical slice

Adds a hosted-safe deterministic `review_key` to suppressed repeat review rows so Portfolio can persist reviewer decisions without relying on raw repeat identity fields or customer question text. Review fixes also backfill legacy stored `deflection.v1` rows and prevent identity-less suppressed rows from colliding.

## Intentional

- `repeat_key` and `cluster_id` remain paid/export-only. The browser receives only the purpose-specific `review_key`.
- Identity-less rows use the stored/report rank only as a discriminator because they lack stable question/source identity; identified rows remain identity-derived and stable across ordering changes.
- This does not add an override endpoint or persisted decision store. It only creates the safe row key needed for the next Portfolio slice.

## Deferred

- Portfolio follow-up: persist reviewer decisions keyed by `(request_id, review_key)` and render reviewed/promoted/suppressed states.
- Future ATLAS follow-up: accept reviewer decisions back into the report generation flow if overrides should regenerate exports instead of only annotating the hosted report.

## Parked hardening

None.

## AI reconciliation

- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: hosted proxy scalar fixture now preserves `review_key`.
- Fixed: stored legacy `deflection.v1` report models backfill missing suppressed-row `review_key` values at read time.
- Fixed: identity-less suppressed rows include a rank discriminator so review decisions cannot collide.
- Waived: none.

## Verification

- `python -m pytest tests/test_content_ops_deflection_report.py -k "suppressed_repeat_review_queue or suppressed_review_key or stored_deflection_report_model_backfills_legacy_suppressed_review_keys or projection_separates_paid_and_hosted_action_fields"` - passed, 5 selected.
- `npm --prefix portfolio-ui run test:deflection-atlas-proxy` - passed.
- `python -m pytest tests/test_generate_deflection_frontend_contract_types.py -k "report_model"` - passed, 11 selected.
- `python scripts/generate_deflection_frontend_contract_types.py --check` - passed.
- `ATLAS_CURRENT_PR_BODY_FILE=/tmp/deflection-suppressed-review-key-pr-body.md bash scripts/local_pr_review.sh` - passed.

## Diff size

9 files, +370 / -4.
