### PR TITLE
Convert refund relock billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Refund-Relock-Live-Adapter.md
+++ b/plans/PR-Billing-Refund-Relock-Live-Adapter.md
@@ -1,0 +1,94 @@
+# PR-Billing-Refund-Relock-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is burning down hand-written fake DB-pool
+webhook tests one money-path boundary at a time. #1888, #1889, #1890, and
+#1891 moved the checkout completed/async success/async failure paid and unpaid
+paths onto live asyncpg/Postgres state checks. The full-refund path still proves
+the relock behavior by sniffing fake SQL strings and in-memory dictionaries.
+
+Root cause: `test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout_lookup`
+asserts `_Pool.execute_calls`, `_Pool.report_rows`, and `_Pool.delivery_rows`
+instead of the real persisted billing/report/delivery state. That can miss DB
+adapter, SQL, and migration drift on a payment-reversal path. This PR fixes the
+root for that one refund/relock path by exercising the real webhook entrypoint
+against a migrated Postgres database.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout_lookup`
+   from `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Assert real persisted effects after a full `charge.refunded`: Stripe checkout
+   session lookup is called, the paid report is relocked, the existing delivery
+   row is revoked, the billing event is recorded exactly once, and duplicate
+   webhook handling is idempotent.
+3. Keep maturity-sweep honest: do not ratchet
+   `atlas_brain/api/billing.py` unless the detector reports an earned
+   reduction. Remaining `_Pool` tests stay grep-visible for later burn-down
+   slices.
+
+### Review Contract
+
+- The converted test uses the real asyncpg pool wrapper, applies the live
+  billing migrations, seeds `saas_accounts`, a real deflection report row, and
+  a pre-existing pending delivery row, then cleans up in `finally`.
+- Stripe remains mocked only at the external webhook/checkout-session SDK
+  boundary; the webhook under test still performs the real checkout-session
+  lookup path.
+- The test asserts persisted report state (`paid=false`, payment reference
+  preserved), persisted delivery state (`delivery_status=revoked`,
+  `payment_revoked:charge.refunded` error), billing event idempotency, and the
+  expected refund log line.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+### Files touched
+
+- `plans/PR-Billing-Refund-Relock-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live report through `PostgresDeflectionReportArtifactStore`, mark it
+paid with the same payment reference the fake used, and insert the pending
+delivery row that the refund path should revoke. Build the existing
+`charge.refunded` event with a full-refund charge and a fake Stripe
+`checkout.Session.list` response, run `_run_stripe_webhook` against the live
+pool, and query Postgres for the report, delivery, and `billing_events` rows.
+Then replay the same webhook once to prove the real `billing_events` table
+short-circuits duplicates.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole refund/dispute cluster.
+- The checkout-session list remains a fake Stripe SDK boundary because the
+  behavior under test is our webhook's DB side effects after Stripe provides the
+  matching Checkout Session.
+
+## Deferred
+
+- Remaining billing fake-pool refund/dispute tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout_lookup -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 52 passed / 6 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214, so no baseline change was earned.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Refund-Relock-Live-Adapter.md` | 94 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 156 |
+| **Total** | **250** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1906,23 +1906,28 @@ async def test_stripe_webhook_deflection_async_failure_is_observed_without_unloc
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout_lookup(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     account_id = str(uuid.uuid4())
+    request_id = "req-live-refund-relock"
+    session_id = "cs_test_deflection_refunded_live"
+    stripe_event_id = "evt_deflection_refunded_live"
     checkout_session = _session(
         account_id=account_id,
-        session_id="cs_test_deflection_refunded",
+        request_id=request_id,
+        session_id=session_id,
     )
     charge = _payment_event_object(
-        payment_intent="pi_test_refunded",
+        payment_intent="pi_test_refunded_live",
         refunded=True,
         amount_refunded=150000,
         amount_captured=150000,
     )
     event = SimpleNamespace(
-        id="evt_deflection_refunded",
+        id=stripe_event_id,
         type="charge.refunded",
         data=SimpleNamespace(object=charge),
     )
@@ -1930,57 +1935,104 @@ async def test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout
         event,
         checkout_sessions=[checkout_session],
     )
