### PR TITLE
Reddit Listening S1: watchlist config + keyword scoring

### DIFF
--- a/.github/workflows/atlas_reddit_checks.yml
+++ b/.github/workflows/atlas_reddit_checks.yml
@@ -1,0 +1,31 @@
+name: Atlas Reddit Listening Checks
+
+on:
+  pull_request:
+    paths:
+      - "atlas_reddit/**"
+      - "tests/test_atlas_reddit_*.py"
+      - ".github/workflows/atlas_reddit_checks.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  atlas-reddit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: python -m pip install --quiet pytest pytest-asyncio pyyaml pydantic-settings
+
+      # Glob, not an explicit list, so future tests/test_atlas_reddit_*.py
+      # files enroll automatically (avoids the per-test-list enrollment trap).
+      - name: Run atlas_reddit unit tests
+        run: python -m pytest tests/test_atlas_reddit_*.py -q

--- a/atlas_reddit/__init__.py
+++ b/atlas_reddit/__init__.py
@@ -1,0 +1,9 @@
+"""Read-only Reddit listening tool for the Resolution Audit (issues #1931 / #1934).
+
+This package is deliberately standalone: it does not import atlas_brain,
+performs no Reddit writes anywhere in any slice, and keeps all runtime
+data under the gitignored data/ directory. See
+plans/PR-Reddit-Listening-Config-Scoring.md and the #1934 arc for scope.
+"""
+
+__version__ = "0.1.0"

--- a/atlas_reddit/config.py
+++ b/atlas_reddit/config.py
@@ -1,0 +1,267 @@
+"""Configuration for the read-only Reddit listening tool.
+
+Two config surfaces:
+
+- Environment settings: typed ``ATLAS_REDDIT_*`` fields on
+  :class:`RedditListeningSettings` (pydantic-settings; never raw
+  ``os.environ``). Paths and, in later slices, credentials live here.
+- Watchlist: a human-edited TOML file (stdlib ``tomllib``, so no new
+  dependency) holding the subreddit list, topic phrase clusters, and
+  scoring knobs. Curation data lives in the file, not in env vars and
+  not in the database.
+
+The watchlist parser fails closed: unknown keys, missing required
+sections, out-of-range weights, and malformed entries raise
+:class:`WatchlistError` instead of being defaulted or skipped.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+ENV_FILES = (".env", ".env.local")
+
+WATCHLIST_VERSION = 1
+
+# Reddit subreddit names: 3-21 chars, letters/digits/underscore, and the
+# first character may not be an underscore.
+_SUBREDDIT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_]{2,20}$")
+
+# Weights are multipliers, not probabilities; 10 is an arbitrary sanity
+# ceiling so a typo like 100 is rejected rather than dominating ranking.
+_MAX_WEIGHT = 10.0
+_MAX_BONUS = 5.0
+
+_ALLOWED_TOP_KEYS = {
+    "version",
+    "subreddits",
+    "topics",
+    "help_signals",
+    "question_bonus",
+    "help_signal_bonus",
+}
+_ALLOWED_SUBREDDIT_KEYS = {"name", "weight"}
+_ALLOWED_TOPIC_KEYS = {"name", "phrases", "weight"}
+
+
+class RedditListeningSettings(BaseSettings):
+    """Environment-backed settings (env prefix ``ATLAS_REDDIT_``)."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_REDDIT_",
+        env_file=ENV_FILES,
+        extra="ignore",
+    )
+
+    watchlist_path: Path = Field(
+        default=Path("data/atlas_reddit/watchlist.toml"),
+        description=(
+            "Path to the local watchlist TOML. The default sits under the "
+            "gitignored data/ tree; copy atlas_reddit/watchlist.sample.toml "
+            "there to start."
+        ),
+    )
+
+
+class WatchlistError(ValueError):
+    """Raised when the watchlist file is missing, malformed, or invalid."""
+
+
+@dataclass(frozen=True)
+class SubredditEntry:
+    name: str
+    weight: float = 1.0
+
+
+@dataclass(frozen=True)
+class Topic:
+    name: str
+    phrases: tuple[str, ...]
+    weight: float = 1.0
+
+
+@dataclass(frozen=True)
+class Watchlist:
+    version: int
+    subreddits: tuple[SubredditEntry, ...]
+    topics: tuple[Topic, ...]
+    help_signals: tuple[str, ...] = ()
+    question_bonus: float = 0.5
+    help_signal_bonus: float = 0.25
+    _weights_by_name: dict[str, float] = field(
+        init=False, repr=False, compare=False, default_factory=dict
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "_weights_by_name",
+            {entry.name.casefold(): entry.weight for entry in self.subreddits},
+        )
+
+    def subreddit_weight(self, name: str) -> float | None:
+        """Weight for a watched subreddit, or None if it is not watched."""
+        return self._weights_by_name.get(name.casefold())
+
+
+def _require_number(value: object, *, context: str, maximum: float, allow_zero: bool) -> float:
+    # bool is a subclass of int, and TOML `weight = true` would otherwise
+    # silently become 1.0.
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise WatchlistError(f"{context} must be a number, got {value!r}")
+    number = float(value)
+    lower_ok = number >= 0.0 if allow_zero else number > 0.0
+    if not lower_ok or number > maximum:
+        bound = "0" if allow_zero else "greater than 0"
+        raise WatchlistError(
+            f"{context} must be {bound} and at most {maximum}, got {value!r}"
+        )
+    return number
+
+
+def _require_table(value: object, *, context: str) -> dict:
+    if not isinstance(value, dict):
+        raise WatchlistError(f"{context} must be a table, got {value!r}")
+    return value
+
+
+def _reject_unknown_keys(raw: dict, allowed: set[str], *, context: str) -> None:
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise WatchlistError(f"{context} has unknown keys: {', '.join(unknown)}")
+
+
+def _parse_subreddits(raw: object) -> tuple[SubredditEntry, ...]:
+    if not isinstance(raw, list) or not raw:
+        raise WatchlistError("subreddits must be a non-empty array of tables")
+    entries: list[SubredditEntry] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw):
+        context = f"subreddits[{index}]"
+        table = _require_table(item, context=context)
+        _reject_unknown_keys(table, _ALLOWED_SUBREDDIT_KEYS, context=context)
+        name = table.get("name")
+        if not isinstance(name, str) or not _SUBREDDIT_NAME_RE.match(name):
+            raise WatchlistError(
+                f"{context}.name must match {_SUBREDDIT_NAME_RE.pattern}, got {name!r}"
+            )
+        if name.casefold() in seen:
+            raise WatchlistError(f"duplicate subreddit name: {name!r}")
+        seen.add(name.casefold())
+        weight = _require_number(
+            table.get("weight", 1.0),
+            context=f"{context}.weight",
+            maximum=_MAX_WEIGHT,
+            allow_zero=False,
+        )
+        entries.append(SubredditEntry(name=name, weight=weight))
+    return tuple(entries)
+
+
+def _parse_phrases(raw: object, *, context: str, allow_empty: bool = False) -> tuple[str, ...]:
+    if not isinstance(raw, list) or (not raw and not allow_empty):
+        shape = "an array" if allow_empty else "a non-empty array"
+        raise WatchlistError(f"{context} must be {shape} of strings")
+    phrases: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, str) or not item.strip():
+            raise WatchlistError(f"{context}[{index}] must be a non-empty string, got {item!r}")
+        phrase = item.strip()
+        if phrase.casefold() in seen:
+            raise WatchlistError(f"{context} has duplicate phrase: {phrase!r}")
+        seen.add(phrase.casefold())
+        phrases.append(phrase)
+    return tuple(phrases)
+
+
+def _parse_topics(raw: object) -> tuple[Topic, ...]:
+    if not isinstance(raw, list) or not raw:
+        raise WatchlistError("topics must be a non-empty array of tables")
+    topics: list[Topic] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw):
+        context = f"topics[{index}]"
+        table = _require_table(item, context=context)
+        _reject_unknown_keys(table, _ALLOWED_TOPIC_KEYS, context=context)
+        name = table.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise WatchlistError(f"{context}.name must be a non-empty string, got {name!r}")
+        if name.casefold() in seen:
+            raise WatchlistError(f"duplicate topic name: {name!r}")
+        seen.add(name.casefold())
+        phrases = _parse_phrases(table.get("phrases"), context=f"{context}.phrases")
+        weight = _require_number(
+            table.get("weight", 1.0),
+            context=f"{context}.weight",
+            maximum=_MAX_WEIGHT,
+            allow_zero=False,
+        )
+        topics.append(Topic(name=name.strip(), phrases=phrases, weight=weight))
+    return tuple(topics)
+
+
+def parse_watchlist(raw: dict) -> Watchlist:
+    """Validate a parsed TOML document into a :class:`Watchlist`.
+
+    Pure function of the input dict; all validation errors raise
+    :class:`WatchlistError` naming the offending key.
+    """
+    if not isinstance(raw, dict):
+        raise WatchlistError(f"watchlist must be a table, got {type(raw).__name__}")
+    _reject_unknown_keys(raw, _ALLOWED_TOP_KEYS, context="watchlist")
+    version = raw.get("version")
+    if isinstance(version, bool) or version != WATCHLIST_VERSION:
+        raise WatchlistError(
+            f"watchlist must declare version = {WATCHLIST_VERSION}, got {version!r}"
+        )
+    subreddits = _parse_subreddits(raw.get("subreddits"))
+    topics = _parse_topics(raw.get("topics"))
+    # An explicitly empty help_signals array is valid config (the bonus
+    # feature unused), unlike empty subreddits/topics which are nonsensical.
+    help_signals = (
+        _parse_phrases(raw["help_signals"], context="help_signals", allow_empty=True)
+        if "help_signals" in raw
+        else ()
+    )
+    question_bonus = _require_number(
+        raw.get("question_bonus", 0.5),
+        context="question_bonus",
+        maximum=_MAX_BONUS,
+        allow_zero=True,
+    )
+    help_signal_bonus = _require_number(
+        raw.get("help_signal_bonus", 0.25),
+        context="help_signal_bonus",
+        maximum=_MAX_BONUS,
+        allow_zero=True,
+    )
+    return Watchlist(
+        version=WATCHLIST_VERSION,
+        subreddits=subreddits,
+        topics=topics,
+        help_signals=help_signals,
+        question_bonus=question_bonus,
+        help_signal_bonus=help_signal_bonus,
+    )
+
+
+def load_watchlist(path: Path) -> Watchlist:
+    """Load and validate the watchlist TOML at ``path``."""
+    try:
+        with path.open("rb") as handle:
+            raw = tomllib.load(handle)
+    except FileNotFoundError as exc:
+        raise WatchlistError(
+            f"watchlist file not found: {path} "
+            "(copy atlas_reddit/watchlist.sample.toml there to start)"
+        ) from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise WatchlistError(f"watchlist TOML is malformed: {path}: {exc}") from exc
+    return parse_watchlist(raw)

