### PR TITLE
Add real-adapters test contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,6 +493,14 @@ boundary you genuinely cannot or should not hit in CI:
   pattern in `atlas_content_ops_deflection_delivery_checks.yml`), not a
   fake pool. If it exists to prove a validator/projection, call the real
   validator/projection. Don't reach around the thing you're testing.
+- **Don't assert on a mock's call arguments -- assert on the real
+  adapter's observable state.** A test that checks the positional tuple or
+  SQL string passed to `pool.execute(...)` is testing the mock, not the
+  behavior: it breaks the moment the call shape changes and proves nothing
+  about the outcome. Use the in-memory port adapter (e.g.
+  `InMemoryDeflectionReportArtifactStore`) and assert the result -- "the row
+  is marked paid", "a mismatched authorized amount is rejected" -- which is
+  invisible to the method's signature.
 - **Don't hand-author a fixture that is supposed to mirror generated or
   produced output.** Derive it (regenerate from the contract / capture
   from the real producer). A hand-kept copy is a second source of truth
@@ -509,7 +517,12 @@ client rejects; a hand-authored ground-truth whose `snapshot_safe_fields`
 drifted from the producer left a `snapshot = projection(report)` guard
 passing vacuously. Every one was a mock of something that did not need
 mocking — extra code to keep in sync, and a new way to be wrong. A real
-adapter can't drift from itself.
+adapter can't drift from itself. Most recently (#1871): a `mark_paid`
+signature change from 3 to 6 positional args broke four tests across three
+files -- two raised `too many values to unpack`, two had stale call-arg
+tuples -- because they asserted on a fake `_Pool`'s `execute` args instead of
+a real store's state; the "fix" patched the fakes to track the new signature,
+adding more mock to keep in sync. The real adapter would not have noticed it.
 
 If a real adapter is genuinely too expensive for the slice, say so in the
 plan's `Intentional`/`Deferred` and name what real-adapter coverage will

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,7 +448,8 @@ Each PR ships its own tests. Acceptable test patterns:
 
 - **Unit-level**: pure validators, parsers, helpers. Live in
   `tests/test_<package>_<module>.py`.
-- **Integration-level**: services + ports with fakes. Live in
+- **Integration-level**: exercise the **real service + adapter**. Fake
+  only true external boundaries (see 3e.1). Live in
   `tests/test_<package>_<service>.py`.
 - **Smoke**: thin wrappers that just check imports / wiring.
 
@@ -477,6 +478,42 @@ fails on un-enrolled tests; the intel-ui workflow does not, so this one
 is manual and has been dropped repeatedly. Reviewer/self check: grep the
 workflow's run list for the new test name — `package.json` presence is
 not CI execution.
+
+### 3e.1. Real adapters by default — mock only true external boundaries
+
+Use the **real** implementation in tests. Mock only at the outermost
+boundary you genuinely cannot or should not hit in CI:
+
+- **Mock-allowed (outermost seam only):** third-party network APIs
+  (Stripe, Resend, the ATLAS service), the email/SMS *transport* (the
+  sender), wall-clock and randomness, and other paid/external services.
+- **Never fake the component whose behavior is under test.** If the test
+  exists to prove a SQL filter, use a real database (provision the gate —
+  `@pytest.mark.integration` + an env-gated skip + a Postgres service, the
+  pattern in `atlas_content_ops_deflection_delivery_checks.yml`), not a
+  fake pool. If it exists to prove a validator/projection, call the real
+  validator/projection. Don't reach around the thing you're testing.
+- **Don't hand-author a fixture that is supposed to mirror generated or
+  produced output.** Derive it (regenerate from the contract / capture
+  from the real producer). A hand-kept copy is a second source of truth
+  that silently goes stale.
+- **All validators of the same shape must share one definition.** A smoke
+  parser, a client guard, and a contract check that each re-encode "what a
+  valid row looks like" will drift; import the one real check.
+
+**Why (this is not style — it cost real rework):** a fake DB pool that
+ignored the account filter let a scoping test pass while proving nothing,
+forcing a real-Postgres redo a slice later; a smoke validator that re-spelled
+the row shape laxer than the real client reported success on payloads the
+client rejects; a hand-authored ground-truth whose `snapshot_safe_fields`
+drifted from the producer left a `snapshot = projection(report)` guard
+passing vacuously. Every one was a mock of something that did not need
+mocking — extra code to keep in sync, and a new way to be wrong. A real
+adapter can't drift from itself.
+
+If a real adapter is genuinely too expensive for the slice, say so in the
+plan's `Intentional`/`Deferred` and name what real-adapter coverage will
+replace it (and the tracking issue), the way #1869 → #1872 did.
 
 ### 3f. Working with the manifest
 

--- a/plans/PR-Agents-Real-Adapters-Test-Contract.md
+++ b/plans/PR-Agents-Real-Adapters-Test-Contract.md
@@ -14,8 +14,9 @@ mock the component under test instead of only mocking true external transports.
 
 This PR fixes the process root by making the real-adapter default explicit in
 the repo's builder contract, including examples of allowed mocks, forbidden
-component fakes, generated-fixture drift, and the required deferral language
-when a real adapter is genuinely too expensive for one slice.
+component fakes, mock call-argument assertions, generated-fixture drift, and
+the required deferral language when a real adapter is genuinely too expensive
+for one slice.
 
 ## Scope (this PR)
 
@@ -34,8 +35,9 @@ Slice phase: Workflow/process
         default.
   - [ ] The new rule distinguishes mock-allowed external seams from forbidden
         component-under-test fakes.
