### PR TITLE
Convert processed checkout billing webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Processed-Checkout-Live-Adapter.md
+++ b/plans/PR-Billing-Processed-Checkout-Live-Adapter.md
@@ -1,0 +1,113 @@
+# PR-Billing-Processed-Checkout-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+tests with live asyncpg/Postgres state assertions one money-path boundary at a
+time. #1898 covered duplicate refund idempotency. The duplicate deflection
+checkout path still proves "return before marking paid" with
+`_Pool.processed_event_ids`, fake fetch-call arguments, and `execute_calls == []`.
+
+Root cause: `test_stripe_webhook_skips_processed_deflection_checkout_before_paid_update`
+asserts fake dedupe state and fake SQL-call absence instead of a real
+`billing_events` dedupe row and persisted report/delivery state. That does not
+prove the real webhook short-circuits before marking a deflection report paid
+when a checkout event was already processed. This PR fixes the root for that one
+processed-checkout path by running the real webhook against a migrated Postgres
+database.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_skips_processed_deflection_checkout_before_paid_update`
+   from `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: a duplicate deflection checkout event
+   returns `already_processed`, does not mark the report paid, does not create
+   delivery rows, and leaves the existing billing event as the only audit row.
+3. Keep maturity-sweep honest: do not ratchet
+   `atlas_brain/api/billing.py` beyond the earned reduction. Remaining `_Pool`
+   tests stay grep-visible for later burn-down slices.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts`, an unpaid deflection report row, and a
+  pre-existing `billing_events` row for the checkout event, then cleans up in
+  `finally`.
+- Stripe remains mocked only at the external webhook SDK boundary; the test
+  exercises the real webhook path until the dedupe row short-circuits before any
+  paid-report update.
+- The test asserts persisted report state remains unpaid with no payment
+  reference, delivery rows remain absent account-wide, and the duplicate
+  checkout has exactly one `billing_events` row.
+- The test proves the duplicate checkout is a report-row no-op by asserting
+  `updated_at` is unchanged across webhook handling.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+Affected surfaces:
+
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` only.
+- Runtime Stripe webhook code is exercised through the existing real endpoint
+  harness, but production implementation files are intentionally unchanged.
+
+Risk areas:
+
+- Billing and webhook idempotency on a money-path checkout event.
+- A duplicate checkout must not unlock/report-deliver a paid report twice.
+- Live adapter coverage must not weaken the old fake-pool no-write/no-delivery
+  contract while removing SQL-call assertions.
+
+Reviewer rules: R1, R2, R3, R6, R8, R10, R13, R14.
+
+### Files touched
+
+- `plans/PR-Billing-Processed-Checkout-Live-Adapter.md`
+- `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live unpaid report through `PostgresDeflectionReportArtifactStore`, insert
+a matching `billing_events` row for the checkout event id, and build the existing
+`checkout.session.completed` event. Run `_run_stripe_webhook` against the live
+pool and query Postgres to prove the webhook returns `already_processed`, the
+report remains unpaid and untouched, no delivery rows exist for the account, and
+the billing-event count remains one.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole idempotency/audit-failure
+  cluster.
+- The Stripe webhook object remains a fake SDK boundary; the DB state uses the
+  real adapter.
+
+## Deferred
+
+- Remaining billing fake-pool checkout/refund/dispute tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_skips_processed_deflection_checkout_before_paid_update -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 45 passed / 13 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --update-baseline` - passed; updated only `atlas_brain/api/billing.py`.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x44`, score 202.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Processed-Checkout-Live-Adapter.md` | 113 |
+| `tests/maturity_sweep/baseline_atlas_brain_api.json` | 4 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 118 |
+| **Total** | **235** |

--- a/tests/maturity_sweep/baseline_atlas_brain_api.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_api.json
@@ -120,11 +120,11 @@
   },
   "atlas_brain/api/billing.py": {
     "counts": {
-      "INTERNAL_MOCK": 47,
+      "INTERNAL_MOCK": 44,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 3
     },
-    "score": 214
+    "score": 202
   },
   "atlas_brain/api/blog_admin.py": {
     "counts": {

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -2976,47 +2976,103 @@ async def test_stripe_webhook_skips_processed_refund_before_revocation(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_skips_processed_deflection_checkout_before_paid_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id)
+    request_id = "req-live-paid-duplicate"
+    session_id = "cs_test_paid_duplicate_live"
+    stripe_event_id = "evt_deflection_paid_duplicate_live"
+    session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
+    )
     event = SimpleNamespace(
-        id="evt_deflection_paid_duplicate",
+        id=stripe_event_id,
         type="checkout.session.completed",
         data=SimpleNamespace(object=session),
     )
+    fake_stripe, session_list = _stripe_module_for_event(event)
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live processed checkout billing test",
+        )
+        await pool.execute(
+            """
+            INSERT INTO billing_events (account_id, stripe_event_id, event_type, payload)
+            VALUES ($1, $2, $3, '{}'::jsonb)
+            """,
+            uuid.UUID(account_id),
+            stripe_event_id,
+            "checkout.session.completed",
+        )
+        report_updated_at_before = await pool.fetchval(
+            """
+            SELECT updated_at
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
 
-    class _Webhook:
-        @staticmethod
-        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
-            return event
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
-    pool = _Pool()
-    pool.processed_event_ids.add("evt_deflection_paid_duplicate")
-    request = SimpleNamespace(
-        headers={"stripe-signature": "valid"},
-        body=lambda: _body(),
-    )
-
-    async def _body() -> bytes:
-        return b"{}"
-
-    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
-    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
-    monkeypatch.setattr(
-        billing.settings.saas_auth,
-        "stripe_webhook_secret",
-        "whsec_test",
-    )
-    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
-
-    response = await billing.stripe_webhook(request)
-
-    assert response == {"status": "already_processed"}
-    assert pool.fetchval_calls[0][1] == ("evt_deflection_paid_duplicate",)
-    assert pool.execute_calls == []
+        assert response == {"status": "already_processed"}
+        assert session_list.calls == []
+        report = await pool.fetchrow(
+            """
+            SELECT paid, paid_at, payment_reference, updated_at
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is False
+        assert report["paid_at"] is None
+        assert report["payment_reference"] is None
+        assert report["updated_at"] == report_updated_at_before
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.completed",
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Processed-Checkout-Live-Adapter.md
Slice phase: Production hardening

Convert the processed deflection checkout idempotency webhook test from fake `_Pool` state to a live asyncpg/Postgres state test. The slice pre-seeds a real `billing_events` dedupe row, runs the real webhook path through the existing live harness, and asserts the duplicate checkout returns `already_processed` without marking the report paid, creating delivery rows, or adding a second event row.

## Intentional
- Stripe remains mocked only at the external webhook SDK boundary; persisted billing/report/delivery state uses the real adapter.
- The maturity baseline ratchet is included because the converted test earned `atlas_brain/api/billing.py` `INTERNAL_MOCK x47 -> x44`.

## Deferred
- Remaining billing fake-pool checkout/refund/dispute tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_skips_processed_deflection_checkout_before_paid_update -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 45 passed / 13 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --update-baseline` - passed; updated only `atlas_brain/api/billing.py`.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x44`, score 202.
- `python scripts/sync_pr_plan.py plans/PR-Billing-Processed-Checkout-Live-Adapter.md --check` - passed.

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes. No findings yet; PR is opening now.

## Diff size
3 files, +202 / -33.
