### PR TITLE
Run pre-push audit from trusted base

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -1,7 +1,14 @@
 name: Pre-push Audit
 
+# Trusted-base execution (#1949 follow-up): PR events run this workflow from the
+# base branch and checkout the base SHA for executable code. The PR head is
+# materialized as a separate worktree and inspected as data by base-owned
+# scripts. Do not add a PR-event step that executes scripts, tests, or package
+# code from the PR worktree.
+
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   push:
     branches:
       - main
@@ -12,24 +19,34 @@ permissions:
 
 jobs:
   pre-push-audit:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - name: Checkout trusted base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 
-      - name: Resolve origin HEAD
+      - name: Materialize PR head as data
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          git remote set-head origin --auto || git remote set-head origin main
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" \
+            "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-${PR_NUMBER}"
+          git worktree add "$RUNNER_TEMP/pr-tree" "refs/remotes/origin/pr-${PR_NUMBER}"
+          git -C "$RUNNER_TEMP/pr-tree" symbolic-ref "refs/remotes/origin/HEAD" "refs/remotes/origin/${BASE_REF}" || true
 
       - name: Write current PR body
-        if: github.event_name == 'pull_request'
         run: |
           python - <<'PY'
           import json
@@ -47,17 +64,49 @@ jobs:
       - name: Run local PR review bundle
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            bash scripts/local_pr_review.sh --current-pr-body-file "$RUNNER_TEMP/current-pr-body.md"
-          else
-            bash scripts/local_pr_review.sh
-          fi
+          bash scripts/local_pr_review.sh \
+            --repo-root "$RUNNER_TEMP/pr-tree" \
+            --script-root "$GITHUB_WORKSPACE" \
+            --current-pr-body-file "$RUNNER_TEMP/current-pr-body.md" \
+            "origin/${BASE_REF}"
 
       # Unit-cover the PR-review tooling itself (including the plans-archive
-      # advisory). This workflow runs the bundle above, so its fixtures belong
-      # in CI rather than only in local dev.
+      # advisory). On pull_request_target these are trusted-base tests only;
+      # the PR checkout above is data and must not be executed.
+      - name: PR-review tooling unit tests
+        run: |
+          python -m pip install --quiet pytest pytest-asyncio pyyaml
+          python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_audit_pr_body.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_check_gitleaks_baseline_rotation.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_claude_workflow_security.py tests/test_deflection_report_ttl_workflow.py tests/test_fix_mode_hook.py tests/test_eval_local_mcp_models.py tests/test_check_diff_budget.py -q
+
+      - name: Workflow security posture audit
+        run: python scripts/audit_workflow_security_posture.py "$RUNNER_TEMP/pr-tree/.github/workflows"
+
+  pre-push-audit-main:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+
+      - name: Resolve origin HEAD
+        run: |
+          git remote set-head origin --auto || git remote set-head origin main
+
+      - name: Run local PR review bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/local_pr_review.sh
+
       - name: PR-review tooling unit tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio pyyaml

