### PR TITLE
Document long-running hook split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,12 +401,20 @@ For long-running coding tasks, after each PR open or push:
 1. Subscribe the session to its owned PR in `SESSION_STATE.local.md`. Record the
    PR number, branch, head SHA, checks URL, review/reconciliation URL or
    commands, the timer hook name, next timer wake time, and the exact action to
-   take when checks turn green or comments appear.
+   take when checks turn green or comments appear. If the operator grants
+   standing merge authorization for the arc, record the authorization source and
+   scheduled-ready-only merge condition there too.
 2. Install or run **two external wake hooks** for the owned PR:
    - a push/review-event hook that wakes immediately when a new push, review
      thread, review event, or reconciliation event arrives;
    - a timer hook that wakes every **30 minutes** to check whether CI is green
      and the PR is mergeable.
+   If the current environment cannot provide a concrete push/review-event hook,
+   record that gap in `SESSION_STATE.local.md`, keep the 30-minute timer hook
+   armed as the autonomous fallback, and do not claim immediate review-event
+   wake-up coverage for the session. The push/review-event hook must not reuse
+   the scheduled green-confirmation command in a way that can grant merge
+   permission, and an operator-only notification is not a builder wake hook.
 3. The timer hook must be a webhook/systemd/cron-style wakeup that exits fast
    after recording state. Do not keep an in-chat `sleep` loop or active polling
    process alive just to wait for green CI.
@@ -419,10 +427,14 @@ For long-running coding tasks, after each PR open or push:
 6. If checks are still pending, record the last observed status and next timer
    wake time in `SESSION_STATE.local.md`; do not ask the operator to babysit
    green and do not burn compute by waiting inside the chat turn.
-7. If all required checks are green and all review/reconciliation gates are
+7. Push/review-event wakes are attention-only. Even if a push/review-event wake
+   observes green checks, record readiness and wait for the 30-minute timer to
+   report the scheduled green confirmation before merging.
+8. If the 30-minute timer wake reports all required checks green, all
+   review/reconciliation gates clean, and merge-conflict/mergeability state
    clean, follow the merge rules for the current arc. If the operator has not
    authorized autonomous merge for this arc, report readiness and wait.
-8. After merge, tear down only the owned worktree/branch, archive the plan as
+9. After merge, tear down only the owned worktree/branch, archive the plan as
    required, sync from `origin/main`, and continue to the next approved slice
    if the arc says to continue. The merge itself is the signal to pick up the
    next slice; do not start the next slice before the owned PR is merged or

--- a/docs/SESSION_STATE_TEMPLATE.md
+++ b/docs/SESSION_STATE_TEMPLATE.md
@@ -26,7 +26,12 @@ Branch: <branch or none>
 Plan: plans/PR-<Slice>.md
 Expected head SHA: <sha or none>
 Ownership lane: <lane from plan>
-Allowed actions: inspect | update | merge-on-operator-signal | none
+Allowed actions: inspect | update | merge-on-operator-signal | merge-after-scheduled-ready-guarded | none
+Standing merge authorization: <none | authorized by <operator/source> for <arc>; scheduled-ready-only>
+Push/review-event hook: <name and trigger | unavailable | none>
+Timer hook: <systemd/cron/webhook name | none>
+Next timer wake: <timestamp or none>
+Last watcher state: <state/details or none>
 
 ## PRs This Session May Touch
 
@@ -74,6 +79,12 @@ Do-NOT-redo: <paths ruled out, checks already green, dead ends>
 - [ ] Confirm the current PR is listed under "Owned Active PR" or "PRs This
       Session May Touch" before inspecting comments, pushing updates, or
       merging.
