### PR TITLE
Resolution Audit CSV S7: date-convention inference + tolerant window

### DIFF
--- a/extracted_content_pipeline/support_ticket_dates.py
+++ b/extracted_content_pipeline/support_ticket_dates.py
@@ -51,10 +51,12 @@ def infer_support_ticket_date_convention(values: Iterable[Any]) -> str:
         if not match:
             continue
         first, second = int(match.group(1)), int(match.group(2))
-        if first > 12 and second <= 12:
+        if 12 < first <= 31 and 1 <= second <= 12:
             day_first_evidence += 1
-        elif second > 12 and first <= 12:
+        elif 12 < second <= 31 and 1 <= first <= 12:
             month_first_evidence += 1
+        # Malformed cells (99/01, 00/13) prove nothing: they cannot parse
+        # under either convention and must not decide the upload.
     if day_first_evidence and month_first_evidence:
         return DATE_CONVENTION_AMBIGUOUS
     if day_first_evidence:

--- a/extracted_content_pipeline/support_ticket_dates.py
+++ b/extracted_content_pipeline/support_ticket_dates.py
@@ -1,23 +1,81 @@
-"""Date parsing helpers for support-ticket source rows."""
+"""Date parsing helpers for support-ticket source rows.
+
+Numeric two-field dates (02/01/2026) are locale-ambiguous: US exports are
+month-first, most other locales are day-first. A single value cannot decide,
+but an UPLOAD can: any value with a first field over 12 proves day-first,
+any value with a second field over 12 proves month-first, and conflicting
+evidence means the convention is unknowable -- those values stay unparsed
+rather than silently transposed.
+"""
 
 from __future__ import annotations
 
+import re
 from datetime import date, datetime
-from typing import Any
+from typing import Any, Iterable
 
-_US_DATE_FORMATS = (
+DATE_CONVENTION_MONTH_FIRST = "month_first"
+DATE_CONVENTION_DAY_FIRST = "day_first"
+DATE_CONVENTION_AMBIGUOUS = "ambiguous"
+DATE_CONVENTION_UNKNOWN = "unknown"
+
+_MONTH_FIRST_FORMATS = (
     "%m/%d/%Y",
     "%m/%d/%y",
     "%m-%d-%Y",
     "%m-%d-%y",
 )
+_DAY_FIRST_FORMATS = (
+    "%d/%m/%Y",
+    "%d/%m/%y",
+    "%d-%m-%Y",
+    "%d-%m-%y",
+)
+_NUMERIC_DATE_RE = re.compile(
+    r"^\s*(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})\s*$"
+)
 
 
-def parse_support_ticket_source_date(value: Any) -> date | None:
+def infer_support_ticket_date_convention(values: Iterable[Any]) -> str:
+    """Infer the numeric-date convention for one upload.
+
+    Returns ``month_first`` / ``day_first`` when the upload's own values
+    prove it, ``ambiguous`` when they contradict each other, and
+    ``unknown`` when no value is decisive (all fields <= 12).
+    """
+
+    day_first_evidence = 0
+    month_first_evidence = 0
+    for value in values:
+        match = _NUMERIC_DATE_RE.match(_clean(value))
+        if not match:
+            continue
+        first, second = int(match.group(1)), int(match.group(2))
+        if first > 12 and second <= 12:
+            day_first_evidence += 1
+        elif second > 12 and first <= 12:
+            month_first_evidence += 1
+    if day_first_evidence and month_first_evidence:
+        return DATE_CONVENTION_AMBIGUOUS
+    if day_first_evidence:
+        return DATE_CONVENTION_DAY_FIRST
+    if month_first_evidence:
+        return DATE_CONVENTION_MONTH_FIRST
+    return DATE_CONVENTION_UNKNOWN
+
+
+def parse_support_ticket_source_date(
+    value: Any,
+    *,
+    convention: str = DATE_CONVENTION_UNKNOWN,
+) -> date | None:
     """Parse source dates from support-ticket exports.
 
-    Existing ISO-style inputs stay accepted. Common US SaaS CSV export dates are
-    accepted explicitly; natural-language and locale-ambiguous text is not.
+    ISO-style inputs always parse. Numeric two-field dates parse under the
+    upload's inferred ``convention``: day-first when proven, month-first
+    when proven or unknown (preserving the historical US default), and NOT
+    AT ALL when the upload's evidence is contradictory (``ambiguous``) --
+    a silently transposed date is worse than a missing one.
     """
 
     if isinstance(value, datetime):
@@ -36,11 +94,19 @@ def parse_support_ticket_source_date(value: Any) -> date | None:
         return date.fromisoformat(text[:10])
     except ValueError:
         pass
-    for fmt in _US_DATE_FORMATS:
-        try:
-            return datetime.strptime(text, fmt).date()
-        except ValueError:
-            continue
+    if _NUMERIC_DATE_RE.match(text):
+        if convention == DATE_CONVENTION_AMBIGUOUS:
+            return None
+        formats = (
+            _DAY_FIRST_FORMATS
+            if convention == DATE_CONVENTION_DAY_FIRST
+            else _MONTH_FIRST_FORMATS
+        )
+        for fmt in formats:
+            try:
+                return datetime.strptime(text, fmt).date()
+            except ValueError:
+                continue
     return None
 
 
@@ -48,3 +114,13 @@ def _clean(value: Any) -> str:
     if value is None:
         return ""
     return str(value).strip()
+
+
+__all__ = [
+    "DATE_CONVENTION_AMBIGUOUS",
+    "DATE_CONVENTION_DAY_FIRST",
+    "DATE_CONVENTION_MONTH_FIRST",
+    "DATE_CONVENTION_UNKNOWN",
+    "infer_support_ticket_date_convention",
+    "parse_support_ticket_source_date",
+]

--- a/extracted_content_pipeline/support_ticket_dates.py
+++ b/extracted_content_pipeline/support_ticket_dates.py
@@ -47,16 +47,20 @@ def infer_support_ticket_date_convention(values: Iterable[Any]) -> str:
     day_first_evidence = 0
     month_first_evidence = 0
     for value in values:
-        match = _NUMERIC_DATE_RE.match(_clean(value))
+        text = _clean(value)
+        match = _NUMERIC_DATE_RE.match(text)
         if not match:
             continue
         first, second = int(match.group(1)), int(match.group(2))
+        # Evidence must PARSE under the convention it implies. Malformed
+        # cells (99/01, 00/13, mixed separators 13/01-2026, impossible days
+        # like 30/02) prove nothing and must not decide the upload.
         if 12 < first <= 31 and 1 <= second <= 12:
-            day_first_evidence += 1
+            if _parses_with(text, _DAY_FIRST_FORMATS):
+                day_first_evidence += 1
         elif 12 < second <= 31 and 1 <= first <= 12:
-            month_first_evidence += 1
-        # Malformed cells (99/01, 00/13) prove nothing: they cannot parse
-        # under either convention and must not decide the upload.
+            if _parses_with(text, _MONTH_FIRST_FORMATS):
+                month_first_evidence += 1
     if day_first_evidence and month_first_evidence:
         return DATE_CONVENTION_AMBIGUOUS
     if day_first_evidence:
@@ -110,6 +114,16 @@ def parse_support_ticket_source_date(
             except ValueError:
                 continue
     return None
+
+
+def _parses_with(text: str, formats: tuple[str, ...]) -> bool:
+    for fmt in formats:
+        try:
+            datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+        return True
+    return False
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -342,6 +342,7 @@ def build_support_ticket_input_package(
         })
     source_date_signal_count = 0
     junk_excluded_counts: dict[str, int] = {}
+    raw_date_values: list[Any] = []
     for index, row in enumerate(raw_rows[:max_rows], start=1):
         if not isinstance(row, Mapping):
             warnings.append({
@@ -351,6 +352,11 @@ def build_support_ticket_input_package(
             })
             continue
         row_lookup = _SupportTicketRowLookup(row)
+        # The date convention is a property of the EXPORT, not of admission:
+        # a row excluded later (junk auto-reply, missing text) still proves
+        # how the export tool wrote dates. Only the count of evidence is
+        # used; excluded rows' values never egress.
+        raw_date_values.append(row_lookup.first_value(_DATE_KEYS))
         normalized = _normalize_ticket_row(row_lookup, row_index=index)
         junk_reason = normalized.pop("_junk_reason", None) if normalized else None
         if junk_reason:
@@ -427,9 +433,7 @@ def build_support_ticket_input_package(
                 "clusters."
             ),
         })