-    pool = _Pool()
-    pool.add_report(
-        account_id=account_id,
-        paid=True,
-        payment_reference="cs_test_deflection_refunded",
-    )
-    pool.delivery_rows[(account_id, "req-123")] = {
-        "account_id": account_id,
-        "request_id": "req-123",
-        "payment_reference": "cs_test_deflection_refunded",
-        "delivery_status": "pending",
-    }
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live refund relock billing test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        assert await store.mark_paid(
+            account_id=account_id,
+            request_id=request_id,
+            payment_reference=session_id,
+        )
+        await pool.execute(
+            """
+            INSERT INTO content_ops_deflection_report_deliveries (
+                account_id, request_id, payment_reference, delivery_status
+            )
+            VALUES ($1, $2, $3, 'pending')
+            """,
+            account_id,
+            request_id,
+            session_id,
+        )
 
-    response = await _run_stripe_webhook(
-        monkeypatch,
-        event=event,
-        pool=pool,
-        stripe_module=fake_stripe,
-    )
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    assert response == {"status": "ok"}
-    assert session_list.calls == [
-        {"payment_intent": "pi_test_refunded", "limit": 1, "timeout": 10}
-    ]
-    update_calls = [
-        call for call in pool.execute_calls if "UPDATE content_ops_deflection_reports" in call[0]
-    ]
-    delivery_update_calls = [
-        call
-        for call in pool.execute_calls
-        if "UPDATE content_ops_deflection_report_deliveries" in call[0]
-    ]
-    billing_event_calls = [
-        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
-    ]
-    assert update_calls[0][1] == (
-        account_id,
-        "req-123",
-        "cs_test_deflection_refunded",
-    )
-    assert "SET paid = false" in update_calls[0][0]
-    assert delivery_update_calls[0][1] == (
-        account_id,
-        "req-123",
-        "payment_revoked:charge.refunded",
-    )
-    assert billing_event_calls[0][1][1] == "evt_deflection_refunded"
-    assert billing_event_calls[0][1][2] == "charge.refunded"
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
-    assert pool.delivery_rows[(account_id, "req-123")]["delivery_status"] == "revoked"
-    assert "access revoked after Stripe payment reversal" in caplog.text
+        assert response == {"status": "ok"}
+        assert session_list.calls == [
+            {"payment_intent": "pi_test_refunded_live", "limit": 1, "timeout": 10}
+        ]
+        report = await pool.fetchrow(
+            """
+            SELECT paid, paid_at, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is False
+        assert report["paid_at"] is None
+        assert report["payment_reference"] == session_id
+        delivery = await pool.fetchrow(
+            """
+            SELECT payment_reference, delivery_status, delivery_error
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert delivery is not None
+        assert delivery["payment_reference"] == session_id
+        assert delivery["delivery_status"] == "revoked"
+        assert delivery["delivery_error"] == "payment_revoked:charge.refunded"
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="charge.refunded",
+        ) == 1
+        assert "access revoked after Stripe payment reversal" in caplog.text
+
+        assert await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        ) == {"status": "already_processed"}
+        assert session_list.calls == [
+            {"payment_intent": "pi_test_refunded_live", "limit": 1, "timeout": 10}
+        ]
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Refund-Relock-Live-Adapter.md
Slice phase: Production hardening

Convert the full-refund deflection webhook test from hand-written `_Pool`
SQL-call assertions to a live asyncpg/Postgres state test. The test now seeds a
paid report plus pending delivery row, runs the real webhook entrypoint, verifies
the report is relocked and delivery is revoked in Postgres, and proves duplicate
webhook idempotency through `billing_events`.

## Intentional
- Stripe checkout-session lookup remains mocked at the external SDK boundary; the DB side effects use the real adapter.
- No maturity baseline ratchet is included because the sweep still reports `billing.py` `INTERNAL_MOCK x47`, score 214.

## Deferred
- Remaining billing fake-pool refund/dispute tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout_lookup -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 52 passed / 6 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214.

## AI reconciliation
- AI findings reviewed: Yes; no automated findings are present yet.
- All fixed or waived: Yes; no findings.

## Diff size
2 files, +198 / -52
