### PR TITLE
Reddit Fit: configurable response_format (fix local backend vs LM Studio)

### DIFF
--- a/atlas_reddit/config.py
+++ b/atlas_reddit/config.py
@@ -52,6 +52,12 @@ MAX_DORMANT_AFTER_HOURS = 8760
 MAX_FIT_MAX_CALLS_PER_RUN = 500
 MAX_FIT_TIMEOUT_SECONDS = 120.0
 FIT_BACKENDS = ("off", "openrouter", "local")
+# Structured-output strategy sent to the server. Which one a server accepts
+# is a property of the SERVER, not the backend name -- LM Studio requires
+# json_schema or text and rejects json_object; vLLM/OpenRouter take
+# json_schema. The parser is the authoritative gate regardless, so text is
+# always a safe fallback for a server that supports neither.
+FIT_RESPONSE_FORMATS = ("json_schema", "json_object", "text")
 
 _ALLOWED_TOP_KEYS = {
     "version",
@@ -200,6 +206,16 @@ class RedditListeningSettings(BaseSettings):
         ge=1.0,
         le=MAX_FIT_TIMEOUT_SECONDS,
         description="Per-call HTTP timeout for the fit backend.",
+    )
+    fit_response_format: str = Field(
+        default="json_schema",
+        description=(
+            "Structured-output strategy: 'json_schema' (LM Studio, vLLM, "
+            "OpenRouter), 'json_object' (older OpenAI-compatible servers), "
+            "or 'text' (no server-side constraint; the parser still gates). "
+            "Default json_schema is the most widely supported by modern "
+            "local servers."
+        ),
     )
 
 

--- a/atlas_reddit/fit_client.py
+++ b/atlas_reddit/fit_client.py
@@ -25,7 +25,7 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Callable
 
-from .config import FIT_BACKENDS, RedditListeningSettings
+from .config import FIT_BACKENDS, FIT_RESPONSE_FORMATS, RedditListeningSettings
 from .fit import FIT_OUTPUT_JSON_SCHEMA, FitDecision, FitParseError, parse_fit_decision
 
 # A transport is any callable that performs the POST and returns
@@ -87,6 +87,7 @@ class OpenAICompatibleJudgeClient:
         model: str,
         api_key: str,
         timeout_seconds: float,
+        response_format: str = "json_schema",
         transport: Transport | None = None,
     ) -> None:
         self._backend = backend
@@ -94,16 +95,20 @@ class OpenAICompatibleJudgeClient:
         self._model = model
         self._api_key = api_key
         self._timeout = timeout_seconds
+        self._response_format_mode = response_format
         self._transport = transport or _default_transport
 
     @property
     def model_id(self) -> str:
         return self._model
 
-    def _response_format(self) -> dict:
-        # OpenRouter reliably supports strict json_schema; a local server's
-        # support is model-dependent, so default to json_object there.
-        if self._backend == "openrouter":
+    def _response_format(self) -> dict | None:
+        # Which structured-output mode a server accepts is a property of the
+        # SERVER, not the backend name -- LM Studio needs json_schema (or
+        # text) and rejects json_object; vLLM/OpenRouter take json_schema.
+        # text returns None (no server-side constraint); the parser is the
+        # authoritative gate in every mode.
+        if self._response_format_mode == "json_schema":
             return {
                 "type": "json_schema",
                 "json_schema": {
@@ -112,7 +117,9 @@ class OpenAICompatibleJudgeClient:
                     "schema": FIT_OUTPUT_JSON_SCHEMA,
                 },
             }
