### PR TITLE
Run PR meta-gates from the trusted base ref (closes #1944 waiver 18)

### DIFF
--- a/.github/workflows/ai_reconciliation_live.yml
+++ b/.github/workflows/ai_reconciliation_live.yml
@@ -11,11 +11,13 @@ name: AI Reconciliation (live)
 # check"), and re-runs when a bot comment lands after the PR opens.
 #
 # Trusted-base execution (#1944 waiver 18): `pull_request_target` resolves
-# this workflow from the BASE branch and the checkout pins the base SHA, so
-# a PR editing this gate is still judged by main's version. The review-event
-# triggers still resolve the workflow file PR-side, but every push/edit also
-# produces a trusted run. The job runs base-ref code only; never add a step
-# that executes PR-ref content.
+# this workflow from the BASE branch and both jobs pin their checkout to the
+# base SHA, so a PR editing this gate is still judged by main's version. The
+# required `live-reconciliation` context comes from the target-only job
+# (audited guard shape in scripts/audit_workflow_security_posture.py); the
+# review-events job re-runs the same base-ref script when bot comments land
+# and reports under its own advisory context. Neither job may ever gain a
+# step that executes PR-ref content.
 
 on:
   # `edited` is included so that when a reviewer fixes a failed check by editing
@@ -32,6 +34,29 @@ permissions:
 
 jobs:
   live-reconciliation:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+
+      - name: Live AI-reconciliation check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_ai_reconciliation_live.py \
+            --pr "${{ github.event.pull_request.number }}"
+
+  live-reconciliation-review-events:
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ai_reconciliation_live.yml
+++ b/.github/workflows/ai_reconciliation_live.yml
@@ -5,16 +5,23 @@ name: AI Reconciliation (live)
 # as all fixed/waived (or carries no record) while unresolved Codex/Copilot
 # review threads still exist.
 #
-# Runs on `pull_request` as well as the review events so that, as a *required*
-# status check, it always runs and reports (a quiet PR with no bot threads
-# reports green instead of wedging the merge as "missing required check"), and
-# re-runs when a bot comment lands after the PR opens.
+# Runs on `pull_request_target` as well as the review events so that, as a
+# *required* status check, it always runs and reports (a quiet PR with no bot
+# threads reports green instead of wedging the merge as "missing required
+# check"), and re-runs when a bot comment lands after the PR opens.
+#
+# Trusted-base execution (#1944 waiver 18): `pull_request_target` resolves
+# this workflow from the BASE branch and the checkout pins the base SHA, so
+# a PR editing this gate is still judged by main's version. The review-event
+# triggers still resolve the workflow file PR-side, but every push/edit also
+# produces a trusted run. The job runs base-ref code only; never add a step
+# that executes PR-ref content.
 
 on:
   # `edited` is included so that when a reviewer fixes a failed check by editing
   # only the PR body (adding the fixed/waived record), the required check re-runs
   # instead of staying stale until the next push.
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, edited]
   pull_request_review:
   pull_request_review_comment:
@@ -26,9 +33,12 @@ permissions:
 jobs:
   live-reconciliation:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - name: Checkout trusted base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/ai_reconciliation_review_retrigger.yml
