### PR TITLE
Add deflection owner category contract

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -9310,6 +9310,7 @@
                 ],
                 "estimated_support_cost": 1282.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Reporting",
                 "product_gap_summary": "Repeated support friction routes to Reporting. 95 support tickets in this upload; estimated assisted-contact cost is $1,283 based on CSV full-thread resolution evidence.",
                 "question": "How do I export attribution reports?",
@@ -9318,6 +9319,7 @@
                 "ticket_count": 95
               },
               "opportunity_score": 95,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Reporting",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -9399,6 +9401,7 @@
                 ],
                 "estimated_support_cost": 1080.0,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Auth / Product UX",
                 "product_gap_summary": "Repeated support friction routes to Auth / Product UX. 80 support tickets in this upload; estimated assisted-contact cost is $1,080 based on CSV index metadata only.",
                 "question": "How do I enable SSO for my team?",
@@ -9407,6 +9410,7 @@
                 "ticket_count": 80
               },
               "opportunity_score": 80,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Auth / Product UX",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -9490,6 +9494,7 @@
                 ],
                 "estimated_support_cost": 1012.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Product / Support Experience",
                 "owner_lane": "Notification Search Controls",
                 "product_gap_summary": "Repeated support friction routes to Notification Search Controls. 75 support tickets in this upload; estimated assisted-contact cost is $1,013 based on CSV full-thread resolution evidence.",
                 "question": "Why do saved search alerts keep firing after I turn them off?",
@@ -9498,6 +9503,7 @@
                 "ticket_count": 75
               },
               "opportunity_score": 75,
+              "owner_category": "Product / Support Experience",
               "owner_lane": "Notification Search Controls",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -9581,6 +9587,7 @@
                 ],
                 "estimated_support_cost": 877.5,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Billing",
                 "product_gap_summary": "Repeated support friction routes to Billing. 65 support tickets in this upload; estimated assisted-contact cost is $878 based on CSV index metadata only.",
                 "question": "How do I pause my subscription for one month?",
@@ -9589,6 +9596,7 @@
                 "ticket_count": 65
               },
               "opportunity_score": 65,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Billing",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -9672,6 +9680,7 @@
                 ],
                 "estimated_support_cost": 742.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Billing",
                 "product_gap_summary": "Repeated support friction routes to Billing. 55 support tickets in this upload; estimated assisted-contact cost is $743 based on CSV full-thread resolution evidence.",
                 "question": "How do I add an invoice recipient?",
@@ -9680,6 +9689,7 @@
                 "ticket_count": 55
               },
               "opportunity_score": 55,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Billing",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -9761,6 +9771,7 @@
                 ],
                 "estimated_support_cost": 607.5,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Admin / Access",
                 "product_gap_summary": "Repeated support friction routes to Admin / Access. 45 support tickets in this upload; estimated assisted-contact cost is $608 based on CSV index metadata only.",
                 "question": "Which role can invite teammates?",
@@ -9769,6 +9780,7 @@
                 "ticket_count": 45
               },
               "opportunity_score": 45,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Admin / Access",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -9852,6 +9864,7 @@
                 ],
                 "estimated_support_cost": 472.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Developer Rate Limit Requests",
                 "product_gap_summary": "Repeated support friction routes to Developer Rate Limit Requests. 35 support tickets in this upload; estimated assisted-contact cost is $473 based on CSV full-thread resolution evidence.",
                 "question": "How do I increase my API rate limit?",
@@ -9860,6 +9873,7 @@
                 "ticket_count": 35
               },
               "opportunity_score": 35,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Developer Rate Limit Requests",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -9978,6 +9992,7 @@
                 ],
                 "estimated_support_cost": 1080.0,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Auth / Product UX",
                 "product_gap_summary": "Repeated support friction routes to Auth / Product UX. 80 support tickets in this upload; estimated assisted-contact cost is $1,080 based on CSV index metadata only.",
                 "question": "How do I enable SSO for my team?",
@@ -9986,6 +10001,7 @@
                 "ticket_count": 80
               },
               "opportunity_score": 80,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Auth / Product UX",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10069,6 +10085,7 @@
                 ],
                 "estimated_support_cost": 877.5,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Billing",
                 "product_gap_summary": "Repeated support friction routes to Billing. 65 support tickets in this upload; estimated assisted-contact cost is $878 based on CSV index metadata only.",
                 "question": "How do I pause my subscription for one month?",
@@ -10077,6 +10094,7 @@
                 "ticket_count": 65
               },
               "opportunity_score": 65,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Billing",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10160,6 +10178,7 @@
                 ],
                 "estimated_support_cost": 607.5,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Admin / Access",
                 "product_gap_summary": "Repeated support friction routes to Admin / Access. 45 support tickets in this upload; estimated assisted-contact cost is $608 based on CSV index metadata only.",
                 "question": "Which role can invite teammates?",
@@ -10168,6 +10187,7 @@
                 "ticket_count": 45
               },
               "opportunity_score": 45,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Admin / Access",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10286,6 +10306,7 @@
                 ],
                 "estimated_support_cost": 1282.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Reporting",
                 "product_gap_summary": "Repeated support friction routes to Reporting. 95 support tickets in this upload; estimated assisted-contact cost is $1,283 based on CSV full-thread resolution evidence.",
                 "question": "How do I export attribution reports?",
@@ -10294,6 +10315,7 @@
                 "ticket_count": 95
               },
               "opportunity_score": 95,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Reporting",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10375,6 +10397,7 @@
                 ],
                 "estimated_support_cost": 742.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Billing",
                 "product_gap_summary": "Repeated support friction routes to Billing. 55 support tickets in this upload; estimated assisted-contact cost is $743 based on CSV full-thread resolution evidence.",
                 "question": "How do I add an invoice recipient?",
