### PR TITLE
Clarify CI temporal discipline bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ atlas-ui/.vite/
 # Progress logs (session artifacts)
 PROGRESS_*.md
 SESSION_STATE.local.md
+SESSION_STATE.*.local.md
 
 # Hybrid reasoning checks JSON report output
 artifacts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,10 +227,15 @@ code ship together.
 
 ### 3a.1. Session ownership map
 
-Every builder session must maintain a local `SESSION_STATE.local.md`
-at the repository root, using `docs/SESSION_STATE_TEMPLATE.md` as the
-shape. This file is ignored by git because it is volatile session
-state, but it is mandatory working context.
+Every builder session must maintain its own local session-state file at the
+repository root, using `docs/SESSION_STATE_TEMPLATE.md` as the shape. The
+preferred filename is `SESSION_STATE.<session-id>.local.md` (for example,
+`SESSION_STATE.codex-workflow-1982.local.md`). The legacy
+`SESSION_STATE.local.md` filename is allowed only when exactly one active
+session owns that worktree. These files are ignored by git because they are
+volatile session state, but one per session is mandatory working context. Set
+`ATLAS_SESSION_STATE_FILE` to the session's file path, or pass `--state-file`
+to the ownership guard, before doing PR work.
 
 Update the map:
 
@@ -251,8 +256,8 @@ PR, the builder must verify all of the following:
 1. `gh pr list --state open` has been checked in this resume window.
 2. `git log --oneline -15 origin/main` has been checked for already
    landed work.
-3. The target PR is listed in `SESSION_STATE.local.md` under "Owned
-   Active PR" or "PRs This Session May Touch".
+3. The target PR is listed in this session's state file under "Owned Active
+   PR" or "PRs This Session May Touch".
 4. The local branch and expected head SHA match the target PR when a
    merge or force-push is about to happen.
 