--- a/extracted/_shared/scripts/check_ascii_python.sh
+++ b/extracted/_shared/scripts/check_ascii_python.sh
@@ -7,7 +7,7 @@ if [[ "$#" -ne 1 ]]; then
 fi
 
 PRODUCT_DIR="$1"
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ROOT_DIR="${ATLAS_AUDIT_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
 cd "$ROOT_DIR"
 
 mapfile -t files < <(python - "$PRODUCT_DIR" <<'PY'

--- a/plans/PR-Trusted-Base-Pre-Push-Audit.md
+++ b/plans/PR-Trusted-Base-Pre-Push-Audit.md
@@ -1,0 +1,109 @@
+# PR-Trusted-Base-Pre-Push-Audit
+
+## Why this slice exists
+
+#1949 moved API-driven PR meta-gates to trusted-base execution, but deferred tree-dependent gates. The first remaining hot path is `.github/workflows/pre_push_audit.yml`, which still executes `scripts/local_pr_review.sh` from the PR tree.
+
+Root cause: the workflow conflates executable audit code with the inspected tree, so a PR can alter the gate that judges it. This fixes that root for pre-push audit only; maturity sweeps are deferred because of their lane filters and baselines.
+
+Diff-size note: this is over the 400 LOC soft cap because the root fix needs the workflow split, wrapper root plumbing, helper adoption, and safety tests in one PR.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Vertical slice
+
+1. Let local review and pre-push wrappers execute from a trusted script root
+   while inspecting a separate repo root.
+2. Convert `.github/workflows/pre_push_audit.yml` so PR events run from the
+   base SHA and materialize the PR head only as inspected data.
+3. Add workflow and unit proof for the trusted split.
+
+### Review Contract
+
+- Acceptance criteria: PR events use `pull_request_target`, SHA-pinned
+  `actions/checkout`, and `${{ github.event.pull_request.base.sha }}` for
+  executable code; the PR head is a separate data worktree passed via
+  `--repo-root`; push-to-main still runs without a PR body file.
+- Affected surfaces: pre-push audit workflow, local review wrappers, and audit
+  helpers that previously resolved the inspected tree from `__file__`.
+- Risk areas: auditing main instead of PR data, executing PR-owned scripts
+  under `pull_request_target`, or breaking normal local review usage.
+- Reviewer rules triggered: R2, R10, R14.
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `extracted/_shared/scripts/check_ascii_python.sh`
+- `plans/PR-Trusted-Base-Pre-Push-Audit.md`
+- `scripts/_audit_repo_root.py`
+- `scripts/audit_claude_md_claims.py`
+- `scripts/audit_extracted_manifests.py`
+- `scripts/audit_mcp_tool_names_match_docs.py`
+- `scripts/audit_plan_code_consistency.py`
+- `scripts/audit_review_rules_triggered.py`
+- `scripts/audit_ui_test_enrollment.py`
+- `scripts/audit_workflow_security_posture.py`
+- `scripts/check_ascii_python.sh`
+- `scripts/local_pr_review.sh`
+- `scripts/pre_push_audit.sh`
+- `tests/test_audit_workflow_security_posture.py`
+- `tests/test_local_pr_review.py`
+- `tests/test_pre_push_audit.py`
+- `tests/test_pre_push_audit_workflow.py`
+
+## Mechanism
+
+The wrappers gain `--repo-root` for inspected files and `--script-root` for
+executed scripts. Defaults keep local behavior unchanged. The PR workflow checks
+out base as `$GITHUB_WORKSPACE`, fetches PR head into `$RUNNER_TEMP/pr-tree`,
+then runs the base copy of `scripts/local_pr_review.sh` against that PR tree.
+
+`scripts/_audit_repo_root.py` lets Python audits read `ATLAS_AUDIT_REPO_ROOT`
+in trusted mode while preserving their old root when no override is set.
+
+## Intentional
+
+- Maturity sweeps are deferred; this is the first tree-dependent vertical.
+- Permissions remain read-only.
+- The PR checkout is data only; PR-owned scripts/tests are not executed here.
+
+## Deferred
+
+- Trusted-base treatment for `maturity_sweep_advisory.yml` and `maturity_sweep_deflection_content_ops.yml`.
+- Scheduled trusted sweep for review-event suppression, carried forward from
+  #1949.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_local_pr_review.py tests/test_pre_push_audit_workflow.py tests/test_audit_workflow_security_posture.py -q (37 passed)
+- python -m pytest tests/test_pre_push_audit.py tests/test_audit_claude_md_claims.py tests/test_audit_mcp_tool_names_match_docs.py tests/test_audit_extracted_manifests.py tests/test_audit_ui_test_enrollment.py tests/test_audit_plan_code_consistency.py tests/test_audit_review_rules_triggered.py -q (56 passed)
+- python -m py_compile scripts/_audit_repo_root.py scripts/audit_claude_md_claims.py scripts/audit_mcp_tool_names_match_docs.py scripts/audit_extracted_manifests.py scripts/audit_ui_test_enrollment.py scripts/audit_plan_code_consistency.py scripts/audit_review_rules_triggered.py scripts/audit_workflow_security_posture.py (passed)
+- python scripts/audit_workflow_security_posture.py .github/workflows (passed with existing warnings only)
+- bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/pr-body-trusted-base-pre-push-audit.md (passed)
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pre_push_audit.yml` | 77 |
+| `extracted/_shared/scripts/check_ascii_python.sh` | 2 |
+| `plans/PR-Trusted-Base-Pre-Push-Audit.md` | 109 |
+| `scripts/_audit_repo_root.py` | 20 |
+| `scripts/audit_claude_md_claims.py` | 5 |
+| `scripts/audit_extracted_manifests.py` | 5 |
+| `scripts/audit_mcp_tool_names_match_docs.py` | 5 |
+| `scripts/audit_plan_code_consistency.py` | 5 |
+| `scripts/audit_review_rules_triggered.py` | 5 |
+| `scripts/audit_ui_test_enrollment.py` | 5 |
+| `scripts/audit_workflow_security_posture.py` | 1 |
+| `scripts/check_ascii_python.sh` | 5 |
+| `scripts/local_pr_review.sh` | 69 |
+| `scripts/pre_push_audit.sh` | 76 |
+| `tests/test_audit_workflow_security_posture.py` | 1 |
+| `tests/test_local_pr_review.py` | 38 |
+| `tests/test_pre_push_audit.py` | 1 |
+| `tests/test_pre_push_audit_workflow.py` | 26 |
+| **Total** | **455** |

--- a/scripts/_audit_repo_root.py
+++ b/scripts/_audit_repo_root.py
@@ -1,0 +1,20 @@
+"""Shared repository-root resolution for mechanical audit scripts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def audit_repo_root(script_file: str | Path) -> Path:
+    """Return the tree inspected by audit scripts.
+
+    Normal local execution inspects the checkout that owns the script. Trusted
+    CI execution can run base-owned scripts against a separate PR checkout by
+    setting ``ATLAS_AUDIT_REPO_ROOT``.
+    """
+
+    override = os.environ.get("ATLAS_AUDIT_REPO_ROOT")
+    if override:
+        return Path(override).resolve()
+    return Path(script_file).resolve().parent.parent

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -7,7 +7,10 @@ import re
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _audit_repo_root import audit_repo_root
+
+REPO_ROOT = audit_repo_root(__file__)
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
 MCP_DIR = REPO_ROOT / "atlas_brain" / "mcp"
 

--- a/scripts/audit_extracted_manifests.py
+++ b/scripts/audit_extracted_manifests.py
@@ -17,7 +17,10 @@ import json
 import sys
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _audit_repo_root import audit_repo_root
+
+REPO_ROOT = audit_repo_root(__file__)
 
 
 def _validate_path(

--- a/scripts/audit_mcp_tool_names_match_docs.py
+++ b/scripts/audit_mcp_tool_names_match_docs.py
@@ -7,7 +7,10 @@ import re
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _audit_repo_root import audit_repo_root
+
+REPO_ROOT = audit_repo_root(__file__)
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
 MCP_DIR = REPO_ROOT / "atlas_brain" / "mcp"
 

--- a/scripts/audit_plan_code_consistency.py
+++ b/scripts/audit_plan_code_consistency.py
@@ -8,7 +8,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _audit_repo_root import audit_repo_root
+
+REPO_ROOT = audit_repo_root(__file__)
 
 BACKTICK_TOKEN = re.compile(r"`([^`]+)`")
 BACKTICK_FUNC = re.compile(r"^([a-z_][a-z0-9_]{3,})\(\)$")

--- a/scripts/audit_review_rules_triggered.py
+++ b/scripts/audit_review_rules_triggered.py
@@ -22,7 +22,10 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _audit_repo_root import audit_repo_root
+
+REPO_ROOT = audit_repo_root(__file__)
 DEFAULT_RULES_DOC = "docs/REVIEWER_RULES.md"
 
 TRIGGER_HEADING_RE = re.compile(r"^\s*#+\s*Path-based rule triggers\b", re.IGNORECASE)

--- a/scripts/audit_ui_test_enrollment.py
+++ b/scripts/audit_ui_test_enrollment.py
@@ -21,7 +21,10 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _audit_repo_root import audit_repo_root
+
+REPO_ROOT = audit_repo_root(__file__)
 WORKFLOWS_SUBDIR = Path(".github") / "workflows"
 
 # Match an explicit `npm run test:<name>` invocation. Names use letters, digits,

--- a/scripts/audit_workflow_security_posture.py
+++ b/scripts/audit_workflow_security_posture.py
@@ -25,6 +25,7 @@ ALLOWED_PULL_REQUEST_TARGET_JOBS = frozenset(
         ("diff_budget.yml", "diff-budget"),
         ("ai_reconciliation_live.yml", "live-reconciliation"),
         ("pr_body_contract.yml", "pr-body-contract"),
+        ("pre_push_audit.yml", "pre-push-audit"),
     }
 )
 ALLOWED_ID_TOKEN_JOB = ("claude.yml", "claude")

--- a/scripts/check_ascii_python.sh
+++ b/scripts/check_ascii_python.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="${ATLAS_AUDIT_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+SCRIPT_ROOT="${ATLAS_AUDIT_SCRIPT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$ROOT_DIR"
 
-bash extracted/_shared/scripts/check_ascii_python.sh extracted_content_pipeline
+bash "$SCRIPT_ROOT/extracted/_shared/scripts/check_ascii_python.sh" extracted_content_pipeline

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -3,15 +3,31 @@
 
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
-
 base_ref="origin/main"
 base_ref_set=0
 allow_dirty=0
 current_pr_body_file="${ATLAS_CURRENT_PR_BODY_FILE:-}"
+repo_root=""
+script_root=""
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        --repo-root)
+            if [ "$#" -lt 2 ]; then
+                echo "local_pr_review.sh: --repo-root requires a path" >&2
+                exit 2
+            fi
+            repo_root="$2"
+            shift 2
+            ;;
+        --script-root)
+            if [ "$#" -lt 2 ]; then
+                echo "local_pr_review.sh: --script-root requires a path" >&2
+                exit 2
+            fi
+            script_root="$2"
+            shift 2
+            ;;
         --allow-dirty)
             allow_dirty=1
             shift