--- a/atlas_reddit/config.py
+++ b/atlas_reddit/config.py
@@ -226,9 +226,16 @@ def parse_watchlist(raw: dict) -> Watchlist:
         raise WatchlistError(f"watchlist must be a table, got {type(raw).__name__}")
     _reject_unknown_keys(raw, _ALLOWED_TOP_KEYS, context="watchlist")
     version = raw.get("version")
-    if isinstance(version, bool) or version != WATCHLIST_VERSION:
+    # Exact-int check: bool is a subclass of int (version = true), and a
+    # TOML float compares equal to the int (1.0 == 1), so both would
+    # otherwise slip past a plain != comparison.
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version != WATCHLIST_VERSION
+    ):
         raise WatchlistError(
-            f"watchlist must declare version = {WATCHLIST_VERSION}, got {version!r}"
+            f"watchlist must declare version = {WATCHLIST_VERSION} (integer), got {version!r}"
         )
     subreddits = _parse_subreddits(raw.get("subreddits"))
     topics = _parse_topics(raw.get("topics"))

--- a/atlas_reddit/config.py
+++ b/atlas_reddit/config.py
@@ -30,8 +30,10 @@ ENV_FILES = (".env", ".env.local")
 WATCHLIST_VERSION = 1
 
 # Reddit subreddit names: 3-21 chars, letters/digits/underscore, and the
-# first character may not be an underscore.
-_SUBREDDIT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_]{2,20}$")
+# first character may not be an underscore. Matched with fullmatch(): a
+# "$" anchor would tolerate a trailing newline ("SaaS\n") and admit a
+# name that later breaks subreddit_weight() lookups.
+_SUBREDDIT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_]{2,20}")
 
 # Weights are multipliers, not probabilities; 10 is an arbitrary sanity
 # ceiling so a typo like 100 is rejected rather than dominating ranking.
@@ -147,9 +149,9 @@ def _parse_subreddits(raw: object) -> tuple[SubredditEntry, ...]:
         table = _require_table(item, context=context)
         _reject_unknown_keys(table, _ALLOWED_SUBREDDIT_KEYS, context=context)
         name = table.get("name")
-        if not isinstance(name, str) or not _SUBREDDIT_NAME_RE.match(name):
+        if not isinstance(name, str) or not _SUBREDDIT_NAME_RE.fullmatch(name):
             raise WatchlistError(
-                f"{context}.name must match {_SUBREDDIT_NAME_RE.pattern}, got {name!r}"
+                f"{context}.name must fully match {_SUBREDDIT_NAME_RE.pattern}, got {name!r}"
             )
         if name.casefold() in seen:
             raise WatchlistError(f"duplicate subreddit name: {name!r}")
@@ -190,9 +192,16 @@ def _parse_topics(raw: object) -> tuple[Topic, ...]:
         context = f"topics[{index}]"
         table = _require_table(item, context=context)
         _reject_unknown_keys(table, _ALLOWED_TOPIC_KEYS, context=context)
-        name = table.get("name")
-        if not isinstance(name, str) or not name.strip():
-            raise WatchlistError(f"{context}.name must be a non-empty string, got {name!r}")
+        raw_name = table.get("name")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise WatchlistError(
+                f"{context}.name must be a non-empty string, got {raw_name!r}"
+            )
+        # Normalize BEFORE the duplicate check so it compares the same
+        # value that gets stored; checking the untrimmed name would let
+        # " ticket-deflection " slip past "ticket-deflection" and
+        # double-count that topic's weight in score_post.
+        name = raw_name.strip()
         if name.casefold() in seen:
             raise WatchlistError(f"duplicate topic name: {name!r}")
         seen.add(name.casefold())
@@ -203,7 +212,7 @@ def _parse_topics(raw: object) -> tuple[Topic, ...]:
             maximum=_MAX_WEIGHT,
             allow_zero=False,
         )
-        topics.append(Topic(name=name.strip(), phrases=phrases, weight=weight))
+        topics.append(Topic(name=name, phrases=phrases, weight=weight))
     return tuple(topics)
 
 

