### PR TITLE
Codex issue queue handoff

### DIFF
--- a/.github/workflows/codex_wake_bridge_checks.yml
+++ b/.github/workflows/codex_wake_bridge_checks.yml
@@ -9,9 +9,11 @@ on:
       - ".github/workflows/codex_wake_bridge_checks.yml"
       - "scripts/audit_pr_watcher_safety.py"
       - "scripts/codex_wake_bridge.py"
+      - "scripts/codex_issue_queue.py"
       - "scripts/install_codex_wake_bridge.py"
       - "tests/test_audit_pr_watcher_safety.py"
       - "tests/test_codex_wake_bridge.py"
+      - "tests/test_codex_issue_queue.py"
       - "tests/test_install_codex_wake_bridge.py"
 
 jobs:
@@ -32,6 +34,7 @@ jobs:
           python -m pip install --quiet pytest pytest-asyncio pyyaml
           python -m pytest \
             tests/test_codex_wake_bridge.py \
+            tests/test_codex_issue_queue.py \
             tests/test_install_codex_wake_bridge.py \
             tests/test_audit_pr_watcher_safety.py \
             -q

--- a/docs/autonomous_coding_repo_playbook.md
+++ b/docs/autonomous_coding_repo_playbook.md
@@ -48,6 +48,16 @@ These rules are repo-agnostic:
 - Technical forks are not operator menus: take the durable engineering fix,
   document the reasoning, and keep moving. Defer only decisions that are
   genuinely business/operator-owned.
+- Long-running sessions pick the next slice from an issue-backed queue, not
+  chat memory. The portable queue marker is `Autonomy lane: <lane>`, with
+  optional `Autonomy priority: <int>`, but the marker must live on a
+  maintainer-controlled surface such as a queue label plus issue body or a
+  trusted maintainer comment.
+- Operator-owned forks are recorded back to the issue queue plus a local
+  email-ready artifact before the agent moves on. Persist the defer in a
+  durable issue field such as a label, not only in a comment page that may be
+  truncated. Real email delivery is a later integration, not the first
+  portability requirement.
 - Tests must prove behavior, including unhappy paths and edge cases.
 
 These rules can live in `AGENTS.md`, `CLAUDE.md`, or a repo-local equivalent.
@@ -138,7 +148,8 @@ Long-running agents need more structure than normal interactive PR work:
 - no merge from a push/review attention wake;
 - scheduled green confirmation before a standing-authorized merge;
 - immediate stop on head-SHA mismatch or dirty owned worktree.
-- a configured queue/notification path before claiming long-horizon autonomy.
+- a configured issue-backed queue/notification path before claiming
+  long-horizon autonomy.
 
 If there is no external push/review-event bridge, record it as unavailable. The
 30-minute scheduled watcher is still useful, but the session does not have

--- a/docs/long_running_session_watcher_handoff.md
+++ b/docs/long_running_session_watcher_handoff.md
@@ -191,6 +191,20 @@ timer can call it with `--source scheduled`.
   tolerance. Deferred operator decisions go to a GitHub issue and notification
   path in the follow-up slice; they are not a blocking chat-stop when other safe
   queued work remains.
+- After a guarded merge, use `scripts/codex_issue_queue.py next --lane <lane>`
+  to find the next issue-backed slice for the same lane. The queue source is
+  GitHub Issues with the `codex` label plus an `Autonomy lane: <lane>` marker
+  and optional `Autonomy priority: <int>` marker. Issue-body markers are trusted
+  only on `codex`-labeled issues; comment markers are trusted only from GitHub
+  author associations with repository write-level trust. Do not infer the next
+  slice from chat memory.
+- If a fork is genuinely operator-owned, record it with
+  `scripts/codex_issue_queue.py defer --issue <n> --lane <lane> --reason
+  "<why this belongs to the operator>"`. This writes a local email-ready
+  artifact under
+  `~/.local/state/atlas-pr-watchers/operator-defers/`; it does not send email.
+  The GitHub issue is then labeled `deferred` and receives a quoted defer
+  comment so multiline operator text cannot become queue-control markers.
 
 This protects against the race where checks turn green before late comments or
 review threads land.