+- [ ] Confirm `Push/review-event hook`, `Timer hook`, `Next timer wake`, and
+      `Last watcher state` reflect the current long-running setup before
+      relying on autonomous wake-ups.
+- [ ] Confirm `Standing merge authorization` is explicit before merging on a
+      scheduled `ready_for_human_merge` wake; do not infer it from watcher
+      state.
 - [ ] Treat every other open PR as "must not touch" unless the operator
       explicitly reassigns it.
 ```

--- a/docs/ci_cd_autonomous_coding_map.md
+++ b/docs/ci_cd_autonomous_coding_map.md
@@ -12,10 +12,12 @@ Atlas has two related workflows:
 1. Ordinary interactive slices stop after the PR is opened or updated. The
    builder reports the PR URL, local checks, and current status, then waits for
    the operator signal.
-2. Explicit long-running coding tasks keep a PR watcher. The builder records
-   the owned PR in `SESSION_STATE.local.md`, polls GitHub every 30 minutes,
-   fixes red CI or actionable review comments inside the current slice, and
-   continues only when the owned PR is clean or merged.
+2. Explicit long-running coding tasks separate push/review-event attention from
+   scheduled green confirmation. A push/review-event hook is immediate only when
+   the operator environment provides an external bridge; otherwise the session
+   records that hook as unavailable and the local 30-minute watcher is the
+   autonomous fallback. The builder does not actively poll GitHub between those
+   wake-ups.
 
 The production loop is:
 
@@ -30,8 +32,11 @@ issue / operator request
   -> PR body contract
   -> GitHub Actions checks
   -> Codex/Copilot/human review
+  -> push/review-event attention wakes the builder only via external bridge/operator signal
+     and never authorizes merge
   -> live AI reconciliation
-  -> merge only when owned PR is clean
+  -> scheduled watcher confirms green
+  -> merge only when owned PR is clean and the arc has explicit merge authorization
   -> worktree teardown + plan archive
   -> next approved slice
 ```
@@ -159,8 +164,13 @@ artifact:
 - Session ownership state prevents one long-running agent from touching another
   lane's PR.
 - Fix-mode batons keep red-check loops narrow after compaction.
-- Long-running watchers remove operator babysitting while preserving ownership
-  and merge-safety rules.
+- Push/review-event signals reduce red-review latency when an operator or
+  external bridge wakes the builder, without becoming merge signals; even green
+  event wakes wait for scheduled confirmation.
+- Long-running scheduled watchers remove operator babysitting while preserving
+  ownership and merge-safety rules.
+- Head-SHA pins catch unexpected remote branch movement before a builder can
+  overwrite or merge another actor's push.
 
 The practical result is less token burn: agents spend less time re-orienting,
 humans spend less time asking "is it green yet?", and reviewers spend more time

--- a/docs/long_running_session_watcher_handoff.md
+++ b/docs/long_running_session_watcher_handoff.md
@@ -11,11 +11,36 @@ map in `docs/ci_cd_autonomous_coding_map.md`.
 Long-running sessions now have two durable responsibilities:
 
 1. Keep `SESSION_STATE.local.md` current for the owned lane and PR.
-2. Run a lane-local PR watcher every 30 minutes after each PR open or push.
+2. Use two signal paths after each PR open or push: a required
+   push/review-event hook when the environment provides one, and the autonomous
+   30-minute scheduled green-confirmation hook.
 
 The watcher is intentionally local and per session. One session equals one
 watcher config. A second session should create a second config and timer rather
 than reuse another session's watcher.
+
+## Two Signal Paths
+
+Long-running sessions should not actively poll GitHub in a loop. They wait for
+signals, then take the narrow action that signal allows. Today, this repo
+provides the scheduled watcher; a push/review-event hook must be supplied by the
+operator environment or recorded as unavailable in `SESSION_STATE.local.md`.
+
+| Signal | Source | Builder action | Autonomous today? | Merge allowed? |
+|---|---|---|---|---|
+| Push/review-event attention | External bridge for GitHub push, review thread, review event, or reconciliation event; operator "review is up" signal if no bridge exists | Inspect only the owned PR, read thread-aware review state, fix actionable feedback in scope, and record readiness if already green | Only when the environment supplies the bridge | No |
+| Scheduled green confirmation | The local `atlas-pr-watch@<session>.timer` 30-minute wake-up | If the scheduled state is `ready_for_human_merge`, run the AGENTS ownership/head/check/thread guards | Yes | Only with explicit standing authorization for this arc |
+
+The push/review-event path exists to reduce red-review latency when something
+wakes the builder. It is an attention signal, not a merge signal. If no concrete
+bridge is installed, record `push/review-event hook: unavailable` in
+`SESSION_STATE.local.md`; the scheduled watcher remains responsible for catching
+`review_changed` while the operator is away.
+
+The scheduled hook is the canonical merge gate. A push/review-event wake that
+observes a clean PR records readiness, leaves the timer armed, and waits for the
+scheduled `ready_for_human_merge` confirmation before any standing-authorized
+merge.
 
 ## Local Watcher Files
 
