### PR TITLE
Convert processed refund billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Processed-Refund-Live-Adapter.md
+++ b/plans/PR-Billing-Processed-Refund-Live-Adapter.md
@@ -1,0 +1,112 @@
+# PR-Billing-Processed-Refund-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+tests with live asyncpg/Postgres state assertions one money-path boundary at a
+time. #1897 covered the unmapped-refund no-mutation branch. The processed-refund
+idempotency branch still proves "return before revocation" with
+`_Pool.processed_event_ids`, fake report rows, and `execute_calls == []`.
+
+Root cause: `test_stripe_webhook_skips_processed_refund_before_revocation`
+asserts fake dedupe state and fake SQL-call absence instead of a real
+`billing_events` dedupe row and persisted report/delivery state. That does not
+prove the real webhook short-circuits before Stripe lookup or refund revocation
+when a refund event was already processed. This PR fixes the root for that one
+processed-refund path by running the real webhook against a migrated Postgres
+database.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_skips_processed_refund_before_revocation` from
+   `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: a duplicate refund event returns
+   `already_processed`, does not call Stripe Checkout Session lookup, does not
+   revoke or mutate the paid report, does not create delivery rows, and leaves
+   the existing billing event as the only audit row.
+3. Keep maturity-sweep honest: do not ratchet
+   `atlas_brain/api/billing.py` unless the detector reports an earned
+   reduction. Remaining `_Pool` tests stay grep-visible for later burn-down
+   slices.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts`, a paid deflection report row, and a
+  pre-existing `billing_events` row for the refund event, then cleans up in
+  `finally`.
+- Stripe remains mocked only at the external webhook/checkout-session SDK
+  boundary; the test asserts the checkout-session lookup is not called because
+  the dedupe row short-circuits first.
+- The test asserts persisted report state remains paid with its payment
+  reference preserved, delivery rows remain absent account-wide, and the
+  duplicate refund has exactly one `billing_events` row.
+- The test proves the duplicate refund is a report-row no-op by asserting
+  `updated_at` is unchanged across webhook handling.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+Affected surfaces:
+
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` only.
+- Runtime Stripe webhook code is exercised through the existing real endpoint
+  harness, but production implementation files are intentionally unchanged.
+
+Risk areas:
+
+- Billing and webhook idempotency on a money-path event.
+- A duplicate refund must not call Stripe lookup or revoke/mutate paid report
+  access.
+- Live adapter coverage must not weaken the old fake-pool no-write/no-delivery
+  contract while removing SQL-call assertions.
+
+Reviewer rules: R1, R2, R3, R6, R8, R10, R13, R14.
+
+### Files touched
+
+- `plans/PR-Billing-Processed-Refund-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live paid report through `PostgresDeflectionReportArtifactStore`, insert a
+matching `billing_events` row for the refund event id, and build the existing
+`charge.refunded` event. Run `_run_stripe_webhook` against the live pool and
+query Postgres to prove the webhook returns `already_processed`, Stripe lookup
+was not called, the report remains paid and untouched, no delivery rows exist
+for the account, and the billing-event count remains one.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole idempotency cluster.
+- Checkout-session lookup remains a fake Stripe SDK boundary because the
+  behavior under test is that duplicate events return before any Stripe lookup.
+
+## Deferred
+
+- Remaining billing fake-pool checkout/refund/dispute tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_skips_processed_refund_before_revocation -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 46 passed / 12 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214, so no baseline change was earned.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Processed-Refund-Live-Adapter.md` | 112 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 111 |
+| **Total** | **223** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -2866,14 +2866,22 @@ async def test_stripe_webhook_unmapped_refund_is_observed_without_mutating_repor
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_skips_processed_refund_before_revocation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     account_id = str(uuid.uuid4())
-    checkout_session = _session(account_id=account_id)
+    request_id = "req-live-refund-duplicate"
+    session_id = "cs_test_refund_duplicate_live"
+    stripe_event_id = "evt_deflection_refund_duplicate_live"
+    checkout_session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
+    )
     charge = _payment_event_object()
     event = SimpleNamespace(
-        id="evt_deflection_refund_duplicate",
+        id=stripe_event_id,
         type="charge.refunded",
         data=SimpleNamespace(object=charge),
     )
@@ -2881,25 +2889,90 @@ async def test_stripe_webhook_skips_processed_refund_before_revocation(
         event,
         checkout_sessions=[checkout_session],
     )
-    pool = _Pool()
-    pool.add_report(
-        account_id=account_id,
-        paid=True,
-        payment_reference="cs_test_deflection",
-    )
-    pool.processed_event_ids.add("evt_deflection_refund_duplicate")
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live processed refund billing test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        assert await store.mark_paid(
+            account_id=account_id,
+            request_id=request_id,
+            payment_reference=session_id,
+        )
+        await pool.execute(
+            """
+            INSERT INTO billing_events (account_id, stripe_event_id, event_type, payload)
+            VALUES ($1, $2, $3, '{}'::jsonb)
+            """,
+            uuid.UUID(account_id),
+            stripe_event_id,
+            "charge.refunded",
+        )
+        report_updated_at_before = await pool.fetchval(
+            """
+            SELECT updated_at
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
 
-    response = await _run_stripe_webhook(
-        monkeypatch,
-        event=event,
-        pool=pool,
-        stripe_module=fake_stripe,
-    )
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    assert response == {"status": "already_processed"}
-    assert session_list.calls == []
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is True
-    assert pool.execute_calls == []
+        assert response == {"status": "already_processed"}
+        assert session_list.calls == []
+        report = await pool.fetchrow(
+            """
+            SELECT paid, paid_at, payment_reference, updated_at
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["paid_at"] is not None
+        assert report["payment_reference"] == session_id
+        assert report["updated_at"] == report_updated_at_before
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="charge.refunded",
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Processed-Refund-Live-Adapter.md
Slice phase: Production hardening

Convert the processed-refund idempotency webhook test from hand-written `_Pool`
state and SQL-call assertions to a live asyncpg/Postgres state test. The test now
pre-seeds the real `billing_events` dedupe row, proves the duplicate refund
returns `already_processed`, does not call Stripe Checkout Session lookup, keeps
the paid report untouched, creates no delivery rows, and keeps the existing
billing event as the only audit row.

## Intentional
- Stripe Checkout Session lookup remains mocked at the external SDK boundary; the DB state uses the real adapter.
- No maturity baseline ratchet is included because the sweep still reports `billing.py` `INTERNAL_MOCK x47`, score 214.

## Deferred
- Remaining billing fake-pool checkout/refund/dispute tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_skips_processed_refund_before_revocation -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 46 passed / 12 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` remains `INTERNAL_MOCK x47`, score 214.

## AI reconciliation
- AI findings reviewed: Yes; no automated findings are present yet.
- All fixed or waived: Yes; no findings.

## Diff size
2 files, +204 / -19