@@ -10383,6 +10406,7 @@
                 "ticket_count": 55
               },
               "opportunity_score": 55,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Billing",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10464,6 +10488,7 @@
                 ],
                 "estimated_support_cost": 472.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Developer Rate Limit Requests",
                 "product_gap_summary": "Repeated support friction routes to Developer Rate Limit Requests. 35 support tickets in this upload; estimated assisted-contact cost is $473 based on CSV full-thread resolution evidence.",
                 "question": "How do I increase my API rate limit?",
@@ -10472,6 +10497,7 @@
                 "ticket_count": 35
               },
               "opportunity_score": 35,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Developer Rate Limit Requests",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10578,6 +10604,7 @@
                 ],
                 "estimated_support_cost": 1012.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Product / Support Experience",
                 "owner_lane": "Notification Search Controls",
                 "product_gap_summary": "Repeated support friction routes to Notification Search Controls. 75 support tickets in this upload; estimated assisted-contact cost is $1,013 based on CSV full-thread resolution evidence.",
                 "question": "Why do saved search alerts keep firing after I turn them off?",
@@ -10586,6 +10613,7 @@
                 "ticket_count": 75
               },
               "opportunity_score": 75,
+              "owner_category": "Product / Support Experience",
               "owner_lane": "Notification Search Controls",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10694,6 +10722,7 @@
                 ],
                 "estimated_support_cost": 1282.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Reporting",
                 "product_gap_summary": "Repeated support friction routes to Reporting. 95 support tickets in this upload; estimated assisted-contact cost is $1,283 based on CSV full-thread resolution evidence.",
                 "question": "How do I export attribution reports?",
@@ -10702,6 +10731,7 @@
                 "ticket_count": 95
               },
               "opportunity_score": 95,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Reporting",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10783,6 +10813,7 @@
                 ],
                 "estimated_support_cost": 1080.0,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Auth / Product UX",
                 "product_gap_summary": "Repeated support friction routes to Auth / Product UX. 80 support tickets in this upload; estimated assisted-contact cost is $1,080 based on CSV index metadata only.",
                 "question": "How do I enable SSO for my team?",
@@ -10791,6 +10822,7 @@
                 "ticket_count": 80
               },
               "opportunity_score": 80,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Auth / Product UX",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10874,6 +10906,7 @@
                 ],
                 "estimated_support_cost": 1012.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Product / Support Experience",
                 "owner_lane": "Notification Search Controls",
                 "product_gap_summary": "Repeated support friction routes to Notification Search Controls. 75 support tickets in this upload; estimated assisted-contact cost is $1,013 based on CSV full-thread resolution evidence.",
                 "question": "Why do saved search alerts keep firing after I turn them off?",
@@ -10882,6 +10915,7 @@
                 "ticket_count": 75
               },
               "opportunity_score": 75,
+              "owner_category": "Product / Support Experience",
               "owner_lane": "Notification Search Controls",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -10965,6 +10999,7 @@
                 ],
                 "estimated_support_cost": 877.5,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Billing",
                 "product_gap_summary": "Repeated support friction routes to Billing. 65 support tickets in this upload; estimated assisted-contact cost is $878 based on CSV index metadata only.",
                 "question": "How do I pause my subscription for one month?",
@@ -10973,6 +11008,7 @@
                 "ticket_count": 65
               },
               "opportunity_score": 65,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Billing",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -11056,6 +11092,7 @@
                 ],
                 "estimated_support_cost": 742.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Billing",
                 "product_gap_summary": "Repeated support friction routes to Billing. 55 support tickets in this upload; estimated assisted-contact cost is $743 based on CSV full-thread resolution evidence.",
                 "question": "How do I add an invoice recipient?",
@@ -11064,6 +11101,7 @@
                 "ticket_count": 55
               },
               "opportunity_score": 55,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Billing",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -11145,6 +11183,7 @@
                 ],
                 "estimated_support_cost": 607.5,
                 "evidence_tier": "csv_index_metadata_only",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Admin / Access",
                 "product_gap_summary": "Repeated support friction routes to Admin / Access. 45 support tickets in this upload; estimated assisted-contact cost is $608 based on CSV index metadata only.",
                 "question": "Which role can invite teammates?",
@@ -11153,6 +11192,7 @@
                 "ticket_count": 45
               },
               "opportunity_score": 45,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Admin / Access",
               "priority_drivers": [
                 "high_repeat_volume",
@@ -11236,6 +11276,7 @@
                 ],
                 "estimated_support_cost": 472.5,
                 "evidence_tier": "csv_full_thread_resolution_evidence",
+                "owner_category": "Content / Support Enablement",
                 "owner_lane": "Developer Rate Limit Requests",
                 "product_gap_summary": "Repeated support friction routes to Developer Rate Limit Requests. 35 support tickets in this upload; estimated assisted-contact cost is $473 based on CSV full-thread resolution evidence.",
                 "question": "How do I increase my API rate limit?",
@@ -11244,6 +11285,7 @@
                 "ticket_count": 35
               },
               "opportunity_score": 35,
