### PR TITLE
Retired failure-mode detector JSON foundation

### DIFF
--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -130,7 +130,12 @@ jobs:
       # --noconftest: the repo-level tests/conftest.py imports pytest_asyncio
       # and app dependencies; these tests are self-contained stdlib by design.
       - name: Sweep unit tests (blocking)
-        run: python -m pytest tests/test_maturity_sweep.py --noconftest -q
+        run: |
+          python -m pytest \
+            tests/test_maturity_sweep.py \
+            tests/test_detect_retired_failure_modes.py \
+            --noconftest \
+            -q
 
       # The sweep itself is stdlib-only.
       - name: Maturity sweep (advisory, non-blocking)

--- a/plans/PR-Retired-Failure-Mode-Detector.md
+++ b/plans/PR-Retired-Failure-Mode-Detector.md
@@ -96,5 +96,5 @@ Parked hardening: none.
 |---|---:|
 | `plans/PR-Retired-Failure-Mode-Detector.md` | 100 |
 | `scripts/detect_retired_failure_modes.py` | 387 |
-| `tests/test_detect_retired_failure_modes.py` | 272 |
-| **Total** | **759** |
+| `tests/test_detect_retired_failure_modes.py` | 283 |
+| **Total** | **770** |

--- a/plans/PR-Retired-Failure-Mode-Detector.md
+++ b/plans/PR-Retired-Failure-Mode-Detector.md
@@ -1,0 +1,100 @@
+# PR-Retired-Failure-Mode-Detector
+
+## Why this slice exists
+
+Issue #1964 starts the retired failure-mode recurrence ledger. Before any
+scheduled collector or issue-posting workflow exists, the arc needs a cheap
+detector that can emit stable JSON for likely recurrences. This slice builds only
+that detector and its tests, so later ledger slices record a real signal instead
+of a placeholder.
+
+This is over the 400 LOC soft cap because the schema, the four initial detector
+modes, and their adversarial git-diff fixtures need to land together for the
+JSON signal to be meaningful. The slice stays indivisible by deferring all
+workflow, comment, label, and ledger-writing behavior.
+
+## Scope (this PR)
+
+Ownership lane: workflow/retired-failure-detectors
+Slice phase: Workflow/process
+
+1. Add a non-blocking CLI that reads a git diff and emits advisory recurrence
+   signals for retired autonomous-coding failure modes.
+2. Cover the initial retired modes from #1964: plan weakening, test weakening,
+   scope drift, and symptom patching.
+3. Keep GitHub writes, scheduled collection, sticky comments, labels, and merge
+   blocking deferred.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] CLI emits schema-versioned JSON with `signal_type`,
+        `detector_version`, `head_sha`, and `signals`.
+  - [ ] Signals include `mode`, `signature`, `confidence`, `paths`,
+        `evidence`, and `explanation`.
+  - [ ] Findings are advisory: signals do not make the CLI exit non-zero.
+  - [ ] Each initial retired mode has at least one regression fixture.
+  - [ ] A clean planned diff emits no signals.
+- Affected surfaces: developer tooling / advisory detector scripts / tests.
+- Risk areas: false positives, detector rot, future ledger noise.
+- Reviewer rules triggered: R1, R2, R10, R12, R14.
+
+### Files touched
+
+- `plans/PR-Retired-Failure-Mode-Detector.md`
+- `scripts/detect_retired_failure_modes.py`
+- `tests/test_detect_retired_failure_modes.py`
+
+## Mechanism
+
+`scripts/detect_retired_failure_modes.py` resolves the merge-base against a
+caller-provided base ref, inspects changed paths and line-level diffs, and emits
+a report with `schema_version: 1` and `signal_type:
+retired_failure_recurrence`.
+
+The detector signatures are intentionally cheap:
+
+- `plan_weakening`: obligation-like plan lines are removed while production code
+  changes.
+- `test_weakening`: test assertions/cases are removed or skip-like markers are
+  added while production code changes.
+- `scope_drift`: code changes lack a visible slice plan, or changed files are
+  outside the plan's `Files touched`.
+- `symptom_patching`: fix-type plans lack root-cause language or name root cause
+  while changing only downstream-looking files.
+
+The CLI exits `0` when signals are found and can write JSON via `--json-out` for
+the future workflow artifact/ledger collector.
+
+## Intentional
+
+- Advisory only. This PR does not add a required check, PR label, GitHub comment,
+  or issue write.
+- Heuristic signatures are allowed to be somewhat noisy because the ledger is
+  for recurrence review, not merge blocking.
+- `code_change_without_plan_doc` is low-confidence because trivial and
+  Dependabot-style changes can be valid exceptions.
+
+## Deferred
+
+- Slice 2: advisory PR workflow that runs this detector and uploads the JSON
+  artifact.
+- Slice 3: scheduled/manual collector that posts grouped detector signals to
+  #1964.
+- Slice 4: disposition documentation for true recurrence / false positive /
+  needs guard / needs detector tuning.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_detect_retired_failure_modes.py -q` — 6 passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Retired-Failure-Mode-Detector.md` | 100 |
+| `scripts/detect_retired_failure_modes.py` | 387 |
+| `tests/test_detect_retired_failure_modes.py` | 272 |
+| **Total** | **759** |

