### PR TITLE
Convert billing checkout completion test to live adapter

### DIFF
--- a/plans/PR-Billing-Checkout-Completion-Live-Adapter.md
+++ b/plans/PR-Billing-Checkout-Completion-Live-Adapter.md
@@ -1,0 +1,112 @@
+# PR-Billing-Checkout-Completion-Live-Adapter
+
+## Why this slice exists
+
+The billing real-adapters lane is replacing hand-written fake DB-pool webhook
+and handler tests with live asyncpg/Postgres state assertions one money-path
+boundary at a time. The checkout-completion happy path still proves "mark the
+deflection report paid and queue delivery" with `_Pool.execute_calls` and fake
+`delivery_rows`.
+
+Root cause: `test_deflection_checkout_completion_marks_report_paid` asserts SQL
+strings and fake call arguments instead of proving the real asyncpg/Postgres
+adapter updates `content_ops_deflection_reports` and upserts
+`content_ops_deflection_report_deliveries`. This PR fixes the root for that one
+handler path by running `_handle_content_ops_deflection_report_checkout_completed`
+against a migrated Postgres database and asserting persisted report/delivery
+state.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert `test_deflection_checkout_completion_marks_report_paid` from
+   `_Pool`/SQL-call assertions to the live asyncpg/Postgres harness.
+2. Preserve the current behavior contract: the handler returns `None`, marks the
+   report paid with the Stripe session reference, and creates one pending
+   delivery row without exposing the delivery email in the row body.
+3. Keep maturity-sweep honest: only ratchet `atlas_brain/api/billing.py` if this
+   conversion earns a detector-visible reduction. Remaining `_Pool` tests stay
+   grep-visible for later burn-down slices.
+
+### Review Contract
+
+Acceptance criteria:
+
+- The converted test uses the real asyncpg pool wrapper, applies live billing
+  migrations, seeds `saas_accounts` plus an unpaid deflection report row, and
+  cleans up in `finally`.
+- The test calls the real `_handle_content_ops_deflection_report_checkout_completed`
+  handler, not the full webhook, because this slice is replacing the direct
+  handler fake-pool proof.
+- Report and delivery state are asserted from Postgres; no SQL-string or fake
+  call-list assertions remain in this test.
+- The test asserts the report is paid with the expected `payment_reference`,
+  delivery status is `pending`, and the delivery row does not store the buyer
+  email.
+- Remaining `_Pool` tests stay detector-visible for later slices.
+
+Affected surfaces:
+
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` only.
+- Runtime billing code is exercised through the existing direct handler, but
+  production implementation files are intentionally unchanged.
+
+Risk areas:
+
+- Billing checkout completion on the paid report unlock path.
+- Delivery upsert state must remain idempotent and not persist buyer email in
+  the delivery queue row.
+- The live adapter proof must not weaken the old fake-pool happy-path contract.
+
+Reviewer rules: R1, R2, R3, R6, R8, R10, R13, R14.
+
+### Files touched
+
+- `plans/PR-Billing-Checkout-Completion-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+Seed a live unpaid report through `PostgresDeflectionReportArtifactStore`, then
+call `_handle_content_ops_deflection_report_checkout_completed` with the existing
+synthetic Stripe Checkout session. Query `content_ops_deflection_reports` and
+`content_ops_deflection_report_deliveries` to prove the handler marked the
+report paid, set `payment_reference`, created one pending delivery row, and did
+not store `buyer@example.com` in the delivery row.
+
+## Intentional
+
+- This is one direct-handler fake-pool burn-down, not the whole checkout helper
+  cluster.
+- This slice does not insert or assert `billing_events`; the direct handler does
+  not own event dedupe/audit logging.
+- The Stripe session remains synthetic; the database adapter and persisted state
+  are real.
+
+## Deferred
+
+- Remaining billing fake-pool checkout/refund/dispute/delta tests and the
+  temporary `_resolve_billing_db_pool` direct-call shim are deferred to follow-up
+  real-adapter burn-down slices.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for
+  `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with
+  `python -m py_compile` - passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_deflection_checkout_completion_marks_report_paid -q` - passed, 1 test.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 42 passed / 16 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; no baseline update because `billing.py` remained `INTERNAL_MOCK x38`, score 178.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Checkout-Completion-Live-Adapter.md` | 112 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 80 |
+| **Total** | **192** |

--- a/plans/PR-Billing-Checkout-Completion-Live-Adapter.md
+++ b/plans/PR-Billing-Checkout-Completion-Live-Adapter.md
@@ -26,7 +26,9 @@ Slice phase: Production hardening
 2. Preserve the current behavior contract: the handler returns `None`, marks the
    report paid with the Stripe session reference, and creates one pending
    delivery row without exposing the delivery email in the row body.
-3. Keep maturity-sweep honest: only ratchet `atlas_brain/api/billing.py` if this
+3. Add live regression probes for checkout terms binding and delivery
+   no-downgrade behavior that the fake-pool SQL-string assertions used to cover.
+4. Keep maturity-sweep honest: only ratchet `atlas_brain/api/billing.py` if this
    conversion earns a detector-visible reduction. Remaining `_Pool` tests stay
    grep-visible for later burn-down slices.
 
@@ -45,6 +47,12 @@ Acceptance criteria:
 - The test asserts the report is paid with the expected `payment_reference`,
   delivery status is `pending`, and the delivery row does not store the buyer
   email.
+- The live test reruns the handler against existing `delivered` and `sending`
+  delivery rows and proves those statuses are preserved instead of downgraded
+  to `pending`.
+- A separate live test records checkout authorization terms, proves a matching
+  Stripe Checkout amount marks the report paid, and proves a mismatched amount
+  leaves the report unpaid and queues no delivery.
 - Remaining `_Pool` tests stay detector-visible for later slices.
 
 Affected surfaces:
@@ -58,6 +66,8 @@ Risk areas:
 - Billing checkout completion on the paid report unlock path.
 - Delivery upsert state must remain idempotent and not persist buyer email in
   the delivery queue row.
+- Checkout completion must remain bound to the amount/currency authorized at
+  checkout creation time, not merely any globally allowed amount.
 - The live adapter proof must not weaken the old fake-pool happy-path contract.
 
 Reviewer rules: R1, R2, R3, R6, R8, R10, R13, R14.
@@ -74,7 +84,16 @@ call `_handle_content_ops_deflection_report_checkout_completed` with the existin
 synthetic Stripe Checkout session. Query `content_ops_deflection_reports` and
 `content_ops_deflection_report_deliveries` to prove the handler marked the
 report paid, set `payment_reference`, created one pending delivery row, and did
-not store `buyer@example.com` in the delivery row.
+not store `buyer@example.com` in the delivery row. Then mutate the same delivery
+row to `delivered` and `sending`, rerun the handler, and prove the upsert keeps
+the terminal/in-flight status instead of downgrading it.
+
+Seed two additional live reports with recorded checkout authorizations for the
+same price variant and `150000/usd`. A matching Checkout session marks one report
+paid; a mismatched `120000` Checkout session leaves the other report unpaid and
+with no delivery row. The test widens the allowed-amount setting only after the
+live pool is connected and restores it in `finally`, so skipped no-DB runs cannot
+leak configuration into the rest of the file.
 
 ## Intentional
 
@@ -84,6 +103,9 @@ not store `buyer@example.com` in the delivery row.
   not own event dedupe/audit logging.
 - The Stripe session remains synthetic; the database adapter and persisted state
   are real.
+- The checkout amount allowlist is temporarily widened in one live test and
+  restored manually because the direct handler reads settings, while the live
+  Postgres adapter is still the boundary under test.
 
 ## Deferred
 
@@ -98,15 +120,15 @@ Parked hardening: none.
 - Python compile check for
   `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` with
   `python -m py_compile` - passed.
-- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_deflection_checkout_completion_marks_report_paid -q` - passed, 1 test.
-- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 42 passed / 16 skipped.
-- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 58 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_deflection_checkout_completion_marks_report_paid tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_deflection_checkout_completion_enforces_authorized_terms_live -q` - passed, 2 tests.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 42 passed / 17 skipped.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 59 passed.
 - `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; no baseline update because `billing.py` remained `INTERNAL_MOCK x38`, score 178.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Billing-Checkout-Completion-Live-Adapter.md` | 112 |
-| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 80 |
-| **Total** | **192** |
+| `plans/PR-Billing-Checkout-Completion-Live-Adapter.md` | 134 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 233 |
+| **Total** | **367** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -736,6 +736,37 @@ async def test_deflection_checkout_completion_marks_report_paid() -> None:
         assert delivery["payment_reference"] == session_id
         assert delivery["delivery_status"] == "pending"
         assert "buyer@example.com" not in delivery["row_json"]
+        for preserved_status in ("delivered", "sending"):
+            await pool.execute(
+                """
+                UPDATE content_ops_deflection_report_deliveries
+                SET delivery_status = $3
+                WHERE account_id = $1 AND request_id = $2
+                """,
+                account_id,
+                request_id,
+                preserved_status,
+            )
+            assert (
+                await billing._handle_content_ops_deflection_report_checkout_completed(
+                    pool,
+                    session,
+                    session.metadata,
+                )
+                is None
+            )
+            assert (
+                await pool.fetchval(
+                    """
+                    SELECT delivery_status
+                    FROM content_ops_deflection_report_deliveries
+                    WHERE account_id = $1 AND request_id = $2
+                    """,
+                    account_id,
+                    request_id,
+                )
+                == preserved_status
+            )
     finally:
         await _cleanup_live_billing_rows(
             pool,
@@ -743,6 +774,130 @@ async def test_deflection_checkout_completion_marks_report_paid() -> None:
             request_id=request_id,
             stripe_event_id="evt_live_checkout_completion_unused",
         )
+        await pool.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_deflection_checkout_completion_enforces_authorized_terms_live(
+) -> None:
+    matching_account_id = str(uuid.uuid4())
+    mismatched_account_id = str(uuid.uuid4())
+    matching_request_id = "req-live-checkout-terms-match"
+    mismatched_request_id = "req-live-checkout-terms-mismatch"
+    pool = await _connect_live_billing_pool()
+    original_allowed_amounts = (
+        billing.settings.saas_auth.stripe_content_ops_deflection_report_allowed_amount_cents
+    )
+    billing.settings.saas_auth.stripe_content_ops_deflection_report_allowed_amount_cents = (
+        "120000,150000"
+    )
+    try:
+        await _apply_live_billing_migrations(pool)
+        for account_id, request_id in (
+            (matching_account_id, matching_request_id),
+            (mismatched_account_id, mismatched_request_id),
+        ):
+            await _cleanup_live_billing_rows(
+                pool,
+                account_id=account_id,
+                request_id=request_id,
+                stripe_event_id="evt_live_checkout_terms_unused",
+            )
+            await _seed_live_deflection_report(
+                pool,
+                account_id=account_id,
+                request_id=request_id,
+                account_name="Live checkout terms billing test",
+            )
+            store = PostgresDeflectionReportArtifactStore(pool=pool)
+            assert await store.record_checkout_authorization(
+                account_id=account_id,
+                request_id=request_id,
+                price_variant="standard",
+                amount_cents=150000,
+                currency="usd",
+                price_id="price_standard",
+            )
+
+        matching_session = _session(
+            account_id=matching_account_id,
+            request_id=matching_request_id,
+            session_id="cs_test_checkout_terms_match_live",
+            amount_total=150000,
+        )
+        assert (
+            await billing._handle_content_ops_deflection_report_checkout_completed(
+                pool,
+                matching_session,
+                matching_session.metadata,
+            )
+            is None
+        )
+        matching_report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            matching_account_id,
+            matching_request_id,
+        )
+        assert matching_report is not None
+        assert matching_report["paid"] is True
+        assert matching_report["payment_reference"] == "cs_test_checkout_terms_match_live"
+
+        mismatched_session = _session(
+            account_id=mismatched_account_id,
+            request_id=mismatched_request_id,
+            session_id="cs_test_checkout_terms_mismatch_live",
+            amount_total=120000,
+        )
+        assert (
+            await billing._handle_content_ops_deflection_report_checkout_completed(
+                pool,
+                mismatched_session,
+                mismatched_session.metadata,
+            )
+            is None
+        )
+        mismatched_report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            mismatched_account_id,
+            mismatched_request_id,
+        )
+        assert mismatched_report is not None
+        assert mismatched_report["paid"] is False
+        assert mismatched_report["payment_reference"] is None
+        assert (
+            await pool.fetchval(
+                """
+                SELECT COUNT(*)
+                FROM content_ops_deflection_report_deliveries
+                WHERE account_id = $1
+                """,
+                mismatched_account_id,
+            )
+            == 0
+        )
+    finally:
+        billing.settings.saas_auth.stripe_content_ops_deflection_report_allowed_amount_cents = (
+            original_allowed_amounts
+        )
+        for account_id, request_id in (
+            (matching_account_id, matching_request_id),
+            (mismatched_account_id, mismatched_request_id),
+        ):
+            await _cleanup_live_billing_rows(
+                pool,
+                account_id=account_id,
+                request_id=request_id,
+                stripe_event_id="evt_live_checkout_terms_unused",
+            )
         await pool.close()
 
 

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -678,28 +678,72 @@ async def _run_stripe_webhook(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_deflection_checkout_completion_marks_report_paid() -> None:
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id)
-    pool = _Pool()
-    pool.add_report(account_id=account_id)
-
-    returned = await billing._handle_content_ops_deflection_report_checkout_completed(
-        pool,
-        session,
-        session.metadata,
+    request_id = "req-live-checkout-completion"
+    session_id = "cs_test_checkout_completion_live"
+    session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id=session_id,
     )
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_completion_unused",
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live checkout completion billing test",
+        )
 
-    assert returned is None
-    assert len(pool.execute_calls) == 2
-    query, args = pool.execute_calls[0]
-    assert "UPDATE content_ops_deflection_reports" in query
-    assert args == (account_id, "req-123", "cs_test_deflection", 150000, "usd", False)
-    delivery_query, delivery_args = pool.execute_calls[1]
-    assert "INSERT INTO content_ops_deflection_report_deliveries" in delivery_query
-    assert "delivery_status IN ('delivered', 'sending')" in delivery_query
-    assert delivery_args == (account_id, "req-123", "cs_test_deflection")
-    assert "buyer@example.com" not in str(pool.delivery_rows)
+        returned = await billing._handle_content_ops_deflection_report_checkout_completed(
+            pool,
+            session,
+            session.metadata,
+        )
+
+        assert returned is None
+        report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert report["paid"] is True
+        assert report["payment_reference"] == session_id
+        delivery = await pool.fetchrow(
+            """
+            SELECT payment_reference, delivery_status, row_to_json(d)::text AS row_json
+            FROM content_ops_deflection_report_deliveries AS d
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert delivery is not None
+        assert delivery["payment_reference"] == session_id
+        assert delivery["delivery_status"] == "pending"
+        assert "buyer@example.com" not in delivery["row_json"]
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_completion_unused",
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Checkout-Completion-Live-Adapter.md
Slice phase: Production hardening

Convert the deflection checkout-completion paid-report handler test from fake DB-pool SQL/call assertions to live asyncpg/Postgres persisted-state assertions, then add the two review-requested live probes that preserve the old contract: delivery no-downgrade and checkout authorized-terms binding.

## Intentional
- Direct handler coverage remains the exercised boundary; the full webhook owns `billing_events` dedupe/audit assertions.
- The Stripe Checkout sessions remain synthetic while the database adapter and persisted report/delivery state are real.
- The checkout amount allowlist is temporarily widened only after the live pool is connected and restored in `finally`, so no-DB skips cannot leak settings.
- No maturity baseline update: `billing.py` remains `INTERNAL_MOCK x38`, score 178.

## Deferred
- Remaining billing fake-pool checkout/refund/dispute/delta tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up real-adapter burn-down slices.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: yes.
- All fixed or waived: yes.
- Human MAJOR addressed: the converted live test now reruns the handler against existing `delivered` and `sending` delivery rows and asserts those statuses are preserved.
- Codex P2 #1 addressed: delivery conflict/no-downgrade behavior is covered with live persisted state instead of SQL-string sniffing.
- Codex P2 #2 addressed: a live authorized-terms test records `150000/usd`, proves a matching Checkout session pays the report, and proves a mismatched `120000` session leaves it unpaid with no delivery queued.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_deflection_checkout_completion_marks_report_paid tests/test_atlas_billing_content_ops_deflection_stripe_paid.py::test_deflection_checkout_completion_enforces_authorized_terms_live -q` - passed, 2 tests.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 42 passed / 17 skipped.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas_dev_password@localhost:5433/atlas python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - passed, 59 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --top 80` - passed; no baseline update because `billing.py` remained `INTERNAL_MOCK x38`, score 178.

## Diff size
2 files, +185 / -8
