### PR TITLE
Partition deflection Snapshot visible ranks

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_snapshot_example.json
+++ b/docs/frontend/content_ops_faq_deflection_snapshot_example.json
@@ -1,14 +1,5 @@
 {
-  "locked_questions": [
-    {
-      "rank": 6,
-      "ticket_count": 45
-    },
-    {
-      "rank": 7,
-      "ticket_count": 35
-    }
-  ],
+  "locked_questions": [],
   "summary": {
     "drafted_answer_count": 4,
     "generated": 7,

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -2500,14 +2500,14 @@ def build_deflection_snapshot(
             "customer_wording": _snapshot_customer_wording(item, question),
         })
     teaser = _snapshot_teaser(items, preview_count=teaser_preview_count)
-    teaser_full_rank = _teaser_full_answer_rank(teaser)
+    visible_ranks = _visible_snapshot_ranks(top_questions, teaser=teaser)
     locked_questions = tuple(
         {
             "rank": rank,
             "ticket_count": _ticket_count(item),
         }
         for rank, item in enumerate(items[top_n:], start=top_n + 1)
-        if rank != teaser_full_rank
+        if rank not in visible_ranks
     )
     return DeflectionSnapshot(
         summary=snapshot_summary,
@@ -2562,16 +2562,6 @@ def _build_deflection_snapshot_from_report_model(
         }
         for index, row in enumerate(ranked_rows[:top_n], start=1)
     ]
-    teaser = _snapshot_teaser(detail_rows, preview_count=teaser_preview_count)
-    teaser_full_rank = _teaser_full_answer_rank(teaser)
-    locked_questions = tuple(
-        {
-            "rank": _int(row.get("rank")) or rank,
-            "ticket_count": _int(row.get("ticket_count")),
-        }
-        for rank, row in enumerate(ranked_rows[top_n:], start=top_n + 1)
-        if (_int(row.get("rank")) or rank) != teaser_full_rank
-    )
     top_blind_spots = tuple(
         {
             "rank": _int(row.get("rank")) or index,
@@ -2580,6 +2570,20 @@ def _build_deflection_snapshot_from_report_model(
         }
         for index, row in enumerate(blind_spot_rows[:blind_spot_limit], start=1)
         if _text(row.get("question"))
+    )
+    teaser = _snapshot_teaser(detail_rows, preview_count=teaser_preview_count)
+    visible_ranks = _visible_snapshot_ranks(
+        top_questions,
+        top_blind_spots,
+        teaser=teaser,
+    )
+    locked_questions = tuple(
+        {
+            "rank": row_rank,
+            "ticket_count": _int(row.get("ticket_count")),
+        }
+        for rank, row in enumerate(ranked_rows[top_n:], start=top_n + 1)
+        if (row_rank := (_int(row.get("rank")) or rank)) not in visible_ranks
     )
     return DeflectionSnapshot(
         summary=snapshot_summary,
@@ -4416,6 +4420,32 @@ def _teaser_full_answer_rank(teaser: Mapping[str, Any]) -> int | None:
         return None
     rank = _int(full_answer.get("rank"))
     return rank if rank > 0 else None
+
+
+def _visible_snapshot_ranks(
+    *row_groups: Sequence[Mapping[str, Any]],
+    teaser: Mapping[str, Any],
+) -> set[int]:
+    ranks: set[int] = set()
+    for row_group in row_groups:
+        for row in row_group:
+            rank = _int(row.get("rank"))
+            if rank > 0:
+                ranks.add(rank)
+    teaser_full_rank = _teaser_full_answer_rank(teaser)
+    if teaser_full_rank is not None:
+        ranks.add(teaser_full_rank)
+    previews = teaser.get("previews")
+    if isinstance(previews, Sequence) and not isinstance(
+        previews, (str, bytes, bytearray)
+    ):
+        for preview in previews:
+            if not isinstance(preview, Mapping):
+                continue
+            rank = _int(preview.get("rank"))
+            if rank > 0:
+                ranks.add(rank)
+    return ranks
 
 
 def _is_teaser_eligible(item: Mapping[str, Any]) -> bool:

--- a/plans/PR-Deflection-Snapshot-Visible-Rank-Partition.md
+++ b/plans/PR-Deflection-Snapshot-Visible-Rank-Partition.md
@@ -1,0 +1,126 @@
+# PR-Deflection-Snapshot-Visible-Rank-Partition
+
+## Why this slice exists
+
+atlas-portfolio #389 exposed a source-projection bug after ATLAS #1859 enriched
+the generated landing demo. The free Snapshot now emits `locked_questions` for
+ranks that are already visible elsewhere: rank 6 is visible in
+`top_blind_spots`, and rank 7 is visible in `teaser.previews`. The portfolio
+landing can hide or filter that locally, but the real contract problem is
+upstream: ATLAS is claiming those ranks are "withheld" even though the Snapshot
+already surfaced their question text in another public section.
+
+Root cause: `build_deflection_snapshot` partitions only the teaser full-answer
+rank out of `locked_questions`. It does not exclude teaser preview ranks or
+blind-spot ranks, so the free Snapshot surfaces can overlap. That violates the
+buyer-facing contract: proven teaser, blind spots, previews, and locked backlog
+should be a partition of ranked questions, with each rank appearing in the
+right public surface exactly once.
+
+This PR fixes the root in the ATLAS projection instead of patching one portfolio
+component. `locked_questions` becomes the genuinely withheld set: ranks already
+visible in the top questions, teaser full answer, teaser previews, or blind
+spots are excluded before the Snapshot is emitted. The generated demo Snapshot
+is then refreshed from that corrected projection.
+
+## Scope (this PR)
+
+Ownership lane: deflection/landing-demo-contract-derived
+Slice phase: Production hardening
+
+1. Change Snapshot `locked_questions` construction to exclude all visible
+   Snapshot ranks, not only the teaser full-answer rank.
+2. Refresh the generated public demo Snapshot after the projection fix.
+3. Add tests proving visible ranks are partitioned and the generated example
+   no longer requires a locked backlog when no rank is genuinely withheld.
+
+### Review Contract
+
+Acceptance criteria:
+
+- `locked_questions` contains only ranks not visible through top questions,
+  teaser full answer, teaser previews, or top blind spots.
+- Both legacy artifact projection and report-model projection follow the same
+  partition rule.
+- The generated docs/frontend Snapshot example is current and may have an empty
+  `locked_questions` list if every post-top-N rank is visible elsewhere.
+- No private fields are added to `locked_questions`; it still exposes only rank
+  and ticket count.
+
+Affected surfaces:
+
+- Free deflection Snapshot JSON.
+- Generated public demo Snapshot consumed by atlas-portfolio #389.
+- Snapshot/report drift tests.
+
+Risk areas:
+
+- Snapshot coverage accounting: ranks removed from `locked_questions` must still
+  be covered by another public surface.
+- Public copy/demo assumptions: downstream consumers must not assume locked rows
+  are always present.
+
+Reviewer rules triggered: R1, R2, R7, R9, R10, R12, R13, R14.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_deflection_snapshot_example.json`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Snapshot-Visible-Rank-Partition.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_deflection_snapshot_example_generator.py`
+- `tests/test_deflection_snapshot_report_drift.py`
+
+## Mechanism
+
+Add small projection helpers that collect visible Snapshot ranks from:
+
+- top questions,
+- teaser full answer,
+- teaser previews,
+- top blind spots.
+
+`locked_questions` then filters out those visible ranks. The legacy artifact
+path has no `top_blind_spots`, but it still excludes teaser preview ranks. The
+report-model path computes `top_blind_spots` before locked rows so blind-spot
+ranks are excluded at the same source boundary.
+
+The drift test's rank-coverage check is updated to count teaser previews and
+blind spots as visible coverage, not just locked rows and the teaser full
+answer. The generated demo example test asserts the public surfaces are
+disjoint instead of requiring a non-empty locked backlog.
+
+## Intentional
+
+- This does not add a portfolio-side locked-row filter. The partition belongs
+  in the ATLAS projection so PDF/email/result-page consumers receive the same
+  corrected Snapshot.
+- The generated demo may have zero `locked_questions` after this fix. That is
+  correct when all post-top-N ranks are already visible as blind spots or
+  teaser previews.
+
+## Deferred
+
+- atlas-portfolio #389 must regenerate after this ATLAS PR lands and can then
+  remove any downstream workaround that only existed for overlapping locked
+  ranks.
+
+Parked hardening: none.
+
+## Verification
+
+- Pass: `python scripts/generate_deflection_snapshot_example.py --check`.
+- Pass: `python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_deflection_snapshot_example_generator.py tests/test_deflection_snapshot_report_drift.py -q` (197 passed).
+- Pending before push: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr_body_deflection_snapshot_visible_rank_partition.md`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_deflection_snapshot_example.json` | 11 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 54 |
+| `plans/PR-Deflection-Snapshot-Visible-Rank-Partition.md` | 126 |
+| `tests/test_content_ops_deflection_report.py` | 10 |
+| `tests/test_content_ops_faq_deflection_snapshot_example_generator.py` | 17 |
+| `tests/test_deflection_snapshot_report_drift.py` | 17 |
+| **Total** | **235** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -2641,7 +2641,6 @@ def test_deflection_snapshot_projected_fields_match_runtime_output() -> None:
     summary_optional = set(fields["summary"]["optional_projected_fields"])
 
     assert snapshot["top_questions"]
-    assert snapshot["locked_questions"]
     assert snapshot["top_blind_spots"]
     assert snapshot["teaser"]["full_answer"] is not None
     assert snapshot["teaser"]["previews"]
@@ -2650,9 +2649,8 @@ def test_deflection_snapshot_projected_fields_match_runtime_output() -> None:
     assert set(snapshot["top_questions"][0]) == set(
         fields["top_questions"]["projected_fields"]
     )
-    assert set(snapshot["locked_questions"][0]) == set(
-        fields["locked_questions"]["projected_fields"]
-    )
+    for locked in snapshot["locked_questions"]:
+        assert set(locked) == set(fields["locked_questions"]["projected_fields"])
     assert set(snapshot["top_blind_spots"][0]) == set(
         fields["top_blind_spots"]["projected_fields"]
     )
@@ -4574,8 +4572,8 @@ def test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions() -> 
             "customer_wording": "",
         }
     ]
+    assert [row["rank"] for row in snapshot["top_blind_spots"]] == [2]
     assert snapshot["locked_questions"] == [
-        {"rank": 2, "ticket_count": 2},
         {"rank": 3, "ticket_count": 0},
     ]
     assert snapshot["top_blind_spots"] == [
@@ -5051,9 +5049,9 @@ def test_deflection_snapshot_omits_full_teaser_rank_from_locked_rows() -> None:
     encoded = json.dumps(snapshot, sort_keys=True)
 
     assert snapshot["teaser"]["full_answer"]["rank"] == 3
+    assert [preview["rank"] for preview in snapshot["teaser"]["previews"]] == [4]
     assert snapshot["locked_questions"] == [
         {"rank": 2, "ticket_count": 1},
-        {"rank": 4, "ticket_count": 1},
     ]
     assert "Third answer" in encoded
     assert "Blocked top answer must not leak" not in encoded

--- a/tests/test_content_ops_faq_deflection_snapshot_example_generator.py
+++ b/tests/test_content_ops_faq_deflection_snapshot_example_generator.py
@@ -66,11 +66,26 @@ def test_generated_demo_example_carries_coherent_marketing_scale_volume() -> Non
     assert snapshot_payload["top_questions"][0]["ticket_count"] >= 90
     assert snapshot_payload["summary"]["generated"] > CLI.SNAPSHOT_TOP_N
     assert len(snapshot_payload["top_questions"]) == CLI.SNAPSHOT_TOP_N
-    assert snapshot_payload["locked_questions"]
     for question in snapshot_payload["locked_questions"]:
         assert set(question) == {"rank", "ticket_count"}
         assert "question" not in question
     assert snapshot_payload["top_blind_spots"]
+    ranked_ranks = {item["rank"] for item in sections["ranked_questions"]["rows"]}
+    visible_ranks = {question["rank"] for question in snapshot_payload["top_questions"]}
+    full_answer = snapshot_payload["teaser"]["full_answer"]
+    if isinstance(full_answer, dict):
+        visible_ranks.add(full_answer["rank"])
+    visible_ranks.update(
+        preview["rank"] for preview in snapshot_payload["teaser"]["previews"]
+    )
+    visible_ranks.update(
+        blind_spot["rank"] for blind_spot in snapshot_payload["top_blind_spots"]
+    )
+    locked_ranks = {
+        question["rank"] for question in snapshot_payload["locked_questions"]
+    }
+    assert visible_ranks.isdisjoint(locked_ranks)
+    assert visible_ranks | locked_ranks == ranked_ranks
     assert sections["support_tax"]["repeat_ticket_count"] == snapshot_payload[
         "summary"
     ]["repeat_ticket_count"]

--- a/tests/test_deflection_snapshot_report_drift.py
+++ b/tests/test_deflection_snapshot_report_drift.py
@@ -181,6 +181,8 @@ def test_snapshot_ranked_coverage_matches_report_ranked_questions(artifact_snaps
 
     snapshot_ranks = {q["rank"] for q in snapshot["top_questions"]}
     snapshot_ranks |= {q["rank"] for q in snapshot["locked_questions"]}
+    snapshot_ranks |= {q["rank"] for q in snapshot["top_blind_spots"]}
+    snapshot_ranks |= {q["rank"] for q in snapshot["teaser"]["previews"]}
     full_answer = snapshot["teaser"]["full_answer"]
     if isinstance(full_answer, Mapping):
         snapshot_ranks.add(full_answer["rank"])
@@ -188,6 +190,20 @@ def test_snapshot_ranked_coverage_matches_report_ranked_questions(artifact_snaps
     # The snapshot must cover exactly the report's ranked questions: a report
     # that adds or drops a ranked question must change the snapshot in lockstep.
     assert snapshot_ranks == ranked_ranks
+
+
+def test_snapshot_locked_questions_exclude_visible_ranks(artifact_snapshot) -> None:
+    _, snapshot, _, _ = artifact_snapshot
+    visible_ranks = {q["rank"] for q in snapshot["top_questions"]}
+    visible_ranks |= {q["rank"] for q in snapshot["top_blind_spots"]}
+    visible_ranks |= {q["rank"] for q in snapshot["teaser"]["previews"]}
+    full_answer = snapshot["teaser"]["full_answer"]
+    if isinstance(full_answer, Mapping):
+        visible_ranks.add(full_answer["rank"])
+
+    locked_ranks = {q["rank"] for q in snapshot["locked_questions"]}
+
+    assert visible_ranks.isdisjoint(locked_ranks)
 
 
 def test_snapshot_summary_is_derived_from_report(artifact_snapshot) -> None:
@@ -235,7 +251,6 @@ def test_snapshot_locked_questions_expose_rank_and_count_only(artifact_snapshot)
     _, snapshot, _, sections = artifact_snapshot
     ranked = _rows_by_rank(sections.get("ranked_questions"))
 
-    assert snapshot["locked_questions"], "expected locked questions at top_n=2"
     for locked in snapshot["locked_questions"]:
         assert set(locked) == {"rank", "ticket_count"}
         assert locked["ticket_count"] == ranked[locked["rank"]]["ticket_count"]


### PR DESCRIPTION
Plan: plans/PR-Deflection-Snapshot-Visible-Rank-Partition.md
Slice phase: Production hardening

Fixes the free deflection Snapshot projection so `locked_questions` is the genuinely withheld backlog instead of repeating ranks already visible through top questions, teaser full answer, teaser previews, or top blind spots. The generated public demo Snapshot is regenerated from the corrected projection, so it now legitimately has an empty `locked_questions` list when every post-top-N rank is visible elsewhere.

## Intentional
- No portfolio-side locked-row filter; the partition belongs in the ATLAS projection so every downstream consumer receives the corrected Snapshot.
- The generated demo may have zero `locked_questions`; that is correct when no ranked question is actually withheld.

## Deferred
- atlas-portfolio #389 must regenerate after this lands and can then continue without a downstream workaround for overlapping locked ranks.

## Parked hardening
- None.

## Verification
- `python scripts/generate_deflection_snapshot_example.py --check`
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_deflection_snapshot_example_generator.py tests/test_deflection_snapshot_report_drift.py -q` (197 passed)

## Diff size
6 files, +205 / -30