@@ -26,11 +42,14 @@ while [ "$#" -gt 0 ]; do
             ;;
         --help|-h)
             cat <<'EOF'
-Usage: bash scripts/local_pr_review.sh [--allow-dirty] [--current-pr-body-file PATH] [base-ref]
+Usage: bash scripts/local_pr_review.sh [--allow-dirty] [--repo-root PATH] [--script-root PATH] [--current-pr-body-file PATH] [base-ref]
 
 Run the local mechanical review bundle before opening or updating a PR.
 By default, the worktree must be clean so committed-diff checks cannot
 silently ignore uncommitted edits.
+
+By default, both roots are the current checkout. Trusted CI can execute scripts
+from --script-root while inspecting --repo-root as data.
 
 When running before the GitHub PR exists, pass --current-pr-body-file
 with the PR description you plan to use. The drift audit validates that
@@ -54,6 +73,20 @@ EOF
             ;;
     esac
 done
+
+if [ -z "$repo_root" ]; then
+    repo_root="$(git rev-parse --show-toplevel)"
+fi
+repo_root="$(cd "$repo_root" && pwd)"
+
+if [ -z "$script_root" ]; then
+    script_root="$repo_root"
+fi
+script_root="$(cd "$script_root" && pwd)"
+
+cd "$repo_root"
+export ATLAS_AUDIT_REPO_ROOT="$repo_root"
+export ATLAS_AUDIT_SCRIPT_ROOT="$script_root"
 
 failures=0
 
