### PR TITLE
Wire deflection delta subscription checkout metadata

### DIFF
--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -57,6 +57,7 @@ LLM_PLAN_LIMITS = {
 
 PRICE_TO_PLAN = {}  # populated at module init from config
 STRIPE_API_VERSION = "2026-05-27.dahlia"
+DEFLECTION_DELTA_SUBSCRIPTION_SOURCE = "content_ops_deflection_delta_subscription"
 _UUID_TEXT_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
@@ -244,6 +245,8 @@ async def create_checkout(req: CheckoutRequest, user: AuthUser = Depends(require
         ]
         if v
     }
+    delta_price_ids = set(_configured_deflection_delta_price_ids())
+    valid_prices.update(delta_price_ids)
     if valid_prices and price_id not in valid_prices:
         raise HTTPException(status_code=400, detail="Invalid price ID")
 
@@ -280,13 +283,22 @@ async def create_checkout(req: CheckoutRequest, user: AuthUser = Depends(require
     if not req.cancel_url:
         raise HTTPException(status_code=400, detail="cancel_url is required")
 
+    checkout_metadata = {"account_id": str(user.account_id)}
+    session_params: dict[str, Any] = {}
+    if price_id in delta_price_ids:
+        checkout_metadata = {
+            **checkout_metadata,
+            "source": DEFLECTION_DELTA_SUBSCRIPTION_SOURCE,
+        }
+        session_params["subscription_data"] = {"metadata": checkout_metadata}
+
     session = stripe.checkout.Session.create(
         customer=customer_id,
         mode="subscription",
         line_items=[{"price": price_id, "quantity": 1}],
         success_url=req.success_url,
         cancel_url=req.cancel_url,
-        metadata={"account_id": str(user.account_id)},
+        metadata=checkout_metadata,
         idempotency_key=_stripe_checkout_idempotency_key(
             account_id=str(user.account_id),
             user_id=str(user.user_id),
@@ -295,6 +307,7 @@ async def create_checkout(req: CheckoutRequest, user: AuthUser = Depends(require
             cancel_url=req.cancel_url,
         ),
         timeout=10,
+        **session_params,
     )
 
     return CheckoutResponse(checkout_url=session.url)
@@ -1360,7 +1373,7 @@ def _deflection_delta_price_id_from_object(obj: Any) -> str | None:
 def _is_deflection_delta_subscription_source(obj: Any) -> bool:
     return (
         _clean_metadata(_stripe_metadata(obj).get("source"))
-        == "content_ops_deflection_delta_subscription"
+        == DEFLECTION_DELTA_SUBSCRIPTION_SOURCE
     )
 
 

--- a/plans/PR-Deflection-Delta-Subscription-Checkout.md
+++ b/plans/PR-Deflection-Delta-Subscription-Checkout.md
@@ -1,0 +1,124 @@
+# PR-Deflection-Delta-Subscription-Checkout
+
+## Why this slice exists
+
+#1873 replaces monthly Report Delta manual entitlement with Stripe Billing
+subscription state. #1880 made webhook lifecycle events mutate the durable
+entitlement table, including `customer.subscription.created`, but ATLAS
+checkout creation still rejects the configured monthly delta Price IDs and does
+not stamp the created Stripe Subscription with the metadata the webhook mapper
+needs.
+
+Root cause: the authenticated `/billing/checkout` allowlist only admits the
+generic SaaS/LLM plan Prices, and its Checkout Session metadata is not copied
+into `subscription_data.metadata`. For monthly delta subscriptions, that means
+ATLAS can have a webhook writer but no ATLAS-owned purchase path that creates a
+subscription object with `source=content_ops_deflection_delta_subscription` and
+`account_id`.
+
+This PR fixes the root for the checkout entrypoint only: configured monthly
+delta Price IDs are valid subscription Checkout prices, and delta checkouts
+stamp both the Checkout Session and resulting Subscription metadata so the
+signed `customer.subscription.created` webhook can grant the entitlement.
+
+## Scope (this PR)
+
+Ownership lane: deflection/delta-billing-entitlements
+Slice phase: Production hardening
+
+1. Allow configured `stripe_content_ops_deflection_delta_price_ids` through the
+   existing authenticated Billing Checkout price gate.
+2. For those Prices only, add the delta source/account metadata to both
+   Checkout Session metadata and `subscription_data.metadata`.
+3. Prove the Checkout Session still uses `mode="subscription"`, omits
+   `payment_method_types`, and keeps generic plan metadata unchanged.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Blank delta Price config remains fail-closed; arbitrary unconfigured
+        Prices are still rejected when any allowed Prices are configured.
+  - [ ] A configured delta Price creates a subscription Checkout Session with
+        `metadata.source` and `subscription_data.metadata.source` set to
+        `content_ops_deflection_delta_subscription`, using the same source
+        constant as the webhook detector.
+  - [ ] The subscription metadata includes the authenticated ATLAS account id so
+        `customer.subscription.created` can map back without guessing.
+  - [ ] The Checkout call still omits `payment_method_types`; Stripe dynamic
+        payment methods remain enabled.
+  - [ ] Existing generic plan checkout behavior and idempotency key derivation
+        remain unchanged.
+- Affected surfaces: `atlas_brain/api/billing.py` and focused billing tests.
+- Risk areas: Stripe Checkout, subscription lifecycle entitlement grants,
+  payment metadata trust boundary, account mapping.
+- Reviewer rules triggered: R1, R2, R3, R5, R8, R10, R11, R13, R14.
+- boundary-probe: real `POST /billing/checkout` with a configured delta Price
+  stamps webhook-detectable subscription metadata; unconfigured Price rejected;
+  generic growth checkout has no delta source metadata.
+
+### Files touched
+
+- `atlas_brain/api/billing.py`
+- `plans/PR-Deflection-Delta-Subscription-Checkout.md`
+- `tests/test_atlas_billing_stripe_hardening.py`
+
+## Mechanism
+
+`create_checkout` reuses the existing monthly delta Price parser from the
+webhook path and includes those Prices in its allowed-price set.
+
+When the selected price is a delta subscription Price, the Checkout Session
+metadata becomes:
+
+```python
+{
+    "account_id": account_id,
+    "source": DEFLECTION_DELTA_SUBSCRIPTION_SOURCE,
+}
+```
+
+and the same mapping is passed as `subscription_data.metadata`. The latter is
+the load-bearing part: Stripe sends that metadata on
+`customer.subscription.created`, and #1880's webhook handler reads the
+subscription object directly.
+
+Generic plan checkouts keep the existing metadata shape and idempotency key.
+The source value is a single billing constant shared by the Checkout producer
+and the webhook detector so producer/consumer drift is caught by the endpoint
+regression.
+
+## Intentional
+
+- No new public Content Ops route is added in this slice. The existing
+  authenticated billing checkout already owns subscription Checkout Session
+  creation; portfolio/browser wiring remains a later consumer.
+- No `payment_method_types` is added. Stripe dynamic payment methods stay
+  dashboard-controlled.
+- No customer portal UX change is included; the existing `/billing/portal`
+  endpoint remains the management surface once a Stripe customer exists.
+
+## Deferred
+
+- Portfolio/results-page upsell wiring is deferred until the frontend lane is
+  ready to call the authenticated billing checkout path.
+- Customer Portal copy/UX for monthly Report Deltas remains deferred.
+- Historical subscription backfill remains deferred; this only affects new
+  Checkout-created subscriptions.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m py_compile atlas_brain/api/billing.py tests/test_atlas_billing_stripe_hardening.py - passed.
+- Command: python -m pytest tests/test_atlas_billing_stripe_hardening.py -q - passed, 9 passed, 1 warning.
+- Command: python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*' - passed, no new brittleness above baseline.
+- Pending before push: local PR review through `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/billing.py` | 17 |
+| `plans/PR-Deflection-Delta-Subscription-Checkout.md` | 124 |
+| `tests/test_atlas_billing_stripe_hardening.py` | 164 |
+| **Total** | **305** |

--- a/tests/test_atlas_billing_stripe_hardening.py
+++ b/tests/test_atlas_billing_stripe_hardening.py
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from atlas_brain.api import billing
-from atlas_brain.auth.dependencies import AuthUser
+from atlas_brain.auth.dependencies import AuthUser, require_auth
 
 
 class _CustomerApi:
@@ -44,6 +46,13 @@ class _Pool:
     async def execute(self, query: str, *args: Any) -> str:
         self.execute_calls.append((query, args))
         return "UPDATE 1"
+
+
+def _billing_app(user: AuthUser) -> FastAPI:
+    app = FastAPI()
+    app.include_router(billing.router)
+    app.dependency_overrides[require_auth] = lambda: user
+    return app
 
 
 def _fake_stripe() -> SimpleNamespace:
@@ -220,3 +229,156 @@ async def test_create_checkout_passes_pinned_version_and_idempotency_keys(
     )
     assert checkout["customer"] == "cus_test_created"
     assert checkout["line_items"] == [{"price": "price_growth", "quantity": 1}]
+    assert checkout["metadata"] == {"account_id": account_id}
+    assert "subscription_data" not in checkout
+    assert "payment_method_types" not in checkout
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_accepts_configured_deflection_delta_price_and_stamps_subscription_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+    fake_stripe = _fake_stripe()
+    pool = _Pool()
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "rk_test_billing")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly, price_delta_partner",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+
+    response = await billing.create_checkout(
+        billing.CheckoutRequest(
+            price_id="price_delta_monthly",
+            success_url="https://app.example.com/delta/success",
+            cancel_url="https://app.example.com/delta/cancel",
+        ),
+        AuthUser(
+            user_id=user_id,
+            account_id=account_id,
+            plan="growth",
+            plan_status="active",
+            role="owner",
+        ),
+    )
+
+    assert response.checkout_url == "https://checkout.stripe.test/session"
+    checkout = _CheckoutSessionApi.created[0]
+    delta_metadata = {
+        "account_id": account_id,
+        "source": billing.DEFLECTION_DELTA_SUBSCRIPTION_SOURCE,
+    }
+    assert checkout["mode"] == "subscription"
+    assert checkout["line_items"] == [
+        {"price": "price_delta_monthly", "quantity": 1}
+    ]
+    assert checkout["metadata"] == delta_metadata
+    assert checkout["subscription_data"] == {"metadata": delta_metadata}
+    assert "payment_method_types" not in checkout
+    assert checkout["idempotency_key"] == billing._stripe_checkout_idempotency_key(
+        account_id=account_id,
+        user_id=user_id,
+        price_id="price_delta_monthly",
+        success_url="https://app.example.com/delta/success",
+        cancel_url="https://app.example.com/delta/cancel",
+    )
+
+
+def test_checkout_endpoint_stamps_delta_subscription_metadata_for_webhook_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+    fake_stripe = _fake_stripe()
+    pool = _Pool()
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "rk_test_billing")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+
+    app = _billing_app(
+        AuthUser(
+            user_id=user_id,
+            account_id=account_id,
+            plan="growth",
+            plan_status="active",
+            role="owner",
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/billing/checkout",
+            json={
+                "price_id": "price_delta_monthly",
+                "success_url": "https://app.example.com/delta/success",
+                "cancel_url": "https://app.example.com/delta/cancel",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "checkout_url": "https://checkout.stripe.test/session"
+    }
+    checkout = _CheckoutSessionApi.created[0]
+    delta_metadata = {
+        "account_id": account_id,
+        "source": billing.DEFLECTION_DELTA_SUBSCRIPTION_SOURCE,
+    }
+    assert checkout["mode"] == "subscription"
+    assert checkout["line_items"] == [
+        {"price": "price_delta_monthly", "quantity": 1}
+    ]
+    assert checkout["metadata"] == delta_metadata
+    assert checkout["subscription_data"] == {"metadata": delta_metadata}
+    assert billing._is_deflection_delta_subscription_source(
+        SimpleNamespace(metadata=checkout["subscription_data"]["metadata"])
+    )
+    assert "payment_method_types" not in checkout
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_rejects_unconfigured_price_when_allowlist_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+    fake_stripe = _fake_stripe()
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "rk_test_billing")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_delta_price_ids",
+        "price_delta_monthly",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await billing.create_checkout(
+            billing.CheckoutRequest(
+                price_id="price_not_configured",
+                success_url="https://app.example.com/success",
+                cancel_url="https://app.example.com/cancel",
+            ),
+            AuthUser(
+                user_id=user_id,
+                account_id=account_id,
+                plan="growth",
+                plan_status="active",
+                role="owner",
+            ),
+        )
+
+    assert getattr(exc_info.value, "status_code", None) == 400
+    assert getattr(exc_info.value, "detail", None) == "Invalid price ID"
+    assert _CheckoutSessionApi.created == []


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delta-Subscription-Checkout.md
Slice phase: Production hardening

Allows configured monthly deflection delta Stripe Price IDs through the authenticated Billing Checkout path and stamps both Checkout Session metadata and subscription_data.metadata with the shared delta source/account so the subscription-created webhook can grant the Billing-backed entitlement.

## Intentional
- No new public Content Ops route is added; the existing authenticated Billing Checkout owns subscription Checkout creation.
- No payment_method_types is added, so Stripe dynamic payment methods remain dashboard-controlled.
- Generic plan Checkout metadata remains unchanged.

## Deferred
- Portfolio/results-page upsell wiring remains deferred.
- Customer Portal copy/UX for monthly Report Deltas remains deferred.
- Historical subscription backfill remains deferred.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/api/billing.py tests/test_atlas_billing_stripe_hardening.py` - passed.
- `python -m pytest tests/test_atlas_billing_stripe_hardening.py -q` - passed, 9 passed, 1 warning.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*'` - passed.

## Diff size
3 files, +302 / -3.
