### PR TITLE
Add Product Gap Jira copy action

### DIFF
--- a/plans/PR-Product-Gaps-Jira-Copy-Action.md
+++ b/plans/PR-Product-Gaps-Jira-Copy-Action.md
@@ -1,0 +1,87 @@
+# PR-Product-Gaps-Jira-Copy-Action
+
+## Why this slice exists
+
+Issue #1846 asks the paid Product Gap card to provide a copy-to-Jira action.
+#1854 added the structured `jira_template` payload and rendered it in a
+`<details>` disclosure, but the buyer still has to manually reconstruct the
+handoff from prose. Root cause: the S3 surface stopped at displaying the Jira
+handoff fields and did not construct a copy-ready handoff artifact at the paid
+card boundary. This PR fixes the root for the buyer surface by rendering a
+bounded, escaped, copy-ready Jira handoff block from the already-hosted-safe
+`jira_template` fields.
+
+## Scope (this PR)
+
+Ownership lane: deflection/product-gaps-report-shape
+Slice phase: Product polish
+
+1. Add a copy-ready Jira handoff affordance to unlocked paid Product Gap cards.
+2. Keep the handoff built only from the hosted-safe `jira_template`/action item
+   fields already admitted by the report-model contract.
+3. Prove the unlocked card renders the handoff and the locked/free page still
+   does not render paid product-gap fields.
+
+### Files touched
+
+- `plans/PR-Product-Gaps-Jira-Copy-Action.md`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Unlocked paid Product Gap cards render a copy-ready Jira handoff payload.
+  - [ ] The payload includes issue, owner lane, impact/repeat count, cost basis,
+        evidence tier, customer vocabulary, and next action when present.
+  - [ ] The handoff is constructed from existing hosted-safe fields only; no
+        `source_ids`, `top_evidence`, raw quotes, or new backend fields are
+        introduced.
+  - [ ] Locked/free result pages still do not render product-gap/Jira handoff
+        fields.
+- Affected surfaces: paid hosted result page, result-page smoke tests, plan docs.
+- Risk areas: privacy boundary, frontend rendering/escaping, scope creep into
+  backend report contract.
+- Reviewer rules triggered: R1, R2, R3, R9, R10, R12, R14.
+
+## Mechanism
+
+Add a small result-page helper that constructs a deterministic Jira handoff
+string from the already parsed action item and nested `jira_template` object.
+The paid card renders that string in a read-only control with a copy affordance
+that uses the browser Clipboard API when available and falls back to selecting
+the text. The existing HTML escaping path remains the boundary for rendered
+text, and the helper deliberately does not read raw evidence collections.
+
+## Intentional
+
+- No backend contract change; #1854 already published the hosted-safe
+  `jira_template` shape.
+- No source ID or raw quote handoff in the browser card; the complete audit trail
+  stays in the paid evidence export.
+- No generic copy-component abstraction; this is one small paid-result affordance
+  for the Product Gap card.
+
+## Deferred
+
+- #1847 remains the next QA/proof slice after this S3 affordance is complete.
+- #1854 plan archiving remains deferred because another active PR is touching
+  `plans/INDEX.md`; keep this product slice conflict-free.
+- Monthly cost normalization and richer owner taxonomy remain deferred from
+  #1854.
+
+Parked hardening: none.
+
+## Verification
+
+- `node portfolio-ui/scripts/faq-deflection-result-page.test.mjs` - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/product-gaps-jira-copy-pr-body.md` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Product-Gaps-Jira-Copy-Action.md` | 87 |
+| `portfolio-ui/api/content-ops/deflection/result-page.js` | 61 |
+| `portfolio-ui/scripts/faq-deflection-result-page.test.mjs` | 14 |
+| **Total** | **162** |

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -356,6 +356,27 @@ function cleanTextList(value, limit = 3) {
   return out;
 }
 
