### PR TITLE
Add DB-backed deflection delta drain scope test

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
@@ -17,6 +17,10 @@ on:
       - "atlas_brain/content_ops_deflection_delivery.py"
       - "atlas_brain/content_ops_deflection_incidents.py"
       - "atlas_brain/deflection_pdf_renderer.py"
+      - "atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql"
+      - "atlas_brain/storage/migrations/331_content_ops_deflection_report_delivery_email.sql"
+      - "atlas_brain/storage/migrations/340_content_ops_deflection_deltas.sql"
+      - "atlas_brain/storage/migrations/341_content_ops_deflection_delta_deliveries.sql"
       - "scripts/send_content_ops_deflection_report_deliveries.py"
       - "tests/test_atlas_content_ops_deflection_delivery.py"
       - "tests/test_alerts.py"
@@ -39,6 +43,10 @@ on:
       - "atlas_brain/content_ops_deflection_delivery.py"
       - "atlas_brain/content_ops_deflection_incidents.py"
       - "atlas_brain/deflection_pdf_renderer.py"
+      - "atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql"
+      - "atlas_brain/storage/migrations/331_content_ops_deflection_report_delivery_email.sql"
+      - "atlas_brain/storage/migrations/340_content_ops_deflection_deltas.sql"
+      - "atlas_brain/storage/migrations/341_content_ops_deflection_delta_deliveries.sql"
       - "scripts/send_content_ops_deflection_report_deliveries.py"
       - "tests/test_atlas_content_ops_deflection_delivery.py"
       - "tests/test_alerts.py"
@@ -50,6 +58,22 @@ on:
 jobs:
   atlas-content-ops-deflection-delivery-checks:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16@sha256:081f1bc7bd5e143dbb6e487b710bbc27712cdcfaced4c071b8e47349aa1b4171
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas_migration_tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas -d atlas_migration_tests"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -64,7 +88,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          python -m pip install pytest pytest-asyncio
+          python -m pip install asyncpg pytest pytest-asyncio
 
       - name: Run Content Ops deflection delivery tests
         run: |

