### PR TITLE
Wire deflection delta Stripe entitlement webhooks

### DIFF
--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -1,9 +1,11 @@
 """Stripe billing endpoints: checkout, portal, status, webhook."""
 
 import logging
+import re
 import time
 import uuid as _uuid
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 from hashlib import sha256
 from typing import Any
 
@@ -16,7 +18,9 @@ from ..content_ops_deflection_incidents import emit_deflection_paid_funnel_incid
 from ..content_ops_deflection_reconciliation import record_paid_report_missing
 from ..storage.database import get_db_pool
 from extracted_content_pipeline.deflection_report_access import (
+    DELTA_ENTITLEMENT_ACTIVE_STATUSES,
     DeflectionReportAccessRecord,
+    DeflectionReportArtifactStore,
     PostgresDeflectionReportArtifactStore,
 )
 
@@ -53,6 +57,9 @@ LLM_PLAN_LIMITS = {
 
 PRICE_TO_PLAN = {}  # populated at module init from config
 STRIPE_API_VERSION = "2026-05-27.dahlia"
+_UUID_TEXT_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 
 def _init_price_map():
@@ -392,6 +399,7 @@ async def stripe_webhook(request: Request):
 
     event_type = event.type
     obj = event.data.object
+    event_created = _stripe_event_created(event)
 
     account_id = None
 
@@ -410,6 +418,22 @@ async def stripe_webhook(request: Request):
                     meta,
                     event_type=event_type,
                     event_created=getattr(event, "created", None),
+                )
+        elif _is_deflection_delta_subscription_source(obj) or (
+            _deflection_delta_price_id_from_object(obj) is not None
+        ):
+            if _stripe_text(obj, "payment_status") == "paid":
+                account_id = await _handle_deflection_delta_invoice_lifecycle(
+                    pool,
+                    obj,
+                    stripe_subscription_status="active",
+                    stripe_event_created=event_created,
+                )
+            else:
+                logger.warning(
+                    "Deflection delta checkout completed before funds were available: session=%s payment_status=%s",
+                    _stripe_text(obj, "id") or "<missing>",
+                    _stripe_text(obj, "payment_status") or "<missing>",
                 )
         else:
             account_id = await _handle_checkout_completed(pool, obj)
@@ -450,16 +474,46 @@ async def stripe_webhook(request: Request):
         )
 
     elif event_type == "invoice.paid":
-        account_id = await _handle_invoice_paid(pool, obj)
+        if _deflection_delta_price_id_from_object(obj) is not None:
+            account_id = await _handle_deflection_delta_invoice_lifecycle(
+                pool,
+                obj,
+                stripe_subscription_status="active",
+                stripe_event_created=event_created,
+            )
+        else:
+            account_id = await _handle_invoice_paid(pool, obj)
 
     elif event_type == "invoice.payment_failed":
-        account_id = await _handle_invoice_failed(pool, obj)
+        if _deflection_delta_price_id_from_object(obj) is not None:
+            account_id = await _handle_deflection_delta_invoice_lifecycle(
+                pool,
+                obj,
+                stripe_subscription_status="past_due",
+                stripe_event_created=event_created,
+            )
+        else:
+            account_id = await _handle_invoice_failed(pool, obj)
 
-    elif event_type == "customer.subscription.updated":
-        account_id = await _handle_subscription_updated(pool, obj)
+    elif event_type in {"customer.subscription.created", "customer.subscription.updated"}:
+        if (
+            event_type == "customer.subscription.created"
+            and _deflection_delta_price_id_from_object(obj) is None
+        ):
+            account_id = None
+        else:
+            account_id = await _handle_subscription_updated(
+                pool,
+                obj,
+                stripe_event_created=event_created,
+            )
 
     elif event_type == "customer.subscription.deleted":
-        account_id = await _handle_subscription_deleted(pool, obj)
+        account_id = await _handle_subscription_deleted(
+            pool,
+            obj,
+            stripe_event_created=event_created,
+        )
 
     # Log event -- pass dict for JSONB column, add ::jsonb cast for asyncpg
     import json
@@ -1217,6 +1271,17 @@ def _stripe_int(obj: Any, key: str) -> int | None:
         return None
 
 
+def _stripe_event_created(event: Any) -> int | None:
+    value = getattr(event, "created", None)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
 def _payment_intent_from_payment_event(obj: Any) -> str:
     payment_intent = _stripe_text(obj, "payment_intent")
     if payment_intent:
@@ -1230,6 +1295,195 @@ def _payment_intent_from_payment_event(obj: Any) -> str:
 def _stripe_metadata(obj: Any) -> Mapping[str, Any]:
     metadata = _stripe_object_value(obj, "metadata")
     return metadata if isinstance(metadata, Mapping) else {}
