### PR TITLE
Resolution Audit CSV S6B: line-preserving HTML hygiene

### DIFF
--- a/docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md
+++ b/docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md
@@ -42,8 +42,8 @@ Minimum true before paid reports ship:
 | 1 | Fragmentation undercount (F1/F3/F6) | S5 #2033 | CONDITIONAL (booster ON+calibrated; default OFF) |
 | 2 | Header/data-loss admission (C1/H4/C2) | S1 #2026 | MOSTLY (dup-header/encoding closed; terse-first-row + missing-ID residual) |
 | 3 | Money reconciliation (P5-2) | S4 #2031 | DISPLAY-only (buyer-visible cents change needs approval; P5-7 model guard -> S8) |
-| 4 | PII private/internal notes | S6A #2046 | BUILT, OPEN PR |
-| 5 | Junk/auto-reply/OOO gate (F2, incl HTML M6) | S6B #2043 | OPEN + scoping gap (junk-DETECTION rules unnamed; may need S6E) |
+| 4 | PII private/internal notes | S6A #2046 | MERGED 2026-07-08 -- CLOSED |
+| 5 | Junk/auto-reply/OOO gate (F2, incl HTML M6) | S6B #2043 (line plumbing) + S6E #2049 (detection rules) | OPEN -- scoping gap RESOLVED by the S6E split |
 | 6 | Date transposition/window (C3/M7) | S7 | OPEN |
 | 7 | Fail-closed runtime guard (P5-7 + scorecard) | S8 | OPEN (scorecard zero runtime callers) |
 
@@ -404,11 +404,13 @@ These are not coding-start items until the operator approves the product shape:
 - [x] S5 clustering first implementation PR linked here: #2033. F1 undercount
   CONDITIONAL -- closes only with the default-OFF embedding booster ON+calibrated.
 - [ ] S5 clustering calibration (real-corpus + booster on/off decision) PR linked here.
