### PR TITLE
Convert async-success billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Async-Success-Live-Adapter.md
+++ b/plans/PR-Billing-Async-Success-Live-Adapter.md
@@ -1,0 +1,89 @@
+# PR-Billing-Async-Success-Live-Adapter
+
+## Why this slice exists
+
+The real-adapters/test-quality lane is burning down billing fake-pool debt only
+when the fake is actually removed. #1887 established the template: keep Stripe
+mocked at the external SDK/signature boundary, but run the application webhook
+against a real asyncpg/Postgres adapter and assert persisted state.
+
+Root cause: the async-payment-succeeded deflection webhook test still uses the
+hand-written `_Pool` fake and verifies SQL call records (`execute_calls`) instead
+of observable database state. That can pass while the real payment persistence
+path is broken. This PR fixes that root for one thin webhook path rather than
+relocating the fake into an uncounted injection shape.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert the
+   `checkout.session.async_payment_succeeded` deflection webhook route test from
+   `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness introduced
+   in #1887.
+2. Ratchet `atlas_brain/api/billing.py` INTERNAL_MOCK only by the earned count
+   from that removed fake-pool test.
+3. Leave the remaining fake-pool tests detector-visible for later slices.
+
+### Review Contract
+
+- The converted test uses the real asyncpg pool wrapper, applies the live
+  billing migrations, seeds `saas_accounts` and a real deflection report row,
+  and cleans up in `finally`.
+- The test asserts persisted effects: paid report row, queued delivery row,
+  billing event insert, and idempotent re-delivery.
+- Stripe remains mocked only at the external SDK/webhook-construction boundary.
+- No consumer hand-editing or fake relocation counts as burn-down.
+
+### Files touched
+
+- `plans/PR-Billing-Async-Success-Live-Adapter.md`
+- `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Reuse the live billing helpers added in #1887:
+
+1. Build the existing async-success Stripe event fixture.
+2. Connect to `ATLAS_MIGRATION_TEST_DATABASE_URL` through asyncpg, then apply
+   the billing migrations required by the webhook path.
+3. Seed `saas_accounts` plus a saved deflection report via
+   `PostgresDeflectionReportArtifactStore`.
+4. Call the real `billing.stripe_webhook` entrypoint through
+   `_run_stripe_webhook`, with Stripe still faked at the SDK module boundary.
+5. Assert the real tables show the paid report, pending delivery, one billing
+   event, and idempotent duplicate handling.
+
+## Intentional
+
+- This does not attempt a broad test rewrite. The lane is intentionally
+  ratcheted one fake-pool case at a time so every baseline drop is reviewable.
+- The remaining `_Pool` tests stay as-is and stay counted by the maturity sweep
+  until their own live-adapter slices land.
+
+## Deferred
+
+- Remaining billing fake-pool webhook tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_routes_deflection_async_success_to_paid_gate -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 56 passed / 2 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x56`, score 250.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Async-Success-Live-Adapter.md` | 89 |
+| `tests/maturity_sweep/baseline_atlas_brain_api.json` | 4 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 143 |
+| **Total** | **236** |

