### PR TITLE
Retired failure detector advisory workflow

### DIFF
--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -134,6 +134,7 @@ jobs:
           python -m pytest \
             tests/test_maturity_sweep.py \
             tests/test_detect_retired_failure_modes.py \
+            tests/test_retired_failure_detector_workflow.py \
             --noconftest \
             -q
 

--- a/.github/workflows/maturity_sweep_advisory.yml
+++ b/.github/workflows/maturity_sweep_advisory.yml
@@ -16,6 +16,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/maturity_sweep_advisory.yml"
+      - ".github/workflows/retired_failure_detector.yml"
       - "scripts/maturity_sweep.py"
       - "scripts/**"
       - "tests/**"
@@ -65,6 +66,7 @@ on:
       - main
     paths:
       - ".github/workflows/maturity_sweep_advisory.yml"
+      - ".github/workflows/retired_failure_detector.yml"
       - "scripts/maturity_sweep.py"
       - "scripts/**"
       - "tests/**"

--- a/.github/workflows/retired_failure_detector.yml
+++ b/.github/workflows/retired_failure_detector.yml
@@ -1,0 +1,50 @@
+name: Retired Failure Detector
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+jobs:
+  retired-failure-detector:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+
+      - name: Resolve base ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          base_ref="${PR_BASE_REF:-main}"
+          git fetch --no-tags origin "+refs/heads/${base_ref}:refs/remotes/origin/${base_ref}"
+          printf 'base_ref=%s\n' "${base_ref}" >> "$GITHUB_ENV"
+
+      - name: Run retired failure detector
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/retired-failure-detector
+          python scripts/detect_retired_failure_modes.py \
+            --base "origin/${base_ref}" \
+            --json-out artifacts/retired-failure-detector/retired-failure-signals.json
+
+      - name: Upload retired failure detector artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: retired-failure-detector-signals-${{ github.run_id }}
+          path: artifacts/retired-failure-detector
+          if-no-files-found: error
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,26 +400,33 @@ For long-running coding tasks, after each PR open or push:
 
 1. Subscribe the session to its owned PR in `SESSION_STATE.local.md`. Record the
    PR number, branch, head SHA, checks URL, review/reconciliation URL or
-   commands, next poll time, and the exact action to take when checks turn
-   green or comments appear.
-2. Install or run a lane-local watcher/poll loop that checks the owned PR every
-   **30 minutes**. It may use GitHub webhooks when available, but it must also
-   have a polling fallback; do not depend on an ephemeral chat turn staying
-   alive.
-3. On each wake, refresh the PR head, CI/check status, review-thread status,
+   commands, the timer hook name, next timer wake time, and the exact action to
+   take when checks turn green or comments appear.
+2. Install or run **two external wake hooks** for the owned PR:
+   - a push/review-event hook that wakes immediately when a new push, review
+     thread, review event, or reconciliation event arrives;
+   - a timer hook that wakes every **30 minutes** to check whether CI is green
+     and the PR is mergeable.
+3. The timer hook must be a webhook/systemd/cron-style wakeup that exits fast
+   after recording state. Do not keep an in-chat `sleep` loop or active polling
+   process alive just to wait for green CI.
+4. On each wake, refresh the PR head, CI/check status, review-thread status,
    live reconciliation, and merge-conflict state before deciding anything.
-4. If checks are red or review comments are actionable, summarize the current
+5. If checks are red or review comments are actionable, summarize the current
    blocker, fix the upstream/root cause inside the current slice, push, resolve
-   fixed threads, update the PR body/reconciliation record, and reset the
-   watcher.
-5. If checks are still pending, record the last observed status and next poll
-   time in `SESSION_STATE.local.md`; do not ask the operator to babysit green.
-6. If all required checks are green and all review/reconciliation gates are
+   fixed threads, update the PR body/reconciliation record, and leave the wake
+   hooks armed for the next push/review/timer event.
+6. If checks are still pending, record the last observed status and next timer
+   wake time in `SESSION_STATE.local.md`; do not ask the operator to babysit
+   green and do not burn compute by waiting inside the chat turn.
+7. If all required checks are green and all review/reconciliation gates are
    clean, follow the merge rules for the current arc. If the operator has not
    authorized autonomous merge for this arc, report readiness and wait.
