### PR TITLE
Codify reconstruction-aware builder rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,15 @@ If the plan changes mid-implementation (you discovered something the
 plan missed), update the plan doc in the same commit. The plan and
 code ship together.
 
+Code for independent reconstruction
+(`docs/CODING_FOR_RECONSTRUCTION_REVIEW.md`). Before opening or updating a PR,
+check the three-way match yourself: what the diff actually does, what a correct
+fix for the stated problem should do, and what the PR body claims. If the diff
+changes unmentioned behavior, either split it out or name it plainly in the
+plan/PR body. If the correct fix needs more than this slice does, name the
+bounded deferral. Do not inflate the description to make the diff look larger
+than it is.
+
 ### 3a.1. Session ownership map
 
 Every builder session must maintain its own local session-state file at the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1129,6 +1129,10 @@ PR independently). The full contract lives in `AGENTS.md`; the highlights:
   halting until the operator notices green. See `AGENTS.md` §3c.1.
 - **Reviewer verdicts:** `BLOCKER` / `MAJOR` / `NIT` / `LGTM`. Reviewer
   reproduces the builder's verification commands; doesn't trust claims.
+- **Code for reconstruction review.** While building, follow
+  `docs/CODING_FOR_RECONSTRUCTION_REVIEW.md`: start from the correct-fix shape,
+  keep the diff self-explaining, test real behavior, and make the PR body a
+  receipt rather than a shield.
 - **No "while I was here" cleanups.** Plan and implementation ship together;
   off-scope changes go to a follow-up slice (added to *Deferred*).
 
@@ -1141,6 +1145,7 @@ Companion docs:
 - `CANONICAL.md` — which implementation is the real one
 - `INTEGRATION_MAP.md` — what's wired to what
 - `docs/CURRENT_PRODUCT_DISCIPLINE.md` — vertical-first discipline, hardening parking, and product-shape consent
+- `docs/CODING_FOR_RECONSTRUCTION_REVIEW.md` — builder rules for coding when the reviewer will reconstruct the diff independently
 - `BUILD_SPEC.md` — deprecated historical context; not current roadmap/DoD
 - `CONTEXT.md` — historical/session notes and known debt; verify before using as current product state
 
@@ -1379,6 +1384,10 @@ Compose files for sub-services:
   hard-code domain prompts inline.
 - **Plans are mandatory** for non-trivial PRs (see *Multi-Session PR
   Workflow* above). No code without a plan doc.
