### PR TITLE
Convert refund lookup failure billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Refund-Lookup-Failure-Live-Adapter.md
+++ b/plans/PR-Billing-Refund-Lookup-Failure-Live-Adapter.md
@@ -1,0 +1,91 @@
+# PR-Billing-Refund-Lookup-Failure-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+tests with live asyncpg/Postgres state assertions one money-path boundary at a
+time. #1892 and #1893 converted the successful refund/dispute relock paths. The
+refund lookup failure path still proves retryability by checking `_Pool`
+in-memory state and `execute_calls == []`.
+
+Root cause: `test_stripe_webhook_refund_lookup_failure_retries_without_unlocking`
+uses a fake pool to assert that a Stripe Checkout Session lookup outage raises
+503 without recording the webhook event or mutating the paid report. That does
+not prove the real database state remains retryable. This PR fixes the root for
+that one failure path by running the real webhook against a migrated Postgres
+database and asserting the paid report and `billing_events` table directly.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_refund_lookup_failure_retries_without_unlocking` from
+   `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: Stripe checkout-session lookup is
+   attempted, lookup failure raises HTTP 503, the report remains paid with its
+   original payment reference, no delivery row appears for the account, and no
+   `billing_events` row is recorded so the event can retry.
+3. Keep maturity-sweep honest: do not ratchet
+   `atlas_brain/api/billing.py` unless the detector reports an earned
+   reduction. Remaining `_Pool` tests stay grep-visible for later burn-down
+   slices.
+
+### Review Contract
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts` and a paid deflection report row, and cleans
+  up in `finally`.
+- Stripe remains mocked only at the external webhook/checkout-session SDK
+  boundary; the test still forces `checkout.Session.list` to raise and asserts
+  the lookup arguments.
+- The test asserts persisted report state (`paid=true`, original
+  `payment_reference`, `paid_at` still present), account-wide absence of
+  delivery rows, and zero `billing_events` rows for the failed event.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+### Files touched
+
+- `plans/PR-Billing-Refund-Lookup-Failure-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live report through `PostgresDeflectionReportArtifactStore`, mark it paid
+with the same payment reference the fake used, and build the existing full
+`charge.refunded` event whose Checkout Session lookup raises. Run
+`_run_stripe_webhook` against the live pool and assert it raises the expected
+503. Then query Postgres to prove the report remains paid, no delivery rows were
+created for the account, and the failed event was not inserted into
+`billing_events`, preserving retryability.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole refund/dispute cluster.
+- The checkout-session list remains a fake Stripe SDK boundary because the
+  behavior under test is our webhook's DB behavior when Stripe lookup fails.
+
+## Deferred
+
+- Remaining billing fake-pool refund/dispute tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_refund_lookup_failure_retries_without_unlocking -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 50 passed / 8 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214, so no baseline change was earned.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Refund-Lookup-Failure-Live-Adapter.md` | 91 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 89 |
+| **Total** | **180** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -2085,18 +2085,22 @@ async def test_stripe_webhook_partial_refund_keeps_deflection_report_paid(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_refund_lookup_failure_retries_without_unlocking(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     account_id = str(uuid.uuid4())
+    request_id = "req-live-refund-lookup-down"
+    session_id = "cs_test_refund_lookup_down_live"
+    stripe_event_id = "evt_deflection_refund_lookup_down_live"
     charge = _payment_event_object(
-        payment_intent="pi_lookup_down",
+        payment_intent="pi_lookup_down_live",
         refunded=True,
         amount_refunded=150000,
         amount_captured=150000,
     )
     event = SimpleNamespace(
-        id="evt_deflection_refund_lookup_down",
+        id=stripe_event_id,
         type="charge.refunded",
         data=SimpleNamespace(object=charge),
     )
@@ -2104,24 +2108,73 @@ async def test_stripe_webhook_refund_lookup_failure_retries_without_unlocking(
         event,
         checkout_error=RuntimeError("stripe down"),
     )
-    pool = _Pool()
-    pool.add_report(account_id=account_id, paid=True, payment_reference="cs_test")
-
-    with pytest.raises(billing.HTTPException) as exc:
-        await _run_stripe_webhook(
-            monkeypatch,
-            event=event,
-            pool=pool,
-            stripe_module=fake_stripe,
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live refund lookup failure billing test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        assert await store.mark_paid(
+            account_id=account_id,
+            request_id=request_id,
+            payment_reference=session_id,
         )
 
-    assert exc.value.status_code == 503
-    assert session_list.calls == [
-        {"payment_intent": "pi_lookup_down", "limit": 1, "timeout": 10}
-    ]
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
-    assert pool.execute_calls == []
-    assert pool.processed_event_ids == set()
+        with pytest.raises(billing.HTTPException) as exc:
+            await _run_stripe_webhook(
+                monkeypatch,
+                event=event,
+                pool=pool,
+                stripe_module=fake_stripe,
+            )
+
+        assert exc.value.status_code == 503
+        assert session_list.calls == [
+            {"payment_intent": "pi_lookup_down_live", "limit": 1, "timeout": 10}
+        ]
+        report = await pool.fetchrow(
+            """
+            SELECT paid, paid_at, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["paid_at"] is not None
+        assert report["payment_reference"] == session_id
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+        ) == 0
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Refund-Lookup-Failure-Live-Adapter.md
Slice phase: Production hardening

Convert the refund lookup failure webhook test from hand-written `_Pool`
no-execute assertions to a live asyncpg/Postgres state test. The test now seeds
a paid report, forces Stripe checkout lookup failure, verifies HTTP 503
retryability, and asserts persisted paid/no-delivery/no-billing-event state.

## Intentional
- Stripe checkout-session lookup remains mocked at the external SDK boundary; the DB state uses the real adapter.
- No maturity baseline ratchet is included because the sweep still reports `billing.py` `INTERNAL_MOCK x47`, score 214.

## Deferred
- Remaining billing fake-pool refund/dispute tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_refund_lookup_failure_retries_without_unlocking -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 50 passed / 8 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214.

## AI reconciliation
- AI findings reviewed: Yes; no automated findings are present yet.
- All fixed or waived: Yes; no findings.

## Diff size
2 files, +162 / -18
