### PR TITLE
Require paid report PDF before delivery

### DIFF
--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -135,6 +135,10 @@ class _DeliveryEmailSummary:
     drafted_resolution_items: tuple[_DeliveryEmailActionItem, ...] = ()
 
 
+class PaidReportPdfRenderError(RuntimeError):
+    """Raised when the paid report PDF renderer fails."""
+
+
 def deflection_delivery_email_surface_observation(
     text_body: str | None,
 ) -> dict[str, dict[str, int]]:
@@ -259,6 +263,29 @@ async def send_pending_deflection_report_deliveries(
                 _provider_message_id("resend", "idempotent-replay"),
             )
             sent += 1
+            continue
+        except PaidReportPdfRenderError as exc:
+            error = _bounded_error(exc)
+            if _claimed_previous_delivery_status(data) == "sending":
+                await _emit_delivery_incident(
+                    "paid_report_delivery_pdf_render_reclaim_deferred",
+                    account_id=account_id,
+                    request_id=request_id,
+                    severity="warning",
+                    error=error,
+                )
+                await _mark_pending(pool, account_id, request_id, error)
+                failed += 1
+                continue
+            await _emit_delivery_incident(
+                "paid_report_delivery_send_failed",
+                account_id=account_id,
+                request_id=request_id,
+                severity="error",
+                error=error,
+            )
+            await _mark_failed(pool, account_id, request_id, error)
+            failed += 1
             continue
         except Exception as exc:
             error = _bounded_error(exc)
@@ -1170,6 +1197,10 @@ def _decoded_artifact(artifact: Any) -> Any:
     return decode_jsonb_field(artifact, default={})
 
 
