### PR TITLE
Add maturity sweep internal-mock ratchet

### DIFF
--- a/plans/PR-Maturity-Sweep-Internal-Mock-Ratchet.md
+++ b/plans/PR-Maturity-Sweep-Internal-Mock-Ratchet.md
@@ -1,0 +1,222 @@
+# PR-Maturity-Sweep-Internal-Mock-Ratchet
+
+## Why this slice exists
+
+Issue #1879 is the second real-adapters slice after #1885. The root cause is
+that the repo now has a policy saying "mock the external edge, not first-party
+code," but no blocking detector prevents new first-party mocks from entering
+tests. Existing maturity-sweep ratchets can block score increases, but they
+currently analyze production Python files and skip tests, so internal mocks in
+tests would remain invisible unless they are attached back to the mocked
+production module.
+
+This PR fixes the root by adding an `INTERNAL_MOCK` finding to the existing
+maturity-sweep model. The detector keys on the mocked target, not the test file
+where the mock appears, so the existing per-file baseline ratchet can fail when
+a PR adds a new mock of `extracted_content_pipeline.*`, `atlas_brain.*`, or
+`scripts.*` while allowing explicitly external seams such as Stripe/httpx/LLM
+clients.
+
+This slice is over the 400 LOC target because the new signal must land with
+refreshed baselines for every currently gated maturity lane that already has
+internal-mock debt. Splitting the detector from its baselines would make CI red
+on arrival; splitting the baselines from the detector would record meaningless
+counts.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Workflow/process
+
+1. Add target-aware internal-mock detection to `scripts/maturity_sweep.py`.
+2. Prove internal targets fail and external targets pass with focused fixtures.
+3. Refresh the affected maturity-sweep baselines so existing mock debt is
+   tracked and only new internal mocks fail.
+
+### Files touched
+
+- `plans/PR-Maturity-Sweep-Internal-Mock-Ratchet.md`
+- `scripts/maturity_sweep.py`
+- `scripts/maturity_sweep_file_lane.py`
+- `tests/maturity_sweep/baseline_ai_content_ops_lane.json`
+- `tests/maturity_sweep/baseline_atlas_brain_agents.json`
+- `tests/maturity_sweep/baseline_atlas_brain_alerts.json`
+- `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- `tests/maturity_sweep/baseline_atlas_brain_auth.json`
+- `tests/maturity_sweep/baseline_atlas_brain_autonomous.json`
+- `tests/maturity_sweep/baseline_atlas_brain_comms.json`
+- `tests/maturity_sweep/baseline_atlas_brain_discovery.json`
+- `tests/maturity_sweep/baseline_atlas_brain_jobs.json`
+- `tests/maturity_sweep/baseline_atlas_brain_mcp.json`
+- `tests/maturity_sweep/baseline_atlas_brain_memory.json`
+- `tests/maturity_sweep/baseline_atlas_brain_modes.json`
+- `tests/maturity_sweep/baseline_atlas_brain_orchestration.json`
+- `tests/maturity_sweep/baseline_atlas_brain_pipelines.json`
+- `tests/maturity_sweep/baseline_atlas_brain_reasoning.json`
+- `tests/maturity_sweep/baseline_atlas_brain_security.json`
+- `tests/maturity_sweep/baseline_atlas_brain_services_b2b.json`
+- `tests/maturity_sweep/baseline_atlas_brain_services_llm.json`
+- `tests/maturity_sweep/baseline_atlas_brain_services_scraping.json`
+- `tests/maturity_sweep/baseline_atlas_brain_skills.json`
+- `tests/maturity_sweep/baseline_atlas_brain_storage.json`
+- `tests/maturity_sweep/baseline_atlas_brain_tools.json`
+- `tests/maturity_sweep/baseline_atlas_brain_voice.json`
+- `tests/maturity_sweep/baseline_deflection_lane.json`
+- `tests/maturity_sweep/baseline_extracted_competitive_intelligence.json`
+- `tests/maturity_sweep/baseline_extracted_content_pipeline.json`
+- `tests/maturity_sweep/baseline_scripts.json`
+- `tests/test_maturity_sweep.py`
+
+### Review Contract
+
+Acceptance criteria:
+- `mock.patch` / `@patch` / `monkeypatch.setattr` with a first-party target is
+  counted as `INTERNAL_MOCK` on the mocked production module.
+- External targets such as Stripe, httpx, urllib, and provider SDKs do not
+  count.
+- Sanctioned wall-clock/randomness seams such as `time`, `datetime`, `random`,
+  `monotonic`, and `perf_counter` do not count.
+- Blocking extracted-package lanes are first-party roots, not blind spots.
+- Dotted no-asname imports and package `__init__.py` exports resolve to the
+  intended target module.
+- Ratchet mode fails when a new internal mock increases a file's
+  `INTERNAL_MOCK` count, and `--update-baseline` remains the visible escape
+  hatch for intentional debt.
+- The changed detector has negative fixtures for internal, external, and
+  ratchet-increase behavior.
+
+Affected surfaces:
+- `scripts/maturity_sweep.py`
+- `tests/test_maturity_sweep.py`
+- Maturity-sweep baseline JSON files touched by the new finding.
+- `scripts/maturity_sweep_file_lane.py`
+
+Risk areas:
+- False positives from string targets that look first-party but do not map to a
+  scanned module.
+- False negatives for dynamic monkeypatch targets. This PR handles the common
+  static target forms; broad dynamic inference is deferred.
+
+Reviewer rules: R1, R2, R9, R10, R13, R14.
+
+## Mechanism
+
+- Index tests as ASTs in addition to source text.
+- Extract mock targets from static forms:
+  - `mock.patch("first.party.module.attr")`
+  - `patch("first.party.module.attr")` and `@patch("first.party.module.attr")`
+  - `patch.object(first_party_module, "attr")`
+  - `monkeypatch.setattr("first.party.module.attr", ...)`
+  - `monkeypatch.setattr(first_party_module, "attr", ...)`
+- Resolve those targets to scanned production files when the target module is
+  under `atlas_brain`, `scripts`, or one of the gated `extracted_*` packages.
+- Suppress known external seams imported through a first-party module, such as
+  `socket`, `httpx`, `stripe`, `asyncpg`, `find_spec`, wall-clock, and
+  randomness seams, so edge fakes do not count as first-party mocks.
+- Resolve dotted no-asname imports by keeping the package root mapped to the
+  root, so `import extracted_content_pipeline.api.control_surfaces` does not
+  double-prefix the target path.
+- Index `__init__.py` both as `package.__init__` and `package`, so package
+  export patches such as `patch("atlas_brain.auth.require_auth")` attach to the
+  package file instead of disappearing.
+- Add `INTERNAL_MOCK` findings to the target file's `FileResult`, so existing
+  baseline score/count comparisons catch new first-party mocks without changing
+  the lane CLI.
+- Apply the same attachment step in `maturity_sweep_file_lane.py`, because the
+  deflection lane is an explicit-file sweep rather than a directory sweep.
+
+## Intentional
+
+- `MagicMock()` is counted when it is part of a target-aware
+  `monkeypatch.setattr` call. Bare `MagicMock()` with no first-party target is
+  not counted in this slice because it cannot be safely assigned to a mocked
+  module without data-flow analysis.
+- Existing internal mocks are accepted by refreshing baselines. The value of
+  this slice is preventing new debt; burn-down belongs to follow-up cleanup.
+- Baseline accounting: the refreshed baseline diff has 227 changed entries.
+  195 are `INTERNAL_MOCK`-only. The remaining 32 are disclosed, intentional
+  ratchet refresh rather than hidden detector scope:
+  - `scripts/maturity_sweep.py` records the new detector's own added AST
+    complexity in the scripts baseline.
+  - The newly enforced extracted-package root adds current internal-mock debt to
+    `baseline_extracted_competitive_intelligence.json`; this is the intended
+    current floor for the formerly blind blocking lane.
+  - Several deflection/script entries were already present production files
+    from prior landed slices that were not yet represented in the broad
+    maturity baselines; refreshing them here keeps the ratchet green while
+    preserving their current scores.
+  - A few atlas `security.py` entries decrease because existing
+    HAPPY_PATH/NO_RAISES attribution now sees the matched tests; those are
+    floor-lowering fixes, not accepted new brittleness.
+  The review-visible escape hatch is still the baseline JSON diff; future PRs
+  fail on score increases or new `INTERNAL_MOCK` counts.
+- The explicit deflection file-lane only attributes mocks whose production
+  target is in the swept file list. A new internal mock against an unchanged
+  production file outside that explicit list is caught by the broad maturity
+  sweep, not by the file-lane wrapper alone.
+
+## Deferred
+
+- Dynamic target inference for variables that build patch strings at runtime.
+- Baseline burn-down for existing internal mocks after the ratchet is in place.
+- Bare `MagicMock()` attribution when no static first-party target is present.
+
+Parked hardening: none.
+
+## Verification
+
+- Maturity sweep unit tests plus explicit-file lane tests - 28 passed.
+- Extracted content pipeline ratchet gate against
+  `tests/maturity_sweep/baseline_extracted_content_pipeline.json` - passed.
+- Deflection explicit-file ratchet gate against
+  `tests/maturity_sweep/baseline_deflection_lane.json` - passed.
+- Scripts ratchet gate against `tests/maturity_sweep/baseline_scripts.json` -
+  passed.
+- AI content ops explicit-file ratchet gate against
+  `tests/maturity_sweep/baseline_ai_content_ops_lane.json` - passed.
+- Refreshed atlas-brain baselines were rechecked against the workflow lane
+  matrix, including the `atlas_brain/skills` lane; all atlas-brain ratchets
+  passed.
+- Extracted package ratchet gates, including the newly enforced C1-C3 roots -
+  passed.
+- Deflection explicit-file and AI content-ops explicit-file ratchet gates -
+  passed.
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed.
+- Pending before push: blocking local review via `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Maturity-Sweep-Internal-Mock-Ratchet.md` | 222 |
+| `scripts/maturity_sweep.py` | 214 |
+| `scripts/maturity_sweep_file_lane.py` | 1 |
+| `tests/maturity_sweep/baseline_ai_content_ops_lane.json` | 12 |
+| `tests/maturity_sweep/baseline_atlas_brain_agents.json` | 7 |
+| `tests/maturity_sweep/baseline_atlas_brain_alerts.json` | 3 |
+| `tests/maturity_sweep/baseline_atlas_brain_api.json` | 112 |
+| `tests/maturity_sweep/baseline_atlas_brain_auth.json` | 8 |
+| `tests/maturity_sweep/baseline_atlas_brain_autonomous.json` | 183 |
+| `tests/maturity_sweep/baseline_atlas_brain_comms.json` | 3 |
+| `tests/maturity_sweep/baseline_atlas_brain_discovery.json` | 3 |
+| `tests/maturity_sweep/baseline_atlas_brain_jobs.json` | 3 |
+| `tests/maturity_sweep/baseline_atlas_brain_mcp.json` | 56 |
+| `tests/maturity_sweep/baseline_atlas_brain_memory.json` | 15 |
+| `tests/maturity_sweep/baseline_atlas_brain_modes.json` | 3 |
+| `tests/maturity_sweep/baseline_atlas_brain_orchestration.json` | 3 |
+| `tests/maturity_sweep/baseline_atlas_brain_pipelines.json` | 12 |
+| `tests/maturity_sweep/baseline_atlas_brain_reasoning.json` | 35 |
+| `tests/maturity_sweep/baseline_atlas_brain_security.json` | 9 |
+| `tests/maturity_sweep/baseline_atlas_brain_services_b2b.json` | 41 |
+| `tests/maturity_sweep/baseline_atlas_brain_services_llm.json` | 14 |
+| `tests/maturity_sweep/baseline_atlas_brain_services_scraping.json` | 50 |
+| `tests/maturity_sweep/baseline_atlas_brain_skills.json` | 9 |
+| `tests/maturity_sweep/baseline_atlas_brain_storage.json` | 20 |
+| `tests/maturity_sweep/baseline_atlas_brain_tools.json` | 10 |
+| `tests/maturity_sweep/baseline_atlas_brain_voice.json` | 6 |
+| `tests/maturity_sweep/baseline_deflection_lane.json` | 108 |
+| `tests/maturity_sweep/baseline_extracted_competitive_intelligence.json` | 18 |
+| `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 108 |
+| `tests/maturity_sweep/baseline_scripts.json` | 52 |
+| `tests/test_maturity_sweep.py` | 201 |
+| **Total** | **1541** |