-7. After merge, tear down only the owned worktree/branch, archive the plan as
+8. After merge, tear down only the owned worktree/branch, archive the plan as
    required, sync from `origin/main`, and continue to the next approved slice
-   if the arc says to continue.
+   if the arc says to continue. The merge itself is the signal to pick up the
+   next slice; do not start the next slice before the owned PR is merged or
+   explicitly released by the operator.
 
 The watcher state is mandatory compaction handoff data. A restarted or compacted
 long-running session reads `SESSION_STATE.local.md` before doing anything else

--- a/plans/PR-Retired-Failure-Detector-Workflow.md
+++ b/plans/PR-Retired-Failure-Detector-Workflow.md
@@ -1,0 +1,102 @@
+# PR-Retired-Failure-Detector-Workflow
+
+## Why this slice exists
+
+#1965 added the JSON-only retired failure-mode detector, but no PR automation
+runs it yet. #1964 needs an always-on, cheap detector signal before any ledger
+collector can group or post recurrence events. This slice adds the advisory PR
+workflow and artifact contract only.
+
+The detector remains a detector, not a guard: recurrence signals are uploaded
+for review and do not fail the workflow. Operational failures still fail so a
+broken detector cannot silently disappear.
+
+## Scope (this PR)
+
+Ownership lane: workflow/retired-failure-detectors
+Slice phase: Workflow/process
+
+1. Add a PR workflow that runs `scripts/detect_retired_failure_modes.py` against
+   the PR diff.
+2. Write the detector JSON report to an artifact directory and upload it with a
+   pinned artifact action.
+3. Add workflow contract tests for advisory behavior, artifact upload, and
+   PR/test enrollment.
+4. Enroll the workflow contract tests in the existing maturity-sweep PR command.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The workflow runs on `pull_request`, not `pull_request_target`.
+  - [ ] The workflow fetches the base ref and runs the detector with `--json-out`.
+  - [ ] The artifact upload uses a SHA-pinned `actions/upload-artifact`.
+  - [ ] Detector signals stay advisory: there is no signal-count failure step.
+  - [ ] The new workflow contract test is enrolled in PR CI.
+- Affected surfaces: GitHub Actions workflow / advisory detector automation /
+  workflow contract tests.
+- Risk areas: PR-code execution posture, artifact drift, accidental hard gate.
+- Reviewer rules triggered: R2, R10, R12, R14.
+
+### Files touched
+
+- `.github/workflows/maturity_sweep_advisory.yml`
+- `.github/workflows/retired_failure_detector.yml`
+- `plans/PR-Retired-Failure-Detector-Workflow.md`
+- `tests/test_retired_failure_detector_workflow.py`
+
+## Mechanism
+
+The new workflow checks out the PR, fetches the base branch into
+`refs/remotes/origin/<base>`, creates `artifacts/retired-failure-detector`, and
+runs:
+
+```bash
+python scripts/detect_retired_failure_modes.py \
+  --base "origin/${BASE_REF}" \
+  --json-out artifacts/retired-failure-detector/retired-failure-signals.json
+```
+
+The workflow uploads the artifact directory even when the JSON report contains
+signals. That is the core detector/guard boundary: signals are data for the
+future ledger, not merge blockers.
+
+`tests/test_retired_failure_detector_workflow.py` parses the workflow YAML and
+checks the execution posture, detector command, artifact upload, and CI
+enrollment. The maturity-sweep workflow runs that test beside the detector
+fixtures so workflow drift is caught on PRs.
+
+## Intentional
+
+- No GitHub issue comment, sticky PR comment, label, or disposition write is
+  added here.
+- No 30-minute watcher/timer is added here. That belongs to the separate
+  long-running PR watcher operating model, not this detector workflow.
+- No `pull_request_target` is used; this workflow needs no secrets and should
+  not run with trusted-base token posture.
+
+## Deferred
+
+- Slice 3: scheduled/manual collector that reads uploaded detector artifacts and
+  posts grouped signals to #1964.
+- Slice 4: disposition documentation for true recurrence / false positive /
+  needs guard / needs detector tuning.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_retired_failure_detector_workflow.py -q` — 4 passed.
+- `python -m pytest tests/test_maturity_sweep.py tests/test_detect_retired_failure_modes.py tests/test_retired_failure_detector_workflow.py --noconftest -q` — 38 passed.
+- `python scripts/audit_workflow_security_posture.py .github/workflows` — passed with existing repo-wide warnings only.
+- `python scripts/detect_retired_failure_modes.py --base origin/main --json-out /tmp/retired-signals-s2.json` — exited 0 and emitted zero signals for this planned diff.
+- `git diff --check` — passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/maturity_sweep_advisory.yml` | 1 |
+| `.github/workflows/retired_failure_detector.yml` | 50 |
+| `plans/PR-Retired-Failure-Detector-Workflow.md` | 102 |
+| `tests/test_retired_failure_detector_workflow.py` | 85 |
+| **Total** | **238** |

