### PR TITLE
Convert completed-unpaid billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Completed-Unpaid-Live-Adapter.md
+++ b/plans/PR-Billing-Completed-Unpaid-Live-Adapter.md
@@ -1,0 +1,84 @@
+# PR-Billing-Completed-Unpaid-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing fake DB-pool webhook tests with
+live asyncpg/Postgres state assertions one money-path boundary at a time. #1889
+proved the async-payment-failed path leaves the report locked; the adjacent
+`checkout.session.completed` path with `payment_status="unpaid"` still relies
+on the hand-written `_Pool` fake and SQL-call assertions.
+
+Root cause: the unpaid-completed test verifies a fake `billing_events` insert
+and fake in-memory report/delivery dictionaries. That does not prove the real
+webhook records the event without unlocking the report or queueing delivery.
+This PR fixes that root for one more fail-closed payment boundary.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_deflection_completed_unpaid_stays_pending` from
+   `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Reuse the live locked-state helper from #1889 to assert real persisted state:
+   report remains unpaid, no payment reference is written, no delivery row is
+   queued, and the billing event is recorded once.
+3. Ratchet `atlas_brain/api/billing.py` INTERNAL_MOCK only by the earned count
+   from the removed fake-pool test.
+
+### Review Contract
+
+- The converted test uses the real asyncpg pool wrapper, applies the live
+  billing migrations, seeds `saas_accounts` and a real deflection report row,
+  and cleans up in `finally`.
+- The test asserts real persisted effects: event recorded, report remains
+  locked, delivery remains absent, and duplicate webhook handling is idempotent.
+- Stripe remains mocked only at the external SDK/webhook-construction boundary.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+### Files touched
+
+- `plans/PR-Billing-Completed-Unpaid-Live-Adapter.md`
+- `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Build the existing unpaid completed Checkout Session event with real
+`account_id`, `request_id`, and `session_id` values. Seed a real report row via
+`PostgresDeflectionReportArtifactStore`, run the actual `billing.stripe_webhook`
+entrypoint through `_run_stripe_webhook`, and verify the persisted locked state
+with `_assert_live_deflection_report_locked`. Then run the same webhook a second
+time to prove idempotency against the real `billing_events` table.
+
+## Intentional
+
+- This is one fake-pool burn-down, not a broad webhook-test sweep.
+- The existing live helper from #1889 is reused instead of adding another custom
+  assertion shape.
+
+## Deferred
+
+- Remaining billing fake-pool webhook tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_deflection_completed_unpaid_stays_pending -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 54 passed / 4 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x50`, score 226.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Completed-Unpaid-Live-Adapter.md` | 84 |
+| `tests/maturity_sweep/baseline_atlas_brain_api.json` | 4 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 99 |
+| **Total** | **187** |

--- a/tests/maturity_sweep/baseline_atlas_brain_api.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_api.json
@@ -120,11 +120,11 @@
   },
   "atlas_brain/api/billing.py": {
     "counts": {
-      "INTERNAL_MOCK": 53,
+      "INTERNAL_MOCK": 50,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 3
     },
-    "score": 238
+    "score": 226
   },
   "atlas_brain/api/blog_admin.py": {
     "counts": {

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1677,55 +1677,80 @@ async def test_stripe_webhook_routes_deflection_async_success_to_paid_gate(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_deflection_completed_unpaid_stays_pending(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id, payment_status="unpaid")
+    request_id = "req-live-completed-unpaid"
+    stripe_event_id = "evt_deflection_pending_payment_live"
+    session_id = "cs_test_deflection_completed_unpaid_live"
+    session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
+        payment_status="unpaid",
+    )
     event = SimpleNamespace(
-        id="evt_deflection_pending_payment",
+        id=stripe_event_id,
         type="checkout.session.completed",
         data=SimpleNamespace(object=session),
     )
+    fake_stripe, _session_list = _stripe_module_for_event(event)
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live completed unpaid billing test",
+        )
 
-    class _Webhook:
-        @staticmethod
-        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
-            return event
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
-    pool = _Pool()
-    pool.add_report(account_id=account_id)
-    request = SimpleNamespace(
-        headers={"stripe-signature": "valid"},
-        body=lambda: _body(),
-    )
+        assert response == {"status": "ok"}
+        assert fake_stripe.api_key == "sk_test"
+        assert fake_stripe.api_version == billing.STRIPE_API_VERSION
+        assert "checkout event arrived before funds were available" in caplog.text
+        await _assert_live_deflection_report_locked(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.completed",
+        )
 
-    async def _body() -> bytes:
-        return b"{}"
-
-    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
-    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
-    monkeypatch.setattr(
-        billing.settings.saas_auth,
-        "stripe_webhook_secret",
-        "whsec_test",
-    )
-    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
-
-    response = await billing.stripe_webhook(request)
-
-    assert response == {"status": "ok"}
-    assert "checkout event arrived before funds were available" in caplog.text
-    assert len(pool.execute_calls) == 1
-    insert_query, insert_args = pool.execute_calls[0]
-    assert "INSERT INTO billing_events" in insert_query
-    assert insert_args[1] == "evt_deflection_pending_payment"
-    assert insert_args[2] == "checkout.session.completed"
-    assert pool.processed_event_ids == {"evt_deflection_pending_payment"}
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
-    assert pool.delivery_rows == {}
+        assert await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        ) == {"status": "already_processed"}
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Completed-Unpaid-Live-Adapter.md
Slice phase: Production hardening

Convert the `checkout.session.completed` + `payment_status=unpaid` deflection webhook test from the hand-written billing `_Pool` fake to the live asyncpg/Postgres harness. This proves the real completed-but-unpaid path records the billing event without unlocking the report or queueing delivery. The maturity baseline drops only by the earned `billing.py` INTERNAL_MOCK count: x53 -> x50, score 238 -> 226.

## Intentional
- This is one fake-pool burn-down, not a broad billing test rewrite.
- Stripe remains mocked at the external SDK/webhook-construction boundary.
- The live locked-state helper from #1889 is reused instead of adding another assertion shape.
- Remaining billing fake-pool tests stay detector-visible until their own live-adapter slices land.

## Deferred
- Remaining billing fake-pool webhook tests and the temporary `_resolve_billing_db_pool` direct-call shim are deferred to follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_deflection_completed_unpaid_stays_pending -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 54 passed / 4 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x50`, score 226.

## Diff size
3 files, +148 / -39