--- a/scripts/maturity_sweep.py
+++ b/scripts/maturity_sweep.py
@@ -49,6 +49,7 @@ WEIGHTS = {
     "MUTABLE_DEFAULT": 2,       # def f(x=[])
     "HEURISTIC_COMMENT": 1,     # TODO/HACK/probably/best effort/brittle...
     "WEAK_CONTRACT": 1,         # public def with zero type annotations
+    "INTERNAL_MOCK": 4,         # tests mock first-party modules instead of edges
     "PARSE_ERROR": 8,           # file does not parse
 }
 
@@ -91,6 +92,37 @@ SKIP_DIRS = {
 
 TEST_NAME_RE = re.compile(r"(^test_.+\.py$)|(.+_test\.py$)")
 SENSITIVE_ZERO_TOLERANCE = ("BARE_EXCEPT", "SWALLOWED_EXCEPT")
+FIRST_PARTY_MOCK_ROOTS = (
+    "atlas_brain",
+    "extracted_competitive_intelligence",
+    "extracted_content_pipeline",
+    "extracted_evidence_to_story",
+    "extracted_llm_infrastructure",
+    "extracted_quality_gate",
+    "extracted_reasoning_core",
+    "scripts",
+)
+EXTERNAL_MOCK_SEAM_ATTRS = {
+    "anthropic",
+    "asyncpg",
+    "boto3",
+    "datetime",
+    "find_spec",
+    "httpx",
+    "monotonic",
+    "openai",
+    "perf_counter",
+    "random",
+    "requests",
+    "resend",
+    "socket",
+    "stripe",
+    "subprocess",
+    "time",
+    "twilio",
+    "urlopen",
+    "urllib",
+}
 
 
 @dataclass
@@ -259,6 +291,179 @@ class Analyzer(ast.NodeVisitor):
 # test scoring
 # ---------------------------------------------------------------------------
 
+
+def _module_name_for_path(path):
+    parts = Path(path).with_suffix("").parts
+    if not parts:
+        return ""
+    for index, part in enumerate(parts):
+        if part in FIRST_PARTY_MOCK_ROOTS:
+            return ".".join(parts[index:])
+    return ".".join(parts)
+
+
+def _mock_target_roots(results):
+    modules = {}
+    for result in results:
+        module = _module_name_for_path(result.path)
+        if module:
+            modules[module] = result
+            if module.endswith(".__init__"):
+                modules[module.rsplit(".", 1)[0]] = result
+    return modules
+
+
+def _constant_string(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _call_name_parts(node):
+    if isinstance(node, ast.Name):
+        return [node.id]
+    if isinstance(node, ast.Attribute):
+        base = _call_name_parts(node.value)
+        if base:
+            return [*base, node.attr]
+    return []
+
+
+def _import_aliases(tree):
+    aliases = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if root in FIRST_PARTY_MOCK_ROOTS:
+                    aliases[alias.asname or root] = alias.name if alias.asname else root
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            root = module.split(".", 1)[0]
+            if root not in FIRST_PARTY_MOCK_ROOTS:
+                continue
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                aliases[alias.asname or alias.name] = "%s.%s" % (module, alias.name)
+    return aliases
+
+
+def _resolve_expr_target(node, aliases):
+    parts = _call_name_parts(node)
+    if not parts:
+        return None
+    first = parts[0]
+    if first in aliases:
+        return ".".join([aliases[first], *parts[1:]])
+    if first in FIRST_PARTY_MOCK_ROOTS:
+        return ".".join(parts)
+    return None
+
+
+def _resolve_mock_target_module(target, module_results):
+    cleaned = str(target or "").strip()
+    if not cleaned:
+        return None
+    parts = cleaned.split(".")
+    if not parts or parts[0] not in FIRST_PARTY_MOCK_ROOTS:
+        return None
+    for end in range(len(parts), 0, -1):
+        candidate = ".".join(parts[:end])
+        result = module_results.get(candidate)
+        if result is not None:
+            remainder = parts[end:]
+            if remainder and remainder[0] in EXTERNAL_MOCK_SEAM_ATTRS:
+                return None
+            return result
+    return None
+
+
+class InternalMockVisitor(ast.NodeVisitor):
+    def __init__(self, aliases):
+        self.aliases = aliases
+        self.targets = []
+
+    def visit_Call(self, node):
+        parts = _call_name_parts(node.func)
+        if parts:
+            name = ".".join(parts)
+            if parts[-1] == "patch":
+                target = self._first_arg_string(node)
+                if target:
+                    self.targets.append((node.lineno, target, name))
+            elif parts[-2:] == ["patch", "object"]:
+                target = self._object_patch_target(node)
+                if target:
+                    self.targets.append((node.lineno, target, name))
+            elif parts[-2:] == ["monkeypatch", "setattr"] or parts[-1] == "setattr":
+                target = self._monkeypatch_target(node)
+                if target:
+                    self.targets.append((node.lineno, target, name))
+        self.generic_visit(node)
+
+    @staticmethod
+    def _first_arg_string(node):
+        if not node.args:
+            return None
+        return _constant_string(node.args[0])
+
+    def _monkeypatch_target(self, node):
+        if not node.args:
+            return None
+        string_target = _constant_string(node.args[0])
+        if string_target:
+            return string_target
+        if len(node.args) < 2:
+            return None
+        base = _resolve_expr_target(node.args[0], self.aliases)
+        attr = _constant_string(node.args[1])
+        if base and attr:
+            return "%s.%s" % (base, attr)
+        return base
+
+    def _object_patch_target(self, node):
+        if len(node.args) < 2:
+            return None
+        base = _resolve_expr_target(node.args[0], self.aliases)
+        attr = _constant_string(node.args[1])
+        if base and attr:
+            return "%s.%s" % (base, attr)
+        return base
+
+
+def internal_mock_findings_by_result(results, test_sources):
+    module_results = _mock_target_roots(results)
+    findings = {id(result): [] for result in results}
+    for source in test_sources.values():
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        visitor = InternalMockVisitor(_import_aliases(tree))
+        visitor.visit(tree)
+        for lineno, target, source_name in visitor.targets:
+            result = _resolve_mock_target_module(target, module_results)
+            if result is None:
+                continue
+            findings[id(result)].append(Finding(
+                "INTERNAL_MOCK",
+                lineno,
+                "test mocks first-party target %s via %s" % (target, source_name),
+            ))
+    return findings
+
+
+def apply_internal_mock_findings(results, test_sources):
+    findings_by_result = internal_mock_findings_by_result(results, test_sources)
+    for result in results:
+        extra = findings_by_result.get(id(result), [])
+        if not extra:
+            continue
+        result.findings.extend(extra)
+        result.score, result.counts = apply_caps(result.findings)
+    return results
+
 def index_tests(root):
     """Return (test_sources, all_test_text). test_sources maps a test-file stem
     to its source; all_test_text is every test file concatenated, for the
@@ -413,6 +618,7 @@ def sweep(root, tests_root=None):
             if is_test_path(path):
                 continue
             results.append(analyze_file(path, test_sources, all_test_text))
+    apply_internal_mock_findings(results, test_sources)
     results.sort(key=lambda r: r.score, reverse=True)
     return results
 
@@ -506,6 +712,14 @@ def ratchet_failures(results, baseline, min_score=None, sensitive_globs=()):
                 path=path,
                 reason="new file at or above min-score",
                 detail="score %d >= %d" % (result.score, min_score),
+            ))
+        old_internal_mocks = baseline_counts.get("INTERNAL_MOCK", 0)
+        new_internal_mocks = int(result.counts.get("INTERNAL_MOCK", 0))
+        if new_internal_mocks > old_internal_mocks:
+            failures.append(GateFailure(
+                path=path,
+                reason="new INTERNAL_MOCK",
+                detail="%d -> %d" % (old_internal_mocks, new_internal_mocks),
             ))
         if _matches_sensitive(path, sensitive_globs):
             for code in SENSITIVE_ZERO_TOLERANCE:

--- a/scripts/maturity_sweep_file_lane.py
+++ b/scripts/maturity_sweep_file_lane.py
@@ -44,6 +44,7 @@ def sweep_files(paths, tests_root):
         result = maturity_sweep.analyze_file(path, test_sources, all_test_text)
         result.path = Path(result.path).as_posix()
         results.append(result)
+    maturity_sweep.apply_internal_mock_findings(results, test_sources)
     results.sort(key=lambda result: result.score, reverse=True)
     return results
 

--- a/tests/maturity_sweep/baseline_ai_content_ops_lane.json
+++ b/tests/maturity_sweep/baseline_ai_content_ops_lane.json
@@ -20,10 +20,17 @@
   },
   "atlas_brain/_content_ops_reasoning.py": {
     "counts": {
+      "INTERNAL_MOCK": 2,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 7
+    "score": 15
+  },
+  "atlas_brain/_content_ops_zendesk_credentials.py": {
+    "counts": {
+      "INTERNAL_MOCK": 12
+    },
+    "score": 48
   },
   "atlas_brain/api/content_ops_brand_voice_profiles.py": {
     "counts": {
@@ -54,9 +61,10 @@
   },
   "atlas_brain/mcp/content_ops_marketer_verify_server.py": {
     "counts": {
+      "INTERNAL_MOCK": 49,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 201
   },
   "scripts/audit_content_ops_marketing_claims.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_agents.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_agents.json
@@ -38,13 +38,6 @@
     },
     "score": 3
   },
-  "atlas_brain/agents/graphs/security.py": {
-    "counts": {
-      "HAPPY_PATH_TESTS": 1,
-      "NO_RAISES_TESTS": 1
-    },
-    "score": 7
-  },
   "atlas_brain/agents/graphs/state.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,

--- a/tests/maturity_sweep/baseline_atlas_brain_alerts.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_alerts.json
@@ -8,9 +8,10 @@
   },
   "atlas_brain/alerts/manager.py": {
     "counts": {
+      "INTERNAL_MOCK": 10,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 43
   },
   "atlas_brain/alerts/rules.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_api.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_api.json
@@ -2,11 +2,12 @@
   "atlas_brain/api/admin_costs.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 5,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 5,
       "UNGUARDED_INDEX": 18
     },
-    "score": 38
+    "score": 58
   },
   "atlas_brain/api/alerts.py": {
     "counts": {
@@ -17,106 +18,133 @@
   },
   "atlas_brain/api/auth.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 15
     },
-    "score": 4
+    "score": 64
   },
   "atlas_brain/api/b2b_affiliates.py": {
     "counts": {
+      "INTERNAL_MOCK": 12,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 53
   },
   "atlas_brain/api/b2b_campaigns.py": {
     "counts": {
+      "INTERNAL_MOCK": 50,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 4
     },
-    "score": 11
+    "score": 211
   },
   "atlas_brain/api/b2b_challenger_claims.py": {
     "counts": {
+      "INTERNAL_MOCK": 4,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 19
   },
   "atlas_brain/api/b2b_crm_events.py": {
     "counts": {
+      "INTERNAL_MOCK": 20,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 7,
       "UNGUARDED_INDEX": 1
     },
-    "score": 40
+    "score": 120
   },
   "atlas_brain/api/b2b_dashboard.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 70,
       "SWALLOWED_EXCEPT": 6,
       "UNGUARDED_INDEX": 13
     },
-    "score": 37
+    "score": 317
   },
   "atlas_brain/api/b2b_evidence.py": {
     "counts": {
+      "INTERNAL_MOCK": 74,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 2
     },
-    "score": 14
+    "score": 310
   },
   "atlas_brain/api/b2b_reviews.py": {
     "counts": {
+      "INTERNAL_MOCK": 18,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 8
+    "score": 80
   },
   "atlas_brain/api/b2b_scrape.py": {
     "counts": {
+      "INTERNAL_MOCK": 47,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 3
     },
-    "score": 18
+    "score": 206
   },
   "atlas_brain/api/b2b_tenant_dashboard.py": {
     "counts": {
+      "INTERNAL_MOCK": 253,
       "SWALLOWED_EXCEPT": 6,
       "UNGUARDED_INDEX": 11
     },
-    "score": 36
+    "score": 1048
   },
   "atlas_brain/api/b2b_vendor_briefing.py": {
     "counts": {
+      "INTERNAL_MOCK": 17,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 5
+    "score": 73
   },
   "atlas_brain/api/b2b_vendor_claims.py": {
     "counts": {
+      "INTERNAL_MOCK": 4,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 19
   },
   "atlas_brain/api/b2b_win_loss.py": {
     "counts": {
+      "INTERNAL_MOCK": 28,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 8
     },
-    "score": 21
+    "score": 133
   },
   "atlas_brain/api/billing.py": {
     "counts": {
+      "INTERNAL_MOCK": 62,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 3
     },
-    "score": 26
+    "score": 274
   },
   "atlas_brain/api/blog_admin.py": {
     "counts": {
+      "INTERNAL_MOCK": 26,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 3
     },
-    "score": 9
+    "score": 113
+  },
+  "atlas_brain/api/blog_public.py": {
+    "counts": {
+      "INTERNAL_MOCK": 4
+    },
+    "score": 16
+  },
+  "atlas_brain/api/campaign_webhooks.py": {
+    "counts": {
+      "INTERNAL_MOCK": 14
+    },
+    "score": 56
   },
   "atlas_brain/api/comms/call_actions.py": {
     "counts": {
@@ -135,11 +163,12 @@
   "atlas_brain/api/comms/webhooks.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 13,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 4,
       "UNGUARDED_INPUT": 1
     },
-    "score": 31
+    "score": 83
   },
   "atlas_brain/api/consumer_dashboard.py": {
     "counts": {
@@ -177,17 +206,25 @@
     },
     "score": 37
   },
+  "atlas_brain/api/email_actions.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
+  },
   "atlas_brain/api/email_drafts.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "UNGUARDED_INDEX": 7
     },
-    "score": 6
+    "score": 10
   },
   "atlas_brain/api/inbox_rules.py": {
     "counts": {
+      "INTERNAL_MOCK": 5,
       "UNGUARDED_INDEX": 1
     },
-    "score": 2
+    "score": 22
   },
   "atlas_brain/api/invoicing/actions.py": {
     "counts": {
@@ -240,9 +277,10 @@
   },
   "atlas_brain/api/pipeline_visibility.py": {
     "counts": {
+      "INTERNAL_MOCK": 22,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 91
   },
   "atlas_brain/api/presence.py": {
     "counts": {
@@ -259,11 +297,12 @@
   },
   "atlas_brain/api/prospects.py": {
     "counts": {
+      "INTERNAL_MOCK": 8,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 10
+    "score": 42
   },
   "atlas_brain/api/query/text.py": {
     "counts": {
@@ -273,22 +312,23 @@
   },
   "atlas_brain/api/recognition.py": {
     "counts": {
+      "INTERNAL_MOCK": 5,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 25
   },
   "atlas_brain/api/security.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1,
-      "NO_RAISES_TESTS": 1
+      "INTERNAL_MOCK": 1
     },
-    "score": 7
+    "score": 4
   },
   "atlas_brain/api/seller_campaigns.py": {
     "counts": {
+      "INTERNAL_MOCK": 9,
       "UNGUARDED_INDEX": 2
     },
-    "score": 4
+    "score": 40
   },
   "atlas_brain/api/session.py": {
     "counts": {
@@ -303,11 +343,29 @@
     },
     "score": 7
   },
+  "atlas_brain/api/universal_scrape.py": {
+    "counts": {
+      "INTERNAL_MOCK": 7
+    },
+    "score": 28
+  },
+  "atlas_brain/api/vendor_targets.py": {
+    "counts": {
+      "INTERNAL_MOCK": 28
+    },
+    "score": 112
+  },
   "atlas_brain/api/video.py": {
     "counts": {
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 7
     },
     "score": 11
+  },
+  "atlas_brain/api/vision.py": {
+    "counts": {
+      "INTERNAL_MOCK": 7
+    },
+    "score": 28
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_auth.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_auth.json
@@ -1,16 +1,18 @@
 {
   "atlas_brain/auth/api_keys.py": {
     "counts": {
-      "HEURISTIC_COMMENT": 1
+      "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 2
     },
-    "score": 1
+    "score": 9
   },
   "atlas_brain/auth/dependencies.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 4,
       "SWALLOWED_EXCEPT": 3
     },
-    "score": 19
+    "score": 35
   },
   "atlas_brain/auth/encryption.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_autonomous.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_autonomous.json
@@ -5,6 +5,12 @@
     },
     "score": 10
   },
+  "atlas_brain/autonomous/config.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
+  },
   "atlas_brain/autonomous/event_queue.py": {
     "counts": {
       "NO_RAISES_TESTS": 1,
@@ -15,29 +21,33 @@
   "atlas_brain/autonomous/presence.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 21,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 9
+    "score": 93
   },
   "atlas_brain/autonomous/runner.py": {
     "counts": {
+      "INTERNAL_MOCK": 17,
       "UNGUARDED_INPUT": 2
     },
-    "score": 8
+    "score": 76
   },
   "atlas_brain/autonomous/scheduler.py": {
     "counts": {
+      "INTERNAL_MOCK": 16,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 3
     },
-    "score": 11
+    "score": 75
   },
   "atlas_brain/autonomous/tasks/_b2b_batch_utils.py": {
     "counts": {
+      "INTERNAL_MOCK": 9,
       "UNGUARDED_INDEX": 2
     },
-    "score": 4
+    "score": 40
   },
   "atlas_brain/autonomous/tasks/_b2b_blog_post_generation_host.py": {
     "counts": {
@@ -47,19 +57,21 @@
   },
   "atlas_brain/autonomous/tasks/_b2b_cross_vendor_synthesis.py": {
     "counts": {
+      "INTERNAL_MOCK": 31,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 15
     },
-    "score": 16
+    "score": 140
   },
   "atlas_brain/autonomous/tasks/_b2b_pool_compression.py": {
     "counts": {
       "HEURISTIC_COMMENT": 11,
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 17,
       "UNGUARDED_INPUT": 1
     },
-    "score": 19
+    "score": 23
   },
   "atlas_brain/autonomous/tasks/_b2b_reasoning_atoms.py": {
     "counts": {
@@ -67,6 +79,12 @@
       "UNGUARDED_INDEX": 3
     },
     "score": 11
+  },
+  "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
   },
   "atlas_brain/autonomous/tasks/_b2b_reasoning_contracts.py": {
     "counts": {
@@ -78,10 +96,11 @@
   "atlas_brain/autonomous/tasks/_b2b_shared.py": {
     "counts": {
       "HEURISTIC_COMMENT": 4,
+      "INTERNAL_MOCK": 152,
       "SWALLOWED_EXCEPT": 26,
       "UNGUARDED_INDEX": 130
     },
-    "score": 140
+    "score": 748
   },
   "atlas_brain/autonomous/tasks/_b2b_specificity.py": {
     "counts": {
@@ -91,16 +110,18 @@
   },
   "atlas_brain/autonomous/tasks/_b2b_synthesis_reader.py": {
     "counts": {
+      "INTERNAL_MOCK": 27,
       "SWALLOWED_EXCEPT": 5
     },
-    "score": 25
+    "score": 133
   },
   "atlas_brain/autonomous/tasks/_b2b_synthesis_validation.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 6
     },
-    "score": 21
+    "score": 33
   },
   "atlas_brain/autonomous/tasks/_b2b_witnesses.py": {
     "counts": {
@@ -148,192 +169,228 @@
   },
   "atlas_brain/autonomous/tasks/amazon_seller_campaign_generation.py": {
     "counts": {
+      "INTERNAL_MOCK": 4,
       "SWALLOWED_EXCEPT": 2
     },
-    "score": 10
+    "score": 26
   },
   "atlas_brain/autonomous/tasks/anomaly_detection.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 6
+    "score": 10
   },
   "atlas_brain/autonomous/tasks/article_enrichment.py": {
     "counts": {
+      "INTERNAL_MOCK": 6,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 8
+    "score": 32
   },
   "atlas_brain/autonomous/tasks/b2b_account_resolution.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 8,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 2
     },
-    "score": 21
+    "score": 53
   },
   "atlas_brain/autonomous/tasks/b2b_accounts_in_motion.py": {
     "counts": {
+      "INTERNAL_MOCK": 53,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 10
     },
-    "score": 11
+    "score": 223
   },
   "atlas_brain/autonomous/tasks/b2b_article_correlation.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 2
     },
-    "score": 4
+    "score": 12
   },
   "atlas_brain/autonomous/tasks/b2b_battle_cards.py": {
     "counts": {
       "HEURISTIC_COMMENT": 2,
+      "INTERNAL_MOCK": 48,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 11
     },
-    "score": 28
+    "score": 220
   },
   "atlas_brain/autonomous/tasks/b2b_blog_post_generation.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 148,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 16,
       "UNGUARDED_INDEX": 42
     },
-    "score": 90
+    "score": 682
   },
   "atlas_brain/autonomous/tasks/b2b_campaign_generation.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
       "HEURISTIC_COMMENT": 3,
+      "INTERNAL_MOCK": 89,
       "SWALLOWED_EXCEPT": 6,
       "UNGUARDED_INDEX": 27
     },
-    "score": 43
+    "score": 399
   },
   "atlas_brain/autonomous/tasks/b2b_challenger_brief.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 45,
       "SWALLOWED_EXCEPT": 5,
       "UNGUARDED_INDEX": 2
     },
-    "score": 30
+    "score": 210
   },
   "atlas_brain/autonomous/tasks/b2b_churn_alert.py": {
     "counts": {
+      "INTERNAL_MOCK": 12,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 51
   },
   "atlas_brain/autonomous/tasks/b2b_churn_intelligence.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
       "HEURISTIC_COMMENT": 3,
+      "INTERNAL_MOCK": 58,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 8,
       "UNGUARDED_INDEX": 22
     },
-    "score": 56
+    "score": 288
   },
   "atlas_brain/autonomous/tasks/b2b_churn_reports.py": {
     "counts": {
+      "INTERNAL_MOCK": 16,
       "SWALLOWED_EXCEPT": 2
     },
-    "score": 10
+    "score": 74
   },
   "atlas_brain/autonomous/tasks/b2b_enrichment.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 81,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 14
+    "score": 338
   },
   "atlas_brain/autonomous/tasks/b2b_enrichment_repair.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 102,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 3
     },
-    "score": 28
+    "score": 436
   },
   "atlas_brain/autonomous/tasks/b2b_keyword_signal.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 15,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 12
+    "score": 72
   },
   "atlas_brain/autonomous/tasks/b2b_parser_upgrade_maintenance.py": {
     "counts": {
+      "INTERNAL_MOCK": 6,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 5
+    "score": 29
   },
   "atlas_brain/autonomous/tasks/b2b_product_profiles.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 55,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 13
     },
-    "score": 18
+    "score": 238
   },
   "atlas_brain/autonomous/tasks/b2b_reasoning_synthesis.py": {
     "counts": {
       "ASSERT_AS_VALIDATION": 2,
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 88,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 9
     },
-    "score": 28
+    "score": 380
   },
   "atlas_brain/autonomous/tasks/b2b_report_subscription_delivery.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 121,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 3
     },
-    "score": 23
+    "score": 507
   },
   "atlas_brain/autonomous/tasks/b2b_scrape_intake.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 26,
       "SWALLOWED_EXCEPT": 13,
       "UNGUARDED_INDEX": 4,
       "UNGUARDED_INPUT": 1
     },
-    "score": 76
+    "score": 180
+  },
+  "atlas_brain/autonomous/tasks/b2b_scrape_target_pruning.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
   },
   "atlas_brain/autonomous/tasks/b2b_tenant_report.py": {
     "counts": {
+      "INTERNAL_MOCK": 20,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 3
     },
-    "score": 9
+    "score": 89
   },
   "atlas_brain/autonomous/tasks/b2b_vendor_briefing.py": {
     "counts": {
+      "INTERNAL_MOCK": 68,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 10,
       "UNGUARDED_INDEX": 13
     },
-    "score": 59
+    "score": 331
   },
   "atlas_brain/autonomous/tasks/b2b_watchlist_alert_delivery.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 6,
       "NO_RAISES_TESTS": 1
     },
-    "score": 7
+    "score": 31
+  },
+  "atlas_brain/autonomous/tasks/b2b_witness_quality_maintenance.py": {
+    "counts": {
+      "INTERNAL_MOCK": 10
+    },
+    "score": 40
   },
   "atlas_brain/autonomous/tasks/blog_post_generation.py": {
     "counts": {
@@ -356,37 +413,42 @@
   },
   "atlas_brain/autonomous/tasks/campaign_audit.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 15
   },
   "atlas_brain/autonomous/tasks/campaign_send.py": {
     "counts": {
+      "INTERNAL_MOCK": 24,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 5
+    "score": 101
   },
   "atlas_brain/autonomous/tasks/campaign_sequence_progression.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 10,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 2
     },
-    "score": 17
+    "score": 57
   },
   "atlas_brain/autonomous/tasks/campaign_suppression.py": {
     "counts": {
+      "INTERNAL_MOCK": 5,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 3
     },
-    "score": 21
+    "score": 41
   },
   "atlas_brain/autonomous/tasks/challenger_target_discovery.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 2
     },
-    "score": 4
+    "score": 12
   },
   "atlas_brain/autonomous/tasks/cleaning_sms_reminder.py": {
     "counts": {
@@ -439,6 +501,18 @@
       "NO_TEST_FILE": 1
     },
     "score": 6
+  },
+  "atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py": {
+    "counts": {
+      "INTERNAL_MOCK": 84
+    },
+    "score": 336
+  },
+  "atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py": {
+    "counts": {
+      "INTERNAL_MOCK": 8
+    },
+    "score": 32
   },
   "atlas_brain/autonomous/tasks/crm_event_processing.py": {
     "counts": {
@@ -503,9 +577,10 @@
   },
   "atlas_brain/autonomous/tasks/email_intake.py": {
     "counts": {
+      "INTERNAL_MOCK": 8,
       "UNGUARDED_INDEX": 2
     },
-    "score": 4
+    "score": 36
   },
   "atlas_brain/autonomous/tasks/email_stale_check.py": {
     "counts": {
@@ -516,10 +591,11 @@
   },
   "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 5
+    "score": 9
   },
   "atlas_brain/autonomous/tasks/gmail_digest.py": {
     "counts": {
@@ -538,6 +614,12 @@
       "NO_TEST_FILE": 1
     },
     "score": 6
+  },
+  "atlas_brain/autonomous/tasks/market_intake.py": {
+    "counts": {
+      "INTERNAL_MOCK": 7
+    },
+    "score": 28
   },
   "atlas_brain/autonomous/tasks/model_swap.py": {
     "counts": {
@@ -559,6 +641,12 @@
       "NO_TEST_FILE": 1
     },
     "score": 10
+  },
+  "atlas_brain/autonomous/tasks/news_intake.py": {
+    "counts": {
+      "INTERNAL_MOCK": 7
+    },
+    "score": 28
   },
   "atlas_brain/autonomous/tasks/news_intelligence.py": {
     "counts": {
@@ -609,6 +697,12 @@
     },
     "score": 4
   },
+  "atlas_brain/autonomous/tasks/reasoning_tick.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
+  },
   "atlas_brain/autonomous/tasks/security_summary.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
@@ -645,8 +739,9 @@
   },
   "atlas_brain/autonomous/visibility.py": {
     "counts": {
-      "HEURISTIC_COMMENT": 1
+      "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 12
     },
-    "score": 1
+    "score": 49
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_comms.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_comms.json
@@ -8,10 +8,11 @@
   },
   "atlas_brain/comms/call_intelligence.py": {
     "counts": {
+      "INTERNAL_MOCK": 29,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 4
     },
-    "score": 16
+    "score": 132
   },
   "atlas_brain/comms/invoice_detector.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_discovery.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_discovery.json
@@ -15,9 +15,10 @@
   "atlas_brain/discovery/service.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 17,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 2
     },
-    "score": 17
+    "score": 85
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_jobs.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_jobs.json
@@ -13,9 +13,10 @@
   },
   "atlas_brain/jobs/nightly_memory_sync.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 2
     },
-    "score": 9
+    "score": 13
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_mcp.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_mcp.json
@@ -41,22 +41,25 @@
   "atlas_brain/mcp/b2b/evidence.py": {
     "counts": {
       "HEURISTIC_COMMENT": 18,
+      "INTERNAL_MOCK": 16,
       "UNGUARDED_INDEX": 4
     },
-    "score": 10
+    "score": 74
   },
   "atlas_brain/mcp/b2b/pipeline.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 9
   },
   "atlas_brain/mcp/b2b/products.py": {
     "counts": {
+      "INTERNAL_MOCK": 4,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 5
+    "score": 21
   },
   "atlas_brain/mcp/b2b/reviews.py": {
     "counts": {
@@ -66,9 +69,10 @@
   },
   "atlas_brain/mcp/b2b/scrape_targets.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 15
   },
   "atlas_brain/mcp/b2b/server.py": {
     "counts": {
@@ -79,9 +83,10 @@
   },
   "atlas_brain/mcp/b2b/signals.py": {
     "counts": {
+      "INTERNAL_MOCK": 11,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 47
   },
   "atlas_brain/mcp/b2b/vendor_history.py": {
     "counts": {
@@ -98,23 +103,26 @@
   },
   "atlas_brain/mcp/b2b/write_intelligence.py": {
     "counts": {
+      "INTERNAL_MOCK": 2,
       "UNGUARDED_INDEX": 3
     },
-    "score": 6
+    "score": 14
   },
   "atlas_brain/mcp/calendar_server.py": {
     "counts": {
+      "INTERNAL_MOCK": 11,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INPUT": 1
     },
-    "score": 9
+    "score": 53
   },
   "atlas_brain/mcp/content_ops_deflection_readonly_server.py": {
     "counts": {
+      "INTERNAL_MOCK": 16,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 7
+    "score": 71
   },
   "atlas_brain/mcp/content_ops_marketer_verify_chatgpt_adapter_server.py": {
     "counts": {
@@ -132,16 +140,24 @@
   },
   "atlas_brain/mcp/content_ops_marketer_verify_server.py": {
     "counts": {
+      "INTERNAL_MOCK": 49,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 201
   },
   "atlas_brain/mcp/crm_server.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 4
     },
-    "score": 11
+    "score": 15
+  },
+  "atlas_brain/mcp/email_server.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
   },
   "atlas_brain/mcp/intelligence_server.py": {
     "counts": {
@@ -151,9 +167,10 @@
   },
   "atlas_brain/mcp/invoicing_draft_writer_server.py": {
     "counts": {
-      "ASSERT_AS_VALIDATION": 1
+      "ASSERT_AS_VALIDATION": 1,
+      "INTERNAL_MOCK": 9
     },
-    "score": 3
+    "score": 39
   },
   "atlas_brain/mcp/invoicing_readonly_oauth.py": {
     "counts": {
@@ -161,18 +178,31 @@
     },
     "score": 5
   },
+  "atlas_brain/mcp/invoicing_readonly_server.py": {
+    "counts": {
+      "INTERNAL_MOCK": 1
+    },
+    "score": 4
+  },
   "atlas_brain/mcp/invoicing_server.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 2,
       "UNGUARDED_INPUT": 2
     },
-    "score": 17
+    "score": 21
   },
   "atlas_brain/mcp/scraper_server.py": {
     "counts": {
       "UNGUARDED_INPUT": 1
     },
     "score": 4
+  },
+  "atlas_brain/mcp/twilio_server.py": {
+    "counts": {
+      "INTERNAL_MOCK": 3
+    },
+    "score": 12
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_memory.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_memory.json
@@ -1,9 +1,10 @@
 {
   "atlas_brain/memory/feedback.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 15
   },
   "atlas_brain/memory/quality.py": {
     "counts": {
@@ -11,19 +12,27 @@
     },
     "score": 10
   },
+  "atlas_brain/memory/query_classifier.py": {
+    "counts": {
+      "INTERNAL_MOCK": 8
+    },
+    "score": 32
+  },
   "atlas_brain/memory/rag_client.py": {
     "counts": {
+      "INTERNAL_MOCK": 18,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 75
   },
   "atlas_brain/memory/service.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 29,
       "NO_RAISES_TESTS": 1
     },
-    "score": 8
+    "score": 124
   },
   "atlas_brain/memory/token_estimator.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_modes.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_modes.json
@@ -8,8 +8,9 @@
   },
   "atlas_brain/modes/manager.py": {
     "counts": {
+      "INTERNAL_MOCK": 4,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 19
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_orchestration.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_orchestration.json
@@ -1,8 +1,9 @@
 {
   "atlas_brain/orchestration/temporal.py": {
     "counts": {
+      "INTERNAL_MOCK": 2,
       "UNGUARDED_INDEX": 1
     },
-    "score": 2
+    "score": 10
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_pipelines.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_pipelines.json
@@ -1,4 +1,10 @@
 {
+  "atlas_brain/pipelines/__init__.py": {
+    "counts": {
+      "INTERNAL_MOCK": 10
+    },
+    "score": 40
+  },
   "atlas_brain/pipelines/comparisons.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
@@ -9,14 +15,16 @@
   },
   "atlas_brain/pipelines/llm.py": {
     "counts": {
+      "INTERNAL_MOCK": 64,
       "SWALLOWED_EXCEPT": 4
     },
-    "score": 20
+    "score": 276
   },
   "atlas_brain/pipelines/notify.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 7
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_reasoning.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_reasoning.json
@@ -37,16 +37,18 @@
   "atlas_brain/reasoning/cross_vendor_selection.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 12,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 3
     },
-    "score": 13
+    "score": 61
   },
   "atlas_brain/reasoning/ecosystem.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "UNGUARDED_INDEX": 1
     },
-    "score": 2
+    "score": 14
   },
   "atlas_brain/reasoning/entity_locks.py": {
     "counts": {
@@ -70,10 +72,17 @@
   "atlas_brain/reasoning/evidence_engine.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 14,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 12
+    "score": 68
+  },
+  "atlas_brain/reasoning/graph.py": {
+    "counts": {
+      "INTERNAL_MOCK": 16
+    },
+    "score": 64
   },
   "atlas_brain/reasoning/knowledge_graph.py": {
     "counts": {
@@ -113,10 +122,11 @@
   },
   "atlas_brain/reasoning/patterns.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 8
+    "score": 12
   },
   "atlas_brain/reasoning/phrase_metadata.py": {
     "counts": {
@@ -125,11 +135,24 @@
     },
     "score": 8
   },
-  "atlas_brain/reasoning/semantic_cache.py": {
+  "atlas_brain/reasoning/port_adapters.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "INTERNAL_MOCK": 1
     },
     "score": 4
+  },
+  "atlas_brain/reasoning/producers.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
+  },
+  "atlas_brain/reasoning/semantic_cache.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 3
+    },
+    "score": 16
   },
   "atlas_brain/reasoning/single_pass_prompts/battle_card_reasoning.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_security.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_security.json
@@ -1,4 +1,10 @@
 {
+  "atlas_brain/security/__init__.py": {
+    "counts": {
+      "INTERNAL_MOCK": 6
+    },
+    "score": 24
+  },
   "atlas_brain/security/assets/drone_tracker.py": {
     "counts": {
       "NO_TEST_FILE": 1
@@ -54,10 +60,11 @@
   "atlas_brain/security/wireless/monitor.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 14
+    "score": 18
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_services_b2b.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_services_b2b.json
@@ -8,24 +8,27 @@
   },
   "atlas_brain/services/b2b/account_resolver.py": {
     "counts": {
+      "INTERNAL_MOCK": 7,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 4
     },
-    "score": 21
+    "score": 49
   },
   "atlas_brain/services/b2b/anthropic_batch.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 37,
       "NO_RAISES_TESTS": 1
     },
-    "score": 7
+    "score": 155
   },
   "atlas_brain/services/b2b/cache_runner.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 39,
       "NO_RAISES_TESTS": 1
     },
-    "score": 7
+    "score": 163
   },
   "atlas_brain/services/b2b/cache_strategy.py": {
     "counts": {
@@ -44,9 +47,10 @@
   },
   "atlas_brain/services/b2b/corrections.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 7
     },
-    "score": 4
+    "score": 32
   },
   "atlas_brain/services/b2b/enrichment_budget.py": {
     "counts": {
@@ -57,9 +61,10 @@
   },
   "atlas_brain/services/b2b/enrichment_contract.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 7
   },
   "atlas_brain/services/b2b/enrichment_derivation.py": {
     "counts": {
@@ -145,6 +150,12 @@
     },
     "score": 5
   },
+  "atlas_brain/services/b2b/enrichment_stage_controller.py": {
+    "counts": {
+      "INTERNAL_MOCK": 10
+    },
+    "score": 40
+  },
   "atlas_brain/services/b2b/enrichment_stage_support.py": {
     "counts": {
       "NO_TEST_FILE": 1,
@@ -201,17 +212,19 @@
   "atlas_brain/services/b2b/llm_exact_cache.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 8,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 2
     },
-    "score": 13
+    "score": 45
   },
   "atlas_brain/services/b2b/pdf_renderer.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 3
     },
-    "score": 11
+    "score": 15
   },
   "atlas_brain/services/b2b/product_claim.py": {
     "counts": {
@@ -221,9 +234,10 @@
   },
   "atlas_brain/services/b2b/product_matching.py": {
     "counts": {
+      "INTERNAL_MOCK": 4,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 21
   },
   "atlas_brain/services/b2b/report_trust.py": {
     "counts": {
@@ -256,24 +270,27 @@
   },
   "atlas_brain/services/b2b/vendor_merge.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 1
     },
-    "score": 12
+    "score": 16
   },
   "atlas_brain/services/b2b/watchlist_alerts.py": {
     "counts": {
+      "INTERNAL_MOCK": 12,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 7
     },
-    "score": 21
+    "score": 69
   },
   "atlas_brain/services/b2b/webhook_dispatcher.py": {
     "counts": {
+      "INTERNAL_MOCK": 18,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 5,
       "UNGUARDED_INDEX": 1
     },
-    "score": 30
+    "score": 102
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_services_llm.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_services_llm.json
@@ -2,16 +2,18 @@
   "atlas_brain/services/llm/anthropic.py": {
     "counts": {
       "HEURISTIC_COMMENT": 1,
+      "INTERNAL_MOCK": 20,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 2
     },
-    "score": 14
+    "score": 94
   },
   "atlas_brain/services/llm/cloud.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 4
     },
-    "score": 4
+    "score": 20
   },
   "atlas_brain/services/llm/groq.py": {
     "counts": {
@@ -35,18 +37,20 @@
   },
   "atlas_brain/services/llm/ollama.py": {
     "counts": {
+      "INTERNAL_MOCK": 4,
       "UNGUARDED_INDEX": 1
     },
-    "score": 2
+    "score": 18
   },
   "atlas_brain/services/llm/openrouter.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 3
     },
-    "score": 23
+    "score": 27
   },
   "atlas_brain/services/llm/together.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_services_scraping.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_services_scraping.json
@@ -2,26 +2,41 @@
   "atlas_brain/services/scraping/browser.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 14,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 3
     },
-    "score": 22
+    "score": 78
+  },
+  "atlas_brain/services/scraping/capabilities.py": {
+    "counts": {
+      "INTERNAL_MOCK": 3
+    },
+    "score": 12
   },
   "atlas_brain/services/scraping/captcha.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 4,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 9
+    "score": 25
   },
   "atlas_brain/services/scraping/capterra_audit.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 2,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 2
     },
-    "score": 23
+    "score": 31
+  },
+  "atlas_brain/services/scraping/client.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
   },
   "atlas_brain/services/scraping/eligibility.py": {
     "counts": {
@@ -49,16 +64,18 @@
   "atlas_brain/services/scraping/getapp_audit.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 2,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 1
     },
-    "score": 21
+    "score": 29
   },
   "atlas_brain/services/scraping/parsers/__init__.py": {
     "counts": {
+      "INTERNAL_MOCK": 4,
       "SWALLOWED_EXCEPT": 2
     },
-    "score": 10
+    "score": 26
   },
   "atlas_brain/services/scraping/parsers/capterra.py": {
     "counts": {
@@ -71,11 +88,12 @@
   "atlas_brain/services/scraping/parsers/g2.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 8,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 2
     },
-    "score": 31
+    "score": 63
   },
   "atlas_brain/services/scraping/parsers/gartner.py": {
     "counts": {
@@ -88,10 +106,11 @@
   },
   "atlas_brain/services/scraping/parsers/getapp.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "SWALLOWED_EXCEPT": 8,
       "UNGUARDED_INDEX": 3
     },
-    "score": 46
+    "score": 58
   },
   "atlas_brain/services/scraping/parsers/peerspot.py": {
     "counts": {
@@ -135,11 +154,12 @@
   "atlas_brain/services/scraping/parsers/slashdot.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 1
     },
-    "score": 24
+    "score": 28
   },
   "atlas_brain/services/scraping/parsers/software_advice.py": {
     "counts": {
@@ -194,9 +214,10 @@
   },
   "atlas_brain/services/scraping/proxy.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 3
     },
-    "score": 4
+    "score": 16
   },
   "atlas_brain/services/scraping/serp_discovery.py": {
     "counts": {
@@ -227,10 +248,17 @@
   },
   "atlas_brain/services/scraping/target_provisioning.py": {
     "counts": {
+      "INTERNAL_MOCK": 9,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 2
     },
-    "score": 9
+    "score": 45
+  },
+  "atlas_brain/services/scraping/target_validation.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
   },
   "atlas_brain/services/scraping/trustpilot_audit.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_skills.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_skills.json
@@ -1,9 +1,16 @@
 {
+  "atlas_brain/skills/__init__.py": {
+    "counts": {
+      "INTERNAL_MOCK": 28
+    },
+    "score": 112
+  },
   "atlas_brain/skills/registry.py": {
     "counts": {
+      "INTERNAL_MOCK": 2,
       "UNGUARDED_INDEX": 1,
       "UNGUARDED_INPUT": 2
     },
-    "score": 10
+    "score": 18
   }
 }

--- a/tests/maturity_sweep/baseline_atlas_brain_storage.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_storage.json
@@ -2,15 +2,17 @@
   "atlas_brain/storage/config.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1
     },
-    "score": 7
+    "score": 11
   },
   "atlas_brain/storage/database.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 31
     },
-    "score": 4
+    "score": 128
   },
   "atlas_brain/storage/models.py": {
     "counts": {
@@ -36,10 +38,11 @@
   },
   "atlas_brain/storage/repositories/competitive_set.py": {
     "counts": {
+      "INTERNAL_MOCK": 9,
       "UNGUARDED_INDEX": 1,
       "UNGUARDED_INPUT": 2
     },
-    "score": 10
+    "score": 46
   },
   "atlas_brain/storage/repositories/conversation.py": {
     "counts": {
@@ -73,18 +76,20 @@
   },
   "atlas_brain/storage/repositories/identity.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "UNGUARDED_INDEX": 2,
       "UNGUARDED_INPUT": 1
     },
-    "score": 8
+    "score": 20
   },
   "atlas_brain/storage/repositories/invoice.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 5,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 12
+    "score": 32
   },
   "atlas_brain/storage/repositories/reminder.py": {
     "counts": {
@@ -96,11 +101,12 @@
   },
   "atlas_brain/storage/repositories/scheduled_task.py": {
     "counts": {
+      "INTERNAL_MOCK": 27,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 1,
       "UNGUARDED_INPUT": 2
     },
-    "score": 20
+    "score": 128
   },
   "atlas_brain/storage/repositories/session.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_tools.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_tools.json
@@ -21,9 +21,10 @@
   },
   "atlas_brain/tools/notify.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 7
   },
   "atlas_brain/tools/presence.py": {
     "counts": {
@@ -47,17 +48,16 @@
   },
   "atlas_brain/tools/scheduling.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "UNGUARDED_INDEX": 6
     },
-    "score": 6
+    "score": 10
   },
   "atlas_brain/tools/security.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1,
-      "NO_RAISES_TESTS": 1,
       "WEAK_CONTRACT": 1
     },
-    "score": 8
+    "score": 1
   },
   "atlas_brain/tools/time.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_voice.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_voice.json
@@ -31,19 +31,21 @@
   "atlas_brain/voice/launcher.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 2,
       "SWALLOWED_EXCEPT": 4
     },
-    "score": 24
+    "score": 32
   },
   "atlas_brain/voice/pipeline.py": {
     "counts": {
       "HEURISTIC_COMMENT": 2,
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 5,
       "UNGUARDED_INDEX": 20,
       "UNGUARDED_INPUT": 1,
       "WEAK_CONTRACT": 6
     },
-    "score": 40
+    "score": 44
   },
   "atlas_brain/voice/playback.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_deflection_lane.json
+++ b/tests/maturity_sweep/baseline_deflection_lane.json
@@ -1,4 +1,16 @@
 {
+  "atlas_brain/autonomous/tasks/content_ops_deflection_delta_automation.py": {
+    "counts": {
+      "INTERNAL_MOCK": 84
+    },
+    "score": 336
+  },
+  "atlas_brain/autonomous/tasks/content_ops_deflection_report_delivery.py": {
+    "counts": {
+      "INTERNAL_MOCK": 8
+    },
+    "score": 32
+  },
   "atlas_brain/content_ops_deflection_delivery.py": {
     "counts": {
       "SWALLOWED_EXCEPT": 1
@@ -7,9 +19,10 @@
   },
   "atlas_brain/content_ops_deflection_incidents.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 7
   },
   "atlas_brain/content_ops_deflection_reconciliation.py": {
     "counts": {
@@ -19,15 +32,30 @@
   },
   "atlas_brain/deflection_pdf_renderer.py": {
     "counts": {
+      "INTERNAL_MOCK": 2,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 2
     },
-    "score": 9
+    "score": 17
   },
   "atlas_brain/mcp/content_ops_deflection_readonly_server.py": {
     "counts": {
+      "INTERNAL_MOCK": 16,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 1
+    },
+    "score": 71
+  },
+  "extracted_content_pipeline/deflection_delta.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "extracted_content_pipeline/deflection_pii_eval_corpus.py": {
+    "counts": {
+      "ASSERT_AS_VALIDATION": 1,
+      "UNGUARDED_INDEX": 2
     },
     "score": 7
   },
@@ -41,10 +69,16 @@
   "extracted_content_pipeline/faq_deflection_report.py": {
     "counts": {
       "SWALLOWED_EXCEPT": 3,
-      "UNGUARDED_INDEX": 3,
+      "UNGUARDED_INDEX": 7,
       "UNGUARDED_INPUT": 2
     },
     "score": 29
+  },
+  "scripts/_deflection_http.py": {
+    "counts": {
+      "UNGUARDED_INPUT": 1
+    },
+    "score": 4
   },
   "scripts/build_content_ops_deflection_report.py": {
     "counts": {
@@ -58,6 +92,12 @@
       "UNGUARDED_INDEX": 7
     },
     "score": 6
+  },
+  "scripts/build_deflection_pii_surrogate_eval_corpus.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
   },
   "scripts/check_deflection_full_report_hosted_smoke.py": {
     "counts": {
@@ -78,6 +118,12 @@
     },
     "score": 3
   },
+  "scripts/check_deflection_pii_source_decision.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
   "scripts/check_deflection_process_contract.py": {
     "counts": {
       "NO_RAISES_TESTS": 1
@@ -86,19 +132,30 @@
   },
   "scripts/check_deflection_product_surface_manifest.py": {
     "counts": {
-      "NO_TEST_FILE": 1,
       "WEAK_CONTRACT": 1
     },
+    "score": 1
+  },
+  "scripts/generate_deflection_frontend_contract_types.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
     "score": 7
+  },
+  "scripts/generate_deflection_snapshot_example.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
   },
   "scripts/prepare_content_ops_deflection_env.py": {
     "counts": {
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
-      "UNGUARDED_INDEX": 1,
-      "UNGUARDED_INPUT": 1
+      "UNGUARDED_INDEX": 1
     },
-    "score": 14
+    "score": 10
   },
   "scripts/probe_deflection_signal_spike.py": {
     "counts": {
@@ -108,20 +165,30 @@
     },
     "score": 8
   },
+  "scripts/purge_content_ops_deflection_reports.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
   "scripts/run_deflection_full_report_qa_live_runner.py": {
     "counts": {
       "NO_RAISES_TESTS": 1,
-      "UNGUARDED_INDEX": 2,
-      "UNGUARDED_INPUT": 1
+      "UNGUARDED_INDEX": 2
     },
-    "score": 11
+    "score": 7
   },
   "scripts/run_deflection_test_mode_checkout_proof.py": {
     "counts": {
-      "UNGUARDED_INDEX": 1,
-      "UNGUARDED_INPUT": 1
+      "UNGUARDED_INDEX": 1
     },
-    "score": 6
+    "score": 2
+  },
+  "scripts/score_deflection_pii_recall.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
   },
   "scripts/send_content_ops_deflection_report_deliveries.py": {
     "counts": {
@@ -139,26 +206,23 @@
     "counts": {
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
-      "UNGUARDED_INDEX": 1,
-      "UNGUARDED_INPUT": 1
+      "UNGUARDED_INDEX": 1
     },
-    "score": 14
+    "score": 10
   },
   "scripts/smoke_content_ops_deflection_stripe_paid_unlock.py": {
     "counts": {
       "NO_RAISES_TESTS": 1,
-      "UNGUARDED_INDEX": 1,
-      "UNGUARDED_INPUT": 1
+      "UNGUARDED_INDEX": 1
     },
-    "score": 9
+    "score": 5
   },
   "scripts/smoke_content_ops_deflection_submit_handoff.py": {
     "counts": {
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 2,
-      "UNGUARDED_INDEX": 1,
-      "UNGUARDED_INPUT": 1
+      "UNGUARDED_INDEX": 1
     },
-    "score": 19
+    "score": 15
   }
 }

--- a/tests/maturity_sweep/baseline_extracted_competitive_intelligence.json
+++ b/tests/maturity_sweep/baseline_extracted_competitive_intelligence.json
@@ -14,10 +14,11 @@
   },
   "extracted_competitive_intelligence/api/b2b_vendor_briefing.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 5
+    "score": 17
   },
   "extracted_competitive_intelligence/autonomous/tasks/_b2b_batch_utils.py": {
     "counts": {
@@ -49,11 +50,12 @@
   },
   "extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py": {
     "counts": {
+      "INTERNAL_MOCK": 8,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 10,
       "UNGUARDED_INDEX": 13
     },
-    "score": 59
+    "score": 91
   },
   "extracted_competitive_intelligence/autonomous/visibility.py": {
     "counts": {
@@ -144,9 +146,16 @@
   "extracted_competitive_intelligence/services/b2b/vendor_briefing_api_ports.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 4,
       "NO_RAISES_TESTS": 1
     },
-    "score": 7
+    "score": 23
+  },
+  "extracted_competitive_intelligence/services/b2b/vendor_briefing_delivery.py": {
+    "counts": {
+      "INTERNAL_MOCK": 4
+    },
+    "score": 16
   },
   "extracted_competitive_intelligence/services/b2b/vendor_briefing_repository.py": {
     "counts": {
@@ -165,9 +174,10 @@
   "extracted_competitive_intelligence/services/b2b_competitive_sets.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 6
+    "score": 10
   },
   "extracted_competitive_intelligence/services/llm_router.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_extracted_content_pipeline.json
+++ b/tests/maturity_sweep/baseline_extracted_content_pipeline.json
@@ -12,26 +12,41 @@
     },
     "score": 3
   },
+  "extracted_content_pipeline/api/b2b_campaigns.py": {
+    "counts": {
+      "INTERNAL_MOCK": 3
+    },
+    "score": 12
+  },
+  "extracted_content_pipeline/api/campaign_operations.py": {
+    "counts": {
+      "INTERNAL_MOCK": 29
+    },
+    "score": 116
+  },
   "extracted_content_pipeline/api/control_surfaces.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
       "HEURISTIC_COMMENT": 5,
+      "INTERNAL_MOCK": 18,
       "SWALLOWED_EXCEPT": 3,
       "UNGUARDED_INDEX": 6
     },
-    "score": 29
+    "score": 101
   },
   "extracted_content_pipeline/api/generated_assets.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 10
     },
-    "score": 4
+    "score": 44
   },
   "extracted_content_pipeline/api/seller_campaigns.py": {
     "counts": {
+      "INTERNAL_MOCK": 35,
       "UNGUARDED_INDEX": 2
     },
-    "score": 4
+    "score": 144
   },
   "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py": {
     "counts": {
@@ -90,9 +105,10 @@
   },
   "extracted_content_pipeline/autonomous/tasks/_blog_ts.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "UNGUARDED_INDEX": 3
     },
-    "score": 6
+    "score": 10
   },
   "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py": {
     "counts": {
@@ -236,12 +252,13 @@
   "extracted_content_pipeline/campaign_customer_data.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 2,
       "UNGUARDED_INPUT": 6
     },
-    "score": 40
+    "score": 44
   },
   "extracted_content_pipeline/campaign_example.py": {
     "counts": {
@@ -254,10 +271,11 @@
   "extracted_content_pipeline/campaign_generation.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 3
     },
-    "score": 20
+    "score": 24
   },
   "extracted_content_pipeline/campaign_install_check.py": {
     "counts": {
@@ -269,9 +287,10 @@
   },
   "extracted_content_pipeline/campaign_llm_client.py": {
     "counts": {
+      "INTERNAL_MOCK": 2,
       "SWALLOWED_EXCEPT": 5
     },
-    "score": 25
+    "score": 33
   },
   "extracted_content_pipeline/campaign_opportunities.py": {
     "counts": {
@@ -288,15 +307,17 @@
   },
   "extracted_content_pipeline/campaign_postgres_export.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 9
   },
   "extracted_content_pipeline/campaign_postgres_import.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1
+      "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1
     },
-    "score": 4
+    "score": 8
   },
   "extracted_content_pipeline/campaign_postgres_review.py": {
     "counts": {
@@ -360,11 +381,12 @@
   "extracted_content_pipeline/campaign_source_adapters.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 1,
       "WEAK_CONTRACT": 1
     },
-    "score": 17
+    "score": 21
   },
   "extracted_content_pipeline/campaign_visibility.py": {
     "counts": {
@@ -396,11 +418,12 @@
   },
   "extracted_content_pipeline/content_image_provider.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INPUT": 2
     },
-    "score": 16
+    "score": 20
   },
   "extracted_content_pipeline/content_ops_cache_policy.py": {
     "counts": {
@@ -440,6 +463,19 @@
     },
     "score": 7
   },
+  "extracted_content_pipeline/deflection_delta.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
+  "extracted_content_pipeline/deflection_pii_eval_corpus.py": {
+    "counts": {
+      "ASSERT_AS_VALIDATION": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 7
+  },
   "extracted_content_pipeline/deflection_report_access.py": {
     "counts": {
       "SWALLOWED_EXCEPT": 2,
@@ -456,7 +492,7 @@
   "extracted_content_pipeline/faq_deflection_report.py": {
     "counts": {
       "SWALLOWED_EXCEPT": 3,
-      "UNGUARDED_INDEX": 3,
+      "UNGUARDED_INDEX": 7,
       "UNGUARDED_INPUT": 2
     },
     "score": 29
@@ -495,9 +531,10 @@
   },
   "extracted_content_pipeline/ingestion_diagnostics.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "NO_RAISES_TESTS": 1
     },
-    "score": 3
+    "score": 7
   },
   "extracted_content_pipeline/landing_page_export.py": {
     "counts": {
@@ -541,9 +578,10 @@
   },
   "extracted_content_pipeline/pipelines/llm.py": {
     "counts": {
+      "INTERNAL_MOCK": 3,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 17
   },
   "extracted_content_pipeline/pipelines/notify.py": {
     "counts": {
@@ -646,9 +684,10 @@
   },
   "extracted_content_pipeline/report_export.py": {
     "counts": {
+      "INTERNAL_MOCK": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 5
+    "score": 9
   },
   "extracted_content_pipeline/report_generation.py": {
     "counts": {
@@ -674,12 +713,24 @@
     },
     "score": 2
   },
+  "extracted_content_pipeline/services/__init__.py": {
+    "counts": {
+      "INTERNAL_MOCK": 2
+    },
+    "score": 8
+  },
   "extracted_content_pipeline/services/b2b/account_opportunity_claims.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
       "NO_RAISES_TESTS": 1
     },
     "score": 7
+  },
+  "extracted_content_pipeline/services/b2b/anthropic_batch.py": {
+    "counts": {
+      "INTERNAL_MOCK": 1
+    },
+    "score": 4
   },
   "extracted_content_pipeline/services/b2b/cache_runner.py": {
     "counts": {
@@ -729,6 +780,12 @@
     },
     "score": 3
   },
+  "extracted_content_pipeline/services/campaign_sender.py": {
+    "counts": {
+      "INTERNAL_MOCK": 1
+    },
+    "score": 4
+  },
   "extracted_content_pipeline/services/llm_router.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
@@ -774,6 +831,12 @@
       "NO_RAISES_TESTS": 1
     },
     "score": 7
+  },
+  "extracted_content_pipeline/skills/registry.py": {
+    "counts": {
+      "INTERNAL_MOCK": 1
+    },
+    "score": 4
   },
   "extracted_content_pipeline/social_post_export.py": {
     "counts": {
@@ -838,13 +901,20 @@
     },
     "score": 7
   },
+  "extracted_content_pipeline/storage/repositories/scheduled_task.py": {
+    "counts": {
+      "INTERNAL_MOCK": 1
+    },
+    "score": 4
+  },
   "extracted_content_pipeline/support_ticket_clustering.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
+      "INTERNAL_MOCK": 2,
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 5
     },
-    "score": 13
+    "score": 21
   },
   "extracted_content_pipeline/support_ticket_context_contract.py": {
     "counts": {
@@ -893,7 +963,7 @@
   "extracted_content_pipeline/ticket_faq_markdown.py": {
     "counts": {
       "SWALLOWED_EXCEPT": 2,
-      "UNGUARDED_INDEX": 30
+      "UNGUARDED_INDEX": 32
     },
     "score": 16
   },

--- a/tests/maturity_sweep/baseline_scripts.json
+++ b/tests/maturity_sweep/baseline_scripts.json
@@ -536,6 +536,12 @@
     },
     "score": 6
   },
+  "scripts/build_deflection_pii_surrogate_eval_corpus.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
   "scripts/build_evidence_to_story_sources.py": {
     "counts": {
       "UNGUARDED_INDEX": 1
@@ -645,6 +651,12 @@
     "score": 7
   },
   "scripts/check_deflection_full_report_proof_bundle.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 3
+  },
+  "scripts/check_deflection_pii_source_decision.py": {
     "counts": {
       "NO_RAISES_TESTS": 1
     },
@@ -1049,6 +1061,19 @@
     },
     "score": 14
   },
+  "scripts/generate_deflection_frontend_contract_types.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1
+    },
+    "score": 7
+  },
+  "scripts/generate_deflection_snapshot_example.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
+  },
   "scripts/import_amazon_reviews.py": {
     "counts": {
       "NO_TEST_FILE": 1,
@@ -1131,11 +1156,11 @@
   "scripts/maturity_sweep.py": {
     "counts": {
       "HEURISTIC_COMMENT": 5,
-      "SWALLOWED_EXCEPT": 2,
-      "UNGUARDED_INDEX": 2,
-      "WEAK_CONTRACT": 25
+      "SWALLOWED_EXCEPT": 3,
+      "UNGUARDED_INDEX": 14,
+      "WEAK_CONTRACT": 28
     },
-    "score": 21
+    "score": 28
   },
   "scripts/maturity_sweep_file_lane.py": {
     "counts": {
@@ -1187,6 +1212,12 @@
       "UNGUARDED_INDEX": 2
     },
     "score": 4
+  },
+  "scripts/purge_content_ops_deflection_reports.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
   },
   "scripts/rag_learning.py": {
     "counts": {
@@ -1420,6 +1451,12 @@
       "SWALLOWED_EXCEPT": 1
     },
     "score": 11
+  },
+  "scripts/score_deflection_pii_recall.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 1
+    },
+    "score": 2
   },
   "scripts/seed_content_ops_faq_saas_demo.py": {
     "counts": {
@@ -1812,6 +1849,13 @@
     "score": 7
   },
   "scripts/start_invoicing_readonly_oauth_server.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 7
+  },
+  "scripts/summarize_maturity_sweep_baselines.py": {
     "counts": {
       "NO_RAISES_TESTS": 1,
       "UNGUARDED_INDEX": 2

--- a/tests/test_maturity_sweep.py
+++ b/tests/test_maturity_sweep.py
@@ -126,6 +126,207 @@ def test_unguarded_boundary_input_detector_fires_and_guarded_is_quiet() -> None:
     assert "UNGUARDED_INPUT" not in {f.code for f in guarded}
 
 
+def test_internal_mock_detector_attaches_to_mocked_first_party_module(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    module = lane / "extracted_content_pipeline" / "faq_deflection_report.py"
+    _write(module, "def build():\n    return []\n")
+    _write(
+        tests / "test_report.py",
+        "from unittest import mock\n\n"
+        "def test_internal_patch():\n"
+        "    with mock.patch('extracted_content_pipeline.faq_deflection_report.build'):\n"
+        "        pass\n\n"
+        "def test_external_patch():\n"
+        "    with mock.patch('httpx.post'):\n"
+        "        pass\n",
+    )
+
+    results = MOD.sweep(lane, tests)
+    result = next(item for item in results if item.path == str(module))
+
+    assert result.counts["INTERNAL_MOCK"] == 1
+    assert any(
+        finding.code == "INTERNAL_MOCK"
+        and "extracted_content_pipeline.faq_deflection_report.build" in finding.detail
+        for finding in result.findings
+    )
+
+
+def test_internal_mock_detector_handles_monkeypatch_module_targets(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    module = lane / "atlas_brain" / "api" / "billing.py"
+    _write(module, "def mark_paid():\n    return True\n")
+    _write(
+        tests / "test_billing.py",
+        "from unittest.mock import MagicMock\n"
+        "from atlas_brain.api import billing\n\n"
+        "def test_internal_monkeypatch(monkeypatch):\n"
+        "    monkeypatch.setattr(billing, 'mark_paid', MagicMock())\n",
+    )
+
+    results = MOD.sweep(lane, tests)
+    result = next(item for item in results if item.path == str(module))
+
+    assert result.counts["INTERNAL_MOCK"] == 1
+
+
+def test_internal_mock_detector_handles_patch_object_module_targets(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    module = lane / "atlas_brain" / "api" / "billing.py"
+    _write(module, "def mark_paid():\n    return True\n")
+    _write(
+        tests / "test_billing.py",
+        "from unittest.mock import patch\n"
+        "from atlas_brain.api import billing\n\n"
+        "def test_internal_patch_object():\n"
+        "    with patch.object(billing, 'mark_paid'):\n"
+        "        pass\n",
+    )
+
+    results = MOD.sweep(lane, tests)
+    result = next(item for item in results if item.path == str(module))
+
+    assert result.counts["INTERNAL_MOCK"] == 1
+    assert any(
+        finding.code == "INTERNAL_MOCK"
+        and "atlas_brain.api.billing.mark_paid" in finding.detail
+        and "patch.object" in finding.detail
+        for finding in result.findings
+    )
+
+
+def test_internal_mock_detector_covers_blocking_extracted_roots(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    module = lane / "extracted_competitive_intelligence" / "worker.py"
+    _write(module, "def run():\n    return True\n")
+    _write(
+        tests / "test_competitive_worker.py",
+        "from unittest.mock import patch\n\n"
+        "def test_internal_patch():\n"
+        "    with patch('extracted_competitive_intelligence.worker.run'):\n"
+        "        pass\n",
+    )
+
+    results = MOD.sweep(lane, tests)
+    result = next(item for item in results if item.path == str(module))
+
+    assert result.counts["INTERNAL_MOCK"] == 1
+
+
+def test_internal_mock_detector_allows_wall_clock_and_randomness_seams(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    module = lane / "atlas_brain" / "jobs" / "scheduler.py"
+    _write(module, "import time\nimport random\n\ndef jitter():\n    return time.perf_counter() + random.random()\n")
+    _write(
+        tests / "test_scheduler.py",
+        "from atlas_brain.jobs import scheduler\n\n"
+        "def test_clock_and_randomness(monkeypatch):\n"
+        "    monkeypatch.setattr(scheduler.time, 'perf_counter', lambda: 1.0)\n"
+        "    monkeypatch.setattr(scheduler.random, 'random', lambda: 0.5)\n",
+    )
+
+    results = MOD.sweep(lane, tests)
+    result = next(item for item in results if item.path == str(module))
+
+    assert "INTERNAL_MOCK" not in result.counts
+
+
+def test_internal_mock_detector_keeps_no_asname_dotted_import_external_seam(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    module = lane / "extracted_content_pipeline" / "api" / "control_surfaces.py"
+    _write(module, "import socket\n\ndef resolve():\n    return socket.getaddrinfo\n")
+    _write(
+        tests / "test_control_surfaces.py",
+        "import extracted_content_pipeline.api.control_surfaces\n\n"
+        "def test_external_socket_monkeypatch(monkeypatch):\n"
+        "    monkeypatch.setattr(\n"
+        "        extracted_content_pipeline.api.control_surfaces.socket,\n"
+        "        'getaddrinfo',\n"
+        "        lambda *a: [],\n"
+        "    )\n",
+    )
+
+    results = MOD.sweep(lane, tests)
+    result = next(item for item in results if item.path == str(module))
+
+    assert "INTERNAL_MOCK" not in result.counts
+
+
+def test_internal_mock_detector_indexes_package_init_exports(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    module = lane / "atlas_brain" / "auth" / "__init__.py"
+    _write(module, "def require_auth():\n    return True\n")
+    _write(
+        tests / "test_auth_package.py",
+        "from unittest.mock import patch\n\n"
+        "def test_package_export_patch():\n"
+        "    with patch('atlas_brain.auth.require_auth'):\n"
+        "        pass\n",
+    )
+
+    results = MOD.sweep(lane, tests)
+    result = next(item for item in results if item.path == str(module))
+
+    assert result.counts["INTERNAL_MOCK"] == 1
+
+
+def test_internal_mock_detector_allows_imported_external_seams(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    module = lane / "extracted_content_pipeline" / "api" / "control_surfaces.py"
+    _write(module, "import socket\n\ndef resolve():\n    return socket.getaddrinfo\n")
+    _write(
+        tests / "test_control_surfaces.py",
+        "from extracted_content_pipeline.api import control_surfaces\n\n"
+        "def test_external_socket_monkeypatch(monkeypatch):\n"
+        "    monkeypatch.setattr(control_surfaces.socket, 'getaddrinfo', lambda *a: [])\n",
+    )
+
+    results = MOD.sweep(lane, tests)
+    result = next(item for item in results if item.path == str(module))
+
+    assert "INTERNAL_MOCK" not in result.counts
+
+
+def test_internal_mock_ratchet_fails_on_new_mock_target(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    tests = tmp_path / "tests"
+    _write(
+        lane / "scripts" / "build_content_ops_deflection_report.py",
+        "def main():\n    return 0\n",
+    )
+    _write(tests / "test_report.py", "def test_clean():\n    assert True\n")
+    baseline = tmp_path / "baseline.json"
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--update-baseline",
+    ]) == 0
+    _write(
+        tests / "test_report.py",
+        "from unittest.mock import patch\n\n"
+        "def test_internal_patch():\n"
+        "    with patch('scripts.build_content_ops_deflection_report.main'):\n"
+        "        pass\n",
+    )
+
+    assert MOD.main([
+        str(lane),
+        "--tests-root", str(tests),
+        "--baseline", str(baseline),
+        "--min-score", "99",
+    ]) == 1
+
+
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")


### PR DESCRIPTION
Plan: plans/PR-Maturity-Sweep-Internal-Mock-Ratchet.md
Slice phase: Workflow/process

Adds a blocking `INTERNAL_MOCK` ratchet to maturity-sweep so first-party test mocks are attached to the production module they mock and fail future PRs when the count increases. This update fixes review findings by covering `patch.object(first_party_module, "attr")`, refreshing the missed `atlas_brain/skills` baseline, documenting the baseline accounting, and closing the second-round detector precision gaps.

## Intentional
- Existing internal-mock debt is accepted in baselines so the gate is green on arrival and fails only on new debt.
- Baseline accounting: 227 changed baseline entries; 195 are `INTERNAL_MOCK`-only, and the remaining 32 are disclosed ratchet refresh/self-score/current-baseline catch-up rather than hidden detector scope.
- Gated extracted-package roots are now first-party targets; sanctioned wall-clock/randomness seams stay external; dotted no-asname imports and package `__init__.py` exports resolve correctly.
- Bare `MagicMock()` without a static first-party target is not attributed in this slice.

## Deferred
- Dynamic target inference for runtime-built patch strings.
- Burn-down of existing internal mocks after the ratchet is in place.
- Bare `MagicMock()` attribution when no static first-party target is present.

## Parked hardening
- None.

## AI reconciliation
All fixed or waived: Yes.
- Codex package `__init__` target mapping finding: fixed by indexing `__init__.py` under both `package.__init__` and `package`, with `test_internal_mock_detector_indexes_package_init_exports`.
- Codex wall-clock/randomness seam finding: fixed by adding `time`, `datetime`, `random`, `monotonic`, and `perf_counter` to the external seam allowlist, with `test_internal_mock_detector_allows_wall_clock_and_randomness_seams`.
- Reviewer/Codex extracted-root, dotted-import, and `patch.object` findings: fixed with targeted resolver changes and regression tests.

## Verification
- `python -m pytest tests/test_maturity_sweep.py tests/test_maturity_sweep_file_lane.py --noconftest -q` - 28 passed.
- Core maturity ratchet gates for extracted packages and scripts, including newly enforced C1-C3 roots - passed.
- Atlas-brain workflow matrix ratchet gates, including `atlas_brain/skills` - passed.
- Deflection explicit-file and AI content-ops explicit-file ratchet gates - passed.
- `bash scripts/local_pr_review.sh --allow-dirty` - passed.

## Diff size
31 files, +1335 / -206.
