### PR TITLE
Codex autonomy wake foundation

### DIFF
--- a/.github/workflows/codex_wake_bridge_checks.yml
+++ b/.github/workflows/codex_wake_bridge_checks.yml
@@ -7,8 +7,12 @@ on:
   pull_request:
     paths:
       - ".github/workflows/codex_wake_bridge_checks.yml"
+      - "scripts/audit_pr_watcher_safety.py"
       - "scripts/codex_wake_bridge.py"
+      - "scripts/install_codex_wake_bridge.py"
+      - "tests/test_audit_pr_watcher_safety.py"
       - "tests/test_codex_wake_bridge.py"
+      - "tests/test_install_codex_wake_bridge.py"
 
 jobs:
   codex-wake-bridge:
@@ -26,4 +30,8 @@ jobs:
       - name: Run wake bridge tests
         run: |
           python -m pip install --quiet pytest pytest-asyncio pyyaml
-          python -m pytest tests/test_codex_wake_bridge.py -q
+          python -m pytest \
+            tests/test_codex_wake_bridge.py \
+            tests/test_install_codex_wake_bridge.py \
+            tests/test_audit_pr_watcher_safety.py \
+            -q

--- a/docs/SESSION_STATE_TEMPLATE.md
+++ b/docs/SESSION_STATE_TEMPLATE.md
@@ -41,6 +41,9 @@ Push/review-event hook: <name and trigger | unavailable | none>
 Timer/poll hook: Claude native 30-minute poll | systemd/cron/webhook name | none
 Wake bridge: Claude native subscription | <external Codex launch/resume bridge> | unavailable | none
 Ready-state handoff: scripts/report_pr_watcher_state.py | <other read-only reporter> | none
+Issue queue: #<issue number or none>
+Operator email: <email or none>
+Deferred decisions issue: #<issue number or none>
 Next timer wake: <timestamp or none>
 Last watcher state: <state/details or none>
 
@@ -102,6 +105,8 @@ Do-NOT-redo: <paths ruled out, checks already green, dead ends>
 - [ ] Confirm `Standing merge authorization` is explicit before the active
       builder merges on a scheduled `ready_for_human_merge` wake; do not infer
       it from watcher state.
+- [ ] At technical forks, choose the durable fix and document it; defer only
+      genuinely operator-owned decisions to the configured issue/email path.
 - [ ] Treat every other open PR as "must not touch" unless the operator
       explicitly reassigns it.
 ```

--- a/docs/autonomous_coding_repo_playbook.md
+++ b/docs/autonomous_coding_repo_playbook.md
@@ -45,6 +45,9 @@ These rules are repo-agnostic:
   clean mergeability, matching expected head SHA, and a clean owned worktree.
 - Red checks and review findings are fixed at the upstream cause, not with a
   symptom patch.
+- Technical forks are not operator menus: take the durable engineering fix,
+  document the reasoning, and keep moving. Defer only decisions that are
+  genuinely business/operator-owned.
 - Tests must prove behavior, including unhappy paths and edge cases.
 
 These rules can live in `AGENTS.md`, `CLAUDE.md`, or a repo-local equivalent.
@@ -135,6 +138,7 @@ Long-running agents need more structure than normal interactive PR work:
 - no merge from a push/review attention wake;
 - scheduled green confirmation before a standing-authorized merge;
 - immediate stop on head-SHA mismatch or dirty owned worktree.
+- a configured queue/notification path before claiming long-horizon autonomy.
 
 If there is no external push/review-event bridge, record it as unavailable. The
 30-minute scheduled watcher is still useful, but the session does not have

--- a/docs/long_running_session_watcher_handoff.md
+++ b/docs/long_running_session_watcher_handoff.md
@@ -101,9 +101,9 @@ as having review-event wake-up coverage.
 
 ## Codex Wake Bridge
 
-The watcher records state; it does not wake Codex by itself. Use
-`scripts/codex_wake_bridge.py` to convert an existing watcher snapshot into a
-resumable handoff:
+The watcher records state; it does not wake Codex by itself. Use the installed
+bridge copy to convert an existing watcher snapshot into a resumable handoff.
+For one-off development checks, the repo script is equivalent:
 
 ```bash
 python scripts/codex_wake_bridge.py "${SESSION_ID}" --source scheduled