-  - [ ] The rule covers SQL filters, validators/projections, generated fixtures,
-        and shared validator definitions.
+  - [ ] The rule covers SQL filters, mock call-argument assertions,
+        validators/projections, generated fixtures, and shared validator
+        definitions.
   - [ ] The rule states what to do when real-adapter coverage is deferred.
 - Affected surfaces: builder/reviewer process documentation only.
 - Risk areas: docs clarity and avoiding accidental overreach into product code.
@@ -58,6 +60,7 @@ terms:
 
 - mock third-party/network/transport/time/randomness seams only;
 - never fake the component whose behavior the test is meant to prove;
+- assert real adapter state instead of fake pool call arguments;
 - derive generated/producer-shaped fixtures instead of hand-authoring copies;
 - share one validator/projection definition across same-shaped checks;
 - if real adapter coverage is deferred, name why and track the replacing slice.
@@ -87,6 +90,6 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `AGENTS.md` | 39 |
-| `plans/PR-Agents-Real-Adapters-Test-Contract.md` | 92 |
-| **Total** | **131** |
+| `AGENTS.md` | 52 |
+| `plans/PR-Agents-Real-Adapters-Test-Contract.md` | 95 |
+| **Total** | **147** |

--- a/plans/PR-Agents-Real-Adapters-Test-Contract.md
+++ b/plans/PR-Agents-Real-Adapters-Test-Contract.md
@@ -1,0 +1,92 @@
+# PR-Agents-Real-Adapters-Test-Contract
+
+## Why this slice exists
+
+Two consecutive deflection billing-entitlement slices exposed the same process
+failure: tests used fake pools/query-string assertions that re-spelled the SQL
+boundary instead of exercising the real adapter behavior, and fail-closed
+billing defects reached review behind green local tests. The operator explicitly
+called out the pattern with "USE THE REAL DB ADAPTERS."
+
+Root cause: AGENTS.md still described integration tests as "services + ports
+with fakes" and did not state the boundary rule clearly enough. Builders could
+mock the component under test instead of only mocking true external transports.
+
+This PR fixes the process root by making the real-adapter default explicit in
+the repo's builder contract, including examples of allowed mocks, forbidden
+component fakes, generated-fixture drift, and the required deferral language
+when a real adapter is genuinely too expensive for one slice.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Update the test guidance in AGENTS.md so integration tests exercise the real
+   service/adapter and fake only true external boundaries.
+2. Add a new 3e.1 subsection with the concrete real-adapter rule and examples
+   tied to recent failure modes.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The integration-test bullet no longer implies fake ports are the
+        default.
+  - [ ] The new rule distinguishes mock-allowed external seams from forbidden
+        component-under-test fakes.
+  - [ ] The rule covers SQL filters, validators/projections, generated fixtures,
+        and shared validator definitions.
+  - [ ] The rule states what to do when real-adapter coverage is deferred.
+- Affected surfaces: builder/reviewer process documentation only.
+- Risk areas: docs clarity and avoiding accidental overreach into product code.
+- Reviewer rules triggered: R1, R10, R14.
+- boundary-probe: read the diff against the two known defect classes: fake DB
+  pools hiding SQL fail-closed behavior and re-spelled validators diverging from
+  real consumers.
+
+### Files touched
+
+- `AGENTS.md`
+- `plans/PR-Agents-Real-Adapters-Test-Contract.md`
+
+## Mechanism
+
+AGENTS.md's test section changes the integration-test definition from
+"services + ports with fakes" to "real service + adapter; fake only true
+external boundaries." A new 3e.1 subsection then spells out the rule in builder
+terms:
+
+- mock third-party/network/transport/time/randomness seams only;
+- never fake the component whose behavior the test is meant to prove;
+- derive generated/producer-shaped fixtures instead of hand-authoring copies;
+- share one validator/projection definition across same-shaped checks;
+- if real adapter coverage is deferred, name why and track the replacing slice.
+
+## Intentional
+
+- This is docs/process only. It does not retrofit existing test suites in this
+  PR; the purpose is to put the rule on main before the next builder session.
+- The wording allows fakes for true external services such as Stripe/Resend
+  transports. The target is over-mocking ATLAS-owned adapters and validators,
+  not banning all test doubles.
+
+## Deferred
+
+- Existing fake-pool tests are not swept here. Future product slices should
+  replace them when they touch the guarded boundary or when review exposes a
+  concrete defect class.
+
+Parked hardening: none.
+
+## Verification
+
+- `python scripts/sync_pr_plan.py plans/PR-Agents-Real-Adapters-Test-Contract.md --check` - passed.
+- `bash scripts/push_pr.sh /tmp/agents-real-adapters-pr-body.md -u origin HEAD` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 39 |
+| `plans/PR-Agents-Real-Adapters-Test-Contract.md` | 92 |
+| **Total** | **131** |


### PR DESCRIPTION
Plan: plans/PR-Agents-Real-Adapters-Test-Contract.md
Slice phase: Workflow/process

Land the real-adapters-by-default testing rule in AGENTS.md so future builder sessions mock only true external boundaries and stop proving fail-closed billing logic with fake pools/query-string copies.

## Intentional
- Docs/process only; this does not retrofit existing fake-pool tests.
- Test doubles remain allowed at true external seams such as Stripe/Resend transports.

## Deferred
- Existing fake-pool tests should be replaced by future slices when they touch the guarded boundary or expose a concrete defect class.

## Parked hardening
- None.

## Verification
- `python scripts/sync_pr_plan.py plans/PR-Agents-Real-Adapters-Test-Contract.md --check` - passed.
- `bash scripts/push_pr.sh /tmp/agents-real-adapters-pr-body.md -u origin HEAD` - passed.

## Diff size
2 files, +146 / -1.