@@ -34,16 +59,54 @@ If `~/.local/bin/atlas-pr-watch` is missing, stop and ask the operator. Do not
 recreate a merge-capable watcher from scratch. The watcher must stay read-only
 with respect to GitHub merges.
 
+## Push/Review-Event Hook
+
+AGENTS.md requires a push/review-event wake hook for fully immediate
+long-running operation. That hook is outside this repo unless the operator has
+provided an integration. Use this concrete contract:
+
+1. Record the hook in `SESSION_STATE.local.md` as
+   `Push/review-event hook: <name and trigger>`.
+2. Configure the external bridge to wake the builder session on new pushes,
+   review threads, review events, and reconciliation events for the owned PR. Do
+   not use the scheduled
+   `~/.local/bin/atlas-pr-watch "${SESSION_ID}"` command as the event bridge
+   unless it has a source-aware event mode that cannot grant merge permission.
+3. If no such bridge exists, record `Push/review-event hook: unavailable` and
+   rely on the scheduled watcher for autonomous review-change detection.
+   Operator-only notifications are a manual fallback, not a recorded
+   push/review-event hook.
+
+The unavailable state is safe but not immediate. Do not describe that session as
+having quick review-event wake-up coverage.
+
 ## Safety Rules
 
 - No auto-merge. The watcher refuses `AUTO_MERGE=1`.
 - A green PR becomes `ready_for_human_merge`; it does not merge itself.
+- If the operator gives explicit standing authorization for an arc, the builder
+  may merge after a scheduled `ready_for_human_merge` wake-up, but only after
+  re-running the AGENTS pre-merge guards: open PR list, `origin/main` log,
+  ownership guard, matching head SHA, current checks, review-thread status,
+  live reconciliation, and merge-conflict/mergeability state.
+- Standing authorization applies only to the scheduled green-confirmation wake,
+  never to a push/review-event attention wake.
+- Review/comment events do not currently wake the local builder session by
+  themselves. Treat them as fast attention only when the operator or another
+  explicit integration wakes the session; otherwise record the event hook as
+  unavailable and use the scheduled watcher as the autonomous fallback.
 - The watcher may alert on red CI, pending CI, new review activity, head SHA
   mismatch, or failed AI reconciliation.
 - A builder may fix only the owned PR and only the files allowed by the active
   slice or PR-fix-mode block.
 - After merge, disable that PR's timer and tear down only that session's owned
   worktree/branch.
+- If the watcher reports a head SHA mismatch, stop before any force-push or
+  merge. Fetch the remote branch, inspect the unexpected delta, and either
+  fast-forward and repair in a new commit or ask the operator if ownership is
+  unclear.
+- Between watcher wake-ups, do not run an ad hoc `gh` polling loop just to see
+  whether CI is green.
 
 This protects against the race where checks turn green before late comments or
 review threads land.
@@ -107,9 +170,9 @@ systemctl --user disable --now "atlas-pr-watch@${SESSION_ID}.timer"
 | State | Meaning | Builder action |
 |---|---|---|
 | `pending` | At least one check is still pending | Record the next poll; do not ask the operator to babysit CI |
-| `attention` | Red/canceled check, head mismatch, or failed AI reconciliation | Inspect the owned PR, fix the root cause in-scope, push, update watcher config head SHA |
+| `attention` | Red/canceled check, failed AI reconciliation, or status details such as `head_mismatch: true` | Inspect the owned PR, fix the root cause in-scope, push, update watcher config head SHA. If `head_mismatch` is true, follow the stop/fetch/inspect branch before any force-push or merge |
 | `review_changed` | New review/comment activity since last poll | Inspect comments before any merge decision |
