### PR TITLE
Convert non-won dispute close billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Non-Won-Dispute-Close-Live-Adapter.md
+++ b/plans/PR-Billing-Non-Won-Dispute-Close-Live-Adapter.md
@@ -1,0 +1,110 @@
+# PR-Billing-Non-Won-Dispute-Close-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+tests with live asyncpg/Postgres state assertions one money-path boundary at a
+time. #1893 covered dispute-created relock, and the non-won dispute-close path
+still proves "observe but do not restore" with `_Pool` dictionaries and
+SQL-call filtering.
+
+Root cause: `test_stripe_webhook_non_won_dispute_close_does_not_restore_report`
+asserts fake `report_rows`, delivery dictionaries, and `execute_calls` instead
+of real persisted report, delivery, and billing-event state. That does not
+prove the real webhook leaves an unpaid/revoked report untouched for a lost
+dispute while still auditing the closed dispute event. This PR fixes the root
+for that one no-restore path by running the real webhook against a migrated
+Postgres database.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_non_won_dispute_close_does_not_restore_report` from
+   `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: non-won dispute close does not call
+   Stripe Checkout Session lookup, does not restore the report, does not create
+   delivery rows, records the billing event once, and logs that the dispute was
+   closed without restore.
+3. Keep maturity-sweep honest: do not ratchet
+   `atlas_brain/api/billing.py` unless the detector reports an earned
+   reduction. Remaining `_Pool` tests stay grep-visible for later burn-down
+   slices.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts` and an unpaid deflection report row with a
+  preserved payment reference, and cleans up in `finally`.
+- Stripe remains mocked only at the external webhook/checkout-session SDK
+  boundary; the test still asserts no checkout-session lookup happens for a
+  non-won dispute.
+- The test asserts persisted report state (`paid=false`, `paid_at=NULL`,
+  payment reference preserved), account-wide absence of delivery rows, and
+  exactly one `billing_events` row for the observed dispute close.
+- The test proves the non-won dispute close is a report-row no-op by asserting
+  `updated_at` is unchanged across webhook handling.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+Affected surfaces:
+
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` only.
+- Runtime Stripe webhook code is exercised through the existing real endpoint
+  harness, but production implementation files are intentionally unchanged.
+
+Risk areas:
+
+- Billing and webhook idempotency on a money-path event.
+- Revoked paid-report access must not be restored for lost or non-won disputes.
+- Live adapter coverage must not weaken the old fake-pool no-write/no-delivery
+  contract while removing SQL-call assertions.
+
+Reviewer rules: R1, R2, R3, R6, R8, R10, R13, R14.
+
+### Files touched
+
+- `plans/PR-Billing-Non-Won-Dispute-Close-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live report through `PostgresDeflectionReportArtifactStore`, set it to a
+paid-then-unpaid state with a stable payment reference to match the pre-existing
+revoked access shape, and build the existing `charge.dispute.closed` event with
+`status="lost"`. Run `_run_stripe_webhook` against the live pool and query
+Postgres to prove the report remains unpaid, no delivery rows exist for the
+account, and the webhook event was still inserted into `billing_events`.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole dispute lifecycle cluster.
+- The checkout-session list remains a fake Stripe SDK boundary because the
+  behavior under test is that non-won disputes return before any lookup.
+
+## Deferred
+
+- Remaining billing fake-pool refund/dispute tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_non_won_dispute_close_does_not_restore_report -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 48 passed / 10 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214, so no baseline change was earned.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Non-Won-Dispute-Close-Live-Adapter.md` | 110 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 124 |
+| **Total** | **234** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -2546,20 +2546,28 @@ async def test_stripe_webhook_stale_won_dispute_preserves_newer_payment_referenc
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_non_won_dispute_close_does_not_restore_report(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.INFO, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    checkout_session = _session(account_id=account_id)
+    request_id = "req-live-dispute-lost"
+    session_id = "cs_test_deflection_dispute_lost_live"
+    stripe_event_id = "evt_deflection_dispute_lost_live"
+    checkout_session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
+    )
     dispute = _payment_event_object(
-        object_id="du_test_deflection_lost",
-        payment_intent="pi_test_dispute_lost",
+        object_id="du_test_deflection_lost_live",
+        payment_intent="pi_test_dispute_lost_live",
         status="lost",
     )
     event = SimpleNamespace(
-        id="evt_deflection_dispute_lost",
+        id=stripe_event_id,
         type="charge.dispute.closed",
         data=SimpleNamespace(object=dispute),
     )
@@ -2567,37 +2575,87 @@ async def test_stripe_webhook_non_won_dispute_close_does_not_restore_report(
         event,
         checkout_sessions=[checkout_session],
     )
-    pool = _Pool()
-    pool.add_report(
-        account_id=account_id,
-        paid=False,
-        payment_reference="cs_test_deflection",
-    )
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live non-won dispute billing test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        assert await store.mark_paid(
+            account_id=account_id,
+            request_id=request_id,
+            payment_reference=session_id,
+        )
+        assert await store.mark_unpaid(
+            account_id=account_id,
+            request_id=request_id,
+            payment_reference=session_id,
+        )
+        report_updated_at_before = await pool.fetchval(
+            """
+            SELECT updated_at
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
 
-    response = await _run_stripe_webhook(
-        monkeypatch,
-        event=event,
-        pool=pool,
-        stripe_module=fake_stripe,
-    )
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    assert response == {"status": "ok"}
-    assert session_list.calls == []
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
-    assert [
-        call for call in pool.execute_calls if "UPDATE content_ops_deflection_reports" in call[0]
-    ] == []
-    assert [
-        call
-        for call in pool.execute_calls
-        if "INSERT INTO content_ops_deflection_report_deliveries" in call[0]
-    ] == []
-    billing_event_calls = [
-        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
-    ]
-    assert billing_event_calls[0][1][1] == "evt_deflection_dispute_lost"
-    assert billing_event_calls[0][1][2] == "charge.dispute.closed"
-    assert "dispute closed without restore" in caplog.text
+        assert response == {"status": "ok"}
+        assert session_list.calls == []
+        report = await pool.fetchrow(
+            """
+            SELECT paid, paid_at, payment_reference, updated_at
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is False
+        assert report["paid_at"] is None
+        assert report["payment_reference"] == session_id
+        assert report["updated_at"] == report_updated_at_before
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="charge.dispute.closed",
+        ) == 1
+        assert "dispute closed without restore" in caplog.text
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Non-Won-Dispute-Close-Live-Adapter.md
Slice phase: Production hardening

Convert the non-won dispute-close webhook test from hand-written `_Pool`
SQL-call assertions to a live asyncpg/Postgres state test. The test now seeds an
unpaid report with a preserved payment reference, proves a lost dispute does not
trigger Checkout Session lookup or restore access, and asserts persisted
unpaid/no-delivery/billing-event state. It also asserts the report row's
`updated_at` is unchanged so the non-won close remains an observable report-row
no-op.

## Intentional
- Stripe checkout-session lookup remains mocked at the external SDK boundary; the DB state uses the real adapter.
- No maturity baseline ratchet is included because the sweep still reports `billing.py` `INTERNAL_MOCK x47`, score 214.

## Deferred
- Remaining billing fake-pool refund/dispute tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_non_won_dispute_close_does_not_restore_report -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 48 passed / 10 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214.

## AI reconciliation
- AI findings reviewed: Yes; Codex/reviewer findings about the no-op assertion
  and incomplete Review Contract were reviewed.
- All fixed or waived: Yes; both findings are fixed, not waived.

## Diff size
2 files, +201 / -33
