### PR TITLE
Add deflection delta entitlement allowlist

### DIFF
--- a/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
+++ b/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Sequence
 
 from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
 from extracted_content_pipeline.campaign_sender import create_campaign_sender
@@ -62,6 +62,49 @@ def _metadata_text(task: ScheduledTask | Any, *keys: str) -> str | None:
     return None
 
 
+def _csv_text_tuple(value: Any) -> tuple[str, ...]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in str(value or "").split(","):
+        text = item.strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return tuple(out)
+
+
+def _entitlement_skip_payload(
+    *,
+    entitled_account_ids: Sequence[str],
+    target_account_id: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "entitled_account_count": len(tuple(entitled_account_ids)),
+        "accounts_scanned": 0,
+        "reports_scanned": 0,
+        "deltas_saved": 0,
+        "delta_deliveries_enqueued": 0,
+        "skipped_no_delta": 0,
+        "failed": 0,
+        "delivery_scanned": 0,
+        "delivery_sent": 0,
+        "delivery_failed": 0,
+        "delivery_deferred": 0,
+        "delivery_dry_run": 0,
+        "delivery_dry_run_enabled": bool(settings.deflection_delivery.dry_run),
+        "account_limit_reached": False,
+        "account_limit_overflow": False,
+        "reports_per_account_limit_reached": False,
+        "reports_per_account_limit_overflow": False,
+        "report_limit_reached_accounts": [],
+        "report_limit_overflow_accounts": [],
+    }
+    if target_account_id:
+        payload["target_account_id"] = target_account_id
+    return payload
+
+
 def _configured(value: Any) -> bool:
     return bool(str(value or "").strip())
 
@@ -114,8 +157,22 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     try:
         target_account_id = _metadata_text(task, "target_account_id", "account_id")
         target_current_request_id = _metadata_text(task, "current_request_id")
+        entitled_account_ids = _csv_text_tuple(cfg.entitled_account_ids)
         if target_current_request_id and not target_account_id:
             raise ValueError("current_request_id requires target_account_id")
+        if target_account_id and target_account_id not in entitled_account_ids:
+            return {
+                "_skip_synthesis": "Deflection delta target account not entitled",
+                **_entitlement_skip_payload(
+                    entitled_account_ids=entitled_account_ids,
+                    target_account_id=target_account_id,
+                ),
+            }
+        if not target_account_id and not entitled_account_ids:
+            return {
+                "_skip_synthesis": "No entitled deflection delta accounts configured",
+                **_entitlement_skip_payload(entitled_account_ids=entitled_account_ids),
+            }
         batch_kwargs: dict[str, Any] = {
             "account_limit": _metadata_int(
                 task,
@@ -127,6 +184,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 "reports_per_account",
                 int(cfg.reports_per_account),
             ),
+            "entitled_account_ids": entitled_account_ids,
         }
         if target_account_id:
             batch_kwargs["account_id"] = target_account_id
@@ -154,6 +212,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             delivery_kwargs["account_id"] = target_account_id
         if target_current_request_id:
             delivery_kwargs["current_request_id"] = target_current_request_id