-| `ready_for_human_merge` | Checks are green and AI reconciliation passes | Report readiness; do not merge unless the operator explicitly authorizes it |
+| `ready_for_human_merge` | Checks are green and AI reconciliation passes on the scheduled timer wake | If this arc has standing merge authorization and this state came from the scheduled timer, run the AGENTS merge guards and merge; otherwise report readiness and wait |
 
 ## Prompt For Other Builder Sessions
 
@@ -131,9 +194,19 @@ New rules to follow:
 - A PR is yours only if SESSION_STATE.local.md lists it under Owned Active PR or PRs This Session May Touch.
 - Do not inspect, push to, close, merge, or modify any other open PR unless the operator explicitly reassigns it and you update SESSION_STATE.local.md first.
 - After every PR open or push, install or refresh a per-session watcher config at ~/.config/atlas-pr-watchers/<session-id>.env.
+- Fill the SESSION_STATE.local.md hook fields: `Push/review-event hook`, `Timer hook`, `Next timer wake`, `Last watcher state`, and `Standing merge authorization`.
+- Record the push/review-event hook in SESSION_STATE.local.md only when it wakes the builder session. If no concrete external bridge wakes the builder, write `Push/review-event hook: unavailable`; the scheduled watcher is then the autonomous fallback and the session does not have immediate review-event wake-up coverage.
+- Do not use the scheduled atlas-pr-watch command as the push/review-event bridge unless it has a source-aware event mode that cannot produce merge permission.
 - The watcher must poll every 30 minutes and must use AUTO_MERGE="0".
-- No auto-merge. When the watcher reports ready_for_human_merge, report readiness and wait for the operator unless this specific arc has explicit merge authorization.
+- No auto-merge in the watcher. When the watcher reports ready_for_human_merge, report readiness and wait for the operator unless this specific arc has explicit standing merge authorization.
+- With standing merge authorization recorded in SESSION_STATE.local.md, merge only after a scheduled watcher wake-up reports ready_for_human_merge and the current AGENTS pre-merge guards pass, including review-thread status and merge-conflict/mergeability state.
+- Do not merge from a push/review-event wake. If that wake observes green checks, record readiness and wait for the scheduled green-confirmation wake.
+- Do not actively poll GitHub for green CI between watcher wake-ups.
+- Review/comment events are fast attention only when the operator or an
+  explicit integration wakes this session. Until a local review-event bridge is
+  installed, rely on the scheduled watcher to catch `review_changed`.
 - If checks are red or review comments are actionable, fix only the owned PR, fix the upstream/root cause within the slice, push with scripts/push_pr.sh, resolve fixed review threads, update the PR body/reconciliation record when needed, and refresh the watcher head SHA.
+- If the watcher reports `attention` with `head_mismatch: true`, stop, fetch the remote head, inspect the delta, and do not force-push over another actor's commit.
 - If checks are pending, update SESSION_STATE.local.md with the current pending list and next poll time.
 - Do not start the next slice while the owned PR has unresolved CI, review, AI reconciliation, or merge state.
 
@@ -178,3 +251,9 @@ AUTO_MERGE=0
 That watcher caught an open Codex reconciliation thread, the builder fixed the
 doc issue, pushed a new head, resolved the outdated thread, and the watcher
 reported `ready_for_human_merge` without merging.
+
+The #1968 run added the standing-authorization case: the operator explicitly
+authorized the builder to merge after a scheduled green confirmation. The
+watcher still did not merge; it only produced the `ready_for_human_merge`
+snapshot. The builder then re-ran the ownership/head/check/thread guards,
+merged, disabled the timer, and tore down the worktree.

