### PR TITLE
Loosen stale workflow artifact pin assertion

### DIFF
--- a/tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
+++ b/tests/test_extracted_pipeline_pii_recall_advisory_artifact.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "extracted_pipeline_checks.yml"
 CHECKS = ROOT / "scripts" / "run_extracted_pipeline_checks.sh"
+PINNED_UPLOAD_ARTIFACT_RE = re.compile(
+    r"actions/upload-artifact@[0-9a-f]{40}\s+#\s+v\d+\.\d+\.\d+"
+)
 
 
 def _workflow_step_block(workflow: str, name: str) -> str:
@@ -40,10 +44,7 @@ def test_extracted_checks_uploads_deflection_pii_recall_advisory_artifact() -> N
     )
     assert "if: ${{ !cancelled() }}" in write_step
     assert "Upload deflection PII recall advisory artifact" in workflow
-    assert (
-        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-        in workflow
-    )
+    assert PINNED_UPLOAD_ARTIFACT_RE.search(upload_step)
     assert "if: ${{ !cancelled() }}" in upload_step
     assert "name: deflection-pii-recall-advisory" in workflow
     assert "\n          path: artifacts/deflection-pii-recall\n" in workflow


### PR DESCRIPTION
Plan: plans/PR-Dependabot-Package-Maintenance-Wave.md
Slice phase: workflow/process

This keeps the extracted pipeline workflow test aligned with the dependency-maintenance wave after `actions/upload-artifact` moved to v7. The assertion still enforces the important security contract: the upload action must be pinned to an immutable 40-character commit SHA and include the adjacent version comment for auditability.

## Intentional
- Replace the historical `actions/upload-artifact` SHA assertion with a regex scoped to the upload step.
- Keep the advisory artifact path, cancellation behavior, and no-gating checks unchanged.

## Deferred
- The separate `portfolio-ui` stale `@vercel/blob` test assertion is not changed in this PR.
- Dependabot PR merges remain gated on their own checks after this unblocker lands.

## Parked hardening
- None.

## Verification
- Not run locally; this environment does not have the repository checkout or GitHub CLI installed.
- Expected CI coverage: PR Body Contract, Pre-push Audit, Security Guardrails, AI Reconciliation, and Extracted Pipeline Checks.

## Diff size
- 1 test file changed.
- +5 / -4 lines.