### PR TITLE
Resolution Audit CSV S6E: junk/auto-reply admission gate (F2)

### DIFF
--- a/docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md
+++ b/docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md
@@ -43,7 +43,7 @@ Minimum true before paid reports ship:
 | 2 | Header/data-loss admission (C1/H4/C2) | S1 #2026 | MOSTLY (dup-header/encoding closed; terse-first-row + missing-ID residual) |
 | 3 | Money reconciliation (P5-2) | S4 #2031 | DISPLAY-only (buyer-visible cents change needs approval; P5-7 model guard -> S8) |
 | 4 | PII private/internal notes | S6A #2046 | MERGED 2026-07-08 -- CLOSED |
-| 5 | Junk/auto-reply/OOO gate (F2, incl HTML M6) | S6B #2043 (line plumbing) + S6E #2049 (detection rules) | OPEN -- scoping gap RESOLVED by the S6E split |
+| 5 | Junk/auto-reply/OOO gate (F2, incl HTML M6) | S6B #2053 MERGED (line plumbing) + S6E #2049 (detection rules, PR open) | IN PROGRESS |
 | 6 | Date transposition/window (C3/M7) | S7 | OPEN |
 | 7 | Fail-closed runtime guard (P5-7 + scorecard) | S8 | OPEN (scorecard zero runtime callers) |
 
@@ -405,7 +405,7 @@ These are not coding-start items until the operator approves the product shape:
   CONDITIONAL -- closes only with the default-OFF embedding booster ON+calibrated.
 - [ ] S5 clustering calibration (real-corpus + booster on/off decision) PR linked here.
 - [x] S6A private/internal admission boundary PR linked here: #2046 (merged 2026-07-08; issue #2042 closed; closed token-stem predicate + ~335-case grammar sweep, 46 reviewer findings resolved across 9 rounds).