--- a/plans/PR-Codex-Issue-Queue-Handoff.md
+++ b/plans/PR-Codex-Issue-Queue-Handoff.md
@@ -1,0 +1,120 @@
+# PR-Codex-Issue-Queue-Handoff
+
+## Why this slice exists
+
+#1999 shipped the Codex wake foundation but explicitly deferred "issue-queue
+continuation plus defer/email notification for operator-owned decisions." The
+operator then approved the plan to make long-horizon Codex sessions continue
+from a GitHub issue queue and defer genuinely operator-owned decisions into a
+trackable issue plus an email-ready local alert artifact.
+
+Root cause: the wake bridge can resume a Codex session on PR state, but after a
+merge or an operator-only fork there is no repo-owned next-work source or
+machine-checkable defer artifact. That leaves continuation dependent on chat
+memory or desktop notifications.
+
+This fixes the root for the workflow/process lane by making GitHub Issues the
+queue source of truth and by giving operator-owned defers a concrete artifact.
+It does not change product behavior.
+
+This exceeds the 400 LOC soft cap because the slice needs the CLI, negative
+tests for the parser/transport safety boundary, CI enrollment, and docs in one
+PR. Splitting those would create the same half-wired workflow tool this lane is
+trying to prevent.
+
+## Scope (this PR)
+
+Ownership lane: workflow/codex-autonomy
+Slice phase: Workflow/process
+
+1. Add a `scripts/codex_issue_queue.py` CLI that selects the next eligible
+   issue for a lane and records operator-owned defers.
+2. Use GitHub Issues as the queue source: open issues with the `codex` label,
+   an `Autonomy lane: <lane>` marker, optional `Autonomy priority: <int>`, and
+   no `deferred` label.
+3. Write local email-ready defer artifacts under the user state directory
+   without sending email or requiring secrets.
+4. Document the queue/defer handoff in the Codex watcher handoff and reusable
+   playbook docs.
+5. Add focused tests that prove ordering, fail-closed ambiguity, defer comments,
+   local artifact output, and no merge/push command path.
+
+### Review Contract
+
+- [ ] The CLI can discover a single next queued issue from mocked GitHub issue
+      data using trusted queue labels/comment associations, lane markers, and
+      priority ordering.
+- [ ] The CLI fails closed when there is no eligible issue or when issue data is
+      ambiguous/malformed.
+- [ ] The defer path writes a local email-ready artifact, persists a durable
+      `deferred` label, and posts a quoted GitHub issue comment, but does not
+      send email or mutate PR/branch state.
+- [ ] The docs tell Codex/local sessions to use the issue queue after merge and
+      to defer only operator-owned decisions.
+- [ ] Triggered reviewer rules: R1, R2, R4/R5 for command safety, R9/R14.
+
+### Files touched
+
+- `.github/workflows/codex_wake_bridge_checks.yml`
+- `docs/autonomous_coding_repo_playbook.md`
+- `docs/long_running_session_watcher_handoff.md`
+- `plans/PR-Codex-Issue-Queue-Handoff.md`
+- `scripts/codex_issue_queue.py`
+- `tests/test_codex_issue_queue.py`
+
+## Mechanism
+
+The CLI shells out to `gh issue list`, `gh issue edit`, and `gh issue comment`
+only. `next` server-filters GitHub Issues by the `codex` queue label before the
+client-side priority sort, then parses trusted issue body/comments for:
+
+- `Autonomy lane: <lane>`
+- `Autonomy priority: <int>` (optional)
+
+`next` filters to open issues in the requested lane without the `deferred`
+label or `Autonomy deferred: true` marker, sorts by priority then updated time,
+and prints JSON plus an optional concise handoff summary. Issue body markers
+count only on `codex`-labeled issues; comment markers count only from trusted
+GitHub author associations (`OWNER`, `MEMBER`, `COLLABORATOR`). `defer` writes
+the local Markdown artifact before GitHub mutation, adds the durable `deferred`
+label, then posts a quoted issue comment so multiline freeform text cannot
+inject queue-control markers. Network and GitHub transport are tested by
+mocking `subprocess.run`; selection/defer logic stays real.
+
+## Intentional
+
+- No real email send in this slice. The operator selected "issue + artifact" as
+  the safe first step; wiring Resend/Gmail would add credentials and a larger
+  blast radius.
+- No repo YAML queue. GitHub Issues plus the maintainer-applied `codex` queue
+  label are already the source of truth for #1962 and survive across
+  sessions/tools.
+- No automatic PR creation or merge. The CLI only selects/records handoffs.
+
+## Deferred
+
+- Real email/ntfy/desktop alert delivery for operator-owned defers remains a
+  follow-up after the issue/artifact contract has review mileage.
+- Optional GitHub label automation for queued/autonomy issues remains deferred;
+  the v1 contract expects maintainers to apply the `codex` queue label before
+  body markers are honored.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_codex_issue_queue.py tests/test_codex_wake_bridge.py tests/test_install_codex_wake_bridge.py tests/test_audit_pr_watcher_safety.py -q` -- 55 passed.
+- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` -- ratchet gate passed.
+- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-issue-queue-1962.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-body-codex-issue-queue-handoff.md` -- passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/codex_wake_bridge_checks.yml` | 3 |
+| `docs/autonomous_coding_repo_playbook.md` | 13 |
+| `docs/long_running_session_watcher_handoff.md` | 14 |
+| `plans/PR-Codex-Issue-Queue-Handoff.md` | 120 |
+| `scripts/codex_issue_queue.py` | 279 |
+| `tests/test_codex_issue_queue.py` | 278 |
+| **Total** | **707** |