@@ -126,13 +126,17 @@ CODEX_WAKE_COMMAND="codex exec -C <repo-dir> -"
 ```
 
 The command receives the generated prompt on stdin. The prompt text is not
-interpolated into a shell command.
+interpolated into a shell command. Do not use no-approval/full-filesystem Codex
+flags in this config unless the watched PR, watcher config, and PR metadata are
+all trusted; watcher-sourced text is treated as untrusted prompt input.
 
 Wake-source rules:
 
 - `--source event` is attention-only. It can wake Codex to inspect review
   activity or a new push, but it must not merge, even if the watcher snapshot is
-  green.
+  green. Pending, ready, review-changed, and failure snapshots are actionable
+  as inspection/fix handoffs only; scheduled green-confirmation is still the
+  only wake source that may proceed to merge consideration after live guards.
 - `--source scheduled` may classify `ready_for_human_merge` as
   `scheduled-ready`, which is only permission to run the AGENTS merge guards.
   The resumed builder still needs explicit standing merge authorization in
@@ -179,6 +183,14 @@ timer can call it with `--source scheduled`.
   unclear.
 - Between watcher wake-ups, do not run an ad hoc `gh` polling loop just to see
   whether CI is green.
+- At a technical fork, take the durable engineering fix that will not break
+  later, document the reasoning in the PR, and keep going. Do not present the
+  shortcut as an equal option. Defer only decisions that are genuinely
+  operator-owned, such as product positioning, customer-facing policy, spend,
+  credentials, production data, irreversible action, scope ownership, or risk
+  tolerance. Deferred operator decisions go to a GitHub issue and notification
+  path in the follow-up slice; they are not a blocking chat-stop when other safe
+  queued work remains.
 
 This protects against the race where checks turn green before late comments or
 review threads land.
@@ -217,42 +229,16 @@ NOTIFY="1"
 EOF
 ```
 
-Install the bridge wrapper and systemd drop-in. The wrapper reads `REPO_DIR`
-from the session config each time it runs, so one systemd template can safely
-serve multiple sessions without baking one worktree path into every timer.
+Install the bridge wrapper, trusted bridge copy, and systemd drop-in through the
+repo-owned installer. The wrapper reads `REPO_DIR` from the session config each
+time it runs, but it invokes the installed bridge copy rather than executing
+`scripts/codex_wake_bridge.py` from the watched PR worktree. One systemd
+template can safely serve multiple sessions without baking one worktree path
+into every timer.
 
 ```bash
-cat > ~/.local/bin/atlas-pr-watch-and-wake <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-session_id="${1:?watcher session id required}"
-config="${HOME}/.config/atlas-pr-watchers/${session_id}.env"
-
-if [ ! -f "$config" ]; then
-  echo "watcher config not found: $config" >&2
-  exit 2
-fi
-
-# shellcheck disable=SC1090
-source "$config"
-
-if [ -z "${REPO_DIR:-}" ] || [ ! -d "$REPO_DIR" ]; then
-  echo "invalid REPO_DIR for ${session_id}: ${REPO_DIR:-}" >&2
-  exit 2
-fi
-
-~/.local/bin/atlas-pr-watch "${session_id}"
-cd "$REPO_DIR"
-python scripts/codex_wake_bridge.py "${session_id}" --source scheduled
-EOF
-chmod +x ~/.local/bin/atlas-pr-watch-and-wake
-
-mkdir -p ~/.config/systemd/user/atlas-pr-watch@.service.d
-cat > ~/.config/systemd/user/atlas-pr-watch@.service.d/wake-bridge.conf <<'EOF'
-[Service]
-ExecStart=
-ExecStart=%h/.local/bin/atlas-pr-watch-and-wake %i
-EOF
+python scripts/install_codex_wake_bridge.py --reload-systemd
+python scripts/install_codex_wake_bridge.py --check
 ```
 
 Run one manual poll through the same wrapper the timer will use:
@@ -319,8 +305,10 @@ New rules to follow:
 - Use `python scripts/codex_wake_bridge.py "${SESSION_ID}" --source event`
   for push/review-event bridges and
   `python scripts/codex_wake_bridge.py "${SESSION_ID}" --source scheduled`
-  after scheduled watcher polls that should wake Codex. Event wakes are always
-  attention-only; scheduled-ready wakes still require live AGENTS guards.
+  after scheduled watcher polls that should wake Codex. Installed systemd
+  wrappers should call the installed bridge copy, not the watched PR worktree's
+  script. Event wakes are always attention-only; scheduled-ready wakes still
+  require live AGENTS guards.
 - A local watcher must poll every 30 minutes and must use AUTO_MERGE="0".
 - Codex/local sessions must run `scripts/report_pr_watcher_state.py` on resume before starting the next slice in a long-running arc.
 - No auto-merge in the watcher. When the watcher reports ready_for_human_merge, the active builder reports readiness and waits for the operator unless this specific arc has explicit active-builder merge authorization.
@@ -361,40 +349,9 @@ NOTIFY="1"
 # CODEX_WAKE_COMMAND="codex exec -C <absolute repo or worktree path> -"
 EOF
 