+def _claimed_previous_delivery_status(data: Mapping[str, Any]) -> str:
+    return _clean(data.get("previous_delivery_status")) or "pending"
+
+
 def _pdf_attachments(
     *,
     artifact: Any,
@@ -1186,7 +1217,7 @@ def _pdf_attachments(
             "Deflection report PDF render failed for %s",
             request_id,
         )
-        raise RuntimeError(
+        raise PaidReportPdfRenderError(
             f"paid_report_pdf_render_failed: {_bounded_error(exc)}"
         ) from exc
     if not pdf_bytes:
@@ -1234,6 +1265,23 @@ async def _mark_failed(pool: Any, account_id: str, request_id: str, error: str) 
         """
         UPDATE content_ops_deflection_report_deliveries
         SET delivery_status = 'failed',
+            delivery_error = $3,
+            updated_at = NOW()
+        WHERE account_id = $1
+          AND request_id = $2
+          AND delivery_status = 'sending'
+        """,
+        account_id,
+        request_id,
+        _bounded_text(error),
+    )
+
+
+async def _mark_pending(pool: Any, account_id: str, request_id: str, error: str) -> None:
+    await pool.execute(
+        """
+        UPDATE content_ops_deflection_report_deliveries
+        SET delivery_status = 'pending',
             delivery_error = $3,
             updated_at = NOW()
         WHERE account_id = $1
@@ -1608,6 +1656,7 @@ _PENDING_SQL = """
 SELECT
     d.account_id,
     d.request_id,
+    d.delivery_status AS previous_delivery_status,
     r.delivery_email,
     r.paid,
     r.artifact
@@ -1625,7 +1674,8 @@ WITH claimed AS (
     SELECT
         d.account_id,
         d.request_id,
-        d.created_at
+        d.created_at,
+        d.delivery_status AS previous_delivery_status
     FROM content_ops_deflection_report_deliveries d
     WHERE d.delivery_status = 'pending'
        OR (
@@ -1649,6 +1699,7 @@ WHERE d.account_id = c.account_id
 RETURNING
     d.account_id,
     d.request_id,
+    c.previous_delivery_status,
     r.delivery_email,
     r.paid,
     r.artifact

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -1221,7 +1221,7 @@ def _pdf_attachments(
             f"paid_report_pdf_render_failed: {_bounded_error(exc)}"
         ) from exc
     if not pdf_bytes:
-        raise ValueError("paid_report_pdf_empty")
+        raise PaidReportPdfRenderError("paid_report_pdf_empty")
     return ({
         "filename": f"{_attachment_slug(request_id)}-support-deflection-report.pdf",
         "content": base64.b64encode(pdf_bytes).decode("ascii"),

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -1176,21 +1176,21 @@ def _pdf_attachments(
     request_id: str,
 ) -> tuple[dict[str, str], ...]:
     if not isinstance(artifact, Mapping):
-        logger.warning(
-            "Skipping deflection report PDF attachment for %s: missing artifact",
-            request_id,
-        )
-        return ()
+        raise ValueError("paid_report_pdf_missing_artifact")
     try:
         from .deflection_pdf_renderer import render_deflection_full_report_pdf
 
         pdf_bytes = render_deflection_full_report_pdf(artifact)
-    except Exception:
+    except Exception as exc:
         logger.exception(
-            "Deflection report PDF render failed for %s; sending link-only email",
+            "Deflection report PDF render failed for %s",
             request_id,
         )
-        return ()
+        raise RuntimeError(
+            f"paid_report_pdf_render_failed: {_bounded_error(exc)}"
+        ) from exc
+    if not pdf_bytes:
+        raise ValueError("paid_report_pdf_empty")
     return ({
         "filename": f"{_attachment_slug(request_id)}-support-deflection-report.pdf",
         "content": base64.b64encode(pdf_bytes).decode("ascii"),

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -274,7 +274,7 @@ async def send_pending_deflection_report_deliveries(
                     severity="warning",
                     error=error,
                 )
-                await _mark_pending(pool, account_id, request_id, error)
+                await _defer_reclaimed_sending(pool, account_id, request_id, error)
                 failed += 1
                 continue
             await _emit_delivery_incident(
@@ -1277,11 +1277,16 @@ async def _mark_failed(pool: Any, account_id: str, request_id: str, error: str) 
     )
 
 
-async def _mark_pending(pool: Any, account_id: str, request_id: str, error: str) -> None:
+async def _defer_reclaimed_sending(
+    pool: Any,
+    account_id: str,
+    request_id: str,
+    error: str,
+) -> None:
     await pool.execute(
         """
         UPDATE content_ops_deflection_report_deliveries
-        SET delivery_status = 'pending',
+        SET delivery_status = 'sending',
             delivery_error = $3,
             updated_at = NOW()
         WHERE account_id = $1

--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -69,6 +69,7 @@ triage proves otherwise:
 - `paid_report_delivery_missing_email`
 - `paid_report_delivery_no_longer_sendable`
 - `paid_report_delivery_idempotent_replay`
+- `paid_report_delivery_pdf_render_reclaim_deferred`
 - `paid_report_delivery_send_failed`
 
 For these incidents, capture the Stripe event ID, checkout session ID, account

--- a/plans/PR-Deflection-Paid-PDF-Required.md
+++ b/plans/PR-Deflection-Paid-PDF-Required.md
@@ -1,0 +1,107 @@
+# PR-Deflection-Paid-PDF-Required
+
+## Why this slice exists
+
+#1921 split the launch proof into a checked runbook plus guard slices for the
+buyer-facing delivery surfaces. The Snapshot guard is handled in
+atlas-portfolio #473. The paid report path still has the same shape: when
+`render_deflection_full_report_pdf(...)` fails, `_pdf_attachments(...)` catches
+the exception, returns no attachments, and `send_pending_deflection_report_deliveries(...)`
+still sends a link-only email and marks the delivery row `delivered`.
+
+Root cause: the paid delivery worker treats the PDF attachment as optional even
+though the launch contract and customer-facing paid deliverable require the
+curated PDF attachment. This change fixes the worker boundary root by making PDF
+render failure a delivery failure before the sender is called.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Make paid report PDF render/missing-artifact failures fail the delivery row
+   instead of sending a link-only paid email.
+2. Update the existing worker regression that currently locks in link-only
+   fallback so it proves no sender call, failed status, and an incident.
+3. Keep idempotent replay coverage for regenerated-but-different PDF payloads
+   so the provider conflict branch remains protected.
+
+### Review Contract
+
+- Acceptance criteria:
+  - A paid report delivery with a malformed/missing artifact does not call
+    `sender.send(...)`.
+  - A paid report delivery whose PDF renderer raises does not call
+    `sender.send(...)`.
+  - Both cases mark the delivery row failed with a bounded error.
+  - Both cases emit a paid-funnel incident so the launch proof can see the
+    missing paid PDF as a hard failure.
+  - Successful deliveries still attach the PDF and mark delivered.
+- Affected surfaces:
+  - Paid report delivery worker only.
+  - Focused worker tests only.
+- Risk areas:
+  - Paid buyer email delivery.
+  - Delivery status lifecycle.
+  - Launch proof passing on link-only paid email.
+- Triggered reviewer rules:
+  - R1 Requirements match.
+  - R2 Test evidence.
+  - R3 Security/auth/money path.
+  - R8 Persistence/data lifecycle.
+  - R14 Codebase verification.
+
+### Files touched
+
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `plans/PR-Deflection-Paid-PDF-Required.md`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+
+## Mechanism
+
+Replace `_pdf_attachments(...)`'s silent fallback with a small required renderer
+helper that raises when the artifact is missing/malformed or when
+`render_deflection_full_report_pdf(...)` fails. The existing `try/except` around
+the delivery build/send path already emits `paid_report_delivery_send_failed`,
+marks the row failed, increments `failed`, and skips `sender.send(...)`.
+
+The test that currently expects link-only fallback becomes the regression for
+the new contract. It asserts the worker records a failed delivery, no email
+request is built, and the incident payload names the PDF failure.
+
+## Intentional
+
+- No CLI flag or configuration escape hatch. Paid report PDF attachment is a
+  launch contract, not an optional enhancement.
+- Dry-run remains queue-only and does not render PDF. The runbook already names
+  dry-run as queue/paid/email gating only; live-send and local render proof own
+  PDF rendering.
+- This slice does not change delta emails. Deltas are a separate subscription
+  surface and do not currently attach a paid report PDF.
+- Tests use the existing worker pool/sender harness because this slice changes
+  the worker branch before sender execution and does not change SQL or adapter
+  behavior. The idempotent replay regression still uses the real
+  `ResendCampaignSender` with a transport fake.
+
+## Deferred
+
+- #1921 PR 4 still owns the deployed full-funnel proof artifact with a real
+  opted-in buyer email and attached paid PDF.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 35 passed,
+  1 skipped.
+- Pending before push wrapper:
+  - `python scripts/sync_pr_plan.py plans/PR-Deflection-Paid-PDF-Required.md --check`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/content_ops_deflection_delivery.py` | 16 |
+| `plans/PR-Deflection-Paid-PDF-Required.md` | 107 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 71 |
+| **Total** | **194** |

--- a/plans/PR-Deflection-Paid-PDF-Required.md
+++ b/plans/PR-Deflection-Paid-PDF-Required.md
@@ -25,6 +25,10 @@ Slice phase: Production hardening
    fallback so it proves no sender call, failed status, and an incident.
 3. Keep idempotent replay coverage for regenerated-but-different PDF payloads
    so the provider conflict branch remains protected.
+4. Treat stale `sending` reclaims differently from first-attempt `pending`
+   sends when PDF rendering fails, so a transient render outage cannot
+   terminal-fail a delivery row after the buyer may already have received the
+   first email.
 
 ### Review Contract
 
@@ -36,6 +40,9 @@ Slice phase: Production hardening
   - Both cases mark the delivery row failed with a bounded error.
   - Both cases emit a paid-funnel incident so the launch proof can see the
     missing paid PDF as a hard failure.
+  - Stale `sending` reclaims whose PDF renderer fails do not call
+    `sender.send(...)` and are reset to `pending` with a warning incident
+    instead of being marked terminal `failed`.
   - Successful deliveries still attach the PDF and mark delivered.
 - Affected surfaces:
   - Paid report delivery worker only.
@@ -61,9 +68,17 @@ Slice phase: Production hardening
 
 Replace `_pdf_attachments(...)`'s silent fallback with a small required renderer
 helper that raises when the artifact is missing/malformed or when
-`render_deflection_full_report_pdf(...)` fails. The existing `try/except` around
-the delivery build/send path already emits `paid_report_delivery_send_failed`,
-marks the row failed, increments `failed`, and skips `sender.send(...)`.
+`render_deflection_full_report_pdf(...)` fails. The claim query now returns the
+row's previous delivery status before it is claimed as `sending`, so the worker
+can distinguish first-attempt `pending` sends from stale `sending` reclaims.
+
+First-attempt PDF render failures still emit `paid_report_delivery_send_failed`,
+mark the row failed, increment `failed`, and skip `sender.send(...)`. Stale
+reclaim PDF render failures emit
+`paid_report_delivery_pdf_render_reclaim_deferred`, reset the row to `pending`,
+increment `failed` for this run, and skip `sender.send(...)`; the next worker
+run can retry rendering instead of terminal-failing a row whose first email may
+already have reached Resend.
 
 The test that currently expects link-only fallback becomes the regression for
 the new contract. It asserts the worker records a failed delivery, no email
@@ -92,16 +107,16 @@ Parked hardening: none.
 
 ## Verification
 
-- `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 35 passed,
+- `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 36 passed,
   1 skipped.
-- Pending before push wrapper:
-  - `python scripts/sync_pr_plan.py plans/PR-Deflection-Paid-PDF-Required.md --check`
+- `python scripts/sync_pr_plan.py plans/PR-Deflection-Paid-PDF-Required.md --check`
+  - passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/content_ops_deflection_delivery.py` | 16 |
-| `plans/PR-Deflection-Paid-PDF-Required.md` | 107 |
-| `tests/test_atlas_content_ops_deflection_delivery.py` | 71 |
-| **Total** | **194** |
+| `atlas_brain/content_ops_deflection_delivery.py` | 69 |
+| `plans/PR-Deflection-Paid-PDF-Required.md` | 122 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 111 |
+| **Total** | **302** |

--- a/plans/PR-Deflection-Paid-PDF-Required.md
+++ b/plans/PR-Deflection-Paid-PDF-Required.md
@@ -41,8 +41,8 @@ Slice phase: Production hardening
   - Both cases emit a paid-funnel incident so the launch proof can see the
     missing paid PDF as a hard failure.
   - Stale `sending` reclaims whose PDF renderer fails do not call
-    `sender.send(...)` and are reset to `pending` with a warning incident
-    instead of being marked terminal `failed`.
+    `sender.send(...)` and remain `sending` with a warning incident instead of
+    being marked terminal `failed` or losing reclaim provenance.
   - Successful deliveries still attach the PDF and mark delivered.
 - Affected surfaces:
   - Paid report delivery worker only.
@@ -76,12 +76,14 @@ can distinguish first-attempt `pending` sends from stale `sending` reclaims.
 First-attempt PDF render failures still emit `paid_report_delivery_send_failed`,
 mark the row failed, increment `failed`, and skip `sender.send(...)`. Stale
 reclaim PDF render failures emit
-`paid_report_delivery_pdf_render_reclaim_deferred`, reset the row to `pending`,
-increment `failed` for this run, and skip `sender.send(...)`; the next worker
-run can retry rendering instead of terminal-failing a row whose first email may
-already have reached Resend. The new warning incident is listed in the paid
-funnel incident response catalog so the security-policy docs gate and launch
-triage surface stay aligned with the worker emitter.
+`paid_report_delivery_pdf_render_reclaim_deferred`, keep the row `sending` with
+the bounded render error, increment `failed` for this run, and skip
+`sender.send(...)`; the next worker run still sees a reclaimed `sending` row
+instead of a fresh `pending` row, so repeated transient render failures cannot
+terminal-fail a row whose first email may already have reached Resend. The new
+warning incident is listed in the paid funnel incident response catalog so the
+security-policy docs gate and launch triage surface stay aligned with the worker
+emitter.
 
 The test that currently expects link-only fallback becomes the regression for
 the new contract. It asserts the worker records a failed delivery, no email
@@ -110,7 +112,7 @@ Parked hardening: none.
 
 ## Verification
 
-- `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 36 passed,
+- `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 37 passed,
   1 skipped.
 - `python -m unittest tests.test_security_policy_docs` - 20 passed.
 - `python scripts/sync_pr_plan.py plans/PR-Deflection-Paid-PDF-Required.md --check`
@@ -120,8 +122,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/content_ops_deflection_delivery.py` | 69 |
+| `atlas_brain/content_ops_deflection_delivery.py` | 74 |
 | `docs/INCIDENT_RESPONSE.md` | 1 |
-| `plans/PR-Deflection-Paid-PDF-Required.md` | 127 |
-| `tests/test_atlas_content_ops_deflection_delivery.py` | 111 |
-| **Total** | **308** |
+| `plans/PR-Deflection-Paid-PDF-Required.md` | 129 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 149 |
+| **Total** | **353** |

--- a/plans/PR-Deflection-Paid-PDF-Required.md
+++ b/plans/PR-Deflection-Paid-PDF-Required.md
@@ -40,9 +40,10 @@ Slice phase: Production hardening
   - Both cases mark the delivery row failed with a bounded error.
   - Both cases emit a paid-funnel incident so the launch proof can see the
     missing paid PDF as a hard failure.
-  - Stale `sending` reclaims whose PDF renderer fails do not call
-    `sender.send(...)` and remain `sending` with a warning incident instead of
-    being marked terminal `failed` or losing reclaim provenance.
+  - Stale `sending` reclaims whose PDF renderer fails or returns empty PDF
+    output do not call `sender.send(...)` and remain `sending` with a warning
+    incident instead of being marked terminal `failed` or losing reclaim
+    provenance.
   - Successful deliveries still attach the PDF and mark delivered.
 - Affected surfaces:
   - Paid report delivery worker only.
@@ -73,9 +74,9 @@ helper that raises when the artifact is missing/malformed or when
 row's previous delivery status before it is claimed as `sending`, so the worker
 can distinguish first-attempt `pending` sends from stale `sending` reclaims.
 
-First-attempt PDF render failures still emit `paid_report_delivery_send_failed`,
-mark the row failed, increment `failed`, and skip `sender.send(...)`. Stale
-reclaim PDF render failures emit
+First-attempt PDF render failures and empty PDF output still emit
+`paid_report_delivery_send_failed`, mark the row failed, increment `failed`, and
+skip `sender.send(...)`. Stale reclaim PDF render failures and empty PDF output emit
 `paid_report_delivery_pdf_render_reclaim_deferred`, keep the row `sending` with
 the bounded render error, increment `failed` for this run, and skip
 `sender.send(...)`; the next worker run still sees a reclaimed `sending` row
@@ -112,7 +113,7 @@ Parked hardening: none.
 
 ## Verification
 
-- `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 37 passed,
+- `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 38 passed,
   1 skipped.
 - `python -m unittest tests.test_security_policy_docs` - 20 passed.
 - `python scripts/sync_pr_plan.py plans/PR-Deflection-Paid-PDF-Required.md --check`
@@ -124,6 +125,6 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/content_ops_deflection_delivery.py` | 74 |
 | `docs/INCIDENT_RESPONSE.md` | 1 |
-| `plans/PR-Deflection-Paid-PDF-Required.md` | 129 |
-| `tests/test_atlas_content_ops_deflection_delivery.py` | 149 |
-| **Total** | **353** |
+| `plans/PR-Deflection-Paid-PDF-Required.md` | 130 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 186 |
+| **Total** | **391** |

--- a/plans/PR-Deflection-Paid-PDF-Required.md
+++ b/plans/PR-Deflection-Paid-PDF-Required.md
@@ -61,6 +61,7 @@ Slice phase: Production hardening
 ### Files touched
 
 - `atlas_brain/content_ops_deflection_delivery.py`
+- `docs/INCIDENT_RESPONSE.md`
 - `plans/PR-Deflection-Paid-PDF-Required.md`
 - `tests/test_atlas_content_ops_deflection_delivery.py`
 
@@ -78,7 +79,9 @@ reclaim PDF render failures emit
 `paid_report_delivery_pdf_render_reclaim_deferred`, reset the row to `pending`,
 increment `failed` for this run, and skip `sender.send(...)`; the next worker
 run can retry rendering instead of terminal-failing a row whose first email may
-already have reached Resend.
+already have reached Resend. The new warning incident is listed in the paid
+funnel incident response catalog so the security-policy docs gate and launch
+triage surface stay aligned with the worker emitter.
 
 The test that currently expects link-only fallback becomes the regression for
 the new contract. It asserts the worker records a failed delivery, no email
@@ -109,6 +112,7 @@ Parked hardening: none.
 
 - `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 36 passed,
   1 skipped.
+- `python -m unittest tests.test_security_policy_docs` - 20 passed.
 - `python scripts/sync_pr_plan.py plans/PR-Deflection-Paid-PDF-Required.md --check`
   - passed.
 
@@ -117,6 +121,7 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/content_ops_deflection_delivery.py` | 69 |
-| `plans/PR-Deflection-Paid-PDF-Required.md` | 122 |
+| `docs/INCIDENT_RESPONSE.md` | 1 |
+| `plans/PR-Deflection-Paid-PDF-Required.md` | 127 |
 | `tests/test_atlas_content_ops_deflection_delivery.py` | 111 |
-| **Total** | **302** |
+| **Total** | **308** |

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -1401,7 +1401,7 @@ async def test_delivery_worker_fails_when_paid_pdf_render_fails(
 
 
 @pytest.mark.asyncio
-async def test_delivery_worker_defers_stale_reclaim_when_paid_pdf_render_fails(
+async def test_delivery_worker_preserves_stale_reclaim_when_paid_pdf_render_fails(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -1425,7 +1425,9 @@ async def test_delivery_worker_defers_stale_reclaim_when_paid_pdf_render_fails(
     assert summary.failed == 1
     assert sender.requests == []
     update_query, update_args = pool.execute_calls[0]
-    assert "delivery_status = 'pending'" in update_query
+    assert "delivery_status = 'sending'" in update_query
+    assert "delivery_status = 'pending'" not in update_query
+    assert "delivery_status = 'failed'" not in update_query
     assert update_args == (
         "acct-123",
         "content-ops-abc123",
@@ -1437,6 +1439,42 @@ async def test_delivery_worker_defers_stale_reclaim_when_paid_pdf_render_fails(
     )
     assert incidents[-1]["severity"] == "warning"
     assert incidents[-1]["error"] == update_args[-1]
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_repeated_stale_render_outage_remains_reclaim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = _Pool([
+        _row(
+            previous_delivery_status="sending",
+            delivery_error="PaidReportPdfRenderError: prior render outage",
+        )
+    ])
+    sender = _Sender()
+
+    def _raise_pdf(_artifact: Any) -> bytes:
+        raise RuntimeError("pdf still down")
+
+    _install_fake_pdf_renderer(monkeypatch, _raise_pdf)
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.sent == 0
+    assert summary.failed == 1
+    assert sender.requests == []
+    update_query, update_args = pool.execute_calls[0]
+    assert "delivery_status = 'sending'" in update_query
+    assert "delivery_status = 'failed'" not in update_query
+    assert update_args == (
+        "acct-123",
+        "content-ops-abc123",
+        "PaidReportPdfRenderError: paid_report_pdf_render_failed: RuntimeError: pdf still down",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -1392,12 +1392,51 @@ async def test_delivery_worker_fails_when_paid_pdf_render_fails(
     assert update_args == (
         "acct-123",
         "content-ops-abc123",
-        "RuntimeError: paid_report_pdf_render_failed: RuntimeError: pdf down",
+        "PaidReportPdfRenderError: paid_report_pdf_render_failed: RuntimeError: pdf down",
     )
     incidents = _incident_payloads(caplog)
     assert incidents[-1]["incident_type"] == "paid_report_delivery_send_failed"
     assert incidents[-1]["error"] == update_args[-1]
     assert "Deflection report PDF render failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_defers_stale_reclaim_when_paid_pdf_render_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pool = _Pool([_row(previous_delivery_status="sending")])
+    sender = _Sender()
+    caplog.set_level("WARNING", logger="atlas.content_ops_deflection_delivery")
+
+    def _raise_pdf(_artifact: Any) -> bytes:
+        raise RuntimeError("pdf down")
+
+    _install_fake_pdf_renderer(monkeypatch, _raise_pdf)
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.scanned == 1
+    assert summary.sent == 0
+    assert summary.failed == 1
+    assert sender.requests == []
+    update_query, update_args = pool.execute_calls[0]
+    assert "delivery_status = 'pending'" in update_query
+    assert update_args == (
+        "acct-123",
+        "content-ops-abc123",
+        "PaidReportPdfRenderError: paid_report_pdf_render_failed: RuntimeError: pdf down",
+    )
+    incidents = _incident_payloads(caplog)
+    assert incidents[-1]["incident_type"] == (
+        "paid_report_delivery_pdf_render_reclaim_deferred"
+    )
+    assert incidents[-1]["severity"] == "warning"
+    assert incidents[-1]["error"] == update_args[-1]
 
 
 @pytest.mark.asyncio
@@ -1498,6 +1537,7 @@ async def test_delivery_worker_claim_query_retries_stale_sending_rows() -> None:
     claim_query, _claim_args = pool.fetch_calls[0]
     assert "d.delivery_status = 'pending'" in claim_query
     assert "d.delivery_status = 'sending'" in claim_query
+    assert "d.delivery_status AS previous_delivery_status" in claim_query
     assert f"INTERVAL '{DELIVERY_CLAIM_STALE_AFTER}'" in claim_query
 
 

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -1364,11 +1364,13 @@ async def test_delivery_worker_renders_pdf_with_lazy_renderer_import(
 
 
 @pytest.mark.asyncio
-async def test_delivery_worker_falls_back_to_link_only_when_pdf_render_fails(
+async def test_delivery_worker_fails_when_paid_pdf_render_fails(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     pool = _Pool([_row()])
     sender = _Sender()
+    caplog.set_level("ERROR", logger="atlas.content_ops_deflection_delivery")
 
     def _raise_pdf(_artifact: Any) -> bytes:
         raise RuntimeError("pdf down")
@@ -1381,14 +1383,51 @@ async def test_delivery_worker_falls_back_to_link_only_when_pdf_render_fails(
         config=_config(),
     )
 
-    assert summary.sent == 1
-    request = sender.requests[0]
-    assert request.attachments == ()
-    assert "full report PDF is attached" not in request.html_body
-    assert "full report PDF is attached" not in (request.text_body or "")
+    assert summary.scanned == 1
+    assert summary.sent == 0
+    assert summary.failed == 1
+    assert sender.requests == []
     update_query, update_args = pool.execute_calls[0]
-    assert "delivery_status = 'delivered'" in update_query
-    assert update_args == ("acct-123", "content-ops-abc123", "resend:email-123")
+    assert "delivery_status = 'failed'" in update_query
+    assert update_args == (
+        "acct-123",
+        "content-ops-abc123",
+        "RuntimeError: paid_report_pdf_render_failed: RuntimeError: pdf down",
+    )
+    incidents = _incident_payloads(caplog)
+    assert incidents[-1]["incident_type"] == "paid_report_delivery_send_failed"
+    assert incidents[-1]["error"] == update_args[-1]
+    assert "Deflection report PDF render failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_fails_when_paid_pdf_artifact_is_malformed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pool = _Pool([_row(artifact=json.dumps(["not", "a", "report"]))])
+    sender = _Sender()
+    caplog.set_level("ERROR", logger="atlas.content_ops_deflection_delivery")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.scanned == 1
+    assert summary.sent == 0
+    assert summary.failed == 1
+    assert sender.requests == []
+    update_query, update_args = pool.execute_calls[0]
+    assert "delivery_status = 'failed'" in update_query
+    assert update_args == (
+        "acct-123",
+        "content-ops-abc123",
+        "ValueError: paid_report_pdf_missing_artifact",
+    )
+    incidents = _incident_payloads(caplog)
+    assert incidents[-1]["incident_type"] == "paid_report_delivery_send_failed"
+    assert incidents[-1]["error"] == update_args[-1]
 
 
 @pytest.mark.asyncio
@@ -1559,11 +1598,11 @@ async def test_reclaim_changing_attachment_payload_marks_delivered_via_real_rese
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # End-to-end regression for the R8 BLOCKER (real ResendCampaignSender + the
-    # real render->link-only fallback transition): first send carries the PDF
-    # attachment; on re-claim the render fails so the email is link-only -- a
-    # DIFFERENT payload under the SAME idempotency key. A Resend-like client
-    # returns 409 invalid_idempotent_request for that mismatch, and the delivery
-    # path must mark the row delivered (idempotent replay), not failed.
+    # real render->attachment transition): both attempts carry a PDF, but a
+    # regenerated attachment can still differ byte-for-byte under the SAME
+    # idempotency key. A Resend-like client returns 409 invalid_idempotent_request
+    # for that mismatch, and the delivery path must mark the row delivered
+    # (idempotent replay), not failed.
     from extracted_content_pipeline.campaign_sender import (
         ResendCampaignSender,
         ResendSenderConfig,
@@ -1608,7 +1647,7 @@ async def test_reclaim_changing_attachment_payload_marks_delivered_via_real_rese
         render_calls["n"] += 1
         if render_calls["n"] == 1:
             return b"%PDF-first-render"
-        raise RuntimeError("render failed on reclaim")
+        return b"%PDF-second-render"
 
     _install_fake_pdf_renderer(monkeypatch, _renderer)
     row = _row()
@@ -1618,7 +1657,7 @@ async def test_reclaim_changing_attachment_payload_marks_delivered_via_real_rese
     )
     assert first.sent == 1 and first.failed == 0
 
-    # Re-claim: render now fails -> link-only -> different payload, same key.
+    # Re-claim: render returns a different PDF payload under the same key.
     second = await send_pending_deflection_report_deliveries(
         _Pool([row]), sender=sender, config=_config()
     )
@@ -1626,7 +1665,7 @@ async def test_reclaim_changing_attachment_payload_marks_delivered_via_real_rese
     assert second.failed == 0
     assert len(http.posts) == 2
     assert http.posts[0]["key"] == http.posts[1]["key"]  # same idempotency key
-    assert http.posts[0]["json"] != http.posts[1]["json"]  # attachment vs link-only
+    assert http.posts[0]["json"] != http.posts[1]["json"]  # regenerated attachment
 
 
 @pytest.mark.asyncio

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -1478,6 +1478,43 @@ async def test_delivery_worker_repeated_stale_render_outage_remains_reclaim(
 
 
 @pytest.mark.asyncio
+async def test_delivery_worker_preserves_stale_reclaim_when_paid_pdf_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pool = _Pool([_row(previous_delivery_status="sending")])
+    sender = _Sender()
+    caplog.set_level("WARNING", logger="atlas.content_ops_deflection_delivery")
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.scanned == 1
+    assert summary.sent == 0
+    assert summary.failed == 1
+    assert sender.requests == []
+    update_query, update_args = pool.execute_calls[0]
+    assert "delivery_status = 'sending'" in update_query
+    assert "delivery_status = 'pending'" not in update_query
+    assert "delivery_status = 'failed'" not in update_query
+    assert update_args == (
+        "acct-123",
+        "content-ops-abc123",
+        "PaidReportPdfRenderError: paid_report_pdf_empty",
+    )
+    incidents = _incident_payloads(caplog)
+    assert incidents[-1]["incident_type"] == (
+        "paid_report_delivery_pdf_render_reclaim_deferred"
+    )
+    assert incidents[-1]["severity"] == "warning"
+    assert incidents[-1]["error"] == update_args[-1]
+
+
+@pytest.mark.asyncio
 async def test_delivery_worker_fails_when_paid_pdf_artifact_is_malformed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Paid-PDF-Required.md
Slice phase: Production hardening

#1921 split the launch proof into a checked runbook plus guard slices for the buyer-facing delivery surfaces. The Snapshot guard is handled in atlas-portfolio #473. This slice makes the paid report delivery worker fail closed when the paid report PDF cannot be attached, instead of sending a link-only paid email and marking the row delivered.

## Intentional
- No CLI flag or configuration escape hatch; the paid report PDF attachment is a launch contract.
- Dry-run remains queue-only and does not render PDF.
- Delta emails are unchanged; they are a separate subscription surface and do not currently attach a paid report PDF.
- Tests use the existing worker pool/sender harness because this branch changes worker behavior before sender execution and does not change SQL or adapter behavior. The idempotent replay regression still uses the real `ResendCampaignSender` with a transport fake.

## Deferred
- #1921 PR 4 still owns the deployed full-funnel proof artifact with a real opted-in buyer email and attached paid PDF.

## AI reconciliation
- AI findings reviewed: yes.
- All fixed or waived: yes.
- Waivers justified in PR body: not applicable.
- Codex P2 stale reclaim/render failure finding: fixed by returning the claimed row's previous delivery status and keeping stale `sending` reclaims in `sending` with a warning incident when PDF rendering fails, instead of terminal-failing rows whose first email may already have reached Resend.
- Codex P2 stale reclaim provenance re-review: fixed by no longer resetting reclaimed rows to `pending`; repeated render outages keep the row distinguishable as a reclaimed `sending` row until rendering succeeds and the idempotent replay branch can run.
- Codex P2 empty PDF stale-reclaim re-review: fixed by treating empty renderer output as `PaidReportPdfRenderError`, so stale `sending` reclaims use the same preserve-as-sending path as renderer exceptions.
- Security policy docs check: fixed by listing `paid_report_delivery_pdf_render_reclaim_deferred` in the paid-funnel incident response catalog.

## Parked hardening
- None.

## Verification
- `pytest tests/test_atlas_content_ops_deflection_delivery.py -q` - 38 passed, 1 skipped.
- `python -m unittest tests.test_security_policy_docs` - 20 passed.
- `python scripts/sync_pr_plan.py plans/PR-Deflection-Paid-PDF-Required.md --check` - passed.

## Diff size
4 files, 391 LOC per `python scripts/sync_pr_plan.py plans/PR-Deflection-Paid-PDF-Required.md`.