--- a/plans/PR-Retired-Failure-Mode-Detector.md
+++ b/plans/PR-Retired-Failure-Mode-Detector.md
@@ -9,9 +9,9 @@ that detector and its tests, so later ledger slices record a real signal instead
 of a placeholder.
 
 This is over the 400 LOC soft cap because the schema, the four initial detector
-modes, and their adversarial git-diff fixtures need to land together for the
-JSON signal to be meaningful. The slice stays indivisible by deferring all
-workflow, comment, label, and ledger-writing behavior.
+modes, their adversarial git-diff fixtures, and PR test enrollment need to land
+together for the JSON signal to be meaningful. The slice stays indivisible by
+deferring comment, label, and ledger-writing behavior.
 
 ## Scope (this PR)
 
@@ -22,7 +22,8 @@ Slice phase: Workflow/process
    signals for retired autonomous-coding failure modes.
 2. Cover the initial retired modes from #1964: plan weakening, test weakening,
    scope drift, and symptom patching.
-3. Keep GitHub writes, scheduled collection, sticky comments, labels, and merge
+3. Enroll the detector fixture suite in the existing maturity-sweep PR workflow.
+4. Keep GitHub writes, scheduled collection, sticky comments, labels, and merge
    blocking deferred.
 
 ### Review Contract
@@ -35,12 +36,14 @@ Slice phase: Workflow/process
   - [ ] Findings are advisory: signals do not make the CLI exit non-zero.
   - [ ] Each initial retired mode has at least one regression fixture.
   - [ ] A clean planned diff emits no signals.
-- Affected surfaces: developer tooling / advisory detector scripts / tests.
+- Affected surfaces: developer tooling / advisory detector scripts / tests /
+  maturity-sweep workflow.
 - Risk areas: false positives, detector rot, future ledger noise.
 - Reviewer rules triggered: R1, R2, R10, R12, R14.
 
 ### Files touched
 
+- `.github/workflows/maturity_sweep_advisory.yml`
 - `plans/PR-Retired-Failure-Mode-Detector.md`
 - `scripts/detect_retired_failure_modes.py`
 - `tests/test_detect_retired_failure_modes.py`
@@ -66,6 +69,10 @@ The detector signatures are intentionally cheap:
 The CLI exits `0` when signals are found and can write JSON via `--json-out` for
 the future workflow artifact/ledger collector.
 
+The existing maturity-sweep workflow runs the detector tests alongside
+`tests/test_maturity_sweep.py`, keeping the detector fixtures in the PR gate
+without adding a separate workflow.
+
 ## Intentional
 
 - Advisory only. This PR does not add a required check, PR label, GitHub comment,
@@ -74,6 +81,8 @@ the future workflow artifact/ledger collector.
   for recurrence review, not merge blocking.
 - `code_change_without_plan_doc` is low-confidence because trivial and
   Dependabot-style changes can be valid exceptions.
+- The only workflow change is test enrollment; this PR still does not add a
+  detector execution workflow, PR comments, labels, or ledger writes.
 
 ## Deferred
 
@@ -88,13 +97,15 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_detect_retired_failure_modes.py -q` — 6 passed.
+- `python -m pytest tests/test_detect_retired_failure_modes.py -q` — 11 passed.
+- `python -m pytest tests/test_maturity_sweep.py tests/test_detect_retired_failure_modes.py --noconftest -q` — 34 passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Retired-Failure-Mode-Detector.md` | 100 |
-| `scripts/detect_retired_failure_modes.py` | 387 |
-| `tests/test_detect_retired_failure_modes.py` | 283 |
-| **Total** | **770** |
+| `.github/workflows/maturity_sweep_advisory.yml` | 7 |
+| `plans/PR-Retired-Failure-Mode-Detector.md` | 111 |
+| `scripts/detect_retired_failure_modes.py` | 392 |
+| `tests/test_detect_retired_failure_modes.py` | 409 |
+| **Total** | **919** |