--- a/plans/PR-Retired-Failure-Detector-Workflow.md
+++ b/plans/PR-Retired-Failure-Detector-Workflow.md
@@ -23,6 +23,8 @@ Slice phase: Workflow/process
 3. Add workflow contract tests for advisory behavior, artifact upload, and
    PR/test enrollment.
 4. Enroll the workflow contract tests in the existing maturity-sweep PR command.
+5. Clarify the long-running task watcher wording in `AGENTS.md` so it describes
+   external wake hooks instead of an active in-chat polling loop.
 
 ### Review Contract
 
@@ -33,7 +35,7 @@ Slice phase: Workflow/process
   - [ ] Detector signals stay advisory: there is no signal-count failure step.
   - [ ] The new workflow contract test is enrolled in PR CI.
 - Affected surfaces: GitHub Actions workflow / advisory detector automation /
-  workflow contract tests.
+  workflow contract tests / agent operating instructions.
 - Risk areas: PR-code execution posture, artifact drift, accidental hard gate.
 - Reviewer rules triggered: R2, R10, R12, R14.
 
@@ -41,6 +43,7 @@ Slice phase: Workflow/process
 
 - `.github/workflows/maturity_sweep_advisory.yml`
 - `.github/workflows/retired_failure_detector.yml`
+- `AGENTS.md`
 - `plans/PR-Retired-Failure-Detector-Workflow.md`
 - `tests/test_retired_failure_detector_workflow.py`
 
@@ -69,8 +72,9 @@ fixtures so workflow drift is caught on PRs.
 
 - No GitHub issue comment, sticky PR comment, label, or disposition write is
   added here.
-- No 30-minute watcher/timer is added here. That belongs to the separate
-  long-running PR watcher operating model, not this detector workflow.
+- No watcher executable or timer unit is added here. This PR only clarifies the
+  long-running PR watcher wording: push/review events wake immediately, while a
+  30-minute timer hook wakes briefly for merge-readiness checks and exits.
 - No `pull_request_target` is used; this workflow needs no secrets and should
   not run with trusted-base token posture.
 
