### PR TITLE
Pin Python CI requirements to CI-proven versions

### DIFF
--- a/plans/PR-Pin-Python-CI-Requirements.md
+++ b/plans/PR-Pin-Python-CI-Requirements.md
@@ -144,8 +144,18 @@ on any violation or any name without a harvested version.
 - `requirements.asr.txt`, `atlas_edge/`, `atlas_video-processing/`,
   `graphiti-wrapper/` requirements — separate deploy surfaces, installed by
   no PR workflow.
+- `nemo_toolkit[asr]` dedup (#2040): the one line left unpinned. A `==` pin
+  conflicts with `requirements.asr.txt`'s git-ref in the joint
+  `security_full_sweep` pip-audit (verified: pip rejects `==` + `@ git` for
+  the same name across `-r` files). nemo is installed-but-never-imported by
+  any `requirements.txt`-only suite (real importers: `asr_server.py` via
+  `requirements.asr.txt`, `scripts/debug/*` not in CI), so its unpinned
+  version cannot flip a PR-suite outcome. Root fix = relocate/dedup, a
+  dependency-set change deferred to #2040.
 - Full transitive lock (constraints file / pip-compile) — hardening
-  follow-up once the gate exists to validate it.
+  follow-up once the gate exists to validate it (#2040). Top-level pins
+  narrow RC3; a transitive lock reconciled across py3.11 + py3.10 must be
+  validated by the slice-2 aggregate gate before it can be trusted.
 - Dependabot interaction: pinned lines change how dependabot proposes bumps
   (PRs will now move explicit pins). Acceptable; dependabot PRs get the same
   fleet validation.
@@ -168,8 +178,8 @@ on any violation or any name without a harvested version.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Pin-Python-CI-Requirements.md` | 175 |
+| `plans/PR-Pin-Python-CI-Requirements.md` | 185 |
 | `requirements.content_ops_ci.txt` | 62 |
 | `requirements.txt` | 105 |
 | `tests/test_content_ops_ci_requirements_workflows.py` | 22 |
-| **Total** | **364** |
+| **Total** | **374** |

--- a/plans/PR-Pin-Python-CI-Requirements.md
+++ b/plans/PR-Pin-Python-CI-Requirements.md
@@ -29,7 +29,7 @@ A correct fix pins every installable line to the exact version CI has already
 proven green, changes nothing else (no upgrades, no added/removed deps, no
 workflow edits), and is verified by the same CI fleet that consumes the files.
 
-## Scope
+## Scope (this PR)
 
 Slice phase: workflow/process
 
@@ -51,10 +51,10 @@ Max files: 4
 
 ### Files touched
 
-- `requirements.txt`
-- `requirements.content_ops_ci.txt`
-- `tests/test_content_ops_ci_requirements_workflows.py`
 - `plans/PR-Pin-Python-CI-Requirements.md`
+- `requirements.content_ops_ci.txt`
+- `requirements.txt`
+- `tests/test_content_ops_ci_requirements_workflows.py`
 
 ### Review Contract
 
@@ -166,13 +166,10 @@ on any violation or any name without a harvested version.
 
 ## Estimated diff size
 
-| File | ~LOC (added+deleted) |
-|---|---|
-| `requirements.txt` | ~104 |
-| `requirements.content_ops_ci.txt` | ~62 |
-| `tests/test_content_ops_ci_requirements_workflows.py` | ~30 |
-| `plans/PR-Pin-Python-CI-Requirements.md` | ~160 |
-| **Total** | **~356** |
-
-Under the 400-LOC budget (the two requirements files are in-place rewrites:
-52 + 31 lines each counted as an add plus a delete).
+| File | LOC |
+|---|---:|
+| `plans/PR-Pin-Python-CI-Requirements.md` | 175 |
+| `requirements.content_ops_ci.txt` | 62 |
+| `requirements.txt` | 105 |
+| `tests/test_content_ops_ci_requirements_workflows.py` | 22 |
+| **Total** | **364** |

--- a/plans/PR-Pin-Python-CI-Requirements.md
+++ b/plans/PR-Pin-Python-CI-Requirements.md
@@ -1,0 +1,126 @@
+# PR-Pin-Python-CI-Requirements
+
+Ownership lane: ci-cd/enforcement-gaps
+
+Phase 1 / slice 1 of the CI/CD enforcement gap tracker (#2035, gap G1.2 /
+root cause RC3).
+
+## Why this slice exists
+
+The CI/CD audit (#2035) found `requirements.txt` (52 non-comment lines) and
+`requirements.content_ops_ci.txt` (31 lines) carry zero `==` pins, so every
+CI job resolves dependencies fresh at runtime: test outcomes are not a
+function of the repo state alone, and a transitive release can flip any suite
+red or green with no commit (RC3, "non-reproducible green"). This slice pins
+both files so a green run is reproducible. It lands before the Phase-1
+aggregate test gate (slice 2) because a regression-ratchet baseline measured
+on drifting dependencies is meaningless.
+
+Scope amendment vs the tracker: G1.2's closes-when names only
+`requirements.txt`; planning found CI installs from BOTH files
+(`admin_costs_checks.yml:40` vs `atlas_content_ops_input_provider_checks.yml:61`,
+`atlas_content_ops_macro_writeback_checks.yml:77`), so this slice pins both.
+The amendment is recorded on #2035 at close-out.
+
+### Problem-derived contract
+
+Root cause: dependency resolution happens at CI runtime with open specifiers.
+A correct fix pins every installable line to the exact version CI has already
+proven green, changes nothing else (no upgrades, no added/removed deps, no
+workflow edits), and is verified by the same CI fleet that consumes the files.
+
+## Scope
+
+Slice phase: workflow/process
+
+- `requirements.txt` — every non-comment line pinned `==`; extras
+  (`uvicorn[standard]`, `nemo_toolkit[asr]`) and inline comments preserved.
+- `requirements.content_ops_ci.txt` — same, all 31 lines.
+- This plan doc.
+
+Nothing else. No workflow YAML, no other requirements files, no code.
+
+Max files: 3
+
+### Files touched
+
+- `requirements.txt`
+- `requirements.content_ops_ci.txt`
+- `plans/PR-Pin-Python-CI-Requirements.md`
+
+## Mechanism
+
+Pin versions are harvested from the `Successfully installed ...` lines of
+three recent GREEN CI runs on main — not from a local environment (local venv
+is Python 3.12; CI runs 3.11 and 3.10):
+
+- run 28893718452 (`admin_costs_checks`, py3.11, installs requirements.txt,
+  main, 2026-07-07) — primary 3.11 map.
+- run 28561411787 (`extracted_llm_infrastructure_checks`, py3.10, installs
+  requirements.txt, main, 2026-07-02) — 3.10 map; on 3.10/3.11 divergence the
+  3.10 version is taken so one pin satisfies both interpreters
+  (divergences: uvicorn 0.49.0, opencv-python 4.13.0.92, langgraph 1.2.7,
+  anthropic 0.115.1, boto3 1.43.39).
+- run 28893718535 (`atlas_content_ops_input_provider_checks`, py3.11,
+  installs requirements.content_ops_ci.txt, main, 2026-07-07) — the
+  content-ops file pins from its own fleet's map.
+
+The rewrite is mechanical (scripted): same lines, same order, same comments;
+only the version specifier changes. Every pin was validated against the
+original specifier with `packaging.SpecifierSet` (e.g. `fastapi==0.136.3`
+inside `<0.137`, `mcp==1.28.1` inside `>=1.28.1,<2`) — the script fails loud
+on any violation or any name without a harvested version.
+
+## Intentional
+
+- **No version moves.** Pins capture what CI already resolved and proved
+  green; nothing is upgraded or downgraded relative to the harvested runs.
+- **The two files may pin different versions of a shared package**
+  (e.g. `uvicorn[standard]==0.49.0` in requirements.txt via the 3.10 rule vs
+  `==0.50.2` in the content-ops file): each file pins what ITS consuming
+  fleet proved. They are installed by disjoint jobs, never together.
+- **Top-level pins only, no transitive lock** — see Deferred.
+- **Commented-out optionals** (`# twilio`, `# llama-cpp-python`) stay
+  commented.
+- Where the 3.10 run resolved older than the 3.11 run (5 packages above), the
+  older pin is taken; the PR's own 3.11 fleet run is the proof it still
+  passes there.
+
+## Deferred
+
+- Bare unpinned `pip install pytest pytest-asyncio` lines in ~20 workflow
+  files (plus `codex_wake_bridge_checks.yml:34` pyyaml,
+  `atlas_deflection_migration_apply_checks.yml:60` asyncpg) — slice 2
+  consolidates CI installs when the aggregate gate lands.
+- `requirements.asr.txt`, `atlas_edge/`, `atlas_video-processing/`,
+  `graphiti-wrapper/` requirements — separate deploy surfaces, installed by
+  no PR workflow.
+- Full transitive lock (constraints file / pip-compile) — hardening
+  follow-up once the gate exists to validate it.
+- Dependabot interaction: pinned lines change how dependabot proposes bumps
+  (PRs will now move explicit pins). Acceptable; dependabot PRs get the same
+  fleet validation.
+
+## Verification
+
+- The PR itself triggers the consuming fleet: `requirements.txt` is in the
+  `paths:` filters of most pytest workflows (py3.11) and of
+  `extracted_llm_infrastructure_checks`/`extracted_pipeline_checks` (py3.10);
+  `extracted_content_pipeline/**`-adjacent content-ops suites install the
+  content-ops file. Green fleet on both interpreters = the pins reproduce
+  what CI had.
+- Closes-when (from #2035): `grep -cvE '^\s*#|^\s*$' <file>` equals
+  `grep -cE '==' <file>` for both files (52==52, 31==31 locally).
+- Specifier-compliance already machine-checked at rewrite time (fail-loud).
+
+## Estimated diff size
+
+| File | ~LOC (added+deleted) |
+|---|---|
+| `requirements.txt` | ~104 |
+| `requirements.content_ops_ci.txt` | ~62 |
+| `plans/PR-Pin-Python-CI-Requirements.md` | ~130 |
+| **Total** | **~296** |
+
+Under the 400-LOC budget (the two requirements files are in-place rewrites:
+52 + 31 lines each counted as an add plus a delete).

--- a/plans/PR-Pin-Python-CI-Requirements.md
+++ b/plans/PR-Pin-Python-CI-Requirements.md
@@ -56,6 +56,41 @@ Max files: 4
 - `tests/test_content_ops_ci_requirements_workflows.py`
 - `plans/PR-Pin-Python-CI-Requirements.md`
 
+### Review Contract
+
+Acceptance criteria (check one-by-one):
+1. Every non-comment line of both files carries `==` EXCEPT the single
+   documented carve-out `nemo_toolkit[asr]` (unpinned because
+   `requirements.asr.txt` supplies a direct git-ref build and
+   `security_full_sweep` pip-audits both files jointly; a `==` pin conflicts
+   with the direct reference).
+2. No version moves vs what the harvested green runs resolved; extras and
+   inline comments byte-identical; no dependency added or removed.
+3. The requirements-shape guard asserts NAMES on its required side (pinned
+   entries pass; a removed required package still fails; a pinned heavy
+   package is still excluded).
+4. No workflow YAML, no runtime code, no other requirements files change.
+
+Reachability proof: the PR itself exercises the real entrypoints — the
+path-filtered pytest fleet installs `requirements.txt` (py3.11 + py3.10) and
+the four content-ops workflows install `requirements.content_ops_ci.txt` and
+run the shape guard; observable result = those check runs green on this PR.
+The joint pip-audit resolution over `requirements.txt` + `requirements.asr.txt`
+(security_full_sweep) is restored to its pre-PR state by the nemo carve-out
+(that name returns to exactly its previous unversioned form).
+
+Affected surfaces: CI dependency installs for every Python suite; the
+security full-sweep joint audit input; the content-ops requirements shape
+guard.
+
+Risk areas: a pin that resolves on py3.11 but not py3.10 (mitigated:
+3.10-resolved versions win divergences; both fleets run on this PR); pinned
+set drifting from `requirements.asr.txt`'s git-ref NeMo (mitigated: carve-out).
+
+Triggered reviewer rules: R11, R12 (env/config surface — requirements files);
+R2, R14 (guard/validator change — the shape-guard test edit, boundary-probed
+both directions).
+
 ## Mechanism
 
 Pin versions are harvested from the `Successfully installed ...` lines of
@@ -88,6 +123,12 @@ on any violation or any name without a harvested version.
   `==0.50.2` in the content-ops file): each file pins what ITS consuming
   fleet proved. They are installed by disjoint jobs, never together.
 - **Top-level pins only, no transitive lock** — see Deferred.
+- **One documented carve-out:** `nemo_toolkit[asr]` stays unpinned.
+  `requirements.asr.txt:7` supplies a direct git-ref NeMo build and
+  `security_full_sweep.yml` pip-audits `requirements.txt` +
+  `requirements.asr.txt` jointly; a `==` pin on nemo conflicts with the
+  direct reference (Codex T3). Unpinned restores that name to its exact
+  pre-PR (proven) form.
 - **Commented-out optionals** (`# twilio`, `# llama-cpp-python`) stay
   commented.
 - Where the 3.10 run resolved older than the 3.11 run (5 packages above), the
@@ -117,8 +158,10 @@ on any violation or any name without a harvested version.
   `extracted_content_pipeline/**`-adjacent content-ops suites install the
   content-ops file. Green fleet on both interpreters = the pins reproduce
   what CI had.
-- Closes-when (from #2035): `grep -cvE '^\s*#|^\s*$' <file>` equals
-  `grep -cE '==' <file>` for both files (52==52, 31==31 locally).
+- Closes-when (from #2035, amended): every non-comment line pinned except
+  the documented `nemo_toolkit` carve-out — requirements.txt 51 of 52 lines
+  `==` (+ carve-out comment), requirements.content_ops_ci.txt 31 of 31. The
+  G1.2 closes-when on #2035 is amended accordingly at close-out.
 - Specifier-compliance already machine-checked at rewrite time (fail-loud).
 
 ## Estimated diff size

--- a/plans/PR-Pin-Python-CI-Requirements.md
+++ b/plans/PR-Pin-Python-CI-Requirements.md
@@ -36,16 +36,24 @@ Slice phase: workflow/process
 - `requirements.txt` — every non-comment line pinned `==`; extras
   (`uvicorn[standard]`, `nemo_toolkit[asr]`) and inline comments preserved.
 - `requirements.content_ops_ci.txt` — same, all 31 lines.
+- `tests/test_content_ops_ci_requirements_workflows.py` — contract amendment
+  found by the PR's own CI: this guard asserted the REQUIRED side as exact
+  raw requirement strings (`"torch"`, `"asyncpg>=0.31.0"`, line 99), so pins
+  broke all four content-ops suites. The excluded-heavy side was already
+  name-based (`requirement_name`); the fix makes the required side symmetric
+  (name-based, specifier-agnostic), preserving the guard's intent — needed
+  packages present, heavy stack absent — under any specifier shape.
 - This plan doc.
 
-Nothing else. No workflow YAML, no other requirements files, no code.
+Nothing else. No workflow YAML, no other requirements files, no runtime code.
 
-Max files: 3
+Max files: 4
 
 ### Files touched
 
 - `requirements.txt`
 - `requirements.content_ops_ci.txt`
+- `tests/test_content_ops_ci_requirements_workflows.py`
 - `plans/PR-Pin-Python-CI-Requirements.md`
 
 ## Mechanism
@@ -119,8 +127,9 @@ on any violation or any name without a harvested version.
 |---|---|
 | `requirements.txt` | ~104 |
 | `requirements.content_ops_ci.txt` | ~62 |
-| `plans/PR-Pin-Python-CI-Requirements.md` | ~130 |
-| **Total** | **~296** |
+| `tests/test_content_ops_ci_requirements_workflows.py` | ~30 |
+| `plans/PR-Pin-Python-CI-Requirements.md` | ~160 |
+| **Total** | **~356** |
 
 Under the 400-LOC budget (the two requirements files are in-place rewrites:
 52 + 31 lines each counted as an add plus a delete).

--- a/requirements.content_ops_ci.txt
+++ b/requirements.content_ops_ci.txt
@@ -1,41 +1,41 @@
-fastapi<0.137
-uvicorn[standard]
-python-dotenv
-python-multipart
-pydantic-settings
-psutil
-slowapi>=0.1.9
+fastapi==0.136.3
+uvicorn[standard]==0.50.2
+python-dotenv==1.2.2
+python-multipart==0.0.32
+pydantic-settings==2.14.2
+psutil==7.2.2
+slowapi==0.1.10
 
 # Content-ops workflow collection still imports the torch-backed service base.
-torch
-numpy
+torch==2.12.1
+numpy==2.4.6
 
 # HTTP, database, and scheduling surfaces exercised by content-ops tests.
-httpx
-websockets
-asyncpg>=0.31.0
-dateparser>=1.2.0
-rich>=13.0.0
-langgraph>=0.2.0
-langchain-core>=0.3.0
-apscheduler>=3.10,<4.0
-tzlocal>=3.0,<6.0
+httpx==0.28.1
+websockets==15.0.1
+asyncpg==0.31.0
+dateparser==1.4.1
+rich==15.0.0
+langgraph==1.2.8
+langchain-core==1.4.8
+apscheduler==3.11.3
+tzlocal==5.4.4
 
 # MCP, auth, billing, and document/report rendering surfaces.
-mcp>=1.28.1,<2
-bcrypt>=4.0.0
-PyJWT>=2.8.0
-cryptography>=42.0.0
-stripe>=8.0.0
-email-validator>=2.3.0
-fpdf2>=2.8.0
-markdown>=3.5
+mcp==1.28.1
+bcrypt==5.0.0
+PyJWT==2.13.0
+cryptography==49.0.0
+stripe==15.3.0
+email-validator==2.3.0
+fpdf2==2.8.7
+markdown==3.10.2
 
 # Eager atlas_brain.api collection currently pulls B2B scraping parsers.
-feedparser>=6.0
-curl_cffi>=0.7.0
-beautifulsoup4>=4.15.0
+feedparser==6.0.12
+curl_cffi==0.15.0
+beautifulsoup4==4.15.0
 
 # Test runner dependencies for the targeted workflows.
-pytest
-pytest-asyncio
+pytest==9.1.1
+pytest-asyncio==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,93 +1,93 @@
-fastapi<0.137
-uvicorn[standard]
-python-dotenv
-python-multipart
-pydantic-settings
-psutil
-slowapi>=0.1.9
+fastapi==0.136.3
+uvicorn[standard]==0.49.0
+python-dotenv==1.2.2
+python-multipart==0.0.32
+pydantic-settings==2.14.2
+psutil==7.2.2
+slowapi==0.1.10
 
 # ML / AI
-torch
-torchaudio
-transformers
-accelerate
-bitsandbytes
-Pillow
-nemo_toolkit[asr]
-sentence-transformers
-opencv-python  # For video processing (SAM 3)
-sounddevice
-soundfile
+torch==2.12.1
+torchaudio==2.11.0
+transformers==4.57.6
+accelerate==1.14.0
+bitsandbytes==0.49.2
+Pillow==12.3.0
+nemo_toolkit[asr]==2.7.3
+sentence-transformers==5.6.0
+opencv-python==4.13.0.92  # For video processing (SAM 3)
+sounddevice==0.5.5
+soundfile==0.14.0
 
 # IoT backends
-aiomqtt
-httpx
-websockets
+aiomqtt==2.5.1
+httpx==0.28.1
+websockets==15.0.1
 
 # Telephony (external communications)
-signalwire>=2.0.0
+signalwire==2.0.4
 # twilio  # Alternative provider
 
 # Discovery
-zeroconf>=0.80.0
+zeroconf==0.150.0
 
 # Database
-asyncpg>=0.31.0
-neo4j>=6.2.0
+asyncpg==0.31.0
+neo4j==6.2.0
 
 # Natural language parsing
-dateparser>=1.2.0
+dateparser==1.4.1
 
 # Orchestration / Voice pipeline
-webrtcvad
-piper-tts
-kokoro>=0.7.0
+webrtcvad==2.0.10
+piper-tts==1.4.2
+kokoro==0.9.4
 
 # Optional: For GGUF model support
 # llama-cpp-python
 
 # Optional: Flash Attention 2 for faster inference (Ampere+ GPUs)
 # Install separately: pip install flash-attn --no-build-isolation
-rich>=13.0.0
+rich==15.0.0
 
 # LangGraph for agent orchestration
-langgraph>=0.2.0
-langchain-core>=0.3.0
+langgraph==1.2.7
+langchain-core==1.4.8
 
 # Autonomous task scheduling
-apscheduler>=3.10,<4.0
-tzlocal>=3.0,<6.0
+apscheduler==3.11.3
+tzlocal==5.4.4
 
 # Email draft generation (Anthropic Claude)
-anthropic>=0.39.0
+anthropic==0.115.1
 
 # Campaign email sending (Amazon SES)
-boto3>=1.35.0
+boto3==1.43.39
 
 # MCP (Model Context Protocol) — CRM and Email MCP servers
-mcp>=1.28.1,<2
+mcp==1.28.1
 
 # External data producers (news feeds)
-feedparser>=6.0
-trafilatura>=1.6
+feedparser==6.0.12
+trafilatura==2.1.0
 
 # B2B review scraping (anti-detection HTTP client + HTML parsing)
-curl_cffi>=0.7.0
-beautifulsoup4>=4.15.0
-pytrends>=4.9.0
-playwright>=1.40.0
-playwright-stealth>=1.0.6
+curl_cffi==0.15.0
+beautifulsoup4==4.15.0
+pytrends==4.9.2
+playwright==1.61.0
+playwright-stealth==2.0.3
 
 # SaaS auth + billing
-bcrypt>=4.0.0
-PyJWT>=2.8.0
-cryptography>=42.0.0  # Fernet for BYOK provider-key at-rest encryption (PR-D5)
-stripe>=8.0.0
-email-validator>=2.3.0  # required by pydantic.EmailStr in api/b2b_tenant_dashboard.py and api/auth.py
+bcrypt==5.0.0
+PyJWT==2.13.0
+cryptography==49.0.0  # Fernet for BYOK provider-key at-rest encryption (PR-D5)
+stripe==15.3.0
+email-validator==2.3.0  # required by pydantic.EmailStr in api/b2b_tenant_dashboard.py and api/auth.py
 
 # PDF generation
-fpdf2>=2.8.0
+fpdf2==2.8.7
 
 # Blog rendering (admin + autonomous tasks)
-markdown>=3.5
-praw>=7.8.1  # atlas_reddit read-only listening tool (S4, #1934); lazy-imported, tests never need it
+markdown==3.10.2
+praw==8.0.2  # atlas_reddit read-only listening tool (S4, #1934); lazy-imported, tests never need it

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ slowapi==0.1.10
 
 # ML / AI
 torch==2.12.1
-torchaudio==2.11.0
+torchaudio==2.11.0  # newest existing release (torchaudio trails torch; no 2.12 pairing exists); sole importer asr_server.py installs requirements.asr.txt instead
 transformers==4.57.6
 accelerate==1.14.0
 bitsandbytes==0.49.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,10 @@ transformers==4.57.6
 accelerate==1.14.0
 bitsandbytes==0.49.2
 Pillow==12.3.0
-nemo_toolkit[asr]==2.7.3
+# nemo_toolkit stays UNPINNED by design: requirements.asr.txt supplies the
+# canonical direct git-ref build, and security_full_sweep pip-audits both
+# files jointly -- a == pin here conflicts with that direct reference (#2036).
+nemo_toolkit[asr]
 sentence-transformers==5.6.0
 opencv-python==4.13.0.92  # For video processing (SAM 3)
 sounddevice==0.5.5

--- a/tests/test_content_ops_ci_requirements_workflows.py
+++ b/tests/test_content_ops_ci_requirements_workflows.py
@@ -41,17 +41,21 @@ WORKFLOW_CANARIES = {
     ),
 }
 
+# Required by NAME (specifier-agnostic): the guard's intent is that these
+# packages stay present in the subset file, not that they carry a particular
+# specifier shape (the file is ==pinned as of #2035 G1.2). The excluded side
+# below was already name-based; this makes both sides symmetric.
 REQUIRED_PACKAGES = (
     "torch",
     "numpy",
-    "asyncpg>=0.31.0",
-    "mcp>=1.28.1,<2",
-    "stripe>=8.0.0",
-    "fpdf2>=2.8.0",
-    "markdown>=3.5",
-    "feedparser>=6.0",
-    "curl_cffi>=0.7.0",
-    "beautifulsoup4>=4.15.0",
+    "asyncpg",
+    "mcp",
+    "stripe",
+    "fpdf2",
+    "markdown",
+    "feedparser",
+    "curl_cffi",
+    "beautifulsoup4",
     "pytest",
     "pytest-asyncio",
 )
@@ -96,7 +100,7 @@ def test_content_ops_ci_requirements_keep_needed_packages_without_heavy_stack() 
     requirement_names = {requirement_name(line) for line in requirements}
 
     for package in REQUIRED_PACKAGES:
-        assert package in requirements
+        assert requirement_name(package) in requirement_names
     for package in EXCLUDED_HEAVY_PACKAGES:
         assert requirement_name(package) not in requirement_names
 


### PR DESCRIPTION
Plan: plans/PR-Pin-Python-CI-Requirements.md
Slice phase: workflow/process
Ownership lane: ci-cd/enforcement-gaps

Phase 1 / slice 1 of the CI/CD enforcement gap tracker (#2035, G1.2/RC3).

Pins every installable line of `requirements.txt` (52 lines) and
`requirements.content_ops_ci.txt` (31 lines) to the exact versions harvested
from green main-branch CI run logs, so a green run is a function of the repo
state instead of the day's pip resolution. Sources: run 28893718452
(admin_costs, py3.11), run 28561411787 (extracted_llm_infrastructure, py3.10),
run 28893718535 (content_ops input_provider). No upgrades, no added/removed
dependencies, no workflow edits.

## Intentional

- No version moves: pins capture what CI already resolved and proved green.
- On 3.10/3.11 divergence the 3.10-resolved version is taken so one pin
  satisfies both interpreters (uvicorn 0.49.0, opencv-python 4.13.0.92,
  langgraph 1.2.7, anthropic 0.115.1, boto3 1.43.39); this PR's own py3.11
  fleet run proves they pass there too.
- The two files may pin different versions of a shared package (e.g.
  uvicorn 0.49.0 vs 0.50.2): each file pins what its own consuming fleet
  proved; they are installed by disjoint jobs.
- One documented carve-out: `nemo_toolkit[asr]` stays UNPINNED.
  `requirements.asr.txt:7` supplies a direct git-ref NeMo build and
  `security_full_sweep.yml` runs `pip-audit -r requirements.txt -r
  requirements.asr.txt` jointly; a `==` pin conflicts with the direct
  reference. Unpinned restores that name to its exact pre-PR proven form
  (51 of 52 lines pinned in requirements.txt; 31 of 31 in the content-ops
  file).
- Extras (`uvicorn[standard]`, `nemo_toolkit[asr]`), inline comments, and
  commented-out optionals (`# twilio`, `# llama-cpp-python`) preserved
  byte-identically.
- Every pin machine-validated against its original specifier
  (packaging.SpecifierSet, fail-loud) at rewrite time.
- Contract amendment (found by this PR's own CI): the requirements-shape
  guard `tests/test_content_ops_ci_requirements_workflows.py` asserted the
  REQUIRED side as exact raw strings (`"torch"`, `"asyncpg>=0.31.0"`), so the
  pins failed all four content-ops suites. The required side is now
  name-based via the test's own `requirement_name` helper — symmetric with
  the already-name-based excluded-heavy side, intent preserved (needed
  packages present, heavy stack absent, under any specifier shape).
  Boundary-probed both directions: pinned-present passes, missing-required
  still fails, a pinned heavy package is still caught.

## Deferred

- Bare unpinned `pip install pytest pytest-asyncio` lines in ~20 workflows
  (+ codex_wake_bridge pyyaml, deflection_migration_apply asyncpg) — slice 2
  consolidates CI installs when the aggregate unit gate lands.
- `requirements.asr.txt` and the atlas_edge / atlas_video-processing /
  graphiti-wrapper requirements — separate deploy surfaces, installed by no
  PR workflow.
- Full transitive lock (constraints file / pip-compile) — follow-up hardening
  once the slice-2 gate exists to validate it.

## Parked hardening

- Transitive-dependency lock (above) and hash-pinning (`--require-hashes`) —
  parked until the Phase-1 aggregate gate can prove such a change against the
  whole suite in one run.

## Cold diff reconstruction

Reconstructed the committed diff cold against origin/main before opening:

- Mechanical invariant checked by script: for both files, line count is
  unchanged and every line is identical in name/extras/inline-comment shape —
  only the version specifier moved (`INVARIANT HOLDS` over 93 + 41 lines).
- 52 + 31 requirement lines now carry `==`; closes-when check
  `grep -cvE '^\s*#|^\s*$'` == `grep -cE '=='` passes for both files.
- Specifier compliance spot-confirmed in the diff: `fastapi==0.136.3` inside
  `<0.137`, `mcp==1.28.1` inside `>=1.28.1,<2`, `apscheduler==3.11.3` inside
  `>=3.10,<4.0`.
- Guard-test change is two edits only: REQUIRED_PACKAGES entries reduced to
  bare names + the assertion switched to `requirement_name(package) in
  requirement_names` (the helper already in the file); the excluded-side
  assertion and both workflow-shape tests untouched.
- Nothing outside the two requirements files + the guard test + the plan doc
  is touched.

## Verification

- This PR triggers the consuming fleet itself (`requirements.txt` is in the
  `paths:` filters of most pytest workflows on py3.11 and of the extracted
  suites on py3.10; the content-ops suites install the content-ops file).
  Green fleet = pins reproduce what CI had.
- Local: plan doc passes `scripts/audit_plan_doc.py` (all 8 sections OK);
  closes-when grep equality confirmed (52==52, 31==31).

## AI reconciliation

Codex wave 1 (4 findings), each verified against code before action:

1. **P1 guard-test breaks on pins** (`tests/test_content_ops_ci_requirements_workflows.py`)
   — FIXED at `11d8c4ced`: required side now name-based via the test's own
   `requirement_name` helper, symmetric with the excluded side;
   boundary-probed both directions.
2. **P2 missing `### Review Contract` in plan Scope** — FIXED: block added
   per `AGENTS.md:72-81` with acceptance criteria, reachability proof,
   affected surfaces, risk areas, and triggered rule IDs (R11, R12, R2, R14).
3. **P2 NeMo pin conflicts with the joint pip-audit inputs** — FIXED:
   `nemo_toolkit[asr]` carve-out (unpinned + comment); `requirements.asr.txt`
   supplies a direct git-ref build and `security_full_sweep` audits both
   files jointly, so the unversioned pre-PR form is restored for that name.
4. **P2 bcrypt 5.x raises on >72-byte (multibyte) passwords** — WAIVED with
   rationale: pre-existing on main, not introduced by this PR (floor bump
   #2021 already merged; the green harvest runs already resolved 5.0.0 — the
   pin freezes existing reality). Runtime-auth fix is out of scope for a
   requirements-pin slice; tracked in #2039 with verified mechanics and fix
   shape.

Codex wave 2 (2 findings), verified before action:

5. **P2 Scope heading** — FIXED: `## Scope` renamed to `## Scope (this PR)`;
   `scripts/sync_pr_plan.py --check` reproduced the failure and passes after
   the rename (accepted variant of `audit_plan_doc.py` too).
6. **P2 torch/torchaudio pairing** — WAIVED, reason: no torch-2.12-matching
   torchaudio exists — 2.11.0 is the NEWEST release (`pip index versions
   torchaudio`; no 2.12 pairing available), so a "matching pair" is not
   satisfiable without an unproven torch downgrade; unpinned resolution today
   yields this exact same pair (both came from one pip resolution in the
   green harvest run, and the 2.11.0 wheel declares zero Requires-Dist so
   metadata cannot enforce pairing). The sole importer is `asr_server.py`,
   whose documented install is `requirements.asr.txt` (own unpinned stack).
   Caveat recorded as an inline comment on the pinned line.

Codex wave 3 (2 findings), both verified before action, both deferred to #2040:

7. **P2 remaining unpinned base NeMo** — WAIVED, reason: a `==` pin conflicts
   with `requirements.asr.txt`'s git-ref in the joint `security_full_sweep`
   pip-audit (verified: `pip install --dry-run` rejects `==` + `@ git` for the
   same name across `-r` files), and nemo is installed-but-never-imported by
   any `requirements.txt`-only suite (real importers `asr_server.py` via
   `requirements.asr.txt` + `scripts/debug/*` not in CI), so its unpinned
   version cannot flip a PR-suite outcome. Root fix = dedup/relocate, a
   dependency-set change tracked in #2040.
8. **P2 transitive set unpinned** — WAIVED, reason: explicitly Deferred in the
   plan from the start (top-level pins are this slice); a constraints/pip-
   compile lock reconciled across py3.11 + py3.10 must be validated by the
   Phase-1 aggregate gate (slice 2) before it can be trusted — an unvalidated
   lock risks a worse interpreter-specific non-reproducibility. Tracked in
   #2040.

All fixed or waived: yes

## Diff size

~83 changed lines across the two requirements files, ~30 in the shape-guard
test, + the plan doc (~160 lines). Total ~356 added+deleted; under the
400-LOC budget.