### PR TITLE
Scope paid deflection delivery proof to one request

### DIFF
--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -174,13 +174,19 @@ async def send_pending_deflection_report_deliveries(
     *,
     sender: DeflectionReportDeliverySender,
     config: DeflectionReportDeliveryConfig,
+    account_id: str | None = None,
+    request_id: str | None = None,
 ) -> DeflectionReportDeliverySummary:
     """Send pending paid-report delivery emails and update queue status."""
 
     _validate_config(config)
+    scoped_account_id = _clean(account_id) or None
+    scoped_request_id = _clean(request_id) or None
     rows = await pool.fetch(
         _PENDING_SQL if config.dry_run else _CLAIM_PENDING_SQL,
         int(config.limit),
+        scoped_account_id,
+        scoped_request_id,
     )
     sent = failed = dry_run = 0
     for row in rows:
@@ -1670,6 +1676,8 @@ JOIN content_ops_deflection_reports r
   ON r.account_id = d.account_id
  AND r.request_id = d.request_id
 WHERE d.delivery_status = 'pending'
+  AND ($2::text IS NULL OR d.account_id = $2)
+  AND ($3::text IS NULL OR d.request_id = $3)
 ORDER BY d.created_at
 LIMIT $1
 """
@@ -1682,11 +1690,15 @@ WITH claimed AS (
         d.created_at,
         d.delivery_status AS previous_delivery_status
     FROM content_ops_deflection_report_deliveries d
-    WHERE d.delivery_status = 'pending'
-       OR (
+    WHERE (
+            d.delivery_status = 'pending'
+            OR (
             d.delivery_status = 'sending'
             AND d.updated_at < NOW() - INTERVAL '{DELIVERY_CLAIM_STALE_AFTER}'
-       )
+            )
+          )
+      AND ($2::text IS NULL OR d.account_id = $2)
+      AND ($3::text IS NULL OR d.request_id = $3)
     ORDER BY d.created_at
     FOR UPDATE SKIP LOCKED
     LIMIT $1

--- a/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
+++ b/docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md
@@ -139,39 +139,42 @@ WHERE r.request_id = '<request-id>';
 ```
 
 Proceed only if `paid` is true, `delivery_email` is the opted-in buyer email,
-and `delivery_status` is `pending`.
+and `delivery_status` is `pending`. Record the returned `account_id` and
+`request_id` for the scoped manual delivery proof:
+
+```bash
+export LAUNCH_ACCOUNT_ID="<account-id-from-query>"
+export LAUNCH_REQUEST_ID="<request-id>"
+```
 
 ## Paid Report Email And PDF Proof
 
-The current manual drain CLI is queue-wide and only has `--limit`; it does not accept a request/account filter. Before running it, prove the target request is
-the only pending/sending delivery row and the only claimable row. This blocks
-older non-target `sending` rows that could age into the stale-reclaim window
-between rehearsal and the live send:
+The manual drain CLI accepts an account/request scope for launch proof. Before
+running it, prove the target row is claimable:
 
 ```bash
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
-WITH delivery_candidates AS (
+psql "$DATABASE_URL" \
+  -v ON_ERROR_STOP=1 \
+  -v account_id="$LAUNCH_ACCOUNT_ID" \
+  -v request_id="$LAUNCH_REQUEST_ID" \
+  -c "
+WITH target AS (
   SELECT account_id, request_id, created_at, updated_at, delivery_status
   FROM content_ops_deflection_report_deliveries
-  WHERE delivery_status IN ('pending', 'sending')
+  WHERE account_id = :'account_id'
+    AND request_id = :'request_id'
 )
 SELECT
   count(*) FILTER (
     WHERE delivery_status = 'pending'
-       OR delivery_status = 'sending'
-  ) AS pending_or_sending_rows,
+  ) AS target_pending_rows,
   count(*) FILTER (
     WHERE delivery_status = 'pending'
        OR (
          delivery_status = 'sending'
          AND updated_at < NOW() - INTERVAL '15 minutes'
        )
-  ) AS claimable_rows,
-  count(*) FILTER (
-    WHERE request_id = '<request-id>'
-      AND delivery_status = 'pending'
-  ) AS target_rows,
-  count(*) FILTER (WHERE request_id <> '<request-id>') AS other_pending_or_sending_rows,
+  ) AS target_claimable_rows,
   min(created_at) FILTER (
     WHERE delivery_status = 'pending'
        OR (
@@ -179,23 +182,24 @@ SELECT
          AND updated_at < NOW() - INTERVAL '15 minutes'
        )
   ) AS oldest_claimable_at
-FROM delivery_candidates;
+FROM target;
 "
 ```
 
-Proceed only if `claimable_rows` is 1, `target_rows` is 1, and
-`other_pending_or_sending_rows` is 0. If any other pending/sending row exists,
-stop and add a scoped paid-delivery proof before live send; otherwise the proof
-can email a different buyer after a non-target `sending` row ages into the
-claim window.
+Proceed only if `target_claimable_rows` is 1 and `target_pending_rows` is 1.
+If the target row is already `sending`, stop unless this is an intentional
+stale reclaim rehearsal; the first launch proof send should start from
+`pending`.
 
-Run the delivery drain in queue-only dry-run mode:
+Run the scoped delivery drain in queue-only dry-run mode:
 
 ```bash
 python scripts/send_content_ops_deflection_report_deliveries.py \
   --database-url "$DATABASE_URL" \
   --from-email "$ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL" \
   --result-base-url "$PORTFOLIO_BASE_URL" \
+  --account-id "$LAUNCH_ACCOUNT_ID" \
+  --request-id "$LAUNCH_REQUEST_ID" \
   --limit 1 \
   --json
 ```
@@ -213,12 +217,14 @@ trap 'rm -rf "$PREFLIGHT_TMP_DIR"' EXIT
 
 psql "$DATABASE_URL" \
   -v ON_ERROR_STOP=1 \
-  -v request_id="<request-id>" \
+  -v account_id="$LAUNCH_ACCOUNT_ID" \
+  -v request_id="$LAUNCH_REQUEST_ID" \
   -v buyer_email="$LAUNCH_BUYER_EMAIL" \
   -At -c "
 SELECT artifact::text
 FROM content_ops_deflection_reports
-WHERE request_id = :'request_id'
+WHERE account_id = :'account_id'
+  AND request_id = :'request_id'
   AND paid IS TRUE
   AND COALESCE(delivery_email, '') = :'buyer_email';
 " > "$PREFLIGHT_TMP_DIR/paid-artifact.json"
@@ -247,11 +253,10 @@ of paid PDF rendering must not be the live buyer send. The files in
 link them. The shell `trap` removes them on exit; if the shell is interrupted,
 run `rm -rf "$PREFLIGHT_TMP_DIR"` before closeout.
 
-Only after queue isolation, queue-only dry-run, and local PDF render validation
-pass, rerun the queue-isolation SQL above immediately before live send. Proceed
-only if it still shows `claimable_rows` 1, `target_rows` 1, and
-`other_pending_or_sending_rows` 0. Then run one manual live send for the
-isolated proof row:
+Only after the scoped dry-run and local PDF render validation pass, rerun the
+target claimability SQL above immediately before live send. Proceed only if it
+still shows `target_claimable_rows` 1 and `target_pending_rows` 1. Then run one
+manual live send for the scoped proof row:
 
 ```bash
 ATLAS_DEFLECTION_DELIVERY_ENABLED=true
@@ -262,6 +267,8 @@ python scripts/send_content_ops_deflection_report_deliveries.py \
   --from-email "$ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL" \
   --result-base-url "$PORTFOLIO_BASE_URL" \
   --resend-api-key "$ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY" \
+  --account-id "$LAUNCH_ACCOUNT_ID" \
+  --request-id "$LAUNCH_REQUEST_ID" \
   --limit 1 \
   --send \
   --json

--- a/plans/PR-Deflection-Scoped-Delivery-Proof.md
+++ b/plans/PR-Deflection-Scoped-Delivery-Proof.md
@@ -1,0 +1,123 @@
+# PR-Deflection-Scoped-Delivery-Proof
+
+## Why this slice exists
+
+#1921 PR 4 is the deployed launch proof: Snapshot email/PDF, real Checkout
+unlock, paid report email/PDF, and the exact emailed hosted URL. The current
+runbook still has a brittle paid-delivery step because
+`scripts/send_content_ops_deflection_report_deliveries.py` can only drain the
+global paid-report delivery queue. To avoid emailing the wrong buyer, the
+runbook must prove the target request is the only pending/sending row before
+live send.
+
+Root cause: the manual launch-proof drain has no account/request scope even
+though the delivery row identity is `(account_id, request_id)`. This change
+fixes the root for the operator proof path by adding paid-report delivery
+scope filters to the shared worker query and exposing them in the manual CLI.
+The scheduler remains queue-wide by default.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-launch-readiness
+Slice phase: Production hardening
+
+1. Add optional paid-report delivery scope filters for `account_id` and
+   `request_id` to `send_pending_deflection_report_deliveries(...)`.
+2. Expose those filters through the manual paid-delivery CLI as
+   `--account-id` and `--request-id`.
+3. Update the launch preflight runbook to use the scoped dry-run/send commands
+   and keep the global queue-empty check only as a scheduler safety gate.
+4. Add focused tests proving both dry-run and claim queries carry the scope
+   filters, the CLI passes filters into the worker, and the unscoped scheduler
+   path remains unchanged.
+
+### Review Contract
+
+- Acceptance criteria:
+  - A scoped dry-run query filters by account/request without claiming rows.
+  - A scoped live-send claim query filters by account/request before
+    `FOR UPDATE SKIP LOCKED`.
+  - The manual CLI passes `--account-id`/`--request-id` to the worker and keeps
+    existing behavior when the flags are omitted.
+  - The autonomous delivery task remains unscoped and queue-wide.
+  - The runbook no longer requires target-row global uniqueness before the
+    manual proof send; it still requires zero claimable rows before probing the
+    deployed scheduler.
+- Affected surfaces:
+  - Paid report delivery worker selection.
+  - Manual launch-proof delivery CLI.
+  - Launch preflight runbook.
+- Risk areas:
+  - Paid buyer email delivery.
+  - Launch proof accidentally sending a non-target report.
+  - Scheduler delivery behavior changing unexpectedly.
+- Triggered reviewer rules:
+  - R1 Requirements match.
+  - R2 Test evidence.
+  - R3 Security/auth/money path.
+  - R8 Persistence/data lifecycle.
+  - R14 Codebase verification.
+
+### Files touched
+
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md`
+- `plans/PR-Deflection-Scoped-Delivery-Proof.md`
+- `scripts/send_content_ops_deflection_report_deliveries.py`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_content_ops_deflection_launch_preflight_runbook.py`
+- `tests/test_send_content_ops_deflection_report_deliveries.py`
+
+## Mechanism
+
+Extend `send_pending_deflection_report_deliveries(...)` with optional
+`account_id` and `request_id` keyword arguments. Normalize blank values to
+`None`, pass them into both pending-selection SQL statements, and add
+`($2::text IS NULL OR d.account_id = $2)` plus
+`($3::text IS NULL OR d.request_id = $3)` predicates before ordering/claiming.
+Existing callers omit the filters and receive the same queue-wide behavior.
+
+The CLI adds `--account-id` and `--request-id`, validates only by passing
+non-empty strings, and forwards them to the worker for both dry-run and
+`--send`. The runbook then uses scoped CLI commands for the target proof row
+instead of requiring all other paid delivery rows to be absent.
+
+## Intentional
+
+- No scheduler metadata override or scoped scheduler mode. Scheduled delivery
+  should remain queue-wide; this slice scopes only the manual proof CLI and
+  shared worker entry point.
+- No live database, Stripe, portfolio, or Resend call is executed in this PR.
+  #1921 PR 4 still owns the actual deployed proof once operator inputs exist.
+- No request-id format validation in the CLI. The database query is parameterized
+  and no looser than the existing row identity; invalid IDs simply match no rows.
+
+## Deferred
+
+- #1921 PR 4 still owns the deployed live proof artifact and tracker closeout.
+- If the operator wants scheduler-level one-shot scoped execution later, add a
+  separate task metadata contract rather than overloading this manual CLI slice.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m py_compile atlas_brain/content_ops_deflection_delivery.py scripts/send_content_ops_deflection_report_deliveries.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_content_ops_deflection_launch_preflight_runbook.py - passed.
+- Command: pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_deflection_report_delivery_task.py tests/test_content_ops_deflection_launch_preflight_runbook.py -q - 62 passed, 1 skipped, 1 warning.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py - OK: 195 matching tests are enrolled.
+- Pending before push:
+  - Command: python scripts/sync_pr_plan.py plans/PR-Deflection-Scoped-Delivery-Proof.md --check
+  - Command: bash scripts/local_pr_review.sh
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/content_ops_deflection_delivery.py` | 18 |
+| `docs/extraction/validation/content_ops_deflection_launch_preflight_runbook.md` | 67 |
+| `plans/PR-Deflection-Scoped-Delivery-Proof.md` | 123 |
+| `scripts/send_content_ops_deflection_report_deliveries.py` | 20 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 74 |
+| `tests/test_content_ops_deflection_launch_preflight_runbook.py` | 32 |
+| `tests/test_send_content_ops_deflection_report_deliveries.py` | 61 |
+| **Total** | **395** |

--- a/scripts/send_content_ops_deflection_report_deliveries.py
+++ b/scripts/send_content_ops_deflection_report_deliveries.py
@@ -93,6 +93,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Maximum pending delivery rows to process.",
     )
     parser.add_argument(
+        "--account-id",
+        default=_env("ATLAS_DEFLECTION_DELIVERY_ACCOUNT_ID"),
+        help="Optional account_id scope for a one-report proof send.",
+    )
+    parser.add_argument(
+        "--request-id",
+        default=_env("ATLAS_DEFLECTION_DELIVERY_REQUEST_ID"),
+        help="Optional request_id scope for a one-report proof send.",
+    )
+    parser.add_argument(
         "--from-email",
         default=_env(*FROM_EMAIL_ENV),
         help="Transactional From email.",
@@ -202,6 +212,15 @@ def _sender(args: argparse.Namespace) -> Any:
     )
 
 
+def _worker_scope(args: argparse.Namespace) -> dict[str, str]:
+    scope: dict[str, str] = {}
+    if _configured(args.account_id):
+        scope["account_id"] = str(args.account_id).strip()
+    if _configured(args.request_id):
+        scope["request_id"] = str(args.request_id).strip()
+    return scope
+
+
 async def _create_pool(database_url: str) -> Any:
     try:
         import asyncpg  # type: ignore[import-not-found]
@@ -230,6 +249,7 @@ async def _main(argv: list[str] | None = None) -> int:
             pool,
             sender=_sender(args),
             config=_delivery_config(args),
+            **_worker_scope(args),
         )
     finally:
         await pool.close()

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -1017,7 +1017,9 @@ async def test_delivery_worker_sends_pending_paid_report_link(
     claim_query, claim_args = pool.fetch_calls[0]
     assert "FOR UPDATE SKIP LOCKED" in claim_query
     assert "SET delivery_status = 'sending'" in claim_query
-    assert claim_args == (20,)
+    assert "AND ($2::text IS NULL OR d.account_id = $2)" in claim_query
+    assert "AND ($3::text IS NULL OR d.request_id = $3)" in claim_query
+    assert claim_args == (20, None, None)
     assert len(sender.requests) == 1
     confirm_query, confirm_args = pool.fetchrow_calls[0]
     assert "RETURNING d.request_id" in confirm_query
@@ -1049,6 +1051,41 @@ async def test_delivery_worker_sends_pending_paid_report_link(
     assert "delivery_status = 'sending'" in update_query
     assert update_args == ("acct-123", "content-ops-abc123", "resend:email-123")
     assert "buyer@example.com" not in str(update_args)
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_scopes_live_claim_query_to_account_and_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = _Pool(
+        [
+            _row(
+                account_id="acct-target",
+                request_id="content-ops-target",
+            )
+        ]
+    )
+    sender = _Sender()
+    _install_fake_pdf_renderer(monkeypatch, lambda _artifact: b"%PDF-fake-bytes")
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+        account_id="acct-target",
+        request_id="content-ops-target",
+    )
+
+    assert summary.scanned == 1
+    assert summary.sent == 1
+    claim_query, claim_args = pool.fetch_calls[0]
+    assert "FOR UPDATE SKIP LOCKED" in claim_query
+    assert "AND ($2::text IS NULL OR d.account_id = $2)" in claim_query
+    assert "AND ($3::text IS NULL OR d.request_id = $3)" in claim_query
+    assert claim_args == (20, "acct-target", "content-ops-target")
+    assert sender.requests[0].campaign_id == (
+        "content_ops_deflection_report:acct-target:content-ops-target"
+    )
 
 
 @pytest.mark.asyncio
@@ -1561,7 +1598,40 @@ async def test_delivery_worker_dry_run_does_not_send_or_update() -> None:
     pending_query, pending_args = pool.fetch_calls[0]
     assert "FOR UPDATE SKIP LOCKED" not in pending_query
     assert "WHERE d.delivery_status = 'pending'" in pending_query
-    assert pending_args == (20,)
+    assert "AND ($2::text IS NULL OR d.account_id = $2)" in pending_query
+    assert "AND ($3::text IS NULL OR d.request_id = $3)" in pending_query
+    assert pending_args == (20, None, None)
+    assert sender.requests == []
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_scopes_dry_run_selection_to_account_and_request() -> None:
+    pool = _Pool(
+        [
+            _row(
+                account_id="acct-target",
+                request_id="content-ops-target",
+            )
+        ]
+    )
+    sender = _Sender()
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(dry_run=True),
+        account_id="acct-target",
+        request_id="content-ops-target",
+    )
+
+    assert summary.scanned == 1
+    assert summary.dry_run == 1
+    pending_query, pending_args = pool.fetch_calls[0]
+    assert "FOR UPDATE SKIP LOCKED" not in pending_query
+    assert "AND ($2::text IS NULL OR d.account_id = $2)" in pending_query
+    assert "AND ($3::text IS NULL OR d.request_id = $3)" in pending_query
+    assert pending_args == (20, "acct-target", "content-ops-target")
     assert sender.requests == []
     assert pool.execute_calls == []
 

--- a/tests/test_content_ops_deflection_launch_preflight_runbook.py
+++ b/tests/test_content_ops_deflection_launch_preflight_runbook.py
@@ -131,20 +131,21 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "r.request_id = '<request-id>'" in unlock
     assert "`paid` is true" in unlock
     assert "`delivery_status` is `pending`" in unlock
-    assert "queue-wide" in delivery
-    assert "does not accept a request/account filter" in delivery
-    assert "claimable_rows" in delivery
-    assert "target_rows" in delivery
-    assert "pending_or_sending_rows" in delivery
-    assert "other_pending_or_sending_rows" in delivery
+    assert 'export LAUNCH_ACCOUNT_ID="<account-id-from-query>"' in unlock
+    assert 'export LAUNCH_REQUEST_ID="<request-id>"' in unlock
+    assert "manual drain CLI accepts an account/request scope" in delivery
+    assert "target_claimable_rows" in delivery
+    assert "target_pending_rows" in delivery
+    assert "pending_or_sending_rows" not in delivery
+    assert "other_pending_or_sending_rows" not in delivery
     assert "SELECT account_id, request_id, created_at, updated_at, delivery_status" in delivery
-    assert "delivery_status IN ('pending', 'sending')" in delivery
-    assert "non-target `sending` row ages into the\nclaim window" in delivery
-    assert (
-        "Proceed only if `claimable_rows` is 1, `target_rows` is 1, and\n"
-        "`other_pending_or_sending_rows` is 0"
-    ) in delivery
+    assert "WHERE account_id = :'account_id'" in delivery
+    assert "AND request_id = :'request_id'" in delivery
+    assert "non-target `sending` row ages into the\nclaim window" not in delivery
+    assert "Proceed only if `target_claimable_rows` is 1 and `target_pending_rows` is 1" in delivery
     assert "scripts/send_content_ops_deflection_report_deliveries.py" in delivery
+    assert "--account-id \"$LAUNCH_ACCOUNT_ID\"" in delivery
+    assert "--request-id \"$LAUNCH_REQUEST_ID\"" in delivery
     assert "--json" in delivery
     assert "--send" in delivery
     assert "--resend-api-key" in delivery
@@ -159,15 +160,18 @@ def test_paid_unlock_and_delivery_proof_require_real_queue_and_live_send() -> No
     assert "trap 'rm -rf \"$PREFLIGHT_TMP_DIR\"' EXIT" in delivery
     assert "paid-artifact.json" in delivery
     assert "paid-report.pdf" in delivery
+    assert "-v account_id=\"$LAUNCH_ACCOUNT_ID\"" in delivery
+    assert "-v request_id=\"$LAUNCH_REQUEST_ID\"" in delivery
     assert "-v buyer_email=\"$LAUNCH_BUYER_EMAIL\"" in delivery
+    assert "WHERE account_id = :'account_id'" in delivery
     assert "COALESCE(delivery_email, '') = :'buyer_email'" in delivery
     assert "COALESCE(delivery_email, '') = '$LAUNCH_BUYER_EMAIL'" not in delivery
     assert "do not commit, upload, or\nlink them" in delivery
     assert "first exercise" in delivery
     assert "paid PDF rendering" in delivery
     assert "live buyer send" in delivery
-    assert "rerun the queue-isolation SQL above immediately before live send" in delivery
-    assert "it still shows `claimable_rows` 1, `target_rows` 1, and\n`other_pending_or_sending_rows` 0" in delivery
+    assert "rerun the\ntarget claimability SQL above immediately before live send" in delivery
+    assert "it\nstill shows `target_claimable_rows` 1 and `target_pending_rows` 1" in delivery
     assert "ATLAS_DEFLECTION_DELIVERY_ENABLED=true" in delivery
     assert "ATLAS_DEFLECTION_DELIVERY_DRY_RUN=false" in delivery
     assert "deploy or restart ATLAS" in delivery

--- a/tests/test_send_content_ops_deflection_report_deliveries.py
+++ b/tests/test_send_content_ops_deflection_report_deliveries.py
@@ -157,6 +157,67 @@ async def test_main_dry_run_wires_worker_without_resend(
 
 
 @pytest.mark.asyncio
+async def test_main_forwards_account_and_request_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pool = _Pool()
+    calls: list[dict[str, Any]] = []
+
+    async def _create_pool(database_url: str) -> _Pool:
+        calls.append({"database_url": database_url})
+        return pool
+
+    async def _send_pending(
+        pool_arg: Any,
+        *,
+        sender: Any,
+        config: Any,
+        account_id: str | None = None,
+        request_id: str | None = None,
+    ) -> Any:
+        calls.append(
+            {
+                "pool": pool_arg,
+                "sender_type": type(sender).__name__,
+                "dry_run": config.dry_run,
+                "account_id": account_id,
+                "request_id": request_id,
+            }
+        )
+        return SimpleNamespace(scanned=1, sent=0, failed=0, dry_run=1)
+
+    monkeypatch.setattr(send_cli, "_create_pool", _create_pool)
+    monkeypatch.setattr(send_cli, "send_pending_deflection_report_deliveries", _send_pending)
+
+    code = await send_cli._main(
+        [
+            *_base_args(
+                "--account-id",
+                "acct-target",
+                "--request-id",
+                "content-ops-target",
+            ),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    assert pool.closed is True
+    assert calls == [
+        {"database_url": "postgresql://atlas@example/db"},
+        {
+            "pool": pool,
+            "sender_type": "_DryRunSender",
+            "dry_run": True,
+            "account_id": "acct-target",
+            "request_id": "content-ops-target",
+        },
+    ]
+    assert json.loads(capsys.readouterr().out)["dry_run"] == 1
+
+
+@pytest.mark.asyncio
 async def test_main_live_send_uses_resend_sender_and_returns_failed_status(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
Plan: plans/PR-Deflection-Scoped-Delivery-Proof.md
Slice phase: Production hardening

#1921 PR 4 needs a live paid-delivery proof against one buyer request. This slice adds account/request scope filters to the paid report delivery worker and exposes them through the manual launch-proof CLI, so the operator can dry-run/send exactly the target paid report row instead of relying on an empty global queue.

## Intentional
- Scheduler delivery remains queue-wide by default; this scopes only the manual proof path and shared worker filters when supplied.
- No live database, Stripe, portfolio, or Resend call is executed in this PR.
- The CLI does not validate request-id format; the parameterized database query simply matches no rows for invalid identities.

## Deferred
- #1921 PR 4 still owns the deployed live proof artifact and tracker closeout once operator inputs are available.
- Scheduler-level one-shot scoped execution, if wanted later, should be a separate task metadata contract.

## Parked hardening
- None.

## Verification
- Command: python -m py_compile atlas_brain/content_ops_deflection_delivery.py scripts/send_content_ops_deflection_report_deliveries.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_content_ops_deflection_launch_preflight_runbook.py - passed.
- Command: pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_deflection_report_delivery_task.py tests/test_content_ops_deflection_launch_preflight_runbook.py -q - 62 passed, 1 skipped, 1 warning.
- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py - OK: 195 matching tests are enrolled.
- Command: python scripts/sync_pr_plan.py plans/PR-Deflection-Scoped-Delivery-Proof.md --check - passed.
- Command: bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr_body_deflection_scoped_delivery_proof.md - passed.

## Diff size
7 files, 395 LOC per `python scripts/sync_pr_plan.py plans/PR-Deflection-Scoped-Delivery-Proof.md`.