@@ -97,6 +101,7 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/maturity_sweep_advisory.yml` | 1 |
 | `.github/workflows/retired_failure_detector.yml` | 50 |
-| `plans/PR-Retired-Failure-Detector-Workflow.md` | 102 |
-| `tests/test_retired_failure_detector_workflow.py` | 85 |
-| **Total** | **238** |
+| `AGENTS.md` | 37 |
+| `plans/PR-Retired-Failure-Detector-Workflow.md` | 107 |
+| `tests/test_retired_failure_detector_workflow.py` | 51 |
+| **Total** | **246** |

--- a/plans/PR-Retired-Failure-Detector-Workflow.md
+++ b/plans/PR-Retired-Failure-Detector-Workflow.md
@@ -95,13 +95,21 @@ Parked hardening: none.
 - `python scripts/detect_retired_failure_modes.py --base origin/main --json-out /tmp/retired-signals-s2.json` — exited 0 and emitted zero signals for this planned diff.
 - `git diff --check` — passed.
 
+## Review fixes
+
+- Codex P1: removed the PyYAML import from the workflow contract test so the
+  maturity-sweep job can run it after installing only pytest.
+- Codex P2: added `.github/workflows/retired_failure_detector.yml` to the
+  maturity-sweep PR and main-push path filters, with a contract assertion, so
+  detector-workflow-only edits still run the detector workflow test.
+
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/maturity_sweep_advisory.yml` | 1 |
+| `.github/workflows/maturity_sweep_advisory.yml` | 3 |
 | `.github/workflows/retired_failure_detector.yml` | 50 |
 | `AGENTS.md` | 37 |
 | `plans/PR-Retired-Failure-Detector-Workflow.md` | 107 |
-| `tests/test_retired_failure_detector_workflow.py` | 51 |
-| **Total** | **246** |
+| `tests/test_retired_failure_detector_workflow.py` | 52 |
+| **Total** | **249** |

--- a/tests/test_retired_failure_detector_workflow.py
+++ b/tests/test_retired_failure_detector_workflow.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "retired_failure_detector.yml"
+MATURITY_WORKFLOW = ROOT / ".github" / "workflows" / "maturity_sweep_advisory.yml"
+UPLOAD_ARTIFACT_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+
+
+def load_workflow(path: Path = WORKFLOW) -> dict[str, object]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def workflow_on(payload: dict[str, object]) -> dict[str, object]:
+    on_block = payload.get(True, payload.get("on"))
+    assert isinstance(on_block, dict)
+    return on_block
+
+
+def job_steps(payload: dict[str, object]) -> list[dict[str, object]]:
+    jobs = payload.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get("retired-failure-detector")
+    assert isinstance(job, dict)
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def step_by_name(steps: list[dict[str, object]], name: str) -> dict[str, object]:
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"missing workflow step: {name}")
+
+
+def test_workflow_runs_on_pull_request_without_target_token_posture() -> None:
+    payload = load_workflow()
+    on_block = workflow_on(payload)
+
+    assert "pull_request" in on_block
+    assert "pull_request_target" not in on_block
+    assert payload["permissions"] == {"contents": "read"}
+
+
+def test_workflow_fetches_base_ref_and_writes_detector_json_artifact() -> None:
+    steps = job_steps(load_workflow())
+    resolve_step = step_by_name(steps, "Resolve base ref")
+    run_step = step_by_name(steps, "Run retired failure detector")
+
+    resolve_script = str(resolve_step.get("run", ""))
+    run_script = str(run_step.get("run", ""))
+
+    assert "refs/remotes/origin/${base_ref}" in resolve_script
+    assert "scripts/detect_retired_failure_modes.py" in run_script
+    assert '--base "origin/${base_ref}"' in run_script
+    assert "--json-out artifacts/retired-failure-detector/retired-failure-signals.json" in run_script
+
+
+def test_workflow_uploads_pinned_detector_artifact_without_signal_failure_step() -> None:
+    steps = job_steps(load_workflow())
+    upload_step = step_by_name(steps, "Upload retired failure detector artifact")
+    all_run_text = "\n".join(str(step.get("run", "")) for step in steps)
+
+    assert upload_step["uses"] == f"actions/upload-artifact@{UPLOAD_ARTIFACT_SHA}"
+    assert upload_step["with"] == {
+        "name": "retired-failure-detector-signals-${{ github.run_id }}",
+        "path": "artifacts/retired-failure-detector",
+        "if-no-files-found": "error",
+        "retention-days": 14,
+    }
+    assert "jq" not in all_run_text
+    assert "signals | length" not in all_run_text
+
+
+def test_workflow_contract_test_is_enrolled_in_maturity_sweep_pr_ci() -> None:
+    workflow = MATURITY_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "tests/test_retired_failure_detector_workflow.py" in workflow

