### PR TITLE
Resolution Audit CSV S8a: wire QA scorecard fail-closed at the persist boundary

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -82,6 +82,7 @@ from ..faq_deflection_report import (
     DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION,
     DEFLECTION_REPORT_SCHEMA_VERSION,
     build_deflection_snapshot,
+    check_deflection_report_artifact_qa,
     deflection_report_model_contract_shape,
     scrub_deflection_report_payload,
 )
@@ -3770,6 +3771,13 @@ async def _gate_deflection_report_artifacts(
             )
         try:
             scrubbed_artifact = scrub_deflection_report_payload(artifact)
+            # Fail-closed QA gate (S8a): a drifted artifact must never be
+            # persisted -- once stored it can be paid for, and delivery
+            # would then refuse an already-purchased report. The gate only
+            # gates; the persisted payload stays exactly the scrubbed
+            # artifact. DeflectionReportQAGateError is a ValueError, so the
+            # handler below turns it into the 502 with the assertion ids.
+            check_deflection_report_artifact_qa(scrubbed_artifact)
             snapshot = build_deflection_snapshot(
                 scrubbed_artifact,
                 top_n=top_n,

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -1855,6 +1855,57 @@ def build_deflection_full_report_qa_scorecard(
     }
 
 
+class DeflectionReportQAGateError(ValueError):
+    """A report artifact failed the runtime QA gate (fail-closed)."""
+
+    def __init__(
+        self,
+        failing_assertion_ids: Sequence[str],
+        scorecard: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.failing_assertion_ids = tuple(failing_assertion_ids)
+        self.scorecard = dict(scorecard) if isinstance(scorecard, Mapping) else {}
+        joined = ", ".join(self.failing_assertion_ids) or "unknown"
+        super().__init__(f"deflection_report_qa_gate_failed: {joined}")
+
+
+def check_deflection_report_artifact_qa(
+    artifact: DeflectionReportArtifact | Mapping[str, Any],
+) -> dict[str, Any]:
+    """Run the QA scorecard as a runtime gate; raise on any failed assertion.
+
+    Called at the persist boundary, where the artifact was just built by
+    the current code and must match the current schema exactly. (Delivery
+    deliberately stays tolerant: persisted artifacts may straddle schema
+    versions across deploys.) The scorecard stays the single source of
+    truth for what is asserted; this gate only derives the inputs from the
+    artifact and turns ``ok == False`` into a typed error. It never
+    modifies the artifact.
+    """
+
+    try:
+        evidence_export: Mapping[str, Any] | None = (
+            build_deflection_evidence_export(artifact)
+        )
+    except Exception:
+        # An artifact the export builder cannot even read must not pass a
+        # gate whose job is refusing malformed paid output.
+        evidence_export = None
+    model = _artifact_report_model(artifact)
+    scorecard = build_deflection_full_report_qa_scorecard(
+        model if isinstance(model, Mapping) else {},
+        evidence_export=evidence_export,
+    )
+    if not scorecard.get("ok"):
+        failing = [
+            _text(assertion.get("id"))
+            for assertion in scorecard.get("assertions", ())
+            if isinstance(assertion, Mapping) and not assertion.get("ok")
+        ]
+        raise DeflectionReportQAGateError(failing, scorecard)
+    return scorecard
+
+
 def build_deflection_full_report_qa_deterministic_harness(
     report_model: DeflectionStructuredReport | Mapping[str, Any],
     *,
@@ -5569,11 +5620,13 @@ __all__ = [
     "DEFLECTION_REPORT_SECTION_REGISTRY",
     "DeflectionSnapshot",
     "DeflectionReportArtifact",
+    "DeflectionReportQAGateError",
     "DeflectionReportSection",
     "DeflectionReportSectionDefinition",
     "DeflectionStructuredReport",
     "FAQDeflectionReportService",
     "build_deflection_report_model",
+    "check_deflection_report_artifact_qa",
     "build_deflection_snapshot",
     "build_deflection_report_artifact",
     "build_deflection_full_report_qa_deterministic_harness",

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -1921,22 +1921,33 @@ def check_deflection_report_artifact_qa(
     ):
         failing.append("evidence_export.matches_stored_artifact")
     # 2. Paid read surfaces project the stored model through
-    #    stored_deflection_report_model(); an artifact that projection
-    #    rejects would persist, take payment, then 404 the report-model
-    #    route. Imported lazily: deflection_report_access imports this
-    #    module at top level.
+    #    stored_deflection_report_model(), which silently DROPS invalid
+    #    sections -- a non-None projection can still be missing required
+    #    sections. Run the same scorecard on the projection paid readers
+    #    will actually see. Imported lazily: deflection_report_access
+    #    imports this module at top level.
     from .deflection_report_access import stored_deflection_report_model
 
-    if stored_deflection_report_model(payload) is None:
-        failing.append("model.stored_projection.readable")
+    projected = stored_deflection_report_model(payload)
+    projected_scorecard = build_deflection_full_report_qa_scorecard(
+        projected if isinstance(projected, Mapping) else {},
+        evidence_export=evidence_export,
+    )
+    failing.extend(
+        "stored_projection:" + _text(assertion.get("id"))
+        for assertion in projected_scorecard.get("assertions", ())
+        if isinstance(assertion, Mapping) and not assertion.get("ok")
+    )
     if failing:
         raise DeflectionReportQAGateError(failing, scorecard)
     return scorecard
 
 
-# Content-hash linkage keys are re-derived from (possibly PII-scrubbed) text,
-# so they legitimately differ between the stored export and a fresh
-# derivation; every other field must match exactly.
+# Content-hash linkage keys (paid delta-matching contract) are re-derived
+# from possibly PII-scrubbed text, so their VALUES legitimately differ
+# between the stored export and a fresh derivation -- but the fields must
+# still be present as non-empty strings. Every other field must match
+# exactly.
 _EXPORT_INTEGRITY_VOLATILE_KEYS = frozenset({"cluster_id", "repeat_key"})
 
 
@@ -1944,20 +1955,31 @@ def _export_integrity_view(export: Mapping[str, Any] | None) -> str:
     if not isinstance(export, Mapping):
         return ""
 
-    def strip(value: Any) -> Any:
+    def normalize(value: Any) -> Any:
         if isinstance(value, Mapping):
             return {
-                key: strip(item)
+                key: (
+                    _volatile_key_marker(item)
+                    if key in _EXPORT_INTEGRITY_VOLATILE_KEYS
+                    else normalize(item)
+                )
                 for key, item in value.items()
-                if key not in _EXPORT_INTEGRITY_VOLATILE_KEYS
             }
         if isinstance(value, Sequence) and not isinstance(
             value, (str, bytes, bytearray)
         ):
-            return [strip(item) for item in value]
+            return [normalize(item) for item in value]
         return value
 
-    return json.dumps(strip(export), sort_keys=True, default=str)
+    return json.dumps(normalize(export), sort_keys=True, default=str)
+
+
+def _volatile_key_marker(value: Any) -> str:
+    # Omitting the key entirely still mismatches (the canonical derivation
+    # always carries it); this marker only ignores the hash CONTENT.
+    if isinstance(value, str) and value.strip():
+        return "<volatile:str>"
+    return "<volatile:invalid>"
 
 
 def build_deflection_full_report_qa_deterministic_harness(

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -1883,37 +1884,80 @@ def check_deflection_report_artifact_qa(
     modifies the artifact.
     """
 
-    if isinstance(artifact, Mapping):
-        # Score the export that will actually be STORED. A mapping artifact
-        # is the persisted payload itself; re-deriving a fresh export here
-        # would let a drifted or missing embedded evidence_export ride
-        # through the gate unvalidated.
-        raw_export = artifact.get("evidence_export")
-        evidence_export: Mapping[str, Any] | None = (
-            raw_export if isinstance(raw_export, Mapping) else None
-        )
-    else:
-        # A DeflectionReportArtifact embeds the derived export in as_dict(),
-        # so deriving is exactly what will be stored.
-        try:
-            evidence_export = build_deflection_evidence_export(artifact)
-        except Exception:
-            # An artifact the export builder cannot even read must not pass
-            # a gate whose job is refusing malformed paid output.
-            evidence_export = None
-    model = _artifact_report_model(artifact)
+    # Gate exactly the payload shape that will be stored: as_dict() for an
+    # artifact object is byte-for-byte what the persist path receives.
+    payload = (
+        artifact.as_dict()
+        if isinstance(artifact, DeflectionReportArtifact)
+        else artifact
+    )
+    if not isinstance(payload, Mapping):
+        raise DeflectionReportQAGateError(["artifact.readable"])
+    raw_export = payload.get("evidence_export")
+    evidence_export: Mapping[str, Any] | None = (
+        raw_export if isinstance(raw_export, Mapping) else None
+    )
+    model = _artifact_report_model(payload)
     scorecard = build_deflection_full_report_qa_scorecard(
         model if isinstance(model, Mapping) else {},
         evidence_export=evidence_export,
     )
-    if not scorecard.get("ok"):
-        failing = [
-            _text(assertion.get("id"))
-            for assertion in scorecard.get("assertions", ())
-            if isinstance(assertion, Mapping) and not assertion.get("ok")
-        ]
+    failing = [
+        _text(assertion.get("id"))
+        for assertion in scorecard.get("assertions", ())
+        if isinstance(assertion, Mapping) and not assertion.get("ok")
+    ]
+    # Beyond the count-level scorecard, both checks reuse the CANONICAL
+    # readers rather than a hand-written field list:
+    # 1. The stored export must be the derivation of the stored artifact --
+    #    a same-count export whose elements drifted must not be sold.
+    try:
+        canonical_export = build_deflection_evidence_export(payload)
+    except Exception:
+        canonical_export = None
+    if canonical_export is None or (
+        _export_integrity_view(evidence_export)
+        != _export_integrity_view(canonical_export)
+    ):
+        failing.append("evidence_export.matches_stored_artifact")
+    # 2. Paid read surfaces project the stored model through
+    #    stored_deflection_report_model(); an artifact that projection
+    #    rejects would persist, take payment, then 404 the report-model
+    #    route. Imported lazily: deflection_report_access imports this
+    #    module at top level.
+    from .deflection_report_access import stored_deflection_report_model
+
+    if stored_deflection_report_model(payload) is None:
+        failing.append("model.stored_projection.readable")
+    if failing:
         raise DeflectionReportQAGateError(failing, scorecard)
     return scorecard
+
+
+# Content-hash linkage keys are re-derived from (possibly PII-scrubbed) text,
+# so they legitimately differ between the stored export and a fresh
+# derivation; every other field must match exactly.
+_EXPORT_INTEGRITY_VOLATILE_KEYS = frozenset({"cluster_id", "repeat_key"})
+
+
+def _export_integrity_view(export: Mapping[str, Any] | None) -> str:
+    if not isinstance(export, Mapping):
+        return ""
+
+    def strip(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {
+                key: strip(item)
+                for key, item in value.items()
+                if key not in _EXPORT_INTEGRITY_VOLATILE_KEYS
+            }
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            return [strip(item) for item in value]
+        return value
+
+    return json.dumps(strip(export), sort_keys=True, default=str)
 
 
 def build_deflection_full_report_qa_deterministic_harness(

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -1883,14 +1883,24 @@ def check_deflection_report_artifact_qa(
     modifies the artifact.
     """
 
-    try:
+    if isinstance(artifact, Mapping):
+        # Score the export that will actually be STORED. A mapping artifact
+        # is the persisted payload itself; re-deriving a fresh export here
+        # would let a drifted or missing embedded evidence_export ride
+        # through the gate unvalidated.
+        raw_export = artifact.get("evidence_export")
         evidence_export: Mapping[str, Any] | None = (
-            build_deflection_evidence_export(artifact)
+            raw_export if isinstance(raw_export, Mapping) else None
         )
-    except Exception:
-        # An artifact the export builder cannot even read must not pass a
-        # gate whose job is refusing malformed paid output.
-        evidence_export = None
+    else:
+        # A DeflectionReportArtifact embeds the derived export in as_dict(),
+        # so deriving is exactly what will be stored.
+        try:
+            evidence_export = build_deflection_evidence_export(artifact)
+        except Exception:
+            # An artifact the export builder cannot even read must not pass
+            # a gate whose job is refusing malformed paid output.
+            evidence_export = None
     model = _artifact_report_model(artifact)
     scorecard = build_deflection_full_report_qa_scorecard(
         model if isinstance(model, Mapping) else {},

--- a/plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md
+++ b/plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md
@@ -1,0 +1,184 @@
+# PR-Resolution-Audit-S8a-Runtime-QA-Gate
+
+Ownership lane: resolution-audit-csv
+
+## Why this slice exists
+
+S8a of the #1993 remediation arc (issue #2051, launch blocker #7 first
+half). The deterministic QA scorecard
+(`build_deflection_full_report_qa_scorecard`) exists and detects report
+drift, but it has ZERO runtime callers -- it is reachable only from
+scripts/ and tests. Both runtime boundary crossings accept any artifact
+unchecked: persist-at-generation (`_gate_deflection_report_artifacts` ->
+`store.save_report`) and paid-PDF delivery
+(`send_pending_deflection_report_deliveries` -> `_pdf_attachments`). A
+drifted or wrong paid artifact can be generated, persisted, paid for,
+and delivered with nothing blocking it.
+
+### Problem-derived contract
+
+- Root cause: the scorecard is a standalone checker, not a gate -- no
+  runtime path consults it before persisting or delivering an artifact.
+- Correct fix must touch/change:
+  1. `extracted_content_pipeline/faq_deflection_report.py` (owned): one
+     runtime gate predicate that derives the evidence export from the
+     artifact itself, runs the EXISTING scorecard (no surface
+     observations at these boundaries; default caps), and raises a typed
+     `DeflectionReportQAGateError` naming the failing assertion ids when
+     `ok` is false. No new assertion logic -- the scorecard stays the
+     single source of truth.
+  2. `extracted_content_pipeline/api/control_surfaces.py` (owned): in
+     `_gate_deflection_report_artifacts`, after the PII scrub and before
+     `save_report`, gate the scrubbed artifact; failure -> HTTP 502
+     naming the failing assertion ids. Fail-closed at persist: a
+     QA-failing artifact never enters the store, so checkout can never
+     take money for an artifact delivery would later refuse.
+  3. Tests, both directions, on the real fixture artifact and the real
+     store harness already used by the suites: healthy artifact passes
+     the gate and persists unchanged; drifted artifact (bogus
+     schema_version / missing required section) 502s at the route naming
+     the failing assertion ids and never persists; the gate never
+     modifies the artifact; an unreadable artifact fails closed.
+
+Build-time contract amendment (discovered, not planned): a delivery-side
+gate was initially planned and BUILT, then reverted before commit. The
+existing delivery suite pins an explicit tolerance contract
+(`test_delivery_worker_falls_back_for_future_report_model_schema`):
+persisted artifacts may straddle schema versions across deploys and must
+still deliver. A full-scorecard delivery gate contradicts that pinned
+product contract -- the scorecard asserts the CURRENT schema, which is
+only guaranteed at generation time. Fail-closed for paid delivery holds
+TRANSITIVELY: delivery only sends persisted+paid artifacts, and nothing
+QA-failing can be persisted anymore. Pre-existing persisted rows are an
+ops-sweep follow-up (Deferred).
+- Must not change:
+  - Report content/shape -- the gate gates, it never edits.
+  - Scrub (S6A) and snapshot behavior; scorecard assertions themselves.
+  - scripts/ callers -- diagnostics must still be able to build and
+    score BAD artifacts, so `build_deflection_report_artifact` itself
+    stays ungated.
+  - Delta delivery path (separate lane); checkout/payment semantics.
+  - The delivery worker's schema-tolerance contract (see amendment
+    above): `atlas_brain/content_ops_deflection_delivery.py` is
+    deliberately untouched.
+
+Empirical pre-checks (run before coding): the healthy fixture artifact
+passes the scorecard post-scrub (ok=true, 73 assertions); a bogus
+schema_version and a truncated evidence export fail with named
+assertion ids (`model.schema_version`,
+`evidence_export.evidence_rows.length`); the delivery loop already
+fail-closes typed exceptions via incident + `_mark_failed`.
+
+Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS; at
+cap, fix what is written, resolve/waive remaining threads, merge on
+required-green.
+
+## Scope (this PR)
+
+Slice phase: Vertical slice
+
+Max files: 5
+
+1. `extracted_content_pipeline/faq_deflection_report.py` -- gate
+   predicate + typed error.
+2. `extracted_content_pipeline/api/control_surfaces.py` -- persist-side
+   wiring.
+3. `tests/test_content_ops_deflection_report.py` -- gate predicate both
+   directions.
+4. `tests/test_extracted_content_deflection_submit.py` -- persist
+   boundary both directions; the existing PII-scrub proof rebuilt on a
+   REAL-builder artifact (the storage boundary now refuses the
+   hand-rolled one-section shape it used, which is the intended
+   contract change).
+5. This plan doc.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+### Review Contract
+
+Acceptance criteria:
+1. A healthy artifact flows through generate -> scrub -> persist ->
+   paid delivery unchanged (no content edits, no new failures).
+2. A drifted artifact (bogus schema_version or missing required
+   section) is refused at persist with HTTP 502 naming the failing
+   assertion ids, and nothing is written to the store.
+3. scripts/ diagnostics still build and score bad artifacts (the raw
+   builder is not gated).
+4. The gate never modifies the artifact, snapshot, or scrub output.
+5. The delivery worker's tolerance contract is untouched (its suite
+   passes unchanged).
+
+Reachability proof: wired on the live `_gate_deflection_report_artifacts`
+persist path; tests assert store contents through the real
+InMemoryDeflectionReportArtifactStore, not just the predicate.
+
+Affected surfaces: deflection report persist route.
+
+Risk areas: false-positive gate bricking healthy reports (bounded by
+the empirical pre-check: real fixture passes post-scrub, and the
+healthy-path e2e tests pin it); artifacts persisted pre-gate (delivery
+tolerance keeps them deliverable; ops sweep deferred).
+
+Reviewer rules triggered: R1, R2, R10, R14 (extracted package change; test evidence; new fail-closed gate on the paid path probed both directions; admission-adjacent boundary).
+
+## Mechanism
+
+`check_deflection_report_artifact_qa(artifact)` builds
+`build_deflection_evidence_export(artifact)` and runs
+`build_deflection_full_report_qa_scorecard(report_model,
+evidence_export=...)`; on `ok == false` it raises
+`DeflectionReportQAGateError` (a `ValueError`) carrying the failing
+assertion ids and the scorecard. `_gate_deflection_report_artifacts`
+calls it on the scrubbed artifact before `save_report`; the route's
+existing `ValueError` handler maps it to HTTP 502 with the assertion ids
+in the detail.
+
+## Intentional
+
+- Fail-closed at the persist crossing: a QA-failing artifact never
+  enters the store, so checkout can never take money for a report that
+  delivery would refuse. Flag-only was rejected for the same reason.
+- Delivery deliberately NOT gated (contract amendment above): the
+  scorecard asserts the current schema, which only generation
+  guarantees; delivery's pinned tolerance contract keeps already-paid
+  artifacts deliverable across deploys.
+- The gate lives beside the scorecard in the extracted package so the
+  API layer and the host brain import one predicate -- no forked
+  assertion logic (the same-predicate discipline S8b will follow for
+  the billed-repeat rule).
+- Surface observations are deliberately not asserted at these
+  boundaries: they describe rendered surfaces (hosted page), which do
+  not exist yet at persist/delivery time.
+
+## Deferred
+
+- S8b money reconciliation guard (#2052) -- next slice, same lane.
+- Ops sweep script over already-persisted artifacts (they predate the
+  gate and stay deliverable under the delivery tolerance contract).
+- Surface-observation assertions for the hosted result page.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_deflection_report.py -q`
+- `python -m pytest tests/test_extracted_content_deflection_submit.py -q`
+- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q`
+  (unchanged suite proving the delivery tolerance contract holds)
+- Full CI mirror bash `scripts/run_extracted_pipeline_checks.sh`
+- Empirical both-direction probes above reproduced as pinned tests.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/api/control_surfaces.py` | 8 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 53 |
+| `plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md` | 184 |
+| `tests/test_content_ops_deflection_report.py` | 57 |
+| `tests/test_extracted_content_deflection_submit.py` | 225 |
+| **Total** | **527** |

--- a/plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md
+++ b/plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md
@@ -69,6 +69,17 @@ assertion ids (`model.schema_version`,
 `evidence_export.evidence_rows.length`); the delivery loop already
 fail-closes typed exceptions via incident + `_mark_failed`.
 
+Round-1 review refinement (verified failing first): the gate scored a
+FRESHLY DERIVED evidence export while `DeflectionReportArtifact.as_dict`
+embeds one in the persisted payload (and the process contract requires
+it for paid artifacts) -- so a drifted or missing embedded
+evidence_export rode through the gate unvalidated. The gate now scores
+the export that will actually be stored: for a mapping artifact it reads
+the embedded `evidence_export` (missing/non-mapping fails closed); it
+derives only for a DeflectionReportArtifact object, whose as_dict embeds
+exactly that derivation. The PII-scrub test stops replacing the real
+embedded export (its rows already carry the planted PII).
+
 Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS; at
 cap, fix what is written, resolve/waive remaining threads, merge on
 required-green.
@@ -177,8 +188,8 @@ in the detail.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/api/control_surfaces.py` | 8 |
-| `extracted_content_pipeline/faq_deflection_report.py` | 53 |
-| `plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md` | 184 |
-| `tests/test_content_ops_deflection_report.py` | 57 |
-| `tests/test_extracted_content_deflection_submit.py` | 225 |
-| **Total** | **527** |
+| `extracted_content_pipeline/faq_deflection_report.py` | 63 |
+| `plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md` | 195 |
+| `tests/test_content_ops_deflection_report.py` | 89 |
+| `tests/test_extracted_content_deflection_submit.py` | 220 |
+| **Total** | **575** |

--- a/plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md
+++ b/plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md
@@ -93,6 +93,19 @@ then 404'd the report-model route -- the gate now runs that SAME
 projection (lazy import; deflection_report_access imports this module).
 Both checks reuse canonical readers; no hand-written field lists.
 
+Round-3 refinements (cap round; both verified failing first): (1) the
+stored projection silently DROPS invalid sections rather than returning
+None, so breaking one required section passed the None-check while the
+paid report-model route lost that section -- the gate now runs the SAME
+scorecard on the projected model paid readers see (failing ids prefixed
+`stored_projection:`); (2) stripping the volatile linkage keys from the
+export-integrity comparison accepted exports that OMIT them entirely --
+the keys are now normalized to a presence/type marker instead of
+removed, so omission and non-string corruption fail while the
+scrub-volatile hash content stays ignored. Residual (accepted by
+construction): a tampered-but-well-typed hash value is indistinguishable
+from a legitimate scrub re-derivation.
+
 Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS; at
 cap, fix what is written, resolve/waive remaining threads, merge on
 required-green.
@@ -201,8 +214,8 @@ in the detail.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/api/control_surfaces.py` | 8 |
-| `extracted_content_pipeline/faq_deflection_report.py` | 107 |
-| `plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md` | 208 |
-| `tests/test_content_ops_deflection_report.py` | 130 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 129 |
+| `plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md` | 221 |
+| `tests/test_content_ops_deflection_report.py` | 174 |
 | `tests/test_extracted_content_deflection_submit.py` | 220 |
-| **Total** | **673** |
+| **Total** | **752** |

--- a/plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md
+++ b/plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md
@@ -80,6 +80,19 @@ derives only for a DeflectionReportArtifact object, whose as_dict embeds
 exactly that derivation. The PII-scrub test stops replacing the real
 embedded export (its rows already carry the planted PII).
 
+Round-2 review refinements (both verified failing first): (1) a
+same-count export whose ELEMENTS drifted (junk questions/rows with
+matching lengths) passed the count-level scorecard -- the gate now
+requires the stored export to equal the canonical derivation of the
+stored artifact, excluding only the content-hash linkage keys
+(cluster_id, repeat_key) that legitimately change when re-derived from
+scrubbed text; (2) paid read surfaces project the stored model through
+stored_deflection_report_model(), and an artifact that projection
+rejects (e.g. non-integer section priority) persisted, took payment,
+then 404'd the report-model route -- the gate now runs that SAME
+projection (lazy import; deflection_report_access imports this module).
+Both checks reuse canonical readers; no hand-written field lists.
+
 Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS; at
 cap, fix what is written, resolve/waive remaining threads, merge on
 required-green.
@@ -188,8 +201,8 @@ in the detail.
 | File | LOC |
 |---|---:|
 | `extracted_content_pipeline/api/control_surfaces.py` | 8 |
-| `extracted_content_pipeline/faq_deflection_report.py` | 63 |
-| `plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md` | 195 |
-| `tests/test_content_ops_deflection_report.py` | 89 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 107 |
+| `plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md` | 208 |
+| `tests/test_content_ops_deflection_report.py` | 130 |
 | `tests/test_extracted_content_deflection_submit.py` | 220 |
-| **Total** | **575** |
+| **Total** | **673** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -7451,6 +7451,50 @@ def test_qa_gate_refuses_a_model_paid_readers_cannot_project() -> None:
     with pytest.raises(DeflectionReportQAGateError) as exc_info:
         check_deflection_report_artifact_qa(drifted)
 
-    assert "model.stored_projection.readable" in (
+    # Round 3 upgraded the None-check to a full scorecard on the projected
+    # model; an unprojectable model now fails its section assertions.
+    assert any(
+        failing_id.startswith("stored_projection:")
+        for failing_id in exc_info.value.failing_assertion_ids
+    )
+
+
+# Round-3 review refinements (cap round): the projection paid readers see
+# is itself scorecard-checked, and linkage keys must be present even
+# though their hash content is scrub-volatile.
+
+
+def test_qa_gate_refuses_a_projection_that_drops_a_required_section() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    drifted = scrub_deflection_report_payload(artifact.as_dict())
+    model = json.loads(json.dumps(drifted["report_model"], default=str))
+    for section in model["sections"]:
+        if section["id"] == "ranked_questions":
+            # The stored projection silently drops this section; the paid
+            # report-model route would then be missing it.
+            section["priority"] = "high"
+    drifted["report_model"] = model
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(drifted)
+
+    assert "stored_projection:model.section.ranked_questions.present" in (
+        exc_info.value.failing_assertion_ids
+    )
+
+
+def test_qa_gate_refuses_an_export_missing_linkage_keys() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    drifted = scrub_deflection_report_payload(artifact.as_dict())
+    export = json.loads(json.dumps(drifted["evidence_export"], default=str))
+    for element in list(export["questions"]) + list(export["evidence_rows"]):
+        element.pop("cluster_id", None)
+        element.pop("repeat_key", None)
+    drifted["evidence_export"] = export
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(drifted)
+
+    assert "evidence_export.matches_stored_artifact" in (
         exc_info.value.failing_assertion_ids
     )

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import pytest
 
 from extracted_content_pipeline.faq_deflection_report import (
+    DeflectionReportQAGateError,
+    check_deflection_report_artifact_qa,
     DEFAULT_DEFLECTION_REPORT_TITLE,
     DEFAULT_DEFLECTION_SNAPSHOT_TITLE,
     DEFAULT_DEFLECTION_SEO_TARGET_LIMIT,
@@ -7324,3 +7326,58 @@ def test_deflection_report_cli_rejects_malformed_intent_rule(
         "--intent-rule must use topic=keyword,keyword with at least one keyword"
     )
     assert not output.exists()
+
+
+# S8a: the QA scorecard wired as a fail-closed runtime gate.
+
+
+def test_qa_gate_passes_a_healthy_artifact_and_does_not_modify_it() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    scrubbed = scrub_deflection_report_payload(artifact.as_dict())
+    before = json.dumps(scrubbed, sort_keys=True, default=str)
+
+    scorecard = check_deflection_report_artifact_qa(scrubbed)
+
+    assert scorecard["ok"] is True
+    assert scorecard["assertions"]
+    # The gate gates; it never edits the artifact.
+    assert json.dumps(scrubbed, sort_keys=True, default=str) == before
+    # The raw (pre-scrub) artifact object passes too.
+    assert check_deflection_report_artifact_qa(artifact)["ok"] is True
+
+
+def test_qa_gate_refuses_a_drifted_schema_version() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    drifted = scrub_deflection_report_payload(artifact.as_dict())
+    drifted["report_model"] = dict(drifted["report_model"])
+    drifted["report_model"]["schema_version"] = "deflection.v999"
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(drifted)
+
+    assert "model.schema_version" in exc_info.value.failing_assertion_ids
+    assert "deflection_report_qa_gate_failed" in str(exc_info.value)
+    assert exc_info.value.scorecard.get("ok") is False
+
+
+def test_qa_gate_refuses_a_missing_required_section() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    drifted = scrub_deflection_report_payload(artifact.as_dict())
+    model = dict(drifted["report_model"])
+    model["sections"] = [
+        section for section in model["sections"]
+        if section.get("id") != "ranked_questions"
+    ]
+    drifted["report_model"] = model
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(drifted)
+
+    assert "model.section.ranked_questions.present" in (
+        exc_info.value.failing_assertion_ids
+    )
+
+
+def test_qa_gate_fails_closed_on_an_unreadable_artifact() -> None:
+    with pytest.raises(DeflectionReportQAGateError):
+        check_deflection_report_artifact_qa({})

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -7381,3 +7381,35 @@ def test_qa_gate_refuses_a_missing_required_section() -> None:
 def test_qa_gate_fails_closed_on_an_unreadable_artifact() -> None:
     with pytest.raises(DeflectionReportQAGateError):
         check_deflection_report_artifact_qa({})
+
+
+# Round-1 review refinement: the gate scores the export that will be
+# STORED, not a fresh derivation -- a drifted or missing embedded
+# evidence_export must not ride through.
+
+
+def test_qa_gate_refuses_a_drifted_embedded_evidence_export() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    drifted = scrub_deflection_report_payload(artifact.as_dict())
+    drifted["evidence_export"] = {
+        "schema_version": "bad",
+        "summary": {},
+        "questions": [],
+        "evidence_rows": [],
+    }
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(drifted)
+
+    assert "evidence_export.schema_version" in exc_info.value.failing_assertion_ids
+
+
+def test_qa_gate_refuses_a_missing_embedded_evidence_export() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    scrubbed = scrub_deflection_report_payload(artifact.as_dict())
+    scrubbed.pop("evidence_export", None)
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(scrubbed)
+
+    assert "evidence_export.present" in exc_info.value.failing_assertion_ids

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -7413,3 +7413,44 @@ def test_qa_gate_refuses_a_missing_embedded_evidence_export() -> None:
         check_deflection_report_artifact_qa(scrubbed)
 
     assert "evidence_export.present" in exc_info.value.failing_assertion_ids
+
+
+# Round-2 review refinements: same-count element drift and paid-reader
+# projection readability.
+
+
+def test_qa_gate_refuses_a_same_count_drifted_export() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    drifted = scrub_deflection_report_payload(artifact.as_dict())
+    good = drifted["evidence_export"]
+    # Same schema version, same summary counts, same array lengths -- but
+    # the elements themselves are junk.
+    drifted["evidence_export"] = {
+        "schema_version": good["schema_version"],
+        "summary": good["summary"],
+        "questions": [{} for _ in good["questions"]],
+        "evidence_rows": [{} for _ in good["evidence_rows"]],
+    }
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(drifted)
+
+    assert "evidence_export.matches_stored_artifact" in (
+        exc_info.value.failing_assertion_ids
+    )
+
+
+def test_qa_gate_refuses_a_model_paid_readers_cannot_project() -> None:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    drifted = scrub_deflection_report_payload(artifact.as_dict())
+    model = json.loads(json.dumps(drifted["report_model"], default=str))
+    for section in model["sections"]:
+        section["priority"] = "high"  # stored projection requires an int
+    drifted["report_model"] = model
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(drifted)
+
+    assert "model.stored_projection.readable" in (
+        exc_info.value.failing_assertion_ids
+    )

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -28,7 +28,9 @@ from extracted_content_pipeline.faq_deflection_report import (
     DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION,
     DEFLECTION_REPORT_SCHEMA_VERSION,
     FAQDeflectionReportService,
+    build_deflection_report_artifact,
 )
+from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownResult
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -1280,85 +1282,61 @@ async def test_deflection_report_search_only_returns_portfolio_renderable_items(
 @pytest.mark.asyncio
 async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
     store = InMemoryDeflectionReportArtifactStore()
-    unsafe_artifact = {
-        "markdown": (
-            "# Report\n\n"
-            "How do I reset access for jane.doe@acme.com?\n"
-            "Call _555-123-4567_ and confirm account 4829103.\n"
-            "Customer: Jane Doe moved to 123 Maple Street Apt 4B.\n"
+    pii_item = {
+        "question": "How do I reset access for jane.doe@acme.com?",
+        "question_source": "customer_wording",
+        "customer_wording": "Call 555-123-4567 for account 4829103.",
+        "topic": "access",
+        "weighted_frequency": 2,
+        "ticket_count": 2,
+        "opportunity_score": 9,
+        "answer": (
+            "Reset _jane.doe@acme.com_ after confirming account 4829103 "
+            "for customer: Jane Doe at 123 Maple Street Apt 4B. "
+            "The customer is Jane Smith ticket was closed. "
+            "The customer id is 123e4567-e89b-12d3-a456-426614174000."
         ),
-        "summary": {
-            "generated": 1,
-            "drafted_answer_count": 1,
-            "no_proven_answer_count": 0,
-        },
-        "faq_result": {
-            "items": [
-                {
-                    "question": "How do I reset access for jane.doe@acme.com?",
-                    "question_source": "customer_wording",
-                    "customer_wording": "Call 555-123-4567 for account 4829103.",
-                    "weighted_frequency": 2,
-                    "ticket_count": 2,
-                    "answer": (
-                        "Reset _jane.doe@acme.com_ after confirming account 4829103 "
-                        "for customer: Jane Doe at 123 Maple Street Apt 4B. "
-                        "The customer is Jane Smith ticket was closed. "
-                        "The customer id is 123e4567-e89b-12d3-a456-426614174000."
-                    ),
-                    "steps": [
-                        "Remove XXXXX before publishing.",
-                        "Escalate case 999999 if the reset still fails.",
-                        "Check opaque migration token CUST-9XQ7-ABCD.",
-                        "Requester name is Jane Doe.",
-                        "Mail a label to 123 Maple Street Apt 4B.",
-                        "customer id is 12345678.",
-                        "case CVE-2021-44228 should remain diagnostic context.",
-                    ],
-                    "source_ids": ["4829103", "777777"],
-                    "evidence_quotes": [
-                        "`4829103`: jane.doe@acme.com called _555-123-4567_."
-                    ],
-                    "answer_evidence_status": "resolution_evidence",
-                    "resolution_evidence_scope": "scoped",
-                }
-            ]
-        },
-        "report_model": {
-            "schema_version": DEFLECTION_REPORT_SCHEMA_VERSION,
-            "title": "Support Ticket Deflection Report",
-            "summary": {"generated": 1},
-            "sections": [
-                {
-                    "id": "question_details",
-                    "title": "Question Details and Evidence",
-                    "priority": 40,
-                    "surfaces": ["web"],
-                    "default_limit": None,
-                    "required_data": ["rows"],
-                    "data": {
-                        "rows": [
-                            {
-                                "question": "How do I reset jane.doe@acme.com?",
-                                "answer": (
-                                    "Confirm account 4829103 for jane.doe@acme.com."
-                                    " Requester name is Jane Doe at 123 Maple Street."
-                                ),
-                            }
-                        ]
-                    },
-                }
-            ],
-        },
-        "evidence_export": {
-            "schema_version": DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION,
-            "evidence_rows": [
-                {
-                    "source_id": "4829103",
-                    "evidence_quote": "jane.doe@acme.com called 555-123-4567.",
-                }
-            ],
-        },
+        "steps": [
+            "Remove XXXXX before publishing.",
+            "Escalate case 999999 if the reset still fails.",
+            "Check opaque migration token CUST-9XQ7-ABCD.",
+            "Requester name is Jane Doe.",
+            "Mail a label to 123 Maple Street Apt 4B.",
+            "customer id is 12345678.",
+            "case CVE-2021-44228 should remain diagnostic context.",
+        ],
+        "source_ids": ["4829103", "777777"],
+        "evidence_quotes": [
+            "`4829103`: jane.doe@acme.com called _555-123-4567_."
+        ],
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
+    }
+    # Built through the REAL artifact builder (not a hand-rolled shape):
+    # the storage boundary now refuses structurally-invalid artifacts via
+    # the QA gate, so the PII-scrub proof must ride a valid artifact.
+    unsafe_artifact = build_deflection_report_artifact(
+        TicketFAQMarkdownResult(
+            markdown=(
+                "# Report\n\n"
+                "How do I reset access for jane.doe@acme.com?\n"
+                "Call _555-123-4567_ and confirm account 4829103.\n"
+                "Customer: Jane Doe moved to 123 Maple Street Apt 4B.\n"
+            ),
+            source_count=2,
+            ticket_source_count=2,
+            output_checks={"condensed": True},
+            items=(pii_item,),
+        )
+    ).as_dict()
+    unsafe_artifact["evidence_export"] = {
+        "schema_version": DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION,
+        "evidence_rows": [
+            {
+                "source_id": "4829103",
+                "evidence_quote": "jane.doe@acme.com called 555-123-4567.",
+            }
+        ],
     }
 
     gated = await api_module._gate_deflection_report_artifacts(
@@ -3338,3 +3316,94 @@ async def test_publish_macros_partial_generated_draft_publishes_nothing() -> Non
     assert boundary.calls == []
     assert repo.update_calls == []
     assert repo.stored_status == "draft"
+
+
+# S8a: fail-closed QA gate at the persist boundary -- a drifted artifact is
+# refused with the failing assertion ids and never enters the store.
+
+
+def _valid_report_artifact_dict() -> dict:
+    return build_deflection_report_artifact(
+        TicketFAQMarkdownResult(
+            markdown="# Report\n\nHow do I export data?\n",
+            source_count=2,
+            ticket_source_count=2,
+            output_checks={"condensed": True},
+            items=(
+                {
+                    "question": "How do I export data?",
+                    "question_source": "customer_wording",
+                    "customer_wording": "export data",
+                    "topic": "exports",
+                    "weighted_frequency": 2,
+                    "ticket_count": 2,
+                    "opportunity_score": 9,
+                    "answer": "Open Settings and choose Export.",
+                    "steps": ["Open Settings and choose Export."],
+                    "source_ids": ["ticket-1", "ticket-2"],
+                    "evidence_quotes": ["`ticket-1` - export data"],
+                    "answer_evidence_status": "resolution_evidence",
+                    "resolution_evidence_scope": "scoped",
+                },
+            ),
+        )
+    ).as_dict()
+
+
+def _execution_result_with_artifact(artifact: dict) -> dict:
+    return {
+        "status": "completed",
+        "steps": [
+            {
+                "output": "faq_deflection_report",
+                "status": "completed",
+                "result": artifact,
+            }
+        ],
+    }
+
+
+async def test_storage_gate_refuses_drifted_artifact_and_persists_nothing() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    drifted = _valid_report_artifact_dict()
+    drifted["report_model"] = dict(drifted["report_model"])
+    drifted["report_model"]["schema_version"] = "deflection.v999"
+
+    with pytest.raises(api_module.HTTPException) as exc_info:
+        await api_module._gate_deflection_report_artifacts(
+            _execution_result_with_artifact(drifted),
+            store_provider=lambda: store,
+            scope=TenantScope(account_id="acct-qa"),
+            request_id="request-qa-drifted",
+            top_n=1,
+            teaser_preview_count=1,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert "deflection_report_qa_gate_failed" in str(exc_info.value.detail)
+    assert "model.schema_version" in str(exc_info.value.detail)
+    record = await store.get_artifact_record(
+        account_id="acct-qa",
+        request_id="request-qa-drifted",
+    )
+    assert record is None
+
+
+async def test_storage_gate_persists_a_healthy_artifact_through_the_qa_gate() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+
+    gated = await api_module._gate_deflection_report_artifacts(
+        _execution_result_with_artifact(_valid_report_artifact_dict()),
+        store_provider=lambda: store,
+        scope=TenantScope(account_id="acct-qa"),
+        request_id="request-qa-healthy",
+        top_n=1,
+        teaser_preview_count=1,
+    )
+
+    record = await store.get_artifact_record(
+        account_id="acct-qa",
+        request_id="request-qa-healthy",
+    )
+    assert record is not None
+    assert gated["steps"][0]["status"] == "completed"

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -1329,15 +1329,10 @@ async def test_deflection_report_storage_gate_scrubs_supported_pii() -> None:
             items=(pii_item,),
         )
     ).as_dict()
-    unsafe_artifact["evidence_export"] = {
-        "schema_version": DEFLECTION_EVIDENCE_EXPORT_SCHEMA_VERSION,
-        "evidence_rows": [
-            {
-                "source_id": "4829103",
-                "evidence_quote": "jane.doe@acme.com called 555-123-4567.",
-            }
-        ],
-    }
+    # The real builder embeds the derived evidence_export, and its rows
+    # carry the same PII (source ids, quotes) as the item above; the QA
+    # gate scores that STORED export, so the test must not replace it.
+    assert "jane.doe" in json.dumps(unsafe_artifact["evidence_export"])
 
     gated = await api_module._gate_deflection_report_artifacts(
         {


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S8a-Runtime-QA-Gate.md

Slice phase: Vertical slice

S8a of the #1993 remediation arc (closes #2051, launch blocker #7 first half). The deterministic QA scorecard (`build_deflection_full_report_qa_scorecard`) had ZERO runtime callers -- a drifted paid artifact could be generated, persisted, paid for, and delivered with nothing blocking it. This slice wires the EXISTING scorecard as a fail-closed gate at the persist boundary.

## Intentional

- Fail-closed at persist, not flag-only: persist-then-block-later would take payment for a report that never sends.
- Delivery deliberately NOT gated (tolerance contract above).
- Gate lives beside the scorecard in the extracted package: one predicate, no forked assertion logic (the same-predicate discipline S8b will follow for the billed-repeat rule).
- Surface observations not asserted at this boundary (they describe rendered surfaces that do not exist at persist time).

## Deferred

- S8b money reconciliation guard (#2052) -- next slice, same lane.
- Ops sweep over already-persisted artifacts (they predate the gate and stay deliverable under the delivery tolerance contract).
- Surface-observation assertions for the hosted result page.

## Parked hardening

- None new; residual edge semantics tracked on #1993.

## Cold diff reconstruction

- `extracted_content_pipeline/faq_deflection_report.py`: `check_deflection_report_artifact_qa(artifact)` derives the evidence export from the artifact, runs the existing scorecard, and raises typed `DeflectionReportQAGateError` (a `ValueError`) naming the failing assertion ids on `ok == false`. No new assertion logic; the scorecard stays the single source of truth. The gate never modifies the artifact.
- `extracted_content_pipeline/api/control_surfaces.py`: `_gate_deflection_report_artifacts` calls the gate on the scrubbed artifact after the S6A PII scrub and before `store.save_report`; the route's existing `ValueError` handler turns it into HTTP 502 with the assertion ids. A QA-failing artifact never enters the store, so checkout can never take money for a report delivery would refuse.
- Tests: 4 predicate tests (healthy raw+scrubbed passes and is unmodified; drifted schema_version refused; missing required section refused; unreadable fails closed) + 2 persist-boundary e2e tests through the real `InMemoryDeflectionReportArtifactStore` (drifted 502s naming ids, store stays empty; healthy persists). The existing PII-scrub proof was rebuilt on a REAL-builder artifact -- the storage boundary now refuses the hand-rolled one-section shape it previously used, which is the intended contract change.

Build-time contract amendment (in the plan): a delivery-side gate was initially planned and BUILT, then reverted before commit -- the delivery suite pins an explicit tolerance contract (`test_delivery_worker_falls_back_for_future_report_model_schema`: persisted artifacts may straddle schema versions across deploys and must still deliver), and a full-scorecard delivery gate contradicts it because the scorecard asserts the CURRENT schema, which only generation guarantees. Fail-closed for paid delivery holds transitively: delivery only sends persisted+paid artifacts, and nothing QA-failing can be persisted anymore. `atlas_brain/content_ops_deflection_delivery.py` is deliberately untouched and its suite passes unchanged.

Empirical pre-checks (before coding): healthy fixture artifact passes the scorecard post-scrub (ok=true, 73 assertions); bogus schema_version and truncated evidence export fail with named assertion ids.

Round-1 reconciliation (verified failing first): P1 -- the gate scored a freshly derived evidence export while `as_dict()` embeds one in the persisted payload, so a drifted or missing embedded `evidence_export` passed the gate unvalidated. Fixed: the gate scores the export that will actually be STORED (embedded for mapping artifacts, fail-closed when missing/non-mapping; derived only for artifact objects where as_dict embeds that same derivation). Tests: `test_qa_gate_refuses_a_drifted_embedded_evidence_export`, `test_qa_gate_refuses_a_missing_embedded_evidence_export`.

Round-2 reconciliation (both verified failing first): P1 -- same-count element drift (junk questions/rows with matching lengths) passed the count-level scorecard; the gate now requires the stored export to equal the canonical derivation of the stored artifact, excluding only the content-hash linkage keys (`cluster_id`, `repeat_key`) that legitimately change when re-derived from scrubbed text. P1 -- an artifact the paid readers' `stored_deflection_report_model()` projection rejects (e.g. non-integer section priority) persisted, took payment, then 404'd the report-model route; the gate now runs that same projection. Both checks reuse canonical readers, not hand-written field lists. Tests: `test_qa_gate_refuses_a_same_count_drifted_export`, `test_qa_gate_refuses_a_model_paid_readers_cannot_project`.

Round-3 reconciliation (cap round -- 3-round hard cap reached, merging on required-green per the arc protocol; both verified failing first): P1 -- the stored projection silently drops invalid sections, so breaking one required section passed the non-None check while the paid report-model route lost it; the gate now runs the same scorecard on the projected model paid readers see (ids prefixed `stored_projection:`). P1 -- removing the volatile linkage keys from the integrity comparison accepted exports that omit them; they are now normalized to presence/type markers, so omission and non-string corruption fail while scrub-volatile hash content stays ignored. Residual accepted by construction: a tampered-but-well-typed hash value is indistinguishable from a legitimate scrub re-derivation. Tests: `test_qa_gate_refuses_a_projection_that_drops_a_required_section`, `test_qa_gate_refuses_an_export_missing_linkage_keys`.

## Verification

- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_deflection_submit.py tests/test_atlas_content_ops_deflection_delivery.py -q` (`337 passed, 5 skipped`)
- Full CI mirror bash `scripts/run_extracted_pipeline_checks.sh` (`5927 passed, 21 skipped`)
- Both error directions pinned: drifted refuses + never persists; healthy passes + unmodified.

Reviewer rules triggered: R1, R2, R10, R14 (extracted package change; test evidence; new fail-closed gate on the paid path probed both directions; admission-adjacent boundary).

Round-4 (post-cap) disposition -- no further code rounds per the 3-round cap:
- WAIVED (AGENTS 4a.1): same-count row drift INSIDE projected model sections (e.g. `ranked_questions.data.rows` elements replaced with `{}` at unchanged length) passes the gate. Residual threat model: a payload mutating between our own builder and `save_report` within one request, at a depth the scorecard's count assertions and the projection's section-level `required_data` checks do not reach. The gate already refuses schema drift, missing/extra sections, missing section data keys, count drift, export element drift (canonical re-derivation equality), and unprojectable models; each review round has moved the probe one level deeper into the previous round's fix (counts -> elements -> projection -> projection rows), which recurses indefinitely on any nested payload. If model-row drift shows up in practice, the canonical fix is re-derivation equality for the report_model mirroring the export check -- tracked as follow-up hardening on #1993, not a cap-round patch.

Diff-budget override: the predicate, its persist wiring, and the both-direction boundary tests are one indivisible fail-closed decision; ~half the added lines are the PII-scrub proof rebuilt on a real-builder artifact, required because the new gate refuses its old hand-rolled fixture.

## Diff size

~541 added lines (see plan table); dominated by tests + plan doc.
