### PR TITLE
Convert billing audit failure unlock test to live adapter

### DIFF
--- a/plans/PR-Billing-Audit-Failure-One-Shot-Live-Adapter.md
+++ b/plans/PR-Billing-Audit-Failure-One-Shot-Live-Adapter.md
@@ -1,0 +1,116 @@
+# PR-Billing-Audit-Failure-One-Shot-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+tests with live asyncpg/Postgres state assertions one money-path boundary at a
+time. #1900 converted the audit-failure retry path and deliberately deferred the
+older one-shot audit-failure log/unlock test. That test still uses
+`_Pool.fail_billing_event_insert`, fake `execute_calls`, and
+`processed_event_ids` to prove "paid unlock survives a failed billing audit
+insert."
+
+Root cause:
+`test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails` simulates a
+`billing_events` insert failure in a fake pool and then asserts fake SQL-call
+order. That does not prove the real asyncpg/Postgres adapter keeps a paid
+deflection report unlocked and delivery-queued when the audit insert fails. This
+PR fixes the root for that one-shot path by reusing the #1900 Postgres trigger
+failure mechanism and asserting persisted report, delivery, and audit-row state.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails` from
+   `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: webhook returns `ok`, logs the audit
+   insert failure, marks the report paid, queues one delivery, and does not
+   record a `billing_events` row while the DB insert is failing.
+3. Keep maturity-sweep honest: only ratchet `atlas_brain/api/billing.py` if this
+   conversion earns a detector-visible reduction. Remaining `_Pool` tests stay
+   grep-visible for later burn-down slices.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts` plus an unpaid deflection report row, and
+  cleans up all rows plus any test trigger/function in `finally`.
+- The audit insert failure is produced by Postgres itself for the specific
+  `stripe_event_id`, not by a fake pool, fake call list, or query-string
+  assertion.
+- Stripe remains mocked only at the external webhook SDK boundary; report,
+  delivery, and `billing_events` state are asserted from Postgres.
+- The test asserts the response, incident log, paid report state, pending
+  delivery state, and absent billing-event row after the forced failure.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+Affected surfaces:
+
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` only.
+- Runtime Stripe webhook code is exercised through the existing real endpoint
+  harness, but production implementation files are intentionally unchanged.
+
+Risk areas:
+
+- Billing/webhook fail-open behavior after a money-path audit insert failure.
+- A paid customer must not lose access because the audit row failed to write.
+- The live adapter proof must not weaken the old fake-pool one-shot contract.
+
+Reviewer rules: R1, R2, R3, R6, R8, R10, R13, R14.
+
+### Files touched
+
+- `plans/PR-Billing-Audit-Failure-One-Shot-Live-Adapter.md`
+- `tests/maturity_sweep/baseline_atlas_brain_api.json`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live unpaid report through `PostgresDeflectionReportArtifactStore`, then
+install a uniquely named Postgres trigger/function that raises before inserting
+the matching `billing_events.stripe_event_id`. Run `_run_stripe_webhook` once and
+assert the response is `ok`, the incident log records the audit insert failure,
+the report is paid with the Stripe session reference, the delivery row is
+pending, and the billing-event count for that event remains zero.
+
+## Intentional
+
+- This is one fake-pool burn-down, not the whole checkout/delta/drain fake-pool
+  cluster.
+- The Stripe webhook object remains a fake SDK boundary; the DB state and the
+  forced audit-insert failure use the real Postgres adapter.
+- The Postgres trigger helper already landed in #1900; this slice reuses it
+  instead of adding another failure-injection path.
+
+## Deferred
+
+- Remaining billing fake-pool checkout/refund/dispute/delta tests and the
+  temporary `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for
+  `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with
+  `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 43 passed / 15 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --update-baseline` - passed; updated only `atlas_brain/api/billing.py`.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x38`, score 178.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Audit-Failure-One-Shot-Live-Adapter.md` | 116 |
+| `tests/maturity_sweep/baseline_atlas_brain_api.json` | 4 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 134 |
+| **Total** | **254** |

