### PR TITLE
Burn down billing internal DB-pool mocks

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
@@ -14,7 +14,12 @@ on:
       - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
       - "atlas_brain/config.py"
+      - "atlas_brain/storage/migrations/076_saas_accounts.sql"
+      - "atlas_brain/storage/migrations/078_billing_events.sql"
+      - "atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql"
+      - "atlas_brain/storage/migrations/331_content_ops_deflection_report_delivery_email.sql"
       - "atlas_brain/storage/migrations/332_content_ops_deflection_report_deliveries.sql"
+      - "atlas_brain/storage/migrations/342_content_ops_deflection_checkout_authorization.sql"
       - "atlas_brain/config_defaults.py"
       - "atlas_brain/content_ops_deflection_incidents.py"
       - "atlas_brain/mcp/content_ops_deflection_readonly_server.py"
@@ -38,7 +43,12 @@ on:
       - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
       - "atlas_brain/config.py"
+      - "atlas_brain/storage/migrations/076_saas_accounts.sql"
+      - "atlas_brain/storage/migrations/078_billing_events.sql"
+      - "atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql"
+      - "atlas_brain/storage/migrations/331_content_ops_deflection_report_delivery_email.sql"
       - "atlas_brain/storage/migrations/332_content_ops_deflection_report_deliveries.sql"
+      - "atlas_brain/storage/migrations/342_content_ops_deflection_checkout_authorization.sql"
       - "atlas_brain/config_defaults.py"
       - "atlas_brain/content_ops_deflection_incidents.py"
       - "atlas_brain/mcp/content_ops_deflection_readonly_server.py"
@@ -54,6 +64,22 @@ on:
 jobs:
   atlas-content-ops-deflection-stripe-paid-checks:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16@sha256:081f1bc7bd5e143dbb6e487b710bbc27712cdcfaced4c071b8e47349aa1b4171
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas_migration_tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas -d atlas_migration_tests"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -68,7 +94,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          python -m pip install pytest pytest-asyncio
+          python -m pip install asyncpg pytest pytest-asyncio
 
       - name: Run Content Ops deflection Stripe paid tests
         run: |

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -10,6 +10,7 @@ from hashlib import sha256
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.params import Depends as DependsMarker
 from pydantic import BaseModel
 
 from ..auth.dependencies import AuthUser, require_auth
@@ -169,6 +170,16 @@ def _get_stripe():
     return _configure_stripe_module(stripe, cfg.stripe_secret_key)
 
 