@@ -93,19 +126,19 @@ echo
 echo "changed files:"
 git diff --name-status "$base"...HEAD || true
 
-run_check "Pre-push audit wrapper" bash scripts/pre_push_audit.sh
+run_check "Pre-push audit wrapper" bash "$script_root/scripts/pre_push_audit.sh" --repo-root "$repo_root" --script-root "$script_root"
 
-if [ -f scripts/audit_extracted_pipeline_ci_enrollment.py ]; then
+if [ -f "$script_root/scripts/audit_extracted_pipeline_ci_enrollment.py" ]; then
     run_check "Extracted pipeline CI enrollment" \
-        python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from "$base_ref"
+        python "$script_root/scripts/audit_extracted_pipeline_ci_enrollment.py" --atlas-brain-tests-from "$base_ref"
 else
     echo
     echo "==> Extracted pipeline CI enrollment"
     echo "    SKIP (scripts/audit_extracted_pipeline_ci_enrollment.py not found)"
 fi
 
-if [ -f scripts/audit_pr_session_drift.py ]; then
-    drift_args=(scripts/audit_pr_session_drift.py "$base_ref" --require-current-pr-body)
+if [ -f "$script_root/scripts/audit_pr_session_drift.py" ]; then
+    drift_args=("$script_root/scripts/audit_pr_session_drift.py" "$base_ref" --require-current-pr-body)
     if [ -n "$current_pr_body_file" ]; then
         drift_args+=(--current-pr-body-file "$current_pr_body_file")
     fi
