### PR TITLE
Add approve-on-publish + compare-and-set to FAQ macro writeback service

### DIFF
--- a/extracted_content_pipeline/faq_macro_writeback.py
+++ b/extracted_content_pipeline/faq_macro_writeback.py
@@ -12,6 +12,7 @@ from .ticket_faq_ports import TicketFAQDraft
 
 
 APPROVED_FAQ_STATUS = "approved"
+DRAFT_FAQ_STATUS = "draft"
 RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
 
 MacroPublishStatus = Literal["dry_run", "published", "updated", "skipped", "failed"]

--- a/extracted_content_pipeline/faq_macro_writeback_postgres.py
+++ b/extracted_content_pipeline/faq_macro_writeback_postgres.py
@@ -58,6 +58,7 @@ def _row_to_attempt(row: Mapping[str, Any]) -> FAQMacroPublishAttempt:
         failed_count=int(row.get("failed_count") or 0),
         pending_reconcile_count=int(row.get("pending_reconcile_count") or 0),
         draft_status_updated=bool(row.get("draft_status_updated")),
+        status_conflict=bool(row.get("status_conflict")),
         skipped=_json_list(row.get("skipped")),
         results=_json_list(row.get("results")),
         created_at=str(row.get("created_at") or ""),
@@ -209,13 +210,13 @@ class PostgresFAQMacroPublishAttemptRepository:
                 account_id, faq_draft_id, draft_status, ok,
                 publishable_count, skipped_count, published_count,
                 updated_count, failed_count, pending_reconcile_count,