+        delivery_kwargs["entitled_account_ids"] = entitled_account_ids
         delivery_summary = await send_pending_deflection_delta_deliveries(
             pool,
             sender=_sender(dry_run=dry_run),
@@ -165,12 +224,16 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             count_kwargs: dict[str, Any] = {"account_id": target_account_id}
             if target_current_request_id:
                 count_kwargs["current_request_id"] = target_current_request_id
+            count_kwargs["entitled_account_ids"] = entitled_account_ids
             pending_delivery_count = await pending_deflection_delta_delivery_count(
                 pool,
                 **count_kwargs,
             )
         else:
-            pending_delivery_count = await pending_deflection_delta_delivery_count(pool)
+            pending_delivery_count = await pending_deflection_delta_delivery_count(
+                pool,
+                entitled_account_ids=entitled_account_ids,
+            )
 
     payload = {
         "accounts_scanned": summary.accounts_scanned,
@@ -199,6 +262,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         "report_limit_overflow_accounts": list(
             summary.report_limit_overflow_accounts
         ),
+        "entitled_account_count": len(entitled_account_ids),
     }
     if target_account_id:
         payload["target_account_id"] = target_account_id

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4049,6 +4049,13 @@ class DeflectionDeltaConfig(BaseSettings):
     cron_expression: str = Field(default="0 8 1 * *", description="Cron expression for monthly deflection delta generation")
     account_limit: int = Field(default=100, ge=1, le=100, description="Maximum paid-report accounts scanned per run")
     reports_per_account: int = Field(default=25, ge=1, le=100, description="Maximum recent paid reports scanned per account")
+    entitled_account_ids: str = Field(
+        default="",
+        description=(
+            "Comma-separated account IDs entitled to monthly deflection delta "
+            "generation and delivery. Blank fails closed."
+        ),
+    )
 
 
 class B2BWebhookConfig(BaseSettings):

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -294,17 +294,20 @@ async def send_pending_deflection_delta_deliveries(
     config: DeflectionDeltaDeliveryConfig,
     account_id: str | None = None,
     current_request_id: str | None = None,
+    entitled_account_ids: Sequence[str] | None = None,
 ) -> DeflectionDeltaDeliveryRunSummary:
     """Send pending paid-report delta delivery emails and update queue status."""
 
     _validate_delta_config(config)
     scoped_account_id = _clean(account_id) or None
     scoped_current_request_id = _clean(current_request_id) or None
+    entitled_accounts = _optional_text_list(entitled_account_ids)
     rows = await pool.fetch(
         _PENDING_DELTA_SQL if config.dry_run else _CLAIM_PENDING_DELTA_SQL,
         int(config.limit),
         scoped_account_id,
         scoped_current_request_id,
+        entitled_accounts,
     )
     sent = failed = deferred = dry_run = 0
     for row in rows:
@@ -442,11 +445,13 @@ async def pending_deflection_delta_delivery_count(
     *,
     account_id: str | None = None,
     current_request_id: str | None = None,
+    entitled_account_ids: Sequence[str] | None = None,
 ) -> int:
     """Return queued delta deliveries that still require a configured sender."""
 
     scoped_account_id = _clean(account_id) or None
     scoped_current_request_id = _clean(current_request_id) or None
+    entitled_accounts = _optional_text_list(entitled_account_ids)
     count = await pool.fetchval(
         f"""
         SELECT COUNT(*)
@@ -460,9 +465,11 @@ async def pending_deflection_delta_delivery_count(
               )
           AND ($1::text IS NULL OR account_id = $1)
           AND ($2::text IS NULL OR current_request_id = $2)
+          AND ($3::text[] IS NULL OR account_id = ANY($3::text[]))
         """,
         scoped_account_id,
         scoped_current_request_id,
+        entitled_accounts,
     )
     parsed = _strict_int(count)
     return parsed if parsed is not None else 0
@@ -1545,6 +1552,20 @@ def _clean(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _optional_text_list(values: Sequence[str] | None) -> list[str] | None:
+    if values is None:
+        return None
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        text = _clean(value)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
 def _email_count(value: int) -> str:
     return f"{int(value):,}"
 
@@ -1658,6 +1679,7 @@ JOIN content_ops_deflection_reports baseline_report
 WHERE d.delivery_status = 'pending'
   AND ($2::text IS NULL OR d.account_id = $2)
   AND ($3::text IS NULL OR d.current_request_id = $3)
+  AND ($4::text[] IS NULL OR d.account_id = ANY($4::text[]))
 ORDER BY d.created_at
 LIMIT $1
 """
@@ -1679,6 +1701,7 @@ WITH claimed AS (
           )
       AND ($2::text IS NULL OR d.account_id = $2)
       AND ($3::text IS NULL OR d.current_request_id = $3)
+      AND ($4::text[] IS NULL OR d.account_id = ANY($4::text[]))
     ORDER BY d.created_at
     FOR UPDATE SKIP LOCKED
     LIMIT $1

--- a/docs/extraction/validation/content_ops_deflection_delta_go_live_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_delta_go_live_runbook.md
@@ -99,7 +99,10 @@ other operator/test address, stop. The go-live check passes only when every
 delivery address you will send to is confirmed as a real paying customer. Copy
 the opted-in row's `account_id` and `current_request_id`; the manual rehearsal
 and live-send commands must use those exact values as `target_account_id` and
-`current_request_id`.
+`current_request_id`. Add the opted-in `account_id` to
+`ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS` before any dry-run or live
+activation; the delta task intentionally skips generation and pending delivery
+drain work when the allowlist is blank or when the target account is absent.
 
 ## Dry-Run Activation
 
@@ -111,6 +114,7 @@ rehearsal. Use the per-run `delivery_dry_run` override below instead.
 ```bash
 ATLAS_DEFLECTION_DELTA_ENABLED=true
 ATLAS_DEFLECTION_DELTA_CRON_EXPRESSION="0 8 1 * *"
+ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS="<account-id>"
 ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL="reports@example.com"
 ```
 
@@ -165,6 +169,7 @@ scheduled monthly cron after the entitlement/opt-in list is ready.
 
 ```bash
 ATLAS_DEFLECTION_DELTA_ENABLED=true
+ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS="<account-id>"
 ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false
 ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL="reports@example.com"
 ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY="<resend-api-key>"

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -142,10 +142,15 @@ class DeflectionReportArtifactStore(Protocol):
         self,
         *,
         limit: int | None = 100,
+        account_ids: Sequence[str] | None = None,
     ) -> tuple[str, ...]:
         """List tenants with paid reports, newest paid activity first."""
 
-    async def count_paid_report_accounts(self) -> int:
+    async def count_paid_report_accounts(
+        self,
+        *,
+        account_ids: Sequence[str] | None = None,
+    ) -> int:
         """Count tenants that have at least one paid report."""
 
     async def count_paid_reports(
@@ -407,11 +412,15 @@ class InMemoryDeflectionReportArtifactStore:
         self,
         *,
         limit: int | None = 100,
+        account_ids: Sequence[str] | None = None,
     ) -> tuple[str, ...]:
+        allowed_accounts = _account_id_tuple(account_ids)
         newest_by_account: dict[str, datetime] = {}
         fallback = datetime.min.replace(tzinfo=timezone.utc)
         for key, row in self._rows.items():
             account_id, _request_id = key
+            if allowed_accounts is not None and account_id not in allowed_accounts:
+                continue
             if not row.paid:
                 continue
             paid_activity_at = self._paid_at_by_key.get(
@@ -427,11 +436,17 @@ class InMemoryDeflectionReportArtifactStore:
             return tuple(ordered)
         return tuple(ordered[:_bounded_limit(limit)])
 
-    async def count_paid_report_accounts(self) -> int:
+    async def count_paid_report_accounts(
+        self,
+        *,
+        account_ids: Sequence[str] | None = None,
+    ) -> int:
+        allowed_accounts = _account_id_tuple(account_ids)
         return len(
             {
                 account_id
                 for (account_id, _request_id), row in self._rows.items()
+                if allowed_accounts is None or account_id in allowed_accounts
                 if row.paid
             }
         )
@@ -827,17 +842,24 @@ class PostgresDeflectionReportArtifactStore:
         self,
         *,
         limit: int | None = 100,
+        account_ids: Sequence[str] | None = None,
     ) -> tuple[str, ...]:
         args: list[Any] = []
+        filters = ["paid = true"]
+        allowed_accounts = _account_id_tuple(account_ids)
+        if allowed_accounts is not None:
+            args.append(list(allowed_accounts))
+            filters.append(f"account_id = ANY(${len(args)}::text[])")
         limit_clause = ""
         if limit is not None:
             args.append(_bounded_limit(limit))
-            limit_clause = "LIMIT $1"
+            limit_clause = f"LIMIT ${len(args)}"
+        where_clause = " AND ".join(filters)
         rows = await self.pool.fetch(
             f"""
             SELECT account_id
             FROM content_ops_deflection_reports
-            WHERE paid = true
+            WHERE {where_clause}
             GROUP BY account_id
             ORDER BY MAX(COALESCE(paid_at, updated_at, created_at)) DESC, account_id ASC
             {limit_clause}
@@ -850,13 +872,25 @@ class PostgresDeflectionReportArtifactStore:
             if (account_id := _clean(row_to_dict(row).get("account_id")))
         )
 
-    async def count_paid_report_accounts(self) -> int:
+    async def count_paid_report_accounts(
+        self,
+        *,
+        account_ids: Sequence[str] | None = None,
+    ) -> int:
+        args: list[Any] = []
+        filters = ["paid = true"]
+        allowed_accounts = _account_id_tuple(account_ids)
+        if allowed_accounts is not None:
+            args.append(list(allowed_accounts))
+            filters.append(f"account_id = ANY(${len(args)}::text[])")
+        where_clause = " AND ".join(filters)
         row = await self.pool.fetchrow(
-            """
+            f"""
             SELECT COUNT(DISTINCT account_id) AS count
             FROM content_ops_deflection_reports
-            WHERE paid = true
-            """
+            WHERE {where_clause}
+            """,
+            *args,
         )
         return _row_count(row)
 
@@ -1683,6 +1717,20 @@ def _text_list(value: Any) -> list[str]:
     return [text for item in value if (text := _clean(item))]
 
 
+def _account_id_tuple(value: Sequence[str] | None) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    seen: set[str] = set()
+    account_ids: list[str] = []
+    for item in value:
+        account_id = _clean(item)
+        if not account_id or account_id in seen:
+            continue
+        seen.add(account_id)
+        account_ids.append(account_id)
+    return tuple(account_ids)
+
+
 def _required_text(value: Any, field: str) -> str:
     text = _clean(value)
     if not text:
@@ -1806,6 +1854,7 @@ async def compute_and_save_recent_deflection_deltas(
     *,
     account_id: str | None = None,
     current_request_id: str | None = None,
+    entitled_account_ids: Sequence[str] | None = None,
     account_limit: int | None = 100,
     reports_per_account: int | None = 25,
 ) -> DeflectionDeltaBatchSummary:
@@ -1813,6 +1862,7 @@ async def compute_and_save_recent_deflection_deltas(
 
     scoped_account_id = _clean(account_id)
     scoped_current_request_id = _clean(current_request_id)
+    entitled_accounts = _account_id_tuple(entitled_account_ids)
     if scoped_current_request_id and not scoped_account_id:
         raise ValueError("current_request_id requires account_id")
     resolved_account_limit = (
@@ -1824,8 +1874,13 @@ async def compute_and_save_recent_deflection_deltas(
     accounts = (
         (scoped_account_id,)
         if scoped_account_id
-        else await store.list_paid_report_accounts(limit=resolved_account_limit)
+        else await store.list_paid_report_accounts(
+            limit=resolved_account_limit,
+            account_ids=entitled_accounts,
+        )
     )
+    if scoped_account_id and entitled_accounts is not None:
+        accounts = (scoped_account_id,) if scoped_account_id in entitled_accounts else ()
     account_limit_reached = (
         not scoped_account_id
         and resolved_account_limit is not None
@@ -1834,7 +1889,7 @@ async def compute_and_save_recent_deflection_deltas(
     account_limit_overflow = False
     if account_limit_reached:
         account_limit_overflow = (
-            await store.count_paid_report_accounts()
+            await store.count_paid_report_accounts(account_ids=entitled_accounts)
         ) > resolved_account_limit
     reports_scanned = 0
     deltas_saved = 0

--- a/plans/PR-Deflection-Delta-Entitlement-Allowlist.md
+++ b/plans/PR-Deflection-Delta-Entitlement-Allowlist.md
@@ -1,0 +1,161 @@
+# PR-Deflection-Delta-Entitlement-Allowlist
+
+## Why this slice exists
+
+#1316 and the archived delta plans repeatedly deferred subscription entitlement
+checks before monthly Report Delta go-live. #1868 made manual activation safely
+account/current-request scoped, but the global monthly path still uses "has at
+least one paid deflection report" as the account roster.
+
+Root cause: paid report access is a one-time purchase state, while monthly delta
+delivery is a subscription entitlement. Reusing paid-report discovery as the
+subscription roster can enqueue recurring emails for accounts that bought a
+single report but did not opt into monthly deltas.
+
+This PR fixes the root for the current architecture by adding an explicit,
+fail-closed account allowlist at the automation/store boundary. It does not add
+a Stripe subscription checkout or webhook sync; that larger Billing-backed
+entitlement source remains deferred until pricing/product enrollment is ready.
+
+Diff-size note: this is over the 400 LOC target because the smallest root-cause
+slice has to update the typed config, the access-boundary protocol plus both
+store implementations, the scheduled task guard, and tests at both layers. A
+task-only guard would leave the batch generator reusable without the entitlement
+filter and would be a symptom fix.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-deltas
+Slice phase: Production hardening
+
+1. Add an `ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS` allowlist to the typed
+   delta config.
+2. Thread the allowlist into recent-delta generation and pending delivery drain
+   queries so global monthly runs scan and send only entitled accounts.
+3. Fail closed when the automation is enabled without any entitled accounts, or
+   when a manual `target_account_id` is not entitled.
+4. Add tests proving global generation excludes non-entitled paid accounts and
+   targeted activation rejects non-entitled accounts before delivery.
+5. Update the go-live runbook so operators set the required allowlist before
+   dry-run or live monthly delta activation.
+
+### Review Contract
+
+Acceptance criteria:
+- Monthly/global delta automation must not call the batch generator when no
+  entitlement allowlist is configured.
+- Manual targeted automation must not generate or drain delivery for a
+  `target_account_id` outside the entitlement allowlist.
+- Batch generation must intersect paid-report discovery with the entitlement
+  allowlist so a paid-but-unentitled account is not scanned/enqueued.
+- Pending delta delivery drain/count queries must also honor the entitlement
+  allowlist so already-queued rows for revoked accounts are not sent later.
+- The go-live runbook must document
+  `ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS` as required activation config.
+- Existing scoped `target_account_id` + `current_request_id` behavior from
+  #1868 remains intact for entitled accounts.
+
+Affected surfaces:
+- Deflection delta task configuration and automation payloads.
+- Recent paid report discovery in the deflection report access boundary.
+- Unit/in-memory persistence tests for batch selection.
+- Monthly delta go-live runbook and its contract test.
+
+Risk areas:
+- Accidentally widening a blank entitlement list into all paid accounts.
+- Breaking the manual go-live path that now requires a configured entitled
+  account.
+- Confusing one-time paid report state with recurring subscription state.
+
+Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R11, R12, R14.
+- R1 Requirements match.
+- R2 Test evidence.
+- R3 Security/auth/billing.
+- R6 Jobs/scheduled automation.
+- R8 Persistence/data lifecycle.
+- R10 Gate/predicate behavior.
+- R14 Codebase verification.
+
+### Files touched
+
+- `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py`
+- `atlas_brain/config.py`
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `docs/extraction/validation/content_ops_deflection_delta_go_live_runbook.md`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `plans/PR-Deflection-Delta-Entitlement-Allowlist.md`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_content_ops_deflection_delta_go_live_runbook.py`
+- `tests/test_content_ops_deflection_delta_persistence.py`
+- `tests/test_deflection_delta_automation_task.py`
+
+## Mechanism
+
+- Add a comma-separated `entitled_account_ids` field under
+  `settings.deflection_delta`.
+- Parse it into normalized account IDs in
+  `content_ops_deflection_delta_automation.run`.
+- If the task is global and the allowlist is empty, return a skip payload before
+  generation or delivery.
+- If the task is targeted and the target is not in the allowlist, return a
+  fail-closed skip payload before generation or delivery.
+- Extend `compute_and_save_recent_deflection_deltas` with an optional entitled
+  account list. Global account discovery uses only the paid accounts in that
+  list, preserving the existing paid gate while separating the recurring
+  entitlement roster from one-time report purchases.
+- Thread the same allowlist into `send_pending_deflection_delta_deliveries` and
+  `pending_deflection_delta_delivery_count`. The delivery claim/read SQL applies
+  an account filter before rows are scanned, claimed, counted, or emailed.
+- Require `ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS` in the dry-run and live
+  activation snippets of the go-live runbook, and pin that requirement in the
+  runbook contract test.
+
+## Intentional
+
+- No Stripe API call, Checkout Session, subscription webhook, or Customer Portal
+  flow lands here. Per the Stripe Billing guidance, the durable product path
+  should use Billing subscriptions/Prices; this slice only adds the local
+  fail-closed roster needed before enabling monthly automation.
+- No wildcard/all-paid escape hatch. A blank allowlist means no monthly delta
+  accounts, because the failure mode we are closing is recurring delivery to
+  one-time report buyers.
+- No new DB table for entitlements in this PR; the source of truth is the
+  typed config until the subscription product is ready.
+
+## Deferred
+
+- Replace the config allowlist with a Stripe Billing-backed subscription
+  entitlement source once the monthly product/Price IDs and webhook lifecycle
+  are defined.
+- #1869: DB-backed live-drain integration coverage once the deflection delivery
+  CI gate has a Postgres service.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed locally:
+  - python -m py_compile atlas_brain/config.py atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py atlas_brain/content_ops_deflection_delivery.py extracted_content_pipeline/deflection_report_access.py tests/test_deflection_delta_automation_task.py tests/test_content_ops_deflection_delta_persistence.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_content_ops_deflection_delta_go_live_runbook.py
+  - pytest tests/test_deflection_delta_automation_task.py tests/test_content_ops_deflection_delta_persistence.py
+    - 53 passed, 1 warning.
+  - pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_deflection_delta_automation_task.py -q
+    - 59 passed, 1 warning.
+  - pytest tests/test_content_ops_deflection_delta_go_live_runbook.py -q
+    - 6 passed.
+  - python scripts/sync_pr_plan.py plans/PR-Deflection-Delta-Entitlement-Allowlist.md --check
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 68 |
+| `atlas_brain/config.py` | 7 |
+| `atlas_brain/content_ops_deflection_delivery.py` | 23 |
+| `docs/extraction/validation/content_ops_deflection_delta_go_live_runbook.md` | 7 |
+| `extracted_content_pipeline/deflection_report_access.py` | 75 |
+| `plans/PR-Deflection-Delta-Entitlement-Allowlist.md` | 161 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 40 |
+| `tests/test_content_ops_deflection_delta_go_live_runbook.py` | 13 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 116 |
+| `tests/test_deflection_delta_automation_task.py` | 106 |
+| **Total** | **616** |

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -639,7 +639,7 @@ async def test_pending_deflection_delta_delivery_count_includes_stale_sending() 
 
     assert count == 2
     query, args = pool.fetchval_calls[0]
-    assert args == (None, None)
+    assert args == (None, None, None)
     assert "delivery_status = 'pending'" in query
     assert "delivery_status = 'sending'" in query
     assert DELIVERY_CLAIM_STALE_AFTER in query
@@ -668,10 +668,10 @@ async def test_delta_delivery_queue_can_be_scoped_to_one_account() -> None:
     assert summary.scanned == 1
     assert count == 1
     fetch_query, fetch_args = pool.fetch_calls[0]
-    assert fetch_args == (5, "acct-target", None)
+    assert fetch_args == (5, "acct-target", None, None)
     assert "AND ($2::text IS NULL OR d.account_id = $2)" in fetch_query
     count_query, count_args = pool.fetchval_calls[0]
-    assert count_args == ("acct-target", None)
+    assert count_args == ("acct-target", None, None)
     assert "AND ($1::text IS NULL OR account_id = $1)" in count_query
 
 
@@ -700,12 +700,42 @@ async def test_delta_delivery_queue_can_be_scoped_to_one_current_request() -> No
     assert summary.scanned == 1
     assert count == 1
     claim_query, claim_args = pool.fetch_calls[0]
-    assert claim_args == (5, "acct-target", "checked-current")
+    assert claim_args == (5, "acct-target", "checked-current", None)
     assert "AND ($2::text IS NULL OR d.account_id = $2)" in claim_query
     assert "AND ($3::text IS NULL OR d.current_request_id = $3)" in claim_query
     count_query, count_args = pool.fetchval_calls[0]
-    assert count_args == ("acct-target", "checked-current")
+    assert count_args == ("acct-target", "checked-current", None)
     assert "AND ($2::text IS NULL OR current_request_id = $2)" in count_query
+
+
+@pytest.mark.asyncio
+async def test_delta_delivery_queue_filters_entitled_accounts_on_global_drain() -> None:
+    pool = _DeltaPool([_delta_delivery_row()])
+    sender = _Sender()
+
+    summary = await send_pending_deflection_delta_deliveries(
+        pool,
+        sender=sender,
+        config=DeflectionDeltaDeliveryConfig(
+            from_email="reports@example.com",
+            limit=5,
+            dry_run=True,
+        ),
+        entitled_account_ids=("acct-active", " ", "acct-active"),
+    )
+    count = await pending_deflection_delta_delivery_count(
+        pool,
+        entitled_account_ids=("acct-active",),
+    )
+
+    assert summary.scanned == 1
+    assert count == 1
+    fetch_query, fetch_args = pool.fetch_calls[0]
+    assert fetch_args == (5, None, None, ["acct-active"])
+    assert "AND ($4::text[] IS NULL OR d.account_id = ANY($4::text[]))" in fetch_query
+    count_query, count_args = pool.fetchval_calls[0]
+    assert count_args == (None, None, ["acct-active"])
+    assert "AND ($3::text[] IS NULL OR account_id = ANY($3::text[]))" in count_query
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_ops_deflection_delta_go_live_runbook.py
+++ b/tests/test_content_ops_deflection_delta_go_live_runbook.py
@@ -59,6 +59,7 @@ def test_deflection_delta_go_live_runbook_rehearses_before_live_send() -> None:
     rollback = _section("Rollback")
 
     assert "ATLAS_DEFLECTION_DELTA_ENABLED=true" in dry_run
+    assert 'ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS="<account-id>"' in dry_run
     assert "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=true" not in dry_run
     assert "shared with the already-live" in dry_run
     assert "ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL" in dry_run
@@ -71,6 +72,7 @@ def test_deflection_delta_go_live_runbook_rehearses_before_live_send() -> None:
     assert "delta_deliveries_enqueued" in dry_run
     assert "`delivery_dry_run` is 1" in dry_run
     assert "delivery_failed" in dry_run
+    assert 'ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS="<account-id>"' in live
     assert "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false" in live
     assert "ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY" in live
     assert "target_account_id" in live
@@ -92,6 +94,17 @@ def test_deflection_delta_go_live_runbook_manual_run_uses_safe_override() -> Non
         "target_account_id": "<account-id>",
         "current_request_id": "<current-request-id>",
     }
+
+
+def test_deflection_delta_go_live_runbook_requires_entitlement_allowlist() -> None:
+    paid_pair = _section("Paid Pair Check")
+    dry_run = _section("Dry-Run Activation")
+    live = _section("Live Activation")
+
+    assert "ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS" in paid_pair
+    assert "skips generation and pending delivery" in paid_pair
+    assert 'ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS="<account-id>"' in dry_run
+    assert 'ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS="<account-id>"' in live
 
 
 def test_deflection_delta_go_live_runbook_autonomous_command_targets_delta_task() -> None:

--- a/tests/test_content_ops_deflection_delta_persistence.py
+++ b/tests/test_content_ops_deflection_delta_persistence.py
@@ -351,6 +351,46 @@ async def test_in_memory_paid_account_discovery_orders_by_paid_activity() -> Non
 
 
 @pytest.mark.asyncio
+async def test_in_memory_paid_account_discovery_filters_entitled_accounts() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await _save(
+        store,
+        account_id="acct-entitled-old",
+        request_id="old-report",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-paid-not-entitled",
+        request_id="newer-report",
+        created_at=datetime(2026, 5, 2, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 3, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-entitled-new",
+        request_id="new-report",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+    )
+
+    accounts = await store.list_paid_report_accounts(
+        limit=10,
+        account_ids=(
+            "acct-entitled-old",
+            "acct-entitled-new",
+            "acct-missing",
+        ),
+    )
+
+    assert accounts == ("acct-entitled-new", "acct-entitled-old")
+    assert await store.count_paid_report_accounts(
+        account_ids=("acct-entitled-old", "acct-entitled-new")
+    ) == 2
+
+
+@pytest.mark.asyncio
 async def test_in_memory_paid_report_listing_orders_by_paid_activity_window() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     await _save(
@@ -485,6 +525,74 @@ async def test_recent_delta_batch_discovers_paid_accounts_and_stays_tenant_scope
         current_request_id="acct-2-current",
         baseline_request_id="acct-1-current",
     ) is None
+
+
+@pytest.mark.asyncio
+async def test_recent_delta_batch_scans_only_entitled_paid_accounts() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    await _save(
+        store,
+        account_id="acct-entitled",
+        request_id="entitled-baseline",
+        model=_model(_row("repeat_entitled", ticket_count=2, cost=27.0)),
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-entitled",
+        request_id="entitled-current",
+        model=_model(_row("repeat_entitled", ticket_count=5, cost=67.5)),
+        delivery_email="entitled@example.com",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 3, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-paid-not-entitled",
+        request_id="unentitled-baseline",
+        model=_model(_row("repeat_unentitled", ticket_count=2, cost=27.0)),
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+    )
+    await _save(
+        store,
+        account_id="acct-paid-not-entitled",
+        request_id="unentitled-current",
+        model=_model(_row("repeat_unentitled", ticket_count=7, cost=94.5)),
+        delivery_email="unentitled@example.com",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        paid_at=datetime(2026, 6, 4, tzinfo=timezone.utc),
+    )
+
+    summary = await compute_and_save_recent_deflection_deltas(
+        store,
+        entitled_account_ids=("acct-entitled",),
+        account_limit=10,
+        reports_per_account=10,
+    )
+
+    assert summary == DeflectionDeltaBatchSummary(
+        accounts_scanned=1,
+        reports_scanned=2,
+        deltas_saved=1,
+        delta_deliveries_enqueued=1,
+        skipped_no_delta=1,
+        failed=0,
+    )
+    assert await store.get_deflection_delta(
+        account_id="acct-entitled",
+        current_request_id="entitled-current",
+        baseline_request_id="entitled-baseline",
+    )
+    assert await store.get_deflection_delta(
+        account_id="acct-paid-not-entitled",
+        current_request_id="unentitled-current",
+        baseline_request_id="unentitled-baseline",
+    ) is None
+    assert store._delta_delivery_keys == {
+        ("acct-entitled", "entitled-current", "entitled-baseline")
+    }
 
 
 @pytest.mark.asyncio
@@ -777,7 +885,13 @@ async def test_recent_delta_batch_marks_report_window_overflow() -> None:
 @pytest.mark.asyncio
 async def test_recent_delta_batch_logs_per_report_failures(caplog) -> None:
     class _FailingStore:
-        async def list_paid_report_accounts(self, *, limit: int | None = 100) -> tuple[str, ...]:
+        async def list_paid_report_accounts(
+            self,
+            *,
+            limit: int | None = 100,
+            account_ids: tuple[str, ...] | None = None,
+        ) -> tuple[str, ...]:
+            assert account_ids is None
             return ("acct-1",)
 
         async def list_reports(

--- a/tests/test_deflection_delta_automation_task.py
+++ b/tests/test_deflection_delta_automation_task.py
@@ -36,6 +36,7 @@ def _set_delta_settings(monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> No
         "cron_expression": "15 8 1 * *",
         "account_limit": 11,
         "reports_per_account": 9,
+        "entitled_account_ids": "acct-1,acct-2,acct-target",
     }
     values.update(overrides)
     for name, value in values.items():
@@ -142,13 +143,20 @@ async def test_run_delegates_to_batch_worker_with_typed_and_metadata_limits(
     pool = _Pool(is_initialized=True)
     calls: list[dict[str, Any]] = []
 
-    async def _compute(store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+    async def _compute(
+        store: Any,
+        *,
+        account_limit: int,
+        reports_per_account: int,
+        entitled_account_ids: tuple[str, ...],
+    ) -> Any:
         calls.append(
             {
                 "store_type": type(store).__name__,
                 "store_pool": getattr(store, "pool", None),
                 "account_limit": account_limit,
                 "reports_per_account": reports_per_account,
+                "entitled_account_ids": entitled_account_ids,
             }
         )
         return DeflectionDeltaBatchSummary(
@@ -172,6 +180,7 @@ async def test_run_delegates_to_batch_worker_with_typed_and_metadata_limits(
             "store_pool": pool,
             "account_limit": 7,
             "reports_per_account": 6,
+            "entitled_account_ids": ("acct-1", "acct-2", "acct-target"),
         }
     ]
     assert result == {
@@ -194,6 +203,7 @@ async def test_run_delegates_to_batch_worker_with_typed_and_metadata_limits(
         "reports_per_account_limit_overflow": False,
         "report_limit_reached_accounts": [],
         "report_limit_overflow_accounts": [],
+        "entitled_account_count": 3,
     }
 
 
@@ -220,6 +230,7 @@ async def test_run_scopes_generation_and_delivery_from_target_account_metadata(
         reports_per_account: int,
         account_id: str,
         current_request_id: str,
+        **_kwargs: Any,
     ) -> Any:
         compute_calls.append(
             {
@@ -244,6 +255,7 @@ async def test_run_scopes_generation_and_delivery_from_target_account_metadata(
         config: Any,
         account_id: str,
         current_request_id: str,
+        **_kwargs: Any,
     ) -> Any:
         delivery_calls.append(
             {
@@ -252,6 +264,7 @@ async def test_run_scopes_generation_and_delivery_from_target_account_metadata(
                 "dry_run": config.dry_run,
                 "account_id": account_id,
                 "current_request_id": current_request_id,
+                "entitled_account_ids": _kwargs.get("entitled_account_ids"),
             }
         )
         return SimpleNamespace(scanned=1, sent=0, failed=0, dry_run=1)
@@ -284,6 +297,7 @@ async def test_run_scopes_generation_and_delivery_from_target_account_metadata(
             "dry_run": True,
             "account_id": "acct-target",
             "current_request_id": "checked-current",
+            "entitled_account_ids": ("acct-1", "acct-2", "acct-target"),
         }
     ]
     assert result["target_account_id"] == "acct-target"
@@ -306,6 +320,7 @@ async def test_run_scopes_generation_to_checked_current_request(
         reports_per_account: int,
         account_id: str,
         current_request_id: str,
+        **_kwargs: Any,
     ) -> Any:
         compute_calls.append(
             {
@@ -365,6 +380,57 @@ async def test_run_rejects_blank_target_account_metadata(
 
 
 @pytest.mark.asyncio
+async def test_run_skips_global_generation_without_entitled_accounts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch, entitled_account_ids=" ")
+    pool = _Pool(is_initialized=True)
+    compute = AsyncMock()
+    send_pending = AsyncMock()
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", compute)
+    monkeypatch.setattr(mod, "send_pending_deflection_delta_deliveries", send_pending)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result["_skip_synthesis"] == "No entitled deflection delta accounts configured"
+    assert result["entitled_account_count"] == 0
+    assert result["accounts_scanned"] == 0
+    assert result["delivery_sent"] == 0
+    compute.assert_not_called()
+    send_pending.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_skips_target_account_not_in_entitlement_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch, entitled_account_ids="acct-other")
+    pool = _Pool(is_initialized=True)
+    compute = AsyncMock()
+    send_pending = AsyncMock()
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", compute)
+    monkeypatch.setattr(mod, "send_pending_deflection_delta_deliveries", send_pending)
+
+    result = await mod.run(
+        SimpleNamespace(
+            metadata={
+                "target_account_id": "acct-target",
+                "current_request_id": "checked-current",
+            }
+        )
+    )
+
+    assert result["_skip_synthesis"] == "Deflection delta target account not entitled"
+    assert result["target_account_id"] == "acct-target"
+    assert result["entitled_account_count"] == 1
+    assert result["accounts_scanned"] == 0
+    compute.assert_not_called()
+    send_pending.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_run_drains_delta_delivery_when_generation_enqueues_work(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -374,7 +440,7 @@ async def test_run_drains_delta_delivery_when_generation_enqueues_work(
     pool = _Pool(is_initialized=True)
     delivery_calls: list[dict[str, Any]] = []
 
-    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int, **_kwargs: Any) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=1,
             reports_scanned=2,
@@ -383,13 +449,14 @@ async def test_run_drains_delta_delivery_when_generation_enqueues_work(
             delta_deliveries_enqueued=1,
         )
 
-    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any, **_kwargs: Any) -> Any:
         delivery_calls.append(
             {
                 "pool": pool_arg,
                 "sender_type": type(sender).__name__,
                 "from_email": config.from_email,
                 "dry_run": config.dry_run,
+                "entitled_account_ids": _kwargs.get("entitled_account_ids"),
             }
         )
         return SimpleNamespace(scanned=1, sent=0, failed=0, dry_run=1)
@@ -406,6 +473,7 @@ async def test_run_drains_delta_delivery_when_generation_enqueues_work(
             "sender_type": "_DryRunSender",
             "from_email": "reports@example.com",
             "dry_run": True,
+            "entitled_account_ids": ("acct-1", "acct-2", "acct-target"),
         }
     ]
     assert result["delta_deliveries_enqueued"] == 1
@@ -425,7 +493,7 @@ async def test_run_drains_existing_delta_delivery_when_no_new_row_enqueued(
     pool = _Pool(is_initialized=True)
     delivery_calls = 0
 
-    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int, **_kwargs: Any) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=1,
             reports_scanned=2,
@@ -434,7 +502,7 @@ async def test_run_drains_existing_delta_delivery_when_no_new_row_enqueued(
             delta_deliveries_enqueued=0,
         )
 
-    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any, **_kwargs: Any) -> Any:
         nonlocal delivery_calls
         delivery_calls += 1
         assert pool_arg is pool
@@ -461,7 +529,7 @@ async def test_run_reports_missing_delivery_config_for_existing_backlog(
     pool = _Pool(is_initialized=True, pending_delta_deliveries=3)
     delivery_calls = 0
 
-    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int, **_kwargs: Any) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=1,
             reports_scanned=2,
@@ -487,6 +555,7 @@ async def test_run_reports_missing_delivery_config_for_existing_backlog(
     assert result["delivery_pending"] == 3
     assert result["delivery_missing_config"] == ["from_email", "resend_api_key"]
     assert pool.fetchval_calls
+    assert pool.fetchval_calls[0][1] == (None, None, ["acct-1", "acct-2", "acct-target"])
 
 
 @pytest.mark.asyncio
@@ -496,7 +565,7 @@ async def test_run_reports_degraded_when_some_reports_fail(
     _set_delta_settings(monkeypatch)
     pool = _Pool(is_initialized=True)
 
-    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int, **_kwargs: Any) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=2,
             reports_scanned=3,
@@ -530,6 +599,7 @@ async def test_run_reports_degraded_when_some_reports_fail(
         "reports_per_account_limit_overflow": False,
         "report_limit_reached_accounts": [],
         "report_limit_overflow_accounts": [],
+        "entitled_account_count": 3,
     }
 
 
@@ -557,6 +627,7 @@ async def test_run_reports_delivery_degraded_before_generation_degraded(
         *,
         account_limit: int,
         reports_per_account: int,
+        **_kwargs: Any,
     ) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=2,
@@ -567,7 +638,7 @@ async def test_run_reports_delivery_degraded_before_generation_degraded(
             delta_deliveries_enqueued=1,
         )
 
-    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any, **_kwargs: Any) -> Any:
         assert pool_arg is pool
         return SimpleNamespace(scanned=2, sent=1, failed=1, dry_run=0)
 
@@ -607,6 +678,7 @@ async def test_run_reports_deferred_delivery_without_total_failure_raise(
         *,
         account_limit: int,
         reports_per_account: int,
+        **_kwargs: Any,
     ) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=1,
@@ -616,7 +688,7 @@ async def test_run_reports_deferred_delivery_without_total_failure_raise(
             delta_deliveries_enqueued=1,
         )
 
-    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any, **_kwargs: Any) -> Any:
         assert pool_arg is pool
         assert config.dry_run is False
         return SimpleNamespace(scanned=2, sent=0, failed=0, deferred=2, dry_run=0)
@@ -658,6 +730,7 @@ async def test_run_reports_generation_degraded_before_deferred_delivery(
         *,
         account_limit: int,
         reports_per_account: int,
+        **_kwargs: Any,
     ) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=2,
@@ -668,7 +741,7 @@ async def test_run_reports_generation_degraded_before_deferred_delivery(
             delta_deliveries_enqueued=1,
         )
 
-    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any, **_kwargs: Any) -> Any:
         assert pool_arg is pool
         return SimpleNamespace(scanned=2, sent=0, failed=0, deferred=2, dry_run=0)
 
@@ -708,6 +781,7 @@ async def test_run_reports_delivery_degraded_when_failed_and_deferred(
         *,
         account_limit: int,
         reports_per_account: int,
+        **_kwargs: Any,
     ) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=1,
@@ -717,7 +791,7 @@ async def test_run_reports_delivery_degraded_when_failed_and_deferred(
             delta_deliveries_enqueued=1,
         )
 
-    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any, **_kwargs: Any) -> Any:
         assert pool_arg is pool
         return SimpleNamespace(scanned=2, sent=0, failed=1, deferred=1, dry_run=0)
 
@@ -741,7 +815,7 @@ async def test_run_raises_when_all_scanned_delta_deliveries_fail(
     monkeypatch.setattr(mod.settings.deflection_delivery, "resend_api_key", "resend-key", raising=False)
     pool = _Pool(is_initialized=True)
 
-    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int, **_kwargs: Any) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=1,
             reports_scanned=2,
@@ -750,7 +824,7 @@ async def test_run_raises_when_all_scanned_delta_deliveries_fail(
             delta_deliveries_enqueued=1,
         )
 
-    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any, **_kwargs: Any) -> Any:
         assert pool_arg is pool
         assert config.dry_run is False
         return SimpleNamespace(scanned=2, sent=0, failed=2, dry_run=0)
@@ -775,6 +849,7 @@ async def test_run_reports_scan_window_saturation_without_failing(
         *,
         account_limit: int,
         reports_per_account: int,
+        **_kwargs: Any,
     ) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=1,
@@ -815,6 +890,7 @@ async def test_run_reports_scan_window_saturation_without_failing(
         "reports_per_account_limit_overflow": False,
         "report_limit_reached_accounts": ["acct-1"],
         "report_limit_overflow_accounts": [],
+        "entitled_account_count": 3,
     }
 
 
@@ -830,6 +906,7 @@ async def test_run_reports_scan_window_overflow_before_saturation_warning(
         *,
         account_limit: int,
         reports_per_account: int,
+        **_kwargs: Any,
     ) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=1,
@@ -870,6 +947,7 @@ async def test_run_reports_scan_window_overflow_before_saturation_warning(
         "reports_per_account_limit_overflow": True,
         "report_limit_reached_accounts": ["acct-1"],
         "report_limit_overflow_accounts": ["acct-1"],
+        "entitled_account_count": 3,
     }
 
 
@@ -880,7 +958,7 @@ async def test_run_raises_when_all_scanned_reports_fail(
     _set_delta_settings(monkeypatch)
     pool = _Pool(is_initialized=True)
 
-    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int) -> Any:
+    async def _compute(_store: Any, *, account_limit: int, reports_per_account: int, **_kwargs: Any) -> Any:
         return DeflectionDeltaBatchSummary(
             accounts_scanned=2,
             reports_scanned=3,


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delta-Entitlement-Allowlist.md
Slice phase: Production hardening

#1316 and the archived delta plans deferred the subscription entitlement check for monthly Report Deltas. This slice separates recurring delta entitlement from one-time paid-report access by adding a fail-closed `ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS` allowlist and intersecting recent-delta generation plus pending delivery drain/count queries with that roster.

## Intentional
- No Stripe API call, Checkout Session, subscription webhook, or Customer Portal flow lands here; the durable source should be Stripe Billing-backed once the monthly product is defined.
- No wildcard/all-paid escape hatch. Blank entitlement config means no monthly delta accounts.
- No new DB entitlement table; config is the temporary source of truth.

## Deferred
- Replace the config allowlist with a Stripe Billing-backed subscription entitlement source once the monthly product/Price IDs and webhook lifecycle are defined.
- #1869: DB-backed live-drain integration coverage once the deflection delivery CI gate has a Postgres service.

## Parked hardening
- None.

## AI reconciliation
- All fixed or waived: yes.
- Fixed reviewer MAJOR: the entitlement allowlist now threads into `send_pending_deflection_delta_deliveries` and `pending_deflection_delta_delivery_count`, so already-queued pending rows for revoked accounts are filtered before claim/count/send.
- Fixed Codex P2: the go-live runbook now requires `ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS` in dry-run and live activation snippets, with a contract test pinning that requirement.
- Waivers: none.

## Verification
- python -m py_compile atlas_brain/config.py atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py atlas_brain/content_ops_deflection_delivery.py extracted_content_pipeline/deflection_report_access.py tests/test_deflection_delta_automation_task.py tests/test_content_ops_deflection_delta_persistence.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_content_ops_deflection_delta_go_live_runbook.py
- pytest tests/test_deflection_delta_automation_task.py tests/test_content_ops_deflection_delta_persistence.py
  - 53 passed, 1 warning.
- pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_deflection_delta_automation_task.py -q
  - 59 passed, 1 warning.
- pytest tests/test_content_ops_deflection_delta_go_live_runbook.py -q
  - 6 passed.
- python scripts/sync_pr_plan.py plans/PR-Deflection-Delta-Entitlement-Allowlist.md --check

## Diff size
10 files, +583 / -33