--- a/plans/PR-Deflection-Delta-Drain-DB-Scope-Test.md
+++ b/plans/PR-Deflection-Delta-Drain-DB-Scope-Test.md
@@ -1,0 +1,121 @@
+# PR-Deflection-Delta-Drain-DB-Scope-Test
+
+## Why this slice exists
+
+#1869 tracks the DB-backed integration coverage deferred from #1868. The unit
+and fake-pool tests prove that the pending deflection delta delivery SQL carries
+`account_id` and `current_request_id` predicates, but they do not prove the live
+Postgres claim/update path leaves non-target queued rows untouched.
+
+Root cause: the delivery CI lane did not provide a Postgres service, so the
+first attempt at live drain coverage could only be skipped locally or fail in CI
+at DB setup. This PR fixes the root by giving the delivery gate a DB service and
+adding one `@pytest.mark.integration` test that executes the real delivery drain
+against migrated tables.
+
+## Scope (this PR)
+
+Ownership lane: deflection/report-deltas
+Slice phase: Robust testing
+
+1. Add a Postgres service and migration-test DSN to the deflection delivery CI
+   workflow so DB-backed delivery tests run instead of skipping.
+2. Add one integration test proving `send_pending_deflection_delta_deliveries`
+   with both `account_id` and `current_request_id` sends only the targeted
+   pending delta row.
+3. Assert the same-account/different-current row and other-account/same-current
+   row remain pending and unsent.
+4. Enroll the migration files the integration test applies in the delivery
+   workflow path filters so schema drift reruns this coverage.
+
+### Review Contract
+
+Acceptance criteria:
+- The delivery workflow must provision Postgres and expose
+  `ATLAS_MIGRATION_TEST_DATABASE_URL`.
+- The delivery workflow path filters must include the deflection report, report
+  email, delta, and delta delivery migrations consumed by the integration test.
+- The new integration test must execute against real Postgres tables, not a fake
+  pool or string-only SQL assertion.
+- The test must insert at least three pending rows: target account/current,
+  same account/different current, and other account/same current.
+- Running the scoped drain must send exactly one email and leave the two
+  non-target rows pending with no sent timestamp/message id.
+- Existing non-DB delivery tests remain enrolled in the same workflow.
+
+Affected surfaces:
+- Deflection delivery CI workflow.
+- Deflection delta delivery integration coverage in
+  `tests/test_atlas_content_ops_deflection_delivery.py`.
+
+Risk areas:
+- Pulling Postgres-only dependencies into the wrong extracted collection lane.
+- Accidentally weakening the existing fast delivery workflow while adding the DB
+  service.
+- Test fixture rows drifting away from the real migration schema.
+
+Reviewer rules triggered: R1, R2, R6, R8, R10, R14.
+- R1 Requirements match.
+- R2 Test evidence.
+- R6 CI/workflow behavior.
+- R8 Persistence/data lifecycle.
+- R10 Gate/predicate behavior.
+- R14 Codebase verification.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml`
+- `plans/PR-Deflection-Delta-Drain-DB-Scope-Test.md`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+
+## Mechanism
+
+- Mirror the repo's existing Postgres service pattern from the review/migration
+  workflows in `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml`.
+- Add the migrations used by the live fixture to both `pull_request` and `push`
+  path filters for the delivery workflow.
+- Add the integration test to the existing delivery test file so workflow
+  enrollment stays local to the delivery gate.
+- The test applies the deflection report/delta/delta-delivery migrations to the
+  disposable DB, inserts paid current/baseline reports, persisted deltas, and
+  three pending delivery rows, then calls the real
+  `send_pending_deflection_delta_deliveries` function with account/current
+  scope.
+- The sender is an in-memory fake at the email boundary only; the DB read,
+  claim, success update, and untouched-row assertions use real Postgres.
+
+## Intentional
+
+- No production delivery code changes are planned. #1870 already threads the
+  scopes into the live drain; this slice proves the live Postgres behavior.
+- The email provider stays fake. The risk in #1869 is queue selection and row
+  state, not Resend transport.
+- The test lives in the delivery workflow rather than the extracted umbrella so
+  asyncpg/Postgres requirements stay in a DB-provisioned Atlas lane.
+
+## Deferred
+
+- None.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed locally:
+  - python -m py_compile tests/test_atlas_content_ops_deflection_delivery.py
+  - pytest tests/test_atlas_content_ops_deflection_delivery.py -k "delta_delivery_scope" -q
+    - 1 skipped, 34 deselected when `ATLAS_MIGRATION_TEST_DATABASE_URL` was unset.
+  - ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_content_ops_deflection_delivery.py -k "delta_delivery_scope" -q
+    - 1 passed, 34 deselected.
+  - ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_content_ops_deflection_delivery.py -q
+    - 35 passed.
+  - python scripts/sync_pr_plan.py plans/PR-Deflection-Delta-Drain-DB-Scope-Test.md --check
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml` | 26 |
+| `plans/PR-Deflection-Delta-Drain-DB-Scope-Test.md` | 121 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 191 |
+| **Total** | **338** |

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import sys
+from pathlib import Path
 from types import ModuleType
 from typing import Any
 
