### PR TITLE
Remove company from product-gap organization routing

### DIFF
--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -196,7 +196,7 @@ _ROUTING_CONTEXT_KEYS = (
     ("assignee", ("assignee", "assigned_to", "agent", "agent_name")),
     ("tags", ("tags", "tag", "ticket_tags", "labels")),
     ("brand", ("brand", "ticket_brand", "zendesk_brand")),
-    ("organization", ("organization", "organisation", "org", "company")),
+    ("organization", ("organization", "organisation", "org", "requester_organization")),
     ("product_area", ("product_area", "product area", "area")),
     (
         "custom_product_area",

--- a/plans/PR-Product-Gap-Company-Organization-Alias.md
+++ b/plans/PR-Product-Gap-Company-Organization-Alias.md
@@ -1,0 +1,95 @@
+# PR-Product-Gap-Company-Organization-Alias
+
+## Why this slice exists
+
+Issue #1925 found one remaining product-gap routing edge after PR #1926:
+plain CSV `Company` currently normalizes into both `company_name` and routing
+`organization`. That can make customer/account identity look like product-gap
+routing evidence, which weakens the trust story for owner-lane handoff data.
+
+This slice keeps company/account data as customer identity while requiring
+explicit organization-style headers for routing `organization`.
+
+## Scope (this PR)
+
+Ownership lane: deflection/product-gap-hardening
+Slice phase: Production hardening
+
+1. Remove plain `company` from routing `organization` aliases in the support
+   ticket normalizer.
+2. Keep `company`, `account`, `account_name`, and `company_name` as
+   `company_name` aliases.
+3. Add focused coverage for a plain `Company` row and an explicit
+   `Organization` row so the boundary is not inferred from prose.
+
+### Review Contract
+
+Acceptance criteria:
+- A row with only `Company` preserves `company_name` and does not emit routing
+  `organization`.
+- Explicit organization aliases still emit routing `organization`.
+- Existing product-gap report output that uses explicit `Organization` keeps
+  its routing signal.
+
+Affected surfaces:
+- Support-ticket input package normalization.
+- Focused support-ticket/report regression tests.
+
+Risk areas:
+- Losing legitimate organization routing metadata.
+- Continuing to leak account identity into product-gap routing evidence.
+
+Reviewer rules triggered: R1, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `plans/PR-Product-Gap-Company-Organization-Alias.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+
+## Mechanism
+
+The support-ticket normalizer already has separate alias lists for routing
+context and company identity. This slice narrows only
+`_ROUTING_CONTEXT_KEYS["organization"]` by dropping `company` from that alias
+tuple and keeping explicit organization aliases (`organization`,
+`organisation`, `org`, and `requester_organization`).
+
+The existing `_COMPANY_KEYS` mapping remains unchanged, so plain company data
+continues to normalize into `company_name` for customer/account identity.
+
+## Intentional
+
+- This does not remove `organization` as a routing signal; explicit
+  organization headers still flow through.
+- This does not change owner-lane precedence. Text-vs-routing conflict behavior
+  remains the next #1925 slice.
+- This does not add provider-specific organization aliases beyond
+  `requester_organization`; broader alias expansion should be evidence-driven.
+
+## Deferred
+
+- #1925: document and test owner-lane text-vs-routing precedence.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py::test_support_ticket_bundle_inherits_parent_fields_and_comment_text tests/test_extracted_support_ticket_input_package.py::test_support_ticket_input_package_keeps_company_out_of_routing_organization tests/test_extracted_support_ticket_input_package.py::test_support_ticket_input_package_preserves_explicit_routing_organization -q` -
+  passed, 6 tests.
+- `python -m pytest tests/test_content_ops_deflection_report.py::test_csv_product_gap_owner_lane_vertical_routes_login_gap -q` -
+  passed, 1 test.
+- Grep for organization/company alias tables in
+  `extracted_content_pipeline/support_ticket_input_package.py` -
+  confirmed `company` remains only in `_COMPANY_KEYS`, while routing
+  `organization` uses explicit organization aliases.
+- Local PR review gate with the current PR body file wired in - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_input_package.py` | 2 |
+| `plans/PR-Product-Gap-Company-Organization-Alias.md` | 95 |
+| `tests/test_extracted_support_ticket_input_package.py` | 43 |
+| **Total** | **140** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -204,7 +204,6 @@ def test_support_ticket_bundle_inherits_parent_fields_and_comment_text() -> None
                 "Manual sequence cleanup after demos Can I automate demo follow-up? "
                 "Automation is not on this plan."
             ),
-            "organization": "Riverbend Supply",
             "company_name": "Riverbend Supply",
             "vendor_name": "LegacyCRM",
             "support_ticket_cluster": "automation cleanup demo follow",
@@ -1116,6 +1115,48 @@ def test_support_ticket_input_package_uses_stable_duplicate_key_precedence() -> 
     ])
 
     assert package.inputs["source_material"][0]["company_name"] == "First Account"
+
+
+def test_support_ticket_input_package_keeps_company_out_of_routing_organization() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Where do I update billing contacts?",
+            "Company": "Acme Only",
+        },
+    ])
+
+    row = package.inputs["source_material"][0]
+
+    assert row["company_name"] == "Acme Only"
+    assert "organization" not in row
+
+
+@pytest.mark.parametrize(
+    ("organization_key", "expected"),
+    (
+        ("Organization", "Acme Org"),
+        ("Organisation", "Acme UK Org"),
+        ("Org", "Acme Short Org"),
+        ("Requester Organization", "Acme Requester Org"),
+    ),
+)
+def test_support_ticket_input_package_preserves_explicit_routing_organization(
+    organization_key: str,
+    expected: str,
+) -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Where is the login button?",
+            organization_key: expected,
+        },
+    ])
+
+    row = package.inputs["source_material"][0]
+
+    assert row["organization"] == expected
+    assert "company_name" not in row
 
 
 def test_support_ticket_input_package_keeps_request_overrides_authoritative() -> None:


### PR DESCRIPTION
Plan: plans/PR-Product-Gap-Company-Organization-Alias.md
Slice phase: Production hardening

#1925 found that plain CSV `Company` normalized into both `company_name` and routing `organization`. This slice keeps `Company` as customer/account identity while requiring explicit organization-style headers for routing organization evidence.

## Intentional
- `company`, `account`, `account_name`, and `company_name` still populate `company_name`.
- Explicit organization aliases still populate routing `organization`.
- Owner-lane text-vs-routing precedence remains deferred to the next #1925 slice.

## Deferred
- #1925: document and test owner-lane text-vs-routing precedence.

## Parked hardening
None.

## Verification
- `python -m pytest tests/test_extracted_support_ticket_input_package.py::test_support_ticket_bundle_inherits_parent_fields_and_comment_text tests/test_extracted_support_ticket_input_package.py::test_support_ticket_input_package_keeps_company_out_of_routing_organization tests/test_extracted_support_ticket_input_package.py::test_support_ticket_input_package_preserves_explicit_routing_organization -q` - passed, 6 tests.
- `python -m pytest tests/test_content_ops_deflection_report.py::test_csv_product_gap_owner_lane_vertical_routes_login_gap -q` - passed, 1 test.
- `rg -n '"organization"|"company"|_ROUTING_CONTEXT_KEYS|_COMPANY_KEYS' extracted_content_pipeline/support_ticket_input_package.py` - confirmed `company` remains only in `_COMPANY_KEYS`, while routing `organization` uses explicit organization aliases.
- Local PR review gate with the current PR body file wired in - passed.

## Diff size
3 files, +118 / -2.

## AI reconciliation
All findings fixed or waived: yes.

- No automated AI findings yet.

Refs #1925
