### PR TITLE
Convert partial refund billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Partial-Refund-Live-Adapter.md
+++ b/plans/PR-Billing-Partial-Refund-Live-Adapter.md
@@ -1,0 +1,90 @@
+# PR-Billing-Partial-Refund-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+tests with live asyncpg/Postgres state assertions one money-path boundary at a
+time. #1892 covered full-refund relock, and #1894 covered full-refund lookup
+failure retryability. The partial-refund path still proves "observe but do not
+revoke" with `_Pool` dictionaries and SQL-call filtering.
+
+Root cause: `test_stripe_webhook_partial_refund_keeps_deflection_report_paid`
+asserts fake `report_rows` and `execute_calls` instead of real persisted report,
+delivery, and billing-event state. That does not prove the real webhook leaves
+paid access intact for a partial refund while still recording the event. This PR
+fixes the root for that one non-revocation path by running the real webhook
+against a migrated Postgres database.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert `test_stripe_webhook_partial_refund_keeps_deflection_report_paid`
+   from `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: partial refund does not call the
+   Stripe Checkout Session lookup, does not relock the report, does not create
+   or revoke delivery rows, records the billing event once, and logs that the
+   partial refund was observed without revocation.
+3. Keep maturity-sweep honest: do not ratchet
+   `atlas_brain/api/billing.py` unless the detector reports an earned
+   reduction. Remaining `_Pool` tests stay grep-visible for later burn-down
+   slices.
+
+### Review Contract
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts` and a paid deflection report row, and cleans
+  up in `finally`.
+- Stripe remains mocked only at the external webhook/checkout-session SDK
+  boundary; the test still asserts no checkout-session lookup happens for a
+  partial refund.
+- The test asserts persisted report state (`paid=true`, original
+  `payment_reference`, `paid_at` still present), account-wide absence of
+  delivery rows, and exactly one `billing_events` row for the observed partial
+  refund.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+### Files touched
+
+- `plans/PR-Billing-Partial-Refund-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live report through `PostgresDeflectionReportArtifactStore`, mark it paid
+with a stable payment reference, and build the existing partial
+`charge.refunded` event (`refunded=false`, `amount_refunded < amount_captured`).
+Run `_run_stripe_webhook` against the live pool and query Postgres to prove the
+report remains paid, no delivery rows exist for the account, and the webhook
+event was still inserted into `billing_events`.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole refund/dispute cluster.
+- The checkout-session list remains a fake Stripe SDK boundary because the
+  behavior under test is that partial refunds return before any lookup.
+
+## Deferred
+
+- Remaining billing fake-pool refund/dispute tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_partial_refund_keeps_deflection_report_paid -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 49 passed / 9 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214, so no baseline change was earned.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Partial-Refund-Live-Adapter.md` | 90 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 100 |
+| **Total** | **190** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -2036,21 +2036,29 @@ async def test_stripe_webhook_refund_relocks_paid_deflection_report_via_checkout
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_partial_refund_keeps_deflection_report_paid(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.INFO, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    checkout_session = _session(account_id=account_id)
+    request_id = "req-live-partial-refund"
+    session_id = "cs_test_partial_refund_live"
+    stripe_event_id = "evt_deflection_partial_refund_live"
+    checkout_session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
+    )
     charge = _payment_event_object(
-        payment_intent="pi_test_partial_refund",
+        payment_intent="pi_test_partial_refund_live",
         refunded=False,
         amount_refunded=50000,
         amount_captured=150000,
     )
     event = SimpleNamespace(
-        id="evt_deflection_partial_refund",
+        id=stripe_event_id,
         type="charge.refunded",
         data=SimpleNamespace(object=charge),
     )
@@ -2058,30 +2066,72 @@ async def test_stripe_webhook_partial_refund_keeps_deflection_report_paid(
         event,
         checkout_sessions=[checkout_session],
     )
-    pool = _Pool()
-    pool.add_report(account_id=account_id, paid=True, payment_reference="cs_test")
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live partial refund billing test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        assert await store.mark_paid(
+            account_id=account_id,
+            request_id=request_id,
+            payment_reference=session_id,
+        )
 
-    response = await _run_stripe_webhook(
-        monkeypatch,
-        event=event,
-        pool=pool,
-        stripe_module=fake_stripe,
-    )
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    assert response == {"status": "ok"}
-    assert session_list.calls == []
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
-    update_calls = [
-        call
-        for call in pool.execute_calls
-        if "UPDATE content_ops_deflection_reports" in call[0]
-    ]
-    assert update_calls == []
-    billing_event_calls = [
-        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
-    ]
-    assert billing_event_calls[0][1][1] == "evt_deflection_partial_refund"
-    assert "partial refund observed without revocation" in caplog.text
+        assert response == {"status": "ok"}
+        assert session_list.calls == []
+        report = await pool.fetchrow(
+            """
+            SELECT paid, paid_at, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["paid_at"] is not None
+        assert report["payment_reference"] == session_id
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="charge.refunded",
+        ) == 1
+        assert "partial refund observed without revocation" in caplog.text
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Partial-Refund-Live-Adapter.md
Slice phase: Production hardening

Convert the partial-refund deflection webhook test from hand-written `_Pool`
SQL-call assertions to a live asyncpg/Postgres state test. The test now seeds a
paid report, proves a partial refund does not trigger Checkout Session lookup or
revoke paid access, and asserts persisted paid/no-delivery/billing-event state.

## Intentional
- Stripe checkout-session lookup remains mocked at the external SDK boundary; the DB state uses the real adapter.
- No maturity baseline ratchet is included because the sweep still reports `billing.py` `INTERNAL_MOCK x47`, score 214.

## Deferred
- Remaining billing fake-pool refund/dispute tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_partial_refund_keeps_deflection_report_paid -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 49 passed / 9 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214.

## AI reconciliation
- AI findings reviewed: Yes; no automated findings are present yet.
- All fixed or waived: Yes; no findings.

## Diff size
2 files, +165 / -25