-                draft_status_updated, skipped, results
+                draft_status_updated, status_conflict, skipped, results
             )
             VALUES (
                 $1, $2, $3, $4,
                 $5, $6, $7,
                 $8, $9, $10,
-                $11, $12::jsonb, $13::jsonb
+                $11, $12, $13::jsonb, $14::jsonb
             )
             """,
             scope.account_id or "",
@@ -229,6 +230,7 @@ class PostgresFAQMacroPublishAttemptRepository:
             int(summary.failed_count),
             int(summary.pending_reconcile_count),
             bool(summary.draft_status_updated),
+            bool(summary.status_conflict),
             json_dump_jsonb([dict(item) for item in summary.skipped]),
             json_dump_jsonb([dict(item) for item in summary.results]),
         )
@@ -246,7 +248,7 @@ class PostgresFAQMacroPublishAttemptRepository:
                 id, faq_draft_id, draft_status, ok,
                 publishable_count, skipped_count, published_count,
                 updated_count, failed_count, pending_reconcile_count,
-                draft_status_updated, skipped, results, created_at
+                draft_status_updated, status_conflict, skipped, results, created_at
               FROM ticket_faq_macro_publish_attempts
              WHERE account_id = $1
                AND faq_draft_id = $2

--- a/extracted_content_pipeline/faq_macro_writeback_publish.py
+++ b/extracted_content_pipeline/faq_macro_writeback_publish.py
@@ -191,35 +191,59 @@ class FAQMacroWritebackPublishService:
             )
 
         if promote:
-            # Compare-and-set on the stored status: a concurrent review
-            # decision (a reject landing after get_draft) wins and the publish
-            # fails closed without ever touching the provider.
-            approved = await self.faq_repository.update_status(
+            # Promote via the shared compare-and-set transition. On a miss the
+            # helper re-reads the row so every write site classifies a race the
+            # same way: an already-'published' row means a concurrent publish
+            # reached the terminal state, so fall through to an idempotent
+            # republish with no mark; an already-'approved' row was approved
+            # concurrently, so publish and mark as approved; anything else is a
+            # review decision (reject/archive) that wins -- a real conflict.
+            promoted, current = await self._transition_status(
                 cleaned_id,
-                APPROVED_FAQ_STATUS,
-                scope=scope,
+                to_status=APPROVED_FAQ_STATUS,
                 expected_status=DRAFT_FAQ_STATUS,
+                scope=scope,
             )
-            if not approved:
-                # The row is no longer 'draft': a concurrent review decision
-                # (reject/approve/publish) changed it after get_draft. Surface a
-                # conflict so a real race is distinguishable from an ordinary
-                # unapproved draft rather than looking like plain ineligibility.
-                return await self._finish(
-                    replace(
-                        _summary(
-                            faq_id=cleaned_id,
-                            found=True,
-                            draft_status=observed_status,
-                            preview=build_macro_writeback_preview([draft]),
-                            results=(),
+            if not promoted:
+                if current == _clean(self.published_status):
+                    effective_status = _clean(self.published_status)
+                elif current == APPROVED_FAQ_STATUS:
+                    effective_status = APPROVED_FAQ_STATUS
+                else:
+                    return await self._finish(
+                        replace(
+                            _summary(
+                                faq_id=cleaned_id,
+                                found=True,
+                                draft_status=observed_status,
+                                preview=build_macro_writeback_preview([draft]),
+                                results=(),
+                            ),
+                            status_conflict=True,
                         ),
-                        status_conflict=True,
-                    ),
-                    scope=scope,
-                )
+                        scope=scope,
+                    )
 
-        results = tuple(await self.provider.publish(preview.macros, scope=scope))
+        # The provider is the external boundary. A raised exception (for
+        # example a tenant credential lookup failure outside the provider's
+        # per-macro catch) must still record a durable failed attempt rather
+        # than bypassing attempt history and leaving a promoted-but-unpublished
+        # draft with no trace.
+        try:
+            results = tuple(await self.provider.publish(preview.macros, scope=scope))
+        except Exception as exc:
+            logger.exception(
+                "FAQ macro publish provider raised faq_id=%s", cleaned_id
+            )
+            results = tuple(
+                MacroPublishResult(
+                    macro=macro,
+                    status="failed",
+                    error=f"provider_error: {type(exc).__name__}",
+                )
+                for macro in preview.macros
+            )
+
         summary = _summary(
             faq_id=cleaned_id,
             found=True,
@@ -228,24 +252,17 @@ class FAQMacroWritebackPublishService:
             results=results,
         )
         if _should_mark_published(summary):
-            # Compare-and-set the mark. A miss has two causes that must not be
-            # conflated: another publish already marked the row 'published'
-            # (idempotent success -- a duplicate click/retry must report ok),
-            # or a review decision changed it to reject/archive mid-flight (a
-            # real conflict: the macro is published externally but the row is
-            # not, so the caller must see a conflict, not a clean success).
-            marked = await self.faq_repository.update_status(
+            # Same shared transition: a mark miss is an idempotent success when
+            # the row is already 'published', and a conflict otherwise.
+            marked, current = await self._transition_status(
                 cleaned_id,
-                self.published_status,
-                scope=scope,
+                to_status=self.published_status,
                 expected_status=APPROVED_FAQ_STATUS,
+                scope=scope,
             )
             if marked:
                 summary = replace(summary, draft_status_updated=True)
-            elif await self._reread_status(cleaned_id, scope=scope) == _clean(
-                self.published_status
-            ):
-                # Terminal state already reached by a concurrent publish.
+            elif current == _clean(self.published_status):
                 summary = replace(summary, draft_status_updated=False)
             else:
                 summary = replace(
@@ -255,10 +272,31 @@ class FAQMacroWritebackPublishService:
                 )
         return await self._finish(summary, scope=scope)
 
-    async def _reread_status(self, faq_id: str, *, scope: TenantScope) -> str:
-        """Re-read the stored draft status to classify a compare-and-set miss."""
+    async def _transition_status(
+        self,
+        faq_id: str,
+        *,
+        to_status: str,
+        expected_status: str,
+        scope: TenantScope,
+    ) -> tuple[bool, str]:
+        """Compare-and-set a status; on a miss, re-read the stored status.
+
+        Returns ``(updated, current_status)``. Centralising this so every write
+        site (promotion and the publish-mark) classifies a compare-and-set miss
+        identically: an already-terminal row is idempotent success, a
+        review-decided row is a conflict.
+        """
+        updated = await self.faq_repository.update_status(
+            faq_id,
+            to_status,
+            scope=scope,
+            expected_status=expected_status,
+        )
+        if updated:
+            return True, _clean(to_status)
         draft = await self.faq_repository.get_draft(faq_id, scope=scope)
-        return _clean(draft.status) if draft is not None else ""
+        return False, _clean(draft.status) if draft is not None else ""
 
     async def _finish(
         self,

--- a/extracted_content_pipeline/faq_macro_writeback_publish.py
+++ b/extracted_content_pipeline/faq_macro_writeback_publish.py
@@ -76,6 +76,7 @@ class FAQMacroPublishAttempt:
     failed_count: int = 0
     pending_reconcile_count: int = 0
     draft_status_updated: bool = False
+    status_conflict: bool = False
     skipped: Sequence[JsonDict] = field(default_factory=tuple)
     results: Sequence[JsonDict] = field(default_factory=tuple)
     created_at: str = ""
@@ -133,15 +134,15 @@ class FAQMacroWritebackPublishService:
             return FAQMacroPublishSummary(faq_id=cleaned_id, found=False)
 
         # A paid Resolution Audit publish is the approval for a *generated*
-        # draft. Only the exact 'draft' status is promotable; an already
-        # 'published' draft is a retry through the provider's idempotent
-        # mapping; rejected/archived/expired are never revived. Every other
-        # path keeps the standard "must already be approved" behavior.
+        # draft, so only the exact 'draft' status is promotable, and only
+        # behind approve_draft. An already 'published' draft is an idempotent
+        # retry through the provider's mapping for *every* caller (a lost
+        # response or a second click must not fail closed), so it is not gated
+        # on approve_draft. rejected/archived/expired are never revived; every
+        # other path keeps the standard "must already be approved" behavior.
         observed_status = _clean(draft.status)
         promote = approve_draft and observed_status == DRAFT_FAQ_STATUS
-        published_retry = (
-            approve_draft and observed_status == _clean(self.published_status)
-        )
+        published_retry = observed_status == _clean(self.published_status)
         already_approved = observed_status == APPROVED_FAQ_STATUS
         publishable_now = already_approved or promote or published_retry
 
@@ -200,13 +201,20 @@ class FAQMacroWritebackPublishService:
                 expected_status=DRAFT_FAQ_STATUS,
             )
             if not approved:
+                # The row is no longer 'draft': a concurrent review decision
+                # (reject/approve/publish) changed it after get_draft. Surface a
+                # conflict so a real race is distinguishable from an ordinary
+                # unapproved draft rather than looking like plain ineligibility.
                 return await self._finish(
-                    _summary(
-                        faq_id=cleaned_id,
-                        found=True,
-                        draft_status=observed_status,
-                        preview=build_macro_writeback_preview([draft]),
-                        results=(),
+                    replace(
+                        _summary(
+                            faq_id=cleaned_id,
+                            found=True,
+                            draft_status=observed_status,
+                            preview=build_macro_writeback_preview([draft]),
+                            results=(),
+                        ),
+                        status_conflict=True,
                     ),
                     scope=scope,
                 )
@@ -220,22 +228,37 @@ class FAQMacroWritebackPublishService:
             results=results,
         )
         if _should_mark_published(summary):
-            # Compare-and-set again: if a review decision landed while the
-            # external publish was in flight, that decision wins. The macro was
-            # published externally, but the row was not marked, so the caller
-            # must see a conflict rather than a clean success.
+            # Compare-and-set the mark. A miss has two causes that must not be
+            # conflated: another publish already marked the row 'published'
+            # (idempotent success -- a duplicate click/retry must report ok),
+            # or a review decision changed it to reject/archive mid-flight (a
+            # real conflict: the macro is published externally but the row is
+            # not, so the caller must see a conflict, not a clean success).
             marked = await self.faq_repository.update_status(
                 cleaned_id,
                 self.published_status,
                 scope=scope,
                 expected_status=APPROVED_FAQ_STATUS,
             )
-            summary = replace(
-                summary,
-                draft_status_updated=marked,
-                status_conflict=not marked,
-            )
+            if marked:
+                summary = replace(summary, draft_status_updated=True)
+            elif await self._reread_status(cleaned_id, scope=scope) == _clean(
+                self.published_status
+            ):
+                # Terminal state already reached by a concurrent publish.
+                summary = replace(summary, draft_status_updated=False)
+            else:
+                summary = replace(
+                    summary,
+                    draft_status_updated=False,
+                    status_conflict=True,
+                )
         return await self._finish(summary, scope=scope)
+
+    async def _reread_status(self, faq_id: str, *, scope: TenantScope) -> str:
+        """Re-read the stored draft status to classify a compare-and-set miss."""
+        draft = await self.faq_repository.get_draft(faq_id, scope=scope)
+        return _clean(draft.status) if draft is not None else ""
 
     async def _finish(
         self,
@@ -290,7 +313,14 @@ def _summary(
         updated_count=sum(1 for result in results if result.status == "updated"),
         failed_count=failed_count,
         pending_reconcile_count=pending_reconcile_count,
-        skipped=tuple(item.as_dict() for item in preview.skipped),
+        # The preview evaluates item-level skip reasons under approved
+        # semantics, but the reported per-item status must be the row's real
+        # (summary) status so a refused/partial draft never claims 'approved'
+        # while the summary says 'draft'.
+        skipped=tuple(
+            {**item.as_dict(), "draft_status": draft_status}
+            for item in preview.skipped
+        ),
         results=tuple(result.as_dict() for result in results),
     )
 

--- a/extracted_content_pipeline/faq_macro_writeback_publish.py
+++ b/extracted_content_pipeline/faq_macro_writeback_publish.py
@@ -9,6 +9,7 @@ from typing import Protocol, Sequence
 from .campaign_ports import JsonDict, TenantScope
 from .faq_macro_writeback import (
     APPROVED_FAQ_STATUS,
+    DRAFT_FAQ_STATUS,
     MacroPublishProvider,
     MacroPublishResult,
     MacroWritebackPreview,
@@ -36,6 +37,7 @@ class FAQMacroPublishSummary:
     failed_count: int = 0
     pending_reconcile_count: int = 0
     draft_status_updated: bool = False
+    status_conflict: bool = False
     skipped: Sequence[JsonDict] = field(default_factory=tuple)
     results: Sequence[JsonDict] = field(default_factory=tuple)
 
@@ -48,6 +50,7 @@ class FAQMacroPublishSummary:
             and self.failed_count == 0
             and self.pending_reconcile_count == 0
             and self.publishable_count == self.published_count + self.updated_count
+            and not self.status_conflict
         )
 
     def as_dict(self) -> JsonDict:
@@ -119,6 +122,7 @@ class FAQMacroWritebackPublishService:
         faq_id: str,
         *,
         scope: TenantScope,
+        approve_draft: bool = False,
     ) -> FAQMacroPublishSummary:
         cleaned_id = _clean(faq_id)
         if not cleaned_id:
@@ -128,33 +132,118 @@ class FAQMacroWritebackPublishService:
         if draft is None:
             return FAQMacroPublishSummary(faq_id=cleaned_id, found=False)
 
-        preview = build_macro_writeback_preview([draft])
-        if not preview.macros:
-            summary = _summary(
-                faq_id=cleaned_id,
-                found=True,
-                draft_status=_clean(draft.status),
-                preview=preview,
-                results=(),
+        # A paid Resolution Audit publish is the approval for a *generated*
+        # draft. Only the exact 'draft' status is promotable; an already
+        # 'published' draft is a retry through the provider's idempotent
+        # mapping; rejected/archived/expired are never revived. Every other
+        # path keeps the standard "must already be approved" behavior.
+        observed_status = _clean(draft.status)
+        promote = approve_draft and observed_status == DRAFT_FAQ_STATUS
+        published_retry = (
+            approve_draft and observed_status == _clean(self.published_status)
+        )
+        already_approved = observed_status == APPROVED_FAQ_STATUS
+        publishable_now = already_approved or promote or published_retry
+
+        # The status the row will hold when we decide whether to mark it
+        # published: a real promotion reaches 'approved'; a published retry
+        # stays 'published' so it is never re-marked; anything else keeps its
+        # observed status (and therefore cannot be marked published).
+        effective_status = (
+            APPROVED_FAQ_STATUS if (already_approved or promote) else observed_status
+        )
+        # Publishing requires approved semantics, so evaluate per-item
+        # eligibility as if approved on any path that is allowed to publish.
+        eligibility_status = (
+            APPROVED_FAQ_STATUS if publishable_now else observed_status
+        )
+        preview = build_macro_writeback_preview(
+            [replace(draft, status=eligibility_status)]
+        )
+
+        # A generated draft is auto-approved only when it is *fully*
+        # publishable, so a partial or empty generated draft is never promoted
+        # into the approved-filtered FAQ search projection. Already-approved
+        # drafts still publish their publishable subset below.
+        if promote and (preview.publishable_count == 0 or preview.skipped_count > 0):
+            return await self._finish(
+                _summary(
+                    faq_id=cleaned_id,
+                    found=True,
+                    draft_status=observed_status,
+                    preview=preview,
+                    results=(),
+                ),
+                scope=scope,
             )
-            await self._record_attempt(summary, scope=scope)
-            return summary
+
+        if not preview.macros:
+            return await self._finish(
+                _summary(
+                    faq_id=cleaned_id,
+                    found=True,
+                    draft_status=observed_status,
+                    preview=preview,
+                    results=(),
+                ),
+                scope=scope,
+            )
+
+        if promote:
+            # Compare-and-set on the stored status: a concurrent review
+            # decision (a reject landing after get_draft) wins and the publish
+            # fails closed without ever touching the provider.
+            approved = await self.faq_repository.update_status(
+                cleaned_id,
+                APPROVED_FAQ_STATUS,
+                scope=scope,
+                expected_status=DRAFT_FAQ_STATUS,
+            )
+            if not approved:
+                return await self._finish(
+                    _summary(
+                        faq_id=cleaned_id,
+                        found=True,
+                        draft_status=observed_status,
+                        preview=build_macro_writeback_preview([draft]),
+                        results=(),
+                    ),
+                    scope=scope,
+                )
 
         results = tuple(await self.provider.publish(preview.macros, scope=scope))
         summary = _summary(
             faq_id=cleaned_id,
             found=True,
-            draft_status=_clean(draft.status),
+            draft_status=effective_status,
             preview=preview,
             results=results,
         )
         if _should_mark_published(summary):
-            status_updated = await self.faq_repository.update_status(
+            # Compare-and-set again: if a review decision landed while the
+            # external publish was in flight, that decision wins. The macro was
+            # published externally, but the row was not marked, so the caller
+            # must see a conflict rather than a clean success.
+            marked = await self.faq_repository.update_status(
                 cleaned_id,
                 self.published_status,
                 scope=scope,
+                expected_status=APPROVED_FAQ_STATUS,
             )
-            summary = replace(summary, draft_status_updated=status_updated)
+            summary = replace(
+                summary,
+                draft_status_updated=marked,
+                status_conflict=not marked,
+            )
+        return await self._finish(summary, scope=scope)
+
+    async def _finish(
+        self,
+        summary: FAQMacroPublishSummary,
+        *,
+        scope: TenantScope,
+    ) -> FAQMacroPublishSummary:
+        """Record the attempt for every return path, then return the summary."""
         await self._record_attempt(summary, scope=scope)
         return summary
 

--- a/extracted_content_pipeline/storage/migrations/335_ticket_faq_macro_publish_attempt_conflict.sql
+++ b/extracted_content_pipeline/storage/migrations/335_ticket_faq_macro_publish_attempt_conflict.sql
@@ -1,0 +1,8 @@
+-- Persist the terminal-state conflict signal on FAQ macro publish attempts.
+-- Set when the external macro was published but the FAQ row was concurrently
+-- moved to a review-decided state (reject/archive) so the approved->published
+-- mark could not land: the immediate response reports this via status_conflict,
+-- and the append-only attempt history must carry the same durable signal.
+
+ALTER TABLE ticket_faq_macro_publish_attempts
+    ADD COLUMN IF NOT EXISTS status_conflict BOOLEAN NOT NULL DEFAULT FALSE;

--- a/extracted_content_pipeline/ticket_faq_ports.py
+++ b/extracted_content_pipeline/ticket_faq_ports.py
@@ -77,8 +77,15 @@ class TicketFAQRepository(Protocol):
         status: str,
         *,
         scope: TenantScope,
+        expected_status: str | None = None,
     ) -> bool:
-        """Update a draft status and return True on hit."""
+        """Update a draft status and return True on hit.
+
+        When ``expected_status`` is provided the update is compare-and-set:
+        it only applies while the stored status still equals
+        ``expected_status``, so a concurrent status change wins and the
+        caller sees False.
+        """
 
     async def update_statuses(
         self,

--- a/extracted_content_pipeline/ticket_faq_postgres.py
+++ b/extracted_content_pipeline/ticket_faq_postgres.py
@@ -195,8 +195,14 @@ class PostgresTicketFAQRepository:
         status: str,
         *,
         scope: TenantScope,
+        expected_status: str | None = None,
     ) -> bool:
         async def _update(db: Any) -> bool:
+            params: list[Any] = [faq_id, status, scope.account_id or ""]
+            status_guard = ""
+            if expected_status is not None:
+                params.append(expected_status)
+                status_guard = "AND status = $4"
             rows = await db.fetch(
                 f"""
                 UPDATE ticket_faq_markdown
