### PR TITLE
Generate hosted-safe report field shapes

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -813,6 +813,11 @@ _REPORT_SUPPORT_TAX_OPTIONAL_FIELDS = (
     "annualized_support_cost",
     "annualized_run_rate_support_cost",
 )
+_REPORT_SOURCE_DATE_WINDOW_FIELDS = (
+    "source_date_start",
+    "source_date_end",
+    "source_window_days",
+)
 _REPORT_SOURCE_FILE_FIELDS = ("source_label",)
 _REPORT_SEO_TARGET_FIELDS = (
     "phrases",
@@ -1018,6 +1023,12 @@ _REPORT_QUESTION_DETAIL_ROW_HOSTED_SAFE_FIELDS = (
     "steps",
     "term_mappings",
 )
+_REPORT_TERM_MAPPING_FIELDS = (
+    "customer_term",
+    "documentation_term",
+    "suggestion",
+    "source_id_count",
+)
 _REPORT_COMPLETE_EVIDENCE_FIELDS = (
     "question_count",
     "evidence_row_count",
@@ -1028,6 +1039,13 @@ _REPORT_SECTION_PROJECTION_METADATA: Mapping[str, Mapping[str, Any]] = MappingPr
     "support_tax": MappingProxyType({
         "projected_fields": _REPORT_SUPPORT_TAX_FIELDS,
         "optional_projected_fields": _REPORT_SUPPORT_TAX_OPTIONAL_FIELDS,
+        "nested_object_fields": (
+            MappingProxyType({
+                "field": "source_date_window",
+                "projected_fields": _REPORT_SOURCE_DATE_WINDOW_FIELDS,
+                "hosted_consumer_safe_fields": _REPORT_SOURCE_DATE_WINDOW_FIELDS,
+            }),
+        ),
     }),
     "source_file": MappingProxyType({
         "projected_fields": _REPORT_SOURCE_FILE_FIELDS,
@@ -1110,6 +1128,14 @@ _REPORT_SECTION_PROJECTION_METADATA: Mapping[str, Mapping[str, Any]] = MappingPr
             "projected_fields": _REPORT_QUESTION_DETAIL_ROW_FIELDS,
             "hosted_consumer_safe_fields": (
                 _REPORT_QUESTION_DETAIL_ROW_HOSTED_SAFE_FIELDS
+            ),
+            "nested_collection_fields": (
+                MappingProxyType({
+                    "field": "term_mappings",
+                    "item_type": "object",
+                    "projected_fields": _REPORT_TERM_MAPPING_FIELDS,
+                    "hosted_consumer_safe_fields": _REPORT_TERM_MAPPING_FIELDS,
+                }),
             ),
         }),
     }),
@@ -1227,6 +1253,9 @@ def _report_projection_collection_entry(metadata: Mapping[str, Any]) -> dict[str
     nested_collections = _nested_collection_entries(metadata)
     if nested_collections:
         out["nested_collection_fields"] = nested_collections
+    record_fields = _field_tuple(metadata, "record_fields")
+    if record_fields:
+        out["record_fields"] = list(record_fields)
     return out
 
 
@@ -1257,7 +1286,7 @@ def _nested_field_entries(metadata: Mapping[str, Any]) -> list[dict[str, Any]]:
         if not field:
             raise ValueError("report projection nested field missing field")
         projected_fields = _field_tuple(raw_entry, "projected_fields")
-        entries.append({
+        entry = {
             "field": field,
             "projected_fields": list(projected_fields),
             "hosted_consumer_safe_fields": list(
@@ -1267,7 +1296,11 @@ def _nested_field_entries(metadata: Mapping[str, Any]) -> list[dict[str, Any]]:
                     default=projected_fields,
                 )
             ),
-        })
+        }
+        record_fields = _field_tuple(raw_entry, "record_fields")
+        if record_fields:
+            entry["record_fields"] = list(record_fields)
+        entries.append(entry)
     return entries
 
 