@@ -27,6 +29,15 @@ from extracted_content_pipeline.campaign_ports import (
 )
 from extracted_content_pipeline.faq_deflection_report import (
     build_deflection_full_report_qa_scorecard,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+_DEFLECTION_DELTA_DELIVERY_MIGRATIONS = (
+    ROOT / "atlas_brain" / "storage" / "migrations" / "328_content_ops_deflection_reports.sql",
+    ROOT / "atlas_brain" / "storage" / "migrations" / "331_content_ops_deflection_report_delivery_email.sql",
+    ROOT / "atlas_brain" / "storage" / "migrations" / "340_content_ops_deflection_deltas.sql",
+    ROOT / "atlas_brain" / "storage" / "migrations" / "341_content_ops_deflection_delta_deliveries.sql",
 )
 
 
@@ -736,6 +747,186 @@ async def test_delta_delivery_queue_filters_entitled_accounts_on_global_drain() 
     count_query, count_args = pool.fetchval_calls[0]
     assert count_args == (None, None, ["acct-active"])
     assert "AND ($3::text[] IS NULL OR account_id = ANY($3::text[]))" in count_query
+
+
+async def _apply_delta_delivery_migrations(conn: Any) -> None:
+    for path in _DEFLECTION_DELTA_DELIVERY_MIGRATIONS:
+        await conn.execute(path.read_text(encoding="utf-8"))
+
+
+async def _cleanup_delta_delivery_scope_rows(conn: Any, accounts: tuple[str, ...]) -> None:
+    await conn.execute(
+        "DELETE FROM content_ops_deflection_reports WHERE account_id = ANY($1::text[])",
+        list(accounts),
+    )
+
+
+async def _insert_delta_delivery_fixture(
+    conn: Any,
+    *,
+    account_id: str,
+    current_request_id: str,
+    baseline_request_id: str,
+    current_email: str,
+) -> None:
+    delta = _delta_read_payload()["delta"]
+    await conn.execute(
+        """
+        INSERT INTO content_ops_deflection_reports (
+            account_id,
+            request_id,
+            snapshot,
+            artifact,
+            paid,
+            paid_at,
+            delivery_email
+        )
+        VALUES
+            ($1, $2, '{}'::jsonb, '{}'::jsonb, true, NOW(), $4),
+            ($1, $3, '{}'::jsonb, '{}'::jsonb, true, NOW(), 'baseline@example.com')
+        ON CONFLICT (account_id, request_id) DO UPDATE
+        SET paid = EXCLUDED.paid,
+            paid_at = EXCLUDED.paid_at,
+            delivery_email = EXCLUDED.delivery_email
+        """,
+        account_id,
+        current_request_id,
+        baseline_request_id,
+        current_email,
+    )
+    await conn.execute(
+        """
+        INSERT INTO content_ops_deflection_deltas (
+            account_id,
+            current_request_id,
+            baseline_request_id,
+            delta
+        )
+        VALUES ($1, $2, $3, $4::jsonb)
+        ON CONFLICT (account_id, current_request_id, baseline_request_id)
+        DO UPDATE SET delta = EXCLUDED.delta
+        """,
+        account_id,
+        current_request_id,
+        baseline_request_id,
+        json.dumps(delta),
+    )
+    await conn.execute(
+        """
+        INSERT INTO content_ops_deflection_delta_deliveries (
+            account_id,
+            current_request_id,
+            baseline_request_id,
+            delivery_email
+        )
+        VALUES ($1, $2, $3, 'queued-address-should-not-send@example.com')
+        ON CONFLICT (account_id, current_request_id, baseline_request_id)
+        DO UPDATE SET delivery_status = 'pending',
+                      delivery_error = NULL,
+                      provider_message_id = NULL,
+                      delivered_at = NULL,
+                      updated_at = NOW()
+        """,
+        account_id,
+        current_request_id,
+        baseline_request_id,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_delta_delivery_scope_live_postgres_drains_only_target_account_current_request() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_MIGRATION_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_MIGRATION_TEST_DATABASE_URL not set")
+
+    target_account = "acct-delta-scope-target"
+    other_account = "acct-delta-scope-other"
+    target_current = "current-delta-scope-target"
+    target_baseline = "baseline-delta-scope-target"
+    other_current = "current-delta-scope-other"
+    other_baseline = "baseline-delta-scope-other"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _apply_delta_delivery_migrations(conn)
+        await _cleanup_delta_delivery_scope_rows(conn, (target_account, other_account))
+        await _insert_delta_delivery_fixture(
+            conn,
+            account_id=target_account,
+            current_request_id=target_current,
+            baseline_request_id=target_baseline,
+            current_email="target-buyer@example.com",
+        )
+        await _insert_delta_delivery_fixture(
+            conn,
+            account_id=target_account,
+            current_request_id=other_current,
+            baseline_request_id=target_baseline,
+            current_email="same-account-other-current@example.com",
+        )
+        await _insert_delta_delivery_fixture(
+            conn,
+            account_id=other_account,
+            current_request_id=target_current,
+            baseline_request_id=other_baseline,
+            current_email="other-account-same-current@example.com",
+        )
+
+        sender = _Sender()
+        summary = await send_pending_deflection_delta_deliveries(
+            conn,
+            sender=sender,
+            config=DeflectionDeltaDeliveryConfig(
+                from_email="reports@example.com",
+                limit=10,
+                dry_run=False,
+            ),
+            account_id=target_account,
+            current_request_id=target_current,
+        )
+
+        rows = await conn.fetch(
+            """
+            SELECT account_id,
+                   current_request_id,
+                   baseline_request_id,
+                   delivery_status,
+                   provider_message_id,
+                   delivered_at
+            FROM content_ops_deflection_delta_deliveries
+            WHERE account_id = ANY($1::text[])
+            ORDER BY account_id, current_request_id, baseline_request_id
+            """,
+            [target_account, other_account],
+        )
+    finally:
+        await _cleanup_delta_delivery_scope_rows(conn, (target_account, other_account))
+        await conn.close()
+
+    assert summary.scanned == 1
+    assert summary.sent == 1
+    assert summary.failed == 0
+    assert summary.deferred == 0
+    assert [request.to_email for request in sender.requests] == ["target-buyer@example.com"]
+    by_key = {
+        (row["account_id"], row["current_request_id"], row["baseline_request_id"]): row
+        for row in rows
+    }
+    target = by_key[(target_account, target_current, target_baseline)]
+    assert target["delivery_status"] == "delivered"
+    assert target["provider_message_id"] == "resend:email-123"
+    assert target["delivered_at"] is not None
+
+    same_account_other_current = by_key[(target_account, other_current, target_baseline)]
+    assert same_account_other_current["delivery_status"] == "pending"
+    assert same_account_other_current["provider_message_id"] is None
+    assert same_account_other_current["delivered_at"] is None
+
+    other_account_same_current = by_key[(other_account, target_current, other_baseline)]
+    assert other_account_same_current["delivery_status"] == "pending"
+    assert other_account_same_current["provider_message_id"] is None
+    assert other_account_same_current["delivered_at"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delta-Drain-DB-Scope-Test.md
Slice phase: Robust testing

#1869 tracks the DB-backed integration coverage deferred from #1868. This slice gives the deflection delivery CI lane a Postgres service and adds one real Postgres test proving the scoped delta delivery drain sends only the target account/current report row while leaving non-target pending rows untouched.

## Intentional
- No production delivery code changes; this is coverage for already-merged scope behavior.
- Email transport stays fake. The test exercises real DB read/claim/update behavior and stops at the sender boundary.
- The DB-backed test stays in the deflection delivery workflow, not the extracted umbrella, so asyncpg/Postgres requirements remain in a DB-provisioned Atlas lane.

## Deferred
- None.

## Parked hardening
- None.

## AI reconciliation
- All fixed or waived: yes.
- Fixed Codex P2: the delivery workflow now includes the four deflection report/delta migration files in both `pull_request` and `push` path filters, so schema changes rerun the DB-backed drain scope test.
- Waivers: none.

## Verification
- python -m py_compile tests/test_atlas_content_ops_deflection_delivery.py
- pytest tests/test_atlas_content_ops_deflection_delivery.py -k "delta_delivery_scope" -q
  - 1 skipped, 34 deselected when `ATLAS_MIGRATION_TEST_DATABASE_URL` was unset.
- ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_content_ops_deflection_delivery.py -k "delta_delivery_scope" -q
  - 1 passed, 34 deselected.
- ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_content_ops_deflection_delivery.py -q
  - 35 passed.
- python scripts/sync_pr_plan.py plans/PR-Deflection-Delta-Drain-DB-Scope-Test.md --check

## Diff size
3 files, +324 / -1