--- a/tests/maturity_sweep/baseline_atlas_brain_api.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_api.json
@@ -120,11 +120,11 @@
   },
   "atlas_brain/api/billing.py": {
     "counts": {
-      "INTERNAL_MOCK": 41,
+      "INTERNAL_MOCK": 38,
       "SWALLOWED_EXCEPT": 4,
       "UNGUARDED_INDEX": 3
     },
-    "score": 190
+    "score": 178
   },
   "atlas_brain/api/blog_admin.py": {
     "counts": {

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -3119,65 +3119,103 @@ async def test_stripe_webhook_skips_processed_deflection_checkout_before_paid_up
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    caplog.set_level(logging.ERROR, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id)
+    request_id = "req-live-paid-audit-failure"
+    session_id = "cs_test_paid_audit_failure_live"
+    stripe_event_id = "evt_deflection_paid_audit_failure_live"
+    session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
+    )
     event = SimpleNamespace(
-        id="evt_deflection_paid_audit_failure",
+        id=stripe_event_id,
         type="checkout.session.completed",
         data=SimpleNamespace(object=session),
     )
+    fake_stripe, session_list = _stripe_module_for_event(event)
+    pool = await _connect_live_billing_pool()
+    trigger_name = ""
+    function_name = ""
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live billing audit failure test",
+        )
+        trigger_name, function_name = await _install_billing_event_insert_failure_trigger(
+            pool,
+            stripe_event_id=stripe_event_id,
+            suffix=uuid.uuid4().hex[:8],
+        )
 
-    class _Webhook:
-        @staticmethod
-        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
-            return event
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+        )
 
-    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
-    pool = _Pool()
-    pool.add_report(account_id=account_id)
-    pool.fail_billing_event_insert = True
-    request = SimpleNamespace(
-        headers={"stripe-signature": "valid"},
-        body=lambda: _body(),
-    )
-
-    async def _body() -> bytes:
-        return b"{}"
-
-    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
-    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
-    monkeypatch.setattr(
-        billing.settings.saas_auth,
-        "stripe_webhook_secret",
-        "whsec_test",
-    )
-    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
-
-    response = await billing.stripe_webhook(request)
-
-    assert response == {"status": "ok"}
-    update_query, update_args = pool.execute_calls[0]
-    delivery_query, delivery_args = pool.execute_calls[1]
-    insert_query, insert_args = pool.execute_calls[2]
-    assert "UPDATE content_ops_deflection_reports" in update_query
-    assert update_args == (
-        account_id,
-        "req-123",
-        "cs_test_deflection",
-        150000,
-        "usd",
-        False,
-    )
-    assert "INSERT INTO content_ops_deflection_report_deliveries" in delivery_query
-    assert delivery_args == (account_id, "req-123", "cs_test_deflection")
-    assert "INSERT INTO billing_events" in insert_query
-    assert insert_args[1] == "evt_deflection_paid_audit_failure"
-    assert "billing_events audit insert failed" in caplog.text
-    assert pool.processed_event_ids == set()
+        assert response == {"status": "ok"}
+        assert session_list.calls == []
+        assert "billing_events audit insert failed" in caplog.text
+        report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["payment_reference"] == session_id
+        delivery = await pool.fetchrow(
+            """
+            SELECT payment_reference, delivery_status
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert delivery is not None
+        assert delivery["payment_reference"] == session_id
+        assert delivery["delivery_status"] == "pending"
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type="checkout.session.completed",
+        ) == 0
+    finally:
+        if trigger_name and function_name:
+            await _drop_billing_event_insert_failure_trigger(
+                pool,
+                trigger_name=trigger_name,
+                function_name=function_name,
+            )
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Audit-Failure-One-Shot-Live-Adapter.md
Slice phase: Production hardening

Convert the one-shot deflection checkout audit-failure test from fake `_Pool` state to a live asyncpg/Postgres state test. The slice reuses the per-test Postgres trigger from the retry slice to force the `billing_events` insert failure, then asserts the paid report unlock, pending delivery row, incident log, and absent billing-event row from persisted state.

## Intentional
- Stripe remains mocked only at the external webhook SDK boundary; report, delivery, and `billing_events` state use the real Postgres adapter.
- The audit insert failure is produced by the existing scoped Postgres trigger helper, not by fake pool call lists or query-string assertions.
- The maturity baseline ratchet is included because the converted test earned `atlas_brain/api/billing.py` `INTERNAL_MOCK x41 -> x38`.

## Deferred
- Remaining billing fake-pool checkout/refund/dispute/delta tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails -q` - passed, 1 test.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 43 passed / 15 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --update-baseline` - passed; updated only `atlas_brain/api/billing.py`.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; `billing.py` is now `INTERNAL_MOCK x38`, score 178.
- `python scripts/sync_pr_plan.py plans/PR-Billing-Audit-Failure-One-Shot-Live-Adapter.md --check` - passed.

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes. No findings yet; PR is opening now.

## Diff size
3 files, +204 / -50.