+              "owner_category": "Content / Support Enablement",
               "owner_lane": "Developer Rate Limit Requests",
               "priority_drivers": [
                 "high_repeat_volume",

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -1458,6 +1458,19 @@ def _normalize_stored_action_owner_metadata(
         if not _clean(row.get("evidence_tier")):
             row["evidence_tier"] = "csv_index_metadata_only"
             changed = True
+        owner_category = _stored_action_owner_category(row.get("status"))
+        if not _clean(row.get("owner_category")):
+            row["owner_category"] = owner_category
+            changed = True
+        jira_template = row.get("jira_template")
+        if isinstance(jira_template, Mapping) and not _clean(
+            jira_template.get("owner_category")
+        ):
+            row["jira_template"] = {
+                **dict(jira_template),
+                "owner_category": owner_category,
+            }
+            changed = True
         routing_signals = _stored_action_routing_labels(row.get("routing_signals"))
         if row.get("routing_signals") != routing_signals:
             row["routing_signals"] = routing_signals
@@ -1477,6 +1490,15 @@ def _stored_action_routing_labels(value: Any) -> dict[str, list[str]]:
         field: _text_list(raw.get(field))[:8]
         for field in _STORED_ACTION_ROUTING_LABEL_FIELDS
     }
+
+
+def _stored_action_owner_category(status: Any) -> str:
+    normalized = _clean(status)
+    if normalized == "Already covered but still recurring":
+        return "Product / Support Experience"
+    if normalized in {"Draft ready", "Needs answer", "Needs review", "Low confidence"}:
+        return "Content / Support Enablement"
+    return "Review"
 
 
 def _normalize_stored_suppressed_review_keys(

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -856,6 +856,7 @@ _REPORT_ACTION_ITEM_FIELDS = (
     "question",
     "status",
     "owner_lane",
+    "owner_category",
     "evidence_tier",
     "routing_signals",
     "product_gap_summary",
@@ -883,6 +884,7 @@ _REPORT_ACTION_ITEM_HOSTED_SAFE_FIELDS = (
     "question",
     "status",
     "owner_lane",
+    "owner_category",
     "evidence_tier",
     "routing_signals",
     "product_gap_summary",
@@ -899,6 +901,7 @@ _REPORT_ACTION_ITEM_HOSTED_SAFE_FIELDS = (
     "csat_signal",
 )
 _REPORT_ACTION_CONTEXT_OPTIONAL_FIELDS = (
+    "owner_category",
     "evidence_tier",
     "routing_signals",
     "product_gap_summary",
@@ -949,6 +952,7 @@ _REPORT_ACTION_JIRA_TEMPLATE_FIELDS = (
     "recommended_title",
     "question",
     "owner_lane",
+    "owner_category",
     "product_gap_summary",
     "ticket_count",
     "estimated_support_cost",
@@ -3296,6 +3300,7 @@ def _action_item(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
     identity = _action_identity(item)
     routing_signals = _action_routing_signals(item)
     owner_lane = _action_owner_lane(item, routing_signals=routing_signals)
+    owner_category = _action_owner_category(status)
     evidence_tier = _action_evidence_tier(item)
     estimated_support_cost = _support_cost(ticket_count)
     recommended_title = _action_recommended_title(item)
@@ -3316,6 +3321,7 @@ def _action_item(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
         "question": _text(item.get("question")),
         "status": status,
         "owner_lane": owner_lane,
+        "owner_category": owner_category,
         "evidence_tier": evidence_tier,
         "routing_signals": routing_signals,
         "product_gap_summary": product_gap_summary,
@@ -3325,6 +3331,7 @@ def _action_item(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
         "jira_template": _action_jira_template(
             item,
             owner_lane=owner_lane,
+            owner_category=owner_category,
             product_gap_summary=product_gap_summary,
             ticket_count=ticket_count,
             estimated_support_cost=estimated_support_cost,
@@ -3402,6 +3409,14 @@ def _action_owner_lane(
         return mapped
     topic = _text(item.get("topic"))
     return _owner_lane_title(topic) if topic else "Unknown"
+
+
+def _action_owner_category(status: str) -> str:
+    if status == "Already covered but still recurring":
+        return "Product / Support Experience"
+    if status in {"Draft ready", "Needs answer", "Needs review", "Low confidence"}:
+        return "Content / Support Enablement"
+    return "Review"
 
 
 def _action_routing_signals(item: Mapping[str, Any]) -> dict[str, list[str]]:
@@ -3665,6 +3680,7 @@ def _action_jira_template(
     item: Mapping[str, Any],
     *,
     owner_lane: str,
+    owner_category: str,
     product_gap_summary: str,
     ticket_count: int,
     estimated_support_cost: float,
@@ -3679,6 +3695,7 @@ def _action_jira_template(
         "recommended_title": recommended_title or _text(item.get("question")),
         "question": _text(item.get("question")),
         "owner_lane": owner_lane,
+        "owner_category": owner_category,
         "product_gap_summary": product_gap_summary,
         "ticket_count": ticket_count,
         "estimated_support_cost": estimated_support_cost,

--- a/plans/PR-Deflection-Owner-Category-Contract.md
+++ b/plans/PR-Deflection-Owner-Category-Contract.md
@@ -1,0 +1,148 @@
+# PR-Deflection-Owner-Category-Contract
+
+## Why this slice exists
+
+atlas-portfolio#384 asks for owner-cost accountability without changing the
+meaning of the existing `owner_lane` field. The portfolio page can now roll up
+cost by the lane it receives, but ATLAS still only emits `owner_lane` as the
+routeable topic/area (`Auth / Product UX`, `Billing`, `Reporting`, etc.). That
+is useful, but it is not the higher-level category the buyer needs for "content
+vs product/support" accountability.
+
+Root cause: action rows have a deterministic `status`/`fix_type` split, but the
+report contract does not expose the category that follows from that split. If
+portfolio repurposes `owner_lane`, the contract changes semantics with no shape
+change; if portfolio invents categories locally, it fakes product truth.
+
+This slice fixes the root for the first category layer by adding an optional,
+hosted-safe `owner_category` field derived from the existing action status. It
+does not claim policy detection yet.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-model
+Slice phase: Vertical slice
+
+1. Add `owner_category` to deflection action rows and Jira handoff data without
+   removing or changing `owner_lane`.
+2. Derive `owner_category` deterministically from existing action status:
+   publishable/missing/review/low-confidence rows route to content/support
+   enablement; recurring-after-answer rows route to product/support experience.
+3. Keep the new field optional for legacy stored `deflection.v1` rows and
+   hosted-safe for paid consumers.
+4. Regenerate frontend report-model contracts from the backend contract.
+5. Add tests for category derivation, contract projection, generated artifacts,
+   and legacy backfill.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `owner_lane` values and semantics remain unchanged.
+  - `owner_category` is present on newly generated action rows, included in
+    `jira_template`, and admitted to hosted paid consumers.
+  - Stored legacy reports that lack `owner_category` are normalized with a
+    deterministic fallback instead of surfacing `undefined`.
+  - No policy category is emitted unless a deterministic policy rule exists in
+    this PR.
+- Affected surfaces:
+  - deflection report producer and generated report-model contracts.
+  - ATLAS `portfolio-ui` proxy contract artifacts.
+- Risk areas:
+  - contract back-compat for persisted reports;
+  - generated artifact drift;
+  - accidental `owner_lane` semantic change.
+- Reviewer rules triggered: R1, R8, R10, R14.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Deflection-Owner-Category-Contract.md`
+- `portfolio-ui/api/content-ops/deflection/report-model-contract.js`
+- `portfolio-ui/src/types/deflectionReportModel.ts`
+- `scripts/generate_deflection_frontend_contract_types.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_generate_deflection_frontend_contract_types.py`
+
+## Mechanism
+
+The producer computes `status = _action_status(item)` before building each
+action row. A new helper maps that status to `owner_category`:
+
+- `Already covered but still recurring` -> `Product / Support Experience`
+- `Draft ready`, `Needs answer`, `Needs review`, and `Low confidence` ->
+  `Content / Support Enablement`
+- unknown statuses -> `Review`
+
+That category is emitted beside `owner_lane` and copied into
+`jira_template`. The report-model collection metadata adds the field to
+projected fields, hosted-safe fields, and optional context fields so older
+stored rows remain compatible. The stored-report normalization/backfill path
+gets the same deterministic fallback used by the producer.
+
+Generated contract artifacts are refreshed with
+`scripts/generate_deflection_frontend_contract_types.py`, so
+`portfolio-ui/src/types/deflectionReportModel.ts` and
+`portfolio-ui/api/content-ops/deflection/report-model-contract.js` match the
+producer contract.
+
+## Intentional
+
+- No `owner_lane` repurpose. It remains the routeable topic/area.
+- No new `cost_by_owner` section in ATLAS. Portfolio already computes the
+  rollup as a view from rows, which keeps this additive.
+- No policy category in this slice. The current data has no deterministic rule
+  strong enough to separate policy failures from missing-content or
+  recurring-after-answer rows.
+- The category labels are broad and buyer-facing; person/team routing remains
+  out of scope.
+
+## Deferred
+
+- Policy as a distinct category remains deferred until a deterministic policy
+  signal or operator taxonomy exists.
+- Person/team routing remains deferred until an assignee/group export field or
+  operator owner map is accepted.
+- Portfolio consumption of `owner_category` is a follow-up after this backend
+  contract lands and the portfolio contract is regenerated from merged ATLAS
+  main.
+
+Parked hardening: none.
+
+## Verification
+
+- `scripts/generate_deflection_frontend_contract_types.py` via Python - passed,
+  regenerated the report-model TS/API contract artifacts.
+- `scripts/generate_deflection_snapshot_example.py` via Python - passed, refreshed
+  the canonical frontend report example with `owner_category`.
+- `python -m pytest tests/test_content_ops_deflection_report.py -q` - passed,
+  173 tests.
+- `python -m pytest tests/test_generate_deflection_frontend_contract_types.py -q`
+  - passed, 23 tests.
+- `python -m pytest tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py -q`
+  - passed, 3 tests.
+- `python -m pytest tests/test_smoke_content_ops_deflection_pdf_export_validators.py -q`
+  - passed, 18 tests.
+- `scripts/validate_extracted_content_pipeline.sh` via Bash - passed.
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` via Python
+  - passed.
+- `scripts/audit_extracted_standalone.py` via Python - passed.
+- `scripts/check_ascii_python.sh` via Bash - passed.
+- `extracted/_shared/scripts/sync_extracted.sh` via Bash
+  - passed; diff unchanged after sync.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/frontend/content_ops_faq_deflection_report_example.json` | 42 |
+| `extracted_content_pipeline/deflection_report_access.py` | 22 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 17 |
+| `plans/PR-Deflection-Owner-Category-Contract.md` | 148 |
+| `portfolio-ui/api/content-ops/deflection/report-model-contract.js` | 48 |
+| `portfolio-ui/src/types/deflectionReportModel.ts` | 60 |
+| `scripts/generate_deflection_frontend_contract_types.py` | 1 |
+| `tests/test_content_ops_deflection_report.py` | 18 |
+| `tests/test_generate_deflection_frontend_contract_types.py` | 12 |
+| **Total** | **368** |

--- a/portfolio-ui/api/content-ops/deflection/report-model-contract.js
+++ b/portfolio-ui/api/content-ops/deflection/report-model-contract.js
@@ -63,17 +63,17 @@ export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_HOSTED_CONSUMER_SAFE_FIELDS = 
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_SUPPORT_COST_BASIS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status"]);
 
-export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["tags", "product_area", "custom_product_area"]);
 
-export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
-export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_FIELDS = Object.freeze(["items", "top_item_count", "result_page_limit", "pdf_limit", "support_cost_basis"]);
 
@@ -85,17 +85,17 @@ export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_HOSTED_CONSUMER_SAFE_FIELD
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_SUPPORT_COST_BASIS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status"]);
 
-export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["tags", "product_area", "custom_product_area"]);
 
-export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
-export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_FIELDS = Object.freeze(["items", "top_item_count", "result_page_limit", "pdf_limit"]);
 
@@ -105,17 +105,17 @@ export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_SNAPSHOT_SAFE_FIELDS = Object
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "top_item_count"]);
 
-export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["tags", "product_area", "custom_product_area"]);
 
-export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
-export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_FIELDS = Object.freeze(["items", "top_item_count", "result_page_limit", "pdf_limit"]);
 
@@ -125,17 +125,17 @@ export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_SNAPSHOT_SAFE_FIE
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "top_item_count"]);
 
-export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["tags", "product_area", "custom_product_area"]);
 
-export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
-export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_FIELDS = Object.freeze(["items", "total_item_count", "default_limit"]);
 
@@ -145,17 +145,17 @@ export const DEFLECTION_REPORT_BACKLOG_TABLE_SNAPSHOT_SAFE_FIELDS = Object.freez
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "total_item_count", "default_limit"]);
 
-export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"]);
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["tags", "product_area", "custom_product_area"]);
 
-export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
-export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"]);
 
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_FIELDS = Object.freeze(["outcome_diagnostic_ticket_count", "outcome_risk_ticket_count", "reopened_ticket_count", "negative_csat_ticket_count", "rows"]);
 
@@ -177,17 +177,17 @@ export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_SNAPSHOT_SAFE_FIEL
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["items", "total_item_count", "default_limit", "reason_counts"]);
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal", "review_key", "suppression_reason", "suppression_reason_label"]);
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal", "review_key", "suppression_reason", "suppression_reason_label"]);
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"]);
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["tags", "product_area", "custom_product_area"]);
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze(["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"]);
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = Object.freeze([]);
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence", "review_key", "suppression_reason", "suppression_reason_label"]);
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = Object.freeze(["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence", "review_key", "suppression_reason", "suppression_reason_label"]);
 
 export const DEFLECTION_REPORT_QUESTION_DETAILS_FIELDS = Object.freeze(["rows"]);
 
@@ -221,6 +221,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -246,6 +247,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -270,6 +272,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -295,6 +298,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -318,6 +322,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -343,6 +348,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -384,6 +390,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -409,6 +416,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -503,6 +511,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -531,6 +540,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -555,6 +565,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -580,6 +591,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = Object.freeze({
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",

--- a/portfolio-ui/src/types/deflectionReportModel.ts
+++ b/portfolio-ui/src/types/deflectionReportModel.ts
@@ -63,17 +63,17 @@ export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_HOSTED_CONSUMER_SAFE_FIELDS = 
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_SUPPORT_COST_BASIS_HOSTED_CONSUMER_SAFE_FIELDS = ["status"] as const;
 
-export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = ["tags", "product_area", "custom_product_area"] as const;
 
-export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
 
 export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
-export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
+export const DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_FIELDS = ["items", "top_item_count", "result_page_limit", "pdf_limit", "support_cost_basis"] as const;
 
@@ -85,17 +85,17 @@ export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_HOSTED_CONSUMER_SAFE_FIELD
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_SUPPORT_COST_BASIS_HOSTED_CONSUMER_SAFE_FIELDS = ["status"] as const;
 
-export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = ["tags", "product_area", "custom_product_area"] as const;
 
-export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
 
 export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
-export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
+export const DEFLECTION_REPORT_TOP_UNRESOLVED_REPEATS_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_FIELDS = ["items", "top_item_count", "result_page_limit", "pdf_limit"] as const;
 
@@ -105,17 +105,17 @@ export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_SNAPSHOT_SAFE_FIELDS = [] as 
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "top_item_count"] as const;
 
-export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = ["tags", "product_area", "custom_product_area"] as const;
 
-export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
 
 export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
-export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
+export const DEFLECTION_REPORT_DRAFTED_RESOLUTIONS_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_FIELDS = ["items", "top_item_count", "result_page_limit", "pdf_limit"] as const;
 
@@ -125,17 +125,17 @@ export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_SNAPSHOT_SAFE_FIE
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "top_item_count"] as const;
 
-export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = ["tags", "product_area", "custom_product_area"] as const;
 
-export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
 
 export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
-export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
+export const DEFLECTION_REPORT_ALREADY_COVERED_STILL_RECURRING_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_FIELDS = ["items", "total_item_count", "default_limit"] as const;
 
@@ -145,17 +145,17 @@ export const DEFLECTION_REPORT_BACKLOG_TABLE_SNAPSHOT_SAFE_FIELDS = [] as const;
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "total_item_count", "default_limit"] as const;
 
-export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal"] as const;
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = ["tags", "product_area", "custom_product_area"] as const;
 
-export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
 
 export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
-export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
+export const DEFLECTION_REPORT_BACKLOG_TABLE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence"] as const;
 
 export const DEFLECTION_REPORT_OUTCOME_DIAGNOSTICS_FIELDS = ["outcome_diagnostic_ticket_count", "outcome_risk_ticket_count", "reopened_ticket_count", "negative_csat_ticket_count", "rows"] as const;
 
@@ -177,17 +177,17 @@ export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_SNAPSHOT_SAFE_FIEL
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_HOSTED_CONSUMER_SAFE_FIELDS = ["items", "total_item_count", "default_limit", "reason_counts"] as const;
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal", "review_key", "suppression_reason", "suppression_reason_label"] as const;
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = ["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "confidence", "recommended_action", "ticket_count", "estimated_support_cost", "priority_score", "priority_drivers", "csat_signal", "review_key", "suppression_reason", "suppression_reason_label"] as const;
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_CSAT_SIGNAL_HOSTED_CONSUMER_SAFE_FIELDS = ["status", "csat_present_count", "negative_csat_ticket_count", "numeric_average"] as const;
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_ROUTING_SIGNALS_HOSTED_CONSUMER_SAFE_FIELDS = ["tags", "product_area", "custom_product_area"] as const;
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = ["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", "ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", "evidence_tier", "customer_vocabulary", "recommended_action"] as const;
 
 export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_TOP_EVIDENCE_HOSTED_CONSUMER_SAFE_FIELDS = [] as const;
 
-export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence", "review_key", "suppression_reason", "suppression_reason_label"] as const;
+export const DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_FIELDS = ["rank", "repeat_key", "cluster_id", "identity_basis", "identity_confidence", "question", "status", "owner_lane", "owner_category", "evidence_tier", "routing_signals", "product_gap_summary", "customer_vocabulary", "cost_period", "cost_confidence", "jira_template", "fix_type", "csat_signal", "confidence", "priority_score", "priority_drivers", "recommended_title", "recommended_action", "representative_phrasing", "ticket_count", "estimated_support_cost", "support_cost_formula", "support_cost_source", "opportunity_score", "top_evidence", "review_key", "suppression_reason", "suppression_reason_label"] as const;
 
 export const DEFLECTION_REPORT_QUESTION_DETAILS_FIELDS = ["rows"] as const;
 
@@ -221,6 +221,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -246,6 +247,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -270,6 +272,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -295,6 +298,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -318,6 +322,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -343,6 +348,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -384,6 +390,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -409,6 +416,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -503,6 +511,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -531,6 +540,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -555,6 +565,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "question": "scalar",
     "status": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "evidence_tier": "scalar",
     "routing_signals": "object",
     "product_gap_summary": "scalar",
@@ -580,6 +591,7 @@ export const DEFLECTION_REPORT_HOSTED_FIELD_SHAPES = {
     "recommended_title": "scalar",
     "question": "scalar",
     "owner_lane": "scalar",
+    "owner_category": "scalar",
     "product_gap_summary": "scalar",
     "ticket_count": "scalar",
     "estimated_support_cost": "scalar",
@@ -742,6 +754,7 @@ export type DeflectionReportPriorityFixQueueJiraTemplate = {
   recommended_title: string;
   question: string;
   owner_lane: string;
+  owner_category: string;
   product_gap_summary: string;
   ticket_count: number;
   estimated_support_cost: number;
@@ -766,6 +779,7 @@ export type DeflectionReportPriorityFixQueueItem = {
   question: string;
   status: string;
   owner_lane: string;
+  owner_category?: string;
   evidence_tier?: string;
   routing_signals?: DeflectionReportPriorityFixQueueRoutingSignals;
   product_gap_summary?: string;
@@ -837,6 +851,7 @@ export type DeflectionReportTopUnresolvedRepeatsJiraTemplate = {
   recommended_title: string;
   question: string;
   owner_lane: string;
+  owner_category: string;
   product_gap_summary: string;
   ticket_count: number;
   estimated_support_cost: number;
@@ -861,6 +876,7 @@ export type DeflectionReportTopUnresolvedRepeatsItem = {
   question: string;
   status: string;
   owner_lane: string;
+  owner_category?: string;
   evidence_tier?: string;
   routing_signals?: DeflectionReportTopUnresolvedRepeatsRoutingSignals;
   product_gap_summary?: string;
@@ -924,6 +940,7 @@ export type DeflectionReportDraftedResolutionsJiraTemplate = {
   recommended_title: string;
   question: string;
   owner_lane: string;
+  owner_category: string;
   product_gap_summary: string;
   ticket_count: number;
   estimated_support_cost: number;
@@ -948,6 +965,7 @@ export type DeflectionReportDraftedResolutionsItem = {
   question: string;
   status: string;
   owner_lane: string;
+  owner_category?: string;
   evidence_tier?: string;
   routing_signals?: DeflectionReportDraftedResolutionsRoutingSignals;
   product_gap_summary?: string;
@@ -1010,6 +1028,7 @@ export type DeflectionReportAlreadyCoveredStillRecurringJiraTemplate = {
   recommended_title: string;
   question: string;
   owner_lane: string;
+  owner_category: string;
   product_gap_summary: string;
   ticket_count: number;
   estimated_support_cost: number;
@@ -1034,6 +1053,7 @@ export type DeflectionReportAlreadyCoveredStillRecurringItem = {
   question: string;
   status: string;
   owner_lane: string;
+  owner_category?: string;
   evidence_tier?: string;
   routing_signals?: DeflectionReportAlreadyCoveredStillRecurringRoutingSignals;
   product_gap_summary?: string;
@@ -1096,6 +1116,7 @@ export type DeflectionReportBacklogTableJiraTemplate = {
   recommended_title: string;
   question: string;
   owner_lane: string;
+  owner_category: string;
   product_gap_summary: string;
   ticket_count: number;
   estimated_support_cost: number;
@@ -1120,6 +1141,7 @@ export type DeflectionReportBacklogTableItem = {
   question: string;
   status: string;
   owner_lane: string;
+  owner_category?: string;
   evidence_tier?: string;
   routing_signals?: DeflectionReportBacklogTableRoutingSignals;
   product_gap_summary?: string;
@@ -1208,6 +1230,7 @@ export type DeflectionReportSuppressedRepeatReviewQueueJiraTemplate = {
   recommended_title: string;
   question: string;
   owner_lane: string;
+  owner_category: string;
   product_gap_summary: string;
   ticket_count: number;
   estimated_support_cost: number;
@@ -1232,6 +1255,7 @@ export type DeflectionReportSuppressedRepeatReviewQueueItem = {
   question: string;
   status: string;
   owner_lane: string;
+  owner_category?: string;
   evidence_tier?: string;
   routing_signals?: DeflectionReportSuppressedRepeatReviewQueueRoutingSignals;
   product_gap_summary?: string;

--- a/scripts/generate_deflection_frontend_contract_types.py
+++ b/scripts/generate_deflection_frontend_contract_types.py
@@ -74,6 +74,7 @@ TYPE_BY_FIELD = {
     "outcome_diagnostic_ticket_count": "number",
     "outcome_diagnostics": "DeflectionReportQuestionOutcomeDiagnostics | null",
     "outcome_risk_ticket_count": "number",
+    "owner_category": "string",
     "owner_lane": "string",
     "pdf_limit": "number",
     "phrases": "string[]",

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -495,6 +495,9 @@ def test_deflection_report_artifact_exposes_structured_model_sections() -> None:
     ]
     assert priority_queue["data"]["items"][0]["fix_type"] == "publish_help_center_answer"
     assert priority_queue["data"]["items"][0]["owner_lane"] == "Reporting"
+    assert priority_queue["data"]["items"][0]["owner_category"] == (
+        "Content / Support Enablement"
+    )
     assert priority_queue["data"]["items"][0]["estimated_support_cost"] == 67.5
     assert priority_queue["data"]["items"][0]["csat_signal"] == {
         "status": "insufficient_data",
@@ -503,6 +506,9 @@ def test_deflection_report_artifact_exposes_structured_model_sections() -> None:
         "numeric_average": None,
     }
     assert priority_queue["data"]["items"][1]["fix_type"] == "create_missing_answer"
+    assert priority_queue["data"]["items"][1]["owner_category"] == (
+        "Content / Support Enablement"
+    )
 
     unresolved = section_by_id["top_unresolved_repeats"]["data"]
     assert unresolved["top_item_count"] == 1
@@ -631,6 +637,9 @@ def test_deflection_action_sections_classify_recurring_covered_answers() -> None
         "improve_discoverability_or_answer_quality"
     )
     assert recurring["items"][0]["owner_lane"] == "Analytics"
+    assert recurring["items"][0]["owner_category"] == (
+        "Product / Support Experience"
+    )
     assert recurring["items"][0]["csat_signal"] == {
         "status": "present",
         "csat_present_count": 4,
@@ -675,6 +684,7 @@ def test_csv_product_gap_owner_lane_vertical_routes_login_gap() -> None:
 
     assert priority_item["question"] == "Where is the login button?"
     assert priority_item["owner_lane"] == "Auth / Product UX"
+    assert priority_item["owner_category"] == "Content / Support Enablement"
     assert priority_item["ticket_count"] == 4
     assert priority_item["estimated_support_cost"] == 54.0
     assert priority_item["evidence_tier"] == "csv_customer_text"
@@ -698,6 +708,7 @@ def test_csv_product_gap_owner_lane_vertical_routes_login_gap() -> None:
         "recommended_title": "Where is the login button?",
         "question": "Where is the login button?",
         "owner_lane": "Auth / Product UX",
+        "owner_category": "Content / Support Enablement",
         "product_gap_summary": priority_item["product_gap_summary"],
         "ticket_count": 4,
         "estimated_support_cost": 54.0,
@@ -2287,6 +2298,7 @@ def test_deflection_report_projection_separates_paid_and_hosted_action_fields() 
         "top_evidence",
     }
     additive_action_context_fields = {
+        "owner_category",
         "evidence_tier",
         "routing_signals",
         "product_gap_summary",
@@ -5685,7 +5697,9 @@ def test_stored_deflection_report_model_backfills_legacy_action_owner_metadata()
         if section["id"] == "priority_fix_queue"
     )
     item = priority_section["data"]["items"][0]
+    item.pop("owner_category", None)
     item.pop("evidence_tier", None)
+    item["jira_template"].pop("owner_category", None)
     item["routing_signals"] = {
         "group": ["Support Queue"],
         "assignee": ["Agent Export"],
@@ -5705,6 +5719,10 @@ def test_stored_deflection_report_model_backfills_legacy_action_owner_metadata()
     )
     normalized_item = section["data"]["items"][0]
 
+    assert normalized_item["owner_category"] == "Content / Support Enablement"
+    assert normalized_item["jira_template"]["owner_category"] == (
+        "Content / Support Enablement"
+    )
     assert normalized_item["evidence_tier"] == "csv_index_metadata_only"
     assert normalized_item["routing_signals"] == {
         "tags": ["login"],

--- a/tests/test_generate_deflection_frontend_contract_types.py
+++ b/tests/test_generate_deflection_frontend_contract_types.py
@@ -79,8 +79,10 @@ def test_deflection_report_model_types_include_backend_projection_fields() -> No
     assert "customer_vocabulary?: string[];" in rendered
     assert "cost_period?: string;" in rendered
     assert "cost_confidence?: string;" in rendered
+    assert "owner_category?: string;" in rendered
     assert "jira_template?: DeflectionReportPriorityFixQueueJiraTemplate;" in rendered
     assert "export type DeflectionReportPriorityFixQueueJiraTemplate" in rendered
+    assert "  owner_category: string;" in rendered
     assert "  product_gap_summary: string;" in rendered
     assert "  customer_vocabulary: string[];" in rendered
     assert "top_evidence: DeflectionReportPriorityFixQueueTopEvidence[];" in rendered
@@ -107,7 +109,7 @@ def test_deflection_report_model_types_publish_hosted_safe_allowlists() -> None:
     ) in rendered
     assert (
         'DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = '
-        '["rank", "question", "status", "owner_lane", "evidence_tier", '
+        '["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", '
         '"routing_signals", "product_gap_summary", "customer_vocabulary", '
         '"cost_period", "cost_confidence", "jira_template", "confidence", '
         '"recommended_action", "ticket_count", "estimated_support_cost", '
@@ -115,7 +117,7 @@ def test_deflection_report_model_types_publish_hosted_safe_allowlists() -> None:
     ) in rendered
     assert (
         'DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = '
-        '["recommended_title", "question", "owner_lane", "product_gap_summary", '
+        '["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", '
         '"ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", '
         '"evidence_tier", "customer_vocabulary", "recommended_action"]'
     ) in rendered
@@ -200,7 +202,7 @@ def test_deflection_report_model_api_contract_publishes_hosted_safe_allowlists()
     ) in rendered
     assert (
         'DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = '
-        'Object.freeze(["rank", "question", "status", "owner_lane", "evidence_tier", '
+        'Object.freeze(["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", '
         '"routing_signals", "product_gap_summary", "customer_vocabulary", '
         '"cost_period", "cost_confidence", "jira_template", "confidence", '
         '"recommended_action", "ticket_count", "estimated_support_cost", '
@@ -208,7 +210,7 @@ def test_deflection_report_model_api_contract_publishes_hosted_safe_allowlists()
     ) in rendered
     assert (
         'DEFLECTION_REPORT_PRIORITY_FIX_QUEUE_ITEMS_JIRA_TEMPLATE_HOSTED_CONSUMER_SAFE_FIELDS = '
-        'Object.freeze(["recommended_title", "question", "owner_lane", "product_gap_summary", '
+        'Object.freeze(["recommended_title", "question", "owner_lane", "owner_category", "product_gap_summary", '
         '"ticket_count", "estimated_support_cost", "cost_period", "cost_confidence", '
         '"evidence_tier", "customer_vocabulary", "recommended_action"])'
     ) in rendered
@@ -227,7 +229,7 @@ def test_deflection_report_model_api_contract_publishes_hosted_safe_allowlists()
     ) in rendered
     assert (
         'DEFLECTION_REPORT_SUPPRESSED_REPEAT_REVIEW_QUEUE_ITEMS_HOSTED_CONSUMER_SAFE_FIELDS = '
-        'Object.freeze(["rank", "question", "status", "owner_lane", "evidence_tier", '
+        'Object.freeze(["rank", "question", "status", "owner_lane", "owner_category", "evidence_tier", '
         '"routing_signals", "product_gap_summary", "customer_vocabulary", '
         '"cost_period", "cost_confidence", "jira_template", "confidence", '
         '"recommended_action", "ticket_count", "estimated_support_cost", '


### PR DESCRIPTION
Plan: plans/PR-Deflection-Owner-Category-Contract.md
Slice phase: Vertical slice

Adds an additive `owner_category` field to deflection action rows so portfolio can roll up accountable buyer-facing buckets without repurposing `owner_lane`. `owner_lane` remains the routeable topic/area; `owner_category` is derived deterministically from existing action status and kept optional/backfilled for legacy stored reports.

## Intentional
- No `owner_lane` repurpose; it remains the routeable topic/area.
- No new ATLAS `cost_by_owner` section; portfolio computes the rollup as a view from rows.
- No policy category in this slice because there is no deterministic policy rule yet.
- Category labels stay broad and buyer-facing; person/team routing remains out of scope.

## Deferred
- Policy as a distinct category remains deferred until a deterministic policy signal or operator taxonomy exists.
- Person/team routing remains deferred until an assignee/group export field or operator owner map is accepted.
- Portfolio consumption of `owner_category` follows after this backend contract lands and portfolio regenerates from merged ATLAS main.

## Parked hardening
- None.

## Verification
- `scripts/generate_deflection_frontend_contract_types.py` via Python - passed, regenerated report-model TS/API contract artifacts.
- `scripts/generate_deflection_snapshot_example.py` via Python - passed, refreshed the canonical frontend report example with `owner_category`.
- `python -m pytest tests/test_content_ops_deflection_report.py -q` - passed, 173 tests.
- `python -m pytest tests/test_generate_deflection_frontend_contract_types.py -q` - passed, 23 tests.
- `python -m pytest tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py -q` - passed, 3 tests.
- `python -m pytest tests/test_smoke_content_ops_deflection_pdf_export_validators.py -q` - passed, 18 tests.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed; diff unchanged after sync.
- Pending in push wrapper: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/deflection-owner-category-contract-pr-body.md`.

## Diff size
9 files, +327 / -41.