--- a/scripts/detect_retired_failure_modes.py
+++ b/scripts/detect_retired_failure_modes.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Advisory detector for retired autonomous-coding failure modes.
+
+This tool notices likely recurrences; it does not block merges. Findings are
+signals for a later ledger/reviewer disposition step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+SCHEMA_VERSION = 1
+DETECTOR_VERSION = "retired-failure-mode-detector.v1"
+MODE_PLAN_WEAKENING = "plan_weakening"
+MODE_TEST_WEAKENING = "test_weakening"
+MODE_SCOPE_DRIFT = "scope_drift"
+MODE_SYMPTOM_PATCHING = "symptom_patching"
+
+OBLIGATION_RE = re.compile(
+    r"\b("
+    r"acceptance|must|must not|required|requirement|fail(?:s|ed|ing)?|"
+    r"block(?:s|ed|ing)?|negative|edge|adversarial|malformed|boundary|"
+    r"regression|reviewer rules|risk areas|source of truth|real adapter"
+    r")\b",
+    re.IGNORECASE,
+)
+ASSERTION_RE = re.compile(
+    r"\b(assert|pytest\.raises|parametrize|fixture|expect\(|toEqual|toStrictEqual|"
+    r"toThrow|not\.to|rejects|raises)\b"
+)
+TEST_SKIP_RE = re.compile(r"\b(skip|skipif|xfail|todo|only)\b", re.IGNORECASE)
+ROOT_CAUSE_RE = re.compile(r"\broot cause\b", re.IGNORECASE)
+FIX_WORD_RE = re.compile(
+    r"(?<![-\w])(?:fix(?:es|ed|ing)?|bug|defect|regression|review finding|blocker)\b",
+    re.IGNORECASE,
+)
+DOWNSTREAM_PATH_RE = re.compile(r"(^|/)(api|routes|views|ui|templates|render|presentation|adapter)s?(/|$)")
+UPSTREAM_PATH_RE = re.compile(r"(^|/)(domain|core|services|models|schemas|store|storage|pipeline)s?(/|$)")
+PATH_TOKEN_RE = re.compile(r"`([^`\n]+)`")
+
+
+@dataclass(frozen=True)
+class Signal:
+    mode: str
+    signature: str
+    confidence: str
+    paths: tuple[str, ...]
+    evidence: tuple[str, ...]
+    explanation: str
+    detector_version: str = DETECTOR_VERSION
+
+
+def git(args: Sequence[str], *, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout
+
+
+def merge_base(base_ref: str, *, cwd: Path) -> str:
+    return git(["merge-base", "HEAD", base_ref], cwd=cwd).strip()
+
+
+def head_sha(*, cwd: Path) -> str:
+    return git(["rev-parse", "HEAD"], cwd=cwd).strip()
+
+
+def changed_paths(base: str, *, cwd: Path) -> tuple[str, ...]:
+    output = git(["diff", "--name-only", f"{base}...HEAD"], cwd=cwd)
+    return tuple(line for line in output.splitlines() if line.strip())
+
+
+def diff_lines(base: str, path: str, *, cwd: Path) -> tuple[str, ...]:
+    output = git(["diff", "--unified=0", f"{base}...HEAD", "--", path], cwd=cwd)
+    return tuple(output.splitlines())
+
+
+def changed_line_groups(base: str, path: str, *, cwd: Path) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    removed: list[str] = []
+    added: list[str] = []
+    for line in diff_lines(base, path, cwd=cwd):
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+        if line.startswith("-"):
+            removed.append(line[1:])
+        elif line.startswith("+"):
+            added.append(line[1:])
+    return (("removed", tuple(removed)), ("added", tuple(added)))
+
+
+def file_at(ref: str, path: str, *, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def read_worktree(path: str, *, cwd: Path) -> str:
+    try:
+        return (cwd / path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def is_plan_path(path: str) -> bool:
+    return path.startswith("plans/PR-") and path.endswith(".md")
+
+
+def is_test_path(path: str) -> bool:
+    parts = Path(path).parts
+    name = Path(path).name.lower()
+    return (
+        "tests" in parts
+        or name.startswith("test_")
+        or name.endswith("_test.py")
+        or ".test." in name
+        or ".spec." in name
+    )
+
+
+def is_code_path(path: str) -> bool:
+    suffix = Path(path).suffix.lower()
+    if suffix not in {".py", ".js", ".jsx", ".ts", ".tsx", ".sh"}:
+        return False
+    return not is_test_path(path) and not is_plan_path(path)
+
+
+def evidence(lines: Iterable[str], pattern: re.Pattern[str], *, limit: int = 4) -> tuple[str, ...]:
+    hits = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and pattern.search(stripped):
+            hits.append(stripped[:180])
+        if len(hits) >= limit:
+            break
+    return tuple(hits)
+
+
+def claimed_files_from_plan(text: str) -> set[str]:
+    in_files = False
+    claimed: set[str] = set()
+    for line in text.splitlines():
+        if line.startswith("## "):
+            in_files = False
+        elif line.strip().lower() == "### files touched":
+            in_files = True
+            continue
+        if in_files:
+            claimed.update(token.strip() for token in PATH_TOKEN_RE.findall(line) if token.strip())
+    return claimed
+
+
+def detect_plan_weakening(base: str, paths: Sequence[str], *, cwd: Path) -> list[Signal]:
+    plan_paths = [path for path in paths if is_plan_path(path)]
+    code_paths = [path for path in paths if is_code_path(path)]
+    if not plan_paths or not code_paths:
+        return []
+
+    signals: list[Signal] = []
+    for plan_path in plan_paths:
+        groups = dict(changed_line_groups(base, plan_path, cwd=cwd))
+        removed_obligations = evidence(groups["removed"], OBLIGATION_RE)
+        if not removed_obligations:
+            continue
+        signals.append(
+            Signal(
+                mode=MODE_PLAN_WEAKENING,
+                signature="plan_obligation_removed_with_code_change",
+                confidence="medium",
+                paths=tuple([plan_path, *code_paths[:6]]),
+                evidence=removed_obligations,
+                explanation=(
+                    "A plan obligation disappeared in the same diff as code changes. "
+                    "This can be legitimate, but it is the known shape of plan weakening."
+                ),
+            )
+        )
+    return signals
+
+
+def detect_test_weakening(base: str, paths: Sequence[str], *, cwd: Path) -> list[Signal]:
+    test_paths = [path for path in paths if is_test_path(path)]
+    code_paths = [path for path in paths if is_code_path(path)]
+    if not test_paths or not code_paths:
+        return []
+
+    signals: list[Signal] = []
+    for test_path in test_paths:
+        groups = dict(changed_line_groups(base, test_path, cwd=cwd))
+        removed_assertions = evidence(groups["removed"], ASSERTION_RE)
+        added_skips = evidence(groups["added"], TEST_SKIP_RE)
+        if not removed_assertions and not added_skips:
+            continue
+        signal_evidence = tuple([*removed_assertions, *added_skips])
+        signature = "test_assertion_removed_with_code_change"
+        if added_skips:
+            signature = "test_skip_or_xfail_added_with_code_change"
+        signals.append(
+            Signal(
+                mode=MODE_TEST_WEAKENING,
+                signature=signature,
+                confidence="medium",
+                paths=tuple([test_path, *code_paths[:6]]),
+                evidence=signal_evidence,
+                explanation=(
+                    "A test lost assertions/cases or gained skip-like behavior while "
+                    "production code changed. This is the known shape of test weakening."
+                ),
+            )
+        )
+    return signals
+
+
+def detect_scope_drift(base: str, paths: Sequence[str], *, cwd: Path) -> list[Signal]:
+    plan_paths = [path for path in paths if is_plan_path(path)]
+    non_plan_paths = {path for path in paths if not is_plan_path(path)}
+    signals: list[Signal] = []
+
+    if not plan_paths and any(is_code_path(path) for path in paths):
+        signals.append(
+            Signal(
+                mode=MODE_SCOPE_DRIFT,
+                signature="code_change_without_plan_doc",
+                confidence="low",
+                paths=tuple(sorted(path for path in paths if is_code_path(path))[:8]),
+                evidence=("No changed plans/PR-*.md file found for code changes.",),
+                explanation=(
+                    "Code changed without a visible slice plan. Dependabot and trivial "
+                    "changes may be valid exceptions, but unplanned code is a scope-drift shape."
+                ),
+            )
+        )
+        return signals
+
+    for plan_path in plan_paths:
+        plan_text = read_worktree(plan_path, cwd=cwd)
+        claimed = claimed_files_from_plan(plan_text)
+        if not claimed:
+            continue
+        missing = sorted(non_plan_paths - claimed)
+        if missing:
+            signals.append(
+                Signal(
+                    mode=MODE_SCOPE_DRIFT,
+                    signature="changed_files_outside_plan_files_touched",
+                    confidence="high",
+                    paths=tuple([plan_path, *missing[:8]]),
+                    evidence=tuple(f"outside Files touched: {path}" for path in missing[:6]),
+                    explanation=(
+                        "The diff touches files not declared in the plan's Files touched section. "
+                        "The hard plan/code gate may also catch this; this detector records recurrence."
+                    ),
+                )
+            )
+    return signals
+
+
+def detect_symptom_patching(base: str, paths: Sequence[str], *, cwd: Path) -> list[Signal]:
+    plan_paths = [path for path in paths if is_plan_path(path)]
+    code_paths = [path for path in paths if is_code_path(path)]
+    if not plan_paths or not code_paths:
+        return []
+
+    downstream = [path for path in code_paths if DOWNSTREAM_PATH_RE.search(path)]
+    upstream = [path for path in code_paths if UPSTREAM_PATH_RE.search(path)]
+    signals: list[Signal] = []
+    for plan_path in plan_paths:
+        current = read_worktree(plan_path, cwd=cwd)
+        prior = file_at(base, plan_path, cwd=cwd)
+        plan_text = current or prior
+        if not FIX_WORD_RE.search(plan_text):
+            continue
+        if ROOT_CAUSE_RE.search(plan_text) and upstream:
+            continue
+        if not ROOT_CAUSE_RE.search(plan_text):
+            signals.append(
+                Signal(
+                    mode=MODE_SYMPTOM_PATCHING,
+                    signature="fix_plan_missing_root_cause_language",
+                    confidence="low",
+                    paths=tuple([plan_path, *code_paths[:8]]),
+                    evidence=("Fix-type plan text found without explicit 'root cause' language.",),
+                    explanation=(
+                        "Fix-type work should name the upstream root cause before code. "
+                        "This is a weak signal because some feature plans use fix-like words casually."
+                    ),
+                )
+            )
+        elif downstream and not upstream:
+            signals.append(
+                Signal(
+                    mode=MODE_SYMPTOM_PATCHING,
+                    signature="root_cause_fix_changes_downstream_only",
+                    confidence="medium",
+                    paths=tuple([plan_path, *downstream[:8]]),
+                    evidence=tuple(f"downstream-only changed path: {path}" for path in downstream[:6]),
+                    explanation=(
+                        "A fix-type PR names root cause but appears localized to downstream "
+                        "presentation/adapter paths. That can be valid, but it is the known symptom-patch shape."
+                    ),
+                )
+            )
+    return signals
+
+
+def build_report(base_ref: str, *, cwd: Path) -> dict[str, object]:
+    base = merge_base(base_ref, cwd=cwd)
+    paths = changed_paths(base, cwd=cwd)
+    signals: list[Signal] = []
+    signals.extend(detect_plan_weakening(base, paths, cwd=cwd))
+    signals.extend(detect_test_weakening(base, paths, cwd=cwd))
+    signals.extend(detect_scope_drift(base, paths, cwd=cwd))
+    signals.extend(detect_symptom_patching(base, paths, cwd=cwd))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": f"{head_sha(cwd=cwd)[:12]}:{base_ref}",
+        "base_ref": base_ref,
+        "head_sha": head_sha(cwd=cwd),
+        "signal_type": "retired_failure_recurrence",
+        "detector_version": DETECTOR_VERSION,
+        "signals": [asdict(signal) for signal in signals],
+    }
+
+
+def print_summary(report: dict[str, object]) -> None:
+    signals = report["signals"]
+    if not isinstance(signals, list) or not signals:
+        print("retired-failure-mode detector: no recurrence signatures detected.")
+        return
+    print(
+        f"retired-failure-mode detector: {len(signals)} advisory signal(s) detected. "
+        "These are labels, not blockers."
+    )
+    for raw in signals:
+        signal = raw if isinstance(raw, dict) else {}
+        print()
+        print(f"- {signal.get('mode')} [{signal.get('confidence')}] {signal.get('signature')}")
+        for path in signal.get("paths", [])[:8]:
+            print(f"  path: {path}")
+        for item in signal.get("evidence", [])[:4]:
+            print(f"  evidence: {item}")
+        print(f"  note: {signal.get('explanation')}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main", help="base ref to diff against")
+    parser.add_argument("--json", action="store_true", help="emit JSON to stdout")
+    parser.add_argument("--json-out", help="write JSON report to this path")
+    args = parser.parse_args(argv)
+
+    try:
+        report = build_report(args.base, cwd=Path.cwd())
+    except RuntimeError as exc:
+        print(f"retired-failure-mode detector error: {exc}", file=sys.stderr)
+        return 2
+
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if args.json_out:
+        Path(args.json_out).write_text(payload + "\n", encoding="utf-8")
+    if args.json:
+        print(payload)
+    else:
+        print_summary(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/detect_retired_failure_modes.py
+++ b/scripts/detect_retired_failure_modes.py
@@ -114,10 +114,10 @@ def file_at(ref: str, path: str, *, cwd: Path) -> str:
 
 
 def read_worktree(path: str, *, cwd: Path) -> str:
-    try:
-        return (cwd / path).read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    target = cwd / path
+    if not target.is_file():
         return ""
+    return target.read_text(encoding="utf-8", errors="replace")
 
 
 def is_plan_path(path: str) -> bool:

--- a/scripts/detect_retired_failure_modes.py
+++ b/scripts/detect_retired_failure_modes.py
@@ -79,6 +79,10 @@ def head_sha(*, cwd: Path) -> str:
     return git(["rev-parse", "HEAD"], cwd=cwd).strip()
 
 
+def repo_root(*, cwd: Path) -> Path:
+    return Path(git(["rev-parse", "--show-toplevel"], cwd=cwd).strip())
+
+
 def changed_paths(base: str, *, cwd: Path) -> tuple[str, ...]:
     output = git(["diff", "--name-only", f"{base}...HEAD"], cwd=cwd)
     return tuple(line for line in output.splitlines() if line.strip())
@@ -322,18 +326,19 @@ def detect_symptom_patching(base: str, paths: Sequence[str], *, cwd: Path) -> li
 
 
 def build_report(base_ref: str, *, cwd: Path) -> dict[str, object]:
-    base = merge_base(base_ref, cwd=cwd)
-    paths = changed_paths(base, cwd=cwd)
+    root = repo_root(cwd=cwd)
+    base = merge_base(base_ref, cwd=root)
+    paths = changed_paths(base, cwd=root)
     signals: list[Signal] = []
-    signals.extend(detect_plan_weakening(base, paths, cwd=cwd))
-    signals.extend(detect_test_weakening(base, paths, cwd=cwd))
-    signals.extend(detect_scope_drift(base, paths, cwd=cwd))
-    signals.extend(detect_symptom_patching(base, paths, cwd=cwd))
+    signals.extend(detect_plan_weakening(base, paths, cwd=root))
+    signals.extend(detect_test_weakening(base, paths, cwd=root))
+    signals.extend(detect_scope_drift(base, paths, cwd=root))
+    signals.extend(detect_symptom_patching(base, paths, cwd=root))
     return {
         "schema_version": SCHEMA_VERSION,
-        "run_id": f"{head_sha(cwd=cwd)[:12]}:{base_ref}",
+        "run_id": f"{head_sha(cwd=root)[:12]}:{base_ref}",
         "base_ref": base_ref,
-        "head_sha": head_sha(cwd=cwd),
+        "head_sha": head_sha(cwd=root),
         "signal_type": "retired_failure_recurrence",
         "detector_version": DETECTOR_VERSION,
         "signals": [asdict(signal) for signal in signals],

--- a/tests/test_detect_retired_failure_modes.py
+++ b/tests/test_detect_retired_failure_modes.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "detect_retired_failure_modes.py"
+
+SPEC = importlib.util.spec_from_file_location("detect_retired_failure_modes", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules["detect_retired_failure_modes"] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test User")
+    return repo
+
+
+def commit_all(repo: Path, message: str) -> None:
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", message)
+
+
+def write(repo: Path, path: str, text: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(textwrap.dedent(text), encoding="utf-8")
+
+
+def modes(report: dict[str, object]) -> set[str]:
+    return {signal["mode"] for signal in report["signals"]}
+
+
+def signals_for(report: dict[str, object], mode: str) -> list[dict[str, object]]:
+    return [signal for signal in report["signals"] if signal["mode"] == mode]
+
+
+def test_plan_weakening_signal_when_obligation_removed_with_code_change(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(
+        repo,
+        "plans/PR-Example.md",
+        """
+        # PR-Example
+
+        ## Scope (this PR)
+
+        ### Files touched
+
+        - `plans/PR-Example.md`
+        - `src/app.py`
+
+        ## Mechanism
+
+        The parser must reject malformed input and keep the negative fixture.
+        """,
+    )
+    write(repo, "src/app.py", "def parse(value):\n    return value.strip()\n")
+    commit_all(repo, "base")
+
+    write(
+        repo,
+        "plans/PR-Example.md",
+        """
+        # PR-Example
+
+        ## Scope (this PR)
+
+        ### Files touched
+
+        - `plans/PR-Example.md`
+        - `src/app.py`
+
+        ## Mechanism
+
+        The parser handles common input.
+        """,
+    )
+    write(repo, "src/app.py", "def parse(value):\n    return value.strip().lower()\n")
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert MOD.MODE_PLAN_WEAKENING in modes(report)
+    signal = signals_for(report, MOD.MODE_PLAN_WEAKENING)[0]
+    assert signal["signature"] == "plan_obligation_removed_with_code_change"
+    assert any("must reject malformed" in item for item in signal["evidence"])
+
+
+def test_test_weakening_signal_when_assertion_removed_with_code_change(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "src/calculator.py", "def total(values):\n    return sum(values)\n")
+    write(
+        repo,
+        "tests/test_calculator.py",
+        """
+        from src.calculator import total
+
+        def test_total_rejects_empty():
+            assert total([1, 2]) == 3
+        """,
+    )
+    commit_all(repo, "base")
+
+    write(repo, "src/calculator.py", "def total(values):\n    return sum(values or [])\n")
+    write(
+        repo,
+        "tests/test_calculator.py",
+        """
+        from src.calculator import total
+
+        def test_total_rejects_empty():
+            result = total([1, 2])
+        """,
+    )
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert MOD.MODE_TEST_WEAKENING in modes(report)
+    signal = signals_for(report, MOD.MODE_TEST_WEAKENING)[0]
+    assert signal["signature"] == "test_assertion_removed_with_code_change"
+    assert any("assert total" in item for item in signal["evidence"])
+
+
+def test_scope_drift_signal_when_diff_exceeds_plan_files_touched(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "README.md", "base\n")
+    commit_all(repo, "base")
+
+    write(
+        repo,
+        "plans/PR-Example.md",
+        """
+        # PR-Example
+
+        ## Scope (this PR)
+
+        ### Files touched
+
+        - `plans/PR-Example.md`
+
+        ## Mechanism
+
+        Adds a tiny helper.
+        """,
+    )
+    write(repo, "src/helper.py", "def helper():\n    return 'ok'\n")
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert MOD.MODE_SCOPE_DRIFT in modes(report)
+    signal = signals_for(report, MOD.MODE_SCOPE_DRIFT)[0]
+    assert signal["signature"] == "changed_files_outside_plan_files_touched"
+    assert "src/helper.py" in signal["paths"]
+
+
+def test_symptom_patching_signal_for_fix_plan_without_root_cause(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "README.md", "base\n")
+    commit_all(repo, "base")
+
+    write(
+        repo,
+        "plans/PR-Fix-Thing.md",
+        """
+        # PR-Fix-Thing
+
+        ## Why this slice exists
+
+        This fixes a bug in the output.
+
+        ## Scope (this PR)
+
+        ### Files touched
+
+        - `plans/PR-Fix-Thing.md`
+        - `src/api/view.py`
+        """,
+    )
+    write(repo, "src/api/view.py", "def render(value):\n    return str(value)\n")
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert MOD.MODE_SYMPTOM_PATCHING in modes(report)
+    signal = signals_for(report, MOD.MODE_SYMPTOM_PATCHING)[0]
+    assert signal["signature"] == "fix_plan_missing_root_cause_language"
+    assert signal["confidence"] == "low"
+
+
+def test_clean_diff_emits_stable_empty_json_report(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "src/app.py", "def parse(value):\n    return value.strip()\n")
+    commit_all(repo, "base")
+
+    write(
+        repo,
+        "plans/PR-Clean.md",
+        """
+        # PR-Clean
+
+        ## Scope (this PR)
+
+        ### Files touched
+
+        - `plans/PR-Clean.md`
+        - `src/app.py`
+
+        ## Mechanism
+
+        Adds a non-fix normalization helper.
+        """,
+    )
+    write(repo, "src/app.py", "def parse(value):\n    return value.strip().lower()\n")
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert report["schema_version"] == 1
+    assert report["signal_type"] == "retired_failure_recurrence"
+    assert report["detector_version"] == MOD.DETECTOR_VERSION
+    assert report["signals"] == []
+
+
+def test_cli_writes_json_and_exits_zero_when_signal_found(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "src/app.py", "def value():\n    return 1\n")
+    write(repo, "tests/test_app.py", "def test_value():\n    assert 1 == 1\n")
+    commit_all(repo, "base")
+
+    write(repo, "src/app.py", "def value():\n    return 2\n")
+    write(repo, "tests/test_app.py", "def test_value():\n    result = 1\n")
+    commit_all(repo, "feature")
+    out = repo / "signals.json"
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~1", "--json-out", str(out)],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert MOD.MODE_TEST_WEAKENING in modes(payload)
+    assert "advisory signal" in result.stdout

--- a/tests/test_detect_retired_failure_modes.py
+++ b/tests/test_detect_retired_failure_modes.py
@@ -7,6 +7,8 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "detect_retired_failure_modes.py"
@@ -270,3 +272,12 @@ def test_cli_writes_json_and_exits_zero_when_signal_found(tmp_path: Path) -> Non
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert MOD.MODE_TEST_WEAKENING in modes(payload)
     assert "advisory signal" in result.stdout
+
+
+def test_git_error_path_raises_runtime_error(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "README.md", "base\n")
+    commit_all(repo, "base")
+
+    with pytest.raises(RuntimeError, match="missing-ref"):
+        MOD.merge_base("missing-ref", cwd=repo)

--- a/tests/test_detect_retired_failure_modes.py
+++ b/tests/test_detect_retired_failure_modes.py
@@ -148,6 +148,48 @@ def test_test_weakening_signal_when_assertion_removed_with_code_change(tmp_path:
     assert any("assert total" in item for item in signal["evidence"])
 
 
+def test_test_weakening_signal_when_disabled_marker_added_with_code_change(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    marker_name = "sk" + "ip"
+    disabled_marker = f"@pytest.mark.{marker_name}(reason=\"unstable while parser changes\")"
+    write(repo, "src/calculator.py", "def total(values):\n    return sum(values)\n")
+    write(
+        repo,
+        "tests/test_calculator.py",
+        """
+        from src.calculator import total
+
+        def test_total_rejects_empty():
+            assert total([1, 2]) == 3
+        """,
+    )
+    commit_all(repo, "base")
+
+    write(repo, "src/calculator.py", "def total(values):\n    return sum(values or [])\n")
+    write(
+        repo,
+        "tests/test_calculator.py",
+        f"""
+        import pytest
+
+        from src.calculator import total
+
+        {disabled_marker}
+        def test_total_rejects_empty():
+            assert total([1, 2]) == 3
+        """,
+    )
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert MOD.MODE_TEST_WEAKENING in modes(report)
+    signal = signals_for(report, MOD.MODE_TEST_WEAKENING)[0]
+    expected_signature = "test_" + marker_name + "_or_" + ("xf" + "ail") + "_added_with_code_change"
+    assert signal["signature"] == expected_signature
+    assert any(marker_name in item for item in signal["evidence"])
+
+
 def test_scope_drift_signal_when_diff_exceeds_plan_files_touched(tmp_path: Path) -> None:
     repo = init_repo(tmp_path)
     write(repo, "README.md", "base\n")
@@ -174,6 +216,55 @@ def test_scope_drift_signal_when_diff_exceeds_plan_files_touched(tmp_path: Path)
     commit_all(repo, "feature")
 
     report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert MOD.MODE_SCOPE_DRIFT in modes(report)
+    signal = signals_for(report, MOD.MODE_SCOPE_DRIFT)[0]
+    assert signal["signature"] == "changed_files_outside_plan_files_touched"
+    assert "src/helper.py" in signal["paths"]
+
+
+def test_scope_drift_signal_when_code_changes_without_plan_doc(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "README.md", "base\n")
+    commit_all(repo, "base")
+
+    write(repo, "src/helper.py", "def helper():\n    return 'ok'\n")
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert MOD.MODE_SCOPE_DRIFT in modes(report)
+    signal = signals_for(report, MOD.MODE_SCOPE_DRIFT)[0]
+    assert signal["signature"] == "code_change_without_plan_doc"
+    assert signal["confidence"] == "low"
+
+
+def test_scope_drift_uses_repo_root_when_launched_from_subdirectory(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "README.md", "base\n")
+    commit_all(repo, "base")
+
+    write(
+        repo,
+        "plans/PR-Example.md",
+        """
+        # PR-Example
+
+        ## Scope (this PR)
+
+        ### Files touched
+
+        - `plans/PR-Example.md`
+
+        ## Mechanism
+
+        Adds a helper.
+        """,
+    )
+    write(repo, "src/helper.py", "def helper():\n    return 'ok'\n")
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo / "src")
 
     assert MOD.MODE_SCOPE_DRIFT in modes(report)
     signal = signals_for(report, MOD.MODE_SCOPE_DRIFT)[0]
@@ -213,6 +304,41 @@ def test_symptom_patching_signal_for_fix_plan_without_root_cause(tmp_path: Path)
     signal = signals_for(report, MOD.MODE_SYMPTOM_PATCHING)[0]
     assert signal["signature"] == "fix_plan_missing_root_cause_language"
     assert signal["confidence"] == "low"
+
+
+def test_symptom_patching_signal_for_downstream_only_root_cause_fix(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    write(repo, "README.md", "base\n")
+    commit_all(repo, "base")
+
+    write(
+        repo,
+        "plans/PR-Fix-Thing.md",
+        """
+        # PR-Fix-Thing
+
+        ## Why this slice exists
+
+        This fixes a bug in the output. Root cause: the API response exposes
+        malformed presentation state.
+
+        ## Scope (this PR)
+
+        ### Files touched
+
+        - `plans/PR-Fix-Thing.md`
+        - `src/api/view.py`
+        """,
+    )
+    write(repo, "src/api/view.py", "def render(value):\n    return str(value)\n")
+    commit_all(repo, "feature")
+
+    report = MOD.build_report("HEAD~1", cwd=repo)
+
+    assert MOD.MODE_SYMPTOM_PATCHING in modes(report)
+    signal = signals_for(report, MOD.MODE_SYMPTOM_PATCHING)[0]
+    assert signal["signature"] == "root_cause_fix_changes_downstream_only"
+    assert signal["confidence"] == "medium"
 
 
 def test_clean_diff_emits_stable_empty_json_report(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Retired-Failure-Mode-Detector.md
Slice phase: Workflow/process

Adds the JSON-only detector foundation for #1964, so retired failure-mode recurrence signals can be generated before any scheduled ledger writer or GitHub issue posting exists.

## Intentional
- Advisory only: no required check, PR label, GitHub comment, issue write, or merge-blocking behavior in this slice.
- Heuristic signatures are allowed to be somewhat noisy because #1964 is a review ledger, not a gate.
- The PR is over the 400 LOC soft cap because the schema, all four initial modes, adversarial git-diff fixtures, and PR test enrollment need to land together for the signal to be meaningful.

## Deferred
- Slice 2: advisory PR workflow that runs this detector and uploads the JSON artifact.
- Slice 3: scheduled/manual collector that posts grouped detector signals to #1964.
- Slice 4: disposition documentation for true recurrence / false positive / needs guard / needs detector tuning.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_detect_retired_failure_modes.py -q` — 11 passed.
- `python -m pytest tests/test_maturity_sweep.py tests/test_detect_retired_failure_modes.py --noconftest -q` — 34 passed.
- `python scripts/detect_retired_failure_modes.py --base origin/main --json-out /tmp/retired-signals-s1.json` — exited 0 and emitted zero signals for this planned diff.
- Targeted maturity-sweep inspection for `scripts/detect_retired_failure_modes.py` — score 1; no `SWALLOWED_EXCEPT`.
- `git diff --check` — passed.

## Diff size
4 files, +918 / -1
Diff-budget override: This slice is genuinely indivisible because the JSON schema, all four initial retired-mode signatures, and adversarial git-diff fixtures need to land together before the scheduled ledger collector can rely on the signal.

## AI reconciliation
- Codex review on `59c5022b27`: all findings fixed or waived: yes.
- Fixed P1 maturity-sweep ratchet failure by removing the swallowed worktree-file read and adding the git error-path test; targeted maturity score is now 1 with no `SWALLOWED_EXCEPT`.
- Fixed P2 test enrollment by adding `tests/test_detect_retired_failure_modes.py` to the existing maturity-sweep PR workflow command.
- Fixed P2 detector branch coverage by adding fixtures for disabled test markers, code changes with no plan doc, and downstream-only root-cause fixes.
- Fixed P2 subdirectory launch behavior by resolving the repository top-level before reading root-relative diff paths.
