### PR TITLE
Add Product Gap CSV QA proof

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -1508,6 +1508,8 @@ DEFAULT_DEFLECTION_FULL_REPORT_SURFACE_CAPS: Mapping[str, Mapping[str, int]] = (
         "result_page": MappingProxyType({
             "ranked_questions": 25,
             "question_details": 10,
+            "product_gap_cards": _ACTION_RESULT_PAGE_LIMIT,
+            "jira_handoffs": _ACTION_RESULT_PAGE_LIMIT,
             "seo_targets": 20,
             "outcome_diagnostics": 25,
         }),
@@ -1541,6 +1543,8 @@ _FULL_REPORT_QA_SURFACE_COUNT_KEYS: Mapping[str, tuple[str, ...]] = (
             "estimated_support_cost",
             "evidence_row_count",
             "source_id_count",
+            "product_gap_card_count",
+            "jira_handoff_count",
         ),
         "pdf": (
             "repeat_ticket_count",
@@ -1595,6 +1599,13 @@ _SCORECARD_COUNT_KEYS = frozenset({
     "drafted_resolutions_count",
     "already_covered_still_recurring_count",
     "suppressed_repeat_review_queue_count",
+    "product_gap_card_count",
+    "jira_handoff_count",
+})
+_SCORECARD_DISPLAY_ROW_KEYS = frozenset({
+    *DEFLECTION_REPORT_SECTION_REGISTRY,
+    "product_gap_cards",
+    "jira_handoffs",
 })
 _SCORECARD_SURFACE_KEYS = frozenset({
     "email",
@@ -1945,7 +1956,7 @@ def _add_full_report_qa_required_metric_assertions(
     for section_index, section_id in enumerate(sorted(caps), start=1):
         section_safe_id = _scorecard_id_segment(
             section_id,
-            allowed=frozenset(DEFLECTION_REPORT_SECTION_REGISTRY),
+            allowed=_SCORECARD_DISPLAY_ROW_KEYS,
             fallback=f"section_{section_index}",
         )
         if _scorecard_section_total(str(section_id), counts) == 0:
@@ -2076,6 +2087,8 @@ def _scorecard_counts(sections: Mapping[str, Mapping[str, Any]]) -> dict[str, An
         "seo_omitted_phrase_count": _int(seo_targets.get("omitted_phrase_count")),
         "outcome_diagnostic_row_count": _scorecard_rows_count(diagnostics),
         "question_detail_count": _scorecard_rows_count(question_details),
+        "product_gap_card_count": _int(support_tax.get("no_proven_answer_count")),
+        "jira_handoff_count": _int(support_tax.get("no_proven_answer_count")),
         "priority_fix_queue_count": _scorecard_items_count(priority_fix_queue),
         "top_unresolved_repeats_count": _scorecard_items_count(unresolved_repeats),
         "drafted_resolutions_count": _scorecard_items_count(drafted_resolutions),
@@ -2168,6 +2181,8 @@ def _scorecard_section_total(section_id: str, counts: Mapping[str, Any]) -> int:
         "outcome_diagnostics": _int(counts.get("outcome_diagnostic_row_count")),
         "question_details": _int(counts.get("question_detail_count")),
         "complete_evidence": _int(counts.get("evidence_row_count")),
+        "product_gap_cards": _int(counts.get("product_gap_card_count")),
+        "jira_handoffs": _int(counts.get("jira_handoff_count")),
         "priority_fix_queue": _int(counts.get("priority_fix_queue_count")),
         "top_unresolved_repeats": _int(counts.get("top_unresolved_repeats_count")),
         "drafted_resolutions": _int(counts.get("drafted_resolutions_count")),
@@ -2371,7 +2386,7 @@ def _add_surface_observation_assertions(
             section_text = str(section_id)
             section_safe_id = _scorecard_id_segment(
                 section_text,
-                allowed=frozenset(DEFLECTION_REPORT_SECTION_REGISTRY),
+                allowed=_SCORECARD_DISPLAY_ROW_KEYS,
                 fallback=f"section_{section_index}",
             )
             total = _scorecard_section_total(section_text, counts)

--- a/plans/PR-Product-Gaps-CSV-QA-Proof.md
+++ b/plans/PR-Product-Gaps-CSV-QA-Proof.md
@@ -1,0 +1,110 @@
+# PR-Product-Gaps-CSV-QA-Proof
+
+## Why this slice exists
+
+#1847 is the S4 proof slice for the CSV-first Product Gap arc. Prior slices
+landed ingestion/routing (#1849), action fields and delivery surfaces (#1854),
+and the paid Jira-copy affordance (#1855), but the remaining proof is split
+across generic tests. Root cause: the product-gap vertical has buyer-visible
+surfaces, yet the explicit QA observation still reports only generic paid-row
+counts, and the synthetic CSV login proof does not assert the uncapped evidence
+export for that same product-gap scenario.
+
+This PR fixes the proof gap without adding new product shape: it extends the
+existing CSV login vertical test to assert the evidence export audit details,
+and extends the paid result-page QA observation to count Product Gap cards and
+copy-ready Jira handoffs.
+
+## Scope (this PR)
+
+Ownership lane: deflection/product-gaps-report-shape
+Slice phase: Functional validation
+
+1. Add Product Gap card/Jira handoff counts to the existing paid result-page QA
+   observation and enroll those counts in the hosted QA scorecard.
+2. Extend the synthetic CSV login product-gap test so the same vertical proves
+   evidence-export question and row details.
+3. Keep report-model fields, snapshot/free projection, and email behavior
+   unchanged.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Product-Gaps-CSV-QA-Proof.md`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The CSV login/discoverability fixture proves repeated product-gap
+        owner lane, cost, routing metadata, action fields, and evidence export
+        question/row audit details together.
+  - [ ] The paid result-page QA observation exposes Product Gap card and Jira
+        handoff counts, and the hosted QA scorecard validates them.
+  - [ ] Locked/free result pages still do not render paid product-gap fields.
+  - [ ] No new backend action/report fields or snapshot-safe fields are added.
+  - [ ] No `source_ids`, `top_evidence`, or raw quotes are added to hosted card
+        rendering.
+- Affected surfaces: report/evidence-export tests, paid result-page QA
+  observation, result-page smoke tests.
+- Risk areas: privacy boundary, QA count truthfulness, scope creep into report
+  contract.
+- Reviewer rules triggered: R1, R2, R3, R9, R10, R12, R14.
+
+## Mechanism
+
+Thread the already-computed `gapItems` from `renderPaidArtifact` into
+`resultPageQaObservation`, then report bounded counts for rendered Product Gap
+cards and copy-ready Jira handoffs in the observation JSON. The Jira count uses
+the same `jiraHandoffText` helper as the renderer, so the observation counts the
+controls the page actually renders. The hosted QA scorecard now enrolls those
+count/displayed-row keys and derives their model-side totals from the existing
+`no_proven_answer_count`. The renderer already gates paid artifact rendering on
+unlocked state, so the new counts remain absent on locked/free pages.
+
+For backend proof, reuse the existing synthetic CSV login fixture and assert
+the evidence export generated from the same artifact includes the product-gap
+question, source IDs, evidence rows, and `needs_review` answer linkage.
+
+## Intentional
+
+- No new report-model fields; this is QA/proof around the existing #1849/#1854
+  shape.
+- No email changes; #1854 already covers compact email rendering and no raw
+  evidence leak.
+- No plan archive cleanup; another active PR has touched `plans/INDEX.md`, so
+  this slice stays conflict-free.
+
+## Deferred
+
+- Closing/updating the parent issue checklist is deferred until this PR lands
+  and the review verdict confirms S4 is complete.
+- #1853 demo-derive remains paused/downstream until the product-gap arc is
+  closed.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_deflection_report.py::test_csv_product_gap_owner_lane_vertical_routes_login_gap -q` - passed.
+- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_full_report_qa_harness_defers_result_page_action_row_observer tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py::test_hosted_smoke_scorecard_passes_sanitized_surface_observations -q` - passed.
+- `node portfolio-ui/scripts/faq-deflection-result-page.test.mjs` - passed.
+- `npm --prefix portfolio-ui run test:deflection-full-report-qa-hosted-smoke` - passed.
+- Portfolio UI workflow-equivalent commands (`test:deflection-upload-shell`, `test:deflection-atlas-proxy`, `test:deflection-result`, `test:deflection-full-report-qa-hosted-smoke`) - passed.
+- `scripts/run_extracted_pipeline_checks.sh` - passed (`4999 passed, 15 skipped`).
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/product-gaps-csv-qa-proof-pr-body.md` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_deflection_report.py` | 19 |
+| `plans/PR-Product-Gaps-CSV-QA-Proof.md` | 105 |
+| `portfolio-ui/api/content-ops/deflection/result-page.js` | 30 |
+| `portfolio-ui/scripts/faq-deflection-result-page.test.mjs` | 19 |
+| `tests/test_content_ops_deflection_report.py` | 38 |
+| `tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py` | 6 |
+| **Total** | **217** |

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -19,6 +19,8 @@ const EVIDENCE_EXPORT_SCHEMA_VERSION = "deflection_evidence.v1";
 const RESULT_PAGE_QA_SURFACE_CAPS = Object.freeze({
   ranked_questions: PAID_QUESTION_LIMIT,
   question_details: PAID_DETAIL_LIMIT * 2,
+  product_gap_cards: PAID_DETAIL_LIMIT,
+  jira_handoffs: PAID_DETAIL_LIMIT,
   seo_targets: PAID_PHRASE_LIMIT,
 });
 const DEFLECTION_REPORT_SECTION_ID_SET = new Set(DEFLECTION_REPORT_SECTION_IDS);
@@ -598,7 +600,7 @@ function renderPaidPhrases(items) {
           </section>`;
 }
 
-function resultPageQaObservation(report) {
+function resultPageQaObservation(report, gapItems = null) {
   const items = paidArtifactItems(report);
   if (!items.length) return null;
 
@@ -614,7 +616,27 @@ function resultPageQaObservation(report) {
   const summary = paidSummary(report, items);
   const publishable = items.filter(hasResolutionEvidence);
   const needsProof = items.filter((item) => !hasResolutionEvidence(item));
+  const productGapItems = Array.isArray(gapItems)
+    ? gapItems
+    : paidGapCardItems(report, items);
   const phrases = paidCustomerPhrases(items);
+  const productGapCards = productGapItems
+    .filter((item) => !hasResolutionEvidence(item))
+    .slice(0, PAID_DETAIL_LIMIT);
+  const jiraHandoffCards = productGapCards.filter((item) => {
+    const evidenceTier = clean(item.evidence_tier);
+    const vocabulary = cleanTextList(item.customer_vocabulary);
+    const costBasis = [
+      costPeriodLabel(item.cost_period),
+      costConfidenceLabel(item.cost_confidence),
+    ].filter(Boolean).join(" / ");
+    const jiraTemplate = isObjectRecord(item.jira_template) ? item.jira_template : {};
+    return Boolean(jiraHandoffText(item, jiraTemplate, {
+      costBasis,
+      evidenceTier,
+      vocabulary,
+    }));
+  });
 
   return {
     counts: {
@@ -653,6 +675,8 @@ function resultPageQaObservation(report) {
         completeEvidence.source_id_count,
         exportSummary.source_id_count,
       ),
+      product_gap_card_count: productGapCards.length,
+      jira_handoff_count: jiraHandoffCards.length,
     },
     displayed_rows: {
       ranked_questions: Math.min(items.length, RESULT_PAGE_QA_SURFACE_CAPS.ranked_questions),
@@ -660,6 +684,8 @@ function resultPageQaObservation(report) {
         rowCount(questionDetails) || publishable.length + needsProof.length,
         RESULT_PAGE_QA_SURFACE_CAPS.question_details,
       ),
+      product_gap_cards: productGapCards.length,
+      jira_handoffs: jiraHandoffCards.length,
       seo_targets: Math.min(
         firstParsedCount(seoTargets.total_phrase_count, phrases.length),
         RESULT_PAGE_QA_SURFACE_CAPS.seo_targets,
@@ -674,7 +700,7 @@ function renderPaidArtifact(report, requestId = "") {
   const gapItems = paidGapCardItems(report, items);
   const summary = paidSummary(report, items);
   const evidenceExportHref = paidEvidenceExportHref(report, requestId);
-  const qaObservation = resultPageQaObservation(report);
+  const qaObservation = resultPageQaObservation(report, gapItems);
   const qaObservationAttr = qaObservation
     ? ` data-atlas-deflection-qa-observation="${escapeHtml(JSON.stringify(qaObservation))}"`
     : "";

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -135,6 +135,18 @@ function mockResponse() {
   };
 }
 
+function parseQaObservation(html) {
+  const match = html.match(/data-atlas-deflection-qa-observation="([^"]+)"/);
+  assert.ok(match, "missing result-page QA observation");
+  const decoded = match[1]
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+  return JSON.parse(decoded);
+}
+
 async function withEnv(nextEnv, fn) {
   const previous = {};
   for (const key of Object.keys(nextEnv)) {
@@ -432,6 +444,13 @@ await test("unlocked paid result page renders CSV owner-lane gap card fields", (
     html,
     /\/api\/content-ops\/deflection\/evidence-export\?request_id=content-ops-owner-lane/,
   );
+  assert.deepEqual(parseQaObservation(html).displayed_rows, {
+    ranked_questions: 1,
+    question_details: 1,
+    product_gap_cards: 1,
+    jira_handoffs: 1,
+    seo_targets: 1,
+  });
   assert.doesNotMatch(html, /zendesk:10422/);
   assert.doesNotMatch(html, /raw source quote should stay out of cards/);
 });

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -668,7 +668,8 @@ def test_csv_product_gap_owner_lane_vertical_routes_login_gap() -> None:
     package = build_support_ticket_input_package(rows)
     faq_result = build_ticket_faq_markdown(package.inputs["source_material"], max_items=4)
 
-    model = build_deflection_report_model(faq_result).as_dict()
+    artifact = build_deflection_report_artifact(faq_result)
+    model = artifact.report_model.as_dict()
     sections = {section["id"]: section for section in model["sections"]}
     priority_item = sections["priority_fix_queue"]["data"]["items"][0]
 
@@ -715,6 +716,37 @@ def test_csv_product_gap_owner_lane_vertical_routes_login_gap() -> None:
     assert "buried" not in priority_item["recommended_action"].lower()
     assert "Account Settings" not in priority_item["product_gap_summary"]
     assert "buried" not in priority_item["product_gap_summary"].lower()
+
+    evidence_export = build_deflection_evidence_export(artifact)
+    assert evidence_export["summary"] == {
+        "question_count": 1,
+        "evidence_row_count": 4,
+        "source_id_count": 4,
+        "drafted_answer_count": 0,
+        "no_proven_answer_count": 1,
+    }
+    assert evidence_export["questions"][0]["question"] == "Where is the login button?"
+    assert evidence_export["questions"][0]["ticket_count"] == 4
+    assert evidence_export["questions"][0]["answer_linkage"] == "needs_review"
+    assert evidence_export["questions"][0]["source_ids"] == [
+        "zd-login-1",
+        "zd-login-2",
+        "zd-login-3",
+        "zd-login-4",
+    ]
+    login_rows = [
+        row
+        for row in evidence_export["evidence_rows"]
+        if row["question"] == "Where is the login button?"
+    ]
+    assert len(login_rows) == 4
+    assert {row["source_id"] for row in login_rows} == {
+        "zd-login-1",
+        "zd-login-2",
+        "zd-login-3",
+        "zd-login-4",
+    }
+    assert {row["answer_linkage"] for row in login_rows} == {"needs_review"}
 
 
 def test_product_gap_summary_does_not_copy_root_cause_or_screen_path_question() -> None:
@@ -3232,10 +3264,14 @@ def test_deflection_full_report_qa_harness_defers_result_page_action_row_observe
                     "estimated_support_cost": counts["estimated_support_cost"],
                     "evidence_row_count": len(export["evidence_rows"]),
                     "source_id_count": export["summary"]["source_id_count"],
+                    "product_gap_card_count": counts["product_gap_card_count"],
+                    "jira_handoff_count": counts["jira_handoff_count"],
                 },
                 "displayed_rows": {
                     "ranked_questions": counts["ranked_question_count"],
                     "question_details": counts["question_detail_count"],
+                    "product_gap_cards": counts["product_gap_card_count"],
+                    "jira_handoffs": counts["jira_handoff_count"],
                     "seo_targets": counts["seo_total_phrase_count"],
                     "outcome_diagnostics": counts["outcome_diagnostic_row_count"],
                 },

--- a/tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py
+++ b/tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py
@@ -145,10 +145,14 @@ def _observations() -> dict[str, object]:
                 "estimated_support_cost": 108.0,
                 "evidence_row_count": 8,
                 "source_id_count": 8,
+                "product_gap_card_count": 1,
+                "jira_handoff_count": 1,
             },
             "displayed_rows": {
                 "ranked_questions": 2,
                 "question_details": 2,
+                "product_gap_cards": 1,
+                "jira_handoffs": 1,
                 "seo_targets": 2,
             },
         },
@@ -169,6 +173,8 @@ def _surface_caps() -> dict[str, object]:
         "result_page": {
             "ranked_questions": 8,
             "question_details": 10,
+            "product_gap_cards": 5,
+            "jira_handoffs": 5,
             "seo_targets": 10,
         },
     }


### PR DESCRIPTION
Plan: plans/PR-Product-Gaps-CSV-QA-Proof.md
Slice phase: Functional validation

#1847 is the S4 proof slice for the CSV-first Product Gap arc. This PR keeps the report shape unchanged and proves the buyer-visible Product Gap path with the same CSV login fixture plus paid result-page QA observation counts. Review follow-up: the hosted QA scorecard now enrolls Product Gap cards and Jira handoffs, and `jira_handoff_count` mirrors the renderer helper so the scorecard counts the copy controls the page actually renders.

## Intentional
- No new report-model fields; this is QA/proof around the existing #1849/#1854 shape.
- No email changes; #1854 already covers compact email rendering and no raw evidence leak.
- No plan archive cleanup; another active PR has touched `plans/INDEX.md`, so this slice stays conflict-free.

## Deferred
- Closing/updating the parent issue checklist is deferred until this PR lands and the review verdict confirms S4 is complete.
- #1853 demo-derive remains paused/downstream until the product-gap arc is closed.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py::test_csv_product_gap_owner_lane_vertical_routes_login_gap -q` - passed.
- `python -m pytest tests/test_content_ops_deflection_report.py::test_deflection_full_report_qa_harness_defers_result_page_action_row_observer tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py::test_hosted_smoke_scorecard_passes_sanitized_surface_observations -q` - passed.
- `node portfolio-ui/scripts/faq-deflection-result-page.test.mjs` - passed.
- `npm --prefix portfolio-ui run test:deflection-full-report-qa-hosted-smoke` - passed.
- Portfolio UI workflow-equivalent commands (`test:deflection-upload-shell`, `test:deflection-atlas-proxy`, `test:deflection-result`, `test:deflection-full-report-qa-hosted-smoke`) - passed.
- `scripts/run_extracted_pipeline_checks.sh` - passed (`4999 passed, 15 skipped`).
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/product-gaps-csv-qa-proof-pr-body.md` - passed.

## Diff size
6 files, +222 / -13