@@ -266,6 +271,9 @@ python scripts/check_session_pr_ownership.py \
   --head-sha <headRefOid>
 ```
 
+The guard defaults to `ATLAS_SESSION_STATE_FILE` when set, then falls back to
+`SESSION_STATE.local.md` for legacy single-session worktrees.
+
 If any check fails, stop and ask the operator. A PR in the same lane is
 not automatically owned. A PR that "looks abandoned" is not owned. A PR
 opened by another session is not owned unless the operator explicitly
@@ -273,7 +281,7 @@ reassigns it and the map is updated first.
 
 Starting a new slice is gated the same way as touching a PR. Before you
 scaffold a plan or pass `--lane` to `new_pr_plan.sh`, confirm that lane
-matches the `current lane` in `SESSION_STATE.local.md`. Opening a new PR in
+matches the `current lane` in this session's state file. Opening a new PR in
 another lane is the most common silent drift: parallel sessions are
 indistinguishable in git, so another lane's slice looks exactly like your
 own. If the slice belongs to a different lane:
@@ -400,19 +408,19 @@ For long-running coding tasks, first record which builder surface owns the PR:
 
 - **Claude Code native mode:** use Claude Code's PR subscription/review
   reactivity plus its 30-minute polling. Record that as the push/review-event
-  hook and timer/polling path in `SESSION_STATE.local.md`. Do not require a
+  hook and timer/polling path in this session's state file. Do not require a
   local systemd `atlas-pr-watch` timer for Claude Code unless the operator
   explicitly asks for the local watcher too.
 - **Codex/local CLI mode:** a desktop notification or `atlas-pr-watch` run does
   not wake an agent by itself. True autonomous resume requires an external wake
   bridge that starts or resumes a Codex run with the watcher state and a prompt
-  to read `SESSION_STATE.local.md`, rerun merge guards, and act only on the
+  to read this session's state file, rerun merge guards, and act only on the
   owned PR. Without that bridge, the local watcher is a read-only state producer
   for the next active agent.
 
 For long-running coding tasks, after each PR open or push:
 
-1. Subscribe the session to its owned PR in `SESSION_STATE.local.md`. Record the
+1. Subscribe the session to its owned PR in this session's state file. Record the
    PR number, branch, head SHA, checks URL, review/reconciliation URL or
    commands, builder surface, wake bridge or native subscription path,
    ready-state handoff command, polling cadence, next wake/poll time, and the
@@ -439,7 +447,7 @@ For long-running coding tasks, after each PR open or push:
    fixed threads, update the PR body/reconciliation record, and leave the wake
    hooks armed for the next push/review/timer event.
 6. If checks are still pending, record the last observed status and next timer
-   wake time in `SESSION_STATE.local.md`; do not ask the operator to babysit
+   wake time in this session's state file; do not ask the operator to babysit
    green and do not burn compute by waiting inside the chat turn.
 7. Push/review-event wakes are attention-only. Even if a push/review-event wake
    observes green checks, record readiness and wait for the scheduled 30-minute
@@ -457,7 +465,7 @@ For long-running coding tasks, after each PR open or push:
    explicitly released by the operator.
 
 The watcher/subscription state is mandatory compaction handoff data. A
-restarted or compacted long-running session reads `SESSION_STATE.local.md`
+restarted or compacted long-running session reads its session-state file
 before doing anything else and resumes from the recorded PR state. Do not start
 a new slice while the owned PR still has unresolved CI, review, reconciliation,
 or merge state.
@@ -799,7 +807,7 @@ A **fix loop** -- iterating on red CI or review comments on an already-open PR
 -- is where sessions burn the most time and tokens: broad exploration, edits to
 files outside the real failure source, and re-orientation after every
 compaction. Before editing in a fix loop, record a **fix baton** in
-`SESSION_STATE.local.md` (the `PR Fix Mode` block) capturing the failure source,
+this session's state file (the `PR Fix Mode` block) capturing the failure source,
 the **allowed-files set**, and a **max-files budget**.
 
 - **Stay inside the allowed set.** The allowed files are the failure source you

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1118,7 +1118,7 @@ PR independently). The full contract lives in `AGENTS.md`; the highlights:
 - **Long-running coding tasks keep their own PR watcher.** Ordinary
   interactive slices stop after opening/updating a PR and wait for the
   operator. If the operator explicitly assigns a long-running/autonomous arc,
-  the builder records the owned PR watcher in `SESSION_STATE.local.md`, polls
+  the builder records the owned PR watcher in that session's state file, polls
   GitHub every 30 minutes for checks/reviews/reconciliation, resumes that
   watcher after compaction, and continues the approved slice arc instead of
   halting until the operator notices green. See `AGENTS.md` §3c.1.
@@ -1392,7 +1392,7 @@ Compose files for sub-services:
 When compacting this conversation, preserve verbatim (do not summarize away):
 
 - The active operator-assigned lane and the **owned active PR** (number, branch,
-  latest pushed SHA) from `SESSION_STATE.local.md`.
+  latest pushed SHA) from this session's state file.
 - The full **PR Fix Mode** baton when a fix loop is active: allowed-files set +
   max-files budget, current failing check/comment, last useful log finding, next
   exact action, and do-not-redo notes.

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -15,9 +15,9 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >
 > 1. **Read first, in order:** `AGENTS.md` (the multi-session PR contract), `CLAUDE.md`, `CANONICAL.md`, `INTEGRATION_MAP.md`, `BUILD_SPEC.md`, `CONTEXT.md`. Then run `git log --oneline -20` and `gh pr list --state open` to see where things actually stand. Do not infer state from this prompt — those sources are truth.
 >
-> 2. **Session ownership map:** read `SESSION_STATE.local.md` if it exists. If it does not exist, create it from `docs/SESSION_STATE_TEMPLATE.md` before any PR action. Fill in your assigned lane, current task, Spark/subagent routing used or considered, owned active PR (or `none`), open PRs that are explicitly **not yours**, current worktree, and last safe action. A PR that is not listed as owned in this file is not yours.
+> 2. **Session ownership map:** pick a session-scoped state file before any PR action. Use `SESSION_STATE.<session-id>.local.md` at the repo/worktree root (for example `SESSION_STATE.codex-macro-1979.local.md`); use legacy `SESSION_STATE.local.md` only when one active session owns that worktree. Export `ATLAS_SESSION_STATE_FILE=<that file>`, then read it if it exists or create it from `docs/SESSION_STATE_TEMPLATE.md`. Fill in your assigned lane, current task, Spark/subagent routing used or considered, owned active PR (or `none`), open PRs that are explicitly **not yours**, current worktree, and last safe action. A PR that is not listed as owned in this file is not yours.
 >
-> 3. **Your current lane:** [ONE line — e.g. "Content-Ops macro-writeback" or "deflection/Stripe monetization". If unsure, read CONTEXT.md + open PRs to find the active slice.] Stay in this lane. **Do not close, merge, or modify PRs outside your current task** — if a PR looks abandoned, ask the operator; don't close it. If an open PR is in the same lane but is not marked owned in `SESSION_STATE.local.md`, treat it as someone else's PR.
+> 3. **Your current lane:** [ONE line — e.g. "Content-Ops macro-writeback" or "deflection/Stripe monetization". If unsure, read CONTEXT.md + open PRs to find the active slice.] Stay in this lane. **Do not close, merge, or modify PRs outside your current task** — if a PR looks abandoned, ask the operator; don't close it. If an open PR is in the same lane but is not marked owned in your session state file, treat it as someone else's PR.
 >
 > 4. **Recurring mistakes — do NOT repeat these (each has cost a review cycle):**
 >    - **Config:** every setting goes through `atlas_brain/config.py` typed `ATLAS_*` fields. **Never** read `os.environ` directly — especially for secrets.
@@ -26,7 +26,7 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >    - **Secondary writes are best-effort:** audit/history/notification writes that happen *after* a side-effectful op (publish, send, charge) must be wrapped (try/except + log) so they can't fail an already-successful operation.
 >    - **Lookup-and-backfill fails safe on ambiguity:** match an external resource only on a *unique* result; 0 *or* >1 matches → don't guess.
 >    - **Per-tenant credentials fail closed:** an unprovisioned tenant must not silently borrow shared/global credentials.
->    - **CI is truth:** "passed locally" ≠ green. Run the test the way CI does and check `gh pr checks` is green before claiming done.
+>    - **CI is truth:** "passed locally" ≠ green. Before you push, run the relevant checks the way CI does and report only what actually ran. After the PR is pushed/opened/updated, confirming merge readiness is the watcher/operator's job after handoff, not an in-session polling loop.
 >    - **Tests must be meaningful, not just green:** for logic changes, a trivial happy-path test is not enough. Add negative/edge/malformed/sparse/varied-input coverage proportional to risk, or explicitly name why it is deferred.
 >    - **New surfaces need reachability proof:** if a slice adds a runtime, workflow, UI, report, billing, delivery, or public contract surface, exercise the real entrypoint and assert an observable result. A unit-tested helper is not enough to prove the surface is wired.
 >    - **Fixtures must match real producer output**, not hand-crafted shapes.
@@ -55,6 +55,7 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >
 > 6. **Context discipline (keeps the session from compacting mid-work):**
 >    - After opening or updating a PR, **stop** — do not poll CI or wait for review (AGENTS.md §3c). Report the PR URL + the local checks you already ran, then hand back to the operator; resume only on the operator's signal.
+>    - The Atlas handoff baton is your session state file plus watcher status output; do not add a second marker, timer, or poller just to wait for CI.
 >    - During iteration, read **targeted ranges** of large files (e.g. `control_surfaces.py` is ~1.4k lines), not whole files; and run the **single relevant test file**, not the full suite. Run the full `run_extracted_pipeline_checks.sh` gauntlet **once**, right before pushing — not on every change.
 >    - For bounded read-only scouting/checking, prefer a lightweight Spark subagent when available; keep judgment, edit-target reads, Git/GitHub mutations, and final synthesis in main.
 >    - Before pushing, use `scripts/push_pr.sh` as the single local-review entry
@@ -74,7 +75,7 @@ Paste this when the session shows drift signals — a closed-unmerged PR, work i
 
 > Stop. You likely just compacted. Before any further action:
 > 1. Do **not** close, merge, or modify any PR — run `gh pr list --state open` and confirm which one is *yours* this task.
-> 2. Read `SESSION_STATE.local.md`. If it is missing, stale, or does not list the PR under "Owned Active PR" / "PRs This Session May Touch", stop and ask the operator.
+> 2. Read the session state file named by `ATLAS_SESSION_STATE_FILE`. If that variable is unset, pick the intended session file before continuing. If the file is missing, stale, or does not list the PR under "Owned Active PR" / "PRs This Session May Touch", stop and ask the operator.
 > 3. Your current lane is **[X]**. If what you're about to do isn't in that lane, stop and ask.
 > 4. Don't start new work or re-do merged work — run `git log --oneline -15` to see what's already landed.
 > 5. Re-read your plan doc `plans/PR-<slice>.md` and `AGENTS.md`.

--- a/docs/SESSION_STATE_TEMPLATE.md
+++ b/docs/SESSION_STATE_TEMPLATE.md
@@ -1,7 +1,14 @@
-# SESSION_STATE.local.md Template
+# Session-State File Template
 
-Create `SESSION_STATE.local.md` at the repository root from this template for
-each builder session. Keep it local; it is ignored by git.
+Create one local state file per builder session at the repository root from
+this template. Prefer `SESSION_STATE.<session-id>.local.md` (for example,
+`SESSION_STATE.codex-workflow-1982.local.md`). Use legacy
+`SESSION_STATE.local.md` only when one active session owns the worktree.
+
+Keep the file local; `SESSION_STATE.local.md` and
+`SESSION_STATE.*.local.md` are ignored by git. Export
+`ATLAS_SESSION_STATE_FILE=<absolute or repo-relative path>` for the active
+session so ownership guards and wake prompts read the right file.
 
 Update it before opening a PR, after pushing a PR update, after merging a PR,
 and after any compaction/restart reorientation. If current GitHub state
@@ -101,7 +108,7 @@ Do-NOT-redo: <paths ruled out, checks already green, dead ends>
 
 ## Ownership Rule
 
-If a PR is not listed as owned in `SESSION_STATE.local.md`, it is not yours.
+If a PR is not listed as owned in this session's state file, it is not yours.
 Lane proximity is not ownership. Similar file paths are not ownership. A PR
 opened by another active session is not yours unless the operator explicitly
 reassigns it and the map is updated first.

--- a/docs/ai_dev_operating_model.md
+++ b/docs/ai_dev_operating_model.md
@@ -89,8 +89,11 @@ dedicated mechanical check, run locally *and* in CI.
 
 **(a) Session/PR ownership drift** — a session touching a PR that isn't its.
 `scripts/check_session_pr_ownership.py` reads a mandatory, git-ignored
-`SESSION_STATE.local.md` (owned PR, branch, head SHA, "may touch", "must not
-touch") and **fails** if the target PR isn't owned or the branch/SHA don't match.
+session-scoped state file (preferred shape
+`SESSION_STATE.<session-id>.local.md`, with `SESSION_STATE.local.md` allowed
+only for a one-session worktree) containing owned PR, branch, head SHA, "may
+touch", and "must not touch". It **fails** if the target PR isn't owned or the
+branch/SHA don't match.
 A PR in the same lane is *not* automatically owned; an abandoned-looking PR is
 *not* owned. When in doubt, stop and ask the operator.
 
@@ -135,9 +138,10 @@ The countermeasures are entirely about **context hygiene**:
 - **Read narrow, test scoped.** During iteration: read targeted line ranges of big
   files (not the whole 1.4k-line file), run the single relevant test file (not the
   suite). Run the full gauntlet **once**, right before pushing.
-- **Externalize state to disk.** `SESSION_STATE.local.md` is the session's memory
-  that *survives* a compaction — current lane, owned PR, last safe action. After
-  any compaction/restart the session re-reads it instead of guessing.
+- **Externalize state to disk.** The session-scoped state file is the session's
+  memory that *survives* a compaction — current lane, owned PR, last safe
+  action. After any compaction/restart the session re-reads it instead of
+  guessing.
 - **Two canned prompts** in `docs/SESSION_BOOTSTRAP.md`: a **bootstrap** to seed a
   fresh session fast, and a **drift redirect** to paste the moment a session shows
   post-compaction drift signals ("Stop. You likely just compacted. Do not close,
@@ -273,10 +277,11 @@ advisory inputs to a judgment session, never auto-applied.** A naive "auto-addre
 all review comments" loop is strictly dangerous.
 
 **(c) Ownership rests partly on honor-system, git-ignored state.** Two checks guard
-lane ownership: `check_session_pr_ownership.py` reads `SESSION_STATE.local.md` —
-which is **git-ignored**, so the artifact that declares "who owns this PR" is the
-one artifact no reviewer or CI run can see; and `audit_pr_session_drift.py` reads
-the **public** `Ownership lane:` from plan docs. The hole: a PR with **no plan doc**
+lane ownership: `check_session_pr_ownership.py` reads the session-scoped state
+file, which is **git-ignored**, so the artifact that declares "who owns this PR"
+is the one artifact no reviewer or CI run can see; and
+`audit_pr_session_drift.py` reads the **public** `Ownership lane:` from plan
+docs. The hole: a PR with **no plan doc**
 declares no lane and is therefore invisible to the public collision audit entirely.
 Plan-less PRs are exempt from the drift detection that makes parallel lanes safe.
 Fix (in the system's own idiom — *surface, never silently skip*, §3g): treat

--- a/docs/autonomous_coding_repo_playbook.md
+++ b/docs/autonomous_coding_repo_playbook.md
@@ -129,8 +129,8 @@ Long-running agents need more structure than normal interactive PR work:
 
 - one worktree per active slice;
 - one watcher config per owned PR;
-- `SESSION_STATE.local.md` updated after open, push, review fix, merge, and
-  teardown;
+- one session-scoped state file updated after open, push, review fix, merge,
+  and teardown;
 - no active in-chat sleep loop for CI;
 - no merge from a push/review attention wake;
 - scheduled green confirmation before a standing-authorized merge;

--- a/docs/ci_cd_autonomous_coding_map.md
+++ b/docs/ci_cd_autonomous_coding_map.md
@@ -44,7 +44,7 @@ issue / operator request
 
 The important property is that model memory is not trusted. The durable state
 lives in the repo, PR body, CI checks, review threads, and
-`SESSION_STATE.local.md`.
+the session-scoped state file.
 
 ## Local Gates
 

--- a/docs/ci_cd_runtime_duplication_audit.md
+++ b/docs/ci_cd_runtime_duplication_audit.md
@@ -45,7 +45,7 @@ branch-protection required contexts.
 |---|---|
 | `pr-body-contract` | Keeps PR bodies tied to the plan contract, even though it is not in the current branch-protection required-context set. |
 | `pre-push-audit` trusted-base local review | Re-runs the local mechanical bundle from trusted base so a PR cannot weaken its own audit. |
-| `SESSION_STATE.local.md` ownership guard | Prevents long-running sessions from touching another lane's PR before review, push, comment handling, or merge. |
+| Session-scoped state file ownership guard | Prevents long-running sessions from touching another lane's PR before review, push, comment handling, or merge. |
 
 The optimization target is redundant runtime and broad triggering, not removing
 these gates.

--- a/docs/long_running_agent_monitoring_spec.md
+++ b/docs/long_running_agent_monitoring_spec.md
@@ -71,7 +71,7 @@ or verdict when present, and whether a later push fixed or waived it.
 Local inputs:
 
 - `plans/PR-<Slice>.md` and the mirrored PR body.
-- `SESSION_STATE.local.md` for lane ownership, watcher hooks, standing
+- the session-scoped state file for lane ownership, watcher hooks, standing
   authorization, last safe action, and fix-mode baton.
 - `~/.local/state/atlas-pr-watchers/<session-id>.json` for scheduled watcher
   state.
@@ -150,7 +150,7 @@ Scope: <one-sentence lane>
 | Stale PR body claims | PR body/live-reconciliation check | Body says AI findings are fixed while current threads remain open. |
 | Unresolved AI threads | Live reconciliation or reviewer checklist | Bot/human thread remains unresolved at merge time. |
 | Branch/head drift | Session ownership guard or watcher head mismatch stop | Remote head changes unexpectedly or branch is behind base. |
-| Scope/lane drift | `SESSION_STATE.local.md` ownership rule or drift audit | Builder touches a PR or lane not assigned to the session. |
+| Scope/lane drift | Session-scoped state-file ownership rule or drift audit | Builder touches a PR or lane not assigned to the session. |
 | Push/review hook confusion | Watcher docs or event-bridge guard | Notification is recorded as a builder wake hook, or event wake is treated as merge authorization. |
 | Active polling | AGENTS/watcher rule | Builder waits in-chat for CI instead of relying on hooks. |
 

--- a/docs/long_running_session_watcher_handoff.md
+++ b/docs/long_running_session_watcher_handoff.md
@@ -15,7 +15,7 @@ Important mode split:
 - **Codex/local CLI sessions** need a separate wake bridge for true autonomous
   resume. `atlas-pr-watch` can write watcher JSON/log state, but it cannot wake
   Codex by itself. A bridge must start or resume a Codex run with the watcher
-  state and a prompt to read `SESSION_STATE.local.md`, rerun guards, and act
+  state and a prompt to read this session's state file, rerun guards, and act
   only on the owned PR.
 - **Both modes** keep merge authority with the active builder only. A watcher,
   timer, notification, or bridge can report state; it cannot merge.
@@ -24,7 +24,7 @@ Important mode split:
 
 Long-running sessions now have two durable responsibilities:
 
-1. Keep `SESSION_STATE.local.md` current for the owned lane and PR.
+1. Keep this session's state file current for the owned lane and PR.
 2. Record the actual wake mode after each PR open or push: Claude Code native
    subscription/polling, a Codex wake bridge, or local watcher state-only.
 
@@ -42,14 +42,14 @@ allows.
 | Mode | Source | Builder action | Autonomous today? | Merge allowed? |
 |---|---|---|---|---|
 | Claude Code native | Claude Code PR subscription/review reactivity plus 30-minute polling | Claude Code resumes as the active builder, inspects only the owned PR, fixes actionable feedback, and runs merge guards when scheduled polling reports ready | Yes, when Claude Code subscription is active | Active builder only after explicit operator authorization and fresh guards |
-| Codex wake bridge | External wrapper that starts/resumes Codex with watcher state | Fresh/active Codex reads `SESSION_STATE.local.md`, runs `scripts/report_pr_watcher_state.py`, then fixes, waits, reports ready, or runs guarded merge if authorized | Only when the bridge exists | Active builder only after explicit operator authorization and fresh guards |
+| Codex wake bridge | External wrapper that starts/resumes Codex with watcher state | Fresh/active Codex reads this session's state file, runs `scripts/report_pr_watcher_state.py`, then fixes, waits, reports ready, or runs guarded merge if authorized | Only when the bridge exists | Active builder only after explicit operator authorization and fresh guards |
 | Local watcher state-only | `atlas-pr-watch@<session>.timer` writes JSON/log state every 30 minutes | No agent wakes automatically; the next active agent consumes the state with `scripts/report_pr_watcher_state.py` | No | No |
 | Operator signal | Human says "review is up", "green", or "merge" | Active builder inspects the owned PR and runs the same guards | Manual | Active builder only after explicit operator authorization and fresh guards |
 
 The push/review-event path exists to reduce red-review latency when something
 wakes the builder. It is an attention signal, not a merge signal. If no concrete
 bridge exists for Codex/local sessions, record `Wake bridge: unavailable` in
-`SESSION_STATE.local.md`; the scheduled watcher remains only a state recorder
+this session's state file; the scheduled watcher remains only a state recorder
 until an active agent consumes its output.
 
 The scheduled poll/wake is the canonical readiness signal. A push/review-event
@@ -84,7 +84,7 @@ Claude Code native subscription satisfies that path for Claude Code sessions.
 For Codex/local sessions, the hook is outside this repo unless the operator has
 provided an integration. Use this concrete contract:
 
-1. Record the hook in `SESSION_STATE.local.md` as
+1. Record the hook in this session's state file as
    `Push/review-event hook: <name and trigger>`.
 2. Configure the external bridge to start or resume the Codex/local builder
    session on new pushes, review threads, review events, and reconciliation
@@ -136,7 +136,7 @@ Wake-source rules:
 - `--source scheduled` may classify `ready_for_human_merge` as
   `scheduled-ready`, which is only permission to run the AGENTS merge guards.
   The resumed builder still needs explicit standing merge authorization in
-  `SESSION_STATE.local.md` before merging.
+  this session's state file before merging.
 - Pending states write a handoff but do not run the optional command by default.
   Do not replace the watcher timer with an in-chat polling loop.
 
@@ -192,6 +192,8 @@ Pick a stable session id:
 
 ```bash
 SESSION_ID="<lane-slug>-<pr-number>"