--- a/scripts/codex_issue_queue.py
+++ b/scripts/codex_issue_queue.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Select the next Codex autonomy issue or record an operator-owned defer."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any, Sequence
+
+
+DEFAULT_REPO = "canfieldjuan/ATLAS"
+DEFAULT_ALERT_DIR = Path.home() / ".local" / "state" / "atlas-pr-watchers" / "operator-defers"
+DEFAULT_ISSUE_LIMIT = 1000
+QUEUE_LABEL = "codex"
+DEFERRED_LABEL = "deferred"
+TRUSTED_COMMENT_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+LANE_RE = re.compile(r"(?im)^\s*Autonomy lane\s*:\s*(?P<value>.+?)\s*$")
+PRIORITY_RE = re.compile(r"(?im)^\s*Autonomy priority\s*:\s*(?P<value>-?\d+)\s*$")
+DEFER_RE = re.compile(r"(?im)^\s*Autonomy deferred\s*:\s*(true|yes|1)\s*$")
+JSON_FIELDS = "number,title,url,body,labels,updatedAt,state,comments"
+
+
+class QueueError(Exception):
+    """Raised for operator-actionable queue failures."""
+
+
+def _run_gh_json(args: Sequence[str]) -> Any:
+    proc = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if proc.returncode != 0:
+        raise QueueError(proc.stderr.strip() or proc.stdout.strip() or f"gh exited {proc.returncode}")
+    try:
+        return json.loads(proc.stdout or "null")
+    except json.JSONDecodeError as exc:
+        raise QueueError(f"gh returned invalid JSON: {exc}") from exc
+
+
+def _run_gh(args: Sequence[str]) -> str:
+    proc = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if proc.returncode != 0:
+        raise QueueError(proc.stderr.strip() or proc.stdout.strip() or f"gh exited {proc.returncode}")
+    return proc.stdout.strip()
+
+
+def _comment_bodies(issue: dict[str, Any]) -> list[str]:
+    comments = issue.get("comments")
+    if not isinstance(comments, list):
+        return []
+    bodies: list[str] = []
+    for comment in comments:
+        if not isinstance(comment, dict) or not isinstance(comment.get("body"), str):
+            continue
+        association = str(comment.get("authorAssociation") or "").upper()
+        if association in TRUSTED_COMMENT_ASSOCIATIONS:
+            bodies.append(comment["body"])
+    return bodies
+
+
+def _text_blocks(issue: dict[str, Any]) -> list[str]:
+    blocks = [str(issue.get("body") or "")] if QUEUE_LABEL in _labels(issue) else []
+    blocks.extend(_comment_bodies(issue))
+    return blocks
+
+
+def _labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    names: set[str] = set()
+    for label in labels:
+        if isinstance(label, dict) and label.get("name") is not None:
+            names.add(str(label["name"]).strip().lower())
+        elif isinstance(label, str):
+            names.add(label.strip().lower())
+    return names
+
+
+def _unique_markers(pattern: re.Pattern[str], blocks: Sequence[str]) -> set[str]:
+    values: set[str] = set()
+    for block in blocks:
+        for match in pattern.finditer(block):
+            value = match.group("value").strip()
+            if value:
+                values.add(value)
+    return values
+
+
+def _issue_metadata(issue: dict[str, Any]) -> dict[str, Any]:
+    blocks = _text_blocks(issue)
+    lanes = _unique_markers(LANE_RE, blocks)
+    priorities = _unique_markers(PRIORITY_RE, blocks)
+    if len(lanes) > 1:
+        raise QueueError(f"issue #{issue.get('number')} has conflicting Autonomy lane markers: {sorted(lanes)}")
+    if len(priorities) > 1:
+        raise QueueError(f"issue #{issue.get('number')} has conflicting Autonomy priority markers: {sorted(priorities)}")
+    priority = int(next(iter(priorities))) if priorities else 1000
+    deferred = DEFERRED_LABEL in _labels(issue) or any(DEFER_RE.search(block) for block in blocks)
+    return {
+        "lane": next(iter(lanes), ""),
+        "priority": priority,
+        "deferred": deferred,
+    }
+
+
+def _list_issues(repo: str, *, limit: int = DEFAULT_ISSUE_LIMIT) -> list[dict[str, Any]]:
+    value = _run_gh_json([
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--label",
+        QUEUE_LABEL,
+        "--limit",
+        str(limit),
+        "--json",
+        JSON_FIELDS,
+    ])
+    if not isinstance(value, list):
+        raise QueueError("gh issue list returned a non-list payload")
+    return [item for item in value if isinstance(item, dict)]
+
+
+def select_next_issue(issues: Sequence[dict[str, Any]], *, lane: str) -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
+    for issue in issues:
+        meta = _issue_metadata(issue)
+        if meta["lane"] != lane or meta["deferred"]:
+            continue
+        candidates.append(
+            {
+                "number": issue.get("number"),
+                "title": issue.get("title", ""),
+                "url": issue.get("url", ""),
+                "updatedAt": issue.get("updatedAt", ""),
+                "priority": meta["priority"],
+            }
+        )
+    if not candidates:
+        raise QueueError(f"no open queued issues found for lane {lane!r}")
+    candidates.sort(key=lambda item: (item["priority"], str(item["updatedAt"]), int(item["number"] or 0)))
+    top = candidates[0]
+    return {
+        "ok": True,
+        "action": "next",
+        "lane": lane,
+        "issue_number": top["number"],
+        "issue_url": top["url"],
+        "title": top["title"],
+        "priority": top["priority"],
+        "updatedAt": top["updatedAt"],
+        "eligible_count": len(candidates),
+    }
+
+
+def _now_stamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _safe_slug(text: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", text).strip("-")[:80] or "defer"
+
+
+def _quote_freeform(text: str) -> str:
+    lines = str(text or "").strip().splitlines() or [""]
+    return "\n".join(f"> {line}" for line in lines)
+
+
+def _defer_comment(*, lane: str, reason: str, source: str) -> str:
+    source_block = f"\nSource:\n{_quote_freeform(source)}\n" if source else ""
+    return (
+        "## Operator-owned defer\n\n"
+        f"Autonomy lane: {lane}\n"
+        "Autonomy deferred: true\n"
+        f"Reason:\n{_quote_freeform(reason)}\n"
+        f"{source_block}\n"
+        "This records a decision that requires operator input. The active agent should "
+        "continue only with other safe queued work."
+    )
+
+
+def _write_alert(*, alert_dir: Path, repo: str, issue: int, lane: str, reason: str, source: str) -> Path:
+    alert_dir.mkdir(parents=True, exist_ok=True)
+    path = alert_dir / f"{_now_stamp()}-issue-{issue}-{_safe_slug(lane)}.md"
+    issue_url = f"https://github.com/{repo}/issues/{issue}"
+    text = (
+        "# Atlas Operator-Owned Defer\n\n"
+        f"- Repository: {repo}\n"
+        f"- Issue: #{issue} {issue_url}\n"
+        f"- Autonomy lane: {lane}\n"
+        f"- Source: {source or 'not provided'}\n"
+        f"- Reason: {reason.strip()}\n\n"
+        "Action needed: decide the operator-owned fork, then update the issue or assign "
+        "a follow-up slice. Until then, agents should continue only with other safe queued work.\n"
+    )
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def defer_issue(*, repo: str, issue: int, lane: str, reason: str, source: str, alert_dir: Path) -> dict[str, Any]:
+    comment = _defer_comment(lane=lane, reason=reason, source=source)
+    alert_path = _write_alert(alert_dir=alert_dir, repo=repo, issue=issue, lane=lane, reason=reason, source=source)
+    _run_gh(["gh", "issue", "edit", str(issue), "--repo", repo, "--add-label", DEFERRED_LABEL])
+    _run_gh(["gh", "issue", "comment", str(issue), "--repo", repo, "--body", comment])
+    return {
+        "ok": True,
+        "action": "defer",
+        "repo": repo,
+        "lane": lane,
+        "issue_number": issue,
+        "issue_url": f"https://github.com/{repo}/issues/{issue}",
+        "reason": reason.strip(),
+        "alert_path": str(alert_path),
+    }
+
+
+def _print_payload(payload: dict[str, Any], *, markdown: bool) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if markdown and payload.get("ok"):
+        print()
+        if payload.get("action") == "next":
+            print(f"Next queued issue: #{payload['issue_number']} {payload['title']}")
+            print(f"URL: {payload['issue_url']}")
+            print(f"Lane: {payload['lane']} | priority: {payload['priority']}")
+        elif payload.get("action") == "defer":
+            print(f"Deferred operator decision for #{payload['issue_number']}")
+            print(f"Alert artifact: {payload['alert_path']}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    next_parser = sub.add_parser("next", help="select the next queued issue for a lane")
+    next_parser.add_argument("--repo", default=DEFAULT_REPO)
+    next_parser.add_argument("--lane", required=True)
+    next_parser.add_argument("--limit", type=int, default=DEFAULT_ISSUE_LIMIT)
+    next_parser.add_argument("--markdown", action="store_true")
+
+    defer_parser = sub.add_parser("defer", help="record an operator-owned defer")
+    defer_parser.add_argument("--repo", default=DEFAULT_REPO)
+    defer_parser.add_argument("--issue", type=int, required=True)
+    defer_parser.add_argument("--lane", required=True)
+    defer_parser.add_argument("--reason", required=True)
+    defer_parser.add_argument("--source", default="")
+    defer_parser.add_argument("--alert-dir", type=Path, default=DEFAULT_ALERT_DIR)
+    defer_parser.add_argument("--markdown", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "next":
+            payload = select_next_issue(_list_issues(args.repo, limit=args.limit), lane=args.lane)
+            payload["repo"] = args.repo
+            _print_payload(payload, markdown=args.markdown)
+            return 0
+        payload = defer_issue(
+            repo=args.repo,
+            issue=args.issue,
+            lane=args.lane,
+            reason=args.reason,
+            source=args.source,
+            alert_dir=args.alert_dir.expanduser(),
+        )
+        _print_payload(payload, markdown=args.markdown)
+        return 0
+    except QueueError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_codex_issue_queue.py
+++ b/tests/test_codex_issue_queue.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "codex_issue_queue.py"
+SPEC = importlib.util.spec_from_file_location("codex_issue_queue", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+queue = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = queue
+SPEC.loader.exec_module(queue)
+
+
+def _issue(
+    number: int,
+    *,
+    lane: str = "workflow/codex-autonomy",
+    priority: int | None = None,
+    updated: str = "2026-07-04T00:00:00Z",
+    labels: list[str] | None = None,
+    comments: list[str | dict[str, str]] | None = None,
+) -> dict[str, object]:
+    markers = [f"Autonomy lane: {lane}"]
+    if priority is not None:
+        markers.append(f"Autonomy priority: {priority}")
+    label_names = [queue.QUEUE_LABEL] if labels is None else labels
+    return {
+        "number": number,
+        "title": f"Issue {number}",
+        "url": f"https://github.com/canfieldjuan/ATLAS/issues/{number}",
+        "body": "\n".join(markers),
+        "labels": [{"name": name} for name in label_names],
+        "updatedAt": updated,
+        "state": "OPEN",
+        "comments": [
+            {"body": item, "authorAssociation": "OWNER"} if isinstance(item, str) else item
+            for item in comments or []
+        ],
+    }
+
+
+def test_select_next_issue_orders_by_priority_then_updated_time() -> None:
+    issues = [
+        _issue(10, priority=20, updated="2026-07-04T02:00:00Z"),
+        _issue(11, priority=5, updated="2026-07-04T03:00:00Z"),
+        _issue(12, priority=5, updated="2026-07-04T01:00:00Z"),
+        _issue(13, lane="content-ops/macro-writeback", priority=1),
+    ]
+
+    selected = queue.select_next_issue(issues, lane="workflow/codex-autonomy")
+
+    assert selected["issue_number"] == 12
+    assert selected["eligible_count"] == 3
+    assert selected["priority"] == 5
+
+
+def test_select_next_issue_excludes_deferred_label_and_defer_marker() -> None:
+    issues = [
+        _issue(10, priority=1, labels=[queue.QUEUE_LABEL, queue.DEFERRED_LABEL]),
+        _issue(11, priority=2, comments=["Autonomy deferred: true"]),
+        _issue(12, priority=3),
+    ]
+
+    selected = queue.select_next_issue(issues, lane="workflow/codex-autonomy")
+
+    assert selected["issue_number"] == 12
+
+
+def test_select_next_issue_fails_closed_on_conflicting_lane_markers() -> None:
+    issue = _issue(
+        10,
+        priority=1,
+        comments=["Autonomy lane: workflow/other"],
+    )
+
+    with pytest.raises(queue.QueueError, match="conflicting Autonomy lane"):
+        queue.select_next_issue([issue], lane="workflow/codex-autonomy")
+
+
+def test_select_next_issue_ignores_untrusted_comment_markers() -> None:
+    issue = _issue(
+        10,
+        priority=1,
+        comments=[
+            {
+                "body": "Autonomy lane: workflow/other\nAutonomy priority: 0\nAutonomy deferred: true",
+                "authorAssociation": "CONTRIBUTOR",
+            }
+        ],
+    )
+
+    selected = queue.select_next_issue([issue], lane="workflow/codex-autonomy")
+
+    assert selected["issue_number"] == 10
+    assert selected["priority"] == 1
+
+
+def test_select_next_issue_ignores_unlabeled_issue_body_markers() -> None:
+    issue = _issue(10, priority=1, labels=[])
+
+    with pytest.raises(queue.QueueError, match="no open queued issues"):
+        queue.select_next_issue([issue], lane="workflow/codex-autonomy")
+
+
+def test_select_next_issue_accepts_trusted_comment_markers() -> None:
+    issue = {
+        "number": 10,
+        "title": "Trusted queue comment",
+        "url": "https://github.com/canfieldjuan/ATLAS/issues/10",
+        "body": "",
+        "labels": [],
+        "updatedAt": "2026-07-04T00:00:00Z",
+        "state": "OPEN",
+        "comments": [
+            {
+                "body": "Autonomy lane: workflow/codex-autonomy\nAutonomy priority: 7",
+                "authorAssociation": "OWNER",
+            }
+        ],
+    }
+
+    selected = queue.select_next_issue([issue], lane="workflow/codex-autonomy")
+
+    assert selected["issue_number"] == 10
+    assert selected["priority"] == 7
+
+
+def test_select_next_issue_fails_closed_when_no_lane_match() -> None:
+    with pytest.raises(queue.QueueError, match="no open queued issues"):
+        queue.select_next_issue([_issue(10, lane="content-ops/macro-writeback")], lane="workflow/codex-autonomy")
+
+
+def test_cli_next_uses_gh_issue_list_transport(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        assert args[:3] == ["gh", "issue", "list"]
+        payload = [_issue(22, priority=1)]
+        return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(queue.subprocess, "run", fake_run)
+
+    code = queue.main(["next", "--repo", "canfieldjuan/ATLAS", "--lane", "workflow/codex-autonomy"])
+
+    assert code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["issue_number"] == 22
+    assert out["repo"] == "canfieldjuan/ATLAS"
+    assert calls == [
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            "canfieldjuan/ATLAS",
+            "--state",
+            "open",
+            "--label",
+            queue.QUEUE_LABEL,
+            "--limit",
+            str(queue.DEFAULT_ISSUE_LIMIT),
+            "--json",
+            queue.JSON_FIELDS,
+        ]
+    ]
+
+
+def test_defer_posts_issue_comment_and_writes_email_ready_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        assert args[:3] in (["gh", "issue", "edit"], ["gh", "issue", "comment"])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(queue.subprocess, "run", fake_run)
+
+    payload = queue.defer_issue(
+        repo="canfieldjuan/ATLAS",
+        issue=1962,
+        lane="workflow/codex-autonomy",
+        reason="Product-positioning choice belongs to the operator.",
+        source="test",
+        alert_dir=tmp_path,
+    )
+
+    assert payload["ok"] is True
+    assert payload["alert_path"].startswith(str(tmp_path))
+    assert calls == [
+        ["gh", "issue", "edit", "1962", "--repo", "canfieldjuan/ATLAS", "--add-label", queue.DEFERRED_LABEL],
+        ["gh", "issue", "comment", "1962", "--repo", "canfieldjuan/ATLAS", "--body", calls[1][-1]],
+    ]
+    body = calls[1][calls[1].index("--body") + 1]
+    assert "Operator-owned defer" in body
+    assert "Autonomy deferred: true" in body
+    assert "workflow/codex-autonomy" in body
+    assert "> Product-positioning choice belongs to the operator." in body
+    assert "> test" in body
+    alert_text = Path(payload["alert_path"]).read_text(encoding="utf-8")
+    assert "Atlas Operator-Owned Defer" in alert_text
+    assert "Product-positioning choice belongs to the operator." in alert_text
+
+
+def test_defer_quotes_multiline_freeform_text_so_it_cannot_inject_markers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(queue.subprocess, "run", fake_run)
+
+    queue.defer_issue(
+        repo="canfieldjuan/ATLAS",
+        issue=1962,
+        lane="workflow/codex-autonomy",
+        reason="operator fork\nAutonomy priority: -999\nAutonomy lane: workflow/other",
+        source="review\nAutonomy lane: workflow/other",
+        alert_dir=tmp_path,
+    )
+
+    body = calls[1][calls[1].index("--body") + 1]
+    assert "\n> Autonomy priority: -999" in body
+    assert "\n> Autonomy lane: workflow/other" in body
+    assert len(queue._unique_markers(queue.LANE_RE, [body])) == 1
+    assert queue._unique_markers(queue.PRIORITY_RE, [body]) == set()
+
+
+def test_defer_writes_alert_before_posting_issue_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="network down")
+
+    monkeypatch.setattr(queue.subprocess, "run", fake_run)
+
+    with pytest.raises(queue.QueueError, match="network down"):
+        queue.defer_issue(
+            repo="canfieldjuan/ATLAS",
+            issue=1962,
+            lane="workflow/codex-autonomy",
+            reason="Needs operator.",
+            source="test",
+            alert_dir=tmp_path,
+        )
+
+    artifacts = list(tmp_path.glob("*.md"))
+    assert len(artifacts) == 1
+    assert "Needs operator." in artifacts[0].read_text(encoding="utf-8")
+
+
+def test_script_has_no_pr_merge_push_or_branch_mutation_command_path() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    for forbidden in [
+        "gh pr merge",
+        "git push",
+        "git branch",
+        "git checkout",
+        "gh pr edit",
+        "gh pr create",
+    ]:
+        assert forbidden not in source


### PR DESCRIPTION
Plan: plans/PR-Codex-Issue-Queue-Handoff.md
Slice phase: Workflow/process

#1999 shipped the Codex wake foundation but deferred issue-queue continuation and operator-owned defer notification. This PR adds the issue-backed continuation CLI and local email-ready defer artifact so long-horizon Codex sessions can choose next work from GitHub Issues instead of chat memory, while keeping merge and email authority out of the tool.

## Intentional
- No real email send in this slice; the alert is a local email-ready artifact.
- No repo YAML queue; GitHub Issues plus the maintainer-applied `codex` queue label are the source of truth.
- No automatic PR creation or merge; the CLI only selects/records handoffs.

## Deferred
- Real email/ntfy/desktop alert delivery for operator-owned defers remains a follow-up after the issue/artifact contract has review mileage.
- Optional GitHub label automation for queued/autonomy issues remains deferred; the v1 contract expects maintainers to apply the `codex` queue label before body markers are honored.

## AI reconciliation
- [chatgpt-codex-connector] Write the defer artifact before posting the marker: fixed by writing the local alert artifact before calling `gh issue comment`, with a regression proving the artifact remains if the comment call fails.
- [chatgpt-codex-connector] Do not trust queue markers from arbitrary comments: fixed by accepting comment markers only from trusted GitHub author associations (`OWNER`, `MEMBER`, `COLLABORATOR`) and adding trusted/untrusted marker tests.
- [chatgpt-codex-connector] Fetch the whole queue before sorting priorities: fixed by server-filtering `gh issue list` with the `codex` queue label before applying the explicit limit, with a transport assertion for the label filter.
- [chatgpt-codex-connector] Require trust for issue-body queue markers: fixed by honoring issue body markers only when the issue carries the maintainer-applied `codex` queue label, with a negative test for unlabeled body markers.
- [chatgpt-codex-connector] Persist defers outside truncated comments: fixed by adding the durable `deferred` issue label in the defer path; comment markers remain a readable annotation, not the only source of defer state.
- [chatgpt-codex-connector] Escape multiline defer text before posting queue markers: fixed by quote-prefixing freeform reason/source text and adding a regression that injected `Autonomy lane`/`Autonomy priority` lines are not parsed as control markers.

All findings fixed or waived: yes.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_codex_issue_queue.py tests/test_codex_wake_bridge.py tests/test_install_codex_wake_bridge.py tests/test_audit_pr_watcher_safety.py -q` -- 55 passed.
- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` -- ratchet gate passed.
- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-issue-queue-1962.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-body-codex-issue-queue-handoff.md` -- passed.

## Diff size
6 files, +706 / -1

Diff-budget override: This workflow/process slice is genuinely indivisible because the CLI, negative parser/transport tests, CI enrollment, and docs must land together; splitting them would create a half-wired autonomy tool.
