### PR TITLE
Resolution Audit CSV S6A private admission boundary

### DIFF
--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -325,6 +325,9 @@
       "target": "extracted_content_pipeline/support_ticket_dates.py"
     },
     {
+      "target": "extracted_content_pipeline/support_ticket_privacy.py"
+    },
+    {
       "target": "extracted_content_pipeline/support_ticket_zendesk_thread.py"
     },
     {

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -27,6 +27,10 @@ from .support_ticket_context_contract import (
     support_ticket_topic_filter,
 )
 from .support_ticket_dates import parse_support_ticket_source_date
+from .support_ticket_privacy import (
+    support_ticket_comment_is_private,
+    support_ticket_row_is_private,
+)
 
 
 DEFAULT_SUPPORT_TICKET_OUTPUTS: tuple[str, ...] = (
@@ -588,6 +592,8 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
         return {}
     if not isinstance(row, _SupportTicketRowLookup):
         row = _SupportTicketRowLookup(row)
+    if support_ticket_row_is_private(row):
+        return {}
     source_title = support_ticket_plain_text(_first_text(row, _SOURCE_TITLE_KEYS))
     text = _ticket_text(row, source_title=source_title)
     if not text:
@@ -742,7 +748,7 @@ def _comments_text(row: Mapping[str, Any]) -> str:
 
 def _comment_text(item: Any) -> str:
     if isinstance(item, Mapping):
-        if item.get("public") is False:
+        if support_ticket_comment_is_private(item):
             return ""
         return _first_text(item, ("body", "message", "text", "content", "description"))
     return _clean(item)

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -46,13 +46,19 @@ _PRIVATE_KEY_STEMS = frozenset({
     "hidden",
     "confidential",
     "nonpublic",
+    "notpublic",
     "restricted",
     "agentonly",
     "agentsonly",
     "staffonly",
 })
 _PUBLIC_KEY_STEMS = frozenset({"public", "visible", "external"})
-_STRICT_LABEL_KEY_STEMS = frozenset({"visibility", "privacy"})
+# Publication/facing flags assert privacy ONLY through boolean values:
+# ``published: false`` is private, but ``published: <date>`` is a data column.
+_PUBLIC_FLAG_KEY_STEMS = frozenset({
+    "published", "customerfacing", "clientfacing", "userfacing", "publicfacing",
+})
+_STRICT_LABEL_KEY_STEMS = frozenset({"visibility", "privacy", "confidentiality"})
 _VALUE_LABEL_KEY_STEMS = frozenset({"access", "audience"})
 _KIND_KEY_STEMS = frozenset({"type", "kind"})
 
@@ -69,12 +75,14 @@ _KEY_STOP_TOKENS = frozenset({
     "customer", "customers", "agent", "agents", "staff",
     "admin", "admins", "team", "teams",
     "user", "users", "viewer", "viewers",
+    "end", "ends", "requester", "requesters", "client", "clients",
+    "support", "supports", "facing",
 })
 # Prefix/suffix strips for keys that arrive pre-compacted (``isprivatenote``).
-_STRIP_PREFIXES = ("is", "has", "was")
+_STRIP_PREFIXES = ("is", "has", "was", "access")
 _STRIP_SUFFIXES = (
     "notes", "note", "comments", "comment", "replies", "reply",
-    "messages", "message", "msg", "flags", "flag", "only",
+    "messages", "message", "msg", "flags", "flag", "only", "access",
 )
 _NOTE_HINTS = ("note", "comment", "reply", "message", "msg")
 # Audience tokens are droppable structure, but a private audience flips a
@@ -82,6 +90,7 @@ _NOTE_HINTS = ("note", "comment", "reply", "message", "msg")
 # ``visible_to_customer``.
 _PRIVATE_AUDIENCE_TOKENS = frozenset({
     "agent", "agents", "staff", "admin", "admins", "team", "teams",
+    "support", "supports",
 })
 # Label-style suffixes are structural ONLY on label-class stems:
 # ``visibility_status`` means visibility, but ``internal_status`` is a data
@@ -134,6 +143,7 @@ _AMBIGUOUS_MARKER = "__ambiguous__"
 
 _KIND_PRIVATE = "private"
 _KIND_PUBLIC = "public"
+_KIND_PUBLIC_FLAG = "public_flag"
 _KIND_STRICT_LABEL = "strict_label"
 _KIND_VALUE_LABEL = "value_label"
 _KIND_KIND = "kind"
@@ -188,31 +198,40 @@ def _marker_is_private(
         boolish = _boolish(marker)
         if boolish is False or marker in _PUBLIC_LABELS:
             return False
-        if (
-            boolish is True
-            or marker == _AMBIGUOUS_MARKER
-            or marker in _PRIVATE_LABELS
-        ):
+        if boolish is True:
             return True
-        # Unresolved free text under a note/comment-suffixed key is a content
-        # column in row mode, not a privacy flag; comment mode fails closed.
-        return not (row_mode and note_alias)
+        if marker != _AMBIGUOUS_MARKER and _label_is_private(marker):
+            return True
+        # Remaining markers are unresolved text or container shapes. Under a
+        # note/comment-suffixed key in row mode these are content columns,
+        # not privacy flags; everywhere else they fail closed.
+        if row_mode and note_alias:
+            return False
+        return True
     if kind == _KIND_PUBLIC:
         boolish = _boolish(marker)
         if boolish is True or marker in _PUBLIC_LABELS:
             return False
-        if boolish is False or marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS:
+        if boolish is False:
             return True
-        # Unresolved free text under a note/comment-suffixed public key is a
-        # content column (public_comment / public_comments hold customer
-        # text in _PUBLIC_COMMENT_KEYS ingestion), not a privacy flag.
+        if marker != _AMBIGUOUS_MARKER and _label_is_private(marker):
+            return True
+        # Remaining markers are unresolved text or container shapes. Under a
+        # note/comment-suffixed public key these are content columns
+        # (public_comment / public_comments hold customer text or comment
+        # lists in _PUBLIC_COMMENT_KEYS ingestion), not privacy flags;
+        # everywhere else they fail closed.
         return not note_alias
+    if kind == _KIND_PUBLIC_FLAG:
+        # Publication/facing flags assert privacy only via booleans:
+        # published: false is private; published: <date> is a data column.
+        return _boolish(marker) is False
     if kind == _KIND_STRICT_LABEL:
         return marker not in _PUBLIC_LABELS
     if kind == _KIND_VALUE_LABEL:
-        return marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS
+        return marker == _AMBIGUOUS_MARKER or _label_is_private(marker)
     # _KIND_KIND: categorical, fail-open on unknown kinds by design.
-    return marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS
+    return marker == _AMBIGUOUS_MARKER or _label_is_private(marker)
 
 
 @lru_cache(maxsize=4096)
@@ -276,6 +295,8 @@ def _stem_kind(stem: str) -> str | None:
         return _KIND_PRIVATE
     if stem in _PUBLIC_KEY_STEMS:
         return _KIND_PUBLIC
+    if stem in _PUBLIC_FLAG_KEY_STEMS:
+        return _KIND_PUBLIC_FLAG
     if stem in _STRICT_LABEL_KEY_STEMS:
         return _KIND_STRICT_LABEL
     if stem in _VALUE_LABEL_KEY_STEMS:
@@ -307,7 +328,8 @@ def _marker(value: Any) -> str | None:
             return numeric
         return _key(text)
     if isinstance(value, (list, tuple, set, frozenset)) and not value:
-        return None
+        # Present-but-empty sequence markers fail closed like empty objects.
+        return _AMBIGUOUS_MARKER
     # Present but shaped in a way this boundary cannot resolve: fail closed.
     return _AMBIGUOUS_MARKER
 
@@ -341,6 +363,33 @@ def _numeric_marker(value: str) -> str | None:
     if number == 1:
         return "true"
     return None
+
+
+def _label_is_private(marker: str) -> bool:
+    """Private-label check with a closed value-stem rule.
+
+    Strips structural suffixes (only/use/access/team) so labels like
+    ``internal only``, ``private-use-only``, and ``agents only`` resolve to a
+    private stem or private audience without enumerating each spelling.
+    """
+
+    if marker == _AMBIGUOUS_MARKER:
+        return True
+    if marker in _PRIVATE_LABELS:
+        return True
+    if marker in _PUBLIC_LABELS or marker in _TRUTHY_TEXT or marker in _FALSEY_TEXT:
+        return False
+    current = marker
+    changed = True
+    while changed:
+        changed = False
+        for suffix in ("only", "use", "uses", "access", "team", "teams"):
+            if current.endswith(suffix) and len(current) > len(suffix):
+                current = current[: -len(suffix)]
+                changed = True
+    if current in _PRIVATE_KEY_STEMS or current in _PRIVATE_AUDIENCE_TOKENS:
+        return True
+    return current in _PRIVATE_LABELS
 
 
 def _boolish(marker: str) -> bool | None:

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -75,7 +75,11 @@ _PRIVATE_LABELS = frozenset({
     "internal",
     "internalcomment",
     "internalnote",
+    "internalreply",
+    "privatereply",
     "agentonly",
+    "restricted",
+    "restrictedaccess",
     "staffonly",
     "nonpublic",
     "hidden",
@@ -110,9 +114,9 @@ def _mapping_is_private(
     *,
     include_comment_alias_keys: bool,
 ) -> bool:
-    markers = {_key(key): marker_value for key, marker_value in value.items()}
+    markers = _marker_values_by_key(value)
     for key in _PUBLIC_BOOL_KEYS:
-        marker = _marker(markers.get(key))
+        marker = _marker_from_values(markers.get(key))
         if marker is None:
             continue
         if _boolish(marker) is True or marker in _PUBLIC_LABELS:
@@ -122,7 +126,7 @@ def _mapping_is_private(
     if include_comment_alias_keys:
         private_keys.update(_COMMENT_PRIVATE_ALIAS_KEYS)
     for key in private_keys:
-        marker = _marker(markers.get(key))
+        marker = _marker_from_values(markers.get(key))
         if marker is None:
             continue
         boolish = _boolish(marker)
@@ -130,21 +134,44 @@ def _mapping_is_private(
             continue
         return True
     for key in _STRICT_PRIVACY_LABEL_KEYS:
-        marker = _marker(markers.get(key))
+        marker = _marker_from_values(markers.get(key))
         if marker is None:
             continue
         if marker in _PUBLIC_LABELS:
             continue
         return True
     for key in _VALUE_PRIVACY_LABEL_KEYS:
-        marker = _marker(markers.get(key))
-        if marker in _PRIVATE_LABELS:
+        marker = _marker_from_values(markers.get(key))
+        if marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS:
             return True
     for key in _KIND_LABEL_KEYS:
-        marker = _marker(markers.get(key))
-        if marker in _PRIVATE_LABELS:
+        marker = _marker_from_values(markers.get(key))
+        if marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS:
             return True
     return False
+
+
+def _marker_values_by_key(value: Mapping[str, Any]) -> dict[str, list[Any]]:
+    markers: dict[str, list[Any]] = {}
+    for key, marker_value in value.items():
+        markers.setdefault(_key(key), []).append(marker_value)
+    return markers
+
+
+def _marker_from_values(values: list[Any] | None) -> str | None:
+    if not values:
+        return None
+    markers = [
+        marker
+        for value in values
+        if (marker := _marker(value)) is not None
+    ]
+    if not markers:
+        return None
+    first = markers[0]
+    if all(marker == first for marker in markers):
+        return first
+    return _AMBIGUOUS_MARKER
 
 
 def _marker(value: Any) -> str | None:
@@ -167,9 +194,9 @@ def _marker(value: Any) -> str | None:
 
 
 def _object_marker(value: Mapping[str, Any]) -> str:
-    markers = {_key(key): marker_value for key, marker_value in value.items()}
+    markers = _marker_values_by_key(value)
     for key in _OBJECT_MARKER_KEYS:
-        marker = _marker(markers.get(_key(key)))
+        marker = _marker_from_values(markers.get(_key(key)))
         if marker is not None:
             return marker
     return _AMBIGUOUS_MARKER

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -59,13 +59,14 @@ _PUBLIC_FLAG_KEY_STEMS = frozenset({
     "published", "customerfacing", "clientfacing", "userfacing", "publicfacing",
 })
 _STRICT_LABEL_KEY_STEMS = frozenset({"visibility", "privacy", "confidentiality"})
+_PUBLIC_FAMILY_TOKENS = frozenset({"public", "visible", "visibility", "external"})
 _VALUE_LABEL_KEY_STEMS = frozenset({"access", "audience"})
 _KIND_KEY_STEMS = frozenset({"type", "kind"})
 
 # Structural tokens that carry no privacy meaning; removing them exposes the
 # semantic remainder (``visible_to_customer`` -> ``visible``).
 _KEY_STOP_TOKENS = frozenset({
-    "is", "has", "was", "are", "to", "for", "of", "the",
+    "is", "has", "was", "are", "to", "for", "of", "the", "from",
     "flag", "flags", "marker", "markers",
     "note", "notes", "comment", "comments", "reply", "replies",
     "message", "messages", "msg",
@@ -265,6 +266,23 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
     filtered = [token for token in tokens if token not in _KEY_STOP_TOKENS]
     if filtered and len(filtered) < len(tokens):
         candidates.append("".join(filtered))
+    # Audience-only compounds (admin_only / team_only / support_team_only):
+    # every token before "only" is a private audience.
+    if (
+        len(tokens) >= 2
+        and tokens[-1] == "only"
+        and all(token in _PRIVATE_AUDIENCE_TOKENS for token in tokens[:-1])
+    ):
+        return (_KIND_PRIVATE, note_alias, flag_shaped)
+    # All-public-family compounds (publicly_visible / public_visibility):
+    # every meaningful token asserts the public side.
+    meaningful = [token for token in tokens if token not in _KEY_STOP_TOKENS]
+    if (
+        meaningful
+        and len(meaningful) >= 2
+        and all(token in _PUBLIC_FAMILY_TOKENS for token in meaningful)
+    ):
+        return (_KIND_PUBLIC, note_alias, flag_shaped)
     for candidate in candidates:
         # Bare audience-only compounds (admin_only / team_only /
         # support_only) are the staff-only side, same as agent_only.
@@ -302,9 +320,21 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
     return None
 
 
+_ADVERB_TOKEN_MAP = {
+    "publicly": "public",
+    "privately": "private",
+    "internally": "internal",
+    "externally": "external",
+    "visibly": "visible",
+}
+
+
 def _key_tokens(key: str) -> tuple[str, ...]:
     spaced = _CAMEL_RE.sub(" ", key)
-    return tuple(_TOKEN_RE.findall(spaced.lower()))
+    return tuple(
+        _ADVERB_TOKEN_MAP.get(token, token)
+        for token in _TOKEN_RE.findall(spaced.lower())
+    )
 
 
 def _stem_forms(compact: str) -> tuple[str, ...]:
@@ -377,7 +407,9 @@ _POSITIVE_OBJECT_MARKER_KEYS = frozenset({"public", "ispublic"})
 
 
 def _object_marker(value: Mapping[str, Any]) -> str:
-    verdicts: set[str] = set()
+    labels: set[str] = set()
+    bools: set[bool] = set()
+    unknown = False
     for key, marker_value in value.items():
         compact_key = _key(key)
         if compact_key not in _OBJECT_MARKER_KEYS:
@@ -386,21 +418,38 @@ def _object_marker(value: Mapping[str, Any]) -> str:
         if marker is None:
             continue
         boolish = _boolish(marker)
-        # Boolean subfields carry the KEY's polarity: {"private": true} is a
-        # private decision, {"public": false} likewise.
+        # Boolean POLARITY subfields carry their own key's direction:
+        # {"private": true} is a private decision, {"public": false} likewise.
         if boolish is not None and compact_key in _NEGATIVE_OBJECT_MARKER_KEYS:
-            verdicts.add("private" if boolish else "public")
+            labels.add("private" if boolish else "public")
             continue
         if boolish is not None and compact_key in _POSITIVE_OBJECT_MARKER_KEYS:
-            verdicts.add("public" if boolish else "private")
+            labels.add("public" if boolish else "private")
             continue
-        verdicts.add(_marker_verdict(marker))
-    # Equivalent forms of the same decision agree ("public" + true is not a
-    # conflict); any private signal or a genuine conflict fails closed.
-    if "private" in verdicts:
-        return "private" if verdicts == {"private"} else _AMBIGUOUS_MARKER
-    if verdicts == {"public"}:
-        return "public"
+        # Boolean NEUTRAL subfields ({"value": true}) keep their boolean-ness
+        # so the ENCLOSING key's polarity applies (private: {"value": true}).
+        if boolish is not None:
+            bools.add(boolish)
+            continue
+        verdict = _marker_verdict(marker)
+        if verdict == "unknown":
+            unknown = True
+        else:
+            labels.add(verdict)
+    if unknown or len(labels) > 1 or len(bools) > 1:
+        return _AMBIGUOUS_MARKER
+    if labels and bools:
+        # A label plus a bare boolean agree only when the boolean reads as
+        # the same side under a neutral/label outer key (true ~ public).
+        label = next(iter(labels))
+        boolean = next(iter(bools))
+        if (label == "public") == boolean:
+            return label
+        return _AMBIGUOUS_MARKER
+    if labels:
+        return next(iter(labels))
+    if bools:
+        return "true" if next(iter(bools)) else "false"
     return _AMBIGUOUS_MARKER
 
 
@@ -447,7 +496,11 @@ def _label_is_private(marker: str) -> bool:
     changed = True
     while changed:
         changed = False
-        for suffix in ("only", "use", "uses", "access", "team", "teams"):
+        for suffix in (
+            "only", "use", "uses", "access", "team", "teams",
+            "note", "notes", "comment", "comments",
+            "reply", "replies", "message", "messages",
+        ):
             if current.endswith(suffix) and len(current) > len(suffix):
                 current = current[: -len(suffix)]
                 changed = True

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -23,21 +23,31 @@ _PRIVATE_BOOL_KEYS = frozenset({
 _COMMENT_PRIVATE_ALIAS_KEYS = frozenset({
     "privatecomment",
     "privatecomments",
+    "isprivatecomment",
+    "isprivatecomments",
     "privatenote",
     "privatenotes",
+    "isprivatenote",
+    "isprivatenotes",
     "internalcomment",
     "internalcomments",
+    "isinternalcomment",
+    "isinternalcomments",
     "internalnote",
     "internalnotes",
+    "isinternalnote",
+    "isinternalnotes",
 })
-_PRIVACY_LABEL_KEYS = frozenset({
+_STRICT_PRIVACY_LABEL_KEYS = frozenset({
     "visibility",
     "commentvisibility",
     "privacy",
     "privacysetting",
-    "access",
 })
-_COMMENT_PRIVACY_LABEL_KEYS = frozenset({"audience"})
+_VALUE_PRIVACY_LABEL_KEYS = frozenset({
+    "access",
+    "audience",
+})
 _KIND_LABEL_KEYS = frozenset({
     "type",
     "kind",
@@ -70,6 +80,17 @@ _PRIVATE_LABELS = frozenset({
     "nonpublic",
     "hidden",
 })
+_OBJECT_MARKER_KEYS = (
+    "name",
+    "label",
+    "value",
+    "status",
+    "visibility",
+    "privacy",
+    "type",
+    "kind",
+)
+_AMBIGUOUS_MARKER = "__ambiguous__"
 
 
 def support_ticket_comment_is_private(comment: Mapping[str, Any]) -> bool:
@@ -108,16 +129,17 @@ def _mapping_is_private(
         if boolish is False or marker in _PUBLIC_LABELS:
             continue
         return True
-    privacy_label_keys = set(_PRIVACY_LABEL_KEYS)
-    if include_comment_alias_keys:
-        privacy_label_keys.update(_COMMENT_PRIVACY_LABEL_KEYS)
-    for key in privacy_label_keys:
+    for key in _STRICT_PRIVACY_LABEL_KEYS:
         marker = _marker(markers.get(key))
         if marker is None:
             continue
         if marker in _PUBLIC_LABELS:
             continue
         return True
+    for key in _VALUE_PRIVACY_LABEL_KEYS:
+        marker = _marker(markers.get(key))
+        if marker in _PRIVATE_LABELS:
+            return True
     for key in _KIND_LABEL_KEYS:
         marker = _marker(markers.get(key))
         if marker in _PRIVATE_LABELS:
@@ -128,6 +150,8 @@ def _mapping_is_private(
 def _marker(value: Any) -> str | None:
     if value in (None, "", [], {}):
         return None
+    if isinstance(value, Mapping):
+        return _object_marker(value)
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, (int, float)) and not isinstance(value, bool):
@@ -140,6 +164,15 @@ def _marker(value: Any) -> str | None:
     if numeric is not None:
         return numeric
     return _key(text)
+
+
+def _object_marker(value: Mapping[str, Any]) -> str:
+    markers = {_key(key): marker_value for key, marker_value in value.items()}
+    for key in _OBJECT_MARKER_KEYS:
+        marker = _marker(markers.get(_key(key)))
+        if marker is not None:
+            return marker
+    return _AMBIGUOUS_MARKER
 
 
 def _numeric_marker(value: str) -> str | None:

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -1,0 +1,167 @@
+"""Support-ticket private/internal admission helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+
+_COMPACT_RE = re.compile(r"[^a-z0-9]+")
+
+_PUBLIC_BOOL_KEYS = frozenset({"public", "ispublic"})
+_PRIVATE_BOOL_KEYS = frozenset({
+    "private",
+    "isprivate",
+    "internal",
+    "isinternal",
+    "hidden",
+    "nonpublic",
+})
+_COMMENT_PRIVATE_ALIAS_KEYS = frozenset({
+    "privatecomment",
+    "privatecomments",
+    "privatenote",
+    "privatenotes",
+    "internalcomment",
+    "internalcomments",
+    "internalnote",
+    "internalnotes",
+})
+_PRIVACY_LABEL_KEYS = frozenset({
+    "visibility",
+    "commentvisibility",
+    "privacy",
+    "privacysetting",
+    "access",
+    "audience",
+})
+_KIND_LABEL_KEYS = frozenset({
+    "type",
+    "kind",
+    "commenttype",
+    "messagetype",
+    "notetype",
+})
+
+_TRUTHY_TEXT = frozenset({"true", "t", "yes", "y", "on"})
+_FALSEY_TEXT = frozenset({"false", "f", "no", "n", "off"})
+_PUBLIC_LABELS = frozenset({
+    "public",
+    "publiccomment",
+    "publicreply",
+    "customer",
+    "customerreply",
+    "external",
+    "visible",
+    "published",
+})
+_PRIVATE_LABELS = frozenset({
+    "private",
+    "privatecomment",
+    "privatenote",
+    "internal",
+    "internalcomment",
+    "internalnote",
+    "agentonly",
+    "staffonly",
+    "nonpublic",
+    "hidden",
+})
+
+
+def support_ticket_comment_is_private(comment: Mapping[str, Any]) -> bool:
+    """Return true when a support-ticket comment should be treated as private."""
+
+    return _mapping_is_private(comment, include_comment_alias_keys=True)
+
+
+def support_ticket_row_is_private(row: Mapping[str, Any]) -> bool:
+    """Return true when a whole support-ticket source row is marked private."""
+
+    return _mapping_is_private(row, include_comment_alias_keys=False)
+
+
+def _mapping_is_private(
+    value: Mapping[str, Any],
+    *,
+    include_comment_alias_keys: bool,
+) -> bool:
+    markers = {_key(key): marker_value for key, marker_value in value.items()}
+    for key in _PUBLIC_BOOL_KEYS:
+        marker = _marker(markers.get(key))
+        if marker is None:
+            continue
+        if _boolish(marker) is True or marker in _PUBLIC_LABELS:
+            continue
+        return True
+    private_keys = set(_PRIVATE_BOOL_KEYS)
+    if include_comment_alias_keys:
+        private_keys.update(_COMMENT_PRIVATE_ALIAS_KEYS)
+    for key in private_keys:
+        marker = _marker(markers.get(key))
+        if marker is None:
+            continue
+        boolish = _boolish(marker)
+        if boolish is False or marker in _PUBLIC_LABELS:
+            continue
+        return True
+    for key in _PRIVACY_LABEL_KEYS:
+        marker = _marker(markers.get(key))
+        if marker is None:
+            continue
+        if marker in _PUBLIC_LABELS:
+            continue
+        return True
+    for key in _KIND_LABEL_KEYS:
+        marker = _marker(markers.get(key))
+        if marker in _PRIVATE_LABELS:
+            return True
+    return False
+
+
+def _marker(value: Any) -> str | None:
+    if value in (None, "", [], {}):
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return _numeric_marker(str(value))
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    numeric = _numeric_marker(text)
+    if numeric is not None:
+        return numeric
+    return _key(text)
+
+
+def _numeric_marker(value: str) -> str | None:
+    try:
+        number = Decimal(value)
+    except (InvalidOperation, ValueError):
+        return None
+    if number == 0:
+        return "false"
+    if number == 1:
+        return "true"
+    return None
+
+
+def _boolish(marker: str) -> bool | None:
+    if marker in _TRUTHY_TEXT:
+        return True
+    if marker in _FALSEY_TEXT:
+        return False
+    return None
+
+
+def _key(value: Any) -> str:
+    return _COMPACT_RE.sub("", str(value or "").lower())
+
+
+__all__ = [
+    "support_ticket_comment_is_private",
+    "support_ticket_row_is_private",
+]

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -67,6 +67,7 @@ _KEY_STOP_TOKENS = frozenset({
     "field", "fields", "setting", "settings",
     "only", "use", "uses",
     "customer", "customers", "agent", "agents", "staff",
+    "admin", "admins", "team", "teams",
     "user", "users", "viewer", "viewers",
 })
 # Prefix/suffix strips for keys that arrive pre-compacted (``isprivatenote``).
@@ -76,6 +77,19 @@ _STRIP_SUFFIXES = (
     "messages", "message", "msg", "flags", "flag", "only",
 )
 _NOTE_HINTS = ("note", "comment", "reply", "message", "msg")
+# Audience tokens are droppable structure, but a private audience flips a
+# public-visibility key private: ``visible_to_agents`` is the inverse of
+# ``visible_to_customer``.
+_PRIVATE_AUDIENCE_TOKENS = frozenset({
+    "agent", "agents", "staff", "admin", "admins", "team", "teams",
+})
+# Label-style suffixes are structural ONLY on label-class stems:
+# ``visibility_status`` means visibility, but ``internal_status`` is a data
+# column, so these strip only when the remainder is a label stem.
+_LABELISH_TOKENS = frozenset({
+    "label", "labels", "status", "state", "states",
+    "value", "values", "level", "levels", "mode", "modes",
+})
 
 _TRUTHY_TEXT = frozenset({"true", "t", "yes", "y", "on"})
 _FALSEY_TEXT = frozenset({"false", "f", "no", "n", "off"})
@@ -99,9 +113,10 @@ _PRIVATE_LABELS = frozenset({
     "internalreply",
     "privatereply",
     "agentonly",
+    "agentsonly",
+    "staffonly",
     "restricted",
     "restrictedaccess",
-    "staffonly",
     "nonpublic",
     "hidden",
 })
@@ -183,9 +198,15 @@ def _marker_is_private(
         # column in row mode, not a privacy flag; comment mode fails closed.
         return not (row_mode and note_alias)
     if kind == _KIND_PUBLIC:
-        if _boolish(marker) is True or marker in _PUBLIC_LABELS:
+        boolish = _boolish(marker)
+        if boolish is True or marker in _PUBLIC_LABELS:
             return False
-        return True
+        if boolish is False or marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS:
+            return True
+        # Unresolved free text under a note/comment-suffixed public key is a
+        # content column (public_comment / public_comments hold customer
+        # text in _PUBLIC_COMMENT_KEYS ingestion), not a privacy flag.
+        return not note_alias
     if kind == _KIND_STRICT_LABEL:
         return marker not in _PUBLIC_LABELS
     if kind == _KIND_VALUE_LABEL:
@@ -201,6 +222,7 @@ def _classify_key(key: str) -> tuple[str, bool] | None:
         return None
     compact_all = "".join(tokens)
     note_alias = any(hint in compact_all for hint in _NOTE_HINTS)
+    private_audience = any(token in _PRIVATE_AUDIENCE_TOKENS for token in tokens)
     candidates = [compact_all]
     filtered = [token for token in tokens if token not in _KEY_STOP_TOKENS]
     if filtered and len(filtered) < len(tokens):
@@ -209,6 +231,18 @@ def _classify_key(key: str) -> tuple[str, bool] | None:
         for stem in _stem_forms(candidate):
             kind = _stem_kind(stem)
             if kind is not None:
+                if kind == _KIND_PUBLIC and private_audience:
+                    # visible_to_agents / public_to_staff assert privacy.
+                    kind = _KIND_PRIVATE
+                return (kind, note_alias)
+    # Label-style suffixes are structural only on label-class stems
+    # (visibility_status / privacy_label / access_label), never on
+    # private stems (internal_status stays a data column).
+    delabeled = [token for token in filtered or tokens if token not in _LABELISH_TOKENS]
+    if delabeled and len(delabeled) < len(filtered or tokens):
+        for stem in _stem_forms("".join(delabeled)):
+            kind = _stem_kind(stem)
+            if kind in (_KIND_STRICT_LABEL, _KIND_VALUE_LABEL):
                 return (kind, note_alias)
     return None
 
@@ -257,8 +291,10 @@ def _marker(value: Any) -> str | None:
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, Mapping):
+        # A present-but-empty structured marker is unresolvable, not absent:
+        # {"privacy": {}} fails closed like any other unreadable marker.
         if not value:
-            return None
+            return _AMBIGUOUS_MARKER
         return _object_marker(value)
     if isinstance(value, (int, float)):
         return _numeric_marker(str(value).strip().lower()) or _key(value)

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -91,6 +91,7 @@ _NOTE_HINTS = ("note", "comment", "reply", "message", "msg")
 _PRIVATE_AUDIENCE_TOKENS = frozenset({
     "agent", "agents", "staff", "admin", "admins", "team", "teams",
     "support", "supports",
+    "internal", "private", "hidden", "confidential", "restricted",
 })
 # Label-style suffixes are structural ONLY on label-class stems:
 # ``visibility_status`` means visibility, but ``internal_status`` is a data
@@ -138,6 +139,12 @@ _OBJECT_MARKER_KEYS = frozenset({
     "privacy",
     "type",
     "kind",
+    "public",
+    "ispublic",
+    "private",
+    "isprivate",
+    "internal",
+    "hidden",
 })
 _AMBIGUOUS_MARKER = "__ambiguous__"
 
@@ -178,11 +185,14 @@ def _mapping_is_private(value: Mapping[str, Any], *, row_mode: bool) -> bool:
         classified = _classify_key(str(key))
         if classified is None:
             continue
-        kind, note_alias = classified
+        kind, note_alias, flag_shaped = classified
         marker = _marker(raw_value)
         if marker is None:
             continue
-        if _marker_is_private(kind, marker, note_alias=note_alias, row_mode=row_mode):
+        content_column = note_alias and not flag_shaped
+        if _marker_is_private(
+            kind, marker, content_column=content_column, row_mode=row_mode
+        ):
             return True
     return False
 
@@ -191,7 +201,7 @@ def _marker_is_private(
     kind: str,
     marker: str,
     *,
-    note_alias: bool,
+    content_column: bool,
     row_mode: bool,
 ) -> bool:
     if kind == _KIND_PRIVATE:
@@ -203,9 +213,10 @@ def _marker_is_private(
         if marker != _AMBIGUOUS_MARKER and _label_is_private(marker):
             return True
         # Remaining markers are unresolved text or container shapes. Under a
-        # note/comment-suffixed key in row mode these are content columns,
-        # not privacy flags; everywhere else they fail closed.
-        if row_mode and note_alias:
+        # non-flag note/comment-suffixed key in row mode these are content
+        # columns, not privacy flags -- but digit-only values are flag
+        # values, not content; everywhere else they fail closed.
+        if row_mode and content_column and not marker.isdigit():
             return False
         return True
     if kind == _KIND_PUBLIC:
@@ -217,11 +228,12 @@ def _marker_is_private(
         if marker != _AMBIGUOUS_MARKER and _label_is_private(marker):
             return True
         # Remaining markers are unresolved text or container shapes. Under a
-        # note/comment-suffixed public key these are content columns
+        # non-flag note/comment-suffixed public key these are content columns
         # (public_comment / public_comments hold customer text or comment
-        # lists in _PUBLIC_COMMENT_KEYS ingestion), not privacy flags;
-        # everywhere else they fail closed.
-        return not note_alias
+        # lists in _PUBLIC_COMMENT_KEYS ingestion), not privacy flags --
+        # but digit-only values are flag values, not content; everywhere
+        # else (incl. is_/has_ flag aliases) they fail closed.
+        return not (content_column and not marker.isdigit())
     if kind == _KIND_PUBLIC_FLAG:
         # Publication/facing flags assert privacy only via booleans:
         # published: false is private; published: <date> is a data column.
@@ -235,25 +247,49 @@ def _marker_is_private(
 
 
 @lru_cache(maxsize=4096)
-def _classify_key(key: str) -> tuple[str, bool] | None:
+def _classify_key(key: str) -> tuple[str, bool, bool] | None:
     tokens = _key_tokens(key)
     if not tokens:
         return None
     compact_all = "".join(tokens)
     note_alias = any(hint in compact_all for hint in _NOTE_HINTS)
+    # Flag-shaped aliases (is_/has_/was_ prefixed or *_flag) are assertions,
+    # never content columns, so the content carveouts must not apply to them.
+    flag_shaped = (
+        compact_all.startswith(_STRIP_PREFIXES)
+        or "flag" in tokens
+        or "flags" in tokens
+    )
     private_audience = any(token in _PRIVATE_AUDIENCE_TOKENS for token in tokens)
     candidates = [compact_all]
     filtered = [token for token in tokens if token not in _KEY_STOP_TOKENS]
     if filtered and len(filtered) < len(tokens):
         candidates.append("".join(filtered))
     for candidate in candidates:
+        # Bare audience-only compounds (admin_only / team_only /
+        # support_only) are the staff-only side, same as agent_only.
+        if candidate.endswith("only") and candidate[:-4] in _PRIVATE_AUDIENCE_TOKENS:
+            return (_KIND_PRIVATE, note_alias, flag_shaped)
         for stem in _stem_forms(candidate):
             kind = _stem_kind(stem)
             if kind is not None:
                 if kind == _KIND_PUBLIC and private_audience:
                     # visible_to_agents / public_to_staff assert privacy.
                     kind = _KIND_PRIVATE
-                return (kind, note_alias)
+                return (kind, note_alias, flag_shaped)
+    # Audience-flip pass: private-audience tokens are droppable structure on
+    # a public-visibility stem (visible_to_internal / public_to_internal).
+    if private_audience:
+        depersoned = [
+            token
+            for token in tokens
+            if token not in _KEY_STOP_TOKENS
+            and token not in _PRIVATE_AUDIENCE_TOKENS
+        ]
+        if depersoned and len(depersoned) < len(tokens):
+            for stem in _stem_forms("".join(depersoned)):
+                if _stem_kind(stem) in (_KIND_PUBLIC, _KIND_PUBLIC_FLAG):
+                    return (_KIND_PRIVATE, note_alias, flag_shaped)
     # Label-style suffixes are structural only on label-class stems
     # (visibility_status / privacy_label / access_label), never on
     # private stems (internal_status stays a data column).
@@ -262,7 +298,7 @@ def _classify_key(key: str) -> tuple[str, bool] | None:
         for stem in _stem_forms("".join(delabeled)):
             kind = _stem_kind(stem)
             if kind in (_KIND_STRICT_LABEL, _KIND_VALUE_LABEL):
-                return (kind, note_alias)
+                return (kind, note_alias, flag_shaped)
     return None
 
 
@@ -334,20 +370,48 @@ def _marker(value: Any) -> str | None:
     return _AMBIGUOUS_MARKER
 
 
+_NEGATIVE_OBJECT_MARKER_KEYS = frozenset({
+    "private", "isprivate", "internal", "hidden",
+})
+_POSITIVE_OBJECT_MARKER_KEYS = frozenset({"public", "ispublic"})
+
+
 def _object_marker(value: Mapping[str, Any]) -> str:
-    resolved: list[str] = []
+    verdicts: set[str] = set()
     for key, marker_value in value.items():
-        if _key(key) not in _OBJECT_MARKER_KEYS:
+        compact_key = _key(key)
+        if compact_key not in _OBJECT_MARKER_KEYS:
             continue
         marker = _marker(marker_value)
-        if marker is not None:
-            resolved.append(marker)
-    if not resolved:
-        return _AMBIGUOUS_MARKER
-    first = resolved[0]
-    if all(marker == first for marker in resolved):
-        return first
+        if marker is None:
+            continue
+        boolish = _boolish(marker)
+        # Boolean subfields carry the KEY's polarity: {"private": true} is a
+        # private decision, {"public": false} likewise.
+        if boolish is not None and compact_key in _NEGATIVE_OBJECT_MARKER_KEYS:
+            verdicts.add("private" if boolish else "public")
+            continue
+        if boolish is not None and compact_key in _POSITIVE_OBJECT_MARKER_KEYS:
+            verdicts.add("public" if boolish else "private")
+            continue
+        verdicts.add(_marker_verdict(marker))
+    # Equivalent forms of the same decision agree ("public" + true is not a
+    # conflict); any private signal or a genuine conflict fails closed.
+    if "private" in verdicts:
+        return "private" if verdicts == {"private"} else _AMBIGUOUS_MARKER
+    if verdicts == {"public"}:
+        return "public"
     return _AMBIGUOUS_MARKER
+
+
+def _marker_verdict(marker: str) -> str:
+    if _boolish(marker) is True or marker in _PUBLIC_LABELS:
+        return "public"
+    if _boolish(marker) is False or (
+        marker != _AMBIGUOUS_MARKER and _label_is_private(marker)
+    ):
+        return "private"
+    return "unknown"
 
 
 def _numeric_marker(value: str) -> str | None:
@@ -386,6 +450,10 @@ def _label_is_private(marker: str) -> bool:
         for suffix in ("only", "use", "uses", "access", "team", "teams"):
             if current.endswith(suffix) and len(current) > len(suffix):
                 current = current[: -len(suffix)]
+                changed = True
+        for prefix in ("for", "is"):
+            if current.startswith(prefix) and len(current) > len(prefix):
+                current = current[len(prefix):]
                 changed = True
     if current in _PRIVATE_KEY_STEMS or current in _PRIVATE_AUDIENCE_TOKENS:
         return True

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -1,60 +1,81 @@
-"""Support-ticket private/internal admission helpers."""
+"""Support-ticket private/internal admission helpers.
+
+Design: fail-closed pattern-family classification, not marker enumeration.
+
+The privacy-marker vocabulary (key aliases x value spellings x container
+shapes) is producer-defined and open, so exact-match enumeration cannot
+converge -- every unlisted alias admits private text. The closed rule here:
+
+- A key is privacy-relevant iff its compacted token remainder (raw, and after
+  dropping structural stopwords and ``is/has/was`` prefixes and
+  note/comment/reply/flag suffixes) EXACTLY equals a privacy stem. Exact
+  equality of the semantic remainder -- never substring containment -- so data
+  columns such as ``internal_id``, ``private_ip``, ``publication_date``,
+  ``hidden_count``, and ``has_access`` are not markers.
+- For a privacy-relevant key, only values that affirmatively resolve public
+  admit the row/comment. Unknown text, conflicting or empty object markers,
+  and malformed numerics all classify private. Kind keys (``type``/``kind``)
+  keep fail-open categorical semantics; ``access``/``audience`` keep
+  value-label semantics.
+- The public predicates are total functions: any unexpected classification
+  error returns private instead of raising, so a malformed marker can never
+  crash package or Zendesk ingestion.
+- Row-mode note-content carveout: a note/comment-suffixed private key whose
+  value is free text is a content column, not a flag, and does not reject the
+  whole row; flag-valued forms (``is_private_note: true``) do.
+"""
 
 from __future__ import annotations
 
 import re
 from collections.abc import Mapping
 from decimal import Decimal
+from functools import lru_cache
 from typing import Any
 
-
 _COMPACT_RE = re.compile(r"[^a-z0-9]+")
+_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
 _NUMERIC_MARKER_RE = re.compile(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?\Z")
 
-_PUBLIC_BOOL_KEYS = frozenset({"public", "ispublic"})
-_PRIVATE_BOOL_KEYS = frozenset({
+# Key stems: the CLOSED set of privacy meanings a key can carry. A key
+# classifies iff its semantic remainder equals one of these exactly.
+_PRIVATE_KEY_STEMS = frozenset({
     "private",
-    "isprivate",
     "internal",
-    "isinternal",
     "hidden",
+    "confidential",
     "nonpublic",
+    "restricted",
+    "agentonly",
+    "agentsonly",
+    "staffonly",
 })
-_COMMENT_PRIVATE_ALIAS_KEYS = frozenset({
-    "privatecomment",
-    "privatecomments",
-    "isprivatecomment",
-    "isprivatecomments",
-    "privatenote",
-    "privatenotes",
-    "isprivatenote",
-    "isprivatenotes",
-    "internalcomment",
-    "internalcomments",
-    "isinternalcomment",
-    "isinternalcomments",
-    "internalnote",
-    "internalnotes",
-    "isinternalnote",
-    "isinternalnotes",
+_PUBLIC_KEY_STEMS = frozenset({"public", "visible", "external"})
+_STRICT_LABEL_KEY_STEMS = frozenset({"visibility", "privacy"})
+_VALUE_LABEL_KEY_STEMS = frozenset({"access", "audience"})
+_KIND_KEY_STEMS = frozenset({"type", "kind"})
+
+# Structural tokens that carry no privacy meaning; removing them exposes the
+# semantic remainder (``visible_to_customer`` -> ``visible``).
+_KEY_STOP_TOKENS = frozenset({
+    "is", "has", "was", "are", "to", "for", "of", "the",
+    "flag", "flags", "marker", "markers",
+    "note", "notes", "comment", "comments", "reply", "replies",
+    "message", "messages", "msg",
+    "row", "rows", "ticket", "tickets", "entry", "entries",
+    "field", "fields", "setting", "settings",
+    "only", "use", "uses",
+    "customer", "customers", "agent", "agents", "staff",
+    "user", "users", "viewer", "viewers",
 })
-_STRICT_PRIVACY_LABEL_KEYS = frozenset({
-    "visibility",
-    "commentvisibility",
-    "privacy",
-    "privacysetting",
-})
-_VALUE_PRIVACY_LABEL_KEYS = frozenset({
-    "access",
-    "audience",
-})
-_KIND_LABEL_KEYS = frozenset({
-    "type",
-    "kind",
-    "commenttype",
-    "messagetype",
-    "notetype",
-})
+# Prefix/suffix strips for keys that arrive pre-compacted (``isprivatenote``).
+_STRIP_PREFIXES = ("is", "has", "was")
+_STRIP_SUFFIXES = (
+    "notes", "note", "comments", "comment", "replies", "reply",
+    "messages", "message", "msg", "flags", "flag", "only",
+)
+_NOTE_HINTS = ("note", "comment", "reply", "message", "msg")
 
 _TRUTHY_TEXT = frozenset({"true", "t", "yes", "y", "on"})
 _FALSEY_TEXT = frozenset({"false", "f", "no", "n", "off"})
@@ -84,7 +105,7 @@ _PRIVATE_LABELS = frozenset({
     "nonpublic",
     "hidden",
 })
-_OBJECT_MARKER_KEYS = (
+_OBJECT_MARKER_KEYS = frozenset({
     "name",
     "label",
     "value",
@@ -93,119 +114,192 @@ _OBJECT_MARKER_KEYS = (
     "privacy",
     "type",
     "kind",
-)
+})
 _AMBIGUOUS_MARKER = "__ambiguous__"
+
+_KIND_PRIVATE = "private"
+_KIND_PUBLIC = "public"
+_KIND_STRICT_LABEL = "strict_label"
+_KIND_VALUE_LABEL = "value_label"
+_KIND_KIND = "kind"
 
 
 def support_ticket_comment_is_private(comment: Mapping[str, Any]) -> bool:
-    """Return true when a support-ticket comment should be treated as private."""
+    """Return true when a support-ticket comment should be treated as private.
 
-    return _mapping_is_private(comment, include_comment_alias_keys=True)
+    Total function: classification errors fail closed (private), never raise.
+    """
+
+    try:
+        return _mapping_is_private(comment, row_mode=False)
+    except Exception:
+        return True
 
 
 def support_ticket_row_is_private(row: Mapping[str, Any]) -> bool:
-    """Return true when a whole support-ticket source row is marked private."""
+    """Return true when a whole support-ticket source row is marked private.
 
-    return _mapping_is_private(row, include_comment_alias_keys=False)
+    Total function: classification errors fail closed (private), never raise.
+    """
+
+    try:
+        return _mapping_is_private(row, row_mode=True)
+    except Exception:
+        return True
 
 
-def _mapping_is_private(
-    value: Mapping[str, Any],
-    *,
-    include_comment_alias_keys: bool,
-) -> bool:
-    markers = _marker_values_by_key(value)
-    for key in _PUBLIC_BOOL_KEYS:
-        marker = _marker_from_values(markers.get(key))
+def _mapping_is_private(value: Mapping[str, Any], *, row_mode: bool) -> bool:
+    for key, raw_value in value.items():
+        classified = _classify_key(str(key))
+        if classified is None:
+            continue
+        kind, note_alias = classified
+        marker = _marker(raw_value)
         if marker is None:
             continue
-        if _boolish(marker) is True or marker in _PUBLIC_LABELS:
-            continue
-        return True
-    private_keys = set(_PRIVATE_BOOL_KEYS)
-    if include_comment_alias_keys:
-        private_keys.update(_COMMENT_PRIVATE_ALIAS_KEYS)
-    for key in private_keys:
-        marker = _marker_from_values(markers.get(key))
-        if marker is None:
-            continue
-        boolish = _boolish(marker)
-        if boolish is False or marker in _PUBLIC_LABELS:
-            continue
-        return True
-    for key in _STRICT_PRIVACY_LABEL_KEYS:
-        marker = _marker_from_values(markers.get(key))
-        if marker is None:
-            continue
-        if marker in _PUBLIC_LABELS:
-            continue
-        return True
-    for key in _VALUE_PRIVACY_LABEL_KEYS:
-        marker = _marker_from_values(markers.get(key))
-        if marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS:
-            return True
-    for key in _KIND_LABEL_KEYS:
-        marker = _marker_from_values(markers.get(key))
-        if marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS:
+        if _marker_is_private(kind, marker, note_alias=note_alias, row_mode=row_mode):
             return True
     return False
 
 
-def _marker_values_by_key(value: Mapping[str, Any]) -> dict[str, list[Any]]:
-    markers: dict[str, list[Any]] = {}
-    for key, marker_value in value.items():
-        markers.setdefault(_key(key), []).append(marker_value)
-    return markers
+def _marker_is_private(
+    kind: str,
+    marker: str,
+    *,
+    note_alias: bool,
+    row_mode: bool,
+) -> bool:
+    if kind == _KIND_PRIVATE:
+        boolish = _boolish(marker)
+        if boolish is False or marker in _PUBLIC_LABELS:
+            return False
+        if (
+            boolish is True
+            or marker == _AMBIGUOUS_MARKER
+            or marker in _PRIVATE_LABELS
+        ):
+            return True
+        # Unresolved free text under a note/comment-suffixed key is a content
+        # column in row mode, not a privacy flag; comment mode fails closed.
+        return not (row_mode and note_alias)
+    if kind == _KIND_PUBLIC:
+        if _boolish(marker) is True or marker in _PUBLIC_LABELS:
+            return False
+        return True
+    if kind == _KIND_STRICT_LABEL:
+        return marker not in _PUBLIC_LABELS
+    if kind == _KIND_VALUE_LABEL:
+        return marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS
+    # _KIND_KIND: categorical, fail-open on unknown kinds by design.
+    return marker == _AMBIGUOUS_MARKER or marker in _PRIVATE_LABELS
 
 
-def _marker_from_values(values: list[Any] | None) -> str | None:
-    if not values:
+@lru_cache(maxsize=4096)
+def _classify_key(key: str) -> tuple[str, bool] | None:
+    tokens = _key_tokens(key)
+    if not tokens:
         return None
-    markers = [
-        marker
-        for value in values
-        if (marker := _marker(value)) is not None
-    ]
-    if not markers:
-        return None
-    first = markers[0]
-    if all(marker == first for marker in markers):
-        return first
-    return _AMBIGUOUS_MARKER
+    compact_all = "".join(tokens)
+    note_alias = any(hint in compact_all for hint in _NOTE_HINTS)
+    candidates = [compact_all]
+    filtered = [token for token in tokens if token not in _KEY_STOP_TOKENS]
+    if filtered and len(filtered) < len(tokens):
+        candidates.append("".join(filtered))
+    for candidate in candidates:
+        for stem in _stem_forms(candidate):
+            kind = _stem_kind(stem)
+            if kind is not None:
+                return (kind, note_alias)
+    return None
+
+
+def _key_tokens(key: str) -> tuple[str, ...]:
+    spaced = _CAMEL_RE.sub(" ", key)
+    return tuple(_TOKEN_RE.findall(spaced.lower()))
+
+
+def _stem_forms(compact: str) -> tuple[str, ...]:
+    """All prefix/suffix-stripped variants of a compacted key, incl itself."""
+
+    seen: set[str] = set()
+    queue = [compact]
+    while queue:
+        current = queue.pop()
+        if not current or current in seen:
+            continue
+        seen.add(current)
+        for prefix in _STRIP_PREFIXES:
+            if current.startswith(prefix) and len(current) > len(prefix):
+                queue.append(current[len(prefix):])
+        for suffix in _STRIP_SUFFIXES:
+            if current.endswith(suffix) and len(current) > len(suffix):
+                queue.append(current[: -len(suffix)])
+    return tuple(seen)
+
+
+def _stem_kind(stem: str) -> str | None:
+    if stem in _PRIVATE_KEY_STEMS:
+        return _KIND_PRIVATE
+    if stem in _PUBLIC_KEY_STEMS:
+        return _KIND_PUBLIC
+    if stem in _STRICT_LABEL_KEY_STEMS:
+        return _KIND_STRICT_LABEL
+    if stem in _VALUE_LABEL_KEY_STEMS:
+        return _KIND_VALUE_LABEL
+    if stem in _KIND_KEY_STEMS:
+        return _KIND_KIND
+    return None
 
 
 def _marker(value: Any) -> str | None:
-    if value in (None, "", [], {}):
+    if value is None:
         return None
-    if isinstance(value, Mapping):
-        return _object_marker(value)
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        text = str(value).strip().lower()
-        return _numeric_marker(text) or _key(text)
-    text = str(value).strip().lower()
-    if not text:
+    if isinstance(value, Mapping):
+        if not value:
+            return None
+        return _object_marker(value)
+    if isinstance(value, (int, float)):
+        return _numeric_marker(str(value).strip().lower()) or _key(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if not text:
+            return None
+        numeric = _numeric_marker(text)
+        if numeric is not None:
+            return numeric
+        return _key(text)
+    if isinstance(value, (list, tuple, set, frozenset)) and not value:
         return None
-    numeric = _numeric_marker(text)
-    if numeric is not None:
-        return numeric
-    return _key(text)
+    # Present but shaped in a way this boundary cannot resolve: fail closed.
+    return _AMBIGUOUS_MARKER
 
 
 def _object_marker(value: Mapping[str, Any]) -> str:
-    markers = _marker_values_by_key(value)
-    for key in _OBJECT_MARKER_KEYS:
-        marker = _marker_from_values(markers.get(_key(key)))
+    resolved: list[str] = []
+    for key, marker_value in value.items():
+        if _key(key) not in _OBJECT_MARKER_KEYS:
+            continue
+        marker = _marker(marker_value)
         if marker is not None:
-            return marker
+            resolved.append(marker)
+    if not resolved:
+        return _AMBIGUOUS_MARKER
+    first = resolved[0]
+    if all(marker == first for marker in resolved):
+        return first
     return _AMBIGUOUS_MARKER
 
 
 def _numeric_marker(value: str) -> str | None:
     if not _NUMERIC_MARKER_RE.fullmatch(value):
         return None
-    number = Decimal(value)
+    try:
+        number = Decimal(value)
+    except (ArithmeticError, ValueError):
+        # Malformed/oversized numerics are unresolvable, never a crash.
+        return _AMBIGUOUS_MARKER
     if number == 0:
         return "false"
     if number == 1:

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -60,6 +60,19 @@ _PUBLIC_FLAG_KEY_STEMS = frozenset({
 })
 _STRICT_LABEL_KEY_STEMS = frozenset({"visibility", "privacy", "confidentiality"})
 _PUBLIC_FAMILY_TOKENS = frozenset({"public", "visible", "visibility", "external"})
+_PUBLIC_AUDIENCE_TOKENS = frozenset({
+    "customer", "customers", "user", "users", "enduser", "endusers",
+    "requester", "requesters", "client", "clients", "viewer", "viewers",
+    "everyone",
+})
+# Structural tokens inside VALUE phrases ("restricted to agents",
+# "private_response", "for internal use only").
+_VALUE_STRUCTURAL_TOKENS = frozenset({
+    "is", "to", "for", "of", "the", "from", "only", "use", "uses",
+    "access", "team", "teams", "note", "notes", "comment", "comments",
+    "reply", "replies", "message", "messages", "msg",
+    "response", "responses", "answer", "answers", "facing",
+})
 _VALUE_LABEL_KEY_STEMS = frozenset({"access", "audience"})
 _KIND_KEY_STEMS = frozenset({"type", "kind"})
 
@@ -113,6 +126,9 @@ _PUBLIC_LABELS = frozenset({
     "external",
     "visible",
     "published",
+    "everyone",
+    "anyone",
+    "all",
 })
 _PRIVATE_LABELS = frozenset({
     "private",
@@ -187,7 +203,7 @@ def _mapping_is_private(value: Mapping[str, Any], *, row_mode: bool) -> bool:
         if classified is None:
             continue
         kind, note_alias, flag_shaped = classified
-        marker = _marker(raw_value)
+        marker = _marker(raw_value, negative_polarity=kind == _KIND_PRIVATE)
         if marker is None:
             continue
         content_column = note_alias and not flag_shaped
@@ -266,6 +282,18 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
     filtered = [token for token in tokens if token not in _KEY_STOP_TOKENS]
     if filtered and len(filtered) < len(tokens):
         candidates.append("".join(filtered))
+    # Negated assertions flip polarity: not_visible_to_customer /
+    # not_publicly_visible / not_customer_facing assert the private side,
+    # not_private asserts the public side.
+    if tokens[0] in ("not", "non") and len(tokens) > 1:
+        rest = _classify_key(" ".join(tokens[1:]))
+        if rest is not None:
+            rest_kind, rest_note, rest_flag = rest
+            if rest_kind in (_KIND_PUBLIC, _KIND_PUBLIC_FLAG):
+                return (_KIND_PRIVATE, note_alias or rest_note, flag_shaped or rest_flag)
+            if rest_kind == _KIND_PRIVATE:
+                return (_KIND_PUBLIC, note_alias or rest_note, flag_shaped or rest_flag)
+        # Unresolvable negations stay unclassified rather than guessing.
     # Audience-only compounds (admin_only / team_only / support_team_only):
     # every token before "only" is a private audience.
     if (
@@ -274,6 +302,22 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
         and all(token in _PRIVATE_AUDIENCE_TOKENS for token in tokens[:-1])
     ):
         return (_KIND_PRIVATE, note_alias, flag_shaped)
+    # Audience-note keys (staff_note / agent_reply / support_note): every
+    # token is a private audience or note structure, with both present.
+    note_structure = frozenset({
+        "note", "notes", "comment", "comments", "reply", "replies",
+        "message", "messages", "msg", "response", "responses",
+    })
+    if (
+        len(tokens) >= 2
+        and any(token in _PRIVATE_AUDIENCE_TOKENS for token in tokens)
+        and any(token in note_structure for token in tokens)
+        and all(
+            token in _PRIVATE_AUDIENCE_TOKENS or token in note_structure
+            for token in tokens
+        )
+    ):
+        return (_KIND_PRIVATE, True, flag_shaped)
     # All-public-family compounds (publicly_visible / public_visibility):
     # every meaningful token asserts the public side.
     meaningful = [token for token in tokens if token not in _KEY_STOP_TOKENS]
@@ -372,7 +416,7 @@ def _stem_kind(stem: str) -> str | None:
     return None
 
 
-def _marker(value: Any) -> str | None:
+def _marker(value: Any, *, negative_polarity: bool = False) -> str | None:
     if value is None:
         return None
     if isinstance(value, bool):
@@ -382,7 +426,7 @@ def _marker(value: Any) -> str | None:
         # {"privacy": {}} fails closed like any other unreadable marker.
         if not value:
             return _AMBIGUOUS_MARKER
-        return _object_marker(value)
+        return _object_marker(value, negative_polarity=negative_polarity)
     if isinstance(value, (int, float)):
         return _numeric_marker(str(value).strip().lower()) or _key(value)
     if isinstance(value, str):
@@ -392,7 +436,7 @@ def _marker(value: Any) -> str | None:
         numeric = _numeric_marker(text)
         if numeric is not None:
             return numeric
-        return _key(text)
+        return _value_marker(text)
     if isinstance(value, (list, tuple, set, frozenset)) and not value:
         # Present-but-empty sequence markers fail closed like empty objects.
         return _AMBIGUOUS_MARKER
@@ -400,57 +444,51 @@ def _marker(value: Any) -> str | None:
     return _AMBIGUOUS_MARKER
 
 
-_NEGATIVE_OBJECT_MARKER_KEYS = frozenset({
-    "private", "isprivate", "internal", "hidden",
-})
-_POSITIVE_OBJECT_MARKER_KEYS = frozenset({"public", "ispublic"})
+def _object_marker(value: Mapping[str, Any], *, negative_polarity: bool) -> str:
+    """Resolve a structured marker to a verdict in the OUTER key's frame.
 
+    Neutral boolean subfields ({"value": true}) take the enclosing key's
+    polarity; alias subfields (publicly_visible, hidden_from_customer) take
+    their own classified polarity; label subfields resolve by value. Any
+    conflict between verdicts fails closed.
+    """
 
-def _object_marker(value: Mapping[str, Any]) -> str:
-    labels: set[str] = set()
-    bools: set[bool] = set()
-    unknown = False
+    verdicts: set[str] = set()
     for key, marker_value in value.items():
         compact_key = _key(key)
-        if compact_key not in _OBJECT_MARKER_KEYS:
-            continue
+        classified = _classify_key(str(key))
+        subfield_kind = classified[0] if classified is not None else None
+        polarity_subfield = subfield_kind in (
+            _KIND_PRIVATE, _KIND_PUBLIC, _KIND_PUBLIC_FLAG,
+        )
+        if not polarity_subfield and compact_key not in _OBJECT_MARKER_KEYS:
+            if subfield_kind is None:
+                continue
         marker = _marker(marker_value)
         if marker is None:
             continue
         boolish = _boolish(marker)
-        # Boolean POLARITY subfields carry their own key's direction:
-        # {"private": true} is a private decision, {"public": false} likewise.
-        if boolish is not None and compact_key in _NEGATIVE_OBJECT_MARKER_KEYS:
-            labels.add("private" if boolish else "public")
-            continue
-        if boolish is not None and compact_key in _POSITIVE_OBJECT_MARKER_KEYS:
-            labels.add("public" if boolish else "private")
-            continue
-        # Boolean NEUTRAL subfields ({"value": true}) keep their boolean-ness
-        # so the ENCLOSING key's polarity applies (private: {"value": true}).
         if boolish is not None:
-            bools.add(boolish)
+            # Assertion subfields carry their OWN polarity ({"private": true},
+            # {"publicly_visible": false}); neutral subfields ({"value": true})
+            # take the enclosing key's polarity.
+            if subfield_kind == _KIND_PRIVATE:
+                verdicts.add("private" if boolish else "public")
+            elif subfield_kind in (_KIND_PUBLIC, _KIND_PUBLIC_FLAG):
+                verdicts.add("public" if boolish else "private")
+            elif compact_key in _OBJECT_MARKER_KEYS:
+                if negative_polarity:
+                    verdicts.add("private" if boolish else "public")
+                else:
+                    verdicts.add("public" if boolish else "private")
+            else:
+                # Label-class alias subfield with a bare boolean: unresolvable.
+                verdicts.add("unknown")
             continue
-        verdict = _marker_verdict(marker)
-        if verdict == "unknown":
-            unknown = True
-        else:
-            labels.add(verdict)
-    if unknown or len(labels) > 1 or len(bools) > 1:
+        verdicts.add(_marker_verdict(marker))
+    if not verdicts or "unknown" in verdicts or len(verdicts) > 1:
         return _AMBIGUOUS_MARKER
-    if labels and bools:
-        # A label plus a bare boolean agree only when the boolean reads as
-        # the same side under a neutral/label outer key (true ~ public).
-        label = next(iter(labels))
-        boolean = next(iter(bools))
-        if (label == "public") == boolean:
-            return label
-        return _AMBIGUOUS_MARKER
-    if labels:
-        return next(iter(labels))
-    if bools:
-        return "true" if next(iter(bools)) else "false"
-    return _AMBIGUOUS_MARKER
+    return next(iter(verdicts))
 
 
 def _marker_verdict(marker: str) -> str:
@@ -461,6 +499,49 @@ def _marker_verdict(marker: str) -> str:
     ):
         return "private"
     return "unknown"
+
+
+def _value_marker(text: str) -> str:
+    """Resolve a text value to a marker, token-classifying label phrases.
+
+    Multi-token values get the same closed token rule as keys, so
+    "restricted to agents", "support staff only", "private_response", and
+    "visible to customer" resolve by their semantic tokens instead of
+    per-spelling compact enumeration. Single tokens and already-known
+    compacts keep the pinned membership behavior.
+    """
+
+    compact = _key(text)
+    if (
+        compact in _PUBLIC_LABELS
+        or compact in _PRIVATE_LABELS
+        or compact in _TRUTHY_TEXT
+        or compact in _FALSEY_TEXT
+    ):
+        return compact
+    tokens = _key_tokens(text)
+    if len(tokens) >= 2:
+        private_side = _PRIVATE_KEY_STEMS | _PRIVATE_AUDIENCE_TOKENS
+        public_side = (
+            _PUBLIC_FAMILY_TOKENS | _PUBLIC_AUDIENCE_TOKENS | _PUBLIC_LABELS
+        )
+        has_private = any(token in private_side for token in tokens)
+        has_public = any(token in public_side for token in tokens)
+        structural = _VALUE_STRUCTURAL_TOKENS
+        if has_private and all(
+            token in private_side or token in structural or token in public_side
+            for token in tokens
+        ):
+            # Any private signal in a privacy phrase fails closed, even
+            # alongside public words ("visible to staff").
+            return "private"
+        if (
+            has_public
+            and not has_private
+            and all(token in public_side or token in structural for token in tokens)
+        ):
+            return "public"
+    return compact
 
 
 def _numeric_marker(value: str) -> str | None:

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from typing import Any
 
 
 _COMPACT_RE = re.compile(r"[^a-z0-9]+")
+_NUMERIC_MARKER_RE = re.compile(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?\Z")
 
 _PUBLIC_BOOL_KEYS = frozenset({"public", "ispublic"})
 _PRIVATE_BOOL_KEYS = frozenset({
@@ -35,8 +36,8 @@ _PRIVACY_LABEL_KEYS = frozenset({
     "privacy",
     "privacysetting",
     "access",
-    "audience",
 })
+_COMMENT_PRIVACY_LABEL_KEYS = frozenset({"audience"})
 _KIND_LABEL_KEYS = frozenset({
     "type",
     "kind",
@@ -107,7 +108,10 @@ def _mapping_is_private(
         if boolish is False or marker in _PUBLIC_LABELS:
             continue
         return True
-    for key in _PRIVACY_LABEL_KEYS:
+    privacy_label_keys = set(_PRIVACY_LABEL_KEYS)
+    if include_comment_alias_keys:
+        privacy_label_keys.update(_COMMENT_PRIVACY_LABEL_KEYS)
+    for key in privacy_label_keys:
         marker = _marker(markers.get(key))
         if marker is None:
             continue
@@ -127,7 +131,8 @@ def _marker(value: Any) -> str | None:
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return _numeric_marker(str(value))
+        text = str(value).strip().lower()
+        return _numeric_marker(text) or _key(text)
     text = str(value).strip().lower()
     if not text:
         return None
@@ -138,10 +143,9 @@ def _marker(value: Any) -> str | None:
 
 
 def _numeric_marker(value: str) -> str | None:
-    try:
-        number = Decimal(value)
-    except (InvalidOperation, ValueError):
+    if not _NUMERIC_MARKER_RE.fullmatch(value):
         return None
+    number = Decimal(value)
     if number == 0:
         return "false"
     if number == 1:

--- a/extracted_content_pipeline/support_ticket_zendesk_thread.py
+++ b/extracted_content_pipeline/support_ticket_zendesk_thread.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from typing import Any
 
 from .support_ticket_clustering import support_ticket_plain_text
-from .support_ticket_privacy import support_ticket_comment_is_private
+from .support_ticket_privacy import (
+    support_ticket_comment_is_private,
+    support_ticket_row_is_private,
+)
 
 
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -34,6 +37,13 @@ _AUTO_ACK_PATTERNS = (
     ),
 )
 _UNRATED_ZENDESK_SCORES = frozenset({"unoffered", "offered"})
+
+
+class _SkipZendeskThreadRow:
+    pass
+
+
+_SKIP_ZENDESK_THREAD_ROW = _SkipZendeskThreadRow()
 
 
 @dataclass(frozen=True)
@@ -109,6 +119,8 @@ def rows_from_zendesk_full_thread(
             break
         processed_row_count = index
         normalized = _row_from_entry(entry, row_index=index)
+        if normalized is _SKIP_ZENDESK_THREAD_ROW:
+            continue
         if normalized is None:
             warnings.append({
                 "code": "zendesk_thread_ticket_missing",
@@ -146,12 +158,14 @@ def _row_from_entry(
     entry: Any,
     *,
     row_index: int,
-) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+) -> tuple[dict[str, Any], list[dict[str, Any]]] | _SkipZendeskThreadRow | None:
     if not isinstance(entry, Mapping):
         return None
     ticket = entry.get("ticket") if isinstance(entry.get("ticket"), Mapping) else entry
     if not isinstance(ticket, Mapping):
         return None
+    if support_ticket_row_is_private(entry) or support_ticket_row_is_private(ticket):
+        return _SKIP_ZENDESK_THREAD_ROW
     requester_id = _id_text(ticket.get("requester_id"))
     ticket_id = _clean(ticket.get("id")) or f"zendesk-ticket-{row_index}"
     subject = _plain(ticket.get("subject") or ticket.get("raw_subject"))

--- a/extracted_content_pipeline/support_ticket_zendesk_thread.py
+++ b/extracted_content_pipeline/support_ticket_zendesk_thread.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from .support_ticket_clustering import support_ticket_plain_text
+from .support_ticket_privacy import support_ticket_comment_is_private
 
 
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -175,7 +176,7 @@ def _row_from_entry(
     private_comment_keys = {
         _text_key(_comment_text(comment))
         for comment in comments
-        if isinstance(comment, Mapping) and comment.get("public") is False
+        if isinstance(comment, Mapping) and support_ticket_comment_is_private(comment)
     }
     description = _plain(ticket.get("description"))
     if description and _text_key(description) not in private_comment_keys:
@@ -189,7 +190,7 @@ def _row_from_entry(
                 "message": "Ignored Zendesk comment because it was not an object.",
             })
             continue
-        if comment.get("public") is False:
+        if support_ticket_comment_is_private(comment):
             continue
         text = _comment_text(comment)
         if not text:

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -98,11 +98,15 @@ The slice adds a small package-owned helper for support-ticket privacy marker
 normalization. It exposes row and comment admission wrappers backed by the same
 normalizer: public markers with false-like values and private/internal markers
 are private, explicit public values are public, and ambiguous privacy markers
-fail closed. Package rows call the row wrapper before any `source_title`, body,
-or comment extraction. Package comments and Zendesk comments use the comment
-wrapper before their text is appended. Zendesk private-description duplicate
-suppression still compares raw normalized text keys, so filtering does not
-depend on a separate sanitizer shape.
+fail closed. Strict privacy labels such as `visibility` and `privacy` still
+fail closed, while ordinary metadata labels such as `access` and `audience`
+classify by value so routing phrases like "Account access" do not drop public
+rows. Object-shaped markers normalize through the same label vocabulary.
+Package rows call the row wrapper before any `source_title`, body, or comment
+extraction. Package comments and Zendesk comments use the comment wrapper before
+their text is appended. Zendesk private-description duplicate suppression still
+compares raw normalized text keys, so filtering does not depend on a separate
+sanitizer shape.
 
 ## Intentional
 
@@ -124,7 +128,7 @@ Parked hardening: none.
 ## Verification
 
 - Passed:
-  - `python -m pytest tests/test_support_ticket_privacy.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`190 passed`)
+  - `python -m pytest tests/test_support_ticket_privacy.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`214 passed`)
   - `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/webhook*' --sensitive-glob '**/payment*' --sensitive-glob '**/*deletion*'`
   - `python -m pytest tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`150 passed`)
   - `bash` `scripts/validate_extracted_content_pipeline.sh`
@@ -141,11 +145,11 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 171 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 204 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 151 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 155 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_extracted_support_ticket_input_package.py` | 183 |
-| `tests/test_smoke_content_ops_support_ticket_package.py` | 94 |
-| `tests/test_support_ticket_privacy.py` | 92 |
-| **Total** | **724** |
+| `tests/test_extracted_support_ticket_input_package.py` | 189 |
+| `tests/test_smoke_content_ops_support_ticket_package.py` | 114 |
+| `tests/test_support_ticket_privacy.py` | 113 |
+| **Total** | **808** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -116,6 +116,18 @@ private (`visible_to_agents` is the inverse of `visible_to_customer`);
 label-class stems so `privacy_label`/`visibility_status`/`access_label`
 classify while `internal_status` stays a data column.
 
+Round-6 refinements (same closed rule; each verified failing first): content
+carveout covers container shapes (`public_comments: [...]` lists/dicts and
+empty sequences are content columns, not flags); empty sequence markers under
+marker keys fail closed like empty objects; publication/facing flags
+(`published`, `customer_facing`) assert privacy ONLY via boolean values so
+`published: <date>` stays a data column; `notpublic` negation stem;
+end-user/requester as public audience and support/support-team as private
+audience; X-only value labels (`internal only`, `private only`,
+`internal-use-only`) resolve by a value-stem strip rule instead of per-spelling
+enumeration; access-composed keys (`restricted_access`, `private_access`,
+`access_internal`) classify private; `confidentiality` strict label added.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -214,11 +226,11 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 361 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 410 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 224 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 236 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/test_extracted_support_ticket_input_package.py` | 194 |
 | `tests/test_smoke_content_ops_support_ticket_package.py` | 119 |
-| `tests/test_support_ticket_privacy.py` | 317 |
-| **Total** | **1248** |
+| `tests/test_support_ticket_privacy.py` | 433 |
+| **Total** | **1425** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -103,6 +103,19 @@ Enumeration cannot close an open vocabulary; the decision rule must.
     enrolled).
   - Existing test expectations from rounds 1-3 (they pin resolved findings).
 
+Round-5 refinements (same closed rule, vocabulary adjustments only; each
+verified failing before the fix): (1) content-column carveout extended to
+public note/comment-suffixed keys so `public_comment`/`public_comments`
+ingestion columns (`_PUBLIC_COMMENT_KEYS`) are not over-rejected while
+flag-valued forms still fail closed; (2) present-but-empty object markers
+(`{"privacy": {}}`) are unresolvable -> private, matching item 2; (3) plural
+`agentsonly` added to private value labels; (4) private-audience tokens
+(agent/agents/staff/admin/admins/team/teams) flip a public-visibility key
+private (`visible_to_agents` is the inverse of `visible_to_customer`);
+(5) label-style suffixes (label/status/state/value/level/mode) strip only on
+label-class stems so `privacy_label`/`visibility_status`/`access_label`
+classify while `internal_status` stays a data column.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -201,11 +214,11 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 325 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 361 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 211 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 224 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/test_extracted_support_ticket_input_package.py` | 194 |
 | `tests/test_smoke_content_ops_support_ticket_package.py` | 119 |
-| `tests/test_support_ticket_privacy.py` | 229 |
-| **Total** | **1111** |
+| `tests/test_support_ticket_privacy.py` | 317 |
+| **Total** | **1248** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -140,6 +140,18 @@ join the private-audience flip (`visible_to_internal`, `public_to_internal`);
 audience-only compounds (`admin_only`, `team_only`, `support_only`) classify
 private; `for internal use only` value labels resolve via prefix strips.
 
+Round-8 refinements (same closed rule; each verified failing first; one was a
+polarity defect in the round-7 object resolver): `hidden_from_customer`-style
+inverse markers classify (`from` is structure); compound audience-only flags
+(`support_team_only`) classify when every pre-`only` token is a private
+audience; object markers preserve boolean-ness for the ENCLOSING key's
+polarity (`private: {"value": true}` fails closed while
+`public: {"value": true}` passes); staff-note kind values (`type:
+"agent_note"`) resolve via value-stem note-suffix strips while
+`customer_note` passes; adverb spellings (`publicly_visible: false`,
+`public_visibility: false`) classify via token normalization + all-public-
+family compounds.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -238,11 +250,11 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 478 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 531 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 248 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 260 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/test_extracted_support_ticket_input_package.py` | 194 |
 | `tests/test_smoke_content_ops_support_ticket_package.py` | 119 |
-| `tests/test_support_ticket_privacy.py` | 516 |
-| **Total** | **1588** |
+| `tests/test_support_ticket_privacy.py` | 597 |
+| **Total** | **1734** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -128,6 +128,18 @@ audience; X-only value labels (`internal only`, `private only`,
 enumeration; access-composed keys (`restricted_access`, `private_access`,
 `access_internal`) classify private; `confidentiality` strict label added.
 
+Round-7 refinements (same closed rule; each verified failing first; three were
+defects in the round-5/6 mechanisms): flag-shaped aliases (`is_`/`has_`
+prefixed, `*_flag`) are excluded from the content-column carveouts and
+digit-only values are flag values, so `is_public_comment: "maybe"` and
+`public_reply: 2` fail closed while bare content columns stay admitted;
+object-marker subfields compare privacy VERDICTS with key polarity, so
+equivalent public forms ({"name": "public", "value": true}) agree instead of
+over-rejecting while nested `{"private": true}` fails closed; internal/private
+join the private-audience flip (`visible_to_internal`, `public_to_internal`);
+audience-only compounds (`admin_only`, `team_only`, `support_only`) classify
+private; `for internal use only` value labels resolve via prefix strips.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -226,11 +238,11 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 410 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 478 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 236 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 248 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/test_extracted_support_ticket_input_package.py` | 194 |
 | `tests/test_smoke_content_ops_support_ticket_package.py` | 119 |
-| `tests/test_support_ticket_privacy.py` | 433 |
-| **Total** | **1425** |
+| `tests/test_support_ticket_privacy.py` | 516 |
+| **Total** | **1588** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -87,8 +87,10 @@ Slice phase: Vertical slice
 - `extracted_content_pipeline/support_ticket_privacy.py`
 - `extracted_content_pipeline/support_ticket_zendesk_thread.py`
 - `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md`
+- `scripts/run_extracted_pipeline_checks.sh`
 - `tests/test_extracted_support_ticket_input_package.py`
 - `tests/test_smoke_content_ops_support_ticket_package.py`
+- `tests/test_support_ticket_privacy.py`
 
 ## Mechanism
 
@@ -122,6 +124,8 @@ Parked hardening: none.
 ## Verification
 
 - Passed:
+  - `python -m pytest tests/test_support_ticket_privacy.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`190 passed`)
+  - `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/webhook*' --sensitive-glob '**/payment*' --sensitive-glob '**/*deletion*'`
   - `python -m pytest tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`150 passed`)
   - `bash` `scripts/validate_extracted_content_pipeline.sh`
   - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
@@ -137,9 +141,11 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 167 |
-| `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 5 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 145 |
-| `tests/test_extracted_support_ticket_input_package.py` | 114 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 171 |
+| `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 151 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_support_ticket_input_package.py` | 183 |
 | `tests/test_smoke_content_ops_support_ticket_package.py` | 94 |
-| **Total** | **536** |
+| `tests/test_support_ticket_privacy.py` | 92 |
+| **Total** | **724** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -140,6 +140,24 @@ join the private-audience flip (`visible_to_internal`, `public_to_internal`);
 audience-only compounds (`admin_only`, `team_only`, `support_only`) classify
 private; `for internal use only` value labels resolve via prefix strips.
 
+Round-9 restructure (each finding verified failing first; the cluster showed
+the VALUE side still used string-strip loops while keys had tokenization):
+values now get the same closed token rule as keys (multi-token label phrases
+like `restricted to agents`, `support staff only`, `private_response`, and
+`visible to customer` classify by semantic tokens in both directions); object
+markers resolve in the ENCLOSING key's polarity frame with classifier-driven
+subfield polarity (fixes `private: {"label": "public", "value": true}` and
+nested alias subfields like `{"visibility": {"publicly_visible": false}}`);
+negated assertions flip polarity (`not_visible_to_customer`,
+`not_customer_facing`; `not_private` passes); audience-note boolean keys
+(`staff_note: true`, `agent_reply: true`) classify private while text-valued
+forms stay content columns; `everyone`/`anyone`/`all` join the affirmative
+public labels. Plus an ADVERSARIAL GRAMMAR SWEEP
+(`tests/test_support_ticket_privacy_sweep.py`, CI-enrolled): ~335 generated
+cases crossing stems x key structure x audiences x value shapes x containers
+in BOTH error directions, so coverage is the family grammar, not
+per-reviewer-finding spellings.
+
 Round-8 refinements (same closed rule; each verified failing first; one was a
 polarity defect in the round-7 object resolver): `hidden_from_customer`-style
 inverse markers classify (`from` is structure); compound audience-only flags
@@ -193,6 +211,7 @@ Slice phase: Vertical slice
 - `tests/test_extracted_support_ticket_input_package.py`
 - `tests/test_smoke_content_ops_support_ticket_package.py`
 - `tests/test_support_ticket_privacy.py`
+- `tests/test_support_ticket_privacy_sweep.py`
 
 ## Mechanism
 
@@ -250,11 +269,12 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 531 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 612 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 260 |
-| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 280 |
+| `scripts/run_extracted_pipeline_checks.sh` | 2 |
 | `tests/test_extracted_support_ticket_input_package.py` | 194 |
 | `tests/test_smoke_content_ops_support_ticket_package.py` | 119 |
-| `tests/test_support_ticket_privacy.py` | 597 |
-| **Total** | **1734** |
+| `tests/test_support_ticket_privacy.py` | 667 |
+| `tests/test_support_ticket_privacy_sweep.py` | 196 |
+| **Total** | **2102** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -50,6 +50,59 @@ plan remains narrowly scoped to this one admission concern.
   - Report/snapshot/email/PDF/landing/checkout/product shape.
   - Final-output scrubber grammar.
 
+### Round-4 design re-cut contract (2026-07-08, builder takeover)
+
+Three review rounds (9 resolved + 5 open Codex P2 findings) grew the predicate
+from 171 to 231 lines without converging. Root cause of the churn, distinct
+from the original root cause above: the predicate classifies privacy markers
+by exact-match enumeration of key names and value spellings, but the marker
+vocabulary (key aliases x value shapes x container nesting) is producer-defined
+and open. Any unlisted alias classifies public (fail-open: `is_hidden`,
+`is_public_comment: false`, row-level `is_private_note`), object markers
+resolve first-field-wins (fail-open on conflict), and a malformed numeric
+marker raises `decimal.InvalidOperation` and crashes ingestion (verified:
+`Decimal("1e999999999999999999999")` raises through `_numeric_marker`).
+Enumeration cannot close an open vocabulary; the decision rule must.
+
+- Correct fix must touch/change (all inside `support_ticket_privacy.py`; the
+  two public function signatures and all call sites unchanged):
+  1. Replace exact-key sets with a closed token-stem rule: split each key on
+     separators + camelCase, lowercase; a key is privacy-relevant iff its
+     compacted token remainder (raw, and after dropping structural stopwords
+     and `is/has/was` prefixes and note/comment/reply/flag suffixes) EXACTLY
+     equals a privacy stem -- private stems (private, internal, hidden,
+     confidential, nonpublic, restricted, agentonly, staffonly), public stems
+     (public, visible, external), strict label stems (visibility, privacy),
+     value label stems (access, audience), kind stems (type, kind). Exact
+     equality of the semantic remainder -- not substring contains -- so data
+     columns like `internal_id`, `private_ip`, `publication_date`,
+     `hidden_count`, `internal_status`, `has_access` are NOT markers.
+  2. Values resolve affirmative-public-or-private for marker keys: truthy /
+     public-label admits (public keys), falsey / public-label skips (private
+     keys); anything unresolvable -- unknown text, conflicting or empty object
+     markers, malformed numerics -- classifies private. Kind keys keep
+     fail-open categorical semantics (private only on private labels /
+     ambiguous), and access/audience keep the head's value-label semantics.
+  3. Object-shaped markers resolve ALL recognized subfields; conflicting
+     resolutions are ambiguous (private), not first-field-wins.
+  4. Numeric parsing guarded: `Decimal` failure -> unresolvable marker, never
+     an exception.
+  5. Total-function guarantee: the two public predicates catch any unexpected
+     exception and return private (fail-closed); a malformed marker can never
+     crash package or Zendesk ingestion.
+  6. Row-mode note-content carveout kept: a note/comment-suffixed private key
+     with free-text value is a content column, not a flag, and does not reject
+     the row; flag-valued forms (`is_private_note: true`, `"yes"`, `1`) do.
+  7. All 14 prior-round findings plus the 5 open ones become parametrized
+     tests of the rule, plus over-rejection negatives for the data columns in
+     (1) and a no-crash test for malformed numerics and a raising Mapping.
+- Must not change (in addition to the list above):
+  - `support_ticket_input_package.py` and `support_ticket_zendesk_thread.py`
+    (wiring landed in earlier rounds; signatures stable).
+  - `manifest.json`, `scripts/run_extracted_pipeline_checks.sh` (already
+    enrolled).
+  - Existing test expectations from rounds 1-3 (they pin resolved findings).
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -148,11 +201,11 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 231 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 325 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 158 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 211 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/test_extracted_support_ticket_input_package.py` | 194 |
 | `tests/test_smoke_content_ops_support_ticket_package.py` | 119 |
-| `tests/test_support_ticket_privacy.py` | 120 |
-| **Total** | **855** |
+| `tests/test_support_ticket_privacy.py` | 229 |
+| **Total** | **1111** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -102,11 +102,14 @@ fail closed. Strict privacy labels such as `visibility` and `privacy` still
 fail closed, while ordinary metadata labels such as `access` and `audience`
 classify by value so routing phrases like "Account access" do not drop public
 rows. Object-shaped markers normalize through the same label vocabulary.
-Package rows call the row wrapper before any `source_title`, body, or comment
-extraction. Package comments and Zendesk comments use the comment wrapper before
-their text is appended. Zendesk private-description duplicate suppression still
-compares raw normalized text keys, so filtering does not depend on a separate
-sanitizer shape.
+Restricted value labels and private/internal reply kind labels are treated as
+private. Case/punctuation variants of the same marker key are grouped before
+classification; conflicting grouped values become ambiguous and fail closed
+instead of using last-writer-wins. Package rows call the row wrapper before any
+`source_title`, body, or comment extraction. Package comments and Zendesk
+comments use the comment wrapper before their text is appended. Zendesk
+private-description duplicate suppression still compares raw normalized text
+keys, so filtering does not depend on a separate sanitizer shape.
 
 ## Intentional
 
@@ -128,7 +131,7 @@ Parked hardening: none.
 ## Verification
 
 - Passed:
-  - `python -m pytest tests/test_support_ticket_privacy.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`214 passed`)
+  - `python -m pytest tests/test_support_ticket_privacy.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`231 passed`)
   - `python scripts/maturity_sweep.py extracted_content_pipeline --tests-root tests --baseline tests/maturity_sweep/baseline_extracted_content_pipeline.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/webhook*' --sensitive-glob '**/payment*' --sensitive-glob '**/*deletion*'`
   - `python -m pytest tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`150 passed`)
   - `bash` `scripts/validate_extracted_content_pipeline.sh`
@@ -145,11 +148,11 @@ Parked hardening: none.
 |---|---:|
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
-| `extracted_content_pipeline/support_ticket_privacy.py` | 204 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 231 |
 | `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 21 |
-| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 155 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 158 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_extracted_support_ticket_input_package.py` | 189 |
-| `tests/test_smoke_content_ops_support_ticket_package.py` | 114 |
-| `tests/test_support_ticket_privacy.py` | 113 |
-| **Total** | **808** |
+| `tests/test_extracted_support_ticket_input_package.py` | 194 |
+| `tests/test_smoke_content_ops_support_ticket_package.py` | 119 |
+| `tests/test_support_ticket_privacy.py` | 120 |
+| **Total** | **855** |

--- a/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
+++ b/plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
@@ -1,0 +1,145 @@
+# PR-Resolution-Audit-S6A-Admission-Boundary
+
+## Why this slice exists
+
+#2042 extracts the privacy/admission boundary from the paused #2037 evidence
+branch into a small shipping slice for #1993. Current `origin/main` admits
+support-ticket text from two independent paths: generic CSV/package rows and
+Zendesk full-thread rows. Both paths only understand the literal Python boolean
+shape `public is False` for private comments, and the package row normalizer
+reads row title/body/comment text before any row-level private/internal marker
+can reject the row. That means string/number privacy markers, private-note
+aliases, internal-comment aliases, and ambiguous privacy markers can be
+admitted as customer evidence.
+
+This fixes the root, not a symptom: admission is moved to the upstream
+normalization boundary shared by both support-ticket ingestion paths before
+private/internal source text is flattened into `text` or `resolution_text`.
+The diff is over the 400 LOC soft cap because the required plan doc and
+same-class tests ship with the shared boundary; the code/test diff excluding the
+plan remains narrowly scoped to this one admission concern.
+
+### Problem-derived contract
+
+- Root cause: support-ticket private/internal admission is split across
+  package-row normalization, package comments, Zendesk full-thread flattening,
+  and private-description duplicate suppression. A package-only predicate
+  cannot protect comments already flattened by the Zendesk path, and row-level
+  private markers can be read after source text extraction.
+- Correct fix must touch/change:
+  1. Add one shared support-ticket private/internal predicate with marker
+     normalization for boolean strings, decimal booleans, private/internal
+     aliases, explicit public labels, and ambiguous markers.
+  2. Reject row-level private/internal support-ticket rows before
+     `_normalize_ticket_row` extracts title/body/comment text.
+  3. Route package comment admission through the shared predicate.
+  4. Route Zendesk full-thread comment admission through the same predicate
+     before `_row_from_entry` flattens customer/resolution text.
+  5. Keep private-first-comment duplicate suppression aligned with the same
+     raw text key used for Zendesk `description` comparison.
+  6. Add focused same-class tests for boolean strings, decimal booleans,
+     private-note aliases, explicit public labels, ambiguous markers,
+     row-level private rows, and Zendesk full-thread comments.
+- Must not change:
+  - HTML/tag line-preserving hygiene or `support_ticket_clustering.py`.
+  - Scalar `ticket_history` / `conversation_history` signature or quote
+    handling.
+  - Evidence-tier/customer-wording semantics beyond excluding private/internal
+    source text from admission.
+  - Status/outcome diagnostics.
+  - Report/snapshot/email/PDF/landing/checkout/product shape.
+  - Final-output scrubber grammar.
+
+## Scope (this PR)
+
+Ownership lane: resolution-audit-csv
+Slice phase: Vertical slice
+
+1. Add a shared support-ticket privacy/admission predicate and apply it at the
+   two current support-ticket ingestion boundaries: generic package rows and
+   Zendesk full-thread rows.
+2. Add targeted tests that exercise the real row normalizers and prove private
+   markers are excluded while public/markerless comments still pass.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Private/internal rows and comments are excluded before source text is
+    admitted.
+  - Markerless customer comments and explicit public labels still pass.
+  - Ambiguous privacy markers fail closed.
+  - Zendesk private-first-comment duplicate suppression keeps the public
+    `description` out when the same private first comment is mirrored there.
+  - The proof covers the class with multiple marker variants, not only one
+    cited example.
+- Affected surfaces: `extracted_content_pipeline` support-ticket CSV/package
+  normalization and Zendesk full-thread normalization.
+- Risk areas: PII/privacy leakage, false-positive dropping of public customer
+  text, and drift between package and Zendesk comment filters.
+- Reviewer rules triggered: R1 requirements match, R2 test evidence, R3
+  privacy/security boundary, R8 contract drift, R10 guard/checker behavior,
+  R13 same-class fix, R14 codebase verification.
+
+### Files touched
+
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `extracted_content_pipeline/support_ticket_privacy.py`
+- `extracted_content_pipeline/support_ticket_zendesk_thread.py`
+- `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_smoke_content_ops_support_ticket_package.py`
+
+## Mechanism
+
+The slice adds a small package-owned helper for support-ticket privacy marker
+normalization. It exposes row and comment admission wrappers backed by the same
+normalizer: public markers with false-like values and private/internal markers
+are private, explicit public values are public, and ambiguous privacy markers
+fail closed. Package rows call the row wrapper before any `source_title`, body,
+or comment extraction. Package comments and Zendesk comments use the comment
+wrapper before their text is appended. Zendesk private-description duplicate
+suppression still compares raw normalized text keys, so filtering does not
+depend on a separate sanitizer shape.
+
+## Intentional
+
+- This slice does not add HTML line-preserving hygiene. That is #2043/S6B; doing
+  it here would mix a text-cleanup concern into the privacy/admission boundary.
+- This slice does not change scalar history parsing. That is #2044/S6C.
+- This slice does not change final report/snapshot/email/PDF or landing shape.
+  The operator has not approved a product-shape change for this slice, and the
+  privacy fix does not require one.
+
+## Deferred
+
+- #2043/S6B: line-preserving HTML/tag hygiene.
+- #2044/S6C: scalar history signature/quote guard.
+- #2045/S6D: QA scorecard/runtime integration and reconciliation defects.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed:
+  - `python -m pytest tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`150 passed`)
+  - `bash` `scripts/validate_extracted_content_pipeline.sh`
+  - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - `python scripts/audit_extracted_standalone.py --fail-on-debt`
+  - `bash` `scripts/check_ascii_python.sh`
+  - `bash` `scripts/run_extracted_pipeline_checks.sh` (`5197 passed, 21 skipped`)
+  - `python scripts/sync_pr_plan.py plans/PR-Resolution-Audit-S6A-Admission-Boundary.md --check`
+  - `git diff --check`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 8 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 167 |
+| `extracted_content_pipeline/support_ticket_zendesk_thread.py` | 5 |
+| `plans/PR-Resolution-Audit-S6A-Admission-Boundary.md` | 145 |
+| `tests/test_extracted_support_ticket_input_package.py` | 114 |
+| `tests/test_smoke_content_ops_support_ticket_package.py` | 94 |
+| **Total** | **536** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -139,6 +139,7 @@ pytest \
   tests/test_extracted_content_ops_input_provider.py \
   tests/test_support_ticket_context_contract.py \
   tests/test_support_ticket_privacy.py \
+  tests/test_support_ticket_privacy_sweep.py \
   tests/test_resolution_audit_s5_clustering_spike.py \
   tests/test_extracted_support_ticket_input_package.py \
   tests/test_extracted_support_ticket_zendesk_export.py \

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -138,6 +138,7 @@ pytest \
   tests/test_extracted_content_ops_cache_policy.py \
   tests/test_extracted_content_ops_input_provider.py \
   tests/test_support_ticket_context_contract.py \
+  tests/test_support_ticket_privacy.py \
   tests/test_resolution_audit_s5_clustering_spike.py \
   tests/test_extracted_support_ticket_input_package.py \
   tests/test_extracted_support_ticket_zendesk_export.py \

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -2034,13 +2034,15 @@ def test_zendesk_full_thread_rows_suppress_private_first_description() -> None:
     {"public": "false"},
     {"public": "0.0"},
     {"is_private": "true"},
+    {"is_private_note": "true"},
     {"private_note": "yes"},
     {"type": "private_note"},
     {"visibility": "internal"},
+    {"visibility": {"name": "internal"}},
     {"public": "maybe"},
 ])
 def test_zendesk_full_thread_rows_skip_private_comment_marker_variants(
-    private_marker: dict[str, str],
+    private_marker: dict[str, object],
 ) -> None:
     result = rows_from_zendesk_full_thread({
         "tickets": [{
@@ -2078,6 +2080,8 @@ def test_zendesk_full_thread_rows_skip_private_comment_marker_variants(
     {"public": "1.0"},
     {"is_public": "yes"},
     {"visibility": "public"},
+    {"visibility": {"name": "public"}},
+    {"privacy": {"label": "customer"}},
 ])
 def test_zendesk_full_thread_rows_keep_public_comment_marker_variants(
     public_marker: dict[str, object],
@@ -2150,6 +2154,8 @@ def test_zendesk_full_thread_rows_suppress_private_first_description_alias() -> 
     {"is_private": "true"},
     {"internal": "yes"},
     {"visibility": "private"},
+    {"visibility": {"name": "private"}},
+    {"access": "internal"},
     {"type": "internal_note"},
 ])
 def test_zendesk_full_thread_rows_skip_ticket_private_markers_before_flattening(

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -2037,8 +2037,11 @@ def test_zendesk_full_thread_rows_suppress_private_first_description() -> None:
     {"is_private_note": "true"},
     {"private_note": "yes"},
     {"type": "private_note"},
+    {"type": "private_reply"},
+    {"message_type": "internal_reply"},
     {"visibility": "internal"},
     {"visibility": {"name": "internal"}},
+    {"Public": False, "public": True},
     {"public": "maybe"},
 ])
 def test_zendesk_full_thread_rows_skip_private_comment_marker_variants(
@@ -2156,7 +2159,9 @@ def test_zendesk_full_thread_rows_suppress_private_first_description_alias() -> 
     {"visibility": "private"},
     {"visibility": {"name": "private"}},
     {"access": "internal"},
+    {"access": "restricted access"},
     {"type": "internal_note"},
+    {"Public": False, "public": True},
 ])
 def test_zendesk_full_thread_rows_skip_ticket_private_markers_before_flattening(
     private_marker: dict[str, object],

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -2144,6 +2144,75 @@ def test_zendesk_full_thread_rows_suppress_private_first_description_alias() -> 
     }]
 
 
+@pytest.mark.parametrize("private_marker", [
+    {"public": False},
+    {"public": 2},
+    {"is_private": "true"},
+    {"internal": "yes"},
+    {"visibility": "private"},
+    {"type": "internal_note"},
+])
+def test_zendesk_full_thread_rows_skip_ticket_private_markers_before_flattening(
+    private_marker: dict[str, object],
+) -> None:
+    result = rows_from_zendesk_full_thread({
+        "tickets": [
+            {
+                "ticket": {
+                    "id": "zd-private-ticket",
+                    "subject": "Internal migration workaround",
+                    "description": "Private account flag should not be admitted.",
+                    "requester_id": "requester-1",
+                    **private_marker,
+                },
+                "comments": [{
+                    "author_id": "requester-1",
+                    "plain_body": "Private mirrored question should not be admitted.",
+                }],
+            },
+            {
+                "ticket": {
+                    "id": "zd-public-ticket",
+                    "subject": "How do I export invoices?",
+                    "description": "Where do invoice exports live?",
+                    "requester_id": "requester-2",
+                },
+                "comments": [{
+                    "author_id": "agent-1",
+                    "plain_body": "Open Billing, then choose Export CSV.",
+                }],
+            },
+        ],
+    })
+
+    assert result.warnings == ()
+    assert [row["source_id"] for row in result.rows] == ["zd-public-ticket"]
+    payload = json.dumps(result.rows)
+    assert "Private account flag" not in payload
+    assert "Private mirrored question" not in payload
+
+
+def test_zendesk_full_thread_rows_skip_entry_private_markers_before_flattening() -> None:
+    result = rows_from_zendesk_full_thread({
+        "tickets": [{
+            "is_private": True,
+            "ticket": {
+                "id": "zd-private-entry",
+                "subject": "Internal migration workaround",
+                "description": "Private account flag should not be admitted.",
+                "requester_id": "requester-1",
+            },
+            "comments": [{
+                "author_id": "requester-1",
+                "plain_body": "Private mirrored question should not be admitted.",
+            }],
+        }],
+    })
+
+    assert result.rows == []
+    assert result.warnings == ()
+
+
 def test_zendesk_full_thread_rows_keep_substantive_agent_reply_after_boilerplate() -> None:
     result = rows_from_zendesk_full_thread({
         "tickets": [{

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -2030,6 +2030,120 @@ def test_zendesk_full_thread_rows_suppress_private_first_description() -> None:
     ]
 
 
+@pytest.mark.parametrize("private_marker", [
+    {"public": "false"},
+    {"public": "0.0"},
+    {"is_private": "true"},
+    {"private_note": "yes"},
+    {"type": "private_note"},
+    {"visibility": "internal"},
+    {"public": "maybe"},
+])
+def test_zendesk_full_thread_rows_skip_private_comment_marker_variants(
+    private_marker: dict[str, str],
+) -> None:
+    result = rows_from_zendesk_full_thread({
+        "tickets": [{
+            "ticket": {
+                "id": "zd-private-marker",
+                "subject": "How do I export invoices?",
+                "description": "Where do invoice exports live?",
+                "requester_id": "requester-1",
+            },
+            "comments": [
+                {
+                    "author_id": "agent-1",
+                    "plain_body": "Internal billing flag; do not publish.",
+                    **private_marker,
+                },
+                {
+                    "author_id": "agent-1",
+                    "public": "public",
+                    "plain_body": "Open Billing, then choose Export CSV.",
+                },
+            ],
+        }],
+    })
+
+    assert result.warnings == ()
+    row = result.rows[0]
+    assert row["resolution_text"] == "Open Billing, then choose Export CSV."
+    assert "Internal billing flag" not in json.dumps(result.rows)
+
+
+@pytest.mark.parametrize("public_marker", [
+    {},
+    {"public": True},
+    {"public": "public"},
+    {"public": "1.0"},
+    {"is_public": "yes"},
+    {"visibility": "public"},
+])
+def test_zendesk_full_thread_rows_keep_public_comment_marker_variants(
+    public_marker: dict[str, object],
+) -> None:
+    result = rows_from_zendesk_full_thread({
+        "tickets": [{
+            "ticket": {
+                "id": "zd-public-marker",
+                "subject": "How do I export invoices?",
+                "description": "Where do invoice exports live?",
+                "requester_id": "requester-1",
+            },
+            "comments": [
+                {
+                    "author_id": "agent-1",
+                    "plain_body": "Open Billing, then choose Export CSV.",
+                    **public_marker,
+                },
+            ],
+        }],
+    })
+
+    assert result.warnings == ()
+    assert result.rows[0]["resolution_text"] == (
+        "Open Billing, then choose Export CSV."
+    )
+
+
+def test_zendesk_full_thread_rows_suppress_private_first_description_alias() -> None:
+    result = rows_from_zendesk_full_thread({
+        "tickets": [{
+            "ticket": {
+                "id": "zd-private-alias",
+                "subject": "Internal migration workaround",
+                "description": (
+                    "Internal note: explain the real workaround only to the owner."
+                ),
+                "requester_id": "requester-1",
+            },
+            "comments": [
+                {
+                    "author_id": "agent-1",
+                    "type": "private_note",
+                    "plain_body": (
+                        "Internal note: explain the real workaround only to the owner."
+                    ),
+                },
+                {
+                    "author_id": "requester-1",
+                    "public": "public",
+                    "plain_body": "What permission do I need for account exports?",
+                },
+            ],
+        }],
+    })
+
+    assert result.warnings == ()
+    assert result.rows == [{
+        "ticket_id": "zd-private-alias",
+        "source_id": "zd-private-alias",
+        "source_type": "support_ticket",
+        "subject": "Internal migration workaround",
+        "description": "What permission do I need for account exports?",
+    }]
+
+
 def test_zendesk_full_thread_rows_keep_substantive_agent_reply_after_boilerplate() -> None:
     result = rows_from_zendesk_full_thread({
         "tickets": [{

--- a/tests/test_smoke_content_ops_support_ticket_package.py
+++ b/tests/test_smoke_content_ops_support_ticket_package.py
@@ -213,6 +213,100 @@ def test_support_ticket_package_skips_private_comment_objects_in_history() -> No
     assert package.warnings == ()
 
 
+@pytest.mark.parametrize("private_marker", [
+    {"public": "false"},
+    {"public": "0.0"},
+    {"is_private": "true"},
+    {"private_note": "yes"},
+    {"type": "private_note"},
+    {"visibility": "internal"},
+    {"public": "maybe"},
+])
+def test_support_ticket_package_skips_private_comment_marker_variants(
+    private_marker: dict[str, str],
+) -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": "zd-marker-private",
+        "subject": "Refund status",
+        "ticket_history": [
+            {"body": "Where can I download the refund receipt?", "public": "public"},
+            {
+                "body": "INTERNAL refund quietly; do not publish",
+                **private_marker,
+            },
+        ],
+    }])
+
+    source_material = package.inputs["source_material"]
+    assert len(source_material) == 1
+    text = source_material[0]["text"]
+    assert "Where can I download the refund receipt?" in text
+    assert "INTERNAL refund quietly" not in text
+    assert source_material[0]["support_ticket_evidence_tier"] == "csv_customer_text"
+
+
+@pytest.mark.parametrize("public_marker", [
+    {},
+    {"public": True},
+    {"public": "public"},
+    {"public": "1.0"},
+    {"is_public": "yes"},
+    {"visibility": "public"},
+])
+def test_support_ticket_package_keeps_public_comment_marker_variants(
+    public_marker: dict[str, object],
+) -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": "zd-marker-public",
+        "subject": "Refund status",
+        "ticket_history": [
+            {
+                "body": "Where can I download the refund receipt?",
+                **public_marker,
+            },
+        ],
+    }])
+
+    source_material = package.inputs["source_material"]
+    assert len(source_material) == 1
+    assert "Where can I download the refund receipt?" in source_material[0]["text"]
+    assert package.warnings == ()
+
+
+@pytest.mark.parametrize("private_marker", [
+    {"public": False},
+    {"public": "false"},
+    {"public": "0.0"},
+    {"is_private": "true"},
+    {"visibility": "private"},
+    {"type": "internal_note"},
+    {"public": "maybe"},
+])
+def test_support_ticket_package_rejects_private_row_markers_before_text_admission(
+    private_marker: dict[str, object],
+) -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "zd-private-row",
+            "subject": "Internal billing note",
+            "description": "Customer card failed because of a private account flag.",
+            **private_marker,
+        },
+        {
+            "ticket_id": "zd-public-row",
+            "subject": "Refund status",
+            "description": "Where can I download the refund receipt?",
+        },
+    ])
+
+    source_material = package.inputs["source_material"]
+    assert [row["source_id"] for row in source_material] == ["zd-public-row"]
+    payload = json.dumps(package.as_dict())
+    assert "private account flag" not in payload
+    assert "Where can I download the refund receipt?" in payload
+    assert package.inputs["skipped_ticket_row_count"] == 1
+
+
 def test_support_ticket_package_private_only_comments_stay_index_metadata() -> None:
     package = build_support_ticket_input_package([{
         "ticket_id": "zd-private",

--- a/tests/test_smoke_content_ops_support_ticket_package.py
+++ b/tests/test_smoke_content_ops_support_ticket_package.py
@@ -220,8 +220,11 @@ def test_support_ticket_package_skips_private_comment_objects_in_history() -> No
     {"is_private_note": "true"},
     {"private_note": "yes"},
     {"type": "private_note"},
+    {"type": "private_reply"},
+    {"message_type": "internal_reply"},
     {"visibility": "internal"},
     {"visibility": {"name": "internal"}},
+    {"Public": False, "public": True},
     {"public": "maybe"},
 ])
 def test_support_ticket_package_skips_private_comment_marker_variants(
@@ -285,7 +288,9 @@ def test_support_ticket_package_keeps_public_comment_marker_variants(
     {"visibility": "private"},
     {"visibility": {"name": "private"}},
     {"access": "internal"},
+    {"access": "restricted access"},
     {"type": "internal_note"},
+    {"Public": False, "public": True},
     {"public": "maybe"},
 ])
 def test_support_ticket_package_rejects_private_row_markers_before_text_admission(

--- a/tests/test_smoke_content_ops_support_ticket_package.py
+++ b/tests/test_smoke_content_ops_support_ticket_package.py
@@ -217,13 +217,15 @@ def test_support_ticket_package_skips_private_comment_objects_in_history() -> No
     {"public": "false"},
     {"public": "0.0"},
     {"is_private": "true"},
+    {"is_private_note": "true"},
     {"private_note": "yes"},
     {"type": "private_note"},
     {"visibility": "internal"},
+    {"visibility": {"name": "internal"}},
     {"public": "maybe"},
 ])
 def test_support_ticket_package_skips_private_comment_marker_variants(
-    private_marker: dict[str, str],
+    private_marker: dict[str, object],
 ) -> None:
     package = build_support_ticket_input_package([{
         "ticket_id": "zd-marker-private",
@@ -252,6 +254,8 @@ def test_support_ticket_package_skips_private_comment_marker_variants(
     {"public": "1.0"},
     {"is_public": "yes"},
     {"visibility": "public"},
+    {"visibility": {"name": "public"}},
+    {"privacy": {"label": "customer"}},
 ])
 def test_support_ticket_package_keeps_public_comment_marker_variants(
     public_marker: dict[str, object],
@@ -279,6 +283,8 @@ def test_support_ticket_package_keeps_public_comment_marker_variants(
     {"public": "0.0"},
     {"is_private": "true"},
     {"visibility": "private"},
+    {"visibility": {"name": "private"}},
+    {"access": "internal"},
     {"type": "internal_note"},
     {"public": "maybe"},
 ])
@@ -305,6 +311,20 @@ def test_support_ticket_package_rejects_private_row_markers_before_text_admissio
     assert "private account flag" not in payload
     assert "Where can I download the refund receipt?" in payload
     assert package.inputs["skipped_ticket_row_count"] == 1
+
+
+def test_support_ticket_package_keeps_access_metadata_rows_before_text_admission() -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": "zd-access-row",
+        "subject": "How do I update account access?",
+        "description": "Where do I add a teammate to the billing role?",
+        "access": "Account access",
+    }])
+
+    source_material = package.inputs["source_material"]
+    assert [row["source_id"] for row in source_material] == ["zd-access-row"]
+    assert "billing role" in source_material[0]["text"]
+    assert package.inputs["skipped_ticket_row_count"] == 0
 
 
 def test_support_ticket_package_private_only_comments_stay_index_metadata() -> None:

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.support_ticket_privacy import (
+    support_ticket_comment_is_private,
+    support_ticket_row_is_private,
+)
+
+
+@pytest.mark.parametrize("marker", [
+    {"public": False},
+    {"public": "false"},
+    {"public": "0.0"},
+    {"public": "0e0"},
+    {"public": 2},
+    {"public": "maybe"},
+    {"is_private": True},
+    {"is_private": "1.0"},
+    {"is_private": 2},
+    {"private_note": "yes"},
+    {"internal_comment": "true"},
+    {"visibility": "internal"},
+    {"privacy": "private"},
+    {"type": "private_note"},
+])
+def test_support_ticket_comment_private_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {},
+    {"public": True},
+    {"public": "true"},
+    {"public": "1.0"},
+    {"public": "1e0"},
+    {"is_public": "yes"},
+    {"visibility": "public"},
+    {"privacy": "customer"},
+    {"private": False},
+    {"internal": "0.0"},
+])
+def test_support_ticket_comment_public_markers_pass(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is False
+
+
+def test_support_ticket_row_private_check_excludes_comment_alias_columns() -> None:
+    row = {
+        "ticket_id": "T-1",
+        "subject": "How do I export reports?",
+        "private_note": "Manager-only context",
+    }
+
+    assert support_ticket_row_is_private(row) is False
+
+
+def test_support_ticket_row_private_check_ignores_audience_metadata() -> None:
+    row = {
+        "ticket_id": "T-1",
+        "subject": "How do I export reports?",
+        "description": "Where does the export button live?",
+        "audience": "enterprise admins",
+    }
+
+    assert support_ticket_row_is_private(row) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"public": "false"},
+    {"private": "yes"},
+    {"visibility": "restricted"},
+    {"type": "internal_note"},
+])
+def test_support_ticket_row_private_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(marker) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"public": "not-a-number"},
+    {"private": "not-a-number"},
+    {"visibility": "agent-only"},
+])
+def test_support_ticket_privacy_unknown_markers_do_not_use_numeric_exceptions(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -514,3 +514,84 @@ def test_support_ticket_for_use_only_labels_fail_closed(
     marker: dict[str, object],
 ) -> None:
     assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+# Round-8 refinements: hidden-from inverse markers, compound audience-only
+# flags, object polarity for enclosing private keys, staff-note kind values,
+# and publicly-visible flag spellings.
+
+
+@pytest.mark.parametrize("marker", [
+    {"hidden_from_customer": True},
+    {"hidden_from_requester": True},
+])
+def test_support_ticket_hidden_from_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+    assert support_ticket_row_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"support_team_only": True},
+    {"support_agent_only": True},
+])
+def test_support_ticket_compound_audience_only_flags_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"private": {"value": True}},
+    {"internal": {"value": True}},
+    {"public": {"value": False}},
+])
+def test_support_ticket_object_wrapped_polarity_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+def test_support_ticket_object_wrapped_public_marker_passes() -> None:
+    assert support_ticket_comment_is_private(
+        {"public": {"value": True}, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"type": "agent_note"},
+    {"comment_type": "staff_note"},
+    {"message_type": "support_note"},
+])
+def test_support_ticket_staff_note_kind_values_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+def test_support_ticket_customer_note_kind_value_passes() -> None:
+    assert support_ticket_comment_is_private(
+        {"type": "customer_note", "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"publicly_visible": False},
+    {"is_publicly_visible": "false"},
+    {"public_visibility": False},
+])
+def test_support_ticket_publicly_visible_flags_false_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("row", [
+    {"body": "x", "publicly_visible": True},
+    {"body": "x", "from_email": "a@b.example"},
+])
+def test_support_ticket_round8_rule_does_not_over_reject(
+    row: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(row) is False

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -431,3 +431,86 @@ def test_support_ticket_round6_rule_does_not_over_reject(
     row: dict[str, object],
 ) -> None:
     assert support_ticket_row_is_private(row) is False
+
+
+# Round-7 refinements: internal-audience visibility flips, nested boolean
+# object subfields with key polarity, flag-shaped aliases excluded from the
+# content carveout, audience-only compounds, equivalent public object forms,
+# and for-X-use-only value labels.
+
+
+@pytest.mark.parametrize("marker", [
+    {"visible_to_internal": True},
+    {"visible_to_private": True},
+    {"public_to_internal": True},
+])
+def test_support_ticket_internal_audience_visibility_fails_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+    assert support_ticket_row_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"visibility": {"name": "public", "public": False}},
+    {"privacy": {"label": "customer", "private": True}},
+    {"visibility": {"private": True}},
+])
+def test_support_ticket_nested_boolean_object_subfields_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True
+
+
+def test_support_ticket_nested_public_boolean_subfield_passes() -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": {"public": True}}
+    ) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"is_public_comment": "maybe"},
+    {"public_reply": 2},
+    {"body": "x", "public_comment": "2"},
+])
+def test_support_ticket_flag_shaped_note_aliases_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True
+
+
+def test_support_ticket_flag_shaped_row_note_alias_fails_closed() -> None:
+    assert support_ticket_row_is_private(
+        {"body": "x", "is_private_note": 2}
+    ) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"admin_only": True},
+    {"team_only": True},
+    {"support_only": True},
+])
+def test_support_ticket_audience_only_compound_keys_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"visibility": {"name": "public", "value": True}},
+    {"privacy": {"label": "customer", "value": 1}},
+])
+def test_support_ticket_equivalent_public_object_forms_pass(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"access": "for internal use only"},
+    {"audience": "for private use only"},
+])
+def test_support_ticket_for_use_only_labels_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -315,3 +315,119 @@ def test_support_ticket_label_suffix_rule_does_not_over_reject(
     row: dict[str, object],
 ) -> None:
     assert support_ticket_row_is_private(row) is False
+
+
+# Round-6 refinements: container-shaped content columns, empty sequence
+# markers, publication flags, negated-public keys, audience synonyms,
+# X-only value labels, and access-composed keys.
+
+
+@pytest.mark.parametrize("row", [
+    {"subject": "s", "public_comments": ["How do I export?"]},
+    {"subject": "s", "public_comments": {"body": "text"}},
+    {"subject": "s", "public_comments": []},
+    {"subject": "s", "private_notes": [{"body": "agent note"}]},
+])
+def test_support_ticket_container_content_columns_do_not_reject_rows(
+    row: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(row) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"privacy": []},
+    {"public": []},
+    {"visibility": ()},
+])
+def test_support_ticket_empty_sequence_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"published": False},
+    {"is_published": "false"},
+    {"customer_facing": False},
+])
+def test_support_ticket_publication_flags_false_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("row", [
+    {"body": "x", "published": "2026-01-01"},
+    {"body": "x", "published": True},
+    {"body": "x", "customer_facing": True},
+])
+def test_support_ticket_publication_flags_only_assert_via_booleans(
+    row: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(row) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"not_public": True},
+    {"is_not_public": True},
+])
+def test_support_ticket_negated_public_keys_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"visible_to_end_user": False},
+    {"visible_to_requester": False},
+])
+def test_support_ticket_end_user_visibility_false_fails_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"visible_to_support": True},
+    {"visible_to_support_team": True},
+])
+def test_support_ticket_support_team_visibility_fails_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+    assert support_ticket_row_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"audience": "internal only"},
+    {"audience": "private only"},
+    {"access": "internal-use-only"},
+    {"confidentiality": "high"},
+])
+def test_support_ticket_only_style_private_labels_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"restricted_access": True},
+    {"private_access": True},
+    {"access_internal": True},
+])
+def test_support_ticket_access_composed_private_keys_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("row", [
+    {"body": "x", "support_ticket_id": "T-1"},
+    {"body": "x", "end_date": "2026-01-01"},
+    {"body": "x", "has_access": True},
+    {"body": "x", "access_label": "billing role"},
+])
+def test_support_ticket_round6_rule_does_not_over_reject(
+    row: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(row) is False

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -27,6 +27,9 @@ from extracted_content_pipeline.support_ticket_privacy import (
     {"privacy": "private"},
     {"privacy": {"label": "private"}},
     {"type": "private_note"},
+    {"type": "private_reply"},
+    {"message_type": "internal_reply"},
+    {"Public": False, "public": True},
 ])
 def test_support_ticket_comment_private_markers_fail_closed(
     marker: dict[str, object],
@@ -92,8 +95,12 @@ def test_support_ticket_row_private_check_ignores_access_metadata() -> None:
     {"visibility": "restricted"},
     {"visibility": {"name": "internal"}},
     {"access": "internal"},
+    {"access": "restricted"},
+    {"access": "restricted access"},
     {"audience": "agent only"},
+    {"audience": "restricted"},
     {"type": "internal_note"},
+    {"Public": False, "public": True},
 ])
 def test_support_ticket_row_private_markers_fail_closed(
     marker: dict[str, object],

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -227,3 +227,91 @@ def test_support_ticket_privacy_predicates_never_raise() -> None:
 
     assert support_ticket_comment_is_private(RaisingMapping()) is True
     assert support_ticket_row_is_private(RaisingMapping()) is True
+
+
+# Round-5 refinements: content-column carveout for public comment keys,
+# fail-closed empty object markers, private-audience key flip, plural
+# audience labels, and label-suffixed privacy keys.
+
+
+@pytest.mark.parametrize("row", [
+    {"subject": "s", "public_comment": "customer wrote a thing"},
+    {"subject": "s", "public_comments": "first reply\nsecond reply"},
+])
+def test_support_ticket_public_comment_content_columns_stay_admitted(
+    row: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(row) is False
+    assert support_ticket_comment_is_private(row) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"public_comment": "false"},
+    {"public_comment": False},
+    {"public_comments": 0},
+])
+def test_support_ticket_flag_valued_public_comment_keys_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"privacy": {}},
+    {"visibility": {}},
+])
+def test_support_ticket_empty_object_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+    assert support_ticket_row_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"audience": "agents only"},
+    {"access": "agents only"},
+])
+def test_support_ticket_plural_agent_audience_labels_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"visible_to_agents": True},
+    {"visible_to_staff": True},
+    {"visible_to_admins": "yes"},
+])
+def test_support_ticket_private_audience_visibility_keys_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+    assert support_ticket_row_is_private({"body": "x", **marker}) is True
+
+
+def test_support_ticket_customer_audience_visibility_still_passes() -> None:
+    assert support_ticket_comment_is_private(
+        {"body": "x", "visible_to_customer": True}
+    ) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"privacy_label": "private"},
+    {"visibility_status": "internal"},
+    {"access_label": "restricted access"},
+])
+def test_support_ticket_label_suffixed_privacy_keys_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("row", [
+    {"body": "x", "visibility_status": "public"},
+    {"body": "x", "internal_status": "open"},
+    {"body": "x", "access_label": "billing role"},
+])
+def test_support_ticket_label_suffix_rule_does_not_over_reject(
+    row: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(row) is False

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -595,3 +595,73 @@ def test_support_ticket_round8_rule_does_not_over_reject(
     row: dict[str, object],
 ) -> None:
     assert support_ticket_row_is_private(row) is False
+
+
+# Round-9 refinements: token-based value classification, outer-polarity
+# object resolution, negation flips, and audience-note keys.
+
+
+def test_support_ticket_object_label_with_boolean_under_private_key() -> None:
+    assert support_ticket_comment_is_private(
+        {"private": {"label": "public", "value": True}, "body": "x"}
+    ) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"staff_note": True},
+    {"agent_reply": True},
+    {"support_note": True},
+])
+def test_support_ticket_audience_note_boolean_keys_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"visibility": {"name": "public", "publicly_visible": False}},
+    {"visibility": {"label": "public", "hidden_from_customer": True}},
+])
+def test_support_ticket_nested_alias_subfields_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True
+
+
+def test_support_ticket_visible_to_customer_label_value_passes() -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": "visible to customer", "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"audience": "support staff only"},
+    {"type": "support_agent_note"},
+    {"access": "restricted to agents"},
+    {"audience": "private to team"},
+    {"access": "internal to staff"},
+    {"type": "private_response"},
+    {"comment_type": "internal_response"},
+    {"message_type": "agent_response"},
+])
+def test_support_ticket_compound_value_phrases_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"not_visible_to_customer": True},
+    {"not_publicly_visible": True},
+    {"not_customer_facing": True},
+])
+def test_support_ticket_negated_visibility_keys_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({"body": "x", **marker}) is True
+
+
+def test_support_ticket_everyone_audience_passes() -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": "everyone", "body": "x"}
+    ) is False

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -19,9 +19,13 @@ from extracted_content_pipeline.support_ticket_privacy import (
     {"is_private": "1.0"},
     {"is_private": 2},
     {"private_note": "yes"},
+    {"is_private_note": "true"},
     {"internal_comment": "true"},
+    {"is_internal_comment": "yes"},
     {"visibility": "internal"},
+    {"visibility": {"name": "internal"}},
     {"privacy": "private"},
+    {"privacy": {"label": "private"}},
     {"type": "private_note"},
 ])
 def test_support_ticket_comment_private_markers_fail_closed(
@@ -38,7 +42,9 @@ def test_support_ticket_comment_private_markers_fail_closed(
     {"public": "1e0"},
     {"is_public": "yes"},
     {"visibility": "public"},
+    {"visibility": {"name": "public"}},
     {"privacy": "customer"},
+    {"privacy": {"label": "customer"}},
     {"private": False},
     {"internal": "0.0"},
 ])
@@ -69,10 +75,24 @@ def test_support_ticket_row_private_check_ignores_audience_metadata() -> None:
     assert support_ticket_row_is_private(row) is False
 
 
+def test_support_ticket_row_private_check_ignores_access_metadata() -> None:
+    row = {
+        "ticket_id": "T-1",
+        "subject": "How do I update billing access?",
+        "description": "Account access still needs the billing role.",
+        "access": "Account access",
+    }
+
+    assert support_ticket_row_is_private(row) is False
+
+
 @pytest.mark.parametrize("marker", [
     {"public": "false"},
     {"private": "yes"},
     {"visibility": "restricted"},
+    {"visibility": {"name": "internal"}},
+    {"access": "internal"},
+    {"audience": "agent only"},
     {"type": "internal_note"},
 ])
 def test_support_ticket_row_private_markers_fail_closed(
@@ -85,6 +105,7 @@ def test_support_ticket_row_private_markers_fail_closed(
     {"public": "not-a-number"},
     {"private": "not-a-number"},
     {"visibility": "agent-only"},
+    {"visibility": {"id": 47}},
 ])
 def test_support_ticket_privacy_unknown_markers_do_not_use_numeric_exceptions(
     marker: dict[str, object],

--- a/tests/test_support_ticket_privacy.py
+++ b/tests/test_support_ticket_privacy.py
@@ -118,3 +118,112 @@ def test_support_ticket_privacy_unknown_markers_do_not_use_numeric_exceptions(
     marker: dict[str, object],
 ) -> None:
     assert support_ticket_comment_is_private(marker) is True
+
+
+# Round-4 design re-cut: closed token-stem rule instead of key enumeration.
+# Each case class below traces to a reviewed finding or an over-rejection
+# guard; the rule -- not a key list -- must classify every member.
+
+
+@pytest.mark.parametrize("marker", [
+    {"is_hidden": True},
+    {"is_nonpublic": True},
+    {"is_public_comment": False},
+    {"public_comment": False},
+    {"public_reply": False},
+    {"publicComment": "false"},
+    {"isprivate": "true"},
+    {"privatenotes": "yes"},
+    {"visible_to_customer": False},
+    {"agent_only": True},
+    {"is_confidential": True},
+])
+def test_support_ticket_comment_alias_class_fails_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"visible_to_customer": True},
+    {"is_public_comment": True},
+    {"public_reply": "yes"},
+])
+def test_support_ticket_comment_alias_class_public_passes(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"body": "How do I export?", "is_private_note": True},
+    {"body": "How do I export?", "is_internal_comment": "yes"},
+    {"body": "How do I export?", "private_note": 1},
+    {"body": "How do I export?", "internal_use_only": True},
+])
+def test_support_ticket_row_flag_valued_note_aliases_reject(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(marker) is True
+
+
+@pytest.mark.parametrize("marker", [
+    {"visibility": {"name": "public", "value": "internal"}},
+    {"privacy": {"label": "customer", "kind": "internal"}},
+    {"visibility": {"id": 47, "note": "free text"}},
+])
+def test_support_ticket_conflicting_object_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True
+
+
+def test_support_ticket_consistent_public_object_marker_passes() -> None:
+    marker = {"visibility": {"name": "public", "value": "public"}}
+    assert support_ticket_comment_is_private(marker) is False
+
+
+@pytest.mark.parametrize("marker", [
+    {"public": "1e999999999999999999999"},
+    {"public": "0e99999999999999999999999999"},
+    {"private": "1e999999999999999999999"},
+    {"visibility": "9" * 100000},
+])
+def test_support_ticket_malformed_numeric_markers_fail_closed_without_raising(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private(marker) is True
+    assert support_ticket_row_is_private({"body": "x", **marker}) is True
+
+
+@pytest.mark.parametrize("row", [
+    {"body": "x", "internal_id": "abc-123"},
+    {"body": "x", "private_ip": "10.0.0.1"},
+    {"body": "x", "publication_date": "2026-01-01"},
+    {"body": "x", "hidden_count": 3},
+    {"body": "x", "internal_status": "open"},
+    {"body": "x", "has_access": True},
+    {"body": "x", "external_id": "z-9"},
+])
+def test_support_ticket_data_columns_are_not_privacy_markers(
+    row: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private(row) is False
+    assert support_ticket_comment_is_private(row) is False
+
+
+def test_support_ticket_privacy_predicates_never_raise() -> None:
+    from collections.abc import Mapping
+
+    class RaisingMapping(Mapping):
+        def __getitem__(self, key: str) -> object:
+            raise RuntimeError("boom")
+
+        def __iter__(self):
+            raise RuntimeError("boom")
+
+        def __len__(self) -> int:
+            return 1
+
+    assert support_ticket_comment_is_private(RaisingMapping()) is True
+    assert support_ticket_row_is_private(RaisingMapping()) is True

--- a/tests/test_support_ticket_privacy_sweep.py
+++ b/tests/test_support_ticket_privacy_sweep.py
@@ -1,0 +1,196 @@
+"""Adversarial grammar sweep for the support-ticket privacy predicates.
+
+Generates the marker vocabulary from its semantic families (stems x key
+structure x audiences x value shapes x containers) in BOTH error directions,
+so the closed rule is exercised across the whole space instead of
+per-reviewer-finding spellings. Every case is deterministic.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from extracted_content_pipeline.support_ticket_privacy import (
+    support_ticket_comment_is_private,
+    support_ticket_row_is_private,
+)
+
+_PRIVATE_STEMS = ("private", "internal", "hidden", "confidential", "restricted")
+_PRIVATE_AUDIENCES = ("agent", "agents", "staff", "admin", "team", "support")
+_PUBLIC_AUDIENCES = (
+    "customer", "customers", "user", "users", "requester", "client", "viewers",
+)
+_TRUE_VALUES = (True, "true", "yes", 1, "1", "on")
+_FALSE_VALUES = (False, "false", "no", 0, "0.0", "off")
+
+
+def _private_assertion_cases() -> list[tuple[str, object]]:
+    cases = []
+    for stem, value in itertools.product(_PRIVATE_STEMS, _TRUE_VALUES):
+        for form in (stem, f"is_{stem}", f"{stem}_flag", f"is{stem}"):
+            cases.append((form, value))
+    return cases
+
+
+@pytest.mark.parametrize(("key", "value"), _private_assertion_cases())
+def test_sweep_private_assertion_keys_fail_closed(key: str, value: object) -> None:
+    assert support_ticket_comment_is_private({key: value, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [(stem, value) for stem in _PRIVATE_STEMS for value in _FALSE_VALUES],
+)
+def test_sweep_private_assertion_false_passes(key: str, value: object) -> None:
+    assert support_ticket_comment_is_private({key: value, "body": "x"}) is False
+
+
+@pytest.mark.parametrize(
+    "key",
+    [f"visible_to_{aud}" for aud in _PRIVATE_AUDIENCES]
+    + [f"{aud}_visible" for aud in _PRIVATE_AUDIENCES]
+    + [f"visible_{aud}" for aud in _PRIVATE_AUDIENCES]
+    + [f"{aud}_only" for aud in _PRIVATE_AUDIENCES]
+    + [f"hidden_from_{aud}" for aud in _PUBLIC_AUDIENCES],
+)
+def test_sweep_private_audience_visibility_keys_fail_closed(key: str) -> None:
+    assert support_ticket_comment_is_private({key: True, "body": "x"}) is True
+
+
+@pytest.mark.parametrize("key", [f"visible_to_{aud}" for aud in _PUBLIC_AUDIENCES])
+def test_sweep_public_audience_visibility(key: str) -> None:
+    assert support_ticket_comment_is_private({key: True, "body": "x"}) is False
+    assert support_ticket_comment_is_private({key: False, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["not_public", "not_visible", "not_customer_facing", "non_public",
+     "not_publicly_visible"],
+)
+def test_sweep_negated_public_keys_fail_closed(key: str) -> None:
+    assert support_ticket_comment_is_private({key: True, "body": "x"}) is True
+
+
+def test_sweep_negated_private_key_passes() -> None:
+    assert support_ticket_comment_is_private(
+        {"not_private": True, "body": "x"}
+    ) is False
+
+
+_PRIVATE_PHRASES = (
+    "internal", "private", "agents only", "internal only",
+    "for internal use only", "restricted to agents", "private to team",
+    "agent_note", "staff note", "internal_response", "support staff only",
+    "agent-only", "staffonly",
+)
+_PUBLIC_PHRASES = (
+    "public", "customer", "external", "visible to customer", "published",
+    "everyone",
+)
+_LABEL_KEYS = (
+    "visibility", "privacy", "audience", "access", "comment_visibility",
+    "privacy_label",
+)
+
+
+@pytest.mark.parametrize(
+    ("key", "phrase"),
+    list(itertools.product(_LABEL_KEYS, _PRIVATE_PHRASES)),
+)
+def test_sweep_private_label_phrases_fail_closed(key: str, phrase: str) -> None:
+    assert support_ticket_comment_is_private({key: phrase, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    ("key", "phrase"),
+    list(itertools.product(
+        ("visibility", "privacy", "audience", "access"), _PUBLIC_PHRASES,
+    )),
+)
+def test_sweep_public_label_phrases_pass(key: str, phrase: str) -> None:
+    assert support_ticket_comment_is_private({key: phrase, "body": "x"}) is False
+
+
+@pytest.mark.parametrize(
+    "kind_value",
+    ["private_note", "internal_comment", "agent_note", "staff_reply",
+     "private_response", "support_agent_note"],
+)
+def test_sweep_private_kind_values_fail_closed(kind_value: str) -> None:
+    assert support_ticket_comment_is_private(
+        {"type": kind_value, "body": "x"}
+    ) is True
+
+
+@pytest.mark.parametrize(
+    "kind_value",
+    ["Comment", "question", "customer_note", "customer_reply", "incident"],
+)
+def test_sweep_public_kind_values_pass(kind_value: str) -> None:
+    assert support_ticket_comment_is_private(
+        {"type": kind_value, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize("stem", ["private", "internal", "hidden"])
+def test_sweep_object_wrapped_polarity(stem: str) -> None:
+    assert support_ticket_comment_is_private(
+        {stem: {"value": True}, "body": "x"}
+    ) is True
+    assert support_ticket_comment_is_private(
+        {stem: {"value": False}, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize("label", ["internal", "private", "agents only"])
+def test_sweep_object_label_subfields_fail_closed(label: str) -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": {"name": label}, "body": "x"}
+    ) is True
+
+
+def test_sweep_object_public_forms_pass() -> None:
+    assert support_ticket_comment_is_private(
+        {"public": {"value": True}, "body": "x"}
+    ) is False
+    assert support_ticket_comment_is_private(
+        {"visibility": {"name": "public", "value": True}, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("internal_id", "x-1"),
+        ("private_ip", "10.0.0.1"),
+        ("publication_date", "2026-01-01"),
+        ("hidden_count", 3),
+        ("internal_status", "open"),
+        ("has_access", True),
+        ("support_ticket_id", "T-1"),
+        ("end_date", "2026-01-01"),
+        ("from_email", "a@b.example"),
+        ("external_id", "z"),
+        ("team_id", "t-9"),
+        ("client_version", "1.2.3"),
+        ("user_agent", "Mozilla"),
+        ("customer_id", "c-1"),
+        ("admin_url", "https://example.test"),
+    ],
+)
+def test_sweep_data_columns_are_never_markers(column: str, value: object) -> None:
+    assert support_ticket_row_is_private({"body": "x", column: value}) is False
+
+
+@pytest.mark.parametrize(
+    "column",
+    ["public_comment", "public_comments", "private_note", "internal_notes",
+     "agent_note", "staff_notes"],
+)
+def test_sweep_content_columns_do_not_reject_rows(column: str) -> None:
+    assert support_ticket_row_is_private(
+        {"body": "x", column: "free text content here"}
+    ) is False


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S6A-Admission-Boundary.md
Slice phase: Vertical slice

Fixes #2042.

This slice moves support-ticket private/internal admission to the upstream normalization boundary shared by generic package rows and Zendesk full-thread rows. Current `origin/main` only skipped comments shaped as literal `public is False`; string booleans, decimal booleans, private-note aliases, internal labels, ambiguous privacy markers, and row-level private markers could still be flattened into customer/resolution text.

**Round-4 design re-cut (builder takeover):** three review rounds grew the predicate by exact-key/value enumeration (171 -> 231 lines) without converging -- 5 further confirmed fail-open aliases plus a `decimal.InvalidOperation` ingestion crash remained. The predicate is re-cut to a closed decision rule: a key is privacy-relevant iff its compacted token remainder (after structural stopwords and `is/has/was` prefixes and note/comment/reply/flag suffixes) EXACTLY equals a privacy stem, and a privacy-relevant marker admits only values that affirmatively resolve public -- unknown aliases, unknown text, conflicting object markers, and malformed numerics all classify private, and the public predicates never raise. See the plan doc "Round-4 design re-cut contract".

## Intentional
- No HTML/tag line-preserving hygiene in this PR; that remains #2043/S6B.
- No scalar history signature/quote parsing change; that remains #2044/S6C.
- No report, snapshot, email, PDF, landing, checkout, or other product-shape change.
- Exact-remainder key matching (never substring contains), so data columns such as `internal_id`, `private_ip`, `publication_date`, `hidden_count`, `internal_status`, `has_access` are NOT markers -- over-rejection is tested as its own error direction.
- Kind keys (`type`/`kind`) stay categorically fail-open and `access`/`audience` keep value-label semantics, unchanged from round 3.
- One deliberate tightening: non-scalar marker values (lists/objects that cannot resolve) now classify ambiguous -> private instead of being `str()`-coerced; strictly fail-closed relative to round 3.

## Deferred
- #2043/S6B: line-preserving HTML/tag hygiene.
- #2044/S6C: scalar history signature/quote guard.
- #2045/S6D: evidence-tier/outcome semantics; QA scorecard/runtime integration remains S8.

## Parked hardening
- None.

## Cold diff reconstruction
Gaps found first: none. Every code change traces to the round-4 contract, every contract item is represented, and no must-not-change surface moved.

- `extracted_content_pipeline/support_ticket_privacy.py:43` defines the closed stem sets (private/public/strict-label/value-label/kind) and `:61` the structural stopwords; `:198` `_classify_key` (lru-cached) tokenizes on separators + camelCase and classifies a key iff a raw or stopword-filtered remainder, under `:221` `_stem_forms` prefix/suffix strips, exactly equals a stem (contract item 1).
- `extracted_content_pipeline/support_ticket_privacy.py:165` `_marker_is_private` implements affirmative-public-or-private per key class, including the row-mode note-content carveout at `:184` (contract items 2, 6).
- `extracted_content_pipeline/support_ticket_privacy.py:279` `_object_marker` resolves ALL recognized subfields and returns ambiguous on conflict or none -- first-field-wins removed (item 3).
- `extracted_content_pipeline/support_ticket_privacy.py:295` `_numeric_marker` guards `Decimal` with `except (ArithmeticError, ValueError)` -> ambiguous, never a raise (item 4).
- `extracted_content_pipeline/support_ticket_privacy.py:127,139` both public predicates are total functions: unexpected classification errors return private (item 5).
- `extracted_content_pipeline/support_ticket_input_package.py:30,595,751` and `extracted_content_pipeline/support_ticket_zendesk_thread.py:13,176,193` -- wiring unchanged this round (must-not-change); same call sites and signatures as round 3.
- `extracted_content_pipeline/manifest.json:328` owned-file registration, unchanged this round.
- `tests/test_support_ticket_privacy.py:123` round-4 parametrized classes: fail-open aliases (`is_hidden`, `is_nonpublic`, `is_public_comment: false`, `public_reply: false`, compacted `isprivate`/`privatenotes`, `visible_to_customer: false`, `agent_only`), public-side passes, row-level flag-valued note aliases reject while free-text note columns stay admitted, conflicting object markers fail closed, malformed/oversized numerics fail closed without raising, data-column over-rejection negatives, and a raising-Mapping total-function test (item 7). Rounds 1-3 tests unchanged and green.
- `tests/test_smoke_content_ops_support_ticket_package.py:216` and `tests/test_extracted_support_ticket_input_package.py:2047` package/Zendesk boundary proofs from earlier rounds, unchanged and green.

Must-not-change check:
- No changes to `support_ticket_input_package.py`, `support_ticket_zendesk_thread.py`, `support_ticket_clustering.py`, `manifest.json`, `scripts/run_extracted_pipeline_checks.sh`, HTML/tag hygiene, scalar history parsing, status/outcome diagnostics, final scrubber grammar, or report/snapshot/email/PDF/landing/checkout product shape in the round-4 commit.

## Reviewer findings reconciliation
All fixed or waived: yes.

Round-9 findings (all eight verified failing first) + structural response: the cluster showed the value side still used string-strips while keys had tokenization, so the value side now shares the closed token rule, and an adversarial grammar sweep (~335 generated cases, `tests/test_support_ticket_privacy_sweep.py`, CI-enrolled) covers the family space in both directions:
- `private: {"label": "public", "value": true}` admitted: fixed -- object markers resolve in the enclosing key's polarity frame; conflicts fail closed. Test: `test_support_ticket_object_label_with_boolean_under_private_key`.
- `staff_note: true`/`agent_reply: true` admitted: fixed -- audience-note boolean keys classify private; text-valued forms stay content columns. Test: `test_support_ticket_audience_note_boolean_keys_fail_closed`.
- Nested alias subfields (`{"visibility": {"publicly_visible": false}}`) skipped: fixed -- object subfields classify through the same key classifier. Test: `test_support_ticket_nested_alias_subfields_fail_closed`.
- `visibility: "visible to customer"` over-rejected: fixed -- token-based value classification resolves public phrases. Test: `test_support_ticket_visible_to_customer_label_value_passes`.
- `audience: "support staff only"` / `type: "support_agent_note"` admitted: fixed -- multi-token private phrases resolve by tokens. Test: `test_support_ticket_compound_value_phrases_fail_closed`.
- `not_visible_to_customer`/`not_publicly_visible`/`not_customer_facing` admitted: fixed -- negation flips assertion polarity (`not_private` passes). Test: `test_support_ticket_negated_visibility_keys_fail_closed`.
- `type: "private_response"`/`"agent_response"` admitted: fixed -- response/answer suffixes are value structure. Covered in `test_support_ticket_compound_value_phrases_fail_closed`.
- `access: "restricted to agents"`/`"private to team"`/`"internal to staff"` admitted: fixed -- same token rule. Covered in `test_support_ticket_compound_value_phrases_fail_closed`.
- Sweep-found over-rejection (mine, not reviewer-cited): `visibility: "everyone"` failed closed; `everyone`/`anyone`/`all` added to affirmative public labels.

Round-8 findings (all five verified failing first; one was a polarity defect in the round-7 object resolver):
- `hidden_from_customer`/`hidden_from_requester` bypass: fixed -- `from` is structural, keys reduce to the `hidden` stem. Test: `test_support_ticket_hidden_from_markers_fail_closed`.
- `support_team_only`/`support_agent_only` bypass: fixed -- compound rule accepts any all-private-audience token sequence before `only`. Test: `test_support_ticket_compound_audience_only_flags_fail_closed`.
- `private: {"value": true}` admitted (object boolean verdicted before enclosing key polarity): fixed -- neutral boolean subfields keep boolean-ness so the enclosing key's polarity applies; `public: {"value": true}` still passes. Tests: `test_support_ticket_object_wrapped_polarity_markers_fail_closed` + `..._public_marker_passes`.
- `type: "agent_note"`/`"staff_note"`/`"support_note"` admitted: fixed -- value-stem rule strips note/comment/reply suffixes, resolving to private audiences; `customer_note` provably passes. Tests: `test_support_ticket_staff_note_kind_values_fail_closed` + `..._customer_note_kind_value_passes`.
- `publicly_visible: false`/`public_visibility: false` bypass: fixed -- adverb token normalization + all-public-family compound rule. Test: `test_support_ticket_publicly_visible_flags_false_fail_closed`.

Round-7 findings (all six verified failing first; three were defects in my round-5/6 mechanisms, three rule-consistent completions):
- Flag-shaped aliases defeated the content carveout (`is_public_comment: "maybe"`, `public_reply: 2` admitted): fixed -- `is_/has_/was_`-prefixed and `*_flag` keys never qualify as content columns, and digit-only values are flag values. Tests: `test_support_ticket_flag_shaped_note_aliases_fail_closed` + `..._row_note_alias_fails_closed`.
- Nested `public`/`private` boolean subfields bypassed object resolution: fixed -- subfields resolve with key polarity ({"private": true} is a private decision). Test: `test_support_ticket_nested_boolean_object_subfields_fail_closed`.
- Equivalent public object forms over-rejected ({"name": "public", "value": true} read as conflict): fixed -- object subfields compare privacy verdicts, not raw token forms; genuine conflicts still fail closed. Test: `test_support_ticket_equivalent_public_object_forms_pass`.
- `visible_to_internal`/`visible_to_private`/`public_to_internal` admitted: fixed -- internal/private/hidden/confidential/restricted join the private-audience flip. Test: `test_support_ticket_internal_audience_visibility_fails_closed`.
- `admin_only`/`team_only`/`support_only` admitted: fixed -- audience-only compound rule. Test: `test_support_ticket_audience_only_compound_keys_fail_closed`.
- `for internal use only` labels admitted: fixed -- value-stem rule strips for/is prefixes. Test: `test_support_ticket_for_use_only_labels_fail_closed`.

Round-6 findings (all eight verified failing before the fix; two were residual over-rejection in the round-5 carveout, six were vocabulary within the closed rule):
- Empty sequence markers (`{"privacy": []}`) admitted: fixed -- fail closed like empty objects. Test: `test_support_ticket_empty_sequence_markers_fail_closed`.
- List/dict-valued `public_comments` rows over-rejected: fixed -- content carveout extended from scalar text to container shapes (these hold the comment payloads `_comments_text()` reads). Test: `test_support_ticket_container_content_columns_do_not_reject_rows`.
- `published: false` bypass: fixed -- publication/facing flags assert only via booleans, so `published: <date>` stays a data column. Tests: `test_support_ticket_publication_flags_false_fail_closed` + `..._only_assert_via_booleans`.
- `not_public`/`is_not_public` bypass: fixed -- `notpublic` negation stem. Test: `test_support_ticket_negated_public_keys_fail_closed`.
- `visible_to_end_user`/`visible_to_requester` false admitted: fixed -- end-user/requester are public-audience structure. Test: `test_support_ticket_end_user_visibility_false_fails_closed`.
- `visible_to_support(_team)` true admitted: fixed -- support is a private-audience token. Test: `test_support_ticket_support_team_visibility_fails_closed`.
- `internal only`/`private only`/`internal-use-only` labels admitted: fixed -- value-stem strip rule resolves X-only labels without per-spelling enumeration. Test: `test_support_ticket_only_style_private_labels_fail_closed`.
- `restricted_access`/`private_access`/`access_internal` bypass: fixed -- access is strippable key structure. Test: `test_support_ticket_access_composed_private_keys_fail_closed`.
- Proactive same-class sweep (not reviewer-cited): `customer_facing: false` family + `confidentiality` strict label, with over-rejection negatives (`support_ticket_id`, `end_date`, `has_access`, `access_label: billing role`).

Round-5 findings (all five verified failing before the fix, all fixed within the same closed rule -- vocabulary adjustments, no design change):
- `public_comment`/`public_comments` content rows over-rejected: fixed -- content-column carveout extended to note/comment-suffixed public keys (these are `_PUBLIC_COMMENT_KEYS` ingestion columns); flag-valued forms (`false`, `False`, `0`) still fail closed. Tests: `test_support_ticket_public_comment_content_columns_stay_admitted`, `test_support_ticket_flag_valued_public_comment_keys_fail_closed`.
- Empty object markers admitted: fixed -- `{"privacy": {}}` is present-but-unresolvable -> private, per the contract. Test: `test_support_ticket_empty_object_markers_fail_closed`.
- Plural `agents only` audience label admitted: fixed -- `agentsonly` added to private value labels. Test: `test_support_ticket_plural_agent_audience_labels_fail_closed`.
- `visible_to_agents`/`visible_to_staff` classified public: fixed -- private-audience tokens flip a public-visibility key private; `visible_to_customer` still passes. Tests: `test_support_ticket_private_audience_visibility_keys_fail_closed`, `test_support_ticket_customer_audience_visibility_still_passes`.
- `privacy_label`/`visibility_status`/`access_label` bypass: fixed -- label-style suffixes strip only on label-class stems; `internal_status` provably stays a data column. Tests: `test_support_ticket_label_suffixed_privacy_keys_fail_closed`, `test_support_ticket_label_suffix_rule_does_not_over_reject`.

Round-3 findings (fixed by the round-4 re-cut, each a committed test case):
- Object-marker first-field-wins conflict admission: fixed -- `_object_marker` resolves all subfields, conflict -> ambiguous -> private; `test_support_ticket_conflicting_object_markers_fail_closed`.
- `decimal.InvalidOperation` crash on oversized numeric markers: fixed -- guarded `Decimal`, unresolvable -> private; `test_support_ticket_malformed_numeric_markers_fail_closed_without_raising` (crash reproduced first on round-3 head).
- `is_hidden`/`is_nonpublic` fail-open: fixed by the token-stem rule; `test_support_ticket_comment_alias_class_fails_closed`.
- `is_public_comment`/`public_comment`/`public_reply` false-means-private: fixed by public-stem classification with prefix/suffix strips; same parametrized class.
- Row-level boolean `is_private_note`/`is_internal_comment` admission: fixed -- row mode now evaluates note-alias keys with flag semantics while keeping the free-text content-column carveout; `test_support_ticket_row_flag_valued_note_aliases_reject`.

## Verification
- `python -m pytest tests/test_support_ticket_privacy.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py -q` (`703 passed` incl. the ~335-case grammar sweep)
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` / `forbid_hard_atlas_imports` clean
- `bash scripts/check_ascii_python.sh`
- `bash scripts/run_extracted_pipeline_checks.sh` (`5750 passed, 21 skipped`)
- `python scripts/sync_pr_plan.py plans/PR-Resolution-Audit-S6A-Admission-Boundary.md <base> --check`
- Empirical round-4 gate run before tests: all 5 findings reproduced failing on round-3 head `681b03806`, all pass on this head; `Decimal("1e999999999999999999999")` crash reproduced and eliminated.

## Diff size
10 files, +2098 / -4 vs base (rounds 4-6: predicate re-cut + vocabulary refinements + tests). Over the 400 LOC soft cap because the required plan doc and same-class tests ship with the shared privacy boundary; the product-code diff is one module implementing one admission concern.

Diff-budget override: S6A is genuinely indivisible because the shared private/internal admission predicate, both real ingestion call sites, and same-class privacy tests must land together; splitting would leave either package or Zendesk admission with the old leak path or an unproven boundary. The round-4 re-cut adds no new surface -- it replaces the predicate internals and tests within the same boundary.