--- a/plans/PR-Long-Running-Hook-Split.md
+++ b/plans/PR-Long-Running-Hook-Split.md
@@ -1,0 +1,154 @@
+# PR-Long-Running-Hook-Split
+
+## Why this slice exists
+
+Issue #1962 S2 documented the first long-running watcher runbook, and S3
+measured CI runtime/duplication. The live #1968 fix loop exposed the next
+operating-model gap: the docs still describe one generic "poll every 30
+minutes" watcher, while the actual safe loop needs to distinguish review-event
+attention from scheduled green confirmation.
+
+The root cause is that review-event attention and CI-green merge confirmation
+are different signals with different safety semantics, but the current runbook
+collapses them into one polling story. This slice fixes the root at the docs and
+operating-contract layer: it names review-event attention as non-autonomous
+unless an operator or external bridge wakes the session, preserves the scheduled
+green-confirmation hook as the autonomous path, updates AGENTS.md with the
+recorded-gap fallback for environments without a concrete event bridge, and
+documents the standing-authorization merge rule plus head-mismatch recovery
+rule. It does not change workflow code or local watcher implementation.
+
+## Scope (this PR)
+
+Ownership lane: workflow/autonomous-ci-cd-map
+Slice phase: Workflow/process
+
+1. Update the long-running watcher handoff to distinguish review-event
+   attention from scheduled CI-green confirmation.
+2. Update the CI/CD map so the operating loop distinguishes event-driven review
+   signals from scheduled merge confirmation.
+3. Align AGENTS.md with the handoff: if no concrete push/review-event hook is
+   available, record the gap and rely on the scheduled watcher as the autonomous
+   fallback.
+4. Document that an explicit standing authorization from the operator lets the
+   builder merge after a scheduled `ready_for_human_merge` wake-up, but only
+   after the normal AGENTS ownership/head/check/thread guards pass.
+5. Document the #1968 head-mismatch recovery rule: stop on unexpected remote
+   head movement, fetch/inspect the delta, and do not force-push over it.
+
+### Review Contract
+
+Acceptance criteria:
+- The runbook names review-event attention and scheduled green confirmation,
+  and states that only the scheduled watcher is an autonomous local wake-up
+  today.
+- The runbook and AGENTS.md both state how to record an unavailable
+  push/review-event hook without claiming immediate wake-up coverage.
+- The scheduled green-confirmation path preserves `AUTO_MERGE=0`; the builder
+  performs the merge only when explicitly authorized for the arc.
+- The canonical AGENTS scheduled merge gate includes clean merge-conflict /
+  mergeability state, not only green checks and clean review/reconciliation.
+- The review-event path is described as an attention/fix trigger, not a merge
+  trigger, and does not claim to wake the builder without an operator or
+  explicit bridge.
+- The canonical AGENTS rule and handoff both reserve standing-authorized merge
+  for scheduled green-confirmation wakes; push/review-event wakes can only
+  inspect, fix, or record readiness.
+- The session-state template has durable fields for the push/review-event hook,
+  timer hook, next timer wake, and last watcher state.
+- The session-state template has a durable standing-authorization field so merge
+  permission does not depend on memory after compaction.
+- The session-state template allowed-action enum includes the scheduled-ready
+  guarded merge mode.
+- The event-bridge contract requires a recorded event hook to wake the builder
+  and does not tell sessions to run the scheduled watcher command as a
+  review-event bridge that could grant merge permission.
+- The docs explicitly forbid active GitHub polling loops between watcher
+  wake-ups.
+- The docs include the head-mismatch stop/fetch/inspect rule learned from
+  #1968.
+- The standing-authorization merge guard list includes review-thread status and
+  merge-conflict/mergeability state.
+- The PR is documentation/plan only; it must not change GitHub Actions, local
+  watcher scripts, branch protection, or CI behavior.
+
+Affected surfaces:
+- Developer workflow docs for long-running Atlas builder sessions.
+
+Risk areas:
+- Accidentally implying a merge-capable watcher.
+- Blurring "review changed" with "ready to merge."
+- Encouraging force-push over another actor's remote head.
+- Weakening AGENTS.md by hiding the missing event-hook bridge instead of making
+  the gap explicit.
+
+Triggered reviewer rules:
+- R1 Requirements match
+- R2 Test evidence
+- R6 Workflow/process
+- R14 Codebase verification
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/SESSION_STATE_TEMPLATE.md`
+- `docs/ci_cd_autonomous_coding_map.md`
+- `docs/long_running_session_watcher_handoff.md`
+- `plans/PR-Long-Running-Hook-Split.md`
+
+## Mechanism
+
+The runbook keeps the watcher read-only and `AUTO_MERGE=0`, but gives the
+builder a precise operating contract:
+
+```text
+push/review-event attention -> inspect/fix owned PR only when operator/bridge wakes
+                              record readiness if green, but never merge
+30-minute watcher -> if ready_for_human_merge and standing authorization exists,
+                     run AGENTS merge guards, merge, teardown, continue
+```
+
+The CI/CD map mirrors that contract in the high-level operating loop so future
+sessions do not treat "polling" as active GitHub sampling.
+
+The session-state template gets the same hook/timer fields so a clean-start
+session has a durable slot for whether immediate review-event wake-up coverage
+exists and whether standing merge authorization was explicitly granted for the
+arc.
+
+## Intentional
+
+- No workflow, branch-protection, or watcher executable changes. This slice
+  makes the operating rule durable before any implementation changes.
+- The push/review-event path is not documented as autonomous unless an external
+  bridge exists. A local webhook bridge is deferred until the monitoring slice
+  proves it is needed.
+- `AUTO_MERGE=0` remains mandatory. The builder can merge after a scheduled
+  green confirmation only because the operator gave explicit standing
+  authorization for this arc.
+
+## Deferred
+
+- #1962 S5 monitoring/reporting spec: decide whether to add a local
+  review-event notification bridge beyond GitHub Actions and desktop
+  notifications.
+- Applying CI speedup candidates from `docs/ci_cd_runtime_duplication_audit.md`.
+
+Parked hardening: none.
+
+## Verification
+
+- `python scripts/sync_pr_plan.py plans/PR-Long-Running-Hook-Split.md --check` - passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/long_running_hook_split_pr_body.md` - passed; non-blocking warning only: plans archive backlog exceeds threshold.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 18 |
+| `docs/SESSION_STATE_TEMPLATE.md` | 13 |
+| `docs/ci_cd_autonomous_coding_map.md` | 24 |
+| `docs/long_running_session_watcher_handoff.md` | 87 |
+| `plans/PR-Long-Running-Hook-Split.md` | 154 |
+| **Total** | **296** |