-        return {"type": "json_object"}
+        if self._response_format_mode == "json_object":
+            return {"type": "json_object"}
+        return None
 
     def judge(self, messages: tuple[dict, ...]) -> tuple[FitDecision | None, FitCallMeta]:
         """Send one prompt, return the parsed decision (or None + a
@@ -120,8 +127,10 @@ class OpenAICompatibleJudgeClient:
         body_obj = {
             "model": self._model,
             "messages": list(messages),
-            "response_format": self._response_format(),
         }
+        response_format = self._response_format()
+        if response_format is not None:
+            body_obj["response_format"] = response_format
         if _REASONING_MODEL_RE.search(self._model):
             body_obj["max_completion_tokens"] = 400
         else:
@@ -197,11 +206,17 @@ def build_judge_client(
         raise RedditFitConfigError(
             "fit_backend=openrouter requires ATLAS_REDDIT_FIT_API_KEY"
         )
+    if settings.fit_response_format not in FIT_RESPONSE_FORMATS:
+        raise RedditFitConfigError(
+            f"invalid fit_response_format {settings.fit_response_format!r}; "
+            f"allowed: {FIT_RESPONSE_FORMATS}"
+        )
     return OpenAICompatibleJudgeClient(
         backend=backend,
         base_url=settings.fit_base_url,
         model=settings.fit_model,
         api_key=api_key,
         timeout_seconds=settings.fit_timeout_seconds,
+        response_format=settings.fit_response_format,
         transport=transport,
     )

--- a/plans/PR-Reddit-Fit-Response-Format.md
+++ b/plans/PR-Reddit-Fit-Response-Format.md
@@ -1,0 +1,116 @@
+# PR-Reddit-Fit-Response-Format
+
+## Why this slice exists
+
+Live testing of the merged v2 fit pass against a local LM Studio server
+found a real integration bug the 562 unit tests could not: the S5 client
+sends `response_format: {"type": "json_object"}` for local backends, but
+LM Studio rejects it with HTTP 400 (`'response_format.type' must be
+'json_schema' or 'text'`). Every local fit call fails. The fake transport
+in the unit suite never spoke LM Studio's dialect, so it passed. This makes
+the local backend -- the whole point of a keyless, offline judge -- unusable
+as shipped.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/reddit-listening/fit-eval
+Slice phase: Production hardening
+
+Root cause: response_format was tied to the BACKEND NAME with a wrong
+assumption ("local servers are model-dependent, default json_object"). Which
+structured-output mode a server accepts is a property of the SERVER, not the
+backend name -- and json_object is in fact *less* supported by modern local
+servers than json_schema.
+
+1. `atlas_reddit/config.py`: `FIT_RESPONSE_FORMATS` constant +
+   `fit_response_format` setting (`json_schema` default | `json_object` |
+   `text`).
+2. `atlas_reddit/fit_client.py`: `_response_format()` is mode-driven (not
+   backend-driven); `text` returns None so the request omits the key
+   entirely; `build_judge_client` validates the mode fail-closed and threads
+   it into the client.
+3. `tests/test_atlas_reddit_fit_client.py`: default is json_schema for both
+   backends; json_object and text modes; invalid mode fails closed.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Default `fit_response_format` is `json_schema` for BOTH local and
+        openrouter (the previously-broken local path now works).
+  - [ ] `json_object` mode sends `{"type": "json_object"}`; `text` mode omits
+        `response_format` from the payload entirely.
+  - [ ] An invalid mode raises `RedditFitConfigError` (fail closed), like the
+        other fit-config validation.
+  - [ ] The parser remains the authoritative gate in every mode (text sends
+        no server constraint yet still parses/validates).
+- Reachability proof (#1952): with `ATLAS_REDDIT_FIT_BACKEND=local` +
+  default json_schema, `judge-fit --eval-cases` against a real LM Studio
+  server returns 16/16 parsed predictions (0 unparsed) -- where the old
+  json_object code returned 16/16 `model_http_error`. Verified live, in
+  Verification below.
+- Affected surfaces: one config field, the client's response_format
+  selection, one test. No store, poller, digest, runner, or Reddit-auth
+  change.
+- Risk areas: back-compat (a server that only supports json_object now needs
+  the explicit setting -- documented; default serves the common case);
+  text-mode payload shape (key omitted, not null).
+- Reviewer rules triggered: R1, R2 (each mode + fail-closed both sides),
+  R11 (zero new dependencies), R12 (test auto-enrolls via the glob), R14
+  (live reachability named above).
+- Test-adapter posture (#1934): unit tests fake the HTTP boundary
+  (injectable transport); the live LM Studio proof is the real integration.
+
+### Files touched
+
+- `atlas_reddit/config.py`
+- `atlas_reddit/fit_client.py`
+- `plans/PR-Reddit-Fit-Response-Format.md`
+- `tests/test_atlas_reddit_fit_client.py`
+
+## Mechanism
+
+`OpenAICompatibleJudgeClient` gains a `response_format` mode. The
+mode-selection helper returns the strict json_schema dict for `json_schema`,
+`{"type": "json_object"}` for `json_object`, and None for `text`; the judge
+call adds the `response_format` key only when non-None, so text mode sends an
+unconstrained request. `build_judge_client` validates
+`settings.fit_response_format` against `FIT_RESPONSE_FORMATS` (fail closed)
+and passes it through. The default `json_schema` is what LM Studio, vLLM and
+OpenRouter all accept.
+
+## Intentional
+
+- **json_schema default, not backend-conditional**: the old backend-name
+  branch was the bug. One default that modern servers accept, overridable
+  for the rare server that needs json_object or neither.
+- **text omits the key**: a server that supports no structured-output mode
+  still works -- the S2 parser validates the content regardless, so text is
+  a safe universal fallback.
+- **Parser stays the only trusted gate**: response_format is a compliance
+  hint, never the validation boundary.
+
+## Deferred
+
+- None. This is a focused fix.
+
+## Verification
+
+- `.venv/bin/python -m pytest tests/test_atlas_reddit_fit_client.py -q`:
+  22 passed (default json_schema both backends; json_object; text-omits-key;
+  invalid fails closed).
+- Full package suite `tests/test_atlas_reddit_*.py -q`: 565 passed.
+- LIVE reachability (real LM Studio, qwen3.6-35b-a3b): `judge-fit
+  --eval-cases` with `ATLAS_REDDIT_FIT_BACKEND=local` (default json_schema)
+  returns 16/16 parsed predictions, 0 unparsed. The pre-fix json_object path
+  returned 16/16 model_http_error.
+- ASCII byte-scan on changed Python files: clean.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_reddit/config.py` | 16 |
+| `atlas_reddit/fit_client.py` | 29 |
+| `plans/PR-Reddit-Fit-Response-Format.md` | 116 |
+| `tests/test_atlas_reddit_fit_client.py` | 31 |
+| **Total** | **192** |

--- a/tests/test_atlas_reddit_fit_client.py
+++ b/tests/test_atlas_reddit_fit_client.py
@@ -149,7 +149,10 @@ def test_request_carries_no_reddit_credentials() -> None:
     assert call["url"] == "https://openrouter.ai/api/v1/chat/completions"
 
 
-def test_openrouter_uses_json_schema_local_uses_json_object() -> None:
+def test_default_response_format_is_json_schema_for_both_backends() -> None:
+    """json_schema is the default for local AND openrouter -- LM Studio,
+    vLLM and OpenRouter all accept it; the old local=json_object default
+    was rejected by LM Studio (400)."""
     or_transport = FakeTransport()
     build_judge_client(_settings(), transport=or_transport).judge(_MESSAGES)
     assert or_transport.calls[0]["payload"]["response_format"]["type"] == "json_schema"
@@ -164,10 +167,32 @@ def test_openrouter_uses_json_schema_local_uses_json_object() -> None:
         ),
         transport=local_transport,
     ).judge(_MESSAGES)
-    fmt = local_transport.calls[0]["payload"]["response_format"]["type"]
-    assert fmt == "json_object"
+    assert local_transport.calls[0]["payload"]["response_format"]["type"] == "json_schema"
     # keyless local: no Authorization header
     assert "Authorization" not in local_transport.calls[0]["headers"]
+
+
+def test_response_format_json_object_mode() -> None:
+    t = FakeTransport()
+    build_judge_client(
+        _settings(fit_response_format="json_object"), transport=t
+    ).judge(_MESSAGES)
+    assert t.calls[0]["payload"]["response_format"] == {"type": "json_object"}
+
+
+def test_response_format_text_mode_omits_the_key() -> None:
+    """text mode sends no server-side constraint -- for servers that support
+    neither json_schema nor json_object; the parser still gates."""
+    t = FakeTransport()
+    build_judge_client(
+        _settings(fit_response_format="text"), transport=t
+    ).judge(_MESSAGES)
+    assert "response_format" not in t.calls[0]["payload"]
+
+
+def test_invalid_response_format_fails_closed() -> None:
+    with pytest.raises(RedditFitConfigError, match="fit_response_format"):
+        build_judge_client(_settings(fit_response_format="yaml"))
 
 
 # -- judge(): failure taxonomy ----------------------------------------------


### PR DESCRIPTION
Plan: plans/PR-Reddit-Fit-Response-Format.md
Slice phase: Production hardening

Live testing of the merged v2 fit pass against a local LM Studio server found a real integration bug the 562 unit tests could not: the S5 client sends `response_format: {"type": "json_object"}` for local backends, but LM Studio rejects it with HTTP 400 (`'response_format.type' must be 'json_schema' or 'text'`). **Every local fit call failed** — the local backend, the whole point of a keyless offline judge, was unusable as shipped. The fake transport in the unit suite never spoke LM Studio's dialect, so CI stayed green.

**Root cause (not the symptom):** response_format was tied to the backend *name* with a wrong assumption ("local servers are model-dependent, default json_object"). Which structured-output mode a server accepts is a property of the *server*, and json_object turned out to be *less* supported by modern local servers than json_schema.

## Fix

- `FIT_RESPONSE_FORMATS` constant + `fit_response_format` setting: `json_schema` (default) | `json_object` | `text`.
- `_response_format` is mode-driven, not backend-driven; `text` returns None so the request omits the key entirely (for a server that supports no structured-output mode — the S2 parser still validates).
- `build_judge_client` validates the mode fail-closed and threads it into the client.
- The parser remains the only trusted gate in every mode; response_format is a compliance hint.

## Intentional

- json_schema default (accepted by LM Studio, vLLM, OpenRouter), overridable for the rare server needing json_object or neither.
- text omits the key rather than sending null — a safe universal fallback.

## Deferred

- None. Focused fix.

## Parked hardening

- None.

## AI reconciliation

No automated-review findings yet at open time; will reconcile per wave.

## Verification

- `.venv/bin/python -m pytest tests/test_atlas_reddit_fit_client.py -q` — 22 passed (default json_schema for BOTH backends; json_object mode; text-omits-key; invalid mode fails closed).
- `.venv/bin/python -m pytest tests/test_atlas_reddit_*.py -q` — 565 passed.
- **LIVE reachability proof (#1952)** — real LM Studio (qwen3.6-35b-a3b), `ATLAS_REDDIT_FIT_BACKEND=local` with default json_schema: `judge-fit --eval-cases` returns 16/16 parsed predictions, **0 unparsed**. The pre-fix json_object path returned 16/16 `model_http_error`. This is the bug fixed, proven against the real server.
- ASCII byte-scan on changed Python files: clean.

## Diff size

4 files, +66 / -10 (code) + plan doc.

Refs #1931.
