### PR TITLE
Add deflection delta billing entitlement resolver

### DIFF
--- a/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
+++ b/atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py
@@ -157,7 +157,17 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     try:
         target_account_id = _metadata_text(task, "target_account_id", "account_id")
         target_current_request_id = _metadata_text(task, "current_request_id")
-        entitled_account_ids = _csv_text_tuple(cfg.entitled_account_ids)
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        fallback_entitled_account_ids = _csv_text_tuple(cfg.entitled_account_ids)
+        account_limit = _metadata_int(
+            task,
+            "account_limit",
+            int(cfg.account_limit),
+        )
+        entitled_account_ids = await store.list_deflection_delta_entitled_account_ids(
+            fallback_account_ids=fallback_entitled_account_ids,
+            limit=account_limit,
+        )
         if target_current_request_id and not target_account_id:
             raise ValueError("current_request_id requires target_account_id")
         if target_account_id and target_account_id not in entitled_account_ids:
@@ -174,11 +184,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 **_entitlement_skip_payload(entitled_account_ids=entitled_account_ids),
             }
         batch_kwargs: dict[str, Any] = {
-            "account_limit": _metadata_int(
-                task,
-                "account_limit",
-                int(cfg.account_limit),
-            ),
+            "account_limit": account_limit,
             "reports_per_account": _metadata_int(
                 task,
                 "reports_per_account",
@@ -191,7 +197,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         if target_current_request_id:
             batch_kwargs["current_request_id"] = target_current_request_id
         summary = await compute_and_save_recent_deflection_deltas(
-            PostgresDeflectionReportArtifactStore(pool=pool),
+            store,
             **batch_kwargs,
         )
     except Exception:

--- a/atlas_brain/storage/migrations/343_content_ops_deflection_delta_entitlements.sql
+++ b/atlas_brain/storage/migrations/343_content_ops_deflection_delta_entitlements.sql
@@ -1,0 +1,38 @@
+-- Stripe Billing-backed monthly delta entitlement records.
+-- The delta automation resolver grants only active/trialing subscription rows.
+
+CREATE TABLE IF NOT EXISTS content_ops_deflection_delta_entitlements (
+    account_id TEXT NOT NULL,
+    stripe_subscription_id TEXT NOT NULL,
+    stripe_customer_id TEXT,
+    stripe_price_id TEXT,
+    stripe_subscription_status TEXT NOT NULL,
+    entitlement_source TEXT NOT NULL DEFAULT 'stripe_billing',
+    current_period_end TIMESTAMPTZ,
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (account_id, stripe_subscription_id),
+    UNIQUE (stripe_subscription_id),
+    CHECK (account_id <> ''),
+    CHECK (stripe_subscription_id <> ''),
+    CHECK (
+        stripe_subscription_status IN (
+            'active',
+            'trialing',
+            'past_due',
+            'unpaid',
+            'canceled',
+            'incomplete',
+            'incomplete_expired',
+            'paused'
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_ops_deflection_delta_entitlements_active
+    ON content_ops_deflection_delta_entitlements (account_id, updated_at DESC)
+    WHERE stripe_subscription_status IN ('active', 'trialing')
+      AND revoked_at IS NULL;

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -21,6 +21,8 @@ from .storage._jsonb_helpers import (
 
 logger = logging.getLogger(__name__)
 
+DELTA_ENTITLEMENT_ACTIVE_STATUSES = ("active", "trialing")
+
 
 @dataclass(frozen=True)
 class DeflectionReportAccessRecord:
@@ -157,6 +159,14 @@ class DeflectionReportArtifactStore(Protocol):
         account_ids: Sequence[str] | None = None,
     ) -> int:
         """Count tenants that have at least one paid report."""
+
+    async def list_deflection_delta_entitled_account_ids(
+        self,
+        *,
+        fallback_account_ids: Sequence[str] | None = None,
+        limit: int | None = None,
+    ) -> tuple[str, ...]:
+        """List tenants with an active monthly delta entitlement."""
 
     async def count_paid_reports(
         self,
@@ -328,7 +338,11 @@ _DEFLECTION_DELTA_CSAT_FIELDS = (
 class InMemoryDeflectionReportArtifactStore:
     """Test store with the same tenant/request semantics as the Postgres store."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        delta_entitlement_rows: Sequence[Mapping[str, Any]] | None = None,
+    ) -> None:
         self._rows: dict[tuple[str, str], DeflectionReportAccessRecord] = {}
         self._created_at_by_key: dict[tuple[str, str], datetime] = {}
         self._paid_at_by_key: dict[tuple[str, str], datetime] = {}
@@ -337,6 +351,9 @@ class InMemoryDeflectionReportArtifactStore:
             DeflectionDeltaAccessRecord,
         ] = {}
         self._delta_delivery_keys: set[tuple[str, str, str]] = set()
+        self._delta_entitlement_rows = [
+            dict(row) for row in (delta_entitlement_rows or ())
+        ]
 
     async def save_report(
         self,
@@ -481,6 +498,34 @@ class InMemoryDeflectionReportArtifactStore:
                 if row.paid
             }
         )
+
+    async def list_deflection_delta_entitled_account_ids(
+        self,
+        *,
+        fallback_account_ids: Sequence[str] | None = None,
+        limit: int | None = None,
+    ) -> tuple[str, ...]:
+        active_account_ids = _account_id_tuple(
+            [
+                account_id
+                for row in self._delta_entitlement_rows
+                if (account_id := _clean(row.get("account_id")))
+                if _clean(row.get("stripe_subscription_status"))
+                in DELTA_ENTITLEMENT_ACTIVE_STATUSES
+                if row.get("revoked_at") is None
+            ]
+        ) or ()
+        known_account_ids = {
+            account_id
+            for row in self._delta_entitlement_rows
+            if (account_id := _clean(row.get("account_id")))
+        }
+        fallback = tuple(
+            account_id
+            for account_id in (_account_id_tuple(fallback_account_ids) or ())
+            if account_id not in known_account_ids
+        )
+        return _limit_account_ids((*active_account_ids, *fallback), limit)
 
     async def count_paid_reports(
         self,
@@ -984,6 +1029,55 @@ class PostgresDeflectionReportArtifactStore:
             *args,
         )
         return _row_count(row)
+
+    async def list_deflection_delta_entitled_account_ids(
+        self,
+        *,
+        fallback_account_ids: Sequence[str] | None = None,
+        limit: int | None = None,
+    ) -> tuple[str, ...]:
+        fallback = _account_id_tuple(fallback_account_ids) or ()
+        args: list[Any] = [list(DELTA_ENTITLEMENT_ACTIVE_STATUSES), list(fallback)]
+        limit_clause = ""
+        if limit is not None:
+            args.append(_bounded_limit(limit))
+            limit_clause = f"LIMIT ${len(args)}"
+        rows = await self.pool.fetch(
+            f"""
+            SELECT
+                account_id,
+                BOOL_OR(
+                    stripe_subscription_status = ANY($1::text[])
+                    AND revoked_at IS NULL
+                ) AS grants_delta_entitlement,
+                MAX(updated_at) AS latest_entitlement_at
+            FROM content_ops_deflection_delta_entitlements
+            WHERE stripe_subscription_status = ANY($1::text[])
+               OR account_id = ANY($2::text[])
+            GROUP BY account_id
+            ORDER BY grants_delta_entitlement DESC, latest_entitlement_at DESC, account_id ASC
+            {limit_clause}
+            """,
+            *args,
+        )
+        row_maps = [row_to_dict(row) for row in rows]
+        active_account_ids = _account_id_tuple(
+            [
+                account_id
+                for row in row_maps
+                if row.get("grants_delta_entitlement") is True
+                if (account_id := _clean(row.get("account_id")))
+            ]
+        ) or ()
+        known_account_ids = {
+            account_id
+            for row in row_maps
+            if (account_id := _clean(row.get("account_id")))
+        }
+        fallback_account_ids = tuple(
+            account_id for account_id in fallback if account_id not in known_account_ids
+        )
+        return _limit_account_ids((*active_account_ids, *fallback_account_ids), limit)
 
     async def count_paid_reports(
         self,
@@ -1917,6 +2011,16 @@ def _account_id_tuple(value: Sequence[str] | None) -> tuple[str, ...] | None:
         seen.add(account_id)
         account_ids.append(account_id)
     return tuple(account_ids)
+
+
+def _limit_account_ids(
+    account_ids: Sequence[str],
+    limit: int | None,
+) -> tuple[str, ...]:
+    resolved = _account_id_tuple(account_ids) or ()
+    if limit is None:
+        return resolved
+    return resolved[:_bounded_limit(limit)]
 
 
 def _required_text(value: Any, field: str) -> str:

--- a/plans/PR-Deflection-Delta-Billing-Entitlement-Resolver.md
+++ b/plans/PR-Deflection-Delta-Billing-Entitlement-Resolver.md
@@ -1,0 +1,79 @@
+# PR-Deflection-Delta-Billing-Entitlement-Resolver
+
+## Why this slice exists
+
+#1873 replaces the monthly deflection delta config allowlist with Stripe Billing subscription entitlements. Root cause: `content_ops_deflection_delta_automation` currently treats `ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS` as the entitlement source of truth, so there is no durable account-level Billing entitlement record for Stripe webhook lifecycle handlers to grant/revoke later. This fixes the upstream seam for the next webhook slice by adding a DB-backed entitlement table/resolver and routing delta generation/delivery through that resolver.
+
+This PR fixes the root storage/resolution gap, but it intentionally does not claim full #1873 completion. The Stripe webhook writer is deferred so the first slice stays reviewable and so the resolver can be proven fail-closed before webhook events mutate it.
+
+Diff-size note: this is over the 400 LOC soft target because the safe first slice needs the migration, the real store-adapter contract, task wiring, adapter tests, task fail-closed tests, and the real-DB migration apply guard in one reviewable contract.
+
+## Scope (this PR)
+
+Ownership lane: deflection/delta-billing-entitlements
+Slice phase: Production hardening
+
+1. Add a `content_ops_deflection_delta_entitlements` migration for account-level monthly delta subscription entitlement records.
+2. Add the Billing-backed entitlement resolver to the real deflection report store adapters, returning only active/trialing, non-revoked entitlement accounts with the existing config allowlist as a rollout fallback for accounts with no Billing row yet.
+3. Route delta automation generation, delivery drain, and pending-count paths through the Postgres store adapter instead of parsing the env allowlist inline.
+4. Prove active/trialing rows allow delivery, canceled/past_due/unpaid rows do not, and blank DB+config state still fails closed.
+
+### Review Contract
+
+- Delta automation must never scan globally when both DB entitlements and config fallback are empty.
+- Active/trialing, non-revoked Billing entitlement rows must feed the existing `entitled_account_ids` filters for compute, drain, and pending-count paths.
+- Inactive Billing statuses (`canceled`, `past_due`, `unpaid`, `incomplete`, `incomplete_expired`, `paused`) must not grant delivery.
+- The existing config allowlist remains fallback-only and is explicitly temporary for rollout safety; it must not revive an account with a known inactive/revoked Billing row.
+- Entitlement resolution must be bounded by the task account scan window.
+- No Stripe Checkout or webhook lifecycle mutation is added in this slice.
+- Reviewer rules triggered: R1, R2, R4, R6, R8, R10, R14.
+
+### Files touched
+
+- `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py`
+- `atlas_brain/storage/migrations/343_content_ops_deflection_delta_entitlements.sql`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `plans/PR-Deflection-Delta-Billing-Entitlement-Resolver.md`
+- `tests/maturity_sweep/deflection_product_surface_manifest.json`
+- `tests/test_content_ops_deflection_delta_persistence.py`
+- `tests/test_deflection_delta_automation_task.py`
+- `tests/test_deflection_migrations_apply.py`
+
+## Mechanism
+
+Migration 343 creates `content_ops_deflection_delta_entitlements` with one row per Stripe subscription/account mapping, constrained subscription status values, and an active-entitlement index that excludes soft-revoked rows. `DeflectionReportArtifactStore` grows a monthly delta entitlement-listing method, implemented by both `InMemoryDeflectionReportArtifactStore` and `PostgresDeflectionReportArtifactStore`, so entitlement reads stay in the same adapter layer as report/delta persistence.
+
+`content_ops_deflection_delta_automation.run()` creates the Postgres store once, asks it for entitled accounts bounded by the task account limit, and then passes that tuple through the existing compute/delivery filters. The resolver returns active/trialing non-revoked Billing accounts plus fallback accounts only when that account has no Billing row yet, so canceled/unpaid/revoked rows cannot be revived by config fallback.
+
+## Intentional
+
+- `active` and `trialing` are the only granting statuses in this slice. `past_due`/`unpaid` are fail-closed until product explicitly chooses a grace policy.
+- The config allowlist stays as fallback to avoid breaking the MVP before Stripe webhook lifecycle sync exists; it is not treated as the durable source of truth and cannot override known inactive/revoked Billing rows.
+- No `payment_method_types`, Checkout Session creation, or subscription Price wiring is added here; that belongs with the customer-facing subscription purchase slice.
+
+## Deferred
+
+- Follow-up #1873 slice: Stripe webhook lifecycle handler upserts/revokes `content_ops_deflection_delta_entitlements` for the monthly delta Price IDs.
+- Follow-up #1873 slice: subscription Checkout Session / customer portal surface once monthly product and Price IDs are finalized.
+
+Parked hardening: none.
+
+## Verification
+
+- PASS: focused pytest bundle covering the delta automation task, deflection delta persistence adapters, deflection migration apply guard, and product-surface manifest (71 passed, 2 skipped).
+- PASS: Python compile check for the delta automation task and deflection report access adapter modules.
+- PASS: repo local PR review bundle.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py` | 20 |
+| `atlas_brain/storage/migrations/343_content_ops_deflection_delta_entitlements.sql` | 38 |
+| `extracted_content_pipeline/deflection_report_access.py` | 106 |
+| `plans/PR-Deflection-Delta-Billing-Entitlement-Resolver.md` | 77 |
+| `tests/maturity_sweep/deflection_product_surface_manifest.json` | 1 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 126 |
+| `tests/test_deflection_delta_automation_task.py` | 192 |
+| `tests/test_deflection_migrations_apply.py` | 85 |
+| **Total** | **645** |

--- a/tests/maturity_sweep/deflection_product_surface_manifest.json
+++ b/tests/maturity_sweep/deflection_product_surface_manifest.json
@@ -27,6 +27,7 @@
     "atlas_brain/storage/migrations/340_content_ops_deflection_deltas.sql",
     "atlas_brain/storage/migrations/341_content_ops_deflection_delta_deliveries.sql",
     "atlas_brain/storage/migrations/342_content_ops_deflection_checkout_authorization.sql",
+    "atlas_brain/storage/migrations/343_content_ops_deflection_delta_entitlements.sql",
     "docs/frontend/content_ops_faq_deflection_checkout_contract.md",
     "docs/frontend/content_ops_faq_deflection_report_example.json",
     "docs/frontend/content_ops_faq_deflection_snapshot_example.json",

--- a/tests/test_content_ops_deflection_delta_persistence.py
+++ b/tests/test_content_ops_deflection_delta_persistence.py
@@ -391,6 +391,87 @@ async def test_in_memory_paid_account_discovery_filters_entitled_accounts() -> N
 
 
 @pytest.mark.asyncio
+async def test_in_memory_delta_entitlement_resolver_prefers_active_billing_rows() -> None:
+    store = InMemoryDeflectionReportArtifactStore(
+        delta_entitlement_rows=[
+            {
+                "account_id": "acct-active",
+                "stripe_subscription_status": "active",
+            },
+            {
+                "account_id": "acct-trial",
+                "stripe_subscription_status": "trialing",
+            },
+            {
+                "account_id": "acct-canceled",
+                "stripe_subscription_status": "canceled",
+            },
+            {
+                "account_id": "acct-revoked",
+                "stripe_subscription_status": "active",
+                "revoked_at": "2026-06-28T00:00:00Z",
+            },
+            {
+                "account_id": "acct-active",
+                "stripe_subscription_status": "active",
+            },
+        ]
+    )
+
+    account_ids = await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=("acct-config",)
+    )
+
+    assert account_ids == ("acct-active", "acct-trial", "acct-config")
+
+
+@pytest.mark.asyncio
+async def test_in_memory_delta_entitlement_resolver_falls_back_when_billing_empty() -> None:
+    store = InMemoryDeflectionReportArtifactStore(
+        delta_entitlement_rows=[
+            {
+                "account_id": "acct-past-due",
+                "stripe_subscription_status": "past_due",
+            },
+            {
+                "account_id": "acct-canceled",
+                "stripe_subscription_status": "canceled",
+            },
+        ]
+    )
+
+    account_ids = await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=("acct-config", "acct-config")
+    )
+
+    assert account_ids == ("acct-config",)
+
+
+@pytest.mark.asyncio
+async def test_in_memory_delta_entitlement_resolver_suppresses_known_inactive_fallback() -> None:
+    store = InMemoryDeflectionReportArtifactStore(
+        delta_entitlement_rows=[
+            {
+                "account_id": "acct-canceled",
+                "stripe_subscription_status": "canceled",
+            },
+            {
+                "account_id": "acct-revoked",
+                "stripe_subscription_status": "trialing",
+                "revoked_at": "2026-06-28T00:00:00Z",
+            },
+        ]
+    )
+
+    account_ids = await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=("acct-canceled", "acct-revoked", "acct-config"),
+        limit=2,
+    )
+
+    assert account_ids == ("acct-config",)
+
+
+@pytest.mark.asyncio
 async def test_in_memory_paid_report_listing_orders_by_paid_activity_window() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     await _save(
@@ -1234,6 +1315,51 @@ async def test_postgres_paid_account_discovery_is_paid_scoped_ordered_and_bounde
         in query
     )
     assert "LIMIT $1" in query
+
+
+@pytest.mark.asyncio
+async def test_postgres_delta_entitlement_resolver_uses_billing_table_and_fallback() -> None:
+    class _Pool:
+        def __init__(self, rows: list[dict[str, object]]) -> None:
+            self.rows = rows
+            self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+
+        async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
+            self.fetch_calls.append((query, args))
+            return self.rows
+
+    pool = _Pool(
+        [
+            {"account_id": "acct-active", "grants_delta_entitlement": True},
+            {"account_id": "acct-trial", "grants_delta_entitlement": True},
+            {"account_id": "acct-canceled", "grants_delta_entitlement": False},
+        ]
+    )
+    store = PostgresDeflectionReportArtifactStore(pool=pool)
+
+    accounts = await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=("acct-canceled", "acct-config"),
+        limit=3,
+    )
+
+    assert accounts == ("acct-active", "acct-trial", "acct-config")
+    query, args = pool.fetch_calls[0]
+    assert args == (["active", "trialing"], ["acct-canceled", "acct-config"], 3)
+    assert "FROM content_ops_deflection_delta_entitlements" in query
+    assert "stripe_subscription_status = ANY($1::text[])" in query
+    assert "revoked_at IS NULL" in query
+    assert "GROUP BY account_id" in query
+    assert "LIMIT $3" in query
+
+    empty_pool = _Pool([])
+    empty_store = PostgresDeflectionReportArtifactStore(pool=empty_pool)
+
+    fallback_accounts = await empty_store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=("acct-config", "acct-config"),
+        limit=1,
+    )
+
+    assert fallback_accounts == ("acct-config",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_deflection_delta_automation_task.py
+++ b/tests/test_deflection_delta_automation_task.py
@@ -17,12 +17,37 @@ class _Pool(SimpleNamespace):
         *,
         is_initialized: bool = True,
         pending_delta_deliveries: int = 0,
+        entitlement_rows: list[dict[str, Any]] | None = None,
     ) -> None:
         super().__init__(
             is_initialized=is_initialized,
             pending_delta_deliveries=pending_delta_deliveries,
+            entitlement_rows=entitlement_rows or [],
+            fetch_calls=[],
             fetchval_calls=[],
         )
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls.append((query, args))
+        assert "content_ops_deflection_delta_entitlements" in query
+        statuses = set(args[0])
+        fallback_accounts = set(args[1]) if len(args) > 1 else set()
+        limit = int(args[2]) if len(args) > 2 else 100
+        rows = []
+        for row in self.entitlement_rows:
+            account_id = row["account_id"]
+            status = row.get("stripe_subscription_status")
+            if status not in statuses and account_id not in fallback_accounts:
+                continue
+            rows.append(
+                {
+                    "account_id": account_id,
+                    "grants_delta_entitlement": status in statuses
+                    and row.get("revoked_at") is None,
+                }
+            )
+        rows.sort(key=lambda row: (not row["grants_delta_entitlement"], row["account_id"]))
+        return rows[:limit]
 
     async def fetchval(self, query: str, *args: Any) -> int:
         self.fetchval_calls.append((query, args))
@@ -205,6 +230,146 @@ async def test_run_delegates_to_batch_worker_with_typed_and_metadata_limits(
         "report_limit_overflow_accounts": [],
         "entitled_account_count": 3,
     }
+
+
+@pytest.mark.asyncio
+async def test_run_uses_billing_entitlement_rows_before_config_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch, entitled_account_ids="acct-config")
+    pool = _Pool(
+        is_initialized=True,
+        entitlement_rows=[
+            {
+                "account_id": "acct-db-active",
+                "stripe_subscription_status": "active",
+            },
+            {
+                "account_id": "acct-db-trial",
+                "stripe_subscription_status": "trialing",
+            },
+            {
+                "account_id": "acct-db-canceled",
+                "stripe_subscription_status": "canceled",
+            },
+        ],
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def _compute(
+        _store: Any,
+        *,
+        entitled_account_ids: tuple[str, ...],
+        **_kwargs: Any,
+    ) -> Any:
+        calls.append({"entitled_account_ids": entitled_account_ids})
+        return DeflectionDeltaBatchSummary(
+            accounts_scanned=2,
+            reports_scanned=2,
+            deltas_saved=0,
+            skipped_no_delta=2,
+            failed=0,
+        )
+
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", _compute)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert calls == [
+        {"entitled_account_ids": ("acct-db-active", "acct-db-trial", "acct-config")}
+    ]
+    assert pool.fetch_calls[0][1] == (["active", "trialing"], ["acct-config"], 11)
+    assert result["entitled_account_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_run_falls_back_to_config_allowlist_when_billing_rows_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch, entitled_account_ids="acct-config,acct-config")
+    pool = _Pool(is_initialized=True)
+    calls: list[dict[str, Any]] = []
+
+    async def _compute(
+        _store: Any,
+        *,
+        entitled_account_ids: tuple[str, ...],
+        **_kwargs: Any,
+    ) -> Any:
+        calls.append({"entitled_account_ids": entitled_account_ids})
+        return DeflectionDeltaBatchSummary(
+            accounts_scanned=1,
+            reports_scanned=1,
+            deltas_saved=0,
+            skipped_no_delta=1,
+            failed=0,
+        )
+
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", _compute)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert calls == [{"entitled_account_ids": ("acct-config",)}]
+    assert result["entitled_account_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_revive_inactive_billing_rows_from_config_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch, entitled_account_ids="acct-canceled")
+    pool = _Pool(
+        is_initialized=True,
+        entitlement_rows=[
+            {
+                "account_id": "acct-canceled",
+                "stripe_subscription_status": "canceled",
+            },
+        ],
+    )
+    compute = AsyncMock()
+    send_pending = AsyncMock()
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", compute)
+    monkeypatch.setattr(mod, "send_pending_deflection_delta_deliveries", send_pending)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result["_skip_synthesis"] == "No entitled deflection delta accounts configured"
+    assert result["entitled_account_count"] == 0
+    compute.assert_not_called()
+    send_pending.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_revive_revoked_active_billing_rows_from_config_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch, entitled_account_ids="acct-revoked")
+    pool = _Pool(
+        is_initialized=True,
+        entitlement_rows=[
+            {
+                "account_id": "acct-revoked",
+                "stripe_subscription_status": "active",
+                "revoked_at": "2026-06-28T00:00:00Z",
+            },
+        ],
+    )
+    compute = AsyncMock()
+    send_pending = AsyncMock()
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", compute)
+    monkeypatch.setattr(mod, "send_pending_deflection_delta_deliveries", send_pending)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result["_skip_synthesis"] == "No entitled deflection delta accounts configured"
+    assert result["entitled_account_count"] == 0
+    compute.assert_not_called()
+    send_pending.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -397,6 +562,33 @@ async def test_run_skips_global_generation_without_entitled_accounts(
     assert result["entitled_account_count"] == 0
     assert result["accounts_scanned"] == 0
     assert result["delivery_sent"] == 0
+    compute.assert_not_called()
+    send_pending.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_skips_global_generation_with_only_inactive_billing_entitlements(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_delta_settings(monkeypatch, entitled_account_ids=" ")
+    pool = _Pool(
+        is_initialized=True,
+        entitlement_rows=[
+            {"account_id": "acct-past-due", "stripe_subscription_status": "past_due"},
+            {"account_id": "acct-unpaid", "stripe_subscription_status": "unpaid"},
+            {"account_id": "acct-canceled", "stripe_subscription_status": "canceled"},
+        ],
+    )
+    compute = AsyncMock()
+    send_pending = AsyncMock()
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod, "compute_and_save_recent_deflection_deltas", compute)
+    monkeypatch.setattr(mod, "send_pending_deflection_delta_deliveries", send_pending)
+
+    result = await mod.run(SimpleNamespace(metadata={}))
+
+    assert result["_skip_synthesis"] == "No entitled deflection delta accounts configured"
+    assert result["entitled_account_count"] == 0
     compute.assert_not_called()
     send_pending.assert_not_called()
 

--- a/tests/test_deflection_migrations_apply.py
+++ b/tests/test_deflection_migrations_apply.py
@@ -12,6 +12,8 @@ This check is scoped to the deflection chain, which has no such dependency:
 - 339 content_ops_deflection_reports retention index
 - 340 content_ops_deflection_deltas
 - 341 content_ops_deflection_delta_deliveries
+- 342 content_ops_deflection_checkout_authorization
+- 343 content_ops_deflection_delta_entitlements
 
 It applies those files in order to a fresh Postgres database and verifies the
 tables exist and the reconciliation table's idempotency constraint holds --
@@ -41,6 +43,8 @@ NULL_SESSION_MIGRATION = "337_content_ops_deflection_reconciliation_null_session
 RETENTION_INDEX_MIGRATION = "339_content_ops_deflection_reports_retention_index.sql"
 DELTA_MIGRATION = "340_content_ops_deflection_deltas.sql"
 DELTA_DELIVERY_MIGRATION = "341_content_ops_deflection_delta_deliveries.sql"
+CHECKOUT_AUTHORIZATION_MIGRATION = "342_content_ops_deflection_checkout_authorization.sql"
+DELTA_ENTITLEMENT_MIGRATION = "343_content_ops_deflection_delta_entitlements.sql"
 
 _TEST_ACCOUNT_ID = "acct-deflection-migration-apply-test"
 
@@ -75,6 +79,7 @@ async def _reset(conn) -> None:
     await conn.execute(
         "DROP TABLE IF EXISTS "
         "content_ops_deflection_paid_reconciliation, "
+        "content_ops_deflection_delta_entitlements, "
         "content_ops_deflection_delta_deliveries, "
         "content_ops_deflection_deltas, "
         "content_ops_deflection_report_deliveries, "
@@ -99,6 +104,8 @@ async def test_deflection_migration_chain_applies_to_a_fresh_database() -> None:
             RETENTION_INDEX_MIGRATION,
             DELTA_MIGRATION,
             DELTA_DELIVERY_MIGRATION,
+            CHECKOUT_AUTHORIZATION_MIGRATION,
+            DELTA_ENTITLEMENT_MIGRATION,
         )
 
         existing = {
@@ -114,6 +121,7 @@ async def test_deflection_migration_chain_applies_to_a_fresh_database() -> None:
             "content_ops_deflection_paid_reconciliation",
             "content_ops_deflection_deltas",
             "content_ops_deflection_delta_deliveries",
+            "content_ops_deflection_delta_entitlements",
         } <= existing
 
         recon_columns = {
@@ -186,6 +194,43 @@ async def test_deflection_migration_chain_applies_to_a_fresh_database() -> None:
             "updated_at",
             "delivered_at",
         } <= delta_delivery_columns
+
+        checkout_columns = {
+            row["column_name"]
+            for row in await conn.fetch(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'content_ops_deflection_reports'"
+            )
+        }
+        assert {
+            "checkout_price_variant",
+            "checkout_amount_cents",
+            "checkout_currency",
+            "checkout_price_id",
+            "checkout_authorized_at",
+        } <= checkout_columns
+
+        delta_entitlement_columns = {
+            row["column_name"]
+            for row in await conn.fetch(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'content_ops_deflection_delta_entitlements'"
+            )
+        }
+        assert {
+            "account_id",
+            "stripe_subscription_id",
+            "stripe_customer_id",
+            "stripe_price_id",
+            "stripe_subscription_status",
+            "entitlement_source",
+            "current_period_end",
+            "granted_at",
+            "revoked_at",
+            "metadata",
+            "created_at",
+            "updated_at",
+        } <= delta_entitlement_columns
 
         # Non-null dedup (ON CONFLICT DO NOTHING): a second event for the same
         # checkout must not create a duplicate ledger row.
@@ -274,6 +319,38 @@ async def test_deflection_migration_chain_applies_to_a_fresh_database() -> None:
             )
             == 1
         )
+        for suffix, status in (("active", "active"), ("trial", "trialing")):
+            await conn.execute(
+                "INSERT INTO content_ops_deflection_delta_entitlements "
+                "(account_id, stripe_subscription_id, stripe_subscription_status) "
+                "VALUES ($1, $2, $3)",
+                f"{_TEST_ACCOUNT_ID}-{suffix}",
+                f"sub-{suffix}",
+                status,
+            )
+        assert (
+            await conn.fetchval(
+                "SELECT count(DISTINCT account_id) "
+                "FROM content_ops_deflection_delta_entitlements "
+                "WHERE stripe_subscription_status IN ('active', 'trialing')"
+            )
+            == 2
+        )
+        delta_entitlement_indexdef = await conn.fetchval(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname = 'public' "
+            "AND tablename = 'content_ops_deflection_delta_entitlements' "
+            "AND indexname = 'idx_content_ops_deflection_delta_entitlements_active'"
+        )
+        assert delta_entitlement_indexdef is not None
+        assert "revoked_at IS NULL" in delta_entitlement_indexdef
+        with pytest.raises(Exception):
+            await conn.execute(
+                "INSERT INTO content_ops_deflection_delta_entitlements "
+                "(account_id, stripe_subscription_id, stripe_subscription_status) "
+                "VALUES ($1, 'sub-invalid', 'renewing')",
+                _TEST_ACCOUNT_ID,
+            )
     finally:
         await _cleanup(conn)
         await conn.close()
@@ -330,6 +407,14 @@ async def test_deflection_337_collapses_pre_existing_null_session_duplicates() -
 
 
 async def _cleanup(conn) -> None:
+    try:
+        await conn.execute(
+            "DELETE FROM content_ops_deflection_delta_entitlements "
+            "WHERE account_id LIKE $1",
+            f"{_TEST_ACCOUNT_ID}%",
+        )
+    except Exception:
+        pass
     try:
         await conn.execute(
             "DELETE FROM content_ops_deflection_deltas "


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delta-Billing-Entitlement-Resolver.md
Slice phase: Production hardening

#1873 replaces the monthly deflection delta config allowlist with Stripe Billing subscription entitlements. This first slice adds the durable entitlement table and resolves active/trialing, non-revoked monthly delta accounts through the real deflection report store adapters before generation, delivery drain, and pending-count paths run.

## Intentional
- `active` and `trialing` are the only granting statuses. `past_due`/`unpaid` fail closed until product explicitly chooses a grace policy.
- The config allowlist remains a temporary fallback only for accounts with no Billing row yet; it cannot revive known inactive/revoked Billing rows.
- Entitlement resolution is bounded by the task account scan window so the scheduled job does not materialize an unbounded subscriber list.
- No `payment_method_types`, Checkout Session creation, subscription Price wiring, or webhook mutation is added here; those belong with follow-up #1873 slices.

## Deferred
- Stripe webhook lifecycle handler upserts/revokes `content_ops_deflection_delta_entitlements` for monthly delta Price IDs.
- Subscription Checkout Session / customer portal surface once monthly product and Price IDs are finalized.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_deflection_delta_automation_task.py tests/test_content_ops_deflection_delta_persistence.py tests/test_deflection_migrations_apply.py tests/test_maturity_sweep_file_lane.py tests/test_deflection_product_surface_manifest.py -q` (71 passed, 2 skipped)
- `python -m py_compile atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py extracted_content_pipeline/deflection_report_access.py`
- `bash scripts/local_pr_review.sh`

## AI reconciliation
All fixed or waived: Yes
- Codex P1 inactive Billing rows revived by config fallback: fixed. Known inactive/revoked Billing accounts suppress fallback; fallback applies only when an account has no Billing row yet.
- Codex P2 revoked entitlement rows: fixed. Active/trialing grants require `revoked_at IS NULL`, mirrored in the migration index and adapter tests.
- Codex P2 unbounded entitlement resolution: fixed. The task passes its account scan limit into the store resolver, and the Postgres resolver applies a bounded query/result.

## Diff size
8 files, +639 / -8