+++ b/.github/workflows/ai_reconciliation_review_retrigger.yml
@@ -1,0 +1,46 @@
+name: AI Reconciliation (review retrigger)
+
+# Trusted follow-up for review events (#1949 review round 2). Review-event
+# workflow runs resolve their workflow file PR-side, so they cannot be
+# trusted to refresh the required `live-reconciliation` context -- but a
+# `workflow_run` workflow always executes from the DEFAULT branch. When the
+# AI Reconciliation workflow completes for a review event (the advisory
+# job), this follow-up re-runs the latest `pull_request_target` run for the
+# same head SHA, so the required context is re-evaluated by trusted base
+# code whenever a bot comment lands after the last push/body edit.
+#
+# Loop-safe: the rerun completes with event == pull_request_target, which
+# this job's `if` ignores. No checkout and no repo scripts: the inline
+# steps below are the default-branch version by construction.
+
+on:
+  workflow_run:
+    workflows: ["AI Reconciliation (live)"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retrigger-required-context:
+    if: >-
+      github.event.workflow_run.event == 'pull_request_review' ||
+      github.event.workflow_run.event == 'pull_request_review_comment'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Rerun latest trusted target run for this head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          run_id=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ai_reconciliation_live.yml/runs?event=pull_request_target&head_sha=${HEAD_SHA}&per_page=1" \
+            --jq '.workflow_runs[0].id // empty')
+          if [ -z "${run_id}" ]; then
+            echo "no pull_request_target run for ${HEAD_SHA}; nothing to refresh"
+            exit 0
+          fi
+          echo "re-running trusted run ${run_id} for ${HEAD_SHA}"
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/rerun"

--- a/.github/workflows/diff_budget.yml
+++ b/.github/workflows/diff_budget.yml
@@ -4,9 +4,15 @@ name: Diff Budget
 # added lines over budget fail unless the body carries an explicit
 # "Diff-budget override: <reason>" line. `edited` is included because the
 # fix path IS a body edit; see plans/PR-Diff-Budget-Gate.md.
+#
+# Trusted-base execution (#1944 waiver 18): `pull_request_target` resolves
+# this workflow file from the BASE branch and the checkout below pins the
+# base SHA, so a PR editing this gate (script or workflow) is still judged
+# by main's version. The job runs base-ref code only; never add a step
+# here that executes PR-ref content.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions:
@@ -15,10 +21,14 @@ permissions:
 
 jobs:
   diff-budget:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - name: Checkout trusted base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/pr_body_contract.yml
+++ b/.github/workflows/pr_body_contract.yml
@@ -1,7 +1,13 @@
 name: PR Body Contract
 
+# Trusted-base execution (#1944 waiver 18): `pull_request_target` resolves
+# this workflow from the BASE branch and the checkout pins the base SHA, so
+# a PR editing this gate is still judged by main's version. The plan doc a
+# body names arrives WITH the PR, so its existence is asked of the fetched
+# PR head ref by inspection (git cat-file) -- PR content is never executed.
+
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
@@ -9,10 +15,23 @@ permissions:
 
 jobs:
   pr-body-contract:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - name: Checkout trusted base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Fetch PR head for plan-doc inspection
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-${PR_NUMBER}"
 
       - name: Write PR body to file
         env:
@@ -22,4 +41,9 @@ jobs:
       - name: Audit PR body against AGENTS.md section 1b
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: python3 scripts/audit_pr_body.py --pr-author "$PR_AUTHOR" /tmp/pr_body.md
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 scripts/audit_pr_body.py \
+            --pr-author "$PR_AUTHOR" \
+            --plan-git-ref "refs/remotes/origin/pr-${PR_NUMBER}" \
+            /tmp/pr_body.md

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -55,9 +55,12 @@ never gain a step that executes PR-ref content -- `pr-body-contract`
 inspects the fetched PR head purely as git data (`git cat-file`) to see
 the plan doc the PR brings with it. Residual PR-ref surface, by design:
 `pre-push-audit` and the maturity sweeps operate on the PR tree and need a
-scripts-from-base split in a follow-up slice, and `live-reconciliation`'s
-review-event triggers resolve the workflow file PR-side (every push/edit
-still produces a trusted run).
+scripts-from-base split in a follow-up slice. Review-event runs resolve the
+workflow file PR-side, so the required `live-reconciliation` context is fed
+only by `pull_request_target` runs; the default-branch
+`ai_reconciliation_review_retrigger.yml` follow-up re-runs the latest
+trusted target run whenever a review event lands, keeping the required
+context fresh through trusted code.
 
 Branch protection for `main` requires `live-reconciliation`, `diff-budget`
 (the AGENTS.md diff-budget gate), `Gitleaks PR secret scan`, and

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -60,7 +60,11 @@ workflow file PR-side, so the required `live-reconciliation` context is fed
 only by `pull_request_target` runs; the default-branch
 `ai_reconciliation_review_retrigger.yml` follow-up re-runs the latest
 trusted target run whenever a review event lands, keeping the required
-context fresh through trusted code.
+context fresh through trusted code. One adversarial residual is accepted
+and tracked: a PR that deletes the review-event triggers from the live
+workflow suppresses the follow-up chain entirely (no event model exists
+that delivers trusted code on review events); the fallback is a scheduled
+trusted sweep, parked in plans/PR-Trusted-Base-Gate-Execution.md.
 
 Branch protection for `main` requires `live-reconciliation`, `diff-budget`
 (the AGENTS.md diff-budget gate), `Gitleaks PR secret scan`, and

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -46,6 +46,19 @@ Current blocking posture: new unbaselined secrets block PRs; Semgrep, Trivy,
 Checkov, pip-audit, and OSV are advisory/report-only until their adoption
 backlogs are triaged and ratcheted.
 
+The same trusted-base execution pattern covers the PR meta-gates
+(#1944 waiver 18): `diff-budget`, `live-reconciliation`, and
+`pr-body-contract` run on `pull_request_target` with a checkout pinned to
+the base SHA, so a PR that edits a gate script or gate workflow is still
+judged by `main`'s version. These jobs run base-ref code only and must
+never gain a step that executes PR-ref content -- `pr-body-contract`
+inspects the fetched PR head purely as git data (`git cat-file`) to see
+the plan doc the PR brings with it. Residual PR-ref surface, by design:
+`pre-push-audit` and the maturity sweeps operate on the PR tree and need a
+scripts-from-base split in a follow-up slice, and `live-reconciliation`'s
+review-event triggers resolve the workflow file PR-side (every push/edit
+still produces a trusted run).
+
 Branch protection for `main` requires `live-reconciliation`, `diff-budget`
 (the AGENTS.md diff-budget gate), `Gitleaks PR secret scan`, and
 `Gitleaks baseline growth guard`. The

--- a/plans/PR-Trusted-Base-Gate-Execution.md
+++ b/plans/PR-Trusted-Base-Gate-Execution.md
@@ -1,0 +1,142 @@
+# PR-Trusted-Base-Gate-Execution
+
+## Why this slice exists
+
+Closes #1944 waiver 18, named there as the priority follow-up: every PR gate
+executes its own scripts from the PR merge ref, so a PR that edits a gate
+script (or the gate's workflow file) is judged by its own edited gate and can
+self-pass. Root cause: the gates were built on `pull_request` checkouts,
+which materialize the untrusted merge ref; nothing in the repo ran gate code
+from the base. The repo already carries the reviewed fix pattern -- the
+Gitleaks baseline growth guard runs on `pull_request_target` with a
+trusted-base checkout -- but it was never applied to the other gates. This
+slice applies that existing pattern to the three API-driven gates
+(diff-budget, live-reconciliation, pr-body-contract); patching just one gate
+or re-describing the risk in docs would treat the symptom.
+
+## Scope (this PR)
+
+Ownership lane: Workflow/process
+Slice phase: Vertical slice
+
+1. `.github/workflows/diff_budget.yml`,
+   `.github/workflows/ai_reconciliation_live.yml`, and
+   `.github/workflows/pr_body_contract.yml`: convert to `pull_request_target` with a checkout of
+   `github.event.pull_request.base.sha` (the Gitleaks-guard shape, checkout
+   action SHA-pinned the same way). Scripts and workflow logic now come
+   from the trusted base on every run.
+2. `scripts/audit_pr_body.py`: the plan-doc-exists check gains a
+   `--plan-git-ref` mode (git cat-file against the fetched PR head ref),
+   because new plan docs arrive WITH the PR and a base checkout cannot see
+   them. Pure core takes an injectable `plan_exists` callable; the git
+   boundary fails closed (unresolvable ref -> exit 2, never a silent pass).
+3. `tests/test_audit_pr_body.py`: failure-branch fixtures for the new mode
+   (plan present at ref, missing at ref, unresolvable ref, callable
+   injection).
+4. `docs/SECURITY_GUARDRAILS.md`: document which gates run trusted-base and
+   the residual PR-ref surface (named below).
+
+### Files touched
+
+- `.github/workflows/diff_budget.yml`
+- `.github/workflows/ai_reconciliation_live.yml`
+- `.github/workflows/pr_body_contract.yml`
+- `scripts/audit_pr_body.py`
+- `tests/test_audit_pr_body.py`
+- `docs/SECURITY_GUARDRAILS.md`
+- `plans/PR-Trusted-Base-Gate-Execution.md`
+
+### Review Contract
+
+Acceptance criteria (reviewer checks one-by-one):
+
+1. All three converted workflows trigger on `pull_request_target` (plus the
+   existing review events for live-reconciliation), check out
+   `github.event.pull_request.base.sha`, and never execute PR-ref code.
+2. Check-run names (`diff-budget`, `live-reconciliation`,
+   `pr-body-contract`) are unchanged, so #1945's required-check audit
+   expectations still match.
+3. `audit_pr_body.py --plan-git-ref` fails closed: a plan doc missing at
+   the head ref is a contract failure naming the ref; an unresolvable ref
+   exits 2 (infra), never 0.
+4. The default (no flag) filesystem behavior is byte-for-byte unchanged --
+   local usage and the pre-push bundle are unaffected.
+5. `python -m pytest tests/test_audit_pr_body.py -q` passes, including the
+   new failure branches.
+
+Affected surfaces: three gate workflows, one gate script + its tests, one
+security doc. No product code.
+
+Risk areas: `pull_request_target` grants base-context tokens -- safe here
+because the jobs run only base-ref code and keep read-only permissions, but
+any FUTURE edit that executes PR-ref content in these jobs is a privilege
+escalation; the guardrails doc says so explicitly. Migration window: see
+Intentional.
+
+Reviewer rules triggered: R2, R10 (gate predicate change in
+`scripts/audit_pr_body.py` -> failure-branch fixtures per AGENTS.md 3h/3i,
+plus the audit-script row), R14 (checked-out PR-head verification).
+
+## Mechanism
+
+`pull_request_target` events resolve the workflow file from the BASE branch,
+and the explicit `base.sha` checkout materializes base-ref scripts, so after
+this merges, neither a gate script edit nor a gate workflow edit in a PR
+changes what judges that PR. diff-budget and live-reconciliation read
+everything they need from the GitHub API (additions, body, review threads)
+and need no PR tree at all. pr-body-contract additionally fetches
+`pull/<n>/head` as a named ref and asks git (`cat-file -e <ref>:<plan>`)
+whether the plan doc exists there -- inspection of untrusted content, never
+execution.
+
+## Intentional
+
+- **Migration window:** on THIS PR the three gates do not run at all --
+  `pull_request` events consult the merge-ref workflows (now
+  target-only) and `pull_request_target` consults main's pre-conversion
+  files. First effective runs happen on the next PR after merge. The other
+  gates (pre-push-audit and reddit/tooling suites) still cover this PR.
+- **Residual PR-ref surface, named not hidden:** pre-push-audit and the
+  maturity sweeps still run PR-ref scripts -- they operate on the PR tree
+  by design (diff audits, tooling pytest) and need a different treatment;
+  live-reconciliation's `pull_request_review*` triggers still resolve the
+  workflow file PR-side, but every push/edit also produces a trusted
+  `pull_request_target` run from main. Consistent with the #1944 threat
+  model: friction and a logged decision for honest-but-hasty authors, not
+  adversary-proofing.
+- Check names, triggers' type lists, and script invocations are otherwise
+  unchanged -- this slice moves WHERE gate code comes from, not what it does.
+
+## Deferred
+
+- Trusted-base treatment for the tree-dependent gates (pre-push-audit,
+  maturity sweeps): needs a scripts-from-base / tree-from-PR split and is
+  its own slice.
+- Factory adoption in the remaining reddit test files (#1947 Deferred).
+
+Parked hardening: none.
+
+## Verification
+
+Commands run from the repo root:
+
+- `python -m pytest tests/test_audit_pr_body.py -q` -- pass count recorded
+  in the PR body, including the new `--plan-git-ref` failure branches.
+- `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>` --
+  all checks PASS.
+- `python scripts/check_diff_budget.py --additions 353 --body-file
+  <pr-body.md>` -- within the 400 budget.
+- Post-merge, first PR: confirm the three checks report from
+  `pull_request_target` runs (workflow run event visible in the check-run
+  URL), then flip/keep branch-protection required contexts.
+
+## Estimated diff size
+
+| File | LOC (added) |
+|---|---:|
+| workflows (3) | 58 |
+| `scripts/audit_pr_body.py` | 62 |
+| `tests/test_audit_pr_body.py` | 78 |
+| `docs/SECURITY_GUARDRAILS.md` | 13 |
+| `plans/PR-Trusted-Base-Gate-Execution.md` | 142 |
+| **Total** | **353** |

--- a/plans/PR-Trusted-Base-Gate-Execution.md
+++ b/plans/PR-Trusted-Base-Gate-Execution.md
@@ -14,7 +14,7 @@ slice applies that existing pattern to the three API-driven gates
 (diff-budget, live-reconciliation, pr-body-contract); patching just one gate
 or re-describing the risk in docs would treat the symptom.
 
-Diff-budget overage (593 added lines vs the 400 cap): the workflow posture
+Diff-budget overage (607 added lines vs the 400 cap): the workflow posture
 audit ITSELF gates pull_request_target adoption behind its allowlist plus
 guard-shape check, so the three workflow conversions, the allowlist
 expansion, its failure-branch tests, and the review-events job split are one
@@ -146,7 +146,17 @@ execution.
   its own slice.
 - Factory adoption in the remaining reddit test files (#1947 Deferred).
 
-Parked hardening: none.
+Parked hardening:
+
+- Scheduled trusted sweep for review-event suppression (review round 3
+  waiver): a PR that removes the review-event triggers from
+  ai_reconciliation_live.yml silences the retrigger chain, because every
+  review-event workflow resolves PR-side -- no event-model fix exists. A
+  default-branch cron that re-runs the latest target run for open PRs with
+  review activity newer than their last target run would bound the
+  staleness window. Adversarial-only (requires deliberately editing the
+  gate to dodge it); accepted under the #1944 threat model and tracked
+  here.
 
 ## Verification
 
@@ -159,7 +169,7 @@ Commands run from the repo root:
   passed; the three converted gates report as allowed guard-shaped jobs.
 - `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>` --
   all checks PASS.
-- `python scripts/check_diff_budget.py --additions 593 --body-file
+- `python scripts/check_diff_budget.py --additions 607 --body-file
   <pr-body.md>` -- within the 400 budget.
 - Post-merge, first PR: confirm the three checks report from
   `pull_request_target` runs (workflow run event visible in the check-run
@@ -174,6 +184,6 @@ Commands run from the repo root:
 | `scripts/audit_workflow_security_posture.py` | 13 |
 | `tests/test_audit_pr_body.py` | 110 |
 | `tests/test_audit_workflow_security_posture.py` | 68 |
-| `docs/SECURITY_GUARDRAILS.md` | 16 |
-| `plans/PR-Trusted-Base-Gate-Execution.md` | 179 |
-| **Total** | **593** |
+| `docs/SECURITY_GUARDRAILS.md` | 23 |
+| `plans/PR-Trusted-Base-Gate-Execution.md` | 190 |
+| **Total** | **607** |

--- a/plans/PR-Trusted-Base-Gate-Execution.md
+++ b/plans/PR-Trusted-Base-Gate-Execution.md
@@ -14,7 +14,7 @@ slice applies that existing pattern to the three API-driven gates
 (diff-budget, live-reconciliation, pr-body-contract); patching just one gate
 or re-describing the risk in docs would treat the symptom.
 
-Diff-budget overage (589 added lines vs the 400 cap): the workflow posture
+Diff-budget overage (593 added lines vs the 400 cap): the workflow posture
 audit ITSELF gates pull_request_target adoption behind its allowlist plus
 guard-shape check, so the three workflow conversions, the allowlist
 expansion, its failure-branch tests, and the review-events job split are one
@@ -159,7 +159,7 @@ Commands run from the repo root:
   passed; the three converted gates report as allowed guard-shaped jobs.
 - `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>` --
   all checks PASS.
-- `python scripts/check_diff_budget.py --additions 589 --body-file
+- `python scripts/check_diff_budget.py --additions 593 --body-file
   <pr-body.md>` -- within the 400 budget.
 - Post-merge, first PR: confirm the three checks report from
   `pull_request_target` runs (workflow run event visible in the check-run
@@ -170,10 +170,10 @@ Commands run from the repo root:
 | File | LOC (added) |
 |---|---:|
 | workflows (4) | 129 |
-| `scripts/audit_pr_body.py` | 74 |
+| `scripts/audit_pr_body.py` | 78 |
 | `scripts/audit_workflow_security_posture.py` | 13 |
 | `tests/test_audit_pr_body.py` | 110 |
 | `tests/test_audit_workflow_security_posture.py` | 68 |
 | `docs/SECURITY_GUARDRAILS.md` | 16 |
 | `plans/PR-Trusted-Base-Gate-Execution.md` | 179 |
-| **Total** | **589** |
+| **Total** | **593** |

--- a/plans/PR-Trusted-Base-Gate-Execution.md
+++ b/plans/PR-Trusted-Base-Gate-Execution.md
@@ -14,7 +14,7 @@ slice applies that existing pattern to the three API-driven gates
 (diff-budget, live-reconciliation, pr-body-contract); patching just one gate
 or re-describing the risk in docs would treat the symptom.
 
-Diff-budget overage (504 added lines vs the 400 cap): the workflow posture
+Diff-budget overage (589 added lines vs the 400 cap): the workflow posture
 audit ITSELF gates pull_request_target adoption behind its allowlist plus
 guard-shape check, so the three workflow conversions, the allowlist
 expansion, its failure-branch tests, and the review-events job split are one
@@ -47,7 +47,15 @@ Slice phase: Vertical slice
    checkout). live-reconciliation splits into the required target-only job
    plus an advisory review-events job (same base-ref script) so bot-comment
    re-runs survive the guard shape.
-5. `docs/SECURITY_GUARDRAILS.md`: document which gates run trusted-base and
+5. `.github/workflows/ai_reconciliation_review_retrigger.yml` (review round
+   2): review-event runs resolve the workflow file PR-side and cannot be
+   trusted to refresh the required context, so this default-branch
+   `workflow_run` follow-up re-runs the latest `pull_request_target` run
+   for the same head SHA whenever a review event lands -- the required
+   `live-reconciliation` context stays fresh through trusted code.
+   Loop-safe: reruns arrive back with event == pull_request_target and are
+   ignored.
+6. `docs/SECURITY_GUARDRAILS.md`: document which gates run trusted-base and
    the residual PR-ref surface (named below).
 
 ### Files touched
@@ -55,6 +63,7 @@ Slice phase: Vertical slice
 - `.github/workflows/diff_budget.yml`
 - `.github/workflows/ai_reconciliation_live.yml`
 - `.github/workflows/pr_body_contract.yml`
+- `.github/workflows/ai_reconciliation_review_retrigger.yml`
 - `scripts/audit_pr_body.py`
 - `scripts/audit_workflow_security_posture.py`
 - `tests/test_audit_pr_body.py`
@@ -105,7 +114,8 @@ this merges, neither a gate script edit nor a gate workflow edit in a PR
 changes what judges that PR. diff-budget and live-reconciliation read
 everything they need from the GitHub API (additions, body, review threads)
 and need no PR tree at all. pr-body-contract additionally fetches
-`pull/<n>/head` as a named ref and asks git (`cat-file -e <ref>:<plan>`)
+`pull/<n>/head` as a named ref and asks git (`ls-tree`, requiring a
+regular-file blob -- a tree or symlink at the plan path is not a plan doc)
 whether the plan doc exists there -- inspection of untrusted content, never
 execution.
 
@@ -119,10 +129,12 @@ execution.
 - **Residual PR-ref surface, named not hidden:** pre-push-audit and the
   maturity sweeps still run PR-ref scripts -- they operate on the PR tree
   by design (diff audits, tooling pytest) and need a different treatment;
-  live-reconciliation's `pull_request_review*` triggers still resolve the
-  workflow file PR-side, but every push/edit also produces a trusted
-  `pull_request_target` run from main. Consistent with the #1944 threat
-  model: friction and a logged decision for honest-but-hasty authors, not
+  review events resolve workflow files PR-side, so the required
+  `live-reconciliation` context is fed only by trusted target runs, and
+  the default-branch review-retrigger follow-up re-runs the latest target
+  run on every review event (keeping the required context fresh without
+  ever trusting PR-side code). Consistent with the #1944 threat model:
+  friction and a logged decision for honest-but-hasty authors, not
   adversary-proofing.
 - Check names, triggers' type lists, and script invocations are otherwise
   unchanged -- this slice moves WHERE gate code comes from, not what it does.
@@ -147,7 +159,7 @@ Commands run from the repo root:
   passed; the three converted gates report as allowed guard-shaped jobs.
 - `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>` --
   all checks PASS.
-- `python scripts/check_diff_budget.py --additions 504 --body-file
+- `python scripts/check_diff_budget.py --additions 589 --body-file
   <pr-body.md>` -- within the 400 budget.
 - Post-merge, first PR: confirm the three checks report from
   `pull_request_target` runs (workflow run event visible in the check-run
@@ -157,11 +169,11 @@ Commands run from the repo root:
 
 | File | LOC (added) |
 |---|---:|
-| workflows (3) | 83 |
-| `scripts/audit_pr_body.py` | 67 |
+| workflows (4) | 129 |
+| `scripts/audit_pr_body.py` | 74 |
 | `scripts/audit_workflow_security_posture.py` | 13 |
-| `tests/test_audit_pr_body.py` | 93 |
+| `tests/test_audit_pr_body.py` | 110 |
 | `tests/test_audit_workflow_security_posture.py` | 68 |
-| `docs/SECURITY_GUARDRAILS.md` | 13 |
-| `plans/PR-Trusted-Base-Gate-Execution.md` | 167 |
-| **Total** | **504** |
+| `docs/SECURITY_GUARDRAILS.md` | 16 |
+| `plans/PR-Trusted-Base-Gate-Execution.md` | 179 |
+| **Total** | **589** |

--- a/plans/PR-Trusted-Base-Gate-Execution.md
+++ b/plans/PR-Trusted-Base-Gate-Execution.md
@@ -14,6 +14,13 @@ slice applies that existing pattern to the three API-driven gates
 (diff-budget, live-reconciliation, pr-body-contract); patching just one gate
 or re-describing the risk in docs would treat the symptom.
 
+Diff-budget overage (484 added lines vs the 400 cap): the workflow posture
+audit ITSELF gates pull_request_target adoption behind its allowlist plus
+guard-shape check, so the three workflow conversions, the allowlist
+expansion, its failure-branch tests, and the review-events job split are one
+indivisible slice -- shipping the workflows without the allowlist leaves CI
+red; shipping the allowlist without the workflows allowlists nothing.
+
 ## Scope (this PR)
 
 Ownership lane: Workflow/process
@@ -33,7 +40,14 @@ Slice phase: Vertical slice
 3. `tests/test_audit_pr_body.py`: failure-branch fixtures for the new mode
    (plan present at ref, missing at ref, unresolvable ref, callable
    injection).
-4. `docs/SECURITY_GUARDRAILS.md`: document which gates run trusted-base and
+4. `scripts/audit_workflow_security_posture.py`: the pull_request_target
+   allowlist generalizes from the single Gitleaks-guard tuple to the four
+   audited gate jobs -- allowlisting is necessary but not sufficient; each
+   entry must still match the guard shape (if-guard + SHA-pinned base-SHA
+   checkout). live-reconciliation splits into the required target-only job
+   plus an advisory review-events job (same base-ref script) so bot-comment
+   re-runs survive the guard shape.
+5. `docs/SECURITY_GUARDRAILS.md`: document which gates run trusted-base and
    the residual PR-ref surface (named below).
 
 ### Files touched
@@ -42,7 +56,9 @@ Slice phase: Vertical slice
 - `.github/workflows/ai_reconciliation_live.yml`
 - `.github/workflows/pr_body_contract.yml`
 - `scripts/audit_pr_body.py`
+- `scripts/audit_workflow_security_posture.py`
 - `tests/test_audit_pr_body.py`
+- `tests/test_audit_workflow_security_posture.py`
 - `docs/SECURITY_GUARDRAILS.md`
 - `plans/PR-Trusted-Base-Gate-Execution.md`
 
@@ -61,7 +77,11 @@ Acceptance criteria (reviewer checks one-by-one):
    exits 2 (infra), never 0.
 4. The default (no flag) filesystem behavior is byte-for-byte unchanged --
    local usage and the pre-push bundle are unaffected.
-5. `python -m pytest tests/test_audit_pr_body.py -q` passes, including the
+5. The posture audit passes with the three gates reported as allowed
+   guard-shaped jobs, and an allowlisted gate that drops the if-guard or
+   the pinned checkout still errors (tested).
+6. `python -m pytest tests/test_audit_pr_body.py
+   tests/test_audit_workflow_security_posture.py -q` passes, including the
    new failure branches.
 
 Affected surfaces: three gate workflows, one gate script + its tests, one
@@ -120,11 +140,14 @@ Parked hardening: none.
 
 Commands run from the repo root:
 
-- `python -m pytest tests/test_audit_pr_body.py -q` -- pass count recorded
-  in the PR body, including the new `--plan-git-ref` failure branches.
+- `python -m pytest tests/test_audit_pr_body.py
+  tests/test_audit_workflow_security_posture.py -q` -- pass count recorded
+  in the PR body, including the new failure branches on both scripts.
+- `python scripts/audit_workflow_security_posture.py .github/workflows` --
+  passed; the three converted gates report as allowed guard-shaped jobs.
 - `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>` --
   all checks PASS.
-- `python scripts/check_diff_budget.py --additions 353 --body-file
+- `python scripts/check_diff_budget.py --additions 484 --body-file
   <pr-body.md>` -- within the 400 budget.
 - Post-merge, first PR: confirm the three checks report from
   `pull_request_target` runs (workflow run event visible in the check-run
@@ -134,9 +157,11 @@ Commands run from the repo root:
 
 | File | LOC (added) |
 |---|---:|
-| workflows (3) | 58 |
+| workflows (3) | 83 |
 | `scripts/audit_pr_body.py` | 62 |
+| `scripts/audit_workflow_security_posture.py` | 13 |
 | `tests/test_audit_pr_body.py` | 78 |
+| `tests/test_audit_workflow_security_posture.py` | 68 |
 | `docs/SECURITY_GUARDRAILS.md` | 13 |
-| `plans/PR-Trusted-Base-Gate-Execution.md` | 142 |
-| **Total** | **353** |
+| `plans/PR-Trusted-Base-Gate-Execution.md` | 167 |
+| **Total** | **484** |

--- a/plans/PR-Trusted-Base-Gate-Execution.md
+++ b/plans/PR-Trusted-Base-Gate-Execution.md
@@ -14,7 +14,7 @@ slice applies that existing pattern to the three API-driven gates
 (diff-budget, live-reconciliation, pr-body-contract); patching just one gate
 or re-describing the risk in docs would treat the symptom.
 
-Diff-budget overage (484 added lines vs the 400 cap): the workflow posture
+Diff-budget overage (504 added lines vs the 400 cap): the workflow posture
 audit ITSELF gates pull_request_target adoption behind its allowlist plus
 guard-shape check, so the three workflow conversions, the allowlist
 expansion, its failure-branch tests, and the review-events job split are one
@@ -147,7 +147,7 @@ Commands run from the repo root:
   passed; the three converted gates report as allowed guard-shaped jobs.
 - `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>` --
   all checks PASS.
-- `python scripts/check_diff_budget.py --additions 484 --body-file
+- `python scripts/check_diff_budget.py --additions 504 --body-file
   <pr-body.md>` -- within the 400 budget.
 - Post-merge, first PR: confirm the three checks report from
   `pull_request_target` runs (workflow run event visible in the check-run
@@ -158,10 +158,10 @@ Commands run from the repo root:
 | File | LOC (added) |
 |---|---:|
 | workflows (3) | 83 |
-| `scripts/audit_pr_body.py` | 62 |
+| `scripts/audit_pr_body.py` | 67 |
 | `scripts/audit_workflow_security_posture.py` | 13 |
-| `tests/test_audit_pr_body.py` | 78 |
+| `tests/test_audit_pr_body.py` | 93 |
 | `tests/test_audit_workflow_security_posture.py` | 68 |
 | `docs/SECURITY_GUARDRAILS.md` | 13 |
 | `plans/PR-Trusted-Base-Gate-Execution.md` | 167 |
-| **Total** | **484** |
+| **Total** | **504** |

--- a/scripts/audit_pr_body.py
+++ b/scripts/audit_pr_body.py
@@ -70,12 +70,16 @@ def plan_exists_at_ref(ref: str, *, repo_root: Path = ROOT) -> Callable[[str], b
     ref by inspection (git cat-file), never by executing PR code."""
 
     def _exists(plan: str) -> bool:
+        # -t, not -e: the object at the path must be a BLOB. cat-file -e
+        # also succeeds for a tree (plans/PR-Foo.md/child in the head
+        # makes plans/PR-Foo.md a directory), which is not a plan doc --
+        # this mirrors the working-tree default's is_file().
         proc = subprocess.run(
-            ["git", "cat-file", "-e", f"{ref}:{plan}"],
+            ["git", "cat-file", "-t", f"{ref}:{plan}"],
             cwd=repo_root,
             capture_output=True,
         )
-        return proc.returncode == 0
+        return proc.returncode == 0 and proc.stdout.strip() == b"blob"
 
     return _exists
 

--- a/scripts/audit_pr_body.py
+++ b/scripts/audit_pr_body.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import re
+import subprocess
 import sys
-from typing import Sequence
+from typing import Callable, Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -50,8 +51,46 @@ def is_dependabot_author(author: str | None) -> bool:
     return author.strip() in DEPENDABOT_AUTHORS
 
 
-def audit_pr_body(body: str, *, root: Path = ROOT) -> list[str]:
+def resolve_git_ref(ref: str, *, repo_root: Path = ROOT) -> bool:
+    """True when ``ref`` resolves to a commit in the local repo. The
+    trusted-base workflow fetches the PR head before auditing; an
+    unresolvable ref is an infrastructure failure, never a silent pass."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        cwd=repo_root,
+        capture_output=True,
+    )
+    return proc.returncode == 0
+
+
+def plan_exists_at_ref(ref: str, *, repo_root: Path = ROOT) -> Callable[[str], bool]:
+    """Plan-doc existence checker against a git ref (the fetched PR head).
+    Trusted-base gate runs execute this script from the BASE checkout, but a
+    new plan doc arrives WITH the PR -- so existence is asked of the PR head
+    ref by inspection (git cat-file), never by executing PR code."""
+
+    def _exists(plan: str) -> bool:
+        proc = subprocess.run(
+            ["git", "cat-file", "-e", f"{ref}:{plan}"],
+            cwd=repo_root,
+            capture_output=True,
+        )
+        return proc.returncode == 0
+
+    return _exists
+
+
+def audit_pr_body(
+    body: str,
+    *,
+    root: Path = ROOT,
+    plan_exists: Callable[[str], bool] | None = None,
+) -> list[str]:
     """Return a list of contract failures (empty means the body passes)."""
+
+    if plan_exists is None:
+        def plan_exists(plan: str) -> bool:
+            return (root / plan).is_file()
 
     failures: list[str] = []
     lines = body.splitlines()
@@ -65,8 +104,7 @@ def audit_pr_body(body: str, *, root: Path = ROOT) -> list[str]:
             "first non-empty line must be 'Plan: plans/PR-<Slice-Name>.md'"
         )
     else:
-        plan_path = root / plan_match.group("plan")
-        if not plan_path.is_file():
+        if not plan_exists(plan_match.group("plan")):
             failures.append(
                 f"plan doc named in the PR body does not exist: {plan_match.group('plan')}"
             )
@@ -118,6 +156,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         default="",
         help="GitHub PR author login; Dependabot PRs are exempt",
     )
+    parser.add_argument(
+        "--plan-git-ref",
+        default="",
+        help=(
+            "check plan-doc existence against this git ref (the fetched PR "
+            "head) instead of the working tree -- for trusted-base gate runs"
+        ),
+    )
     parser.add_argument("body_file", help="path to a file holding the PR body")
     args = parser.parse_args(argv)
 
@@ -131,7 +177,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("pr body audit: PASS (Dependabot PR body exempt)")
         return 0
 
-    failures = audit_pr_body(body)
+    plan_exists = None
+    if args.plan_git_ref:
+        if not resolve_git_ref(args.plan_git_ref):
+            print(
+                f"pr body audit: plan ref not resolvable: {args.plan_git_ref} "
+                "(fetch the PR head before auditing)",
+                file=sys.stderr,
+            )
+            return 2  # infrastructure failure -- never a silent pass
+        plan_exists = plan_exists_at_ref(args.plan_git_ref)
+
+    failures = audit_pr_body(body, plan_exists=plan_exists)
     if failures:
         print("pr body audit: FAIL (AGENTS.md section 1b contract)")
         for failure in failures:

--- a/scripts/audit_pr_body.py
+++ b/scripts/audit_pr_body.py
@@ -51,42 +51,46 @@ def is_dependabot_author(author: str | None) -> bool:
     return author.strip() in DEPENDABOT_AUTHORS
 
 
+def _git_read(args: list[str], *, repo_root: Path) -> tuple[int, bytes]:
+    """Run a read-only git command. A missing or broken git binary is an
+    infrastructure condition surfaced as a nonzero code (fail-closed for
+    every caller), never a traceback."""
+    try:
+        proc = subprocess.run(
+            ["git", *args], cwd=repo_root, capture_output=True
+        )
+    except OSError:
+        return 1, b""
+    return proc.returncode, proc.stdout
+
+
 def resolve_git_ref(ref: str, *, repo_root: Path = ROOT) -> bool:
     """True when ``ref`` resolves to a commit in the local repo. The
     trusted-base workflow fetches the PR head before auditing; an
     unresolvable ref is an infrastructure failure, never a silent pass."""
-    proc = subprocess.run(
-        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
-        cwd=repo_root,
-        capture_output=True,
+    code, _ = _git_read(
+        ["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        repo_root=repo_root,
     )
-    return proc.returncode == 0
+    return code == 0
 
 
 def plan_exists_at_ref(ref: str, *, repo_root: Path = ROOT) -> Callable[[str], bool]:
     """Plan-doc existence checker against a git ref (the fetched PR head).
     Trusted-base gate runs execute this script from the BASE checkout, but a
     new plan doc arrives WITH the PR -- so existence is asked of the PR head
-    ref by inspection (git cat-file), never by executing PR code."""
+    ref by inspection (git ls-tree), never by executing PR code."""
 
     def _exists(plan: str) -> bool:
-        # ls-tree mode, not cat-file existence: the entry must be a
-        # REGULAR-FILE blob. cat-file -e also accepts a tree at the path
-        # (plans/PR-Foo.md/child) and cat-file -t reports symlinks as
-        # blobs (mode 120000, possibly dangling) -- neither is a plan
-        # doc. Requiring mode 100644/100755 mirrors the working-tree
+        # ls-tree lines are "<mode> <type> <sha>\t<path>". The entry must
+        # be a REGULAR-FILE blob: a tree at the path (plans/PR-Foo.md/child)
+        # or a symlink (mode 120000, possibly dangling) is not a plan doc.
+        # Requiring the 100644/100755 blob prefix mirrors the working-tree
         # default's is_file().
-        proc = subprocess.run(
-            ["git", "ls-tree", ref, "--", plan],
-            cwd=repo_root,
-            capture_output=True,
-        )
-        fields = proc.stdout.split()
-        return (
-            proc.returncode == 0
-            and len(fields) >= 2
-            and fields[0] in (b"100644", b"100755")
-            and fields[1] == b"blob"
+        code, out = _git_read(["ls-tree", ref, "--", plan], repo_root=repo_root)
+        line = out.strip()
+        return code == 0 and (
+            line.startswith(b"100644 blob") or line.startswith(b"100755 blob")
         )
 
     return _exists

--- a/scripts/audit_pr_body.py
+++ b/scripts/audit_pr_body.py
@@ -70,16 +70,24 @@ def plan_exists_at_ref(ref: str, *, repo_root: Path = ROOT) -> Callable[[str], b
     ref by inspection (git cat-file), never by executing PR code."""
 
     def _exists(plan: str) -> bool:
-        # -t, not -e: the object at the path must be a BLOB. cat-file -e
-        # also succeeds for a tree (plans/PR-Foo.md/child in the head
-        # makes plans/PR-Foo.md a directory), which is not a plan doc --
-        # this mirrors the working-tree default's is_file().
+        # ls-tree mode, not cat-file existence: the entry must be a
+        # REGULAR-FILE blob. cat-file -e also accepts a tree at the path
+        # (plans/PR-Foo.md/child) and cat-file -t reports symlinks as
+        # blobs (mode 120000, possibly dangling) -- neither is a plan
+        # doc. Requiring mode 100644/100755 mirrors the working-tree
+        # default's is_file().
         proc = subprocess.run(
-            ["git", "cat-file", "-t", f"{ref}:{plan}"],
+            ["git", "ls-tree", ref, "--", plan],
             cwd=repo_root,
             capture_output=True,
         )
-        return proc.returncode == 0 and proc.stdout.strip() == b"blob"
+        fields = proc.stdout.split()
+        return (
+            proc.returncode == 0
+            and len(fields) >= 2
+            and fields[0] in (b"100644", b"100755")
+            and fields[1] == b"blob"
+        )
 
     return _exists
 

--- a/scripts/audit_workflow_security_posture.py
+++ b/scripts/audit_workflow_security_posture.py
@@ -15,7 +15,18 @@ import yaml
 
 WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 PINNED_REF_RE = re.compile(r"^[0-9a-f]{40}$")
-ALLOWED_PULL_REQUEST_TARGET_JOB = ("gitleaks_baseline_growth_guard.yml", "gitleaks-baseline-guard")
+# The ONLY jobs allowed to run on pull_request_target, each of which must
+# also match the trusted-base guard shape below (event-name if-guard +
+# SHA-pinned checkout of the base SHA). Gate adoption is an audited,
+# explicit decision -- see plans/PR-Trusted-Base-Gate-Execution.md.
+ALLOWED_PULL_REQUEST_TARGET_JOBS = frozenset(
+    {
+        ("gitleaks_baseline_growth_guard.yml", "gitleaks-baseline-guard"),
+        ("diff_budget.yml", "diff-budget"),
+        ("ai_reconciliation_live.yml", "live-reconciliation"),
+        ("pr_body_contract.yml", "pr-body-contract"),
+    }
+)
 ALLOWED_ID_TOKEN_JOB = ("claude.yml", "claude")
 CLAUDE_OWNER_GATE = "github.actor == github.repository_owner"
 
@@ -82,7 +93,7 @@ def _job_runs_on_pull_request_target(job: dict[str, Any]) -> bool:
 
 
 def _is_allowed_pull_request_target_job(path: Path, job_name: str, job: dict[str, Any]) -> bool:
-    if (path.name, job_name) != ALLOWED_PULL_REQUEST_TARGET_JOB:
+    if (path.name, job_name) not in ALLOWED_PULL_REQUEST_TARGET_JOBS:
         return False
     if job.get("if") != "github.event_name == 'pull_request_target'":
         return False

--- a/tests/test_audit_pr_body.py
+++ b/tests/test_audit_pr_body.py
@@ -324,3 +324,19 @@ def test_plan_path_that_is_a_tree_at_ref_is_not_a_plan_doc(tmp_path: Path) -> No
     assert exists("plans/PR-Example.md") is False
     failures = audit_pr_body(_valid_body(), plan_exists=exists)
     assert any("does not exist" in failure for failure in failures)
+
+
+def test_plan_path_that_is_a_symlink_at_ref_is_not_a_plan_doc(tmp_path: Path) -> None:
+    """cat-file -t reports symlinks as blobs (mode 120000, possibly
+    dangling); the working-tree is_file() rejects dangling symlinks, so
+    the ref checker requires a regular-file mode."""
+    import os
+
+    repo = tmp_path / "repo"
+    (repo / "plans").mkdir(parents=True)
+    os.symlink("nowhere-real.md", repo / "plans" / "PR-Example.md")
+    _git(repo, "init", "-q")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "seed")
+    exists = audit_pr_body_module.plan_exists_at_ref("HEAD", repo_root=repo)
+    assert exists("plans/PR-Example.md") is False

--- a/tests/test_audit_pr_body.py
+++ b/tests/test_audit_pr_body.py
@@ -230,3 +230,81 @@ def test_normal_author_cli_rejects_same_invalid_body() -> None:
         assert "AGENTS.md section 1b contract" in result.stdout
     finally:
         body_path.unlink(missing_ok=True)
+
+
+# -- trusted-base plan-doc inspection (--plan-git-ref) ---------------------------
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _git_repo_with_plan(tmp_path: Path, plan: str = "plans/PR-Example.md") -> Path:
+    repo = tmp_path / "repo"
+    (repo / plan).parent.mkdir(parents=True)
+    (repo / plan).write_text("# PR-Example\n", encoding="utf-8")
+    _git(repo, "init", "-q")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "seed")
+    return repo
+
+
+def test_plan_exists_callable_is_injectable() -> None:
+    failures = audit_pr_body(_valid_body(), plan_exists=lambda plan: False)
+    assert any("does not exist" in failure for failure in failures)
+    assert audit_pr_body(_valid_body(), plan_exists=lambda plan: True) == []
+
+
+def test_plan_exists_at_ref_sees_committed_plan_and_misses_absent_one(
+    tmp_path: Path,
+) -> None:
+    repo = _git_repo_with_plan(tmp_path)
+    exists = audit_pr_body_module.plan_exists_at_ref("HEAD", repo_root=repo)
+    assert exists("plans/PR-Example.md") is True
+    assert exists("plans/PR-Not-There.md") is False
+
+
+def test_audit_against_ref_fails_when_plan_missing_at_ref(tmp_path: Path) -> None:
+    repo = _git_repo_with_plan(tmp_path)
+    exists = audit_pr_body_module.plan_exists_at_ref("HEAD", repo_root=repo)
+    failures = audit_pr_body(
+        _valid_body(plan="plans/PR-Not-There.md"), plan_exists=exists
+    )
+    assert any("does not exist" in failure for failure in failures)
+
+
+def test_resolve_git_ref_true_for_head_false_for_unfetched(tmp_path: Path) -> None:
+    repo = _git_repo_with_plan(tmp_path)
+    assert audit_pr_body_module.resolve_git_ref("HEAD", repo_root=repo) is True
+    assert (
+        audit_pr_body_module.resolve_git_ref(
+            "refs/remotes/origin/pr-999", repo_root=repo
+        )
+        is False
+    )
+
+
+def test_cli_unresolvable_plan_ref_is_infra_failure_exit_2() -> None:
+    """A trusted-base run whose PR-head fetch did not happen must exit 2
+    (infrastructure), never 0 -- the gate cannot silently pass."""
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as handle:
+        handle.write(_valid_body())
+        body_file = handle.name
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--plan-git-ref",
+            "refs/remotes/origin/pr-0",
+            body_file,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert "not resolvable" in proc.stderr

--- a/tests/test_audit_pr_body.py
+++ b/tests/test_audit_pr_body.py
@@ -308,3 +308,19 @@ def test_cli_unresolvable_plan_ref_is_infra_failure_exit_2() -> None:
     )
     assert proc.returncode == 2
     assert "not resolvable" in proc.stderr
+
+
+def test_plan_path_that_is_a_tree_at_ref_is_not_a_plan_doc(tmp_path: Path) -> None:
+    """cat-file -e would accept a TREE at the plan path (a PR shipping
+    plans/PR-Example.md/child); only a blob counts as a plan doc."""
+    repo = tmp_path / "repo"
+    nested = repo / "plans" / "PR-Example.md"
+    nested.mkdir(parents=True)
+    (nested / "child").write_text("not a plan doc\n", encoding="utf-8")
+    _git(repo, "init", "-q")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "seed")
+    exists = audit_pr_body_module.plan_exists_at_ref("HEAD", repo_root=repo)
+    assert exists("plans/PR-Example.md") is False
+    failures = audit_pr_body(_valid_body(), plan_exists=exists)
+    assert any("does not exist" in failure for failure in failures)

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -376,3 +376,71 @@ jobs:
     findings = auditor.audit_workflow(workflow)
 
     assert findings == []
+
+
+def _trusted_gate_workflow(job: str) -> str:
+    return f"""
+name: Gate
+on:
+  pull_request_target:
+jobs:
+  {job}:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{{{ github.event.pull_request.base.sha }}}}
+"""
+
+
+def test_converted_meta_gates_pull_request_target_is_allowed(tmp_path: Path) -> None:
+    auditor = load_auditor()
+    for name, job in (
+        ("diff_budget.yml", "diff-budget"),
+        ("ai_reconciliation_live.yml", "live-reconciliation"),
+        ("pr_body_contract.yml", "pr-body-contract"),
+    ):
+        workflow = _write_workflow(tmp_path, name, _trusted_gate_workflow(job))
+        findings = auditor.audit_workflow(workflow)
+        assert not [f for f in findings if f.level == "ERROR"], (name, findings)
+        assert any("allowed pull_request_target" in f.detail for f in findings)
+
+
+def test_allowlisted_gate_without_guard_shape_is_still_error(tmp_path: Path) -> None:
+    """Allowlisting is necessary but not sufficient: an allowlisted gate
+    that drops the if-guard or the pinned base-SHA checkout fails."""
+    auditor = load_auditor()
+    workflow = _write_workflow(
+        tmp_path,
+        "diff_budget.yml",
+        """
+name: Gate
+on:
+  pull_request_target:
+jobs:
+  diff-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+""",
+    )
+    findings = auditor.audit_workflow(workflow)
+    assert any(
+        f.level == "ERROR" and "trusted-base guard shape" in f.detail
+        for f in findings
+    )
+
+
+def test_gate_job_name_in_wrong_file_is_error(tmp_path: Path) -> None:
+    auditor = load_auditor()
+    workflow = _write_workflow(
+        tmp_path, "impostor.yml", _trusted_gate_workflow("diff-budget")
+    )
+    findings = auditor.audit_workflow(workflow)
+    assert any(
+        f.level == "ERROR" and "trusted-base guard shape" in f.detail
+        for f in findings
+    )


### PR DESCRIPTION
Plan: plans/PR-Trusted-Base-Gate-Execution.md
Slice phase: Vertical slice
Ownership lane: Workflow/process

Closes #1944 waiver 18, named there as the priority follow-up: every PR gate
ran its scripts from the PR merge ref, so a PR editing a gate (script or
workflow) was judged by its own edited gate and could self-pass. This slice
applies the repo's existing reviewed pattern (the Gitleaks baseline guard's
`pull_request_target` + trusted-base checkout) to the three API-driven
gates: diff-budget, live-reconciliation, and pr-body-contract now resolve
both their workflow logic and their scripts from `main`, never from the PR.
Because a new plan doc arrives WITH the PR, `audit_pr_body.py` gains a
`--plan-git-ref` mode that inspects the fetched PR head as git data
(`git ls-tree`, regular-file blobs only) -- PR content is never executed.
The workflow posture audit's pull_request_target allowlist generalizes to
the four audited gate jobs (still shape-checked), live-reconciliation
splits into the required target-only job plus an advisory review-events
job, and a default-branch `workflow_run` follow-up re-runs the latest
trusted target run on every review event so the required context never
goes stale on a bot comment.

Diff-budget override: the workflow posture audit itself gates pull_request_target adoption behind its allowlist plus guard-shape check, so the three workflow conversions, the allowlist expansion, its failure-branch tests, the review-events job split, and the trusted review retrigger are one indivisible slice -- shipping the workflows without the allowlist leaves CI red, and shipping the allowlist without the workflows allowlists nothing.

## Intentional

- Migration window: on THIS PR the three converted gates' required contexts
  do not run from `pull_request_target` (`pull_request` events consult the
  now-target-only merge-ref workflows; `pull_request_target` consults
  main's pre-conversion files). The required `live-reconciliation` context
  still reports on the head via the review-event runs' skipped target-only
  job (skipped satisfies branch protection), and `diff-budget` is not yet
  enabled in live branch protection (the #1945 toggle is staged to flip
  after this merge). First effective trusted runs happen on the next PR
  after merge; pre-push-audit and the tooling suites still cover this one.
- Residual PR-ref surface, named not hidden: pre-push-audit and the
  maturity sweeps operate on the PR tree by design and need a
  scripts-from-base split in a follow-up. Review events resolve workflow
  files PR-side, so the required `live-reconciliation` context is fed only
  by trusted target runs, and the default-branch review-retrigger re-runs
  the latest target run on every review event.
- Check-run names for the required contexts are unchanged, so #1945's
  required-check audit expectations still match.

## Deferred

- Trusted-base treatment for the tree-dependent gates (pre-push-audit,
  maturity sweeps): scripts-from-base / tree-from-PR split, its own slice.
- Factory adoption in the remaining reddit test files (#1947 Deferred).

## Parked hardening

- Scheduled trusted sweep for review-event suppression (review round 3
  waiver): a PR that removes the review-event triggers from
  ai_reconciliation_live.yml silences the retrigger chain, because every
  review-event workflow resolves PR-side -- no event-model fix exists. A
  default-branch cron that re-runs the latest target run for open PRs with
  review activity newer than their last target run would bound the
  staleness window. Adversarial-only; accepted under the #1944 threat model
  and tracked in the plan doc.

## AI reconciliation

Codex raised 8 findings across four rounds (cfdab748, 88328cc1, 96389115,
4b7cb2f4): 5 verified real and FIXED, 2 verified incorrect against live
run/repo state (no change), 1 waived with reason and tracked in Parked
hardening. The scripts-lane maturity ratchet also flagged the new git
boundary (score 7 -> 9); brittleness was reduced (prefix matching,
OSError-guarded reader) rather than baselined.

All fixed or waived: Yes

1. **P1 -- posture audit allowlist missing the converted gates (CI red).**
   Fixed in 075b0c28: `ALLOWED_PULL_REQUEST_TARGET_JOBS` generalizes to the
   four audited gate jobs, each still required to match the guard shape;
   failure branches tested.
2. **P1 -- review-event triggers left the self-pass window on the required
   check.** Fixed in 075b0c28: live-reconciliation split into the required
   target-only job and an advisory review-events job.
3. **P2 -- `git cat-file -e` accepts trees/gitlinks at the plan path.**
   Fixed in 24387b35: blob type required; tree-impostor test added.
4. **P1 (round 2) -- required context goes stale when a bot comment lands
   after the last push/edit.** Fixed in ccceca47: the default-branch
   `ai_reconciliation_review_retrigger.yml` workflow_run follow-up re-runs
   the latest `pull_request_target` run for the same head SHA on every
   review event, so the required context is refreshed by trusted code
   (loop-safe: target-event completions are ignored).
5. **P2 (round 2) -- symlink blobs at the plan path.** Fixed in ccceca47:
   the checker requires a regular-file blob (100644/100755 via ls-tree),
   mirroring `is_file()`; symlink-impostor test added.
6. **P2 (round 3) -- claim: review-event runs carry a merge SHA, so the
   retrigger's head_sha filter never matches.** Verified INCORRECT against
   live run objects: review-event run 28631524913 and pull_request_target
   run 28630129241 both carry the PR head SHA, so the
   `event=pull_request_target&head_sha=` filter compares PR-head to
   PR-head and finds the trusted run. Evidence linked in the thread; no
   change.
7. **P2 (round 3) -- a PR can delete the review-event triggers from the
   live workflow and silence the retrigger chain.** WAIVED. Reason: adversarial-only
   (requires deliberately editing the gate), and no event model delivers
   trusted code on review events, so no in-slice fix exists. Fallback
   (default-branch scheduled trusted sweep) parked in
   plans/PR-Trusted-Base-Gate-Execution.md and documented in
   docs/SECURITY_GUARDRAILS.md (4b7cb2f4), consistent with the #1944
   threat model and its wave-5 waiver precedent.
8. **P1 (round 4) -- claim: the migration window leaves the required
   contexts missing on this commit, so it cannot merge without an admin
   bypass.** Verified INCORRECT against the live repo state: the required
   `live-reconciliation` context IS reported on head 4b7cb2f4 (review-event
   runs report the target-only job as skipped, which satisfies branch
   protection), `diff-budget` is not yet enabled in live branch protection
   (the #1945 toggle is deliberately staged to flip after this merge --
   exactly the "stage the branch-protection transition" option the finding
   suggests), and GitHub reports mergeable_state clean. The alternative (a
   temporary compatibility `pull_request` job) would let PR-ref code
   satisfy the required contexts again, reinstating the self-pass window
   this slice closes. No change.

## Verification

- `python -m pytest tests/test_audit_pr_body.py tests/test_audit_workflow_security_posture.py tests/test_security_guardrails_workflow.py -q`
  -- 52 passed (20 body-audit incl. the `--plan-git-ref` failure branches
  and the tree/symlink impostor cases; 17 posture-audit incl. allowlist
  shape/impostor failure branches; 15 guardrails-docs checks).
- `python scripts/audit_workflow_security_posture.py .github/workflows` --
  passed; the three converted gates report as allowed guard-shaped jobs.
- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline
  tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob
  'scripts/**'` -- ratchet gate passed, no baseline change.
- `bash scripts/local_pr_review.sh --current-pr-body-file <local body>` --
  all checks PASS, 0 failed.
- `python scripts/check_diff_budget.py --additions 607 --body-file
  <local body>` -- PASS via the override above.

## Diff size

10 files, +607 / -21 (workflows 129, scripts 91, tests 178, guardrails
doc 20, plan 189). Over the 400 cap; carried by the override above.

Refs #1944 (waiver 18), #1945, #1943.
