### PR TITLE
Convert billing checkout missing-session reconciliation test to live adapter

### DIFF
--- a/plans/PR-Billing-Checkout-Missing-Session-Reconciliation-Live-Adapter.md
+++ b/plans/PR-Billing-Checkout-Missing-Session-Reconciliation-Live-Adapter.md
@@ -1,0 +1,125 @@
+# PR-Billing-Checkout-Missing-Session-Reconciliation-Live-Adapter
+
+## Why this slice exists
+
+The real-adapters/test-quality lane is burning down billing tests that still
+prove money-path behavior with hand-written DB-pool fakes. #1905 converted the
+aged paid-but-missing Checkout reconciliation test and explicitly deferred the
+missing-session variant once migrations 336/337 were enrolled in the live test
+harness.
+
+Root cause: `test_deflection_reconciliation_binds_empty_string_for_missing_session_id`
+asserts the behavior by sniffing `_Pool.execute_calls` and checking bound SQL
+arguments. That proves the fake saw `""`, but it does not prove Postgres
+enforces the real invariant that `stripe_session_id` is stored as non-NULL
+`""` and dedupes on `(account_id, request_id, stripe_session_id)` during a
+Stripe retry.
+
+This change fixes the root for this edge by moving the test to the same live
+asyncpg/Postgres adapter harness as the adjacent reconciliation test and
+asserting persisted ledger state plus retry idempotency.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert only `test_deflection_reconciliation_binds_empty_string_for_missing_session_id`
+   from `_Pool` SQL-call assertions to a live Postgres reconciliation ledger
+   assertion.
+2. Prove the aged missing-report Checkout handler records `stripe_session_id`
+   as `""` for an empty session id, never `NULL`.
+3. Prove retry idempotency by invoking the handler twice and asserting one
+   reconciliation row remains.
+4. Preserve the no-delivery side effect for the account.
+
+### Review Contract
+
+- Acceptance criteria:
+  - The converted test uses `_connect_live_billing_pool()` and
+    `_apply_live_billing_migrations()`, not `_Pool`.
+  - The test asserts the persisted reconciliation row shape, including
+    `stripe_session_id == ""`.
+  - The test asserts `COUNT(*) == 1` after the first handler call and again
+    after a same-event retry.
+  - The test asserts no report delivery was queued for the account.
+- Affected surfaces:
+  - `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+- Risk areas:
+  - Billing/payment reconciliation idempotency.
+  - Empty Stripe session id handling in the unique ledger key.
+  - Live test cleanup isolation.
+- Reviewer rules:
+  - R1 Requirements match.
+  - R2 Test evidence.
+  - R4 Data integrity / persistence.
+  - R8 Error / edge cases.
+  - R11 Money path.
+  - R14 Codebase verification.
+
+### Files touched
+
+- `plans/PR-Billing-Checkout-Missing-Session-Reconciliation-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+The test creates a synthetic Checkout session with `session_id=""`, applies the
+live billing migrations, cleans account/request rows, and calls
+`_handle_content_ops_deflection_report_checkout_completed()` with an aged event
+so the handler takes the permanent paid-but-missing reconciliation path.
+
+Instead of inspecting fake SQL calls, the test reads
+`content_ops_deflection_paid_reconciliation` through asyncpg and asserts the
+row persisted with:
+
+```python
+{
+    "account_id": account_id,
+    "request_id": "req-live-checkout-missing-session-reconciliation",
+    "stripe_session_id": "",
+    "event_type": "checkout.session.completed",
+    "reason": "paid_report_missing",
+}
+```
+
+It then replays the same handler call and asserts the ledger count remains one,
+which proves the real `ON CONFLICT`/migration 337 empty-string behavior rather
+than the fake call path.
+
+## Intentional
+
+- This keeps direct handler coverage as the exercised boundary; full webhook
+  event dedupe/audit coverage remains owned by the existing webhook tests.
+- This does not modify production billing code. Migrations 336/337 and the
+  `session_id or ""` path already landed; this slice replaces the fake proof
+  with persisted-state proof.
+- The Stripe Checkout session remains synthetic while the database adapter and
+  reconciliation ledger state are real.
+
+## Deferred
+
+- Remaining billing fake-pool checkout/refund/dispute/delta tests and the
+  temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up
+  slices.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  - Pass.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -k 'missing_session_id'`
+  - Pass: 1 passed, 58 deselected.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  - Pass: 59 passed.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --top 10`
+  - Pass/advisory: `billing.py` remains score 178 with `INTERNAL_MOCK x38`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Checkout-Missing-Session-Reconciliation-Live-Adapter.md` | 125 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 104 |
+| **Total** | **229** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1204,6 +1204,7 @@ async def test_deflection_checkout_completion_records_reconciliation_when_event_
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_deflection_reconciliation_binds_empty_string_for_missing_session_id(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -1212,33 +1213,88 @@ async def test_deflection_reconciliation_binds_empty_string_for_missing_session_
     # so a NULL would defeat the ON CONFLICT dedup on a Stripe retry (#1462 gap).
     caplog.set_level(logging.ERROR, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id, session_id="")
-    pool = _Pool()
-    pool.update_result = "UPDATE 0"
+    request_id = "req-live-checkout-missing-session-reconciliation"
+    session = _session(account_id=account_id, request_id=request_id, session_id="")
     aged_event_created = int(time.time()) - 100_000  # past the 300s grace
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_missing_session_unused",
+        )
 
-    returned = await billing._handle_content_ops_deflection_report_checkout_completed(
-        pool,
-        session,
-        session.metadata,
-        event_created=aged_event_created,
-    )
+        returned = (
+            await billing._handle_content_ops_deflection_report_checkout_completed(
+                pool,
+                session,
+                session.metadata,
+                event_created=aged_event_created,
+            )
+        )
 
-    assert returned is None
-    reconciliations = [
-        call
-        for call in pool.execute_calls
-        if "content_ops_deflection_paid_reconciliation" in call[0]
-    ]
-    assert len(reconciliations) == 1
-    _query, args = reconciliations[0]
-    assert args == (
-        account_id,
-        "req-123",
-        "",  # '' not None -- the NULL-dedup gap fix
-        "checkout.session.completed",
-        "paid_report_missing",
-    )
+        assert returned is None
+        reconciliation = await pool.fetchrow(
+            """
+            SELECT account_id, request_id, stripe_session_id, event_type, reason
+            FROM content_ops_deflection_paid_reconciliation
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert reconciliation is not None
+        assert dict(reconciliation) == {
+            "account_id": account_id,
+            "request_id": request_id,
+            "stripe_session_id": "",
+            "event_type": "checkout.session.completed",
+            "reason": "paid_report_missing",
+        }
+        reconciliation_count_query = """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_paid_reconciliation
+            WHERE account_id = $1 AND request_id = $2
+            """
+        assert (
+            await pool.fetchval(reconciliation_count_query, account_id, request_id)
+            == 1
+        )
+
+        retry_returned = (
+            await billing._handle_content_ops_deflection_report_checkout_completed(
+                pool,
+                session,
+                session.metadata,
+                event_created=aged_event_created,
+            )
+        )
+        assert retry_returned is None
+        assert (
+            await pool.fetchval(reconciliation_count_query, account_id, request_id)
+            == 1
+        )
+        assert (
+            await pool.fetchval(
+                """
+                SELECT COUNT(*)
+                FROM content_ops_deflection_report_deliveries
+                WHERE account_id = $1
+                """,
+                account_id,
+            )
+            == 0
+        )
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_missing_session_unused",
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Checkout-Missing-Session-Reconciliation-Live-Adapter.md
Slice phase: Production hardening

Convert the missing-session paid reconciliation checkout test from fake DB-pool SQL-call assertions to live asyncpg/Postgres persisted-state assertions. The test now proves the ledger stores `stripe_session_id` as an empty string, retries dedupe to one row, and no delivery is queued for the account.

## Intentional
- Direct handler coverage remains the exercised boundary; full webhook event dedupe/audit coverage stays with existing webhook tests.
- No production billing code changes; this replaces fake proof with persisted-state proof for behavior already in `billing.py` and migration 337.
- The Stripe Checkout session remains synthetic while the database adapter and reconciliation ledger state are real.

## Deferred
- Remaining billing fake-pool checkout/refund/dispute/delta tests and the temporary `_resolve_billing_db_pool` direct-call shim stay for follow-up slices.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` — pass.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -k 'missing_session_id'` — pass: 1 passed, 58 deselected.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` — pass: 59 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --top 10` — pass/advisory: `billing.py` remains score 178 with `INTERNAL_MOCK x38`.

## Diff size
2 files, +205 / -24.