+def _billing_db_pool() -> Any:
+    return get_db_pool()
+
+
+def _resolve_billing_db_pool(pool: Any) -> Any:
+    if isinstance(pool, DependsMarker):
+        return _billing_db_pool()
+    return pool
+
+
 # -- Request/Response schemas --
 
 PLAN_NAME_TO_CONFIG_KEY = {
@@ -215,10 +226,14 @@ class BillingStatus(BaseModel):
 # -- Endpoints --
 
 @router.post("/checkout", response_model=CheckoutResponse)
-async def create_checkout(req: CheckoutRequest, user: AuthUser = Depends(require_auth)):
+async def create_checkout(
+    req: CheckoutRequest,
+    user: AuthUser = Depends(require_auth),
+    pool: Any = Depends(_billing_db_pool),
+):
     """Create a Stripe Checkout session for plan upgrade."""
     stripe = _get_stripe()
-    pool = get_db_pool()
+    pool = _resolve_billing_db_pool(pool)
     acct_uuid = _uuid.UUID(user.account_id)
     user_uuid = _uuid.UUID(user.user_id)
 
@@ -314,13 +329,17 @@ async def create_checkout(req: CheckoutRequest, user: AuthUser = Depends(require
 
 
 @router.post("/portal", response_model=PortalResponse)
-async def create_portal(req: PortalRequest, user: AuthUser = Depends(require_auth)):
+async def create_portal(
+    req: PortalRequest,
+    user: AuthUser = Depends(require_auth),
+    pool: Any = Depends(_billing_db_pool),
+):
     """Create a Stripe Customer Portal session."""
     if user.role not in ("owner", "admin"):
         raise HTTPException(status_code=403, detail="Only account owner/admin can manage billing")
 
     stripe = _get_stripe()
-    pool = get_db_pool()
+    pool = _resolve_billing_db_pool(pool)
 
     customer_id = await pool.fetchval(
         "SELECT stripe_customer_id FROM saas_accounts WHERE id = $1",
@@ -339,9 +358,12 @@ async def create_portal(req: PortalRequest, user: AuthUser = Depends(require_aut
 
 
 @router.get("/status", response_model=BillingStatus)
-async def billing_status(user: AuthUser = Depends(require_auth)):
+async def billing_status(
+    user: AuthUser = Depends(require_auth),
+    pool: Any = Depends(_billing_db_pool),
+):
     """Get current billing status for the account."""
-    pool = get_db_pool()
+    pool = _resolve_billing_db_pool(pool)
     row = await pool.fetchrow(
         """
         SELECT plan, plan_status, asin_limit, trial_ends_at, stripe_customer_id
@@ -364,7 +386,10 @@ async def billing_status(user: AuthUser = Depends(require_auth)):
 # -- Stripe Webhook --
 
 @webhook_router.post("/webhooks/stripe")
-async def stripe_webhook(request: Request):
+async def stripe_webhook(
+    request: Request,
+    pool: Any = Depends(_billing_db_pool),
+):
     """Handle Stripe webhook events."""
     cfg = settings.saas_auth
     if not cfg.stripe_secret_key:
@@ -395,7 +420,7 @@ async def stripe_webhook(request: Request):
         logger.warning("Stripe webhook signature verification failed: %s", e)
         raise HTTPException(status_code=400, detail="Invalid signature")
 
-    pool = get_db_pool()
+    pool = _resolve_billing_db_pool(pool)
     if not pool.is_initialized:
         raise HTTPException(status_code=503, detail="Database not ready")
 

--- a/plans/PR-Billing-Internal-Mock-Burndown.md
+++ b/plans/PR-Billing-Internal-Mock-Burndown.md
@@ -1,0 +1,130 @@
+# PR-Billing-Internal-Mock-Burndown
+
+## Why this slice exists
+
+Issue #1879 made first-party mocks visible through the maturity sweep. The
+first high-severity debt burn-down target is `atlas_brain/api/billing.py`
+because it is the money path and currently carries `INTERNAL_MOCK x62` in
+`tests/maturity_sweep/baseline_atlas_brain_api.json`.
+
+Root cause: billing route/webhook coverage leaned on hand-written pool fakes
+that record SQL calls and return canned command tags. The earlier first pass
+only moved those fakes from `monkeypatch(get_db_pool)` into direct function
+arguments, which lowered the detector count without removing the fake. This
+revision fixes the root for one representative checkout-paid path: it replaces
+that fake with a live asyncpg/Postgres adapter and asserts persisted report,
+delivery, and billing-event state. Existing fake tests remain detector-visible
+until they are replaced by real adapter coverage in later slices.
+
+This slice is slightly over the 400 LOC soft cap because the fix must include
+the live Postgres test harness and workflow service enrollment in the same PR;
+shipping only the DI seam or only the test would recreate the detector-evasion
+gap the review flagged.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Add an explicit billing DB-pool dependency seam used by checkout, portal,
+   status, and Stripe webhook routes.
+2. Replace one fake-pool checkout-paid webhook test with a live asyncpg-backed
+   integration test that asserts durable state, not SQL call arguments.
+3. Add the pinned Postgres service/env to the billing Stripe-paid workflow so
+   the live test runs in CI.
+4. Refresh the atlas-brain API maturity baseline to the earned lower
+   `billing.py` `INTERNAL_MOCK` floor.
+5. Max files: 7.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Billing routes still call the same production `get_db_pool()` path through
+    the new dependency.
+  - Existing fake-pool tests stay visible to the ratchet; they are not
+    relocated into an uncounted argument shape.
+  - The new checkout-paid webhook integration test uses a live asyncpg pool and
+    asserts persisted report/delivery/billing-event rows.
+  - Stripe remains an external seam in tests; Checkout Session and webhook
+    behavior is unchanged.
+  - The maturity baseline for `atlas_brain/api/billing.py` decreases only by
+    the fake test replaced with live coverage.
+- Affected surfaces:
+  - `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml`
+  - `atlas_brain/api/billing.py`
+  - focused billing tests
+  - `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- Risk areas:
+  - Stripe Checkout metadata/idempotency behavior.
+  - Stripe webhook signature verification and idempotency.
+  - FastAPI direct-call tests accidentally receiving a `Depends` sentinel
+    instead of a pool.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R13, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml`
+- `atlas_brain/api/billing.py`
+- `plans/PR-Billing-Internal-Mock-Burndown.md`
+- `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+- Add a `_billing_db_pool()` dependency wrapper that returns the existing
+  `get_db_pool()` result. Production still uses the same database adapter.
+- Thread `pool=Depends(_billing_db_pool)` into the billing endpoints that read
+  the pool at route time.
+- Add `_resolve_billing_db_pool()` so direct function tests that omit the
+  dependency parameter still resolve the same production getter. That keeps
+  their existing fake-pool monkeypatches visible to the `INTERNAL_MOCK`
+  detector until those tests are actually replaced.
+- Replace the fake checkout-paid webhook route test with a live Postgres test
+  that applies the required migrations, saves a report through the
+  `PostgresDeflectionReportArtifactStore`, runs the signed webhook path, and
+  asserts the report is paid, a delivery row exists, and the Stripe event is
+  idempotently recorded.
+- Add a pinned `postgres:16` service to the billing Stripe-paid workflow.
+- Refresh only the relevant maturity baseline after the real test replacement.
+
+## Intentional
+
+- Stripe SDK remains faked in unit tests because it is the external transport
+  seam; this slice is about first-party billing DB adapter fakes.
+- Existing settings overrides and remaining fake-pool tests are left for later
+  slices. The remaining fakes are intentionally still visible to the detector.
+- No production SQL or Stripe behavior changes are intended.
+- The Stripe planner MCP was checked but failed with a missing `mcp_session_id`;
+  this plan uses the local Stripe billing/security references instead.
+
+## Deferred
+
+- Continue replacing the remaining fake-pool webhook tests with live
+  asyncpg-backed state assertions in follow-up slices.
+- Burn down billing settings/config `INTERNAL_MOCK` entries after the DB-pool
+  fake class is drained.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: Python compile check for `atlas_brain/api/billing.py`,
+  `tests/test_atlas_billing_stripe_hardening.py`,
+  `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`, and
+  `tests/test_atlas_billing_content_ops_deflection_paid_flow.py` - passed.
+- Command: `python -m pytest tests/test_atlas_billing_stripe_hardening.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 68 passed, 1 skipped, 1 existing torch/pynvml warning.
+- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_live_postgres_marks_deflection_report_paid_and_idempotent -q` - 1 passed, 1 existing torch/pynvml warning.
+- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_stripe_hardening.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 69 passed, 1 existing torch/pynvml warning.
+- Command: `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x59`, score 262.
+- Pending before push: `bash scripts/push_pr.sh <pr-body-file>`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml` | 28 |
+| `atlas_brain/api/billing.py` | 41 |
+| `plans/PR-Billing-Internal-Mock-Burndown.md` | 130 |
+| `tests/maturity_sweep/baseline_atlas_brain_api.json` | 4 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 234 |
+| **Total** | **437** |

--- a/tests/maturity_sweep/baseline_atlas_brain_api.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_api.json
@@ -120,11 +120,11 @@
   },
   "atlas_brain/api/billing.py": {
     "counts": {
-      "INTERNAL_MOCK": 62,
+      "INTERNAL_MOCK": 59,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 3
     },
-    "score": 274
+    "score": 262
   },
   "atlas_brain/api/blog_admin.py": {
     "counts": {

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import time
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -13,6 +15,19 @@ from atlas_brain.api import billing
 from atlas_brain.content_ops_deflection_incidents import INCIDENT_LOG_MARKER
 from extracted_content_pipeline.deflection_report_access import (
     InMemoryDeflectionReportArtifactStore,
+    PostgresDeflectionReportArtifactStore,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = ROOT / "atlas_brain" / "storage" / "migrations"
+_LIVE_BILLING_MIGRATIONS = (
+    "076_saas_accounts.sql",
+    "078_billing_events.sql",
+    "328_content_ops_deflection_reports.sql",
+    "331_content_ops_deflection_report_delivery_email.sql",
+    "332_content_ops_deflection_report_deliveries.sql",
+    "342_content_ops_deflection_checkout_authorization.sql",
 )
 
 
@@ -25,6 +40,73 @@ def _incident_payloads(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]
         if INCIDENT_LOG_MARKER in message:
             payloads.append(json.loads(message.split(INCIDENT_LOG_MARKER, 1)[1].strip()))
     return payloads
+
+
+class _InitializedAsyncpgPool:
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+        self.is_initialized = True
+
+    async def execute(self, query: str, *args: Any) -> str:
+        return await self._pool.execute(query, *args)
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        return await self._pool.fetchval(query, *args)
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        return await self._pool.fetchrow(query, *args)
+
+    async def fetch(self, query: str, *args: Any) -> list[Any]:
+        return await self._pool.fetch(query, *args)
+
+    async def close(self) -> None:
+        await self._pool.close()
+
+
+async def _connect_live_billing_pool() -> _InitializedAsyncpgPool:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_MIGRATION_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_MIGRATION_TEST_DATABASE_URL not set")
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+    return _InitializedAsyncpgPool(pool)
+
+
+async def _apply_live_billing_migrations(pool: _InitializedAsyncpgPool) -> None:
+    for migration in _LIVE_BILLING_MIGRATIONS:
+        await pool.execute((MIGRATIONS_DIR / migration).read_text())
+
+
+async def _cleanup_live_billing_rows(
+    pool: _InitializedAsyncpgPool,
+    *,
+    account_id: str,
+    request_id: str,
+    stripe_event_id: str,
+) -> None:
+    account_uuid = uuid.UUID(account_id)
+    await pool.execute(
+        "DELETE FROM billing_events WHERE account_id = $1 OR stripe_event_id = $2",
+        account_uuid,
+        stripe_event_id,
+    )
+    await pool.execute(
+        """
+        DELETE FROM content_ops_deflection_report_deliveries
+        WHERE account_id = $1 AND request_id = $2
+        """,
+        account_id,
+        request_id,
+    )
+    await pool.execute(
+        """
+        DELETE FROM content_ops_deflection_reports
+        WHERE account_id = $1 AND request_id = $2
+        """,
+        account_id,
+        request_id,
+    )
+    await pool.execute("DELETE FROM saas_accounts WHERE id = $1", account_uuid)
 
 
 class _Pool:
@@ -398,7 +480,7 @@ async def _run_stripe_webhook(
     monkeypatch: pytest.MonkeyPatch,
     *,
     event: Any,
-    pool: _Pool,
+    pool: Any,
     stripe_module: Any,
     entitlement_store: InMemoryDeflectionReportArtifactStore | None = None,
 ) -> dict[str, Any]:
@@ -1318,67 +1400,113 @@ async def test_delta_invoice_lifecycle_uses_real_store_and_ignores_stale_events(
 
 
 @pytest.mark.asyncio
-async def test_stripe_webhook_routes_deflection_checkout_to_paid_gate(
+@pytest.mark.integration
+async def test_stripe_webhook_live_postgres_marks_deflection_report_paid_and_idempotent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id)
+    request_id = "req-live-paid"
+    stripe_event_id = "evt_deflection_paid_live"
+    session_id = "cs_test_deflection_live"
+    session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
+    )
     event = SimpleNamespace(
-        id="evt_deflection_paid",
+        id=stripe_event_id,
         type="checkout.session.completed",
         data=SimpleNamespace(object=session),
     )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.execute(
+            """
+            INSERT INTO saas_accounts (id, name)
+            VALUES ($1, $2)
+            """,
+            uuid.UUID(account_id),
+            "Live billing test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        await store.save_report(
+            account_id=account_id,
+            request_id=request_id,
+            snapshot={"summary": {"generated": 1}},
+            artifact={"report_model": {"schema_version": "test"}},
+            delivery_email="buyer@example.com",
+        )
 
-    class _Webhook:
-        @staticmethod
-        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
-            return event
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
-    pool = _Pool()
-    pool.add_report(account_id=account_id)
-    request = SimpleNamespace(
-        headers={"stripe-signature": "valid"},
-        body=lambda: _body(),
-    )
+        assert response == {"status": "ok"}
+        assert fake_stripe.api_key == "sk_test"
+        assert fake_stripe.api_version == billing.STRIPE_API_VERSION
+        report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["payment_reference"] == session_id
+        delivery = await pool.fetchrow(
+            """
+            SELECT payment_reference, delivery_status
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert delivery is not None
+        assert delivery["payment_reference"] == session_id
+        assert delivery["delivery_status"] == "pending"
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM billing_events
+            WHERE stripe_event_id = $1 AND event_type = $2
+            """,
+            stripe_event_id,
+            "checkout.session.completed",
+        ) == 1
 
-    async def _body() -> bytes:
-        return b"{}"
-
-    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
-    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
-    monkeypatch.setattr(
-        billing.settings.saas_auth,
-        "stripe_webhook_secret",
-        "whsec_test",
-    )
-    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
-
-    response = await billing.stripe_webhook(request)
-
-    assert response == {"status": "ok"}
-    assert fake_stripe.api_key == "sk_test"
-    assert fake_stripe.api_version == billing.STRIPE_API_VERSION
-    assert pool.fetchval_calls[0][1] == ("evt_deflection_paid",)
-    update_query, update_args = pool.execute_calls[0]
-    delivery_query, delivery_args = pool.execute_calls[1]
-    insert_query, insert_args = pool.execute_calls[2]
-    assert "UPDATE content_ops_deflection_reports" in update_query
-    assert update_args == (
-        account_id,
-        "req-123",
-        "cs_test_deflection",
-        150000,
-        "usd",
-        False,
-    )
-    assert "INSERT INTO content_ops_deflection_report_deliveries" in delivery_query
-    assert delivery_args == (account_id, "req-123", "cs_test_deflection")
-    assert "INSERT INTO billing_events" in insert_query
-    assert insert_args[0] is None
-    assert insert_args[1] == "evt_deflection_paid"
-    assert insert_args[2] == "checkout.session.completed"
-    assert pool.processed_event_ids == {"evt_deflection_paid"}
+        assert await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        ) == {"status": "already_processed"}
+        assert await pool.fetchval(
+            "SELECT COUNT(*) FROM billing_events WHERE stripe_event_id = $1",
+            stripe_event_id,
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Internal-Mock-Burndown.md
Slice phase: Production hardening

Billing is the first high-severity INTERNAL_MOCK burn-down target after #1886 because it is the money path and currently carried `INTERNAL_MOCK x62`. This slice keeps the new DB-pool dependency seam, but fixes the first-pass review miss: it replaces one fake-pool checkout-paid webhook test with a live asyncpg/Postgres test that asserts persisted report, delivery, and billing-event state. Existing fake-pool tests remain detector-visible until they are actually replaced.

## Intentional
- Stripe SDK remains mocked at the external transport seam; no Stripe API behavior changes are intended.
- Existing billing settings/config overrides and remaining fake-pool tests are deferred to follow-up burn-down slices.
- No production SQL, Checkout Session metadata, idempotency, or webhook signature behavior changes are intended.
- Stripe planner MCP was checked but failed with a missing `mcp_session_id`; local Stripe billing/security references were used instead.

## Deferred
- Continue replacing remaining fake-pool webhook tests with live asyncpg-backed state assertions.
- Burn down remaining billing settings/config `INTERNAL_MOCK` entries after the DB-pool fake class is drained.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/api/billing.py tests/test_atlas_billing_stripe_hardening.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py` - passed.
- `python -m pytest tests/test_atlas_billing_stripe_hardening.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 68 passed, 1 skipped, 1 existing torch/pynvml warning.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_live_postgres_marks_deflection_report_paid_and_idempotent -q` - 1 passed, 1 existing torch/pynvml warning.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_stripe_hardening.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 69 passed, 1 existing torch/pynvml warning.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x59`, score 262.

## Diff size
5 files, +373 / -64