@@ -1280,7 +1313,7 @@ def _nested_collection_entries(metadata: Mapping[str, Any]) -> list[dict[str, An
         if not field:
             raise ValueError("report projection nested collection missing field")
         projected_fields = _field_tuple(raw_entry, "projected_fields")
-        entries.append({
+        entry = {
             "field": field,
             "item_type": _text(raw_entry.get("item_type")) or "object",
             "projected_fields": list(projected_fields),
@@ -1291,7 +1324,11 @@ def _nested_collection_entries(metadata: Mapping[str, Any]) -> list[dict[str, An
                     default=projected_fields,
                 )
             ),
-        })
+        }
+        record_fields = _field_tuple(raw_entry, "record_fields")
+        if record_fields:
+            entry["record_fields"] = list(record_fields)
+        entries.append(entry)
     return entries
 
 

--- a/plans/PR-Deflection-Report-Hosted-Shape-Metadata.md
+++ b/plans/PR-Deflection-Report-Hosted-Shape-Metadata.md
@@ -1,0 +1,161 @@
+# PR-Deflection-Report-Hosted-Shape-Metadata
+
+## Why this slice exists
+
+#1831 made the hosted paid report projection safe and added a fail-closed
+parity test, but it intentionally left one maintenance root behind: field-shape
+knowledge still lives in code/tests instead of the generated ATLAS-owned report
+model contract.
+
+Root cause: the backend report projection contract already owns which fields are
+hosted-safe and which fields are nested objects, nested collections, records, or
+scalars. The generated frontend artifacts only expose field-name constants, so
+`report.js` and the parity fixture must infer shapes locally. #1831 made that
+inference fail closed, but future hosted-safe shape additions still require
+editing runtime and test classifiers by hand.
+
+This change fixes the root by publishing generated hosted-safe field-shape
+metadata from the ATLAS projection contract and making both the public hosted
+projection and its parity fixture consume that one generated source.
+
+Review follow-up: the shape contract also covers nullable object-shaped fields.
+`source_date_window` is hosted-safe and required-nullable, so the public
+projection must preserve `null` instead of treating it as an invalid object
+value. This slice now locks that boundary in the proxy parity test.
+
+This slice is expected to exceed the 400 LOC soft cap because the root fix has
+one small source contract change plus regenerated JavaScript and TypeScript
+artifacts. Splitting the generated outputs from the generator/runtime change
+would leave the repo in a stale-artifact state and defeat the contract gate this
+slice is adding.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-contract-1805
+Slice phase: Production hardening
+
+1. Extend the report projection metadata so hosted-safe nested object,
+   nested collection, and record shapes are represented in the backend
+   contract.
+2. Generate a `DEFLECTION_REPORT_HOSTED_FIELD_SHAPES` artifact into both
+   frontend contract outputs.
+3. Replace local runtime/test shape maps in `portfolio-ui` with the generated
+   shape artifact.
+4. Keep #1831's fail-closed behavior: unknown/unclassified shapes do not pass
+   as scalars.
+5. Preserve legitimate `null` values for hosted-safe nullable object fields.
+
+### Review Contract
+
+Acceptance criteria:
+
+1. `source_date_window`, `term_mappings`, `status_mix`, `status_counts`, and
+   `reason_counts` shapes come from generated metadata, not local maps.
+2. `publicHostedReportModel` projects scalar, scalar-array, record, object, and
+   object-array fields from `DEFLECTION_REPORT_HOSTED_FIELD_SHAPES`.
+3. The parity fixture builds expected data from the same generated shape map.
+4. Generator validation rejects hosted-safe non-scalar fields without shape
+   metadata.
+5. Generated TypeScript types still represent record and nested shapes
+   correctly.
+6. Nullable hosted-safe object fields survive as `null` instead of being
+   dropped.
+
+Affected surfaces:
+
+- Backend report projection contract metadata.
+- Frontend contract generator output.
+- Public paid report JSON proxy projection.
+- Public paid report JSON proxy parity test.
+
+Risk areas:
+
+- Generator drift between Python contract metadata and JavaScript/TypeScript
+  artifacts.
+- Accidentally broadening public projection to arbitrary objects instead of
+  allowlist-shaped fields.
+- Generated artifact churn in `portfolio-ui`.
+
+- Reviewer rules triggered: R1, R2, R5, R10, R13, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Report-Hosted-Shape-Metadata.md`
+- `portfolio-ui/api/content-ops/deflection/report-model-contract.js`
+- `portfolio-ui/api/content-ops/deflection/report.js`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+- `portfolio-ui/src/types/deflectionReportModel.ts`
+- `scripts/generate_deflection_frontend_contract_types.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_generate_deflection_frontend_contract_types.py`
+
+## Mechanism
+
+The backend projection metadata adds explicit nested field/collection entries
+for hosted-safe non-scalar fields that previously had only local runtime
+knowledge. The frontend contract generator walks each section and nested owner,
+derives each hosted-safe field's shape (`scalar`, `scalar_array`, `record`,
+`object`, or `object_array`), and emits a path-keyed
+`DEFLECTION_REPORT_HOSTED_FIELD_SHAPES` map.
+
+`report.js` then projects by owner path instead of by generated field-name
+constant plus local shape sets. For each generated shape it clones only the
+corresponding safe structure: scalars, scalar arrays, scalar-valued records,
+allowlisted nested objects, and allowlisted object arrays. Object-shaped fields
+also preserve `null` when the generated contract admits the field and the
+producer emits a legitimate nullable value.
+
+The parity fixture uses the same generated shape map to build test data and to
+assert every hosted-safe path survives. That keeps runtime projection and test
+coverage anchored to one generated contract artifact instead of parallel
+hand-maintained classifiers.
+
+## Intentional
+
+- This slice keeps the generated shape artifact path-keyed instead of emitting
+  a richer schema tree. The path map is enough to remove the dual-map drift and
+  keeps the public projection small.
+- Unknown shape values remain fail-closed in the fixture and runtime: they are
+  not treated as scalars.
+- Non-null non-object values for object-shaped fields still fail closed; only a
+  legitimate nullable `null` value is preserved.
+- This does not change the hosted public payload contract beyond preserving the
+  fields already marked hosted-safe by the ATLAS report projection contract.
+
+## Deferred
+
+- Cross-repo `atlas-portfolio` consumption of the generated report-model
+  artifact remains a separate consumer slice after the ATLAS artifact is stable.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: generator write command, python scripts/generate_deflection_frontend_contract_types.py.
+- Passed: generator check command, python scripts/generate_deflection_frontend_contract_types.py --check.
+- Passed: Python compile check for scripts/generate_deflection_frontend_contract_types.py.
+- Passed: generator pytest command for tests/test_generate_deflection_frontend_contract_types.py - 23 tests.
+- Passed: deflection report pytest command for tests/test_content_ops_deflection_report.py - 164 tests.
+- Passed: portfolio-ui deflection proxy test script - 29 tests.
+- Passed: extracted_content_pipeline manifest validation script.
+- Passed: extracted_content_pipeline Atlas reasoning import audit.
+- Passed: extracted standalone audit with fail-on-debt.
+- Passed: extracted_content_pipeline ASCII Python check.
+- Pending before push: push wrapper local review.
+  (runs the local PR review bundle through the managed push path).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 45 |
+| `plans/PR-Deflection-Report-Hosted-Shape-Metadata.md` | 161 |
+| `portfolio-ui/api/content-ops/deflection/report-model-contract.js` | 240 |
+| `portfolio-ui/api/content-ops/deflection/report.js` | 89 |
+| `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs` | 273 |
+| `portfolio-ui/src/types/deflectionReportModel.ts` | 259 |
+| `scripts/generate_deflection_frontend_contract_types.py` | 204 |
+| `tests/test_content_ops_deflection_report.py` | 72 |
+| `tests/test_generate_deflection_frontend_contract_types.py` | 96 |
+| **Total** | **1439** |

--- a/portfolio-ui/api/content-ops/deflection/report-model-contract.js
+++ b/portfolio-ui/api/content-ops/deflection/report-model-contract.js
@@ -23,6 +23,8 @@ export const DEFLECTION_REPORT_SUPPORT_TAX_SNAPSHOT_SAFE_FIELDS = Object.freeze(
 
 export const DEFLECTION_REPORT_SUPPORT_TAX_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["repeat_ticket_count", "non_repeat_ticket_count", "generated_question_count", "assisted_contact_cost", "estimated_support_cost", "source_date_window", "drafted_answer_count", "no_proven_answer_count", "ticket_source_count", "annualized_support_cost", "annualized_run_rate_support_cost"]);
 
+export const DEFLECTION_REPORT_SUPPORT_TAX_SOURCE_DATE_WINDOW_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["source_date_start", "source_date_end", "source_window_days"]);
+
 export const DEFLECTION_REPORT_SOURCE_FILE_FIELDS = Object.freeze(["source_label"]);
 
 export const DEFLECTION_REPORT_SOURCE_FILE_REQUIRED_DATA = Object.freeze(["source_label"]);
@@ -173,6 +175,8 @@ export const DEFLECTION_REPORT_QUESTION_DETAILS_HOSTED_CONSUMER_SAFE_FIELDS = Ob
 
 export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "customer_wording", "topic", "ticket_count", "weighted_frequency", "source_count", "estimated_support_cost", "answer_status", "answer_evidence_status", "resolution_evidence_scope", "answer_linkage", "answer", "steps", "term_mappings"]);
 
+export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_TERM_MAPPINGS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["customer_term", "documentation_term", "suggestion", "source_id_count"]);
+
 export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_FIELDS = Object.freeze(["rank", "question", "customer_wording", "topic", "ticket_count", "weighted_frequency", "source_count", "estimated_support_cost", "answer_status", "answer_evidence_status", "resolution_evidence_scope", "answer_linkage", "answer", "steps", "term_mappings", "source_ids", "evidence_quotes", "outcome_diagnostics"]);
 
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_FIELDS = Object.freeze(["question_count", "evidence_row_count", "source_id_count", "surfaces"]);
@@ -182,3 +186,239 @@ export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_REQUIRED_DATA = Object.freeze([
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_SNAPSHOT_SAFE_FIELDS = Object.freeze([]);
 
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
+
+export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
+  "already_covered_still_recurring": Object.freeze({
+    "items": "object_array",
+    "top_item_count": "scalar",
+  }),
+  "already_covered_still_recurring.items": Object.freeze({
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  }),
+  "already_covered_still_recurring.items.csat_signal": Object.freeze({
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  }),
+  "backlog_table": Object.freeze({
+    "items": "object_array",
+    "total_item_count": "scalar",
+    "default_limit": "scalar",
+  }),
+  "backlog_table.items": Object.freeze({
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  }),
+  "backlog_table.items.csat_signal": Object.freeze({
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  }),
+  "drafted_resolutions": Object.freeze({
+    "items": "object_array",
+    "top_item_count": "scalar",
+  }),
+  "drafted_resolutions.items": Object.freeze({
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  }),
+  "drafted_resolutions.items.csat_signal": Object.freeze({
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  }),
+  "outcome_diagnostics": Object.freeze({
+    "outcome_diagnostic_ticket_count": "scalar",
+    "outcome_risk_ticket_count": "scalar",
+    "reopened_ticket_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "rows": "object_array",
+  }),
+  "outcome_diagnostics.rows": Object.freeze({
+    "question": "scalar",
+    "status_mix": "scalar",
+    "reopened_ticket_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "guidance": "scalar",
+  }),
+  "priority_fix_queue": Object.freeze({
+    "items": "object_array",
+    "status_counts": "record",
+    "result_page_limit": "scalar",
+    "pdf_limit": "scalar",
+    "backlog_limit": "scalar",
+    "support_cost_basis": "object",
+  }),
+  "priority_fix_queue.items": Object.freeze({
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  }),
+  "priority_fix_queue.items.csat_signal": Object.freeze({
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  }),
+  "priority_fix_queue.support_cost_basis": Object.freeze({
+    "status": "scalar",
+  }),
+  "question_details": Object.freeze({
+    "rows": "object_array",
+  }),
+  "question_details.rows": Object.freeze({
+    "rank": "scalar",
+    "question": "scalar",
+    "customer_wording": "scalar",
+    "topic": "scalar",
+    "ticket_count": "scalar",
+    "weighted_frequency": "scalar",
+    "source_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "answer_status": "scalar",
+    "answer_evidence_status": "scalar",
+    "resolution_evidence_scope": "scalar",
+    "answer_linkage": "scalar",
+    "answer": "scalar",
+    "steps": "scalar_array",
+    "term_mappings": "object_array",
+  }),
+  "question_details.rows.term_mappings": Object.freeze({
+    "customer_term": "scalar",
+    "documentation_term": "scalar",
+    "suggestion": "scalar",
+    "source_id_count": "scalar",
+  }),
+  "ranked_questions": Object.freeze({
+    "rows": "object_array",
+  }),
+  "ranked_questions.rows": Object.freeze({
+    "rank": "scalar",
+    "question": "scalar",
+    "ticket_count": "scalar",
+    "weighted_frequency": "scalar",
+    "customer_wording": "scalar",
+    "estimated_support_cost": "scalar",
+    "opportunity_score": "scalar",
+    "answer_status": "scalar",
+    "source_proof": "scalar",
+  }),
+  "seo_targets": Object.freeze({
+    "phrases": "scalar_array",
+    "total_phrase_count": "scalar",
+    "displayed_phrase_count": "scalar",
+    "omitted_phrase_count": "scalar",
+    "limit": "scalar",
+  }),
+  "support_tax": Object.freeze({
+    "repeat_ticket_count": "scalar",
+    "non_repeat_ticket_count": "scalar",
+    "generated_question_count": "scalar",
+    "assisted_contact_cost": "scalar",
+    "estimated_support_cost": "scalar",
+    "source_date_window": "object",
+    "drafted_answer_count": "scalar",
+    "no_proven_answer_count": "scalar",
+    "ticket_source_count": "scalar",
+    "annualized_support_cost": "scalar",
+    "annualized_run_rate_support_cost": "scalar",
+  }),
+  "support_tax.source_date_window": Object.freeze({
+    "source_date_start": "scalar",
+    "source_date_end": "scalar",
+    "source_window_days": "scalar",
+  }),
+  "suppressed_repeat_review_queue": Object.freeze({
+    "items": "object_array",
+    "total_item_count": "scalar",
+    "default_limit": "scalar",
+    "reason_counts": "record",
+  }),
+  "suppressed_repeat_review_queue.items": Object.freeze({
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+    "suppression_reason": "scalar",
+    "suppression_reason_label": "scalar",
+  }),
+  "suppressed_repeat_review_queue.items.csat_signal": Object.freeze({
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  }),
+  "top_unresolved_repeats": Object.freeze({
+    "items": "object_array",
+    "top_item_count": "scalar",
+    "support_cost_basis": "object",
+  }),
+  "top_unresolved_repeats.items": Object.freeze({
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  }),
+  "top_unresolved_repeats.items.csat_signal": Object.freeze({
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  }),
+  "top_unresolved_repeats.support_cost_basis": Object.freeze({
+    "status": "scalar",
+  }),
+});

--- a/portfolio-ui/api/content-ops/deflection/report.js
+++ b/portfolio-ui/api/content-ops/deflection/report.js
@@ -2,36 +2,14 @@ import { clean, loadDeflectionReport, proxyErrorPublicPayload } from "./atlas-re
 import * as reportModelContract from "./report-model-contract.js";
 
 const DEFLECTION_REPORT_SECTION_ID_SET = new Set(reportModelContract.DEFLECTION_REPORT_SECTION_IDS);
-const HOSTED_SAFE_RECORD_FIELDS = new Set([
-  "reason_counts",
-  "source_date_window",
-  "status_counts",
-  "status_mix",
-]);
-const HOSTED_SAFE_OBJECT_ARRAY_FIELDS = Object.freeze({
-  term_mappings: Object.freeze([
-    "customer_term",
-    "documentation_term",
-    "suggestion",
-    "source_id_count",
-  ]),
-});
 
 function isObjectRecord(value) {
   return value && typeof value === "object" && !Array.isArray(value);
 }
 
-function fieldConstToken(field) {
-  return String(field).toUpperCase().replace(/[^A-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
-}
-
-function sectionConstPrefix(sectionId) {
-  return `DEFLECTION_REPORT_${fieldConstToken(sectionId)}`;
-}
-
-function generatedFields(name) {
-  const fields = reportModelContract[name];
-  return Array.isArray(fields) ? fields : [];
+function hostedFieldShapes(ownerPath) {
+  const shapes = reportModelContract.DEFLECTION_REPORT_HOSTED_FIELD_SHAPES?.[ownerPath];
+  return isObjectRecord(shapes) ? shapes : {};
 }
 
 function cloneScalar(value) {
@@ -68,51 +46,34 @@ function cloneScalarRecord(value) {
   return cloned;
 }
 
-function projectKnownObjectArray(field, value) {
-  const fields = HOSTED_SAFE_OBJECT_ARRAY_FIELDS[field];
-  if (!fields || !Array.isArray(value)) return undefined;
-  return value
-    .filter(isObjectRecord)
-    .map((item) => projectHostedFields(item, fields, `${fieldConstToken(field)}_ITEM`));
-}
-
-function projectHostedFields(record, fields, prefix) {
+function projectHostedFields(record, ownerPath) {
   if (!isObjectRecord(record)) return {};
   const projected = {};
-  for (const field of fields) {
+  for (const [field, shape] of Object.entries(hostedFieldShapes(ownerPath))) {
     if (!Object.prototype.hasOwnProperty.call(record, field)) continue;
     const value = record[field];
-    const nestedPrefix = `${prefix}_${fieldConstToken(field)}`;
-    const nestedFields = generatedFields(`${nestedPrefix}_HOSTED_CONSUMER_SAFE_FIELDS`);
-    if (nestedFields.length > 0) {
+    const nestedPath = `${ownerPath}.${field}`;
+    if (shape === "object") {
+      if (value === null) {
+        projected[field] = null;
+      } else if (isObjectRecord(value)) {
+        projected[field] = projectHostedFields(value, nestedPath);
+      }
+    } else if (shape === "object_array") {
       if (Array.isArray(value)) {
         projected[field] = value
           .filter(isObjectRecord)
-          .map((item) => projectHostedFields(item, nestedFields, nestedPrefix));
-      } else if (isObjectRecord(value)) {
-        projected[field] = projectHostedFields(value, nestedFields, nestedPrefix);
+          .map((item) => projectHostedFields(item, nestedPath));
       }
-      continue;
-    }
-
-    const scalar = cloneScalar(value);
-    if (scalar !== undefined) {
-      projected[field] = scalar;
-      continue;
-    }
-    const scalarArray = cloneScalarArray(value);
-    if (scalarArray !== undefined) {
-      projected[field] = scalarArray;
-      continue;
-    }
-    if (HOSTED_SAFE_RECORD_FIELDS.has(field)) {
-      const scalarRecord = cloneScalarRecord(value);
-      if (scalarRecord !== undefined) projected[field] = scalarRecord;
-      continue;
-    }
-    const objectArray = projectKnownObjectArray(field, value);
-    if (objectArray !== undefined) {
-      projected[field] = objectArray;
+    } else if (shape === "record") {
+      const recordValue = cloneScalarRecord(value);
+      if (recordValue !== undefined) projected[field] = recordValue;
+    } else if (shape === "scalar_array") {
+      const scalarArray = cloneScalarArray(value);
+      if (scalarArray !== undefined) projected[field] = scalarArray;
+    } else if (shape === "scalar") {
+      const scalar = cloneScalar(value);
+      if (scalar !== undefined) projected[field] = scalar;
     }
   }
   return projected;
@@ -125,8 +86,6 @@ function publicHostedReportModel(model) {
     if (!isObjectRecord(section)) continue;
     const sectionId = clean(section.id);
     if (!DEFLECTION_REPORT_SECTION_ID_SET.has(sectionId)) continue;
-    const prefix = sectionConstPrefix(sectionId);
-    const hostedFields = generatedFields(`${prefix}_HOSTED_CONSUMER_SAFE_FIELDS`);
     sections.push({
       id: sectionId,
       title: clean(section.title),
@@ -139,7 +98,7 @@ function publicHostedReportModel(model) {
         : null,
       required_data: cloneScalarArray(section.required_data) || [],
       snapshot_safe_fields: cloneScalarArray(section.snapshot_safe_fields) || [],
-      data: projectHostedFields(section.data, hostedFields, prefix),
+      data: projectHostedFields(section.data, sectionId),
     });
   }
   return {

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -209,95 +209,17 @@ function withEnv(nextEnv, fn) {
     });
 }
 
-const HOSTED_SAFE_SCALAR_FIELDS = new Set([
-  "annualized_run_rate_support_cost",
-  "annualized_support_cost",
-  "answer",
-  "answer_evidence_status",
-  "answer_linkage",
-  "answer_status",
-  "assisted_contact_cost",
-  "backlog_limit",
-  "confidence",
-  "csat_present_count",
-  "customer_wording",
-  "default_limit",
-  "displayed_phrase_count",
-  "drafted_answer_count",
-  "estimated_support_cost",
-  "generated_question_count",
-  "guidance",
-  "limit",
-  "negative_csat_ticket_count",
-  "no_proven_answer_count",
-  "non_repeat_ticket_count",
-  "numeric_average",
-  "omitted_phrase_count",
-  "opportunity_score",
-  "outcome_diagnostic_ticket_count",
-  "outcome_risk_ticket_count",
-  "owner_lane",
-  "pdf_limit",
-  "priority_score",
-  "question",
-  "rank",
-  "recommended_action",
-  "reopened_ticket_count",
-  "repeat_ticket_count",
-  "resolution_evidence_scope",
-  "result_page_limit",
-  "source_count",
-  "source_proof",
-  "status",
-  "suppression_reason",
-  "suppression_reason_label",
-  "ticket_count",
-  "ticket_source_count",
-  "top_item_count",
-  "topic",
-  "total_item_count",
-  "total_phrase_count",
-  "weighted_frequency",
-]);
-
-const HOSTED_SAFE_SCALAR_ARRAY_FIELDS = new Set(["phrases", "priority_drivers", "steps"]);
-const HOSTED_SAFE_RECORD_FIELDS = new Set([
-  "reason_counts",
-  "source_date_window",
-  "status_counts",
-  "status_mix",
-]);
-const HOSTED_SAFE_OBJECT_ARRAY_FIELDS = Object.freeze({
-  term_mappings: Object.freeze([
-    "customer_term",
-    "documentation_term",
-    "suggestion",
-    "source_id_count",
-  ]),
-});
-const HOSTED_SAFE_OBJECT_CONTAINERS = new Set(["csat_signal", "support_cost_basis"]);
-const HOSTED_SAFE_ARRAY_CONTAINERS = new Set(["items", "rows"]);
 const HOSTED_SAFE_PRIVATE_MARKER = "hosted-safe-private-marker";
 
-function fieldConstToken(field) {
-  return String(field).toUpperCase().replace(/[^A-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
-}
-
-function sectionConstPrefix(sectionId) {
-  return `DEFLECTION_REPORT_${fieldConstToken(sectionId)}`;
-}
-
-function generatedFields(name) {
-  const fields = reportModelContract[name];
-  return Array.isArray(fields) ? fields : [];
-}
-
 function scalarHostedValue(field, variant) {
+  if (field === "source_date_start") return "2026-06-01";
+  if (field === "source_date_end") return "2026-06-30";
   if (
     field === "rank" ||
     field === "limit" ||
     field.endsWith("_count") ||
     field.endsWith("_cost") ||
+    field.endsWith("_days") ||
     field.endsWith("_frequency") ||
     field.endsWith("_limit") ||
     field.endsWith("_score") ||
@@ -308,61 +230,34 @@ function scalarHostedValue(field, variant) {
   return `${field} value ${variant}`;
 }
 
-function hostedLeafValue(field, variant) {
-  if (HOSTED_SAFE_SCALAR_FIELDS.has(field)) return scalarHostedValue(field, variant);
-  if (HOSTED_SAFE_SCALAR_ARRAY_FIELDS.has(field)) {
-    return [`${field} value ${variant}`, `${field} follow-up ${variant}`];
-  }
-  if (field === "source_date_window") {
-    return {
-      source_date_start: "2026-06-01",
-      source_date_end: "2026-06-30",
-      source_window_days: 30 + variant,
-    };
-  }
-  if (HOSTED_SAFE_RECORD_FIELDS.has(field)) {
-    return { solved: 3 + variant, reopened: 1 + variant };
-  }
-  if (HOSTED_SAFE_OBJECT_ARRAY_FIELDS[field]) {
-    return [
-      {
-        customer_term: `billing reset ${variant}`,
-        documentation_term: `billing access reset ${variant}`,
-        suggestion: `Use customer wording in the help-center title ${variant}.`,
-        source_id_count: 2 + variant,
-        source_ids: [HOSTED_SAFE_PRIVATE_MARKER],
-      },
-      {
-        customer_term: `refund receipt ${variant}`,
-        documentation_term: `refund confirmation ${variant}`,
-        suggestion: `Mirror receipt language in the billing article ${variant}.`,
-        source_id_count: 4 + variant,
-        source_ids: [HOSTED_SAFE_PRIVATE_MARKER],
-      },
-    ];
-  }
-  return { unclassified_hosted_safe_shape: field };
+function hostedFieldShapes(ownerPath) {
+  const shapes = reportModelContract.DEFLECTION_REPORT_HOSTED_FIELD_SHAPES?.[ownerPath];
+  return shapes && typeof shapes === "object" && !Array.isArray(shapes) ? shapes : {};
 }
 
-function buildHostedRecord(fields, prefix, variant = 1) {
+function buildHostedRecord(ownerPath, variant = 1) {
   const record = {};
-  for (const field of fields) {
-    const nestedPrefix = `${prefix}_${fieldConstToken(field)}`;
-    const nestedFields = generatedFields(`${nestedPrefix}_HOSTED_CONSUMER_SAFE_FIELDS`);
-    if (nestedFields.length > 0) {
-      if (HOSTED_SAFE_ARRAY_CONTAINERS.has(field)) {
-        record[field] = [
-          buildHostedRecord(nestedFields, nestedPrefix, 1),
-          buildHostedRecord(nestedFields, nestedPrefix, 2),
-        ];
-      } else if (HOSTED_SAFE_OBJECT_CONTAINERS.has(field)) {
-        record[field] = buildHostedRecord(nestedFields, nestedPrefix, variant);
-      } else {
-        record[field] = { unclassified_hosted_safe_container: field };
-      }
-      continue;
+  for (const [field, shape] of Object.entries(hostedFieldShapes(ownerPath))) {
+    const nestedPath = `${ownerPath}.${field}`;
+    if (shape === "object") {
+      record[field] = buildHostedRecord(nestedPath, variant);
+    } else if (shape === "object_array") {
+      record[field] = [1, 2].map((nestedVariant) => {
+        const item = buildHostedRecord(nestedPath, nestedVariant);
+        if (field === "term_mappings") {
+          item.source_ids = [HOSTED_SAFE_PRIVATE_MARKER];
+        }
+        return item;
+      });
+    } else if (shape === "record") {
+      record[field] = { solved: 3 + variant, reopened: 1 + variant };
+    } else if (shape === "scalar_array") {
+      record[field] = [`${field} value ${variant}`, `${field} follow-up ${variant}`];
+    } else if (shape === "scalar") {
+      record[field] = scalarHostedValue(field, variant);
+    } else {
+      record[field] = { unclassified_hosted_safe_shape: shape };
     }
-    record[field] = hostedLeafValue(field, variant);
   }
   return record;
 }
@@ -377,7 +272,6 @@ function buildCompleteHostedReportModelFixture() {
       private_note: HOSTED_SAFE_PRIVATE_MARKER,
     },
     sections: reportModelContract.DEFLECTION_REPORT_SECTION_IDS.map((sectionId, index) => {
-      const prefix = sectionConstPrefix(sectionId);
       return {
         id: sectionId,
         title: `${sectionId} section`,
@@ -386,69 +280,41 @@ function buildCompleteHostedReportModelFixture() {
         default_limit: 5 + index,
         required_data: ["fixture"],
         snapshot_safe_fields: [],
-        data: buildHostedRecord(
-          generatedFields(`${prefix}_HOSTED_CONSUMER_SAFE_FIELDS`),
-          prefix,
-        ),
+        data: buildHostedRecord(sectionId),
       };
     }),
   };
 }
 
-function assertObjectArrayFieldSurvives(projectedValue, expectedValue, fields, path) {
-  assert.equal(Array.isArray(projectedValue), true, `${path} must stay an array`);
-  assert.equal(projectedValue.length, expectedValue.length, `${path} length`);
-  for (const [index, expectedItem] of expectedValue.entries()) {
-    const projectedItem = projectedValue[index];
-    for (const field of fields) {
-      assert.deepEqual(projectedItem[field], expectedItem[field], `${path}.${index}.${field}`);
-    }
-    assert.equal("source_ids" in projectedItem, false, `${path}.${index}.source_ids must stay private`);
-  }
-}
-
-function assertHostedFieldsSurvive(projected, expected, fields, prefix, path) {
-  for (const field of fields) {
-    const nestedPrefix = `${prefix}_${fieldConstToken(field)}`;
-    const nestedFields = generatedFields(`${nestedPrefix}_HOSTED_CONSUMER_SAFE_FIELDS`);
+function assertHostedFieldsSurvive(projected, expected, ownerPath, path) {
+  for (const [field, shape] of Object.entries(hostedFieldShapes(ownerPath))) {
     assert.equal(Object.prototype.hasOwnProperty.call(projected, field), true, `${path}.${field}`);
-
-    if (nestedFields.length > 0) {
-      if (HOSTED_SAFE_ARRAY_CONTAINERS.has(field)) {
-        assert.equal(Array.isArray(projected[field]), true, `${path}.${field} must stay an array`);
-        assert.equal(projected[field].length, expected[field].length, `${path}.${field} length`);
-        for (const [index, expectedItem] of expected[field].entries()) {
-          assertHostedFieldsSurvive(
-            projected[field][index],
-            expectedItem,
-            nestedFields,
-            nestedPrefix,
-            `${path}.${field}.${index}`,
-          );
-        }
-      } else {
+    const nestedPath = `${ownerPath}.${field}`;
+    if (shape === "object") {
+      if (expected[field] === null) {
+        assert.equal(projected[field], null, `${path}.${field}`);
+        continue;
+      }
+      assertHostedFieldsSurvive(projected[field], expected[field], nestedPath, `${path}.${field}`);
+    } else if (shape === "object_array") {
+      assert.equal(Array.isArray(projected[field]), true, `${path}.${field} must stay an array`);
+      assert.equal(projected[field].length, expected[field].length, `${path}.${field} length`);
+      for (const [index, expectedItem] of expected[field].entries()) {
         assertHostedFieldsSurvive(
-          projected[field],
-          expected[field],
-          nestedFields,
-          nestedPrefix,
-          `${path}.${field}`,
+          projected[field][index],
+          expectedItem,
+          nestedPath,
+          `${path}.${field}.${index}`,
+        );
+        assert.equal(
+          "source_ids" in projected[field][index],
+          false,
+          `${path}.${field}.${index}.source_ids must stay private`,
         );
       }
-      continue;
+    } else {
+      assert.deepEqual(projected[field], expected[field], `${path}.${field}`);
     }
-
-    if (HOSTED_SAFE_OBJECT_ARRAY_FIELDS[field]) {
-      assertObjectArrayFieldSurvives(
-        projected[field],
-        expected[field],
-        HOSTED_SAFE_OBJECT_ARRAY_FIELDS[field],
-        `${path}.${field}`,
-      );
-      continue;
-    }
-
-    assert.deepEqual(projected[field], expected[field], `${path}.${field}`);
   }
 }
 
@@ -699,17 +565,39 @@ await test("public hosted report projection preserves every generated hosted-saf
     assert.deepEqual(projectedSection.surfaces, expectedSection.surfaces);
     assert.deepEqual(projectedSection.required_data, expectedSection.required_data);
     assert.deepEqual(projectedSection.snapshot_safe_fields, expectedSection.snapshot_safe_fields);
-    const prefix = sectionConstPrefix(expectedSection.id);
     assertHostedFieldsSurvive(
       projectedSection.data,
       expectedSection.data,
-      generatedFields(`${prefix}_HOSTED_CONSUMER_SAFE_FIELDS`),
-      prefix,
+      expectedSection.id,
       expectedSection.id,
     );
   }
 
   assert.equal(JSON.stringify(projected).includes(HOSTED_SAFE_PRIVATE_MARKER), false);
+});
+
+await test("public hosted report projection preserves nullable hosted object fields", () => {
+  const reportModel = buildCompleteHostedReportModelFixture();
+  const supportTax = reportModel.sections.find((section) => section.id === "support_tax");
+  assert.ok(supportTax, "support_tax section");
+  supportTax.data.source_date_window = null;
+
+  const projected = publicHostedReportModel(reportModel);
+  const projectedSupportTax = projected.sections.find((section) => section.id === "support_tax");
+  assert.ok(projectedSupportTax, "projected support_tax section");
+
+  assertHostedFieldsSurvive(
+    projectedSupportTax.data,
+    supportTax.data,
+    "support_tax",
+    "support_tax",
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(projectedSupportTax.data, "source_date_window"),
+    true,
+    "support_tax.source_date_window",
+  );
+  assert.equal(projectedSupportTax.data.source_date_window, null);
 });
 
 await test("public report API returns only hosted-safe paid report model after unlock", async () => {
@@ -839,10 +727,7 @@ await test("public report API returns only hosted-safe paid report model after u
             rows: [
               {
                 question: "How do I reset billing access?",
-                status_mix: {
-                  reopened: 2,
-                  solved: 3,
-                },
+                status_mix: "reopened: 2, solved: 3",
                 reopened_ticket_count: 2,
                 negative_csat_ticket_count: 1,
                 guidance: "Review billing reset workflow.",
@@ -880,7 +765,7 @@ await test("public report API returns only hosted-safe paid report model after u
     assert.match(encoded, /billing access reset/);
     assert.match(encoded, /Use customer wording in the help-center title/);
     assert.match(encoded, /"status_counts":\{"Needs answer":1\}/);
-    assert.match(encoded, /"status_mix":\{"reopened":2,"solved":3\}/);
+    assert.match(encoded, /"status_mix":"reopened: 2, solved: 3"/);
     for (const forbidden of [
       "raw markdown must not reach browser JSON",
       "faq_result",

--- a/portfolio-ui/src/types/deflectionReportModel.ts
+++ b/portfolio-ui/src/types/deflectionReportModel.ts
@@ -23,6 +23,8 @@ export const DEFLECTION_REPORT_SUPPORT_TAX_SNAPSHOT_SAFE_FIELDS = ["repeat_ticke
 
 export const DEFLECTION_REPORT_SUPPORT_TAX_HOSTED_CONSUMER_SAFE_FIELDS = ["repeat_ticket_count", "non_repeat_ticket_count", "generated_question_count", "assisted_contact_cost", "estimated_support_cost", "source_date_window", "drafted_answer_count", "no_proven_answer_count", "ticket_source_count", "annualized_support_cost", "annualized_run_rate_support_cost"] as const;
 
+export const DEFLECTION_REPORT_SUPPORT_TAX_SOURCE_DATE_WINDOW_HOSTED_CONSUMER_SAFE_FIELDS = ["source_date_start", "source_date_end", "source_window_days"] as const;
+
 export const DEFLECTION_REPORT_SOURCE_FILE_FIELDS = ["source_label"] as const;
 
 export const DEFLECTION_REPORT_SOURCE_FILE_REQUIRED_DATA = ["source_label"] as const;
@@ -173,6 +175,8 @@ export const DEFLECTION_REPORT_QUESTION_DETAILS_HOSTED_CONSUMER_SAFE_FIELDS = ["
 
 export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "customer_wording", "topic", "ticket_count", "weighted_frequency", "source_count", "estimated_support_cost", "answer_status", "answer_evidence_status", "resolution_evidence_scope", "answer_linkage", "answer", "steps", "term_mappings"] as const;
 
+export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_TERM_MAPPINGS_HOSTED_CONSUMER_SAFE_FIELDS = ["customer_term", "documentation_term", "suggestion", "source_id_count"] as const;
+
 export const DEFLECTION_REPORT_QUESTION_DETAILS_ROWS_FIELDS = ["rank", "question", "customer_wording", "topic", "ticket_count", "weighted_frequency", "source_count", "estimated_support_cost", "answer_status", "answer_evidence_status", "resolution_evidence_scope", "answer_linkage", "answer", "steps", "term_mappings", "source_ids", "evidence_quotes", "outcome_diagnostics"] as const;
 
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_FIELDS = ["question_count", "evidence_row_count", "source_id_count", "surfaces"] as const;
@@ -182,6 +186,242 @@ export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_REQUIRED_DATA = ["question_coun
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_SNAPSHOT_SAFE_FIELDS = [] as const;
 
 export const DEFLECTION_REPORT_COMPLETE_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
+
+export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
+  "already_covered_still_recurring": {
+    "items": "object_array",
+    "top_item_count": "scalar",
+  },
+  "already_covered_still_recurring.items": {
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  },
+  "already_covered_still_recurring.items.csat_signal": {
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  },
+  "backlog_table": {
+    "items": "object_array",
+    "total_item_count": "scalar",
+    "default_limit": "scalar",
+  },
+  "backlog_table.items": {
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  },
+  "backlog_table.items.csat_signal": {
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  },
+  "drafted_resolutions": {
+    "items": "object_array",
+    "top_item_count": "scalar",
+  },
+  "drafted_resolutions.items": {
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  },
+  "drafted_resolutions.items.csat_signal": {
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  },
+  "outcome_diagnostics": {
+    "outcome_diagnostic_ticket_count": "scalar",
+    "outcome_risk_ticket_count": "scalar",
+    "reopened_ticket_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "rows": "object_array",
+  },
+  "outcome_diagnostics.rows": {
+    "question": "scalar",
+    "status_mix": "scalar",
+    "reopened_ticket_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "guidance": "scalar",
+  },
+  "priority_fix_queue": {
+    "items": "object_array",
+    "status_counts": "record",
+    "result_page_limit": "scalar",
+    "pdf_limit": "scalar",
+    "backlog_limit": "scalar",
+    "support_cost_basis": "object",
+  },
+  "priority_fix_queue.items": {
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  },
+  "priority_fix_queue.items.csat_signal": {
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  },
+  "priority_fix_queue.support_cost_basis": {
+    "status": "scalar",
+  },
+  "question_details": {
+    "rows": "object_array",
+  },
+  "question_details.rows": {
+    "rank": "scalar",
+    "question": "scalar",
+    "customer_wording": "scalar",
+    "topic": "scalar",
+    "ticket_count": "scalar",
+    "weighted_frequency": "scalar",
+    "source_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "answer_status": "scalar",
+    "answer_evidence_status": "scalar",
+    "resolution_evidence_scope": "scalar",
+    "answer_linkage": "scalar",
+    "answer": "scalar",
+    "steps": "scalar_array",
+    "term_mappings": "object_array",
+  },
+  "question_details.rows.term_mappings": {
+    "customer_term": "scalar",
+    "documentation_term": "scalar",
+    "suggestion": "scalar",
+    "source_id_count": "scalar",
+  },
+  "ranked_questions": {
+    "rows": "object_array",
+  },
+  "ranked_questions.rows": {
+    "rank": "scalar",
+    "question": "scalar",
+    "ticket_count": "scalar",
+    "weighted_frequency": "scalar",
+    "customer_wording": "scalar",
+    "estimated_support_cost": "scalar",
+    "opportunity_score": "scalar",
+    "answer_status": "scalar",
+    "source_proof": "scalar",
+  },
+  "seo_targets": {
+    "phrases": "scalar_array",
+    "total_phrase_count": "scalar",
+    "displayed_phrase_count": "scalar",
+    "omitted_phrase_count": "scalar",
+    "limit": "scalar",
+  },
+  "support_tax": {
+    "repeat_ticket_count": "scalar",
+    "non_repeat_ticket_count": "scalar",
+    "generated_question_count": "scalar",
+    "assisted_contact_cost": "scalar",
+    "estimated_support_cost": "scalar",
+    "source_date_window": "object",
+    "drafted_answer_count": "scalar",
+    "no_proven_answer_count": "scalar",
+    "ticket_source_count": "scalar",
+    "annualized_support_cost": "scalar",
+    "annualized_run_rate_support_cost": "scalar",
+  },
+  "support_tax.source_date_window": {
+    "source_date_start": "scalar",
+    "source_date_end": "scalar",
+    "source_window_days": "scalar",
+  },
+  "suppressed_repeat_review_queue": {
+    "items": "object_array",
+    "total_item_count": "scalar",
+    "default_limit": "scalar",
+    "reason_counts": "record",
+  },
+  "suppressed_repeat_review_queue.items": {
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+    "suppression_reason": "scalar",
+    "suppression_reason_label": "scalar",
+  },
+  "suppressed_repeat_review_queue.items.csat_signal": {
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  },
+  "top_unresolved_repeats": {
+    "items": "object_array",
+    "top_item_count": "scalar",
+    "support_cost_basis": "object",
+  },
+  "top_unresolved_repeats.items": {
+    "rank": "scalar",
+    "question": "scalar",
+    "status": "scalar",
+    "owner_lane": "scalar",
+    "confidence": "scalar",
+    "recommended_action": "scalar",
+    "ticket_count": "scalar",
+    "estimated_support_cost": "scalar",
+    "priority_score": "scalar",
+    "priority_drivers": "scalar_array",
+    "csat_signal": "object",
+  },
+  "top_unresolved_repeats.items.csat_signal": {
+    "status": "scalar",
+    "csat_present_count": "scalar",
+    "negative_csat_ticket_count": "scalar",
+    "numeric_average": "scalar",
+  },
+  "top_unresolved_repeats.support_cost_basis": {
+    "status": "scalar",
+  },
+} as const;
 
 export type DeflectionReportSourceDateWindow = {
   source_date_start: string | null;
@@ -206,13 +446,19 @@ export type DeflectionReportQuestionOutcomeDiagnostics = {
   csat_score_average?: number | null;
 };
 
+export type DeflectionReportSupportTaxSourceDateWindow = {
+  source_date_start: string | null;
+  source_date_end: string | null;
+  source_window_days: number | null;
+};
+
 export type DeflectionReportSupportTaxData = {
   repeat_ticket_count: number;
   non_repeat_ticket_count: number;
   generated_question_count: number;
   assisted_contact_cost: number;
   estimated_support_cost: number;
-  source_date_window: DeflectionReportSourceDateWindow | null;
+  source_date_window: DeflectionReportSupportTaxSourceDateWindow | null;
   drafted_answer_count: number;
   no_proven_answer_count: number;
   ticket_source_count: number;
@@ -585,7 +831,7 @@ export type DeflectionReportBacklogTableSection = {
 
 export type DeflectionReportOutcomeDiagnosticsRow = {
   question: string;
-  status_mix: Record<string, number>;
+  status_mix: string;
   reopened_ticket_count: number;
   negative_csat_ticket_count: number;
   guidance: string;
@@ -667,6 +913,13 @@ export type DeflectionReportSuppressedRepeatReviewQueueSection = {
   data: DeflectionReportSuppressedRepeatReviewQueueData;
 };
 
+export type DeflectionReportQuestionDetailsTermMappings = {
+  customer_term: string;
+  documentation_term: string;
+  suggestion: string;
+  source_id_count: number;
+};
+
 export type DeflectionReportQuestionDetailsRow = {
   rank: number;
   question: string;
@@ -682,7 +935,7 @@ export type DeflectionReportQuestionDetailsRow = {
   answer_linkage: string;
   answer: string;
   steps: string[];
-  term_mappings: DeflectionReportTermMapping[];
+  term_mappings: DeflectionReportQuestionDetailsTermMappings[];
   source_ids: string[];
   evidence_quotes: string[];
   outcome_diagnostics: DeflectionReportQuestionOutcomeDiagnostics | null;

--- a/scripts/generate_deflection_frontend_contract_types.py
+++ b/scripts/generate_deflection_frontend_contract_types.py
@@ -36,10 +36,12 @@ TYPE_BY_FIELD = {
     "body_withheld": "boolean",
     "cluster_id": "string",
     "confidence": "string",
+    "customer_term": "string",
     "customer_wording": "string",
     "csat_present_count": "number",
     "default_limit": "number",
     "displayed_phrase_count": "number",
+    "documentation_term": "string",
     "drafted_answer_count": "number",
     "estimated_support_cost": "number",
     "evidence_row_count": "number",
@@ -78,6 +80,7 @@ TYPE_BY_FIELD = {
     "repeat_ticket_count": "number",
     "repeat_key": "string",
     "representative_phrasing": "string",
+    "reason_counts": "Record<string, number>",
     "resolution_evidence_scope": "string",
     "result_page_limit": "number",
     "source": "string",
@@ -92,7 +95,8 @@ TYPE_BY_FIELD = {
     "source_proof": "string",
     "source_window_days": "number | null",
     "status": "string",
-    "status_mix": "Record<string, number>",
+    "status_counts": "Record<string, number>",
+    "status_mix": "string",
     "step_count": "number",
     "steps": "string[]",
     "suppression_reason": "string",
@@ -101,6 +105,7 @@ TYPE_BY_FIELD = {
     "support_cost_source": "string",
     "support_ticket_resolution_evidence_count": "number",
     "support_ticket_resolution_evidence_present": "boolean",
+    "suggestion": "string",
     "surfaces": "string[]",
     "term_mappings": "DeflectionReportTermMapping[]",
     "ticket_count": "number",
@@ -442,17 +447,7 @@ def _report_projection_metadata(contract: Mapping[str, Any] | None = None) -> di
 
         projected_fields = _projected_fields(section)
         optional_fields = _optional_projected_fields(section)
-        record_fields = section.get("record_fields", [])
-        if not isinstance(record_fields, list) or not all(
-            isinstance(field, str) for field in record_fields
-        ):
-            raise ValueError(f"report_projection section {section_id!r} has invalid record_fields")
-        unknown_records = [field for field in record_fields if field not in projected_fields]
-        if unknown_records:
-            raise ValueError(
-                f"record fields are not projected for {section_id!r}: "
-                + ", ".join(unknown_records)
-            )
+        record_fields = _record_fields(section, section_id, projected_fields)
 
         structural_fields: list[str] = []
         collection = section.get("collection")
@@ -489,6 +484,11 @@ def _report_projection_metadata(contract: Mapping[str, Any] | None = None) -> di
                 )
             if item_type == "object":
                 item_fields = _projected_fields(collection)
+                collection_record_fields = _record_fields(
+                    collection,
+                    f"{section_id}.{collection_field}",
+                    item_fields,
+                )
                 collection_structural_fields: list[str] = []
                 for nested in collection.get("nested_object_fields", []):
                     if isinstance(nested, Mapping) and isinstance(nested.get("field"), str):
@@ -500,7 +500,7 @@ def _report_projection_metadata(contract: Mapping[str, Any] | None = None) -> di
                     section_id,
                     item_fields,
                     [],
-                    [],
+                    collection_record_fields,
                     collection_structural_fields,
                 )
                 _hosted_consumer_safe_fields(
@@ -542,6 +542,24 @@ def _validate_report_fields(
         _field_type(field)
 
 
+def _record_fields(
+    owner: Mapping[str, Any],
+    owner_id: str,
+    projected_fields: Sequence[str],
+) -> list[str]:
+    fields = owner.get("record_fields", [])
+    if not isinstance(fields, list) or not all(isinstance(field, str) for field in fields):
+        raise ValueError(f"report_projection {owner_id!r} has invalid record_fields")
+    projected = set(projected_fields)
+    unknown_records = [field for field in fields if field not in projected]
+    if unknown_records:
+        raise ValueError(
+            f"record fields are not projected for {owner_id!r}: "
+            + ", ".join(unknown_records)
+        )
+    return list(fields)
+
+
 def _validate_nested_fields(
     section_id: str,
     owner: Mapping[str, Any],
@@ -560,12 +578,122 @@ def _validate_nested_fields(
                     f"report_projection section {section_id!r} nested field must be projected"
                 )
             nested_fields = _projected_fields(entry)
-            _validate_report_fields(section_id, nested_fields, [], [])
+            record_fields = _record_fields(
+                entry,
+                f"{section_id}.{field}",
+                nested_fields,
+            )
+            _validate_report_fields(section_id, nested_fields, [], record_fields)
             _hosted_consumer_safe_fields(entry, f"{section_id}.{field}")
 
 
 def _field_const_token(field: str) -> str:
     return re.sub(r"[^A-Z0-9]+", "_", field.upper()).strip("_")
+
+
+def _scalar_hosted_shape(field: str) -> str:
+    field_type = _field_type(field)
+    if field_type in {"string", "number", "boolean", "string | null", "number | null"}:
+        return "scalar"
+    if field_type == "string[]":
+        return "scalar_array"
+    raise ValueError(
+        f"hosted-safe field {field!r} has non-scalar type {field_type!r} "
+        "but no record/nested shape metadata"
+    )
+
+
+def _hosted_shape_paths(section: Mapping[str, Any]) -> dict[str, dict[str, str]]:
+    section_id = str(section["id"])
+    paths: dict[str, dict[str, str]] = {}
+
+    def add_owner(owner: Mapping[str, Any], owner_path: str, owner_label: str) -> None:
+        hosted_fields = _hosted_consumer_safe_fields(owner, owner_label)
+        if not hosted_fields:
+            return
+
+        record_fields = set(str(field) for field in owner.get("record_fields", []))
+        nested_objects = {
+            str(entry["field"]): entry
+            for entry in owner.get("nested_object_fields", [])
+            if isinstance(entry, Mapping) and isinstance(entry.get("field"), str)
+        }
+        nested_collections = {
+            str(entry["field"]): entry
+            for entry in owner.get("nested_collection_fields", [])
+            if isinstance(entry, Mapping) and isinstance(entry.get("field"), str)
+        }
+        collection = owner.get("collection")
+        collection_field = (
+            str(collection["field"])
+            if isinstance(collection, Mapping) and isinstance(collection.get("field"), str)
+            else None
+        )
+
+        field_shapes: dict[str, str] = {}
+        for field in hosted_fields:
+            if field in record_fields:
+                field_shapes[field] = "record"
+            elif field in nested_objects:
+                field_shapes[field] = "object"
+            elif field in nested_collections:
+                nested = nested_collections[field]
+                field_shapes[field] = (
+                    "object_array" if nested.get("item_type", "object") == "object" else "scalar_array"
+                )
+            elif field == collection_field and isinstance(collection, Mapping):
+                field_shapes[field] = (
+                    "object_array" if collection.get("item_type", "object") == "object" else "scalar_array"
+                )
+            else:
+                field_shapes[field] = _scalar_hosted_shape(field)
+        paths[owner_path] = field_shapes
+
+        for field, nested in nested_objects.items():
+            if field in hosted_fields:
+                add_owner(nested, f"{owner_path}.{field}", f"{owner_label}.{field}")
+        for field, nested in nested_collections.items():
+            if field in hosted_fields and nested.get("item_type", "object") == "object":
+                add_owner(nested, f"{owner_path}.{field}", f"{owner_label}.{field}")
+        if (
+            collection_field
+            and collection_field in hosted_fields
+            and isinstance(collection, Mapping)
+            and collection.get("item_type", "object") == "object"
+        ):
+            add_owner(
+                collection,
+                f"{owner_path}.{collection_field}",
+                f"{owner_label}.{collection_field}",
+            )
+
+    add_owner(section, section_id, section_id)
+    return paths
+
+
+def _render_report_hosted_shape_map(
+    name: str,
+    sections: Sequence[Mapping[str, Any]],
+    *,
+    typescript: bool,
+) -> list[str]:
+    shape_paths: dict[str, dict[str, str]] = {}
+    for section in sections:
+        shape_paths.update(_hosted_shape_paths(section))
+
+    opener = "{" if typescript else "Object.freeze({"
+    lines = [f"export const {name} = {opener}"]
+    for owner_path in sorted(shape_paths):
+        owner_opener = "{" if typescript else "Object.freeze({"
+        lines.append(f'  "{owner_path}": {owner_opener}')
+        for field, shape in shape_paths[owner_path].items():
+            lines.append(f'    "{field}": "{shape}",')
+        owner_suffix = "}," if typescript else "}),"
+        lines.append(f"  {owner_suffix}")
+    suffix = " as const;" if typescript else ";"
+    closer = "}" if typescript else "})"
+    lines.append(f"{closer}{suffix}")
+    return lines
 
 
 def _render_report_hosted_safe_constants(
@@ -683,11 +811,23 @@ def _render_report_nested_types(section: Mapping[str, Any]) -> list[str]:
     def add_nested(owner: Mapping[str, Any]) -> None:
         for nested in owner.get("nested_object_fields", []):
             nested_type = _nested_type_name(section_id, str(nested["field"]))
-            generated.extend(_object_type_with_overrides(nested_type, _projected_fields(nested)))
+            generated.extend(
+                _object_type_with_overrides(
+                    nested_type,
+                    _projected_fields(nested),
+                    type_overrides=_record_type_overrides(nested),
+                )
+            )
             generated.append("")
         for nested in owner.get("nested_collection_fields", []):
             nested_type = _nested_type_name(section_id, str(nested["field"]))
-            generated.extend(_object_type_with_overrides(nested_type, _projected_fields(nested)))
+            generated.extend(
+                _object_type_with_overrides(
+                    nested_type,
+                    _projected_fields(nested),
+                    type_overrides=_record_type_overrides(nested),
+                )
+            )
             generated.append("")
 
     add_nested(section)
@@ -695,7 +835,7 @@ def _render_report_nested_types(section: Mapping[str, Any]) -> list[str]:
     if isinstance(collection, Mapping):
         add_nested(collection)
         if collection.get("item_type") == "object":
-            collection_overrides: dict[str, str] = {}
+            collection_overrides: dict[str, str] = _record_type_overrides(collection)
             for nested in collection.get("nested_object_fields", []):
                 field = str(nested["field"])
                 collection_overrides[field] = _nested_type_name(section_id, field)
@@ -714,6 +854,16 @@ def _render_report_nested_types(section: Mapping[str, Any]) -> list[str]:
     return generated
 
 
+def _record_type_overrides(owner: Mapping[str, Any]) -> dict[str, str]:
+    return {str(field): "Record<string, number>" for field in owner.get("record_fields", [])}
+
+
+def _nested_override_type(section_id: str, field: str) -> str:
+    nested_type = _nested_type_name(section_id, field)
+    field_type = TYPE_BY_FIELD.get(field, "")
+    return f"{nested_type} | null" if "| null" in field_type else nested_type
+
+
 def _report_section_type_overrides(section: Mapping[str, Any]) -> dict[str, str]:
     section_id = str(section["id"])
     overrides: dict[str, str] = {}
@@ -721,7 +871,7 @@ def _report_section_type_overrides(section: Mapping[str, Any]) -> dict[str, str]
         overrides[str(field)] = "Record<string, number>"
     for nested in section.get("nested_object_fields", []):
         field = str(nested["field"])
-        overrides[field] = _nested_type_name(section_id, field)
+        overrides[field] = _nested_override_type(section_id, field)
     collection = section.get("collection")
     if isinstance(collection, Mapping):
         field = str(collection["field"])
@@ -793,6 +943,15 @@ def render_report_model_types(contract: Mapping[str, Any] | None = None) -> str:
                 )
             )
             generated.append("")
+
+    generated.extend(
+        _render_report_hosted_shape_map(
+            "DEFLECTION_REPORT_HOSTED_FIELD_SHAPES",
+            sections,
+            typescript=True,
+        )
+    )
+    generated.append("")
 
     generated.extend(_render_report_support_types())
     generated.append("")
@@ -922,6 +1081,15 @@ def render_report_model_api_contract(contract: Mapping[str, Any] | None = None) 
                 )
             )
             generated.append("")
+
+    generated.extend(
+        _render_report_hosted_shape_map(
+            "DEFLECTION_REPORT_HOSTED_FIELD_SHAPES",
+            sections,
+            typescript=False,
+        )
+    )
+    generated.append("")
 
     return "\n".join(generated)
 

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -163,6 +163,17 @@ def _structured_report_fixture_result() -> TicketFAQMarkdownResult:
 
 def _report_projection_runtime_fixture_result() -> TicketFAQMarkdownResult:
     base = _structured_report_fixture_result()
+    sso_item = {
+        **base.items[1],
+        "term_mappings": (
+            {
+                "customer_term": "SSO for all",
+                "documentation_term": "single sign-on rollout",
+                "suggestion": "Mirror SSO rollout wording in setup docs.",
+                "source_id_count": 3,
+            },
+        ),
+    }
     recurring_item = {
         "question": "How do I fix a stale dashboard?",
         "customer_wording": "dashboard is stale again",
@@ -179,7 +190,20 @@ def _report_projection_runtime_fixture_result() -> TicketFAQMarkdownResult:
             "ticket-dashboard-3",
             "ticket-dashboard-4",
         ),
+        "source_date_span": {
+            "start": "2026-05-16",
+            "end": "2026-05-19",
+            "missing_source_count": 0,
+        },
         "evidence_quotes": ("`ticket-dashboard-1` - Dashboard stale again",),
+        "term_mappings": (
+            {
+                "customer_term": "stale dashboard",
+                "documentation_term": "dashboard cache refresh",
+                "suggestion": "Use stale dashboard wording in the troubleshooting guide.",
+                "source_id_count": 4,
+            },
+        ),
         "outcome_diagnostics": {
             "csat_present_count": 4,
             "csat_score_average": 2.0,
@@ -200,12 +224,25 @@ def _report_projection_runtime_fixture_result() -> TicketFAQMarkdownResult:
         "answer_evidence_status": "draft_needs_review",
         "source_count": 1,
         "source_ids": ("ticket-sparse-only",),
+        "source_date_span": {
+            "start": "2026-05-20",
+            "end": "2026-05-20",
+            "missing_source_count": 0,
+        },
+        "term_mappings": (
+            {
+                "customer_term": "contacts duplicated",
+                "documentation_term": "deduplicate imported contacts",
+                "suggestion": "Add duplicate-import wording to the import docs.",
+                "source_id_count": 1,
+            },
+        ),
     }
     return replace(
         base,
         source_count=base.source_count + 5,
         ticket_source_count=base.ticket_source_count + 5,
-        items=base.items + (recurring_item, sparse_item),
+        items=(base.items[0], sso_item, recurring_item, sparse_item),
     )
 
 
@@ -1629,6 +1666,19 @@ def test_deflection_report_projection_contract_is_registry_derived() -> None:
     assert set(support_tax["optional_projected_fields"]) <= set(
         support_tax["projected_fields"]
     )
+    support_tax_nested = {
+        entry["field"]: entry for entry in support_tax["nested_object_fields"]
+    }
+    assert support_tax_nested["source_date_window"]["projected_fields"] == [
+        "source_date_start",
+        "source_date_end",
+        "source_window_days",
+    ]
+    assert support_tax_nested["source_date_window"]["hosted_consumer_safe_fields"] == [
+        "source_date_start",
+        "source_date_end",
+        "source_window_days",
+    ]
 
     source_file = sections["source_file"]
     assert source_file["presence"] == {
@@ -1642,6 +1692,9 @@ def test_deflection_report_projection_contract_is_registry_derived() -> None:
         "mode": "conditional",
         "condition": "outcome_diagnostics_rendered",
     }
+    outcome_rows = outcome_diagnostics["collection"]
+    assert "status_mix" in outcome_rows["projected_fields"]
+    assert "status_mix" in outcome_rows["hosted_consumer_safe_fields"]
 
     assert sections["support_tax"]["presence"] == {"mode": "required"}
     top_unresolved = sections["top_unresolved_repeats"]
@@ -1750,6 +1803,23 @@ def test_deflection_report_projection_marks_raw_question_evidence_export_only() 
         "outcome_diagnostics",
     }.isdisjoint(question_details["hosted_consumer_safe_fields"])
     assert "source_count" in question_details["hosted_consumer_safe_fields"]
+    term_mapping_contract = {
+        entry["field"]: entry
+        for entry in question_details["nested_collection_fields"]
+    }["term_mappings"]
+    assert term_mapping_contract["item_type"] == "object"
+    assert term_mapping_contract["projected_fields"] == [
+        "customer_term",
+        "documentation_term",
+        "suggestion",
+        "source_id_count",
+    ]
+    assert term_mapping_contract["hosted_consumer_safe_fields"] == [
+        "customer_term",
+        "documentation_term",
+        "suggestion",
+        "source_id_count",
+    ]
     assert complete_evidence["projected_fields"] == [
         "question_count",
         "evidence_row_count",

--- a/tests/test_generate_deflection_frontend_contract_types.py
+++ b/tests/test_generate_deflection_frontend_contract_types.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import runpy
 from pathlib import Path
@@ -77,7 +78,8 @@ def test_deflection_report_model_types_include_backend_projection_fields() -> No
     assert "top_evidence: DeflectionReportPriorityFixQueueTopEvidence[];" in rendered
     assert "suppression_reason: string;" in rendered
     assert "suppression_reason_label: string;" in rendered
-    assert "term_mappings: DeflectionReportTermMapping[];" in rendered
+    assert "source_date_window: DeflectionReportSupportTaxSourceDateWindow | null;" in rendered
+    assert "term_mappings: DeflectionReportQuestionDetailsTermMappings[];" in rendered
     assert "outcome_diagnostics: DeflectionReportQuestionOutcomeDiagnostics | null;" in rendered
     assert "source_file?: DeflectionReportSourceFileData;" in rendered
     assert "outcome_diagnostics?: DeflectionReportOutcomeDiagnosticsData;" in rendered
@@ -107,6 +109,24 @@ def test_deflection_report_model_types_publish_hosted_safe_allowlists() -> None:
         "[]"
     ) in rendered
     assert "hosted_consumer_safe_fields: string[];" not in rendered
+
+
+def test_deflection_report_model_types_publish_hosted_field_shapes() -> None:
+    rendered = MOD["render_report_model_types"]()
+
+    assert "export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {" in rendered
+    assert '"support_tax": {' in rendered
+    assert '"source_date_window": "object",' in rendered
+    assert '"support_tax.source_date_window": {' in rendered
+    assert '"source_window_days": "scalar",' in rendered
+    assert '"question_details.rows": {' in rendered
+    assert '"term_mappings": "object_array",' in rendered
+    assert '"question_details.rows.term_mappings": {' in rendered
+    assert '"source_id_count": "scalar",' in rendered
+    assert '"outcome_diagnostics.rows": {' in rendered
+    assert '"status_mix": "scalar",' in rendered
+    assert '"suppressed_repeat_review_queue": {' in rendered
+    assert '"reason_counts": "record",' in rendered
 
 
 def test_deflection_report_model_api_contract_includes_backend_projection_fields() -> None:
@@ -163,6 +183,58 @@ def test_deflection_report_model_api_contract_publishes_hosted_safe_allowlists()
         "DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = "
         "Object.freeze([])"
     ) in rendered
+
+
+def test_deflection_report_model_api_contract_publishes_hosted_field_shapes() -> None:
+    rendered = MOD["render_report_model_api_contract"]()
+
+    assert "export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({" in rendered
+    assert '"support_tax": Object.freeze({' in rendered
+    assert '"source_date_window": "object",' in rendered
+    assert '"support_tax.source_date_window": Object.freeze({' in rendered
+    assert '"question_details.rows": Object.freeze({' in rendered
+    assert '"term_mappings": "object_array",' in rendered
+    assert '"outcome_diagnostics.rows": Object.freeze({' in rendered
+    assert '"status_mix": "scalar",' in rendered
+    assert '"suppressed_repeat_review_queue": Object.freeze({' in rendered
+    assert '"reason_counts": "record",' in rendered
+
+
+def test_deflection_report_hosted_shape_map_rejects_non_scalar_without_metadata() -> None:
+    base = MOD["deflection_report_model_contract_shape"]()
+    cases = [
+        ("support_tax", None, "nested_object_fields", "source_date_window"),
+        ("question_details", "rows", "nested_collection_fields", "term_mappings"),
+        ("priority_fix_queue", None, "record_fields", "status_counts"),
+    ]
+
+    for section_id, collection_field, metadata_key, field in cases:
+        contract = copy.deepcopy(base)
+        sections = {
+            section["id"]: section
+            for section in contract["report_projection"]["sections"]
+        }
+        owner = sections[section_id]
+        if collection_field:
+            owner = owner["collection"]
+            assert owner["field"] == collection_field
+
+        if metadata_key == "record_fields":
+            owner[metadata_key] = [
+                record_field for record_field in owner[metadata_key] if record_field != field
+            ]
+        else:
+            owner[metadata_key] = [
+                entry for entry in owner[metadata_key] if entry["field"] != field
+            ]
+
+        try:
+            MOD["render_report_model_api_contract"](contract)
+        except ValueError as exc:
+            assert field in str(exc)
+            assert "non-scalar type" in str(exc)
+        else:
+            raise AssertionError(f"{field} should require hosted shape metadata")
 
 
 def test_generated_deflection_api_contracts_are_enrolled_in_product_surface_manifest() -> None:
@@ -433,3 +505,25 @@ def test_deflection_report_model_types_reject_unknown_hosted_safe_nested_field()
         assert "raw_unprojected_hosted_field" in str(exc)
     else:
         raise AssertionError("hosted-safe nested fields must also be projected")
+
+
+def test_deflection_report_model_types_reject_hosted_non_scalar_without_shape_metadata() -> None:
+    contract = MOD["deflection_report_model_contract_shape"]()
+    section = {
+        entry["id"]: entry
+        for entry in contract["report_projection"]["sections"]
+    }["support_tax"]
+    section["nested_object_fields"] = [
+        entry
+        for entry in section["nested_object_fields"]
+        if entry["field"] != "source_date_window"
+    ]
+
+    try:
+        MOD["render_report_model_types"](contract)
+    except ValueError as exc:
+        message = str(exc)
+        assert "source_date_window" in message
+        assert "no record/nested shape metadata" in message
+    else:
+        raise AssertionError("hosted-safe non-scalar report fields need shape metadata")


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-Hosted-Shape-Metadata.md
Slice phase: Production hardening

#1831 made hosted paid report projection fail closed, but runtime and test code still owned field-shape classifiers separately from the ATLAS report projection contract. This publishes generated hosted-safe field-shape metadata and makes both the public projection and parity fixture consume that single generated source.

## Intentional
- The shape artifact is path-keyed instead of a richer schema tree; the path map is enough to remove dual-map drift while keeping projection small.
- Unknown shape values remain fail-closed in runtime/test and are not treated as scalars.
- Nullable hosted-safe object fields preserve legitimate `null` values instead of being dropped.
- The diff exceeds 400 LOC because the generator change necessarily refreshes JS and TS contract artifacts in the same PR.

## Deferred
- Cross-repo `atlas-portfolio` consumption of the generated report-model artifact remains a separate consumer slice after this ATLAS artifact is stable.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes.
- Fixed Codex P2 / human MAJOR: nullable object-shaped hosted fields now preserve `null`, with proxy parity coverage for `source_date_window: null`.

## Verification
- `python scripts/generate_deflection_frontend_contract_types.py`
- `python scripts/generate_deflection_frontend_contract_types.py --check`
- `python -m py_compile scripts/generate_deflection_frontend_contract_types.py`
- `python -m pytest tests/test_generate_deflection_frontend_contract_types.py -q` (23 tests)
- `python -m pytest tests/test_content_ops_deflection_report.py -q` (167 tests)
- `npm --prefix portfolio-ui run test:deflection-atlas-proxy` (29 tests)
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- Merge refresh over #1832: merged `origin/main`, resolved source conflicts, regenerated report-model JS/TS artifacts.

## Diff size
9 files, +1155 / -287