### PR DESCRIPTION
Plan: plans/PR-Long-Running-Hook-Split.md
Slice phase: Workflow/process

Issue #1962 needs the long-running runbook to distinguish push/review-event attention from scheduled CI-green confirmation. This slice documents that review-event attention is not an autonomous local wake-up without an explicit bridge that wakes the builder, aligns AGENTS.md with the unavailable-hook fallback, preserves the 30-minute watcher as the autonomous scheduled path, adds durable session-state hook/timer/standing-authorization fields, and records the standing-authorization merge rule, no-active-polling rule, review/mergeability pre-merge guards, scheduled-only merge gate with clean mergeability, and #1968 head-mismatch recovery rule without changing workflow or watcher behavior.

## Intentional
- Documentation/plan only; no GitHub Actions, branch-protection, or local watcher executable changes.
- `AUTO_MERGE=0` remains mandatory. The builder may merge after a scheduled green wake-up only when the arc has explicit standing authorization and the AGENTS pre-merge guards pass.
- The scheduled merge gate requires clean merge-conflict/mergeability state, not just green checks.
- The push/review-event path is an attention/fix/readiness-record signal, not a merge signal, and is not documented as autonomous until a local bridge exists.
- A recorded push/review-event bridge must wake the builder session; operator-only notifications are manual fallback and should be recorded as unavailable.
- A push/review-event bridge must not reuse the scheduled watcher command unless it has a source-aware mode that cannot grant merge permission.

## Deferred
- #1962 S5 monitoring/reporting spec: decide whether a local review-event notification bridge is needed beyond existing GitHub review events and desktop notifications.
- Applying CI speedup candidates from `docs/ci_cd_runtime_duplication_audit.md`.

## Parked hardening
- None.

## Verification
- `python scripts/sync_pr_plan.py plans/PR-Long-Running-Hook-Split.md --check` - passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/long_running_hook_split_pr_body.md` - passed; non-blocking warning only: plans archive backlog exceeds threshold.

## Diff size
5 files, +281 / -15