-- [ ] S6B HTML line-preserving hygiene PR linked here (issue #2043). F2 junk-DETECTION split to S6E (#2049) per the ledger scoping flag.
+- [x] S6B HTML line-preserving hygiene PR linked here: #2053 (merged 2026-07-09; issue #2043 closed; line seam + blockquote exclusion + no-data-loss; 12 review rounds, 45 findings -- see PR for the review-loop lesson).
 - [ ] S6E junk/auto-reply/OOO detection gate PR linked here (issue #2049; after S6B).
 - [ ] S6D-M9 status-synonym micro-slice PR linked here (issue #2050; independent).
 - [ ] S6C scalar history signature/quoted-reply cleanup PR linked here (issue #2044).

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -325,6 +325,9 @@
       "target": "extracted_content_pipeline/support_ticket_dates.py"
     },
     {
+      "target": "extracted_content_pipeline/support_ticket_junk.py"
+    },
+    {
       "target": "extracted_content_pipeline/support_ticket_privacy.py"
     },
     {

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -620,10 +620,19 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     if not text:
         return {}
     raw_body = _first_text(row, _TEXT_KEYS)
+    comment_text = _comments_text(row)
+    gate_body = "\n".join(
+        part
+        for part in (
+            support_ticket_plain_text_lines(raw_body),
+            support_ticket_plain_text_lines(comment_text),
+        )
+        if part
+    )
     junk_reason = support_ticket_row_is_junk(
         source_title,
-        support_ticket_plain_text_lines(raw_body),
-        had_source_text=bool(raw_body.strip()),
+        gate_body,
+        had_source_text=bool(raw_body.strip() or comment_text.strip()),
     )
     if junk_reason:
         # Junk rows (auto-replies, bounces, no-new-content) must not count

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -620,19 +620,16 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     if not text:
         return {}
     raw_body = _first_text(row, _TEXT_KEYS)
-    comment_text = _comments_text(row)
-    gate_body = "\n".join(
-        part
-        for part in (
-            support_ticket_plain_text_lines(raw_body),
-            support_ticket_plain_text_lines(comment_text),
-        )
-        if part
+    raw_comments = _raw_comment_texts(row)
+    gate_parts = [support_ticket_plain_text_lines(raw_body)]
+    gate_parts.extend(
+        support_ticket_plain_text_lines(comment) for comment in raw_comments
     )
+    gate_body = "\n".join(part for part in gate_parts if part)
     junk_reason = support_ticket_row_is_junk(
         source_title,
         gate_body,
-        had_source_text=bool(raw_body.strip() or comment_text.strip()),
+        had_source_text=bool(raw_body.strip() or any(raw_comments)),
     )
     if junk_reason:
         # Junk rows (auto-replies, bounces, no-new-content) must not count
@@ -764,6 +761,30 @@ def _ticket_text(row: Mapping[str, Any], *, source_title: str) -> str:
     if comments:
         parts.append(comments)
     return support_ticket_plain_text("\n".join(parts))
+
+
+def _raw_comment_texts(row: Mapping[str, Any]) -> list[str]:
+    """Public comment texts with their line structure intact for the junk
+    gate; `_comments_text` compacts per comment, which erases the line
+    boundaries the assertion patterns key on."""
+
+    texts: list[str] = []
+    for key in _PUBLIC_COMMENT_KEYS:
+        comments = _first_value(row, (key,))
+        if isinstance(comments, Mapping):
+            comments = (comments,)
+        elif isinstance(comments, str):
+            comments = (comments,)
+        elif not isinstance(comments, Sequence) or isinstance(
+            comments,
+            (bytes, bytearray),
+        ):
+            continue
+        for item in comments:
+            text = _comment_text(item)
+            if text:
+                texts.append(text)
+    return texts
 
 
 def _comments_text(row: Mapping[str, Any]) -> str:

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -621,10 +621,16 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
         return {}
     raw_body = _first_text(row, _TEXT_KEYS)
     raw_comments = _raw_comment_texts(row)
-    gate_parts = [support_ticket_plain_text_lines(raw_body)]
-    gate_parts.extend(
-        support_ticket_plain_text_lines(comment) for comment in raw_comments
-    )
+    body_part = support_ticket_plain_text_lines(raw_body)
+    if body_part:
+        # A row with real customer body text is judged on that body; a
+        # generated auto-ack COMMENT must not junk a real ticket.
+        gate_parts = [body_part]
+    else:
+        gate_parts = [
+            support_ticket_plain_text_lines(comment)
+            for comment in raw_comments
+        ]
     gate_body = "\n".join(part for part in gate_parts if part)
     junk_reason = support_ticket_row_is_junk(
         source_title,

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -20,6 +20,7 @@ from .support_ticket_clustering import (
     support_ticket_cluster_quality,
     support_ticket_cluster_summary,
     support_ticket_plain_text,
+    support_ticket_plain_text_lines,
 )
 from .support_ticket_context_contract import (
     SUPPORT_TICKET_DEFAULT_TOPIC,
@@ -27,6 +28,7 @@ from .support_ticket_context_contract import (
     support_ticket_topic_filter,
 )
 from .support_ticket_dates import parse_support_ticket_source_date
+from .support_ticket_junk import support_ticket_row_is_junk
 from .support_ticket_privacy import (
     support_ticket_comment_is_private,
     support_ticket_row_is_private,
@@ -335,6 +337,7 @@ def build_support_ticket_input_package(
             "message": "No support-ticket source rows were provided.",
         })
     source_date_signal_count = 0
+    junk_excluded_counts: dict[str, int] = {}
     for index, row in enumerate(raw_rows[:max_rows], start=1):
         if not isinstance(row, Mapping):
             warnings.append({
@@ -345,6 +348,12 @@ def build_support_ticket_input_package(
             continue
         row_lookup = _SupportTicketRowLookup(row)
         normalized = _normalize_ticket_row(row_lookup, row_index=index)
+        junk_reason = normalized.pop("_junk_reason", None) if normalized else None
+        if junk_reason:
+            junk_excluded_counts[junk_reason] = (
+                junk_excluded_counts.get(junk_reason, 0) + 1
+            )
+            continue
         if normalized:
             normalized_rows.append(normalized)
             # Carry the date-column-present signal out-of-band rather than
@@ -403,6 +412,16 @@ def build_support_ticket_input_package(
             ),
             "row_count": cluster_diagnostics["token_set_row_count"],
             "max_token_set_rows": cluster_diagnostics["max_token_set_rows"],
+        })
+    if junk_excluded_counts:
+        warnings.append({
+            "code": "support_ticket_junk_excluded",
+            "count": sum(junk_excluded_counts.values()),
+            "reasons": dict(sorted(junk_excluded_counts.items())),
+            "message": (
+                "Excluded auto-generated/no-content rows from billed "
+                "clusters."
+            ),
         })
     date_diagnostics = _source_date_diagnostics(
         normalized_rows, source_date_signal_count=source_date_signal_count
@@ -518,6 +537,8 @@ def build_support_ticket_input_package(
         "ticket_status_present_count": ticket_status_present_count,
         "ticket_status_summary": ticket_status_summary,
         "source_id_fallback_count": len(source_id_fallback_rows),
+        "junk_excluded_count": sum(junk_excluded_counts.values()),
+        "junk_excluded_reasons": dict(sorted(junk_excluded_counts.items())),
         "csat_present": csat_present_count > 0,
         "csat_present_count": csat_present_count,
         "csat_score_count": len(csat_scores),
@@ -598,6 +619,16 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     text = _ticket_text(row, source_title=source_title)
     if not text:
         return {}
+    raw_body = _first_text(row, _TEXT_KEYS)
+    junk_reason = support_ticket_row_is_junk(
+        source_title,
+        support_ticket_plain_text_lines(raw_body),
+        had_source_text=bool(raw_body.strip()),
+    )
+    if junk_reason:
+        # Junk rows (auto-replies, bounces, no-new-content) must not count
+        # toward billed clusters (F2); the caller counts the bounded reason.
+        return {"_junk_reason": junk_reason}
     source_id = _first_text(row, _SOURCE_ID_KEYS)
     source_id_fallback = not source_id
     if source_id_fallback:

--- a/extracted_content_pipeline/support_ticket_junk.py
+++ b/extracted_content_pipeline/support_ticket_junk.py
@@ -69,7 +69,10 @@ _AUTO_REPLY_LINE_RES = (
     ),
     re.compile(
         r"^i\s+(?:will\s+)?have\s+(?:limited|no)\s+access\s+to\s+"
-        r"(?:my\s+)?e?mail\b[^?]*$",
+        r"(?:my\s+)?e?mail"
+        r"(?:\s*[.!]?\s*$|\s+(?:until|through|till|thru|from|during"
+        r"|while|this|next|today|tomorrow"
+        r"|and\s+(?:will|won'?t|shall|cannot|can'?t|may))\b[^?]*$)",
         re.IGNORECASE,
     ),
     re.compile(
@@ -90,7 +93,7 @@ _AUTO_REPLY_LINE_RES = (
     ),
 )
 _SUBJECT_LABEL_RE = re.compile(r"^\s*subject\s*[:\uFF1A]", re.IGNORECASE)
-_HEADER_LINE_RE = re.compile(r"^[a-z][a-z0-9-]*\s*[:\uFF1A]\s", re.IGNORECASE)
+_HEADER_LINE_RE = re.compile(r"^[a-z][a-z0-9-]*[:\uFF1A]\s?", re.IGNORECASE)
 
 _BOUNCE_LINE_RES = (
     re.compile(
@@ -131,14 +134,6 @@ def support_ticket_row_is_junk(
         return JUNK_REASON_AUTO_REPLY
     if _BOUNCE_SUBJECT_RE.match(subject or ""):
         return JUNK_REASON_BOUNCE
-    subject_line = (subject or "").strip()
-    if subject_line:
-        for pattern in _AUTO_REPLY_LINE_RES:
-            if pattern.match(subject_line):
-                return JUNK_REASON_AUTO_REPLY
-        for pattern in _BOUNCE_LINE_RES:
-            if pattern.match(subject_line):
-                return JUNK_REASON_BOUNCE
     lines = [line.strip() for line in (body_lines or "").split("\n") if line.strip()]
     if lines:
         if _AUTO_REPLY_SUBJECT_RE.match(lines[0]):
@@ -173,6 +168,17 @@ def support_ticket_row_is_junk(
         for line in lines
     ):
         return None
+    # Machine assertions in the SUBJECT classify only once body voice has
+    # been heard: a machine-shaped subject with a real customer question in
+    # the body is a customer ticket.
+    subject_line = (subject or "").strip()
+    if subject_line:
+        for pattern in _AUTO_REPLY_LINE_RES:
+            if pattern.match(subject_line):
+                return JUNK_REASON_AUTO_REPLY
+        for pattern in _BOUNCE_LINE_RES:
+            if pattern.match(subject_line):
+                return JUNK_REASON_BOUNCE
     for line in lines:
         for pattern in _AUTO_REPLY_LINE_RES:
             if pattern.match(line):

--- a/extracted_content_pipeline/support_ticket_junk.py
+++ b/extracted_content_pipeline/support_ticket_junk.py
@@ -33,7 +33,7 @@ JUNK_REASONS = (
 # about the feature ("Out of office not working") does not carry it.
 _AUTO_REPLY_SUBJECT_RE = re.compile(
     r"^\s*(?:\[[^\]]{1,40}\]\s*)*"
-    r"(?:(?:subject|fw|fwd|re)\s*[:\uFF1A]\s*)*"
+    r"(?:subject\s*[:\uFF1A]\s*)?"
     r"(?:automatic\s+reply|auto[\s_-]*reply|autoreply|auto[\s_-]*response"
     r"|automated\s+(?:reply|response)|out\s+of\s+(?:the\s+)?office"
     r"|abwesenheitsnotiz|reponse\s+automatique)"
@@ -42,7 +42,7 @@ _AUTO_REPLY_SUBJECT_RE = re.compile(
 )
 _BOUNCE_SUBJECT_RE = re.compile(
     r"^\s*(?:\[[^\]]{1,40}\]\s*)*"
-    r"(?:(?:subject|fw|fwd|re)\s*[:\uFF1A]\s*)*"
+    r"(?:subject\s*[:\uFF1A]\s*)?"
     r"(?:(?:undeliverable|undelivered\s+mail|returned\s+mail"
     r"|failure\s+notice|mail\s+delivery\s+(?:failed|failure|subsystem))"
     r"\s*[:\uFF1A]"
@@ -60,7 +60,10 @@ _AUTO_REPLY_LINE_RES = (
         r"^i(?:\s+am|['\u2019]m|\s+will\s+be|['\u2019]ll\s+be)\s+"
         r"(?:currently\s+)?"
         r"(?:out\s+of\s+(?:the\s+)?office|away\s+from\s+(?:my\s+)?"
-        r"(?:desk|email|the\s+office)|on\s+(?:vacation|leave|holiday|pto))\b"
+        r"(?:desk|email|the\s+office)|on\s+(?:vacation|leave|holiday|pto))"
+        r"(?:\s*[.,!]|\s+(?:until|through|till|thru|from|starting"
+        r"|beginning|on|this|next|for|all|today|tomorrow|and|with(?:out)?"
+        r"|returning|back)\b)"
         r"[^?]*$",
         re.IGNORECASE,
     ),
@@ -145,21 +148,22 @@ def support_ticket_row_is_junk(
                 if _AUTO_REPLY_SUBJECT_RE.match(line):
                     return JUNK_REASON_AUTO_REPLY
                 return JUNK_REASON_BOUNCE
-    # Bounce assertions are machine statements: a DSN quoting the original
-    # (often interrogative) subject is still a bounce, so bounce lines
-    # classify BEFORE the question veto.
-    for line in lines:
-        for pattern in _BOUNCE_LINE_RES:
-            if pattern.match(line):
-                return JUNK_REASON_BOUNCE
-    if any("?" in line for line in lines):
-        # An interrogative anywhere means a customer is asking something;
-        # residual junk that quotes questions is quantified by diagnostics.
+    # Question VOICE is the discriminator: an UNLABELED question is the
+    # customer speaking (veto -- the row is a real ticket even if it quotes
+    # an OOO template or bounce text), while a "Subject:"-labeled question
+    # is machine mail quoting the customer's original subject and does not
+    # veto. Residual junk quoting questions is quantified by diagnostics.
+    if any(
+        "?" in line and not _SUBJECT_LABEL_RE.match(line) for line in lines
+    ):
         return None
     for line in lines:
         for pattern in _AUTO_REPLY_LINE_RES:
             if pattern.match(line):
                 return JUNK_REASON_AUTO_REPLY
+        for pattern in _BOUNCE_LINE_RES:
+            if pattern.match(line):
+                return JUNK_REASON_BOUNCE
     if had_source_text and not lines and not (subject or "").strip():
         return JUNK_REASON_NO_NEW_CONTENT
     return None

--- a/extracted_content_pipeline/support_ticket_junk.py
+++ b/extracted_content_pipeline/support_ticket_junk.py
@@ -33,6 +33,7 @@ JUNK_REASONS = (
 # about the feature ("Out of office not working") does not carry it.
 _AUTO_REPLY_SUBJECT_RE = re.compile(
     r"^\s*(?:\[[^\]]{1,40}\]\s*)*"
+    r"(?:(?:subject|fw|fwd|re)\s*[:\uFF1A]\s*)*"
     r"(?:automatic\s+reply|auto[\s_-]*reply|autoreply|auto[\s_-]*response"
     r"|automated\s+(?:reply|response)|out\s+of\s+(?:the\s+)?office"
     r"|abwesenheitsnotiz|reponse\s+automatique)"
@@ -41,11 +42,13 @@ _AUTO_REPLY_SUBJECT_RE = re.compile(
 )
 _BOUNCE_SUBJECT_RE = re.compile(
     r"^\s*(?:\[[^\]]{1,40}\]\s*)*"
+    r"(?:(?:subject|fw|fwd|re)\s*[:\uFF1A]\s*)*"
     r"(?:(?:undeliverable|undelivered\s+mail|returned\s+mail"
     r"|failure\s+notice|mail\s+delivery\s+(?:failed|failure|subsystem))"
     r"\s*[:\uFF1A]"
     r"|delivery\s+status\s+notification\s*(?:\([^)]*\))?\s*$"
-    r"|delivery\s+has\s+failed\s+to\s+these\s+recipients)",
+    r"|delivery\s+has\s+failed\s+to\s+these\s+recipients\s*"
+    r"(?:or\s+groups)?\s*[:.]?\s*$)",
     re.IGNORECASE,
 )
 
@@ -126,7 +129,9 @@ def support_ticket_row_is_junk(
             return JUNK_REASON_AUTO_REPLY
         if _BOUNCE_SUBJECT_RE.match(lines[0]):
             return JUNK_REASON_BOUNCE
-    if any(line.endswith("?") for line in lines):
+    if any("?" in line for line in lines):
+        # An interrogative anywhere means a customer is asking something;
+        # residual junk that quotes questions is quantified by diagnostics.
         return None
     for line in lines:
         for pattern in _AUTO_REPLY_LINE_RES:

--- a/extracted_content_pipeline/support_ticket_junk.py
+++ b/extracted_content_pipeline/support_ticket_junk.py
@@ -36,14 +36,16 @@ _AUTO_REPLY_SUBJECT_RE = re.compile(
     r"(?:automatic\s+reply|auto[\s_-]*reply|autoreply|auto[\s_-]*response"
     r"|automated\s+(?:reply|response)|out\s+of\s+(?:the\s+)?office"
     r"|abwesenheitsnotiz|reponse\s+automatique)"
-    r"\s*[:\(\[-]",
+    r"\s*[:\uFF1A]",
     re.IGNORECASE,
 )
 _BOUNCE_SUBJECT_RE = re.compile(
     r"^\s*(?:\[[^\]]{1,40}\]\s*)*"
-    r"(?:undeliverable|undelivered\s+mail|delivery\s+status\s+notification"
-    r"|mail\s+delivery\s+(?:failed|failure|subsystem)|returned\s+mail"
-    r"|failure\s+notice|delivery\s+has\s+failed)\b",
+    r"(?:(?:undeliverable|undelivered\s+mail|returned\s+mail"
+    r"|failure\s+notice|mail\s+delivery\s+(?:failed|failure|subsystem))"
+    r"\s*[:\uFF1A]"
+    r"|delivery\s+status\s+notification\s*(?:\([^)]*\))?\s*$"
+    r"|delivery\s+has\s+failed\s+to\s+these\s+recipients)",
     re.IGNORECASE,
 )
 
@@ -82,7 +84,7 @@ _AUTO_REPLY_LINE_RES = (
 _BOUNCE_LINE_RES = (
     re.compile(
         r"^(?:your\s+)?message\s+(?:could\s+not|couldn't|was\s+not|wasn't)\s+"
-        r"be?\s*delivered\b[^?]*$",
+        r"(?:be\s+)?delivered\b[^?]*$",
         re.IGNORECASE,
     ),
     re.compile(
@@ -101,10 +103,17 @@ def support_ticket_row_is_junk(
     """Classify a normalized row as junk, or return None to admit it.
 
     ``subject`` is the admitted title text; ``body_lines`` is the
-    line-preserving admitted body (``support_ticket_plain_text_lines``).
+    line-preserving admitted body (``support_ticket_plain_text_lines``),
+    including public comment text so comment-only rows are in scope.
     ``had_source_text`` marks rows whose raw source had text so that a body
     emptied by hygiene (an all-quote row) counts as no-new-content instead
     of being confused with a legitimately empty row.
+
+    A row containing ANY interrogative line is a customer asking something
+    -- quoted auto-reply templates inside a real question stay admitted --
+    so body-shape rules apply only to question-free rows. Generator subject
+    prefixes are definitive, and are also checked on the first body line
+    for exports that land the email subject in the text column.
     """
 
     if _AUTO_REPLY_SUBJECT_RE.match(subject or ""):
@@ -112,6 +121,13 @@ def support_ticket_row_is_junk(
     if _BOUNCE_SUBJECT_RE.match(subject or ""):
         return JUNK_REASON_BOUNCE
     lines = [line.strip() for line in (body_lines or "").split("\n") if line.strip()]
+    if lines:
+        if _AUTO_REPLY_SUBJECT_RE.match(lines[0]):
+            return JUNK_REASON_AUTO_REPLY
+        if _BOUNCE_SUBJECT_RE.match(lines[0]):
+            return JUNK_REASON_BOUNCE
+    if any(line.endswith("?") for line in lines):
+        return None
     for line in lines:
         for pattern in _AUTO_REPLY_LINE_RES:
             if pattern.match(line):

--- a/extracted_content_pipeline/support_ticket_junk.py
+++ b/extracted_content_pipeline/support_ticket_junk.py
@@ -1,0 +1,133 @@
+"""Support-ticket junk/auto-reply admission gate (S6E, F2).
+
+Design: closed structural rules, not phrase enumeration.
+
+Machine-generated mail betrays itself by POSITION and SHAPE, not vocabulary:
+auto-replies and bounces carry a generator prefix in the subject
+("Automatic reply: ...", "Undeliverable: ..."), and out-of-office bodies are
+first-person ASSERTIONS occupying whole lines ("I am out of the office
+until Monday."). Customer text ABOUT those features is interrogative or
+descriptive ("How do I set an out of office auto-reply?", "Out of office
+not working") and matches neither shape, so it passes.
+
+The gate returns a bounded reason code so diagnostics report counts, never
+content.
+"""
+
+from __future__ import annotations
+
+import re
+
+JUNK_REASON_AUTO_REPLY = "auto_reply"
+JUNK_REASON_BOUNCE = "bounce"
+JUNK_REASON_NO_NEW_CONTENT = "no_new_content"
+
+JUNK_REASONS = (
+    JUNK_REASON_AUTO_REPLY,
+    JUNK_REASON_BOUNCE,
+    JUNK_REASON_NO_NEW_CONTENT,
+)
+
+# Subject prefixes mail software prepends to generated messages. The
+# trailing colon/bracket position is the discriminator: a HUMAN subject
+# about the feature ("Out of office not working") does not carry it.
+_AUTO_REPLY_SUBJECT_RE = re.compile(
+    r"^\s*(?:\[[^\]]{1,40}\]\s*)*"
+    r"(?:automatic\s+reply|auto[\s_-]*reply|autoreply|auto[\s_-]*response"
+    r"|automated\s+(?:reply|response)|out\s+of\s+(?:the\s+)?office"
+    r"|abwesenheitsnotiz|reponse\s+automatique)"
+    r"\s*[:\(\[-]",
+    re.IGNORECASE,
+)
+_BOUNCE_SUBJECT_RE = re.compile(
+    r"^\s*(?:\[[^\]]{1,40}\]\s*)*"
+    r"(?:undeliverable|undelivered\s+mail|delivery\s+status\s+notification"
+    r"|mail\s+delivery\s+(?:failed|failure|subsystem)|returned\s+mail"
+    r"|failure\s+notice|delivery\s+has\s+failed)\b",
+    re.IGNORECASE,
+)
+
+# First-person out-of-office / automated-sender assertions, matched as
+# WHOLE admitted lines. Questions and feature discussions are not
+# first-person assertions and never match these anchored shapes.
+_AUTO_REPLY_LINE_RES = (
+    re.compile(
+        r"^i\s+(?:am|will\s+be)\s+(?:currently\s+)?"
+        r"(?:out\s+of\s+(?:the\s+)?office|away\s+from\s+(?:my\s+)?"
+        r"(?:desk|email|the\s+office)|on\s+(?:vacation|leave|holiday|pto))\b"
+        r"[^?]*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^i\s+(?:will\s+)?have\s+(?:limited|no)\s+access\s+to\s+"
+        r"(?:my\s+)?e?mail\b[^?]*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^this\s+is\s+an\s+automat(?:ed|ic)\s+"
+        r"(?:reply|response|message|notification)\b[^?]*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^(?:please\s+)?do\s+not\s+reply\s+to\s+this\s+"
+        r"(?:automated\s+)?(?:email|message)\b[^?]*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^i\s+(?:will\s+)?(?:be\s+)?return(?:ing)?\s+"
+        r"(?:to\s+the\s+office\s+)?on\s+\S+[^?]*$",
+        re.IGNORECASE,
+    ),
+)
+_BOUNCE_LINE_RES = (
+    re.compile(
+        r"^(?:your\s+)?message\s+(?:could\s+not|couldn't|was\s+not|wasn't)\s+"
+        r"be?\s*delivered\b[^?]*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^delivery\s+to\s+the\s+following\s+recipients?\s+failed\b[^?]*$",
+        re.IGNORECASE,
+    ),
+)
+
+
+def support_ticket_row_is_junk(
+    subject: str,
+    body_lines: str,
+    *,
+    had_source_text: bool = False,
+) -> str | None:
+    """Classify a normalized row as junk, or return None to admit it.
+
+    ``subject`` is the admitted title text; ``body_lines`` is the
+    line-preserving admitted body (``support_ticket_plain_text_lines``).
+    ``had_source_text`` marks rows whose raw source had text so that a body
+    emptied by hygiene (an all-quote row) counts as no-new-content instead
+    of being confused with a legitimately empty row.
+    """
+
+    if _AUTO_REPLY_SUBJECT_RE.match(subject or ""):
+        return JUNK_REASON_AUTO_REPLY
+    if _BOUNCE_SUBJECT_RE.match(subject or ""):
+        return JUNK_REASON_BOUNCE
+    lines = [line.strip() for line in (body_lines or "").split("\n") if line.strip()]
+    for line in lines:
+        for pattern in _AUTO_REPLY_LINE_RES:
+            if pattern.match(line):
+                return JUNK_REASON_AUTO_REPLY
+        for pattern in _BOUNCE_LINE_RES:
+            if pattern.match(line):
+                return JUNK_REASON_BOUNCE
+    if had_source_text and not lines and not (subject or "").strip():
+        return JUNK_REASON_NO_NEW_CONTENT
+    return None
+
+
+__all__ = [
+    "JUNK_REASONS",
+    "JUNK_REASON_AUTO_REPLY",
+    "JUNK_REASON_BOUNCE",
+    "JUNK_REASON_NO_NEW_CONTENT",
+    "support_ticket_row_is_junk",
+]

--- a/extracted_content_pipeline/support_ticket_junk.py
+++ b/extracted_content_pipeline/support_ticket_junk.py
@@ -145,6 +145,13 @@ def support_ticket_row_is_junk(
                 if _AUTO_REPLY_SUBJECT_RE.match(line):
                     return JUNK_REASON_AUTO_REPLY
                 return JUNK_REASON_BOUNCE
+    # Bounce assertions are machine statements: a DSN quoting the original
+    # (often interrogative) subject is still a bounce, so bounce lines
+    # classify BEFORE the question veto.
+    for line in lines:
+        for pattern in _BOUNCE_LINE_RES:
+            if pattern.match(line):
+                return JUNK_REASON_BOUNCE
     if any("?" in line for line in lines):
         # An interrogative anywhere means a customer is asking something;
         # residual junk that quotes questions is quantified by diagnostics.
@@ -153,9 +160,6 @@ def support_ticket_row_is_junk(
         for pattern in _AUTO_REPLY_LINE_RES:
             if pattern.match(line):
                 return JUNK_REASON_AUTO_REPLY
-        for pattern in _BOUNCE_LINE_RES:
-            if pattern.match(line):
-                return JUNK_REASON_BOUNCE
     if had_source_text and not lines and not (subject or "").strip():
         return JUNK_REASON_NO_NEW_CONTENT
     return None

--- a/extracted_content_pipeline/support_ticket_junk.py
+++ b/extracted_content_pipeline/support_ticket_junk.py
@@ -61,10 +61,10 @@ _AUTO_REPLY_LINE_RES = (
         r"(?:currently\s+)?"
         r"(?:out\s+of\s+(?:the\s+)?office|away\s+from\s+(?:my\s+)?"
         r"(?:desk|email|the\s+office)|on\s+(?:vacation|leave|holiday|pto))"
-        r"(?:\s*[.,!]|\s+(?:until|through|till|thru|from|starting"
-        r"|beginning|on|this|next|for|all|today|tomorrow|and|with(?:out)?"
-        r"|returning|back)\b)"
-        r"[^?]*$",
+        r"(?:\s*[.!]?\s*$|\s+(?:until|through|till|thru|from|starting"
+        r"|beginning|on|this|next|for|all|today|tomorrow|with(?:out)?"
+        r"|returning|back"
+        r"|and\s+(?:will|won'?t|shall|cannot|can'?t|may))\b[^?]*$)",
         re.IGNORECASE,
     ),
     re.compile(
@@ -90,6 +90,7 @@ _AUTO_REPLY_LINE_RES = (
     ),
 )
 _SUBJECT_LABEL_RE = re.compile(r"^\s*subject\s*[:\uFF1A]", re.IGNORECASE)
+_HEADER_LINE_RE = re.compile(r"^[a-z][a-z0-9-]*\s*[:\uFF1A]\s", re.IGNORECASE)
 
 _BOUNCE_LINE_RES = (
     re.compile(
@@ -130,6 +131,14 @@ def support_ticket_row_is_junk(
         return JUNK_REASON_AUTO_REPLY
     if _BOUNCE_SUBJECT_RE.match(subject or ""):
         return JUNK_REASON_BOUNCE
+    subject_line = (subject or "").strip()
+    if subject_line:
+        for pattern in _AUTO_REPLY_LINE_RES:
+            if pattern.match(subject_line):
+                return JUNK_REASON_AUTO_REPLY
+        for pattern in _BOUNCE_LINE_RES:
+            if pattern.match(subject_line):
+                return JUNK_REASON_BOUNCE
     lines = [line.strip() for line in (body_lines or "").split("\n") if line.strip()]
     if lines:
         if _AUTO_REPLY_SUBJECT_RE.match(lines[0]):
@@ -137,10 +146,15 @@ def support_ticket_row_is_junk(
         if _BOUNCE_SUBJECT_RE.match(lines[0]):
             return JUNK_REASON_BOUNCE
         # Text exports often carry a leading header block (From:/To:/
-        # Subject:); a Subject:-labeled generator prefix anywhere in it is
-        # definitive. Unlabeled prefixes stay first-line-only so quoted
-        # replies deeper in a body cannot junk the row.
-        for line in lines[1:5]:
+        # Subject:); a Subject:-labeled generator prefix inside it is
+        # definitive -- but only while every preceding line is
+        # header-shaped, so customer prose mentioning "Subject: ..." never
+        # junks a row. Unlabeled prefixes stay first-line-only.
+        for index, line in enumerate(lines[1:5], start=1):
+            if not all(
+                _HEADER_LINE_RE.match(previous) for previous in lines[:index]
+            ):
+                break
             if _SUBJECT_LABEL_RE.match(line) and (
                 _AUTO_REPLY_SUBJECT_RE.match(line)
                 or _BOUNCE_SUBJECT_RE.match(line)
@@ -154,7 +168,9 @@ def support_ticket_row_is_junk(
     # is machine mail quoting the customer's original subject and does not
     # veto. Residual junk quoting questions is quantified by diagnostics.
     if any(
-        "?" in line and not _SUBJECT_LABEL_RE.match(line) for line in lines
+        _line_has_customer_question(line)
+        and not _SUBJECT_LABEL_RE.match(line)
+        for line in lines
     ):
         return None
     for line in lines:
@@ -167,6 +183,18 @@ def support_ticket_row_is_junk(
     if had_source_text and not lines and not (subject or "").strip():
         return JUNK_REASON_NO_NEW_CONTENT
     return None
+
+
+def _line_has_customer_question(line: str) -> bool:
+    """A '?' counts as customer voice only outside URL tokens."""
+
+    for token in line.split():
+        if "?" not in token:
+            continue
+        if "://" in token or token.lower().startswith("www."):
+            continue
+        return True
+    return False
 
 
 __all__ = [

--- a/extracted_content_pipeline/support_ticket_junk.py
+++ b/extracted_content_pipeline/support_ticket_junk.py
@@ -57,7 +57,8 @@ _BOUNCE_SUBJECT_RE = re.compile(
 # first-person assertions and never match these anchored shapes.
 _AUTO_REPLY_LINE_RES = (
     re.compile(
-        r"^i\s+(?:am|will\s+be)\s+(?:currently\s+)?"
+        r"^i(?:\s+am|['\u2019]m|\s+will\s+be|['\u2019]ll\s+be)\s+"
+        r"(?:currently\s+)?"
         r"(?:out\s+of\s+(?:the\s+)?office|away\s+from\s+(?:my\s+)?"
         r"(?:desk|email|the\s+office)|on\s+(?:vacation|leave|holiday|pto))\b"
         r"[^?]*$",
@@ -80,10 +81,13 @@ _AUTO_REPLY_LINE_RES = (
     ),
     re.compile(
         r"^i\s+(?:will\s+)?(?:be\s+)?return(?:ing)?\s+"
-        r"(?:to\s+the\s+office\s+)?on\s+\S+[^?]*$",
+        r"(?:to\s+the\s+office|from\s+(?:leave|vacation|holiday|pto))\s+"
+        r"on\s+\S+[^?]*$",
         re.IGNORECASE,
     ),
 )
+_SUBJECT_LABEL_RE = re.compile(r"^\s*subject\s*[:\uFF1A]", re.IGNORECASE)
+
 _BOUNCE_LINE_RES = (
     re.compile(
         r"^(?:your\s+)?message\s+(?:could\s+not|couldn't|was\s+not|wasn't)\s+"
@@ -129,6 +133,18 @@ def support_ticket_row_is_junk(
             return JUNK_REASON_AUTO_REPLY
         if _BOUNCE_SUBJECT_RE.match(lines[0]):
             return JUNK_REASON_BOUNCE
+        # Text exports often carry a leading header block (From:/To:/
+        # Subject:); a Subject:-labeled generator prefix anywhere in it is
+        # definitive. Unlabeled prefixes stay first-line-only so quoted
+        # replies deeper in a body cannot junk the row.
+        for line in lines[1:5]:
+            if _SUBJECT_LABEL_RE.match(line) and (
+                _AUTO_REPLY_SUBJECT_RE.match(line)
+                or _BOUNCE_SUBJECT_RE.match(line)
+            ):
+                if _AUTO_REPLY_SUBJECT_RE.match(line):
+                    return JUNK_REASON_AUTO_REPLY
+                return JUNK_REASON_BOUNCE
     if any("?" in line for line in lines):
         # An interrogative anywhere means a customer is asking something;
         # residual junk that quotes questions is quantified by diagnostics.

--- a/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
+++ b/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
@@ -98,6 +98,18 @@ assertions classify BEFORE the question veto -- a DSN quoting the original
 interrogative subject is still a bounce; customer questions about bounces
 still pass.
 
+Round-5 refinements (all four verified failing first; rounds 4-5 demanded
+opposite verdicts on adjacent bounce/question shapes, dissolved by ONE rule):
+question VOICE is the discriminator -- an UNLABELED question is the customer
+speaking and vetoes body-shape junk (mixed troubleshooting/template tickets
+admit), while a "Subject:"-labeled question is machine mail quoting the
+customer's original subject and does not veto (DSNs and OOO bodies quoting
+the original subject classify). Also: OOO assertions require a temporal/
+access/punctuation continuation so descriptive feature reports ("I am out of
+the office auto-reply setting is not working") admit; re/fw labels removed
+from generator-subject tolerance so customer replies to auto-reply subjects
+admit (only the "Subject:" header label remains).
+
 Review-loop guard (the #2053 lesson): if review exceeds ~3 rounds of novel
 junk-PHRASING probes, residuals are class-waived against this closed-rule
 contract (structural position/shape rules; vocabulary is deliberately not
@@ -207,9 +219,9 @@ into `junk_excluded_counts`, drops the rows before clustering, and reports
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 4 |
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 61 |
-| `extracted_content_pipeline/support_ticket_junk.py` | 174 |
-| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 215 |
+| `extracted_content_pipeline/support_ticket_junk.py` | 178 |
+| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 227 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 28 |
-| `tests/test_support_ticket_junk.py` | 328 |
-| **Total** | **814** |
+| `tests/test_support_ticket_junk.py` | 362 |
+| **Total** | **864** |

--- a/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
+++ b/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
@@ -93,6 +93,11 @@ while unlabeled prefixes stay first-line-only so deep quoted replies cannot
 junk a row. The review-loop cap is now REACHED: further phrasing-only probes
 are class-waived per the guard below.
 
+Round-4 refinement (structural ordering, verified failing first): bounce
+assertions classify BEFORE the question veto -- a DSN quoting the original
+interrogative subject is still a bounce; customer questions about bounces
+still pass.
+
 Review-loop guard (the #2053 lesson): if review exceeds ~3 rounds of novel
 junk-PHRASING probes, residuals are class-waived against this closed-rule
 contract (structural position/shape rules; vocabulary is deliberately not
@@ -202,9 +207,9 @@ into `junk_excluded_counts`, drops the rows before clustering, and reports
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 4 |
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 61 |
-| `extracted_content_pipeline/support_ticket_junk.py` | 170 |
-| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 210 |
+| `extracted_content_pipeline/support_ticket_junk.py` | 174 |
+| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 215 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 28 |
-| `tests/test_support_ticket_junk.py` | 310 |
-| **Total** | **787** |
+| `tests/test_support_ticket_junk.py` | 328 |
+| **Total** | **814** |

--- a/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
+++ b/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
@@ -1,0 +1,173 @@
+# PR-Resolution-Audit-S6E-Junk-Gate
+
+Ownership lane: resolution-audit-csv
+
+## Why this slice exists
+
+Issue #2049 (S6E), parent #1993, launch blocker #5 (F2). The audit's live run
+proved: 5 real "reset my password" tickets + 6 identical "Automatic reply:
+Out of Office" rows produce a JUNK cluster ranked #1 with `ticket_count=6`,
+owning the top priority-fix/drafted-resolution recommendation and inflating
+the headline support tax by ~2x (F2, `docs/audits/resolution-audit-csv/FINDINGS.md`).
+No junk gate exists anywhere before a ticket counts toward a billed cluster,
+and S5's semantic clustering makes byte-identical junk cluster TIGHTER, so
+the fix must be admission-side, upstream of clustering, at the same boundary
+S6A guards. The original repro fixture lives in gitignored `_audit_scratch/`,
+so this slice commits an equivalent F2 acceptance test.
+
+### Problem-derived contract
+
+- Root cause: no spam/auto-reply gate before a ticket counts toward a billed
+  cluster; machine-generated rows (auto-replies, out-of-office, delivery
+  bounces) are admitted as customer evidence and form billed clusters.
+- Correct fix must touch/change:
+  1. New owned module `extracted_content_pipeline/support_ticket_junk.py`
+     (stdlib-only, mirrors `support_ticket_privacy.py`):
+     `support_ticket_row_is_junk(subject, body_lines, had_source_text)`
+     returning a bounded reason code (`auto_reply` | `bounce` |
+     `no_new_content`) or None. Closed STRUCTURAL rules, not phrase
+     enumeration: machine-generated mail betrays itself by position and
+     shape -- (a) generator SUBJECT PREFIX forms with the trailing
+     colon/bracket position as the discriminator ("Automatic reply:",
+     "Out of Office:", "Undeliverable:", delivery-status families, optional
+     leading [EXT]-style brackets); (b) FIRST-PERSON assertion shapes matched
+     as whole admitted lines on the S6B line seam ("I am out of the office
+     until...", "This is an automated response...", never ending in "?");
+     (c) `no_new_content` for rows whose admitted text empties under line
+     hygiene with no subject content.
+  2. Gate wired in `_normalize_ticket_row` after text admission (beside the
+     S6A privacy check), returning a `_junk_reason` marker the caller counts
+     and drops before clustering.
+  3. Diagnostics: `junk_excluded_count` + `junk_excluded_reasons` in package
+     METADATA (the `source_id_fallback_count` surface) plus a
+     `support_ticket_junk_excluded` warning -- counts, never content.
+  4. Tests: the rebuilt F2 acceptance shape through the real
+     `build_support_ticket_input_package` (junk forms no cluster, 5 real rows
+     admitted, diagnostics = 6 auto_reply); BOTH error directions (customer
+     tickets ABOUT auto-reply/out-of-office features -- "How do I set an out
+     of office auto-reply?", "Out of office not working" -- provably pass);
+     generator-subject and assertion-line classes parametrized; bounces;
+     all-quote/no-content rows; row accounting still sums; CI enrollment in
+     the same PR.
+- Must not change:
+  - Privacy admission (`support_ticket_privacy.py`, S6A).
+  - The S6B extractor/scanner (`support_ticket_clustering.py`) -- this slice
+    CONSUMES `support_ticket_plain_text_lines`, its first runtime consumer.
+  - Clustering thresholds/semantics (S5).
+  - Evidence-tier/status logic (S6D #2045 / M9 #2050).
+  - Product shape: no new report fields; diagnostics are operator-facing
+    metadata/warnings only.
+  - Final-output scrubber grammar.
+  - Zendesk `_AUTO_ACK_PATTERNS` (comment-level auto-ack filtering; separate
+    concern, untouched).
+
+Review-loop guard (the #2053 lesson): if review exceeds ~3 rounds of novel
+junk-PHRASING probes, residuals are class-waived against this closed-rule
+contract (structural position/shape rules; vocabulary is deliberately not
+enumerable) rather than extended per spelling.
+
+## Scope (this PR)
+
+Slice phase: Vertical slice
+
+Max files: 7
+
+1. `extracted_content_pipeline/support_ticket_junk.py` -- the gate module.
+2. `extracted_content_pipeline/support_ticket_input_package.py` -- wiring +
+   diagnostics (imports, `_normalize_ticket_row` check, caller counting,
+   metadata + warning).
+3. `extracted_content_pipeline/manifest.json` -- owned-file registration.
+4. `tests/test_support_ticket_junk.py` -- F2 acceptance + class tests.
+5. `scripts/run_extracted_pipeline_checks.sh` -- CI enrollment, same PR.
+6. `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` --
+   tracker discipline: S6B #2053 ticked merged; ledger row 5 marked in
+   progress with this slice.
+7. This plan doc.
+
+### Files touched
+
+- `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `extracted_content_pipeline/support_ticket_junk.py`
+- `plans/PR-Resolution-Audit-S6E-Junk-Gate.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_support_ticket_junk.py`
+
+### Review Contract
+
+Acceptance criteria:
+1. The F2 shape (5 real + 6 identical OOO auto-replies) yields NO junk
+   cluster, 5 admitted rows, and `junk_excluded_reasons == {"auto_reply": 6}`
+   through the real package builder.
+2. Customer tickets about auto-reply/out-of-office features are admitted
+   (both cited shapes pass; question/description forms never match the
+   first-person assertion patterns).
+3. Diagnostics expose counts and bounded reason codes, never row content.
+4. Row accounting still sums (included + skipped == source rows).
+5. The gate runs at row admission, upstream of clustering, beside S6A.
+
+Reachability proof: wired into `_normalize_ticket_row` on the live
+`build_support_ticket_input_package` path -- the F2 acceptance test exercises
+the real builder end-to-end and asserts cluster output, not just the
+predicate. This is also the first runtime consumer of the S6B line seam.
+
+Affected surfaces: support-ticket row admission feeding clustering, evidence,
+and report generation; package metadata/warnings diagnostics.
+
+Risk areas: over-exclusion of real tickets mentioning auto-reply features
+(guarded by assertion-shape rules + both-direction tests); junk vocabulary
+gaps (bounded by the closed-rule contract; residual junk is quantified by
+diagnostics).
+
+Reviewer rules triggered: R1, R2, R10, R14 (extracted package change; test evidence; guard behavior; parser admission rule probed both directions).
+
+## Mechanism
+
+`support_ticket_row_is_junk` classifies by structure: subject generator
+prefixes (colon/bracket position), first-person whole-line assertions on the
+line-preserving body, and empty-after-hygiene rows. `_normalize_ticket_row`
+returns a `{"_junk_reason": code}` marker; the package builder counts reasons
+into `junk_excluded_counts`, drops the rows before clustering, and reports
+`junk_excluded_count`/`junk_excluded_reasons` in metadata plus one warning.
+
+## Intentional
+
+- Admission-side gate (upstream of clustering), not a cluster-side filter:
+  fixes the root (junk counts toward billed evidence) rather than hiding the
+  symptom cluster.
+- Structural rules over vocabulary: subject-prefix POSITION and
+  first-person-assertion SHAPE are closed classes; junk phrasing is not.
+- `no_new_content` fires only for empty-subject rows emptied by hygiene;
+  subject-only rows stay admitted (S6D owns subject-only evidence semantics).
+- Reasons are a bounded enum; diagnostics never carry content.
+
+## Deferred
+
+- S6C (#2044) scalar-history state machine; S6D (#2045) evidence tier; M9
+  (#2050) status synonyms; S8a/S8b (#2051/#2052) runtime scorecard + money
+  guard.
+- Any junk-vocabulary extension beyond the structural classes (class-waived
+  per the review-loop guard unless a structural gap is shown).
+
+## Verification
+
+- `python -m pytest tests/test_support_ticket_junk.py -q` (23 passed)
+- Full CI mirror scripts/run_extracted_pipeline_checks.sh (5864 passed, 21
+  skipped)
+- scripts/validate_extracted_content_pipeline.sh (mapped files match)
+- F2 acceptance verified live before tests: junk cluster absent, 6 excluded
+  with reason auto_reply, feature questions admitted.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 4 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 31 |
+| `extracted_content_pipeline/support_ticket_junk.py` | 133 |
+| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 175 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_support_ticket_junk.py` | 171 |
+| **Total** | **518** |

--- a/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
+++ b/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
@@ -72,6 +72,17 @@ admitted); any interrogative line vetoes body-shape junk so mixed tickets
 quoting a template stay admitted; generator prefixes are also checked on
 the first body line for subject-in-text exports.
 
+Round-2 review refinements (all four verified failing first): a question
+ANYWHERE in a line vetoes body-shape junk ("Why is it not sending? Thanks");
+comments reach the gate line-preserved per raw comment (`_raw_comment_texts`)
+instead of pre-compacted, so multiline comment-only auto-replies classify;
+the delivery-has-failed subject branch is anchored to the exact DSN sentence
+so customer prose stays admitted; labeled subject lines
+("Subject: Automatic reply: ...") in text exports classify. The
+maturity-sweep ratchet's new-file finding is accepted via its documented
+baseline flow: the module scores on regex density, and its behavior is
+pinned by 34 both-direction tests.
+
 Review-loop guard (the #2053 lesson): if review exceeds ~3 rounds of novel
 junk-PHRASING probes, residuals are class-waived against this closed-rule
 contract (structural position/shape rules; vocabulary is deliberately not
@@ -81,7 +92,7 @@ enumerable) rather than extended per spelling.
 
 Slice phase: Vertical slice
 
-Max files: 7
+Max files: 8
 
 1. `extracted_content_pipeline/support_ticket_junk.py` -- the gate module.
 2. `extracted_content_pipeline/support_ticket_input_package.py` -- wiring +
@@ -93,7 +104,10 @@ Max files: 7
 6. `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` --
    tracker discipline: S6B #2053 ticked merged; ledger row 5 marked in
    progress with this slice.
-7. This plan doc.
+7. `tests/maturity_sweep/baseline_extracted_content_pipeline.json` --
+   ratchet acceptance for the new module via the sweep's documented
+   baseline flow.
+8. This plan doc.
 
 ### Files touched
 
@@ -103,6 +117,7 @@ Max files: 7
 - `extracted_content_pipeline/support_ticket_junk.py`
 - `plans/PR-Resolution-Audit-S6E-Junk-Gate.md`
 - `scripts/run_extracted_pipeline_checks.sh`
+- `tests/maturity_sweep/baseline_extracted_content_pipeline.json`
 - `tests/test_support_ticket_junk.py`
 
 ### Review Contract
@@ -176,9 +191,10 @@ into `junk_excluded_counts`, drops the rows before clustering, and reports
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 4 |
 | `extracted_content_pipeline/manifest.json` | 3 |
-| `extracted_content_pipeline/support_ticket_input_package.py` | 40 |
-| `extracted_content_pipeline/support_ticket_junk.py` | 149 |
-| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 184 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 61 |
+| `extracted_content_pipeline/support_ticket_junk.py` | 154 |
+| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 200 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_junk.py` | 231 |
-| **Total** | **612** |
+| `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 28 |
+| `tests/test_support_ticket_junk.py` | 269 |
+| **Total** | **720** |

--- a/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
+++ b/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
@@ -83,6 +83,16 @@ maturity-sweep ratchet's new-file finding is accepted via its documented
 baseline flow: the module scores on regex density, and its behavior is
 pinned by 34 both-direction tests.
 
+Round-3 review refinements (all three verified failing first; shape
+corrections, not phrasing probes): contracted first-person forms (I'm /
+I'll be) join the same assertion shape; return-on-date lines require office/
+leave context so real evidence ("I will return on Tuesday with the debug
+logs") stays admitted; Subject:-labeled generator prefixes are scanned in
+the leading header block (first 5 lines) for header-order text exports,
+while unlabeled prefixes stay first-line-only so deep quoted replies cannot
+junk a row. The review-loop cap is now REACHED: further phrasing-only probes
+are class-waived per the guard below.
+
 Review-loop guard (the #2053 lesson): if review exceeds ~3 rounds of novel
 junk-PHRASING probes, residuals are class-waived against this closed-rule
 contract (structural position/shape rules; vocabulary is deliberately not
@@ -192,9 +202,9 @@ into `junk_excluded_counts`, drops the rows before clustering, and reports
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 4 |
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 61 |
-| `extracted_content_pipeline/support_ticket_junk.py` | 154 |
-| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 200 |
+| `extracted_content_pipeline/support_ticket_junk.py` | 170 |
+| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 210 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 28 |
-| `tests/test_support_ticket_junk.py` | 269 |
-| **Total** | **720** |
+| `tests/test_support_ticket_junk.py` | 310 |
+| **Total** | **787** |

--- a/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
+++ b/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
@@ -110,6 +110,20 @@ the office auto-reply setting is not working") admit; re/fw labels removed
 from generator-subject tolerance so customer replies to auto-reply subjects
 admit (only the "Subject:" header label remains).
 
+Round-6 (4 fixed, 1 waived): OOO continuations are bounded (temporal/access
+words, end punctuation, or 'and'+modal -- 'and will respond' continues the
+assertion while 'and the auto-reply is broken' is a customer report); URL
+query strings do not count as customer questions; machine assertions in the
+SUBJECT classify subject-only rows; the header-block Subject: scan requires
+every preceding line to be header-shaped so customer prose mentioning
+'Subject: ...' never junks a row. WAIVED (undecidable voice, per the guard
+below): a mixed template ticket whose customer context is IMPERATIVE rather
+than interrogative ('Template we configured: ... Please fix this
+auto-reply.') classifies as junk -- it is structurally identical to the
+greeting-wrapped machine OOO ('Hello, / I am out... / Best, / Bob') that
+must classify, imperative-vs-redirect verb discrimination is content
+judgment, and the fail direction is quantified in junk_excluded_reasons.
+
 Review-loop guard (the #2053 lesson): if review exceeds ~3 rounds of novel
 junk-PHRASING probes, residuals are class-waived against this closed-rule
 contract (structural position/shape rules; vocabulary is deliberately not
@@ -219,9 +233,9 @@ into `junk_excluded_counts`, drops the rows before clustering, and reports
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 4 |
 | `extracted_content_pipeline/manifest.json` | 3 |
 | `extracted_content_pipeline/support_ticket_input_package.py` | 61 |
-| `extracted_content_pipeline/support_ticket_junk.py` | 178 |
-| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 227 |
+| `extracted_content_pipeline/support_ticket_junk.py` | 206 |
+| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 241 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 28 |
-| `tests/test_support_ticket_junk.py` | 362 |
-| **Total** | **864** |
+| `tests/test_support_ticket_junk.py` | 401 |
+| **Total** | **945** |

--- a/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
+++ b/plans/PR-Resolution-Audit-S6E-Junk-Gate.md
@@ -61,6 +61,17 @@ so this slice commits an equivalent F2 acceptance test.
   - Zendesk `_AUTO_ACK_PATTERNS` (comment-level auto-ack filtering; separate
     concern, untouched).
 
+Round-1 review refinements (all six verified failing first; correctness
+gaps, not phrasing probes): comment-only rows join the gate's body input
+(public comment text was admitted by `_ticket_text` but invisible to the
+gate); the was-not-delivered bounce line matches (`(?:be\s+)?` was
+mandatory); generator delimiters are colon-only so customer separators
+("Out of office - not working") stay admitted; bounce subjects need their
+generator delimiter ("Undeliverable emails are not reaching customers"
+admitted); any interrogative line vetoes body-shape junk so mixed tickets
+quoting a template stay admitted; generator prefixes are also checked on
+the first body line for subject-in-text exports.
+
 Review-loop guard (the #2053 lesson): if review exceeds ~3 rounds of novel
 junk-PHRASING probes, residuals are class-waived against this closed-rule
 contract (structural position/shape rules; vocabulary is deliberately not
@@ -165,9 +176,9 @@ into `junk_excluded_counts`, drops the rows before clustering, and reports
 |---|---:|
 | `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 4 |
 | `extracted_content_pipeline/manifest.json` | 3 |
-| `extracted_content_pipeline/support_ticket_input_package.py` | 31 |
-| `extracted_content_pipeline/support_ticket_junk.py` | 133 |
-| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 175 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 40 |
+| `extracted_content_pipeline/support_ticket_junk.py` | 149 |
+| `plans/PR-Resolution-Audit-S6E-Junk-Gate.md` | 184 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
-| `tests/test_support_ticket_junk.py` | 171 |
-| **Total** | **518** |
+| `tests/test_support_ticket_junk.py` | 231 |
+| **Total** | **612** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -141,6 +141,7 @@ pytest \
   tests/test_support_ticket_privacy.py \
   tests/test_support_ticket_privacy_sweep.py \
   tests/test_support_ticket_plain_text_lines.py \
+  tests/test_support_ticket_junk.py \
   tests/test_resolution_audit_s5_clustering_spike.py \
   tests/test_extracted_support_ticket_input_package.py \
   tests/test_extracted_support_ticket_zendesk_export.py \

--- a/tests/maturity_sweep/baseline_extracted_content_pipeline.json
+++ b/tests/maturity_sweep/baseline_extracted_content_pipeline.json
@@ -894,13 +894,6 @@
     },
     "score": 4
   },
-  "extracted_content_pipeline/storage/models.py": {
-    "counts": {
-      "HAPPY_PATH_TESTS": 1,
-      "NO_RAISES_TESTS": 1
-    },
-    "score": 7
-  },
   "extracted_content_pipeline/storage/repositories/scheduled_task.py": {
     "counts": {
       "INTERNAL_MOCK": 1
@@ -939,13 +932,26 @@
   },
   "extracted_content_pipeline/support_ticket_input_package.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1,
       "HEURISTIC_COMMENT": 2,
-      "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 1
     },
-    "score": 16
+    "score": 9
+  },
+  "extracted_content_pipeline/support_ticket_junk.py": {
+    "counts": {
+      "HAPPY_PATH_TESTS": 1,
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 11
+  },
+  "extracted_content_pipeline/support_ticket_privacy.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "UNGUARDED_INDEX": 2
+    },
+    "score": 7
   },
   "extracted_content_pipeline/text_truncate.py": {
     "counts": {
@@ -963,7 +969,7 @@
   "extracted_content_pipeline/ticket_faq_markdown.py": {
     "counts": {
       "SWALLOWED_EXCEPT": 2,
-      "UNGUARDED_INDEX": 32
+      "UNGUARDED_INDEX": 33
     },
     "score": 16
   },

--- a/tests/test_support_ticket_junk.py
+++ b/tests/test_support_ticket_junk.py
@@ -326,3 +326,37 @@ def test_customer_question_about_bounces_still_passes() -> None:
         "Bounce troubleshooting",
         "Why do my customers see Your message could not be delivered?",
     ) is None
+
+
+# Round-5 refinements: first-line assertion precedence, temporal OOO tails,
+# and reply-label narrowing.
+
+
+def test_leading_assertion_beats_quoted_question() -> None:
+    assert support_ticket_row_is_junk(
+        "Re: something",
+        "I am out of the office until Monday.\nSubject: Why can't I login?",
+    ) == JUNK_REASON_AUTO_REPLY
+
+
+def test_customer_context_before_bounce_line_is_admitted() -> None:
+    assert support_ticket_row_is_junk(
+        "Email issue",
+        "Customer reports seeing this error:\n"
+        "Your message could not be delivered to the recipient.\n"
+        "How do we fix this?",
+    ) is None
+
+
+def test_descriptive_ooo_feature_report_is_admitted() -> None:
+    assert support_ticket_row_is_junk(
+        "Settings issue",
+        "I am out of the office auto-reply setting is not working",
+    ) is None
+
+
+def test_customer_reply_to_auto_reply_subject_is_admitted() -> None:
+    assert support_ticket_row_is_junk(
+        "Re: Automatic reply: Out of Office",
+        "Why is my auto-reply not sending?",
+    ) is None

--- a/tests/test_support_ticket_junk.py
+++ b/tests/test_support_ticket_junk.py
@@ -267,3 +267,44 @@ def test_labeled_subject_line_in_text_export_is_junk() -> None:
     assert support_ticket_row_is_junk(
         "", "Subject: Automatic reply: Out of Office\nI am away."
     ) == JUNK_REASON_AUTO_REPLY
+
+
+# Round-3 review refinements: contracted first-person forms, office-context
+# return lines, and header-block subject scanning.
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "I'm out of the office until Monday with limited access to email",
+        "I'll be away from my desk this week",
+    ],
+)
+def test_contracted_first_person_assertions_are_junk(line: str) -> None:
+    assert support_ticket_row_is_junk("Re: help", line) == JUNK_REASON_AUTO_REPLY
+
+
+def test_return_lines_need_office_context() -> None:
+    assert support_ticket_row_is_junk(
+        "Update", "I will return on Tuesday with the debug logs."
+    ) is None
+    assert support_ticket_row_is_junk(
+        "Re: help", "I will return to the office on Monday."
+    ) == JUNK_REASON_AUTO_REPLY
+
+
+def test_header_block_subject_lines_are_scanned() -> None:
+    assert support_ticket_row_is_junk(
+        "",
+        "From: Mail Delivery Subsystem\n"
+        "Subject: Undeliverable: your message\n"
+        "Diagnostic-Code: smtp 550",
+    ) == JUNK_REASON_BOUNCE
+
+
+def test_deep_unlabeled_prefixes_do_not_junk_the_row() -> None:
+    assert support_ticket_row_is_junk(
+        "Setup question",
+        "here is what my customers see\nsome context\nmore context\n"
+        "extra line\nAutomatic reply: Out of Office",
+    ) is None

--- a/tests/test_support_ticket_junk.py
+++ b/tests/test_support_ticket_junk.py
@@ -399,3 +399,44 @@ def test_prose_before_subject_label_does_not_junk() -> None:
         "Subject: Automatic reply: Out of Office\n"
         "Why is this happening?",
     ) is None
+
+
+# Round-7 refinements: compact headers, bounded limited-access tails,
+# body-over-comment gating, and subject assertions deferring to body voice.
+
+
+def test_compact_header_lines_are_header_shaped() -> None:
+    assert support_ticket_row_is_junk(
+        "", "From:Mail Delivery Subsystem\nSubject: Undeliverable: your message"
+    ) == JUNK_REASON_BOUNCE
+
+
+def test_limited_access_tail_is_bounded() -> None:
+    assert support_ticket_row_is_junk(
+        "Settings",
+        "I will have limited access to email auto-reply setting is not working",
+    ) is None
+    assert support_ticket_row_is_junk(
+        "Re: help", "I will have limited access to email until 7/20."
+    ) == JUNK_REASON_AUTO_REPLY
+
+
+def test_auto_ack_comment_does_not_junk_a_real_ticket() -> None:
+    package = build_support_ticket_input_package([{
+        "id": "r1",
+        "subject": "Login broken",
+        "description": "Login is broken for our team.",
+        "comments": ["We received your ticket and will get back to you soon."],
+    }])
+    assert package.metadata["junk_excluded_count"] == 0
+    assert package.inputs["included_ticket_row_count"] == 1
+
+
+def test_machine_subject_defers_to_customer_body_voice() -> None:
+    assert support_ticket_row_is_junk(
+        "Your message could not be delivered",
+        "Why are our invoices bouncing?",
+    ) is None
+    assert support_ticket_row_is_junk(
+        "Your message could not be delivered", ""
+    ) == JUNK_REASON_BOUNCE

--- a/tests/test_support_ticket_junk.py
+++ b/tests/test_support_ticket_junk.py
@@ -169,3 +169,63 @@ def test_all_quote_rows_count_as_no_new_content() -> None:
     assert support_ticket_row_is_junk(
         "Re: export question", "", had_source_text=True
     ) is None
+
+
+# Round-1 review refinements: comment-only rows in scope, bounce regex,
+# colon-only generator delimiters, question-line veto, body-only prefixes.
+
+
+def test_comment_only_junk_rows_are_gated() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "id": f"c{i}",
+            "subject": "Re: help",
+            "comments": [
+                "I am out of the office until Monday with limited access "
+                "to email."
+            ],
+        }
+        for i in range(3)
+    ])
+    assert package.metadata["junk_excluded_count"] == 3
+
+
+def test_was_not_delivered_bounce_body_matches() -> None:
+    assert support_ticket_row_is_junk(
+        "Re: x", "Your message was not delivered to the recipient."
+    ) == JUNK_REASON_BOUNCE
+
+
+@pytest.mark.parametrize(
+    ("subject", "body"),
+    [
+        ("Out of office - not working", "my replies are not sending"),
+        ("Auto reply - setup question", "how to configure the auto reply"),
+        (
+            "Undeliverable emails are not reaching customers",
+            "our outbound emails keep bouncing",
+        ),
+    ],
+)
+def test_customer_separators_are_not_generator_delimiters(
+    subject: str, body: str,
+) -> None:
+    assert support_ticket_row_is_junk(subject, body) is None
+
+
+def test_mixed_ticket_quoting_a_template_is_admitted() -> None:
+    assert support_ticket_row_is_junk(
+        "Template help",
+        "Template we configured:\n"
+        "I am out of the office until Monday.\n"
+        "Why is it not sending?",
+    ) is None
+
+
+def test_generator_prefix_on_first_body_line_is_junk() -> None:
+    assert support_ticket_row_is_junk(
+        "", "Automatic reply: Out of Office\nI am away."
+    ) == JUNK_REASON_AUTO_REPLY
+    assert support_ticket_row_is_junk(
+        "", "Undeliverable: your message\ndetails follow"
+    ) == JUNK_REASON_BOUNCE

--- a/tests/test_support_ticket_junk.py
+++ b/tests/test_support_ticket_junk.py
@@ -308,3 +308,21 @@ def test_deep_unlabeled_prefixes_do_not_junk_the_row() -> None:
         "here is what my customers see\nsome context\nmore context\n"
         "extra line\nAutomatic reply: Out of Office",
     ) is None
+
+
+# Round-4 refinement: bounce assertions classify before the question veto.
+
+
+def test_bounce_quoting_an_interrogative_subject_is_still_a_bounce() -> None:
+    assert support_ticket_row_is_junk(
+        "Re: something",
+        "Your message could not be delivered to the recipient.\n"
+        "Subject: Why can't I login?",
+    ) == JUNK_REASON_BOUNCE
+
+
+def test_customer_question_about_bounces_still_passes() -> None:
+    assert support_ticket_row_is_junk(
+        "Bounce troubleshooting",
+        "Why do my customers see Your message could not be delivered?",
+    ) is None

--- a/tests/test_support_ticket_junk.py
+++ b/tests/test_support_ticket_junk.py
@@ -360,3 +360,42 @@ def test_customer_reply_to_auto_reply_subject_is_admitted() -> None:
         "Re: Automatic reply: Out of Office",
         "Why is my auto-reply not sending?",
     ) is None
+
+
+# Round-6 refinements: bounded OOO continuations, URL-safe question voice,
+# subject-only assertions, and header-shape-guarded subject scanning.
+
+
+def test_comma_and_feature_report_is_admitted() -> None:
+    assert support_ticket_row_is_junk(
+        "Settings", "I am out of the office, and the auto-reply is not sending"
+    ) is None
+    assert support_ticket_row_is_junk(
+        "Re: help", "I am out of the office."
+    ) == JUNK_REASON_AUTO_REPLY
+
+
+def test_url_query_strings_are_not_customer_questions() -> None:
+    assert support_ticket_row_is_junk(
+        "Re: help",
+        "I am out of the office until Monday.\n"
+        "https://help.example.com/contact?id=12",
+    ) == JUNK_REASON_AUTO_REPLY
+
+
+def test_subject_only_machine_assertions_classify() -> None:
+    assert support_ticket_row_is_junk(
+        "Your message could not be delivered", ""
+    ) == JUNK_REASON_BOUNCE
+    assert support_ticket_row_is_junk(
+        "I am out of the office until Monday", ""
+    ) == JUNK_REASON_AUTO_REPLY
+
+
+def test_prose_before_subject_label_does_not_junk() -> None:
+    assert support_ticket_row_is_junk(
+        "Auto reply help",
+        "I need help with auto replies\n"
+        "Subject: Automatic reply: Out of Office\n"
+        "Why is this happening?",
+    ) is None

--- a/tests/test_support_ticket_junk.py
+++ b/tests/test_support_ticket_junk.py
@@ -1,0 +1,171 @@
+"""S6E: junk/auto-reply admission gate (F2).
+
+The F2 acceptance shape (from the audit's live run): repeated auto-replies
+must not form a billed cluster or own the top recommendation. Both error
+directions are pinned: machine-generated mail is excluded by positional
+shape (subject generator prefixes, first-person whole-line assertions),
+while customer tickets ABOUT auto-reply/out-of-office features pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.support_ticket_input_package import (
+    build_support_ticket_input_package,
+)
+from extracted_content_pipeline.support_ticket_junk import (
+    JUNK_REASON_AUTO_REPLY,
+    JUNK_REASON_BOUNCE,
+    JUNK_REASON_NO_NEW_CONTENT,
+    support_ticket_row_is_junk,
+)
+
+
+def _f2_rows() -> list[dict[str, str]]:
+    real = [
+        {
+            "id": f"r{i}",
+            "subject": "Cannot reset my password",
+            "description": "I cannot reset my password from the login page.",
+        }
+        for i in range(5)
+    ]
+    junk = [
+        {
+            "id": f"j{i}",
+            "subject": "Automatic reply: Out of Office",
+            "description": (
+                "I am out of the office until Monday with limited access "
+                "to email."
+            ),
+        }
+        for i in range(6)
+    ]
+    return real + junk
+
+
+def test_f2_auto_replies_do_not_form_a_billed_cluster() -> None:
+    package = build_support_ticket_input_package(_f2_rows())
+    labels = " ".join(
+        str(cluster.get("label", "")).lower()
+        for cluster in package.inputs.get("top_ticket_clusters") or []
+    )
+    assert "office" not in labels
+    assert "automatic" not in labels
+    assert package.inputs["included_ticket_row_count"] == 5
+    assert package.metadata["junk_excluded_count"] == 6
+    assert package.metadata["junk_excluded_reasons"] == {"auto_reply": 6}
+
+
+def test_f2_diagnostics_report_counts_not_content() -> None:
+    package = build_support_ticket_input_package(_f2_rows())
+    warning = next(
+        w for w in package.warnings
+        if w.get("code") == "support_ticket_junk_excluded"
+    )
+    assert warning["count"] == 6
+    assert warning["reasons"] == {"auto_reply": 6}
+    assert "Out of Office" not in str(warning)
+
+
+def test_row_accounting_still_sums() -> None:
+    package = build_support_ticket_input_package(_f2_rows())
+    inputs = package.inputs
+    assert (
+        inputs["included_ticket_row_count"]
+        + inputs["skipped_ticket_row_count"]
+        == inputs["source_row_count"]
+    )
+
+
+def test_feature_questions_about_auto_reply_are_admitted() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "id": "a",
+            "subject": "How do I set an out of office auto-reply?",
+            "description": (
+                "I want to configure the out of office auto-reply feature "
+                "for my team."
+            ),
+        },
+        {
+            "id": "b",
+            "subject": "Out of office not working",
+            "description": (
+                "My out of office replies are not sending to external "
+                "contacts."
+            ),
+        },
+    ])
+    assert package.metadata["junk_excluded_count"] == 0
+    assert package.inputs["included_ticket_row_count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("subject", "reason"),
+    [
+        ("Automatic reply: Out of Office", JUNK_REASON_AUTO_REPLY),
+        ("Auto-Reply: your ticket", JUNK_REASON_AUTO_REPLY),
+        ("[EXT] Automatic reply: away", JUNK_REASON_AUTO_REPLY),
+        ("Out of Office: Re: invoice question", JUNK_REASON_AUTO_REPLY),
+        ("Undeliverable: your message", JUNK_REASON_BOUNCE),
+        ("Delivery Status Notification (Failure)", JUNK_REASON_BOUNCE),
+        ("Mail delivery failed: returning message", JUNK_REASON_BOUNCE),
+    ],
+)
+def test_generator_subject_prefixes_are_junk(subject: str, reason: str) -> None:
+    assert support_ticket_row_is_junk(subject, "some body") == reason
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "I am out of the office until Monday.",
+        "I will be away from my desk this week",
+        "I am currently on vacation and will respond on my return.",
+        "I will have limited access to email until 7/20.",
+        "This is an automated response to your inquiry.",
+        "Please do not reply to this automated email.",
+        "Your message could not be delivered to the recipient.",
+    ],
+)
+def test_first_person_assertion_lines_are_junk(line: str) -> None:
+    assert support_ticket_row_is_junk("Re: help", line) is not None
+
+
+@pytest.mark.parametrize(
+    ("subject", "body"),
+    [
+        (
+            "How do I set an out of office auto-reply?",
+            "I want the out of office feature to reply automatically.",
+        ),
+        (
+            "Out of office not working",
+            "My out of office replies are not sending.",
+        ),
+        (
+            "Question about automated responses",
+            "Can I customize what the automated response says?",
+        ),
+        (
+            "Vacation policy",
+            "Am I able to be out of the office next month?",
+        ),
+    ],
+)
+def test_customer_wording_about_the_features_passes(
+    subject: str, body: str,
+) -> None:
+    assert support_ticket_row_is_junk(subject, body) is None
+
+
+def test_all_quote_rows_count_as_no_new_content() -> None:
+    assert support_ticket_row_is_junk(
+        "", "", had_source_text=True
+    ) == JUNK_REASON_NO_NEW_CONTENT
+    # A subject-only row keeps its subject content and is not junk.
+    assert support_ticket_row_is_junk(
+        "Re: export question", "", had_source_text=True
+    ) is None

--- a/tests/test_support_ticket_junk.py
+++ b/tests/test_support_ticket_junk.py
@@ -229,3 +229,41 @@ def test_generator_prefix_on_first_body_line_is_junk() -> None:
     assert support_ticket_row_is_junk(
         "", "Undeliverable: your message\ndetails follow"
     ) == JUNK_REASON_BOUNCE
+
+
+# Round-2 review refinements: mid-line questions veto, line-preserved
+# comments, anchored delivery-failed subjects, labeled subject lines.
+
+
+def test_question_before_trailing_text_vetoes_body_junk() -> None:
+    assert support_ticket_row_is_junk(
+        "Template help",
+        "I am out of the office until Monday.\nWhy is it not sending? Thanks",
+    ) is None
+
+
+def test_multiline_comment_auto_reply_is_gated() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "id": "c1",
+            "subject": "Re: help",
+            "comments": ["Hello,\nI am out of the office until Monday.\nBest,\nBob"],
+        }
+    ])
+    assert package.metadata["junk_excluded_count"] == 1
+
+
+def test_delivery_failed_prose_subject_is_admitted() -> None:
+    assert support_ticket_row_is_junk(
+        "Delivery has failed to these recipients when sending invoices",
+        "our invoices bounce",
+    ) is None
+    assert support_ticket_row_is_junk(
+        "Delivery has failed to these recipients or groups:", "x"
+    ) == JUNK_REASON_BOUNCE
+
+
+def test_labeled_subject_line_in_text_export_is_junk() -> None:
+    assert support_ticket_row_is_junk(
+        "", "Subject: Automatic reply: Out of Office\nI am away."
+    ) == JUNK_REASON_AUTO_REPLY


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S6E-Junk-Gate.md
Slice phase: Vertical slice
Ownership lane: resolution-audit-csv

Fixes #2049.

S6E of the #1993 remediation arc: the F2 junk/auto-reply gate -- launch
blocker #5. The audit's live run proved 6 identical "Automatic reply: Out of
Office" rows form their own billed cluster, rank #1, own the top
recommendation, and inflate the headline support tax ~2x; no gate existed
before a ticket counted toward a billed cluster, and S5's semantic clustering
makes byte-identical junk cluster TIGHTER, so the gate is admission-side at
the same boundary S6A guards. First runtime consumer of the S6B line seam.

## Intentional
- Admission-side gate, upstream of clustering: fixes the root (junk counts
  toward billed evidence), not the symptom cluster.
- Closed STRUCTURAL rules, not phrase enumeration: generator subject-prefix
  POSITION ("Automatic reply:", "Undeliverable:", optional [EXT] brackets)
  and first-person whole-line assertion SHAPE ("I am out of the office
  until..."; never matching questions) are closed classes; junk phrasing is
  not. Residual junk-vocabulary probes in review are class-waived against
  this contract per the plan's review-loop guard.
- Diagnostics are counts + bounded reason codes (auto_reply/bounce/
  no_new_content) in package metadata + one warning -- never row content.
- subject-only rows stay admitted (S6D owns subject-only evidence semantics).

## Deferred
- S6C (#2044), S6D (#2045), M9 (#2050), S8a/S8b (#2051/#2052).
- Junk-vocabulary extensions beyond the structural classes.

## Parked hardening
- None.

## Cold diff reconstruction
Gaps found first: none. Every change traces to the plan contract, every
contract item appears, and no must-not-change surface moved.

- `extracted_content_pipeline/support_ticket_junk.py` (new, owned): the gate
  module -- generator subject-prefix regexes (colon/bracket position
  discriminator), first-person assertion line patterns (anchored, reject
  question forms via the no-`?` tail), bounce subject/line families, and the
  bounded reason enum (contract item 1).
- `extracted_content_pipeline/support_ticket_input_package.py`: imports; the
  gate call in `_normalize_ticket_row` after text admission beside the S6A
  check, returning a `_junk_reason` marker; caller counts reasons and drops
  rows before clustering; `junk_excluded_count`/`junk_excluded_reasons` in
  metadata beside `source_id_fallback_count`; one
  `support_ticket_junk_excluded` warning (items 2, 3).
- `extracted_content_pipeline/manifest.json`: owned-file registration.
- `tests/test_support_ticket_junk.py` (23 tests): the F2 acceptance shape
  through the REAL package builder (no junk cluster, 5 admitted,
  reasons=={auto_reply: 6}); counts-not-content warning check; row accounting
  sums; both-direction feature-question guards; parametrized generator
  subjects, assertion lines, bounces; all-quote no_new_content + subject-only
  admitted (item 4).
- `scripts/run_extracted_pipeline_checks.sh`: CI enrollment, same PR.
- `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md`: tracker
  discipline -- S6B #2053 ticked merged; ledger row 5 in progress.
- Must-not-change check: `support_ticket_privacy.py`,
  `support_ticket_clustering.py`, clustering semantics, evidence-tier/status
  logic, scrubber grammar untouched; no new report fields.

## Reviewer findings reconciliation
All fixed or waived: yes. Round-1 findings (all six verified failing first; correctness gaps in my wiring/regexes, not phrasing probes -- the loop cap was not triggered):
- Comment-only junk rows bypassed the gate: fixed -- public comment text joins the gate's body input. Test: `test_comment_only_junk_rows_are_gated`.
- `was not delivered` could not match (mandatory `be`): fixed -- `(?:be\s+)?`. Test: `test_was_not_delivered_bounce_body_matches`.
- Dash/paren accepted as generator delimiters (over-exclusion of "Out of office - not working"): fixed -- colon-only. Test: `test_customer_separators_are_not_generator_delimiters`.
- Mixed tickets quoting an OOO template dropped: fixed -- any interrogative line vetoes body-shape junk. Test: `test_mixed_ticket_quoting_a_template_is_admitted`.
- Bounce subjects without generator delimiters dropped customer prose: fixed -- per-family delimiters. Covered in `test_customer_separators_are_not_generator_delimiters`.
- Generator prefixes in body-only rows missed: fixed -- prefix rules also run on the first body line. Test: `test_generator_prefix_on_first_body_line_is_junk`.

Round-2 findings (all four verified failing first):
- Question veto only fired on line-ENDING `?`: fixed -- a question anywhere in a line vetoes body-shape junk. Test: `test_question_before_trailing_text_vetoes_body_junk`.
- Comments were pre-compacted before the gate, hiding multiline auto-replies: fixed -- raw comment texts flow through the line seam individually. Test: `test_multiline_comment_auto_reply_is_gated`.
- The delivery-has-failed branch was unanchored (customer prose dropped): fixed -- exact anchored DSN sentence only. Test: `test_delivery_failed_prose_subject_is_admitted`.
- Labeled subject lines (`Subject: Automatic reply: ...`) in text exports admitted: fixed -- optional subject/fw/re labels before generator prefixes. Test: `test_labeled_subject_line_in_text_export_is_junk`.

Maturity-sweep: the new module's score (regex density) is accepted via the sweep's documented baseline flow; behavior is pinned by 34 both-direction tests. Ratchet verified green locally with CI's exact flags.

Round-3 findings (all three verified failing first; shape corrections):
- Contracted first-person forms (`I'm out of the office...`) admitted: fixed -- same assertion shape, contraction alternation. Test: `test_contracted_first_person_assertions_are_junk`.
- `I will return on Tuesday with the debug logs.` dropped (over-exclusion): fixed -- return-on lines require office/leave context. Test: `test_return_lines_need_office_context`.
- Header-order text exports (`From:...\nSubject: Undeliverable:...`) admitted: fixed -- Subject:-labeled generator prefixes scanned in the leading header block; unlabeled prefixes stay first-line-only (deep quoted replies cannot junk a row). Tests: `test_header_block_subject_lines_are_scanned` + `test_deep_unlabeled_prefixes_do_not_junk_the_row`.

Review-loop cap reached (3 rounds): further phrasing-only probes are class-waived per the plan's guard.

Round-4 finding (structural, verified failing first): the question veto ran before bounce-line classification, so a DSN quoting the original interrogative subject was admitted. Fixed -- bounce assertions classify first (machine statements); customer questions about bounces still pass. Tests: `test_bounce_quoting_an_interrogative_subject_is_still_a_bounce` + `test_customer_question_about_bounces_still_passes`.

Round-5 findings (all four verified failing first; rounds 4-5 demanded opposite verdicts on adjacent shapes -- dissolved by the question-VOICE rule):
- Leading OOO + machine-quoted subject admitted / customer-context bounce dropped: both fixed by one rule -- an UNLABELED question is the customer speaking (veto); a `Subject:`-labeled question is machine-quoted and does not veto. Tests: `test_leading_assertion_beats_quoted_question`, `test_customer_context_before_bounce_line_is_admitted`, plus the round-2/4 pins unchanged.
- Descriptive feature reports (`I am out of the office auto-reply setting is not working`) dropped: fixed -- OOO assertions require a temporal/access/punctuation continuation. Test: `test_descriptive_ooo_feature_report_is_admitted`.
- Customer replies to auto-reply subjects (`Re: Automatic reply: ...` + real question) dropped: fixed -- re/fw removed from label tolerance; only the `Subject:` header label remains. Test: `test_customer_reply_to_auto_reply_subject_is_admitted`.

Round-6 findings (4 fixed -- each verified failing first -- 1 waived):
- `, and <arbitrary>` continuation re-admitted feature reports: fixed -- continuations are bounded; `and` continues only with a modal (`and will respond` machine vs `and the auto-reply is broken` customer). Test: `test_comma_and_feature_report_is_admitted`.
- URL query strings counted as customer questions: fixed -- `?` inside URL tokens is ignored by the voice rule. Test: `test_url_query_strings_are_not_customer_questions`.
- Subject-only machine assertions admitted: fixed -- assertion patterns also run on the subject. Test: `test_subject_only_machine_assertions_classify`.
- Header-block Subject: scan fired past customer prose: fixed -- every preceding line must be header-shaped. Test: `test_prose_before_subject_label_does_not_junk`.
- WAIVED (reason: undecidable voice class per the plan's review-loop guard -- an imperative mixed template ('Template we configured: ... Please fix this auto-reply.') is structurally identical to the greeting-wrapped machine OOO ('Hello, / I am out... / Best, / Bob') that must classify; imperative-vs-redirect verb discrimination is content judgment beyond structural rules; the fail direction is junk-exclusion of an ambiguous row, quantified in `junk_excluded_reasons`): imperative mixed-template tickets classify as junk.

## Verification
- `python -m pytest tests/test_support_ticket_junk.py -q` (`49 passed`)
- Full CI mirror `run_extracted_pipeline_checks.sh` (`5890 passed, 21 skipped`)
- `validate_extracted_content_pipeline.sh` (mapped files match)
- F2 acceptance verified live before tests: junk cluster absent, 6 excluded
  as auto_reply, feature questions admitted both directions.

## Diff size
8 files (incl. the maturity baseline), +707/-13 (module + wiring ~190; tests ~170; plan + tracker + CI ~156).

Diff-budget override: the required plan doc and tracker update account for
the overage; the code diff (module + wiring) is ~180 LOC on one admission
concern, and the F2 acceptance tests must land with the gate.
