### PR TITLE
Point the Reddit tool at the operator's own profile (read side)

### DIFF
--- a/atlas_reddit/__main__.py
+++ b/atlas_reddit/__main__.py
@@ -23,11 +23,13 @@ from .config import (
     MAX_HISTORY_LIMIT,
     MAX_PACE_SECONDS,
     MAX_PER_SUBREDDIT_LIMIT,
+    MAX_PROFILE_LIMIT,
     RedditListeningSettings,
     WatchlistError,
     load_watchlist,
 )
 from .digest import write_digest
+from .profile import sync_profile_once
 from .reddit_client import (
     PrawDeletionSource,
     PrawHistorySource,
@@ -52,6 +54,17 @@ def _valid_date(value: str) -> str:
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"invalid date {value!r}: {exc}") from exc
     return value
+
+
+def _utc_date(timestamp: int) -> str:
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).date().isoformat()
+
+
+def _as_submission_fullname(value: str) -> str:
+    """Operator ergonomics: accept a bare submission id or its fullname.
+    Every stored id is a fullname, so a bare id is prefixed, never used
+    as-is."""
+    return value if value.startswith("t3_") else f"t3_{value}"
 
 
 def _finite_float(value: str) -> float:
@@ -207,6 +220,58 @@ def _build_parser(defaults: RedditListeningSettings) -> argparse.ArgumentParser:
     )
     mark.add_argument("reply_id", help="Reply id, e.g. t1_abc123")
     mark.add_argument(
+        "--db",
+        type=Path,
+        default=defaults.db_path,
+        help=f"SQLite state file (default: {defaults.db_path})",
+    )
+
+    profile = subparsers.add_parser(
+        "profile",
+        help="Sync own posts from the profile listing into local state.",
+    )
+    profile.add_argument(
+        "--db",
+        type=Path,
+        default=defaults.db_path,
+        help=f"SQLite state file (default: {defaults.db_path})",
+    )
+    profile.add_argument(
+        "--limit",
+        type=int,
+        default=defaults.profile_limit,
+        help=f"Newest own posts fetched (default: {defaults.profile_limit})",
+    )
+
+    posts = subparsers.add_parser(
+        "posts", help="List synced own posts from local state (offline)."
+    )
+    posts.add_argument(
+        "--db",
+        type=Path,
+        default=defaults.db_path,
+        help=f"SQLite state file (default: {defaults.db_path})",
+    )
+    posts.add_argument(
+        "--subreddit",
+        default=None,
+        help="Only posts in this subreddit (default: all)",
+    )
+    posts.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum posts listed (default: all synced posts)",
+    )
+
+    post = subparsers.add_parser(
+        "post",
+        help="Show one synced own post with its tracked replies (offline).",
+    )
+    post.add_argument(
+        "post_id", help="Post id, bare (abc123) or fullname (t3_abc123)"
+    )
+    post.add_argument(
         "--db",
         type=Path,
         default=defaults.db_path,
@@ -368,6 +433,92 @@ def main(argv: list[str] | None = None) -> int:
             print(f"error: {exc}", file=sys.stderr)
             return 2
         print(f"marked seen: {args.reply_id}")
+        return 0
+
+    if args.command == "profile":
+        if not 1 <= args.limit <= MAX_PROFILE_LIMIT:
+            parser.error(
+                f"--limit must be 1..{MAX_PROFILE_LIMIT}, got {args.limit}"
+            )
+        try:
+            source = PrawHistorySource(settings)
+            with ListeningStore(args.db) as store:
+                stats = sync_profile_once(
+                    store,
+                    source,
+                    now=int(datetime.now(tz=timezone.utc).timestamp()),
+                    limit=args.limit,
+                )
+        except (StoreError, RedditAuthError, OSError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print(
+            f"fetched={stats.fetched} new={stats.new} "
+            f"refreshed={stats.refreshed} errors={len(stats.errors)}"
+        )
+        for line in stats.errors:
+            print(f"warning: {line}", file=sys.stderr)
+        return 0 if not stats.errors else 1
+
+    if args.command == "posts":
+        # Default is no cap (list every synced post) so "all your posts in
+        # one place" is literal; --limit only narrows, and must be >= 1.
+        if args.limit is not None and args.limit < 1:
+            parser.error(f"--limit must be at least 1, got {args.limit}")
+        try:
+            with ListeningStore(args.db) as store:
+                rows = store.list_own_posts(
+                    subreddit=args.subreddit, limit=args.limit
+                )
+        except (StoreError, OSError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        if not rows:
+            print("no synced posts (run: python -m atlas_reddit profile)")
+            return 0
+        for row in rows:
+            day = _utc_date(row.created_utc)
+            print(
+                f"{day}  r/{row.subreddit}  score={row.reddit_score} "
+                f"comments={row.num_comments}  {row.post_id}  {row.title}"
+            )
+        return 0
+
+    if args.command == "post":
+        post_id = _as_submission_fullname(args.post_id)
+        try:
+            with ListeningStore(args.db) as store:
+                row = store.get_own_post(post_id)
+                replies = (
+                    store.list_replies(thread_id=post_id) if row else []
+                )
+        except (StoreError, OSError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        if row is None:
+            print(
+                f"error: unknown own post: {post_id} "
+                "(run: python -m atlas_reddit profile)",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"{row.title}")
+        print(
+            f"r/{row.subreddit}  {_utc_date(row.created_utc)}  "
+            f"score={row.reddit_score}  comments={row.num_comments}  {row.post_id}"
+        )
+        print(row.url)
+        if row.selftext:
+            print()
+            print(row.selftext)
+        print()
+        if not replies:
+            print("no tracked replies (run: python -m atlas_reddit track)")
+        for reply in replies:
+            marker = " " if reply.seen else "*"
+            author = reply.author or "[unknown]"
+            print(f"{marker} {reply.reply_id}  {author}  {_utc_date(reply.created_utc)}")
+            print(f"  {reply.body}")
         return 0
 
     parser.error(f"unknown command {args.command!r}")  # pragma: no cover

--- a/atlas_reddit/config.py
+++ b/atlas_reddit/config.py
@@ -49,6 +49,12 @@ MAX_PER_SUBREDDIT_LIMIT = 100
 MAX_PACE_SECONDS = 60.0
 MAX_HISTORY_LIMIT = 100
 MAX_DORMANT_AFTER_HOURS = 8760
+# Profile sync fetches the operator's OWN submission listing (one listing,
+# run occasionally), so it is not bound by the per-subreddit radar's tight
+# request budget. Reddit's listing API returns at most ~1000 newest items
+# per listing regardless, so 1000 is the real ceiling for "all my posts":
+# PRAW paginates there in batches of 100 within this single command.
+MAX_PROFILE_LIMIT = 1000
 
 _ALLOWED_TOP_KEYS = {
     "version",
@@ -145,6 +151,15 @@ class RedditListeningSettings(BaseSettings):
         ge=1,
         le=MAX_HISTORY_LIMIT,
         description="Own recent comments/submissions fetched per tracking pass.",
+    )
+    profile_limit: int = Field(
+        default=MAX_PROFILE_LIMIT,
+        ge=1,
+        le=MAX_PROFILE_LIMIT,
+        description=(
+            "Own posts fetched per profile sync. Defaults to Reddit's "
+            "listing ceiling so the profile mirror holds all reachable posts."
+        ),
     )
     dormant_after_hours: int = Field(
         default=168,

--- a/atlas_reddit/profile.py
+++ b/atlas_reddit/profile.py
@@ -1,0 +1,70 @@
+"""Own-profile sync: profile listing -> own_posts store.
+
+The operator's profile ("home page") is the one feed that already carries
+every post they made and the subreddit each landed in. This pass mirrors
+that feed into the local ``own_posts`` table so all their posts live in
+one inspectable place, each readable individually (together with the
+replies the tracker collects on the same thread fullnames).
+
+Same orchestration posture as the poller and tracker: the transport
+arrives as a :class:`~atlas_reddit.reddit_client.ProfileSource` and the
+clock as ``now`` -- fully deterministic under test.
+
+Unlike the radar there are NO admission filters: the radar's
+is_self/freshness/score gates triage strangers' posts, but every own post
+belongs in the profile mirror (link posts and old posts included).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .reddit_client import ProfileSource
+from .store import ListeningStore
+
+
+@dataclass
+class ProfileStats:
+    fetched: int = 0
+    new: int = 0
+    refreshed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def sync_profile_once(
+    store: ListeningStore,
+    source: ProfileSource,
+    *,
+    now: int,
+    limit: int,
+) -> ProfileStats:
+    """One sync pass over the operator's own submission listing (a single
+    paginated PRAW listing request -- same request-budget family as the
+    tracker's history fetches)."""
+    stats = ProfileStats()
+    try:
+        posts = source.fetch_my_posts(limit=limit)
+    except Exception as exc:  # noqa: BLE001 -- a transport failure is a
+        # pass-level error surfaced to the operator, never a traceback.
+        stats.errors.append(f"profile fetch: {exc}")
+        return stats
+
+    for post in posts:
+        stats.fetched += 1
+        inserted = store.upsert_own_post(
+            post_id=post.post_id,
+            subreddit=post.subreddit,
+            title=post.title,
+            url=post.url,
+            created_utc=post.created_utc,
+            reddit_score=post.score,
+            num_comments=post.num_comments,
+            selftext=post.selftext,
+            observed_at=now,
+        )
+        if inserted:
+            stats.new += 1
+        else:
+            stats.refreshed += 1
+
+    return stats

--- a/atlas_reddit/reddit_client.py
+++ b/atlas_reddit/reddit_client.py
@@ -100,6 +100,18 @@ class ThreadReply:
     is_reply_to_me: bool
 
 
+class ProfileSource(Protocol):
+    """The transport boundary the profile watcher consumes. The operator's
+    profile listing is the one feed that carries every post they made and
+    the subreddit each landed in. Tests provide a fake; production
+    provides :class:`PrawHistorySource` (same scopes, richer mapping than
+    its skinny reply-discovery listings)."""
+
+    def fetch_my_posts(self, *, limit: int) -> list[ListingPost]:
+        """Return the operator's newest submissions across subreddits."""
+        ...
+
+
 class DeletionSource(Protocol):
     """The transport boundary the purge job consumes (S6). Given stored
     item fullnames, report which still carry live third-party content."""
@@ -328,6 +340,31 @@ class PrawHistorySource:
                 )
             )
         return items
+
+    def fetch_my_posts(self, *, limit: int) -> list[ListingPost]:
+        """The profile watcher's rich mapping over the same own-submission
+        listing the tracker reads skinny ids from. The subreddit comes off
+        each submission (a profile listing spans subreddits, unlike
+        ``fetch_new`` where the caller names one)."""
+        posts: list[ListingPost] = []
+        for submission in self._me.submissions.new(limit=limit):
+            author = getattr(submission.author, "name", None)
+            subreddit = getattr(submission.subreddit, "display_name", "") or ""
+            posts.append(
+                ListingPost(
+                    post_id=submission.fullname,
+                    subreddit=subreddit,
+                    title=submission.title or "",
+                    url=f"https://www.reddit.com{submission.permalink}",
+                    author=author,
+                    created_utc=int(submission.created_utc),
+                    score=int(submission.score),
+                    num_comments=int(submission.num_comments),
+                    is_self=bool(submission.is_self),
+                    selftext=submission.selftext or "",
+                )
+            )
+        return posts
 
     def fetch_thread_replies(
         self,

--- a/atlas_reddit/store.py
+++ b/atlas_reddit/store.py
@@ -6,6 +6,8 @@ dependencies, no network, no ORM. One store file (default
 
 - ``candidates``: scored radar posts with a review status
   (new/seen/dismissed/responded).
+- ``own_posts``: the operator's own submissions synced from their profile
+  listing -- the "one place where all my posts live" surface.
 - ``tracked_threads``: threads Juan participated in (reply tracker).
 - ``replies``: replies observed on tracked threads, with seen state.
 - ``purge_log``: the deletion-compliance audit trail. The purge *fields*
@@ -37,7 +39,7 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 CANDIDATE_STATUSES = ("new", "seen", "dismissed", "responded")
 PURGE_ITEM_TYPES = ("candidate", "reply", "thread")
@@ -94,6 +96,32 @@ CREATE TABLE purge_log (
     tombstone INTEGER NOT NULL DEFAULT 1 CHECK (tombstone IN (0, 1))
 );
 """
+
+# Shared between the fresh-store DDL and the v3 -> v4 migration rung so the
+# two paths cannot drift. IF NOT EXISTS keeps the migration rung idempotent
+# against a store that already carries own_posts with a stale version stamp
+# (an interrupted upgrade, or a version wound back for testing); own_posts
+# is new in v4, so a present copy always has this exact shape -- there is no
+# legacy shape for IF NOT EXISTS to mask.
+_OWN_POSTS_DDL = """
+CREATE TABLE IF NOT EXISTS own_posts (
+    post_id TEXT PRIMARY KEY NOT NULL,
+    subreddit TEXT NOT NULL,
+    title TEXT NOT NULL,
+    url TEXT NOT NULL,
+    created_utc INTEGER NOT NULL,
+    reddit_score INTEGER NOT NULL DEFAULT 0,
+    num_comments INTEGER NOT NULL DEFAULT 0,
+    selftext TEXT NOT NULL DEFAULT '',
+    first_seen INTEGER NOT NULL,
+    last_seen INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_own_posts_created ON own_posts (created_utc DESC);
+CREATE INDEX IF NOT EXISTS idx_own_posts_subreddit
+    ON own_posts (subreddit, created_utc DESC);
+"""
+
+_SCHEMA_DDL = _SCHEMA_DDL + _OWN_POSTS_DDL
 
 
 class StoreError(RuntimeError):
@@ -168,6 +196,20 @@ class Candidate:
     final_score: float
     matched_topics: tuple[str, ...]
     status: str
+    first_seen: int
+    last_seen: int
+
+
+@dataclass(frozen=True)
+class OwnPost:
+    post_id: str
+    subreddit: str
+    title: str
+    url: str
+    created_utc: int
+    reddit_score: int
+    num_comments: int
+    selftext: str
     first_seen: int
     last_seen: int
 
@@ -314,6 +356,10 @@ class ListeningStore:
                         "ALTER TABLE purge_log ADD COLUMN tombstone INTEGER "
                         "NOT NULL DEFAULT 1 CHECK (tombstone IN (0, 1))"
                     )
+                if version < 5:
+                    # v4 -> v5: the own-profile watcher gains its own
+                    # table. Purely additive; existing rows untouched.
+                    self._conn.executescript(_OWN_POSTS_DDL)
                 self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
             return
         # Fail closed on schemas this code does not know how to read --
@@ -449,6 +495,95 @@ class ListeningStore:
             params.append(limit)
         rows = self._conn.execute(query, params).fetchall()
         return [_candidate_from_row(row) for row in rows]
+
+    # -- own posts (profile watcher) ---------------------------------------
+
+    def upsert_own_post(
+        self,
+        *,
+        post_id: str,
+        subreddit: str,
+        title: str,
+        url: str,
+        created_utc: int,
+        reddit_score: int,
+        num_comments: int,
+        selftext: str,
+        observed_at: int,
+    ) -> bool:
+        """Insert or refresh one of the operator's own posts. Replay-safe
+        the same two ways as candidates: on conflict the volatile fields
+        update while ``first_seen`` is preserved, and a stale
+        (out-of-order) observation updates nothing. Returns True when the
+        post was newly inserted, False on a refresh or a stale replay."""
+        _require_id(post_id, field="post_id")
+        _require_int(created_utc, field="created_utc")
+        _require_int(reddit_score, field="reddit_score")
+        _require_int(num_comments, field="num_comments")
+        _require_int(observed_at, field="observed_at")
+        existed = (
+            self._conn.execute(
+                "SELECT 1 FROM own_posts WHERE post_id = ?", (post_id,)
+            ).fetchone()
+            is not None
+        )
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO own_posts (
+                    post_id, subreddit, title, url, created_utc,
+                    reddit_score, num_comments, selftext, first_seen, last_seen
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(post_id) DO UPDATE SET
+                    subreddit = excluded.subreddit,
+                    title = excluded.title,
+                    url = excluded.url,
+                    reddit_score = excluded.reddit_score,
+                    num_comments = excluded.num_comments,
+                    selftext = excluded.selftext,
+                    last_seen = excluded.last_seen
+                WHERE excluded.last_seen >= own_posts.last_seen
+                """,
+                (
+                    post_id,
+                    subreddit,
+                    title,
+                    url,
+                    created_utc,
+                    reddit_score,
+                    num_comments,
+                    selftext,
+                    observed_at,
+                    observed_at,
+                ),
+            )
+        return not existed
+
+    def get_own_post(self, post_id: str) -> OwnPost | None:
+        row = self._conn.execute(
+            "SELECT * FROM own_posts WHERE post_id = ?", (post_id,)
+        ).fetchone()
+        return _own_post_from_row(row) if row else None
+
+    def list_own_posts(
+        self,
+        *,
+        subreddit: str | None = None,
+        limit: int | None = None,
+    ) -> list[OwnPost]:
+        query = "SELECT * FROM own_posts"
+        params: list[object] = []
+        if subreddit is not None:
+            # Case-insensitive: subreddit names are case-preserving but
+            # case-insensitive on Reddit, and the operator types them.
+            query += " WHERE subreddit = ? COLLATE NOCASE"
+            params.append(subreddit)
+        query += " ORDER BY created_utc DESC, post_id ASC"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
+        rows = self._conn.execute(query, params).fetchall()
+        return [_own_post_from_row(row) for row in rows]
 
     # -- tracked threads --------------------------------------------------
 
@@ -738,6 +873,21 @@ def _candidate_from_row(row: sqlite3.Row) -> Candidate:
         final_score=row["final_score"],
         matched_topics=tuple(json.loads(row["matched_topics"])),
         status=row["status"],
+        first_seen=row["first_seen"],
+        last_seen=row["last_seen"],
+    )
+
+
+def _own_post_from_row(row: sqlite3.Row) -> OwnPost:
+    return OwnPost(
+        post_id=row["post_id"],
+        subreddit=row["subreddit"],
+        title=row["title"],
+        url=row["url"],
+        created_utc=row["created_utc"],
+        reddit_score=row["reddit_score"],
+        num_comments=row["num_comments"],
+        selftext=row["selftext"],
         first_seen=row["first_seen"],
         last_seen=row["last_seen"],
     )

--- a/docs/REDDIT_LISTENING_SETUP_RUNBOOK.md
+++ b/docs/REDDIT_LISTENING_SETUP_RUNBOOK.md
@@ -95,10 +95,38 @@ python -m atlas_reddit digest   # ...so it never surfaces content deleted
                                 # on Reddit since the last purge
 ```
 
+Own profile (all your posts in one place, read individually):
+
+```bash
+python -m atlas_reddit profile        # sync own posts from your profile listing
+python -m atlas_reddit posts          # list synced own posts (offline)
+python -m atlas_reddit posts --subreddit SaaS
+python -m atlas_reddit post t3_abc123 # one post + its tracked replies (offline)
+```
+
+`profile` reads your own submission listing with the same
+identity/history/read scopes `track` already uses -- no new credentials.
+It fetches the newest posts up to Reddit's listing ceiling (~1000, the
+most the API returns for a profile), so the local mirror holds all
+reachable own posts. `posts` and `post` read only local state (`posts`
+lists every synced post by default). Reply collection stays `track`'s
+job, and the two surfaces have different reach: `track` discovers own
+submissions through its recent-history window (`--history-limit`, capped
+at 100), so `post` shows tracked replies only for submissions `track` has
+already picked up. Older profile-synced posts still list and open, but
+show no tracked replies until they fall within a `track` pass; profile
+sync deliberately does not enqueue them for tracking (it does not write
+`tracked_threads` -- that table's lifecycle is the tracker's alone).
+
 Deletion compliance: run `purge` at least every 48 hours while any stored
-content exists. It re-checks every stored post and reply in batched reads
-(100 per request); content that is deleted/removed/missing on Reddit is
-dropped locally and recorded in `purge_log` with the detection reason.
+content exists. It re-checks every stored radar candidate and tracked
+reply in batched reads (100 per request); third-party content that is
+deleted/removed/missing on Reddit is dropped locally and recorded in
+`purge_log` with the detection reason. Your own profile-synced posts
+(`own_posts`) are your own words, not third-party content, so they are
+retained across `purge` and are outside the 48h deletion-compliance
+guarantee; a post you delete on Reddit stays in your local mirror until
+you drop it yourself.
 
 The first `poll` run proves the auth boundary end to end: if the token
 carries any scope beyond identity/history/read (or the wildcard `*`), the

--- a/plans/PR-Reddit-Own-Profile-Watcher.md
+++ b/plans/PR-Reddit-Own-Profile-Watcher.md
@@ -1,0 +1,227 @@
+# PR-Reddit-Own-Profile-Watcher
+
+## Why this slice exists
+
+The operator asked for the Reddit tool to be pointed at their own profile
+("home page") -- the one listing that already carries every post they made
+and the subreddit each landed in -- so all their posts live in one local
+place and can be read individually. Today the package cannot do that: the
+radar (`poll`) watches watchlist subreddits for OTHER people's posts, and
+the reply tracker (`track`) sees the operator's own submissions only as
+skinny thread ids for reply discovery -- no title, no subreddit, no body.
+Root cause: no producer method fetches the operator's own submission
+listing with content fields, and no table holds it. This slice adds that
+vertical: a read-only profile listing fetch (same identity/history/read
+scopes the tracker already requires) -> a new `own_posts` table -> CLI
+commands to sync the profile, list all own posts, and read one post
+together with its tracked replies.
+
+The write half of the operator's ask (replying to and editing those posts
+via the API) is deliberately the NEXT slice: it reverses the package's
+enforced read-only contract (scope ceiling, static no-write probe, package
+docstring, runbook) and cannot function until the operator re-mints the
+refresh token with write scopes -- so it is sequenced behind this read
+slice, where each contract change is reviewable on its own.
+
+Diff-budget overage (if any): the producer method, the table + migration,
+the sync pass, and the CLI read surface are one indivisible vertical -- a
+sync with no read surface delivers nothing user-visible, and a read
+surface without the table reads nothing. Tests follow the #1947
+producer-fidelity factory discipline rather than hand-seeded shapes.
+
+## Scope (this PR)
+
+Ownership lane: reddit-listening-tool
+Slice phase: Vertical slice
+
+1. `atlas_reddit/reddit_client.py`: `ProfileSource` protocol
+   (`fetch_my_posts`) + implementation on `PrawHistorySource` -- the rich
+   `ListingPost` mapping over `me.submissions.new()`, subreddit taken from
+   the submission's own `subreddit.display_name` (a profile listing spans
+   subreddits, unlike `fetch_new` where the caller names one).
+2. `atlas_reddit/store.py`: schema v5 -- `own_posts` table (+ subreddit
+   index), `OwnPost` row type, `upsert_own_post` / `get_own_post` /
+   `list_own_posts`, and an additive v4 -> v5 migration on the existing
+   ladder (main reached v4 via #1948's purge tombstone while this slice
+   was in flight, so own_posts stacks as v5). Upsert is replay-safe the
+   same two ways as candidates: `first_seen` preserved on conflict, and a
+   stale (out-of-order) observation updates nothing.
+3. `atlas_reddit/profile.py`: `sync_profile_once` -- fetch own posts,
+   upsert each, report new/refreshed/error stats. No admission filters:
+   unlike the radar, every own post belongs in "one place where all of it
+   lives" (link posts included).
+4. `atlas_reddit/__main__.py`: three commands -- `profile` (sync pass,
+   network), `posts` (list from local state, offline; defaults to ALL
+   synced posts, no silent newest-N cap, so "all my posts" is literal),
+   `post <id>` (one post + its tracked replies, offline; accepts bare id
+   or t3_ fullname).
+5. `atlas_reddit/config.py`: `MAX_PROFILE_LIMIT` (1000, Reddit's listing
+   ceiling) + a `profile_limit` setting defaulting to it, so the profile
+   sync backfills all reachable own posts rather than the tracker's tight
+   100-item history window (review finding: "all my posts" must not stop
+   at 100).
+6. `tests/atlas_reddit_fixtures.py`: `fake_submission` gains a
+   `subreddit` attribute, `real_history_source` gains `own_submissions`
+   (closing the deferred own-submission gap noted in its docstring), and
+   `seed_own_posts` runs the real producer + sync pipeline.
+7. `tests/test_atlas_reddit_profile.py`: producer-fidelity sync tests +
+   store failure branches + migration + CLI wiring.
+8. `docs/REDDIT_LISTENING_SETUP_RUNBOOK.md`: section 4 command list gains
+   the three new commands, the profile listing-ceiling note, the
+   own_posts purge-exclusion clarification, and a reply-coverage note
+   (review findings) -- `post` shows tracked replies only for submissions
+   the tracker has already discovered in its history window, since profile
+   sync deliberately does not enqueue own posts into `tracked_threads`.
+
+### Files touched
+
+- `atlas_reddit/reddit_client.py`
+- `atlas_reddit/store.py`
+- `atlas_reddit/config.py`
+- `atlas_reddit/profile.py` (new)
+- `atlas_reddit/__main__.py`
+- `tests/atlas_reddit_fixtures.py`
+- `tests/test_atlas_reddit_profile.py`
+- `tests/test_atlas_reddit_tracker.py`
+- `tests/test_atlas_reddit_purge.py`
+- `docs/REDDIT_LISTENING_SETUP_RUNBOOK.md`
+- `plans/PR-Reddit-Own-Profile-Watcher.md`
+
+The tracker-test and purge-test edits are consequences of the schema bump
+landing on top of main's v4: each migration probe's terminal schema
+version now follows SCHEMA_VERSION (the tracker probe also asserts the
+own_posts rung created the table), and the tracker's HistorySource
+public-surface probe gains the new profile fetch method.
+
+### Review Contract
+
+Acceptance criteria (reviewer checks one-by-one):
+
+1. The new producer surface is read-only: `fetch_my_posts` only reads
+   listings; the static no-write probe
+   (`test_no_reddit_write_calls_anywhere`) and the public-surface probes
+   still pass unchanged.
+2. `upsert_own_post` is replay-safe: `first_seen` survives re-sync, and a
+   stale `observed_at` (older than the stored `last_seen`) regresses
+   nothing -- both covered by failure-branch tests, plus StoreError
+   branches for malformed ids/ints.
+3. A v3 store opens and walks the ladder to the current version (v4
+   tombstone, then v5 own_posts; existing rows untouched, `own_posts`
+   created); a NEWER schema version still fails closed. Covered by tests.
+4. `posts` and `post` read only local state (no praw import on those
+   paths); an unknown post id exits 2 naming the id.
+5. Sync tests go through the REAL producer mapping via the fixture
+   factory (praw-shaped stubs; no hand-seeded id shapes), per the #1947
+   discipline.
+6. `python -m pytest tests/test_atlas_reddit_profile.py
+   tests/test_atlas_reddit_store.py tests/test_atlas_reddit_poller.py
+   tests/test_atlas_reddit_tracker.py tests/test_atlas_reddit_fixture_fidelity.py -q`
+   passes.
+
+Affected surfaces: the atlas_reddit package + its tests + one runbook
+section. No atlas_brain code, no gate scripts, no workflows.
+
+Risk areas: schema migration on the shared SQLite state file (additive
+only -- new table + index; the ladder pattern and fail-closed
+newer-version branch are already established); the profile sync spends one
+PRAW listing per run, which PRAW paginates in 100-item batches up to
+`MAX_PROFILE_LIMIT` (1000) -- run occasionally, not per-subreddit, so it
+is not bound by the radar's tight request budget.
+
+Reviewer rules triggered: R10 (schema/persistence change ->
+failure-branch fixtures per AGENTS.md 3h/3i), R14 (checked-out PR-head
+verification).
+
+## Mechanism
+
+`me.submissions.new()` IS the profile page's submission feed: the
+authenticated user's posts, newest first, each carrying the subreddit it
+was posted in. `PrawHistorySource` already authenticates with exactly the
+scopes this needs (identity to resolve `me`, history for own listings,
+read), so pointing the tool at the "home page" is a new mapping over an
+already-authorized listing -- no new credentials, no scope change.
+`sync_profile_once` upserts the mapped posts into `own_posts`, keyed by
+fullname like every other stored id in the package, so a post row joins
+its replies (tracked by `track`, keyed by the same `t3_` thread fullname)
+with a plain equality -- `post <id>` renders the post plus its stored
+replies without touching the network. Reply collection itself stays the
+tracker's job: single writer per table, and the tracker already handles
+top-level comments on own submissions (`include_top_level=True`).
+
+## Intentional
+
+- **The subreddit radar stays.** `poll`, the watchlist, and scoring are
+  untouched -- this slice repoints the tool's center of gravity to the
+  operator's profile without deleting the listening radar. If the radar
+  should retire once the profile surface proves out, that is its own
+  slice (named in Deferred), not a silent removal here.
+- **Own posts are admitted unfiltered.** The radar's is_self/freshness/
+  score filters exist to triage strangers' posts; "all of the posts" from
+  the operator's profile means link posts and old posts belong too.
+- **Profile sync does not write `tracked_threads`.** The tracker already
+  discovers own submissions from history and owns that table's lifecycle
+  (dormancy, wake). Two writers would race the dormancy state machine.
+- **Purge scope unchanged; own_posts retention documented.** The 48h
+  deletion-compliance contract exists for third-party content (other
+  people's posts and replies); `own_posts` rows are the operator's own
+  words, so `purge` does not touch them and a post deleted on Reddit
+  stays in the local mirror. The runbook now says this explicitly (review
+  finding: the deletion-compliance paragraph must not imply it covers
+  own posts).
+- **The read-only contract is intact this slice.** ALLOWED_SCOPES, the
+  static no-write probe, and the package docstring are unchanged.
+
+## Deferred
+
+- **Write surface (the operator's slice 2):** reply to comments on own
+  posts and edit own post bodies via the API. Requires the operator to
+  re-mint the refresh token with `submit` + `edit` scopes; in code it
+  means an explicit write client behind its own scope floor, a widened
+  ceiling, reworking the static no-write probe into an allowlist over the
+  write module, and runbook + package-docstring updates. Deliberately its
+  own reviewable slice.
+- Radar retirement decision (delete `poll`/watchlist/scoring) once the
+  profile surface is the proven center.
+- Digest section for own posts (the digest currently renders radar
+  candidates + warm replies only).
+- Factory adoption in the remaining reddit test files (#1947 Deferred,
+  narrowed here: `real_history_source` now covers own submissions).
+
+Parked hardening: none new this slice.
+
+## Verification
+
+Commands run from the repo root:
+
+- `python -m pytest tests/test_atlas_reddit_profile.py
+  tests/test_atlas_reddit_store.py tests/test_atlas_reddit_poller.py
+  tests/test_atlas_reddit_tracker.py tests/test_atlas_reddit_fixture_fidelity.py
+  tests/test_atlas_reddit_digest.py tests/test_atlas_reddit_purge.py
+  tests/test_atlas_reddit_config.py -q` -- pass count recorded in the PR
+  body (the purge/config suites cover the schema-ladder terminal version
+  and the profile-limit ceiling).
+- `scripts/check_ascii_python.sh` (via bash) -- passes.
+- `bash scripts/local_pr_review.sh --current-pr-body-file <pr-body.md>`
+  -- all checks PASS.
+- `python scripts/check_diff_budget.py --additions <n> --body-file
+  <pr-body.md>` -- recorded in the PR body.
+- Operator smoke (with creds in env): `python -m atlas_reddit profile`
+  then `python -m atlas_reddit posts` and
+  `python -m atlas_reddit post <id>` against the live profile.
+
+## Estimated diff size
+
+| File | LOC (added) |
+|---|---:|
+| `atlas_reddit/__main__.py` | 151 |
+| `atlas_reddit/store.py` | 151 |
+| `atlas_reddit/profile.py` | 70 |
+| `atlas_reddit/reddit_client.py` | 37 |
+| `atlas_reddit/config.py` | 15 |
+| `tests/test_atlas_reddit_profile.py` | 339 |
+| `tests/atlas_reddit_fixtures.py` | 40 |
+| `tests/test_atlas_reddit_tracker.py` | 4 |
+| `tests/test_atlas_reddit_purge.py` | 2 |
+| `docs/REDDIT_LISTENING_SETUP_RUNBOOK.md` | 31 |
+| `plans/PR-Reddit-Own-Profile-Watcher.md` | 222 |
+| **Total** | **1062** |

--- a/tests/atlas_reddit_fixtures.py
+++ b/tests/atlas_reddit_fixtures.py
@@ -31,6 +31,7 @@ from unittest import mock
 
 from atlas_reddit.config import SubredditEntry, Topic, Watchlist
 from atlas_reddit.poller import poll_once
+from atlas_reddit.profile import sync_profile_once
 from atlas_reddit.store import ListeningStore
 from atlas_reddit.tracker import track_once
 
@@ -74,10 +75,13 @@ def fake_submission(
     score: int = 5,
     num_comments: int = 1,
     is_self: bool = True,
+    subreddit: str = "CustomerSuccess",
 ):
     """A praw-shaped submission. The default title carries the probe
     phrase the seeding watchlist matches on; override it and admission
-    fails loudly in :func:`seed_candidates` rather than silently."""
+    fails loudly in :func:`seed_candidates` rather than silently. The
+    ``subreddit`` attribute mirrors praw's lazy Subreddit object (the
+    profile producer reads its ``display_name``)."""
     _require_bare_id(bare_id)
     return types.SimpleNamespace(
         id=bare_id,
@@ -90,6 +94,7 @@ def fake_submission(
         num_comments=num_comments,
         is_self=is_self,
         selftext=selftext,
+        subreddit=types.SimpleNamespace(display_name=subreddit),
     )
 
 
@@ -158,18 +163,22 @@ def real_listing_source(submissions):
 
 
 @contextmanager
-def real_history_source(*, own_comments=(), replies_by_parent=None):
+def real_history_source(*, own_comments=(), own_submissions=(), replies_by_parent=None):
     """Yield a REAL PrawHistorySource: own-history listings and per-own-
     comment reply children flow through the production admission code
-    (including the removeprefix('t1_') refresh lookup). Own submissions
-    are deferred to the tracker-test conversion slice."""
+    (including the removeprefix('t1_') refresh lookup). ``own_submissions``
+    are praw-shaped submissions (from :func:`fake_submission`) served by
+    the same listing the profile producer and the tracker read."""
     children = {k: list(v) for k, v in (replies_by_parent or {}).items()}
+    submissions = list(own_submissions)
     me = types.SimpleNamespace(
         name=_USERNAME,
         comments=types.SimpleNamespace(
             new=lambda *, limit: iter(list(own_comments)[:limit])
         ),
-        submissions=types.SimpleNamespace(new=lambda *, limit: iter(())),
+        submissions=types.SimpleNamespace(
+            new=lambda *, limit: iter(submissions[:limit])
+        ),
     )
 
     class _Replies(list):
@@ -195,6 +204,32 @@ def real_history_source(*, own_comments=(), replies_by_parent=None):
         from atlas_reddit.reddit_client import PrawHistorySource
 
         yield PrawHistorySource(settings)
+
+
+def seed_own_posts(
+    store: ListeningStore,
+    submissions,
+    *,
+    now: int,
+) -> list[str]:
+    """Store own-post rows through the REAL pipeline (producer mapping over
+    the profile listing + sync_profile_once). Returns the producer-emitted
+    post ids, in input order. Asserts every fixture was synced -- a
+    silently dropped fixture is a factory misuse, not a soft no-op."""
+    items = list(submissions)
+    with real_history_source(own_submissions=items) as source:
+        produced = [
+            post.post_id
+            for post in source.fetch_my_posts(limit=max(len(items), 1))
+        ]
+        stats = sync_profile_once(
+            store, source, now=now, limit=max(len(items), 1)
+        )
+    assert stats.fetched == len(items), (
+        f"factory fixtures must never be silently dropped: fetched "
+        f"{stats.fetched} of {len(items)} ({stats})"
+    )
+    return produced
 
 
 def seed_candidates(

--- a/tests/test_atlas_reddit_profile.py
+++ b/tests/test_atlas_reddit_profile.py
@@ -1,0 +1,339 @@
+"""Tests for the own-profile watcher (plan:
+plans/PR-Reddit-Own-Profile-Watcher.md).
+
+Producer-fidelity discipline (slice from #1947): sync-path tests run the
+REAL producer mapping (PrawHistorySource.fetch_my_posts over a stubbed
+praw module) and the REAL consumer (sync_profile_once) via the fixture
+factory -- a test physically cannot seed an own-post shape the pipeline
+never emits. Store, migration, and CLI branches are covered directly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from atlas_reddit.__main__ import main
+from atlas_reddit.profile import sync_profile_once
+from atlas_reddit.store import SCHEMA_VERSION, ListeningStore, StoreError
+from tests.atlas_reddit_fixtures import fake_submission, seed_own_posts
+
+NOW = 1_751_600_000
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    with ListeningStore(tmp_path / "listening.db") as s:
+        yield s
+
+
+def _add_own_post(
+    store: ListeningStore,
+    *,
+    post_id: str = "t3_abc",
+    subreddit: str = "CustomerSuccess",
+    title: str = "My post",
+    url: str = "https://www.reddit.com/r/x/comments/abc/",
+    created_utc: int = 1_700_000_000,
+    reddit_score: int = 5,
+    num_comments: int = 2,
+    selftext: str = "body",
+    observed_at: int = 1_700_000_100,
+) -> bool:
+    return store.upsert_own_post(
+        post_id=post_id,
+        subreddit=subreddit,
+        title=title,
+        url=url,
+        created_utc=created_utc,
+        reddit_score=reddit_score,
+        num_comments=num_comments,
+        selftext=selftext,
+        observed_at=observed_at,
+    )
+
+
+# -- producer mapping ----------------------------------------------------------
+
+
+def test_fetch_my_posts_maps_rich_fields_including_subreddit() -> None:
+    """The profile producer emits fullnames and reads the subreddit off
+    each submission (a profile listing spans subreddits)."""
+    from tests.atlas_reddit_fixtures import real_history_source
+
+    subs = [
+        fake_submission("aaa", subreddit="CustomerSuccess", title="one"),
+        fake_submission("bbb", subreddit="SaaS", title="two", is_self=False),
+    ]
+    with real_history_source(own_submissions=subs) as source:
+        posts = source.fetch_my_posts(limit=10)
+    assert [p.post_id for p in posts] == ["t3_aaa", "t3_bbb"]
+    assert [p.subreddit for p in posts] == ["CustomerSuccess", "SaaS"]
+    assert posts[0].url.startswith("https://www.reddit.com/")
+    # Link posts are mapped, not filtered (unlike the radar).
+    assert posts[1].is_self is False
+
+
+# -- sync pass (producer fidelity) ---------------------------------------------
+
+
+def test_sync_stores_all_own_posts_through_real_pipeline(store: ListeningStore) -> None:
+    ids = seed_own_posts(
+        store,
+        [
+            fake_submission("aaa", subreddit="CustomerSuccess"),
+            fake_submission("bbb", subreddit="SaaS", is_self=False),
+        ],
+        now=NOW,
+    )
+    assert ids == ["t3_aaa", "t3_bbb"]
+    stored = {p.post_id: p for p in store.list_own_posts()}
+    assert set(stored) == {"t3_aaa", "t3_bbb"}
+    assert stored["t3_bbb"].subreddit == "SaaS"
+
+
+def test_sync_stats_new_then_refreshed(store: ListeningStore) -> None:
+    from tests.atlas_reddit_fixtures import real_history_source
+
+    subs = [fake_submission("aaa"), fake_submission("bbb")]
+    with real_history_source(own_submissions=subs) as source:
+        first = sync_profile_once(store, source, now=NOW, limit=10)
+        second = sync_profile_once(store, source, now=NOW + 60, limit=10)
+    assert (first.fetched, first.new, first.refreshed) == (2, 2, 0)
+    assert (second.fetched, second.new, second.refreshed) == (2, 0, 2)
+    assert len(store.list_own_posts()) == 2  # no duplicates
+
+
+def test_sync_fetch_error_surfaced_not_raised(store: ListeningStore) -> None:
+    class _Boom:
+        def fetch_my_posts(self, *, limit):
+            raise RuntimeError("429 rate limited")
+
+    stats = sync_profile_once(store, _Boom(), now=NOW, limit=10)
+    assert stats.fetched == 0 and stats.new == 0
+    assert len(stats.errors) == 1 and "429" in stats.errors[0]
+    assert store.list_own_posts() == []
+
+
+# -- store: upsert / get / list ------------------------------------------------
+
+
+def test_upsert_and_get_roundtrip(store: ListeningStore) -> None:
+    assert _add_own_post(store) is True  # newly inserted
+    row = store.get_own_post("t3_abc")
+    assert row is not None
+    assert row.subreddit == "CustomerSuccess"
+    assert row.title == "My post"
+    assert row.first_seen == 1_700_000_100
+    assert row.last_seen == 1_700_000_100
+    assert store.get_own_post("t3_missing") is None
+
+
+def test_upsert_replay_preserves_first_seen(store: ListeningStore) -> None:
+    _add_own_post(store)
+    assert _add_own_post(
+        store, reddit_score=99, num_comments=40, observed_at=1_700_000_900
+    ) is False  # refresh, not insert
+    row = store.get_own_post("t3_abc")
+    assert row is not None
+    assert row.first_seen == 1_700_000_100  # preserved
+    assert row.last_seen == 1_700_000_900  # refreshed
+    assert row.reddit_score == 99
+    assert len(store.list_own_posts()) == 1
+
+
+def test_upsert_stale_observation_regresses_nothing(store: ListeningStore) -> None:
+    _add_own_post(store, reddit_score=50, observed_at=1_700_000_500)
+    # An out-of-order (older) observation must not overwrite fresher state.
+    _add_own_post(store, reddit_score=1, observed_at=1_700_000_100)
+    row = store.get_own_post("t3_abc")
+    assert row is not None
+    assert row.reddit_score == 50  # fresher value held
+    assert row.last_seen == 1_700_000_500
+
+
+def test_list_own_posts_ordering_and_subreddit_filter(store: ListeningStore) -> None:
+    _add_own_post(store, post_id="t3_old", created_utc=1, subreddit="SaaS")
+    _add_own_post(store, post_id="t3_new", created_utc=3, subreddit="CustomerSuccess")
+    _add_own_post(store, post_id="t3_mid", created_utc=2, subreddit="saas")
+    ordered = [p.post_id for p in store.list_own_posts()]
+    assert ordered == ["t3_new", "t3_mid", "t3_old"]  # newest first
+    # Subreddit filter is case-insensitive (SaaS vs saas).
+    saas = [p.post_id for p in store.list_own_posts(subreddit="SaaS")]
+    assert saas == ["t3_mid", "t3_old"]
+    assert [p.post_id for p in store.list_own_posts(limit=1)] == ["t3_new"]
+
+
+def test_upsert_rejects_malformed_ids_and_ints(store: ListeningStore) -> None:
+    with pytest.raises(StoreError, match="post_id"):
+        _add_own_post(store, post_id="")
+    with pytest.raises(StoreError, match="created_utc"):
+        store.upsert_own_post(
+            post_id="t3_x",
+            subreddit="X",
+            title="t",
+            url="u",
+            created_utc="soon",  # type: ignore[arg-type]
+            reddit_score=0,
+            num_comments=0,
+            selftext="",
+            observed_at=NOW,
+        )
+
+
+# -- migration -----------------------------------------------------------------
+
+
+def test_v3_store_migrates_to_current_additively(tmp_path: Path) -> None:
+    """A v3 database opens, walks the ladder (v4 tombstone, v5 own_posts),
+    gains own_posts, keeps existing candidate rows, and lands on the
+    current schema version."""
+    db = tmp_path / "v3.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE candidates (
+            post_id TEXT PRIMARY KEY NOT NULL, subreddit TEXT NOT NULL,
+            title TEXT NOT NULL, url TEXT NOT NULL, author TEXT,
+            created_utc INTEGER NOT NULL, reddit_score INTEGER NOT NULL DEFAULT 0,
+            num_comments INTEGER NOT NULL DEFAULT 0, keyword_score REAL NOT NULL,
+            final_score REAL NOT NULL, matched_topics TEXT NOT NULL DEFAULT '[]',
+            status TEXT NOT NULL DEFAULT 'new'
+                CHECK (status IN ('new', 'seen', 'dismissed', 'responded')),
+            first_seen INTEGER NOT NULL, last_seen INTEGER NOT NULL
+        );
+        CREATE TABLE tracked_threads (
+            thread_id TEXT PRIMARY KEY NOT NULL,
+            my_comment_ids TEXT NOT NULL DEFAULT '[]', last_checked INTEGER,
+            dormant INTEGER NOT NULL DEFAULT 0 CHECK (dormant IN (0, 1)),
+            is_own_submission INTEGER NOT NULL DEFAULT 0
+                CHECK (is_own_submission IN (0, 1)),
+            last_activity INTEGER
+        );
+        CREATE TABLE replies (
+            reply_id TEXT PRIMARY KEY NOT NULL, thread_id TEXT NOT NULL,
+            parent_id TEXT, author TEXT, body TEXT NOT NULL DEFAULT '',
+            created_utc INTEGER NOT NULL,
+            is_reply_to_me INTEGER NOT NULL CHECK (is_reply_to_me IN (0, 1)),
+            seen INTEGER NOT NULL DEFAULT 0 CHECK (seen IN (0, 1)),
+            FOREIGN KEY (thread_id) REFERENCES tracked_threads (thread_id)
+        );
+        CREATE TABLE purge_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, item_id TEXT NOT NULL,
+            item_type TEXT NOT NULL
+                CHECK (item_type IN ('candidate', 'reply', 'thread')),
+            deleted_detected_at INTEGER NOT NULL, purged_at INTEGER NOT NULL,
+            reason TEXT NOT NULL
+        );
+        INSERT INTO candidates (post_id, subreddit, title, url, created_utc,
+            keyword_score, final_score, first_seen, last_seen)
+        VALUES ('t3_keep', 'X', 'kept', 'u', 1, 1.0, 1.0, 1, 1);
+        PRAGMA user_version = 3;
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    with ListeningStore(db) as migrated:
+        assert migrated.get_candidate("t3_keep") is not None  # preserved
+        assert migrated.list_own_posts() == []  # new table usable
+        _add_own_post(migrated, post_id="t3_new")
+        assert migrated.get_own_post("t3_new") is not None
+    conn = sqlite3.connect(db)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    conn.close()
+
+
+# -- CLI -----------------------------------------------------------------------
+
+
+def test_cli_posts_lists_synced_posts(store, tmp_path, capsys) -> None:
+    _add_own_post(store, post_id="t3_abc", subreddit="SaaS", title="Hello world")
+    store.close()
+    rc = main(["posts", "--db", str(tmp_path / "listening.db")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "r/SaaS" in out and "t3_abc" in out and "Hello world" in out
+
+
+def test_cli_posts_defaults_to_all_no_silent_cap(store, tmp_path, capsys) -> None:
+    """The default listing lists every synced post (no silent newest-N cap),
+    so "all your posts in one place" is literal even past the old 50."""
+    for i in range(60):
+        _add_own_post(
+            store, post_id=f"t3_p{i:03d}", created_utc=1_700_000_000 + i
+        )
+    store.close()
+    rc = main(["posts", "--db", str(tmp_path / "listening.db")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.count("\n") >= 60  # all 60, not a silent 50
+    assert "t3_p000" in out and "t3_p059" in out
+    # --limit still narrows on request.
+    rc = main(["posts", "--db", str(tmp_path / "listening.db"), "--limit", "5"])
+    assert rc == 0
+    assert capsys.readouterr().out.count("\n") == 5
+
+
+def test_cli_posts_empty_hint(tmp_path, capsys) -> None:
+    with ListeningStore(tmp_path / "listening.db"):
+        pass
+    rc = main(["posts", "--db", str(tmp_path / "listening.db")])
+    assert rc == 0
+    assert "no synced posts" in capsys.readouterr().out
+
+
+def test_cli_post_shows_post_and_accepts_bare_id(store, tmp_path, capsys) -> None:
+    _add_own_post(store, post_id="t3_abc", title="Deep dive", selftext="the body")
+    store.close()
+    # Bare id is accepted and prefixed to the stored fullname.
+    rc = main(["post", "abc", "--db", str(tmp_path / "listening.db")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Deep dive" in out and "the body" in out and "t3_abc" in out
+
+
+def test_cli_post_unknown_exits_2(tmp_path, capsys) -> None:
+    with ListeningStore(tmp_path / "listening.db"):
+        pass
+    rc = main(["post", "t3_nope", "--db", str(tmp_path / "listening.db")])
+    assert rc == 2
+    assert "unknown own post: t3_nope" in capsys.readouterr().err
+
+
+def test_cli_profile_limit_out_of_range_errors(tmp_path) -> None:
+    from atlas_reddit.config import MAX_PROFILE_LIMIT
+
+    db = str(tmp_path / "listening.db")
+    # Below the floor and above the profile ceiling (1000, not the tracker's
+    # 100) both reject; the raised cap is what lets the mirror hold "all my
+    # posts" for established accounts.
+    with pytest.raises(SystemExit):
+        main(["profile", "--db", db, "--limit", "0"])
+    with pytest.raises(SystemExit):
+        main(["profile", "--db", db, "--limit", str(MAX_PROFILE_LIMIT + 1)])
+
+
+# -- read-only contract still holds --------------------------------------------
+
+
+def test_profile_producer_adds_no_write_surface() -> None:
+    """The profile method is another read; the package's static no-write
+    probe (in test_atlas_reddit_poller) still governs, and the history
+    source's public surface stays read-only."""
+    from atlas_reddit.reddit_client import PrawHistorySource
+
+    public = {
+        name
+        for name in dir(PrawHistorySource)
+        if not name.startswith("_") and callable(getattr(PrawHistorySource, name))
+    }
+    assert public == {
+        "fetch_my_recent_comments",
+        "fetch_my_recent_submissions",
+        "fetch_my_posts",
+        "fetch_thread_replies",
+        "granted_scopes",
+    }

--- a/tests/test_atlas_reddit_purge.py
+++ b/tests/test_atlas_reddit_purge.py
@@ -19,7 +19,7 @@ from atlas_reddit.reddit_client import (
     RedditAuthError,
     validate_scopes,
 )
-from atlas_reddit.store import ListeningStore, StoreError
+from atlas_reddit.store import SCHEMA_VERSION, ListeningStore, StoreError
 from tests.atlas_reddit_fixtures import fake_reply, fake_submission, seed_candidates, seed_replies
 
 NOW = 1_751_600_000
@@ -661,7 +661,7 @@ def test_v3_store_gains_tombstone_backfilled_conservative(tmp_path: Path) -> Non
         _seed_candidate(migrated, "t3_old")
         assert migrated.get_candidate("t3_old") is None  # still refused
     conn = sqlite3.connect(db)
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
     conn.close()
 
 

--- a/tests/test_atlas_reddit_tracker.py
+++ b/tests/test_atlas_reddit_tracker.py
@@ -19,7 +19,7 @@ from atlas_reddit.reddit_client import (
     ThreadReply,
     validate_scopes,
 )
-from atlas_reddit.store import ListeningStore
+from atlas_reddit.store import SCHEMA_VERSION, ListeningStore
 from atlas_reddit.tracker import track_once
 
 NOW = 1_751_500_000
@@ -290,6 +290,7 @@ def test_history_source_read_only_public_surface() -> None:
     assert public == {
         "fetch_my_recent_comments",
         "fetch_my_recent_submissions",
+        "fetch_my_posts",
         "fetch_thread_replies",
         "granted_scopes",
     }
@@ -504,8 +505,9 @@ def test_v1_store_migrates_to_current_preserving_data(tmp_path: Path) -> None:
         # last_checked.
         assert threads["t3_lonely"].last_activity == 200
         assert migrated.list_replies()[0].reply_id == "t1_r"
+        assert migrated.list_own_posts() == []  # v4 -> v5 rung: table exists
     conn = sqlite3.connect(db)
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
     conn.close()
 
 


### PR DESCRIPTION
Plan: plans/PR-Reddit-Own-Profile-Watcher.md
Slice phase: Vertical slice
Ownership lane: reddit-listening-tool

Points the Reddit tool at the operator's own profile -- the one listing
that already carries every post they made and the subreddit each landed
in -- so all their posts live in one local place, each readable
individually. Today the package can't: the radar (`poll`) watches
watchlist subreddits for other people's posts, and the reply tracker
(`track`) sees the operator's own submissions only as skinny thread ids
for reply discovery (no title, subreddit, or body). Root cause: no
producer fetches the operator's own submission listing with content
fields, and no table holds it. This slice adds that read-only vertical: a
profile listing fetch on the SAME identity/history/read scopes the tracker
already uses -> a new `own_posts` table -> CLI `profile` (sync), `posts`
(list all, offline), and `post <id>` (one post + its tracked replies,
offline). The write half of the ask (replying to and editing those posts
via the API) is deliberately the next slice: it reverses the package's
enforced read-only contract and needs a re-minted token with write scopes,
so it is sequenced behind this read slice where each contract change is
reviewable on its own.

Diff-budget override: the producer method, the `own_posts` table +
migration, the sync pass, the profile-limit config, and the CLI read
surface are one indivisible vertical -- a sync with no read surface
delivers nothing user-visible, and a read surface with no table reads
nothing. The bulk of the added lines is the new producer-fidelity test
file (339) and the plan (222); product code is ~424 across five files.

## Intentional

- The subreddit radar stays. `poll`, the watchlist, and scoring are
  untouched -- this repoints the tool's center of gravity to the profile
  without deleting the listening radar. Retiring the radar, if wanted, is
  its own slice (named in Deferred), not a silent removal here.
- Own posts are admitted unfiltered, up to Reddit's listing ceiling. The
  radar's is_self/freshness/score filters triage strangers' posts; "all of
  the posts" from the operator's profile means link posts and old posts
  belong too. Profile sync fetches up to `MAX_PROFILE_LIMIT` (1000,
  Reddit's per-listing max), not the tracker's tight 100-item history
  window, so established accounts back-fill their full reachable history,
  and `posts` lists all of them by default (no silent newest-N cap).
- Profile sync does not write `tracked_threads`. The tracker already owns
  that table's lifecycle (dormancy, wake) and discovers own submissions
  from history; two writers would race the dormancy state machine. `post`
  joins an own post to its replies by the shared `t3_` thread fullname,
  and shows tracked replies only for submissions `track` has already
  discovered in its history window (older profile-only posts open but show
  no tracked replies until a `track` pass reaches them).
- Purge scope unchanged; own_posts retention documented. The 48h
  deletion-compliance contract exists for third-party content; `own_posts`
  rows are the operator's own words, so `purge` does not touch them and a
  post deleted on Reddit stays in the local mirror. The runbook now says
  this explicitly.
- The read-only contract is intact this slice: ALLOWED_SCOPES, the static
  no-write probe, and the package docstring are unchanged. `fetch_my_posts`
  is another read over the already-authorized own-submission listing.

## Deferred

- Write surface (the operator's slice 2): reply to comments on own posts
  and edit own post bodies via the API. Needs the operator to re-mint the
  refresh token with `submit` + `edit` scopes; in code, an explicit write
  client behind its own scope floor, a widened ceiling, reworking the
  static no-write probe into an allowlist over the write module, and
  runbook + docstring updates. Its own reviewable slice.
- Radar retirement decision, once the profile surface is the proven center.
- Digest section for own posts (the digest renders radar candidates + warm
  replies only today).

## Parked hardening

None new this slice.

## AI reconciliation

Codex raised 4 findings across two rounds (all P2); all FIXED, no waivers.
Rounds 1-2 (findings 1-2) landed on the pre-rebase commit; round 3
(findings 3-4) on the rebased commit and are the read-side consistency
gaps the round-1 sync-cap fix exposed.

All fixed or waived: Yes

1. **P2 -- profile sync capped at 100 posts, so >100-post accounts can
   never back-fill "all my posts."** Fixed: added `MAX_PROFILE_LIMIT`
   (1000, Reddit's listing ceiling) + a `profile_limit` setting defaulting
   to it; the `profile` command now validates/defaults against it instead
   of the tracker's `MAX_HISTORY_LIMIT`. Runbook states the ~1000 ceiling.
   CLI test asserts the raised cap rejects `MAX_PROFILE_LIMIT + 1`.
2. **P2 -- runbook deletion-compliance paragraph implied it covered every
   stored post, but `purge` never reads `own_posts`.** Fixed: the runbook
   now states own profile-synced posts are the operator's own words,
   retained across `purge`, and outside the 48h third-party
   deletion-compliance guarantee (matches the plan's Intentional decision).
3. **P2 -- `posts` still defaulted to newest 50, silently hiding older
   synced posts from the read surface.** Fixed: `posts --limit` now
   defaults to no cap (list every synced post) -- it is a cheap offline
   SQLite read; `--limit` still narrows on request. New CLI test asserts
   60 synced posts all list (no silent 50-cap) and `--limit 5` narrows.
4. **P2 -- runbook over-promised reply tracking for every synced post.**
   Fixed: narrowed the sentence -- `track` discovers own submissions only
   through its `--history-limit` window (capped 100), and profile sync
   deliberately does not enqueue own posts into `tracked_threads` (that
   table's lifecycle is the tracker's), so `post` shows tracked replies
   only for submissions `track` has already picked up. Older profile-only
   posts list and open but show no tracked replies until a `track` pass
   reaches them.

Rebase note: main advanced under this branch while it was in flight
(#1948 listener hardening reached schema v4 via a purge tombstone; #1954 /
#1967 Reddit Fit v2 added adjacent suites). Rebased onto current main;
resolved the schema-version collision by stacking own_posts as v5 (main's
tombstone stays v4), and the two migration probes' terminal-version
assertions now follow `SCHEMA_VERSION`.

## Verification

- `python -m pytest tests/test_atlas_reddit_profile.py
  tests/test_atlas_reddit_store.py tests/test_atlas_reddit_poller.py
  tests/test_atlas_reddit_tracker.py tests/test_atlas_reddit_fixture_fidelity.py
  tests/test_atlas_reddit_digest.py tests/test_atlas_reddit_purge.py
  tests/test_atlas_reddit_config.py tests/test_atlas_reddit_fit.py
  tests/test_atlas_reddit_fit_eval.py -q` -- 480 passed. New: profile
  producer mapping + sync (producer-fidelity factory), own_posts store
  upsert/get/list + replay/stale/failure branches, v4 -> v5 additive
  migration, CLI wiring (posts/post/profile) incl. unknown-post exit 2,
  bare-id acceptance, the profile-limit ceiling, and the `posts`
  list-all default (60 posts list, no silent 50-cap).
- `scripts/check_ascii_python.sh` (via bash) -- passed.
- Offline CLI smoke: seeded one own post + a tracked reply, then
  `posts` listed it and `post abc123` (bare id) rendered the post body and
  the reply; `post t3_missing` exited 2; `profile --limit` default is 1000.

## Diff size

11 files, +1062 / -13 (product: `__main__.py` 151, `store.py` 151,
`profile.py` 70, `reddit_client.py` 37, `config.py` 15; tests 385; runbook
31; plan 222). Over the 400 cap; carried by the override above.

Refs #1934 (atlas_reddit arc), #1948 (schema v4 base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBjR7LHvYC9JP9GTe58tRE