+- **Code for reconstruction review**: start from the problem and correct-fix
+  shape, keep every touched file tied to that shape, test behavior with real
+  adapters where available, and make the PR description match the diff exactly.
+  See `docs/CODING_FOR_RECONSTRUCTION_REVIEW.md`.
 - **Root cause, not symptoms**: a fix names the underlying problem and
   addresses it, not the surface symptom or a reviewer's exact wording. A change
   that fights another stage (split-then-remerge, widen-then-filter,

--- a/docs/CODING_FOR_RECONSTRUCTION_REVIEW.md
+++ b/docs/CODING_FOR_RECONSTRUCTION_REVIEW.md
@@ -1,0 +1,62 @@
+# Coding For Reconstruction Review
+
+These are builder rules. They describe how to write code when the PR will be
+reviewed by reconstructing the diff independently instead of trusting the PR
+description.
+
+The goal is not to game review. The goal is to make the code, tests, plan, and
+PR body tell the same truth.
+
+## Builder Rules
+
+1. **Start from the problem, not the patch.** Before coding, write the correct
+   fix shape in the plan: what must become true, what surfaces likely need to
+   change, what tests should prove it, and what is explicitly out of scope.
+
+2. **Make the diff explain itself.** A reviewer reading only the diff should be
+   able to tell what changed. Prefer clear names, direct control flow, and tests
+   that exercise the real path over clever glue that needs PR-body narration.
+
+3. **Keep scope visible.** Every touched file must map to the stated problem or
+   to verification for that problem. If the work uncovers another behavior
+   change, either add the shipped behavior to Scope/Mechanism and the PR body,
+   or split it out and name only the follow-up work in Deferred.
+
+4. **Fix the upstream cause.** Do not patch the child symptom just because it is
+   the line the reviewer or CI noticed. If the root is broader than this slice,
+   fix the correct bounded layer and name the remaining upstream work.
+
+5. **Test the behavior, not the story.** Add the happy path and the edge case
+   that would expose the bug or contract drift. Use real local adapters when
+   they exist; mock only external boundaries such as third-party network APIs,
+   wall-clock time, randomness, or paid external services.
+
+6. **Make the PR description a receipt.** The PR body describes exactly what the
+   diff does and what the verification proves. Do not claim a full fix when the
+   slice only adds a prerequisite, guard, doc rule, or partial path.
+
+7. **Run the reconstruction self-check before push.** Compare three things:
+   what the diff actually does, what a correct fix for the problem should do,
+   and what the PR body claims. Any mismatch becomes a code change, a scope
+   split, or a clearer Deferred note before the PR goes up.
+
+## Self-Check Template
+
+Use this mentally before opening or updating a PR:
+
+```text
+Problem:
+What must be true after this slice?
+
+Correct fix shape:
+Which files, contracts, tests, and user-visible behavior should change?
+
+Diff:
+What did the diff actually change?
+
+Description:
+Does the PR body claim exactly that, no more and no less?
+
+Gaps:
+What is incomplete, intentionally deferred, or out of scope?
+```

--- a/plans/PR-Coding-For-Reconstruction-Review.md
+++ b/plans/PR-Coding-For-Reconstruction-Review.md
@@ -1,0 +1,114 @@
+# PR-Coding-For-Reconstruction-Review
+
+## Why this slice exists
+
+#2005 codified how reviewers reconstruct a PR independently from the diff. The
+missing builder-side rule is what to do while coding when you know that review
+method will be used. Without that, builders can still treat reconstruction as a
+post-hoc review format instead of a design constraint on the plan, diff, tests,
+and PR body.
+
+This slice fixes the process root: add builder rules for coding toward
+reconstruction review, then reference them from the Atlas workflow contract and
+Claude Code repo guidance.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Add `docs/CODING_FOR_RECONSTRUCTION_REVIEW.md` with builder rules for coding
+   when a PR will be reviewed by independent reconstruction.
+2. Reference that doc from `AGENTS.md` §3a so builders apply it before opening
+   or updating a PR.
+3. Reference that doc from `CLAUDE.md` in the workflow summary and key
+   conventions so fresh Claude Code sessions inherit the rule.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `docs/CODING_FOR_RECONSTRUCTION_REVIEW.md` is builder-focused, not a
+        duplicate reviewer protocol.
+  - [ ] The rules tell builders to start from the problem/correct-fix shape,
+        keep the diff self-explaining, keep scope visible, fix upstream, test
+        behavior, and keep the PR body exact.
+  - [ ] `AGENTS.md` references the builder rule from the builder workflow before
+        PR mutation.
+  - [ ] `CLAUDE.md` references the builder rule for fresh Claude Code sessions.
+  - [ ] Docs-only change; no code, config, migration, workflow, or test touched.
+- Reachability proof: N/A -- docs/process-only change with no runtime, UI,
+  report, billing, or public-contract surface. Proof is the committed docs and
+  references.
+- Affected surfaces: builder workflow docs (`AGENTS.md`), Claude Code repo
+  guidance (`CLAUDE.md`), and the new builder rule doc.
+- Risk areas: process clarity; avoid confusing the new builder rules with the
+  already-merged reviewer reconstruction protocol.
+- Reviewer rules triggered: R1.
+
+### Files touched
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/CODING_FOR_RECONSTRUCTION_REVIEW.md`
+- `plans/PR-Coding-For-Reconstruction-Review.md`
+
+## Mechanism
+
+The new doc states the builder operating rules:
+
+- start from the problem, not the patch;
+- make the diff explain itself;
+- keep scope visible;
+- fix the upstream cause;
+- test behavior, not story;
+- make the PR description a receipt;
+- run the diff/correct-fix/description self-check before push.
+
+`AGENTS.md` points builders to this doc immediately after the plan-first rule
+and applies the self-check before PR opens and updates. `CLAUDE.md` references
+the same doc in the workflow highlights and key conventions so a fresh Claude
+Code session sees it before PR work.
+
+## Intentional
+
+- This does not change the reviewer protocol from #2005. That remains
+  `docs/PR_RECONSTRUCTION_PROTOCOL.md`; this slice adds the builder-side
+  companion.
+- This does not add a mechanical CI gate. The rule is a coding discipline,
+  not a detector or blocker.
+- AI reconciliation: narrowed the mock allowance so storage is not named as a
+  mockable external boundary, preserving the existing real-adapter rule.
+- AI reconciliation: matched the AGENTS.md wiring to the rule's "before opening
+  or updating a PR" self-check scope.
+- AI reconciliation: clarified that shipped behavior changes belong in
+  Scope/Mechanism and the PR body, while Deferred is only for split-out
+  follow-up work.
+
+## Deferred
+
+- If the rule later needs enforcement, add a separate detector/audit slice for
+  PR-body overclaims, plan/diff drift, or missing self-check evidence.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: focused grep for the coding-rule doc name, "Code for reconstruction",
+  and "correct-fix" across `AGENTS.md`, `CLAUDE.md`, and the new doc.
+- Passed: plan shape audit on this plan.
+- Passed: plan files-touched audit against `origin/main`.
+- Passed: plan diff-size audit against `origin/main` -- actual diff is 184 LOC.
+- Passed: reviewer-rules trigger audit against `origin/main`.
+- Passed: local PR review with planned PR body.
+- Passed: local PR review with updated PR body after AI reconciliation.
+- Passed: focused docs grep after AI reconciliation wording update.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 9 |
+| `CLAUDE.md` | 9 |
+| `docs/CODING_FOR_RECONSTRUCTION_REVIEW.md` | 62 |
+| `plans/PR-Coding-For-Reconstruction-Review.md` | 114 |
+| **Total** | **194** |


### PR DESCRIPTION
Plan: plans/PR-Coding-For-Reconstruction-Review.md
Slice phase: Workflow/process

This adds the builder-side companion to the already-merged PR reconstruction review protocol. The rule is how to code when that review style is expected: start from the problem and correct-fix shape, keep the diff self-explaining, test behavior, and make the PR body a receipt rather than a shield.

## Intentional
- This does not change the reviewer protocol from #2005; docs/PR_RECONSTRUCTION_PROTOCOL.md remains the reviewer method.
- Docs only. No code, config, workflow, migration, CI gate, detector, or automation is added.

## AI reconciliation
- [chatgpt-codex-connector] Narrow the storage mock allowance: fixed by removing storage from the mock-allowed external-boundary examples and keeping the wording aligned with AGENTS.md real-adapter discipline.
- [chatgpt-codex-connector] Apply the reconstruction check to PR updates too: fixed by changing the AGENTS.md wiring to require the self-check before opening or updating a PR.
- [chatgpt-codex-connector] Do not put shipped behavior changes in Deferred: fixed by separating shipped behavior changes into Scope/Mechanism/PR body and reserving Deferred for split-out follow-up work.

All findings fixed or waived: yes.

## Deferred
- Mechanical enforcement for overclaims, plan/diff drift, or missing self-check evidence remains a separate detector/audit slice.

## Parked hardening
- None.

## Verification
- rg -n "CODING_FOR_RECONSTRUCTION_REVIEW|Code for reconstruction|correct-fix" AGENTS.md CLAUDE.md docs/CODING_FOR_RECONSTRUCTION_REVIEW.md
- python scripts/audit_plan_doc.py plans/PR-Coding-For-Reconstruction-Review.md
- python scripts/audit_plan_doc_files_touched.py plans/PR-Coding-For-Reconstruction-Review.md origin/main
- python scripts/audit_plan_doc_diff_size.py plans/PR-Coding-For-Reconstruction-Review.md origin/main
- python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-Coding-For-Reconstruction-Review.md
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-body-coding-for-reconstruction-review.md -- passed after AI reconciliation.

## Diff size
4 files, 189 LOC.