--- a/atlas_reddit/scoring.py
+++ b/atlas_reddit/scoring.py
@@ -93,9 +93,12 @@ def score_post(
     question_bonus = watchlist.question_bonus if "?" in title or "?" in body else 0.0
 
     base = sum(hit.weight for hit in topic_hits)
+    # The raw product is the ranking signal; no rounding. Quantizing here
+    # (an earlier round(total, 4)) collapsed valid tiny weights to 0.0,
+    # making a real match indistinguishable from the zero-gate no-match.
     total = subreddit_weight * (base + help_bonus + question_bonus)
     return ScoreBreakdown(
-        total=round(total, 4),
+        total=total,
         subreddit_weight=subreddit_weight,
         topic_hits=tuple(topic_hits),
         help_signal_hits=help_hits,

--- a/atlas_reddit/scoring.py
+++ b/atlas_reddit/scoring.py
@@ -1,0 +1,104 @@
+"""Pure keyword/topic scoring for Reddit listening candidates.
+
+No I/O, no network, no clock, no randomness: :func:`score_post` is a
+deterministic function of its inputs so ranking is reproducible and
+directly testable.
+
+Semantics:
+
+- A post scores 0.0 unless at least one topic phrase matches. The
+  help-signal and question bonuses only amplify already-topical posts;
+  they never make an off-topic post surface.
+- Each matched topic contributes its weight once, regardless of how
+  many of its phrases hit (matched phrases are reported in the
+  breakdown for digest display, not multiplied into the score).
+- Matching is case-insensitive on word boundaries, so a phrase does
+  not match inside a longer word ("sla" does not match "island").
+  Plural or variant forms need their own phrase entries in the
+  watchlist; there is no stemming.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+
+from .config import Watchlist
+
+
+@dataclass(frozen=True)
+class TopicHit:
+    topic: str
+    weight: float
+    matched_phrases: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ScoreBreakdown:
+    total: float
+    subreddit_weight: float
+    topic_hits: tuple[TopicHit, ...]
+    help_signal_hits: tuple[str, ...]
+    question_bonus_applied: float
+    help_signal_bonus_applied: float
+
+
+@lru_cache(maxsize=4096)
+def _phrase_pattern(phrase: str) -> re.Pattern[str]:
+    # Lookarounds instead of \b so phrases that start or end with a
+    # non-word character still anchor correctly after re.escape.
+    return re.compile(r"(?<!\w)" + re.escape(phrase.casefold()) + r"(?!\w)")
+
+
+def score_post(
+    *,
+    title: str,
+    body: str,
+    subreddit_weight: float,
+    watchlist: Watchlist,
+) -> ScoreBreakdown:
+    """Score one post against the watchlist. Deterministic and pure."""
+    if subreddit_weight <= 0:
+        raise ValueError(
+            f"subreddit_weight must be positive, got {subreddit_weight!r} "
+            "(weights come from a validated watchlist)"
+        )
+    text = f"{title}\n{body}".casefold()
+
+    topic_hits: list[TopicHit] = []
+    for topic in watchlist.topics:
+        matched = tuple(
+            phrase for phrase in topic.phrases if _phrase_pattern(phrase).search(text)
+        )
+        if matched:
+            topic_hits.append(
+                TopicHit(topic=topic.name, weight=topic.weight, matched_phrases=matched)
+            )
+
+    if not topic_hits:
+        return ScoreBreakdown(
+            total=0.0,
+            subreddit_weight=subreddit_weight,
+            topic_hits=(),
+            help_signal_hits=(),
+            question_bonus_applied=0.0,
+            help_signal_bonus_applied=0.0,
+        )
+
+    help_hits = tuple(
+        signal for signal in watchlist.help_signals if _phrase_pattern(signal).search(text)
+    )
+    help_bonus = watchlist.help_signal_bonus if help_hits else 0.0
+    question_bonus = watchlist.question_bonus if "?" in title or "?" in body else 0.0
+
+    base = sum(hit.weight for hit in topic_hits)
+    total = subreddit_weight * (base + help_bonus + question_bonus)
+    return ScoreBreakdown(
+        total=round(total, 4),
+        subreddit_weight=subreddit_weight,
+        topic_hits=tuple(topic_hits),
+        help_signal_hits=help_hits,
+        question_bonus_applied=question_bonus,
+        help_signal_bonus_applied=help_bonus,
+    )

--- a/atlas_reddit/watchlist.sample.toml
+++ b/atlas_reddit/watchlist.sample.toml
@@ -1,0 +1,115 @@
+# Sample watchlist for the read-only Reddit listening tool (Resolution Audit).
+#
+# Copy to data/atlas_reddit/watchlist.toml (the gitignored default path,
+# configurable via ATLAS_REDDIT_WATCHLIST_PATH) and edit locally. This
+# committed sample is illustrative only.
+#
+# Semantics (see atlas_reddit/scoring.py):
+# - A post scores 0 unless at least one topic phrase matches; bonuses only
+#   amplify topical posts.
+# - Matching is case-insensitive on word boundaries. There is no stemming:
+#   add plural/variant forms as their own phrases ("repeat ticket" and
+#   "repeat tickets" are two entries).
+# - Weights are multipliers: subreddit weight scales the whole post score;
+#   topic weight is the topic's contribution when any of its phrases match.
+
+version = 1
+
+# Bonus added once when any help signal matches an already-topical post.
+help_signal_bonus = 0.25
+# Bonus added once when an already-topical post contains a question mark.
+question_bonus = 0.5
+
+help_signals = [
+    "how do you",
+    "how do people",
+    "what do you use",
+    "any recommendations",
+    "is there a tool",
+    "am i missing something",
+    "advice",
+]
+
+[[subreddits]]
+name = "CustomerSuccess"
+weight = 1.0
+
+[[subreddits]]
+name = "CustomerService"
+weight = 0.9
+
+[[subreddits]]
+name = "SaaS"
+weight = 0.8
+
+[[subreddits]]
+name = "helpdesk"
+weight = 0.8
+
+[[subreddits]]
+name = "Zendesk"
+weight = 0.7
+
+[[topics]]
+name = "ticket-deflection"
+weight = 1.0
+phrases = [
+    "ticket deflection",
+    "deflect tickets",
+    "deflection rate",
+    "self-service rate",
+]
+
+[[topics]]
+name = "repeat-tickets"
+weight = 1.0
+phrases = [
+    "same question",
+    "same questions",
+    "repeat ticket",
+    "repeat tickets",
+    "keep asking",
+    "asked again and again",
+]
+
+[[topics]]
+name = "cost-per-resolution"
+weight = 0.9
+phrases = [
+    "cost per ticket",
+    "cost per resolution",
+    "support costs",
+    "cost of support",
+]
+
+[[topics]]
+name = "help-center-gaps"
+weight = 0.8
+phrases = [
+    "help center",
+    "knowledge base",
+    "kb article",
+    "kb articles",
+    "self service",
+    "self-service",
+]
+
+[[topics]]
+name = "support-volume"
+weight = 0.8
+phrases = [
+    "ticket volume",
+    "ticket backlog",
+    "drowning in tickets",
+    "flooded with tickets",
+]
+
+[[topics]]
+name = "resolution-quality"
+weight = 0.9
+phrases = [
+    "first contact resolution",
+    "resolution rate",
+    "unresolved tickets",
+    "reopened tickets",
+]

--- a/plans/PR-Reddit-Listening-Config-Scoring.md
+++ b/plans/PR-Reddit-Listening-Config-Scoring.md
@@ -105,8 +105,9 @@ subreddit_weight, watchlist) -> ScoreBreakdown`. Phrases compile to
 `title\nbody`. If no topic matches, the result is 0.0 and bonuses are not
 evaluated. Otherwise: `total = subreddit_weight * (sum(topic weights with a
 hit) + help_signal_bonus if any signal hit + question_bonus if '?' present)`,
-rounded to 4 places. The breakdown carries matched topics/phrases so the S3
-digest can show why a thread surfaced.
+kept as the raw float (no rounding: quantizing the ranking value collapsed
+valid tiny weights to 0.0). The breakdown carries matched topics/phrases so
+the S3 digest can show why a thread surfaced.
 
 ## Intentional
 
@@ -163,6 +164,16 @@ fixed at root in this PR):
   `subreddit_weight("SaaS")` missed and a future poller would fetch an
   invalid subreddit. Fixed with `fullmatch()`; class-proofed with
   trailing/leading/internal newline and carriage-return probes.
+- **`round(total, 4)` collapsed valid tiny-weight matches to 0.0** (Codex
+  wave 2 on the fix commit): weight 0.00001 passes validation (> 0) but the
+  rounded total became indistinguishable from the zero-gate no-match,
+  silently suppressing curated topics. Root cause: cosmetic quantization
+  baked into the ranking computation, not the validation floor -- tightening
+  validation was rejected as a symptom patch because composed small products
+  (subreddit 0.01 x topic 0.001) would still collapse. Fixed by removing the
+  rounding; the exact-equality test assertions it papered over moved to
+  pytest.approx. Class-proofed with the cited tiny weight, an unseen
+  composed-smallness probe, and a tiny-match-outranks-any-no-match property.
 
 ## Deferred
 
@@ -204,9 +215,9 @@ Parked hardening: none.
 | `.github/workflows/atlas_reddit_checks.yml` | 31 |
 | `atlas_reddit/__init__.py` | 9 |
 | `atlas_reddit/config.py` | 276 |
-| `atlas_reddit/scoring.py` | 104 |
+| `atlas_reddit/scoring.py` | 107 |
 | `atlas_reddit/watchlist.sample.toml` | 115 |
-| `plans/PR-Reddit-Listening-Config-Scoring.md` | 212 |
+| `plans/PR-Reddit-Listening-Config-Scoring.md` | 223 |
 | `tests/test_atlas_reddit_config.py` | 365 |
-| `tests/test_atlas_reddit_scoring.py` | 263 |
-| **Total** | **1375** |
+| `tests/test_atlas_reddit_scoring.py` | 319 |
+| **Total** | **1445** |

--- a/plans/PR-Reddit-Listening-Config-Scoring.md
+++ b/plans/PR-Reddit-Listening-Config-Scoring.md
@@ -1,0 +1,196 @@
+# PR-Reddit-Listening-Config-Scoring
+
+## Why this slice exists
+
+First implementation slice (S1) of the approved #1934 arc (Fable 5 builder
+trial; product epic #1931): a read-only Reddit listening tool for the
+Resolution Audit. S1 lays the two foundations everything downstream consumes:
+the operator-curated watchlist (subreddits + topic phrase clusters + scoring
+knobs) and the deterministic keyword scorer that ranks candidate threads. No
+network, no database, no LLM in this slice.
+
+Diff-budget note: the total lands over the 400 LOC soft cap because a first
+slice of a new package carries one-time arc scaffolding (package init, CI
+workflow enrollment, sample watchlist, this plan) and because the watchlist
+parser is guard-shaped, so AGENTS.md 3i requires a negative fixture per
+detection branch. The code under test is ~330 LOC; the rest is mandated test
+coverage and scaffolding that later slices reuse rather than repeat.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/reddit-listening/resolution-audit
+Slice phase: Vertical slice
+
+1. New top-level package `atlas_reddit/` (modeled on `atlas_comms/`,
+   deliberately outside `atlas_brain`'s import graph).
+2. Typed env settings (`ATLAS_REDDIT_*` via pydantic-settings; no raw
+   `os.environ`) with the watchlist path as the only S1 field.
+3. Fail-closed TOML watchlist loader (stdlib `tomllib`): unknown keys,
+   bad versions, invalid subreddit names, out-of-range or bool-typed
+   weights, duplicates, and malformed/missing files all raise
+   `WatchlistError` rather than being defaulted or skipped.
+4. Pure deterministic keyword scorer: case-insensitive word-boundary
+   phrase matching; a post scores 0 unless a topic phrase matches;
+   help-signal and question bonuses only amplify topical posts; topic
+   weight counts once per topic regardless of phrase count.
+5. Committed `atlas_reddit/watchlist.sample.toml` (illustrative, no secrets,
+   no usernames) plus a test asserting the shipped sample always parses.
+6. CI enrollment in the same PR: new path-filtered
+   `.github/workflows/atlas_reddit_checks.yml` running
+   `tests/test_atlas_reddit_config.py` and `tests/test_atlas_reddit_scoring.py`
+   via the tests/test_atlas_reddit_*.py glob so future slices auto-enroll.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `parse_watchlist`/`load_watchlist` accept the documented shape and
+        reject every invalid shape with a `WatchlistError` naming the
+        offending key (negative fixture per detection branch).
+  - [ ] Weight/bonus bounds probed both sides: weight 0 and >10 rejected,
+        10.0 and 0.0001 accepted; bonus 0 accepted, negative and >5
+        rejected; TOML `true` (bool-is-int trap) rejected as a number.
+  - [ ] `score_post` is pure and deterministic; zero-gate holds (no topic
+        match -> 0.0 even with question mark + help signals).
+  - [ ] Word-boundary matching proven ("sla" does not match "island" or
+        "translate"); documented no-stemming behavior has a test.
+  - [ ] Public-API contract holds under adversarial input: non-dict
+        documents raise `WatchlistError` (never bare AttributeError);
+        regex-metachar phrases ("c++", "(deflection)") match literally;
+        emoji-adjacent phrases still match (second side of the
+        word-boundary lookarounds).
+  - [ ] The committed sample watchlist parses through the real loader.
+  - [ ] New tests run in PR CI via the new path-filtered workflow.
+- Affected surfaces: new standalone package + tests + one new CI workflow.
+  No existing Atlas surface is imported, touched, or re-exported.
+- Risk areas: none live yet (no network, no DB, no secrets); main risk is
+  validator false-accept/false-reject, covered by the boundary probes above.
+- Reviewer rules triggered: R1, R2 (guard-shaped validator: failure branches
+  + near-miss fixtures), R10, R11 (zero new dependencies; tomllib over
+  undeclared-transitive pyyaml; typed settings), R12 (CI enrollment ships in
+  this PR).
+- Test-adapter posture (#1934 real-adapters rule): zero mocks in this slice.
+  Scoring tests build watchlists through the real `parse_watchlist`; config
+  tests do real file I/O under pytest `tmp_path` (an allowed temp-filesystem
+  boundary); the committed sample is validated through the real loader.
+
+### Files touched
+
+- `.github/workflows/atlas_reddit_checks.yml`
+- `atlas_reddit/__init__.py`
+- `atlas_reddit/config.py`
+- `atlas_reddit/scoring.py`
+- `atlas_reddit/watchlist.sample.toml`
+- `plans/PR-Reddit-Listening-Config-Scoring.md`
+- `tests/test_atlas_reddit_config.py`
+- `tests/test_atlas_reddit_scoring.py`
+
+## Mechanism
+
+`atlas_reddit/config.py` holds both config surfaces. Env settings are a
+pydantic-settings class (`env_prefix="ATLAS_REDDIT_"`); S1 exposes only
+`watchlist_path`, defaulting under the gitignored `data/` tree. The watchlist
+itself is TOML parsed with stdlib `tomllib` into frozen dataclasses
+(`SubredditEntry`, `Topic`, `Watchlist`). Validation is centralized in
+`parse_watchlist(dict) -> Watchlist` (pure, unit-testable without files);
+`load_watchlist(Path)` adds file I/O and wraps `FileNotFoundError` /
+`TOMLDecodeError` into `WatchlistError` so callers have one error surface.
+Every check rejects rather than defaults: unknown keys at any level, version
+!= 1, subreddit names failing Reddit's `[A-Za-z0-9][A-Za-z0-9_]{2,20}` shape,
+weights outside (0, 10], bonuses outside [0, 5], bools where numbers belong
+(TOML `true` would otherwise coerce to 1.0), and case-insensitive duplicates.
+
+`atlas_reddit/scoring.py` is a pure function `score_post(title, body,
+subreddit_weight, watchlist) -> ScoreBreakdown`. Phrases compile to
+`(?<!\w)escaped(?!\w)` patterns (lru_cached), matched against casefolded
+`title\nbody`. If no topic matches, the result is 0.0 and bonuses are not
+evaluated. Otherwise: `total = subreddit_weight * (sum(topic weights with a
+hit) + help_signal_bonus if any signal hit + question_bonus if '?' present)`,
+rounded to 4 places. The breakdown carries matched topics/phrases so the S3
+digest can show why a thread surfaced.
+
+## Intentional
+
+- **TOML over the issue-sketch YAML**: PyYAML is importable here only as a
+  transitive dependency (not declared in requirements.txt), and CI images run
+  Python 3.11+ where `tomllib` is stdlib. Zero new dependencies beats format
+  preference; the sketch's intent (human-edited watchlist file) is preserved.
+- **Watchlist in a file, not SQLite** (approved arc amendment c): one
+  human-editable source of truth; the S2 database holds runtime state only.
+- **Topic weight counts once per topic, not per matched phrase**: phrase
+  counts reward keyword-stuffed posts, not relevant ones. Matched phrases are
+  still reported for digest display.
+- **Zero-gate on bonuses**: an off-topic question with help language must not
+  surface; bonuses amplify topical posts only.
+- **No stemming/fuzzy matching**: plural/variant forms are explicit phrase
+  entries. Deterministic and inspectable beats clever for a v1 radar; the
+  sample file documents the behavior.
+- **`active` flag and `list_type` from the #1931 sketch omitted**: dead
+  fields until the S4 poller exists; unknown-key rejection means adding them
+  later is an explicit, reviewed change.
+- **Synchronous stdlib code, no async**: this is a local single-user CLI
+  tool, not a brain service; the async-first convention targets `atlas_brain`
+  I/O paths. Nothing here does I/O except reading one config file.
+- **Package placement `atlas_reddit/` at repo root**: matches the
+  `atlas_comms`/`atlas_edge` standalone-service precedent; keeps
+  brain-startup and extracted-checks import graphs untouched.
+
+Root-cause notes (per the #1934 retroactive fix rule; both found and fixed
+pre-push during implementation):
+
+- **Empty `help_signals = []` was rejected by the parser.** Root cause: the
+  shared phrase-list validator conflated "present but empty" (coherent
+  config: the bonus feature unused) with invalid, because topic phrases
+  genuinely may not be empty. Fixed at the parser (`allow_empty` for
+  help_signals only), not by adjusting the failing test fixtures; a
+  dedicated boundary test locks the semantic.
+- **`parse_watchlist` crashed with bare AttributeError/TypeError on
+  non-dict input.** Root cause: the public validator assumed its own
+  caller's contract instead of checking it; fixed with a type guard at the
+  function boundary so every invalid input surfaces as `WatchlistError`.
+
+## Deferred
+
+- S2 SQLite store (candidates/tracked_threads/replies/purge_log; PRAGMA
+  user_version migrations).
+- S3 Markdown digest + `python -m atlas_reddit` CLI (adds `digest_dir` and
+  `db_path` settings fields when they become real).
+- S4 PRAW read-only poller: verify the current Reddit OAuth + PRAW auth path
+  against live docs BEFORE auth code (operator-required gate); fail-closed
+  scope assertion (read/identity/history only); setup runbook; praw
+  dependency justification.
+- S5 reply tracker; S6 deletion-compliance purge job.
+- LLM `judge_fit` pass: beyond this arc entirely (claim-registry-gated,
+  OpenRouter + local backend behind one port).
+- Hard filters (unseen/dismissed/fresh/text-post) live with the poller (S4),
+  where the post metadata exists.
+
+Parked hardening: none.
+
+## Verification
+
+- pytest on `tests/test_atlas_reddit_config.py` and
+  `tests/test_atlas_reddit_scoring.py`: 88 passed (happy path, per-branch
+  negative fixtures, boundary values both sides, bool-typed-number traps,
+  duplicates, mixed valid/invalid collections, near-miss zero-scores,
+  word-boundary probes, regex-metachar phrases, emoji-adjacent matches,
+  non-dict input contract, committed-sample-parses, env override).
+- bash `scripts/check_ascii_python.sh`: passed (no non-ASCII in new .py).
+- python `scripts/audit_workflow_security_posture.py` over .github/workflows:
+  passed (new workflow clean; pre-existing WARNs on other files unchanged).
+- python `scripts/sync_pr_plan.py` on this plan: Files touched + diff table
+  regenerated from the real diff.
+- Local review bundle runs via `scripts/push_pr.sh` before push.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_reddit_checks.yml` | 31 |
+| `atlas_reddit/__init__.py` | 9 |
+| `atlas_reddit/config.py` | 267 |
+| `atlas_reddit/scoring.py` | 104 |
+| `atlas_reddit/watchlist.sample.toml` | 115 |
+| `plans/PR-Reddit-Listening-Config-Scoring.md` | 174 |
+| `tests/test_atlas_reddit_config.py` | 305 |
+| `tests/test_atlas_reddit_scoring.py` | 263 |
+| **Total** | **1268** |

--- a/plans/PR-Reddit-Listening-Config-Scoring.md
+++ b/plans/PR-Reddit-Listening-Config-Scoring.md
@@ -174,6 +174,17 @@ fixed at root in this PR):
   rounding; the exact-equality test assertions it papered over moved to
   pytest.approx. Class-proofed with the cited tiny weight, an unseen
   composed-smallness probe, and a tiny-match-outranks-any-no-match property.
+- **`version = 1.0` (TOML float) passed the version check** (Codex wave 3):
+  Python's `1.0 == 1` means a plain `!=` comparison admits the float form.
+  Same class as the bool-is-int trap already guarded one line up; root cause
+  is type-loose numeric comparison in a strict-shape validator. Fixed by
+  requiring exact int; class-proofed with 1.0/0.0/2.0/1.5 float probes in
+  the version parametrize.
+- **Stale verification counts in the contract docs** (Codex wave 3): the
+  plan's Verification said 88 and the PR body said 106 while the suite had
+  grown to 109 (now 113). Root cause: the same fact manually duplicated in
+  two documents across fix waves. Fixed by updating both and declaring the
+  plan's Verification line the single count source that the body mirrors.
 
 ## Deferred
 
@@ -196,11 +207,15 @@ Parked hardening: none.
 ## Verification
 
 - pytest on `tests/test_atlas_reddit_config.py` and
-  `tests/test_atlas_reddit_scoring.py`: 88 passed (happy path, per-branch
-  negative fixtures, boundary values both sides, bool-typed-number traps,
-  duplicates, mixed valid/invalid collections, near-miss zero-scores,
-  word-boundary probes, regex-metachar phrases, emoji-adjacent matches,
-  non-dict input contract, committed-sample-parses, env override).
+  `tests/test_atlas_reddit_scoring.py`: 113 passed (happy path, per-branch
+  negative fixtures, boundary values both sides, bool- and float-typed
+  version/number traps, duplicates incl. normalized whitespace/case
+  variants, mixed valid/invalid collections, near-miss zero-scores,
+  word-boundary probes, newline/CR name probes, regex-metachar phrases,
+  emoji-adjacent matches, tiny-weight ranking probes, non-dict input
+  contract, committed-sample-parses, env override). Count current as of the
+  wave-3 review fixes; this line is the single verification-count source and
+  the PR body mirrors it.
 - bash `scripts/check_ascii_python.sh`: passed (no non-ASCII in new .py).
 - python `scripts/audit_workflow_security_posture.py` over .github/workflows:
   passed (new workflow clean; pre-existing WARNs on other files unchanged).
@@ -214,10 +229,10 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/atlas_reddit_checks.yml` | 31 |
 | `atlas_reddit/__init__.py` | 9 |
-| `atlas_reddit/config.py` | 276 |
+| `atlas_reddit/config.py` | 283 |
 | `atlas_reddit/scoring.py` | 107 |
 | `atlas_reddit/watchlist.sample.toml` | 115 |
-| `plans/PR-Reddit-Listening-Config-Scoring.md` | 223 |
-| `tests/test_atlas_reddit_config.py` | 365 |
+| `plans/PR-Reddit-Listening-Config-Scoring.md` | 238 |
+| `tests/test_atlas_reddit_config.py` | 378 |
 | `tests/test_atlas_reddit_scoring.py` | 319 |
-| **Total** | **1445** |
+| **Total** | **1480** |

--- a/plans/PR-Reddit-Listening-Config-Scoring.md
+++ b/plans/PR-Reddit-Listening-Config-Scoring.md
@@ -148,6 +148,22 @@ pre-push during implementation):
   caller's contract instead of checking it; fixed with a type guard at the
   function boundary so every invalid input surfaces as `WatchlistError`.
 
+Review-fix notes (Codex review of 26b3a878a; both findings verified real and
+fixed at root in this PR):
+
+- **Topic duplicate check compared untrimmed names while `Topic` stored
+  stripped ones** (check/store mismatch class): " ticket-deflection "
+  slipped past "ticket-deflection", stored as an identical name, and
+  `score_post` would double-count that topic's weight. Fixed by normalizing
+  once before the duplicate check so validation, dedupe, and storage all see
+  one value; class-proofed with the cited case plus unseen
+  whitespace/case/newline variants.
+- **Subreddit name regex used `match()` with a `$` anchor**, which tolerates
+  a trailing newline: "SaaS\n" passed validation, then
+  `subreddit_weight("SaaS")` missed and a future poller would fetch an
+  invalid subreddit. Fixed with `fullmatch()`; class-proofed with
+  trailing/leading/internal newline and carriage-return probes.
+
 ## Deferred
 
 - S2 SQLite store (candidates/tracked_threads/replies/purge_log; PRAGMA
@@ -187,10 +203,10 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/atlas_reddit_checks.yml` | 31 |
 | `atlas_reddit/__init__.py` | 9 |
-| `atlas_reddit/config.py` | 267 |
+| `atlas_reddit/config.py` | 276 |
 | `atlas_reddit/scoring.py` | 104 |
 | `atlas_reddit/watchlist.sample.toml` | 115 |
-| `plans/PR-Reddit-Listening-Config-Scoring.md` | 174 |
-| `tests/test_atlas_reddit_config.py` | 305 |
+| `plans/PR-Reddit-Listening-Config-Scoring.md` | 212 |
+| `tests/test_atlas_reddit_config.py` | 365 |
 | `tests/test_atlas_reddit_scoring.py` | 263 |
-| **Total** | **1268** |
+| **Total** | **1375** |

--- a/tests/test_atlas_reddit_config.py
+++ b/tests/test_atlas_reddit_config.py
@@ -83,8 +83,21 @@ def test_subreddit_weight_lookup_is_case_insensitive() -> None:
     assert watchlist.subreddit_weight("NotWatched") is None
 
 
-@pytest.mark.parametrize("version", [None, 0, 2, "1", True])
-def test_version_must_be_exactly_one(version: object) -> None:
+@pytest.mark.parametrize(
+    "version",
+    [
+        None,
+        0,
+        2,
+        "1",
+        True,
+        1.0,  # Codex-cited: float compares equal to int 1 under !=
+        0.0,
+        2.0,
+        1.5,
+    ],
+)
+def test_version_must_be_exactly_integer_one(version: object) -> None:
     raw = _valid_raw()
     if version is None:
         del raw["version"]

--- a/tests/test_atlas_reddit_config.py
+++ b/tests/test_atlas_reddit_config.py
@@ -1,0 +1,305 @@
+"""Watchlist config validation tests for atlas_reddit (slice S1, #1934).
+
+The watchlist parser is guard-shaped, so every detection branch gets a
+negative fixture (AGENTS.md 3i): unknown keys, bad versions, invalid
+names, out-of-range weights, bool-typed numbers, duplicates, and
+malformed/missing files. Boundary values are probed on both sides.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from atlas_reddit.config import (
+    RedditListeningSettings,
+    Watchlist,
+    WatchlistError,
+    load_watchlist,
+    parse_watchlist,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _valid_raw() -> dict:
+    return {
+        "version": 1,
+        "help_signal_bonus": 0.25,
+        "question_bonus": 0.5,
+        "help_signals": ["how do you", "any recommendations"],
+        "subreddits": [
+            {"name": "CustomerSuccess", "weight": 1.0},
+            {"name": "SaaS", "weight": 0.8},
+        ],
+        "topics": [
+            {
+                "name": "ticket-deflection",
+                "weight": 1.0,
+                "phrases": ["ticket deflection", "deflection rate"],
+            },
+            {
+                "name": "repeat-tickets",
+                "weight": 0.9,
+                "phrases": ["same question", "repeat tickets"],
+            },
+        ],
+    }
+
+
+def test_parse_valid_full() -> None:
+    watchlist = parse_watchlist(_valid_raw())
+    assert isinstance(watchlist, Watchlist)
+    assert watchlist.version == 1
+    assert [s.name for s in watchlist.subreddits] == ["CustomerSuccess", "SaaS"]
+    assert watchlist.subreddits[1].weight == 0.8
+    assert [t.name for t in watchlist.topics] == ["ticket-deflection", "repeat-tickets"]
+    assert watchlist.topics[0].phrases == ("ticket deflection", "deflection rate")
+    assert watchlist.help_signals == ("how do you", "any recommendations")
+    assert watchlist.question_bonus == 0.5
+    assert watchlist.help_signal_bonus == 0.25
+
+
+def test_parse_defaults_applied() -> None:
+    raw = {
+        "version": 1,
+        "subreddits": [{"name": "SaaS"}],
+        "topics": [{"name": "t", "phrases": ["ticket deflection"]}],
+    }
+    watchlist = parse_watchlist(raw)
+    assert watchlist.subreddits[0].weight == 1.0
+    assert watchlist.topics[0].weight == 1.0
+    assert watchlist.help_signals == ()
+    assert watchlist.question_bonus == 0.5
+    assert watchlist.help_signal_bonus == 0.25
+
+
+def test_subreddit_weight_lookup_is_case_insensitive() -> None:
+    watchlist = parse_watchlist(_valid_raw())
+    assert watchlist.subreddit_weight("customersuccess") == 1.0
+    assert watchlist.subreddit_weight("CUSTOMERSUCCESS") == 1.0
+    assert watchlist.subreddit_weight("NotWatched") is None
+
+
+@pytest.mark.parametrize("version", [None, 0, 2, "1", True])
+def test_version_must_be_exactly_one(version: object) -> None:
+    raw = _valid_raw()
+    if version is None:
+        del raw["version"]
+    else:
+        raw["version"] = version
+    with pytest.raises(WatchlistError, match="version"):
+        parse_watchlist(raw)
+
+
+@pytest.mark.parametrize("raw", ["not a table", [{"version": 1}], 42, None])
+def test_non_table_document_rejected_with_watchlist_error(raw: object) -> None:
+    """Public-API contract: invalid input raises WatchlistError, never a
+    bare AttributeError/TypeError from the internals."""
+    with pytest.raises(WatchlistError, match="table"):
+        parse_watchlist(raw)  # type: ignore[arg-type]
+
+
+def test_unknown_top_level_key_rejected() -> None:
+    raw = _valid_raw()
+    raw["surprise"] = True
+    with pytest.raises(WatchlistError, match="surprise"):
+        parse_watchlist(raw)
+
+
+def test_unknown_subreddit_key_rejected() -> None:
+    raw = _valid_raw()
+    raw["subreddits"][0]["list_type"] = "core"
+    with pytest.raises(WatchlistError, match="list_type"):
+        parse_watchlist(raw)
+
+
+def test_unknown_topic_key_rejected() -> None:
+    raw = _valid_raw()
+    raw["topics"][0]["llm"] = "never"
+    with pytest.raises(WatchlistError, match="llm"):
+        parse_watchlist(raw)
+
+
+@pytest.mark.parametrize("value", [None, [], "SaaS", [1, 2]])
+def test_subreddits_must_be_nonempty_array_of_tables(value: object) -> None:
+    raw = _valid_raw()
+    if value is None:
+        del raw["subreddits"]
+    else:
+        raw["subreddits"] = value
+    with pytest.raises(WatchlistError, match="subreddits"):
+        parse_watchlist(raw)
+
+
+@pytest.mark.parametrize(
+    "name", ["", "ab", "a" * 22, "bad name", "bad-name", "_lead", 123, None]
+)
+def test_subreddit_name_invalid(name: object) -> None:
+    raw = _valid_raw()
+    raw["subreddits"][0] = {"name": name} if name is not None else {}
+    with pytest.raises(WatchlistError, match="name"):
+        parse_watchlist(raw)
+
+
+def test_subreddit_name_length_boundaries_pass() -> None:
+    raw = _valid_raw()
+    raw["subreddits"] = [{"name": "abc"}, {"name": "a" * 21}]
+    watchlist = parse_watchlist(raw)
+    assert [s.name for s in watchlist.subreddits] == ["abc", "a" * 21]
+
+
+@pytest.mark.parametrize("weight", [0, 0.0, -1, 10.5, "1.0", True, False])
+def test_subreddit_weight_invalid(weight: object) -> None:
+    raw = _valid_raw()
+    raw["subreddits"][0]["weight"] = weight
+    with pytest.raises(WatchlistError, match="weight"):
+        parse_watchlist(raw)
+
+
+def test_weight_boundaries_pass() -> None:
+    raw = _valid_raw()
+    raw["subreddits"][0]["weight"] = 10.0
+    raw["topics"][0]["weight"] = 0.0001
+    watchlist = parse_watchlist(raw)
+    assert watchlist.subreddits[0].weight == 10.0
+    assert watchlist.topics[0].weight == 0.0001
+
+
+def test_duplicate_subreddit_names_rejected_case_insensitive() -> None:
+    raw = _valid_raw()
+    raw["subreddits"].append({"name": "customersuccess"})
+    with pytest.raises(WatchlistError, match="duplicate subreddit"):
+        parse_watchlist(raw)
+
+
+def test_mixed_valid_and_invalid_subreddits_rejected() -> None:
+    raw = _valid_raw()
+    raw["subreddits"] = [{"name": "GoodName"}, {"name": "bad name"}]
+    with pytest.raises(WatchlistError, match=r"subreddits\[1\]"):
+        parse_watchlist(raw)
+
+
+@pytest.mark.parametrize("value", [None, [], "topic"])
+def test_topics_must_be_nonempty_array_of_tables(value: object) -> None:
+    raw = _valid_raw()
+    if value is None:
+        del raw["topics"]
+    else:
+        raw["topics"] = value
+    with pytest.raises(WatchlistError, match="topics"):
+        parse_watchlist(raw)
+
+
+@pytest.mark.parametrize("phrases", [None, [], [""], ["  "], [123], ["ok", "ok"]])
+def test_topic_phrases_invalid(phrases: object) -> None:
+    raw = _valid_raw()
+    if phrases is None:
+        del raw["topics"][0]["phrases"]
+    else:
+        raw["topics"][0]["phrases"] = phrases
+    with pytest.raises(WatchlistError, match="phrases"):
+        parse_watchlist(raw)
+
+
+def test_duplicate_topic_names_rejected() -> None:
+    raw = _valid_raw()
+    raw["topics"][1]["name"] = "Ticket-Deflection"
+    with pytest.raises(WatchlistError, match="duplicate topic"):
+        parse_watchlist(raw)
+
+
+@pytest.mark.parametrize("signals", [[""], [42], ["dup", "DUP"], "how do you"])
+def test_help_signals_invalid(signals: object) -> None:
+    raw = _valid_raw()
+    raw["help_signals"] = signals
+    with pytest.raises(WatchlistError, match="help_signals"):
+        parse_watchlist(raw)
+
+
+def test_help_signals_empty_list_allowed() -> None:
+    """Explicitly empty help_signals is valid: the bonus feature unused."""
+    raw = _valid_raw()
+    raw["help_signals"] = []
+    assert parse_watchlist(raw).help_signals == ()
+
+
+@pytest.mark.parametrize("key", ["question_bonus", "help_signal_bonus"])
+@pytest.mark.parametrize("value", [-0.1, 5.1, True, "0.5"])
+def test_bonus_out_of_range_or_wrong_type(key: str, value: object) -> None:
+    raw = _valid_raw()
+    raw[key] = value
+    with pytest.raises(WatchlistError, match=key):
+        parse_watchlist(raw)
+
+
+@pytest.mark.parametrize("key", ["question_bonus", "help_signal_bonus"])
+def test_bonus_zero_is_allowed(key: str) -> None:
+    raw = _valid_raw()
+    raw[key] = 0.0
+    watchlist = parse_watchlist(raw)
+    assert getattr(watchlist, key) == 0.0
+
+
+def test_parse_does_not_mutate_input() -> None:
+    raw = _valid_raw()
+    snapshot = copy.deepcopy(raw)
+    parse_watchlist(raw)
+    assert raw == snapshot
+
+
+def test_load_watchlist_valid_file(tmp_path: Path) -> None:
+    path = tmp_path / "watchlist.toml"
+    path.write_text(
+        "\n".join(
+            [
+                "version = 1",
+                "[[subreddits]]",
+                'name = "SaaS"',
+                "weight = 0.8",
+                "[[topics]]",
+                'name = "deflection"',
+                'phrases = ["ticket deflection"]',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    watchlist = load_watchlist(path)
+    assert watchlist.subreddit_weight("saas") == 0.8
+    assert watchlist.topics[0].phrases == ("ticket deflection",)
+
+
+def test_load_watchlist_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.toml"
+    with pytest.raises(WatchlistError, match="not found"):
+        load_watchlist(missing)
+
+
+def test_load_watchlist_malformed_toml(tmp_path: Path) -> None:
+    path = tmp_path / "watchlist.toml"
+    path.write_text("version = = 1", encoding="utf-8")
+    with pytest.raises(WatchlistError, match="malformed"):
+        load_watchlist(path)
+
+
+def test_committed_sample_watchlist_is_valid() -> None:
+    """The shipped sample must always parse through the real loader."""
+    sample = REPO_ROOT / "atlas_reddit" / "watchlist.sample.toml"
+    watchlist = load_watchlist(sample)
+    assert watchlist.subreddit_weight("CustomerSuccess") == 1.0
+    assert any(t.name == "ticket-deflection" for t in watchlist.topics)
+    assert watchlist.help_signals
+
+
+def test_settings_default_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_REDDIT_WATCHLIST_PATH", raising=False)
+    settings = RedditListeningSettings(_env_file=None)
+    assert settings.watchlist_path == Path("data/atlas_reddit/watchlist.toml")
+
+
+def test_settings_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_REDDIT_WATCHLIST_PATH", "/tmp/custom.toml")
+    settings = RedditListeningSettings(_env_file=None)
+    assert settings.watchlist_path == Path("/tmp/custom.toml")

--- a/tests/test_atlas_reddit_config.py
+++ b/tests/test_atlas_reddit_config.py
@@ -211,6 +211,66 @@ def test_duplicate_topic_names_rejected() -> None:
         parse_watchlist(raw)
 
 
+@pytest.mark.parametrize(
+    "variant",
+    [
+        " ticket-deflection ",  # Codex-cited case
+        "\tticket-deflection",
+        "TICKET-DEFLECTION  ",
+        "  Ticket-Deflection\t",
+        "ticket-deflection\n",
+    ],
+)
+def test_topic_duplicate_check_normalizes_whitespace_and_case(variant: str) -> None:
+    """Class fix for the check/store mismatch: the duplicate check must
+    compare the same normalized value that gets stored, or a curation
+    typo silently double-counts the topic's weight in score_post."""
+    raw = _valid_raw()
+    raw["topics"][1]["name"] = variant
+    with pytest.raises(WatchlistError, match="duplicate topic"):
+        parse_watchlist(raw)
+
+
+def test_topic_name_stored_stripped() -> None:
+    raw = _valid_raw()
+    raw["topics"][0]["name"] = "  spaced-name\t"
+    watchlist = parse_watchlist(raw)
+    assert watchlist.topics[0].name == "spaced-name"
+
+
+@pytest.mark.parametrize("name", [None, "", "   ", 42, ["x"]])
+def test_topic_name_invalid(name: object) -> None:
+    raw = _valid_raw()
+    if name is None:
+        del raw["topics"][0]["name"]
+    else:
+        raw["topics"][0]["name"] = name
+    with pytest.raises(WatchlistError, match="name"):
+        parse_watchlist(raw)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "SaaS\n",  # Codex-cited case: "$" would match before the final newline
+        "abc\n",
+        "a1b\n",
+        "\nSaaS",
+        "Sa\naS",
+        "SaaS\n\n",
+        "helpdesk\r",
+    ],
+)
+def test_subreddit_name_with_newline_or_cr_rejected(name: str) -> None:
+    """Class fix for the anchor trap: fullmatch leaves no position where
+    a stray newline survives validation and then breaks
+    subreddit_weight() lookups or a future poller's subreddit fetch."""
+    raw = _valid_raw()
+    raw["subreddits"][0]["name"] = name
+    with pytest.raises(WatchlistError, match="name"):
+        parse_watchlist(raw)
+
+
 @pytest.mark.parametrize("signals", [[""], [42], ["dup", "DUP"], "how do you"])
 def test_help_signals_invalid(signals: object) -> None:
     raw = _valid_raw()

--- a/tests/test_atlas_reddit_scoring.py
+++ b/tests/test_atlas_reddit_scoring.py
@@ -1,0 +1,263 @@
+"""Scoring tests for atlas_reddit (slice S1, #1934).
+
+Watchlists are built through the real parser (parse_watchlist), not
+hand-built dataclasses, so the tests exercise the same objects
+production uses. Scoring is pure, so every assertion is exact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atlas_reddit.config import parse_watchlist
+from atlas_reddit.scoring import score_post
+
+
+def _watchlist(**overrides: object):
+    raw: dict = {
+        "version": 1,
+        "help_signal_bonus": 0.25,
+        "question_bonus": 0.5,
+        "help_signals": ["how do you", "any recommendations"],
+        "subreddits": [{"name": "CustomerSuccess", "weight": 1.0}],
+        "topics": [
+            {
+                "name": "ticket-deflection",
+                "weight": 1.0,
+                "phrases": ["ticket deflection", "deflection rate"],
+            },
+            {
+                "name": "repeat-tickets",
+                "weight": 0.9,
+                "phrases": ["same question", "repeat tickets"],
+            },
+        ],
+    }
+    raw.update(overrides)
+    return parse_watchlist(raw)
+
+
+def test_single_topic_single_phrase() -> None:
+    result = score_post(
+        title="Measuring ticket deflection",
+        body="We rolled out a portal last month.",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert result.total == 1.0
+    assert [h.topic for h in result.topic_hits] == ["ticket-deflection"]
+    assert result.topic_hits[0].matched_phrases == ("ticket deflection",)
+    assert result.question_bonus_applied == 0.0
+    assert result.help_signal_bonus_applied == 0.0
+
+
+def test_no_topic_match_scores_zero_even_with_question_and_help_signal() -> None:
+    """Bonuses only amplify topical posts; they never surface off-topic ones."""
+    result = score_post(
+        title="How do you like your standing desk?",
+        body="Any recommendations for a home office chair?",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert result.total == 0.0
+    assert result.topic_hits == ()
+    assert result.help_signal_hits == ()
+    assert result.question_bonus_applied == 0.0
+
+
+def test_multiple_topics_sum() -> None:
+    result = score_post(
+        title="Ticket deflection is up but customers ask the same question daily",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert {h.topic for h in result.topic_hits} == {"ticket-deflection", "repeat-tickets"}
+    assert result.total == 1.9  # 1.0 + 0.9, no bonuses
+
+
+def test_multiple_phrases_in_one_topic_count_once() -> None:
+    result = score_post(
+        title="Our ticket deflection rate: deflection rate math inside",
+        body="ticket deflection numbers for the quarter.",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert len(result.topic_hits) == 1
+    hit = result.topic_hits[0]
+    assert set(hit.matched_phrases) == {"ticket deflection", "deflection rate"}
+    assert result.total == 1.0  # weight once, not per phrase
+
+
+def test_question_bonus_applied_once() -> None:
+    result = score_post(
+        title="Is our ticket deflection rate normal?",
+        body="Numbers inside? Really?",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert result.question_bonus_applied == 0.5
+    assert result.total == 1.5
+
+
+def test_help_signal_bonus_applied_once_for_multiple_signals() -> None:
+    result = score_post(
+        title="How do you improve ticket deflection",
+        body="Any recommendations appreciated.",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert set(result.help_signal_hits) == {"how do you", "any recommendations"}
+    assert result.help_signal_bonus_applied == 0.25
+    assert result.total == 1.25
+
+
+def test_matching_is_case_insensitive() -> None:
+    result = score_post(
+        title="TICKET DEFLECTION strategies",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert result.total == 1.0
+
+
+def test_phrase_does_not_match_inside_longer_word() -> None:
+    watchlist = _watchlist(
+        topics=[{"name": "sla", "weight": 1.0, "phrases": ["sla"]}],
+        help_signals=[],
+    )
+    result = score_post(
+        title="Visited an island to translate documents",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=watchlist,
+    )
+    assert result.total == 0.0
+
+    hit = score_post(
+        title="Our SLA is slipping",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=watchlist,
+    )
+    assert hit.total == 1.0
+
+
+def test_no_stemming_plural_needs_own_phrase() -> None:
+    """Documented behavior: 'repeat tickets' does not match 'repeat ticket'."""
+    result = score_post(
+        title="One repeat ticket ruined my week",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert result.total == 0.0
+
+
+def test_hyphenated_phrase_matches() -> None:
+    watchlist = _watchlist(
+        topics=[{"name": "self-service", "weight": 1.0, "phrases": ["self-service"]}],
+        help_signals=[],
+    )
+    result = score_post(
+        title="Improving our self-service portal.",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=watchlist,
+    )
+    assert result.total == 1.0
+
+
+def test_subreddit_weight_scales_total() -> None:
+    weighted = score_post(
+        title="ticket deflection?",
+        body="",
+        subreddit_weight=0.8,
+        watchlist=_watchlist(),
+    )
+    assert weighted.total == pytest.approx(0.8 * 1.5)
+    assert weighted.subreddit_weight == 0.8
+
+
+@pytest.mark.parametrize("weight", [0.0, -1.0])
+def test_nonpositive_subreddit_weight_raises(weight: float) -> None:
+    with pytest.raises(ValueError, match="subreddit_weight"):
+        score_post(
+            title="ticket deflection",
+            body="",
+            subreddit_weight=weight,
+            watchlist=_watchlist(),
+        )
+
+
+def test_near_miss_neutral_text_scores_zero() -> None:
+    """Topic vocabulary nearby is not a match: 'ticket' alone is not
+    'ticket deflection', and measurement language stays neutral."""
+    result = score_post(
+        title="We use page views as one signal for the ticket queue",
+        body="Tracking deflection-adjacent metrics like search exits.",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert result.total == 0.0
+
+
+def test_regex_metacharacters_in_phrases_match_literally() -> None:
+    """Phrases are operator-typed text, not regexes: metachars must not
+    crash compilation or change matching semantics."""
+    watchlist = _watchlist(
+        topics=[
+            {"name": "cpp", "weight": 1.0, "phrases": ["c++"]},
+            {"name": "paren", "weight": 1.0, "phrases": ["(deflection)"]},
+        ],
+        help_signals=[],
+    )
+    result = score_post(
+        title="Moving our c++ tooling",
+        body="Our (deflection) numbers are flat.",
+        subreddit_weight=1.0,
+        watchlist=watchlist,
+    )
+    assert {h.topic for h in result.topic_hits} == {"cpp", "paren"}
+    assert result.total == 2.0
+
+    miss = score_post(
+        title="Moving our cpp tooling",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=watchlist,
+    )
+    assert miss.total == 0.0
+
+
+def test_emoji_adjacent_phrase_still_matches() -> None:
+    """Reddit titles wrap words in emoji; non-word neighbors must not
+    defeat the word-boundary lookarounds."""
+    result = score_post(
+        title="\N{FIRE}ticket deflection\N{FIRE} wins this quarter",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert result.total == 1.0
+
+
+def test_body_only_match_counts() -> None:
+    result = score_post(
+        title="Quarterly support review",
+        body="The deflection rate dropped after the docs migration.",
+        subreddit_weight=1.0,
+        watchlist=_watchlist(),
+    )
+    assert result.total == 1.0
+
+
+def test_deterministic_repeat_calls() -> None:
+    kwargs = dict(
+        title="Is our ticket deflection rate normal?",
+        body="how do you measure it",
+        subreddit_weight=0.9,
+        watchlist=_watchlist(),
+    )
+    assert score_post(**kwargs) == score_post(**kwargs)

--- a/tests/test_atlas_reddit_scoring.py
+++ b/tests/test_atlas_reddit_scoring.py
@@ -73,7 +73,7 @@ def test_multiple_topics_sum() -> None:
         watchlist=_watchlist(),
     )
     assert {h.topic for h in result.topic_hits} == {"ticket-deflection", "repeat-tickets"}
-    assert result.total == 1.9  # 1.0 + 0.9, no bonuses
+    assert result.total == pytest.approx(1.9)  # 1.0 + 0.9, no bonuses
 
 
 def test_multiple_phrases_in_one_topic_count_once() -> None:
@@ -251,6 +251,62 @@ def test_body_only_match_counts() -> None:
         watchlist=_watchlist(),
     )
     assert result.total == 1.0
+
+
+def test_tiny_topic_weight_match_stays_above_zero_gate() -> None:
+    """Codex-cited class: a valid tiny weight must never collapse a real
+    match to the no-match total. The ranking signal is the raw product."""
+    watchlist = _watchlist(
+        topics=[{"name": "tiny", "weight": 0.00001, "phrases": ["ticket deflection"]}],
+        help_signals=[],
+    )
+    result = score_post(
+        title="ticket deflection numbers",
+        body="",
+        subreddit_weight=1.0,
+        watchlist=watchlist,
+    )
+    assert result.topic_hits, "the phrase matched"
+    assert result.total > 0.0
+    assert result.total == pytest.approx(0.00001)
+
+
+def test_composed_small_weights_stay_above_zero_gate() -> None:
+    """Unseen same-class probe: smallness composed across subreddit and
+    topic weights (each individually sane) must also survive."""
+    watchlist = _watchlist(
+        topics=[{"name": "small", "weight": 0.001, "phrases": ["ticket deflection"]}],
+        help_signals=[],
+    )
+    result = score_post(
+        title="ticket deflection numbers",
+        body="",
+        subreddit_weight=0.01,
+        watchlist=watchlist,
+    )
+    assert result.total > 0.0
+    assert result.total == pytest.approx(1e-5)
+
+
+def test_tiny_match_ranks_above_any_no_match() -> None:
+    watchlist = _watchlist(
+        topics=[{"name": "tiny", "weight": 0.00001, "phrases": ["ticket deflection"]}],
+        help_signals=[],
+    )
+    match = score_post(
+        title="ticket deflection",
+        body="",
+        subreddit_weight=0.0001,
+        watchlist=watchlist,
+    )
+    miss = score_post(
+        title="standing desk question?",
+        body="",
+        subreddit_weight=10.0,
+        watchlist=watchlist,
+    )
+    assert miss.total == 0.0
+    assert match.total > miss.total
 
 
 def test_deterministic_repeat_calls() -> None:


### PR DESCRIPTION
Plan: plans/PR-Reddit-Listening-Config-Scoring.md
Slice phase: Vertical slice

First implementation slice (S1) of the approved #1934 arc (Fable 5 builder trial; product epic #1931): the operator-curated watchlist config and the deterministic keyword scorer every downstream slice consumes. New top-level package `atlas_reddit/` (atlas_comms precedent, outside atlas_brain's import graph), typed `ATLAS_REDDIT_*` settings, fail-closed TOML watchlist loader (stdlib tomllib), pure scorer with zero-gate bonuses, committed sample watchlist, and same-PR CI enrollment via a path-filtered workflow. No network, no database, no LLM, no mocks.

## Intentional

- TOML over the issue-sketch YAML: pyyaml is only an undeclared transitive dependency here; tomllib is stdlib on the CI Python. Zero new dependencies; the sketch's intent (human-edited watchlist file) is preserved.
- Watchlist lives in a file, not SQLite (approved arc amendment c); the S2 database will hold runtime state only.
- Topic weight counts once per topic regardless of matched-phrase count (phrase counts reward keyword stuffing); matched phrases still reported for the digest.
- Zero-gate on bonuses: no topic match means 0.0 even with question marks and help signals; bonuses only amplify topical posts.
- No stemming/fuzzy matching: plural/variant forms are explicit phrase entries (documented in the sample).
- `active`/`list_type` from the #1931 sketch omitted until the S4 poller makes them real; unknown-key rejection makes adding them an explicit reviewed change.
- Synchronous stdlib code: local single-user CLI tool, not a brain service.
- Root-cause notes (#1934 retroactive fix rule; both found and fixed pre-push): (1) empty `help_signals = []` was wrongly rejected -- root cause was the shared phrase validator conflating "present but empty" with invalid; fixed at the parser with `allow_empty` for help_signals only, not by adjusting failing fixtures, with a boundary test locking the semantic. (2) `parse_watchlist` crashed with bare AttributeError on non-dict input -- fixed with a type guard at the public boundary so all invalid input raises `WatchlistError`.
- Test-adapter posture (#1934 real-adapters rule): zero mocks. Scoring tests build watchlists through the real `parse_watchlist`; config tests use real file I/O under pytest `tmp_path` (allowed temp-filesystem boundary); the committed sample is validated through the real loader.

## Deferred

- S2 SQLite store (candidates/tracked_threads/replies/purge_log, PRAGMA user_version).
- S3 Markdown digest + `python -m atlas_reddit` CLI.
- S4 PRAW read-only poller: doc-verify the current Reddit OAuth + PRAW auth path BEFORE auth code (operator-required gate); fail-closed scope assertion (read/identity/history only); setup runbook; praw dependency justification. Hard filters (unseen/dismissed/fresh/text-post) land here where post metadata exists.
- S5 reply tracker; S6 deletion-compliance purge job.
- LLM `judge_fit` pass: beyond this arc entirely.

## Parked hardening

- None.

## AI reconciliation

Codex reviews: wave 1 on `26b3a878a` (2 findings), wave 2 on `c91d67c85` (1 finding), wave 3 on `1f3c09669` (2 findings). All 5 verified real and FIXED at root. No waivers.

All fixed or waived: yes.

1. **Topic duplicate check compared untrimmed names while `Topic` stored stripped ones** (comment 3509220860) -- check/store mismatch class: `" ticket-deflection "` slipped past `"ticket-deflection"`, stored identically, and `score_post` would double-count the weight. Fixed by normalizing once before the duplicate check so validation, dedupe, and storage see one value. Class-proofed with the cited case plus unseen whitespace/case/newline variants (`test_topic_duplicate_check_normalizes_whitespace_and_case`, `test_topic_name_stored_stripped`).
2. **Subreddit regex used `match()` with a `$` anchor that tolerates a trailing newline** (comment 3509220866) -- `"SaaS\n"` passed validation, then `subreddit_weight("SaaS")` missed and a future poller would fetch an invalid subreddit. Fixed with `fullmatch()`. Class-proofed with trailing/leading/internal newline and carriage-return probes (`test_subreddit_name_with_newline_or_cr_rejected`).

3. **`round(total, 4)` collapsed valid tiny-weight matches to 0.0** (comment 3509279225, wave 2) -- weight `0.00001` passes validation (> 0) but the rounded total became indistinguishable from the zero-gate no-match, silently suppressing curated topics. Root cause: cosmetic quantization baked into the ranking computation (not the validation floor -- tightening validation was rejected as a symptom patch since composed small products like subreddit `0.01` x topic `0.001` would still collapse). Fixed by removing the rounding; the exact-equality assertions it papered over moved to `pytest.approx`. Class-proofed with the cited tiny weight, an unseen composed-smallness probe, and a tiny-match-outranks-any-no-match property (`test_tiny_topic_weight_match_stays_above_zero_gate`, `test_composed_small_weights_stay_above_zero_gate`, `test_tiny_match_ranks_above_any_no_match`).

4. **`version = 1.0` (TOML float) passed the version check** (wave 3) -- `1.0 == 1` in Python, so a plain `!=` admits the float form; same class as the bool-is-int trap guarded one line up. Root cause: type-loose numeric comparison in a strict-shape validator. Fixed by requiring exact int; class-proofed with 1.0/0.0/2.0/1.5 probes (`test_version_must_be_exactly_integer_one`).
5. **Stale verification counts in the contract docs** (wave 3) -- plan said 88, body said 106, suite was 109. Root cause: one fact manually duplicated across two documents through fix waves. Fixed: both now carry the current count, and the plan's Verification line is declared the single source the body mirrors.

All review threads resolved after their fixes were verified by tests.

## Verification

- `.venv/bin/python -m pytest tests/test_atlas_reddit_config.py tests/test_atlas_reddit_scoring.py -q` -- 113 passed (happy path, per-branch negative fixtures, boundary values both sides, bool- and float-typed version/number traps, duplicates incl. normalized whitespace/case variants, mixed valid/invalid collections, near-miss zero-scores, word-boundary probes, newline/CR name probes, regex-metachar phrases, emoji-adjacent matches, tiny-weight ranking probes, non-dict input contract, committed-sample-parses, env override). Mirrors the plan's Verification line (the single count source).
- `bash scripts/check_ascii_python.sh` -- passed.
- `python scripts/audit_workflow_security_posture.py .github/workflows` -- passed (new workflow clean; pre-existing WARNs on other files unchanged).
- `python scripts/sync_pr_plan.py plans/PR-Reddit-Listening-Config-Scoring.md` -- Files touched + diff table regenerated from the real diff.

## Diff size

8 files, +1480 / -0