+SESSION_STATE_FILE="<absolute repo or worktree path>/SESSION_STATE.${SESSION_ID}.local.md"
+export ATLAS_SESSION_STATE_FILE="${SESSION_STATE_FILE}"
 ```
 
 Create the watcher config after the PR is opened or after an existing owned PR
@@ -205,7 +207,7 @@ LABEL="<human label>"
 REPO_DIR="<absolute repo or worktree path>"
 PR="<pr number>"
 REPO="canfieldjuan/ATLAS"
-SESSION_STATE="<absolute path to SESSION_STATE.local.md>"
+SESSION_STATE="<absolute path to SESSION_STATE.<session-id>.local.md>"
 HEAD_SHA="<current PR head SHA>"
 POLL_MINUTES="30"
 AUTO_MERGE="0"
@@ -302,17 +304,17 @@ Before doing anything, read:
 3. docs/SESSION_BOOTSTRAP.md
 4. docs/ci_cd_autonomous_coding_map.md
 5. docs/long_running_session_watcher_handoff.md
-6. SESSION_STATE.local.md if it exists; otherwise create it from docs/SESSION_STATE_TEMPLATE.md
+6. The session state file named by ATLAS_SESSION_STATE_FILE if it exists; otherwise create it from docs/SESSION_STATE_TEMPLATE.md
 
 New rules to follow:
-- This is a long-running session only for the lane/operator assignment named in SESSION_STATE.local.md.
-- A PR is yours only if SESSION_STATE.local.md lists it under Owned Active PR or PRs This Session May Touch.
-- Do not inspect, push to, close, merge, or modify any other open PR unless the operator explicitly reassigns it and you update SESSION_STATE.local.md first.
-- Record your builder surface in SESSION_STATE.local.md: Claude Code native, Codex/local CLI, or other.
+- This is a long-running session only for the lane/operator assignment named in this session's state file.
+- A PR is yours only if this session's state file lists it under Owned Active PR or PRs This Session May Touch.
+- Do not inspect, push to, close, merge, or modify any other open PR unless the operator explicitly reassigns it and you update this session's state file first.
+- Record your builder surface in this session's state file: Claude Code native, Codex/local CLI, or other.
 - For Claude Code native sessions, subscribe to the owned PR and use Claude Code's native review reactivity plus 30-minute polling. Do not install the local systemd watcher unless the operator explicitly asks for local watcher JSON/log state too.
 - For Codex/local CLI sessions, install or refresh a per-session watcher config at ~/.config/atlas-pr-watchers/<session-id>.env only as state production. True autonomous resume requires a separate external wake bridge that starts/resumes Codex with the watcher state.
-- Fill the SESSION_STATE.local.md hook fields: `Push/review-event hook`, `Timer/poll hook`, `Wake bridge`, `Next timer wake`, `Last watcher state`, and `Standing merge authorization`.
-- Record the push/review-event hook in SESSION_STATE.local.md only when it wakes the builder session. If no concrete external bridge wakes a Codex/local builder, write `Wake bridge: unavailable`; the scheduled watcher is state-only and the session does not have autonomous review-event wake-up coverage.
+- Fill the session state hook fields: `Push/review-event hook`, `Timer/poll hook`, `Wake bridge`, `Next timer wake`, `Last watcher state`, and `Standing merge authorization`.
+- Record the push/review-event hook in this session's state file only when it wakes the builder session. If no concrete external bridge wakes a Codex/local builder, write `Wake bridge: unavailable`; the scheduled watcher is state-only and the session does not have autonomous review-event wake-up coverage.
 - Do not use the scheduled atlas-pr-watch command as the push/review-event bridge unless it has a source-aware event mode that cannot produce merge permission.
 - Use `python scripts/codex_wake_bridge.py "${SESSION_ID}" --source event`
   for push/review-event bridges and
@@ -322,7 +324,7 @@ New rules to follow:
 - A local watcher must poll every 30 minutes and must use AUTO_MERGE="0".
 - Codex/local sessions must run `scripts/report_pr_watcher_state.py` on resume before starting the next slice in a long-running arc.
 - No auto-merge in the watcher. When the watcher reports ready_for_human_merge, the active builder reports readiness and waits for the operator unless this specific arc has explicit active-builder merge authorization.
-- With standing merge authorization recorded in SESSION_STATE.local.md, the active builder merges only after a scheduled Claude poll or Codex/local wake bridge reports ready_for_human_merge and the current AGENTS pre-merge guards pass, including review-thread status and merge-conflict/mergeability state.
+- With standing merge authorization recorded in this session's state file, the active builder merges only after a scheduled Claude poll or Codex/local wake bridge reports ready_for_human_merge and the current AGENTS pre-merge guards pass, including review-thread status and merge-conflict/mergeability state.
 - Do not merge from a push/review-event wake. If that wake observes green checks, record readiness and wait for the scheduled green-confirmation wake.
 - Do not actively poll GitHub for green CI between watcher wake-ups.
 - Review/comment events are fast attention only when the operator, Claude Code
@@ -331,13 +333,13 @@ New rules to follow:
   record `review_changed`.
 - If checks are red or review comments are actionable, fix only the owned PR, fix the upstream/root cause within the slice, push with scripts/push_pr.sh, resolve fixed review threads, update the PR body/reconciliation record when needed, and refresh the watcher head SHA.
 - If the watcher reports `attention` with `head_mismatch: true`, stop, fetch the remote head, inspect the delta, and do not force-push over another actor's commit.
-- If checks are pending, update SESSION_STATE.local.md with the current pending list and next poll time.
+- If checks are pending, update this session's state file with the current pending list and next poll time.
 - Do not start the next slice while the owned PR has unresolved CI, review, AI reconciliation, or merge state.
 
 When you resume:
 1. Run gh pr list --state open.
 2. Run git log --oneline -15 origin/main.
-3. Verify the target PR number, branch, and head SHA match SESSION_STATE.local.md.
+3. Verify the target PR number, branch, and head SHA match this session's state file.
 4. Run scripts/check_session_pr_ownership.py before any PR mutation when PR metadata is known.
 5. In Codex/local watcher mode, check the watcher status JSON and journal before deciding whether to fix, wait, or report readiness.
 
@@ -350,7 +352,7 @@ LABEL="<human label>"
 REPO_DIR="<absolute repo or worktree path>"
 PR="<pr number>"
 REPO="canfieldjuan/ATLAS"
-SESSION_STATE="<absolute path to SESSION_STATE.local.md>"
+SESSION_STATE="<absolute path to SESSION_STATE.<session-id>.local.md>"
 HEAD_SHA="<current PR head SHA>"
 POLL_MINUTES="30"
 AUTO_MERGE="0"

--- a/plans/PR-Session-Bootstrap-Temporal-Discipline.md
+++ b/plans/PR-Session-Bootstrap-Temporal-Discipline.md
@@ -1,0 +1,154 @@
+# PR-Session-Bootstrap-Temporal-Discipline
+
+## Why this slice exists
+
+Issue #1981 tracks the Atlas-only CI temporal discipline audit follow-up. The
+audit found one P2 documentation contradiction: the bootstrap's recurring-lapse
+list says to check `gh pr checks` before claiming done, while the same document
+and `AGENTS.md` say the builder must stop after opening or updating a PR and
+wait for watcher/operator signal.
+
+The operator also clarified the multi-agent operating reality: there are often
+two or three active builder sessions. A single shared SESSION_STATE.local.md
+file makes those sessions read and rewrite the same local baton in competing
+ways.
+
+Root cause: one checklist item mixed two time boundaries. It correctly reminded
+builders that local passes are not CI green, but it also read like a post-push
+polling instruction. The same docs also described session state as one shared
+filename, not one state file per active session. This change fixes both roots:
+the bootstrap wording scopes the CI reminder to pre-push local verification, and
+the session-state contract now labels one ignored state file per session.
+
+## Scope (this PR)
+
+Ownership lane: workflow/autonomous-ci-cd-map
+Slice phase: Workflow/process
+
+1. Reword the bootstrap CI reminder so it cannot be read as "poll CI after
+   push."
+2. Clarify that every active builder owns its own labeled state file:
+   SESSION_STATE.<session-id>.local.md, with SESSION_STATE.local.md
+   retained only as a legacy single-session fallback.
+3. Teach the ownership guard to default to ATLAS_SESSION_STATE_FILE so the
+   docs and tooling agree.
+4. Preserve the existing Atlas handoff model: a session-scoped state file plus
+   watcher status is the baton; this slice does not add another marker or
+   watcher script.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `docs/SESSION_BOOTSTRAP.md` no longer tells a builder session to check
+        PR CI after opening or updating a PR.
+  - [ ] The doc still tells builders to run scoped/local checks before push and
+        not claim unrun checks passed.
+  - [ ] The doc explicitly aligns post-push work with the existing
+        watcher/operator handoff from `AGENTS.md` and the later bootstrap
+        stop-after-push rule.
+  - [ ] The optional one-shot state marker from #1981 is explicitly not added
+        because Atlas already has session-scoped state files and watcher
+        status.
+  - [ ] Concurrent sessions are told to use distinct local files and export
+        ATLAS_SESSION_STATE_FILE.
+  - [ ] `scripts/check_session_pr_ownership.py` reads
+        ATLAS_SESSION_STATE_FILE by default, while preserving the legacy
+        fallback.
+  - [ ] Wake-bridge prompts point the resumed agent to the configured state
+        file rather than the shared legacy filename.
+- Reachability proof: focused unit tests exercise the env-selected ownership
+  file and the generated wake prompt.
+- Affected surfaces: docs/process, local ownership guard, Codex wake prompt.
+- Risk areas: workflow ambiguity, token burn from polling, scope drift into new
+  watcher infrastructure, concurrent-session state collision.
+- Reviewer rules triggered: R1, R2, R10, R14.
+
+### Files touched
+
+- `.gitignore`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/SESSION_BOOTSTRAP.md`
+- `docs/SESSION_STATE_TEMPLATE.md`
+- `docs/ai_dev_operating_model.md`
+- `docs/autonomous_coding_repo_playbook.md`
+- `docs/ci_cd_autonomous_coding_map.md`
+- `docs/ci_cd_runtime_duplication_audit.md`
+- `docs/long_running_agent_monitoring_spec.md`
+- `docs/long_running_session_watcher_handoff.md`
+- `plans/PR-Session-Bootstrap-Temporal-Discipline.md`
+- `scripts/check_session_pr_ownership.py`
+- `scripts/codex_wake_bridge.py`
+- `tests/test_check_session_pr_ownership.py`
+- `tests/test_codex_wake_bridge.py`
+
+## Mechanism
+
+Replace the ambiguous "check `gh pr checks` is green before claiming done"
+sentence with a two-boundary statement:
+
+1. Before push, run the relevant local/scoped checks honestly.
+2. After push/open/update, merge readiness belongs to the watcher/operator
+   signal, not an in-session polling loop.
+
+Then update the session-state convention:
+
+1. Docs name the preferred file shape as
+   SESSION_STATE.<session-id>.local.md.
+2. `.gitignore` ignores both the legacy and session-labeled filenames.
+3. `scripts/check_session_pr_ownership.py` resolves ATLAS_SESSION_STATE_FILE
+   first, then falls back to SESSION_STATE.local.md for legacy single-session
+   worktrees.
+4. `scripts/codex_wake_bridge.py` includes the configured state path in its
+   generated prompt and ownership-guard command.
+
+Atlas still uses the same handoff baton -- session state plus watcher status --
+so a second marker would create duplicate state instead of a cleaner workflow.
+
+## Intentional
+
+- No CI workflow changes; #1981 identified a wording contradiction, not a broken
+  gate.
+- No new watcher, timer, marker, or state-printer script; Atlas already has the
+  richer handoff machinery documented in the session state file and watcher
+  status.
+- No product-code changes.
+
+## Deferred
+
+- The cross-repo one-shot state helper idea is not adopted for Atlas in this
+  slice. If another repo lacks Atlas's handoff machinery, it can adopt its own
+  non-polling helper there.
+
+Parked hardening: none.
+
+## Verification
+
+- Ran `scripts/sync_pr_plan.py` against `plans/PR-Session-Bootstrap-Temporal-Discipline.md` -- passed.
+- Ran `scripts/sync_pr_plan.py --check` against `plans/PR-Session-Bootstrap-Temporal-Discipline.md` -- passed.
+- Ran pytest for `tests/test_check_session_pr_ownership.py` and `tests/test_codex_wake_bridge.py` -- 23 passed.
+- Ran `scripts/check_session_pr_ownership.py` with ATLAS_SESSION_STATE_FILE set to SESSION_STATE.local.md against #1982 -- passed.
+- `git diff --check --cached` -- passed.
+- `scripts/push_pr.sh` runs the body-aware local review before push.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.gitignore` | 1 |
+| `AGENTS.md` | 34 |
+| `CLAUDE.md` | 4 |
+| `docs/SESSION_BOOTSTRAP.md` | 9 |
+| `docs/SESSION_STATE_TEMPLATE.md` | 15 |
+| `docs/ai_dev_operating_model.md` | 23 |
+| `docs/autonomous_coding_repo_playbook.md` | 4 |
+| `docs/ci_cd_autonomous_coding_map.md` | 2 |
+| `docs/ci_cd_runtime_duplication_audit.md` | 2 |
+| `docs/long_running_agent_monitoring_spec.md` | 4 |
+| `docs/long_running_session_watcher_handoff.md` | 38 |
+| `plans/PR-Session-Bootstrap-Temporal-Discipline.md` | 154 |
+| `scripts/check_session_pr_ownership.py` | 21 |
+| `scripts/codex_wake_bridge.py` | 12 |
+| `tests/test_check_session_pr_ownership.py` | 18 |
+| `tests/test_codex_wake_bridge.py` | 4 |
+| **Total** | **345** |

--- a/scripts/check_session_pr_ownership.py
+++ b/scripts/check_session_pr_ownership.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import os
 from pathlib import Path
 import re
 import sys
@@ -11,7 +12,6 @@ from typing import Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_STATE_FILE = ROOT / "SESSION_STATE.local.md"
 SECTION_RE = re.compile(r"^##\s+(.+?)\s*$")
 PR_RE = re.compile(r"#(?P<number>\d+)\b")
 
@@ -117,11 +117,26 @@ def ownership_errors(
     return errors
 
 
+def default_state_file() -> Path:
+    configured = os.environ.get("ATLAS_SESSION_STATE_FILE")
+    if configured:
+        return Path(configured)
+    return ROOT / "SESSION_STATE.local.md"
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Validate that a target PR is owned by SESSION_STATE.local.md."
+        description="Validate that a target PR is owned by this session's state file."
     )
-    parser.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
+    parser.add_argument(
+        "--state-file",
+        type=Path,
+        default=default_state_file(),
+        help=(
+            "Session state file to read. Defaults to ATLAS_SESSION_STATE_FILE, "
+            "then SESSION_STATE.local.md."
+        ),
+    )
     parser.add_argument("--pr", type=int, required=True)
     parser.add_argument("--branch", required=True)
     parser.add_argument("--head-sha", default="")

--- a/scripts/codex_wake_bridge.py
+++ b/scripts/codex_wake_bridge.py
@@ -132,6 +132,8 @@ def build_prompt(
     state = str(status.get("state") or "unknown")
     next_poll = str(status.get("next_poll_at") or "unknown")
     reconciliation_code = status.get("reconciliation_exit_code")
+    session_state_label = session_state or "SESSION_STATE.local.md"
+    session_state_shell = shlex.quote(session_state_label)
 
     lines = [
         "# Atlas Codex Wake Bridge Handoff",
@@ -155,12 +157,12 @@ def build_prompt(
         f"Handoff Markdown: {handoff_md_path}",
         "",
         "Before doing anything:",
-        "1. Read AGENTS.md and SESSION_STATE.local.md.",
+        f"1. Read AGENTS.md and the session state file named above: {session_state_label}.",
         "2. Run `gh pr list --state open`.",
         "3. Run `git log --oneline -15 origin/main`.",
-        "4. Confirm this PR is listed as owned or may-touch in SESSION_STATE.local.md.",
+        "4. Confirm this PR is listed as owned or may-touch in that session state file.",
         "5. Run the ownership guard before any PR mutation:",
-        f"   `python scripts/check_session_pr_ownership.py --pr {pr_number} --branch {branch} --head-sha {head_sha}`",
+        f"   `ATLAS_SESSION_STATE_FILE={session_state_shell} python scripts/check_session_pr_ownership.py --pr {pr_number} --branch {branch} --head-sha {head_sha}`",
         "6. Refresh current checks, review-thread status, live reconciliation, and mergeability.",
         "",
         "Safety boundary: this bridge is a wake/handoff only. It did not poll GitHub,",
@@ -179,7 +181,7 @@ def build_prompt(
             "Scheduled green-confirmation wake:",
             "- This is the only wake class that can proceed to merge consideration.",
             "- Do not trust the watcher alone; run every AGENTS pre-merge guard live.",
-            "- Merge only if SESSION_STATE.local.md records explicit standing merge authorization for this arc.",
+            "- Merge only if that session state file records explicit standing merge authorization for this arc.",
             "- If authorization is absent or any guard is not clean, report readiness or the blocker and stop.",
         ])
     elif wake_kind == "event-attention":
@@ -194,7 +196,7 @@ def build_prompt(
         lines.extend([
             "Pending watcher state:",
             "- Do not start a chat-side polling loop.",
-            "- Record the pending state and next watcher poll in SESSION_STATE.local.md, then stop.",
+            "- Record the pending state and next watcher poll in the session state file, then stop.",
         ])
     elif wake_kind == "closed":
         lines.extend([

--- a/tests/test_check_session_pr_ownership.py
+++ b/tests/test_check_session_pr_ownership.py
@@ -171,3 +171,21 @@ def test_main_accepts_may_touch_pr_when_owned_slot_is_empty(tmp_path, capsys) ->
 
     assert code == 0
     assert "session PR ownership check passed for PR #1189" in capsys.readouterr().out
+
+
+def test_main_reads_session_state_from_env(tmp_path, monkeypatch, capsys) -> None:
+    state_file = tmp_path / "SESSION_STATE.codex-workflow-1982.local.md"
+    state_file.write_text(_state_text(), encoding="utf-8")
+    monkeypatch.setenv("ATLAS_SESSION_STATE_FILE", str(state_file))
+
+    code = guard.main([
+        "--pr",
+        "1189",
+        "--branch",
+        "claude/pr-agents-session-pr-map",
+        "--head-sha",
+        "abc123",
+    ])
+
+    assert code == 0
+    assert "session PR ownership check passed for PR #1189" in capsys.readouterr().out

--- a/tests/test_codex_wake_bridge.py
+++ b/tests/test_codex_wake_bridge.py
@@ -48,7 +48,7 @@ def _write_fixture(
         "REPO_DIR": f'"{repo_dir}"',
         "PR": '"123"',
         "REPO": '"canfieldjuan/ATLAS"',
-        "SESSION_STATE": f'"{repo_dir / "SESSION_STATE.local.md"}"',
+        "SESSION_STATE": f'"{repo_dir / "SESSION_STATE.slice-123.local.md"}"',
         "HEAD_SHA": '"abc123"',
         "POLL_MINUTES": '"30"',
         "AUTO_MERGE": '"0"',
@@ -113,6 +113,8 @@ def test_scheduled_ready_writes_guarded_merge_prompt(tmp_path: Path) -> None:
     assert payload["wake_kind"] == "scheduled-ready"
     assert payload["actionable"] is True
     assert "Scheduled green-confirmation wake" in prompt
+    assert "SESSION_STATE.slice-123.local.md" in prompt
+    assert "ATLAS_SESSION_STATE_FILE=" in prompt
     assert "scripts/check_session_pr_ownership.py --pr 123" in prompt
     assert "explicit standing merge authorization" in prompt
     assert "did not merge anything" in prompt


### PR DESCRIPTION
Plan: plans/PR-Session-Bootstrap-Temporal-Discipline.md
Slice phase: Workflow/process

Refs #1981.

Clarifies the Atlas builder bootstrap so the "passed locally is not green" reminder applies before push, while post-push merge readiness stays with the watcher/operator handoff. It also closes the concurrent-session ambiguity the operator flagged: each active builder now gets its own labeled local state file instead of sharing one mutable `SESSION_STATE.local.md`.

## Intentional

- No CI workflow changes; #1981 found a bootstrap wording contradiction, not a broken gate.
- No new watcher, timer, marker, or state-printer script; Atlas already uses a session-scoped state file plus watcher status as the handoff baton.
- No product-code changes.
- `SESSION_STATE.local.md` remains as a legacy fallback for one-session worktrees; concurrent sessions should use `SESSION_STATE.<session-id>.local.md` and export `ATLAS_SESSION_STATE_FILE`.

## Deferred

- The cross-repo one-shot state helper idea is not adopted for Atlas. Repos without Atlas's handoff machinery can add their own non-polling helper separately.

## Parked hardening

- None.

## Verification

- Ran `scripts/sync_pr_plan.py` against `plans/PR-Session-Bootstrap-Temporal-Discipline.md`
- Ran `scripts/sync_pr_plan.py --check` against `plans/PR-Session-Bootstrap-Temporal-Discipline.md`
- Ran pytest for `tests/test_check_session_pr_ownership.py` and `tests/test_codex_wake_bridge.py` -- 23 passed
- Ran `scripts/check_session_pr_ownership.py` with `ATLAS_SESSION_STATE_FILE=SESSION_STATE.local.md` against #1982
- `git diff --check --cached`
- `bash scripts/push_pr.sh /tmp/pr-session-bootstrap-temporal-discipline.md -u origin HEAD` (body-aware local review)

## Diff size

16 files, +280 / -65