-cat > ~/.local/bin/atlas-pr-watch-and-wake <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-session_id="${1:?watcher session id required}"
-config="${HOME}/.config/atlas-pr-watchers/${session_id}.env"
-
-if [ ! -f "$config" ]; then
-  echo "watcher config not found: $config" >&2
-  exit 2
-fi
-
-# shellcheck disable=SC1090
-source "$config"
-
-if [ -z "${REPO_DIR:-}" ] || [ ! -d "$REPO_DIR" ]; then
-  echo "invalid REPO_DIR for ${session_id}: ${REPO_DIR:-}" >&2
-  exit 2
-fi
-
-~/.local/bin/atlas-pr-watch "${session_id}"
-cd "$REPO_DIR"
-python scripts/codex_wake_bridge.py "${session_id}" --source scheduled
-EOF
-chmod +x ~/.local/bin/atlas-pr-watch-and-wake
-
-mkdir -p ~/.config/systemd/user/atlas-pr-watch@.service.d
-cat > ~/.config/systemd/user/atlas-pr-watch@.service.d/wake-bridge.conf <<'EOF'
-[Service]
-ExecStart=
-ExecStart=%h/.local/bin/atlas-pr-watch-and-wake %i
-EOF
-
+python scripts/install_codex_wake_bridge.py --reload-systemd
+python scripts/install_codex_wake_bridge.py --check
 ~/.local/bin/atlas-pr-watch-and-wake "${SESSION_ID}"
-systemctl --user daemon-reload
 systemctl --user enable --now "atlas-pr-watch@${SESSION_ID}.timer"
 ```
 

--- a/plans/PR-Codex-Autonomy-Wake-Foundation.md
+++ b/plans/PR-Codex-Autonomy-Wake-Foundation.md
@@ -1,0 +1,135 @@
+# PR-Codex-Autonomy-Wake-Foundation
+
+## Why this slice exists
+
+Issue #1962 is now a living tracker for the autonomous CI/CD operating model.
+The current documented Codex wake bridge can write a handoff and can run an
+operator-provided command, but the local systemd service installed on this
+machine still calls bare `atlas-pr-watch` instead of the documented
+`atlas-pr-watch-and-wake` wrapper. That means the watcher records state but does
+not wake Codex. The same local state also showed a stale timer repeatedly
+failing against a deleted worktree.
+
+Root cause: the bridge contract was documented but not made easy to install or
+verify as repo-owned tooling, and event-source wakes were too broad to be a safe
+autonomous trigger. This slice fixes the root for the first autonomous step:
+make the scheduled watcher capable of launching Codex through a checked wrapper,
+make review/event wakes attention-only, and add tests so the setup cannot drift
+back to "state-only" without being noticed.
+
+Diff budget note: this is over the 400 LOC soft cap because the behavior, its
+installer, its source-aware wake tests, and the safety documentation need to land
+together. Splitting the tests or docs out would recreate the exact
+"documented-but-not-installed" gap this slice fixes.
+
+## Scope (this PR)
+
+Ownership lane: workflow/codex-autonomy
+Slice phase: Workflow/process
+
+1. Add repo tooling that installs/verifies the local
+   `atlas-pr-watch-and-wake` wrapper, trusted bridge copy, and systemd drop-in
+   so the timer runs the watcher and then the installed Codex wake bridge.
+2. Tighten `scripts/codex_wake_bridge.py` event-source classification so event
+   wakes remain attention-only, while scheduled wakes remain the only
+   merge-consideration path.
+3. Document the autonomous decision rule: durable technical fix by default;
+   operator-owned decisions defer to GitHub/email in a later slice instead of
+   becoming chat-stop menus.
+4. Keep this PR below the queue/email continuation boundary.
+
+### Review Contract
+
+Acceptance criteria:
+
+- A reviewer can run the installer in `--check` mode and see whether the local
+  systemd service calls `atlas-pr-watch-and-wake`.
+- The generated wrapper runs `atlas-pr-watch`, then
+  the installed `atlas-codex-wake-bridge --source scheduled` copy rather than
+  executing bridge code out of the watched PR worktree, and never contains merge
+  commands.
+- Event-source bridge wakes are actionable inspection/fix handoffs for pending,
+  ready, review-changed, and failure snapshots, but never grant merge authority.
+- Scheduled `ready_for_human_merge` keeps producing a guarded merge prompt, but
+  the prompt still requires explicit standing authorization and live AGENTS
+  guards.
+- The docs name the "technical fork is not a menu" rule and defer issue-queue
+  plus email notification to the next slice.
+
+Affected surfaces: local Codex watcher setup, wake-bridge classification,
+long-running-session docs, session template.
+
+Risk areas: accidentally granting merge authority to watcher/systemd, making
+review-event wakes unable to respond to real feedback, or breaking the existing
+manual handoff flow.
+
+Triggered reviewer rules: R2 test evidence, R14 codebase verification.
+
+Reachability proof: run the new installer in `--check` mode against fixture
+directories and run `tests/test_codex_wake_bridge.py` to prove event/scheduled
+wake behavior.
+
+### Files touched
+
+- `.github/workflows/codex_wake_bridge_checks.yml`
+- `docs/SESSION_STATE_TEMPLATE.md`
+- `docs/autonomous_coding_repo_playbook.md`
+- `docs/long_running_session_watcher_handoff.md`
+- `plans/PR-Codex-Autonomy-Wake-Foundation.md`
+- `scripts/codex_wake_bridge.py`
+- `scripts/install_codex_wake_bridge.py`
+- `tests/test_codex_wake_bridge.py`
+- `tests/test_install_codex_wake_bridge.py`
+
+## Mechanism
+
+- Add `scripts/install_codex_wake_bridge.py` as a small local-setup tool. In
+  normal mode it writes the wrapper, trusted bridge copy, and systemd drop-in;
+  in `--check` mode it validates the current local files without mutation. Tests
+  use temporary `$HOME`-style directories and never touch real systemd.
+- Update `classify_wake()` so `source=event` preserves immediate
+  push/review-event wakes as attention-only for pending, ready, and review
+  states while still forbidding merge from event wakes.
+- Update the handoff docs and session template so future Codex sessions record
+  issue queue / operator email fields, but this slice does not implement queue
+  selection or email sending yet.
+
+## Intentional
+
+- No watcher merge path is added. The watcher and wrapper remain read-only with
+  respect to GitHub writes.
+- The installer is local tooling, not a GitHub Action. Autonomy depends on the
+  operator's workstation and must be explicit per machine/session.
+- Issue-queue continuation and defer/email notification are intentionally left
+  to the next slice so this PR can first make waking Codex reliable.
+
+## Deferred
+
+- Next slice: issue-queue continuation plus defer-and-email notification for
+  operator-owned decisions.
+- Later slice: optional push/review webhook bridge. This PR only makes the
+  scheduled local systemd path and event-source bridge semantics safe.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_codex_wake_bridge.py tests/test_install_codex_wake_bridge.py tests/test_audit_pr_watcher_safety.py -q` - 43 passed.
+- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - ratchet gate passed.
+- `rm -rf /tmp/atlas-watch-bin /tmp/atlas-watch-systemd && python scripts/install_codex_wake_bridge.py --bin-dir /tmp/atlas-watch-bin --systemd-dir /tmp/atlas-watch-systemd && python scripts/install_codex_wake_bridge.py --check --bin-dir /tmp/atlas-watch-bin --systemd-dir /tmp/atlas-watch-systemd` - install/check smoke passed.
+- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-autonomy-wake-foundation-1962.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-body-codex-autonomy-wake-foundation.md` - local PR review passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/codex_wake_bridge_checks.yml` | 10 |
+| `docs/SESSION_STATE_TEMPLATE.md` | 5 |
+| `docs/autonomous_coding_repo_playbook.md` | 4 |
+| `docs/long_running_session_watcher_handoff.md` | 105 |
+| `plans/PR-Codex-Autonomy-Wake-Foundation.md` | 135 |
+| `scripts/codex_wake_bridge.py` | 13 |
+| `scripts/install_codex_wake_bridge.py` | 174 |
+| `tests/test_codex_wake_bridge.py` | 67 |
+| `tests/test_install_codex_wake_bridge.py` | 217 |
+| **Total** | **730** |

