### PR TITLE
Add producer-fidelity fixture factory for atlas_reddit tests (codification slice 2)

### DIFF
--- a/.github/workflows/atlas_reddit_checks.yml
+++ b/.github/workflows/atlas_reddit_checks.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "atlas_reddit/**"
       - "tests/test_atlas_reddit_*.py"
+      - "tests/atlas_reddit_fixtures.py"
       - ".github/workflows/atlas_reddit_checks.yml"
 
 permissions:

--- a/plans/PR-Producer-Fidelity-Fixture-Factory.md
+++ b/plans/PR-Producer-Fidelity-Fixture-Factory.md
@@ -1,0 +1,135 @@
+# PR-Producer-Fidelity-Fixture-Factory
+
+## Why this slice exists
+
+Fable-arc codification slice 2 (from the #1943 review of the #1934 arc; slice
+1 was the #1944 diff-budget gate). Root cause of the S6 mass-deletion P1: the
+producer's id contract (PrawListingSource / PrawHistorySource emit Reddit
+fullnames, t3_/t1_) and the consumers' expectations (store rows, purge kind
+regexes) are two independent encodings connected only by prose, so consumer
+tests could hand-seed bare ids the pipeline never emits and stay green while
+production drifted. The arc's fix added one probe test
+(test_real_poller_mapping_stores_fullnames) but left fixture construction
+hand-rolled at every consumer site -- the drift class is still open. This
+slice fixes that root: a shared factory derives consumer-test fixtures from
+the REAL producer mappings and seeds stores through the REAL consumers
+(poll_once / track_once), so a consumer test physically cannot seed a shape
+the pipeline never emits.
+
+Diff-budget overage (562 added lines vs the 400 cap): the factory, its
+enforcing fidelity tests, and the S6-site (purge tests) adoption are one
+indivisible slice. The factory without adoption reproduces the S6 failure
+mode -- fixtures exist, nothing uses them -- and the fidelity tests are the
+slice's acceptance evidence. Splitting would ship an unused fixture library
+and defer the enforcement that is the point.
+
+## Scope (this PR)
+
+Ownership lane: Workflow/process
+Slice phase: Robust testing
+
+1. `tests/atlas_reddit_fixtures.py` -- praw-shaped doubles encoding the praw
+   fullname contract exactly once; contextmanagers running the real Praw*
+   sources over a stubbed praw module; seeding helpers running the real
+   poll_once / track_once.
+2. `tests/test_atlas_reddit_fixture_fidelity.py` -- enforcing tests:
+   producer output locksteps with the purge kind regexes; pipeline-seeded
+   rows purge cleanly end to end; the factory rejects non-producer ids.
+3. Purge-test seed helpers adopt the factory; corrupt-row simulations move
+   to explicitly named `_seed_raw_*` helpers.
+4. One workflow paths line so factory edits re-trigger the reddit checks.
+
+### Files touched
+
+- `tests/atlas_reddit_fixtures.py`
+- `tests/test_atlas_reddit_fixture_fidelity.py`
+- `tests/test_atlas_reddit_purge.py`
+- `.github/workflows/atlas_reddit_checks.yml`
+- `plans/PR-Producer-Fidelity-Fixture-Factory.md`
+
+### Review Contract
+
+Acceptance criteria (reviewer checks one-by-one):
+
+1. The factory never hand-writes a stored id: candidate ids come from the
+   real `PrawListingSource.fetch_new` mapping, reply ids from the real
+   `PrawHistorySource.fetch_thread_replies` mapping, and the praw
+   `{kind}_{id}` fullname contract is encoded in exactly one place (the
+   praw doubles).
+2. Store seeding runs the real consumers (`poll_once`, `track_once`) and
+   fails loudly (assert) when a fixture is silently filtered.
+3. The fidelity test imports BOTH real sides (producer path and purge
+   `_KIND_RE`) -- lockstep, not a copied regex.
+4. Purge-test `_seed_candidate` / `_seed_reply` reject non-producer shapes;
+   only `_seed_raw_*` (used by the four corrupt-row sites) can seed
+   malformed ids, and they say so.
+5. `python -m pytest tests/test_atlas_reddit_*.py -q` passes.
+
+Affected surfaces: `tests/` plus one CI workflow paths line. No production
+code changes; `atlas_reddit/` is untouched.
+
+Risk areas: praw doubles drifting from praw's API (the fullname contract is
+pinned by a fidelity test; wider transport fidelity is documented as out of
+the doubles' scope); poll_once-based seeding coupling to scoring admission
+(mitigated by a fixed probe phrase plus the admitted-count assert).
+
+Reviewer rule IDs triggered: R2 (failure-branch fixtures -- corrupt-row raw
+path stays covered); R14 (checked-out PR-head verification). No other
+path-glob row in `docs/REVIEWER_RULES.md` matches a tests+workflow diff.
+
+## Mechanism
+
+The factory stubs the praw MODULE (generalizing the `_stub_praw_with`
+pattern the purge tests established) and instantiates the real
+`PrawListingSource` / `PrawHistorySource`, so the production mapping lines
+-- fullname passthrough, permalink-to-url, int casts, own-author filtering,
+`removeprefix("t1_")` refresh lookups -- execute under test. Seeding drives
+the real `poll_once` (watchlist with a fixed probe phrase, admitted count
+asserted) and `track_once` (own-comment discovery, then reply admission),
+so every stored row was produced by the pipeline. The fidelity test then
+asserts producer output satisfies purge's `_KIND_RE` per table -- the one
+place the two contracts are mechanically joined.
+
+## Intentional
+
+- The four corrupt-row purge tests keep seeding malformed ids on purpose,
+  through `_seed_raw_*` helpers named for it: "never delete on a data-shape
+  mismatch" is a real branch that needs real bad rows.
+- The praw doubles mimic only the attributes the real sources read; they
+  are not a praw emulator. Their one load-bearing contract (fullname ==
+  kind_id) is pinned by a fidelity test.
+- Store/tracker/poller/digest test files are not converted here; the purge
+  tests are the S6 site and the adoption template.
+
+## Deferred
+
+- Factory adoption in `tests/test_atlas_reddit_store.py` / `_tracker.py` /
+  `_poller.py` / `_digest.py` (mechanical follow-up on this template),
+  including own-submission history support in `real_history_source`.
+- Repo-wide trusted-base-ref execution for gate scripts (#1944 waiver 18).
+
+Parked hardening: none.
+
+## Verification
+
+Commands run from the repo root:
+
+- `python -m pytest tests/test_atlas_reddit_*.py -q` -- **322 passed**
+  (full reddit suite: new fidelity tests + factory-backed purge tests +
+  all pre-existing files).
+- `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>` --
+  all checks PASS, 0 failed.
+- `python scripts/check_diff_budget.py --additions 562 --body-file
+  <pr-body.md>` -- overage carried by the line-anchored override in the PR
+  body (see Why this slice exists). Result: PASS with override.
+
+## Estimated diff size
+
+| File | LOC (added) |
+|---|---:|
+| `tests/atlas_reddit_fixtures.py` | 279 |
+| `tests/test_atlas_reddit_fixture_fidelity.py` | 110 |
+| `tests/test_atlas_reddit_purge.py` | 37 |
+| `.github/workflows/atlas_reddit_checks.yml` | 1 |
+| `plans/PR-Producer-Fidelity-Fixture-Factory.md` | 135 |
+| **Total** | **562** |

--- a/tests/atlas_reddit_fixtures.py
+++ b/tests/atlas_reddit_fixtures.py
@@ -1,0 +1,279 @@
+"""Producer-fidelity fixture factory for atlas_reddit consumer tests.
+
+Fable-arc codification slice 2 (plan:
+plans/PR-Producer-Fidelity-Fixture-Factory.md). The S6 mass-deletion
+class was consumer tests hand-seeding id shapes (bare ids) the real
+producer never emits (fullnames) and staying green. This factory removes
+the hand-rolled encoding:
+
+- ids enter fixtures as BARE Reddit ids; the kind prefix is added only
+  by the praw doubles below, mirroring praw's FullnameMixin contract
+  (``fullname == f"{kind}_{id}"``; t3_ submissions, t1_ comments) --
+  encoded exactly ONCE, here;
+- fixture objects flow through the REAL producer mappings
+  (:class:`PrawListingSource` / :class:`PrawHistorySource` over a
+  stubbed praw module, the pattern the purge tests established);
+- store rows are written by the REAL consumers (:func:`poll_once` /
+  :func:`track_once`), asserted loudly if anything is silently filtered.
+
+A consumer test built on these helpers physically cannot seed a shape
+the pipeline never emits.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import types
+from contextlib import contextmanager
+from unittest import mock
+
+from atlas_reddit.config import SubredditEntry, Topic, Watchlist
+from atlas_reddit.poller import poll_once
+from atlas_reddit.store import ListeningStore
+from atlas_reddit.tracker import track_once
+
+_SUBMISSION_KIND = "t3"
+_COMMENT_KIND = "t1"
+_PROBE_PHRASE = "producer fixture probe"
+_USERNAME = "juan_c"
+_SCOPES = ["read", "identity", "history"]
+_ENV = {
+    "ATLAS_REDDIT_CLIENT_ID": "cid",
+    "ATLAS_REDDIT_CLIENT_SECRET": "cs",
+    "ATLAS_REDDIT_REFRESH_TOKEN": "rt",
+    "ATLAS_REDDIT_USERNAME": _USERNAME,
+}
+_PREFIXED_RE = re.compile(r"^t\d_")
+# Reddit ids are lowercase base36; anything else could not have come off
+# the wire, so the factory refuses it at construction time.
+_BARE_ID_RE = re.compile(r"^[a-z0-9]+$")
+
+
+def _require_bare_id(value: str) -> str:
+    if _PREFIXED_RE.match(value):
+        raise ValueError(
+            f"pass a bare Reddit id, not a fullname: {value!r} -- the kind "
+            "prefix is added by the producer path, never by a test"
+        )
+    if not _BARE_ID_RE.match(value):
+        raise ValueError(
+            f"not a Reddit id shape: {value!r} (lowercase base36 only)"
+        )
+    return value
+
+
+def fake_submission(
+    bare_id: str,
+    *,
+    title: str | None = None,
+    selftext: str = "body text",
+    author: str | None = "someone",
+    created_utc: int = 1_751_596_400,
+    score: int = 5,
+    num_comments: int = 1,
+    is_self: bool = True,
+):
+    """A praw-shaped submission. The default title carries the probe
+    phrase the seeding watchlist matches on; override it and admission
+    fails loudly in :func:`seed_candidates` rather than silently."""
+    _require_bare_id(bare_id)
+    return types.SimpleNamespace(
+        id=bare_id,
+        fullname=f"{_SUBMISSION_KIND}_{bare_id}",
+        title=title if title is not None else f"{_PROBE_PHRASE} {bare_id}",
+        permalink=f"/r/x/comments/{bare_id}/probe/",
+        author=types.SimpleNamespace(name=author) if author else None,
+        created_utc=float(created_utc),
+        score=score,
+        num_comments=num_comments,
+        is_self=is_self,
+        selftext=selftext,
+    )
+
+
+def fake_own_comment(bare_id: str, *, thread_bare_id: str, created_utc: int):
+    """One of the operator's own comments, as praw's history listing
+    shapes it (fullname + t3_ link_id)."""
+    _require_bare_id(bare_id)
+    _require_bare_id(thread_bare_id)
+    return types.SimpleNamespace(
+        fullname=f"{_COMMENT_KIND}_{bare_id}",
+        link_id=f"{_SUBMISSION_KIND}_{thread_bare_id}",
+        created_utc=float(created_utc),
+    )
+
+
+def fake_reply(
+    bare_id: str,
+    *,
+    author: str | None = "other_user",
+    body: str = "hello there",
+    created_utc: int = 1_751_596_400,
+):
+    """A praw-shaped third-party reply comment."""
+    _require_bare_id(bare_id)
+    return types.SimpleNamespace(
+        fullname=f"{_COMMENT_KIND}_{bare_id}",
+        author=types.SimpleNamespace(name=author) if author else None,
+        body=body,
+        created_utc=float(created_utc),
+    )
+
+
+@contextmanager
+def _patched(reddit_cls):
+    stub = types.ModuleType("praw")
+    stub.Reddit = reddit_cls
+    with mock.patch.dict(sys.modules, {"praw": stub}), mock.patch.dict(
+        os.environ, _ENV
+    ):
+        from atlas_reddit.config import RedditListeningSettings
+
+        yield RedditListeningSettings(_env_file=None)
+
+
+@contextmanager
+def real_listing_source(submissions):
+    """Yield a REAL PrawListingSource whose transport returns the given
+    praw-shaped submissions -- the production fullname mapping runs."""
+    items = list(submissions)
+
+    class _Subreddit:
+        def new(self, *, limit):
+            return iter(items[:limit])
+
+    class _Reddit:
+        def __init__(self, **kwargs):
+            self.auth = types.SimpleNamespace(scopes=lambda: list(_SCOPES))
+
+        def subreddit(self, name):
+            return _Subreddit()
+
+    with _patched(_Reddit) as settings:
+        from atlas_reddit.reddit_client import PrawListingSource
+
+        yield PrawListingSource(settings)
+
+
+@contextmanager
+def real_history_source(*, own_comments=(), replies_by_parent=None):
+    """Yield a REAL PrawHistorySource: own-history listings and per-own-
+    comment reply children flow through the production admission code
+    (including the removeprefix('t1_') refresh lookup). Own submissions
+    are deferred to the tracker-test conversion slice."""
+    children = {k: list(v) for k, v in (replies_by_parent or {}).items()}
+    me = types.SimpleNamespace(
+        name=_USERNAME,
+        comments=types.SimpleNamespace(
+            new=lambda *, limit: iter(list(own_comments)[:limit])
+        ),
+        submissions=types.SimpleNamespace(new=lambda *, limit: iter(())),
+    )
+
+    class _Replies(list):
+        def replace_more(self, *, limit):
+            return []
+
+    class _OwnComment:
+        def __init__(self, kids):
+            self.replies = _Replies(kids)
+
+        def refresh(self):
+            return self
+
+    class _Reddit:
+        def __init__(self, **kwargs):
+            self.auth = types.SimpleNamespace(scopes=lambda: list(_SCOPES))
+            self.user = types.SimpleNamespace(me=lambda: me)
+
+        def comment(self, *, id):
+            return _OwnComment(children.get(id, []))
+
+    with _patched(_Reddit) as settings:
+        from atlas_reddit.reddit_client import PrawHistorySource
+
+        yield PrawHistorySource(settings)
+
+
+def seed_candidates(
+    store: ListeningStore,
+    submissions,
+    *,
+    now: int,
+    subreddit: str = "CustomerSuccess",
+) -> list[str]:
+    """Store candidate rows through the REAL pipeline (producer mapping +
+    poll_once). Returns the producer-emitted post ids, in input order.
+    Asserts every fixture was admitted -- a silently filtered fixture is
+    a factory misuse, not a soft no-op."""
+    items = list(submissions)
+    watchlist = Watchlist(
+        version=1,
+        subreddits=(SubredditEntry(name=subreddit),),
+        topics=(Topic(name="probe", phrases=(_PROBE_PHRASE,)),),
+    )
+    with real_listing_source(items) as source:
+        produced = [
+            post.post_id
+            for post in source.fetch_new(subreddit, limit=max(len(items), 1))
+        ]
+        stats = poll_once(
+            store,
+            watchlist,
+            source,
+            now=now,
+            freshness_hours=24 * 365 * 20,
+            per_subreddit_limit=max(len(items), 1),
+            min_final_score=0.0,
+            pace_seconds=0.0,
+        )
+    assert stats.admitted == len(items), (
+        f"factory fixtures must never be silently filtered: admitted "
+        f"{stats.admitted} of {len(items)} ({stats})"
+    )
+    return produced
+
+
+def seed_replies(
+    store: ListeningStore,
+    replies,
+    *,
+    now: int,
+    thread_bare_id: str = "thread",
+    my_comment_bare_id: str = "mine",
+) -> list[str]:
+    """Store reply rows through the REAL pipeline (own-history discovery +
+    track_once reply admission). Returns the producer-emitted reply ids,
+    in input order. Repeat calls against the SAME thread are replay-safe;
+    seeding several DISTINCT threads needs a distinct my_comment_bare_id
+    per thread (track_once polls every active thread each pass)."""
+    items = list(replies)
+    own = fake_own_comment(
+        my_comment_bare_id, thread_bare_id=thread_bare_id, created_utc=now - 60
+    )
+    with real_history_source(
+        own_comments=[own], replies_by_parent={my_comment_bare_id: items}
+    ) as source:
+        produced = [
+            reply.reply_id
+            for reply in source.fetch_thread_replies(
+                own.link_id,
+                my_comment_ids=frozenset({own.fullname}),
+                include_top_level=False,
+            )
+        ]
+        stats = track_once(
+            store,
+            source,
+            now=now,
+            history_limit=10,
+            dormant_after_hours=24 * 365 * 20,
+            pace_seconds=0.0,
+        )
+    assert stats.replies_new == len(items), (
+        f"factory fixtures must never be silently filtered: inserted "
+        f"{stats.replies_new} of {len(items)} ({stats})"
+    )
+    return produced

--- a/tests/test_atlas_reddit_fixture_fidelity.py
+++ b/tests/test_atlas_reddit_fixture_fidelity.py
@@ -1,0 +1,110 @@
+"""Enforcing tests for the producer-fidelity fixture factory (slice 2,
+plan: plans/PR-Producer-Fidelity-Fixture-Factory.md).
+
+The lockstep tests import BOTH real sides -- the producer path (via the
+factory) and the purge kind contract (``_KIND_RE``) -- so the S6 class
+(consumer fixtures drifting from producer output) fails HERE, at
+test-authoring time, instead of in production.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlas_reddit.purge import _KIND_RE, purge_once
+from atlas_reddit.store import ListeningStore
+from tests.atlas_reddit_fixtures import (
+    fake_own_comment,
+    fake_reply,
+    fake_submission,
+    seed_candidates,
+    seed_replies,
+)
+
+NOW = 1_751_600_000
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    with ListeningStore(tmp_path / "listening.db") as s:
+        yield s
+
+
+class _GoneSource:
+    def __init__(self, gone: set[str]) -> None:
+        self._gone = gone
+
+    def fetch_gone_items(self, fullnames: list[str]) -> dict[str, str]:
+        return {
+            item: "missing (not returned by the API)"
+            for item in fullnames
+            if item in self._gone
+        }
+
+
+def test_candidate_ids_lockstep_with_purge_kind_contract(store) -> None:
+    ids = seed_candidates(
+        store, [fake_submission("livex"), fake_submission("gonex")], now=NOW
+    )
+    assert ids == ["t3_livex", "t3_gonex"]
+    for item in ids:
+        assert _KIND_RE["candidate"].match(item)
+    assert {c.post_id for c in store.list_candidates()} == set(ids)
+
+
+def test_reply_ids_lockstep_with_purge_kind_contract(store) -> None:
+    ids = seed_replies(store, [fake_reply("livey"), fake_reply("goney")], now=NOW)
+    assert ids == ["t1_livey", "t1_goney"]
+    for item in ids:
+        assert _KIND_RE["reply"].match(item)
+    assert {r.reply_id for r in store.list_replies()} == set(ids)
+
+
+def test_pipeline_seeded_rows_purge_cleanly_end_to_end(store) -> None:
+    """Producer mapping -> poller/tracker -> store -> purge, all real
+    components, fakes only at the praw/deletion transports: nothing the
+    factory seeds is ever flagged as malformed."""
+    live_c, gone_c = seed_candidates(
+        store, [fake_submission("livex"), fake_submission("gonex")], now=NOW
+    )
+    live_r, gone_r = seed_replies(
+        store, [fake_reply("livey"), fake_reply("goney")], now=NOW
+    )
+    stats = purge_once(
+        store, _GoneSource({gone_c, gone_r}), now=NOW, pace_seconds=0.0
+    )
+    assert stats.errors == []  # zero data-shape mismatches
+    assert stats.purged_candidates == 1 and stats.purged_replies == 1
+    assert store.get_candidate(live_c) is not None
+    assert store.get_candidate(gone_c) is None
+    assert {r.reply_id for r in store.list_replies()} == {live_r}
+
+
+def test_factory_rejects_prefixed_and_non_reddit_ids() -> None:
+    for bad in ("t3_abc", "t1_abc", "t2_abc"):
+        with pytest.raises(ValueError, match="bare Reddit id"):
+            fake_submission(bad)
+        with pytest.raises(ValueError, match="bare Reddit id"):
+            fake_reply(bad)
+    with pytest.raises(ValueError, match="not a Reddit id shape"):
+        fake_submission("ABC!")
+    with pytest.raises(ValueError, match="bare Reddit id"):
+        fake_own_comment("t1_x", thread_bare_id="y", created_utc=NOW)
+
+
+def test_fake_praw_fullname_contract() -> None:
+    """The praw fullname contract (fullname == f"{kind}_{id}") is encoded
+    exactly once, in the factory doubles; this pins it."""
+    assert fake_submission("abc").fullname == "t3_abc"
+    assert fake_reply("def2").fullname == "t1_def2"
+    own = fake_own_comment("ghi", thread_bare_id="jkl", created_utc=NOW)
+    assert own.fullname == "t1_ghi" and own.link_id == "t3_jkl"
+
+
+def test_silently_filtered_fixture_fails_loudly(store) -> None:
+    """A fixture the pipeline would drop (link post) is a factory-misuse
+    error, not a silent no-op."""
+    with pytest.raises(AssertionError, match="silently filtered"):
+        seed_candidates(store, [fake_submission("linkpost", is_self=False)], now=NOW)

--- a/tests/test_atlas_reddit_purge.py
+++ b/tests/test_atlas_reddit_purge.py
@@ -15,6 +15,7 @@ import pytest
 from atlas_reddit.purge import BATCH_SIZE, purge_once
 from atlas_reddit.reddit_client import PrawDeletionSource, RedditAuthError, validate_scopes
 from atlas_reddit.store import ListeningStore
+from tests.atlas_reddit_fixtures import fake_reply, fake_submission, seed_candidates, seed_replies
 
 NOW = 1_751_600_000
 
@@ -48,6 +49,22 @@ def store(tmp_path: Path):
 
 
 def _seed_candidate(store: ListeningStore, post_id: str) -> None:
+    """Producer-fidelity seeding: the row is written by the REAL pipeline
+    (fixture factory), so a test cannot seed a shape the producer never
+    emits -- the given id must be exactly what the producer makes of it."""
+    bare = post_id.removeprefix("t3_")
+    [produced] = seed_candidates(
+        store, [fake_submission(bare)], now=NOW - 3600
+    )
+    assert produced == post_id, (
+        f"{post_id!r} is not a producer-emitted id (producer made {produced!r})"
+    )
+
+
+def _seed_raw_candidate(store: ListeningStore, post_id: str) -> None:
+    """Direct store write, bypassing the producer. ONLY for simulating
+    corrupt rows the pipeline could never create (the never-delete-on-
+    data-shape-mismatch branch needs real bad rows)."""
     store.upsert_candidate(
         post_id=post_id,
         subreddit="CustomerSuccess",
@@ -65,6 +82,22 @@ def _seed_candidate(store: ListeningStore, post_id: str) -> None:
 
 
 def _seed_reply(store: ListeningStore, reply_id: str, thread_id: str = "t3_thread") -> None:
+    """Producer-fidelity seeding via the REAL tracker; same contract as
+    :func:`_seed_candidate`."""
+    [produced] = seed_replies(
+        store,
+        [fake_reply(reply_id.removeprefix("t1_"))],
+        now=NOW - 3600,
+        thread_bare_id=thread_id.removeprefix("t3_"),
+    )
+    assert produced == reply_id, (
+        f"{reply_id!r} is not a producer-emitted id (producer made {produced!r})"
+    )
+
+
+def _seed_raw_reply(store: ListeningStore, reply_id: str, thread_id: str = "t3_thread") -> None:
+    """Direct store write, bypassing the producer. ONLY for corrupt-row
+    simulation (see :func:`_seed_raw_candidate`)."""
     store.upsert_tracked_thread(thread_id=thread_id, my_comment_ids=("t1_mine",), checked_at=0)
     store.insert_reply(
         reply_id=reply_id,
@@ -193,7 +226,7 @@ def test_malformed_stored_id_is_error_never_missing(store: ListeningStore) -> No
     """P1 class, defensive layer: an id that is not a Reddit fullname
     cannot be liveness-checked -- it must be surfaced as an error and the
     row RETAINED, never classified as missing and deleted."""
-    _seed_candidate(store, "abc123")  # bare id, not a fullname
+    _seed_raw_candidate(store, "abc123")  # bare id, not a fullname
     _seed_candidate(store, "t3_good")
     source = FakeDeletionSource()
     stats = _purge(store, source)
@@ -336,8 +369,8 @@ def test_wrong_kind_fullname_per_table_retained(store: ListeningStore) -> None:
     """Wave-2 class: the shape guard must validate the KIND per table --
     a t2_ user id in candidates or a t3_ post id in replies cannot be
     liveness-checked for that table and must be retained + surfaced."""
-    _seed_candidate(store, "t2_useridx")  # wrong kind for candidates
-    _seed_reply(store, "t3_postidx")      # wrong kind for replies
+    _seed_raw_candidate(store, "t2_useridx")  # wrong kind for candidates
+    _seed_raw_reply(store, "t3_postidx")      # wrong kind for replies
     source = FakeDeletionSource()
     stats = _purge(store, source)
     assert len(stats.errors) == 2
@@ -557,7 +590,7 @@ def test_cross_table_id_twin_is_not_shielded(store: ListeningStore) -> None:
     """Wave-3 class: a corrupt reply holding a t3_ id must not shield the
     legitimate candidate with the same id from purging."""
     _seed_candidate(store, "t3_x")
-    _seed_reply(store, "t3_x")  # wrong kind for replies (corrupt row)
+    _seed_raw_reply(store, "t3_x")  # wrong kind for replies (corrupt row)
     source = FakeDeletionSource(gone={"t3_x": "content shows [deleted]"})
     stats = _purge(store, source)
     assert len(stats.errors) == 1  # the corrupt reply is surfaced


### PR DESCRIPTION
Plan: plans/PR-Producer-Fidelity-Fixture-Factory.md
Slice phase: Robust testing
Ownership lane: Workflow/process

Fable-arc codification slice 2 (slice 1 was the #1944 diff-budget gate). The
S6 mass-deletion root cause: consumer tests hand-seeded id shapes (bare ids)
the real producer never emits (t3_/t1_ fullnames) and stayed green. This
slice lands a producer-fidelity fixture factory: fixtures flow through the
REAL producer mappings (PrawListingSource / PrawHistorySource over a stubbed
praw module) and stores are seeded by the REAL consumers (poll_once /
track_once), so a consumer test physically cannot seed a shape the pipeline
never emits. Enforcing fidelity tests lockstep producer output with the
purge kind regexes, and the purge tests (the S6 site) adopt the factory.

Diff-budget override: the factory, its enforcing fidelity tests, and the S6-site purge-test adoption are one indivisible slice -- the factory without adoption reproduces the S6 failure mode (fixtures exist, nothing uses them), and the fidelity tests are the slice's acceptance evidence; splitting would ship an unused fixture library and defer the enforcement that is the point.

## Scope

- `tests/atlas_reddit_fixtures.py` -- the factory: praw-shaped doubles
  (fullname contract encoded exactly once), real Praw* sources over a praw
  module stub, seeding via the real poll_once / track_once.
- `tests/test_atlas_reddit_fixture_fidelity.py` -- lockstep + end-to-end +
  rejection tests.
- `tests/test_atlas_reddit_purge.py` -- seed helpers adopt the factory;
  corrupt-row simulation moves to explicit `_seed_raw_*` helpers.
- `.github/workflows/atlas_reddit_checks.yml` -- one paths line so factory
  edits re-trigger the reddit checks.

## Intentional

- The four corrupt-row purge tests keep seeding malformed ids via
  `_seed_raw_*` helpers named for it: the never-delete-on-shape-mismatch
  branch needs real bad rows.
- The praw doubles mimic only the attributes the real sources read; their
  one load-bearing contract (fullname == kind_id) is pinned by a test.
- Store/tracker/poller/digest tests are not converted here; the purge tests
  are the S6 site and the template.

## Deferred

- Factory adoption in the store/tracker/poller/digest test files, including
  own-submission history support in `real_history_source`.
- Repo-wide trusted-base-ref execution for gate scripts (#1944 waiver 18).

## Parked hardening

None.

## Verification

- `python -m pytest tests/test_atlas_reddit_*.py -q` -- 322 passed (full
  reddit suite: new fidelity tests, factory-backed purge tests, all
  pre-existing files).
- `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>` --
  all checks PASS, 0 failed.
- `python scripts/check_diff_budget.py --additions 562 --body-file
  <pr-body.md>` -- PASS via the override above.

## Diff size

5 files, +562 / -4 (factory 279, fidelity tests 110, purge adoption 37,
workflow 1, plan 135). Over the 400 cap; carried by the override above.

Refs #1943, #1944, #1934.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBjR7LHvYC9JP9GTe58tRE)_