### PR TITLE
Add deflection launch preflight runbook

### DIFF
--- a/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
@@ -34,11 +34,19 @@ GAP_REPORT_NOTIFICATION_RESEND_API_KEY
 GAP_REPORT_NOTIFICATION_FROM_EMAIL
 ```
 
-Verify ATLAS can send the paid report email:
+The Snapshot sender is implemented in the deployed `atlas-portfolio` Next.js
+app (`web/src/lib/gap-report-intake.ts`, `sendSnapshotEmail`). The hosted result
+URL must be served by that same `atlas-portfolio` deployment at
+`/systems/support-ticket-deflection/results/{request_id}`. Do not point this
+proof at the legacy in-repo `portfolio-ui` SPA route
+`/services/faq-deflection/results/{request_id}`.
+
+Verify ATLAS has the paid report email config present, but keep live scheduling
+off until after queue isolation and PDF render validation:
 
 ```bash
-ATLAS_DEFLECTION_DELIVERY_ENABLED=true
-ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false
+ATLAS_DEFLECTION_DELIVERY_ENABLED=false
+ATLAS_DEFLECTION_DELIVERY_DRY_RUN=true
 ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL
 ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY
 ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL="https://juancanfield.com"
@@ -49,7 +57,9 @@ ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL="https://juancanfield.com"
 `{request_id}` and resolve to
 `/systems/support-ticket-deflection/results/{request_id}`.
 
-Confirm the paid delivery task is enabled and scheduled:
+Confirm the paid delivery task will not auto-send before the rehearsal. Before
+checkout, either the task must be disabled or deployed delivery must still be in
+dry-run:
 
 ```bash
 curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
@@ -57,8 +67,9 @@ curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
   | jq '.tasks[] | select(.name == "content_ops_deflection_report_delivery") | {id, enabled, next_run_at, metadata}'
 ```
 
-Stop if `enabled` is not true, if `next_run_at` is empty, or if the deployed
-delivery config still reports dry-run for the live-send proof.
+Stop if the scheduler is enabled and live-send config is active before the
+queue-only rehearsal. That can claim the pending delivery row as soon as Stripe
+queues it and bypass the dry-run proof.
 
 ## Database Gate
 
@@ -102,8 +113,8 @@ An email without the Snapshot PDF is not launch proof.
 
 ## Paid Unlock Gate
 
-Complete checkout for the same `request_id`, then confirm the webhook unlocked
-the report and queued paid delivery:
+Complete a real Stripe Checkout for the same `request_id`, then confirm the
+webhook unlocked the report and queued paid delivery. Do not replay a synthetic webhook for launch proof; replay proves delivery wiring but can skip the real Checkout price authorization path.
 
 ```bash
 psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
@@ -127,7 +138,33 @@ and `delivery_status` is `pending`.
 
 ## Paid Report Email And PDF Proof
 
-Rehearse the delivery drain first:
+The current manual drain CLI is queue-wide and only has `--limit`; it does not accept a request/account filter. Before running it, prove the target request is
+the only claimable delivery row:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
+WITH claimable AS (
+  SELECT account_id, request_id, created_at, delivery_status
+  FROM content_ops_deflection_report_deliveries
+  WHERE delivery_status = 'pending'
+     OR (
+       delivery_status = 'sending'
+       AND updated_at < NOW() - INTERVAL '15 minutes'
+     )
+)
+SELECT
+  count(*) AS claimable_rows,
+  count(*) FILTER (WHERE request_id = '<request-id>') AS target_rows,
+  min(created_at) AS oldest_claimable_at
+FROM claimable;
+"
+```
+
+Proceed only if `claimable_rows` is 1 and `target_rows` is 1. If any other
+claimable row exists, stop and add a scoped paid-delivery proof before live
+send; otherwise the proof can email a different buyer.
+
+Run the delivery drain in queue-only dry-run mode:
 
 ```bash
 python scripts/send_content_ops_deflection_report_deliveries.py \
@@ -139,12 +176,48 @@ python scripts/send_content_ops_deflection_report_deliveries.py \
 ```
 
 The dry-run JSON must show at least one scanned row, `dry_run` at least 1,
-`sent` 0, and `failed` 0. If the dry run scans zero rows, the email path was
-not rehearsed.
+`sent` 0, and `failed` 0. This proves queue selection and paid/email gating
+only. It does not render the PDF or build the email body.
 
-Only after the dry-run payload is reviewed, send live:
+Before live send, render the paid PDF from the target artifact with the real
+renderer:
 
 ```bash
+mkdir -p tmp/deflection-launch-preflight
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "
+SELECT artifact::text
+FROM content_ops_deflection_reports
+WHERE request_id = '<request-id>'
+  AND paid IS TRUE
+  AND COALESCE(delivery_email, '') = '$LAUNCH_BUYER_EMAIL';
+" > tmp/deflection-launch-preflight/paid-artifact.json
+
+python - <<'PY'
+import json
+from pathlib import Path
+from atlas_brain.deflection_pdf_renderer import render_deflection_full_report_pdf
+
+artifact_path = Path("tmp/deflection-launch-preflight/paid-artifact.json")
+pdf_path = Path("tmp/deflection-launch-preflight/paid-report.pdf")
+artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+pdf_bytes = render_deflection_full_report_pdf(artifact)
+assert pdf_bytes.startswith(b"%PDF-")
+assert len(pdf_bytes) > 1000
+pdf_path.write_bytes(pdf_bytes)
+print(f"rendered {pdf_path} ({len(pdf_bytes)} bytes)")
+PY
+```
+
+Stop if rendering fails or the artifact query returns no row. The first exercise
+of paid PDF rendering must not be the live buyer send.
+
+Only after queue isolation, queue-only dry-run, and local PDF render validation
+pass, temporarily enable live delivery and send:
+
+```bash
+ATLAS_DEFLECTION_DELIVERY_ENABLED=true
+ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false
+
 python scripts/send_content_ops_deflection_report_deliveries.py \
   --database-url "$DATABASE_URL" \
   --from-email "$ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL" \

--- a/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
@@ -4,8 +4,9 @@ Use this runbook before public paid Resolution Audit traffic. The launch proof
 is not complete until both buyer-facing email surfaces are observed with their
 PDF attachments and the emailed hosted result URL opens the expected report.
 
-Track the finished proof on #1921, then link the final artifact back to #1440
-and #1386.
+Track the finished proof on #1921, then link the sanitized proof scorecard back
+to #1440 and #1386. Never attach raw live emails, exact result URLs, PDFs, or
+artifact JSON to GitHub issues.
 
 ## Inputs
 
@@ -185,22 +186,26 @@ Before live send, render the paid PDF from the target artifact with the real
 renderer:
 
 ```bash
-mkdir -p tmp/deflection-launch-preflight
+export PREFLIGHT_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/deflection-launch-preflight.XXXXXX")"
+trap 'rm -rf "$PREFLIGHT_TMP_DIR"' EXIT
+
 psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "
 SELECT artifact::text
 FROM content_ops_deflection_reports
 WHERE request_id = '<request-id>'
   AND paid IS TRUE
   AND COALESCE(delivery_email, '') = '$LAUNCH_BUYER_EMAIL';
-" > tmp/deflection-launch-preflight/paid-artifact.json
+" > "$PREFLIGHT_TMP_DIR/paid-artifact.json"
 
 python - <<'PY'
 import json
+import os
 from pathlib import Path
 from atlas_brain.deflection_pdf_renderer import render_deflection_full_report_pdf
 
-artifact_path = Path("tmp/deflection-launch-preflight/paid-artifact.json")
-pdf_path = Path("tmp/deflection-launch-preflight/paid-report.pdf")
+tmp_dir = Path(os.environ["PREFLIGHT_TMP_DIR"])
+artifact_path = tmp_dir / "paid-artifact.json"
+pdf_path = tmp_dir / "paid-report.pdf"
 artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
 pdf_bytes = render_deflection_full_report_pdf(artifact)
 assert pdf_bytes.startswith(b"%PDF-")
@@ -211,7 +216,10 @@ PY
 ```
 
 Stop if rendering fails or the artifact query returns no row. The first exercise
-of paid PDF rendering must not be the live buyer send.
+of paid PDF rendering must not be the live buyer send. The files in
+`PREFLIGHT_TMP_DIR` contain paid buyer report data; do not commit, upload, or
+link them. The shell `trap` removes them on exit; if the shell is interrupted,
+run `rm -rf "$PREFLIGHT_TMP_DIR"` before closeout.
 
 Only after queue isolation, queue-only dry-run, and local PDF render validation
 pass, run one manual live send for the isolated proof row:
@@ -241,7 +249,7 @@ ATLAS_DEFLECTION_DELIVERY_ENABLED=true
 ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false
 ```
 
-Then verify the deployed scheduler picked up that configuration:
+Then verify the deployed scheduler is enabled and scheduled:
 
 ```bash
 curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
@@ -249,10 +257,74 @@ curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
   | jq '.tasks[] | select(.name == "content_ops_deflection_report_delivery") | {id, enabled, next_run_at, metadata}'
 ```
 
-Proceed only if the task is `enabled`, has a `next_run_at`, and its metadata
-shows the enabled config value is live. Stop if the hosted scheduler still
-reports disabled or dry-run config; a manual one-off email is not enough to
-launch public paid delivery.
+Proceed only if the task is `enabled` and has a `next_run_at`. Metadata alone
+does not prove the live dry-run setting.
+
+Before probing the hosted scheduler, prove there are no claimable paid delivery
+rows left; the manual proof row should now be delivered, and the earlier
+isolation gate proved no other row was claimable:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
+WITH claimable AS (
+  SELECT account_id, request_id
+  FROM content_ops_deflection_report_deliveries
+  WHERE delivery_status = 'pending'
+     OR (
+       delivery_status = 'sending'
+       AND updated_at < NOW() - INTERVAL '15 minutes'
+     )
+)
+SELECT count(*) AS claimable_rows FROM claimable;
+"
+```
+
+Proceed only if `claimable_rows` is 0. If any row is claimable, stop and drain
+or quarantine it before running the autonomous task probe.
+
+Now run the deployed task without metadata overrides and inspect the completed
+execution result. Do not pass `{"dry_run": false}` in the request body; that
+would prove only an override, not the hosted setting.
+
+```bash
+TASK_ID="$(
+  curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
+    -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
+    | jq -er '.tasks[]
+      | select(.name == "content_ops_deflection_report_delivery")
+      | select(.enabled == true and .next_run_at != null)
+      | .id'
+)"
+
+RUN_ID="$(
+  curl -fsS -X POST \
+    "$ATLAS_API_BASE_URL/api/v1/autonomous/content_ops_deflection_report_delivery/run" \
+    -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{}' \
+    | jq -er '.execution_id'
+)"
+
+sleep 5
+
+curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/$TASK_ID/executions?limit=5" \
+  -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
+  | jq -e --arg run_id "$RUN_ID" '
+      .executions[]
+      | select(.id == $run_id)
+      | select(.status == "completed")
+      | (.result_text | fromjson) as $result
+      | select($result.dry_run_enabled == false)
+      | select($result.scanned == 0)
+      | select($result.sent == 0)
+      | select($result.failed == 0)
+    '
+```
+
+Proceed only if the execution result proves `dry_run_enabled` is false with zero
+claimable work scanned/sent/failed. Stop if the task is disabled, has no
+`next_run_at`, the execution is missing/failed/running, `result_text` is not
+valid JSON, `dry_run_enabled` is true, or any row is scanned. The manual one-off email is not enough to launch public paid delivery.
 
 The paid email must include key numbers, next actions, ready-to-publish rows
 when available, the hosted result URL, and a paid report PDF attachment. A
@@ -288,7 +360,25 @@ Before launch, also confirm:
 - portfolio cleanup cron is installed and authenticated with `CRON_SECRET`;
 - Privacy, Security, Terms, refund, and support-contact links are present or
   explicitly accepted as hand-held beta gaps;
-- the final proof artifact is linked on #1921, #1440, and #1386.
+- the local paid artifact/PDF temp directory has been removed:
+  `rm -rf "${PREFLIGHT_TMP_DIR:-}"`;
+- a sanitized proof scorecard, not raw live artifacts, is linked on #1921, #1440, and #1386.
+
+Build the scorecard from manually sanitized proof notes only. Exclude raw
+emails, exact hosted result URLs, raw PDFs, paid artifact JSON, source IDs,
+ticket evidence, buyer email addresses, request IDs, checkout session IDs,
+Resend message IDs, and Stripe event IDs. Raw live bundles stay uncommitted.
+Before linking anything, run the redaction gate:
+
+```bash
+python scripts/check_deflection_full_report_proof_bundle.py \
+  tmp/deflection-launch-preflight-scorecard \
+  --output tmp/deflection-launch-preflight-scorecard/redaction-check.json \
+  --pretty
+```
+
+Link only the sanitized scorecard plus the passing redaction-check output. Stop
+if the redaction gate fails.
 
 If any gate fails, stop launch, record the failed gate on #1921, and rerun this
 runbook after the fix lands.

--- a/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
@@ -81,15 +81,17 @@ SELECT name
 FROM schema_migrations
 WHERE name IN (
   '331_content_ops_deflection_report_delivery_email',
-  '332_content_ops_deflection_report_deliveries'
+  '332_content_ops_deflection_report_deliveries',
+  '342_content_ops_deflection_checkout_authorization'
 )
 ORDER BY name;
 "
 ```
 