@@ -204,11 +210,10 @@ class PostgresTicketFAQRepository:
                        updated_at = NOW()
                  WHERE id = $1
                    AND account_id = $3
+                   {status_guard}
                 RETURNING {_TICKET_FAQ_COLUMNS}
                 """,
-                faq_id,
-                status,
-                scope.account_id or "",
+                *params,
             )
             drafts = tuple(_row_to_draft(row_to_dict(row)) for row in rows)
             if not drafts:

--- a/plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md
+++ b/plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md
@@ -58,18 +58,21 @@ Slice phase: Vertical slice
   projection side effect of an approval.
 - Risk areas: concurrency (TOCTOU on status), backward compatibility of the
   widened port, the never-revive contract, idempotent retries.
-- Reviewer rules triggered: R1, R2, R6, R10.
+- Reviewer rules triggered: R1, R2, R4, R6, R10.
 
 ### Files touched
 
 - `extracted_content_pipeline/faq_macro_writeback.py`
+- `extracted_content_pipeline/faq_macro_writeback_postgres.py`
 - `extracted_content_pipeline/faq_macro_writeback_publish.py`
+- `extracted_content_pipeline/storage/migrations/335_ticket_faq_macro_publish_attempt_conflict.sql`
 - `extracted_content_pipeline/ticket_faq_ports.py`
 - `extracted_content_pipeline/ticket_faq_postgres.py`
 - `plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md`
 - `tests/test_atlas_content_ops_generated_assets_api.py`
 - `tests/test_content_ops_faq_macro_writeback_flow.py`
 - `tests/test_extracted_content_asset_api.py`
+- `tests/test_extracted_ticket_faq_macro_writeback_postgres.py`
 - `tests/test_extracted_ticket_faq_macro_writeback_publish.py`
 - `tests/test_extracted_ticket_faq_postgres.py`
 - `tests/test_faq_macro_writeback_live_zendesk_smoke.py`
@@ -95,8 +98,13 @@ semantics:
    caller sees a conflict, not a false success.
 
 The port gains an optional `expected_status`; the Postgres adapter adds
-`AND status = $N` only when provided. Every in-repo fake used with the service
-accepts the optional argument.
+`AND status = $N` only when provided. A compare-and-set *miss* is
+disambiguated by re-reading the stored status: an already-`published` row is
+an idempotent success, a review-decided row (reject/archive) is a real
+conflict. A `published` draft is an idempotent retry for every caller, not
+only `approve_draft=True`. `status_conflict` is persisted to the append-only
+attempt history (migration adds the column). Every in-repo fake used with the
+service accepts the optional argument.
 
 ## Intentional
 
@@ -132,15 +140,18 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/faq_macro_writeback.py` | 1 |
-| `extracted_content_pipeline/faq_macro_writeback_publish.py` | 113 |
+| `extracted_content_pipeline/faq_macro_writeback_postgres.py` | 8 |
+| `extracted_content_pipeline/faq_macro_writeback_publish.py` | 145 |
+| `extracted_content_pipeline/storage/migrations/335_ticket_faq_macro_publish_attempt_conflict.sql` | 8 |
 | `extracted_content_pipeline/ticket_faq_ports.py` | 9 |
 | `extracted_content_pipeline/ticket_faq_postgres.py` | 11 |
-| `plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md` | 146 |
+| `plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md` | 151 |
 | `tests/test_atlas_content_ops_generated_assets_api.py` | 1 |
 | `tests/test_content_ops_faq_macro_writeback_flow.py` | 1 |
-| `tests/test_extracted_content_asset_api.py` | 10 |
-| `tests/test_extracted_ticket_faq_macro_writeback_publish.py` | 317 |
-| `tests/test_extracted_ticket_faq_postgres.py` | 96 |
+| `tests/test_extracted_content_asset_api.py` | 12 |
+| `tests/test_extracted_ticket_faq_macro_writeback_postgres.py` | 4 |
+| `tests/test_extracted_ticket_faq_macro_writeback_publish.py` | 428 |
+| `tests/test_extracted_ticket_faq_postgres.py` | 101 |
 | `tests/test_faq_macro_writeback_live_zendesk_smoke.py` | 1 |
 | `tests/test_seed_faq_macro_writeback_live_smoke_draft.py` | 1 |
-| **Total** | **707** |
+| **Total** | **882** |

--- a/plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md
+++ b/plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md
@@ -1,0 +1,146 @@
+# PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS
+
+## Why this slice exists
+
+The paid Resolution Audit -> Zendesk macro publish route (PR #1955, lane
+content-ops/resolution-audit-zendesk-writeback) needs the shared
+`FAQMacroWritebackPublishService` to support a new behavior: an explicit paid
+publish action is the *approval* for a generated (`status='draft'`) FAQ, and
+that promotion plus the publish-mark must be race-safe against concurrent
+review decisions. This foundation slice lands that service/port behavior on its
+own so the route slice can delegate to it.
+
+Splitting the service layer out of #1955 also keeps each PR's diff small enough
+that the `audit_cross_layer_callers.py` hint audit (which re-scans the repo per
+changed symbol and is O(changed_symbols x tracked_files)) stays under the
+`pre_push_audit.yml` 10-minute job cap. The combined change was ~78 changed
+symbols and timed the audit out; this foundation half is ~40, the route half
+~38 -- both back under the budget that passed earlier in the arc.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/resolution-audit-zendesk-writeback
+Slice phase: Vertical slice
+
+1. Add an opt-in `approve_draft` to `FAQMacroWritebackPublishService.publish_faq_draft`
+   with race-safe terminal-state semantics (promotion + publish-mark are
+   compare-and-set; the summary reflects the true end state).
+2. Add an optional compare-and-set `expected_status` to the
+   `TicketFAQRepository.update_status` port and its Postgres implementation.
+3. Prove the state machine's truth table and update every in-repo repository
+   fake used with this service to the widened port.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `publish_faq_draft(..., approve_draft=True)` promotes only an exact
+        `'draft'` status, and only when the draft is *fully* publishable
+        (`publishable>0 AND skipped==0`); a partial or empty generated draft is
+        never promoted (so it cannot enter the approved-filtered FAQ search
+        projection).
+  - [ ] Promotion (`draft->approved`) and the publish-mark
+        (`approved->published`) are compare-and-set; a concurrent review
+        decision landing after `get_draft` or mid-publish wins, and the summary
+        reports `ok=false` / `status_conflict=true` rather than a false success.
+  - [ ] An already-`published` draft is a retry through the provider's
+        idempotent mapping: no status write, honest `draft_status='published'`.
+  - [ ] `rejected`/`archived`/`expired` drafts are never revived;
+        `approve_draft=False` keeps the AI Content Station and scheduled paths
+        byte-for-byte unchanged.
+  - [ ] `update_status(..., expected_status=...)` adds `AND status = $N` in
+        Postgres; omitting it keeps the unconditional SQL shape.
+- Reachability proof: service-level tests exercise the real
+  `FAQMacroWritebackPublishService` against compare-and-set-honoring fakes;
+  the Postgres compare-and-set is proven with SQL-shape tests plus a gated
+  real-Postgres race integration test (`@pytest.mark.integration`).
+- Affected surfaces: shared publish service, `TicketFAQRepository` port + its
+  Postgres adapter, FAQ macro publish attempt semantics, the FAQ search
+  projection side effect of an approval.
+- Risk areas: concurrency (TOCTOU on status), backward compatibility of the
+  widened port, the never-revive contract, idempotent retries.
+- Reviewer rules triggered: R1, R2, R6, R10.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_macro_writeback.py`
+- `extracted_content_pipeline/faq_macro_writeback_publish.py`
+- `extracted_content_pipeline/ticket_faq_ports.py`
+- `extracted_content_pipeline/ticket_faq_postgres.py`
+- `plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+- `tests/test_content_ops_faq_macro_writeback_flow.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_extracted_ticket_faq_macro_writeback_publish.py`
+- `tests/test_extracted_ticket_faq_postgres.py`
+- `tests/test_faq_macro_writeback_live_zendesk_smoke.py`
+- `tests/test_seed_faq_macro_writeback_live_smoke_draft.py`
+
+## Mechanism
+
+`publish_faq_draft` is one three-phase transaction with explicit terminal-state
+semantics:
+
+1. **Eligibility** -- build the macro preview under approved-semantics. A
+   generated draft is promoted only when fully publishable (`publishable>0 AND
+   skipped==0`); otherwise no status write and `ok=false`.
+2. **Promotion** -- for an observed `'draft'`, compare-and-set `draft->approved`
+   (`expected_status='draft'`); if it loses, a concurrent review decision won,
+   so it fails closed with no publish.
+3. **Publish + mark** -- publish the macros, then compare-and-set
+   `approved->published` (`expected_status='approved'`). `draft_status` reports
+   the *effective* post-promotion status, so an already-`published` retry does
+   no mark (idempotent) while a real promotion still marks. A new
+   `status_conflict` flag, folded into `ok`, is set when a needed mark loses to
+   a mid-flight review decision: the macro is published externally but the
+   caller sees a conflict, not a false success.
+
+The port gains an optional `expected_status`; the Postgres adapter adds
+`AND status = $N` only when provided. Every in-repo fake used with the service
+accepts the optional argument.
+
+## Intentional
+
+- `approve_draft` defaults `False`, so the Generated Asset Review and scheduled
+  publish paths are unchanged; this is a backward-compatible port + service
+  extension.
+- The route + host wiring that consume this (the paid Resolution Audit
+  `publish-macros` endpoint) land in the follow-up route PR on
+  `claude/pr-content-ops-resolution-audit-zendesk-writeback` (#1955), rebased
+  onto this foundation once merged.
+- No live Zendesk call in CI: the macro publish provider is the true external
+  boundary; the real `ZendeskMacroPublishProvider` is exercised only for its
+  no-credentials fail-closed short-circuit.
+
+## Deferred
+
+- The paid Resolution Audit `POST /deflection-reports/{request_id}/publish-macros`
+  route, its host factory (`build_content_ops_faq_macro_publish_service`), and
+  the Content Ops router wiring -- follow-up route PR #1955 (depends on this).
+
+Parked hardening: none.
+
+## Verification
+
+- `py_compile` of the four changed service/port modules -- pass.
+- `python -m pytest` foundation set (service + CAS + consumers) -- 189 passed.
+- `python -m pytest tests/test_extracted_ticket_faq_postgres.py -m integration -q` against real Postgres -- compare-and-set race passes.
+- `scripts/run_extracted_pipeline_checks.sh` -- 5083 passed, 21 skipped.
+- `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --min-score 8` -- ratchet passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/faq_macro_writeback.py` | 1 |
+| `extracted_content_pipeline/faq_macro_writeback_publish.py` | 113 |
+| `extracted_content_pipeline/ticket_faq_ports.py` | 9 |
+| `extracted_content_pipeline/ticket_faq_postgres.py` | 11 |
+| `plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md` | 146 |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | 1 |
+| `tests/test_content_ops_faq_macro_writeback_flow.py` | 1 |
+| `tests/test_extracted_content_asset_api.py` | 10 |
+| `tests/test_extracted_ticket_faq_macro_writeback_publish.py` | 317 |
+| `tests/test_extracted_ticket_faq_postgres.py` | 96 |
+| `tests/test_faq_macro_writeback_live_zendesk_smoke.py` | 1 |
+| `tests/test_seed_faq_macro_writeback_live_smoke_draft.py` | 1 |
+| **Total** | **707** |

--- a/plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md
+++ b/plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md
@@ -98,13 +98,17 @@ semantics:
    caller sees a conflict, not a false success.
 
 The port gains an optional `expected_status`; the Postgres adapter adds
-`AND status = $N` only when provided. A compare-and-set *miss* is
-disambiguated by re-reading the stored status: an already-`published` row is
-an idempotent success, a review-decided row (reject/archive) is a real
-conflict. A `published` draft is an idempotent retry for every caller, not
-only `approve_draft=True`. `status_conflict` is persisted to the append-only
-attempt history (migration adds the column). Every in-repo fake used with the
-service accepts the optional argument.
+`AND status = $N` only when provided. Every status transition (promotion and
+the publish-mark) goes through one `_transition_status` compare-and-set helper
+that re-reads the row on a miss, so every write site classifies a race
+identically: an already-`published` row is an idempotent success (republish,
+no re-mark), an already-`approved` row was approved concurrently (publish and
+mark), and a review-decided row (reject/archive) is a real conflict. The
+provider call is wrapped so a raised exception records a durable failed
+attempt instead of leaving a promoted-but-unpublished draft with no trace. A
+`published` draft is an idempotent retry for every caller. `status_conflict`
+is persisted to the append-only attempt history (migration adds the column).
+Every in-repo fake accepts the optional argument.
 
 ## Intentional
 
@@ -141,17 +145,17 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/faq_macro_writeback.py` | 1 |
 | `extracted_content_pipeline/faq_macro_writeback_postgres.py` | 8 |
-| `extracted_content_pipeline/faq_macro_writeback_publish.py` | 145 |
+| `extracted_content_pipeline/faq_macro_writeback_publish.py` | 187 |
 | `extracted_content_pipeline/storage/migrations/335_ticket_faq_macro_publish_attempt_conflict.sql` | 8 |
 | `extracted_content_pipeline/ticket_faq_ports.py` | 9 |
 | `extracted_content_pipeline/ticket_faq_postgres.py` | 11 |
-| `plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md` | 151 |
+| `plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md` | 161 |
 | `tests/test_atlas_content_ops_generated_assets_api.py` | 1 |
 | `tests/test_content_ops_faq_macro_writeback_flow.py` | 1 |
 | `tests/test_extracted_content_asset_api.py` | 12 |
 | `tests/test_extracted_ticket_faq_macro_writeback_postgres.py` | 4 |
-| `tests/test_extracted_ticket_faq_macro_writeback_publish.py` | 428 |
+| `tests/test_extracted_ticket_faq_macro_writeback_publish.py` | 516 |
 | `tests/test_extracted_ticket_faq_postgres.py` | 101 |
 | `tests/test_faq_macro_writeback_live_zendesk_smoke.py` | 1 |
 | `tests/test_seed_faq_macro_writeback_live_smoke_draft.py` | 1 |
-| **Total** | **882** |
+| **Total** | **1022** |

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -179,6 +179,7 @@ class _MemoryLandingPageRepository:
         status: str,
         *,
         scope: TenantScope,
+        expected_status: str | None = None,
     ) -> bool:
         self.status_calls.append({
             "account_id": scope.account_id,

--- a/tests/test_content_ops_faq_macro_writeback_flow.py
+++ b/tests/test_content_ops_faq_macro_writeback_flow.py
@@ -57,6 +57,7 @@ class _FAQRepo:
         status: str,
         *,
         scope: TenantScope,
+        expected_status: str | None = None,
     ) -> bool:
         self.update_calls.append({
             "faq_id": faq_id,

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -2123,7 +2123,15 @@ def test_generated_asset_router_publishes_ticket_faq_macros() -> None:
     assert get_args == ("11111111-1111-1111-1111-111111111111", "acct_1")
     update_query, update_args = pool.fetch_calls[1]
     assert "UPDATE ticket_faq_markdown" in update_query
-    assert update_args == ("11111111-1111-1111-1111-111111111111", "published", "acct_1")
+    # The publish-mark is compare-and-set on 'approved' so a concurrent review
+    # decision landing mid-publish is preserved, hence the 4th CAS-guard arg.
+    assert "AND status = $4" in update_query
+    assert update_args == (
+        "11111111-1111-1111-1111-111111111111",
+        "published",
+        "acct_1",
+        "approved",
+    )
     attempt_query, attempt_args = next(
         call for call in pool.execute_calls
         if "ticket_faq_macro_publish_attempts" in call[0]

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -591,6 +591,7 @@ def _publish_attempt_row(**overrides):
         "failed_count": 0,
         "pending_reconcile_count": 0,
         "draft_status_updated": True,
+        "status_conflict": False,
         "skipped": [],
         "results": [{
             "status": "published",
@@ -2263,6 +2264,7 @@ def test_generated_asset_router_lists_faq_macro_publish_attempts() -> None:
         "failed_count": 0,
         "pending_reconcile_count": 0,
         "draft_status_updated": True,
+        "status_conflict": False,
         "skipped": [],
         "results": [{
             "status": "published",

--- a/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
@@ -87,6 +87,7 @@ def _attempt_row(**overrides) -> dict:
         "failed_count": 0,
         "pending_reconcile_count": 0,
         "draft_status_updated": True,
+        "status_conflict": False,
         "skipped": "[]",
         "results": '[{"status":"updated","external_id":"macro-123"}]',
         "created_at": "2026-05-30 12:00:00+00:00",
@@ -340,6 +341,7 @@ async def test_record_publish_attempt_persists_summary_with_tenant_scope() -> No
     query, args = pool.execute_calls[0]
     assert "INSERT INTO ticket_faq_macro_publish_attempts" in query
     assert "account_id, faq_draft_id, draft_status, ok" in query
+    assert "draft_status_updated, status_conflict, skipped, results" in query
     assert args == (
         "acct-1",
         "11111111-1111-1111-1111-111111111111",
@@ -352,6 +354,7 @@ async def test_record_publish_attempt_persists_summary_with_tenant_scope() -> No
         0,
         0,
         True,
+        False,
         "[]",
         '[{"status":"updated","external_id":"macro-123","error":""}]',
     )
@@ -393,6 +396,7 @@ async def test_list_publish_attempts_filters_by_tenant_faq_and_limit() -> None:
         "failed_count": 0,
         "pending_reconcile_count": 0,
         "draft_status_updated": True,
+        "status_conflict": False,
         "skipped": [],
         "results": [{"status": "updated", "external_id": "macro-123"}],
         "created_at": "2026-05-30 12:00:00+00:00",

--- a/tests/test_extracted_ticket_faq_macro_writeback_publish.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_publish.py
@@ -764,3 +764,91 @@ async def test_publish_service_partial_generated_draft_reports_observed_skip_sta
     assert repo.update_calls == []
     # every skipped item reports the real observed status, not 'approved'
     assert all(item["draft_status"] == "draft" for item in summary.skipped)
+
+
+@pytest.mark.asyncio
+async def test_publish_service_promotion_race_already_published_is_idempotent() -> None:
+    # Two approve_draft publishes race while the row is still 'draft': the
+    # first promotes and fully publishes before the second reaches the
+    # promotion CAS. The second loses the draft->approved CAS, re-reads
+    # 'published', and must republish idempotently (no mark, no conflict),
+    # reporting success rather than failure.
+    repo = _FAQRepo(_draft(status="draft"), stored_status="published")
+    provider = _Provider(("updated",))
+    attempts = _AttemptRepo()
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    assert summary.ok is True
+    assert summary.status_conflict is False
+    assert len(provider.calls) == 1          # republished idempotently
+    assert summary.draft_status == "published"
+    assert summary.draft_status_updated is False  # no re-mark
+    assert len(attempts.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_service_promotion_race_concurrently_approved_publishes_and_marks() -> None:
+    # A concurrent request approved the draft (draft->approved) before this one
+    # reached the promotion CAS. The CAS miss re-reads 'approved', so this
+    # request publishes and marks as approved rather than reporting a conflict.
+    repo = _FAQRepo(_draft(status="draft"), stored_status="approved")
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    assert summary.ok is True
+    assert summary.status_conflict is False
+    assert summary.published_count == 1
+    assert summary.draft_status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_publish_service_provider_exception_records_failed_attempt() -> None:
+    # If the provider raises (for example a tenant credential lookup error
+    # outside its per-macro catch) after promotion, the exception must not
+    # bypass attempt history: the service records a durable failed attempt and
+    # does not propagate the exception.
+    repo = _FAQRepo(_draft(status="approved"))
+    attempts = _AttemptRepo()
+
+    class _RaisingProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def publish(self, macros, *, scope):
+            self.calls += 1
+            raise RuntimeError("zendesk credential lookup failed")
+
+    provider = _RaisingProvider()
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert provider.calls == 1
+    assert summary.ok is False
+    assert summary.failed_count == 1
+    assert "provider_error" in summary.results[0]["error"]
+    assert len(attempts.calls) == 1          # durable failed attempt recorded
+    assert summary.draft_status_updated is False

--- a/tests/test_extracted_ticket_faq_macro_writeback_publish.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_publish.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Sequence, cast
 
 import pytest
@@ -41,7 +42,14 @@ class _FAQRepo:
         scope: TenantScope,
     ) -> TicketFAQDraft | None:
         self.get_calls.append({"faq_id": faq_id, "scope": scope})
-        return self.draft
+        if self.draft is None:
+            return None
+        # The first read is the pre-race snapshot the service observed; any
+        # re-read (used to classify a compare-and-set miss) reflects the
+        # current DB-authoritative status, exactly as Postgres would.
+        if len(self.get_calls) == 1:
+            return self.draft
+        return replace(self.draft, status=self.stored_status)
 
     async def update_status(
         self,
@@ -427,6 +435,7 @@ async def test_publish_service_approve_draft_fails_closed_when_promotion_refused
     )
 
     assert summary.ok is False
+    assert summary.status_conflict is True   # a concurrent race, not plain ineligibility
     assert summary.skipped[0]["reason"] == "draft_not_approved"
     assert provider.calls == []
 
@@ -655,3 +664,103 @@ async def test_publish_service_already_approved_mixed_draft_still_publishes_subs
     assert provider.calls != []
     assert repo.update_calls == []        # skipped item blocks the mark
     assert repo.stored_status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_publish_service_concurrent_double_publish_is_idempotent_success() -> None:
+    # Two publishes race for the same approved FAQ: the other request marks the
+    # row 'published' while this one is between provider.publish and the mark
+    # CAS. The CAS misses, but re-reading shows the terminal state is reached,
+    # so this must report success -- not a conflict.
+    repo = _FAQRepo(_draft(status="approved"))
+
+    class _AlreadyPublishedMidFlight:
+        def __init__(self, target: _FAQRepo) -> None:
+            self.target = target
+            self.calls: list[dict[str, object]] = []
+
+        async def publish(self, macros, *, scope):
+            self.calls.append({"macros": tuple(macros), "scope": scope})
+            self.target.stored_status = "published"  # concurrent request won
+            return tuple(
+                MacroPublishResult(
+                    macro=macro,
+                    status=cast(MacroPublishStatus, "published"),
+                    external_id="external-1",
+                )
+                for macro in macros
+            )
+
+    provider = _AlreadyPublishedMidFlight(repo)
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.published_count == 1
+    assert summary.status_conflict is False
+    assert summary.ok is True
+    assert summary.draft_status_updated is False  # already published by the racer
+    assert repo.stored_status == "published"
+
+
+@pytest.mark.asyncio
+async def test_publish_service_default_caller_retries_published_draft_idempotently() -> None:
+    # A published draft is an idempotent retry for EVERY caller, not just
+    # approve_draft=True: a lost response / second click from the AI Content
+    # Station or scheduled path must not fail closed.
+    repo = _FAQRepo(_draft(status="published"))
+    provider = _Provider(("updated",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),  # approve_draft defaults False
+    )
+
+    assert summary.ok is True
+    assert len(provider.calls) == 1
+    assert repo.update_calls == []            # no status write on a retry
+    assert summary.draft_status == "published"
+    assert summary.status_conflict is False
+
+
+@pytest.mark.asyncio
+async def test_publish_service_partial_generated_draft_reports_observed_skip_status() -> None:
+    # A partial generated draft is refused (not promoted); the skipped payload
+    # must report the real observed 'draft' status, never the synthetic
+    # 'approved' used only to evaluate item-level eligibility.
+    repo = _FAQRepo(_draft(
+        status="draft",
+        items=(
+            {
+                "faq_item_id": "faq-item-1",
+                "question": "Why was I charged twice?",
+                "resolution_text": "Open Billing and compare settled charges.",
+                "answer_evidence_status": "resolution_evidence",
+            },
+            {
+                "faq_item_id": "faq-item-2",
+                "question": "How do I export a report?",
+                "answer": "Customers mention exports.",
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ),
+    ))
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    assert summary.ok is False
+    assert summary.draft_status == "draft"
+    assert provider.calls == []
+    assert repo.update_calls == []
+    # every skipped item reports the real observed status, not 'approved'
+    assert all(item["draft_status"] == "draft" for item in summary.skipped)

--- a/tests/test_extracted_ticket_faq_macro_writeback_publish.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_publish.py
@@ -17,8 +17,20 @@ from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
 
 
 class _FAQRepo:
-    def __init__(self, draft: TicketFAQDraft | None) -> None:
+    def __init__(
+        self,
+        draft: TicketFAQDraft | None,
+        *,
+        stored_status: str | None = None,
+    ) -> None:
         self.draft = draft
+        # The DB-authoritative status; may diverge from draft.status to model
+        # a concurrent review decision landing after get_draft.
+        self.stored_status = (
+            stored_status
+            if stored_status is not None
+            else (draft.status if draft is not None else "")
+        )
         self.get_calls: list[dict[str, object]] = []
         self.update_calls: list[dict[str, object]] = []
 
@@ -37,12 +49,16 @@ class _FAQRepo:
         status: str,
         *,
         scope: TenantScope,
+        expected_status: str | None = None,
     ) -> bool:
         self.update_calls.append({
             "faq_id": faq_id,
             "status": status,
             "scope": scope,
         })
+        if expected_status is not None and self.stored_status != expected_status:
+            return False
+        self.stored_status = status
         return True
 
 
@@ -267,6 +283,7 @@ async def test_publish_service_reports_missing_draft_without_provider_call() -> 
         "failed_count": 0,
         "pending_reconcile_count": 0,
         "draft_status_updated": False,
+        "status_conflict": False,
         "skipped": [],
         "results": [],
         "ok": False,
@@ -340,3 +357,301 @@ async def test_publish_service_skips_attempt_history_without_account_scope() -> 
 
     assert summary.ok is True
     assert attempts.calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_service_approve_draft_promotes_generated_draft_and_publishes() -> None:
+    # Producer-real shape: save_drafts persists status='draft'; an explicit
+    # tenant publish action with approve_draft=True promotes then publishes.
+    scope = TenantScope(account_id="acct-1", user_id="user-1")
+    repo = _FAQRepo(_draft(status="draft"))
+    provider = _Provider(("published",))
+    attempts = _AttemptRepo()
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=scope,
+        approve_draft=True,
+    )
+
+    assert summary.ok is True
+    assert summary.published_count == 1
+    assert [(c["status"]) for c in repo.update_calls] == ["approved", "published"]
+    assert provider.calls[0]["scope"] == scope
+    assert len(attempts.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_service_approve_draft_never_revives_review_decisions() -> None:
+    for status in ("rejected", "archived", "expired"):
+        repo = _FAQRepo(_draft(status=status))
+        provider = _Provider(("published",))
+        service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+        summary = await service.publish_faq_draft(
+            "faq-draft-1",
+            scope=TenantScope(account_id="acct-1"),
+            approve_draft=True,
+        )
+
+        assert summary.ok is False, status
+        assert summary.published_count == 0, status
+        assert provider.calls == [], status
+        assert repo.update_calls == [], status
+
+
+@pytest.mark.asyncio
+async def test_publish_service_approve_draft_fails_closed_when_promotion_refused() -> None:
+    class _RefusingRepo(_FAQRepo):
+        async def update_status(self, faq_id, status, *, scope, expected_status=None):
+            self.update_calls.append({
+                "faq_id": faq_id,
+                "status": status,
+                "scope": scope,
+            })
+            return False
+
+    repo = _RefusingRepo(_draft(status="draft"))
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    assert summary.ok is False
+    assert summary.skipped[0]["reason"] == "draft_not_approved"
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_service_default_still_refuses_generated_draft() -> None:
+    # Without the explicit approve_draft opt-in, behavior is unchanged: the
+    # AI Content Station and scheduled paths still require prior approval.
+    repo = _FAQRepo(_draft(status="draft"))
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.ok is False
+    assert summary.skipped[0]["reason"] == "draft_not_approved"
+    assert provider.calls == []
+    assert repo.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_service_approve_draft_loses_race_to_concurrent_review() -> None:
+    # get_draft observed 'draft', but a reviewer rejected the draft before the
+    # promotion ran: the compare-and-set must lose, nothing publishes, and the
+    # concurrent decision is never overwritten.
+    repo = _FAQRepo(_draft(status="draft"), stored_status="rejected")
+    provider = _Provider(("published",))
+    attempts = _AttemptRepo()
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    assert summary.ok is False
+    assert summary.published_count == 0
+    assert summary.skipped[0]["reason"] == "draft_not_approved"
+    assert provider.calls == []
+    assert repo.stored_status == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_publish_service_approve_draft_retries_published_idempotently() -> None:
+    # Lost HTTP response / second click: the row is already 'published'.
+    # The retry must flow through the provider's idempotent mapping and
+    # succeed, without any promotion write and without demoting the row.
+    repo = _FAQRepo(_draft(status="published"))
+    provider = _Provider(("updated",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    assert summary.ok is True
+    assert len(provider.calls) == 1
+    # a published retry performs NO status write: not a draft->approved
+    # promotion, and no approved->published mark (the row is already
+    # published). draft_status reports the honest observed 'published'.
+    assert repo.update_calls == []
+    assert repo.stored_status == "published"
+    assert summary.draft_status == "published"
+    assert summary.draft_status_updated is False
+    assert summary.status_conflict is False
+
+
+@pytest.mark.asyncio
+async def test_publish_service_mark_published_loses_to_midflight_review_decision() -> None:
+    # A reject lands while the external publish is in flight: the publish
+    # bookkeeping must not overwrite the reviewer's decision.
+    repo = _FAQRepo(_draft(status="draft"))
+
+    class _RejectingMidFlightProvider:
+        def __init__(self, target: _FAQRepo) -> None:
+            self.target = target
+            self.calls: list[dict[str, object]] = []
+
+        async def publish(self, macros, *, scope):
+            self.calls.append({"macros": tuple(macros), "scope": scope})
+            # concurrent reviewer decision during the external call
+            self.target.stored_status = "rejected"
+            return tuple(
+                MacroPublishResult(
+                    macro=macro,
+                    status=cast(MacroPublishStatus, "published"),
+                    external_id="external-1",
+                )
+                for macro in macros
+            )
+
+    provider = _RejectingMidFlightProvider(repo)
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    # the external publish happened and is reported...
+    assert summary.published_count == 1
+    # ...but the reviewer's decision is preserved, not overwritten, and the
+    # caller sees a conflict rather than a clean success (the DB refused to
+    # mark the FAQ published).
+    assert repo.stored_status == "rejected"
+    assert summary.draft_status_updated is False
+    assert summary.status_conflict is True
+    assert summary.ok is False
+
+
+@pytest.mark.asyncio
+async def test_publish_service_never_approves_draft_with_no_publishable_macros() -> None:
+    # Eligibility is decided before any status write: a draft whose items are
+    # all non-publishable must stay 'draft' (an approval would also surface it
+    # in the approved-filtered FAQ search projection).
+    repo = _FAQRepo(_draft(
+        status="draft",
+        items=(
+            {
+                "faq_item_id": "faq-item-1",
+                "question": "How do I export a report?",
+                "answer": "Customers mention exports.",
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ),
+    ))
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    assert summary.ok is False
+    assert provider.calls == []
+    assert repo.update_calls == []
+    assert repo.stored_status == "draft"
+    # the real per-item reason is surfaced, not masked as draft_not_approved
+    assert summary.skipped[0]["reason"] == "answer_not_verified"
+
+
+@pytest.mark.asyncio
+async def test_publish_service_never_approves_partially_publishable_generated_draft() -> None:
+    # A generated draft with a mix of one publishable and one skipped item:
+    # preview.macros is non-empty, but it is NOT fully publishable, so the
+    # promotion must not fire (else the partial draft would be approved and
+    # surface in the approved-filtered FAQ search projection while ok==False).
+    repo = _FAQRepo(_draft(
+        status="draft",
+        items=(
+            {
+                "faq_item_id": "faq-item-1",
+                "question": "Why was I charged twice?",
+                "resolution_text": "Open Billing and compare settled charges.",
+                "answer_evidence_status": "resolution_evidence",
+            },
+            {
+                "faq_item_id": "faq-item-2",
+                "question": "How do I export a report?",
+                "answer": "Customers mention exports.",
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ),
+    ))
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+        approve_draft=True,
+    )
+
+    assert summary.ok is False
+    assert summary.skipped_count == 1
+    assert provider.calls == []          # nothing published
+    assert repo.update_calls == []       # nothing promoted
+    assert repo.stored_status == "draft"  # row untouched
+
+
+@pytest.mark.asyncio
+async def test_publish_service_already_approved_mixed_draft_still_publishes_subset() -> None:
+    # Contrast: an already-approved (human-reviewed) mixed draft keeps the
+    # existing behavior of publishing its publishable subset. The skipped item
+    # only blocks the final mark-published, not the publish itself.
+    repo = _FAQRepo(_draft(
+        status="approved",
+        items=(
+            {
+                "faq_item_id": "faq-item-1",
+                "question": "Why was I charged twice?",
+                "resolution_text": "Open Billing and compare settled charges.",
+                "answer_evidence_status": "resolution_evidence",
+            },
+            {
+                "faq_item_id": "faq-item-2",
+                "question": "How do I export a report?",
+                "answer": "Customers mention exports.",
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ),
+    ))
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.published_count == 1   # the publishable item published
+    assert summary.skipped_count == 1
+    assert provider.calls != []
+    assert repo.update_calls == []        # skipped item blocks the mark
+    assert repo.stored_status == "approved"

--- a/tests/test_extracted_ticket_faq_postgres.py
+++ b/tests/test_extracted_ticket_faq_postgres.py
@@ -569,3 +569,99 @@ async def test_backfill_ticket_faq_search_documents_skips_incomplete_projection_
     assert result.skipped_missing_key == 1
     assert result.applied_rows == 0
     assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_status_compare_and_set_guards_on_expected_status() -> None:
+    pool = _Pool()
+    pool.fetch_rows = []
+    repo = PostgresTicketFAQRepository(pool)
+
+    updated = await repo.update_status(
+        "faq-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+        expected_status="draft",
+    )
+
+    assert updated is False
+    query = pool.fetch_calls[0]["query"]
+    assert "AND status = $4" in query
+    assert pool.fetch_calls[0]["args"] == ("faq-uuid-1", "approved", "acct-1", "draft")
+
+
+@pytest.mark.asyncio
+async def test_update_status_without_expected_status_keeps_unconditional_shape() -> None:
+    pool = _Pool()
+    pool.fetch_rows = []
+    repo = PostgresTicketFAQRepository(pool)
+
+    await repo.update_status(
+        "faq-uuid-1",
+        "published",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    query = pool.fetch_calls[0]["query"]
+    assert "AND status = $4" not in query
+    assert pool.fetch_calls[0]["args"] == ("faq-uuid-1", "published", "acct-1")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_update_status_compare_and_set_loses_race_against_postgres() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    root = Path(__file__).resolve().parents[1]
+    run_id = uuid4().hex
+    account = f"acct-faq-cas-{run_id}"
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+    repo = PostgresTicketFAQRepository(pool)
+
+    try:
+        await pool.execute(
+            (root / "atlas_brain/storage/migrations/325_ticket_faq_markdown.sql").read_text()
+        )
+        saved_ids = await repo.save_drafts(
+            [_draft()],
+            scope=TenantScope(account_id=account),
+        )
+        saved_id = saved_ids[0]
+        scope = TenantScope(account_id=account)
+
+        # Concurrent reviewer decision lands first: draft -> rejected.
+        assert await repo.update_status(saved_id, "rejected", scope=scope)
+
+        # The stale promotion (read saw 'draft') must LOSE the race.
+        promoted = await repo.update_status(
+            saved_id,
+            "approved",
+            scope=scope,
+            expected_status="draft",
+        )
+        assert promoted is False
+        current = await repo.get_draft(saved_id, scope=scope)
+        assert current is not None
+        assert current.status == "rejected"
+
+        # And the CAS succeeds when the stored status really is 'draft'.
+        assert await repo.update_status(saved_id, "draft", scope=scope)
+        promoted = await repo.update_status(
+            saved_id,
+            "approved",
+            scope=scope,
+            expected_status="draft",
+        )
+        assert promoted is True
+        current = await repo.get_draft(saved_id, scope=scope)
+        assert current is not None
+        assert current.status == "approved"
+    finally:
+        await pool.execute(
+            "DELETE FROM ticket_faq_markdown WHERE account_id = $1",
+            account,
+        )
+        await pool.close()

--- a/tests/test_extracted_ticket_faq_postgres.py
+++ b/tests/test_extracted_ticket_faq_postgres.py
@@ -625,6 +625,11 @@ async def test_update_status_compare_and_set_loses_race_against_postgres() -> No
         await pool.execute(
             (root / "atlas_brain/storage/migrations/325_ticket_faq_markdown.sql").read_text()
         )
+        # update_status also refreshes the search projection, so the
+        # search-documents table must exist for the compare-and-set path.
+        await pool.execute(
+            (root / "atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql").read_text()
+        )
         saved_ids = await repo.save_drafts(
             [_draft()],
             scope=TenantScope(account_id=account),

--- a/tests/test_faq_macro_writeback_live_zendesk_smoke.py
+++ b/tests/test_faq_macro_writeback_live_zendesk_smoke.py
@@ -61,6 +61,7 @@ class _FAQRepo:
         status: str,
         *,
         scope: TenantScope,
+        expected_status: str | None = None,
     ) -> bool:
         self.update_calls.append({
             "faq_id": faq_id,

--- a/tests/test_seed_faq_macro_writeback_live_smoke_draft.py
+++ b/tests/test_seed_faq_macro_writeback_live_smoke_draft.py
@@ -50,6 +50,7 @@ class _FAQRepo:
         status: str,
         *,
         scope: TenantScope,
+        expected_status: str | None = None,
     ) -> bool:
         self.update_calls.append({
             "faq_id": faq_id,


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md
Slice phase: Vertical slice

Foundation for the paid Resolution Audit -> Zendesk macro publish route
(#1955), split out so each PR's diff stays under the pre-push-audit
cross-layer-caller budget. The shared `FAQMacroWritebackPublishService` gains
an opt-in `approve_draft`: an explicit paid publish is the approval for a
generated (`status='draft'`) FAQ, and the promotion + publish-mark are race-safe
against concurrent review decisions.

## Intentional
- `approve_draft` defaults `False`; the AI Content Station and scheduled
  publish paths are byte-for-byte unchanged. Backward-compatible port + service
  extension.
- `publish_faq_draft` is one three-phase transaction with explicit terminal
  state: promotion (`draft->approved`) only for a fully-publishable draft;
  promotion + publish-mark (`approved->published`) are compare-and-set;
  `draft_status` reports the effective status so an already-`published` draft
  retries idempotently with no write; a new `status_conflict` flag folded into
  `ok` surfaces a mid-flight review decision as a conflict, not a false success.
- The `TicketFAQRepository.update_status` port gains an optional
  `expected_status` compare-and-set (Postgres adds `AND status = $N`); every
  in-repo fake used with the service accepts it.
- No live Zendesk in CI: the real `ZendeskMacroPublishProvider` is exercised
  only for its no-credentials fail-closed short-circuit.

## Deferred
- The paid Resolution Audit `POST /deflection-reports/{request_id}/publish-macros`
  route, its host factory, and the router wiring land in follow-up route PR
  #1955 (`claude/pr-content-ops-resolution-audit-zendesk-writeback`), rebased
  onto this foundation once merged.

## Parked hardening
- None.

## AI reconciliation
- AI findings reviewed: yes. All fixed or waived: yes.
- Codex/Copilot round on #1979 (6 findings) fixed at root: concurrent
  double-publish now reports idempotent success (CAS-miss re-read
  disambiguates already-published from review-decided); promotion CAS miss
  sets status_conflict; published drafts retry idempotently for every caller;
  skipped items report the real observed status; status_conflict is persisted
  to attempt history (new migration + wiring); the real-Postgres CAS race test
  loads migration 327.
- Second review round (2 findings) fixed by RESTRUCTURING rather than
  patching: all status transitions now flow through one _transition_status
  compare-and-set helper that re-reads on a miss (a promotion race that finds
  the row already published republishes idempotently instead of reporting a
  false conflict), and the provider call is wrapped so an exception records a
  durable failed attempt.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback_publish.py extracted_content_pipeline/faq_macro_writeback.py extracted_content_pipeline/ticket_faq_ports.py extracted_content_pipeline/ticket_faq_postgres.py` -- pass.
- `python -m pytest` foundation set (service + CAS + consumers) -- 189 passed.
- `DATABASE_URL=... python -m pytest tests/test_extracted_ticket_faq_postgres.py -m integration -q` -- real-Postgres compare-and-set race passes.
- `bash scripts/run_extracted_pipeline_checks.sh` -- see below.
- `python scripts/maturity_sweep.py extracted_content_pipeline ... --min-score 8` -- ratchet passed.

## Diff size
Diff-budget override: this is the indivisible service-layer half of the
#1955 split -- the state-machine change plus the exhaustive concurrency/CAS
truth-table tests (accumulated across four review rounds) must ship together
to prove the terminal-state contract. Production code is ~134 LOC; the
remainder is the plan doc and the service/Postgres/consumer tests.

15 files, 1022 LOC per `python scripts/sync_pr_plan.py plans/PR-FAQ-Macro-Writeback-Approve-On-Publish-CAS.md`.