### PR TITLE
Assert claude.yml actions are SHA-pinned by shape, not a literal SHA

### DIFF
--- a/plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md
+++ b/plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md
@@ -1,0 +1,114 @@
+# PR-Claude-Workflow-SHA-Pin-Test-Robust
+
+## Why this slice exists
+
+`tests/test_claude_workflow_security.py::test_claude_actions_are_sha_pinned`
+hard-codes the exact commit SHA each pinned action must carry. When Dependabot
+PR #1818 bumped `anthropics/claude-code-action` in
+`.github/workflows/claude.yml` to a new SHA, the workflow was updated but the
+test fixture was not, so the assertion now fails on `main` and in
+`pre-push-audit` on every open PR (the PR merge-ref includes main's bumped
+workflow). The test is a tripwire that breaks on its own success criterion --
+every legitimate, already-reviewed action bump turns it red until someone hand-
+edits the fixture.
+
+Root cause: the test encodes the wrong invariant. Its purpose (per its name) is
+"actions are SHA-pinned" -- i.e. pinned to an immutable 40-char commit SHA
+rather than a mutable tag/branch -- not "pinned to this one specific SHA".
+This fixes the root by asserting the security property (each required action is
+present and pinned to a 40-char hex SHA) instead of a rotating literal, so
+routine Dependabot SHA bumps pass while a tag/branch pin (`@v1`, `@main`) still
+fails.
+
+## Scope (this PR)
+
+Ownership lane: security/workflow
+Slice phase: Production hardening
+
+1. Rework `test_claude_actions_are_sha_pinned` in
+   `tests/test_claude_workflow_security.py` to assert each required action
+   (`actions/checkout`, `anthropics/claude-code-action`) is present in
+   `.github/workflows/claude.yml` and pinned to a 40-char hex commit SHA, via
+   regex, instead of two hard-coded SHA string matches.
+2. Add this plan doc.
+
+No workflow change: `.github/workflows/claude.yml` is already correctly
+SHA-pinned (Dependabot #1818); only the stale test fixture is wrong.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The test passes against the current `.github/workflows/claude.yml`
+  (claude-code-action pinned to its post-#1818 SHA).
+- A mutable ref (`@v1`, `@main`) or a missing required action still fails the
+  test.
+- `test_claude_oidc_job_is_owner_gated` is unchanged.
+
+Affected surfaces:
+
+- CI fixture for the claude.yml security posture test (test-only change).
+
+Risk areas:
+
+- Loosening a security tripwire: mitigated by still requiring a 40-char hex SHA
+  (not any tag) and still requiring each named action to be present, so the
+  "no mutable action ref" property is preserved, only the specific-SHA coupling
+  is dropped.
+
+Triggered reviewer rules:
+
+- R2 Test evidence
+- R3 Security/auth
+- R8 CI/workflow safety
+- R14 Codebase verification
+
+### Files touched
+
+- `plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md`
+- `tests/test_claude_workflow_security.py`
+
+## Mechanism
+
+The rewritten test iterates a `PINNED_ACTIONS` tuple and, for each, searches
+`.github/workflows/claude.yml` for `<action>@<ref>` and asserts the captured
+ref matches `re.fullmatch(r"[0-9a-f]{40}", ref)`. A 40-char hex SHA (old or new)
+passes; a tag (`@v1`), branch (`@main`), or absent action fails. This preserves
+the original dual intent (the actions are used AND immutably pinned) without
+coupling the test to a value Dependabot rotates.
+
+## Intentional
+
+- Test-only change: no product code, no workflow edit. The workflow is already
+  pinned correctly; only the fixture encoded the wrong invariant.
+- Keeps the named-action presence checks so removing `claude-code-action` or
+  `checkout` still fails the test, matching the prior behavior.
+- No `plans/INDEX.md` entry: in-flight plans live in the `plans/` root; INDEX is
+  the archive index, updated when the slice is archived after merge.
+
+## Deferred
+
+- None. (Other stale hard-coded-SHA fixtures, if any surface later, would be
+  separate slices.)
+
+Parked hardening: none.
+
+## Verification
+
+- Direct execution (local; pytest not installed here): importing
+  `tests/test_claude_workflow_security.py` and calling both test functions
+  passes against the current `.github/workflows/claude.yml`.
+- Negative check (local): `re.fullmatch(r"[0-9a-f]{40}", ref)` returns a match
+  for both the old and new 40-char SHAs and `None` for `v1` / `main`.
+- Format gates (local): `scripts/sync_pr_plan.py --check` on this plan doc,
+  `scripts/check_ascii_python.sh`, and `git diff --check` all pass.
+- CI: `pre-push-audit` / the unit suite runs the test and it passes, clearing
+  the failure now seen on `main` and on the other open PRs.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md` | 114 |
+| `tests/test_claude_workflow_security.py` | 16 |
+| **Total** | **130** |

--- a/plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md
+++ b/plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md
@@ -43,6 +43,9 @@ Acceptance criteria:
   (claude-code-action pinned to its post-#1818 SHA).
 - A mutable ref (`@v1`, `@main`) or a missing required action still fails the
   test.
+- A pinned SHA left only in a comment/example, or a look-alike fork such as
+  `some-fork/actions/checkout`, does not satisfy the check (it is anchored to
+  real `uses:` steps and matches the exact `owner/repo`).
 - `test_claude_oidc_job_is_owner_gated` is unchanged.
 
 Affected surfaces:
@@ -70,12 +73,15 @@ Triggered reviewer rules:
 
 ## Mechanism
 
-The rewritten test iterates a `PINNED_ACTIONS` tuple and, for each, searches
-`.github/workflows/claude.yml` for `<action>@<ref>` and asserts the captured
-ref matches `re.fullmatch(r"[0-9a-f]{40}", ref)`. A 40-char hex SHA (old or new)
-passes; a tag (`@v1`), branch (`@main`), or absent action fails. This preserves
-the original dual intent (the actions are used AND immutably pinned) without
-coupling the test to a value Dependabot rotates.
+The rewritten test extracts the action ref from each real `uses:` step
+(`_USES_RE`, anchored to `uses:` line starts so a pinned SHA left in a comment
+or example cannot satisfy the check), then for each required action matches the
+exact `owner/repo` (so a look-alike such as `some-fork/actions/checkout` cannot
+stand in for `actions/checkout`) and asserts every matching `uses:` ref is
+pinned to a 40-char hex SHA (`_SHA_RE`). A 40-char SHA (old or new) passes; a
+tag (`@v1`), branch (`@main`), look-alike fork, or absent action fails. This
+preserves the original dual intent (the actions are used AND immutably pinned)
+without coupling the test to a value Dependabot rotates.
 
 ## Intentional
 
@@ -109,6 +115,6 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md` | 114 |
-| `tests/test_claude_workflow_security.py` | 16 |
-| **Total** | **130** |
+| `plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md` | 120 |
+| `tests/test_claude_workflow_security.py` | 34 |
+| **Total** | **154** |

--- a/tests/test_claude_workflow_security.py
+++ b/tests/test_claude_workflow_security.py
@@ -12,6 +12,18 @@ WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "clau
 # routine Dependabot SHA bumps that would otherwise require a fixture edit.
 PINNED_ACTIONS = ("actions/checkout", "anthropics/claude-code-action")
 
+# Capture the action ref from real `uses:` steps only (optionally a "- uses:"
+# list item, optional surrounding quote). Anchoring to `uses:` means a pinned
+# SHA left in a comment or example cannot satisfy the check, and the exact
+# owner/repo comparison below means a look-alike such as
+# `some-fork/actions/checkout` cannot stand in for `actions/checkout`.
+_USES_RE = re.compile(r"^\s*-?\s*uses:\s*['\"]?([^\s'\"#]+)", re.MULTILINE)
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def _uses_refs(text: str) -> list[str]:
+    return _USES_RE.findall(text)
+
 
 def test_claude_oidc_job_is_owner_gated() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
@@ -21,12 +33,14 @@ def test_claude_oidc_job_is_owner_gated() -> None:
 
 
 def test_claude_actions_are_sha_pinned() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
+    uses_refs = _uses_refs(WORKFLOW.read_text(encoding="utf-8"))
 
     for action in PINNED_ACTIONS:
-        match = re.search(re.escape(action) + r"@([^\s#]+)", text)
-        assert match is not None, f"{action} must be used in claude.yml"
-        ref = match.group(1)
-        assert re.fullmatch(r"[0-9a-f]{40}", ref), (
-            f"{action} must be pinned to a 40-char commit SHA, got {ref!r}"
-        )
+        pinned = [ref for ref in uses_refs if ref.split("@", 1)[0] == action]
+        assert pinned, f"{action} must be used in a `uses:` step in claude.yml"
+        for ref in pinned:
+            _, _, sha = ref.partition("@")
+            assert _SHA_RE.fullmatch(sha), (
+                f"{action} must be pinned to a 40-char commit SHA in every "
+                f"`uses:` step, got {ref!r}"
+            )

--- a/tests/test_claude_workflow_security.py
+++ b/tests/test_claude_workflow_security.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "claude.yml"
+
+# Actions that must stay present in claude.yml and pinned to an immutable
+# commit SHA. Asserting a 40-char hex SHA (rather than a hard-coded value)
+# keeps the "no mutable tag/branch ref" security tripwire while tolerating
+# routine Dependabot SHA bumps that would otherwise require a fixture edit.
+PINNED_ACTIONS = ("actions/checkout", "anthropics/claude-code-action")
 
 
 def test_claude_oidc_job_is_owner_gated() -> None:
@@ -16,5 +23,10 @@ def test_claude_oidc_job_is_owner_gated() -> None:
 def test_claude_actions_are_sha_pinned() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3" in text
-    assert "anthropics/claude-code-action@9dd8b95a392eb34b6f5fb56cf5a64cb735912d4b # v1" in text
+    for action in PINNED_ACTIONS:
+        match = re.search(re.escape(action) + r"@([^\s#]+)", text)
+        assert match is not None, f"{action} must be used in claude.yml"
+        ref = match.group(1)
+        assert re.fullmatch(r"[0-9a-f]{40}", ref), (
+            f"{action} must be pinned to a 40-char commit SHA, got {ref!r}"
+        )


### PR DESCRIPTION
Plan: plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md
Slice phase: Production hardening

`test_claude_actions_are_sha_pinned` hard-coded the exact commit SHA each pinned action must carry. Dependabot **#1818** bumped `anthropics/claude-code-action` in `.github/workflows/claude.yml` to a new SHA but left the test fixture asserting the old one — so the test now fails on `main` itself and in `pre-push-audit` on every open PR (the PR merge-ref includes main's bumped workflow). The test's purpose (per its name) is "actions are SHA-pinned" — pinned to an immutable 40-char commit SHA, not a mutable tag — not "pinned to this exact SHA". This reworks it to assert that property by shape (anchored to real `uses:` steps, exact owner/repo, 40-char hex SHA), so legitimate Dependabot SHA bumps pass while a tag/branch ref (`@v1`, `@main`), a look-alike fork, or a missing required action still fails.

## AI reconciliation
- [chatgpt-codex-connector] Anchor action-pin checks to `uses:` lines (P2): fixed in head `679c557` — `_USES_RE` now parses refs from real `uses:` steps only, so a SHA left in a comment/example cannot satisfy the check, and every matching `uses:` ref is validated.
- [copilot-pull-request-reviewer] Regex substring false positives (e.g. `some-fork/actions/checkout` satisfying `actions/checkout`): fixed by the same change — exact `owner/repo == action` comparison on `uses:` refs.

All fixed or waived: yes (both bot threads resolved at head `679c557`).

## Intentional
- Test-only change: no product code, no workflow edit. `.github/workflows/claude.yml` is already pinned correctly; only the fixture encoded the wrong invariant.
- Keeps the named-action presence checks (`actions/checkout`, `anthropics/claude-code-action`), so removing either still fails — preserving the original dual intent.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- Direct execution (local; pytest not installed in this env): importing the test module and calling both functions passes against the current `claude.yml` (claude-code-action pinned to its post-#1818 SHA `80b31826…`).
- Negative checks: a tag (`@v1`/`@main`), a comment-only SHA, and a look-alike fork all fail; the two real `uses:` steps pass.
- Format gates: `scripts/sync_pr_plan.py --check`, `scripts/check_ascii_python.sh`, `git diff --check` — all pass.
- CI: the unit suite runs the test green, clearing the failure now seen on `main` and on PRs #1837 / #1838.

## Diff size
2 files, +150 / -4 (`tests/test_claude_workflow_security.py`; `plans/PR-Claude-Workflow-SHA-Pin-Test-Robust.md` new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep8Avf5AC9f9DX4AYRMQ3m