-Both rows must be present before paid delivery proof. Migration 331 stores the
-buyer delivery email on the report; migration 332 creates the paid delivery
-queue.
+All three rows must be present before paid delivery proof. Migration 331 stores
+the buyer delivery email on the report; migration 332 creates the paid delivery
+queue; migration 342 adds the checkout authorization columns that the real
+Stripe unlock path reads and writes.
 
 ## Snapshot Email And PDF Proof
 
@@ -212,7 +214,7 @@ Stop if rendering fails or the artifact query returns no row. The first exercise
 of paid PDF rendering must not be the live buyer send.
 
 Only after queue isolation, queue-only dry-run, and local PDF render validation
-pass, temporarily enable live delivery and send:
+pass, run one manual live send for the isolated proof row:
 
 ```bash
 ATLAS_DEFLECTION_DELIVERY_ENABLED=true
@@ -230,6 +232,27 @@ python scripts/send_content_ops_deflection_report_deliveries.py \
 
 Proceed only if the live JSON has `sent` 1 and `failed` 0, and the buyer inbox
 receives the paid report email.
+
+Before launch, deploy or restart ATLAS with the hosted scheduler configured for
+live paid delivery, not only the one-off manual CLI:
+
+```bash
+ATLAS_DEFLECTION_DELIVERY_ENABLED=true
+ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false
+```
+
+Then verify the deployed scheduler picked up that configuration:
+
+```bash
+curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
+  -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
+  | jq '.tasks[] | select(.name == "content_ops_deflection_report_delivery") | {id, enabled, next_run_at, metadata}'
+```
+
+Proceed only if the task is `enabled`, has a `next_run_at`, and its metadata
+shows the enabled config value is live. Stop if the hosted scheduler still
+reports disabled or dry-run config; a manual one-off email is not enough to
+launch public paid delivery.
 
 The paid email must include key numbers, next actions, ready-to-publish rows
 when available, the hosted result URL, and a paid report PDF attachment. A

--- a/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
@@ -19,6 +19,8 @@ export ATLAS_ADMIN_TOKEN="<operator-token>"
 export DATABASE_URL="<production-postgres-dsn>"
 export LAUNCH_BUYER_EMAIL="<real-opted-in-buyer-email>"
 export LAUNCH_CSV_FILE="<realistic-or-full-volume-support-export.csv>"
+export ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL="<paid-report-from-email>"
+export ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY="<paid-report-resend-key>"
 ```
 
 Use an opted-in buyer address for the live proof. Do not use `@example.com`,
@@ -142,30 +144,50 @@ and `delivery_status` is `pending`.
 ## Paid Report Email And PDF Proof
 
 The current manual drain CLI is queue-wide and only has `--limit`; it does not accept a request/account filter. Before running it, prove the target request is
-the only claimable delivery row:
+the only pending/sending delivery row and the only claimable row. This blocks
+older non-target `sending` rows that could age into the stale-reclaim window
+between rehearsal and the live send:
 
 ```bash
 psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
-WITH claimable AS (
-  SELECT account_id, request_id, created_at, delivery_status
+WITH delivery_candidates AS (
+  SELECT account_id, request_id, created_at, updated_at, delivery_status
   FROM content_ops_deflection_report_deliveries
-  WHERE delivery_status = 'pending'
-     OR (
-       delivery_status = 'sending'
-       AND updated_at < NOW() - INTERVAL '15 minutes'
-     )
+  WHERE delivery_status IN ('pending', 'sending')
 )
 SELECT
-  count(*) AS claimable_rows,
-  count(*) FILTER (WHERE request_id = '<request-id>') AS target_rows,
-  min(created_at) AS oldest_claimable_at
-FROM claimable;
+  count(*) FILTER (
+    WHERE delivery_status = 'pending'
+       OR delivery_status = 'sending'
+  ) AS pending_or_sending_rows,
+  count(*) FILTER (
+    WHERE delivery_status = 'pending'
+       OR (
+         delivery_status = 'sending'
+         AND updated_at < NOW() - INTERVAL '15 minutes'
+       )
+  ) AS claimable_rows,
+  count(*) FILTER (
+    WHERE request_id = '<request-id>'
+      AND delivery_status = 'pending'
+  ) AS target_rows,
+  count(*) FILTER (WHERE request_id <> '<request-id>') AS other_pending_or_sending_rows,
+  min(created_at) FILTER (
+    WHERE delivery_status = 'pending'
+       OR (
+         delivery_status = 'sending'
+         AND updated_at < NOW() - INTERVAL '15 minutes'
+       )
+  ) AS oldest_claimable_at
+FROM delivery_candidates;
 "
 ```
 
-Proceed only if `claimable_rows` is 1 and `target_rows` is 1. If any other
-claimable row exists, stop and add a scoped paid-delivery proof before live
-send; otherwise the proof can email a different buyer.
+Proceed only if `claimable_rows` is 1, `target_rows` is 1, and
+`other_pending_or_sending_rows` is 0. If any other pending/sending row exists,
+stop and add a scoped paid-delivery proof before live send; otherwise the proof
+can email a different buyer after a non-target `sending` row ages into the
+claim window.
 
 Run the delivery drain in queue-only dry-run mode:
 
@@ -226,7 +248,10 @@ link them. The shell `trap` removes them on exit; if the shell is interrupted,
 run `rm -rf "$PREFLIGHT_TMP_DIR"` before closeout.
 
 Only after queue isolation, queue-only dry-run, and local PDF render validation
-pass, run one manual live send for the isolated proof row:
+pass, rerun the queue-isolation SQL above immediately before live send. Proceed
+only if it still shows `claimable_rows` 1, `target_rows` 1, and
+`other_pending_or_sending_rows` 0. Then run one manual live send for the
+isolated proof row:
 
 ```bash
 ATLAS_DEFLECTION_DELIVERY_ENABLED=true
@@ -283,6 +308,8 @@ expected_prefix = (
 )
 if parsed.netloc != urlparse("https://juancanfield.com").netloc:
     raise SystemExit(f"deployed result URL host mismatch: {url}")
+if parsed.scheme != "https":
+    raise SystemExit(f"deployed result URL scheme mismatch: {url}")
 if parsed.path != expected_prefix:
     raise SystemExit(f"deployed result URL path mismatch: {url}")
 print(url)
@@ -461,8 +488,11 @@ python scripts/check_deflection_full_report_proof_bundle.py \
   --pretty
 ```
 
-Link only the sanitized scorecard plus the passing redaction-check output. Stop
-if the redaction gate fails.
+The redaction gate must fail on request IDs, exact result URLs, buyer emails,
+checkout session IDs, payment intent IDs, Resend provider message IDs, Stripe
+event IDs, raw evidence, source ID lists, private notes, local paths, unreadable
+artifacts, and PDFs. Link only the sanitized scorecard plus the passing
+redaction-check output. Stop if the redaction gate fails.
 
 If any gate fails, stop launch, record the failed gate on #1921, and rerun this
 runbook after the fix lands.

--- a/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
@@ -252,13 +252,19 @@ ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false
 Then verify the deployed scheduler is enabled and scheduled:
 
 ```bash
+curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/status/summary" \
+  -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
+  | jq -e 'select(.running == true and .scheduled_count > 0)'
+
 curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
   -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
   | jq '.tasks[] | select(.name == "content_ops_deflection_report_delivery") | {id, enabled, next_run_at, metadata}'
 ```
 
-Proceed only if the task is `enabled` and has a `next_run_at`. Metadata alone
-does not prove the live dry-run setting.
+Proceed only if the scheduler summary reports `running` true with at least one
+scheduled task, and the delivery task row is `enabled` with a `next_run_at`.
+Metadata alone does not prove the scheduler loop is running or the live dry-run
+setting.
 
 Before probing the hosted scheduler, prove there are no claimable paid delivery
 rows left; the manual proof row should now be delivered, and the earlier
@@ -305,26 +311,59 @@ RUN_ID="$(
     | jq -er '.execution_id'
 )"
 
-sleep 5
+python - <<'PY'
+import ast
+import json
+import os
+import time
+import urllib.request
 
-curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/$TASK_ID/executions?limit=5" \
-  -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
-  | jq -e --arg run_id "$RUN_ID" '
-      .executions[]
-      | select(.id == $run_id)
-      | select(.status == "completed")
-      | (.result_text | fromjson) as $result
-      | select($result.dry_run_enabled == false)
-      | select($result.scanned == 0)
-      | select($result.sent == 0)
-      | select($result.failed == 0)
-    '
+base_url = os.environ["ATLAS_API_BASE_URL"].rstrip("/")
+task_id = os.environ["TASK_ID"]
+run_id = os.environ["RUN_ID"]
+token = os.environ["ATLAS_ADMIN_TOKEN"]
+
+for _ in range(12):
+    req = urllib.request.Request(
+        f"{base_url}/api/v1/autonomous/{task_id}/executions?limit=5",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    payload = json.loads(urllib.request.urlopen(req, timeout=30).read())
+    execution = next(
+        (item for item in payload.get("executions", []) if item.get("id") == run_id),
+        None,
+    )
+    if execution and execution.get("status") != "running":
+        break
+    time.sleep(5)
+else:
+    raise SystemExit("scheduler proof execution did not finish")
+
+if execution is None:
+    raise SystemExit("scheduler proof execution missing")
+if execution.get("status") != "completed":
+    raise SystemExit(f"scheduler proof execution failed: {execution!r}")
+
+# HeadlessRunner persists builtin dict results with str(result), not JSON.
+result = ast.literal_eval(str(execution.get("result_text") or "{}"))
+expected = {
+    "dry_run_enabled": False,
+    "scanned": 0,
+    "sent": 0,
+    "failed": 0,
+}
+for key, value in expected.items():
+    if result.get(key) != value:
+        raise SystemExit(f"scheduler proof mismatch for {key}: {result!r}")
+print(json.dumps({"execution_id": run_id, "result": result}, sort_keys=True))
+PY
 ```
 
 Proceed only if the execution result proves `dry_run_enabled` is false with zero
 claimable work scanned/sent/failed. Stop if the task is disabled, has no
-`next_run_at`, the execution is missing/failed/running, `result_text` is not
-valid JSON, `dry_run_enabled` is true, or any row is scanned. The manual one-off email is not enough to launch public paid delivery.
+`next_run_at`, the scheduler summary is not running, the execution is
+missing/failed/running, `result_text` cannot be parsed as the builtin task
+result repr, `dry_run_enabled` is true, or any row is scanned. The manual one-off email is not enough to launch public paid delivery.
 
 The paid email must include key numbers, next actions, ready-to-publish rows
 when available, the hosted result URL, and a paid report PDF attachment. A

--- a/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
@@ -189,12 +189,16 @@ renderer:
 export PREFLIGHT_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/deflection-launch-preflight.XXXXXX")"
 trap 'rm -rf "$PREFLIGHT_TMP_DIR"' EXIT
 
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "
+psql "$DATABASE_URL" \
+  -v ON_ERROR_STOP=1 \
+  -v request_id="<request-id>" \
+  -v buyer_email="$LAUNCH_BUYER_EMAIL" \
+  -At -c "
 SELECT artifact::text
 FROM content_ops_deflection_reports
-WHERE request_id = '<request-id>'
+WHERE request_id = :'request_id'
   AND paid IS TRUE
-  AND COALESCE(delivery_email, '') = '$LAUNCH_BUYER_EMAIL';
+  AND COALESCE(delivery_email, '') = :'buyer_email';
 " > "$PREFLIGHT_TMP_DIR/paid-artifact.json"
 
 python - <<'PY'
@@ -249,7 +253,44 @@ ATLAS_DEFLECTION_DELIVERY_ENABLED=true
 ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false
 ```
 
-Then verify the deployed scheduler is enabled and scheduled:
+First, from the deployed ATLAS runtime after deploy/restart, verify the
+scheduler-owned URL config builds the buyer result URL. This must use the same
+environment as the autonomous scheduler, not local CLI flags:
+
+```bash
+python - <<'PY'
+from urllib.parse import urlparse
+
+from atlas_brain.config import settings
+from atlas_brain.content_ops_deflection_delivery import (
+    DeflectionReportDeliveryConfig,
+    deflection_report_result_url,
+)
+
+cfg = settings.deflection_delivery
+url = deflection_report_result_url(
+    request_id="preflight-url-check",
+    config=DeflectionReportDeliveryConfig(
+        from_email=str(cfg.from_email or "").strip(),
+        result_base_url=str(cfg.result_base_url or "").strip(),
+        result_url_template=str(cfg.result_url_template or "").strip(),
+        subject=str(cfg.subject or "").strip(),
+    ),
+)
+parsed = urlparse(url)
+expected_prefix = (
+    "/systems/support-ticket-deflection/results/preflight-url-check"
+)
+if parsed.netloc != urlparse("https://juancanfield.com").netloc:
+    raise SystemExit(f"deployed result URL host mismatch: {url}")
+if parsed.path != expected_prefix:
+    raise SystemExit(f"deployed result URL path mismatch: {url}")
+print(url)
+PY
+```
+
+Then, from the operator shell, verify the deployed scheduler is enabled and
+scheduled:
 
 ```bash
 curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/status/summary" \
@@ -262,9 +303,13 @@ curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
 ```
 
 Proceed only if the scheduler summary reports `running` true with at least one
-scheduled task, and the delivery task row is `enabled` with a `next_run_at`.
-Metadata alone does not prove the scheduler loop is running or the live dry-run
-setting.
+scheduled task, the delivery task row is `enabled` with a `next_run_at`, and the
+deployed runtime URL probe prints a
+`https://juancanfield.com/systems/support-ticket-deflection/results/preflight-url-check`
+URL. Run the URL probe inside the deployed ATLAS runtime after deploy/restart;
+do not satisfy it with the local CLI `--result-base-url`. Metadata alone does
+not prove the scheduler loop is running, the deployed URL config, or the live
+dry-run setting.
 
 Before probing the hosted scheduler, prove there are no claimable paid delivery
 rows left; the manual proof row should now be delivered, and the earlier
@@ -293,7 +338,7 @@ execution result. Do not pass `{"dry_run": false}` in the request body; that
 would prove only an override, not the hosted setting.
 
 ```bash
-TASK_ID="$(
+export TASK_ID="$(
   curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
     -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
     | jq -er '.tasks[]
@@ -302,7 +347,7 @@ TASK_ID="$(
       | .id'
 )"
 
-RUN_ID="$(
+export RUN_ID="$(
   curl -fsS -X POST \
     "$ATLAS_API_BASE_URL/api/v1/autonomous/content_ops_deflection_report_delivery/run" \
     -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \

--- a/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
@@ -1,0 +1,198 @@
+# Content Ops Deflection Launch Preflight Runbook
+
+Use this runbook before public paid Resolution Audit traffic. The launch proof
+is not complete until both buyer-facing email surfaces are observed with their
+PDF attachments and the emailed hosted result URL opens the expected report.
+
+Track the finished proof on #1921, then link the final artifact back to #1440
+and #1386.
+
+## Inputs
+
+Set these locally before the proof:
+
+```bash
+export PORTFOLIO_BASE_URL="https://juancanfield.com"
+export ATLAS_API_BASE_URL="https://atlas.example.com"
+export ATLAS_ADMIN_TOKEN="<operator-token>"
+export DATABASE_URL="<production-postgres-dsn>"
+export LAUNCH_BUYER_EMAIL="<real-opted-in-buyer-email>"
+export LAUNCH_CSV_FILE="<realistic-or-full-volume-support-export.csv>"
+```
+
+Use an opted-in buyer address for the live proof. Do not use `@example.com`,
+`@test`, seed data, or an operator-only inbox as proof of customer delivery.
+
+## Deployed Config Check
+
+Verify portfolio can submit to ATLAS and send the Snapshot email:
+
+```bash
+ATLAS_API_BASE_URL
+ATLAS_B2B_SERVICE_TOKEN
+GAP_REPORT_NOTIFICATION_RESEND_API_KEY
+GAP_REPORT_NOTIFICATION_FROM_EMAIL
+```
+
+Verify ATLAS can send the paid report email:
+
+```bash
+ATLAS_DEFLECTION_DELIVERY_ENABLED=true
+ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false
+ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL
+ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY
+ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL="https://juancanfield.com"
+```
+
+`ATLAS_DEFLECTION_DELIVERY_RESULT_URL_TEMPLATE` may replace
+`ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL`, but it must contain
+`{request_id}` and resolve to
+`/systems/support-ticket-deflection/results/{request_id}`.
+
+Confirm the paid delivery task is enabled and scheduled:
+
+```bash
+curl -fsS "$ATLAS_API_BASE_URL/api/v1/autonomous/?include_disabled=true" \
+  -H "Authorization: Bearer $ATLAS_ADMIN_TOKEN" \
+  | jq '.tasks[] | select(.name == "content_ops_deflection_report_delivery") | {id, enabled, next_run_at, metadata}'
+```
+
+Stop if `enabled` is not true, if `next_run_at` is empty, or if the deployed
+delivery config still reports dry-run for the live-send proof.
+
+## Database Gate
+
+Verify the paid-report delivery migrations are present:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
+SELECT name
+FROM schema_migrations
+WHERE name IN (
+  '331_content_ops_deflection_report_delivery_email',
+  '332_content_ops_deflection_report_deliveries'
+)
+ORDER BY name;
+"
+```
+
+Both rows must be present before paid delivery proof. Migration 331 stores the
+buyer delivery email on the report; migration 332 creates the paid delivery
+queue.
+
+## Snapshot Email And PDF Proof
+
+Submit the CSV through the deployed portfolio intake, not by directly writing
+rows. The route must create an ATLAS report request, fetch the free Snapshot,
+and call the customer Snapshot sender with the fetched Snapshot.
+
+Proceed only when the received Snapshot email proves all of the following:
+
+- Subject matches the Snapshot intake offer.
+- Body says the free Snapshot is ready.
+- Body includes the hosted result URL:
+  `/systems/support-ticket-deflection/results/<request-id>`.
+- A Snapshot PDF is attached.
+- The PDF opens and contains summary counts, top repeat questions, customer
+  wording, the free answer teaser, and locked rank/count placeholders.
+- The PDF excludes source IDs, evidence quotes, raw ticket bodies, paid report markdown, and locked answer bodies.
+
+Stop if the portfolio logs `deflection.record.snapshot_pdf_attachment_skipped`.
+An email without the Snapshot PDF is not launch proof.
+
+## Paid Unlock Gate
+
+Complete checkout for the same `request_id`, then confirm the webhook unlocked
+the report and queued paid delivery:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
+SELECT
+  r.account_id,
+  r.request_id,
+  r.paid,
+  r.delivery_email,
+  d.delivery_status,
+  d.payment_reference
+FROM content_ops_deflection_reports r
+LEFT JOIN content_ops_deflection_report_deliveries d
+  ON d.account_id = r.account_id
+ AND d.request_id = r.request_id
+WHERE r.request_id = '<request-id>';
+"
+```
+
+Proceed only if `paid` is true, `delivery_email` is the opted-in buyer email,
+and `delivery_status` is `pending`.
+
+## Paid Report Email And PDF Proof
+
+Rehearse the delivery drain first:
+
+```bash
+python scripts/send_content_ops_deflection_report_deliveries.py \
+  --database-url "$DATABASE_URL" \
+  --from-email "$ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL" \
+  --result-base-url "$PORTFOLIO_BASE_URL" \
+  --limit 1 \
+  --json
+```
+
+The dry-run JSON must show at least one scanned row, `dry_run` at least 1,
+`sent` 0, and `failed` 0. If the dry run scans zero rows, the email path was
+not rehearsed.
+
+Only after the dry-run payload is reviewed, send live:
+
+```bash
+python scripts/send_content_ops_deflection_report_deliveries.py \
+  --database-url "$DATABASE_URL" \
+  --from-email "$ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL" \
+  --result-base-url "$PORTFOLIO_BASE_URL" \
+  --resend-api-key "$ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY" \
+  --limit 1 \
+  --send \
+  --json
+```
+
+Proceed only if the live JSON has `sent` 1 and `failed` 0, and the buyer inbox
+receives the paid report email.
+
+The paid email must include key numbers, next actions, ready-to-publish rows
+when available, the hosted result URL, and a paid report PDF attachment. A
+link-only paid email is not launch proof.
+
+## Paid PDF Shape Check
+
+The paid PDF is the curated/shareable report, not the full evidence archive.
+Confirm the attachment:
+
+- Opens as a PDF.
+- Includes a Table of contents.
+- Includes the actionable report sections from the report model.
+- Is not a 600+ page raw evidence dump.
+- Keeps ranked question tables capped at 25 rows for PDF readability.
+- Keeps question detail blocks capped at 10 questions for PDF readability.
+- Points complete source IDs and evidence quotes to the complete evidence export
+  JSON on the hosted paid result page.
+
+The complete evidence export belongs on the hosted result page/export surface,
+not in the email attachment.
+
+## Hosted URL, Cleanup, And Tracker Closeout
+
+Open the exact URL from each email:
+
+- Before checkout, the Snapshot URL must render the locked/free Snapshot state.
+- After checkout, the paid URL must render the unlocked paid report.
+- The page must not fall back to demo data for the buyer request.
+
+Before launch, also confirm:
+
+- portfolio cleanup cron is installed and authenticated with `CRON_SECRET`;
+- Privacy, Security, Terms, refund, and support-contact links are present or
+  explicitly accepted as hand-held beta gaps;
+- the final proof artifact is linked on #1921, #1440, and #1386.
+
+If any gate fails, stop launch, record the failed gate on #1921, and rerun this
+runbook after the fix lands.

--- a/plans/PR-Deflection-Launch-Preflight-Runbook.md
+++ b/plans/PR-Deflection-Launch-Preflight-Runbook.md
@@ -38,8 +38,9 @@ Slice phase: Production hardening
     is link-only without its PDF attachment.
   - The runbook names the portfolio intake path for Snapshot delivery and the
     ATLAS paid delivery drain for paid report delivery.
-  - The runbook pins ATLAS delivery config, delivery scheduler state, paid
-    delivery migrations, paid unlock queue state, dry-run rehearsal, live send,
+  - The runbook pins ATLAS delivery config, pre-rehearsal scheduler safety,
+    paid delivery migrations, real Stripe Checkout unlock, target queue
+    isolation, queue-only dry-run, local paid-PDF render validation, live send,
     curated PDF/TOC shape, hosted URL checks, cleanup/legal/support checks, and
     #1921/#1440/#1386 closeout.
   - Tests fail if those gates disappear.
@@ -76,18 +77,24 @@ with the operator sequence:
 3. Submit through deployed portfolio intake and require Snapshot email with PDF
    attachment.
 4. Complete checkout/webhook unlock and require a pending paid delivery row.
-5. Dry-run the paid delivery drain, then send live only after a positive dry
-   run.
-6. Verify the paid email attachment is the curated PDF with TOC/caps and that
+5. Keep the scheduler from auto-sending before rehearsal, prove the target row
+   is the only claimable delivery row, and run the current unscoped drain only
+   after that isolation check passes.
+6. Treat the dry run as queue-only, render the target artifact locally with the
+   real paid PDF renderer, then send live only after queue isolation and render
+   validation pass.
+7. Verify the paid email attachment is the curated PDF with TOC/caps and that
    complete evidence remains on the hosted/export surface.
-7. Open the exact emailed URLs and close out cleanup/legal/support plus
+8. Open the exact emailed URLs and close out cleanup/legal/support plus
    #1921/#1440/#1386.
 
 Add `tests/test_content_ops_deflection_launch_preflight_runbook.py` to assert
 the checked runbook still contains the required surfaces, env gates,
 migrations, skip-log blocker, delivery script, live-send proof, PDF shape, URL
-checks, and tracker closeout. Enroll that test in the extracted-pipeline
-runner next to the existing delta go-live runbook test.
+checks, legacy-route rejection, real-checkout wording, queue isolation,
+queue-only dry-run wording, local render validation, and tracker closeout.
+Enroll that test in the extracted-pipeline runner next to the existing delta
+go-live runbook test.
 
 ## Intentional
 
@@ -121,8 +128,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 198 |
-| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 128 |
+| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 271 |
+| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 135 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 146 |
-| **Total** | **473** |
+| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 171 |
+| **Total** | **578** |

--- a/plans/PR-Deflection-Launch-Preflight-Runbook.md
+++ b/plans/PR-Deflection-Launch-Preflight-Runbook.md
@@ -41,9 +41,10 @@ Slice phase: Production hardening
   - The runbook pins ATLAS delivery config, pre-rehearsal scheduler safety,
     paid delivery and checkout authorization migrations, real Stripe Checkout
     unlock, target queue isolation, queue-only dry-run, local paid-PDF render
-    validation, live send, deployed scheduler enablement, curated PDF/TOC
-    shape, hosted URL checks, cleanup/legal/support checks, and #1921/#1440/#1386
-    closeout.
+    validation, live send, deployed scheduler enablement plus live
+    `dry_run_enabled=false` execution proof, curated PDF/TOC shape, hosted URL
+    checks, local proof-file cleanup, sanitized proof scorecard redaction, and
+    #1921/#1440/#1386 closeout.
   - Tests fail if those gates disappear.
   - The new test is enrolled in `scripts/run_extracted_pipeline_checks.sh`.
 - Affected surfaces:
@@ -85,18 +86,22 @@ with the operator sequence:
    real paid PDF renderer, then send live only after queue isolation and render
    validation pass.
 7. Verify the deployed scheduler has been restarted with live paid delivery
-   config before launch; the manual drain proves one row, not public automation.
+   config before launch, prove there are zero claimable rows, then run the real
+   autonomous task and inspect its execution result for `dry_run_enabled=false`;
+   the manual drain proves one row, not public automation.
 8. Verify the paid email attachment is the curated PDF with TOC/caps and that
    complete evidence remains on the hosted/export surface.
 9. Open the exact emailed URLs and close out cleanup/legal/support plus
-   #1921/#1440/#1386.
+   #1921/#1440/#1386 using only a sanitized proof scorecard that passes the
+   full-report proof-bundle redaction gate.
 
 Add `tests/test_content_ops_deflection_launch_preflight_runbook.py` to assert
 the checked runbook still contains the required surfaces, env gates,
 migrations, checkout authorization gate, skip-log blocker, delivery script,
-live-send proof, deployed scheduler enablement, PDF shape, URL checks,
-legacy-route rejection, real-checkout wording, queue isolation, queue-only
-dry-run wording, local render validation, and tracker closeout.
+live-send proof, deployed scheduler enablement, actual `dry_run_enabled=false`
+execution proof, PDF shape, URL checks, legacy-route rejection, real-checkout
+wording, queue isolation, queue-only dry-run wording, local render validation,
+proof-file cleanup, sanitized scorecard redaction, and tracker closeout.
 Enroll that test in the extracted-pipeline runner next to the existing delta
 go-live runbook test.
 
@@ -132,8 +137,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 294 |
-| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 139 |
+| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 384 |
+| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 144 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 186 |
-| **Total** | **620** |
+| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 204 |
+| **Total** | **733** |

--- a/plans/PR-Deflection-Launch-Preflight-Runbook.md
+++ b/plans/PR-Deflection-Launch-Preflight-Runbook.md
@@ -1,0 +1,128 @@
+# PR-Deflection-Launch-Preflight-Runbook
+
+## Why this slice exists
+
+#1921 tracks the final launch preflight for the Resolution Audit funnel. The
+code paths for Snapshot email/PDF and paid report email/PDF exist, but the
+launch proof was still ambiguous: "email sent" could degrade into link-only
+delivery, paid delivery is opt-in/dry-run by default, and #1440 still needed a
+repeatable operator sequence that proves the emailed URLs and attachments.
+
+Root cause: the repo had the individual surfaces and tests, but no checked
+operator contract tying deployed config, Snapshot delivery, Stripe unlock,
+paid delivery, PDF shape, hosted URL, cleanup, and tracker closeout into one
+launch gate. This slice fixes the operator-contract root by adding a checked
+runbook plus parser-light tests that pin the load-bearing gates.
+
+The diff is slightly over the 400 LOC target because the runbook needs to be a
+complete operator sequence, and the companion tests intentionally pin each
+load-bearing launch gate so the doc cannot drift back to a vague checklist.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Add the launch preflight runbook for Snapshot email/PDF and paid report
+   email/PDF proof.
+2. Add a focused runbook test so the attachment, scheduler/config, curated PDF,
+   hosted URL, cleanup, and tracker-closeout gates cannot silently disappear.
+3. Enroll the focused test in the extracted-pipeline CI runner.
+
+### Review Contract
+
+- Acceptance criteria:
+  - The runbook treats Snapshot email/PDF and paid report email/PDF as required
+    launch surfaces.
+  - The runbook fails launch proof if Snapshot fetch is skipped or either email
+    is link-only without its PDF attachment.
+  - The runbook names the portfolio intake path for Snapshot delivery and the
+    ATLAS paid delivery drain for paid report delivery.
+  - The runbook pins ATLAS delivery config, delivery scheduler state, paid
+    delivery migrations, paid unlock queue state, dry-run rehearsal, live send,
+    curated PDF/TOC shape, hosted URL checks, cleanup/legal/support checks, and
+    #1921/#1440/#1386 closeout.
+  - Tests fail if those gates disappear.
+  - The new test is enrolled in `scripts/run_extracted_pipeline_checks.sh`.
+- Affected surfaces:
+  - Operator documentation only.
+  - Focused parser-light test only.
+- Risk areas:
+  - Money/customer email path activation.
+  - Launch proof passing on incomplete delivery.
+  - Operator runbook drift.
+- Triggered reviewer rules:
+  - R1 Requirements match.
+  - R2 Test evidence.
+  - R3 Security/auth/money path.
+  - R6 Workflow/job behavior.
+  - R8 Persistence/data lifecycle.
+  - R14 Codebase verification.
+
+### Files touched
+
+- `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md`
+- `plans/PR-Deflection-Launch-Preflight-Runbook.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_content_ops_deflection_launch_preflight_runbook.py`
+
+## Mechanism
+
+Add `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md`
+with the operator sequence:
+
+1. Verify deployed portfolio/ATLAS email and delivery config.
+2. Verify paid delivery migrations and scheduler state.
+3. Submit through deployed portfolio intake and require Snapshot email with PDF
+   attachment.
+4. Complete checkout/webhook unlock and require a pending paid delivery row.
+5. Dry-run the paid delivery drain, then send live only after a positive dry
+   run.
+6. Verify the paid email attachment is the curated PDF with TOC/caps and that
+   complete evidence remains on the hosted/export surface.
+7. Open the exact emailed URLs and close out cleanup/legal/support plus
+   #1921/#1440/#1386.
+
+Add `tests/test_content_ops_deflection_launch_preflight_runbook.py` to assert
+the checked runbook still contains the required surfaces, env gates,
+migrations, skip-log blocker, delivery script, live-send proof, PDF shape, URL
+checks, and tracker closeout. Enroll that test in the extracted-pipeline
+runner next to the existing delta go-live runbook test.
+
+## Intentional
+
+- No production defaults change. Paid report delivery remains opt-in and dry-run
+  by default until an operator performs the runbook.
+- No live database, Stripe, portfolio, or Resend call is executed in this PR.
+  This slice creates the checked operator contract; the live proof remains a
+  separate #1921 execution artifact.
+- No launch copy changes here. Landing-page copy waits until the delivery proof
+  gates settle.
+
+## Deferred
+
+- PR 2 from #1921: make the Snapshot delivery proof fail/flag when the Snapshot
+  PDF attachment is skipped.
+- PR 3 from #1921: make the paid delivery proof fail/flag when the paid PDF
+  attachment is missing.
+- PR 4 from #1921: run the full deployed proof and update #1440/#1386/#1921
+  with artifacts.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m py_compile tests/test_content_ops_deflection_launch_preflight_runbook.py -- passed
+- pytest tests/test_content_ops_deflection_launch_preflight_runbook.py -q -- 7 passed
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 195 matching tests are enrolled
+- python scripts/sync_pr_plan.py plans/PR-Deflection-Launch-Preflight-Runbook.md --check -- passed
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 198 |
+| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 128 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 146 |
+| **Total** | **473** |

--- a/plans/PR-Deflection-Launch-Preflight-Runbook.md
+++ b/plans/PR-Deflection-Launch-Preflight-Runbook.md
@@ -86,9 +86,10 @@ with the operator sequence:
    real paid PDF renderer, then send live only after queue isolation and render
    validation pass.
 7. Verify the deployed scheduler has been restarted with live paid delivery
-   config before launch, prove there are zero claimable rows, then run the real
-   autonomous task and inspect its execution result for `dry_run_enabled=false`;
-   the manual drain proves one row, not public automation.
+   config before launch, prove the scheduler loop reports `running`, prove
+   there are zero claimable rows, then run the real autonomous task and inspect
+   its repr-encoded execution result for `dry_run_enabled=false`; the manual
+   drain proves one row, not public automation.
 8. Verify the paid email attachment is the curated PDF with TOC/caps and that
    complete evidence remains on the hosted/export surface.
 9. Open the exact emailed URLs and close out cleanup/legal/support plus
@@ -98,10 +99,11 @@ with the operator sequence:
 Add `tests/test_content_ops_deflection_launch_preflight_runbook.py` to assert
 the checked runbook still contains the required surfaces, env gates,
 migrations, checkout authorization gate, skip-log blocker, delivery script,
-live-send proof, deployed scheduler enablement, actual `dry_run_enabled=false`
-execution proof, PDF shape, URL checks, legacy-route rejection, real-checkout
-wording, queue isolation, queue-only dry-run wording, local render validation,
-proof-file cleanup, sanitized scorecard redaction, and tracker closeout.
+live-send proof, deployed scheduler enablement, scheduler-loop running proof,
+actual `dry_run_enabled=false` execution proof, builtin-result repr decoding,
+PDF shape, URL checks, legacy-route rejection, real-checkout wording, queue
+isolation, queue-only dry-run wording, local render validation, proof-file
+cleanup, sanitized scorecard redaction, and tracker closeout.
 Enroll that test in the extracted-pipeline runner next to the existing delta
 go-live runbook test.
 
@@ -137,8 +139,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 384 |
-| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 144 |
+| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 423 |
+| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 146 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 204 |
-| **Total** | **733** |
+| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 211 |
+| **Total** | **781** |

--- a/plans/PR-Deflection-Launch-Preflight-Runbook.md
+++ b/plans/PR-Deflection-Launch-Preflight-Runbook.md
@@ -41,10 +41,10 @@ Slice phase: Production hardening
   - The runbook pins ATLAS delivery config, pre-rehearsal scheduler safety,
     paid delivery and checkout authorization migrations, real Stripe Checkout
     unlock, target queue isolation, queue-only dry-run, local paid-PDF render
-    validation, live send, deployed scheduler enablement plus live
-    `dry_run_enabled=false` execution proof, curated PDF/TOC shape, hosted URL
-    checks, local proof-file cleanup, sanitized proof scorecard redaction, and
-    #1921/#1440/#1386 closeout.
+    validation, live send, deployed scheduler enablement plus deployed URL
+    config proof and live `dry_run_enabled=false` execution proof, curated
+    PDF/TOC shape, hosted URL checks, local proof-file cleanup, sanitized proof
+    scorecard redaction, and #1921/#1440/#1386 closeout.
   - Tests fail if those gates disappear.
   - The new test is enrolled in `scripts/run_extracted_pipeline_checks.sh`.
 - Affected surfaces:
@@ -86,10 +86,12 @@ with the operator sequence:
    real paid PDF renderer, then send live only after queue isolation and render
    validation pass.
 7. Verify the deployed scheduler has been restarted with live paid delivery
-   config before launch, prove the scheduler loop reports `running`, prove
-   there are zero claimable rows, then run the real autonomous task and inspect
-   its repr-encoded execution result for `dry_run_enabled=false`; the manual
-   drain proves one row, not public automation.
+   config before launch, prove the deployed runtime's delivery URL config builds
+   the expected `/systems/...` buyer result URL, prove the scheduler loop
+   reports `running`, prove there are zero claimable rows, then run the real
+   autonomous task and inspect its repr-encoded execution result for
+   `dry_run_enabled=false`; the manual drain proves one row, not public
+   automation.
 8. Verify the paid email attachment is the curated PDF with TOC/caps and that
    complete evidence remains on the hosted/export surface.
 9. Open the exact emailed URLs and close out cleanup/legal/support plus
@@ -99,11 +101,13 @@ with the operator sequence:
 Add `tests/test_content_ops_deflection_launch_preflight_runbook.py` to assert
 the checked runbook still contains the required surfaces, env gates,
 migrations, checkout authorization gate, skip-log blocker, delivery script,
-live-send proof, deployed scheduler enablement, scheduler-loop running proof,
-actual `dry_run_enabled=false` execution proof, builtin-result repr decoding,
-PDF shape, URL checks, legacy-route rejection, real-checkout wording, queue
-isolation, queue-only dry-run wording, local render validation, proof-file
-cleanup, sanitized scorecard redaction, and tracker closeout.
+live-send proof, deployed scheduler enablement, deployed URL config proof,
+scheduler-loop running proof, exported task/run identifiers, safe psql variable
+quoting for the buyer email, actual `dry_run_enabled=false` execution proof,
+builtin-result repr decoding, PDF shape, URL checks, legacy-route rejection,
+real-checkout wording, queue isolation, queue-only dry-run wording, local render
+validation, proof-file cleanup, sanitized scorecard redaction, and tracker
+closeout.
 Enroll that test in the extracted-pipeline runner next to the existing delta
 go-live runbook test.
 
@@ -139,8 +143,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 423 |
-| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 146 |
+| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 468 |
+| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 150 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 211 |
-| **Total** | **781** |
+| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 222 |
+| **Total** | **841** |

--- a/plans/PR-Deflection-Launch-Preflight-Runbook.md
+++ b/plans/PR-Deflection-Launch-Preflight-Runbook.md
@@ -39,10 +39,11 @@ Slice phase: Production hardening
   - The runbook names the portfolio intake path for Snapshot delivery and the
     ATLAS paid delivery drain for paid report delivery.
   - The runbook pins ATLAS delivery config, pre-rehearsal scheduler safety,
-    paid delivery migrations, real Stripe Checkout unlock, target queue
-    isolation, queue-only dry-run, local paid-PDF render validation, live send,
-    curated PDF/TOC shape, hosted URL checks, cleanup/legal/support checks, and
-    #1921/#1440/#1386 closeout.
+    paid delivery and checkout authorization migrations, real Stripe Checkout
+    unlock, target queue isolation, queue-only dry-run, local paid-PDF render
+    validation, live send, deployed scheduler enablement, curated PDF/TOC
+    shape, hosted URL checks, cleanup/legal/support checks, and #1921/#1440/#1386
+    closeout.
   - Tests fail if those gates disappear.
   - The new test is enrolled in `scripts/run_extracted_pipeline_checks.sh`.
 - Affected surfaces:
@@ -73,7 +74,7 @@ Add `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.
 with the operator sequence:
 
 1. Verify deployed portfolio/ATLAS email and delivery config.
-2. Verify paid delivery migrations and scheduler state.
+2. Verify paid delivery/checkout authorization migrations and scheduler state.
 3. Submit through deployed portfolio intake and require Snapshot email with PDF
    attachment.
 4. Complete checkout/webhook unlock and require a pending paid delivery row.
@@ -83,16 +84,19 @@ with the operator sequence:
 6. Treat the dry run as queue-only, render the target artifact locally with the
    real paid PDF renderer, then send live only after queue isolation and render
    validation pass.
-7. Verify the paid email attachment is the curated PDF with TOC/caps and that
+7. Verify the deployed scheduler has been restarted with live paid delivery
+   config before launch; the manual drain proves one row, not public automation.
+8. Verify the paid email attachment is the curated PDF with TOC/caps and that
    complete evidence remains on the hosted/export surface.
-8. Open the exact emailed URLs and close out cleanup/legal/support plus
+9. Open the exact emailed URLs and close out cleanup/legal/support plus
    #1921/#1440/#1386.
 
 Add `tests/test_content_ops_deflection_launch_preflight_runbook.py` to assert
 the checked runbook still contains the required surfaces, env gates,
-migrations, skip-log blocker, delivery script, live-send proof, PDF shape, URL
-checks, legacy-route rejection, real-checkout wording, queue isolation,
-queue-only dry-run wording, local render validation, and tracker closeout.
+migrations, checkout authorization gate, skip-log blocker, delivery script,
+live-send proof, deployed scheduler enablement, PDF shape, URL checks,
+legacy-route rejection, real-checkout wording, queue isolation, queue-only
+dry-run wording, local render validation, and tracker closeout.
 Enroll that test in the extracted-pipeline runner next to the existing delta
 go-live runbook test.
 
@@ -128,8 +132,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 271 |
-| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 135 |
+| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 294 |
+| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 139 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 171 |
-| **Total** | **578** |
+| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 186 |
+| **Total** | **620** |

--- a/plans/PR-Deflection-Launch-Preflight-Runbook.md
+++ b/plans/PR-Deflection-Launch-Preflight-Runbook.md
@@ -40,11 +40,12 @@ Slice phase: Production hardening
     ATLAS paid delivery drain for paid report delivery.
   - The runbook pins ATLAS delivery config, pre-rehearsal scheduler safety,
     paid delivery and checkout authorization migrations, real Stripe Checkout
-    unlock, target queue isolation, queue-only dry-run, local paid-PDF render
-    validation, live send, deployed scheduler enablement plus deployed URL
-    config proof and live `dry_run_enabled=false` execution proof, curated
-    PDF/TOC shape, hosted URL checks, local proof-file cleanup, sanitized proof
-    scorecard redaction, and #1921/#1440/#1386 closeout.
+    unlock, target queue isolation, immediate pre-send queue re-isolation,
+    queue-only dry-run, local paid-PDF render validation, live send, deployed
+    scheduler enablement plus deployed URL config proof and live
+    `dry_run_enabled=false` execution proof, curated PDF/TOC shape, hosted URL
+    checks, local proof-file cleanup, sanitized proof scorecard redaction, and
+    #1921/#1440/#1386 closeout.
   - Tests fail if those gates disappear.
   - The new test is enrolled in `scripts/run_extracted_pipeline_checks.sh`.
 - Affected surfaces:
@@ -54,19 +55,23 @@ Slice phase: Production hardening
   - Money/customer email path activation.
   - Launch proof passing on incomplete delivery.
   - Operator runbook drift.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R14.
 - Triggered reviewer rules:
   - R1 Requirements match.
   - R2 Test evidence.
   - R3 Security/auth/money path.
   - R6 Workflow/job behavior.
   - R8 Persistence/data lifecycle.
+  - R10 Logic/checker correctness.
   - R14 Codebase verification.
 
 ### Files touched
 
 - `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md`
 - `plans/PR-Deflection-Launch-Preflight-Runbook.md`
+- `scripts/check_deflection_full_report_proof_bundle.py`
 - `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_check_deflection_full_report_proof_bundle.py`
 - `tests/test_content_ops_deflection_launch_preflight_runbook.py`
 
 ## Mechanism
@@ -80,8 +85,9 @@ with the operator sequence:
    attachment.
 4. Complete checkout/webhook unlock and require a pending paid delivery row.
 5. Keep the scheduler from auto-sending before rehearsal, prove the target row
-   is the only claimable delivery row, and run the current unscoped drain only
-   after that isolation check passes.
+   is the only pending/sending and claimable delivery row, rerun that isolation
+   check immediately before live send, and run the current unscoped drain only
+   after those isolation checks pass.
 6. Treat the dry run as queue-only, render the target artifact locally with the
    real paid PDF renderer, then send live only after queue isolation and render
    validation pass.
@@ -97,17 +103,22 @@ with the operator sequence:
 9. Open the exact emailed URLs and close out cleanup/legal/support plus
    #1921/#1440/#1386 using only a sanitized proof scorecard that passes the
    full-report proof-bundle redaction gate.
+10. Extend the proof-bundle redaction gate so a passing scorecard also excludes
+    Resend provider message IDs and Stripe event IDs.
 
 Add `tests/test_content_ops_deflection_launch_preflight_runbook.py` to assert
 the checked runbook still contains the required surfaces, env gates,
 migrations, checkout authorization gate, skip-log blocker, delivery script,
-live-send proof, deployed scheduler enablement, deployed URL config proof,
-scheduler-loop running proof, exported task/run identifiers, safe psql variable
-quoting for the buyer email, actual `dry_run_enabled=false` execution proof,
-builtin-result repr decoding, PDF shape, URL checks, legacy-route rejection,
-real-checkout wording, queue isolation, queue-only dry-run wording, local render
-validation, proof-file cleanup, sanitized scorecard redaction, and tracker
-closeout.
+live-send proof, local sender env exports, deployed scheduler enablement,
+deployed URL config proof with HTTPS enforcement, scheduler-loop running proof,
+exported task/run identifiers, safe psql variable quoting for the buyer email,
+actual `dry_run_enabled=false` execution proof, builtin-result repr decoding,
+PDF shape, URL checks, legacy-route rejection, real-checkout wording, queue
+isolation, immediate pre-send queue re-isolation, queue-only dry-run wording,
+local render validation, proof-file cleanup, sanitized scorecard redaction, and
+tracker closeout.
+Update `scripts/check_deflection_full_report_proof_bundle.py` and its tests so
+the redaction gate catches Resend provider message IDs and Stripe event IDs.
 Enroll that test in the extracted-pipeline runner next to the existing delta
 go-live runbook test.
 
@@ -134,17 +145,20 @@ Parked hardening: none.
 
 ## Verification
 
-- python -m py_compile tests/test_content_ops_deflection_launch_preflight_runbook.py -- passed
-- pytest tests/test_content_ops_deflection_launch_preflight_runbook.py -q -- 7 passed
+- python -m py_compile tests/test_content_ops_deflection_launch_preflight_runbook.py tests/test_check_deflection_full_report_proof_bundle.py scripts/check_deflection_full_report_proof_bundle.py -- passed
+- pytest tests/test_content_ops_deflection_launch_preflight_runbook.py tests/test_check_deflection_full_report_proof_bundle.py -q -- 39 passed
 - python scripts/audit_extracted_pipeline_ci_enrollment.py -- OK: 195 matching tests are enrolled
 - python scripts/sync_pr_plan.py plans/PR-Deflection-Launch-Preflight-Runbook.md --check -- passed
+- Local PR review gate with the current PR body file wired in -- passed
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 468 |
-| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 150 |
+| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 498 |
+| `plans/PR-Deflection-Launch-Preflight-Runbook.md` | 164 |
+| `scripts/check_deflection_full_report_proof_bundle.py` | 8 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 222 |
-| **Total** | **841** |
+| `tests/test_check_deflection_full_report_proof_bundle.py` | 2 |
+| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 238 |
+| **Total** | **911** |

--- a/scripts/check_deflection_full_report_proof_bundle.py
+++ b/scripts/check_deflection_full_report_proof_bundle.py
@@ -22,6 +22,8 @@ CHECK_KEYS = (
     "absolute_local_path",
     "stripe_checkout_session_id",
     "stripe_payment_intent_id",
+    "stripe_event_id",
+    "resend_message_id",
     "raw_evidence_quote",
     "source_id_list",
     "private_note",
@@ -41,6 +43,8 @@ _ABSOLUTE_LOCAL_PATH_RE = re.compile(
 )
 _STRIPE_CHECKOUT_RE = re.compile(r"\bcs_(?:test|live)_[A-Za-z0-9]{8,}\b")
 _STRIPE_PAYMENT_RE = re.compile(r"\bpi_[A-Za-z0-9]{8,}\b")
+_STRIPE_EVENT_RE = re.compile(r"\bevt_[A-Za-z0-9_]{8,}\b")
+_RESEND_MESSAGE_RE = re.compile(r"\bresend:[A-Za-z0-9_-]{8,}\b")
 _RAW_EVIDENCE_RE = re.compile(r"(?i)(\"evidence_quotes?\"\s*:|`[^`]+`\s*-\s+|raw evidence|complete evidence)")
 _SOURCE_ID_LIST_RE = re.compile(
     r"(?im)(\"source_ids?\"\s*:|(?:^|[\n\r,])source_ids?(?:[, \t\r\n]|$)|source ids? \(full list\)|full source[-_ ]id list)"
@@ -56,6 +60,8 @@ DETECTORS = (
     ("absolute_local_path", _ABSOLUTE_LOCAL_PATH_RE, None),
     ("stripe_checkout_session_id", _STRIPE_CHECKOUT_RE, None),
     ("stripe_payment_intent_id", _STRIPE_PAYMENT_RE, None),
+    ("stripe_event_id", _STRIPE_EVENT_RE, None),
+    ("resend_message_id", _RESEND_MESSAGE_RE, None),
     ("raw_evidence_quote", _RAW_EVIDENCE_RE, None),
     ("source_id_list", _SOURCE_ID_LIST_RE, None),
     ("private_note", _PRIVATE_NOTE_RE, None),
@@ -125,6 +131,8 @@ def _redact_sensitive_text(text: str) -> str:
     text = _EMAIL_RE.sub("[email]", text)
     text = _STRIPE_CHECKOUT_RE.sub("[stripe_checkout_session_id]", text)
     text = _STRIPE_PAYMENT_RE.sub("[stripe_payment_intent_id]", text)
+    text = _STRIPE_EVENT_RE.sub("[stripe_event_id]", text)
+    text = _RESEND_MESSAGE_RE.sub("[resend_message_id]", text)
     text = _ABSOLUTE_LOCAL_PATH_RE.sub("[absolute_local_path]", text)
     return text
 

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -63,6 +63,7 @@ pytest \
   tests/test_content_ops_deflection_delta.py \
   tests/test_content_ops_deflection_delta_persistence.py \
   tests/test_content_ops_deflection_delta_go_live_runbook.py \
+  tests/test_content_ops_deflection_launch_preflight_runbook.py \
   tests/test_content_ops_deflection_resolution_live_proof.py \
   tests/test_extracted_content_deflection_submit.py \
   tests/test_prepare_content_ops_deflection_env.py \

--- a/tests/test_check_deflection_full_report_proof_bundle.py
+++ b/tests/test_check_deflection_full_report_proof_bundle.py
@@ -34,6 +34,8 @@ FORBIDDEN_FIXTURES = {
     "absolute_local_path": "artifact written to /home/juan-canfield/Desktop/live/report.pdf",
     "stripe_checkout_session_id": "checkout session cs_live_a1b2c3d4e5f6g7h8",
     "stripe_payment_intent_id": "payment intent pi_3Pmtlivea1b2c3d4",
+    "stripe_event_id": "stripe event evt_deflection_paid_live_123456789",
+    "resend_message_id": "provider message resend:email_123456789abcdef",
     "raw_evidence_quote": '{"evidence_quote": "Customer says their invoice exposes PII"}',
     "source_id_list": '{"source_ids": ["zd-proof-001", "zd-proof-002"]}',
     "private_note": '{"public": false, "body": "private note from agent"}',

--- a/tests/test_content_ops_deflection_launch_preflight_runbook.py
+++ b/tests/test_content_ops_deflection_launch_preflight_runbook.py
@@ -61,8 +61,8 @@ def test_launch_runbook_pins_deployed_config_and_scheduler_gates() -> None:
         "ATLAS_B2B_SERVICE_TOKEN",
         "GAP_REPORT_NOTIFICATION_RESEND_API_KEY",
         "GAP_REPORT_NOTIFICATION_FROM_EMAIL",
-        "ATLAS_DEFLECTION_DELIVERY_ENABLED=true",
-        "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false",
+        "ATLAS_DEFLECTION_DELIVERY_ENABLED=false",
+        "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=true",
         "ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL",
         "ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY",
         "ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL",
@@ -72,8 +72,13 @@ def test_launch_runbook_pins_deployed_config_and_scheduler_gates() -> None:
         "{id, enabled, next_run_at, metadata}",
     ):
         assert required in section
+    assert "sendSnapshotEmail" in section
+    assert "atlas-portfolio" in section
+    assert "legacy in-repo `portfolio-ui` SPA route" in section
+    assert "/services/faq-deflection/results/{request_id}" in section
     assert "/systems/support-ticket-deflection/results/{request_id}" in section
-    assert "Stop if `enabled` is not true" in section
+    assert "will not auto-send before the rehearsal" in section
+    assert "bypass the dry-run proof" in section
 
 
 def test_launch_runbook_requires_paid_delivery_schema() -> None:
@@ -106,16 +111,36 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     unlock = _section("Paid Unlock Gate")
     delivery = _section("Paid Report Email And PDF Proof")
 
+    assert "real Stripe Checkout" in unlock
+    assert "Do not replay a synthetic webhook" in unlock
+    assert "Checkout price authorization" in unlock
     assert "content_ops_deflection_reports" in unlock
     assert "content_ops_deflection_report_deliveries" in unlock
     assert "r.request_id = '<request-id>'" in unlock
     assert "`paid` is true" in unlock
     assert "`delivery_status` is `pending`" in unlock
+    assert "queue-wide" in delivery
+    assert "does not accept a request/account filter" in delivery
+    assert "claimable_rows" in delivery
+    assert "target_rows" in delivery
+    assert "Proceed only if `claimable_rows` is 1 and `target_rows` is 1" in delivery
     assert "scripts/send_content_ops_deflection_report_deliveries.py" in delivery
     assert "--json" in delivery
     assert "--send" in delivery
     assert "--resend-api-key" in delivery
     assert "dry-run JSON must show at least one scanned row" in delivery
+    assert "queue selection" in delivery
+    assert "paid/email gating" in delivery
+    assert "does not render the PDF" in delivery
+    assert "build the email body" in delivery
+    assert "render_deflection_full_report_pdf" in delivery
+    assert "paid-artifact.json" in delivery
+    assert "paid-report.pdf" in delivery
+    assert "first exercise" in delivery
+    assert "paid PDF rendering" in delivery
+    assert "live buyer send" in delivery
+    assert "ATLAS_DEFLECTION_DELIVERY_ENABLED=true" in delivery
+    assert "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false" in delivery
     assert "live JSON has `sent` 1 and `failed` 0" in delivery
     assert "link-only paid email is not launch proof" in delivery
 

--- a/tests/test_content_ops_deflection_launch_preflight_runbook.py
+++ b/tests/test_content_ops_deflection_launch_preflight_runbook.py
@@ -26,6 +26,13 @@ PAID_QUEUE_MIGRATION = (
     / "migrations"
     / "332_content_ops_deflection_report_deliveries.sql"
 )
+CHECKOUT_AUTHORIZATION_MIGRATION = (
+    ROOT
+    / "atlas_brain"
+    / "storage"
+    / "migrations"
+    / "342_content_ops_deflection_checkout_authorization.sql"
+)
 
 
 def _doc() -> str:
@@ -87,9 +94,12 @@ def test_launch_runbook_requires_paid_delivery_schema() -> None:
     assert "schema_migrations" in section
     assert "331_content_ops_deflection_report_delivery_email" in section
     assert "332_content_ops_deflection_report_deliveries" in section
-    assert "Both rows must be present" in section
+    assert "342_content_ops_deflection_checkout_authorization" in section
+    assert "All three rows must be present" in section
+    assert "checkout authorization columns" in section
     assert PAID_EMAIL_MIGRATION.exists()
     assert PAID_QUEUE_MIGRATION.exists()
+    assert CHECKOUT_AUTHORIZATION_MIGRATION.exists()
 
 
 def test_snapshot_email_proof_requires_attachment_and_blocks_skip_log() -> None:
@@ -141,6 +151,11 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "live buyer send" in delivery
     assert "ATLAS_DEFLECTION_DELIVERY_ENABLED=true" in delivery
     assert "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false" in delivery
+    assert "deploy or restart ATLAS" in delivery
+    assert "hosted scheduler configured for" in delivery
+    assert "live paid delivery" in delivery
+    assert "enabled config value is live" in delivery
+    assert "manual one-off email is not enough" in delivery
     assert "live JSON has `sent` 1 and `failed` 0" in delivery
     assert "link-only paid email is not launch proof" in delivery
 

--- a/tests/test_content_ops_deflection_launch_preflight_runbook.py
+++ b/tests/test_content_ops_deflection_launch_preflight_runbook.py
@@ -58,6 +58,8 @@ def test_launch_runbook_names_required_surfaces_and_trackers() -> None:
     assert "paid report PDF attachment" in doc
     assert "emailed hosted result URL" in doc
     assert "not complete until both buyer-facing email surfaces" in doc
+    assert 'export ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL="<paid-report-from-email>"' in doc
+    assert 'export ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY="<paid-report-resend-key>"' in doc
 
 
 def test_launch_runbook_pins_deployed_config_and_scheduler_gates() -> None:
@@ -133,7 +135,15 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "does not accept a request/account filter" in delivery
     assert "claimable_rows" in delivery
     assert "target_rows" in delivery
-    assert "Proceed only if `claimable_rows` is 1 and `target_rows` is 1" in delivery
+    assert "pending_or_sending_rows" in delivery
+    assert "other_pending_or_sending_rows" in delivery
+    assert "SELECT account_id, request_id, created_at, updated_at, delivery_status" in delivery
+    assert "delivery_status IN ('pending', 'sending')" in delivery
+    assert "non-target `sending` row ages into the\nclaim window" in delivery
+    assert (
+        "Proceed only if `claimable_rows` is 1, `target_rows` is 1, and\n"
+        "`other_pending_or_sending_rows` is 0"
+    ) in delivery
     assert "scripts/send_content_ops_deflection_report_deliveries.py" in delivery
     assert "--json" in delivery
     assert "--send" in delivery
@@ -156,6 +166,8 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "first exercise" in delivery
     assert "paid PDF rendering" in delivery
     assert "live buyer send" in delivery
+    assert "rerun the queue-isolation SQL above immediately before live send" in delivery
+    assert "it still shows `claimable_rows` 1, `target_rows` 1, and\n`other_pending_or_sending_rows` 0" in delivery
     assert "ATLAS_DEFLECTION_DELIVERY_ENABLED=true" in delivery
     assert "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false" in delivery
     assert "deploy or restart ATLAS" in delivery
@@ -164,6 +176,8 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "settings.deflection_delivery" in delivery
     assert "deflection_report_result_url" in delivery
     assert "preflight-url-check" in delivery
+    assert "parsed.scheme != \"https\"" in delivery
+    assert "deployed result URL scheme mismatch" in delivery
     assert "deployed result URL path mismatch" in delivery
     assert "do not satisfy it with the local CLI `--result-base-url`" in delivery
     assert "/api/v1/autonomous/status/summary" in delivery
@@ -215,8 +229,10 @@ def test_hosted_url_cleanup_and_closeout_are_required() -> None:
     assert "rm -rf \"${PREFLIGHT_TMP_DIR:-}\"" in section
     assert "sanitized proof scorecard" in section
     assert "not raw live artifacts" in section
+    assert "Resend provider message IDs" in section
+    assert "Stripe\nevent IDs" in section
     assert "Raw live bundles stay uncommitted" in section
     assert "scripts/check_deflection_full_report_proof_bundle.py" in section
     assert "redaction-check.json" in section
-    assert "Stop\nif the redaction gate fails" in section
+    assert "Stop if the redaction gate fails" in " ".join(section.split())
     assert "#1921, #1440, and #1386" in section

--- a/tests/test_content_ops_deflection_launch_preflight_runbook.py
+++ b/tests/test_content_ops_deflection_launch_preflight_runbook.py
@@ -149,6 +149,9 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "trap 'rm -rf \"$PREFLIGHT_TMP_DIR\"' EXIT" in delivery
     assert "paid-artifact.json" in delivery
     assert "paid-report.pdf" in delivery
+    assert "-v buyer_email=\"$LAUNCH_BUYER_EMAIL\"" in delivery
+    assert "COALESCE(delivery_email, '') = :'buyer_email'" in delivery
+    assert "COALESCE(delivery_email, '') = '$LAUNCH_BUYER_EMAIL'" not in delivery
     assert "do not commit, upload, or\nlink them" in delivery
     assert "first exercise" in delivery
     assert "paid PDF rendering" in delivery
@@ -158,14 +161,22 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "deploy or restart ATLAS" in delivery
     assert "hosted scheduler configured for" in delivery
     assert "live paid delivery" in delivery
+    assert "settings.deflection_delivery" in delivery
+    assert "deflection_report_result_url" in delivery
+    assert "preflight-url-check" in delivery
+    assert "deployed result URL path mismatch" in delivery
+    assert "do not satisfy it with the local CLI `--result-base-url`" in delivery
     assert "/api/v1/autonomous/status/summary" in delivery
     assert "select(.running == true and .scheduled_count > 0)" in delivery
     assert "scheduler summary reports `running` true" in delivery
     assert "scheduler loop is running" in delivery
     assert "Metadata alone" in delivery
-    assert "live dry-run\nsetting" in delivery
+    assert "deployed URL config" in delivery
+    assert "live dry-run setting" in " ".join(delivery.split())
     assert "claimable_rows` is 0" in delivery
     assert "content_ops_deflection_report_delivery/run" in delivery
+    assert "export TASK_ID" in delivery
+    assert "export RUN_ID" in delivery
     assert "Do not pass `{\"dry_run\": false}`" in delivery
     assert "executions?limit=5" in delivery
     assert "ast.literal_eval" in delivery

--- a/tests/test_content_ops_deflection_launch_preflight_runbook.py
+++ b/tests/test_content_ops_deflection_launch_preflight_runbook.py
@@ -158,13 +158,20 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "deploy or restart ATLAS" in delivery
     assert "hosted scheduler configured for" in delivery
     assert "live paid delivery" in delivery
-    assert "Metadata alone\ndoes not prove the live dry-run setting" in delivery
+    assert "/api/v1/autonomous/status/summary" in delivery
+    assert "select(.running == true and .scheduled_count > 0)" in delivery
+    assert "scheduler summary reports `running` true" in delivery
+    assert "scheduler loop is running" in delivery
+    assert "Metadata alone" in delivery
+    assert "live dry-run\nsetting" in delivery
     assert "claimable_rows` is 0" in delivery
     assert "content_ops_deflection_report_delivery/run" in delivery
     assert "Do not pass `{\"dry_run\": false}`" in delivery
     assert "executions?limit=5" in delivery
-    assert ".result_text | fromjson" in delivery
-    assert "dry_run_enabled == false" in delivery
+    assert "ast.literal_eval" in delivery
+    assert "HeadlessRunner persists builtin dict results with str(result)" in delivery
+    assert ".result_text | fromjson" not in delivery
+    assert '"dry_run_enabled": False' in delivery
     assert "zero\nclaimable work scanned/sent/failed" in delivery
     assert "manual one-off email is not enough" in delivery
     assert "live JSON has `sent` 1 and `failed` 0" in delivery

--- a/tests/test_content_ops_deflection_launch_preflight_runbook.py
+++ b/tests/test_content_ops_deflection_launch_preflight_runbook.py
@@ -144,8 +144,12 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "does not render the PDF" in delivery
     assert "build the email body" in delivery
     assert "render_deflection_full_report_pdf" in delivery
+    assert "mktemp -d" in delivery
+    assert "PREFLIGHT_TMP_DIR" in delivery
+    assert "trap 'rm -rf \"$PREFLIGHT_TMP_DIR\"' EXIT" in delivery
     assert "paid-artifact.json" in delivery
     assert "paid-report.pdf" in delivery
+    assert "do not commit, upload, or\nlink them" in delivery
     assert "first exercise" in delivery
     assert "paid PDF rendering" in delivery
     assert "live buyer send" in delivery
@@ -154,7 +158,14 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "deploy or restart ATLAS" in delivery
     assert "hosted scheduler configured for" in delivery
     assert "live paid delivery" in delivery
-    assert "enabled config value is live" in delivery
+    assert "Metadata alone\ndoes not prove the live dry-run setting" in delivery
+    assert "claimable_rows` is 0" in delivery
+    assert "content_ops_deflection_report_delivery/run" in delivery
+    assert "Do not pass `{\"dry_run\": false}`" in delivery
+    assert "executions?limit=5" in delivery
+    assert ".result_text | fromjson" in delivery
+    assert "dry_run_enabled == false" in delivery
+    assert "zero\nclaimable work scanned/sent/failed" in delivery
     assert "manual one-off email is not enough" in delivery
     assert "live JSON has `sent` 1 and `failed` 0" in delivery
     assert "link-only paid email is not launch proof" in delivery
@@ -183,4 +194,11 @@ def test_hosted_url_cleanup_and_closeout_are_required() -> None:
     assert "CRON_SECRET" in section
     assert "Privacy, Security, Terms" in section
     assert "refund" in section
+    assert "rm -rf \"${PREFLIGHT_TMP_DIR:-}\"" in section
+    assert "sanitized proof scorecard" in section
+    assert "not raw live artifacts" in section
+    assert "Raw live bundles stay uncommitted" in section
+    assert "scripts/check_deflection_full_report_proof_bundle.py" in section
+    assert "redaction-check.json" in section
+    assert "Stop\nif the redaction gate fails" in section
     assert "#1921, #1440, and #1386" in section

--- a/tests/test_content_ops_deflection_launch_preflight_runbook.py
+++ b/tests/test_content_ops_deflection_launch_preflight_runbook.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNBOOK = (
+    ROOT
+    / "docs"
+    / "extraction"
+    / "validation"
+    / "content_ops_deflection_launch_preflight_runbook.md"
+)
+PAID_EMAIL_MIGRATION = (
+    ROOT
+    / "atlas_brain"
+    / "storage"
+    / "migrations"
+    / "331_content_ops_deflection_report_delivery_email.sql"
+)
+PAID_QUEUE_MIGRATION = (
+    ROOT
+    / "atlas_brain"
+    / "storage"
+    / "migrations"
+    / "332_content_ops_deflection_report_deliveries.sql"
+)
+
+
+def _doc() -> str:
+    return RUNBOOK.read_text(encoding="utf-8")
+
+
+def _section(title: str) -> str:
+    doc = _doc()
+    start = doc.index(f"## {title}")
+    next_heading = doc.find("\n## ", start + 1)
+    return doc[start:] if next_heading == -1 else doc[start:next_heading]
+
+
+def test_launch_runbook_names_required_surfaces_and_trackers() -> None:
+    doc = _doc()
+
+    assert "#1921" in doc
+    assert "#1440" in doc
+    assert "#1386" in doc
+    assert "Snapshot email" in doc
+    assert "Snapshot PDF" in doc
+    assert "paid report email" in doc
+    assert "paid report PDF attachment" in doc
+    assert "emailed hosted result URL" in doc
+    assert "not complete until both buyer-facing email surfaces" in doc
+
+
+def test_launch_runbook_pins_deployed_config_and_scheduler_gates() -> None:
+    section = _section("Deployed Config Check")
+
+    for required in (
+        "ATLAS_API_BASE_URL",
+        "ATLAS_B2B_SERVICE_TOKEN",
+        "GAP_REPORT_NOTIFICATION_RESEND_API_KEY",
+        "GAP_REPORT_NOTIFICATION_FROM_EMAIL",
+        "ATLAS_DEFLECTION_DELIVERY_ENABLED=true",
+        "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false",
+        "ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL",
+        "ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY",
+        "ATLAS_DEFLECTION_DELIVERY_RESULT_BASE_URL",
+        "ATLAS_DEFLECTION_DELIVERY_RESULT_URL_TEMPLATE",
+        "content_ops_deflection_report_delivery",
+        "include_disabled=true",
+        "{id, enabled, next_run_at, metadata}",
+    ):
+        assert required in section
+    assert "/systems/support-ticket-deflection/results/{request_id}" in section
+    assert "Stop if `enabled` is not true" in section
+
+
+def test_launch_runbook_requires_paid_delivery_schema() -> None:
+    section = _section("Database Gate")
+
+    assert "schema_migrations" in section
+    assert "331_content_ops_deflection_report_delivery_email" in section
+    assert "332_content_ops_deflection_report_deliveries" in section
+    assert "Both rows must be present" in section
+    assert PAID_EMAIL_MIGRATION.exists()
+    assert PAID_QUEUE_MIGRATION.exists()
+
+
+def test_snapshot_email_proof_requires_attachment_and_blocks_skip_log() -> None:
+    section = _section("Snapshot Email And PDF Proof")
+
+    assert "deployed portfolio intake" in section
+    assert "fetch the free Snapshot" in section
+    assert "Body says the free Snapshot is ready" in section
+    assert "/systems/support-ticket-deflection/results/<request-id>" in section
+    assert "A Snapshot PDF is attached" in section
+    assert "deflection.record.snapshot_pdf_attachment_skipped" in section
+    assert "email without the Snapshot PDF is not launch proof" in section
+    assert "excludes source IDs" in section
+    assert "raw ticket bodies" in section
+    assert "paid report markdown" in section
+
+
+def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> None:
+    unlock = _section("Paid Unlock Gate")
+    delivery = _section("Paid Report Email And PDF Proof")
+
+    assert "content_ops_deflection_reports" in unlock
+    assert "content_ops_deflection_report_deliveries" in unlock
+    assert "r.request_id = '<request-id>'" in unlock
+    assert "`paid` is true" in unlock
+    assert "`delivery_status` is `pending`" in unlock
+    assert "scripts/send_content_ops_deflection_report_deliveries.py" in delivery
+    assert "--json" in delivery
+    assert "--send" in delivery
+    assert "--resend-api-key" in delivery
+    assert "dry-run JSON must show at least one scanned row" in delivery
+    assert "live JSON has `sent` 1 and `failed` 0" in delivery
+    assert "link-only paid email is not launch proof" in delivery
+
+
+def test_paid_pdf_shape_is_curated_with_toc_and_export_pointer() -> None:
+    section = _section("Paid PDF Shape Check")
+
+    assert "curated/shareable report" in section
+    assert "not the full evidence archive" in section
+    assert "Table of contents" in section
+    assert "not a 600+ page raw evidence dump" in section
+    assert re.search(r"capped at 25 rows", section)
+    assert re.search(r"capped at 10 questions", section)
+    assert "complete evidence export" in section
+    assert "hosted paid result page" in section
+
+
+def test_hosted_url_cleanup_and_closeout_are_required() -> None:
+    section = _section("Hosted URL, Cleanup, And Tracker Closeout")
+
+    assert "exact URL from each email" in section
+    assert "locked/free Snapshot state" in section
+    assert "unlocked paid report" in section
+    assert "must not fall back to demo data" in section
+    assert "CRON_SECRET" in section
+    assert "Privacy, Security, Terms" in section
+    assert "refund" in section
+    assert "#1921, #1440, and #1386" in section


### PR DESCRIPTION
Plan: plans/PR-Deflection-Launch-Preflight-Runbook.md
Slice phase: Production hardening

#1921 tracks the final launch preflight for the Resolution Audit funnel. This PR adds the checked operator runbook and parser-light tests that pin the required Snapshot email/PDF and paid report email/PDF proof gates before launch.

## Intentional
- No production defaults change. Paid report delivery remains opt-in and dry-run by default until an operator performs the runbook.
- No live database, Stripe, portfolio, or Resend call is executed in this PR. This slice creates the checked operator contract; the live proof remains a separate #1921 execution artifact.
- No launch copy changes here. Landing-page copy waits until the delivery proof gates settle.

## Deferred
- PR 2 from #1921: make the Snapshot delivery proof fail/flag when the Snapshot PDF attachment is skipped.
- PR 3 from #1921: make the paid delivery proof fail/flag when the paid PDF attachment is missing.
- PR 4 from #1921: run the full deployed proof and update #1440/#1386/#1921 with artifacts.

## AI reconciliation
- [chatgpt-codex-connector] Use the served portfolio result route: fixed by naming the deployed `atlas-portfolio` Next.js `/systems/support-ticket-deflection/results/{request_id}` route as the source of truth and explicitly rejecting the legacy in-repo `portfolio-ui` `/services/faq-deflection/results/{request_id}` SPA route for this launch proof.
- [chatgpt-codex-connector] Keep live scheduling off until after rehearsal: fixed by requiring pre-rehearsal scheduler safety (`ATLAS_DEFLECTION_DELIVERY_ENABLED=false` or dry-run) and stopping if scheduler/live-send config can auto-claim before proof.
- [chatgpt-codex-connector] Point the snapshot gate at a real sender: fixed by naming the deployed `atlas-portfolio` `sendSnapshotEmail` implementation and env surface that actually sends the Snapshot email/PDF.
- [chatgpt-codex-connector] Scope the delivery drain to the proof request: fixed by adding a claimable-row isolation query and requiring `claimable_rows = 1` and `target_rows = 1` before using the current unscoped manual drain CLI.
- [chatgpt-codex-connector] Do not treat dry-run as an email/PDF rehearsal: fixed by labeling the dry-run as queue-only and adding a pre-live local render of the target paid artifact through `render_deflection_full_report_pdf`.
- [chatgpt-codex-connector] Require the checkout authorization migration: fixed by adding `342_content_ops_deflection_checkout_authorization` to the required migration gate because the real Stripe unlock path reads/writes those checkout authorization columns.
- [chatgpt-codex-connector] Enable the deployed delivery task before launch: fixed by making the runbook require a deploy/restart with `ATLAS_DEFLECTION_DELIVERY_ENABLED=true` and `ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false`, followed by an autonomous-task API verification that the hosted scheduler is enabled with a next run. The manual CLI send remains only the isolated proof row, not the launch automation mode.
- [chatgpt-codex-connector] Verify the scheduler dry-run flag before launch: fixed by requiring zero claimable delivery rows, running the deployed autonomous task without metadata overrides, polling the execution, parsing `result_text`, and requiring `dry_run_enabled == false` with `scanned/sent/failed == 0`.
- [chatgpt-codex-connector] Clean up paid artifact proof files: fixed by using a `mktemp` proof directory with a shell `trap`, warning that paid artifact/PDF files contain buyer data, and requiring explicit temp-dir removal before closeout.
- [chatgpt-codex-connector] Redact live proof artifacts before linking them: fixed by requiring a sanitized proof scorecard only, forbidding raw live emails/URLs/PDFs/artifact JSON/IDs in issue links, and running `scripts/check_deflection_full_report_proof_bundle.py` before linking anything to #1921/#1440/#1386.
- [chatgpt-codex-connector] Decode the scheduler result before applying the gate: fixed by parsing the builtin task's repr-encoded `result_text` with `ast.literal_eval` instead of `jq fromjson`.
- [chatgpt-codex-connector] Prove the scheduler loop is actually running: fixed by requiring `/api/v1/autonomous/status/summary` to report `running == true` and `scheduled_count > 0` before the task-row and manual-run probes.
- [chatgpt-codex-connector] Export task identifiers before polling the execution: fixed by exporting `TASK_ID` and `RUN_ID` before the Python heredoc reads them from `os.environ`.
- [chatgpt-codex-connector] Verify the scheduler's deployed URL config: fixed by adding a deployed-runtime probe that builds `deflection_report_result_url(...)` from `settings.deflection_delivery` and rejects any host/path other than `https://juancanfield.com/systems/support-ticket-deflection/results/preflight-url-check`.
- [chatgpt-codex-connector] Quote the buyer email through psql variables: fixed by passing `request_id` and `buyer_email` via `psql -v` variables and using `:'buyer_email'` instead of shell-interpolating `LAUNCH_BUYER_EMAIL` into SQL.
- [chatgpt-codex-connector] Recheck reclaimable rows immediately before live send: fixed by strengthening the isolation query to block any non-target `pending` or `sending` row, then requiring the same isolation gate to be rerun immediately before the unfiltered live-send drain.
- [chatgpt-codex-connector] Export local delivery sender variables: fixed by adding local `ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL` and `ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY` exports to the runbook inputs before the CLI dry-run/live-send proof steps.
- [chatgpt-codex-connector] Enforce HTTPS in the URL probe: fixed by making the deployed-runtime URL probe reject any scheme other than `https`.
- [chatgpt-codex-connector] Cover all listed IDs in the redaction gate: fixed by adding `stripe_event_id` and `resend_message_id` detectors to `scripts/check_deflection_full_report_proof_bundle.py` with fixtures, so the passing gate covers the IDs the runbook excludes.

All findings fixed or waived: yes.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_content_ops_deflection_launch_preflight_runbook.py tests/test_check_deflection_full_report_proof_bundle.py scripts/check_deflection_full_report_proof_bundle.py`
- `pytest tests/test_content_ops_deflection_launch_preflight_runbook.py tests/test_check_deflection_full_report_proof_bundle.py -q` -- 39 passed
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- OK: 195 matching tests are enrolled
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Launch-Preflight-Runbook.md --check`

## Diff size
6 files, 911 LOC per `python scripts/sync_pr_plan.py plans/PR-Deflection-Launch-Preflight-Runbook.md`.
