### PR TITLE
Convert billing delta invoice payment-failed test to live adapter

### DIFF
--- a/plans/PR-Billing-Delta-Invoice-Payment-Failed-Live-Adapter.md
+++ b/plans/PR-Billing-Delta-Invoice-Payment-Failed-Live-Adapter.md
@@ -1,0 +1,122 @@
+# PR-Billing-Delta-Invoice-Payment-Failed-Live-Adapter
+
+## Why this slice exists
+
+Issue #1877 is burning down tests that mock first-party billing persistence
+instead of exercising the real DB adapter. #1910 converted the delta
+`customer.subscription.updated` grant path. The next fake-pool delta webhook is
+`invoice.payment_failed`, which proves entitlement revocation but still uses the
+hand-written `_Pool` fake for billing-event persistence and account mutation
+guards.
+
+Root cause: `test_stripe_webhook_delta_invoice_payment_failed_revokes_entitlement`
+uses `_Pool.execute_calls` as the persistence proof and as the no-account-update
+guard. That proves a fake SQL recorder, not the real asyncpg/Postgres adapter.
+
+This PR fixes the root for one webhook event (`invoice.payment_failed`) by
+replacing `_Pool` with the live billing DB adapter, persisted `billing_events`
+assertions, and a live before/after `saas_accounts` no-mutation assertion.
+
+## Scope (this PR)
+
+Ownership lane: real-adapters/test-quality
+Slice phase: Production hardening
+
+1. Convert
+   `test_stripe_webhook_delta_invoice_payment_failed_revokes_entitlement` from
+   `_Pool` to `_connect_live_billing_pool()`.
+2. Assert the webhook still revokes deflection-delta entitlement through the
+   in-memory artifact store while the billing event is persisted in the live
+   database with the expected account, event id, event type, and payload.
+3. Preserve the prior no-`saas_accounts`-mutation invariant as a live
+   before/after row-state assertion.
+4. Keep Stripe itself mocked at the webhook boundary; this is a billing
+   persistence/adapter proof, not a Stripe API integration test.
+
+### Review Contract
+
+- Acceptance criteria:
+  - The converted test has `@pytest.mark.integration`.
+  - The converted test no longer instantiates `_Pool` or asserts on
+    `execute_calls`.
+  - The entitlement revocation remains observable through
+    `list_deflection_delta_entitled_account_ids()`.
+  - The test proves `saas_accounts` plan/status/customer/subscription fields do
+    not change during a delta invoice payment-failed webhook.
+  - The billing event is asserted from Postgres, not from fake SQL call capture.
+- Affected surfaces:
+  - Stripe webhook tests for deflection-delta invoice entitlement revocation.
+  - Live billing test helpers in
+    `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`.
+- Risk areas:
+  - Accidentally widening cleanup beyond the test account/event.
+  - Reintroducing constant values for unique Stripe customer/subscription
+    sentinel fields.
+  - Leaving the live DB test in the non-integration unit backstop.
+- Triggered reviewer rules:
+  - R2 Test evidence.
+  - R3 Security/auth/payment path.
+  - R8 Stateful persistence.
+  - R14 Codebase verification.
+
+### Files touched
+
+- `plans/PR-Billing-Delta-Invoice-Payment-Failed-Live-Adapter.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+- In the converted test:
+  - connect to the live migration test DB;
+  - apply the billing migrations;
+  - delete prior rows for the generated account/event with the existing
+    account-scoped live cleanup helper;
+  - seed a `saas_accounts` row with account-scoped sentinel
+    plan/status/customer/subscription values for the `billing_events` account
+    FK and no-mutation proof;
+  - seed an active in-memory delta entitlement;
+  - run the webhook with the same mocked Stripe module and in-memory entitlement
+    store;
+  - assert the entitlement store no longer returns the account;
+  - assert the seeded `saas_accounts` fields are unchanged after the webhook;
+  - assert `billing_events` contains exactly one row for the delta invoice
+    payment-failed event, account, event type, and JSON payload.
+- Close the live pool in a `finally` block.
+
+## Intentional
+
+- The entitlement artifact store remains in-memory because this slice is focused
+  on replacing billing DB persistence. Later slices can decide whether to
+  exercise the Postgres artifact store for entitlement rows.
+- This does not delete `_Pool`; other delta invoice/checkout/subscription tests
+  still use it and will be converted in follow-up slices.
+- Stripe remains mocked because the true external boundary is Stripe webhook
+  construction, not first-party persistence.
+
+## Deferred
+
+- Convert the remaining delta invoice-paid, subscription-created, checkout, and
+  non-delta subscription fake-pool tests.
+- Drain or remove `_Pool` only after the remaining fake-pool users are gone.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+- Command: ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -k 'delta_invoice_payment_failed'
+  - 1 passed, 58 deselected.
+- Command: ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+  - 59 passed.
+- Command: python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --top 10
+  - Pass/advisory; `atlas_brain/api/billing.py` remains flagged with known
+    existing debt (`SWALLOWED_EXCEPT x4`, `INTERNAL_MOCK x38`,
+    `UNGUARDED_INDEX x3`).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Billing-Delta-Invoice-Payment-Failed-Live-Adapter.md` | 122 |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | 117 |
+| **Total** | **239** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1950,10 +1950,15 @@ async def test_stripe_webhook_delta_subscription_updated_upserts_entitlement(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_stripe_webhook_delta_invoice_payment_failed_revokes_entitlement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     account_id = str(uuid.uuid4())
+    existing_customer_id = f"cus_existing_delta_failed_{account_id}"
+    existing_subscription_id = f"sub_existing_delta_failed_{account_id}"
+    stripe_event_id = f"evt_delta_invoice_failed_{account_id}"
+    event_type = "invoice.payment_failed"
     monkeypatch.setattr(
         billing.settings.saas_auth,
         "stripe_content_ops_deflection_delta_price_ids",
@@ -1962,12 +1967,11 @@ async def test_stripe_webhook_delta_invoice_payment_failed_revokes_entitlement(
     invoice = _dahlia_subscription_invoice(account_id=account_id)
     event = SimpleNamespace(
         created=200,
-        id="evt_delta_invoice_failed",
-        type="invoice.payment_failed",
+        id=stripe_event_id,
+        type=event_type,
         data=SimpleNamespace(object=invoice),
     )
     fake_stripe, _session_list = _stripe_module_for_event(event)
-    pool = _Pool()
     store = InMemoryDeflectionReportArtifactStore()
     await store.upsert_deflection_delta_entitlement(
         account_id=account_id,
@@ -1977,20 +1981,103 @@ async def test_stripe_webhook_delta_invoice_payment_failed_revokes_entitlement(
         stripe_subscription_status="active",
         stripe_event_created=100,
     )
+    pool = await _connect_live_billing_pool()
+    try:
+        await _apply_live_billing_migrations(pool)
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id="delta-invoice-payment-failed",
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.execute(
+            """
+            INSERT INTO saas_accounts (
+                id,
+                name,
+                plan,
+                plan_status,
+                stripe_customer_id,
+                stripe_subscription_id
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            uuid.UUID(account_id),
+            "Delta Invoice Payment Failed Test",
+            "trial",
+            "trialing",
+            existing_customer_id,
+            existing_subscription_id,
+        )
+        account_before = await pool.fetchrow(
+            """
+            SELECT plan, plan_status, stripe_customer_id, stripe_subscription_id
+            FROM saas_accounts
+            WHERE id = $1
+            """,
+            uuid.UUID(account_id),
+        )
+        assert dict(account_before) == {
+            "plan": "trial",
+            "plan_status": "trialing",
+            "stripe_customer_id": existing_customer_id,
+            "stripe_subscription_id": existing_subscription_id,
+        }
 
-    response = await _run_stripe_webhook(
-        monkeypatch,
-        event=event,
-        pool=pool,
-        stripe_module=fake_stripe,
-        entitlement_store=store,
-    )
+        response = await _run_stripe_webhook(
+            monkeypatch,
+            event=event,
+            pool=pool,
+            stripe_module=fake_stripe,
+            entitlement_store=store,
+        )
 
-    assert response == {"status": "ok"}
-    assert await store.list_deflection_delta_entitled_account_ids(
-        fallback_account_ids=(account_id, "acct-config"),
-    ) == ("acct-config",)
-    assert not any("UPDATE saas_accounts" in query for query, _args in pool.execute_calls)
+        assert response == {"status": "ok"}
+        assert await store.list_deflection_delta_entitled_account_ids(
+            fallback_account_ids=(account_id, "acct-config"),
+        ) == ("acct-config",)
+        account_after = await pool.fetchrow(
+            """
+            SELECT plan, plan_status, stripe_customer_id, stripe_subscription_id
+            FROM saas_accounts
+            WHERE id = $1
+            """,
+            uuid.UUID(account_id),
+        )
+        assert dict(account_after) == dict(account_before)
+        event_row = await pool.fetchrow(
+            """
+            SELECT account_id, event_type, payload
+            FROM billing_events
+            WHERE stripe_event_id = $1
+            """,
+            stripe_event_id,
+        )
+        assert event_row is not None
+        assert str(event_row["account_id"]) == account_id
+        assert event_row["event_type"] == event_type
+        payload = event_row["payload"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        assert payload["id"] == "in_delta"
+        assert payload["metadata"]["account_id"] == account_id
+        assert (
+            payload["parent"]["subscription_details"]["subscription"]
+            == "sub_delta"
+        )
+        assert await _billing_event_count(
+            pool,
+            stripe_event_id=stripe_event_id,
+            event_type=event_type,
+        ) == 1
+    finally:
+        await _cleanup_live_billing_rows(
+            pool,
+            account_id=account_id,
+            request_id="delta-invoice-payment-failed",
+            stripe_event_id=stripe_event_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Billing-Delta-Invoice-Payment-Failed-Live-Adapter.md
Slice phase: Production hardening

Convert the delta invoice.payment_failed webhook test from the hand-written `_Pool` SQL recorder to the live billing DB adapter. The slice preserves the entitlement-revocation assertion, adds persisted `billing_events` coverage, and keeps the old no-`saas_accounts` mutation guard as a live before/after row-state assertion.

## Intentional
- The entitlement artifact store remains in-memory because this slice is focused on billing DB persistence and account mutation behavior.
- Stripe remains mocked at the webhook boundary; this is not a Stripe API integration test.
- `_Pool` remains for other tests that will be converted in follow-up slices.

## Deferred
- Convert the remaining delta invoice-paid, subscription-created, checkout, and non-delta subscription fake-pool tests.
- Drain or remove `_Pool` after the remaining fake-pool users are gone.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: No findings yet; PR not opened.
- All fixed or waived: N/A.
- Waivers justified: N/A.

## Verification
- Command: python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
- Command: ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -k 'delta_invoice_payment_failed'
  - 1 passed, 58 deselected.
- Command: ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
  - 59 passed.
- Command: python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --top 10
  - Pass/advisory; `atlas_brain/api/billing.py` remains flagged with known existing debt (`SWALLOWED_EXCEPT x4`, `INTERNAL_MOCK x38`, `UNGUARDED_INDEX x3`).

## Diff size
2 files, +224 / -15
