### PR TITLE
Codify the PR reconstruction protocol as the mandatory review method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -881,16 +881,18 @@ go in the §2a template.
 
 **Reconstruct the PR independently from the diff -- never review it against its
 description** (`docs/PR_RECONSTRUCTION_PROTOCOL.md`, mandatory for every review).
-Build two INDEPENDENT reconstructions, then compare them:
+Build two INDEPENDENT reconstructions, then compare them. They are independent,
+not sequential: derive (2) purely from the problem, never from the diff, so the
+diff cannot anchor it (the challenger pass -- easiest if you derive it before
+opening the diff, but the binding requirement is only that the diff never shapes
+it).
 
 1. **What the diff actually does** -- read the diff alone and state it change by
    change, in your own words. The code is ground truth; the description, commit,
    and title are unverified claims.
 2. **What a correct fix should do** -- from the problem and the Review Contract
-   alone, derive which files *should* change and which tests *should* exist,
-   without letting the diff shape the answer. This is the **challenger pass**:
-   do it before the builder's confident narrative -- and ideally before the
-   diff -- anchors you into believing the story.
+   alone (the challenger pass), derive which files *should* change and which
+   tests *should* exist, never letting the diff shape the answer.
 3. **Compare** those two against what the description claims and report every
    gap: diff != description; diff != correct fix (wrong / incomplete / symptom
    patch); diff changes unmentioned things.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1157,9 +1157,14 @@ Read AUDITOR_PROMPT.md for the cross-cutting audit checks
 
 For each PR you review:
 
-1. Challenger pass first: read the Review Contract, predict which
-   files and tests should exist, THEN open the diff. Do not anchor
-   on the builder's summary.
+1. Reconstruct independently (`docs/PR_RECONSTRUCTION_PROTOCOL.md`,
+   mandatory): build two independent reconstructions -- what a correct
+   fix should do (from the Review Contract and problem, never shaped by
+   the diff) and what the diff actually does (read the diff alone) --
+   then report every gap (diff != description; diff != correct fix; diff
+   changes unmentioned things), cited `file:line`, sorted confirmed /
+   contradicted / could-not-determine, gaps first. Do not anchor on the
+   builder's summary.
 2. Reproduce the named verification commands from the PR body.
    Don't trust claims; re-run them. Spot-check the plan's
    invariants at the actual file:line cited in the diff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -873,6 +873,18 @@ go in the §2a template.
 
 ### 4a. Independent verification
 
