### PR TITLE
Exempt Dependabot from PR body contract

### DIFF
--- a/.github/workflows/pr_body_contract.yml
+++ b/.github/workflows/pr_body_contract.yml
@@ -20,4 +20,6 @@ jobs:
         run: printf '%s\n' "$PR_BODY" > /tmp/pr_body.md
 
       - name: Audit PR body against AGENTS.md section 1b
-        run: python3 scripts/audit_pr_body.py /tmp/pr_body.md
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: python3 scripts/audit_pr_body.py --pr-author "$PR_AUTHOR" /tmp/pr_body.md

--- a/plans/PR-Dependabot-Body-Contract-Exemption.md
+++ b/plans/PR-Dependabot-Body-Contract-Exemption.md
@@ -1,0 +1,108 @@
+# PR-Dependabot-Body-Contract-Exemption
+
+## Why this slice exists
+
+Dependabot PRs in the operator-assigned security/update ranges #1776-#1790 and
+#1911-#1919 are blocked by the `pr-body-contract` workflow because generated
+Dependabot bodies do not include Atlas plan documents. That check is still the
+right contract for human and agent-authored PRs, but it turns routine
+dependency/security bumps into metadata work instead of letting their real CI
+decide mergeability.
+
+Root cause: `scripts/audit_pr_body.py` only understands the Atlas human PR body
+shape and receives no PR author context, so bot-authored dependency PRs fail the
+contract even when their diffs and package checks are otherwise valid.
+
+## Scope (this PR)
+
+Ownership lane: dependency-maintenance/pr-body-contract
+Slice phase: Workflow/process
+
+1. Teach the PR body audit to accept known Dependabot author logins as an
+   explicit exemption.
+2. Pass `github.event.pull_request.user.login` from the workflow into the audit.
+3. Add focused regression coverage proving Dependabot is exempt while malformed
+   non-Dependabot PR bodies still fail.
+
+### Review Contract
+
+Acceptance criteria:
+
+- Dependabot-authored PRs can pass `pr-body-contract` without a plan-shaped body.
+- Human and agent-authored PRs still require the existing plan-line,
+  slice-phase, why paragraph, and required-section contract.
+- The exemption is based on the GitHub PR author login, not on body text or
+  changed files.
+- Existing `audit_pr_body(body, root=...)` callers keep the same default
+  behavior.
+
+Affected surfaces:
+
+- PR body contract CI workflow.
+- PR body audit script and its regression tests.
+
+Risk areas:
+
+- Over-broad bot exemption that would weaken the review contract for normal PRs.
+- Required check churn on queued Dependabot PRs.
+
+Reviewer rules triggered: R2, R10, R14.
+
+### Files touched
+
+- `.github/workflows/pr_body_contract.yml`
+- `plans/PR-Dependabot-Body-Contract-Exemption.md`
+- `scripts/audit_pr_body.py`
+- `tests/test_audit_pr_body.py`
+
+## Mechanism
+
+The PR body workflow continues writing the PR body to a temporary Markdown
+file, then passes the GitHub PR author login through the new PR-author CLI
+option. The audit has a small allowlist for Dependabot identities
+(`app/dependabot`, `dependabot`, and `dependabot[bot]`). If the author is
+Dependabot, the CLI returns success before body-shape validation; otherwise it
+runs the existing validation unchanged.
+
+The pure `audit_pr_body(body, root=...)` function remains strict. Tests cover the
+pure strict path, the author detector, the CLI exemption, and the CLI failure
+path for a normal author with the same invalid body.
+
+## Intentional
+
+- The exemption does not inspect dependency diffs. Mergeability still belongs to
+  each Dependabot PR's package checks, security scans, and review state.
+- This does not edit Dependabot PR bodies to point at the old shared maintenance
+  plan; author-aware workflow behavior is clearer and avoids metadata-only churn
+  on bot PRs.
+- This does not merge the Tailwind major PRs or any PR with red package checks.
+
+## Deferred
+
+- Re-run or refresh the queued Dependabot PRs after this workflow change lands.
+- Real red dependency PRs stay separate: Tailwind 3 to 4 UI package PRs and any
+  other package-check failures need their own compatibility slices or should
+  remain blocked.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_audit_pr_body.py -q - passed: 13 tests.
+- Command: python scripts/audit_pr_body.py --pr-author app/dependabot plans/PR-Dependabot-Body-Contract-Exemption.md
+  - passed with `pr body audit: PASS (Dependabot PR body exempt)`.
+- Command: python scripts/audit_pr_body.py plans/PR-Dependabot-Body-Contract-Exemption.md
+  - failed as expected with normal AGENTS.md section 1b body-contract errors,
+    proving a non-Dependabot invalid body remains invalid.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file
+  /tmp/atlas_dependabot_body_contract_pr_body.md - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pr_body_contract.yml` | 4 |
+| `plans/PR-Dependabot-Body-Contract-Exemption.md` | 108 |
+| `scripts/audit_pr_body.py` | 24 |
+| `tests/test_audit_pr_body.py` | 61 |
+| **Total** | **197** |

--- a/scripts/audit_pr_body.py
+++ b/scripts/audit_pr_body.py
@@ -33,6 +33,21 @@ REQUIRED_SECTIONS = (
     "Verification",
     "Diff size",
 )
+DEPENDABOT_AUTHORS = frozenset(
+    {
+        "app/dependabot",
+        "dependabot",
+        "dependabot[bot]",
+    }
+)
+
+
+def is_dependabot_author(author: str | None) -> bool:
+    """Return true for Dependabot identities seen in GitHub PR events."""
+
+    if author is None:
+        return False
+    return author.strip() in DEPENDABOT_AUTHORS
 
 
 def audit_pr_body(body: str, *, root: Path = ROOT) -> list[str]:
@@ -98,6 +113,11 @@ def audit_pr_body(body: str, *, root: Path = ROOT) -> list[str]:
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pr-author",
+        default="",
+        help="GitHub PR author login; Dependabot PRs are exempt",
+    )
     parser.add_argument("body_file", help="path to a file holding the PR body")
     args = parser.parse_args(argv)
 
@@ -106,6 +126,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"pr body audit: body file not found: {body_path}", file=sys.stderr)
         return 2
     body = body_path.read_text(encoding="utf-8", errors="replace")
+
+    if is_dependabot_author(args.pr_author):
+        print("pr body audit: PASS (Dependabot PR body exempt)")
+        return 0
 
     failures = audit_pr_body(body)
     if failures:

--- a/tests/test_audit_pr_body.py
+++ b/tests/test_audit_pr_body.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
 import sys
+import tempfile
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -16,6 +18,7 @@ sys.modules[SPEC.name] = audit_pr_body_module
 SPEC.loader.exec_module(audit_pr_body_module)
 
 audit_pr_body = audit_pr_body_module.audit_pr_body
+is_dependabot_author = audit_pr_body_module.is_dependabot_author
 
 
 def _valid_body(plan: str = "plans/PR-Example.md") -> str:
@@ -169,3 +172,61 @@ def test_slice_phase_after_first_heading_fails(tmp_path: Path) -> None:
     failures = audit_pr_body(body, root=root)
 
     assert any("Slice phase" in failure for failure in failures)
+
+
+def test_dependabot_author_detection() -> None:
+    assert is_dependabot_author("app/dependabot")
+    assert is_dependabot_author("dependabot[bot]")
+    assert is_dependabot_author(" dependabot ")
+    assert not is_dependabot_author("canfieldjuan")
+    assert not is_dependabot_author(None)
+
+
+def test_dependabot_cli_exempts_invalid_body() -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_file:
+        body_file.write("Dependabot generated body without the Atlas plan contract.\n")
+        body_path = Path(body_file.name)
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--pr-author",
+                "app/dependabot",
+                str(body_path),
+            ],
+            check=False,
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 0
+        assert "Dependabot PR body exempt" in result.stdout
+    finally:
+        body_path.unlink(missing_ok=True)
+
+
+def test_normal_author_cli_rejects_same_invalid_body() -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_file:
+        body_file.write("Dependabot generated body without the Atlas plan contract.\n")
+        body_path = Path(body_file.name)
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--pr-author",
+                "canfieldjuan",
+                str(body_path),
+            ],
+            check=False,
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 1
+        assert "AGENTS.md section 1b contract" in result.stdout
+    finally:
+        body_path.unlink(missing_ok=True)


### PR DESCRIPTION
Plan: plans/PR-Dependabot-Body-Contract-Exemption.md
Slice phase: Workflow/process

Dependabot dependency PRs in the assigned security/update ranges are blocked by the Atlas PR-body contract because generated bot bodies do not include local plan docs. This keeps the strict body contract for human and agent PRs while explicitly exempting known Dependabot author logins, so dependency PRs are judged by their real package checks and security scans.

## Intentional

- Human and agent-authored PRs still require the normal Atlas plan-line, slice-phase, why, and section structure.
- The exemption is author-based, not body-text-based or diff-based.
- This does not merge Tailwind major PRs or any dependency PR with red package checks.

## Deferred

- Re-run or refresh the queued Dependabot PRs after this workflow change lands.
- Tailwind 3 to 4 UI package PRs and any other red package checks remain separate compatibility work.

## Parked hardening

None.

## Verification

- `python -m pytest tests/test_audit_pr_body.py -q` — passed: 13 tests.
- `python scripts/audit_pr_body.py --pr-author app/dependabot plans/PR-Dependabot-Body-Contract-Exemption.md` — passed with the Dependabot exemption message.
- `python scripts/audit_pr_body.py plans/PR-Dependabot-Body-Contract-Exemption.md` — failed as expected with normal AGENTS.md section 1b body-contract errors.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas_dependabot_body_contract_pr_body.md` — passed.

## Diff size

4 files, +196 / -1.
