### PR TITLE
Convert billing audit failure retry webhook test to live adapter

### DIFF
--- a/plans/PR-Billing-Audit-Failure-Retry-Live-Adapter.md
+++ b/plans/PR-Billing-Audit-Failure-Retry-Live-Adapter.md
@@ -1,0 +1,130 @@
+# PR-Billing-Audit-Failure-Retry-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+tests with live asyncpg/Postgres state assertions one money-path boundary at a
+time. #1899 covered duplicate checkout idempotency. The checkout audit-failure
+retry path still proves "side effect can complete before the billing audit row,
+then a Stripe retry restores idempotency" with `_Pool.fail_billing_event_insert`,
+`processed_event_ids`, and fake `execute_calls`.
+
+Root cause:
+`test_stripe_webhook_retry_after_audit_failure_restores_idempotency` simulates a
+`billing_events` insert failure in a fake pool after mutating fake report and
+delivery dictionaries. That does not prove the real asyncpg/Postgres adapter
+preserves the paid report unlock when the audit insert fails, leaves the event
+undeduped for a Stripe retry, then inserts the dedupe row on retry so the next
+delivery is idempotently skipped. This PR fixes the root for that one retry path
+by running the real webhook against migrated Postgres and forcing the first
+audit insert to fail at the database layer.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_retry_after_audit_failure_restores_idempotency` from
+   `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: first webhook returns `ok` and marks
+   the report paid even when the `billing_events` insert fails; the event is not
+   deduped; a retry returns `ok`, keeps the report paid, and inserts the
+   `billing_events` row; a later duplicate returns `already_processed` without
+   queuing another delivery.
+3. Keep maturity-sweep honest: only ratchet `atlas_brain/api/billing.py` if this
+   conversion earns a detector-visible reduction. Remaining `_Pool` tests stay
+   grep-visible for later burn-down slices.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts` plus an unpaid deflection report row, and
+  cleans up all rows plus any test trigger/function in `finally`.
+- The first audit insert failure is produced by Postgres itself for the specific
+  `stripe_event_id`, not by a fake pool, fake call list, or query-string
+  assertion.
+- Stripe remains mocked only at the external webhook SDK boundary; report,
+  delivery, and `billing_events` state are asserted from Postgres.
+- The test asserts first-run side effects survive the audit failure, the audit
+  row is absent after that failure, retry inserts exactly one audit row, and the
+  third duplicate does not create an additional delivery row.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+Affected surfaces:
+
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` only.
+- Runtime Stripe webhook code is exercised through the existing real endpoint
+  harness, but production implementation files are intentionally unchanged.
+
+Risk areas:
+
+- Billing/webhook idempotency after a money-path audit insert failure.
+- A retry after an audit failure must restore idempotency without double
+  delivery.
+- The live adapter proof must not weaken the old fake-pool retry contract.
+
+Reviewer rules: R1, R2, R3, R6, R8, R10, R13, R14.
+
+### Files touched
+
+- `plans/PR-Billing-Audit-Failure-Retry-Live-Adapter.md`
+- `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live unpaid report through `PostgresDeflectionReportArtifactStore`, then
+install a uniquely named Postgres trigger/function that raises before inserting
+the matching `billing_events.stripe_event_id`. Run `_run_stripe_webhook` once and
+assert the response is `ok`, the incident log records the audit insert failure,
+the report is paid, the delivery row is pending, and the billing-event count is
+zero.
+
+Drop the trigger, run the same webhook again, and assert the retry returns `ok`
+with the report and delivery still in the paid/pending state and exactly one
+`billing_events` row. Run a third duplicate webhook and assert it returns
+`already_processed` and the account still has exactly one delivery row.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole audit-failure/idempotency
+  cluster.
+- The Stripe webhook object remains a fake SDK boundary; the DB state and the
+  forced audit-insert failure use the real Postgres adapter.
+- The Postgres trigger is per-test and keyed to one synthetic `stripe_event_id`
+  so it cannot affect other tests or rows; cleanup drops both trigger and
+  function.
+
+## Deferred
+
+- `test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails` still covers
+  the one-shot audit-failure log shape with `_Pool`; it is mostly subsumed by
+  this retry proof but remains grep-visible for a later consolidation slice.
+- Remaining billing fake-pool checkout/refund/dispute tests and the temporary
+  `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for
+  `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with
+  `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_retry_after_audit_failure_restores_idempotency -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 44 passed / 14 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --update-baseline` - passed; updated only `atlas_brain/api/billing.py`.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x41`, score 190.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Audit-Failure-Retry-Live-Adapter.md` | 130 |
+| `tests/maturity_sweep/baseline_atlas_brain_api.json` | 4 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 231 |
+| **Total** | **365** |

--- a/tests/maturity_sweep/baseline_atlas_brain_api.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_api.json
@@ -120,11 +120,11 @@
   },
   "atlas_brain/api/billing.py": {
     "counts": {
-      "INTERNAL_MOCK": 44,
+      "INTERNAL_MOCK": 41,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 3
     },
-    "score": 202
+    "score": 190
   },
   "atlas_brain/api/blog_admin.py": {
     "counts": {

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -159,6 +159,49 @@ async def _billing_event_count(
     )
 
 
+async def _install_billing_event_insert_failure_trigger(
+    pool: _InitializedAsyncpgPool,
+    *,
+    stripe_event_id: str,
+    suffix: str,
+) -> tuple[str, str]:
+    trigger_name = f"test_fail_billing_event_insert_{suffix}"
+    function_name = f"test_fail_billing_event_insert_fn_{suffix}"
+    event_literal = stripe_event_id.replace("'", "''")
+    await pool.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION public.{function_name}()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            RAISE EXCEPTION 'billing event insert failed';
+        END;
+        $$;
+        """
+    )
+    await pool.execute(
+        f"""
+        CREATE TRIGGER {trigger_name}
+        BEFORE INSERT ON billing_events
+        FOR EACH ROW
+        WHEN (NEW.stripe_event_id = '{event_literal}')
+        EXECUTE FUNCTION public.{function_name}();
+        """
+    )
+    return trigger_name, function_name
+
+
+async def _drop_billing_event_insert_failure_trigger(
+    pool: _InitializedAsyncpgPool,
+    *,
+    trigger_name: str,
+    function_name: str,
+) -> None:
+    await pool.execute(f"DROP TRIGGER IF EXISTS {trigger_name} ON billing_events")
+    await pool.execute(f"DROP FUNCTION IF EXISTS public.{function_name}()")
+
+
 async def _assert_live_deflection_report_paid(
     pool: _InitializedAsyncpgPool,
     *,
@@ -3138,81 +3181,149 @@ async def test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_retry_after_audit_failure_restores_idempotency(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    caplog.set_level(logging.ERROR, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id)
+    request_id = "req-live-paid-audit-retry"
+    session_id = "cs_test_paid_audit_retry_live"
+    stripe_event_id = "evt_deflection_paid_retry_live"
+    session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
+    )
     event = SimpleNamespace(
-        id="evt_deflection_paid_retry",
+        id=stripe_event_id,
         type="checkout.session.completed",
         data=SimpleNamespace(object=session),
     )
-
-    class _Webhook:
-        @staticmethod
-        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
-            return event
-
-    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
-    pool = _Pool()
-    pool.add_report(account_id=account_id)
-    pool.fail_billing_event_insert = True
-    request = SimpleNamespace(
-        headers={"stripe-signature": "valid"},
-        body=lambda: _body(),
-    )
-
-    async def _body() -> bytes:
-        return b"{}"
-
-    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
-    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
-    monkeypatch.setattr(
-        billing.settings.saas_auth,
-        "stripe_webhook_secret",
-        "whsec_test",
-    )
-    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
-
-    assert await billing.stripe_webhook(request) == {"status": "ok"}
-    assert pool.processed_event_ids == set()
-    assert "billing_events audit insert failed" in caplog.text
-
-    pool.fail_billing_event_insert = False
-    assert await billing.stripe_webhook(request) == {"status": "ok"}
-    assert pool.processed_event_ids == {"evt_deflection_paid_retry"}
-
-    assert await billing.stripe_webhook(request) == {"status": "already_processed"}
-
-    update_calls = [
-        call
-        for call in pool.execute_calls
-        if "UPDATE content_ops_deflection_reports" in call[0]
-    ]
-    insert_calls = [
-        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
-    ]
-    assert len(update_calls) == 2
-    assert all(
-        call[1] == (
-            account_id,
-            "req-123",
-            "cs_test_deflection",
-            150000,
-            "usd",
-            False,
+    fake_stripe, session_list = _stripe_module_for_event(event)
+    pool = await _connect_live_billing_pool()
+    trigger_name = ""
+    function_name = ""
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
         )
-        for call in update_calls
-    )
-    delivery_calls = [
-        call
-        for call in pool.execute_calls
-        if "INSERT INTO content_ops_deflection_report_deliveries" in call[0]
-    ]
-    assert len(delivery_calls) == 2
-    assert len(insert_calls) == 2
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live billing audit retry test",
+        )
+        trigger_name, function_name = await _install_billing_event_insert_failure_trigger(
+            pool,
+            stripe_event_id=stripe_event_id,
+            suffix=uuid.uuid4().hex[:8],
+        )
+
+        assert await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        ) == {"status": "ok"}
+        assert session_list.calls == []
+        assert "billing_events audit insert failed" in caplog.text
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.completed",
+        ) == 0
+        report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["payment_reference"] == session_id
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        ) == 1
+
+        await _drop_billing_event_insert_failure_trigger(
+            pool,
+            trigger_name=trigger_name,
+            function_name=function_name,
+        )
+        trigger_name = ""
+        function_name = ""
+
+        assert await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        ) == {"status": "ok"}
+        await _assert_live_deflection_report_paid(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            session_id=session_id,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.completed",
+        )
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 1
+
+        assert await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        ) == {"status": "already_processed"}
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 1
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.completed",
+        ) == 1
+    finally:
+        if trigger_name and function_name:
+            await _drop_billing_event_insert_failure_trigger(
+                pool,
+                trigger_name=trigger_name,
+                function_name=function_name,
+            )
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Audit-Failure-Retry-Live-Adapter.md
Slice phase: Production hardening

Convert the deflection checkout audit-failure retry test from fake `_Pool` state to a live asyncpg/Postgres state test. The slice forces the first `billing_events` insert to fail with a per-test Postgres trigger, proves the paid report unlock and delivery row survive that audit failure, then drops the trigger and proves a Stripe retry inserts the dedupe row and a later duplicate returns `already_processed` without double-delivery.

## Intentional
- Stripe remains mocked only at the external webhook SDK boundary; report, delivery, and `billing_events` state use the real Postgres adapter.
- The audit insert failure is produced by Postgres itself for one synthetic `stripe_event_id`, not by fake pool call lists or query-string assertions.
- The maturity baseline ratchet is included because the converted test earned `atlas_brain/api/billing.py` `INTERNAL_MOCK x44 -> x41`.

## Deferred
- `test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails` still covers the one-shot audit-failure log shape with `_Pool`; it is mostly subsumed by this retry proof but remains grep-visible for a later consolidation slice.
- Remaining billing fake-pool checkout/refund/dispute tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_retry_after_audit_failure_restores_idempotency -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 44 passed / 14 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --update-baseline` - passed; updated only `atlas_brain/api/billing.py`.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x41`, score 190.
- `python scripts/sync_pr_plan.py plans/PR-Billing-Audit-Failure-Retry-Live-Adapter.md --check` - passed.

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes. No findings yet; PR is opening now.

## Diff size
3 files, +303 / -62.