+**Reconstruct the PR independently from the diff -- never review it against its
+description** (`docs/PR_RECONSTRUCTION_PROTOCOL.md`, mandatory for every review):
+(1) read the diff alone and state what it actually does, change by change, in
+your own words -- the code is ground truth, the description/commit/title are
+unverified claims; (2) from the problem alone, derive what a correct fix would
+need to touch and change, without letting the diff shape the answer; (3) report
+every gap between what the diff does, what a correct fix should do, and what the
+description claims (diff != description; diff != correct fix; diff changes
+unmentioned things); (4) cite `file:line` for every claim, sort each into
+confirmed / contradicted / could-not-determine (never confirmed without a
+citation), and lead with the gaps.
+
 Run a **challenger pass first, before reading the builder's summary** -- the
 builder's confident narrative anchors you into believing the story. In order:
 read the Review Contract, predict which files *should* change and which tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,12 @@ The reviewer should produce something like:
 ```
 **Reviewed head:** `<sha from checked-out PR head>`
 
+**Reconstruction (gaps first, per docs/PR_RECONSTRUCTION_PROTOCOL.md):**
+- Gaps: <diff != description / diff != correct fix / diff changes unmentioned
+  things>, each cited `file:line`.
+- Confirmed: <finding + citation>. Contradicted: <finding + citation>.
+  Could-not-determine: <finding + why unresolved>.
+
 **Verification (independent):**
 1. <claim from PR description> -- verified via <command>
 2. <invariant from Mechanism> -- confirmed at <file:line>
@@ -874,21 +880,23 @@ go in the §2a template.
 ### 4a. Independent verification
 
 **Reconstruct the PR independently from the diff -- never review it against its
-description** (`docs/PR_RECONSTRUCTION_PROTOCOL.md`, mandatory for every review):
-(1) read the diff alone and state what it actually does, change by change, in
-your own words -- the code is ground truth, the description/commit/title are
-unverified claims; (2) from the problem alone, derive what a correct fix would
-need to touch and change, without letting the diff shape the answer; (3) report
-every gap between what the diff does, what a correct fix should do, and what the
-description claims (diff != description; diff != correct fix; diff changes
-unmentioned things); (4) cite `file:line` for every claim, sort each into
-confirmed / contradicted / could-not-determine (never confirmed without a
-citation), and lead with the gaps.
+description** (`docs/PR_RECONSTRUCTION_PROTOCOL.md`, mandatory for every review).
+Build two INDEPENDENT reconstructions, then compare them:
 
-Run a **challenger pass first, before reading the builder's summary** -- the
-builder's confident narrative anchors you into believing the story. In order:
-read the Review Contract, predict which files *should* change and which tests
-*should* exist, *then* open the diff.
+1. **What the diff actually does** -- read the diff alone and state it change by
+   change, in your own words. The code is ground truth; the description, commit,
+   and title are unverified claims.
+2. **What a correct fix should do** -- from the problem and the Review Contract
+   alone, derive which files *should* change and which tests *should* exist,
+   without letting the diff shape the answer. This is the **challenger pass**:
+   do it before the builder's confident narrative -- and ideally before the
+   diff -- anchors you into believing the story.
+3. **Compare** those two against what the description claims and report every
+   gap: diff != description; diff != correct fix (wrong / incomplete / symptom
+   patch); diff changes unmentioned things.
+4. **Cite `file:line` for every claim**, sort each into confirmed /
+   contradicted / could-not-determine (never confirmed without a citation), and
+   lead with the gaps (record them in the §2a template's Reconstruction block).
 
 Don't trust the PR description's claims; reproduce them. The
 reviewer should:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -896,9 +896,11 @@ it).
 3. **Compare** those two against what the description claims and report every
    gap: diff != description; diff != correct fix (wrong / incomplete / symptom
    patch); diff changes unmentioned things.
-4. **Cite `file:line` for every claim**, sort each into confirmed /
-   contradicted / could-not-determine (never confirmed without a citation), and
-   lead with the gaps (record them in the §2a template's Reconstruction block).
+4. **Cite checkable evidence for every claim**: `file:line` for code/content
+   claims, or a named non-file artifact such as command output, CI run/job,
+   generated artifact, or PR metadata. Sort each into confirmed / contradicted /
+   could-not-determine (never confirmed without evidence), and lead with the
+   gaps (record them in the §2a template's Reconstruction block).
 
 Don't trust the PR description's claims; reproduce them. The
 reviewer should:

--- a/docs/PR_RECONSTRUCTION_PROTOCOL.md
+++ b/docs/PR_RECONSTRUCTION_PROTOCOL.md
@@ -1,10 +1,12 @@
 # PR Reconstruction Protocol
 
 Every PR review **reconstructs the PR independently from the diff**. Never
-review a PR against its description. This binds every reviewer that reads this
-contract -- human Claude sessions and the Codex/reconciliation review gate. (No
-automated CI review action exists in the repo today; when one is added, wire it
-to this protocol then.)
+review a PR against its description. This binds every reviewer session that
+reads this contract -- the human/Claude builder and reviewer sessions. External
+review bots (Codex) are advisory inputs, not bound by it; the CI reconciliation
+gate (`ai_reconciliation_live.yml`) is a mechanical bot-finding comparison, not
+a reviewer; and no automated CI review action that would follow this protocol
+exists in the repo today. When one is added, wire it to this protocol then.
 
 ## Why
 

--- a/docs/PR_RECONSTRUCTION_PROTOCOL.md
+++ b/docs/PR_RECONSTRUCTION_PROTOCOL.md
@@ -1,0 +1,47 @@
+# PR Reconstruction Protocol
+
+Every PR review **reconstructs the PR independently from the diff**. Never
+review a PR against its description. This applies to all reviewers -- human
+Claude sessions, Codex, and the CI review action.
+
+## Why
+
+Reviewing off the description reproduces the author's framing and misses where
+the diff diverges from a correct fix. The description, commit message, and title
+are unverified claims; the code is ground truth.
+
+Exemplar (Atlas #1999, 2026-07-04): a review posted a `BLOCKER` plus "six
+blocking findings" read off the PR description and stale bot thread-titles. The
+head code had already resolved every one of them. Reconstructing from the diff
+caught the error before it stuck.
+
+## The protocol (in order)
+
+1. **Read the diff alone.** State what it actually does, change by change, in
+   your own words. Do not read intent off the description, commit message, or
+   title -- the code is ground truth, everything else is an unverified claim.
+
+2. **Derive the correct fix from the problem alone.** From the problem the PR
+   says it solves, derive what a correct fix would need to touch and change --
+   without letting the diff shape the answer.
+
+3. **Compare three things** -- what the diff does, what a correct fix should do,
+   and what the description claims -- and report **every** gap between any two:
+   - the diff does not match its description;
+   - the diff does not match a correct fix (wrong, incomplete, or symptom patch);
+   - the diff changes things the description never mentions.
+
+4. **Cite file and line for every claim.** Sort each finding into
+   **confirmed / contradicted / could-not-determine**. Never mark a finding
+   confirmed without a citation. **Lead with the gaps, not a summary.** Post
+   findings inline on the changed line; use the review body (with a `file:line`
+   reference) only for out-of-diff lines.
+
+## Composition
+
+- Run this before, and feed it into, the §4a independent-verification pass and
+  the `docs/REVIEWER_RULES.md` rule walk (R1-R14 -> BLOCKER / MAJOR / NIT).
+- Apply the vertical-progress lens in the same pass: is the slice a vertical
+  MVP step, or harness/hardening/polish drift that defers the core?
+- This is the strict-review form of "no evidence lifted from prose": no verdict
+  claim survives without a checked-out `file:line` behind it.

--- a/docs/PR_RECONSTRUCTION_PROTOCOL.md
+++ b/docs/PR_RECONSTRUCTION_PROTOCOL.md
@@ -19,7 +19,12 @@ blocking findings" read off the PR description and stale bot thread-titles. The
 head code had already resolved every one of them. Reconstructing from the diff
 caught the error before it stuck.
 
-## The protocol (in order)
+## The Protocol
+
+Build two independent reconstructions, then compare them. They are independent,
+not sequential: derive the correct-fix reconstruction from the problem before
+or separately from the diff so the diff cannot anchor it. The reporting order
+below is for the final review write-up, not the investigation order.
 
 1. **Read the diff alone.** State what it actually does, change by change, in
    your own words. Do not read intent off the description, commit message, or
@@ -35,11 +40,14 @@ caught the error before it stuck.
    - the diff does not match a correct fix (wrong, incomplete, or symptom patch);
    - the diff changes things the description never mentions.
 
-4. **Cite file and line for every claim.** Sort each finding into
-   **confirmed / contradicted / could-not-determine**. Never mark a finding
-   confirmed without a citation. **Lead with the gaps, not a summary.** Post
-   findings inline on the changed line; use the review body (with a `file:line`
-   reference) only for out-of-diff lines.
+4. **Cite checkable evidence for every claim.** For code or content claims,
+   cite `file:line`. For non-file evidence, cite the named artifact: command
+   output, CI run/job, generated artifact, PR metadata, or another inspectable
+   source. Sort each finding into **confirmed / contradicted /
+   could-not-determine**. Never mark a finding confirmed without checkable
+   evidence. **Lead with the gaps, not a summary.** Post findings inline on the
+   changed line when the evidence lives in the diff; use the review body for
+   out-of-diff lines and non-file evidence.
 
 ## Composition
 
@@ -48,4 +56,4 @@ caught the error before it stuck.
 - Apply the vertical-progress lens in the same pass: is the slice a vertical
   MVP step, or harness/hardening/polish drift that defers the core?
 - This is the strict-review form of "no evidence lifted from prose": no verdict
-  claim survives without a checked-out `file:line` behind it.
+  claim survives without checkable evidence behind it.

--- a/docs/PR_RECONSTRUCTION_PROTOCOL.md
+++ b/docs/PR_RECONSTRUCTION_PROTOCOL.md
@@ -1,8 +1,10 @@
 # PR Reconstruction Protocol
 
 Every PR review **reconstructs the PR independently from the diff**. Never
-review a PR against its description. This applies to all reviewers -- human
-Claude sessions, Codex, and the CI review action.
+review a PR against its description. This binds every reviewer that reads this
+contract -- human Claude sessions and the Codex/reconciliation review gate. (No
+automated CI review action exists in the repo today; when one is added, wire it
+to this protocol then.)
 
 ## Why
 

--- a/plans/PR-Reconstruction-Protocol.md
+++ b/plans/PR-Reconstruction-Protocol.md
@@ -53,11 +53,14 @@ names the protocol mandatory and links the doc. No code paths change.
 
 ## Intentional
 
-- Codified in the repo (not only in a session memory) so it reaches Codex and
-  the reconciliation gate, not just one session lineage. (No automated CI review
-  action exists in the repo today; wiring one is a when-added follow-up.)
-  Session-local layers (operator memory, global reviewer rules) mirror it for
-  redundancy but the repo doc is the canonical source.
+- Codified in the repo (not only in a session memory) so it binds every reviewer
+  session that reads the contract -- including a fresh session pasting the §8
+  reseed prompt -- not just one session lineage. (External Codex/bots are
+  advisory inputs, not bound; the CI reconciliation gate is a mechanical
+  bot-comparison, not a reviewer; no automated CI review action exists today,
+  and wiring one is a when-added follow-up.) Session-local layers (operator
+  memory, global reviewer rules) mirror it for redundancy but the repo doc is
+  the canonical source.
 
 ## Deferred
 
@@ -74,7 +77,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `AGENTS.md` | 30 |
+| `AGENTS.md` | 41 |
 | `docs/PR_RECONSTRUCTION_PROTOCOL.md` | 51 |
-| `plans/PR-Reconstruction-Protocol.md` | 80 |
-| **Total** | **161** |
+| `plans/PR-Reconstruction-Protocol.md` | 83 |
+| **Total** | **175** |

--- a/plans/PR-Reconstruction-Protocol.md
+++ b/plans/PR-Reconstruction-Protocol.md
@@ -17,18 +17,19 @@ Ownership lane: workflow/process
 Slice phase: Workflow/process
 
 1. Add `docs/PR_RECONSTRUCTION_PROTOCOL.md` -- the canonical 4-step protocol
-   (read the diff alone; derive the correct fix from the problem alone; report
-   every gap; cite file:line, sort confirmed/contradicted/could-not-determine,
-   gaps first).
+   (independently reconstruct what the diff does and what a correct fix should
+   do; report every gap; cite checkable evidence, sort
+   confirmed/contradicted/could-not-determine, gaps first).
 2. Make it mandatory in the reviewer workflow by referencing it at the head of
    `AGENTS.md` §4a (Independent verification).
 
 ### Review Contract
 
 - Acceptance criteria:
-  - [ ] `docs/PR_RECONSTRUCTION_PROTOCOL.md` states the 4 ordered steps and the
-        confirmed/contradicted/could-not-determine sorting with file:line
-        citations and gaps-first ordering.
+  - [ ] `docs/PR_RECONSTRUCTION_PROTOCOL.md` states the 4-step protocol without
+        making diff-reading the required first investigation step, and requires
+        confirmed/contradicted/could-not-determine sorting with checkable
+        evidence and gaps-first ordering.
   - [ ] `AGENTS.md` §4a names the protocol as mandatory for every review and
         links the doc.
   - [ ] Docs-only change; no code, config, migration, or test touched.
@@ -72,12 +73,13 @@ Parked hardening: none.
 
 - `scripts/audit_plan_doc.py` on this plan -- OK.
 - `git diff --name-status` -- one new doc + `AGENTS.md` + this plan; no code.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-body-reconstruction-protocol.md`
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `AGENTS.md` | 41 |
-| `docs/PR_RECONSTRUCTION_PROTOCOL.md` | 51 |
-| `plans/PR-Reconstruction-Protocol.md` | 83 |
-| **Total** | **175** |
+| `AGENTS.md` | 43 |
+| `docs/PR_RECONSTRUCTION_PROTOCOL.md` | 59 |
+| `plans/PR-Reconstruction-Protocol.md` | 85 |
+| **Total** | **187** |

