### PR TITLE
Cache Resolution Audit row-key lookups

### DIFF
--- a/docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md
+++ b/docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md
@@ -81,7 +81,8 @@ Expected fix:
 
 ### S2 - Row-Key Normalization Cache
 
-Status: open.
+Status: in review. Fixing PR:
+[#2029](https://github.com/canfieldjuan/ATLAS/pull/2029).
 
 Root: support-ticket and FAQ markdown paths repeatedly normalize row keys while
 scanning every lookup, even though a cached field-lookup pattern already exists
@@ -103,6 +104,15 @@ Expected fix:
 - Add parity fixtures proving output does not change.
 - Add a focused runtime/perf guard or benchmark artifact before claiming the
   cache removed the hot path.
+
+Implementation notes:
+
+- Support-ticket input package now carries a per-row lookup wrapper through the
+  normalization hot path while keeping ordinary `row.get(...)` exact.
+- FAQ markdown now wraps each opportunity/evidence row once before the helper
+  graph calls `_field_value`.
+- Focused tests assert cached-vs-raw lookup parity and that repeated cached
+  lookups do not rescan the raw mapping.
 
 ### S3 - Submit Row Cap And Heavy Inline Build
 

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -9,7 +9,7 @@ the existing FAQ, landing-page, and blog planners already understand.
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import ItemsView, Mapping, Sequence
 from datetime import date
 from typing import Any
 
@@ -339,7 +339,8 @@ def build_support_ticket_input_package(
                 "message": "Skipped ticket row because it was not an object.",
             })
             continue
-        normalized = _normalize_ticket_row(row, row_index=index)
+        row_lookup = _SupportTicketRowLookup(row)
+        normalized = _normalize_ticket_row(row_lookup, row_index=index)
         if normalized:
             normalized_rows.append(normalized)
             # Carry the date-column-present signal out-of-band rather than
