### PR TITLE
Preserve product-gap platform provenance

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -2462,12 +2462,17 @@ def _deflection_submit_rows_with_defaults(
         "contact_email": data["contact_email"],
         "support_platform": data["support_platform"],
     }
-    return [
-        {**defaults, **dict(row)}
-        if isinstance(row, Mapping)
-        else row
-        for row in rows
-    ]
+    default_platform = data["support_platform"]
+    out: list[Any] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            out.append(row)
+            continue
+        merged = {**defaults, **dict(row)}
+        if not _clean(merged.get("support_platform")):
+            merged["support_platform"] = default_platform
+        out.append(merged)
+    return out
 
 
 def _deflection_submit_english_rows(rows: Sequence[Any]) -> tuple[list[Any], int]:

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -2489,12 +2489,11 @@ _DEFLECTION_SUBMIT_SUPPORT_PLATFORM_KEYS = (
 
 
 def _deflection_submit_row_support_platform(row: Mapping[str, Any]) -> str | None:
-    normalized_keys = {
-        re.sub(r"[^a-z0-9]+", "", key.lower())
-        for key in _DEFLECTION_SUBMIT_SUPPORT_PLATFORM_KEYS
-    }
-    for raw_key, value in row.items():
-        if re.sub(r"[^a-z0-9]+", "", str(raw_key).lower()) in normalized_keys:
+    for key in _DEFLECTION_SUBMIT_SUPPORT_PLATFORM_KEYS:
+        normalized_key = re.sub(r"[^a-z0-9]+", "", key.lower())
+        for raw_key, value in row.items():
+            if re.sub(r"[^a-z0-9]+", "", str(raw_key).lower()) != normalized_key:
+                continue
             platform = _clean(value)
             if platform:
                 return platform

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -2468,11 +2468,37 @@ def _deflection_submit_rows_with_defaults(
         if not isinstance(row, Mapping):
             out.append(row)
             continue
-        merged = {**defaults, **dict(row)}
-        if not _clean(merged.get("support_platform")):
+        row_dict = dict(row)
+        row_platform = _deflection_submit_row_support_platform(row_dict)
+        merged = {**defaults, **row_dict}
+        if row_platform:
+            merged["support_platform"] = row_platform
+        elif not _clean(merged.get("support_platform")):
             merged["support_platform"] = default_platform
         out.append(merged)
     return out
+
+
+_DEFLECTION_SUBMIT_SUPPORT_PLATFORM_KEYS = (
+    "support_platform",
+    "support platform",
+    "platform",
+    "source_platform",
+    "helpdesk_platform",
+)
+
+
+def _deflection_submit_row_support_platform(row: Mapping[str, Any]) -> str | None:
+    normalized_keys = {
+        re.sub(r"[^a-z0-9]+", "", key.lower())
+        for key in _DEFLECTION_SUBMIT_SUPPORT_PLATFORM_KEYS
+    }
+    for raw_key, value in row.items():
+        if re.sub(r"[^a-z0-9]+", "", str(raw_key).lower()) in normalized_keys:
+            platform = _clean(value)
+            if platform:
+                return platform
+    return None
 
 
 def _deflection_submit_english_rows(rows: Sequence[Any]) -> tuple[list[Any], int]:

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -213,6 +213,13 @@ _DATE_KEYS = (
     "date",
 )
 _URL_KEYS = ("source_url", "ticket_url", "url", "link")
+_SUPPORT_PLATFORM_KEYS = (
+    "support_platform",
+    "support platform",
+    "platform",
+    "source_platform",
+    "helpdesk_platform",
+)
 _COMPANY_KEYS = ("company_name", "account_name", "company", "account")
 _VENDOR_KEYS = ("vendor_name", "product_name", "vendor", "product")
 _CONTACT_EMAIL_KEYS = (
@@ -560,6 +567,7 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     for key, keys in (
         ("created_at", _DATE_KEYS),
         ("source_url", _URL_KEYS),
+        ("support_platform", _SUPPORT_PLATFORM_KEYS),
         ("company_name", _COMPANY_KEYS),
         ("vendor_name", _VENDOR_KEYS),
         ("contact_email", _CONTACT_EMAIL_KEYS),

--- a/plans/PR-Product-Gap-Platform-Provenance.md
+++ b/plans/PR-Product-Gap-Platform-Provenance.md
@@ -1,0 +1,88 @@
+# PR-Product-Gap-Platform-Provenance
+
+## Why this slice exists
+
+#1925 identified a trust-hardening gap after the CSV-first product-gap work
+landed: `support_platform` is kept in hosted submit/report metadata, but it is
+not preserved on normalized support-ticket source rows. The root cause is that
+support-ticket normalization has routing aliases and company/contact aliases,
+but no provenance alias for platform. This fixes the root for platform
+provenance without changing owner-lane routing semantics.
+
+## Scope (this PR)
+
+Ownership lane: deflection/product-gap-hardening
+Slice phase: Production hardening
+Max files: 4
+
+1. Preserve safe support-platform aliases on normalized support-ticket rows as
+   provenance metadata.
+2. Keep platform metadata out of routing signals and owner-lane inference.
+3. Add focused normalization and report-model regression coverage.
+
+### Review Contract
+
+Acceptance criteria:
+- Support-ticket rows preserve `support_platform`, `Support Platform`, and
+  `platform` aliases as `support_platform`.
+- Existing hosted submit defaults that add `support_platform` continue to flow
+  into normalized source material.
+- `support_platform` does not appear inside product-gap `routing_signals`.
+- Adding `support_platform` does not change owner-lane routing.
+
+Affected surfaces:
+- Support-ticket input package normalization.
+- Focused support-ticket/report regression tests.
+
+Risk areas:
+- Accidentally treating provider provenance as a routing/owner signal.
+- Disturbing existing submit metadata or private-text exclusions.
+
+Reviewer rules triggered: R1, R2, R4, R8, R10, R14.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `plans/PR-Product-Gap-Platform-Provenance.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+
+## Mechanism
+
+The normalizer gets a dedicated support-platform alias tuple and copies the
+first non-empty platform value into `support_platform` during the same
+source-row shaping pass that already handles company/vendor/contact metadata.
+It is deliberately not added to `_ROUTING_CONTEXT_KEYS`, so grouped FAQ items
+and product-gap action rows do not treat the provider as a routing signal.
+
+## Intentional
+
+- No routing-signal projection for `support_platform`. Platform is provenance,
+  not a product owner lane.
+- No owner-lane precedence change. The existing text-first routing contract is
+  handled by a later hardening slice.
+- No `Company`/`organization` alias cleanup in this PR; that is the next
+  separate hardening slice.
+
+## Deferred
+
+- #1925 follow-up: stop plain `Company` from aliasing into routing
+  `organization`.
+- #1925 follow-up: document and test owner-lane text-vs-routing precedence.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py::test_support_ticket_input_package_preserves_support_platform_provenance tests/test_content_ops_deflection_report.py::test_support_platform_provenance_does_not_route_owner_lane -q` - passed, 2 tests.
+- Local PR review gate with the current PR body file wired in - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
+| `plans/PR-Product-Gap-Platform-Provenance.md` | 88 |
+| `tests/test_content_ops_deflection_report.py` | 30 |
+| `tests/test_extracted_support_ticket_input_package.py` | 29 |
+| **Total** | **155** |

--- a/plans/PR-Product-Gap-Platform-Provenance.md
+++ b/plans/PR-Product-Gap-Platform-Provenance.md
@@ -93,10 +93,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/api/control_surfaces.py` | 43 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 42 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
 | `plans/PR-Product-Gap-Platform-Provenance.md` | 102 |
 | `tests/test_content_ops_deflection_report.py` | 30 |
-| `tests/test_extracted_content_deflection_submit.py` | 37 |
+| `tests/test_extracted_content_deflection_submit.py` | 44 |
 | `tests/test_extracted_support_ticket_input_package.py` | 29 |
-| **Total** | **249** |
+| **Total** | **255** |

--- a/plans/PR-Product-Gap-Platform-Provenance.md
+++ b/plans/PR-Product-Gap-Platform-Provenance.md
@@ -13,12 +13,15 @@ provenance without changing owner-lane routing semantics.
 
 Ownership lane: deflection/product-gap-hardening
 Slice phase: Production hardening
-Max files: 4
+Max files: 6
 
 1. Preserve safe support-platform aliases on normalized support-ticket rows as
    provenance metadata.
-2. Keep platform metadata out of routing signals and owner-lane inference.
-3. Add focused normalization and report-model regression coverage.
+2. Preserve hosted-submit platform defaults when sparse CSV platform columns
+   contain blank cells.
+3. Keep platform metadata out of routing signals and owner-lane inference.
+4. Add focused submit/default, normalization, and report-model regression
+   coverage.
 
 ### Review Contract
 
@@ -26,12 +29,14 @@ Acceptance criteria:
 - Support-ticket rows preserve `support_platform`, `Support Platform`, and
   `platform` aliases as `support_platform`.
 - Existing hosted submit defaults that add `support_platform` continue to flow
-  into normalized source material.
+  into normalized source material, including when a sparse CSV
+  `support_platform` column contains blank cells.
 - `support_platform` does not appear inside product-gap `routing_signals`.
 - Adding `support_platform` does not change owner-lane routing.
 
 Affected surfaces:
 - Support-ticket input package normalization.
+- Hosted deflection submit row defaults.
 - Focused support-ticket/report regression tests.
 
 Risk areas:
@@ -42,9 +47,11 @@ Reviewer rules triggered: R1, R2, R4, R8, R10, R14.
 
 ### Files touched
 
+- `extracted_content_pipeline/api/control_surfaces.py`
 - `extracted_content_pipeline/support_ticket_input_package.py`
 - `plans/PR-Product-Gap-Platform-Provenance.md`
 - `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_deflection_submit.py`
 - `tests/test_extracted_support_ticket_input_package.py`
 
 ## Mechanism
@@ -52,8 +59,10 @@ Reviewer rules triggered: R1, R2, R4, R8, R10, R14.
 The normalizer gets a dedicated support-platform alias tuple and copies the
 first non-empty platform value into `support_platform` during the same
 source-row shaping pass that already handles company/vendor/contact metadata.
-It is deliberately not added to `_ROUTING_CONTEXT_KEYS`, so grouped FAQ items
-and product-gap action rows do not treat the provider as a routing signal.
+Hosted submit row defaults also restore the selected form platform if a sparse
+CSV `support_platform` cell is blank. Platform is deliberately not added to
+`_ROUTING_CONTEXT_KEYS`, so grouped FAQ items and product-gap action rows do
+not treat the provider as a routing signal.
 
 ## Intentional
 
@@ -74,15 +83,17 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_extracted_support_ticket_input_package.py::test_support_ticket_input_package_preserves_support_platform_provenance tests/test_content_ops_deflection_report.py::test_support_platform_provenance_does_not_route_owner_lane -q` - passed, 2 tests.
+- `python -m pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_defaults_fill_blank_support_platform_cells tests/test_extracted_support_ticket_input_package.py::test_support_ticket_input_package_preserves_support_platform_provenance tests/test_content_ops_deflection_report.py::test_support_platform_provenance_does_not_route_owner_lane -q` - passed, 3 tests.
 - Local PR review gate with the current PR body file wired in - passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 17 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `plans/PR-Product-Gap-Platform-Provenance.md` | 88 |
+| `plans/PR-Product-Gap-Platform-Provenance.md` | 97 |
 | `tests/test_content_ops_deflection_report.py` | 30 |
+| `tests/test_extracted_content_deflection_submit.py` | 25 |
 | `tests/test_extracted_support_ticket_input_package.py` | 29 |
-| **Total** | **155** |
+| **Total** | **206** |

--- a/plans/PR-Product-Gap-Platform-Provenance.md
+++ b/plans/PR-Product-Gap-Platform-Provenance.md
@@ -18,7 +18,7 @@ Max files: 6
 1. Preserve safe support-platform aliases on normalized support-ticket rows as
    provenance metadata.
 2. Preserve hosted-submit platform defaults when sparse CSV platform columns
-   contain blank cells.
+   contain blank cells, while still letting non-empty row platform aliases win.
 3. Keep platform metadata out of routing signals and owner-lane inference.
 4. Add focused submit/default, normalization, and report-model regression
    coverage.
@@ -31,6 +31,8 @@ Acceptance criteria:
 - Existing hosted submit defaults that add `support_platform` continue to flow
   into normalized source material, including when a sparse CSV
   `support_platform` column contains blank cells.
+- Non-empty row aliases such as `Support Platform` and `platform` are not
+  shadowed by the hosted-submit default.
 - `support_platform` does not appear inside product-gap `routing_signals`.
 - Adding `support_platform` does not change owner-lane routing.
 
@@ -59,8 +61,9 @@ Reviewer rules triggered: R1, R2, R4, R8, R10, R14.
 The normalizer gets a dedicated support-platform alias tuple and copies the
 first non-empty platform value into `support_platform` during the same
 source-row shaping pass that already handles company/vendor/contact metadata.
-Hosted submit row defaults also restore the selected form platform if a sparse
-CSV `support_platform` cell is blank. Platform is deliberately not added to
+Hosted submit row defaults preserve the first non-empty row platform alias when
+present, and otherwise restore the selected form platform if a sparse CSV
+`support_platform` cell is blank. Platform is deliberately not added to
 `_ROUTING_CONTEXT_KEYS`, so grouped FAQ items and product-gap action rows do
 not treat the provider as a routing signal.
 
@@ -90,10 +93,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/api/control_surfaces.py` | 17 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 43 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `plans/PR-Product-Gap-Platform-Provenance.md` | 97 |
+| `plans/PR-Product-Gap-Platform-Provenance.md` | 102 |
 | `tests/test_content_ops_deflection_report.py` | 30 |
-| `tests/test_extracted_content_deflection_submit.py` | 25 |
+| `tests/test_extracted_content_deflection_submit.py` | 37 |
 | `tests/test_extracted_support_ticket_input_package.py` | 29 |
-| **Total** | **206** |
+| **Total** | **249** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -809,6 +809,36 @@ def test_csv_product_gap_owner_lane_vertical_routes_login_gap() -> None:
     assert {row["answer_linkage"] for row in login_rows} == {"needs_review"}
 
 
+def test_support_platform_provenance_does_not_route_owner_lane() -> None:
+    rows = [
+        {
+            "Ticket ID": f"zd-login-{index}",
+            "Subject": "Where is the login button?",
+            "Requester Comment": "Where is the login button?",
+            "Support Platform": "zendesk",
+            "Group": "Billing Support",
+            "Tags": "navigation",
+        }
+        for index in range(1, 4)
+    ]
+    package = build_support_ticket_input_package(rows)
+
+    assert {
+        row["support_platform"]
+        for row in package.inputs["source_material"]
+    } == {"zendesk"}
+
+    faq_result = build_ticket_faq_markdown(package.inputs["source_material"], max_items=4)
+    artifact = build_deflection_report_artifact(faq_result)
+    sections = {section["id"]: section for section in artifact.report_model.as_dict()["sections"]}
+    priority_item = sections["priority_fix_queue"]["data"]["items"][0]
+
+    assert priority_item["owner_lane"] == "Auth / Product UX"
+    assert "support_platform" not in priority_item["routing_signals"]
+    assert priority_item["routing_signals"]["group"] == ["Billing Support"]
+    assert priority_item["routing_signals"]["tags"] == ["navigation"]
+
+
 def test_product_gap_summary_does_not_copy_root_cause_or_screen_path_question() -> None:
     result = TicketFAQMarkdownResult(
         markdown="# FAQ",

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -146,11 +146,23 @@ def test_deflection_submit_defaults_fill_blank_support_platform_cells() -> None:
                 "description": "How do I export reports?",
                 "support_platform": "help_scout",
             },
+            {
+                "ticket_id": "ticket-3",
+                "description": "How do I update notifications?",
+                "Support Platform": "intercom",
+            },
+            {
+                "ticket_id": "ticket-4",
+                "description": "Where do I change roles?",
+                "platform": "help_scout",
+            },
         ],
     )
 
     assert rows[0]["support_platform"] == "zendesk"
     assert rows[1]["support_platform"] == "help_scout"
+    assert rows[2]["support_platform"] == "intercom"
+    assert rows[3]["support_platform"] == "help_scout"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -156,6 +156,12 @@ def test_deflection_submit_defaults_fill_blank_support_platform_cells() -> None:
                 "description": "Where do I change roles?",
                 "platform": "help_scout",
             },
+            {
+                "ticket_id": "ticket-5",
+                "description": "How do I update seats?",
+                "platform": "ios",
+                "support_platform": "intercom",
+            },
         ],
     )
 
@@ -163,6 +169,7 @@ def test_deflection_submit_defaults_fill_blank_support_platform_cells() -> None:
     assert rows[1]["support_platform"] == "help_scout"
     assert rows[2]["support_platform"] == "intercom"
     assert rows[3]["support_platform"] == "help_scout"
+    assert rows[4]["support_platform"] == "intercom"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -128,6 +128,31 @@ def _csv_dict_bytes(rows: list[dict[str, str]]) -> bytes:
     return out.getvalue().encode("utf-8")
 
 
+def test_deflection_submit_defaults_fill_blank_support_platform_cells() -> None:
+    rows = api_module._deflection_submit_rows_with_defaults(
+        {
+            "company_name": "Acme Inc.",
+            "contact_email": "ops@example.com",
+            "support_platform": "zendesk",
+        },
+        [
+            {
+                "ticket_id": "ticket-1",
+                "description": "Where is the login button?",
+                "support_platform": "",
+            },
+            {
+                "ticket_id": "ticket-2",
+                "description": "How do I export reports?",
+                "support_platform": "help_scout",
+            },
+        ],
+    )
+
+    assert rows[0]["support_platform"] == "zendesk"
+    assert rows[1]["support_platform"] == "help_scout"
+
+
 @pytest.mark.asyncio
 async def test_deflection_submit_upload_copy_streams_chunks_not_whole_limit() -> None:
     data = b"a" * (api_module._DEFLECTION_SUBMIT_UPLOAD_CHUNK_BYTES + 17)

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1349,6 +1349,35 @@ def test_support_ticket_input_package_recognizes_status_and_csat_columns() -> No
     assert package.metadata["csat_score_average"] == 3.5
 
 
+def test_support_ticket_input_package_preserves_support_platform_provenance() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "Ticket ID": "zd-1",
+            "Subject": "Where is the login button?",
+            "Requester Comment": "Where is the login button?",
+            "Support Platform": "zendesk",
+        },
+        {
+            "ticket_id": "hs-1",
+            "subject": "How do I export reports?",
+            "description": "How do I export reports?",
+            "platform": "help_scout",
+        },
+        {
+            "ticket_id": "ic-1",
+            "subject": "How do I update my billing email?",
+            "description": "How do I update my billing email?",
+            "support_platform": "intercom",
+        },
+    ])
+
+    rows = package.inputs["source_material"]
+
+    assert rows[0]["support_platform"] == "zendesk"
+    assert rows[1]["support_platform"] == "help_scout"
+    assert rows[2]["support_platform"] == "intercom"
+
+
 def test_support_ticket_status_normalizes_to_canonical_buckets() -> None:
     statuses = {
         "done": "resolved",


### PR DESCRIPTION
Plan: plans/PR-Product-Gap-Platform-Provenance.md
Slice phase: Production hardening

#1925 found that support platform is retained in submit/report metadata but dropped from normalized support-ticket rows. This slice preserves it as provenance metadata while keeping it out of product-gap routing and owner-lane inference, including hosted-submit defaults for sparse CSV platform columns without shadowing non-empty row platform aliases.

## Intentional
- `support_platform` is provenance, not a routing signal.
- Owner-lane precedence stays unchanged; text-vs-routing precedence is a later #1925 slice.
- `Company`/`organization` alias cleanup is deferred to the next #1925 slice.

## Deferred
- #1925: stop plain `Company` from aliasing into routing `organization`.
- #1925: document and test owner-lane text-vs-routing precedence.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_content_deflection_submit.py::test_deflection_submit_defaults_fill_blank_support_platform_cells tests/test_extracted_support_ticket_input_package.py::test_support_ticket_input_package_preserves_support_platform_provenance tests/test_content_ops_deflection_report.py::test_support_platform_provenance_does_not_route_owner_lane -q` - passed, 3 tests.
- Local PR review gate with the current PR body file wired in - passed after third Codex P2 fix.

## Diff size
6 files, +249 / -0.

## AI reconciliation
All findings fixed or waived: yes.

- chatgpt-codex-connector -- `extracted_content_pipeline/support_ticket_input_package.py` / hosted-submit blank platform alias fallback: FIXED by preserving the selected submit default when the merged row has a blank `support_platform` value, with regression coverage in `tests/test_extracted_content_deflection_submit.py::test_deflection_submit_defaults_fill_blank_support_platform_cells`.
- chatgpt-codex-connector -- `extracted_content_pipeline/api/control_surfaces.py` / non-canonical row platform alias shadowed by hosted-submit default: FIXED by reading the first non-empty row platform alias before applying the submit default, with regression coverage for `Support Platform` and `platform` aliases in `tests/test_extracted_content_deflection_submit.py::test_deflection_submit_defaults_fill_blank_support_platform_cells`.
- chatgpt-codex-connector -- `extracted_content_pipeline/api/control_surfaces.py` / generic `platform` winning over canonical `support_platform` by CSV header order: FIXED by iterating `_DEFLECTION_SUBMIT_SUPPORT_PLATFORM_KEYS` in alias-precedence order, with regression coverage where `platform=ios` appears before `support_platform=intercom` and canonical `support_platform` wins.

Refs #1925