--- a/tests/maturity_sweep/baseline_atlas_brain_api.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_api.json
@@ -120,11 +120,11 @@
   },
   "atlas_brain/api/billing.py": {
     "counts": {
-      "INTERNAL_MOCK": 59,
+      "INTERNAL_MOCK": 56,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 3
     },
-    "score": 262
+    "score": 250
   },
   "atlas_brain/api/blog_admin.py": {
     "counts": {

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1510,70 +1510,113 @@ async def test_stripe_webhook_live_postgres_marks_deflection_report_paid_and_ide
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_routes_deflection_async_success_to_paid_gate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     account_id = str(uuid.uuid4())
+    request_id = "req-live-async-success"
+    stripe_event_id = "evt_deflection_async_success_live"
+    session_id = "cs_test_deflection_async_success_live"
     session = _session(
         account_id=account_id,
-        session_id="cs_test_deflection_async_success",
+        request_id=request_id,
+        session_id=session_id,
     )
     event = SimpleNamespace(
-        id="evt_deflection_async_success",
+        id=stripe_event_id,
         type="checkout.session.async_payment_succeeded",
         data=SimpleNamespace(object=session),
     )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.execute(
+            """
+            INSERT INTO saas_accounts (id, name)
+            VALUES ($1, $2)
+            """,
+            uuid.UUID(account_id),
+            "Live async success billing test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        await store.save_report(
+            account_id=account_id,
+            request_id=request_id,
+            snapshot={"summary": {"generated": 1}},
+            artifact={"report_model": {"schema_version": "test"}},
+            delivery_email="buyer@example.com",
+        )
 
-    class _Webhook:
-        @staticmethod
-        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
-            return event
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
-    pool = _Pool()
-    pool.add_report(account_id=account_id)
-    request = SimpleNamespace(
-        headers={"stripe-signature": "valid"},
-        body=lambda: _body(),
-    )
+        assert response == {"status": "ok"}
+        assert fake_stripe.api_key == "sk_test"
+        assert fake_stripe.api_version == billing.STRIPE_API_VERSION
+        report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["payment_reference"] == session_id
+        delivery = await pool.fetchrow(
+            """
+            SELECT payment_reference, delivery_status
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert delivery is not None
+        assert delivery["payment_reference"] == session_id
+        assert delivery["delivery_status"] == "pending"
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM billing_events
+            WHERE stripe_event_id = $1 AND event_type = $2
+            """,
+            stripe_event_id,
+            "checkout.session.async_payment_succeeded",
+        ) == 1
 
-    async def _body() -> bytes:
-        return b"{}"
-
-    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
-    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
-    monkeypatch.setattr(
-        billing.settings.saas_auth,
-        "stripe_webhook_secret",
-        "whsec_test",
-    )
-    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
-
-    response = await billing.stripe_webhook(request)
-
-    assert response == {"status": "ok"}
-    update_query, update_args = pool.execute_calls[0]
-    delivery_query, delivery_args = pool.execute_calls[1]
-    insert_query, insert_args = pool.execute_calls[2]
-    assert "UPDATE content_ops_deflection_reports" in update_query
-    assert update_args == (
-        account_id,
-        "req-123",
-        "cs_test_deflection_async_success",
-        150000,
-        "usd",
-        False,
-    )
-    assert "INSERT INTO content_ops_deflection_report_deliveries" in delivery_query
-    assert delivery_args == (
-        account_id,
-        "req-123",
-        "cs_test_deflection_async_success",
-    )
-    assert "INSERT INTO billing_events" in insert_query
-    assert insert_args[1] == "evt_deflection_async_success"
-    assert insert_args[2] == "checkout.session.async_payment_succeeded"
-    assert pool.processed_event_ids == {"evt_deflection_async_success"}
+        assert await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        ) == {"status": "already_processed"}
+        assert await pool.fetchval(
+            "SELECT COUNT(*) FROM billing_events WHERE stripe_event_id = $1",
+            stripe_event_id,
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Async-Success-Live-Adapter.md
Slice phase: Production hardening

Convert the `checkout.session.async_payment_succeeded` deflection webhook route test from the hand-written billing `_Pool` fake to the live asyncpg/Postgres harness introduced in #1887. This keeps Stripe mocked at the external SDK/webhook-construction boundary, but asserts the app's real persisted effects instead of SQL call records. The maturity baseline drops only by the earned `billing.py` INTERNAL_MOCK count: x59 -> x56, score 262 -> 250.

## Intentional
- This is one fake-pool burn-down, not a broad billing test rewrite.
- Remaining billing fake-pool tests stay detector-visible until their own live-adapter slices land.

## Deferred
- Remaining billing fake-pool webhook tests and the temporary `_resolve_billing_db_pool` direct-call shim are deferred to follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_routes_deflection_async_success_to_paid_gate -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 56 passed / 2 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x56`, score 250.

## Diff size
3 files, +184 / -52