--- a/scripts/codex_wake_bridge.py
+++ b/scripts/codex_wake_bridge.py
@@ -92,7 +92,9 @@ def classify_wake(status: dict[str, Any], *, source: str, status_error: str | No
     if state == "closed":
         return "closed"
     if source == "event":
-        return "event-attention"
+        if state in {"attention", "pending", "ready_for_human_merge", "review_changed"} or _truthy(status.get("review_changed")):
+            return "event-attention"
+        return "event-noop"
     if state == "pending" or _truthy(status.get("check_pending")):
         return "pending"
     if source == "scheduled" and state == "ready_for_human_merge":
@@ -191,6 +193,13 @@ def build_prompt(
             "- Inspect the owned PR for new pushes, review comments, review threads, or reconciliation changes.",
             "- If feedback is actionable, fix the root cause in scope, push with scripts/push_pr.sh, resolve fixed threads, and refresh the watcher head SHA.",
             "- If everything is clean, record readiness and wait for the scheduled green-confirmation wake.",
+        ])
+    elif wake_kind == "event-noop":
+        lines.extend([
+            "Push/review-event no-op wake:",
+            "- Do not merge from this wake.",
+            "- The watcher snapshot has no review/failure attention signal.",
+            "- Record the no-op handoff if useful and wait for the scheduled green-confirmation wake.",
         ])
     elif wake_kind == "pending":
         lines.extend([
@@ -297,7 +306,7 @@ def maybe_run_command(
 
 
 def _valid_watcher_id(watcher_id: str) -> bool:
-    return bool(SAFE_WATCHER_ID_RE.fullmatch(watcher_id))
+    return bool(SAFE_WATCHER_ID_RE.fullmatch(watcher_id)) and ".." not in watcher_id and not watcher_id.startswith(".")
 
 
 def _command_cwd(config: dict[str, str]) -> tuple[Path | None, str | None]:

--- a/scripts/install_codex_wake_bridge.py
+++ b/scripts/install_codex_wake_bridge.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Install or verify the local Codex watcher wake wrapper.
+
+This writes local user files only. The wrapper keeps the watcher read-only:
+it runs the one-shot watcher, then asks the repo bridge to build/run the Codex
+handoff for scheduled wakes.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import stat
+import subprocess
+from typing import Sequence
+
+
+WRAPPER_NAME = "atlas-pr-watch-and-wake"
+BRIDGE_NAME = "atlas-codex-wake-bridge"
+DROPIN_REL = Path("atlas-pr-watch@.service.d") / "wake-bridge.conf"
+BRIDGE_SOURCE = Path(__file__).with_name("codex_wake_bridge.py")
+
+
+def _shell_token(path: Path) -> str:
+    escaped = str(path).replace("'", "'\"'\"'")
+    return f"'{escaped}'"
+
+
+def _wrapper_text(bridge: Path) -> str:
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+session_id="${{1:?watcher session id required}}"
+bridge={_shell_token(bridge)}
+
+if [[ ! "$session_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || [[ "$session_id" == *..* ]]; then
+  echo "invalid watcher id: $session_id" >&2
+  exit 2
+fi
+
+config="${{HOME}}/.config/atlas-pr-watchers/${{session_id}}.env"
+
+if [ ! -f "$config" ]; then
+  echo "watcher config not found: $config" >&2
+  exit 2
+fi
+
+# shellcheck disable=SC1090
+source "$config"
+
+if [ -z "${{REPO_DIR:-}}" ] || [ ! -d "$REPO_DIR" ]; then
+  echo "invalid REPO_DIR for ${{session_id}}: ${{REPO_DIR:-}}" >&2
+  exit 2
+fi
+
+~/.local/bin/atlas-pr-watch "${{session_id}}"
+python "$bridge" "${{session_id}}" --source scheduled
+"""
+
+
+def _bridge_text() -> str:
+    return BRIDGE_SOURCE.read_text(encoding="utf-8")
+
+def _systemd_exec_token(path: Path) -> str:
+    resolved = path.expanduser().resolve(strict=False)
+    escaped = (
+        str(resolved)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("%", "%%")
+    )
+    return f'"{escaped}"'
+
+
+def _dropin_text(wrapper: Path) -> str:
+    return f"""[Service]
+ExecStart=
+ExecStart={_systemd_exec_token(wrapper)} %i
+"""
+
+
+def _write(path: Path, text: str, *, executable: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    if executable:
+        mode = path.stat().st_mode
+        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _matches(path: Path, expected: str, *, executable: bool = False) -> tuple[bool, str]:
+    if not path.exists():
+        return False, f"missing: {path}"
+    try:
+        actual = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return False, f"unreadable {path}: {exc}"
+    if actual != expected:
+        return False, f"content drift: {path}"
+    if executable and not os.access(path, os.X_OK):
+        return False, f"not executable: {path}"
+    return True, f"ok: {path}"
+
+
+def check_install(bin_dir: Path, systemd_dir: Path) -> tuple[bool, list[str]]:
+    wrapper = bin_dir / WRAPPER_NAME
+    bridge = bin_dir / BRIDGE_NAME
+    checks = [
+        _matches(wrapper, _wrapper_text(bridge), executable=True),
+        _matches(bridge, _bridge_text(), executable=True),
+        _matches(systemd_dir / DROPIN_REL, _dropin_text(wrapper)),
+    ]
+    ok = all(item[0] for item in checks)
+    return ok, [item[1] for item in checks]
+
+
+def install(bin_dir: Path, systemd_dir: Path, *, reload_systemd: bool) -> tuple[int, list[str]]:
+    wrapper = bin_dir / WRAPPER_NAME
+    bridge = bin_dir / BRIDGE_NAME
+    dropin = systemd_dir / DROPIN_REL
+    _write(wrapper, _wrapper_text(bridge), executable=True)
+    _write(bridge, _bridge_text(), executable=True)
+    _write(dropin, _dropin_text(wrapper))
+    messages = [f"wrote: {wrapper}", f"wrote: {bridge}", f"wrote: {dropin}"]
+    exit_code = 0
+    if reload_systemd:
+        proc = subprocess.run(
+            ["systemctl", "--user", "daemon-reload"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        messages.append(f"systemctl --user daemon-reload exited {proc.returncode}")
+        exit_code = proc.returncode
+        if proc.stdout.strip():
+            messages.append(proc.stdout.strip())
+        if proc.stderr.strip():
+            messages.append(proc.stderr.strip())
+    return exit_code, messages
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bin-dir", type=Path, default=Path.home() / ".local" / "bin")
+    parser.add_argument(
+        "--systemd-dir",
+        type=Path,
+        default=Path.home() / ".config" / "systemd" / "user",
+    )
+    parser.add_argument("--check", action="store_true", help="verify without writing")
+    parser.add_argument(
+        "--reload-systemd",
+        action="store_true",
+        help="run systemctl --user daemon-reload after installing",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    bin_dir = args.bin_dir.expanduser().resolve(strict=False)
+    systemd_dir = args.systemd_dir.expanduser().resolve(strict=False)
+    if args.check:
+        ok, messages = check_install(bin_dir, systemd_dir)
+        for message in messages:
+            print(message)
+        return 0 if ok else 1
+    exit_code, messages = install(bin_dir, systemd_dir, reload_systemd=args.reload_systemd)
+    for message in messages:
+        print(message)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_codex_wake_bridge.py
+++ b/tests/test_codex_wake_bridge.py
@@ -120,8 +120,14 @@ def test_scheduled_ready_writes_guarded_merge_prompt(tmp_path: Path) -> None:
     assert "did not merge anything" in prompt
 
 
-def test_event_ready_is_attention_only_and_forbids_merge(tmp_path: Path) -> None:
+def test_event_ready_without_attention_is_attention_only_and_forbids_merge(tmp_path: Path) -> None:
     config_dir, state_dir, watcher_id = _write_fixture(tmp_path)
+    receiver = tmp_path / "receiver.py"
+    output = tmp_path / "prompt.txt"
+    receiver.write_text(
+        "from pathlib import Path\nimport sys\nPath(sys.argv[1]).write_text(sys.stdin.read())\n",
+        encoding="utf-8",
+    )
 
     code = bridge.main([
         watcher_id,
@@ -131,6 +137,8 @@ def test_event_ready_is_attention_only_and_forbids_merge(tmp_path: Path) -> None
         str(config_dir),
         "--state-dir",
         str(state_dir),
+        "--run-command",
+        f"{sys.executable} {receiver} {output}",
     ])
 
     assert code == 0
@@ -139,7 +147,41 @@ def test_event_ready_is_attention_only_and_forbids_merge(tmp_path: Path) -> None
     assert payload["actionable"] is True
     assert "Push/review-event attention wake" in prompt
     assert "Do not merge from this wake" in prompt
-    assert "wait for the scheduled green-confirmation wake" in prompt
+    assert output.read_text(encoding="utf-8") == prompt
+
+
+def test_event_review_change_is_attention_only_and_forbids_merge(tmp_path: Path) -> None:
+    config_dir, state_dir, watcher_id = _write_fixture(
+        tmp_path,
+        state="review_changed",
+        extra_status={"review_changed": True},
+    )
+    receiver = tmp_path / "receiver.py"
+    output = tmp_path / "prompt.txt"
+    receiver.write_text(
+        "from pathlib import Path\nimport sys\nPath(sys.argv[1]).write_text(sys.stdin.read())\n",
+        encoding="utf-8",
+    )
+
+    code = bridge.main([
+        watcher_id,
+        "--source",
+        "event",
+        "--config-dir",
+        str(config_dir),
+        "--state-dir",
+        str(state_dir),
+        "--run-command",
+        f"{sys.executable} {receiver} {output}",
+    ])
+
+    assert code == 0
+    payload, prompt = _read_handoff(state_dir, watcher_id)
+    assert payload["wake_kind"] == "event-attention"
+    assert payload["actionable"] is True
+    assert "Push/review-event attention wake" in prompt
+    assert "Do not merge from this wake" in prompt
+    assert output.read_text(encoding="utf-8") == prompt
 
 
 def test_failure_flags_override_scheduled_ready(tmp_path: Path) -> None:
@@ -246,7 +288,7 @@ def test_pending_does_not_run_optional_command_by_default(tmp_path: Path) -> Non
     assert not output.exists()
 
 
-def test_pending_event_source_still_wakes_attention_prompt(tmp_path: Path) -> None:
+def test_pending_event_source_is_attention_only_and_forbids_merge(tmp_path: Path) -> None:
     config_dir, state_dir, watcher_id = _write_fixture(tmp_path, state="pending")
     receiver = tmp_path / "receiver.py"
     output = tmp_path / "prompt.txt"
@@ -368,6 +410,25 @@ def test_rejects_watcher_ids_that_escape_watcher_dirs(tmp_path: Path, capsys) ->
 
     code = bridge.main([
         "../slice-123",
+        "--source",
+        "scheduled",
+        "--config-dir",
+        str(config_dir),
+        "--state-dir",
+        str(state_dir),
+    ])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "invalid watcher id" in captured.err
+    assert not list(state_dir.glob("*.wake.json"))
+
+
+def test_rejects_watcher_ids_with_dotdot_without_slash(tmp_path: Path, capsys) -> None:
+    config_dir, state_dir, _watcher_id = _write_fixture(tmp_path)
+
+    code = bridge.main([
+        "slice..123",
         "--source",
         "scheduled",
         "--config-dir",

--- a/tests/test_install_codex_wake_bridge.py
+++ b/tests/test_install_codex_wake_bridge.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+from unittest import mock
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "install_codex_wake_bridge.py"
+SPEC = importlib.util.spec_from_file_location("install_codex_wake_bridge", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+installer = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = installer
+SPEC.loader.exec_module(installer)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_install_writes_wrapper_and_systemd_dropin(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    systemd_dir = tmp_path / "systemd"
+
+    result = _run("--bin-dir", str(bin_dir), "--systemd-dir", str(systemd_dir))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    wrapper = bin_dir / "atlas-pr-watch-and-wake"
+    bridge = bin_dir / "atlas-codex-wake-bridge"
+    dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
+    wrapper_text = wrapper.read_text(encoding="utf-8")
+    assert wrapper_text == installer._wrapper_text(bridge)
+    assert bridge.read_text(encoding="utf-8") == (ROOT / "scripts" / "codex_wake_bridge.py").read_text(encoding="utf-8")
+    assert dropin.read_text(encoding="utf-8") == installer._dropin_text(wrapper)
+    assert os.access(wrapper, os.X_OK)
+    assert os.access(bridge, os.X_OK)
+    assert "invalid watcher id" in wrapper_text
+    assert "atlas-pr-watch" in wrapper_text
+    assert str(bridge) in wrapper_text
+    assert "scripts/codex_wake_bridge.py" not in wrapper_text
+    assert 'cd "$REPO_DIR"' not in wrapper_text
+    assert "gh pr merge" not in wrapper_text
+    assert "--delete-branch" not in wrapper_text
+    assert f'ExecStart="{wrapper}" %i' in dropin.read_text(encoding="utf-8")
+
+
+def test_check_mode_fails_when_dropin_points_at_default_wrapper_with_custom_bin_dir(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "custom-bin"
+    systemd_dir = tmp_path / "systemd"
+    wrapper = bin_dir / "atlas-pr-watch-and-wake"
+    bridge = bin_dir / "atlas-codex-wake-bridge"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text(installer._wrapper_text(bridge), encoding="utf-8")
+    bridge.write_text(installer._bridge_text(), encoding="utf-8")
+    bridge.chmod(bridge.stat().st_mode | stat.S_IXUSR)
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+    dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
+    dropin.parent.mkdir(parents=True)
+    dropin.write_text(
+        "[Service]\nExecStart=\nExecStart=%h/.local/bin/atlas-pr-watch-and-wake %i\n",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        "--check",
+        "--bin-dir",
+        str(bin_dir),
+        "--systemd-dir",
+        str(systemd_dir),
+    )
+
+    assert result.returncode == 1
+    assert "content drift" in result.stdout
+
+
+def test_dropin_uses_absolute_quoted_wrapper_for_relative_bin_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    bin_dir = Path("relative bin")
+    systemd_dir = tmp_path / "systemd"
+
+    result = _run("--bin-dir", str(bin_dir), "--systemd-dir", str(systemd_dir))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    wrapper = (tmp_path / "relative bin" / "atlas-pr-watch-and-wake").resolve(strict=False)
+    bridge = (tmp_path / "relative bin" / "atlas-codex-wake-bridge").resolve(strict=False)
+    dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
+    assert wrapper.read_text(encoding="utf-8") == installer._wrapper_text(bridge)
+    assert dropin.read_text(encoding="utf-8") == installer._dropin_text(wrapper)
+    assert f'ExecStart="{wrapper}" %i' in dropin.read_text(encoding="utf-8")
+
+
+def test_dropin_with_space_path_is_valid_systemd_execstart(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin with spaces"
+    systemd_dir = tmp_path / "systemd"
+    result = _run("--bin-dir", str(bin_dir), "--systemd-dir", str(systemd_dir))
+    assert result.returncode == 0, result.stdout + result.stderr
+    dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
+    text = dropin.read_text(encoding="utf-8")
+    assert f'ExecStart="{bin_dir / "atlas-pr-watch-and-wake"}" %i' in text
+
+    systemd_analyze = shutil.which("systemd-analyze")
+    if systemd_analyze is None:
+        return
+    unit = tmp_path / "atlas-pr-watch@example.service"
+    unit.write_text(text, encoding="utf-8")
+    verify = subprocess.run(
+        [systemd_analyze, "verify", str(unit)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert verify.returncode == 0, verify.stdout + verify.stderr
+
+
+def test_check_mode_passes_after_install(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    systemd_dir = tmp_path / "systemd"
+    assert _run("--bin-dir", str(bin_dir), "--systemd-dir", str(systemd_dir)).returncode == 0
+
+    result = _run(
+        "--check",
+        "--bin-dir",
+        str(bin_dir),
+        "--systemd-dir",
+        str(systemd_dir),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ok:" in result.stdout
+
+
+def test_check_mode_fails_when_systemd_still_calls_bare_watcher(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    systemd_dir = tmp_path / "systemd"
+    wrapper = bin_dir / "atlas-pr-watch-and-wake"
+    bridge = bin_dir / "atlas-codex-wake-bridge"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text(installer._wrapper_text(bridge), encoding="utf-8")
+    bridge.write_text(installer._bridge_text(), encoding="utf-8")
+    bridge.chmod(bridge.stat().st_mode | stat.S_IXUSR)
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+    dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
+    dropin.parent.mkdir(parents=True)
+    dropin.write_text("[Service]\nExecStart=%h/.local/bin/atlas-pr-watch %i\n", encoding="utf-8")
+
+    result = _run(
+        "--check",
+        "--bin-dir",
+        str(bin_dir),
+        "--systemd-dir",
+        str(systemd_dir),
+    )
+
+    assert result.returncode == 1
+    assert "content drift" in result.stdout
+
+
+def test_check_mode_fails_when_wrapper_is_not_executable(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    systemd_dir = tmp_path / "systemd"
+    wrapper = bin_dir / "atlas-pr-watch-and-wake"
+    bridge = bin_dir / "atlas-codex-wake-bridge"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text(installer._wrapper_text(bridge), encoding="utf-8")
+    bridge.write_text(installer._bridge_text(), encoding="utf-8")
+    bridge.chmod(bridge.stat().st_mode | stat.S_IXUSR)
+    dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
+    dropin.parent.mkdir(parents=True)
+    dropin.write_text(installer._dropin_text(wrapper), encoding="utf-8")
+
+    result = _run(
+        "--check",
+        "--bin-dir",
+        str(bin_dir),
+        "--systemd-dir",
+        str(systemd_dir),
+    )
+
+    assert result.returncode == 1
+    assert "not executable" in result.stdout
+
+
+def test_main_rejects_unknown_argument() -> None:
+    with pytest.raises(SystemExit):
+        installer.main(["--definitely-not-a-real-installer-flag"])
+
+
+def test_reload_systemd_failure_returns_nonzero(tmp_path: Path) -> None:
+    failure = subprocess.CompletedProcess(
+        ["systemctl", "--user", "daemon-reload"],
+        1,
+        stdout="",
+        stderr="no user bus",
+    )
+
+    with mock.patch.object(installer.subprocess, "run", return_value=failure):
+        code, messages = installer.install(
+            tmp_path / "bin",
+            tmp_path / "systemd",
+            reload_systemd=True,
+        )
+
+    assert code == 1
+    assert "systemctl --user daemon-reload exited 1" in messages
+    assert "no user bus" in messages


### PR DESCRIPTION
Plan: plans/PR-Codex-Autonomy-Wake-Foundation.md
Slice phase: Workflow/process

This foundation slice makes the documented Codex wake bridge installable and testable instead of leaving it as a state-only watcher pattern. It adds repo tooling to install/check the local `atlas-pr-watch-and-wake` wrapper plus trusted bridge copy, keeps event-source wakes attention-only, and documents the durable-fix-vs-operator-defer rule for long-horizon autonomy.

Review update: addressed the review threads by validating watcher ids in the shell wrapper before sourcing configs, generating/checking the systemd drop-in from the normalized quoted `--bin-dir` wrapper path, failing non-zero on `--reload-systemd` daemon-reload failure, preserving event-source wakes as attention-only for pending/ready/review states, enrolling the installer plus watcher-safety tests in PR-head CI, installing a trusted bridge copy so scheduled wakes do not execute bridge code from the watched PR worktree, removing unsafe no-approval/full-access command examples, and making relative install paths stable.

## AI reconciliation
AI findings reviewed: yes.
All fixed or waived: yes.
Waivers justified: N/A.

- Fixed Codex P2: installer tests are enrolled in `.github/workflows/codex_wake_bridge_checks.yml` and run against PR-head code.
- Fixed Codex P2: `--reload-systemd` daemon-reload failures now return non-zero.
- Fixed Codex P2: watcher ids are validated in the shell wrapper before any config file is sourced.
- Fixed Codex P2: event-source wakes remain actionable attention-only handoffs for pending/ready/review states and never grant merge authority.
- Fixed Codex P2: handoff docs now match the classifier and no longer claim pending/ready event handoffs are non-actionable.
- Fixed Codex P2: docs no longer recommend no-approval/full-filesystem Codex flags in `CODEX_WAKE_COMMAND`.
- Fixed Codex P1: installed systemd wrapper invokes the trusted installed `atlas-codex-wake-bridge` copy rather than `scripts/codex_wake_bridge.py` from the watched PR worktree.
- Fixed reviewer note: relative `--bin-dir`/`--systemd-dir` values resolve to stable absolute paths before install/check comparison.

## Intentional
- No watcher merge path is added; watcher/systemd remains read-only with respect to GitHub writes.
- Issue-queue continuation and defer/email notification are left for the next slice.
- The PR is over the 400 LOC soft cap because the installer, behavior change, tests, and safety docs need to land together.
- Diff-budget override: this slice is genuinely indivisible because the wake behavior, installer/check tooling, source-aware tests, and safety docs must land together to avoid recreating the documented-but-not-installed gap.

## Deferred
- Next slice: issue-queue continuation plus defer-and-email notification for operator-owned decisions.
- Later slice: optional push/review webhook bridge.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_codex_wake_bridge.py tests/test_install_codex_wake_bridge.py tests/test_audit_pr_watcher_safety.py -q` - 43 passed.
- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - ratchet gate passed.
- `rm -rf /tmp/atlas-watch-bin /tmp/atlas-watch-systemd && python scripts/install_codex_wake_bridge.py --bin-dir /tmp/atlas-watch-bin --systemd-dir /tmp/atlas-watch-systemd && python scripts/install_codex_wake_bridge.py --check --bin-dir /tmp/atlas-watch-bin --systemd-dir /tmp/atlas-watch-systemd` - install/check smoke passed.
- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-autonomy-wake-foundation-1962.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-body-codex-autonomy-wake-foundation.md` - local PR review passed.

## Diff size
9 files, 730 LOC. Over soft cap with rationale in the plan and explicit diff-budget override above.