-- [ ] S6A private/internal admission boundary PR linked here: OPEN #2046 (issue #2042, in review).
-- [ ] S6B HTML line hygiene + F2 auto-reply/OOO junk-DETECTION gate PR linked here (issue #2043). See scoping gap in the ledger above.
+- [x] S6A private/internal admission boundary PR linked here: #2046 (merged 2026-07-08; issue #2042 closed; closed token-stem predicate + ~335-case grammar sweep, 46 reviewer findings resolved across 9 rounds).
+- [ ] S6B HTML line-preserving hygiene PR linked here (issue #2043). F2 junk-DETECTION split to S6E (#2049) per the ledger scoping flag.
+- [ ] S6E junk/auto-reply/OOO detection gate PR linked here (issue #2049; after S6B).
+- [ ] S6D-M9 status-synonym micro-slice PR linked here (issue #2050; independent).
 - [ ] S6C scalar history signature/quoted-reply cleanup PR linked here (issue #2044).
 - [ ] S6D customer evidence tier + outcome semantics PR linked here (issue #2045).
-- [ ] S6E (only if S6B does not cover F2): explicit auto-reply/OOO junk-detection rules PR linked here.
 - [ ] S7 date/window policy PR linked here.
-- [ ] S8 runtime QA scorecard + P5-7 reconciliation guard PR linked here.
+- [ ] S8a runtime scorecard fail-closed wiring PR linked here (issue #2051).
+- [ ] S8b P5-7 money reconciliation guard PR linked here (issue #2052; after S8a).
 - [ ] Operator-approved product-surface issue/PR linked here, if any.

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -43,7 +43,7 @@ _HTML_SIGNAL_RE = re.compile(
 _HTML_EXCLUDED_TAG_AT_START_RE = re.compile(
     r"\A\s*(?:(?:\[[^\]\n]{1,80}\]|<!doctype[^>]*>|<!--.*?-->"
     r"|<title[^>]*>[^<]*</title\s*>"
-    r"|</?(?:html|head|body|meta|title|link)[^>]*>)\s*)*"
+    r"|</?(?:html|head|body|meta|title|link|base)[^>]*>)\s*)*"
     r"<(script|style|blockquote)\b",
     re.IGNORECASE | re.DOTALL,
 )
@@ -380,10 +380,25 @@ class _HTMLTextExtractor(HTMLParser):
                     # CDATA may have swallowed outer scopes' close tags
                     # (<blockquote><script>x</blockquote></script>): unwind
                     # scopes whose close tags sit in the buffer outside code
-                    # literals, then drop the buffer -- a closed scope's
-                    # content is excluded and must never leak into a later
+                    # literals. If the unwind empties the stack, the tail
+                    # AFTER the last swallowed close is real markup the
+                    # parser never saw -- re-emit it. Then drop the buffer:
+                    # a closed scope's content never leaks into a later
                     # malformed scope's recovery.
-                    self._unwind_swallowed_scopes("".join(self._pending))
+                    buffered = "".join(self._pending)
+                    tail_from = self._unwind_swallowed_scopes(buffered)
+                    if tail_from is not None and not self._skip_stack:
+                        tail = buffered[tail_from:]
+                        if tail.strip():
+                            recovered = _extract_html_text(
+                                tail,
+                                exclude_blockquote=(
+                                    "blockquote" in self._excluded
+                                ),
+                            )
+                            if recovered.strip():
+                                self.parts.append("\n")
+                                self.parts.append(recovered)
                     self._pending.clear()
                 if not self._skip_stack:
                     self.parts.append(
@@ -392,23 +407,36 @@ class _HTMLTextExtractor(HTMLParser):
             return
         self.parts.append("\n" if lowered in _BLOCK_TAG_NAMES else " ")
 
-    def _unwind_swallowed_scopes(self, buffered: str) -> None:
+    def _unwind_swallowed_scopes(self, buffered: str) -> int | None:
+        """Pop scopes whose close tags the buffer swallowed.
+
+        Returns the end offset just past the last consumed close tag, or
+        None when nothing was unwound. Comparison-shaped tags (preceded by
+        identifiers, not statement boundaries) count for neither opens nor
+        closes.
+        """
+
         if not self._skip_stack or not buffered:
-            return
+            return None
         masked = _code_literal_regions(buffered)
         available: dict[str, int] = {}
+        ends: dict[str, list[int]] = {}
+        last_end: int | None = None
         while self._skip_stack:
             scope = self._skip_stack[-1]
             if scope not in available:
-                closes = sum(
-                    1
+                # Close tags are never comparisons (a</b is not valid JS),
+                # so only the mask filters them; OPENS also need the
+                # statement-boundary rule to skip comparison shapes.
+                close_matches = [
+                    match
                     for match in re.finditer(
                         rf"</{scope}\s*>", buffered, re.IGNORECASE
                     )
                     if not any(
                         lo <= match.start() <= hi for lo, hi in masked
                     )
-                )
+                ]
                 opens = sum(
                     1
                     for match in re.finditer(
@@ -417,14 +445,19 @@ class _HTMLTextExtractor(HTMLParser):
                     if not any(
                         lo <= match.start() <= hi for lo, hi in masked
                     )
+                    and _statement_boundary_precedes(buffered, match.start())
                 )
                 # A close belonging to a balanced pair INSIDE the buffer
                 # cannot close a pre-existing outer scope.
-                available[scope] = max(0, closes - opens)
+                available[scope] = max(0, len(close_matches) - opens)
+                ends[scope] = [match.end() for match in close_matches]
             if available[scope] <= 0:
                 break
             available[scope] -= 1
+            if ends[scope]:
+                last_end = ends[scope][len(ends[scope]) - available[scope] - 1]
             self._skip_stack.pop()
+        return last_end
 
     def handle_data(self, data: str) -> None:
         if self._skip_stack:
@@ -495,15 +528,25 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
     for position in sorted(candidates):
         if any(lo <= position <= hi for lo, hi in masked):
             continue
-        # Tag-shaped code such as comparisons (if (x<p>y)) is not markup:
-        # a real tag follows a code/markup boundary, not an identifier.
-        preceding = buffered[position - 1] if position > 0 else ""
-        if preceding and not (
-            preceding.isspace() or preceding in ";{}()>,=&|!?:/"
-        ):
+        # Tag-shaped code such as comparisons (if (x<p>y), if (x <p> y))
+        # is not markup: a real tag follows a STATEMENT boundary -- a
+        # newline, or ;{}>/ before at most intra-line whitespace -- never
+        # an identifier or expression operator.
+        if not _statement_boundary_precedes(buffered, position):
             continue
         return position
     return None
+
+
+def _statement_boundary_precedes(buffered: str, position: int) -> bool:
+    i = position - 1
+    while i >= 0 and buffered[i] in " \t":
+        i -= 1
+    if i < 0:
+        return True
+    if buffered[i] == "\n":
+        return True
+    return buffered[i] in ";{}>/"
 
 
 # Recovery-only tag shape: like _HTML_SIGNAL_RE but attributes may be bare
@@ -546,7 +589,9 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
     word = ""
     prev_word = ""
     paren_stack: list[bool] = []
+    brace_stack: list[bool] = []
     control_paren_just_closed = False
+    block_just_closed = False
     while i < length:
         ch = buffered[i]
         nxt = buffered[i + 1] if i + 1 < length else ""
@@ -565,6 +610,7 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
             elif ch == "/" and (
                 (word or prev_word) in _JS_EXPRESSION_KEYWORDS
                 or control_paren_just_closed
+                or block_just_closed
                 or (
                     # "</tag>" (slash ADJACENT to <) is markup; a spaced
                     # "< /" is a less-than operator before a regex.
@@ -577,6 +623,7 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                 # Expression-position slash: candidate regex literal.
                 state, start = "re", i
                 in_char_class = False
+                control_paren_just_closed = False
             if state is None:
                 if ch.isspace():
                     # Whitespace completes a word (x in /re/): remember it
@@ -597,12 +644,31 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                             (word or prev_word) in _JS_CONTROL_KEYWORDS
                         )
                         control_paren_just_closed = False
+                        block_just_closed = False
                     elif ch == ")":
                         control_paren_just_closed = (
                             paren_stack.pop() if paren_stack else False
                         )
+                        block_just_closed = False
+                    elif ch == "{":
+                        # A block brace (after a control header, statement
+                        # boundary, or start) closes into statement
+                        # position; an object-literal brace is a value.
+                        brace_stack.append(
+                            control_paren_just_closed
+                            or prev in ";{}"
+                            or prev == ""
+                        )
+                        control_paren_just_closed = False
+                        block_just_closed = False
+                    elif ch == "}":
+                        block_just_closed = (
+                            brace_stack.pop() if brace_stack else False
+                        )
+                        control_paren_just_closed = False
                     elif not ch.isspace():
                         control_paren_just_closed = False
+                        block_just_closed = False
                     word = ""
                     prev_word = ""
                     prev2, prev = prev, ch
@@ -646,7 +712,11 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                 state = None
                 i += 1
         elif state == "<!--":
-            if buffered[i:i + 3] == "-->":
+            # In script text "<!--" behaves as a line comment.
+            if ch == "\n":
+                masked.append((start, i))
+                state = None
+            elif buffered[i:i + 3] == "-->":
                 masked.append((start, i + 2))
                 state = None
                 i += 2

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -15,7 +15,7 @@ _WHITESPACE_RE = re.compile(r"\s+")
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _LEADING_BRACKETED_METADATA_RE = re.compile(r"^(?:\[[^\]\n]{1,80}\]\s*)+")
 _HTML_TAG_NAMES_RE = (
-    r"(?:a|abbr|article|aside|b|blockquote|body|br|button|cite|code|dd|"
+    r"(?:a|abbr|article|aside|b|body|br|button|cite|code|dd|"
     r"del|div|dl|dt|em|figcaption|figure|footer|h[1-6]|header|hr|html|i|"
     r"img|ins|li|main|mark|nav|ol|p|pre|s|section|small|span|strike|strong|"
     r"sub|sup|table|tbody|td|tfoot|th|thead|time|tr|u|ul)"
@@ -28,10 +28,12 @@ _HTML_SIGNAL_RE = re.compile(
     rf"</?{_HTML_TAG_NAMES_RE}(?:{_HTML_ATTR_RE})*\s*/?>",
     re.IGNORECASE,
 )
-# A LONE <script>/<style> in prose ("How do I add <script> to the page?")
-# is customer wording, not markup; only a paired open+close is an HTML signal.
+# A LONE <script>/<style>/<blockquote> in prose ("How do I add <script> to
+# the page?") is customer wording, not markup; only a paired open+close is an
+# HTML signal. Inside a document detected via other tags, an unclosed
+# blockquote still excludes to EOF (a quote to end-of-message is a quote).
 _HTML_SCRIPT_STYLE_PAIRED_RE = re.compile(
-    r"<(script|style)\b[^>]*>.*?</\1\s*>",
+    r"<(script|style|blockquote)\b[^>]*>.*?</\1\s*>",
     re.IGNORECASE | re.DOTALL,
 )
 _HTML_CUSTOM_TAG_RE = re.compile(
@@ -352,6 +354,28 @@ class _HTMLTextExtractor(HTMLParser):
         if self._skip_stack:
             if lowered == self._skip_stack[-1]:
                 self._skip_stack.pop()
+                if self._skip_stack and lowered in {"script", "style"}:
+                    # CDATA may have swallowed outer scopes' close tags
+                    # (<blockquote><script>x</blockquote></script>): unwind
+                    # any remaining scope whose close tag sits in the buffer
+                    # outside code literals, so later real markup is not
+                    # treated as still-quoted.
+                    buffered = "".join(self._pending)
+                    masked = _code_literal_regions(buffered)
+                    while self._skip_stack:
+                        scope = self._skip_stack[-1]
+                        found = False
+                        for match in re.finditer(
+                            rf"</{scope}\s*>", buffered, re.IGNORECASE
+                        ):
+                            if not any(
+                                lo <= match.start() <= hi for lo, hi in masked
+                            ):
+                                found = True
+                                break
+                        if not found:
+                            break
+                        self._skip_stack.pop()
                 if not self._skip_stack:
                     # Scope closed properly: excluded content stays excluded.
                     self._pending.clear()
@@ -401,16 +425,42 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
     """First HTML-signal offset outside string literals and comments.
 
     Script/CSS code embeds markup in quoted templates ('<p>x</p>'),
-    template literals, and comments; those are code, not lost ticket text.
-    Only markup in plain code context marks where real trailing HTML began.
+    template literals, regex literals, and comments; those are code, not
+    lost ticket text. Only markup in plain code context marks where real
+    trailing HTML began.
+    """
+
+    masked = _code_literal_regions(buffered)
+    candidates = [
+        match.start()
+        for pattern in (_HTML_SIGNAL_RE, _HTML_CUSTOM_TAG_RE)
+        for match in pattern.finditer(buffered)
+    ]
+    for position in sorted(candidates):
+        if not any(lo <= position <= hi for lo, hi in masked):
+            return position
+    return None
+
+
+def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
+    """Mask string/template/regex literals and comments in script text.
+
+    Regex-literal handling is deliberately bounded: a slash opens a regex
+    only in expression position (not after a value: alphanumerics, closing
+    brackets/braces, closed literals, or postfix ++/--), a slash inside a
+    character class does not close it, and a candidate that reaches a
+    newline was division all along (JS regex literals cannot span lines),
+    so a misread slash can never mask to EOF.
     """
 
     masked: list[tuple[int, int]] = []
     state: str | None = None
     start = 0
+    in_char_class = False
     i = 0
     length = len(buffered)
-    last_code_char = ""
+    prev = ""
+    prev2 = ""
     while i < length:
         ch = buffered[i]
         nxt = buffered[i + 1] if i + 1 < length else ""
@@ -425,21 +475,31 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
                 i += 1
             elif (
                 ch == "/"
-                and last_code_char not in ")]}\"'`"
-                and not last_code_char.isalnum()
+                and prev != "<"  # "</tag>" is markup, never a regex
+                and prev not in ")]}\"'`"
+                and not prev.isalnum()
+                and not (prev in "+-" and prev2 == prev)
             ):
-                # JS regex literal: a slash in expression position (after an
-                # operator/opening context, not after a value) opens /.../.
+                # Expression-position slash: candidate regex literal.
                 state, start = "re", i
+                in_char_class = False
             if state is None and not ch.isspace():
-                last_code_char = ch
+                prev2, prev = prev, ch
         elif state == "re":
             if ch == "\\":
                 i += 1
-            elif ch == "/":
+            elif ch == "\n":
+                # JS regex literals cannot span lines: this was division.
+                state = None
+                prev2, prev = "", "/"
+            elif ch == "[":
+                in_char_class = True
+            elif ch == "]":
+                in_char_class = False
+            elif ch == "/" and not in_char_class:
                 masked.append((start, i))
                 state = None
-                last_code_char = "/"
+                prev2, prev = "", "/"
         elif state in "'\"`":
             if ch == "\\":
                 i += 1
@@ -447,7 +507,7 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
                 masked.append((start, i))
                 state = None
                 # A closed literal is a value: a following slash is division.
-                last_code_char = ch
+                prev2, prev = "", ch
         elif state == "//":
             if ch == "\n":
                 masked.append((start, i))
@@ -458,19 +518,15 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
                 state = None
                 i += 1
         i += 1
-    if state is not None:
-        # Unterminated literal/comment runs to EOF: everything after it is
+    if state == "re":
+        # Unclosed single-line regex candidate at EOF: treat as division,
+        # masking nothing, rather than swallowing the buffer.
+        pass
+    elif state is not None:
+        # Unterminated string/comment runs to EOF: everything after it is
         # still code context, never recoverable ticket text.
         masked.append((start, length - 1))
-    candidates = [
-        match.start()
-        for pattern in (_HTML_SIGNAL_RE, _HTML_CUSTOM_TAG_RE)
-        for match in pattern.finditer(buffered)
-    ]
-    for position in sorted(candidates):
-        if not any(lo <= position <= hi for lo, hi in masked):
-            return position
-    return None
+    return masked
 
 
 def _extract_html_text(text: str, *, exclude_blockquote: bool) -> str:

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -375,16 +375,68 @@ class _HTMLTextExtractor(HTMLParser):
             # An unclosed blockquote is a quote to EOF and stays excluded.
             if self._skip_stack[0] in {"script", "style"}:
                 buffered = "".join(self._pending)
-                signal = _HTML_SIGNAL_RE.search(buffered)
-                if signal is not None:
+                start = _first_markup_outside_code_literals(buffered)
+                if start is not None:
                     recovered = _extract_html_text(
-                        buffered[signal.start():],
+                        buffered[start:],
                         exclude_blockquote="blockquote" in self._excluded,
                     )
                     if recovered.strip():
                         self.parts.append("\n")
                         self.parts.append(recovered)
         return "".join(self.parts)
+
+
+def _first_markup_outside_code_literals(buffered: str) -> int | None:
+    """First HTML-signal offset outside string literals and comments.
+
+    Script/CSS code embeds markup in quoted templates ('<p>x</p>'),
+    template literals, and comments; those are code, not lost ticket text.
+    Only markup in plain code context marks where real trailing HTML began.
+    """
+
+    masked: list[tuple[int, int]] = []
+    state: str | None = None
+    start = 0
+    i = 0
+    length = len(buffered)
+    while i < length:
+        ch = buffered[i]
+        nxt = buffered[i + 1] if i + 1 < length else ""
+        if state is None:
+            if ch in "'\"`":
+                state, start = ch, i
+            elif ch == "/" and nxt == "/":
+                state, start = "//", i
+                i += 1
+            elif ch == "/" and nxt == "*":
+                state, start = "/*", i
+                i += 1
+        elif state in "'\"`":
+            if ch == "\\":
+                i += 1
+            elif ch == state:
+                masked.append((start, i))
+                state = None
+        elif state == "//":
+            if ch == "\n":
+                masked.append((start, i))
+                state = None
+        elif state == "/*":
+            if ch == "*" and nxt == "/":
+                masked.append((start, i + 1))
+                state = None
+                i += 1
+        i += 1
+    if state is not None:
+        # Unterminated literal/comment runs to EOF: everything after it is
+        # still code context, never recoverable ticket text.
+        masked.append((start, length - 1))
+    for match in _HTML_SIGNAL_RE.finditer(buffered):
+        position = match.start()
+        if not any(lo <= position <= hi for lo, hi in masked):
+            return position
+    return None
 
 
 def _extract_html_text(text: str, *, exclude_blockquote: bool) -> str:

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -36,6 +36,7 @@ _HTML_SIGNAL_RE = re.compile(
 # document detected via other tags, exclusion applies as usual.
 _HTML_EXCLUDED_TAG_AT_START_RE = re.compile(
     r"\A\s*(?:(?:\[[^\]\n]{1,80}\]|<!doctype[^>]*>|<!--.*?-->"
+    r"|<title[^>]*>[^<]*</title\s*>"
     r"|</?(?:html|head|body|meta|title|link)[^>]*>)\s*)*"
     r"<(script|style|blockquote)\b",
     re.IGNORECASE | re.DOTALL,
@@ -557,16 +558,22 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
             elif ch == "/" and not in_char_class:
                 masked.append((start, i))
                 state = None
-                # A closed regex is a value: a following slash is division.
+                # A closed regex is a value and consumes any keyword
+                # context: a following slash is division.
                 prev2, prev = "", ")"
+                word = ""
+                prev_word = ""
         elif state in "'\"`":
             if ch == "\\":
                 i += 1
             elif ch == state:
                 masked.append((start, i))
                 state = None
-                # A closed literal is a value: a following slash is division.
+                # A closed literal is a value and consumes any keyword
+                # context: a following slash is division.
                 prev2, prev = "", ch
+                word = ""
+                prev_word = ""
         elif state == "//":
             if ch == "\n":
                 masked.append((start, i))
@@ -583,9 +590,10 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                 i += 2
         i += 1
     if state == "re":
-        # Unclosed single-line regex candidate at EOF: treat as division,
-        # masking nothing, rather than swallowing the buffer.
-        pass
+        # Unterminated regex candidate at EOF: mask it. The newline reset
+        # already bounds candidates to one line, so this can swallow at
+        # most the final line, never the buffer.
+        masked.append((start, length - 1))
     elif state is not None:
         # Unterminated string/comment runs to EOF: everything after it is
         # still code context, never recoverable ticket text.

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -20,9 +20,15 @@ _HTML_TAG_NAMES_RE = (
     r"img|ins|li|main|mark|nav|ol|p|pre|s|section|small|span|strike|strong|"
     r"sub|sup|table|tbody|td|tfoot|th|thead|time|tr|u|ul)"
 )
+_HTML_BOOLEAN_ATTRS_RE = (
+    r"(?:hidden|disabled|checked|selected|readonly|required|multiple|"
+    r"autofocus|autoplay|controls|loop|muted|open|reversed|async|defer|"
+    r"novalidate|itemscope|contenteditable|spellcheck|translate|inert)"
+)
 _HTML_ATTR_RE = (
-    r"(?:\s+[a-z_:][a-z0-9_:.-]*\s*=\s*"
-    r"(?:\"[^\"]*\"|'[^']*'|[^\s\"'=<>`]+))"
+    r"(?:\s+(?:[a-z_:][a-z0-9_:.-]*\s*=\s*"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\s\"'=<>`]+)"
+    rf"|{_HTML_BOOLEAN_ATTRS_RE}\b))"
 )
 _HTML_SIGNAL_RE = re.compile(
     rf"</?{_HTML_TAG_NAMES_RE}(?:{_HTML_ATTR_RE})*\s*/?>",
@@ -394,7 +400,7 @@ class _HTMLTextExtractor(HTMLParser):
         while self._skip_stack:
             scope = self._skip_stack[-1]
             if scope not in available:
-                available[scope] = sum(
+                closes = sum(
                     1
                     for match in re.finditer(
                         rf"</{scope}\s*>", buffered, re.IGNORECASE
@@ -403,6 +409,18 @@ class _HTMLTextExtractor(HTMLParser):
                         lo <= match.start() <= hi for lo, hi in masked
                     )
                 )
+                opens = sum(
+                    1
+                    for match in re.finditer(
+                        rf"<{scope}\b[^>]*(?<!/)>", buffered, re.IGNORECASE
+                    )
+                    if not any(
+                        lo <= match.start() <= hi for lo, hi in masked
+                    )
+                )
+                # A close belonging to a balanced pair INSIDE the buffer
+                # cannot close a pre-existing outer scope.
+                available[scope] = max(0, closes - opens)
             if available[scope] <= 0:
                 break
             available[scope] -= 1
@@ -503,6 +521,7 @@ _JS_EXPRESSION_KEYWORDS = frozenset({
     "return", "typeof", "case", "in", "of", "delete", "void", "throw",
     "do", "else", "yield", "await", "instanceof", "new",
 })
+_JS_CONTROL_KEYWORDS = frozenset({"if", "for", "while", "switch", "catch"})
 
 
 def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
@@ -526,6 +545,8 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
     prev2 = ""
     word = ""
     prev_word = ""
+    paren_stack: list[bool] = []
+    control_paren_just_closed = False
     while i < length:
         ch = buffered[i]
         nxt = buffered[i + 1] if i + 1 < length else ""
@@ -543,6 +564,7 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                 i += 3
             elif ch == "/" and (
                 (word or prev_word) in _JS_EXPRESSION_KEYWORDS
+                or control_paren_just_closed
                 or (
                     # "</tag>" (slash ADJACENT to <) is markup; a spaced
                     # "< /" is a less-than operator before a regex.
@@ -567,6 +589,20 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                     word = word + ch if word else ("." + ch if prev == "." else ch)
                     prev2, prev = prev, ch
                 else:
+                    if ch == "(":
+                        # Remember whether this paren is a control-flow
+                        # header: its close puts a slash in expression
+                        # position (if (ok) /re/) unlike a value paren.
+                        paren_stack.append(
+                            (word or prev_word) in _JS_CONTROL_KEYWORDS
+                        )
+                        control_paren_just_closed = False
+                    elif ch == ")":
+                        control_paren_just_closed = (
+                            paren_stack.pop() if paren_stack else False
+                        )
+                    elif not ch.isspace():
+                        control_paren_just_closed = False
                     word = ""
                     prev_word = ""
                     prev2, prev = prev, ch

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -28,13 +28,19 @@ _HTML_SIGNAL_RE = re.compile(
     rf"</?{_HTML_TAG_NAMES_RE}(?:{_HTML_ATTR_RE})*\s*/?>",
     re.IGNORECASE,
 )
-# A LONE <script>/<style>/<blockquote> in prose ("How do I add <script> to
-# the page?") is customer wording, not markup; only a paired open+close is an
-# HTML signal. Inside a document detected via other tags, an unclosed
-# blockquote still excludes to EOF (a quote to end-of-message is a quote).
-_HTML_SCRIPT_STYLE_PAIRED_RE = re.compile(
-    r"<(script|style|blockquote)\b[^>]*>.*?</\1\s*>",
-    re.IGNORECASE | re.DOTALL,
+# Excluded tags mentioned MID-PROSE ("How do I add <script> to the page?",
+# "How do I write <blockquote>hello</blockquote> in the editor?") are
+# customer wording, not markup. A body that STARTS with an excluded tag
+# ("<script>alert(1)", "<blockquote>quoted prior reply") is markup intent:
+# script-only bodies exclude, quote-to-EOF bodies are all-quote. Inside a
+# document detected via other tags, exclusion applies as usual.
+_HTML_EXCLUDED_TAG_AT_START_RE = re.compile(
+    r"\A\s*<(script|style|blockquote)\b",
+    re.IGNORECASE,
+)
+_HTML_EXCLUDED_TAG_RE = re.compile(
+    r"</?(script|style|blockquote)\b[^>]*>",
+    re.IGNORECASE,
 )
 _HTML_CUSTOM_TAG_RE = re.compile(
     r"</?[a-z][a-z0-9:-]*-[a-z0-9:-]*(?:\s+[^<>]*)?/?>",
@@ -433,13 +439,23 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
     masked = _code_literal_regions(buffered)
     candidates = [
         match.start()
-        for pattern in (_HTML_SIGNAL_RE, _HTML_CUSTOM_TAG_RE)
+        for pattern in (
+            _HTML_SIGNAL_RE,
+            _HTML_CUSTOM_TAG_RE,
+            _HTML_EXCLUDED_TAG_RE,
+        )
         for match in pattern.finditer(buffered)
     ]
     for position in sorted(candidates):
         if not any(lo <= position <= hi for lo, hi in masked):
             return position
     return None
+
+
+_JS_EXPRESSION_KEYWORDS = frozenset({
+    "return", "typeof", "case", "in", "of", "delete", "void", "throw",
+    "do", "else", "yield", "await", "instanceof", "new",
+})
 
 
 def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
@@ -461,6 +477,7 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
     length = len(buffered)
     prev = ""
     prev2 = ""
+    word = ""
     while i < length:
         ch = buffered[i]
         nxt = buffered[i + 1] if i + 1 < length else ""
@@ -473,17 +490,20 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
             elif ch == "/" and nxt == "*":
                 state, start = "/*", i
                 i += 1
-            elif (
-                ch == "/"
-                and prev != "<"  # "</tag>" is markup, never a regex
-                and prev not in ")]}\"'`"
-                and not prev.isalnum()
-                and not (prev in "+-" and prev2 == prev)
+            elif ch == "/" and (
+                word in _JS_EXPRESSION_KEYWORDS
+                or (
+                    prev != "<"  # "</tag>" is markup, never a regex
+                    and prev not in ")]}\"'`"
+                    and not prev.isalnum()
+                    and not (prev in "+-" and prev2 == prev)
+                )
             ):
                 # Expression-position slash: candidate regex literal.
                 state, start = "re", i
                 in_char_class = False
             if state is None and not ch.isspace():
+                word = word + ch if (ch.isalnum() or ch in "$_") else ""
                 prev2, prev = prev, ch
         elif state == "re":
             if ch == "\\":
@@ -596,7 +616,7 @@ def _compact_lines(text: str) -> str:
 def _looks_like_html(text: str) -> bool:
     return bool(
         _HTML_SIGNAL_RE.search(text)
-        or _HTML_SCRIPT_STYLE_PAIRED_RE.search(text)
+        or _HTML_EXCLUDED_TAG_AT_START_RE.search(text)
         or _HTML_CUSTOM_TAG_RE.search(text)
     )
 

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -35,7 +35,7 @@ _HTML_SIGNAL_RE = re.compile(
 # script-only bodies exclude, quote-to-EOF bodies are all-quote. Inside a
 # document detected via other tags, exclusion applies as usual.
 _HTML_EXCLUDED_TAG_AT_START_RE = re.compile(
-    r"\A\s*<(script|style|blockquote)\b",
+    r"\A\s*(?:\[[^\]\n]{1,80}\]\s*)*<(script|style|blockquote)\b",
     re.IGNORECASE,
 )
 _HTML_EXCLUDED_TAG_RE = re.compile(
@@ -368,19 +368,23 @@ class _HTMLTextExtractor(HTMLParser):
                     # treated as still-quoted.
                     buffered = "".join(self._pending)
                     masked = _code_literal_regions(buffered)
+                    available: dict[str, int] = {}
                     while self._skip_stack:
                         scope = self._skip_stack[-1]
-                        found = False
-                        for match in re.finditer(
-                            rf"</{scope}\s*>", buffered, re.IGNORECASE
-                        ):
-                            if not any(
-                                lo <= match.start() <= hi for lo, hi in masked
-                            ):
-                                found = True
-                                break
-                        if not found:
+                        if scope not in available:
+                            available[scope] = sum(
+                                1
+                                for match in re.finditer(
+                                    rf"</{scope}\s*>", buffered, re.IGNORECASE
+                                )
+                                if not any(
+                                    lo <= match.start() <= hi
+                                    for lo, hi in masked
+                                )
+                            )
+                        if available[scope] <= 0:
                             break
+                        available[scope] -= 1
                         self._skip_stack.pop()
                 if not self._skip_stack:
                     # Scope closed properly: excluded content stays excluded.
@@ -478,6 +482,7 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
     prev = ""
     prev2 = ""
     word = ""
+    prev_word = ""
     while i < length:
         ch = buffered[i]
         nxt = buffered[i + 1] if i + 1 < length else ""
@@ -491,9 +496,11 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                 state, start = "/*", i
                 i += 1
             elif ch == "/" and (
-                word in _JS_EXPRESSION_KEYWORDS
+                (word or prev_word) in _JS_EXPRESSION_KEYWORDS
                 or (
-                    prev != "<"  # "</tag>" is markup, never a regex
+                    # "</tag>" (slash ADJACENT to <) is markup; a spaced
+                    # "< /" is a less-than operator before a regex.
+                    not (prev == "<" and i > 0 and buffered[i - 1] == "<")
                     and prev not in ")]}\"'`"
                     and not prev.isalnum()
                     and not (prev in "+-" and prev2 == prev)
@@ -502,9 +509,21 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                 # Expression-position slash: candidate regex literal.
                 state, start = "re", i
                 in_char_class = False
-            if state is None and not ch.isspace():
-                word = word + ch if (ch.isalnum() or ch in "$_") else ""
-                prev2, prev = prev, ch
+            if state is None:
+                if ch.isspace():
+                    # Whitespace completes a word (x in /re/): remember it
+                    # for the keyword check without polluting the buffer.
+                    if word:
+                        prev_word, word = word, ""
+                elif ch.isalnum() or ch in "$_":
+                    # A word opened by "." is a property access, never an
+                    # expression keyword (obj.return / 2 is division).
+                    word = word + ch if word else ("." + ch if prev == "." else ch)
+                    prev2, prev = prev, ch
+                else:
+                    word = ""
+                    prev_word = ""
+                    prev2, prev = prev, ch
         elif state == "re":
             if ch == "\\":
                 i += 1

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -289,28 +289,89 @@ class _ClusterBucket:
     token_counts: Counter[str] = field(default_factory=Counter)
 
 
+# Block-level members of the SAME tag families _HTML_SIGNAL_RE recognizes,
+# so HTML detection and line extraction cannot drift apart. These tags carry
+# the message structure (paragraph/break/list/table/heading/quote boundaries)
+# that line-based hygiene downstream keys on.
+_BLOCK_TAG_NAMES = frozenset({
+    "article", "aside", "blockquote", "body", "br", "dd", "div", "dl", "dt",
+    "figcaption", "figure", "footer", "h1", "h2", "h3", "h4", "h5", "h6",
+    "header", "hr", "html", "li", "main", "nav", "ol", "p", "pre", "section",
+    "table", "tbody", "tfoot", "thead", "tr", "ul",
+})
+# Bodies excluded from customer text: script/style are markup machinery;
+# blockquote is the HTML-native quoted-prior-message marker.
+_EXCLUDED_CONTENT_TAGS = frozenset({"script", "style", "blockquote"})
+
+
 class _HTMLTextExtractor(HTMLParser):
-    def __init__(self) -> None:
+    """Extract text with line boundaries at block tags.
+
+    Block-level tags emit newlines so downstream line-based hygiene sees the
+    structure rich HTML encodes in tags; inline tags emit spaces as before.
+    script/style bodies (and blockquote bodies when ``exclude_blockquote``)
+    are excluded. Excluded content is buffered, not discarded: if a
+    script/style scope never closes (malformed HTML puts the parser in CDATA
+    mode and would otherwise swallow the rest of the ticket), the buffered
+    text is recovered tag-stripped at EOF so customer text is never lost. An
+    unclosed blockquote stays excluded -- a quote running to end-of-message
+    is a quote, not data loss.
+    """
+
+    def __init__(self, *, exclude_blockquote: bool = True) -> None:
         super().__init__(convert_charrefs=True)
         self.parts: list[str] = []
-        self._skip_depth = 0
+        self._skip_stack: list[str] = []
+        self._pending: list[str] = []
+        self._excluded = {"script", "style"}
+        if exclude_blockquote:
+            self._excluded = _EXCLUDED_CONTENT_TAGS
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         del attrs
         lowered = tag.lower()
-        if lowered in {"script", "style"}:
-            self._skip_depth += 1
-        self.parts.append(" ")
+        if lowered in self._excluded:
+            self._skip_stack.append(lowered)
+            return
+        if self._skip_stack:
+            return
+        self.parts.append("\n" if lowered in _BLOCK_TAG_NAMES else " ")
 
     def handle_endtag(self, tag: str) -> None:
         lowered = tag.lower()
-        if lowered in {"script", "style"} and self._skip_depth:
-            self._skip_depth -= 1
-        self.parts.append(" ")
+        if self._skip_stack:
+            if lowered == self._skip_stack[-1]:
+                self._skip_stack.pop()
+                if not self._skip_stack:
+                    # Scope closed properly: excluded content stays excluded.
+                    self._pending.clear()
+                    self.parts.append("\n")
+            return
+        self.parts.append("\n" if lowered in _BLOCK_TAG_NAMES else " ")
 
     def handle_data(self, data: str) -> None:
-        if not self._skip_depth:
-            self.parts.append(data)
+        if self._skip_stack:
+            self._pending.append(data)
+            return
+        self.parts.append(data)
+
+    def finalize(self) -> str:
+        self.close()
+        if self._skip_stack and self._pending:
+            # Unclosed script/style swallowed trailing content via CDATA
+            # mode; recover it tag-stripped rather than losing the ticket.
+            # An unclosed blockquote is a quote to EOF and stays excluded.
+            if self._skip_stack[0] in {"script", "style"}:
+                recovered = _TAG_FALLBACK_RE.sub(" ", "".join(self._pending))
+                self.parts.append("\n")
+                self.parts.append(recovered)
+        return "".join(self.parts)
+
+
+def _extract_html_text(text: str, *, exclude_blockquote: bool) -> str:
+    parser = _HTMLTextExtractor(exclude_blockquote=exclude_blockquote)
+    parser.feed(text)
+    return parser.finalize()
 
 
 def support_ticket_plain_text(value: Any) -> str:
@@ -325,14 +386,50 @@ def support_ticket_plain_text(value: Any) -> str:
         if not _looks_like_html(decoded):
             return _compact(decoded)
         text = decoded
-    parser = _HTMLTextExtractor()
     try:
-        parser.feed(text)
-        parser.close()
-        parsed = "".join(parser.parts)
+        parsed = _extract_html_text(text, exclude_blockquote=True)
+        compacted = _compact(parsed)
+        if compacted:
+            return compacted
+        # An all-quote body would otherwise turn a previously admitted row
+        # empty; keep the unexcluded extraction rather than losing the row.
+        parsed = _extract_html_text(text, exclude_blockquote=False)
     except Exception:
         parsed = _TAG_FALLBACK_RE.sub(" ", text)
     return _compact(parsed)
+
+
+def support_ticket_plain_text_lines(value: Any) -> str:
+    """Return readable text with line boundaries preserved.
+
+    The line-preserving seam for downstream line-based hygiene (scalar
+    history signature/quote handling and the junk/auto-reply gate): block
+    tags become newlines, each line is whitespace-compacted, and empty lines
+    are dropped. Plain-text input keeps its own newlines. Quoted
+    ``blockquote`` bodies and script/style bodies are excluded with no
+    all-quote fallback -- an all-quote body is genuinely empty of new
+    customer text for hygiene purposes.
+    """
+
+    raw = str(value or "")
+    if not raw.strip():
+        return ""
+    text = raw
+    if not _looks_like_html(text):
+        decoded = unescape(text)
+        if not _looks_like_html(decoded):
+            return _compact_lines(decoded)
+        text = decoded
+    try:
+        parsed = _extract_html_text(text, exclude_blockquote=True)
+    except Exception:
+        parsed = _TAG_FALLBACK_RE.sub(" ", text)
+    return _compact_lines(parsed)
+
+
+def _compact_lines(text: str) -> str:
+    lines = [_compact(line) for line in text.split("\n")]
+    return "\n".join(line for line in lines if line)
 
 
 def _looks_like_html(text: str) -> bool:

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -45,6 +45,13 @@ _HTML_EXCLUDED_TAG_RE = re.compile(
     r"</?(script|style|blockquote)\b[^>]*>",
     re.IGNORECASE,
 )
+# A paired excluded element that CLOSES the body ("Real<script>x</script>",
+# "question<blockquote>quoted</blockquote>") is markup; a mention keeps
+# trailing prose ("... <blockquote>hello</blockquote> in the editor?").
+_HTML_EXCLUDED_TAG_AT_END_RE = re.compile(
+    r"<(script|style|blockquote)\b[^>]*>.*?</\1\s*>\s*\Z",
+    re.IGNORECASE | re.DOTALL,
+)
 _HTML_CUSTOM_TAG_RE = re.compile(
     r"</?[a-z][a-z0-9:-]*-[a-z0-9:-]*(?:\s+[^<>]*)?/?>",
     re.IGNORECASE,
@@ -461,17 +468,36 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
     candidates = [
         match.start()
         for pattern in (
-            _HTML_SIGNAL_RE,
+            _HTML_RECOVERY_TAG_RE,
             _HTML_CUSTOM_TAG_RE,
             _HTML_EXCLUDED_TAG_RE,
         )
         for match in pattern.finditer(buffered)
     ]
     for position in sorted(candidates):
-        if not any(lo <= position <= hi for lo, hi in masked):
-            return position
+        if any(lo <= position <= hi for lo, hi in masked):
+            continue
+        # Tag-shaped code such as comparisons (if (x<p>y)) is not markup:
+        # a real tag follows a code/markup boundary, not an identifier.
+        preceding = buffered[position - 1] if position > 0 else ""
+        if preceding and not (
+            preceding.isspace() or preceding in ";{}()>,=&|!?:/"
+        ):
+            continue
+        return position
     return None
 
+
+# Recovery-only tag shape: like _HTML_SIGNAL_RE but attributes may be bare
+# booleans (<p hidden>), which real fragments use and code rarely does.
+_HTML_RECOVERY_ATTR_RE = (
+    r"(?:\s+[a-z_:][a-z0-9_:.-]*"
+    r"(?:\s*=\s*(?:\"[^\"]*\"|'[^']*'|[^\s\"'=<>`]+))?)"
+)
+_HTML_RECOVERY_TAG_RE = re.compile(
+    rf"</?{_HTML_TAG_NAMES_RE}(?:{_HTML_RECOVERY_ATTR_RE})*\s*/?>",
+    re.IGNORECASE,
+)
 
 _JS_EXPRESSION_KEYWORDS = frozenset({
     "return", "typeof", "case", "in", "of", "delete", "void", "throw",
@@ -669,6 +695,7 @@ def _looks_like_html(text: str) -> bool:
     return bool(
         _HTML_SIGNAL_RE.search(text)
         or _HTML_EXCLUDED_TAG_AT_START_RE.search(text)
+        or _HTML_EXCLUDED_TAG_AT_END_RE.search(text)
         or _HTML_CUSTOM_TAG_RE.search(text)
     )
 

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -35,8 +35,10 @@ _HTML_SIGNAL_RE = re.compile(
 # script-only bodies exclude, quote-to-EOF bodies are all-quote. Inside a
 # document detected via other tags, exclusion applies as usual.
 _HTML_EXCLUDED_TAG_AT_START_RE = re.compile(
-    r"\A\s*(?:\[[^\]\n]{1,80}\]\s*)*<(script|style|blockquote)\b",
-    re.IGNORECASE,
+    r"\A\s*(?:(?:\[[^\]\n]{1,80}\]|<!doctype[^>]*>|<!--.*?-->"
+    r"|</?(?:html|head|body|meta|title|link)[^>]*>)\s*)*"
+    r"<(script|style|blockquote)\b",
+    re.IGNORECASE | re.DOTALL,
 )
 _HTML_EXCLUDED_TAG_RE = re.compile(
     r"</?(script|style|blockquote)\b[^>]*>",
@@ -360,40 +362,43 @@ class _HTMLTextExtractor(HTMLParser):
         if self._skip_stack:
             if lowered == self._skip_stack[-1]:
                 self._skip_stack.pop()
-                if self._skip_stack and lowered in {"script", "style"}:
+                if lowered in {"script", "style"}:
                     # CDATA may have swallowed outer scopes' close tags
                     # (<blockquote><script>x</blockquote></script>): unwind
-                    # any remaining scope whose close tag sits in the buffer
-                    # outside code literals, so later real markup is not
-                    # treated as still-quoted.
-                    buffered = "".join(self._pending)
-                    masked = _code_literal_regions(buffered)
-                    available: dict[str, int] = {}
-                    while self._skip_stack:
-                        scope = self._skip_stack[-1]
-                        if scope not in available:
-                            available[scope] = sum(
-                                1
-                                for match in re.finditer(
-                                    rf"</{scope}\s*>", buffered, re.IGNORECASE
-                                )
-                                if not any(
-                                    lo <= match.start() <= hi
-                                    for lo, hi in masked
-                                )
-                            )
-                        if available[scope] <= 0:
-                            break
-                        available[scope] -= 1
-                        self._skip_stack.pop()
-                if not self._skip_stack:
-                    # Scope closed properly: excluded content stays excluded.
+                    # scopes whose close tags sit in the buffer outside code
+                    # literals, then drop the buffer -- a closed scope's
+                    # content is excluded and must never leak into a later
+                    # malformed scope's recovery.
+                    self._unwind_swallowed_scopes("".join(self._pending))
                     self._pending.clear()
+                if not self._skip_stack:
                     self.parts.append(
                         "\n" if lowered in _BLOCK_TAG_NAMES else " "
                     )
             return
         self.parts.append("\n" if lowered in _BLOCK_TAG_NAMES else " ")
+
+    def _unwind_swallowed_scopes(self, buffered: str) -> None:
+        if not self._skip_stack or not buffered:
+            return
+        masked = _code_literal_regions(buffered)
+        available: dict[str, int] = {}
+        while self._skip_stack:
+            scope = self._skip_stack[-1]
+            if scope not in available:
+                available[scope] = sum(
+                    1
+                    for match in re.finditer(
+                        rf"</{scope}\s*>", buffered, re.IGNORECASE
+                    )
+                    if not any(
+                        lo <= match.start() <= hi for lo, hi in masked
+                    )
+                )
+            if available[scope] <= 0:
+                break
+            available[scope] -= 1
+            self._skip_stack.pop()
 
     def handle_data(self, data: str) -> None:
         if self._skip_stack:
@@ -417,6 +422,17 @@ class _HTMLTextExtractor(HTMLParser):
             # An unclosed blockquote is a quote to EOF and stays excluded.
             if self._skip_stack[-1] in {"script", "style"}:
                 buffered = "".join(self._pending)
+                # The buffer may hold swallowed close tags of outer scopes;
+                # unwind them first. If a non-CDATA scope (an unclosed
+                # blockquote) still remains, the tail is quoted content and
+                # stays excluded.
+                self._skip_stack.pop()
+                self._unwind_swallowed_scopes(buffered)
+                if any(
+                    scope not in {"script", "style"}
+                    for scope in self._skip_stack
+                ):
+                    return "".join(self.parts)
                 start = _first_markup_outside_code_literals(buffered)
                 if start is not None:
                     recovered = _extract_html_text(
@@ -495,6 +511,9 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
             elif ch == "/" and nxt == "*":
                 state, start = "/*", i
                 i += 1
+            elif ch == "<" and buffered[i:i + 4] == "<!--":
+                state, start = "<!--", i
+                i += 3
             elif ch == "/" and (
                 (word or prev_word) in _JS_EXPRESSION_KEYWORDS
                 or (
@@ -538,7 +557,8 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
             elif ch == "/" and not in_char_class:
                 masked.append((start, i))
                 state = None
-                prev2, prev = "", "/"
+                # A closed regex is a value: a following slash is division.
+                prev2, prev = "", ")"
         elif state in "'\"`":
             if ch == "\\":
                 i += 1
@@ -556,6 +576,11 @@ def _code_literal_regions(buffered: str) -> list[tuple[int, int]]:
                 masked.append((start, i + 1))
                 state = None
                 i += 1
+        elif state == "<!--":
+            if buffered[i:i + 3] == "-->":
+                masked.append((start, i + 2))
+                state = None
+                i += 2
         i += 1
     if state == "re":
         # Unclosed single-line regex candidate at EOF: treat as division,

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -17,8 +17,8 @@ _LEADING_BRACKETED_METADATA_RE = re.compile(r"^(?:\[[^\]\n]{1,80}\]\s*)+")
 _HTML_TAG_NAMES_RE = (
     r"(?:a|abbr|article|aside|b|blockquote|body|br|button|cite|code|dd|"
     r"del|div|dl|dt|em|figcaption|figure|footer|h[1-6]|header|hr|html|i|"
-    r"img|ins|li|main|mark|nav|ol|p|pre|s|section|small|span|strike|strong|"
-    r"sub|sup|table|tbody|td|tfoot|th|thead|time|tr|u|ul)"
+    r"img|ins|li|main|mark|nav|ol|p|pre|s|script|section|small|span|strike|"
+    r"strong|style|sub|sup|table|tbody|td|tfoot|th|thead|time|tr|u|ul)"
 )
 _HTML_ATTR_RE = (
     r"(?:\s+[a-z_:][a-z0-9_:.-]*\s*=\s*"
@@ -330,10 +330,14 @@ class _HTMLTextExtractor(HTMLParser):
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         del attrs
         lowered = tag.lower()
-        if lowered in self._excluded:
+        if lowered in self._excluded and not self._skip_stack:
+            # The excluded tag's own boundary follows the block rule too.
+            self.parts.append("\n" if lowered in _BLOCK_TAG_NAMES else " ")
             self._skip_stack.append(lowered)
             return
         if self._skip_stack:
+            if lowered in self._excluded:
+                self._skip_stack.append(lowered)
             return
         self.parts.append("\n" if lowered in _BLOCK_TAG_NAMES else " ")
 
@@ -345,13 +349,18 @@ class _HTMLTextExtractor(HTMLParser):
                 if not self._skip_stack:
                     # Scope closed properly: excluded content stays excluded.
                     self._pending.clear()
-                    self.parts.append("\n")
+                    self.parts.append(
+                        "\n" if lowered in _BLOCK_TAG_NAMES else " "
+                    )
             return
         self.parts.append("\n" if lowered in _BLOCK_TAG_NAMES else " ")
 
     def handle_data(self, data: str) -> None:
         if self._skip_stack:
-            self._pending.append(data)
+            # Buffer only scopes finalize() can recover (script/style);
+            # blockquote bodies are never recovered, so never buffered.
+            if self._skip_stack[0] in {"script", "style"}:
+                self._pending.append(data)
             return
         self.parts.append(data)
 
@@ -359,12 +368,22 @@ class _HTMLTextExtractor(HTMLParser):
         self.close()
         if self._skip_stack and self._pending:
             # Unclosed script/style swallowed trailing content via CDATA
-            # mode; recover it tag-stripped rather than losing the ticket.
+            # mode. Everything before the first recognized HTML signal in
+            # the buffer is script/CSS machinery and stays excluded; the
+            # remainder is real markup the parser never saw -- re-extract it
+            # so customer text is recovered without admitting machinery.
             # An unclosed blockquote is a quote to EOF and stays excluded.
             if self._skip_stack[0] in {"script", "style"}:
-                recovered = _TAG_FALLBACK_RE.sub(" ", "".join(self._pending))
-                self.parts.append("\n")
-                self.parts.append(recovered)
+                buffered = "".join(self._pending)
+                signal = _HTML_SIGNAL_RE.search(buffered)
+                if signal is not None:
+                    recovered = _extract_html_text(
+                        buffered[signal.start():],
+                        exclude_blockquote="blockquote" in self._excluded,
+                    )
+                    if recovered.strip():
+                        self.parts.append("\n")
+                        self.parts.append(recovered)
         return "".join(self.parts)
 
 
@@ -804,5 +823,6 @@ __all__ = [
     "support_ticket_cluster_quality",
     "support_ticket_cluster_summary",
     "support_ticket_plain_text",
+    "support_ticket_plain_text_lines",
     "support_ticket_tokens",
 ]

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -363,9 +363,11 @@ class _HTMLTextExtractor(HTMLParser):
 
     def handle_data(self, data: str) -> None:
         if self._skip_stack:
-            # Buffer only scopes finalize() can recover (script/style);
-            # blockquote bodies are never recovered, so never buffered.
-            if self._skip_stack[0] in {"script", "style"}:
+            # Buffer whenever the parser may be in CDATA mode (an open
+            # script/style is always innermost -- CDATA parses no tags), so a
+            # malformed script nested in a blockquote can still recover the
+            # swallowed tail. Blockquote-only scopes are never buffered.
+            if self._skip_stack[-1] in {"script", "style"}:
                 self._pending.append(data)
             return
         self.parts.append(data)
@@ -379,7 +381,7 @@ class _HTMLTextExtractor(HTMLParser):
             # remainder is real markup the parser never saw -- re-extract it
             # so customer text is recovered without admitting machinery.
             # An unclosed blockquote is a quote to EOF and stays excluded.
-            if self._skip_stack[0] in {"script", "style"}:
+            if self._skip_stack[-1] in {"script", "style"}:
                 buffered = "".join(self._pending)
                 start = _first_markup_outside_code_literals(buffered)
                 if start is not None:
@@ -421,7 +423,11 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
             elif ch == "/" and nxt == "*":
                 state, start = "/*", i
                 i += 1
-            elif ch == "/" and last_code_char not in ")]" and not last_code_char.isalnum():
+            elif (
+                ch == "/"
+                and last_code_char not in ")]}\"'`"
+                and not last_code_char.isalnum()
+            ):
                 # JS regex literal: a slash in expression position (after an
                 # operator/opening context, not after a value) opens /.../.
                 state, start = "re", i
@@ -440,6 +446,8 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
             elif ch == state:
                 masked.append((start, i))
                 state = None
+                # A closed literal is a value: a following slash is division.
+                last_code_char = ch
         elif state == "//":
             if ch == "\n":
                 masked.append((start, i))
@@ -454,8 +462,12 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
         # Unterminated literal/comment runs to EOF: everything after it is
         # still code context, never recoverable ticket text.
         masked.append((start, length - 1))
-    for match in _HTML_SIGNAL_RE.finditer(buffered):
-        position = match.start()
+    candidates = [
+        match.start()
+        for pattern in (_HTML_SIGNAL_RE, _HTML_CUSTOM_TAG_RE)
+        for match in pattern.finditer(buffered)
+    ]
+    for position in sorted(candidates):
         if not any(lo <= position <= hi for lo, hi in masked):
             return position
     return None

--- a/extracted_content_pipeline/support_ticket_clustering.py
+++ b/extracted_content_pipeline/support_ticket_clustering.py
@@ -17,8 +17,8 @@ _LEADING_BRACKETED_METADATA_RE = re.compile(r"^(?:\[[^\]\n]{1,80}\]\s*)+")
 _HTML_TAG_NAMES_RE = (
     r"(?:a|abbr|article|aside|b|blockquote|body|br|button|cite|code|dd|"
     r"del|div|dl|dt|em|figcaption|figure|footer|h[1-6]|header|hr|html|i|"
-    r"img|ins|li|main|mark|nav|ol|p|pre|s|script|section|small|span|strike|"
-    r"strong|style|sub|sup|table|tbody|td|tfoot|th|thead|time|tr|u|ul)"
+    r"img|ins|li|main|mark|nav|ol|p|pre|s|section|small|span|strike|strong|"
+    r"sub|sup|table|tbody|td|tfoot|th|thead|time|tr|u|ul)"
 )
 _HTML_ATTR_RE = (
     r"(?:\s+[a-z_:][a-z0-9_:.-]*\s*=\s*"
@@ -27,6 +27,12 @@ _HTML_ATTR_RE = (
 _HTML_SIGNAL_RE = re.compile(
     rf"</?{_HTML_TAG_NAMES_RE}(?:{_HTML_ATTR_RE})*\s*/?>",
     re.IGNORECASE,
+)
+# A LONE <script>/<style> in prose ("How do I add <script> to the page?")
+# is customer wording, not markup; only a paired open+close is an HTML signal.
+_HTML_SCRIPT_STYLE_PAIRED_RE = re.compile(
+    r"<(script|style)\b[^>]*>.*?</\1\s*>",
+    re.IGNORECASE | re.DOTALL,
 )
 _HTML_CUSTOM_TAG_RE = re.compile(
     r"</?[a-z][a-z0-9:-]*-[a-z0-9:-]*(?:\s+[^<>]*)?/?>",
@@ -382,7 +388,9 @@ class _HTMLTextExtractor(HTMLParser):
                         exclude_blockquote="blockquote" in self._excluded,
                     )
                     if recovered.strip():
-                        self.parts.append("\n")
+                        # The scope-open boundary was already emitted per the
+                        # block rule; the recovered extraction carries its own
+                        # boundaries. Do not invent one here.
                         self.parts.append(recovered)
         return "".join(self.parts)
 
@@ -400,6 +408,7 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
     start = 0
     i = 0
     length = len(buffered)
+    last_code_char = ""
     while i < length:
         ch = buffered[i]
         nxt = buffered[i + 1] if i + 1 < length else ""
@@ -412,6 +421,19 @@ def _first_markup_outside_code_literals(buffered: str) -> int | None:
             elif ch == "/" and nxt == "*":
                 state, start = "/*", i
                 i += 1
+            elif ch == "/" and last_code_char not in ")]" and not last_code_char.isalnum():
+                # JS regex literal: a slash in expression position (after an
+                # operator/opening context, not after a value) opens /.../.
+                state, start = "re", i
+            if state is None and not ch.isspace():
+                last_code_char = ch
+        elif state == "re":
+            if ch == "\\":
+                i += 1
+            elif ch == "/":
+                masked.append((start, i))
+                state = None
+                last_code_char = "/"
         elif state in "'\"`":
             if ch == "\\":
                 i += 1
@@ -506,6 +528,7 @@ def _compact_lines(text: str) -> str:
 def _looks_like_html(text: str) -> bool:
     return bool(
         _HTML_SIGNAL_RE.search(text)
+        or _HTML_SCRIPT_STYLE_PAIRED_RE.search(text)
         or _HTML_CUSTOM_TAG_RE.search(text)
     )
 

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -1,0 +1,169 @@
+# PR-Resolution-Audit-S6B-HTML-Line-Hygiene
+
+## Why this slice exists
+
+Issue #2043 (S6B), parent #1993. Rich helpdesk HTML stores message structure
+(paragraph/break/list/table/heading/quote boundaries) in tags, but the single
+extraction chokepoint flattens every tag boundary to a space, so line-based
+hygiene downstream -- the S6C transcript state machine (#2044) and the S6E
+junk/auto-reply gate (#2049, split from this slice per the launch-blocker
+ledger scoping flag) -- can never work on HTML tickets. Three consequences
+verified failing on `origin/main` before coding: signatures/questions flatten
+into one run-on line; `blockquote` quoted-prior-message bodies are admitted as
+customer text; and an unclosed `<script>` tag swallows the ENTIRE ticket body
+(`support_ticket_plain_text` returns `""` -- silent data loss).
+
+### Problem-derived contract
+
+- Root cause: `_HTMLTextExtractor` emits a single space at every tag boundary
+  and `_compact` collapses all whitespace, destroying the structure HTML
+  encodes in tags; `blockquote` bodies are admitted as new customer text; the
+  depth-based skip mechanism lets an unclosed `script`/`style` tag put the
+  parser in CDATA mode and silently swallow all subsequent customer text.
+- Correct fix must touch/change (all in
+  `extracted_content_pipeline/support_ticket_clustering.py`, owned, the single
+  extraction chokepoint, plus tests):
+  1. Block-level tags -- members of the SAME `_HTML_TAG_NAMES_RE` families the
+     HTML detector uses, so detection and extraction cannot drift -- emit
+     newlines; inline tags keep emitting spaces.
+  2. New public seam `support_ticket_plain_text_lines(value) -> str`:
+     newline-preserving, per-line compacted, empty lines dropped; raw and
+     escaped HTML route through it; plain text keeps its own newlines. This is
+     the named input seam for S6C (#2044) and S6E (#2049).
+  3. `blockquote` joins `script`/`style` as excluded content (the HTML-native
+     quoted-prior-message marker).
+  4. Robustness both directions: excluded bodies stay excluded when scopes
+     close properly; an unclosed `script`/`style` scope recovers its buffered
+     text tag-stripped at EOF instead of losing the ticket; an unclosed
+     `blockquote` stays excluded (a quote to end-of-message is a quote, not
+     data loss); self-closing skip tags cannot suppress later text.
+  5. `support_ticket_plain_text` keeps its exact single-line compact output
+     shape, now blockquote-excluded, with a non-empty fallback: if exclusion
+     empties a previously non-empty body (all-quote ticket), keep the
+     unexcluded extraction so no admitted row silently disappears.
+  6. Tests: boundary families (p/br/div/li/h1-6/tr/section), escaped HTML,
+     script/style/blockquote exclusion incl. nesting, all-quote fallback,
+     unclosed + self-closing skip tags, near-miss guard (customer wording
+     about out-of-office is untouched -- S6B strips nothing content-based),
+     compact-API regression pins, and a drift-guard test asserting every
+     block tag is inside the detector's tag families.
+- Must not change:
+  - `support_ticket_privacy.py` (S6A, merged), `support_ticket_input_package.py`
+    admission/evidence logic, `support_ticket_zendesk_thread.py`.
+  - The compact output SHAPE of `support_ticket_plain_text` for existing
+    consumers (tokens, cluster keys, labels, titles).
+  - Tokenization/clustering semantics beyond quoted-body exclusion.
+  - No junk/auto-reply detection rules (S6E #2049); no scalar-history
+    signature/quote state (S6C); no status/evidence-tier changes (S6D/M9).
+  - Report/snapshot/email/PDF/landing/checkout/product shape; final-output
+    scrubber grammar.
+  - Goldens untouched (verified: full gauntlet green with no golden changes).
+
+## Scope (this PR)
+
+Ownership lane: resolution-audit-csv
+Slice phase: Vertical slice
+
+Max files: 5
+
+1. `extracted_content_pipeline/support_ticket_clustering.py` -- the extractor
+   rewrite per the contract (owned file; manifest target-only).
+2. `tests/test_support_ticket_plain_text_lines.py` -- the contract tests.
+3. `scripts/run_extracted_pipeline_checks.sh` -- CI enrollment of the new test
+   file in the same PR.
+4. `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` -- the
+   arc's standing rule: every remediation PR updates the tracker. Ticks S6A
+   (#2046 merged), records the S6E/M9/S8a/S8b splits (#2049-#2052), resolves
+   the ledger row-5 scoping flag.
+5. This plan doc.
+
+### Files touched
+
+- `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md`
+- `extracted_content_pipeline/support_ticket_clustering.py`
+- `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_support_ticket_plain_text_lines.py`
+
+### Review Contract
+
+Acceptance criteria:
+1. HTML variants in the detector's tag families reach line-based consumers
+   with line breaks preserved (`support_ticket_plain_text_lines`).
+2. Parser-excluded bodies (script/style/blockquote) stay excluded, including
+   nested quotes; later valid customer text is never erased by self-closing
+   or unclosed skip tags (the unclosed-`<script>` data-loss bug is fixed and
+   pinned by test).
+3. The compact `support_ticket_plain_text` output shape is unchanged for all
+   existing pinned inputs; an all-quote body falls back instead of emptying a
+   previously admitted row.
+4. Customer wording about auto-reply/out-of-office features is untouched
+   (S6B strips nothing content-based; detection rules are S6E #2049).
+5. A drift-guard test binds every block tag to the detector's tag families.
+
+Reachability proof: `support_ticket_plain_text` is the live chokepoint for
+package/Zendesk text extraction -- blockquote exclusion and the unclosed-script
+recovery change real admitted text on the existing paths today;
+`support_ticket_plain_text_lines` is the named seam consumed by S6C/S6E next.
+
+Affected surfaces: support-ticket text extraction feeding clustering,
+evidence, and markdown generation.
+
+Risk areas: over-exclusion (legit text in blockquote -- mitigated by the
+all-quote fallback + tests), compact-shape regression (pinned), goldens
+(gauntlet green, none changed).
+
+Reviewer rules triggered: R1 requirements match (extracted package change), R2 test evidence, R10 guard/checker behavior, R14
+sanitizer/parser admission change (boundary probed both directions).
+
+## Mechanism
+
+One extractor, two output shapes. `_HTMLTextExtractor` gains a block-tag set
+(`_BLOCK_TAG_NAMES`, drift-bound to `_HTML_TAG_NAMES_RE`), an excluded-content
+set (`_EXCLUDED_CONTENT_TAGS`), a skip STACK with a buffered `_pending` list
+(instead of a bare depth counter), and a `finalize()` that recovers buffered
+text tag-stripped when a script/style scope never closed. Block tags emit
+`\n`, inline tags emit a space. `support_ticket_plain_text` compacts the
+joined parts exactly as before (newlines collapse -- shape identical) and
+falls back to unexcluded extraction when exclusion empties a non-empty body.
+`support_ticket_plain_text_lines` splits on the emitted boundaries, compacts
+each line, drops empties.
+
+## Intentional
+
+- Blockquote exclusion lands at the existing compact chokepoint TODAY (real
+  behavioral change: quoted reply chains stop polluting clustering/evidence),
+  not just in the new seam.
+- The lines seam has NO all-quote fallback: an all-quote body is genuinely
+  empty of new customer text for hygiene purposes.
+- Unclosed-blockquote content stays excluded while unclosed-script content is
+  recovered: the first is semantically a quote to EOF, the second is a parser
+  artifact that was silently eating tickets.
+- No junk-detection rules here: S6E (#2049) owns F2, sequenced right after.
+
+## Deferred
+
+- S6E (#2049): junk/auto-reply/OOO detection rules on the new line seam.
+- S6C (#2044): scalar-history signature/quote state machine consuming the seam.
+- S6D (#2045) evidence tier + M9 micro-slice (#2050).
+
+## Verification
+
+- `python -m pytest tests/test_support_ticket_plain_text_lines.py -q` (22 passed)
+- Adjacent regression: `tests/test_extracted_support_ticket_input_package.py`,
+  `tests/test_smoke_content_ops_support_ticket_package.py`,
+  `tests/test_support_ticket_privacy.py`, `tests/test_support_ticket_privacy_sweep.py` (703 passed)
+- scripts/run_extracted_pipeline_checks.sh full CI mirror (5772 passed, 21 skipped)
+- Root-cause repro before coding: boundary flattening, blockquote admission,
+  and the unclosed-script `""` data loss all reproduced on `origin/main`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 125 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 169 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_support_ticket_plain_text_lines.py` | 147 |
+| **Total** | **456** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -141,6 +141,14 @@ context so `return /x/ / 2` reads as division; unterminated regex candidates
 at EOF are masked -- the newline reset bounds the mask to at most the final
 line, so the round-5 no-mask rationale is superseded safely.
 
+Round-10 refinements (each verified failing first): a paired excluded element
+that CLOSES the body ("Real<script>x</script>",
+"question<blockquote>quoted</blockquote>") is markup while mentions keep
+trailing prose; recovery candidates must follow a code/markup boundary
+character, so tag-shaped comparisons (`if (x<p>y)`) are never boundaries; a
+recovery-only tag shape tolerates boolean attributes (`<p hidden>`), which
+real fragments use and code rarely does.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -244,8 +252,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 362 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 251 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 389 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 259 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 511 |
-| **Total** | **1139** |
+| `tests/test_support_ticket_plain_text_lines.py` | 537 |
+| **Total** | **1200** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -167,6 +167,20 @@ Bob wrote:") stays preserved by the mention rule rounds 3/5 required for
 admitted reply-chain text is exactly the line-level pattern the S6E junk
 gate (#2049) detects downstream.
 
+Round-12 (7 findings fixed; one round-11 pin superseded by a single
+documented rule): recovery candidates and unwind OPEN-counting share the
+statement-boundary rule (a real tag follows newline/;{}>/ before intra-line
+whitespace, never an identifier -- kills spaced comparisons `if (x <p> y)`);
+unwind CLOSE tags always count (a</b is not valid JS, and swallowed closes
+legitimately follow code text); ties between quote-leak and data-loss resolve
+toward admitting possible customer text (quoted-reply patterns are S6E's
+layer), superseding the round-11 balanced-pair expectation for
+text-preceded opens; the control-flow flag is one-shot; `<!--` behaves as a
+line comment in script text; the tail after a properly-closed script whose
+buffer swallowed the outer close is re-emitted; a block-closing brace puts a
+following slash in expression position while object braces divide; `<base>`
+joins the prolog scaffold.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -270,8 +284,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 429 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 277 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 499 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 291 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 564 |
-| **Total** | **1285** |
+| `tests/test_support_ticket_plain_text_lines.py` | 625 |
+| **Total** | **1430** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -116,6 +116,15 @@ include excluded-tag positions so re-extraction opens the scope instead of
 starting inside an excluded body; regex literals after expression keywords
 (`return /.../;`) are masked via a bounded JS keyword set.
 
+Round-7 refinements (each verified failing first): property-access keywords
+(`obj.return / 2`) are division, and whitespace-completed words are tracked so
+infix keywords (`x in /re/`) open regexes; the markup exception applies only
+to a slash ADJACENT to `<` (`</tag>`), so a spaced less-than (`y < /re/`)
+opens a regex; the CDATA unwind consumes each swallowed close tag once, so
+nested same-name scopes are not over-popped; the start rule tolerates leading
+bracketed ticket metadata (`[External] <script>...`) using the module's
+existing metadata prefix shape.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -219,8 +228,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 310 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 226 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 329 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 235 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 383 |
-| **Total** | **934** |
+| `tests/test_support_ticket_plain_text_lines.py` | 429 |
+| **Total** | **1008** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -94,6 +94,18 @@ buffering/recovery key on the CDATA condition (top of skip stack is
 script/style), so a malformed script nested inside a blockquote still
 recovers the swallowed tail while quoted text before it stays excluded.
 
+Round-5 refinements (each verified failing first; the scanner is now bounded
+by JS lexical facts rather than heuristics): postfix `++`/`--` are value
+positions (division); a slash inside a regex character class does not close
+it; a regex candidate that reaches a newline was division all along (JS regex
+literals cannot span lines), so a misread slash can never mask to EOF; a
+slash after `<` is markup, never a regex; close tags swallowed as CDATA
+unwind their scopes when the script closes (checked outside code literals),
+so later real markup is not treated as still-quoted; `blockquote` joins the
+paired-only detection family, so lone mentions in prose stay customer wording
+while quote-to-EOF inside real HTML stays excluded; the drift-guard test
+accepts either detector family.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -197,8 +209,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 232 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 204 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 290 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 216 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 295 |
-| **Total** | **746** |
+| `tests/test_support_ticket_plain_text_lines.py` | 344 |
+| **Total** | **865** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -76,6 +76,16 @@ templates (`var t="<p>template</p>"`, backtick templates, commented markup,
 escaped quotes) is never recovered as ticket text; unterminated literals run
 to EOF and recover nothing.
 
+Round-3 refinements (each verified failing first; one was a regression from
+the round-1 detector change): lone `<script>`/`<style>` mentions in prose are
+customer wording -- script/style detect only as a PAIRED open+close
+(`_HTML_SCRIPT_STYLE_PAIRED_RE`), restoring "How do I add <script> to the
+page?" while paired script-only bodies stay excluded; the code-literal
+scanner also masks JS regex literals (expression-position slash, escapes,
+division distinguished); recovery no longer invents a line boundary -- the
+scope-open boundary and the recovered extraction's own boundaries are the
+only ones emitted.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -179,8 +189,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 201 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 186 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 220 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 196 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 223 |
-| **Total** | **625** |
+| `tests/test_support_ticket_plain_text_lines.py` | 260 |
+| **Total** | **691** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -59,6 +59,16 @@ customer text; and an unclosed `<script>` tag swallows the ENTIRE ticket body
     scrubber grammar.
   - Goldens untouched (verified: full gauntlet green with no golden changes).
 
+Round-1 review refinements (each verified failing first; two were blockers):
+`script`/`style` join the detector tag families so script-only bodies are
+excluded instead of passed through raw; EOF recovery re-extracts only the
+markup after the first HTML signal in the buffer, so script/CSS machinery is
+never admitted alongside rescued customer text (pure-machinery buffers recover
+nothing); excluded-scope open/close boundaries follow the same block-tag rule
+(an inline script inside a paragraph no longer splits the line); blockquote
+bodies are no longer buffered (only recoverable script/style scopes are);
+`support_ticket_plain_text_lines` exported via `__all__`.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -162,8 +172,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 125 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 169 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 149 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 179 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 147 |
-| **Total** | **456** |
+| `tests/test_support_ticket_plain_text_lines.py` | 190 |
+| **Total** | **533** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -69,6 +69,13 @@ nothing); excluded-scope open/close boundaries follow the same block-tag rule
 bodies are no longer buffered (only recoverable script/style scopes are);
 `support_ticket_plain_text_lines` exported via `__all__`.
 
+Round-2 refinement (verified failing first): EOF recovery starts at the first
+HTML signal OUTSIDE string literals and comments
+(`_first_markup_outside_code_literals`), so script code embedding HTML
+templates (`var t="<p>template</p>"`, backtick templates, commented markup,
+escaped quotes) is never recovered as ticket text; unterminated literals run
+to EOF and recover nothing.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -172,8 +179,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 149 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 179 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 201 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 186 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 190 |
-| **Total** | **533** |
+| `tests/test_support_ticket_plain_text_lines.py` | 223 |
+| **Total** | **625** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -149,6 +149,24 @@ character, so tag-shaped comparisons (`if (x<p>y)`) are never boundaries; a
 recovery-only tag shape tolerates boolean attributes (`<p hidden>`), which
 real fragments use and code rarely does.
 
+Round-11 (3 fixed, 2 waived; the waivers mark the semantic boundary of
+lexical rules): unwind counts NET closes (a balanced pair inside the buffer
+cannot close a pre-existing outer scope); control-flow parens (if/for/while/
+switch/catch headers) put a following slash in expression position while
+value parens divide; known HTML boolean attributes (a bounded spec list)
+are valid tag shapes in the main detector while arbitrary words are not
+("a<b and c>d" stays prose). WAIVED as semantically undecidable at a lexical
+boundary: (1) a paired excluded element ending a syntax question ("How do I
+write <blockquote>hello</blockquote>") is excluded by the paired-at-EOF rule
+that round 10 required for "question<blockquote>quoted</blockquote>" -- the
+two are formally identical, and the product fail direction (quote/PII
+leakage worse than a truncated syntax example) keeps the exclusion; (2) an
+UNPAIRED excluded tag after leading text ("My new question<blockquote>On Mon
+Bob wrote:") stays preserved by the mention rule rounds 3/5 required for
+"How do I add <script> to the page?" -- also formally identical; the
+admitted reply-chain text is exactly the line-level pattern the S6E junk
+gate (#2049) detects downstream.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -252,8 +270,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 389 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 259 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 429 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 277 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 537 |
-| **Total** | **1200** |
+| `tests/test_support_ticket_plain_text_lines.py` | 564 |
+| **Total** | **1285** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -86,6 +86,14 @@ division distinguished); recovery no longer invents a line boundary -- the
 scope-open boundary and the recovered extraction's own boundaries are the
 only ones emitted.
 
+Round-4 refinements (each verified failing first): closed string/template
+literals and closing braces are value positions, so division after them is
+never misread as a regex open (no mask-to-EOF data loss); EOF recovery also
+searches custom-element signals (`<x-ticket>`), matching `_looks_like_html`;
+buffering/recovery key on the CDATA condition (top of skip stack is
+script/style), so a malformed script nested inside a blockquote still
+recovers the swallowed tail while quoted text before it stays excluded.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -189,8 +197,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 220 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 196 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 232 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 204 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 260 |
-| **Total** | **691** |
+| `tests/test_support_ticket_plain_text_lines.py` | 295 |
+| **Total** | **746** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -134,6 +134,13 @@ regex literal is a value predecessor (following slash is division); legacy
 HTML comments (`<!-- -->`) in script bodies are masked; the start rule
 tolerates doctype/comment/html-scaffold prologs before excluded-only bodies.
 
+Round-9 refinements (each verified failing first): titled prologs
+(`<title>Forwarded</title>` incl. the title text) count as prolog before an
+excluded-only body; closed literals (strings and regexes) consume keyword
+context so `return /x/ / 2` reads as division; unterminated regex candidates
+at EOF are masked -- the newline reset bounds the mask to at most the final
+line, so the round-5 no-mask rationale is superseded safely.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -237,8 +244,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 354 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 244 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 362 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 251 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 473 |
-| **Total** | **1086** |
+| `tests/test_support_ticket_plain_text_lines.py` | 511 |
+| **Total** | **1139** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -106,6 +106,16 @@ paired-only detection family, so lone mentions in prose stay customer wording
 while quote-to-EOF inside real HTML stays excluded; the drift-guard test
 accepts either detector family.
 
+Round-6 refinements (each verified failing first; the mention-vs-markup rule
+is now POSITION-based, dissolving the paired-vs-unpaired contradiction across
+rounds 3-6): an excluded tag at the START of the body is markup intent
+(`<script>alert(1)` excludes, `<blockquote>quoted prior reply` is all-quote)
+while mid-prose mentions -- lone OR paired -- are customer wording ("How do I
+write <blockquote>hello</blockquote> in the editor?"); EOF recovery candidates
+include excluded-tag positions so re-extraction opens the scope instead of
+starting inside an excluded body; regex literals after expression keywords
+(`return /.../;`) are masked via a bounded JS keyword set.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -209,8 +219,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 290 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 216 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 310 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 226 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 344 |
-| **Total** | **865** |
+| `tests/test_support_ticket_plain_text_lines.py` | 383 |
+| **Total** | **934** |

--- a/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
+++ b/plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
@@ -125,6 +125,15 @@ nested same-name scopes are not over-popped; the start rule tolerates leading
 bracketed ticket metadata (`[External] <script>...`) using the module's
 existing metadata prefix shape.
 
+Round-8 refinements (each verified failing first): CDATA buffers live per
+scope -- a closed script's buffer is dropped immediately (after the swallowed
+close-tag unwind, now a shared helper), so it can never leak into a later
+malformed scope's recovery; EOF recovery is skipped while a non-CDATA scope
+(unclosed blockquote) remains open, keeping quoted tails excluded; a closed
+regex literal is a value predecessor (following slash is division); legacy
+HTML comments (`<!-- -->`) in script bodies are masked; the start rule
+tolerates doctype/comment/html-scaffold prologs before excluded-only bodies.
+
 ## Scope (this PR)
 
 Ownership lane: resolution-audit-csv
@@ -228,8 +237,8 @@ each line, drops empties.
 | File | LOC |
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 14 |
-| `extracted_content_pipeline/support_ticket_clustering.py` | 329 |
-| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 235 |
+| `extracted_content_pipeline/support_ticket_clustering.py` | 354 |
+| `plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md` | 244 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_plain_text_lines.py` | 429 |
-| **Total** | **1008** |
+| `tests/test_support_ticket_plain_text_lines.py` | 473 |
+| **Total** | **1086** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -140,6 +140,7 @@ pytest \
   tests/test_support_ticket_context_contract.py \
   tests/test_support_ticket_privacy.py \
   tests/test_support_ticket_privacy_sweep.py \
+  tests/test_support_ticket_plain_text_lines.py \
   tests/test_resolution_audit_s5_clustering_spike.py \
   tests/test_extracted_support_ticket_input_package.py \
   tests/test_extracted_support_ticket_zendesk_export.py \

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -145,3 +145,46 @@ def test_every_block_tag_is_in_the_detector_families() -> None:
     # Drift guard: line extraction and HTML detection share tag families.
     for tag in sorted(_BLOCK_TAG_NAMES):
         assert re.fullmatch(_HTML_TAG_NAMES_RE, tag, re.IGNORECASE), tag
+
+
+# Round-1 review refinements: script/style are detector signals, EOF
+# recovery admits only customer text, excluded-scope boundaries follow the
+# block rule, and the lines seam is exported.
+
+
+def test_script_only_bodies_are_excluded_not_passed_through() -> None:
+    assert support_ticket_plain_text_lines("<script>alert(1)</script>") == ""
+    assert support_ticket_plain_text("<script>alert(1)</script>") == ""
+
+
+def test_script_then_text_extracts_only_the_text() -> None:
+    assert support_ticket_plain_text_lines(
+        "<script>x=1;</script><p>Real question</p>"
+    ) == "Real question"
+
+
+def test_unclosed_script_recovery_drops_machinery() -> None:
+    assert support_ticket_plain_text(
+        "<p>before</p><script>var x=1;<p>after</p>"
+    ) == "before after"
+    assert support_ticket_plain_text_lines(
+        "<p>before</p><script>var x=1;<p>after</p>"
+    ) == "before\nafter"
+
+
+def test_unclosed_script_with_no_markup_recovers_nothing() -> None:
+    assert support_ticket_plain_text(
+        "<p>before</p><script>var x=1; no more tags"
+    ) == "before"
+
+
+def test_inline_excluded_scope_does_not_split_the_line() -> None:
+    assert support_ticket_plain_text_lines(
+        "<p>foo<script>x</script>bar</p>"
+    ) == "foo bar"
+
+
+def test_lines_seam_is_exported() -> None:
+    import extracted_content_pipeline.support_ticket_clustering as module
+
+    assert "support_ticket_plain_text_lines" in module.__all__

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -188,3 +188,36 @@ def test_lines_seam_is_exported() -> None:
     import extracted_content_pipeline.support_ticket_clustering as module
 
     assert "support_ticket_plain_text_lines" in module.__all__
+
+
+# Round-2 refinement: EOF recovery ignores markup inside script string
+# literals and comments -- code templates are code, not lost ticket text.
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        ('<script>var t="<p>template</p>";<p>Real after</p>', "Real after"),
+        ("<script>let t=`<div>tpl</div>`;<p>Real</p>", "Real"),
+        ("<script>// <p>note</p>\n<p>Real</p>", "Real"),
+        ("<script>/* <p>x</p> */<p>Real</p>", "Real"),
+        ('<script>var s="a\\"<p>t</p>";<p>Real</p>', "Real"),
+    ],
+)
+def test_unclosed_script_recovery_skips_code_literals(
+    html: str, expected: str,
+) -> None:
+    assert support_ticket_plain_text(html) == expected
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        '<p>before</p><script>var t="<p>only template</p>";',
+        '<p>before</p><script>var t="<p>unterminated tpl</p>',
+    ],
+)
+def test_unclosed_script_with_only_code_templates_recovers_nothing(
+    html: str,
+) -> None:
+    assert support_ticket_plain_text(html) == "before"

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -471,3 +471,41 @@ def test_prologs_before_excluded_only_bodies_are_detected(
     html: str, expected: str,
 ) -> None:
     assert support_ticket_plain_text_lines(html) == expected
+
+
+# Round-9 refinements: titled prologs, keyword context consumed by closed
+# literals, and unterminated regex candidates masked at EOF (newline-bounded).
+
+
+def test_titled_prologs_before_excluded_bodies_are_detected() -> None:
+    # The script is excluded; the title text is data, not machinery.
+    assert support_ticket_plain_text_lines(
+        "<title>Forwarded</title><script>x</script>"
+    ) == "Forwarded"
+    assert support_ticket_plain_text_lines(
+        "<head><title>Forwarded</title></head><blockquote>old"
+    ) == "Forwarded"
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<script>return /x/ / 2;<p>Real</p>",
+        '<script>return "x" / 2;<p>Real</p>',
+    ],
+)
+def test_closed_literals_consume_keyword_context(html: str) -> None:
+    assert support_ticket_plain_text(html) == "Real"
+
+
+def test_unterminated_regex_at_eof_is_masked() -> None:
+    assert support_ticket_plain_text("<script>var r=/<p>template") == ""
+    assert support_ticket_plain_text(
+        "<p>before</p><script>var r=/<p>template"
+    ) == "before"
+
+
+def test_newline_still_bounds_regex_candidates() -> None:
+    assert support_ticket_plain_text(
+        "<script>a = b / 2\n<p>Real</p>"
+    ) == "Real"

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -509,3 +509,29 @@ def test_newline_still_bounds_regex_candidates() -> None:
     assert support_ticket_plain_text(
         "<script>a = b / 2\n<p>Real</p>"
     ) == "Real"
+
+
+# Round-10 refinements: paired excluded bodies after leading text, code
+# comparisons rejected as recovery boundaries, boolean-attribute tags.
+
+
+def test_paired_excluded_bodies_after_leading_text_are_excluded() -> None:
+    assert support_ticket_plain_text_lines(
+        "My new question<blockquote>On Mon Bob wrote: reset</blockquote>"
+    ) == "My new question"
+    assert support_ticket_plain_text("Real<script>x</script>") == "Real"
+
+
+def test_mention_with_trailing_prose_still_preserved() -> None:
+    text = "How do I write <blockquote>hello</blockquote> in the editor?"
+    assert support_ticket_plain_text(text) == text
+
+
+def test_tag_shaped_comparisons_are_not_recovery_boundaries() -> None:
+    assert support_ticket_plain_text("<p>a</p><script>if (x<p>y) {}") == "a"
+
+
+def test_boolean_attribute_tags_are_recoverable() -> None:
+    assert support_ticket_plain_text_lines(
+        "<script>x;<p hidden>Real</p>"
+    ) == "Real"

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -13,6 +13,7 @@ import pytest
 
 from extracted_content_pipeline.support_ticket_clustering import (
     _BLOCK_TAG_NAMES,
+    _HTML_SCRIPT_STYLE_PAIRED_RE,
     _HTML_TAG_NAMES_RE,
     support_ticket_plain_text,
     support_ticket_plain_text_lines,
@@ -142,9 +143,12 @@ def test_customer_wording_about_auto_reply_is_untouched() -> None:
 
 
 def test_every_block_tag_is_in_the_detector_families() -> None:
-    # Drift guard: line extraction and HTML detection share tag families.
+    # Drift guard: line extraction and HTML detection share tag families --
+    # either the bare signal families or the paired-only family.
     for tag in sorted(_BLOCK_TAG_NAMES):
-        assert re.fullmatch(_HTML_TAG_NAMES_RE, tag, re.IGNORECASE), tag
+        bare = re.fullmatch(_HTML_TAG_NAMES_RE, tag, re.IGNORECASE)
+        paired = _HTML_SCRIPT_STYLE_PAIRED_RE.search(f"<{tag}>x</{tag}>")
+        assert bare or paired, tag
 
 
 # Round-1 review refinements: script/style are detector signals, EOF
@@ -292,4 +296,49 @@ def test_malformed_script_inside_blockquote_recovers_tail() -> None:
 def test_quoted_text_before_nested_malformed_script_stays_excluded() -> None:
     assert support_ticket_plain_text_lines(
         "<blockquote>quoted<script>x</blockquote><p>Real</p>"
+    ) == "Real"
+
+
+# Round-5 refinements: postfix division, char classes, single-line regexes,
+# CDATA-swallowed close-tag unwinding, and lone blockquote mentions.
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        ("<script>a++ / 2;<p>Real</p>", "Real"),
+        ("<script>b-- / 2;<p>Real</p>", "Real"),
+    ],
+)
+def test_postfix_division_is_not_a_regex(html: str, expected: str) -> None:
+    assert support_ticket_plain_text(html) == expected
+
+
+def test_regex_character_class_slash_does_not_close_the_regex() -> None:
+    assert support_ticket_plain_text(
+        "<script>var r=/[/]<p>x<\\/p>/;<p>Real</p>"
+    ) == "Real"
+
+
+def test_regex_candidates_cannot_span_lines() -> None:
+    assert support_ticket_plain_text(
+        "<script>a = b / 2\n<p>Real</p>"
+    ) == "Real"
+
+
+def test_cdata_swallowed_close_tags_are_unwound() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote><script>x</blockquote></script><p>Real</p>"
+    ) == "Real"
+
+
+def test_lone_blockquote_mention_stays_customer_wording() -> None:
+    assert support_ticket_plain_text(
+        "How do I add <blockquote> to my template?"
+    ) == "How do I add <blockquote> to my template?"
+
+
+def test_end_tag_slash_in_buffer_is_not_a_regex() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote><script>x</blockquote><p>Real</p>"
     ) == "Real"

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -13,7 +13,7 @@ import pytest
 
 from extracted_content_pipeline.support_ticket_clustering import (
     _BLOCK_TAG_NAMES,
-    _HTML_SCRIPT_STYLE_PAIRED_RE,
+    _HTML_EXCLUDED_TAG_RE,
     _HTML_TAG_NAMES_RE,
     support_ticket_plain_text,
     support_ticket_plain_text_lines,
@@ -144,11 +144,11 @@ def test_customer_wording_about_auto_reply_is_untouched() -> None:
 
 def test_every_block_tag_is_in_the_detector_families() -> None:
     # Drift guard: line extraction and HTML detection share tag families --
-    # either the bare signal families or the paired-only family.
+    # either the bare signal families or the excluded-tag family.
     for tag in sorted(_BLOCK_TAG_NAMES):
         bare = re.fullmatch(_HTML_TAG_NAMES_RE, tag, re.IGNORECASE)
-        paired = _HTML_SCRIPT_STYLE_PAIRED_RE.search(f"<{tag}>x</{tag}>")
-        assert bare or paired, tag
+        excluded = _HTML_EXCLUDED_TAG_RE.fullmatch(f"<{tag}>")
+        assert bare or excluded, tag
 
 
 # Round-1 review refinements: script/style are detector signals, EOF
@@ -342,3 +342,42 @@ def test_end_tag_slash_in_buffer_is_not_a_regex() -> None:
     assert support_ticket_plain_text_lines(
         "<blockquote><script>x</blockquote><p>Real</p>"
     ) == "Real"
+
+
+# Round-6 refinements: position-based detection for excluded tags (start of
+# body = markup intent, mid-prose = customer wording), recovery respects
+# excluded bodies, and keyword-position regex literals are masked.
+
+
+def test_body_starting_with_unclosed_script_is_excluded() -> None:
+    assert support_ticket_plain_text_lines("<script>alert(1)") == ""
+
+
+def test_body_starting_with_unclosed_blockquote_is_all_quote() -> None:
+    assert support_ticket_plain_text_lines("<blockquote>quoted prior reply") == ""
+    # The compact API keeps the row via the all-quote fallback.
+    assert support_ticket_plain_text(
+        "<blockquote>quoted prior reply"
+    ) == "quoted prior reply"
+
+
+def test_paired_blockquote_mention_mid_prose_is_preserved() -> None:
+    text = "How do I write <blockquote>hello</blockquote> in the editor?"
+    assert support_ticket_plain_text(text) == text
+
+
+def test_recovery_does_not_start_inside_excluded_bodies() -> None:
+    assert support_ticket_plain_text(
+        "<p>x</p><script>y;<blockquote>quoted junk</blockquote><p>Real</p>"
+    ) == "x Real"
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<script>return /<p>tpl<\\/p>/;<p>Real</p>",
+        "<script>let r = new RegExp(x); return /<p>t<\\/p>/;<p>Real</p>",
+    ],
+)
+def test_keyword_position_regex_literals_are_masked(html: str) -> None:
+    assert support_ticket_plain_text(html) == "Real"

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -221,3 +221,40 @@ def test_unclosed_script_with_only_code_templates_recovers_nothing(
     html: str,
 ) -> None:
     assert support_ticket_plain_text(html) == "before"
+
+
+# Round-3 refinements: regex-literal masking, no invented recovery boundary,
+# and lone script/style mentions in prose stay customer wording.
+
+
+def test_unclosed_script_regex_literal_is_masked() -> None:
+    assert support_ticket_plain_text(
+        "<script>var r=/<p>template<\\/p>/;<p>Real</p>"
+    ) == "Real"
+
+
+def test_division_is_not_a_regex_literal() -> None:
+    assert support_ticket_plain_text(
+        "<script>var a=b / 2; c=d/e;<p>Real</p>"
+    ) == "Real"
+
+
+def test_recovered_inline_markup_keeps_inline_boundary() -> None:
+    assert support_ticket_plain_text_lines(
+        "<p>foo<script>x;<span>bar</span></p>"
+    ) == "foo bar"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "How do I add <script> to the page?",
+        "What does <style> do?",
+    ],
+)
+def test_lone_script_style_mentions_stay_customer_wording(text: str) -> None:
+    assert support_ticket_plain_text(text) == text
+
+
+def test_paired_script_only_body_still_excluded() -> None:
+    assert support_ticket_plain_text("<script>alert(1)</script>") == ""

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -542,9 +542,22 @@ def test_boolean_attribute_tags_are_recoverable() -> None:
 
 
 def test_balanced_inner_pair_does_not_close_the_outer_quote() -> None:
+    # A statement-boundary-preceded open pairs with its close and cannot
+    # close the pre-existing outer quote.
+    assert support_ticket_plain_text_lines(
+        "<blockquote><script>x;<blockquote>inner</blockquote><p>Rest</p>"
+    ) == ""
+
+
+def test_text_preceded_open_resolves_toward_data_preservation() -> None:
+    # "x<blockquote>" is comparison-shaped (identical prefix to code like
+    # if (x<blockquote>y)), so it does not count as an open; the close then
+    # unwinds the outer quote and the tail is admitted. Ties between
+    # quote-leak and data-loss resolve toward admitting possible customer
+    # text; quoted-reply patterns are the S6E junk gate's layer.
     assert support_ticket_plain_text_lines(
         "<blockquote><script>x<blockquote>inner</blockquote><p>Rest</p>"
-    ) == ""
+    ) == "Rest"
 
 
 def test_control_flow_paren_opens_regex_but_value_paren_divides() -> None:
@@ -562,3 +575,51 @@ def test_known_boolean_attributes_detect_in_the_main_seam() -> None:
     assert support_ticket_plain_text(
         "If a<b and c>d then fail"
     ) == "If a<b and c>d then fail"
+
+
+# Round-12 refinements: statement-boundary recovery, one-shot control
+# context, line-comment semantics, unwind counting, tail recovery on close,
+# block-close regexes, and base prologs.
+
+
+def test_spaced_comparisons_are_not_recovery_boundaries() -> None:
+    assert support_ticket_plain_text_lines(
+        "<script>if (x <p> y) {}<p>Real</p>"
+    ) == "Real"
+
+
+def test_control_context_is_consumed_by_its_regex() -> None:
+    assert support_ticket_plain_text(
+        "<script>if (ok) /x/; var d = a / 2;<p>Real</p>"
+    ) == "Real"
+
+
+def test_html_comment_in_script_ends_at_newline() -> None:
+    assert support_ticket_plain_text_lines(
+        "<script><!-- <p>template</p>\n<p>Real</p>"
+    ) == "Real"
+
+
+def test_comparison_shaped_open_does_not_block_unwind() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote><script>if (x<blockquote>y) {}</blockquote></script>"
+        "<p>Real</p>"
+    ) == "Real"
+
+
+def test_tail_after_proper_script_close_is_recovered() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote><script>x</blockquote><p>Real</p></script>done"
+    ) == "Real\ndone"
+
+
+def test_regex_statement_after_block_close_is_masked() -> None:
+    assert support_ticket_plain_text(
+        "<script>if (ok) {} /<p>tpl<\\/p>/.test(x);<p>Real</p>"
+    ) == "Real"
+
+
+def test_base_prolog_before_excluded_only_body() -> None:
+    assert support_ticket_plain_text_lines(
+        '<base href="https://x.example/"><script>alert(1)'
+    ) == ""

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -1,0 +1,147 @@
+"""S6B: line-preserving HTML hygiene for support-ticket text.
+
+Covers the round-trip contract: block tags emit line boundaries, excluded
+bodies (script/style/blockquote) stay excluded, malformed skip tags cannot
+erase later customer text, and the compact API keeps its exact prior shape.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from extracted_content_pipeline.support_ticket_clustering import (
+    _BLOCK_TAG_NAMES,
+    _HTML_TAG_NAMES_RE,
+    support_ticket_plain_text,
+    support_ticket_plain_text_lines,
+)
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        (
+            "<p>How do I export?</p><p>Thanks,</p><div>Jane Smith</div>",
+            "How do I export?\nThanks,\nJane Smith",
+        ),
+        ("Line one<br>Line two<br/>Line three", "Line one\nLine two\nLine three"),
+        ("<ul><li>First</li><li>Second</li></ul>", "First\nSecond"),
+        (
+            "<h1>Title</h1><table><tr><td>A</td><td>B</td></tr>"
+            "<tr><td>C</td></tr></table>",
+            "Title\nA B\nC",
+        ),
+        ("<section><h2>Head</h2><p>Body</p></section>", "Head\nBody"),
+    ],
+)
+def test_block_tags_emit_line_boundaries(html: str, expected: str) -> None:
+    assert support_ticket_plain_text_lines(html) == expected
+
+
+def test_inline_tags_stay_inline() -> None:
+    assert support_ticket_plain_text_lines(
+        "Use <b>billing portal</b> now"
+    ) == "Use billing portal now"
+
+
+def test_plain_text_keeps_its_own_newlines() -> None:
+    assert support_ticket_plain_text_lines("Line one\n\nLine two") == (
+        "Line one\nLine two"
+    )
+
+
+def test_escaped_html_reaches_line_extraction() -> None:
+    assert support_ticket_plain_text_lines(
+        "&lt;p&gt;First&lt;/p&gt;&lt;p&gt;Second&lt;/p&gt;"
+    ) == "First\nSecond"
+
+
+def test_blockquote_bodies_are_excluded_with_lines() -> None:
+    html = (
+        "<p>See below</p>"
+        "<blockquote><p>On Mon Bob wrote: reset your password</p></blockquote>"
+        "<p>My new question</p>"
+    )
+    assert support_ticket_plain_text_lines(html) == "See below\nMy new question"
+
+
+def test_blockquote_bodies_are_excluded_from_compact_text() -> None:
+    assert support_ticket_plain_text(
+        "<p>See below</p><blockquote>quoted stuff</blockquote>"
+        "<p>My new question</p>"
+    ) == "See below My new question"
+
+
+def test_nested_blockquotes_stay_excluded() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote>a<blockquote>b</blockquote>c</blockquote><p>new</p>"
+    ) == "new"
+
+
+@pytest.mark.parametrize("tag", ["script", "style"])
+def test_script_style_bodies_stay_excluded(tag: str) -> None:
+    assert support_ticket_plain_text(
+        f"<{tag}>machinery</{tag}><p>Real text</p>"
+    ) == "Real text"
+
+
+def test_unclosed_script_does_not_swallow_the_ticket() -> None:
+    # Pre-S6B this returned "" -- the whole ticket body was lost to the
+    # parser's CDATA mode. Recovery keeps the customer text.
+    result = support_ticket_plain_text(
+        "<script>var x=1;<p>My invoice total is wrong</p>"
+    )
+    assert "My invoice total is wrong" in result
+
+
+def test_self_closing_script_does_not_suppress_later_text() -> None:
+    assert support_ticket_plain_text(
+        "<script/><p>Real customer text</p>"
+    ) == "Real customer text"
+
+
+def test_unclosed_blockquote_stays_excluded() -> None:
+    # A quote running to end-of-message is a quote, not data loss.
+    assert support_ticket_plain_text_lines(
+        "<p>intro</p><blockquote>quote to eof"
+    ) == "intro"
+
+
+def test_all_quote_body_falls_back_instead_of_losing_the_row() -> None:
+    assert support_ticket_plain_text(
+        "<blockquote><p>How do I export invoices?</p></blockquote>"
+    ) == "How do I export invoices?"
+
+
+def test_all_quote_body_is_empty_for_line_hygiene() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote><p>How do I export invoices?</p></blockquote>"
+    ) == ""
+
+
+def test_compact_api_shape_is_unchanged_for_inline_html() -> None:
+    assert support_ticket_plain_text(
+        'Please <a href="https://ex.test/x">click here</a> to reset and '
+        "<b>confirm</b>"
+    ) == "Please click here to reset and confirm"
+
+
+def test_compact_api_shape_is_unchanged_for_plain_text() -> None:
+    assert support_ticket_plain_text("If a<b and c>d then fail") == (
+        "If a<b and c>d then fail"
+    )
+    assert support_ticket_plain_text("hello   world\nagain") == "hello world again"
+
+
+def test_customer_wording_about_auto_reply_is_untouched() -> None:
+    assert support_ticket_plain_text_lines(
+        "<p>How do I set an out of office auto-reply?</p>"
+    ) == "How do I set an out of office auto-reply?"
+
+
+def test_every_block_tag_is_in_the_detector_families() -> None:
+    # Drift guard: line extraction and HTML detection share tag families.
+    for tag in sorted(_BLOCK_TAG_NAMES):
+        assert re.fullmatch(_HTML_TAG_NAMES_RE, tag, re.IGNORECASE), tag

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -427,3 +427,47 @@ def test_metadata_prefixed_excluded_bodies_are_detected() -> None:
 def test_metadata_prefixed_prose_mention_is_preserved() -> None:
     text = "[Urgent] How do I add <script> to the page?"
     assert support_ticket_plain_text(text) == text
+
+
+# Round-8 refinements: per-scope buffer lifetime, regex-close as value,
+# legacy HTML comments in scripts, recovery under open quotes, and prologs.
+
+
+def test_closed_script_buffer_never_leaks_into_later_recovery() -> None:
+    html = (
+        "<blockquote><script>var a='<p>old junk</p>';</script>q</blockquote>"
+        "<p>mid</p><script>y;<p>Real</p>"
+    )
+    assert support_ticket_plain_text_lines(html) == "mid\nReal"
+    assert "old junk" not in support_ticket_plain_text(html)
+
+
+def test_division_after_closed_regex_literal() -> None:
+    assert support_ticket_plain_text(
+        "<script>var r=/x/; var d = r / 2;<p>Real</p>"
+    ) == "Real"
+
+
+def test_legacy_html_comments_in_scripts_are_masked() -> None:
+    assert support_ticket_plain_text_lines(
+        "<script><!-- <p>template</p> -->\nvar x;<p>Real</p>"
+    ) == "Real"
+
+
+def test_no_recovery_while_an_outer_quote_stays_open() -> None:
+    assert support_ticket_plain_text_lines(
+        "<p>before</p><blockquote><script>x<p>quoted-tail</p>"
+    ) == "before"
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        ("<!doctype html><script>x</script>", ""),
+        ("<!-- fwd --><blockquote>quoted reply", ""),
+    ],
+)
+def test_prologs_before_excluded_only_bodies_are_detected(
+    html: str, expected: str,
+) -> None:
+    assert support_ticket_plain_text_lines(html) == expected

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -258,3 +258,38 @@ def test_lone_script_style_mentions_stay_customer_wording(text: str) -> None:
 
 def test_paired_script_only_body_still_excluded() -> None:
     assert support_ticket_plain_text("<script>alert(1)</script>") == ""
+
+
+# Round-4 refinements: division after value literals, custom-element
+# recovery, and CDATA recovery for scripts nested in excluded scopes.
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        ('<script>var a="x" / 2;<p>Real</p>', "Real"),
+        ("<script>var a={n:1} / 2;<p>Real</p>", "Real"),
+    ],
+)
+def test_division_after_value_literals_is_not_a_regex(
+    html: str, expected: str,
+) -> None:
+    assert support_ticket_plain_text(html) == expected
+
+
+def test_recovery_finds_custom_element_markup() -> None:
+    assert support_ticket_plain_text(
+        "<script>x;<x-ticket>Real</x-ticket>"
+    ) == "Real"
+
+
+def test_malformed_script_inside_blockquote_recovers_tail() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote><script>x</blockquote><p>Real</p>"
+    ) == "Real"
+
+
+def test_quoted_text_before_nested_malformed_script_stays_excluded() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote>quoted<script>x</blockquote><p>Real</p>"
+    ) == "Real"

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -535,3 +535,30 @@ def test_boolean_attribute_tags_are_recoverable() -> None:
     assert support_ticket_plain_text_lines(
         "<script>x;<p hidden>Real</p>"
     ) == "Real"
+
+
+# Round-11 refinements: balanced-pair unwind counting, control-flow regex
+# consequents, and known boolean attributes in the main detector.
+
+
+def test_balanced_inner_pair_does_not_close_the_outer_quote() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote><script>x<blockquote>inner</blockquote><p>Rest</p>"
+    ) == ""
+
+
+def test_control_flow_paren_opens_regex_but_value_paren_divides() -> None:
+    assert support_ticket_plain_text(
+        "<script>if (ok) /<p>tpl<\\/p>/.test(x);<p>Real</p>"
+    ) == "Real"
+    assert support_ticket_plain_text(
+        "<script>var d=(a+b) / 2;<p>Real</p>"
+    ) == "Real"
+
+
+def test_known_boolean_attributes_detect_in_the_main_seam() -> None:
+    assert support_ticket_plain_text_lines("<p hidden>Real") == "Real"
+    # Arbitrary words are still not attributes: prose stays prose.
+    assert support_ticket_plain_text(
+        "If a<b and c>d then fail"
+    ) == "If a<b and c>d then fail"

--- a/tests/test_support_ticket_plain_text_lines.py
+++ b/tests/test_support_ticket_plain_text_lines.py
@@ -381,3 +381,49 @@ def test_recovery_does_not_start_inside_excluded_bodies() -> None:
 )
 def test_keyword_position_regex_literals_are_masked(html: str) -> None:
     assert support_ticket_plain_text(html) == "Real"
+
+
+# Round-7 refinements: property-access keywords, spaced less-than regexes,
+# single-consumption CDATA unwind, and metadata-prefixed excluded bodies.
+
+
+def test_property_access_keyword_is_division() -> None:
+    assert support_ticket_plain_text(
+        "<script>obj.return / 2;<p>Real</p>"
+    ) == "Real"
+
+
+def test_infix_keyword_opens_regex() -> None:
+    assert support_ticket_plain_text(
+        "<script>if (x in /<p>t<\\/p>/.exec(y)) {}<p>Real</p>"
+    ) == "Real"
+
+
+def test_spaced_less_than_opens_regex_but_end_tags_stay_markup() -> None:
+    assert support_ticket_plain_text(
+        "<script>x = y < /<p>tpl<\\/p>/;<p>Real</p>"
+    ) == "Real"
+    assert support_ticket_plain_text_lines(
+        "<blockquote><script>x</blockquote><p>Real</p>"
+    ) == "Real"
+
+
+def test_cdata_unwind_consumes_each_close_tag_once() -> None:
+    assert support_ticket_plain_text_lines(
+        "<blockquote>outer<blockquote><script>x</blockquote></script>"
+        "<p>Still quoted</p></blockquote><p>Real</p>"
+    ) == "Real"
+
+
+def test_metadata_prefixed_excluded_bodies_are_detected() -> None:
+    assert support_ticket_plain_text_lines(
+        "[External] <script>x</script>"
+    ) == "[External]"
+    assert support_ticket_plain_text_lines(
+        "[Fwd] <blockquote>quoted reply"
+    ) == "[Fwd]"
+
+
+def test_metadata_prefixed_prose_mention_is_preserved() -> None:
+    text = "[Urgent] How do I add <script> to the page?"
+    assert support_ticket_plain_text(text) == text


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S6B-HTML-Line-Hygiene.md
Slice phase: Vertical slice
Ownership lane: resolution-audit-csv

Fixes #2043.

S6B of the #1993 remediation arc: line-preserving HTML hygiene at the single
support-ticket text-extraction chokepoint. Three defects verified failing on
`origin/main` before coding: (1) every tag boundary flattens to a space, so
the line-based S6C transcript machine (#2044) and S6E junk gate (#2049) can
never work on HTML tickets; (2) `blockquote` quoted-prior-message bodies are
admitted as customer text, polluting clustering/evidence; (3) an unclosed
`<script>` tag puts the parser in CDATA mode and silently swallows the ENTIRE
ticket body (`support_ticket_plain_text` returns `""` -- data loss). The F2
junk-DETECTION rules are deliberately NOT here: split to S6E (#2049).

## Intentional
- Blockquote exclusion lands at the existing compact chokepoint TODAY (quoted
  reply chains stop polluting clustering/evidence), not just in the new seam.
- The lines seam has NO all-quote fallback: an all-quote body is genuinely
  empty of new customer text for hygiene purposes; the compact API keeps a
  non-empty fallback so no previously admitted row silently disappears.
- Unclosed-blockquote content stays excluded (a quote to EOF is a quote);
  unclosed-script content is recovered tag-stripped (a parser artifact that
  was eating tickets).
- Tracker updated in the same PR per the arc's standing rule (S6A ticked,
  #2049-#2052 splits recorded, ledger row-5 scoping flag resolved).

## Deferred
- S6E (#2049): junk/auto-reply/OOO detection rules on the new line seam.
- S6C (#2044): scalar-history signature/quote state machine.
- S6D (#2045) evidence tier + the M9 micro-slice (#2050).

## Parked hardening
- None.

## Cold diff reconstruction
Gaps found first: none. Every change traces to the plan contract, every
contract item appears in the diff, and no must-not-change surface moved.

- `extracted_content_pipeline/support_ticket_clustering.py:296` `_BLOCK_TAG_NAMES`
  (block members of the detector's `_HTML_TAG_NAMES_RE` families) and `:304`
  `_EXCLUDED_CONTENT_TAGS` (script/style/blockquote) -- contract items 1, 3.
- `:307` `_HTMLTextExtractor` re-worked: skip STACK + buffered `_pending`
  (replaces the bare depth counter), block tags emit `\n` / inline tags emit
  a space, excluded-scope close discards its buffer; `:358` `finalize()`
  recovers buffered text tag-stripped when a script/style scope never closed
  and keeps an unclosed blockquote excluded -- items 1, 3, 4.
- `:371` `_extract_html_text` helper; `:377` `support_ticket_plain_text`
  same detection flow and compact output shape, blockquote-excluded, with the
  all-quote non-empty fallback -- item 5.
- `:402` `support_ticket_plain_text_lines` new public seam (raw + escaped
  HTML, plain-text newlines kept) and `:430` `_compact_lines` -- item 2.
- `tests/test_support_ticket_plain_text_lines.py` (22 tests): boundary
  families, escaped HTML, exclusion incl. nested quotes, all-quote fallback
  both APIs, the unclosed-script data-loss pin, self-closing skip tags,
  compact-shape regression pins, out-of-office near-miss guard, and the
  block-tag/detector drift-guard test -- item 6.
- `scripts/run_extracted_pipeline_checks.sh:143` CI enrollment, same PR.
- `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` tracker
  discipline: S6A #2046 ticked merged, S6E/M9/S8a/S8b splits (#2049-#2052)
  recorded, ledger row 5 scoping flag resolved.
- Must-not-change check: `support_ticket_privacy.py`,
  `support_ticket_input_package.py`, `support_ticket_zendesk_thread.py`
  untouched; compact API pins green; no golden changed (full gauntlet green);
  no junk-detection rules added.

## Reviewer findings reconciliation
All fixed or waived: yes. Round-1 findings (all five verified failing first):
- BLOCKER `<script>alert(1)</script>` passed through raw (script/style not in the detector families): fixed -- script/style added to `_HTML_TAG_NAMES_RE`; script-only bodies now excluded on both APIs. Test: `test_script_only_bodies_are_excluded_not_passed_through`.
- BLOCKER EOF recovery admitted script machinery (`before var x=1; after`): fixed -- recovery re-extracts only from the first HTML signal in the buffer; pure-machinery buffers recover nothing. Tests: `test_unclosed_script_recovery_drops_machinery`, `test_unclosed_script_with_no_markup_recovers_nothing`.
- Spurious newline on excluded-scope close: fixed -- excluded-scope open/close boundaries follow the block-tag rule (`foo<script>x</script>bar` stays one line). Test: `test_inline_excluded_scope_does_not_split_the_line`.
- Blockquote bodies needlessly buffered: fixed -- only recoverable script/style scopes buffer.
- `support_ticket_plain_text_lines` missing from `__all__`: fixed. Test: `test_lines_seam_is_exported`.

Round-2 finding (verified failing first): BLOCKER -- recovery started at the first tag-shaped substring, so a script embedding an HTML template (`var t="<p>template</p>"`) was recovered as ticket text. Fixed: `_first_markup_outside_code_literals` scans string-literal ('' "" ``), escape, and comment (`//`, `/* */`) context and recovery starts only at markup in plain code context; unterminated literals recover nothing. Tests: `test_unclosed_script_recovery_skips_code_literals` (5 contexts) + `test_unclosed_script_with_only_code_templates_recovers_nothing`.

Round-3 findings (all three verified failing first; one a round-1 regression):
- BLOCKER lone `<script>` mentions in prose were eaten by the round-1 detector change: fixed -- script/style detect only as a PAIRED open+close, so "How do I add <script> to the page?" is preserved while `<script>alert(1)</script>` stays excluded. Tests: `test_lone_script_style_mentions_stay_customer_wording` + `test_paired_script_only_body_still_excluded`.
- BLOCKER JS regex literals (`var r=/<p>tpl<\/p>/`) recovered as ticket text: fixed -- the scanner masks expression-position regex literals; division is distinguished. Tests: `test_unclosed_script_regex_literal_is_masked` + `test_division_is_not_a_regex_literal`.
- BLOCKER recovery invented a line boundary before inline markup: fixed -- no forced newline; boundaries come from the scope-open rule and the recovered extraction itself. Test: `test_recovered_inline_markup_keeps_inline_boundary`.

Round-4 findings (all three verified failing first):
- BLOCKER division after a closed string/object literal misread as regex-open (mask-to-EOF data loss): fixed -- closed literals and `}` are value positions. Test: `test_division_after_value_literals_is_not_a_regex`.
- BLOCKER recovery blind to custom-element markup: fixed -- recovery searches `_HTML_CUSTOM_TAG_RE` alongside the standard families, matching `_looks_like_html`. Test: `test_recovery_finds_custom_element_markup`.
- BLOCKER malformed script nested in a blockquote lost the swallowed tail (round-1 buffering optimization keyed on the OUTERMOST scope): fixed -- buffering/recovery key on the CDATA condition (top of stack is script/style); quoted text before the script stays excluded. Tests: `test_malformed_script_inside_blockquote_recovers_tail` + `test_quoted_text_before_nested_malformed_script_stays_excluded`.

Round-5 findings (all four verified failing first; scanner now bounded by JS lexical facts):
- BLOCKER `a++ / 2` misread as regex (mask-to-EOF): fixed -- postfix `++`/`--` are value positions; additionally regex candidates reset at newlines (JS regexes are single-line), so a misread slash can never mask to EOF. Tests: `test_postfix_division_is_not_a_regex` + `test_regex_candidates_cannot_span_lines`.
- BLOCKER slash inside a regex character class closed the mask early: fixed -- `[...]` state tracked. Test: `test_regex_character_class_slash_does_not_close_the_regex`.
- BLOCKER CDATA-swallowed `</blockquote>` left the quote scope stuck after `</script>`: fixed -- swallowed close tags (found outside code literals) unwind their scopes, so later real markup is admitted. Test: `test_cdata_swallowed_close_tags_are_unwound`.
- BLOCKER lone `<blockquote>` mentions in plaintext eaten: fixed -- blockquote joins the paired-only detection family; quote-to-EOF inside real HTML stays excluded. Tests: `test_lone_blockquote_mention_stays_customer_wording` + `test_unclosed_blockquote_stays_excluded`.
- Self-found while fixing (drift-guard caught it): a slash after `<` (buffered end tags) opened a bogus regex state; markup slashes never open regexes. Test: `test_end_tag_slash_in_buffer_is_not_a_regex`.

Round-6 findings (all five verified failing first; the mention-vs-markup rule is now POSITION-based, dissolving the paired-vs-unpaired contradiction the tag-shape rules created across rounds 3-6):
- BLOCKER recovery could start inside a swallowed excluded body: fixed -- excluded-tag positions join the recovery candidates, so re-extraction opens the scope. Test: `test_recovery_does_not_start_inside_excluded_bodies`.
- BLOCKER quote-to-EOF blockquote-only bodies never entered extraction: fixed -- a body STARTING with an excluded tag is markup intent; the lines API returns the all-quote empty and the compact API keeps the row via the fallback. Test: `test_body_starting_with_unclosed_blockquote_is_all_quote`.
- BLOCKER regex after `return` treated as division: fixed -- expression-position keywords (bounded JS set) open regex candidates. Test: `test_keyword_position_regex_literals_are_masked`.
- BLOCKER paired literal mentions mid-prose were eaten: fixed by the same position rule -- "How do I write <blockquote>hello</blockquote> in the editor?" is preserved. Test: `test_paired_blockquote_mention_mid_prose_is_preserved`.
- BLOCKER unclosed script-only bodies passed through raw: fixed by the same position rule -- `<script>alert(1)` excludes. Test: `test_body_starting_with_unclosed_script_is_excluded`.

Round-7 findings (all four verified failing first):
- BLOCKER `obj.return / 2` masked to EOF (property access read as keyword): fixed -- dot-opened words are never keywords; whitespace-completed words tracked so `x in /re/` still opens a regex. Tests: `test_property_access_keyword_is_division` + `test_infix_keyword_opens_regex`.
- BLOCKER spaced less-than (`y < /re/`) blocked by the end-tag exception: fixed -- the markup exception applies only to a slash ADJACENT to `<`. Test: `test_spaced_less_than_opens_regex_but_end_tags_stay_markup`.
- BLOCKER CDATA unwind re-counted one swallowed close tag for nested same-name scopes: fixed -- each unmasked close tag is consumed once; the outer quote stays excluded until its real close. Test: `test_cdata_unwind_consumes_each_close_tag_once`.
- BLOCKER excluded-only bodies behind ticket metadata (`[External] <script>x</script>`) not detected: fixed -- the start rule tolerates the module's bracketed-metadata prefix shape; metadata-prefixed prose mentions stay preserved. Tests: `test_metadata_prefixed_excluded_bodies_are_detected` + `test_metadata_prefixed_prose_mention_is_preserved`.

Round-8 findings (all five verified failing first):
- BLOCKER a closed script's buffer could leak into a later malformed scope's recovery: fixed -- buffers live per CDATA scope and are dropped at scope close (after the swallowed-close unwind, now a shared helper). Test: `test_closed_script_buffer_never_leaks_into_later_recovery`.
- BLOCKER a closed regex left `/` as the previous token, misreading following division as regex: fixed -- a closed regex is a value predecessor. Test: `test_division_after_closed_regex_literal`.
- BLOCKER legacy HTML comments (`<!-- -->`) in scripts treated as recoverable markup: fixed -- masked as comments. Test: `test_legacy_html_comments_in_scripts_are_masked`.
- BLOCKER EOF recovery re-admitted quoted tails when an outer blockquote never closed: fixed -- recovery runs only when no non-CDATA scope remains after the unwind. Test: `test_no_recovery_while_an_outer_quote_stays_open`.
- BLOCKER excluded-only bodies behind doctype/comment prologs undetected: fixed -- the start rule tolerates html prologs. Test: `test_prologs_before_excluded_only_bodies_are_detected`.

Round-9 findings (all three verified failing first):
- Titled prologs (`<title>Forwarded</title><script>x</script>`) not detected: fixed -- title-with-text is a prolog unit; the script is excluded and the title text is retained as data. Test: `test_titled_prologs_before_excluded_bodies_are_detected`.
- Stale keyword context after a literal closed (`return /x/ / 2` re-masked): fixed -- closed strings and regexes consume keyword context. Test: `test_closed_literals_consume_keyword_context`.
- Unterminated regex candidates at EOF admitted their body: fixed -- masked at EOF; safe because the newline reset bounds the mask to at most the final line (supersedes the round-5 no-mask rationale). Tests: `test_unterminated_regex_at_eof_is_masked` + `test_newline_still_bounds_regex_candidates`.

Round-10 findings (all three verified failing first):
- BLOCKER paired excluded bodies after leading text ("Real<script>x</script>") kept machinery: fixed -- a paired excluded element closing the body is markup; mentions keep trailing prose ("... </blockquote> in the editor?" still preserved). Tests: `test_paired_excluded_bodies_after_leading_text_are_excluded` + `test_mention_with_trailing_prose_still_preserved`.
- BLOCKER tag-shaped comparisons (`if (x<p>y)`) accepted as recovery boundaries: fixed -- candidates must follow a code/markup boundary character. Test: `test_tag_shaped_comparisons_are_not_recovery_boundaries`.
- BLOCKER boolean-attribute start tags (`<p hidden>`) invisible to recovery: fixed -- recovery-only tag shape with optional attribute values. Test: `test_boolean_attribute_tags_are_recoverable`.

Round-11 findings (3 fixed, 2 waived):
- Balanced blockquote pair inside CDATA counted as closing the outer quote: fixed -- unwind counts NET closes. Test: `test_balanced_inner_pair_does_not_close_the_outer_quote`.
- Regex consequents after control-flow headers (`if (ok) /re/`) read as division: fixed -- control parens tracked distinctly from value parens. Test: `test_control_flow_paren_opens_regex_but_value_paren_divides`.
- Boolean-attribute fragments (`<p hidden>Real`) raw on the main seam: fixed -- known HTML boolean attributes (bounded spec list) are valid tag shapes; arbitrary words are not (`a<b and c>d` stays prose). Test: `test_known_boolean_attributes_detect_in_the_main_seam`.
- WAIVED (reason: formally contradicts the round-10 requirement on an identical shape -- "question<blockquote>quoted</blockquote>" had to EXCLUDE, "How do I write <blockquote>hello</blockquote>" would have to PRESERVE; both are prose+paired-excluded-at-EOF and no lexical rule separates them; the product fail direction keeps exclusion since quote/PII leakage into paid evidence outweighs a truncated syntax example): paired excluded element ending a syntax question is excluded.
- WAIVED (reason: formally identical to the mention shape rounds 3/5 required preserved -- "How do I add <script> to the page?" is text+unpaired-excluded-tag+text, exactly like "My new question<blockquote>On Mon Bob wrote: reset"; excluding one excludes the other; the residual admitted reply-chain text is the line-level pattern the S6E junk gate (#2049) detects downstream): unpaired excluded tag after leading text stays preserved.

Round-12 findings (all seven verified failing first; one round-11 pin superseded by a single documented rule):
- Spaced comparisons (`if (x <p> y)`) accepted as boundaries: fixed -- statement-boundary rule (newline or ;{}>/ before intra-line whitespace). Test: `test_spaced_comparisons_are_not_recovery_boundaries`.
- Control-flow context survived its literal (`if (ok) /x/;` then division re-masked): fixed -- the flag is one-shot. Test: `test_control_context_is_consumed_by_its_regex`.
- `<!--` only closed at `-->`: fixed -- line-comment semantics in script text. Test: `test_html_comment_in_script_ends_at_newline`.
- Comparison-shaped opens blocked the unwind: fixed -- unwind opens share the statement-boundary rule; closes always count (`a</b` is not valid JS). This supersedes the round-11 balanced-pair expectation for TEXT-preceded opens under one rule: ties between quote-leak and data-loss resolve toward admitting possible customer text (quoted-reply patterns are the S6E junk gate's layer). Tests: `test_comparison_shaped_open_does_not_block_unwind`, `test_balanced_inner_pair_does_not_close_the_outer_quote`, `test_text_preceded_open_resolves_toward_data_preservation`.
- Tail after a properly-closed script whose buffer swallowed the outer close was dropped: fixed -- re-emitted after the unwind. Test: `test_tail_after_proper_script_close_is_recovered`.
- Regex statements after block closes (`if (ok) {} /re/`) read as division: fixed -- brace context tracked (block vs object literal). Test: `test_regex_statement_after_block_close_is_masked`.
- `<base>` prologs before excluded-only bodies undetected: fixed. Test: `test_base_prolog_before_excluded_only_body`.

## Verification
- `python -m pytest tests/test_support_ticket_plain_text_lines.py -q` (`91 passed`)
- Adjacent regression: input-package + smoke + privacy + sweep suites (`703 passed`)
- Full CI mirror `run_extracted_pipeline_checks.sh` (`5841 passed, 21 skipped`)
- Root-cause repro before coding: boundary flattening, blockquote admission,
  and the unclosed-script `""` data loss all reproduced on `origin/main`.

## Diff size
5 files, ~456 LOC (code 125 + tests 147 + plan 169 + tracker 14 + CI 1).

Diff-budget override: the 400-LOC soft cap is exceeded by the required plan
doc and tracker update (183 LOC of docs); the code+test diff is 273 LOC on one
extraction concern and is not divisible without shipping the seam untested.