@@ -116,16 +149,16 @@ else
     echo "    SKIP (scripts/audit_pr_session_drift.py not found)"
 fi
 
-if [ -f scripts/audit_cross_layer_callers.py ]; then
-    run_check "Cross-layer caller hints" python scripts/audit_cross_layer_callers.py "$base_ref"
+if [ -f "$script_root/scripts/audit_cross_layer_callers.py" ]; then
+    run_check "Cross-layer caller hints" python "$script_root/scripts/audit_cross_layer_callers.py" "$base_ref"
 else
     echo
     echo "==> Cross-layer caller hints"
     echo "    SKIP (scripts/audit_cross_layer_callers.py not found)"
 fi
 
-if [ -f scripts/audit_ai_reconciliation.py ]; then
-    reconcile_args=(scripts/audit_ai_reconciliation.py)
+if [ -f "$script_root/scripts/audit_ai_reconciliation.py" ]; then
+    reconcile_args=("$script_root/scripts/audit_ai_reconciliation.py")
     if [ -n "$current_pr_body_file" ]; then
         reconcile_args+=(--current-pr-body-file "$current_pr_body_file")
     fi
@@ -145,13 +178,13 @@ committed_plan_docs=$(
 if [ -n "$committed_plan_docs" ]; then
     while IFS= read -r doc; do
         [ -z "$doc" ] && continue
-        if [ -f scripts/audit_plan_code_consistency.py ]; then
+        if [ -f "$script_root/scripts/audit_plan_code_consistency.py" ]; then
             run_check "Plan/code consistency: $doc" \
-                python scripts/audit_plan_code_consistency.py "$doc"
+                python "$script_root/scripts/audit_plan_code_consistency.py" "$doc"
         fi
-        if [ -f scripts/audit_review_rules_triggered.py ]; then
+        if [ -f "$script_root/scripts/audit_review_rules_triggered.py" ]; then
             run_check "Reviewer rules triggered: $doc" \
-                python scripts/audit_review_rules_triggered.py "$base_ref" --plan "$doc"
+                python "$script_root/scripts/audit_review_rules_triggered.py" "$base_ref" --plan "$doc"
         fi
     done <<< "$committed_plan_docs"
 else
@@ -167,8 +200,8 @@ run_check "git diff --check" git diff --check
 # always exits 0, and the guard keeps set -e happy if it is ever absent.
 echo
 echo "==> Plans archive backlog (advisory, non-blocking)"
-if [ -f scripts/archive_plans.py ]; then
-    python scripts/archive_plans.py check || true
+if [ -f "$script_root/scripts/archive_plans.py" ]; then
+    python "$script_root/scripts/archive_plans.py" check || true
     echo "    advisory only -- run 'python scripts/archive_plans.py archive' to archive merged plans"
 else
     echo "    SKIP (scripts/archive_plans.py not found)"

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -3,7 +3,61 @@
 
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+repo_root=""
+script_root=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo-root)
+            if [ "$#" -lt 2 ]; then
+                echo "pre_push_audit.sh: --repo-root requires a path" >&2
+                exit 2
+            fi
+            repo_root="$2"
+            shift 2
+            ;;
+        --script-root)
+            if [ "$#" -lt 2 ]; then
+                echo "pre_push_audit.sh: --script-root requires a path" >&2
+                exit 2
+            fi
+            script_root="$2"
+            shift 2
+            ;;
+        --help|-h)
+            cat <<'EOF'
+Usage: bash scripts/pre_push_audit.sh [--repo-root PATH] [--script-root PATH]
+
+Run mechanical audit checks before opening or updating a PR. By default, both
+roots are the current checkout. Trusted CI can execute scripts from
+--script-root while inspecting --repo-root as data.
+EOF
+            exit 0
+            ;;
+        --*)
+            echo "pre_push_audit.sh: unknown option: $1" >&2
+            exit 2
+            ;;
+        *)
+            echo "pre_push_audit.sh: unexpected argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$repo_root" ]; then
+    repo_root="$(git rev-parse --show-toplevel)"
+fi
+repo_root="$(cd "$repo_root" && pwd)"
+
+if [ -z "$script_root" ]; then
+    script_root="$repo_root"
+fi
+script_root="$(cd "$script_root" && pwd)"
+
+cd "$repo_root"
+export ATLAS_AUDIT_REPO_ROOT="$repo_root"
+export ATLAS_AUDIT_SCRIPT_ROOT="$script_root"
 
 failures=0
 