--- a/tests/test_retired_failure_detector_workflow.py
+++ b/tests/test_retired_failure_detector_workflow.py
@@ -49,3 +49,4 @@ def test_workflow_contract_test_is_enrolled_in_maturity_sweep_pr_ci() -> None:
     workflow = MATURITY_WORKFLOW.read_text(encoding="utf-8")
 
     assert "tests/test_retired_failure_detector_workflow.py" in workflow
+    assert '- ".github/workflows/retired_failure_detector.yml"' in workflow

--- a/tests/test_retired_failure_detector_workflow.py
+++ b/tests/test_retired_failure_detector_workflow.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
-
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "retired_failure_detector.yml"
@@ -11,72 +9,40 @@ MATURITY_WORKFLOW = ROOT / ".github" / "workflows" / "maturity_sweep_advisory.ym
 UPLOAD_ARTIFACT_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 
 
-def load_workflow(path: Path = WORKFLOW) -> dict[str, object]:
-    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
-    assert isinstance(payload, dict)
-    return payload
-
-
-def workflow_on(payload: dict[str, object]) -> dict[str, object]:
-    on_block = payload.get(True, payload.get("on"))
-    assert isinstance(on_block, dict)
-    return on_block
-
-
-def job_steps(payload: dict[str, object]) -> list[dict[str, object]]:
-    jobs = payload.get("jobs")
-    assert isinstance(jobs, dict)
-    job = jobs.get("retired-failure-detector")
-    assert isinstance(job, dict)
-    steps = job.get("steps")
-    assert isinstance(steps, list)
-    return [step for step in steps if isinstance(step, dict)]
-
-
-def step_by_name(steps: list[dict[str, object]], name: str) -> dict[str, object]:
-    for step in steps:
-        if step.get("name") == name:
-            return step
-    raise AssertionError(f"missing workflow step: {name}")
+def workflow_text(path: Path = WORKFLOW) -> str:
+    return path.read_text(encoding="utf-8")
 
 
 def test_workflow_runs_on_pull_request_without_target_token_posture() -> None:
-    payload = load_workflow()
-    on_block = workflow_on(payload)
+    workflow = workflow_text()
 
-    assert "pull_request" in on_block
-    assert "pull_request_target" not in on_block
-    assert payload["permissions"] == {"contents": "read"}
+    assert "\n  pull_request:\n" in workflow
+    assert "pull_request_target:" not in workflow
+    assert "\npermissions:\n  contents: read\n" in workflow
 
 
 def test_workflow_fetches_base_ref_and_writes_detector_json_artifact() -> None:
-    steps = job_steps(load_workflow())
-    resolve_step = step_by_name(steps, "Resolve base ref")
-    run_step = step_by_name(steps, "Run retired failure detector")
+    workflow = workflow_text()
 
-    resolve_script = str(resolve_step.get("run", ""))
-    run_script = str(run_step.get("run", ""))
-
-    assert "refs/remotes/origin/${base_ref}" in resolve_script
-    assert "scripts/detect_retired_failure_modes.py" in run_script
-    assert '--base "origin/${base_ref}"' in run_script
-    assert "--json-out artifacts/retired-failure-detector/retired-failure-signals.json" in run_script
+    assert "- name: Resolve base ref" in workflow
+    assert "refs/remotes/origin/${base_ref}" in workflow
+    assert "- name: Run retired failure detector" in workflow
+    assert "scripts/detect_retired_failure_modes.py" in workflow
+    assert '--base "origin/${base_ref}"' in workflow
+    assert "--json-out artifacts/retired-failure-detector/retired-failure-signals.json" in workflow
 
 
 def test_workflow_uploads_pinned_detector_artifact_without_signal_failure_step() -> None:
-    steps = job_steps(load_workflow())
-    upload_step = step_by_name(steps, "Upload retired failure detector artifact")
-    all_run_text = "\n".join(str(step.get("run", "")) for step in steps)
+    workflow = workflow_text()
 
-    assert upload_step["uses"] == f"actions/upload-artifact@{UPLOAD_ARTIFACT_SHA}"
-    assert upload_step["with"] == {
-        "name": "retired-failure-detector-signals-${{ github.run_id }}",
-        "path": "artifacts/retired-failure-detector",
-        "if-no-files-found": "error",
-        "retention-days": 14,
-    }
-    assert "jq" not in all_run_text
-    assert "signals | length" not in all_run_text
+    assert "- name: Upload retired failure detector artifact" in workflow
+    assert f"uses: actions/upload-artifact@{UPLOAD_ARTIFACT_SHA}" in workflow
+    assert "name: retired-failure-detector-signals-${{ github.run_id }}" in workflow
+    assert "path: artifacts/retired-failure-detector" in workflow
+    assert "if-no-files-found: error" in workflow
+    assert "retention-days: 14" in workflow
+    assert "jq" not in workflow
+    assert "signals | length" not in workflow
 
 
 def test_workflow_contract_test_is_enrolled_in_maturity_sweep_pr_ci() -> None:


### PR DESCRIPTION
Plan: plans/PR-Retired-Failure-Detector-Workflow.md
Slice phase: Workflow/process

Adds the advisory PR workflow for #1964 so retired failure-mode detector JSON is generated and uploaded on PRs before any ledger/comment writer exists. Also clarifies the long-running task watcher rule in `AGENTS.md`: push/review events wake immediately, and a separate 30-minute timer hook checks merge readiness and exits fast.

## Intentional
- Advisory detector semantics: recurrence signals do not fail the workflow.
- Operational failures still fail so detector breakage is visible.
- Uses `pull_request`, not `pull_request_target`; this workflow needs no secrets and should not run with trusted-base token posture.
- No watcher executable or timer unit is added here; this only fixes the operating-model wording.

## Deferred
- Slice 3: scheduled/manual collector that reads uploaded detector artifacts and posts grouped signals to #1964.
- Slice 4: disposition documentation for true recurrence / false positive / needs guard / needs detector tuning.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_retired_failure_detector_workflow.py -q` — 4 passed.
- `python -m pytest tests/test_maturity_sweep.py tests/test_detect_retired_failure_modes.py tests/test_retired_failure_detector_workflow.py --noconftest -q` — 38 passed.
- `python scripts/audit_workflow_security_posture.py .github/workflows` — passed with existing repo-wide warnings only.
- `python scripts/detect_retired_failure_modes.py --base origin/main --json-out /tmp/retired-signals-s2.json` — exited 0 and emitted zero signals for this planned diff.
- `git diff --check` — passed.

## CI/review fixes
- Fixed Codex P1 by making `tests/test_retired_failure_detector_workflow.py` stdlib-only; the workflow installs only `pytest`, not `pyyaml`.
- Fixed Codex P2 by adding `.github/workflows/retired_failure_detector.yml` to the maturity-sweep PR and main-push path filters, with a contract assertion, so detector-workflow-only edits still run the workflow contract test.

## Diff size
5 files, +242 / -15

## AI reconciliation
All fixed or waived: yes.

- Codex P1 (`tests/test_retired_failure_detector_workflow.py` PyYAML import) fixed in `32c4ea2` by removing the dependency and proving the maturity-sweep command locally.
- Codex P2 (`.github/workflows/maturity_sweep_advisory.yml` missing retired detector workflow path filter) fixed in `32c4ea2` by adding the path to PR/main filters and a test assertion.
