### PR TITLE
Sync Claude action SHA pin test with workflow

### DIFF
--- a/plans/PR-Claude-Action-Sha-Pin-Test-Sync.md
+++ b/plans/PR-Claude-Action-Sha-Pin-Test-Sync.md
@@ -1,0 +1,22 @@
+# PR-Claude-Action-Sha-Pin-Test-Sync
+
+## Summary
+Sync the Claude workflow security test with the SHA-pinned Claude action already present on `main` after the Dependabot security update.
+
+## Intentional
+- Test-only update; no workflow behavior or action version change.
+- Keeps the security assertion strict by matching the exact SHA currently pinned in `.github/workflows/claude.yml`.
+- Unblocks Dependabot PR pre-push checks that currently fail on the stale expected Claude action SHA.
+
+## Deferred
+- None.
+
+## Parked hardening
+- None.
+
+## Verification
+- CI should run the pre-push audit and `tests/test_claude_workflow_security.py` against this branch.
+- Local verification was not run from this projectless workspace because the repo is not checked out locally.
+
+## Diff size
+2 files: one test expectation update and one plan document.

--- a/tests/test_claude_workflow_security.py
+++ b/tests/test_claude_workflow_security.py
@@ -17,4 +17,4 @@ def test_claude_actions_are_sha_pinned() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3" in text
-    assert "anthropics/claude-code-action@9dd8b95a392eb34b6f5fb56cf5a64cb735912d4b # v1" in text
+    assert "anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1" in text


### PR DESCRIPTION
Plan: plans/PR-Claude-Action-Sha-Pin-Test-Sync.md
Slice phase: Workflow/process

Superseded by #1839, which landed the same Dependabot-queue unblocker with a stronger SHA-pinning invariant and green checks. Closing this duplicate instead of repairing its plan-doc shape.

## Intentional
- Close duplicate PR in favor of the already-merged robust fix.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- #1839 merged after green PR Body Contract, Pre-push Audit, Security Guardrails, AI Reconciliation, maturity sweeps, and Vercel.

## Diff size
Closed without merge.