### PR TITLE
Convert async-failure billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Async-Failure-Live-Adapter.md
+++ b/plans/PR-Billing-Async-Failure-Live-Adapter.md
@@ -1,0 +1,97 @@
+# PR-Billing-Async-Failure-Live-Adapter
+
+## Why this slice exists
+
+The real-adapters/test-quality lane is burning down billing fake-pool debt only
+when fake database behavior is replaced by real persisted-state verification.
+#1887 and #1888 proved the paid checkout routes with live asyncpg/Postgres tests;
+the adjacent async-payment-failed safety boundary still uses the hand-written
+`_Pool` fake and SQL-call assertions.
+
+Root cause: the failure-path test verifies that `_Pool.execute_calls` contains a
+billing-event insert and that the fake in-memory report row remains unpaid. That
+does not prove the real webhook keeps a failed async payment from unlocking a
+report or queueing delivery. This PR fixes that root for one failure path and
+adds small shared live helpers so the paid-state contract from #1887/#1888 does
+not drift as more event types convert.
+
+Diff-size note: this lands slightly over the 400 LOC soft cap because it pairs
+one fake-pool conversion with the small helper extraction the #1888 review
+flagged before adding a third copy of the same live paid-state assertions. The
+work remains single-file test code plus the earned baseline update.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_deflection_async_failure_is_observed_without_unlock`
+   from `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Add focused live helper functions for seeding deflection report rows and
+   asserting paid persisted state, then reuse them in the existing two live paid
+   tests.
+3. Ratchet `atlas_brain/api/billing.py` INTERNAL_MOCK only by the earned count
+   from the removed fake-pool failure-path test.
+
+### Review Contract
+
+- The converted async-failure test uses the real asyncpg pool wrapper, applies
+  the live billing migrations, seeds `saas_accounts` and a real deflection
+  report row, and cleans up in `finally`.
+- The failure test asserts real persisted effects: report remains unpaid,
+  delivery is not queued, billing event is recorded once, and duplicate delivery
+  is idempotent.
+- The existing paid live tests share the same paid-state assertion helper rather
+  than copy-pasting the row checks a third time.
+- Stripe remains mocked only at the external SDK/webhook-construction boundary.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+### Files touched
+
+- `plans/PR-Billing-Async-Failure-Live-Adapter.md`
+- `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Reuse the live billing harness added in #1887:
+
+1. Add helper functions for live report seeding and paid-state assertions.
+2. Refactor the two existing live paid webhook tests to use the paid-state
+   helper without changing their event-specific assertions.
+3. Convert the async-payment-failed route test to build the same Stripe event
+   fixture, run the real `billing.stripe_webhook` entrypoint with a live pool,
+   and assert the report stays locked while the billing event is recorded once.
+
+## Intentional
+
+- This is not a broad fake-pool cleanup. One more webhook route is converted so
+  the maturity baseline drop remains reviewable.
+- The helper extraction is limited to live billing fixtures/assertions already
+  duplicated by #1887/#1888; production code is unchanged.
+
+## Deferred
+
+- Remaining billing fake-pool webhook tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_deflection_async_failure_is_observed_without_unlock -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 55 passed / 3 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x53`, score 238.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Async-Failure-Live-Adapter.md` | 97 |
+| `tests/maturity_sweep/baseline_atlas_brain_api.json` | 4 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 343 |
+| **Total** | **444** |

--- a/tests/maturity_sweep/baseline_atlas_brain_api.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_api.json
@@ -120,11 +120,11 @@
   },
   "atlas_brain/api/billing.py": {
     "counts": {
-      "INTERNAL_MOCK": 56,
+      "INTERNAL_MOCK": 53,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 3
     },
-    "score": 250
+    "score": 238
   },
   "atlas_brain/api/blog_admin.py": {
     "counts": {

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -109,6 +109,133 @@ async def _cleanup_live_billing_rows(
     await pool.execute("DELETE FROM saas_accounts WHERE id = $1", account_uuid)
 
 
+async def _seed_live_deflection_report(
+    pool: _InitializedAsyncpgPool,
+    *,
+    account_id: str,
+    request_id: str,
+    account_name: str,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO saas_accounts (id, name)
+        VALUES ($1, $2)
+        """,
+        uuid.UUID(account_id),
+        account_name,
+    )
+    store = PostgresDeflectionReportArtifactStore(pool=pool)
+    await store.save_report(
+        account_id=account_id,
+        request_id=request_id,
+        snapshot={"summary": {"generated": 1}},
+        artifact={"report_model": {"schema_version": "test"}},
+        delivery_email="buyer@example.com",
+    )
+
+
+async def _billing_event_count(
+    pool: _InitializedAsyncpgPool,
+    *,
+    stripe_event_id: str,
+    event_type: str | None = None,
+) -> int:
+    if event_type is None:
+        return int(
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM billing_events WHERE stripe_event_id = $1",
+                stripe_event_id,
+            )
+        )
+    return int(
+        await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM billing_events
+            WHERE stripe_event_id = $1 AND event_type = $2
+            """,
+            stripe_event_id,
+            event_type,
+        )
+    )
+
+
+async def _assert_live_deflection_report_paid(
+    pool: _InitializedAsyncpgPool,
+    *,
+    account_id: str,
+    request_id: str,
+    session_id: str,
+    stripe_event_id: str,
+    event_type: str,
+) -> None:
+    report = await pool.fetchrow(
+        """
+        SELECT paid, payment_reference
+        FROM content_ops_deflection_reports
+        WHERE account_id = $1 AND request_id = $2
+        """,
+        account_id,
+        request_id,
+    )
+    assert report is not None
+    assert report["paid"] is True
+    assert report["payment_reference"] == session_id
+    delivery = await pool.fetchrow(
+        """
+        SELECT payment_reference, delivery_status
+        FROM content_ops_deflection_report_deliveries
+        WHERE account_id = $1 AND request_id = $2
+        """,
+        account_id,
+        request_id,
+    )
+    assert delivery is not None
+    assert delivery["payment_reference"] == session_id
+    assert delivery["delivery_status"] == "pending"
+    assert await _billing_event_count(
+        pool,
+        stripe_event_id=stripe_event_id,
+        event_type=event_type,
+    ) == 1
+
+
+async def _assert_live_deflection_report_locked(
+    pool: _InitializedAsyncpgPool,
+    *,
+    account_id: str,
+    request_id: str,
+    stripe_event_id: str,
+    event_type: str,
+) -> None:
+    report = await pool.fetchrow(
+        """
+        SELECT paid, payment_reference
+        FROM content_ops_deflection_reports
+        WHERE account_id = $1 AND request_id = $2
+        """,
+        account_id,
+        request_id,
+    )
+    assert report is not None
+    assert report["paid"] is False
+    assert report["payment_reference"] is None
+    assert await pool.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM content_ops_deflection_report_deliveries
+        WHERE account_id = $1 AND request_id = $2
+        """,
+        account_id,
+        request_id,
+    ) == 0
+    assert await _billing_event_count(
+        pool,
+        stripe_event_id=stripe_event_id,
+        event_type=event_type,
+    ) == 1
+
+
 class _Pool:
     def __init__(self) -> None:
         self.is_initialized = True
@@ -1428,21 +1555,11 @@ async def test_stripe_webhook_live_postgres_marks_deflection_report_paid_and_ide
             request_id=request_id,
             stripe_event_id=stripe_event_id,
         )
-        await pool.execute(
-            """
-            INSERT INTO saas_accounts (id, name)
-            VALUES ($1, $2)
-            """,
-            uuid.UUID(account_id),
-            "Live billing test",
-        )
-        store = PostgresDeflectionReportArtifactStore(pool=pool)
-        await store.save_report(
+        await _seed_live_deflection_report(
+            pool,
             account_id=account_id,
             request_id=request_id,
-            snapshot={"summary": {"generated": 1}},
-            artifact={"report_model": {"schema_version": "test"}},
-            delivery_email="buyer@example.com",
+            account_name="Live billing test",
         )
 
         response = await _run_stripe_webhook(
@@ -1455,39 +1572,14 @@ async def test_stripe_webhook_live_postgres_marks_deflection_report_paid_and_ide
         assert response == {"status": "ok"}
         assert fake_stripe.api_key == "sk_test"
         assert fake_stripe.api_version == billing.STRIPE_API_VERSION
-        report = await pool.fetchrow(
-            """
-            SELECT paid, payment_reference
-            FROM content_ops_deflection_reports
-            WHERE account_id = $1 AND request_id = $2
-            """,
-            account_id,
-            request_id,
+        await _assert_live_deflection_report_paid(
+            pool,
+            account_id=account_id,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.completed",
+            request_id=request_id,
+            session_id=session_id,
         )
-        assert report is not None
-        assert report["paid"] is True
-        assert report["payment_reference"] == session_id
-        delivery = await pool.fetchrow(
-            """
-            SELECT payment_reference, delivery_status
-            FROM content_ops_deflection_report_deliveries
-            WHERE account_id = $1 AND request_id = $2
-            """,
-            account_id,
-            request_id,
-        )
-        assert delivery is not None
-        assert delivery["payment_reference"] == session_id
-        assert delivery["delivery_status"] == "pending"
-        assert await pool.fetchval(
-            """
-            SELECT COUNT(*)
-            FROM billing_events
-            WHERE stripe_event_id = $1 AND event_type = $2
-            """,
-            stripe_event_id,
-            "checkout.session.completed",
-        ) == 1
 
         assert await _run_stripe_webhook(
             monkeypatch,
@@ -1495,9 +1587,9 @@ async def test_stripe_webhook_live_postgres_marks_deflection_report_paid_and_ide
             pool=pool,
             stripe_module=fake_stripe,
         ) == {"status": "already_processed"}
-        assert await pool.fetchval(
-            "SELECT COUNT(*) FROM billing_events WHERE stripe_event_id = $1",
-            stripe_event_id,
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
         ) == 1
     finally:
         await _cleanup_live_billing_rows(
@@ -1538,21 +1630,11 @@ async def test_stripe_webhook_routes_deflection_async_success_to_paid_gate(
             request_id=request_id,
             stripe_event_id=stripe_event_id,
         )
-        await pool.execute(
-            """
-            INSERT INTO saas_accounts (id, name)
-            VALUES ($1, $2)
-            """,
-            uuid.UUID(account_id),
-            "Live async success billing test",
-        )
-        store = PostgresDeflectionReportArtifactStore(pool=pool)
-        await store.save_report(
+        await _seed_live_deflection_report(
+            pool,
             account_id=account_id,
             request_id=request_id,
-            snapshot={"summary": {"generated": 1}},
-            artifact={"report_model": {"schema_version": "test"}},
-            delivery_email="buyer@example.com",
+            account_name="Live async success billing test",
         )
 
         response = await _run_stripe_webhook(
@@ -1565,39 +1647,14 @@ async def test_stripe_webhook_routes_deflection_async_success_to_paid_gate(
         assert response == {"status": "ok"}
         assert fake_stripe.api_key == "sk_test"
         assert fake_stripe.api_version == billing.STRIPE_API_VERSION
-        report = await pool.fetchrow(
-            """
-            SELECT paid, payment_reference
-            FROM content_ops_deflection_reports
-            WHERE account_id = $1 AND request_id = $2
-            """,
-            account_id,
-            request_id,
+        await _assert_live_deflection_report_paid(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            session_id=session_id,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.async_payment_succeeded",
         )
-        assert report is not None
-        assert report["paid"] is True
-        assert report["payment_reference"] == session_id
-        delivery = await pool.fetchrow(
-            """
-            SELECT payment_reference, delivery_status
-            FROM content_ops_deflection_report_deliveries
-            WHERE account_id = $1 AND request_id = $2
-            """,
-            account_id,
-            request_id,
-        )
-        assert delivery is not None
-        assert delivery["payment_reference"] == session_id
-        assert delivery["delivery_status"] == "pending"
-        assert await pool.fetchval(
-            """
-            SELECT COUNT(*)
-            FROM billing_events
-            WHERE stripe_event_id = $1 AND event_type = $2
-            """,
-            stripe_event_id,
-            "checkout.session.async_payment_succeeded",
-        ) == 1
 
         assert await _run_stripe_webhook(
             monkeypatch,
@@ -1605,9 +1662,9 @@ async def test_stripe_webhook_routes_deflection_async_success_to_paid_gate(
             pool=pool,
             stripe_module=fake_stripe,
         ) == {"status": "already_processed"}
-        assert await pool.fetchval(
-            "SELECT COUNT(*) FROM billing_events WHERE stripe_event_id = $1",
-            stripe_event_id,
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
         ) == 1
     finally:
         await _cleanup_live_billing_rows(
@@ -1724,58 +1781,80 @@ async def test_stripe_webhook_deflection_async_success_unpaid_stays_pending(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_deflection_async_failure_is_observed_without_unlock(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     account_id = str(uuid.uuid4())
+    request_id = "req-live-async-failed"
+    stripe_event_id = "evt_deflection_async_failed_live"
+    session_id = "cs_test_deflection_async_failed_live"
     session = _session(
         account_id=account_id,
-        session_id="cs_test_deflection_async_failed",
+        request_id=request_id,
+        session_id=session_id,
         payment_status="failed",
     )
     event = SimpleNamespace(
-        id="evt_deflection_async_failed",
+        id=stripe_event_id,
         type="checkout.session.async_payment_failed",
         data=SimpleNamespace(object=session),
     )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live async failed billing test",
+        )
 
-    class _Webhook:
-        @staticmethod
-        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
-            return event
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
-    pool = _Pool()
-    pool.add_report(account_id=account_id)
-    request = SimpleNamespace(
-        headers={"stripe-signature": "valid"},
-        body=lambda: _body(),
-    )
+        assert response == {"status": "ok"}
+        assert fake_stripe.api_key == "sk_test"
+        assert fake_stripe.api_version == billing.STRIPE_API_VERSION
+        assert "async payment failed" in caplog.text
+        await _assert_live_deflection_report_locked(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.async_payment_failed",
+        )
 
-    async def _body() -> bytes:
-        return b"{}"
-
-    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
-    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
-    monkeypatch.setattr(
-        billing.settings.saas_auth,
-        "stripe_webhook_secret",
-        "whsec_test",
-    )
-    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
-
-    response = await billing.stripe_webhook(request)
-
-    assert response == {"status": "ok"}
-    assert "async payment failed" in caplog.text
-    assert len(pool.execute_calls) == 1
-    insert_query, insert_args = pool.execute_calls[0]
-    assert "INSERT INTO billing_events" in insert_query
-    assert insert_args[1] == "evt_deflection_async_failed"
-    assert insert_args[2] == "checkout.session.async_payment_failed"
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
-    assert pool.delivery_rows == {}
+        assert await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        ) == {"status": "already_processed"}
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Async-Failure-Live-Adapter.md
Slice phase: Production hardening

Convert the `checkout.session.async_payment_failed` deflection webhook test from the hand-written billing `_Pool` fake to the live asyncpg/Postgres harness. This proves the real failed-payment path records the billing event without unlocking the report or queueing delivery. The slice also consolidates the live paid-state assertion block from #1887/#1888 before adding a third copy. The maturity baseline drops only by the earned `billing.py` INTERNAL_MOCK count: x56 -> x53, score 250 -> 238.

## Intentional
- This is one fake-pool burn-down plus the small live-helper extraction requested by the prior review signal, not a broad billing test rewrite.
- Stripe remains mocked at the external SDK/webhook-construction boundary.
- Remaining billing fake-pool tests stay detector-visible until their own live-adapter slices land.

## Deferred
- Remaining billing fake-pool webhook tests and the temporary `_resolve_billing_db_pool` direct-call shim are deferred to follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_deflection_async_failure_is_observed_without_unlock -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 55 passed / 3 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x53`, score 238.

## Diff size
3 files, +310 / -134. Slightly over the 400 LOC soft cap because the slice pairs one live-adapter conversion with the helper extraction needed to avoid a third copy of the live paid-state assertion contract.