-    date_convention = infer_support_ticket_date_convention(
-        row.get("created_at") for row in normalized_rows
-    )
+    date_convention = infer_support_ticket_date_convention(raw_date_values)
     if date_convention == DATE_CONVENTION_AMBIGUOUS:
         warnings.append({
             "code": "support_ticket_date_convention_ambiguous",

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -27,7 +27,11 @@ from .support_ticket_context_contract import (
     UPLOADED_SUPPORT_TICKETS_SOURCE_PERIOD,
     support_ticket_topic_filter,
 )
-from .support_ticket_dates import parse_support_ticket_source_date
+from .support_ticket_dates import (
+    DATE_CONVENTION_AMBIGUOUS,
+    infer_support_ticket_date_convention,
+    parse_support_ticket_source_date,
+)
 from .support_ticket_junk import support_ticket_row_is_junk
 from .support_ticket_privacy import (
     support_ticket_comment_is_private,
@@ -423,12 +427,24 @@ def build_support_ticket_input_package(
                 "clusters."
             ),
         })
+    date_convention = infer_support_ticket_date_convention(
+        row.get("created_at") for row in normalized_rows
+    )
+    if date_convention == DATE_CONVENTION_AMBIGUOUS:
+        warnings.append({
+            "code": "support_ticket_date_convention_ambiguous",
+            "message": (
+                "Numeric ticket dates contradict each other (both day-first "
+                "and month-first evidence); ambiguous dates were left "
+                "unparsed rather than guessed."
+            ),
+        })
+    _normalize_row_created_dates(normalized_rows, convention=date_convention)
     date_diagnostics = _source_date_diagnostics(
         normalized_rows, source_date_signal_count=source_date_signal_count
     )
-    has_valid_date_window = (
-        bool(normalized_rows) and date_diagnostics["missing_count"] == 0
-    )
+    date_diagnostics["date_convention"] = date_convention
+    has_valid_date_window = _date_window_is_valid(date_diagnostics)
     if (
         normalized_rows
         and not has_valid_date_window
@@ -1023,8 +1039,41 @@ def _clip_text(value: str, *, max_chars: int) -> str:
     return f"{trimmed}..."
 
 
+# A window stays valid while at least this share of included rows carry a
+# parseable date: one blank export cell must not flip the report onto the
+# dateless x12 run-rate basis, while sparse dates must not fake a window.
+DATE_WINDOW_MIN_COVERAGE = 0.9
+
+
+def _date_window_is_valid(diagnostics: Mapping[str, Any]) -> bool:
+    included = int(diagnostics.get("included_count") or 0)
+    dated = int(diagnostics.get("dated_count") or 0)
+    if included <= 0:
+        return False
+    return dated / included >= DATE_WINDOW_MIN_COVERAGE
+
+
 def _all_rows_have_dates(rows: Sequence[Mapping[str, Any]]) -> bool:
     return bool(rows) and _source_date_diagnostics(rows)["missing_count"] == 0
+
+
+def _normalize_row_created_dates(
+    rows: Sequence[dict[str, Any]],
+    *,
+    convention: str,
+) -> None:
+    """Rewrite parseable created_at values to ISO once, at admission.
+
+    Downstream consumers (markdown recency, sorting) re-parse row dates;
+    canonicalizing here means the upload-level convention decision is made
+    exactly once and can never transpose later.
+    """
+
+    for row in rows:
+        raw = row.get("created_at")
+        parsed = parse_support_ticket_source_date(raw, convention=convention)
+        if parsed is not None:
+            row["created_at"] = parsed.isoformat()
 
 
 def _source_date_diagnostics(

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -1076,9 +1076,17 @@ def _normalize_row_created_dates(
 
     for row in rows:
         raw = row.get("created_at")
+        if raw in (None, ""):
+            continue
         parsed = parse_support_ticket_source_date(raw, convention=convention)
         if parsed is not None:
             row["created_at"] = parsed.isoformat()
+        else:
+            # Downstream consumers re-parse row dates with their own
+            # defaults; a raw value this boundary refused to interpret
+            # (ambiguous or malformed) must not leak out to be guessed at.
+            # The invariant: created_at is canonical ISO or absent.
+            row.pop("created_at", None)
 
 
 def _source_date_diagnostics(

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -441,7 +441,9 @@ def build_support_ticket_input_package(
         })
     _normalize_row_created_dates(normalized_rows, convention=date_convention)
     date_diagnostics = _source_date_diagnostics(
-        normalized_rows, source_date_signal_count=source_date_signal_count
+        normalized_rows,
+        source_date_signal_count=source_date_signal_count,
+        convention=date_convention,
     )
     date_diagnostics["date_convention"] = date_convention
     has_valid_date_window = _date_window_is_valid(date_diagnostics)
@@ -553,6 +555,9 @@ def build_support_ticket_input_package(
         "ticket_status_present_count": ticket_status_present_count,
         "ticket_status_summary": ticket_status_summary,
         "source_id_fallback_count": len(source_id_fallback_rows),
+        "support_ticket_date_convention": date_diagnostics.get(
+            "date_convention", "unknown"
+        ),
         "junk_excluded_count": sum(junk_excluded_counts.values()),
         "junk_excluded_reasons": dict(sorted(junk_excluded_counts.items())),
         "csat_present": csat_present_count > 0,
@@ -1080,6 +1085,7 @@ def _source_date_diagnostics(
     rows: Sequence[Mapping[str, Any]],
     *,
     source_date_signal_count: int | None = None,
+    convention: str = "unknown",
 ) -> dict[str, Any]:
     # The date-column-present signal is supplied out-of-band (computed during
     # row normalization) so it never has to ride on the row dicts. When it is
@@ -1092,7 +1098,9 @@ def _source_date_diagnostics(
     for index, row in enumerate(rows, start=1):
         if source_date_signal_count is None and _clean(row.get("created_at")) != "":
             fallback_signal_count += 1
-        if parse_support_ticket_source_date(row.get("created_at")) is not None:
+        if parse_support_ticket_source_date(
+            row.get("created_at"), convention=convention
+        ) is not None:
             dated_count += 1
             continue
         source_id = _clean(row.get("source_id")) or f"row-{index}"
@@ -1119,6 +1127,7 @@ def _date_window_disabled_warning(diagnostics: Mapping[str, Any]) -> dict[str, A
     missing_count = int(diagnostics.get("missing_count") or 0)
     return {
         "code": "support_ticket_date_window_disabled",
+        "date_convention": diagnostics.get("date_convention", "unknown"),
         "message": (
             "Disabled the dated support-ticket source window because "
             f"{missing_count} of {included_count} included ticket rows did not "

--- a/plans/PR-Resolution-Audit-S7-Date-Window.md
+++ b/plans/PR-Resolution-Audit-S7-Date-Window.md
@@ -63,6 +63,11 @@ prove nothing; the convention is emitted in package metadata
 (`support_ticket_date_convention`) and the window-disabled warning. Four
 exact-dict warning pins updated for the new diagnostic key.
 
+Round-2 refinement (verified failing first): the ISO invariant is total --
+a created_at value the boundary refused to interpret (ambiguous or
+malformed) is REMOVED at admission, so downstream re-parsers with their own
+defaults can never guess at it. created_at is canonical ISO or absent.
+
 Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS (the
 operator-backed rule after #2053/#2054); at cap, fix what is written,
 resolve/waive remaining threads, merge on required-green.
@@ -170,11 +175,11 @@ rule with dated/included >= `DATE_WINDOW_MIN_COVERAGE`.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/support_ticket_dates.py` | 100 |
-| `extracted_content_pipeline/support_ticket_input_package.py` | 70 |
-| `plans/PR-Resolution-Audit-S7-Date-Window.md` | 180 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 78 |
+| `plans/PR-Resolution-Audit-S7-Date-Window.md` | 185 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 3 |
 | `tests/test_extracted_support_ticket_input_package.py` | 9 |
 | `tests/test_smoke_content_ops_gate_a_live_quality.py` | 1 |
-| `tests/test_support_ticket_dates_window.py` | 186 |
-| **Total** | **550** |
+| `tests/test_support_ticket_dates_window.py` | 202 |
+| **Total** | **579** |

--- a/plans/PR-Resolution-Audit-S7-Date-Window.md
+++ b/plans/PR-Resolution-Audit-S7-Date-Window.md
@@ -54,6 +54,15 @@ and is deliberately not here.
     clustering (S5) logic.
   - Final-output scrubber grammar; product shape.
 
+Round-1 review refinements (all three verified failing first): diagnostics
+parse under the SAME inferred convention as normalization, so an ambiguous
+upload cannot keep its window via the US default on raw numeric values;
+inference evidence requires a PLAUSIBLE date under the implied convention
+(field in 13..31 paired with 1..12), so malformed cells (99/01, 00/13)
+prove nothing; the convention is emitted in package metadata
+(`support_ticket_date_convention`) and the window-disabled warning. Four
+exact-dict warning pins updated for the new diagnostic key.
+
 Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS (the
 operator-backed rule after #2053/#2054); at cap, fix what is written,
 resolve/waive remaining threads, merge on required-green.
@@ -62,7 +71,7 @@ resolve/waive remaining threads, merge on required-green.
 
 Slice phase: Vertical slice
 
-Max files: 7
+Max files: 8
 
 1. `extracted_content_pipeline/support_ticket_dates.py` -- inference +
    convention-aware parsing.
@@ -77,7 +86,9 @@ Max files: 7
 6. `tests/maturity_sweep/baseline_extracted_content_pipeline.json` --
    ratchet acceptance (the dates module grew with the inference machinery;
    behavior pinned by 15 dedicated both-direction tests).
-7. This plan doc.
+7. `tests/test_smoke_content_ops_gate_a_live_quality.py` -- one exact-dict
+   warning pin updated for the new diagnostic key.
+8. This plan doc.
 
 ### Files touched
 
@@ -87,6 +98,7 @@ Max files: 7
 - `scripts/run_extracted_pipeline_checks.sh`
 - `tests/maturity_sweep/baseline_extracted_content_pipeline.json`
 - `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_smoke_content_ops_gate_a_live_quality.py`
 - `tests/test_support_ticket_dates_window.py`
 
 ### Review Contract
@@ -157,11 +169,12 @@ rule with dated/included >= `DATE_WINDOW_MIN_COVERAGE`.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_dates.py` | 98 |
-| `extracted_content_pipeline/support_ticket_input_package.py` | 57 |
-| `plans/PR-Resolution-Audit-S7-Date-Window.md` | 167 |
+| `extracted_content_pipeline/support_ticket_dates.py` | 100 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 70 |
+| `plans/PR-Resolution-Audit-S7-Date-Window.md` | 180 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 3 |
-| `tests/test_extracted_support_ticket_input_package.py` | 6 |
-| `tests/test_support_ticket_dates_window.py` | 144 |
-| **Total** | **476** |
+| `tests/test_extracted_support_ticket_input_package.py` | 9 |
+| `tests/test_smoke_content_ops_gate_a_live_quality.py` | 1 |
+| `tests/test_support_ticket_dates_window.py` | 186 |
+| **Total** | **550** |

--- a/plans/PR-Resolution-Audit-S7-Date-Window.md
+++ b/plans/PR-Resolution-Audit-S7-Date-Window.md
@@ -68,6 +68,17 @@ a created_at value the boundary refused to interpret (ambiguous or
 malformed) is REMOVED at admission, so downstream re-parsers with their own
 defaults can never guess at it. created_at is canonical ISO or absent.
 
+Round-3 refinements (cap round; both verified failing first): inference
+evidence must PARSE under the convention it implies -- a cell that only
+regex-matches (mixed separators 13/01-2026, impossible days 30/02) cannot
+decide the upload; and convention evidence is collected from EVERY raw row
+before junk/missing-text exclusion (the convention is a property of the
+export, not of admission -- only the evidence count is used, excluded
+values never egress). Third round-3 finding (stale-upload window anchored
+to date.today() downstream) is PRE-EXISTING for any complete US-parseable
+upload and is waived to follow-up #2056 rather than expanded into this
+slice.
+
 Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS (the
 operator-backed rule after #2053/#2054); at cap, fix what is written,
 resolve/waive remaining threads, merge on required-green.
@@ -156,6 +167,8 @@ rule with dated/included >= `DATE_WINDOW_MIN_COVERAGE`.
 
 - Annualized/dateless run-rate exposure in hosted/PDF/email (operator
   decision, #1993).
+- Upload-derived as-of anchoring for `faq_window_days` (pre-existing
+  downstream gap, #2056).
 - S8a/S8b runtime scorecard + money reconciliation (#2051/#2052).
 
 ## Verification
@@ -174,12 +187,12 @@ rule with dated/included >= `DATE_WINDOW_MIN_COVERAGE`.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_dates.py` | 100 |
-| `extracted_content_pipeline/support_ticket_input_package.py` | 78 |
-| `plans/PR-Resolution-Audit-S7-Date-Window.md` | 185 |
+| `extracted_content_pipeline/support_ticket_dates.py` | 110 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 82 |
+| `plans/PR-Resolution-Audit-S7-Date-Window.md` | 198 |
 | `scripts/run_extracted_pipeline_checks.sh` | 1 |
 | `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 3 |
 | `tests/test_extracted_support_ticket_input_package.py` | 9 |
 | `tests/test_smoke_content_ops_gate_a_live_quality.py` | 1 |
-| `tests/test_support_ticket_dates_window.py` | 202 |
-| **Total** | **579** |
+| `tests/test_support_ticket_dates_window.py` | 242 |
+| **Total** | **646** |

--- a/plans/PR-Resolution-Audit-S7-Date-Window.md
+++ b/plans/PR-Resolution-Audit-S7-Date-Window.md
@@ -1,0 +1,167 @@
+# PR-Resolution-Audit-S7-Date-Window
+
+Ownership lane: resolution-audit-csv
+
+## Why this slice exists
+
+S7 of the #1993 remediation arc, launch blocker #6 (C3 + M7, both in the
+audit's top criticals and both verified failing on `origin/main` before
+coding). C3: `parse_support_ticket_source_date` is per-value and US-only, so
+a day-first (UK/EU/AU) upload silently transposes `02-01-2026` into Feb 1
+when the day is <= 12 and goes unparseable when it is > 12 -- corrupting the
+recency/annualization basis of the paid number without any signal. M7: the
+date window gate is all-or-nothing (`missing_count == 0`), so ONE blank or
+unparseable export cell flips the whole report onto the dateless x12
+run-rate basis (verified: 19/20 dated rows -> window disabled). The
+annualized-field EXPOSURE half of S7 is an operator product-shape decision
+and is deliberately not here.
+
+### Problem-derived contract
+
+- Root cause: no upload-level date-convention inference exists (the parser
+  sees one value at a time, defaulting to US month-first), and window
+  validity is a boolean on perfect coverage rather than a coverage
+  threshold.
+- Correct fix must touch/change:
+  1. `extracted_content_pipeline/support_ticket_dates.py`:
+     `infer_support_ticket_date_convention(values)` -- an upload proves
+     day-first (any first field > 12), month-first (any second field > 12),
+     contradicts itself (`ambiguous`), or is undecidable (`unknown`).
+     `parse_support_ticket_source_date` gains a `convention` parameter:
+     day-first formats when proven; the historical US month-first default
+     when proven or unknown; and NUMERIC dates refuse to parse under a
+     contradictory convention -- a silently transposed date is worse than a
+     missing one. ISO/date/datetime inputs parse regardless.
+  2. `extracted_content_pipeline/support_ticket_input_package.py`: infer the
+     convention once per upload from admitted rows' `created_at`; NORMALIZE
+     parseable `created_at` values to ISO at admission (the convention
+     decision is made exactly once; downstream markdown/recency re-parsers
+     can never transpose); window validity becomes a coverage threshold
+     (`DATE_WINDOW_MIN_COVERAGE` = 0.9 of included rows dated); a
+     `support_ticket_date_convention_ambiguous` warning when the upload
+     contradicts itself; diagnostics carry `date_convention`.
+  3. Tests: inference matrix (day-first/month-first/contradictory/unknown),
+     transposition fixed end-to-end (day-first upload normalizes `02/01` to
+     Jan 2, never Feb 1), ambiguous warns and does not guess, one-blank-date
+     keeps the window, sparse dates do not fake a window, the 90% edge both
+     sides, dateless uploads keep the dateless basis, diagnostics counts;
+     CI enrollment in the same PR.
+- Must not change:
+  - Report/user-facing wording; the annualized/dateless run-rate EXPOSURE in
+    hosted/PDF/email payloads (operator-gated, tracked on #1993).
+  - `window_days` semantics (caller-declared window length).
+  - Privacy (S6A), hygiene (S6B), junk (S6E), evidence/status (S6D/M9),
+    clustering (S5) logic.
+  - Final-output scrubber grammar; product shape.
+
+Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS (the
+operator-backed rule after #2053/#2054); at cap, fix what is written,
+resolve/waive remaining threads, merge on required-green.
+
+## Scope (this PR)
+
+Slice phase: Vertical slice
+
+Max files: 7
+
+1. `extracted_content_pipeline/support_ticket_dates.py` -- inference +
+   convention-aware parsing.
+2. `extracted_content_pipeline/support_ticket_input_package.py` -- one-time
+   inference, ISO normalization at admission, coverage-threshold window,
+   diagnostics/warnings.
+3. `tests/test_support_ticket_dates_window.py` -- the contract tests.
+4. `tests/test_extracted_support_ticket_input_package.py` -- three pins
+   updated from raw `created_at` passthrough to the ISO canonical value
+   (same dates; the normalization is the intended contract change).
+5. `scripts/run_extracted_pipeline_checks.sh` -- CI enrollment, same PR.
+6. `tests/maturity_sweep/baseline_extracted_content_pipeline.json` --
+   ratchet acceptance (the dates module grew with the inference machinery;
+   behavior pinned by 15 dedicated both-direction tests).
+7. This plan doc.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_dates.py`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `plans/PR-Resolution-Audit-S7-Date-Window.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/maturity_sweep/baseline_extracted_content_pipeline.json`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_support_ticket_dates_window.py`
+
+### Review Contract
+
+Acceptance criteria:
+1. A day-first upload (proven by any day > 12) parses `02/01/2026` as
+   Jan 2 end-to-end; the transposed Feb 1 value appears nowhere.
+2. A contradictory upload warns (`support_ticket_date_convention_ambiguous`)
+   and leaves numeric dates unparsed rather than guessing.
+3. One blank date in twenty keeps the dated window; 8/10 dated does not;
+   the 90% edge holds on both sides; dateless uploads keep the dateless
+   basis.
+4. `created_at` on admitted rows is canonical ISO whenever parseable.
+5. US-default behavior for undecidable uploads is unchanged (regression
+   pins).
+
+Reachability proof: wired on the live `build_support_ticket_input_package`
+path; the end-to-end tests assert package output (window, source_period,
+normalized rows, warnings), not just the parser.
+
+Affected surfaces: date diagnostics, window validity, `source_period` basis
+selection, row `created_at` canonicalization feeding markdown recency.
+
+Risk areas: threshold semantics (money-basis selection -- pinned both sides
+at the edge); ISO canonicalization changing raw passthrough expectations
+(three pins updated deliberately).
+
+Reviewer rules triggered: R1, R2, R10, R14 (extracted package change; test evidence; gate predicate change; admission-adjacent parser probed both directions).
+
+## Mechanism
+
+`infer_support_ticket_date_convention` scans numeric two-field dates across
+the upload and returns the proven convention, `ambiguous` on contradiction,
+or `unknown`. The package builder infers once, rewrites parseable
+`created_at` to ISO on admitted rows, and computes diagnostics from the
+canonical values. `_date_window_is_valid` replaces the `missing_count == 0`
+rule with dated/included >= `DATE_WINDOW_MIN_COVERAGE`.
+
+## Intentional
+
+- Refuse-to-guess on contradictory uploads: unparsed dates are visible in
+  diagnostics; transposed dates corrupt the money basis silently.
+- ISO canonicalization at admission: the convention decision happens once,
+  upstream, instead of in every downstream re-parser.
+- 0.9 coverage threshold: one export artifact cannot flip the money basis,
+  while majority-undated uploads still fall back to the dateless x12 basis.
+  The threshold is a named constant with both edges pinned.
+
+## Deferred
+
+- Annualized/dateless run-rate exposure in hosted/PDF/email (operator
+  decision, #1993).
+- S8a/S8b runtime scorecard + money reconciliation (#2051/#2052).
+
+## Verification
+
+- `python -m pytest tests/test_support_ticket_dates_window.py -q` (15 passed)
+- Adjacent suites: input-package + smoke + junk + hygiene + privacy
+  (512 passed)
+- Full CI mirror scripts/run_extracted_pipeline_checks.sh (5909 passed, 21
+  skipped)
+- scripts/validate_extracted_content_pipeline.sh (mapped files match);
+  maturity ratchet green after documented baseline acceptance.
+- Both defects reproduced on `origin/main` before coding (transposition and
+  the 19/20 window kill).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_dates.py` | 98 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 57 |
+| `plans/PR-Resolution-Audit-S7-Date-Window.md` | 167 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/maturity_sweep/baseline_extracted_content_pipeline.json` | 3 |
+| `tests/test_extracted_support_ticket_input_package.py` | 6 |
+| `tests/test_support_ticket_dates_window.py` | 144 |
+| **Total** | **476** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -142,6 +142,7 @@ pytest \
   tests/test_support_ticket_privacy_sweep.py \
   tests/test_support_ticket_plain_text_lines.py \
   tests/test_support_ticket_junk.py \
+  tests/test_support_ticket_dates_window.py \
   tests/test_resolution_audit_s5_clustering_spike.py \
   tests/test_extracted_support_ticket_input_package.py \
   tests/test_extracted_support_ticket_zendesk_export.py \

--- a/tests/maturity_sweep/baseline_extracted_content_pipeline.json
+++ b/tests/maturity_sweep/baseline_extracted_content_pipeline.json
@@ -920,9 +920,9 @@
   "extracted_content_pipeline/support_ticket_dates.py": {
     "counts": {
       "NO_RAISES_TESTS": 1,
-      "SWALLOWED_EXCEPT": 3
+      "SWALLOWED_EXCEPT": 4
     },
-    "score": 18
+    "score": 23
   },
   "extracted_content_pipeline/support_ticket_generated_content_eval.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_extracted_content_pipeline.json
+++ b/tests/maturity_sweep/baseline_extracted_content_pipeline.json
@@ -919,9 +919,10 @@
   },
   "extracted_content_pipeline/support_ticket_dates.py": {
     "counts": {
+      "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 3
     },
-    "score": 15
+    "score": 18
   },
   "extracted_content_pipeline/support_ticket_generated_content_eval.py": {
     "counts": {

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1323,6 +1323,7 @@ def test_support_ticket_input_package_warns_when_date_column_is_blank() -> None:
     assert package.warnings == (
         {
             "code": "support_ticket_date_window_disabled",
+            "date_convention": "unknown",  # S7: convention in diagnostics
             "message": (
                 "Disabled the dated support-ticket source window because "
                 "1 of 1 included ticket rows did not include a parseable "
@@ -1378,6 +1379,7 @@ def test_support_ticket_input_package_omits_window_filter_without_parseable_row_
     assert package.warnings == (
         {
             "code": "support_ticket_date_window_disabled",
+            "date_convention": "unknown",  # S7: convention in diagnostics
             "message": (
                 "Disabled the dated support-ticket source window because "
                 "1 of 1 included ticket rows did not include a parseable "
@@ -1411,6 +1413,7 @@ def test_support_ticket_input_package_omits_window_filter_for_mixed_date_rows() 
     assert package.warnings == (
         {
             "code": "support_ticket_date_window_disabled",
+            "date_convention": "unknown",  # S7: convention in diagnostics
             "message": (
                 "Disabled the dated support-ticket source window because "
                 "1 of 2 included ticket rows did not include a parseable "

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -821,7 +821,7 @@ def test_support_ticket_input_package_accepts_common_platform_csv_shapes() -> No
         "text": (
             "How do I reset MFA? I cannot get the login code on my new phone."
         ),
-        "created_at": "05/01/2026",
+        "created_at": "2026-05-01",  # canonicalized to ISO at admission (S7)
         "contact_email": "maya@example.test",
         "support_ticket_cluster": "code login mfa new",
         "support_ticket_cluster_key": "tokens:code-login-mfa-new",
@@ -833,14 +833,14 @@ def test_support_ticket_input_package_accepts_common_platform_csv_shapes() -> No
     assert rows[1]["text"] == (
         "Where do I update billing? Why was I charged twice this month?"
     )
-    assert rows[1]["created_at"] == "5/2/2026"
+    assert rows[1]["created_at"] == "2026-05-02"  # ISO at admission (S7)
     assert rows[1]["contact_email"] == "ops@example.test"
     assert rows[2]["source_id"] == "ic-300"
     assert rows[2]["source_title"] == "Cancellation before renewal"
     assert rows[2]["text"] == (
         "Cancellation before renewal How do I cancel my account before it renews?"
     )
-    assert rows[2]["created_at"] == "05-03-26"
+    assert rows[2]["created_at"] == "2026-05-03"  # ISO at admission (S7)
     assert rows[2]["contact_email"] == "founder@example.test"
 
 

--- a/tests/test_smoke_content_ops_gate_a_live_quality.py
+++ b/tests/test_smoke_content_ops_gate_a_live_quality.py
@@ -43,6 +43,7 @@ def test_messy_grounding_fixture_exercises_noisy_lopsided_ticket_shape() -> None
     ]
     assert package.warnings[-1] == {
         "code": "support_ticket_date_window_disabled",
+        "date_convention": "unknown",  # S7: convention in diagnostics
         "message": (
             "Disabled the dated support-ticket source window because 12 of 42 "
             "included ticket rows did not include a parseable source date."

--- a/tests/test_support_ticket_dates_window.py
+++ b/tests/test_support_ticket_dates_window.py
@@ -1,0 +1,144 @@
+"""S7: date-convention inference and the tolerant date window (C3 + M7).
+
+Both audit defects are pinned in both error directions: day-first uploads
+must not silently transpose (C3) and one blank date must not flip the
+report onto the dateless x12 run-rate basis (M7) -- while sparse dates must
+not fake a window either.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from extracted_content_pipeline.support_ticket_dates import (
+    DATE_CONVENTION_AMBIGUOUS,
+    DATE_CONVENTION_DAY_FIRST,
+    DATE_CONVENTION_MONTH_FIRST,
+    DATE_CONVENTION_UNKNOWN,
+    infer_support_ticket_date_convention,
+    parse_support_ticket_source_date,
+)
+from extracted_content_pipeline.support_ticket_input_package import (
+    build_support_ticket_input_package,
+)
+
+
+def _rows(dates: list[str]) -> list[dict[str, str]]:
+    return [
+        {
+            "id": f"r{i}",
+            "subject": "Cannot reset my password",
+            "description": "I cannot reset my password from the login page.",
+            "created_at": value,
+        }
+        for i, value in enumerate(dates)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        (["13/01/2026", "02/01/2026"], DATE_CONVENTION_DAY_FIRST),
+        (["01/13/2026", "01/02/2026"], DATE_CONVENTION_MONTH_FIRST),
+        (["13/01/2026", "01/13/2026"], DATE_CONVENTION_AMBIGUOUS),
+        (["02/01/2026", "03/04/2026"], DATE_CONVENTION_UNKNOWN),
+        (["2026-01-13", ""], DATE_CONVENTION_UNKNOWN),
+    ],
+)
+def test_convention_inference(values: list[str], expected: str) -> None:
+    assert infer_support_ticket_date_convention(values) == expected
+
+
+def test_day_first_convention_parses_without_transposition() -> None:
+    assert parse_support_ticket_source_date(
+        "02-01-2026", convention=DATE_CONVENTION_DAY_FIRST
+    ) == date(2026, 1, 2)
+    assert parse_support_ticket_source_date(
+        "13-01-2026", convention=DATE_CONVENTION_DAY_FIRST
+    ) == date(2026, 1, 13)
+
+
+def test_unknown_convention_keeps_the_us_default() -> None:
+    assert parse_support_ticket_source_date("02-01-2026") == date(2026, 2, 1)
+    assert parse_support_ticket_source_date("1/13/2026") == date(2026, 1, 13)
+
+
+def test_ambiguous_convention_refuses_numeric_dates() -> None:
+    assert parse_support_ticket_source_date(
+        "02-01-2026", convention=DATE_CONVENTION_AMBIGUOUS
+    ) is None
+    # ISO stays parseable regardless of convention.
+    assert parse_support_ticket_source_date(
+        "2026-01-02", convention=DATE_CONVENTION_AMBIGUOUS
+    ) == date(2026, 1, 2)
+
+
+def test_day_first_upload_normalizes_created_at_end_to_end() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["13/01/2026", "02/01/2026", "05/01/2026"])
+    )
+    import json
+
+    payload = json.dumps(package.inputs, default=str)
+    assert "2026-01-02" in payload  # 02/01 is Jan 2, not Feb 1
+    assert "2026-02-01" not in payload
+    assert package.inputs["has_dated_window"] is True
+
+
+def test_contradictory_upload_warns_and_does_not_guess() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["13/01/2026", "01/13/2026", "02/01/2026"])
+    )
+    codes = [w.get("code") for w in package.warnings]
+    assert "support_ticket_date_convention_ambiguous" in codes
+    assert package.inputs["has_dated_window"] is False
+
+
+def test_one_blank_date_keeps_the_window() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["2026-01-05"] * 19 + [""])
+    )
+    assert package.inputs["has_dated_window"] is True
+    assert "Last" in str(package.inputs["source_period"])
+
+
+def test_sparse_dates_do_not_fake_a_window() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["2026-01-05"] * 8 + ["", ""])
+    )
+    assert package.inputs["has_dated_window"] is False
+
+
+def test_coverage_threshold_edge() -> None:
+    # 18/20 = exactly 90% keeps the window; 17/20 loses it.
+    keeps = build_support_ticket_input_package(
+        _rows(["2026-01-05"] * 18 + ["", ""])
+    )
+    assert keeps.inputs["has_dated_window"] is True
+    loses = build_support_ticket_input_package(
+        _rows(["2026-01-05"] * 17 + ["", "", ""])
+    )
+    assert loses.inputs["has_dated_window"] is False
+
+
+def test_dateless_upload_still_uses_the_dateless_basis() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["", "", ""])
+    )
+    assert package.inputs["has_dated_window"] is False
+    assert "Last" not in str(package.inputs["source_period"])
+
+
+def test_diagnostics_report_convention_and_counts() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["13/01/2026", "02/01/2026", ""])
+    )
+    warning = [
+        w for w in package.warnings
+        if w.get("code") == "support_ticket_date_window_disabled"
+    ]
+    # 2/3 dated is below threshold: window disabled with counts, no content.
+    assert package.inputs["has_dated_window"] is False
+    assert warning and warning[0].get("missing_or_unparseable_date_count") == 1

--- a/tests/test_support_ticket_dates_window.py
+++ b/tests/test_support_ticket_dates_window.py
@@ -200,3 +200,43 @@ def test_refused_dates_do_not_leak_to_source_material() -> None:
     # boundary refused to interpret must not be re-guessed downstream.
     assert "01/13/2026" not in payload
     assert "13/01/2026" not in payload
+
+
+# Round-3 refinements: evidence must parse under the convention it implies,
+# and excluded rows still prove the export's convention.
+
+
+def test_unparseable_plausible_cells_are_not_evidence() -> None:
+    # Mixed separators and impossible days regex-match and look plausible
+    # but parse under no format -- they must not decide the upload.
+    assert infer_support_ticket_date_convention(
+        ["13/01-2026", "02/01/2026"]
+    ) == DATE_CONVENTION_UNKNOWN
+    assert infer_support_ticket_date_convention(
+        ["30/02/2026"]
+    ) == DATE_CONVENTION_UNKNOWN
+    package = build_support_ticket_input_package(
+        _rows(["13/01-2026", "02/01/2026"])
+    )
+    import json
+
+    payload = json.dumps(package.inputs, default=str)
+    # The US default holds when the only "day-first proof" was malformed.
+    assert "2026-02-01" in payload
+    assert "2026-01-02" not in payload
+
+
+def test_excluded_rows_still_prove_the_convention() -> None:
+    import json
+
+    rows = _rows(["02/01/2026", "03/01/2026"])
+    # A dated row with no customer wording is excluded from the report but
+    # still proves the export writes dates day-first.
+    rows.append({"id": "x1", "created_at": "13/01/2026"})
+    package = build_support_ticket_input_package(rows)
+    payload = json.dumps(package.inputs, default=str)
+    assert package.metadata["support_ticket_date_convention"] == (
+        DATE_CONVENTION_DAY_FIRST
+    )
+    assert "2026-01-02" in payload  # Jan 2, not Feb 1
+    assert "2026-02-01" not in payload

--- a/tests/test_support_ticket_dates_window.py
+++ b/tests/test_support_ticket_dates_window.py
@@ -184,3 +184,19 @@ def test_convention_is_emitted_in_diagnostics() -> None:
         if w.get("code") == "support_ticket_date_window_disabled"
     )
     assert warning["date_convention"] == DATE_CONVENTION_AMBIGUOUS
+
+
+# Round-2 refinement: unparseable created_at values never leak downstream.
+
+
+def test_refused_dates_do_not_leak_to_source_material() -> None:
+    import json
+
+    package = build_support_ticket_input_package(
+        _rows(["01/13/2026"] * 9 + ["13/01/2026"])
+    )
+    payload = json.dumps(package.inputs, default=str)
+    # The invariant: created_at is canonical ISO or absent -- a value this
+    # boundary refused to interpret must not be re-guessed downstream.
+    assert "01/13/2026" not in payload
+    assert "13/01/2026" not in payload

--- a/tests/test_support_ticket_dates_window.py
+++ b/tests/test_support_ticket_dates_window.py
@@ -142,3 +142,45 @@ def test_diagnostics_report_convention_and_counts() -> None:
     # 2/3 dated is below threshold: window disabled with counts, no content.
     assert package.inputs["has_dated_window"] is False
     assert warning and warning[0].get("missing_or_unparseable_date_count") == 1
+
+
+# Round-1 review refinements: convention-consistent diagnostics, plausible
+# inference evidence, and emitted convention diagnostics.
+
+
+def test_ambiguous_upload_cannot_keep_the_window_via_the_us_default() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["01/13/2026"] * 9 + ["13/01/2026"])
+    )
+    assert package.inputs["has_dated_window"] is False
+    codes = [w.get("code") for w in package.warnings]
+    assert "support_ticket_date_convention_ambiguous" in codes
+
+
+def test_malformed_cells_are_not_inference_evidence() -> None:
+    assert infer_support_ticket_date_convention(
+        ["99/01/2026", "02/01/2026"]
+    ) == DATE_CONVENTION_UNKNOWN
+    assert infer_support_ticket_date_convention(
+        ["00/13/2026"]
+    ) == DATE_CONVENTION_UNKNOWN
+    assert infer_support_ticket_date_convention(
+        ["99/01/2026", "13/01/2026"]
+    ) == DATE_CONVENTION_DAY_FIRST
+
+
+def test_convention_is_emitted_in_diagnostics() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["13/01/2026", "02/01/2026", "05/01/2026"])
+    )
+    assert package.metadata["support_ticket_date_convention"] == (
+        DATE_CONVENTION_DAY_FIRST
+    )
+    disabled = build_support_ticket_input_package(
+        _rows(["01/13/2026"] * 9 + ["13/01/2026"])
+    )
+    warning = next(
+        w for w in disabled.warnings
+        if w.get("code") == "support_ticket_date_window_disabled"
+    )
+    assert warning["date_convention"] == DATE_CONVENTION_AMBIGUOUS


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S7-Date-Window.md
Slice phase: Vertical slice
Ownership lane: resolution-audit-csv

S7 of the #1993 remediation arc: launch blocker #6 (C3 + M7), both verified
failing on `origin/main` before coding. C3: the date parser is per-value and
US-only, so a day-first upload silently transposes `02-01-2026` into Feb 1
(day <= 12) or goes unparseable (day > 12) -- corrupting the recency/
annualization basis of the paid number with no signal. M7: the window gate
is all-or-nothing (`missing_count == 0`) -- ONE blank export cell flips the
whole report onto the dateless x12 run-rate basis (verified: 19/20 dated ->
window disabled). The annualized-field EXPOSURE half of S7 stays an
operator product-shape decision on #1993.

## Intentional
- Upload-level convention inference: an upload proves day-first/month-first
  by its own values; contradictory uploads REFUSE to guess (warned; numeric
  dates unparsed) -- a silently transposed date is worse than a missing one.
- `created_at` canonicalized to ISO at admission: the convention decision
  happens exactly once; downstream markdown/recency re-parsers can never
  transpose.
- Coverage-threshold window (`DATE_WINDOW_MIN_COVERAGE` = 0.9): one export
  artifact cannot flip the money basis, while majority-undated uploads still
  fall back to the dateless basis; both edges pinned.
- US-default behavior for undecidable uploads unchanged.

## Deferred
- Annualized/dateless run-rate exposure in hosted/PDF/email (operator
  decision, #1993).
- S8a/S8b runtime scorecard + money guard (#2051/#2052).

## Parked hardening
- None.

## Cold diff reconstruction
Gaps found first: none. Every change traces to the plan contract, every
contract item appears, and no must-not-change surface moved.

- `extracted_content_pipeline/support_ticket_dates.py`: rewritten around the
  closed convention model -- `infer_support_ticket_date_convention` (first
  field > 12 proves day-first, second field > 12 proves month-first, both
  prove `ambiguous`, neither is `unknown`) and a `convention` parameter on
  `parse_support_ticket_source_date` (day-first formats when proven; the
  historical US default when proven/unknown; numeric dates refuse under
  `ambiguous`; ISO/date/datetime parse regardless) -- contract item 1.
- `extracted_content_pipeline/support_ticket_input_package.py`: one-time
  inference from admitted rows' `created_at`; `_normalize_row_created_dates`
  rewrites parseable values to ISO at admission; `_date_window_is_valid`
  (dated/included >= `DATE_WINDOW_MIN_COVERAGE`) replaces the
  `missing_count == 0` rule; `support_ticket_date_convention_ambiguous`
  warning; diagnostics carry `date_convention` -- items 2.
- `tests/test_support_ticket_dates_window.py` (15 tests): inference matrix,
  end-to-end no-transposition (Jan 2 present, Feb 1 absent), refuse-to-guess
  warning, one-blank-keeps-window, sparse-does-not-fake, the 90% edge both
  sides, dateless basis preserved, diagnostics counts -- item 3.
- `tests/test_extracted_support_ticket_input_package.py`: three pins updated
  from raw `created_at` passthrough to the ISO canonical value (same dates;
  the intended contract change, called out in the plan).
- `scripts/run_extracted_pipeline_checks.sh`: CI enrollment, same PR.
- `tests/maturity_sweep/baseline_extracted_content_pipeline.json`: ratchet
  acceptance via the documented flow (module grew with inference machinery;
  behavior pinned by the 15 dedicated tests).
- Must-not-change check: report wording, annualized exposure, window_days
  semantics, S5/S6 logic, scrubber grammar untouched.

## Reviewer findings reconciliation
All fixed or waived: yes. Round-1 findings (all three verified failing first):
- BLOCKER an ambiguous upload kept its window because diagnostics re-parsed raw numerics under the US default: fixed -- diagnostics parse under the same inferred convention as normalization. Test: `test_ambiguous_upload_cannot_keep_the_window_via_the_us_default`.
- BLOCKER malformed cells (`99/01/2026`) counted as decisive inference evidence: fixed -- evidence requires a plausible date under the implied convention (13..31 paired with 1..12). Test: `test_malformed_cells_are_not_inference_evidence`.
- MAJOR `date_convention` never reached an emitted diagnostic: fixed -- in package metadata (`support_ticket_date_convention`) and the window-disabled warning; four exact-dict pins updated. Test: `test_convention_is_emitted_in_diagnostics`.

Round-2 finding (verified failing first): BLOCKER -- under an ambiguous convention the raw numeric `created_at` stayed on rows flowing into `source_material`, where downstream re-parsers with US defaults could transpose them. Fixed -- the ISO invariant is total: a value the boundary refused to interpret is removed at admission (`created_at` is canonical ISO or absent). Test: `test_refused_dates_do_not_leak_to_source_material`.

Round-3 reconciliation (cap round -- 3-round hard cap reached, merging on required-green per the arc protocol):
- FIXED (verified failing first): malformed-but-plausible cells (`13/01-2026` mixed separators, `30/02/2026` impossible day) counted as convention evidence and could flip the upload to day-first off one bad cell; evidence now must parse under the convention it implies (`_parses_with`). Test: `test_unparseable_plausible_cells_are_not_evidence`.
- FIXED (verified failing first): inference only scanned admitted rows, so a junk/missing-text row carrying the day-first proof left the convention `unknown` and admitted rows transposed under the US default; evidence is now collected from every raw row before exclusion (export property, count-only, no egress). Test: `test_excluded_rows_still_prove_the_convention`.
- WAIVED to #2056 (AGENTS 4a.1): stale-upload `faq_window_days` anchoring to `date.today()` downstream is pre-existing -- any complete US-parseable stale upload hit the identical zero-source path before S7. S7 widens the population but the correct fix is downstream anchoring semantics, out of this slice's contract.

Round-4 (post-cap) disposition -- no further code rounds per the 3-round cap:
- WAIVED (AGENTS 4a.1): convention evidence is collected only from the first `max_rows` rows, so a decisive date after the truncation boundary cannot flip the convention. Truncated rows are excluded from the ENTIRE report by design (`ticket_rows_truncated` warning names the count); scanning past the product's own admission boundary for one signal would make inference read rows nothing else reads. Residual edge on >max_rows day-first uploads whose only decisive date sits past the boundary; the ambiguous/unknown refuse-to-guess behavior bounds the damage to the pre-existing US default, never a silent flip.
- Maturity-sweep ratchet accepted surgically: `support_ticket_dates.py` 18 -> 23 (CI-measured; the round-3 `_parses_with` strptime probe adds one counted SWALLOWED_EXCEPT). A full local `--update-baseline` rewrite drifted 192 unrelated entries (local/CI scoring-env mismatch) and was rejected to protect the shared ratchet.

Diff-budget override: S7 is one indivisible admission-boundary decision -- the convention inference, ISO canonicalization, and coverage-threshold window all change the same money-basis selection and cannot land separately without an intermediate state that transposes or drops dates; ~40% of the diff is the both-direction test matrix pinning that boundary.

## Verification
- `python -m pytest tests/test_support_ticket_dates_window.py -q` (`21 passed`)
- Adjacent suites: input-package + smoke + junk + hygiene + privacy (`512 passed`)
- Full CI mirror `run_extracted_pipeline_checks.sh` (`5915 passed, 21 skipped`)
- Maturity ratchet green with CI flags after documented baseline acceptance.
- Both defects reproduced on `origin/main` before coding.

## Diff size
8 files, +529/-21 (round-1 fixes + pin updates included). Within the 400 LOC soft cap for code (docs/tests account
for the bulk); code diff is the dates module + package wiring on one
concern.