--- a/plans/PR-Reconstruction-Protocol.md
+++ b/plans/PR-Reconstruction-Protocol.md
@@ -5,7 +5,7 @@
 Reviews that trust the PR description reproduce the author's framing and miss
 where the diff diverges from a correct fix. This codifies the independent
 reconstruction method as the mandatory review protocol so it applies to every
-reviewer -- human Claude sessions and the Codex/reconciliation gate -- and
+reviewer -- the human/Claude builder and reviewer sessions (Codex/bots are advisory inputs, not bound; the reconciliation gate is a mechanical bot-comparison) -- and
 survives compactions and new sessions. Exemplar: on #1999 a review posted a
 BLOCKER + "six blocking findings" read off the description and stale bot
 thread-titles that the head code had already resolved; reconstructing from the
@@ -74,7 +74,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `AGENTS.md` | 28 |
-| `docs/PR_RECONSTRUCTION_PROTOCOL.md` | 49 |
+| `AGENTS.md` | 30 |
+| `docs/PR_RECONSTRUCTION_PROTOCOL.md` | 51 |
 | `plans/PR-Reconstruction-Protocol.md` | 80 |
-| **Total** | **157** |
+| **Total** | **161** |

--- a/plans/PR-Reconstruction-Protocol.md
+++ b/plans/PR-Reconstruction-Protocol.md
@@ -1,0 +1,79 @@
+# PR-Reconstruction-Protocol
+
+## Why this slice exists
+
+Reviews that trust the PR description reproduce the author's framing and miss
+where the diff diverges from a correct fix. This codifies the independent
+reconstruction method as the mandatory review protocol so it applies to every
+reviewer -- human Claude sessions, Codex, and the CI review action -- and
+survives compactions and new sessions. Exemplar: on #1999 a review posted a
+BLOCKER + "six blocking findings" read off the description and stale bot
+thread-titles that the head code had already resolved; reconstructing from the
+diff caught it.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Add `docs/PR_RECONSTRUCTION_PROTOCOL.md` -- the canonical 4-step protocol
+   (read the diff alone; derive the correct fix from the problem alone; report
+   every gap; cite file:line, sort confirmed/contradicted/could-not-determine,
+   gaps first).
+2. Make it mandatory in the reviewer workflow by referencing it at the head of
+   `AGENTS.md` §4a (Independent verification).
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `docs/PR_RECONSTRUCTION_PROTOCOL.md` states the 4 ordered steps and the
+        confirmed/contradicted/could-not-determine sorting with file:line
+        citations and gaps-first ordering.
+  - [ ] `AGENTS.md` §4a names the protocol as mandatory for every review and
+        links the doc.
+  - [ ] Docs-only change; no code, config, migration, or test touched.
+- Reachability proof: N/A -- docs/process-only change with no runtime, UI,
+  report, billing, or public-contract surface. Proof is the rendered doc + the
+  AGENTS.md reference.
+- Affected surfaces: the reviewer contract (`AGENTS.md`) and a new docs file.
+- Risk areas: none (documentation); the protocol composes with, and does not
+  replace, `docs/REVIEWER_RULES.md` (R1-R14) or §4a's existing challenger pass.
+- Reviewer rules triggered: R1.
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/PR_RECONSTRUCTION_PROTOCOL.md`
+- `plans/PR-Reconstruction-Protocol.md`
+
+## Mechanism
+
+A new markdown doc plus a paragraph inserted at the top of `AGENTS.md` §4a that
+names the protocol mandatory and links the doc. No code paths change.
+
+## Intentional
+
+- Codified in the repo (not only in a session memory) so it reaches Codex and
+  the CI review action, not just one session lineage. Session-local layers
+  (operator memory, global reviewer rules) mirror it for redundancy but the
+  repo doc is the canonical source.
+
+## Deferred
+
+- None.
+
+Parked hardening: none.
+
+## Verification
+
+- `scripts/audit_plan_doc.py` on this plan -- OK.
+- `git diff --name-status` -- one new doc + `AGENTS.md` + this plan; no code.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 12 |
+| `docs/PR_RECONSTRUCTION_PROTOCOL.md` | 47 |
+| `plans/PR-Reconstruction-Protocol.md` | 79 |
+| **Total** | **138** |

--- a/plans/PR-Reconstruction-Protocol.md
+++ b/plans/PR-Reconstruction-Protocol.md
@@ -5,7 +5,7 @@
 Reviews that trust the PR description reproduce the author's framing and miss
 where the diff diverges from a correct fix. This codifies the independent
 reconstruction method as the mandatory review protocol so it applies to every
-reviewer -- human Claude sessions, Codex, and the CI review action -- and
+reviewer -- human Claude sessions and the Codex/reconciliation gate -- and
 survives compactions and new sessions. Exemplar: on #1999 a review posted a
 BLOCKER + "six blocking findings" read off the description and stale bot
 thread-titles that the head code had already resolved; reconstructing from the
@@ -54,9 +54,10 @@ names the protocol mandatory and links the doc. No code paths change.
 ## Intentional
 
 - Codified in the repo (not only in a session memory) so it reaches Codex and
-  the CI review action, not just one session lineage. Session-local layers
-  (operator memory, global reviewer rules) mirror it for redundancy but the
-  repo doc is the canonical source.
+  the reconciliation gate, not just one session lineage. (No automated CI review
+  action exists in the repo today; wiring one is a when-added follow-up.)
+  Session-local layers (operator memory, global reviewer rules) mirror it for
+  redundancy but the repo doc is the canonical source.
 
 ## Deferred
 
@@ -73,7 +74,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `AGENTS.md` | 12 |
-| `docs/PR_RECONSTRUCTION_PROTOCOL.md` | 47 |
-| `plans/PR-Reconstruction-Protocol.md` | 79 |
-| **Total** | **138** |
+| `AGENTS.md` | 28 |
+| `docs/PR_RECONSTRUCTION_PROTOCOL.md` | 49 |
+| `plans/PR-Reconstruction-Protocol.md` | 80 |
+| **Total** | **157** |


### PR DESCRIPTION
Plan: plans/PR-Reconstruction-Protocol.md
Slice phase: Workflow/process

Codifies the independent **PR reconstruction protocol** as the mandatory review
method, so every reviewer -- human Claude sessions and the reviewer sessions that read the review contract (Codex/bots are advisory; the reconciliation CI is a mechanical bot-comparison; no automated CI review action exists yet).
Survives compactions and new sessions because it lives in the repo review
contract.

Adds `docs/PR_RECONSTRUCTION_PROTOCOL.md` (independently reconstruct what the
diff does and what a correct fix should do; report every gap; cite checkable
evidence; sort confirmed/contradicted/could-not-determine; lead with gaps) and
references it at the head of `AGENTS.md` section 4a.

## Intentional
- Repo-level codification so it reaches Codex + the CI action, not one session.
  Operator memory and global reviewer rules mirror it for redundancy; this doc
  is canonical.
- Composes with (does not replace) `docs/REVIEWER_RULES.md` (R1-R14) and section
  4a's existing challenger pass.

## Deferred
- None.

## Parked hardening
- None.

## AI reconciliation
AI findings reviewed: yes.
All fixed or waived: yes.
Waivers justified: N/A.

- Fixed Codex P2: `docs/PR_RECONSTRUCTION_PROTOCOL.md` no longer makes
  diff-reading the required first investigation step; it matches `AGENTS.md`
  §4a's independent, non-sequential reconstruction requirement.
- Fixed Codex P2 + reviewer confirmation: the protocol and `AGENTS.md` now
  require checkable evidence, with `file:line` for code/content claims and
  named non-file artifacts for CI, command output, generated artifacts, and PR
  metadata.
- Fixed Codex P2: `plans/PR-Reconstruction-Protocol.md` now records the
  required `local_pr_review.sh` verification gate.

## Verification
- `scripts/audit_plan_doc.py` on the plan -- OK; plan/code consistency OK (all
  path claims resolve); ASCII gate OK.
- Docs-only: `git diff --name-status` shows one new doc + `AGENTS.md` + the plan.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-body-reconstruction-protocol.md`

## Diff size
3 files, +168 / -7 (187 LOC estimated; docs only).
