### PR TITLE
Convert billing delta subscription updated test to live adapter

### DIFF
--- a/plans/PR-Billing-Delta-Subscription-Updated-Live-Adapter.md
+++ b/plans/PR-Billing-Delta-Subscription-Updated-Live-Adapter.md
@@ -1,0 +1,126 @@
+# PR-Billing-Delta-Subscription-Updated-Live-Adapter
+
+## Why this slice exists
+
+Issue #1877 is burning down tests that mock first-party billing persistence
+instead of exercising the real DB adapter. The Checkout-completion endpoint is
+now closed through #1909, so the next fake cluster is the deflection-delta
+subscription entitlement webhook path.
+
+Root cause: `test_stripe_webhook_delta_subscription_updated_upserts_entitlement`
+uses the hand-written `_Pool` fake and asserts SQL snippets / call order for
+`billing_events` instead of proving the webhook persists the billing event
+through asyncpg/Postgres. That keeps the entitlement grant path partly real
+through `InMemoryDeflectionReportArtifactStore` but leaves the audit/idempotency
+boundary fake.
+
+This PR fixes the root for one webhook event (`customer.subscription.updated`)
+by replacing `_Pool` with the live billing DB adapter and persisted
+`billing_events` assertions. It does not try to drain every remaining delta
+event in one PR; those are separate permutations with their own event payloads.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_delta_subscription_updated_upserts_entitlement` from
+   `_Pool` to `_connect_live_billing_pool()`.
+2. Assert the webhook still grants deflection-delta entitlement through the
+   in-memory artifact store while the billing event is persisted in the live
+   database with the expected account, event id, and event type.
+3. Preserve the prior no-`saas_accounts`-mutation invariant as a live
+   before/after row-state assertion.
+4. Keep Stripe itself mocked at the webhook boundary; this is a billing
+   persistence/adapter proof, not a Stripe API integration test.
+
+### Review Contract
+
+- Acceptance criteria:
+  - The converted test has `@pytest.mark.integration`.
+  - The converted test no longer instantiates `_Pool` or asserts on
+    `execute_calls`.
+  - The test applies live billing migrations, account-scoped cleanup, and closes
+    the pool in `finally`.
+  - The entitlement grant remains observable through
+    `list_deflection_delta_entitled_account_ids()`.
+  - The test proves `saas_accounts` plan/status/customer/subscription fields do
+    not change during a delta subscription entitlement webhook.
+  - The billing event is asserted from Postgres, not from fake SQL call capture.
+- Affected surfaces:
+  - Stripe webhook tests for deflection-delta subscription entitlement.
+  - Live billing test helpers in
+    `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`.
+- Risk areas:
+  - Accidentally widening cleanup beyond the test account/event.
+  - Masking the entitlement grant by replacing the artifact store boundary with
+    another fake.
+  - Leaving the test in the non-integration unit backstop.
+- Triggered reviewer rules:
+  - R2 Test evidence.
+  - R3 Security/auth/payment path.
+  - R8 Stateful persistence.
+  - R14 Codebase verification.
+
+### Files touched
+
+- `plans/PR-Billing-Delta-Subscription-Updated-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+- In the converted test:
+  - connect to the live migration test DB;
+  - apply the billing migrations;
+  - delete prior rows for the generated account/event with the existing
+    account-scoped live cleanup helper;
+  - seed a `saas_accounts` row with account-scoped sentinel
+    plan/status/customer/subscription values required by the `billing_events`
+    account FK and no-mutation proof;
+  - run the webhook with the same mocked Stripe module and in-memory entitlement
+    store;
+  - assert the entitlement store includes the account;
+  - assert the seeded `saas_accounts` fields are unchanged after the webhook;
+  - assert `billing_events` contains exactly one row for the delta subscription
+    event, account, event type, and JSON payload.
+- Close the live pool in a `finally` block.
+
+## Intentional
+
+- The entitlement artifact store remains in-memory because this slice is focused
+  on replacing the billing DB fake. Later slices can decide whether to exercise
+  the Postgres artifact store for entitlement rows.
+- This does not delete `_Pool`; other delta/invoice tests still use it and will
+  be converted in follow-up slices.
+- Stripe remains mocked because the true external boundary is Stripe webhook
+  construction, not first-party persistence.
+
+## Deferred
+
+- Convert the remaining delta invoice/checkout/subscription fake-pool tests.
+- Convert `test_non_delta_subscription_does_not_create_delta_entitlement` from
+  fake customer-account lookup to live DB.
+- Drain or remove `_Pool` only after the remaining fake-pool users are gone.
+
+Parked hardening: none.
+
+## Verification
+
+- py_compile for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  - Pass.
+- Focused live pytest for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  with `-k 'delta_subscription_updated'`
+  - Pass: 1 passed, 58 deselected.
+- Full live pytest for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+  - Pass: 59 passed.
+- Maturity sweep: `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --top 10`
+  - Pass/advisory: `billing.py` remains score 178 with `INTERNAL_MOCK x38`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Delta-Subscription-Updated-Live-Adapter.md` | 126 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 114 |
+| **Total** | **240** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
@@ -1832,10 +1833,15 @@ def test_deflection_delta_price_ids_parse_as_exact_deduped_set(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_delta_subscription_updated_upserts_entitlement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     account_id = str(uuid.uuid4())
+    existing_customer_id = f"cus_existing_delta_{account_id}"
+    existing_subscription_id = f"sub_existing_delta_{account_id}"
+    stripe_event_id = "evt_delta_subscription_active"
+    event_type = "customer.subscription.updated"
     monkeypatch.setattr(
         billing.settings.saas_auth,
         "stripe_content_ops_deflection_delta_price_ids",
@@ -1844,29 +1850,103 @@ async def test_stripe_webhook_delta_subscription_updated_upserts_entitlement(
     subscription = _subscription(account_id=account_id, status="active")
     event = SimpleNamespace(
         created=1_781_000_000,
-        id="evt_delta_subscription_active",
-        type="customer.subscription.updated",
+        id=stripe_event_id,
+        type=event_type,
         data=SimpleNamespace(object=subscription),
     )
     fake_stripe, _session_list = _stripe_module_for_event(event)
-    pool = _Pool()
     store = InMemoryDeflectionReportArtifactStore()
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id="delta-subscription-updated",
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.execute(
+            """
+            INSERT INTO saas_accounts (
+                id,
+                name,
+                plan,
+                plan_status,
+                stripe_customer_id,
+                stripe_subscription_id
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            uuid.UUID(account_id),
+            "Delta Subscription Updated Test",
+            "trial",
+            "trialing",
+            existing_customer_id,
+            existing_subscription_id,
+        )
+        account_before = await pool.fetchrow(
+            """
+            SELECT plan, plan_status, stripe_customer_id, stripe_subscription_id
+            FROM saas_accounts
+            WHERE id = $1
+            """,
+            uuid.UUID(account_id),
+        )
+        assert dict(account_before) == {
+            "plan": "trial",
+            "plan_status": "trialing",
+            "stripe_customer_id": existing_customer_id,
+            "stripe_subscription_id": existing_subscription_id,
+        }
 
-    response = await _run_stripe_webhook(
-        monkeypatch,
-        event=event,
-        pool=pool,
-        stripe_module=fake_stripe,
-        entitlement_store=store,
-    )
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+            entitlement_store=store,
+        )
 
-    assert response == {"status": "ok"}
-    assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
-    assert not any("UPDATE saas_accounts" in query for query, _args in pool.execute_calls)
-    billing_event_query, billing_event_args = pool.execute_calls[0]
-    assert "INSERT INTO billing_events" in billing_event_query
-    assert str(billing_event_args[0]) == account_id
-    assert billing_event_args[1] == "evt_delta_subscription_active"
+        assert response == {"status": "ok"}
+        assert await store.list_deflection_delta_entitled_account_ids() == (account_id,)
+        account_after = await pool.fetchrow(
+            """
+            SELECT plan, plan_status, stripe_customer_id, stripe_subscription_id
+            FROM saas_accounts
+            WHERE id = $1
+            """,
+            uuid.UUID(account_id),
+        )
+        assert dict(account_after) == dict(account_before)
+        event_row = await pool.fetchrow(
+            """
+            SELECT account_id, event_type, payload
+            FROM billing_events
+            WHERE stripe_event_id = $1
+            """,
+            stripe_event_id,
+        )
+        assert event_row is not None
+        assert str(event_row["account_id"]) == account_id
+        assert event_row["event_type"] == event_type
+        payload = event_row["payload"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        assert payload["id"] == "sub_delta"
+        assert payload["metadata"]["account_id"] == account_id
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type=event_type,
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id="delta-subscription-updated",
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Delta-Subscription-Updated-Live-Adapter.md
Slice phase: Production hardening

Convert the delta `customer.subscription.updated` webhook test from the hand-written `_Pool` fake to live asyncpg/Postgres billing-event assertions. This keeps Stripe mocked at the external webhook boundary and keeps the entitlement store in-memory, but the billing audit/idempotency boundary is now proved against the real DB adapter.

## Intentional
- Entitlement artifact store remains in-memory because this slice targets billing DB persistence.
- `_Pool` remains for the remaining delta invoice/checkout/subscription permutations.
- Stripe remains mocked; the true external boundary is webhook construction, not first-party persistence.

## Deferred
- Convert the remaining delta invoice/checkout/subscription fake-pool tests.
- Convert the non-delta subscription lookup test from fake customer-account lookup to live DB.
- Drain or remove `_Pool` after the remaining fake-pool users are gone.

## Parked hardening
- None.

## AI reconciliation
- All findings fixed or waived: Yes.
- Codex P2: restored the no-`saas_accounts`-mutation invariant as a live DB before/after row-state assertion.
- Codex P2: made the Stripe customer/subscription sentinel values account-scoped so interrupted live DB runs cannot collide on UNIQUE columns.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` — pass.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -k 'delta_subscription_updated'` — pass: 1 passed, 58 deselected.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` — pass: 59 passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --top 10` — pass/advisory: `billing.py` remains score 178 with `INTERNAL_MOCK x38`.

## Diff size
2 files, +223 / -17.