@@ -41,11 +95,11 @@ fi
 
 base="$(git merge-base HEAD "$base_ref")"
 
-run_check "CLAUDE.md MCP tool counts" python scripts/audit_claude_md_claims.py
-run_check "MCP port assignments" python scripts/audit_mcp_port_assignments.py
-run_check "MCP tool-name inventories" python scripts/audit_mcp_tool_names_match_docs.py
-run_check "Extracted manifest sync" python scripts/audit_extracted_manifests.py
-run_check "UI test:* CI enrollment" python scripts/audit_ui_test_enrollment.py
+run_check "CLAUDE.md MCP tool counts" python "$script_root/scripts/audit_claude_md_claims.py"
+run_check "MCP port assignments" python "$script_root/scripts/audit_mcp_port_assignments.py"
+run_check "MCP tool-name inventories" python "$script_root/scripts/audit_mcp_tool_names_match_docs.py"
+run_check "Extracted manifest sync" python "$script_root/scripts/audit_extracted_manifests.py"
+run_check "UI test:* CI enrollment" python "$script_root/scripts/audit_ui_test_enrollment.py"
 
 committed=$(
     git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null || true
@@ -66,13 +120,13 @@ diff_plan_docs=$(
 if [ -n "$plan_docs" ]; then
     while IFS= read -r doc; do
         [ -z "$doc" ] && continue
-        run_check "Plan shape: $doc" python scripts/audit_plan_doc.py "$doc"
+        run_check "Plan shape: $doc" python "$script_root/scripts/audit_plan_doc.py" "$doc"
     done <<< "$plan_docs"
 
     while IFS= read -r doc; do
         [ -z "$doc" ] && continue
-        run_check "Plan files touched: $doc" python scripts/audit_plan_doc_files_touched.py "$doc" "$base_ref"
-        run_check "Plan diff size: $doc" python scripts/audit_plan_doc_diff_size.py "$doc" "$base_ref"
+        run_check "Plan files touched: $doc" python "$script_root/scripts/audit_plan_doc_files_touched.py" "$doc" "$base_ref"
+        run_check "Plan diff size: $doc" python "$script_root/scripts/audit_plan_doc_diff_size.py" "$doc" "$base_ref"
     done <<< "$diff_plan_docs"
 else
     echo
@@ -80,8 +134,8 @@ else
     echo "    SKIP (no plans/PR-*.md added or modified vs $base_ref or working tree)"
 fi
 
-if [ -f scripts/check_ascii_python.sh ]; then
-    run_check "ASCII Python policy" bash scripts/check_ascii_python.sh
+if [ -f "$script_root/scripts/check_ascii_python.sh" ]; then
+    run_check "ASCII Python policy" bash "$script_root/scripts/check_ascii_python.sh"
 else
     echo
     echo "==> ASCII Python policy"

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -400,6 +400,7 @@ def test_converted_meta_gates_pull_request_target_is_allowed(tmp_path: Path) -> 
         ("diff_budget.yml", "diff-budget"),
         ("ai_reconciliation_live.yml", "live-reconciliation"),
         ("pr_body_contract.yml", "pr-body-contract"),
+        ("pre_push_audit.yml", "pre-push-audit"),
     ):
         workflow = _write_workflow(tmp_path, name, _trusted_gate_workflow(job))
         findings = auditor.audit_workflow(workflow)

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -118,6 +118,44 @@ def test_local_pr_review_runs_plans_archive_advisory_when_present(tmp_path: Path
     assert "local PR review passed" in result.stdout
 
 
+def test_local_pr_review_trusted_script_root_does_not_execute_repo_scripts(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_executable(
+        repo / "scripts" / "pre_push_audit.sh",
+        "#!/usr/bin/env bash\necho repo pre-push should not run >&2\nexit 99\n",
+    )
+    _git(repo, "add", "scripts/pre_push_audit.sh")
+    _git(repo, "commit", "-m", "hostile repo pre-push")
+
+    trusted = tmp_path / "trusted"
+    (trusted / "scripts").mkdir(parents=True)
+    _write_executable(
+        trusted / "scripts" / "local_pr_review.sh",
+        (REPO_ROOT / "scripts" / "local_pr_review.sh").read_text(encoding="utf-8"),
+    )
+    _write_executable(
+        trusted / "scripts" / "pre_push_audit.sh",
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf 'trusted pre-push cwd=%s\\n' \"$PWD\"\n",
+    )
+
+    result = _run(
+        tmp_path,
+        [
+            "bash",
+            str(trusted / "scripts" / "local_pr_review.sh"),
+            "--repo-root",
+            str(repo),
+            "--script-root",
+            str(trusted),
+        ],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"trusted pre-push cwd={repo}" in result.stdout
+    assert "repo pre-push should not run" not in result.stderr
+
+
 def test_local_pr_review_skips_plans_advisory_when_absent(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)

--- a/tests/test_pre_push_audit.py
+++ b/tests/test_pre_push_audit.py
@@ -115,6 +115,7 @@ def test_pre_push_audit_runs_shape_only_for_locally_modified_committed_plan(tmp_
 def _write_fixture_repo(repo: Path) -> None:
     (repo / "scripts").mkdir(parents=True)
     for name in (
+        "_audit_repo_root.py",
         "audit_claude_md_claims.py",
         "audit_extracted_manifests.py",
         "audit_mcp_port_assignments.py",

--- a/tests/test_pre_push_audit_workflow.py
+++ b/tests/test_pre_push_audit_workflow.py
@@ -6,21 +6,35 @@ from pathlib import Path
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "pre_push_audit.yml"
 
 
-def test_pre_push_audit_workflow_passes_pr_body_to_local_review() -> None:
+def test_pre_push_audit_workflow_pr_event_runs_trusted_base_split() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull_request_target:" in text
+    assert "if: github.event_name == 'pull_request_target'" in text
+    assert "Checkout trusted base" in text
+    assert "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" in text
+    assert "ref: ${{ github.event.pull_request.base.sha }}" in text
+    assert 'git worktree add "$RUNNER_TEMP/pr-tree" "refs/remotes/origin/pr-${PR_NUMBER}"' in text
+    assert '--repo-root "$RUNNER_TEMP/pr-tree"' in text
+    assert '--script-root "$GITHUB_WORKSPACE"' in text
+    assert "bash scripts/local_pr_review.sh \\" in text
+    assert 'python scripts/audit_workflow_security_posture.py "$RUNNER_TEMP/pr-tree/.github/workflows"' in text
+
+
+def test_pre_push_audit_workflow_passes_pr_body_to_trusted_local_review() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "Write current PR body" in text
-    assert "github.event_name == 'pull_request'" in text
     assert 'Path(os.environ["RUNNER_TEMP"], "current-pr-body.md")' in text
-    assert 'EVENT_NAME: ${{ github.event_name }}' in text
-    assert 'bash scripts/local_pr_review.sh --current-pr-body-file "$RUNNER_TEMP/current-pr-body.md"' in text
+    assert '--current-pr-body-file "$RUNNER_TEMP/current-pr-body.md"' in text
 
 
 def test_pre_push_audit_workflow_keeps_push_to_main_without_pr_body() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in text
-    assert "else\n            bash scripts/local_pr_review.sh\n          fi" in text
+    assert "pre-push-audit-main:" in text
+    assert "if: github.event_name == 'push'" in text
+    assert "run: bash scripts/local_pr_review.sh" in text
 
 
 def test_pre_push_audit_workflow_enrolls_push_pr_wrapper_tests() -> None:


### PR DESCRIPTION
Plan: plans/PR-Trusted-Base-Pre-Push-Audit.md
Slice phase: Vertical slice

Move the pre-push audit PR gate to trusted-base execution while inspecting the PR head as data. This closes the first tree-dependent follow-up from #1949: PR-owned local review scripts can no longer alter the pre-push audit gate that evaluates them.

## Intentional
- Maturity sweep trusted-base conversion is deferred to its own slice.
- PR-owned scripts and tests are not executed under `pull_request_target`; the PR checkout is data only.
- Permissions remain read-only.

## Deferred
- Trusted-base treatment for `maturity_sweep_advisory.yml` and `maturity_sweep_deflection_content_ops.yml`.
- Scheduled trusted sweep for review-event suppression from #1949.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_local_pr_review.py tests/test_pre_push_audit_workflow.py tests/test_audit_workflow_security_posture.py -q`
- `python -m pytest tests/test_pre_push_audit.py tests/test_audit_claude_md_claims.py tests/test_audit_mcp_tool_names_match_docs.py tests/test_audit_extracted_manifests.py tests/test_audit_ui_test_enrollment.py tests/test_audit_plan_code_consistency.py tests/test_audit_review_rules_triggered.py -q`
- `python -m py_compile scripts/_audit_repo_root.py scripts/audit_claude_md_claims.py scripts/audit_mcp_tool_names_match_docs.py scripts/audit_extracted_manifests.py scripts/audit_ui_test_enrollment.py scripts/audit_plan_code_consistency.py scripts/audit_review_rules_triggered.py scripts/audit_workflow_security_posture.py`
- `python scripts/audit_workflow_security_posture.py .github/workflows`
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-trusted-base-pre-push-audit.md`

## Diff size
18 files, +397 / -58