@@ -348,7 +349,7 @@ def build_support_ticket_input_package(
             # has the signal when the raw upload carried a date column, even
             # if that cell was blank -- _has_any_key supersets a parseable
             # created_at, so this reproduces the old marker exactly.
-            if _has_any_key(row, _DATE_KEYS):
+            if _has_any_key(row_lookup, _DATE_KEYS):
                 source_date_signal_count += 1
             continue
         warnings.append({
@@ -543,9 +544,50 @@ def _rows_from_source_material(source_material: Any) -> list[Any]:
     return source_material_to_source_rows(source_material)
 
 
+class _SupportTicketRowLookup(Mapping[str, Any]):
+    """Mapping wrapper that caches support-ticket alias lookups for one row."""
+
+    def __init__(self, row: Mapping[str, Any]) -> None:
+        self._row = row
+        self._present_keys: set[str] = set()
+        self._values_by_key: dict[str, Any] = {}
+        for raw_key, value in row.items():
+            normalized_key = _key(raw_key)
+            self._present_keys.add(normalized_key)
+            if normalized_key not in self._values_by_key and _has_value(value):
+                self._values_by_key[normalized_key] = value
+
+    def __getitem__(self, key: str) -> Any:
+        return self._row[key]
+
+    def __iter__(self):
+        return iter(self._row)
+
+    def __len__(self) -> int:
+        return len(self._row)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._row.get(key, default)
+
+    def items(self) -> ItemsView[str, Any]:
+        return self._row.items()
+
+    def first_value(self, keys: Sequence[str]) -> Any:
+        for key in keys:
+            normalized_key = _key(key)
+            if normalized_key in self._values_by_key:
+                return self._values_by_key[normalized_key]
+        return None
+
+    def has_any_key(self, keys: Sequence[str]) -> bool:
+        return any(_key(key) in self._present_keys for key in keys)
+
+
 def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     if not isinstance(row, Mapping):
         return {}
+    if not isinstance(row, _SupportTicketRowLookup):
+        row = _SupportTicketRowLookup(row)
     source_title = support_ticket_plain_text(_first_text(row, _SOURCE_TITLE_KEYS))
     text = _ticket_text(row, source_title=source_title)
     if not text:
@@ -995,6 +1037,8 @@ def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:
 
 
 def _first_value(row: Mapping[str, Any], keys: Sequence[str]) -> Any:
+    if isinstance(row, _SupportTicketRowLookup):
+        return row.first_value(keys)
     for key in keys:
         normalized_key = _key(key)
         for raw_key, value in row.items():
@@ -1010,6 +1054,8 @@ def _has_value(value: Any) -> bool:
 
 
 def _has_any_key(row: Mapping[str, Any], keys: Sequence[str]) -> bool:
+    if isinstance(row, _SupportTicketRowLookup):
+        return row.has_any_key(keys)
     normalized_keys = {_key(key) for key in keys}
     return any(_key(raw_key) in normalized_keys for raw_key in row)
 

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, ItemsView, Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import date, datetime, timedelta
 import math
@@ -121,6 +121,7 @@ _FAILURE_RISK_RULES = (
     ("incorrect_record", ("wrong", "incorrect", "inaccurate", "error", "mistake", "does not recognize")),
     ("money_or_account_risk", ("charged", "fee", "fees", "payment", "balance", "debt", "foreclosure", "fraud")),
 )
+_FIELD_LOOKUP_MISSING = object()
 DEFAULT_INTENT_RULES = (
     ("credit report disputes", (
         "credit report",
@@ -739,8 +740,13 @@ def build_ticket_faq_markdown(
     seen: set[tuple[str, str]] = set()
     source_keys: set[str] = set()
 
-    for opportunity_index, opportunity in enumerate(opportunities, start=1):
-        for evidence_index, evidence in enumerate(_evidence_rows(opportunity), start=1):
+    for opportunity_index, raw_opportunity in enumerate(opportunities, start=1):
+        opportunity = _TicketFAQFieldLookup(raw_opportunity)
+        for evidence_index, raw_evidence in enumerate(
+            _evidence_rows(opportunity),
+            start=1,
+        ):
+            evidence = _TicketFAQFieldLookup(raw_evidence)
             if date_window is not None and not _inside_date_window(
                 opportunity,
                 evidence,
@@ -962,6 +968,51 @@ def _evidence_rows(opportunity: Mapping[str, Any]) -> tuple[Mapping[str, Any], .
         "source_type": opportunity.get("source_type") or "",
         "source_title": opportunity.get("source_title") or "",
     },)
+
+
+class _TicketFAQFieldLookup(Mapping[str, Any]):
+    """Mapping wrapper that caches FAQ source-row alias lookups for one row."""
+
+    def __init__(self, row: Mapping[str, Any]) -> None:
+        self._row = row
+        self._indexed = tuple(
+            (
+                _source_type_key(raw_key),
+                _compact_key(raw_key),
+                value,
+            )
+            for raw_key, value in row.items()
+        )
+        self._cache: dict[str, Any] = {}
+
+    def __getitem__(self, key: str) -> Any:
+        return self._row[key]
+
+    def __iter__(self):
+        return iter(self._row)
+
+    def __len__(self) -> int:
+        return len(self._row)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._row.get(key, default)
+
+    def items(self) -> ItemsView[str, Any]:
+        return self._row.items()
+
+    def field_value(self, key: str) -> Any:
+        if key in self._row:
+            return self._row.get(key)
+        if key in self._cache:
+            return self._cache[key]
+        target = _source_type_key(key)
+        compact_target = _compact_key(key)
+        for raw_target, raw_compact, value in self._indexed:
+            if raw_target == target or raw_compact == compact_target:
+                self._cache[key] = value
+                return value
+        self._cache[key] = _FIELD_LOOKUP_MISSING
+        return _FIELD_LOOKUP_MISSING
 
 
 # --- Question sub-clustering (#1460) -------------------------------------
@@ -3379,6 +3430,9 @@ def _source_date(row: Mapping[str, Any]) -> date | None:
 
 
 def _field_value(row: Mapping[str, Any], key: str) -> Any:
+    if isinstance(row, _TicketFAQFieldLookup):
+        value = row.field_value(key)
+        return None if value is _FIELD_LOOKUP_MISSING else value
     if key in row:
         return row.get(key)
     target = _source_type_key(key)

--- a/plans/PR-Resolution-Audit-S2-Row-Key-Cache.md
+++ b/plans/PR-Resolution-Audit-S2-Row-Key-Cache.md
@@ -1,0 +1,142 @@
+# PR-Resolution-Audit-S2-Row-Key-Cache
+
+## Why this slice exists
+
+Issue #1993 S2 tracks a live current-code performance defect in the
+Resolution Audit CSV path. The finding is confirmed against current code, not
+accepted from the older audit text: `campaign_source_adapters._SourceFieldLookup`
+already shows a per-row cached alias lookup pattern, while
+`support_ticket_input_package._first_value` and
+`ticket_faq_markdown._field_value` still normalize raw row keys while scanning
+`row.items()` for every field lookup.
+
+Root cause: the support-ticket input package and FAQ markdown builder do not
+carry a cached field lookup object through their repeated per-row lookup hot
+paths. They re-run the same raw-key normalization work for each alias lookup
+even though the row is unchanged.
+
+Correct fix contract:
+
+1. Cache normalized row-key lookups once per row in the support-ticket input
+   package while preserving current alias order, blank-value skipping, and
+   exact `row.get(...)` passthrough semantics.
+2. Cache source-type/compact row-key lookups once per opportunity/evidence row
+   in the FAQ markdown builder while preserving exact-key precedence and output
+   values.
+3. Prove parity with realistic fixtures so rendered/package outputs do not
+   change.
+4. Prove the hot path no longer repeatedly scans raw row keys for cached
+   lookups.
+
+This fixes the root for S2's queued defect; it is not a user-facing product
+shape change.
+
+Diff-budget note: this slice is slightly over 400 LOC because the root fix
+requires two module-local cache wrappers plus parity/cache guards in both
+existing focused test files. Splitting the wrappers from their proof would
+leave the hot-path claim unprotected.
+
+## Scope (this PR)
+
+Ownership lane: resolution-audit-csv
+Slice phase: Functional validation
+
+1. Add local per-row lookup wrappers for the support-ticket package and FAQ
+   markdown builder lookup helpers.
+2. Route the existing normalization/build hot paths through those wrappers.
+3. Add parity tests and focused cache-use guards.
+4. Update the current-code remediation tracker for S2.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Support-ticket package outputs remain identical for alias-heavy rows,
+    including blank source-ID fallback behavior from S1.
+  - FAQ markdown outputs remain identical for rows whose fields are reachable
+    only through compact/source-type alias matching.
+  - Cache guards show repeated lookups do not rescan the raw mapping.
+  - `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` records
+    S2 as addressed by this PR.
+- Affected surfaces:
+  - `extracted_content_pipeline/support_ticket_input_package.py`
+  - `extracted_content_pipeline/ticket_faq_markdown.py`
+  - focused tests for those modules
+  - Resolution Audit CSV remediation tracker
+- Risk areas:
+  - Alias precedence and blank-value semantics in support-ticket rows.
+  - Exact-key precedence in FAQ markdown rows.
+  - Accidentally widening fuzzy lookup behavior to ordinary `row.get(...)`.
+- Reviewer rules triggered: R1, R10, R13, R14.
+
+### Files touched
+
+- `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Resolution-Audit-S2-Row-Key-Cache.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+## Mechanism
+
+The support-ticket path gets a mapping wrapper that delegates normal mapping
+operations to the raw row, but indexes compact normalized raw keys once. The
+existing `_first_value` and `_has_any_key` helpers use the wrapper when present,
+so direct passthrough `row.get(...)` remains exact and unchanged.
+
+The FAQ markdown path gets the same shape for `_field_value`: exact keys still
+win first, then cached source-type/compact aliases are consulted without
+rescanning `row.items()`. `build_ticket_faq_markdown` wraps each opportunity
+and evidence row once before calling the existing helper graph.
+
+Tests cover both the semantic parity and the cache behavior. The cache guards
+use counting mappings to prove repeated helper calls do not re-enter the raw
+row-item scan after the wrapper is built.
+
+## Intentional
+
+- No shared cross-module abstraction in this slice. The lookup rules are close
+  but not identical: support-ticket lookups skip blank values, while FAQ
+  markdown preserves blank/falsey values and exact-key precedence.
+- No user-facing report, snapshot, landing, email, or PDF shape changes. S2 is
+  an internal hot-path remediation.
+- No clustering, source-ID, or admission policy changes. Those are separate
+  queued items in #1993.
+
+## Deferred
+
+- Broader runtime benchmarking across large customer-style uploads remains
+  deferred; this slice adds a focused regression guard for the repeated scan
+  class without turning the PR into a benchmark harness.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py -q`
+  (90 passed)
+- `python -m pytest tests/test_extracted_ticket_faq_markdown.py -q`
+  (424 passed)
+- `scripts/maturity_sweep_file_lane.py` on `extracted_content_pipeline/ticket_faq_markdown.py`
+  with `tests/maturity_sweep/baseline_extracted_content_pipeline.json`
+  (ratchet passed; score back to baseline 16)
+- `scripts/maturity_sweep.py` on `extracted_content_pipeline` with
+  `tests/maturity_sweep/baseline_extracted_content_pipeline.json`
+  (ratchet passed)
+- `scripts/validate_extracted_content_pipeline.sh` via bash (passed)
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  (passed)
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` (passed)
+- `scripts/check_ascii_python.sh` via bash (passed)
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 12 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 52 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 60 |
+| `plans/PR-Resolution-Audit-S2-Row-Key-Cache.md` | 142 |
+| `tests/test_extracted_support_ticket_input_package.py` | 120 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 118 |
+| **Total** | **504** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 import json
 from pathlib import Path
 
 import pytest
 
+import extracted_content_pipeline.support_ticket_input_package as support_ticket_input_package
 from extracted_content_pipeline.campaign_customer_data import (
     CsvCustomerDataParseError,
 )
@@ -42,6 +44,25 @@ from extracted_content_pipeline.support_ticket_zendesk_thread import (
 
 ROOT = Path(__file__).resolve().parents[1]
 ZENDESK_THREAD_SAMPLE = ROOT / "tests/fixtures/zendesk_full_thread_seed_sample.json"
+
+
+class _CountingMapping(Mapping[str, object]):
+    def __init__(self, data: Mapping[str, object]) -> None:
+        self._data = dict(data)
+        self.items_calls = 0
+
+    def __getitem__(self, key: str) -> object:
+        return self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def items(self):
+        self.items_calls += 1
+        return self._data.items()
 
 
 def test_csv_loader_rejects_duplicate_headers(tmp_path: Path) -> None:
@@ -267,6 +288,105 @@ def test_support_ticket_package_skips_blank_source_id_aliases() -> None:
         warning["code"] for warning in package.warnings
     }.isdisjoint({"support_ticket_missing_source_id"})
     assert package.inputs["source_material"][0]["source_id"] == "T-1"
+
+
+def test_support_ticket_row_lookup_preserves_raw_alias_semantics() -> None:
+    row = {
+        "source_id": "  ",
+        "Ticket ID": "T-1",
+        "Request Subject": "How do I export reports?",
+        "Latest Message": "I cannot find the export button.",
+        "Created At": "",
+    }
+    lookup = support_ticket_input_package._SupportTicketRowLookup(row)
+
+    assert support_ticket_input_package._first_value(
+        lookup,
+        support_ticket_input_package._SOURCE_ID_KEYS,
+    ) == support_ticket_input_package._first_value(
+        row,
+        support_ticket_input_package._SOURCE_ID_KEYS,
+    )
+    assert support_ticket_input_package._first_text(
+        lookup,
+        support_ticket_input_package._SOURCE_TITLE_KEYS,
+    ) == support_ticket_input_package._first_text(
+        row,
+        support_ticket_input_package._SOURCE_TITLE_KEYS,
+    )
+    assert support_ticket_input_package._has_any_key(
+        lookup,
+        support_ticket_input_package._DATE_KEYS,
+    ) == support_ticket_input_package._has_any_key(
+        row,
+        support_ticket_input_package._DATE_KEYS,
+    )
+
+
+def test_support_ticket_row_lookup_reuses_cached_row_key_scan() -> None:
+    row = _CountingMapping({
+        **{f"Unused Field {index}": "" for index in range(40)},
+        "Ticket ID": "T-1",
+        "Request Subject": "How do I export reports?",
+        "Latest Message": "I cannot find the export button.",
+        "Created At": "",
+    })
+    lookup = support_ticket_input_package._SupportTicketRowLookup(row)
+
+    for _ in range(5):
+        assert support_ticket_input_package._first_value(
+            lookup,
+            support_ticket_input_package._SOURCE_ID_KEYS,
+        ) == "T-1"
+        assert support_ticket_input_package._first_text(
+            lookup,
+            support_ticket_input_package._TEXT_KEYS,
+        ) == "I cannot find the export button."
+        assert support_ticket_input_package._has_any_key(
+            lookup,
+            support_ticket_input_package._DATE_KEYS,
+        )
+
+    assert row.items_calls == 1
+
+
+def test_support_ticket_row_lookup_empty_and_blank_values_are_missing() -> None:
+    empty_lookup = support_ticket_input_package._SupportTicketRowLookup({})
+    blank_lookup = support_ticket_input_package._SupportTicketRowLookup({
+        "Ticket ID": " ",
+        "Case ID": "",
+    })
+
+    assert support_ticket_input_package._first_value(
+        empty_lookup,
+        support_ticket_input_package._SOURCE_ID_KEYS,
+    ) is None
+    assert not support_ticket_input_package._has_any_key(
+        empty_lookup,
+        support_ticket_input_package._SOURCE_ID_KEYS,
+    )
+    assert support_ticket_input_package._first_value(
+        blank_lookup,
+        support_ticket_input_package._SOURCE_ID_KEYS,
+    ) is None
+    assert support_ticket_input_package._has_any_key(
+        blank_lookup,
+        support_ticket_input_package._SOURCE_ID_KEYS,
+    )
+
+
+def test_support_ticket_row_lookup_duplicate_normalized_key_keeps_first_value() -> None:
+    row = {
+        "Ticket ID": "T-first",
+        "ticket_id": "T-second",
+        "Subject": "How do I export reports?",
+    }
+    lookup = support_ticket_input_package._SupportTicketRowLookup(row)
+
+    assert support_ticket_input_package._first_value(
+        lookup,
+        support_ticket_input_package._SOURCE_ID_KEYS,
+    ) == "T-first"
 
 
 def test_support_ticket_fold_targets_survive_tokenization() -> None:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 import csv
 from html.parser import HTMLParser
 import json
@@ -11,6 +12,7 @@ from pathlib import Path
 import markdown
 import pytest
 
+import extracted_content_pipeline.ticket_faq_markdown as ticket_faq_markdown
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
 )
@@ -62,6 +64,25 @@ _IRREGULAR_PAST_RESOLUTION_ACTION_INFLECTIONS = {
     "reran": "rerun",
     "sent": "send",
 }
+
+
+class _CountingMapping(Mapping[str, object]):
+    def __init__(self, data: Mapping[str, object]) -> None:
+        self._data = dict(data)
+        self.items_calls = 0
+
+    def __getitem__(self, key: str) -> object:
+        return self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def items(self):
+        self.items_calls += 1
+        return self._data.items()
 
 
 class _StubEmbeddingPort:
@@ -317,6 +338,103 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
         "has_action_items": True,
         "resolution_evidence_scoped": True,
     }
+
+
+def test_ticket_faq_field_lookup_preserves_raw_alias_semantics() -> None:
+    row = {
+        "created_at": "",
+        "Created At": "2026-02-01",
+        "Source Weight": 3,
+        "Resolution Text": "Choose Export CSV from Analytics.",
+    }
+    lookup = ticket_faq_markdown._TicketFAQFieldLookup(row)
+
+    for key in ("created_at", "source_weight", "resolution_text", "missing"):
+        assert ticket_faq_markdown._field_value(
+            lookup,
+            key,
+        ) == ticket_faq_markdown._field_value(
+            row,
+            key,
+        )
+
+
+def test_ticket_faq_field_lookup_reuses_cached_row_key_scan() -> None:
+    row = _CountingMapping({
+        **{f"Unused Field {index}": "" for index in range(40)},
+        "Created At": "2026-02-01",
+        "Source Weight": "4",
+        "Resolution Text": "Choose Export CSV from Analytics.",
+    })
+    lookup = ticket_faq_markdown._TicketFAQFieldLookup(row)
+
+    for _ in range(5):
+        assert ticket_faq_markdown._field_value(lookup, "created_at") == "2026-02-01"
+        assert ticket_faq_markdown._field_value(lookup, "source_weight") == "4"
+        assert ticket_faq_markdown._field_value(
+            lookup,
+            "resolution_text",
+        ) == "Choose Export CSV from Analytics."
+        assert ticket_faq_markdown._field_value(lookup, "missing") is None
+
+    assert row.items_calls == 1
+
+
+def test_ticket_faq_field_lookup_empty_and_missing_keys_return_none() -> None:
+    lookup = ticket_faq_markdown._TicketFAQFieldLookup({})
+
+    assert ticket_faq_markdown._field_value(lookup, "created_at") is None
+    assert ticket_faq_markdown._field_value(lookup, "source_weight") is None
+
+
+def test_ticket_faq_field_lookup_duplicate_compact_key_keeps_first_alias() -> None:
+    row = {
+        "Source Weight": "4",
+        "source.weight": "8",
+    }
+    lookup = ticket_faq_markdown._TicketFAQFieldLookup(row)
+
+    assert ticket_faq_markdown._field_value(lookup, "source_weight") == "4"
+
+
+def test_ticket_faq_field_lookup_falsey_exact_key_is_not_missing() -> None:
+    row = {
+        "source_weight": 0,
+        "Source Weight": "4",
+    }
+    lookup = ticket_faq_markdown._TicketFAQFieldLookup(row)
+
+    assert ticket_faq_markdown._field_value(lookup, "source_weight") == 0
+
+
+def test_build_ticket_faq_markdown_uses_alias_fields_through_cached_lookup() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Export issue",
+            "evidence": [{
+                "text": "How do I export the attribution dashboard before renewal?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+                "Created At": "2026-02-01",
+                "Source Weight": "4",
+                "Resolution Text": (
+                    "Open Analytics, choose the attribution dashboard, and select "
+                    "Export CSV."
+                ),
+            }],
+        }],
+        as_of_date="2026-02-15",
+        window_days=30,
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["weighted_frequency"] == 4
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == (
+        "Open Analytics, choose the attribution dashboard, and select Export CSV."
+    )
 
 
 def test_build_ticket_faq_markdown_does_not_invent_support_contact() -> None:


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S2-Row-Key-Cache.md
Slice phase: Functional validation

Issue #1993 S2 fixes the confirmed current-code row-key normalization hot path: support-ticket input packaging and FAQ markdown repeatedly scan and normalize raw row keys for every alias lookup, while the repo already has a cached per-row lookup pattern. This PR mirrors that cache locally, preserves output semantics, and adds parity plus cache-use guards.

## Intentional
- No shared cross-module abstraction: support-ticket lookup skips blank values, while FAQ markdown preserves falsey values and exact-key precedence.
- No user-facing report, snapshot, landing, email, or PDF shape changes.
- No clustering, source-ID, CSV admission, or date-window policy changes.

## Deferred
- Broader large-upload runtime benchmarking remains deferred; this slice adds focused cache-use guards rather than a benchmark harness.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_support_ticket_input_package.py -q` (90 passed)
- `python -m pytest tests/test_extracted_ticket_faq_markdown.py -q` (424 passed)
- `python scripts/maturity_sweep_file_lane.py extracted_content_pipeline/ticket_faq_markdown.py --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json` (ratchet passed; score back to baseline 16)
- `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/webhook*' --sensitive-glob '**/payment*' --sensitive-glob '**/*deletion*'` (ratchet passed)
- `bash scripts/validate_extracted_content_pipeline.sh` (passed)
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` (passed)
- `python scripts/audit_extracted_standalone.py --fail-on-debt` (passed)
- `bash scripts/check_ascii_python.sh` (passed)

## Diff size
6 files, +497 / -7.

Diff-budget override: This S2 root fix is indivisible because both hot paths need the wrapper implementation plus parity/cache guards in the same PR; splitting proof from the cache change would leave the performance claim unprotected.

## Cold diff reconstruction
- `extracted_content_pipeline/support_ticket_input_package.py`: adds `_SupportTicketRowLookup`, routes per-row normalization/date-signal lookup through it, and keeps ordinary mapping access exact.
- `extracted_content_pipeline/ticket_faq_markdown.py`: adds `_TicketFAQFieldLookup`, wraps each opportunity/evidence row once, and keeps `_field_value` exact-key precedence before cached alias lookup.
- `tests/test_extracted_support_ticket_input_package.py` and `tests/test_extracted_ticket_faq_markdown.py`: add cached-vs-raw parity assertions, counting-mapping guards, and edge tests for empty/blank rows, duplicate normalized keys, absent lookups, and falsey exact-key precedence.
- `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md`: marks S2 in review with implementation notes and links #2029.

Gaps found during reconstruction: none. Every code/test change traces to the S2 contract; no declared out-of-scope user-facing product surface changed.