+function jiraHandoffText(item, jiraTemplate, { costBasis = "", evidenceTier = "", vocabulary = [] } = {}) {
+  const issue = clean(item.question) || clean(item.customer_wording);
+  const ownerLane = clean(jiraTemplate.owner_lane) || clean(item.owner_lane);
+  const summary = clean(jiraTemplate.product_gap_summary) || clean(item.product_gap_summary);
+  const nextAction = clean(jiraTemplate.recommended_action) || clean(item.recommended_action);
+  const ticketCount = itemTicketCount(item);
+  const estimatedCost = firstParsedCount(item.estimated_support_cost);
+  const lines = [
+    issue ? `Issue: ${issue}` : "",
+    ownerLane ? `Owner lane: ${ownerLane}` : "",
+    ticketCount > 0 ? `Impact: ${formatNumber(ticketCount)} repeat tickets` : "",
+    estimatedCost > 0 ? `Estimated handling cost: ${formatMoney(estimatedCost)}` : "",
+    costBasis ? `Cost basis: ${costBasis}` : "",
+    evidenceTier ? `Evidence tier: ${evidenceTierLabel(evidenceTier)}` : "",
+    vocabulary.length > 0 ? `Customer vocabulary: ${vocabulary.join(", ")}` : "",
+    summary ? `Summary: ${summary}` : "",
+    nextAction ? `Next action: ${nextAction}` : "",
+  ];
+  return lines.filter(Boolean).join("\n");
+}
+
 function paidActionItems(report, sectionIds) {
   const rows = [];
   const seen = new Set();
@@ -525,6 +546,11 @@ function renderPaidGapCards(items, evidenceExportHref = "") {
                     const jiraTemplate = isObjectRecord(item.jira_template) ? item.jira_template : {};
                     const jiraSummary = clean(jiraTemplate.product_gap_summary) || clean(item.product_gap_summary);
                     const jiraAction = clean(jiraTemplate.recommended_action) || clean(item.recommended_action);
+                    const jiraHandoff = jiraHandoffText(item, jiraTemplate, {
+                      costBasis,
+                      evidenceTier,
+                      vocabulary,
+                    });
                     return `<article class="paid-card">
                     <p class="rank">${escapeHtml(formatNumber(itemTicketCount(item)))} tickets</p>
                     <h4>${escapeHtml(item.question || item.customer_wording || "Untitled question")}</h4>
@@ -541,6 +567,13 @@ function renderPaidGapCards(items, evidenceExportHref = "") {
                           ${jiraSummary ? `<p>${escapeHtml(jiraSummary)}</p>` : ""}
                           ${jiraAction ? `<p>${escapeHtml(jiraAction)}</p>` : ""}
                         </details>`
+                      : ""}
+                    ${jiraHandoff
+                      ? `<div class="jira-copy">
+                          <label>Copy-ready Jira handoff</label>
+                          <textarea readonly rows="9" data-atlas-deflection-jira-handoff>${escapeHtml(jiraHandoff)}</textarea>
+                          <button type="button" class="jira-copy-button" data-atlas-deflection-jira-copy>Copy Jira handoff</button>
+                        </div>`
                       : ""}
                     <p>This is routeable product friction, not exact UI root-cause proof.</p>
                     ${evidenceExportHref
@@ -712,6 +745,29 @@ function renderArtifactRetryScript({ requestId, shouldRetry }) {
   </script>`;
 }
 
+function renderJiraCopyScript({ enabled }) {
+  if (!enabled) return "";
+
+  return `\n  <script data-atlas-deflection-jira-copy-script>
+    document.querySelectorAll("[data-atlas-deflection-jira-copy]").forEach((copyButton) => {
+      copyButton.addEventListener("click", async () => {
+        const handoff = copyButton
+          .closest(".jira-copy")
+          ?.querySelector("[data-atlas-deflection-jira-handoff]");
+        if (!handoff) return;
+        try {
+          await navigator.clipboard.writeText(handoff.value);
+          copyButton.textContent = "Copied";
+        } catch {
+          handoff.focus();
+          handoff.select();
+          copyButton.textContent = "Select and copy";
+        }
+      });
+    });
+  </script>`;
+}
+
 function renderResultPage({ requestId, accountId, checkoutStatus = "", report = null }) {
   const safeRequestId = escapeHtml(requestId);
   const safeCheckoutStatus = escapeHtml(checkoutStatus);
@@ -814,6 +870,10 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     .paid-card { padding: 14px; }
     .paid-card h4 { margin: 6px 0 8px; font-size: 16px; }
     .paid-card p:not(.rank) { margin: 0; color: rgba(226, 232, 240, .75); line-height: 1.55; }
+    .jira-copy { display: grid; gap: 8px; margin-top: 12px; }
+    .jira-copy label { color: rgba(226, 232, 240, .66); font-size: 12px; font-weight: 800; text-transform: uppercase; }
+    .jira-copy textarea { width: 100%; box-sizing: border-box; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(15, 23, 42, .68); color: #f8fafc; padding: 10px; font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; line-height: 1.45; resize: vertical; }
+    .jira-copy-button { width: auto; justify-self: start; padding: 9px 12px; font-size: 12px; }
     .paid-phrase-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 0; padding: 0; list-style: none; }
     .paid-phrase-list li { padding: 9px 11px; line-height: 1.45; }
     .notice { margin-top: 20px; border-radius: 8px; padding: 14px 16px; color: #fde68a; background: rgba(251, 191, 36, .1); border: 1px solid rgba(251, 191, 36, .28); }
@@ -887,6 +947,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     }
   </script>
   ${renderArtifactRetryScript({ requestId, shouldRetry: shouldRetryArtifact })}
+  ${renderJiraCopyScript({ enabled: isUnlocked })}
 </body>
 </html>`;
 }

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -416,6 +416,16 @@ await test("unlocked paid result page renders CSV owner-lane gap card fields", (
   assert.match(html, /Customer vocabulary: login button, where do I sign in/);
   assert.match(html, /Jira handoff/);
   assert.match(html, /Review login discoverability and create the missing answer/);
+  assert.match(html, /Copy-ready Jira handoff/);
+  assert.match(html, /data-atlas-deflection-jira-handoff/);
+  assert.match(html, /data-atlas-deflection-jira-copy/);
+  assert.match(html, /Issue: Where is the login button\?/);
+  assert.match(html, /Owner lane: Auth \/ Product UX/);
+  assert.match(html, /Impact: 65 repeat tickets/);
+  assert.match(html, /Estimated handling cost: \$878/);
+  assert.match(html, /Cost basis: this upload \/ benchmark cost with customer text/);
+  assert.match(html, /Evidence tier: CSV customer text/);
+  assert.match(html, /Next action: Review login discoverability and create the missing answer/);
   assert.match(html, /routeable product friction, not exact UI root-cause proof/);
   assert.match(html, /Download evidence JSON/);
   assert.match(
@@ -521,6 +531,10 @@ await test("locked result page does not render paid report-model fields", () => 
     "hidden customer vocabulary",
     "Hidden Jira product gap summary",
     "Hidden Jira next action",
+    "Copy-ready Jira handoff",
+    "data-atlas-deflection-jira-handoff",
+    "data-atlas-deflection-jira-copy",
+    "Owner lane: Auth / Product UX",
     "Hidden fallback product gap summary",
     "hidden fallback vocabulary",
     "Hidden fallback Jira summary",


### PR DESCRIPTION
Plan: plans/PR-Product-Gaps-Jira-Copy-Action.md
Slice phase: Product polish

This completes the #1846 paid Product Gap card affordance: unlocked cards now render a copy-ready Jira handoff payload from the hosted-safe action fields published in #1854, while locked/free pages continue hiding paid product-gap fields.

## Intentional
- No backend report contract change; #1854 already published the hosted-safe `jira_template` shape.
- Raw evidence and source IDs stay in the paid evidence export, not the card handoff.
- No generic copy-component abstraction; this is one small paid-result affordance for the Product Gap card.

## Deferred
- #1847 remains the next QA/proof slice after this S3 affordance is complete.
- #1854 plan archiving remains deferred because another active PR is touching `plans/INDEX.md`; keep this product slice conflict-free.
- Monthly cost normalization and richer owner taxonomy remain deferred from #1854.

## Parked hardening
- None.

## Verification
- `node portfolio-ui/scripts/faq-deflection-result-page.test.mjs` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/product-gaps-jira-copy-pr-body.md` - passed.

## Diff size
3 files, +162 / -0

Refs #1843 #1846 #1847 #1853.
