### PR TITLE
Convert unmapped refund billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Unmapped-Refund-Live-Adapter.md
+++ b/plans/PR-Billing-Unmapped-Refund-Live-Adapter.md
@@ -1,0 +1,112 @@
+# PR-Billing-Unmapped-Refund-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+tests with live asyncpg/Postgres state assertions one money-path boundary at a
+time. #1896 closed the non-won dispute no-op path. The unmapped refund path
+still proves "observe, audit, but do not mutate reports" with `_Pool`
+dictionaries and SQL-call filtering.
+
+Root cause: `test_stripe_webhook_unmapped_refund_is_observed_without_mutating_reports`
+asserts fake `report_rows`, `execute_calls`, and billing-event call arguments
+instead of real persisted report, delivery, and billing-event state. That does
+not prove the real webhook leaves unrelated paid reports untouched when Stripe
+cannot map a refund to a Checkout Session. This PR fixes the root for that one
+unmapped-refund path by running the real webhook against a migrated Postgres
+database.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_unmapped_refund_is_observed_without_mutating_reports`
+   from `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: an unmapped refund does not find a
+   Checkout Session mapping, does not revoke or mutate unrelated report access,
+   does not create delivery rows, records the billing event once, and logs that
+   the refund could not be mapped.
+3. Keep maturity-sweep honest: do not ratchet
+   `atlas_brain/api/billing.py` unless the detector reports an earned
+   reduction. Remaining `_Pool` tests stay grep-visible for later burn-down
+   slices.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts` and an unrelated paid deflection report row,
+  and cleans up in `finally`.
+- Stripe remains mocked only at the external webhook/checkout-session SDK
+  boundary; the test still runs the real webhook path for a refund that cannot
+  be mapped to a Checkout Session.
+- The test asserts persisted report state remains paid with the unrelated
+  payment reference preserved, delivery rows remain absent account-wide, and
+  exactly one `billing_events` row is inserted for the observed refund.
+- The test proves the unmapped refund is a report-row no-op by asserting
+  `updated_at` is unchanged across webhook handling.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+Affected surfaces:
+
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` only.
+- Runtime Stripe webhook code is exercised through the existing real endpoint
+  harness, but production implementation files are intentionally unchanged.
+
+Risk areas:
+
+- Billing and webhook idempotency on a money-path event.
+- A refund that cannot be mapped must not revoke or mutate unrelated paid
+  reports.
+- Live adapter coverage must not weaken the old fake-pool no-write/no-delivery
+  contract while removing SQL-call assertions.
+
+Reviewer rules: R1, R2, R3, R6, R8, R10, R13, R14.
+
+### Files touched
+
+- `plans/PR-Billing-Unmapped-Refund-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live paid report through `PostgresDeflectionReportArtifactStore` with a
+payment reference that does not match the refund event. Build the existing
+`charge.refunded` event with a payment intent that returns no Checkout Session
+mapping. Run `_run_stripe_webhook` against the live pool and query Postgres to
+prove the unrelated report remains paid and untouched, no delivery rows exist
+for the account, and the webhook event was still inserted into `billing_events`.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole refund lifecycle cluster.
+- Checkout-session lookup remains a fake Stripe SDK boundary because the
+  behavior under test is the no-mapping branch after Stripe returns no Checkout
+  Sessions.
+
+## Deferred
+
+- Remaining billing fake-pool refund/dispute tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_unmapped_refund_is_observed_without_mutating_reports -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 47 passed / 11 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214, so no baseline change was earned.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Unmapped-Refund-Live-Adapter.md` | 112 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 112 |
+| **Total** | **224** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -2763,12 +2763,16 @@ async def test_stripe_webhook_revocation_miss_emits_paid_funnel_incident(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_unmapped_refund_is_observed_without_mutating_reports(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.INFO, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
+    request_id = "req-live-refund-unmapped"
+    stripe_event_id = "evt_deflection_refund_unmapped_live"
+    payment_reference = "cs_unrelated_live"
     charge = _payment_event_object(
         payment_intent="pi_missing_metadata",
         refunded=True,
@@ -2776,41 +2780,89 @@ async def test_stripe_webhook_unmapped_refund_is_observed_without_mutating_repor
         amount_captured=150000,
     )
     event = SimpleNamespace(
-        id="evt_deflection_refund_unmapped",
+        id=stripe_event_id,
         type="charge.refunded",
         data=SimpleNamespace(object=charge),
     )
-    fake_stripe, _session_list = _stripe_module_for_event(event, checkout_sessions=[])
-    pool = _Pool()
-    pool.add_report(
-        account_id=account_id,
-        paid=True,
-        payment_reference="cs_unrelated",
-    )
+    fake_stripe, session_list = _stripe_module_for_event(event, checkout_sessions=[])
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live unmapped refund billing test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        assert await store.mark_paid(
+            account_id=account_id,
+            request_id=request_id,
+            payment_reference=payment_reference,
+        )
+        report_updated_at_before = await pool.fetchval(
+            """
+            SELECT updated_at
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
 
-    response = await _run_stripe_webhook(
-        monkeypatch,
-        event=event,
-        pool=pool,
-        stripe_module=fake_stripe,
-    )
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    assert response == {"status": "ok"}
-    assert "could not be mapped" in caplog.text
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
-    assert [
-        call for call in pool.execute_calls if "UPDATE content_ops_deflection_reports" in call[0]
-    ] == []
-    assert [
-        call
-        for call in pool.execute_calls
-        if "UPDATE content_ops_deflection_report_deliveries" in call[0]
-    ] == []
-    billing_event_calls = [
-        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
-    ]
-    assert billing_event_calls[0][1][1] == "evt_deflection_refund_unmapped"
-    assert billing_event_calls[0][1][2] == "charge.refunded"
+        assert response == {"status": "ok"}
+        assert session_list.calls == [
+            {"payment_intent": "pi_missing_metadata", "limit": 1, "timeout": 10}
+        ]
+        assert "could not be mapped" in caplog.text
+        report = await pool.fetchrow(
+            """
+            SELECT paid, paid_at, payment_reference, updated_at
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["paid_at"] is not None
+        assert report["payment_reference"] == payment_reference
+        assert report["updated_at"] == report_updated_at_before
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="charge.refunded",
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Unmapped-Refund-Live-Adapter.md
Slice phase: Production hardening

Convert the unmapped refund webhook test from hand-written `_Pool` SQL-call
assertions to a live asyncpg/Postgres state test. The test now seeds an
unrelated paid report, proves a refund with no Checkout Session mapping leaves
that report untouched, creates no delivery rows, records the refund event once,
and keeps the `updated_at` no-op assertion as the live replacement for the old
"no UPDATE" fake-pool check.

## Intentional
- Stripe Checkout Session lookup remains mocked at the external SDK boundary; the DB state uses the real adapter.
- No maturity baseline ratchet is included because the sweep still reports `billing.py` `INTERNAL_MOCK x47`, score 214.

## Deferred
- Remaining billing fake-pool refund/dispute tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_unmapped_refund_is_observed_without_mutating_reports -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 47 passed / 11 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214.

## AI reconciliation
- AI findings reviewed: Yes; no automated findings are present yet.
- All fixed or waived: Yes; no findings.

## Diff size
2 files, +194 / -30