+
+
+def _configured_deflection_delta_price_ids() -> tuple[str, ...]:
+    raw = str(
+        getattr(
+            settings.saas_auth,
+            "stripe_content_ops_deflection_delta_price_ids",
+            "",
+        )
+        or ""
+    )
+    seen: set[str] = set()
+    price_ids: list[str] = []
+    for item in raw.split(","):
+        price_id = item.strip()
+        if not price_id or price_id in seen:
+            continue
+        seen.add(price_id)
+        price_ids.append(price_id)
+    return tuple(price_ids)
+
+
+def _stripe_price_ids_from_object(obj: Any) -> tuple[str, ...]:
+    price_ids: list[str] = []
+
+    def add_price_id(value: Any) -> None:
+        price_id = _stripe_text(value, "id") if not isinstance(value, str) else value
+        if price_id:
+            price_ids.append(price_id)
+
+    direct_price = _stripe_object_value(obj, "price")
+    if direct_price is not None:
+        add_price_id(direct_price)
+
+    items = _stripe_object_value(obj, "items")
+    data = _stripe_object_value(items, "data")
+    if isinstance(data, Sequence) and not isinstance(data, (str, bytes, bytearray)):
+        for item in data:
+            add_price_id(_stripe_object_value(item, "price"))
+
+    lines = _stripe_object_value(obj, "lines")
+    line_data = _stripe_object_value(lines, "data")
+    if isinstance(line_data, Sequence) and not isinstance(line_data, (str, bytes, bytearray)):
+        for line in line_data:
+            add_price_id(_stripe_object_value(line, "price"))
+            pricing = _stripe_object_value(line, "pricing")
+            price_details = _stripe_object_value(pricing, "price_details")
+            add_price_id(_stripe_object_value(price_details, "price"))
+
+    return tuple(dict.fromkeys(price_ids))
+
+
+def _deflection_delta_price_id_from_object(obj: Any) -> str | None:
+    configured = set(_configured_deflection_delta_price_ids())
+    if not configured:
+        return None
+    for price_id in _stripe_price_ids_from_object(obj):
+        if price_id in configured:
+            return price_id
+    return None
+
+
+def _is_deflection_delta_subscription_source(obj: Any) -> bool:
+    return (
+        _clean_metadata(_stripe_metadata(obj).get("source"))
+        == "content_ops_deflection_delta_subscription"
+    )
+
+
+def _stripe_subscription_id(obj: Any) -> str:
+    subscription_id = _stripe_text(obj, "id")
+    object_type = _stripe_text(obj, "object")
+    if subscription_id.startswith("sub_") or object_type == "subscription":
+        return subscription_id
+    legacy_subscription_id = _stripe_text(obj, "subscription")
+    if legacy_subscription_id:
+        return legacy_subscription_id
+    parent = _stripe_object_value(obj, "parent")
+    subscription_details = _stripe_object_value(parent, "subscription_details")
+    return _stripe_text(subscription_details, "subscription")
+
+
+def _stripe_current_period_end(obj: Any) -> datetime | None:
+    period_end = _stripe_int(obj, "current_period_end")
+    if period_end is None or period_end <= 0 or period_end > 4_102_444_800:
+        return None
+    return datetime.fromtimestamp(period_end, timezone.utc)
+
+
+async def _account_id_for_stripe_object(pool: Any, obj: Any) -> _uuid.UUID | None:
+    meta = _stripe_metadata(obj)
+    account_id_str = _clean_metadata(meta.get("account_id"))
+    if account_id_str:
+        if not _UUID_TEXT_RE.fullmatch(account_id_str):
+            return None
+        return _uuid.UUID(account_id_str)
+    customer_id = _stripe_text(obj, "customer")
+    if not customer_id:
+        return None
+    return await _find_account_by_customer(pool, customer_id)
+
+
+async def _handle_deflection_delta_subscription_lifecycle(
+    pool: Any,
+    subscription: Any,
+    *,
+    stripe_subscription_status: str | None = None,
+    stripe_event_created: int | None = None,
+    store: DeflectionReportArtifactStore | None = None,
+) -> _uuid.UUID | None:
+    price_id = _deflection_delta_price_id_from_object(subscription)
+    if price_id is None:
+        return None
+    subscription_id = _stripe_subscription_id(subscription)
+    if not subscription_id:
+        logger.warning("Deflection delta subscription event missing subscription id")
+        return None
+    account_id = await _account_id_for_stripe_object(pool, subscription)
+    if account_id is None:
+        logger.warning(
+            "Deflection delta subscription event missing account mapping: customer=%s subscription=%s",
+            _stripe_text(subscription, "customer") or "<missing>",
+            subscription_id,
+        )
+        return None
+    status = stripe_subscription_status or _stripe_text(subscription, "status")
+    if not status:
+        logger.warning(
+            "Deflection delta subscription event missing status: account=%s subscription=%s",
+            account_id,
+            subscription_id,
+        )
+        return account_id
+    entitlement_store = store or PostgresDeflectionReportArtifactStore(pool)
+    await entitlement_store.upsert_deflection_delta_entitlement(
+        account_id=str(account_id),
+        stripe_subscription_id=subscription_id,
+        stripe_customer_id=_stripe_text(subscription, "customer") or None,
+        stripe_price_id=price_id,
+        stripe_subscription_status=status,
+        current_period_end=_stripe_current_period_end(subscription),
+        stripe_event_created=stripe_event_created,
+        metadata={
+            "source": "stripe_billing_webhook",
+            "grants_delta_entitlement": status in DELTA_ENTITLEMENT_ACTIVE_STATUSES,
+        },
+    )
+    return account_id
+
+
+async def _handle_deflection_delta_invoice_lifecycle(
+    pool: Any,
+    invoice: Any,
+    *,
+    stripe_subscription_status: str,
+    stripe_event_created: int | None = None,
+    store: DeflectionReportArtifactStore | None = None,
+) -> _uuid.UUID | None:
+    price_id = _deflection_delta_price_id_from_object(invoice)
+    if price_id is None:
+        return None
+    subscription_id = _stripe_subscription_id(invoice)
+    if not subscription_id:
+        logger.warning("Deflection delta invoice event missing subscription id")
+        return None
+    account_id = await _account_id_for_stripe_object(pool, invoice)
+    if account_id is None:
+        logger.warning(
+            "Deflection delta invoice event missing account mapping: customer=%s subscription=%s",
+            _stripe_text(invoice, "customer") or "<missing>",
+            subscription_id,
+        )
+        return None
+    entitlement_store = store or PostgresDeflectionReportArtifactStore(pool)
+    await entitlement_store.upsert_deflection_delta_entitlement(
+        account_id=str(account_id),
+        stripe_subscription_id=subscription_id,
+        stripe_customer_id=_stripe_text(invoice, "customer") or None,
+        stripe_price_id=price_id,
+        stripe_subscription_status=stripe_subscription_status,
+        current_period_end=_stripe_current_period_end(invoice),
+        stripe_event_created=stripe_event_created,
+        metadata={
+            "source": "stripe_billing_invoice_webhook",
+            "grants_delta_entitlement": stripe_subscription_status
+            in DELTA_ENTITLEMENT_ACTIVE_STATUSES,
+        },
+    )
+    return account_id
 
 
 def _log_content_ops_deflection_report_payment_pending(
@@ -1411,8 +1665,20 @@ async def _handle_invoice_failed(pool, invoice) -> _uuid.UUID | None:
     return account_id
 
 
-async def _handle_subscription_updated(pool, subscription) -> _uuid.UUID | None:
+async def _handle_subscription_updated(
+    pool,
+    subscription,
+    *,
+    stripe_event_created: int | None = None,
+) -> _uuid.UUID | None:
     """Handle subscription changes (upgrades/downgrades)."""
+    if _deflection_delta_price_id_from_object(subscription) is not None:
+        return await _handle_deflection_delta_subscription_lifecycle(
+            pool,
+            subscription,
+            stripe_event_created=stripe_event_created,
+        )
+
     customer_id = subscription.customer
     account_id = await _find_account_by_customer(pool, customer_id)
     if not account_id:
@@ -1472,8 +1738,21 @@ async def _handle_subscription_updated(pool, subscription) -> _uuid.UUID | None:
     return account_id
 
 
-async def _handle_subscription_deleted(pool, subscription) -> _uuid.UUID | None:
+async def _handle_subscription_deleted(
+    pool,
+    subscription,
+    *,
+    stripe_event_created: int | None = None,
+) -> _uuid.UUID | None:
     """Handle subscription cancellation."""
+    if _deflection_delta_price_id_from_object(subscription) is not None:
+        return await _handle_deflection_delta_subscription_lifecycle(
+            pool,
+            subscription,
+            stripe_subscription_status="canceled",
+            stripe_event_created=stripe_event_created,
+        )
+
     customer_id = subscription.customer
     account_id = await _find_account_by_customer(pool, customer_id)
     if account_id:

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -122,6 +122,13 @@ class SaaSAuthConfig(BaseSettings):
             "deflection report"
         ),
     )
