### PR TITLE
Convert billing checkout completion leftovers to live adapter

### DIFF
--- a/plans/PR-Billing-Checkout-Completion-Leftovers-Live-Adapter.md
+++ b/plans/PR-Billing-Checkout-Completion-Leftovers-Live-Adapter.md
@@ -1,0 +1,141 @@
+# PR-Billing-Checkout-Completion-Leftovers-Live-Adapter
+
+## Why this slice exists
+
+The real-adapters/test-quality lane is burning down billing tests that still
+prove money-path behavior with hand-written DB-pool fakes. #1902-#1908 covered
+the main Checkout completion success, delivery, missing-report, reconciliation,
+race-window, and lower-authorized-amount paths. The remaining Checkout
+completion fake-pool tests are the endpoint for this sub-arc: invalid session
+fail-closed, amount terms mismatch, missing-report incident emission, and wrong
+authorized variant.
+
+Root cause: these tests still rely on `_Pool` call history, `_Pool.add_report()`,
+or fake row dictionaries. That proves the fake's internal bookkeeping, but it
+does not prove persisted state for money-path failures and it weakens the
+pre-adapter fail-closed boundary by using a fake DB object rather than proving
+the DB is not touched.
+
+This change fixes the root for the Checkout completion leftovers by:
+
+1. using an explicit no-DB sentinel for invalid sessions, because those cases
+   must return before any persistence adapter is touched;
+2. using live asyncpg/Postgres state for terms mismatch, missing-report incident,
+   and wrong-authorized-variant paths.
+
+Diff budget note: this slice is over the 400 LOC soft cap because it deliberately
+closes the Checkout-completion fake-test endpoint before the delta/subscription
+section. Splitting it would leave the same handler boundary half-fake and add
+another review/merge cycle for tightly coupled edge cases that share the same
+helper setup and verification command.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert only the remaining Checkout-completion fake tests before the
+   delta/subscription section:
+   - `test_deflection_checkout_completion_fails_closed_for_invalid_sessions`
+   - `test_deflection_checkout_completion_emits_incident_when_report_missing`
+   - `test_deflection_checkout_completion_emits_incident_for_terms_mismatch`
+   - `test_deflection_checkout_completion_rejects_wrong_authorized_variant`
+2. Prove invalid sessions do not touch persistence at all.
+3. Prove amount terms mismatch leaves the live report unpaid and queues no
+   delivery.
+4. Prove missing-report incident emission on the live missing-report path.
+5. Prove wrong authorized variant leaves the live report unpaid, queues no
+   delivery, and emits expected authorized-terms mismatch evidence.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Invalid-session coverage no longer uses `_Pool`; it uses a sentinel whose
+    DB methods fail if touched.
+  - Terms mismatch uses `_connect_live_billing_pool()` and asserts persisted
+    unpaid/no-delivery state plus the incident payload.
+  - Missing-report incident uses `_connect_live_billing_pool()` and asserts the
+    409, incident payload, no report row, and no delivery row.
+  - Wrong authorized variant uses live `record_checkout_authorization()` metadata
+    and asserts persisted unpaid/no-delivery state plus the expected mismatch
+    payload fields.
+- Affected surfaces:
+  - `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+- Risk areas:
+  - Billing/payment fail-closed behavior.
+  - Checkout amount/currency gates.
+  - Authorized checkout terms.
+  - Paid-but-missing incident visibility.
+  - Live test cleanup isolation.
+- Reviewer rules:
+  - R1 Requirements match.
+  - R2 Test evidence.
+  - R4 Data integrity / persistence.
+  - R8 Error / edge cases.
+  - R11 Money path.
+  - R14 Codebase verification.
+
+### Files touched
+
+- `plans/PR-Billing-Checkout-Completion-Leftovers-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+The invalid-session test gets a tiny sentinel object with `is_initialized =
+True` and DB methods that raise if called. That proves invalid mode/status,
+missing/invalid IDs, bad amount, and bad currency return before the persistence
+boundary.
+
+The other three tests use the live billing pool, apply the same migrations as
+the surrounding live Checkout tests, clean unique account/request rows, and
+assert observable state:
+
+- terms mismatch: seeded report remains unpaid, no delivery row, incident
+  payload emitted;
+- missing report: handler raises 409, no report/delivery rows, incident payload
+  emitted;
+- wrong authorized variant: seeded report has standard authorization metadata,
+  lower paid session is globally allowed but does not match the report; report
+  remains unpaid, no delivery row, expected mismatch payload emitted.
+
+## Intentional
+
+- Invalid sessions intentionally use a no-DB sentinel rather than a live pool:
+  the correct behavior is to stop before the DB adapter, so a live adapter would
+  be weaker than a fail-if-touched boundary probe.
+- This groups the remaining Checkout-completion fake tests because they form a
+  single endpoint before the delta/subscription section; the modest soft-cap
+  overage is called out in Why this slice exists.
+- This does not modify production billing code. The slice replaces fake proof
+  with persisted-state or explicit no-DB proof for existing behavior.
+
+## Deferred
+
+- Delta subscription/entitlement fake-pool tests remain for the next sub-arc.
+- Won-dispute/restore and remaining miss-incident fake-pool tests remain for
+  follow-up slices.
+- The temporary `_resolve_billing_db_pool` direct-call shim stays until the
+  remaining fake-pool tests are drained.
+
+Parked hardening: none.
+
+## Verification
+
+- py_compile for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  - Pass.
+- Focused live pytest for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  with `-k 'invalid_sessions or terms_mismatch or report_missing or wrong_authorized_variant'`
+  - Pass: 14 passed, 45 deselected.
+- Full live pytest for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  - Pass: 59 passed.
+- Maturity sweep: `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --top 10`
+  - Pass/advisory: `billing.py` remains score 178 with `INTERNAL_MOCK x38`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Checkout-Completion-Leftovers-Live-Adapter.md` | 141 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 319 |
+| **Total** | **460** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -65,6 +65,22 @@ class _InitializedAsyncpgPool:
         await self._pool.close()
 
 
+class _NoDbPool:
+    is_initialized = True
+
+    async def execute(self, *_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("invalid session should not touch the DB")
+
+    async def fetchval(self, *_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("invalid session should not touch the DB")
+
+    async def fetchrow(self, *_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("invalid session should not touch the DB")
+
+    async def fetch(self, *_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("invalid session should not touch the DB")
+
+
 async def _connect_live_billing_pool() -> _InitializedAsyncpgPool:
     asyncpg = pytest.importorskip("asyncpg")
     database_url = os.environ.get("ATLAS_MIGRATION_TEST_DATABASE_URL")
@@ -998,7 +1014,7 @@ async def test_deflection_checkout_completion_fails_closed_for_invalid_sessions(
     kwargs = {"account_id": str(uuid.uuid4())}
     kwargs[field] = value
     session = _session(**kwargs)
-    pool = _Pool()
+    pool = _NoDbPool()
 
     returned = await billing._handle_content_ops_deflection_report_checkout_completed(
         pool,
@@ -1007,7 +1023,6 @@ async def test_deflection_checkout_completion_fails_closed_for_invalid_sessions(
     )
 
     assert returned is None
-    assert pool.execute_calls == []
 
 
 @pytest.mark.asyncio
@@ -1073,33 +1088,73 @@ async def test_deflection_checkout_completion_fails_closed_when_report_missing()
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_deflection_checkout_completion_emits_incident_when_report_missing(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.ERROR, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id)
-    pool = _Pool()
-    pool.update_result = "UPDATE 0"
-
-    with pytest.raises(billing.HTTPException):
-        await billing._handle_content_ops_deflection_report_checkout_completed(
+    request_id = "req-live-checkout-missing-report-incident"
+    session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id="cs_test_checkout_missing_report_incident_live",
+    )
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
             pool,
-            session,
-            session.metadata,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_missing_report_incident_unused",
         )
 
-    payloads = _incident_payloads(caplog)
-    assert payloads == [
-        {
-            "account_id": account_id,
-            "event_type": "checkout.session.completed",
-            "incident_type": "paid_report_missing_after_payment",
-            "request_id": "req-123",
-            "severity": "error",
-            "stripe_session_id": "cs_test_deflection",
-        }
-    ]
+        with pytest.raises(billing.HTTPException) as exc:
+            await billing._handle_content_ops_deflection_report_checkout_completed(
+                pool,
+                session,
+                session.metadata,
+            )
+
+        assert exc.value.status_code == 409
+        assert exc.value.detail == "Deflection report not found"
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        ) == 0
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        payloads = _incident_payloads(caplog)
+        assert payloads == [
+            {
+                "account_id": account_id,
+                "event_type": "checkout.session.completed",
+                "incident_type": "paid_report_missing_after_payment",
+                "request_id": request_id,
+                "severity": "error",
+                "stripe_session_id": "cs_test_checkout_missing_report_incident_live",
+            }
+        ]
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_missing_report_incident_unused",
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio
@@ -1376,36 +1431,90 @@ def test_reconcile_grace_config_rejects_non_positive_values() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_deflection_checkout_completion_emits_incident_for_terms_mismatch(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.ERROR, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id, amount_total=149999)
-    pool = _Pool()
-    pool.add_report(account_id=account_id)
-
-    returned = await billing._handle_content_ops_deflection_report_checkout_completed(
-        pool,
-        session,
-        session.metadata,
+    request_id = "req-live-checkout-terms-mismatch-amount"
+    session = _session(
+        account_id=account_id,
+        request_id=request_id,
+        session_id="cs_test_checkout_terms_mismatch_amount_live",
+        amount_total=149999,
     )
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_terms_mismatch_unused",
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live checkout terms mismatch billing test",
+        )
 
-    assert returned is None
-    assert pool.execute_calls == []
-    payloads = _incident_payloads(caplog)
-    assert payloads == [
-        {
-            "account_id": account_id,
-            "amount_total": "149999",
-            "currency": "usd",
-            "event_type": "checkout.session.completed",
-            "incident_type": "paid_report_checkout_terms_mismatch",
-            "request_id": "req-123",
-            "severity": "error",
-            "stripe_session_id": "cs_test_deflection",
+        returned = await billing._handle_content_ops_deflection_report_checkout_completed(
+            pool,
+            session,
+            session.metadata,
+        )
+
+        assert returned is None
+        report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference, checkout_price_variant,
+                   checkout_amount_cents, checkout_currency, checkout_price_id
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert dict(report) == {
+            "paid": False,
+            "payment_reference": None,
+            "checkout_price_variant": None,
+            "checkout_amount_cents": None,
+            "checkout_currency": None,
+            "checkout_price_id": None,
         }
-    ]
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        payloads = _incident_payloads(caplog)
+        assert payloads == [
+            {
+                "account_id": account_id,
+                "amount_total": "149999",
+                "currency": "usd",
+                "event_type": "checkout.session.completed",
+                "incident_type": "paid_report_checkout_terms_mismatch",
+                "request_id": request_id,
+                "severity": "error",
+                "stripe_session_id": "cs_test_checkout_terms_mismatch_amount_live",
+            }
+        ]
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_terms_mismatch_unused",
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio
@@ -1502,61 +1611,107 @@ async def test_deflection_checkout_completion_accepts_lower_authorized_amount(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_deflection_checkout_completion_rejects_wrong_authorized_variant(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.ERROR, logger="atlas.api.billing")
     account_id = str(uuid.uuid4())
-    session = _session(account_id=account_id, amount_total=120000)
-    pool = _Pool()
-    pool.add_report(
+    request_id = "req-live-checkout-wrong-authorized-variant"
+    session = _session(
         account_id=account_id,
-        checkout_price_variant="standard",
-        checkout_amount_cents=150000,
-        checkout_currency="usd",
-        checkout_price_id="price_standard",
+        request_id=request_id,
+        session_id="cs_test_checkout_wrong_authorized_variant_live",
+        amount_total=120000,
     )
     monkeypatch.setattr(
         billing.settings.saas_auth,
         "stripe_content_ops_deflection_report_allowed_amount_cents",
         "120000,150000",
     )
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_wrong_authorized_variant_unused",
+        )
+        await _seed_live_deflection_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            account_name="Live checkout wrong authorized variant test",
+        )
+        store = PostgresDeflectionReportArtifactStore(pool=pool)
+        assert await store.record_checkout_authorization(
+            account_id=account_id,
+            request_id=request_id,
+            price_variant="standard",
+            amount_cents=150000,
+            currency="usd",
+            price_id="price_standard",
+        )
 
-    returned = await billing._handle_content_ops_deflection_report_checkout_completed(
-        pool,
-        session,
-        session.metadata,
-    )
+        returned = await billing._handle_content_ops_deflection_report_checkout_completed(
+            pool,
+            session,
+            session.metadata,
+        )
 
-    assert returned is None
-    assert pool.report_rows[(account_id, "req-123")]["paid"] is False
-    update_query, update_args = pool.execute_calls[0]
-    assert "UPDATE content_ops_deflection_reports" in update_query
-    assert update_args == (
-        account_id,
-        "req-123",
-        "cs_test_deflection",
-        120000,
-        "usd",
-        True,
-    )
-    assert len(pool.execute_calls) == 1
-    assert _incident_payloads(caplog) == [
-        {
-            "account_id": account_id,
-            "amount_total": "120000",
-            "currency": "usd",
-            "event_type": "checkout.session.completed",
-            "expected_amount_cents": "150000",
-            "expected_currency": "usd",
-            "expected_price_variant": "standard",
-            "incident_type": "paid_report_checkout_terms_mismatch",
-            "request_id": "req-123",
-            "severity": "error",
-            "stripe_session_id": "cs_test_deflection",
+        assert returned is None
+        report = await pool.fetchrow(
+            """
+            SELECT paid, payment_reference, checkout_price_variant,
+                   checkout_amount_cents, checkout_currency, checkout_price_id
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        assert report is not None
+        assert dict(report) == {
+            "paid": False,
+            "payment_reference": None,
+            "checkout_price_variant": "standard",
+            "checkout_amount_cents": 150000,
+            "checkout_currency": "usd",
+            "checkout_price_id": "price_standard",
         }
-    ]
+        assert await pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM content_ops_deflection_report_deliveries
+            WHERE account_id = $1
+            """,
+            account_id,
+        ) == 0
+        assert _incident_payloads(caplog) == [
+            {
+                "account_id": account_id,
+                "amount_total": "120000",
+                "currency": "usd",
+                "event_type": "checkout.session.completed",
+                "expected_amount_cents": "150000",
+                "expected_currency": "usd",
+                "expected_price_variant": "standard",
+                "incident_type": "paid_report_checkout_terms_mismatch",
+                "request_id": request_id,
+                "severity": "error",
+                "stripe_session_id": "cs_test_checkout_wrong_authorized_variant_live",
+            }
+        ]
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+            stripe_event_id="evt_live_checkout_wrong_authorized_variant_unused",
+        )
+        await pool.close()
 
 
 def test_deflection_checkout_amount_requires_exact_default_amount() -> None:


### PR DESCRIPTION
Plan: plans/PR-Billing-Checkout-Completion-Leftovers-Live-Adapter.md
Slice phase: Production hardening

Convert the remaining Checkout-completion fake-pool edge tests to live asyncpg/Postgres state assertions or an explicit no-DB boundary sentinel. This closes invalid-session, terms-mismatch, missing-report incident, and wrong-authorized-variant coverage before the delta/subscription sub-arc.

## Intentional
- Invalid sessions use a fail-if-touched no-DB sentinel because correct behavior is to return before persistence.
- The slice modestly exceeds the 400 LOC soft cap to close the Checkout-completion fake-test endpoint in one review cycle.
- No production billing code changes; this replaces fake proof with persisted-state or explicit no-DB proof for existing behavior.

## Deferred
- Delta subscription/entitlement fake-pool tests remain for the next sub-arc.
- Won-dispute/restore and remaining miss-incident fake-pool tests remain for follow-up slices.
- The temporary `_resolve_billing_db_pool` direct-call shim stays until the remaining fake-pool tests are drained.

## Parked hardening
- None.

## AI reconciliation
- All findings fixed or waived: Yes.
- Human MAJOR: added `@pytest.mark.integration` to the three live-DB tests.
- Human NIT: terms-mismatch now asserts the full report row keeps paid/payment and checkout fields empty.
- Codex marker finding: addressed by the same integration marker additions.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` — pass.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -k 'invalid_sessions or terms_mismatch or report_missing or wrong_authorized_variant'` — pass: 14 passed, 45 deselected.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` — pass: 59 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --top 10` — pass/advisory: `billing.py` remains score 178 with `INTERNAL_MOCK x38`.

## Diff size
2 files, +378 / -82.