+    stripe_content_ops_deflection_delta_price_ids: str = Field(
+        default="",
+        description=(
+            "Comma-separated Stripe Price IDs for the monthly Content Ops "
+            "deflection delta subscription. Blank fails closed."
+        ),
+    )
     stripe_content_ops_deflection_report_allowed_amount_cents: str = Field(
         default="",
         description=(

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -168,6 +168,20 @@ class DeflectionReportArtifactStore(Protocol):
     ) -> tuple[str, ...]:
         """List tenants with an active monthly delta entitlement."""
 
+    async def upsert_deflection_delta_entitlement(
+        self,
+        *,
+        account_id: str,
+        stripe_subscription_id: str,
+        stripe_subscription_status: str,
+        stripe_customer_id: str | None = None,
+        stripe_price_id: str | None = None,
+        current_period_end: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        stripe_event_created: int | None = None,
+    ) -> None:
+        """Record the latest Stripe Billing lifecycle state for monthly deltas."""
+
     async def count_paid_reports(
         self,
         *,
@@ -526,6 +540,60 @@ class InMemoryDeflectionReportArtifactStore:
             if account_id not in known_account_ids
         )
         return _limit_account_ids((*active_account_ids, *fallback), limit)
+
+    async def upsert_deflection_delta_entitlement(
+        self,
+        *,
+        account_id: str,
+        stripe_subscription_id: str,
+        stripe_subscription_status: str,
+        stripe_customer_id: str | None = None,
+        stripe_price_id: str | None = None,
+        current_period_end: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        stripe_event_created: int | None = None,
+    ) -> None:
+        resolved_account = _required_text(account_id, "account_id")
+        resolved_subscription = _required_text(
+            stripe_subscription_id,
+            "stripe_subscription_id",
+        )
+        status = _required_text(
+            stripe_subscription_status,
+            "stripe_subscription_status",
+        )
+        now = datetime.now(timezone.utc)
+        row_metadata = _delta_entitlement_metadata(
+            metadata,
+            stripe_event_created=stripe_event_created,
+        )
+        row = {
+            "account_id": resolved_account,
+            "stripe_subscription_id": resolved_subscription,
+            "stripe_customer_id": _clean(stripe_customer_id),
+            "stripe_price_id": _clean(stripe_price_id),
+            "stripe_subscription_status": status,
+            "current_period_end": current_period_end,
+            "metadata": row_metadata,
+            "updated_at": now,
+            "revoked_at": None
+            if _delta_entitlement_status_grants(status)
+            else now,
+        }
+        for index, existing in enumerate(self._delta_entitlement_rows):
+            if _clean(existing.get("stripe_subscription_id")) == resolved_subscription:
+                if _delta_entitlement_update_is_stale(row, existing):
+                    return
+                granted_at = existing.get("granted_at")
+                if row["revoked_at"] is None and existing.get("revoked_at") is not None:
+                    granted_at = now
+                row["granted_at"] = granted_at or now
+                row["created_at"] = existing.get("created_at") or now
+                self._delta_entitlement_rows[index] = row
+                return
+        row["granted_at"] = now
+        row["created_at"] = now
+        self._delta_entitlement_rows.append(row)
 
     async def count_paid_reports(
         self,
@@ -1078,6 +1146,88 @@ class PostgresDeflectionReportArtifactStore:
             account_id for account_id in fallback if account_id not in known_account_ids
         )
         return _limit_account_ids((*active_account_ids, *fallback_account_ids), limit)
+
+    async def upsert_deflection_delta_entitlement(
+        self,
+        *,
+        account_id: str,
+        stripe_subscription_id: str,
+        stripe_subscription_status: str,
+        stripe_customer_id: str | None = None,
+        stripe_price_id: str | None = None,
+        current_period_end: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        stripe_event_created: int | None = None,
+    ) -> None:
+        status = _required_text(
+            stripe_subscription_status,
+            "stripe_subscription_status",
+        )
+        row_metadata = _delta_entitlement_metadata(
+            metadata,
+            stripe_event_created=stripe_event_created,
+        )
+        await self.pool.execute(
+            """
+            INSERT INTO content_ops_deflection_delta_entitlements (
+                account_id,
+                stripe_subscription_id,
+                stripe_customer_id,
+                stripe_price_id,
+                stripe_subscription_status,
+                current_period_end,
+                metadata,
+                revoked_at
+            )
+            VALUES (
+                $1,
+                $2,
+                $3,
+                $4,
+                $5,
+                $6,
+                $7::jsonb,
+                CASE WHEN $5 = ANY($8::text[]) THEN NULL ELSE NOW() END
+            )
+            ON CONFLICT (stripe_subscription_id) DO UPDATE
+            SET account_id = EXCLUDED.account_id,
+                stripe_customer_id = EXCLUDED.stripe_customer_id,
+                stripe_price_id = EXCLUDED.stripe_price_id,
+                stripe_subscription_status = EXCLUDED.stripe_subscription_status,
+                current_period_end = EXCLUDED.current_period_end,
+                metadata = EXCLUDED.metadata,
+                revoked_at = EXCLUDED.revoked_at,
+                granted_at = CASE
+                    WHEN EXCLUDED.revoked_at IS NULL
+                     AND content_ops_deflection_delta_entitlements.revoked_at IS NOT NULL
+                    THEN NOW()
+                    ELSE content_ops_deflection_delta_entitlements.granted_at
+                END,
+                updated_at = NOW()
+            WHERE jsonb_typeof(EXCLUDED.metadata->'stripe_event_created') = 'number'
+              AND COALESCE(
+                    CASE
+                        WHEN jsonb_typeof(EXCLUDED.metadata->'stripe_event_created') = 'number'
+                        THEN (EXCLUDED.metadata->>'stripe_event_created')::bigint
+                    END,
+                    -1
+                ) >= COALESCE(
+                    CASE
+                        WHEN jsonb_typeof(content_ops_deflection_delta_entitlements.metadata->'stripe_event_created') = 'number'
+                        THEN (content_ops_deflection_delta_entitlements.metadata->>'stripe_event_created')::bigint
+                    END,
+                    -1
+                )
+            """,
+            _required_text(account_id, "account_id"),
+            _required_text(stripe_subscription_id, "stripe_subscription_id"),
+            _clean(stripe_customer_id) or None,
+            _clean(stripe_price_id) or None,
+            status,
+            current_period_end,
+            json_dump_jsonb(row_metadata),
+            list(DELTA_ENTITLEMENT_ACTIVE_STATUSES),
+        )
 
     async def count_paid_reports(
         self,
@@ -2021,6 +2171,45 @@ def _limit_account_ids(
     if limit is None:
         return resolved
     return resolved[:_bounded_limit(limit)]
+
+
+def _delta_entitlement_status_grants(status: Any) -> bool:
+    return _clean(status) in DELTA_ENTITLEMENT_ACTIVE_STATUSES
+
+
+def _delta_entitlement_metadata(
+    metadata: Mapping[str, Any] | None,
+    *,
+    stripe_event_created: int | None,
+) -> dict[str, Any]:
+    row_metadata = dict(metadata or {})
+    if stripe_event_created is not None:
+        row_metadata["stripe_event_created"] = stripe_event_created
+    return row_metadata
+
+
+def _delta_entitlement_event_created(row: Mapping[str, Any]) -> int | None:
+    metadata = row.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return None
+    value = metadata.get("stripe_event_created")
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def _delta_entitlement_update_is_stale(
+    incoming: Mapping[str, Any],
+    existing: Mapping[str, Any],
+) -> bool:
+    incoming_created = _delta_entitlement_event_created(incoming)
+    existing_created = _delta_entitlement_event_created(existing)
+    if incoming_created is None:
+        return existing_created is not None
+    return (
+        existing_created is not None
+        and incoming_created < existing_created
+    )
 
 
 def _required_text(value: Any, field: str) -> str:

--- a/plans/PR-Deflection-Delta-Stripe-Entitlement-Webhooks.md
+++ b/plans/PR-Deflection-Delta-Stripe-Entitlement-Webhooks.md
@@ -1,0 +1,180 @@
+# PR-Deflection-Delta-Stripe-Entitlement-Webhooks
+
+## Why this slice exists
+
+#1873's durable target is "Stripe Billing subscriptions are the source of truth
+for monthly deflection delta delivery." #1876 added the fail-closed resolver and
+table, but nothing writes Stripe lifecycle state into that table yet. The
+monthly task can now read Billing-backed entitlements, but Stripe webhooks still
+only update generic SaaS plan state and one-time paid report access.
+
+Root cause: the deflection delta subscription product has no configured Price-ID
+gate and no webhook producer for `content_ops_deflection_delta_entitlements`.
+That leaves monthly deltas dependent on the transitional config allowlist, and a
+future delta subscription event would fall through the generic subscription
+handler instead of preserving the one-time-report/monthly-delta boundary.
+
+This PR fixes the root for the first Stripe lifecycle vertical: configured
+monthly delta Price IDs produce ATLAS-owned entitlement rows, and inactive
+Stripe states fail closed by revoking those rows.
+
+Review-finding root cause: the first push recorded lifecycle state but did not
+persist any monotonic Stripe event basis, so a later-delivered older `active`
+event could overwrite a newer revoke. The same first pass also proved routing
+with fake-pool SQL assertions instead of a handler-level store contract. This
+fixes that root by carrying Stripe `event.created` into the entitlement row,
+ignoring older lifecycle updates on conflict, and proving the lifecycle handler
+against the real in-memory store/resolver.
+
+Round-2 review root cause: the webhook fixture covered the legacy invoice shape
+instead of the configured `2026-05-27.dahlia` shape, so renewal/dunning invoice
+events could miss both Price ID and subscription ID extraction. The recency
+guard also treated a missing incoming event timestamp as newest. This update
+adds the dahlia invoice paths, routes configured delta
+`customer.subscription.created`, and requires an incoming numeric event
+timestamp before an existing entitlement row can be overwritten.
+
+Diff-size note: this exceeds the 400 LOC soft cap because the smallest safe
+root fix crosses the billing webhook and the entitlement store boundary, and the
+tests intentionally cover the real adapter contract plus the webhook routing
+matrix that prevents one-time and generic subscription flows from merging.
+Splitting out the tests or store adapter would recreate the fake-transport gap
+that #1876 just closed.
+
+## Scope (this PR)
+
+Ownership lane: deflection/delta-billing-entitlements
+Slice phase: Production hardening
+
+1. Add a typed config field for the monthly deflection delta Stripe Price IDs
+   and a billing helper that treats only those configured Prices as delta
+   subscription products.
+2. Add store-level entitlement write/revoke methods and route Stripe
+   subscription lifecycle events through the real store adapter, not hand-coded
+   webhook SQL.
+3. Handle `checkout.session.completed`, `customer.subscription.created`,
+   `customer.subscription.updated`, `customer.subscription.deleted`,
+   `invoice.paid`, and
+   `invoice.payment_failed` only when the Stripe object contains a configured
+   monthly delta Price ID.
+4. Prove active/trialing rows grant and past_due/unpaid/canceled/deleted rows
+   revoke/fail closed without touching one-time paid report access.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Configured delta Price IDs are the only path that can create/update
+        `content_ops_deflection_delta_entitlements`.
+  - [ ] Unconfigured subscription Prices do not create a delta entitlement and
+        continue through the existing generic SaaS subscription path.
+  - [ ] Active/trialing delta subscription lifecycle events write
+        `revoked_at = NULL`; past_due/unpaid/canceled/incomplete/paused/deleted
+        lifecycle events set `revoked_at` and therefore fail closed under the
+        #1876 resolver.
+  - [ ] Out-of-order Stripe redelivery cannot revive a revoked subscription:
+        lifecycle writes carry Stripe `event.created`, and older events lose to
+        newer entitlement rows; missing incoming event timestamps cannot
+        overwrite existing timestamped rows.
+  - [ ] Dahlia invoice payloads resolve delta Price IDs from
+        `lines.data[].pricing.price_details.price` and subscription IDs from
+        `parent.subscription_details.subscription`.
+  - [ ] `customer.subscription.created` grants active/trialing configured
+        delta subscriptions without broadening generic subscription-created
+        handling.
+  - [ ] One-time paid deflection report checkout/refund/dispute behavior is
+        unchanged.
+  - [ ] Tests use the real entitlement store adapter contract for the DB write
+        behavior; fakes may mock transport, but must not reimplement the
+        entitlement predicate.
+- Affected surfaces: `atlas_brain/api/billing.py`,
+  `atlas_brain/config.py`, `extracted_content_pipeline/deflection_report_access.py`,
+  and their billing/adapter tests.
+- Risk areas: billing/auth/payment lifecycle, fail-closed entitlement state,
+  Stripe webhook idempotency, and config misclassification.
+- Reviewer rules triggered: R1, R2, R3, R5, R7, R8, R10, R11, R12, R13, R14.
+- boundary-probe: negative tests for unconfigured Price IDs, inactive/revoked
+  statuses, missing account/customer mapping, and a one-time report checkout
+  event that must not create a delta entitlement.
+
+### Files touched
+
+- `atlas_brain/api/billing.py`
+- `atlas_brain/config.py`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `plans/PR-Deflection-Delta-Stripe-Entitlement-Webhooks.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+- `tests/test_content_ops_deflection_delta_persistence.py`
+
+## Mechanism
+
+`SaaSAuthConfig` gains a comma-separated
+`ATLAS_SAAS_STRIPE_CONTENT_OPS_DEFLECTION_DELTA_PRICE_IDS` setting. Billing
+parses it into an exact Price-ID set; blank means no Stripe subscription can
+grant monthly deltas.
+
+`DeflectionReportArtifactStore` gets explicit entitlement lifecycle methods.
+The Postgres implementation upserts by `stripe_subscription_id` into
+`content_ops_deflection_delta_entitlements`, stores customer/price/status/period
+metadata, clears `revoked_at` for active/trialing, and sets `revoked_at` for
+non-granting statuses. Stripe webhook handlers pass the signed event's
+`created` timestamp into the write, and the upsert only updates an existing row
+when the incoming event timestamp is present and at least as new as the stored
+timestamp.
+The in-memory implementation mirrors that state so the resolver and writer are
+tested as one adapter contract.
+
+`billing.py` extracts subscription Price IDs from Stripe objects and only
+handles monthly delta entitlement writes when one of those IDs matches the
+configured allowlist. For matching subscription events, billing resolves the
+ATLAS account from subscription metadata or Stripe customer mapping, then calls
+`PostgresDeflectionReportArtifactStore(pool)` to upsert/revoke. Non-delta
+subscription events keep the existing generic SaaS plan behavior.
+
+Invoice paid/failed events use the invoice's subscription/line Price IDs when
+present, including dahlia `pricing.price_details.price` and
+`parent.subscription_details.subscription`, so a payment recovery can regrant
+and a failed renewal can revoke before the next subscription update arrives. If
+the invoice lacks enough subscription identity to prove it is the configured
+delta product, it does not write an entitlement.
+
+## Intentional
+
+- No Stripe API fetch is added in this slice. The webhook must be deterministic
+  from the signed event payload and existing ATLAS account mapping; missing
+  subscription/price/account data fails closed instead of guessing.
+- The transitional `ATLAS_DEFLECTION_DELTA_ENTITLED_ACCOUNT_IDS` allowlist
+  remains as a fallback for accounts with no Billing row yet. #1876 made known
+  inactive/revoked Billing rows suppress that fallback.
+- The generic SaaS plan subscription handler remains in place for non-delta
+  products; this PR only carves out the monthly deflection delta product so it
+  cannot mutate unrelated plan state.
+
+## Deferred
+
+- Stripe Checkout creation for the delta subscription landing/upsell path is
+  deferred. This slice only consumes signed lifecycle events once the product
+  and Price IDs are configured.
+- Customer Portal UX and go-live rehearsal remain deferred to the #1873
+  operational checklist.
+- Event backfill for historical subscriptions is deferred; this slice is
+  going-forward lifecycle wiring.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m py_compile atlas_brain/api/billing.py atlas_brain/config.py extracted_content_pipeline/deflection_report_access.py tests/test_content_ops_deflection_delta_persistence.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py - passed.
+- Command: python -m pytest tests/test_content_ops_deflection_delta_persistence.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q - passed, 92 passed, 1 warning.
+- Command: python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*' - passed, no new brittleness above baseline.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/billing.py` | 295 |
+| `atlas_brain/config.py` | 7 |
+| `extracted_content_pipeline/deflection_report_access.py` | 189 |
+| `plans/PR-Deflection-Delta-Stripe-Entitlement-Webhooks.md` | 180 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 537 |
+| `tests/test_content_ops_deflection_delta_persistence.py` | 125 |
+| **Total** | **1333** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -11,6 +11,9 @@ import pytest
 
 from atlas_brain.api import billing
 from atlas_brain.content_ops_deflection_incidents import INCIDENT_LOG_MARKER
+from extracted_content_pipeline.deflection_report_access import (
+    InMemoryDeflectionReportArtifactStore,
+)
 
 
 def _incident_payloads(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
@@ -35,6 +38,7 @@ class _Pool:
         self.report_rows: dict[tuple[str, str], dict[str, Any]] = {}
         self.delivery_rows: dict[tuple[str, str], dict[str, Any]] = {}
         self.delta_delivery_rows: dict[tuple[str, str, str], dict[str, Any]] = {}
+        self.customer_accounts: dict[str, uuid.UUID] = {}
 
     async def fetchval(self, query: str, *args: Any) -> Any:
         self.fetchval_calls.append((query, args))
@@ -44,6 +48,8 @@ class _Pool:
             and args[0] in self.processed_event_ids
         ):
             return "billing-event-id"
+        if "FROM saas_accounts WHERE stripe_customer_id = $1" in query:
+            return self.customer_accounts.get(str(args[0]))
         return None
 
     async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
@@ -202,6 +208,116 @@ def _session(
     )
 
 
+def _price_line(price_id: str) -> SimpleNamespace:
+    return SimpleNamespace(price=SimpleNamespace(id=price_id))
+
+
+def _subscription(
+    *,
+    account_id: str | None,
+    subscription_id: str = "sub_delta",
+    customer_id: str = "cus_delta",
+    price_id: str = "price_delta_monthly",
+    status: str = "active",
+    current_period_end: int = 1782864000,
+) -> SimpleNamespace:
+    metadata = {}
+    if account_id is not None:
+        metadata["account_id"] = account_id
+    return SimpleNamespace(
+        id=subscription_id,
+        object="subscription",
+        customer=customer_id,
+        status=status,
+        current_period_end=current_period_end,
+        metadata=metadata,
+        items=SimpleNamespace(data=[_price_line(price_id)]),
+        to_dict=lambda: {
+            "id": subscription_id,
+            "object": "subscription",
+            "customer": customer_id,
+            "status": status,
+            "current_period_end": current_period_end,
+            "metadata": dict(metadata),
+            "items": {"data": [{"price": {"id": price_id}}]},
+        },
+    )
+
+
+def _subscription_invoice(
+    *,
+    account_id: str | None,
+    invoice_id: str = "in_delta",
+    subscription_id: str = "sub_delta",
+    customer_id: str = "cus_delta",
+    price_id: str = "price_delta_monthly",
+) -> SimpleNamespace:
+    metadata = {}
+    if account_id is not None:
+        metadata["account_id"] = account_id
+    return SimpleNamespace(
+        id=invoice_id,
+        object="invoice",
+        customer=customer_id,
+        subscription=subscription_id,
+        metadata=metadata,
+        lines=SimpleNamespace(data=[_price_line(price_id)]),
+        to_dict=lambda: {
+            "id": invoice_id,
+            "object": "invoice",
+            "customer": customer_id,
+            "subscription": subscription_id,
+            "metadata": dict(metadata),
+            "lines": {"data": [{"price": {"id": price_id}}]},
+        },
+    )
+
+
+def _dahlia_subscription_invoice(
+    *,
+    account_id: str | None,
+    invoice_id: str = "in_delta",
+    subscription_id: str = "sub_delta",
+    customer_id: str = "cus_delta",
+    price_id: str = "price_delta_monthly",
+) -> SimpleNamespace:
+    metadata = {}
+    if account_id is not None:
+        metadata["account_id"] = account_id
+    parent = SimpleNamespace(
+        subscription_details=SimpleNamespace(subscription=subscription_id)
+    )
+    pricing = SimpleNamespace(
+        price_details=SimpleNamespace(price=price_id)
+    )
+    return SimpleNamespace(
+        id=invoice_id,
+        object="invoice",
+        customer=customer_id,
+        parent=parent,
+        metadata=metadata,
+        lines=SimpleNamespace(data=[SimpleNamespace(pricing=pricing)]),
+        to_dict=lambda: {
+            "id": invoice_id,
+            "object": "invoice",
+            "customer": customer_id,
+            "parent": {
+                "subscription_details": {"subscription": subscription_id},
+            },
+            "metadata": dict(metadata),
+            "lines": {
+                "data": [
+                    {
+                        "pricing": {
+                            "price_details": {"price": price_id},
+                        },
+                    }
+                ]
+            },
+        },
+    )
+
+
 def _payment_event_object(
     *,
     object_id: str = "ch_test_deflection_refund",
@@ -284,6 +400,7 @@ async def _run_stripe_webhook(
     event: Any,
     pool: _Pool,
     stripe_module: Any,
+    entitlement_store: InMemoryDeflectionReportArtifactStore | None = None,
 ) -> dict[str, Any]:
     request = SimpleNamespace(
         headers={"stripe-signature": "valid"},
@@ -300,6 +417,12 @@ async def _run_stripe_webhook(
         "stripe_webhook_secret",
         "whsec_test",
     )
+    if entitlement_store is not None:
+        monkeypatch.setattr(
+            billing,
+            "PostgresDeflectionReportArtifactStore",
+            lambda *args, **kwargs: entitlement_store,
+        )
     monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
     return await billing.stripe_webhook(request)
 
@@ -754,6 +877,11 @@ def test_deflection_checkout_amount_rejects_misconfigured_price_gate(
         "stripe_content_ops_deflection_report_currency",
         currency,
     )
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_report_allowed_amount_cents",
+        "",
+    )
 
     assert billing._deflection_checkout_amount_is_valid(session) is False
 
@@ -778,6 +906,415 @@ def test_deflection_checkout_amount_rejects_misconfigured_allowed_amount_gate(
     )
 
     assert billing._deflection_checkout_amount_is_valid(session) is False
+
+
+def test_deflection_delta_price_ids_parse_as_exact_deduped_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        " price_delta_monthly,price_delta_monthly,price_delta_partner ",
+    )
+
+    assert billing._configured_deflection_delta_price_ids() == (
+        "price_delta_monthly",
+        "price_delta_partner",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_delta_subscription_updated_upserts_entitlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    subscription = _subscription(account_id=account_id, status="active")
+    event = SimpleNamespace(
+        created=1_781_000_000,
+        id="evt_delta_subscription_active",
+        type="customer.subscription.updated",
+        data=SimpleNamespace(object=subscription),
+    )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = _Pool()
+    store = InMemoryDeflectionReportArtifactStore()
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+        entitlement_store=store,
+    )
+
+    assert response == {"status": "ok"}
+    assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
+    assert not any("UPDATE saas_accounts" in query for query, _args in pool.execute_calls)
+    billing_event_query, billing_event_args = pool.execute_calls[0]
+    assert "INSERT INTO billing_events" in billing_event_query
+    assert str(billing_event_args[0]) == account_id
+    assert billing_event_args[1] == "evt_delta_subscription_active"
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_delta_invoice_payment_failed_revokes_entitlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    invoice = _dahlia_subscription_invoice(account_id=account_id)
+    event = SimpleNamespace(
+        created=200,
+        id="evt_delta_invoice_failed",
+        type="invoice.payment_failed",
+        data=SimpleNamespace(object=invoice),
+    )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = _Pool()
+    store = InMemoryDeflectionReportArtifactStore()
+    await store.upsert_deflection_delta_entitlement(
+        account_id=account_id,
+        stripe_subscription_id="sub_delta",
+        stripe_customer_id="cus_delta",
+        stripe_price_id="price_delta_monthly",
+        stripe_subscription_status="active",
+        stripe_event_created=100,
+    )
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+        entitlement_store=store,
+    )
+
+    assert response == {"status": "ok"}
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=(account_id, "acct-config"),
+    ) == ("acct-config",)
+    assert not any("UPDATE saas_accounts" in query for query, _args in pool.execute_calls)
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_delta_invoice_paid_grants_from_dahlia_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    invoice = _dahlia_subscription_invoice(account_id=account_id)
+    event = SimpleNamespace(
+        created=300,
+        id="evt_delta_invoice_paid",
+        type="invoice.paid",
+        data=SimpleNamespace(object=invoice),
+    )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = _Pool()
+    store = InMemoryDeflectionReportArtifactStore()
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+        entitlement_store=store,
+    )
+
+    assert response == {"status": "ok"}
+    assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
+    assert not any("UPDATE saas_accounts" in query for query, _args in pool.execute_calls)
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_delta_subscription_created_grants_entitlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    subscription = _subscription(account_id=account_id, status="trialing")
+    event = SimpleNamespace(
+        created=125,
+        id="evt_delta_subscription_created",
+        type="customer.subscription.created",
+        data=SimpleNamespace(object=subscription),
+    )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = _Pool()
+    store = InMemoryDeflectionReportArtifactStore()
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+        entitlement_store=store,
+    )
+
+    assert response == {"status": "ok"}
+    assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
+    assert not any("UPDATE saas_accounts" in query for query, _args in pool.execute_calls)
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_delta_checkout_completed_grants_entitlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    session = SimpleNamespace(
+        id="cs_delta_subscription",
+        customer="cus_delta",
+        subscription="sub_delta_checkout",
+        payment_status="paid",
+        metadata={"account_id": account_id},
+        lines=SimpleNamespace(data=[_price_line("price_delta_monthly")]),
+        to_dict=lambda: {
+            "id": "cs_delta_subscription",
+            "customer": "cus_delta",
+            "subscription": "sub_delta_checkout",
+            "payment_status": "paid",
+            "metadata": {"account_id": account_id},
+            "lines": {"data": [{"price": {"id": "price_delta_monthly"}}]},
+        },
+    )
+    event = SimpleNamespace(
+        id="evt_delta_checkout",
+        type="checkout.session.completed",
+        data=SimpleNamespace(object=session),
+    )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = _Pool()
+    store = InMemoryDeflectionReportArtifactStore()
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+        entitlement_store=store,
+    )
+
+    assert response == {"status": "ok"}
+    assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
+    assert not any(
+        "UPDATE content_ops_deflection_reports" in query
+        for query, _args in pool.execute_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_delta_checkout_source_without_price_does_not_fall_through_to_generic_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    session = SimpleNamespace(
+        id="cs_delta_subscription_no_price",
+        customer="cus_delta",
+        subscription="sub_delta_no_price",
+        payment_status="paid",
+        metadata={
+            "account_id": account_id,
+            "source": "content_ops_deflection_delta_subscription",
+        },
+        to_dict=lambda: {
+            "id": "cs_delta_subscription_no_price",
+            "customer": "cus_delta",
+            "subscription": "sub_delta_no_price",
+            "payment_status": "paid",
+            "metadata": {
+                "account_id": account_id,
+                "source": "content_ops_deflection_delta_subscription",
+            },
+        },
+    )
+    event = SimpleNamespace(
+        id="evt_delta_checkout_no_price",
+        type="checkout.session.completed",
+        data=SimpleNamespace(object=session),
+    )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = _Pool()
+    store = InMemoryDeflectionReportArtifactStore()
+
+    response = await _run_stripe_webhook(
+        monkeypatch,
+        event=event,
+        pool=pool,
+        stripe_module=fake_stripe,
+        entitlement_store=store,
+    )
+
+    assert response == {"status": "ok"}
+    assert await store.list_deflection_delta_entitled_account_ids() == ()
+    assert not any("UPDATE saas_accounts" in query for query, _args in pool.execute_calls)
+    assert any("INSERT INTO billing_events" in query for query, _args in pool.execute_calls)
+
+
+@pytest.mark.asyncio
+async def test_non_delta_subscription_does_not_create_delta_entitlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = uuid.uuid4()
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    subscription = _subscription(
+        account_id=None,
+        customer_id="cus_regular",
+        price_id="price_regular",
+        status="active",
+    )
+    pool = _Pool()
+    pool.customer_accounts["cus_regular"] = account_id
+
+    returned = await billing._handle_subscription_updated(pool, subscription)
+
+    assert returned == account_id
+    query, args = pool.execute_calls[0]
+    assert "UPDATE saas_accounts" in query
+    assert args[3] == "sub_delta"
+
+
+@pytest.mark.asyncio
+async def test_delta_subscription_lifecycle_uses_real_store_and_ignores_stale_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    store = InMemoryDeflectionReportArtifactStore()
+    pool = _Pool()
+
+    await billing._handle_deflection_delta_subscription_lifecycle(
+        pool,
+        _subscription(account_id=account_id, status="active"),
+        stripe_event_created=100,
+        store=store,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
+
+    await billing._handle_deflection_delta_subscription_lifecycle(
+        pool,
+        _subscription(account_id=account_id, status="canceled"),
+        stripe_subscription_status="canceled",
+        stripe_event_created=200,
+        store=store,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=(account_id, "acct-config"),
+    ) == ("acct-config",)
+
+    await billing._handle_deflection_delta_subscription_lifecycle(
+        pool,
+        _subscription(account_id=account_id, status="active"),
+        store=store,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=(account_id, "acct-config"),
+    ) == ("acct-config",)
+
+    await billing._handle_deflection_delta_subscription_lifecycle(
+        pool,
+        _subscription(account_id=account_id, status="active"),
+        stripe_event_created=150,
+        store=store,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=(account_id, "acct-config"),
+    ) == ("acct-config",)
+
+    await billing._handle_deflection_delta_subscription_lifecycle(
+        pool,
+        _subscription(account_id=account_id, status="active"),
+        stripe_event_created=250,
+        store=store,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
+
+
+@pytest.mark.asyncio
+async def test_delta_invoice_lifecycle_uses_real_store_and_ignores_stale_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    store = InMemoryDeflectionReportArtifactStore()
+    pool = _Pool()
+
+    await billing._handle_deflection_delta_invoice_lifecycle(
+        pool,
+        _subscription_invoice(account_id=account_id),
+        stripe_subscription_status="active",
+        stripe_event_created=100,
+        store=store,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
+
+    await billing._handle_deflection_delta_invoice_lifecycle(
+        pool,
+        _subscription_invoice(account_id=account_id),
+        stripe_subscription_status="past_due",
+        stripe_event_created=200,
+        store=store,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=(account_id, "acct-config"),
+    ) == ("acct-config",)
+
+    await billing._handle_deflection_delta_invoice_lifecycle(
+        pool,
+        _subscription_invoice(account_id=account_id),
+        stripe_subscription_status="active",
+        stripe_event_created=150,
+        store=store,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=(account_id, "acct-config"),
+    ) == ("acct-config",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_ops_deflection_delta_persistence.py
+++ b/tests/test_content_ops_deflection_delta_persistence.py
@@ -472,6 +472,82 @@ async def test_in_memory_delta_entitlement_resolver_suppresses_known_inactive_fa
 
 
 @pytest.mark.asyncio
+async def test_in_memory_delta_entitlement_upsert_revokes_and_regrants() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    period_end = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+    await store.upsert_deflection_delta_entitlement(
+        account_id="acct-1",
+        stripe_subscription_id="sub-delta",
+        stripe_customer_id="cus-delta",
+        stripe_price_id="price-delta",
+        stripe_subscription_status="active",
+        current_period_end=period_end,
+        metadata={"source": "test"},
+        stripe_event_created=100,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids() == ("acct-1",)
+
+    await store.upsert_deflection_delta_entitlement(
+        account_id="acct-1",
+        stripe_subscription_id="sub-delta",
+        stripe_customer_id="cus-delta",
+        stripe_price_id="price-delta",
+        stripe_subscription_status="past_due",
+        current_period_end=period_end,
+        metadata={"source": "test"},
+        stripe_event_created=200,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=("acct-1", "acct-config")
+    ) == ("acct-config",)
+
+    await store.upsert_deflection_delta_entitlement(
+        account_id="acct-1",
+        stripe_subscription_id="sub-delta",
+        stripe_customer_id="cus-delta",
+        stripe_price_id="price-delta",
+        stripe_subscription_status="active",
+        current_period_end=period_end,
+        metadata={"source": "test"},
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=("acct-1", "acct-config")
+    ) == ("acct-config",)
+
+    await store.upsert_deflection_delta_entitlement(
+        account_id="acct-1",
+        stripe_subscription_id="sub-delta",
+        stripe_customer_id="cus-delta",
+        stripe_price_id="price-delta",
+        stripe_subscription_status="active",
+        current_period_end=period_end,
+        metadata={"source": "test"},
+        stripe_event_created=150,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids(
+        fallback_account_ids=("acct-1", "acct-config")
+    ) == ("acct-config",)
+
+    await store.upsert_deflection_delta_entitlement(
+        account_id="acct-1",
+        stripe_subscription_id="sub-delta",
+        stripe_customer_id="cus-delta",
+        stripe_price_id="price-delta",
+        stripe_subscription_status="trialing",
+        current_period_end=period_end,
+        metadata={"source": "test"},
+        stripe_event_created=250,
+    )
+
+    assert await store.list_deflection_delta_entitled_account_ids() == ("acct-1",)
+
+
+@pytest.mark.asyncio
 async def test_in_memory_paid_report_listing_orders_by_paid_activity_window() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     await _save(
@@ -1360,6 +1436,55 @@ async def test_postgres_delta_entitlement_resolver_uses_billing_table_and_fallba
     )
 
     assert fallback_accounts == ("acct-config",)
+
+
+@pytest.mark.asyncio
+async def test_postgres_delta_entitlement_upsert_uses_status_revocation_boundary() -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+
+        async def execute(self, query: str, *args: object) -> str:
+            self.execute_calls.append((query, args))
+            return "INSERT 0 1"
+
+    pool = _Pool()
+    store = PostgresDeflectionReportArtifactStore(pool=pool)
+    period_end = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+    await store.upsert_deflection_delta_entitlement(
+        account_id="acct-1",
+        stripe_subscription_id="sub-delta",
+        stripe_customer_id="cus-delta",
+        stripe_price_id="price-delta",
+        stripe_subscription_status="past_due",
+        current_period_end=period_end,
+        metadata={"event": "invoice.payment_failed"},
+        stripe_event_created=1_781_000_000,
+    )
+
+    query, args = pool.execute_calls[0]
+    assert "INSERT INTO content_ops_deflection_delta_entitlements" in query
+    assert "ON CONFLICT (stripe_subscription_id) DO UPDATE" in query
+    assert "CASE WHEN $5 = ANY($8::text[]) THEN NULL ELSE NOW() END" in query
+    assert "revoked_at = EXCLUDED.revoked_at" in query
+    assert "jsonb_typeof(EXCLUDED.metadata->'stripe_event_created')" in query
+    assert "jsonb_typeof(EXCLUDED.metadata->'stripe_event_created') = 'number'" in query
+    assert ">= COALESCE" in query
+    assert "9223372036854775807" not in query
+    assert args[:6] == (
+        "acct-1",
+        "sub-delta",
+        "cus-delta",
+        "price-delta",
+        "past_due",
+        period_end,
+    )
+    assert json.loads(str(args[6])) == {
+        "event": "invoice.payment_failed",
+        "stripe_event_created": 1_781_000_000,
+    }
+    assert args[7] == ["active", "trialing"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delta-Stripe-Entitlement-Webhooks.md
Slice phase: Production hardening

Adds Stripe Billing webhook wiring for monthly deflection delta entitlements: configured delta Price IDs write ATLAS-owned entitlement rows, active/trialing statuses grant, inactive statuses revoke, dahlia invoice payloads resolve nested Price/subscription fields, and stale or missing-timestamp lifecycle events cannot revive revoked entitlement state.

## Intentional
- No Stripe API fetch is added; signed webhook payloads must prove the delta Price, subscription, and account mapping or fail closed.
- The transitional config account allowlist remains for accounts with no Billing row yet.
- Generic SaaS subscription handling remains for non-delta Prices; subscription-created routing is limited to configured delta subscriptions.

## Deferred
- Delta subscription Checkout creation and Customer Portal UX remain deferred.
- Historical subscription backfill remains deferred.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/api/billing.py atlas_brain/config.py extracted_content_pipeline/deflection_report_access.py tests/test_content_ops_deflection_delta_persistence.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `python -m pytest tests/test_content_ops_deflection_delta_persistence.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 92 passed, 1 warning.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*'` - passed.

## Diff size
6 files, +1249 / -6. Full PR remains over 400 LOC because it spans webhook routing, the entitlement store adapter, and focused billing/persistence tests.
