### PR TITLE
Resolution Audit CSV S8b: money reconciliation guard + canonical delta rounding

### DIFF
--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -19,7 +19,10 @@ from extracted_content_pipeline.deflection_report_access import (
     deflection_delta_read_payload,
     stored_deflection_report_model,
 )
-from extracted_content_pipeline.deflection_money import format_support_cost_usd
+from extracted_content_pipeline.deflection_money import (
+    format_support_cost_usd,
+    signed_support_cost_delta_usd,
+)
 from extracted_content_pipeline.faq_deflection_report import (
     deflection_report_email_action_rows,
 )
@@ -1647,7 +1650,14 @@ def _signed_email_money(value: float) -> str:
 
 
 def _whole_dollar_money(value: float) -> str:
-    return f"${float(value):,.0f}"
+    # f-string float formatting rounds half-even; money rounds half-up
+    # (the canonical deflection_money rule), so quantize before display.
+    from decimal import Decimal, ROUND_HALF_UP
+
+    dollars = Decimal(str(abs(signed_support_cost_delta_usd(value)))).quantize(
+        Decimal("1"), rounding=ROUND_HALF_UP
+    )
+    return f"${dollars:,}"
 
 
 def _signed_count(value: int) -> str:

--- a/extracted_content_pipeline/deflection_delta.py
+++ b/extracted_content_pipeline/deflection_delta.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any, Mapping
 
+from .deflection_money import signed_support_cost_delta_usd
+
 
 DEFLECTION_DELTA_SCHEMA_VERSION = "deflection_delta.v1"
 SUPPORTED_DEFLECTION_MODEL_SCHEMA_VERSION = "deflection.v1"
@@ -134,7 +136,7 @@ def _delta_row(
         "ticket_count_delta": current_count - baseline_count,
         "current_estimated_support_cost": current_cost,
         "baseline_estimated_support_cost": baseline_cost,
-        "support_cost_delta": round(current_cost - baseline_cost, 2),
+        "support_cost_delta": signed_support_cost_delta_usd(current_cost - baseline_cost),
         "current_csat_signal": _csat(current_row),
         "baseline_csat_signal": _csat(baseline_row),
         "change_types": _change_types(current_row, baseline_row, effective_confidence),
@@ -206,7 +208,7 @@ def _summary(
         "matched_item_count": sum(
             1 for item in items if item["current_status"] and item["baseline_status"]
         ),
-        "support_cost_delta": round(sum(float(item["support_cost_delta"]) for item in items), 2),
+        "support_cost_delta": signed_support_cost_delta_usd(sum(float(item["support_cost_delta"]) for item in items)),
     }
     for change in (
         "NEW",

--- a/extracted_content_pipeline/deflection_money.py
+++ b/extracted_content_pipeline/deflection_money.py
@@ -31,6 +31,18 @@ def annualized_support_cost_usd(ticket_count: Any, window_days: Any) -> float:
     return float(_quantize_usd(amount))
 
 
+def signed_support_cost_delta_usd(value: Any) -> float:
+    """Quantize a SIGNED money delta with the same ROUND_HALF_UP rule.
+
+    `support_cost_usd` clamps to zero for report displays; deltas must
+    keep their sign, rounding half-up by magnitude on both sides.
+    """
+
+    amount = _coerce_decimal(value)
+    quantized = abs(amount).quantize(_CENT, rounding=ROUND_HALF_UP)
+    return float(-quantized if amount < 0 else quantized)
+
+
 def format_support_cost_usd(value: Any) -> str:
     quantized = _quantize_usd(_coerce_decimal(value))
     return f"${quantized:,.2f}"

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -1841,6 +1841,7 @@ def build_deflection_full_report_qa_scorecard(
             )
 
     _add_evidence_export_assertions(add, counts, evidence_export)
+    _add_money_reconciliation_assertions(add, sections)
     _add_surface_observation_assertions(
         add,
         counts,
@@ -2270,6 +2271,110 @@ def _scorecard_counts(sections: Mapping[str, Mapping[str, Any]]) -> dict[str, An
             suppressed_repeat_review,
         ),
     }
+
+
+def _add_money_reconciliation_assertions(
+    add: Any,
+    sections: Mapping[str, Mapping[str, Any]],
+) -> None:
+    """Verify the model's money figures against the billed-repeat predicate.
+
+    Pure verification (P5-7): every expected value is recomputed from the
+    model's OWN rows via the same `_is_billed_repeat_item` /
+    `deflection_money` functions that produced the figures at build time.
+    Money is linear and quantized once, so equality is exact.
+    """
+
+    support_tax = sections.get("support_tax", {})
+    tax_data = (
+        support_tax.get("data")
+        if isinstance(support_tax.get("data"), Mapping)
+        else {}
+    )
+    ranked = sections.get("ranked_questions", {})
+    ranked_data = (
+        ranked.get("data") if isinstance(ranked.get("data"), Mapping) else {}
+    )
+    raw_rows = ranked_data.get("rows")
+    rows = [
+        row
+        for row in (raw_rows if isinstance(raw_rows, Sequence) else ())
+        if isinstance(row, Mapping)
+    ]
+
+    headline_repeat = _int(tax_data.get("repeat_ticket_count"))
+    predicate_repeat = _repeat_ticket_count(rows)
+    add(
+        "money.support_tax.repeat_ticket_count.matches_predicate",
+        headline_repeat == predicate_repeat,
+        expected=predicate_repeat,
+        actual=headline_repeat,
+    )
+
+    headline_cost = _money_value(tax_data.get("estimated_support_cost"))
+    expected_cost = support_cost_usd(headline_repeat)
+    add(
+        "money.support_tax.estimated_support_cost.matches_rule",
+        headline_cost == expected_cost,
+        expected=expected_cost,
+        actual=headline_cost,
+    )
+
+    billed_row_sum = round(
+        sum(
+            _money_value(row.get("estimated_support_cost"))
+            for row in rows
+            if _is_billed_repeat_item(row)
+        ),
+        2,
+    )
+    add(
+        "money.rows.billed_sum_matches_headline",
+        billed_row_sum == headline_cost,
+        expected=headline_cost,
+        actual=billed_row_sum,
+    )
+    rows_priced_by_rule = all(
+        _money_value(row.get("estimated_support_cost"))
+        == support_cost_usd(_ticket_count(row))
+        for row in rows
+    )
+    add(
+        "money.rows.each_priced_by_rule",
+        rows_priced_by_rule,
+        expected=True,
+        actual=rows_priced_by_rule,
+    )
+
+    window = tax_data.get("source_date_window")
+    if isinstance(window, Mapping) and window:
+        expected_annualized = annualized_support_cost_usd(
+            headline_repeat,
+            _int(window.get("source_window_days")),
+        )
+        add(
+            "money.support_tax.annualized_support_cost.matches_rule",
+            _money_value(tax_data.get("annualized_support_cost"))
+            == expected_annualized,
+            expected=expected_annualized,
+            actual=_money_value(tax_data.get("annualized_support_cost")),
+        )
+    else:
+        expected_run_rate = support_cost_usd(headline_repeat * 12)
+        add(
+            "money.support_tax.annualized_run_rate.matches_rule",
+            _money_value(tax_data.get("annualized_run_rate_support_cost"))
+            == expected_run_rate,
+            expected=expected_run_rate,
+            actual=_money_value(tax_data.get("annualized_run_rate_support_cost")),
+        )
+
+
+def _money_value(value: Any) -> float:
+    try:
+        return round(float(value), 2)
+    except (TypeError, ValueError):
+        return -1.0
 
 
 def _add_evidence_export_assertions(
@@ -4864,14 +4969,20 @@ def _source_count(item: Mapping[str, Any]) -> int:
     return source_count or _int(item.get("ticket_count"))
 
 
+def _is_billed_repeat_item(item: Mapping[str, Any]) -> bool:
+    # THE billed-repeat rule. A question asked once is not a repeat:
+    # resolution-scoped items can still carry a single ticket, and they
+    # stay in the report as drafted answers, but they do not count as
+    # repeat work (#1481). The money reconciliation guard applies this
+    # same function -- never a re-hardcoded threshold (P5-7).
+    return _ticket_count(item) >= 2
+
+
 def _repeat_ticket_count(items: Sequence[Mapping[str, Any]]) -> int:
-    # A question asked once is not a repeat: resolution-scoped items can
-    # still carry a single ticket, and they stay in the report as drafted
-    # answers, but they do not count as repeat work (#1481).
     return sum(
         _ticket_count(item)
         for item in items
-        if _ticket_count(item) >= 2
+        if _is_billed_repeat_item(item)
     )
 
 

--- a/plans/PR-Resolution-Audit-S8b-Money-Reconciliation.md
+++ b/plans/PR-Resolution-Audit-S8b-Money-Reconciliation.md
@@ -1,0 +1,211 @@
+# PR-Resolution-Audit-S8b-Money-Reconciliation
+
+Ownership lane: resolution-audit-csv
+
+## Why this slice exists
+
+S8b of the #1993 remediation arc (issue #2052, launch blocker #7 second
+half; P5-7 in the audit). No model-level money reconciliation exists:
+the headline `estimated_support_cost`, the per-row money in
+`ranked_questions.data.rows`, and the annualized figures are computed
+independently at build time and never cross-checked afterward, so
+sum-of-rendered-rows vs headline can silently drift (with x16
+annualized amplification). S4/#2031 shipped DISPLAY reconciliation
+only. Separately, the S4-deferred delta-money path still rounds with
+float semantics: `deflection_delta.py` uses `round(x, 2)` (half-even)
+and the delta email's `_whole_dollar_money` uses raw f-string float
+formatting (half-even), while canonical money in `deflection_money.py`
+is Decimal ROUND_HALF_UP.
+
+### Problem-derived contract
+
+- Root cause: money figures are computed once and trusted forever --
+  no verifier ties headline, rows, and annualized figures back to the
+  billed-repeat predicate; and the delta path never adopted the
+  canonical Decimal rounding.
+- Correct fix must touch/change:
+  1. `extracted_content_pipeline/faq_deflection_report.py` (owned):
+     extract the per-item billed-repeat test into ONE named predicate
+     (`_is_billed_repeat_item`, the existing `_ticket_count(item) >= 2`
+     rule) and make `_repeat_ticket_count` use it; add
+     totals-reconciliation assertions to
+     `build_deflection_full_report_qa_scorecard` that VERIFY (never
+     compute): headline `repeat_ticket_count` equals the predicate
+     applied to the model's own `ranked_questions.data.rows`; headline
+     `estimated_support_cost` equals
+     `support_cost_usd(repeat_ticket_count)`; the billed rows' money
+     sums exactly to the headline; each row's money equals
+     `support_cost_usd(row.ticket_count)`; the annualized figure equals
+     `annualized_support_cost_usd(repeat, window_days)` on the dated
+     basis or `support_cost_usd(repeat * 12)` on the dateless run-rate
+     basis. Because S8a's gate runs this scorecard at persist (raw and
+     projected), the guard is live at the runtime boundary with no new
+     wiring.
+  2. `extracted_content_pipeline/deflection_money.py` (owned): a signed
+     quantizer (`signed_support_cost_delta_usd`) using the SAME Decimal
+     ROUND_HALF_UP rule, sign-preserving (no zero-clamp). (A signed
+     FORMATTER was drafted and removed at cold-diff review: no consumer
+     exists -- the delta email keeps its own signed whole-dollar shape.)
+  3. `extracted_content_pipeline/deflection_delta.py` (owned): replace
+     both float `round(x, 2)` call sites with the signed quantizer.
+  4. `atlas_brain/content_ops_deflection_delivery.py`:
+     `_whole_dollar_money` quantizes via Decimal ROUND_HALF_UP instead
+     of f-string float rounding; display shape (signed whole dollars)
+     unchanged.
+  5. Tests: drifted fixtures proving the guard trips at the scorecard
+     AND through the S8a persist gate (inflated headline count,
+     tampered headline cost, tampered row money, wrong annualized
+     basis); healthy fixture still passes raw + projected; delta
+     rounding boundary cases (.005 cents, .5 whole dollars) proving
+     half-up on both signs.
+- Must not change:
+  - Money COMPUTATION and display on the report path (S4 owns display;
+    the guard verifies, it does not compute).
+  - The billed-repeat rule itself (>=2 with source-ids fallback) --
+    it moves into a named function, semantics identical.
+  - Email/delta display shape (same strings; only the rounding rule at
+    the half-cent / half-dollar boundary).
+  - Scorecard schema_version; S8a gate mechanics.
+
+Empirical pre-checks (run before coding): on the real fixture the
+invariant holds exactly on BOTH the raw and the projected model
+(headline repeat=8, cost=108.0 == billed-row sum == recompute; rows are
+stored uncapped, so summing `data.rows` is sound); money is linear
+(13.50 x integer is always exact at 2dp), so the equality is exact, not
+tolerance-based. `_signed_email_money` currently formats via
+`f"{float(value):,.0f}"` (half-even) and `deflection_delta.py` uses
+float `round` (half-even), both diverging from the canonical
+ROUND_HALF_UP.
+
+Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS; at
+cap, fix what is written, resolve/waive remaining threads, merge on
+required-green.
+
+## Scope (this PR)
+
+Slice phase: Vertical slice
+
+Max files: 10
+
+1. `extracted_content_pipeline/faq_deflection_report.py` -- named
+   billed-repeat predicate + scorecard reconciliation assertions.
+2. `extracted_content_pipeline/deflection_money.py` -- signed
+   quantizer.
+3. `extracted_content_pipeline/deflection_delta.py` -- canonical
+   rounding at both delta call sites.
+4. `atlas_brain/content_ops_deflection_delivery.py` -- half-up whole
+   dollar signed display.
+5. `tests/test_content_ops_deflection_report.py` -- reconciliation
+   guard both directions.
+6. `tests/test_atlas_content_ops_deflection_delivery.py` -- delta
+   rounding boundary pins.
+7-9. `tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py`,
+   `tests/test_smoke_content_ops_deflection_pdf_export_validators.py`,
+   `tests/test_run_deflection_full_report_qa_live_runner.py` --
+   hand-rolled fixtures made money-consistent (rows without
+   ticket_count/money against a nonzero headline are exactly the drift
+   the guard now refuses; intended contract change, same shape as the
+   S8a PII-fixture rebuild).
+10. This plan doc.
+
+### Files touched
+
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `extracted_content_pipeline/deflection_delta.py`
+- `extracted_content_pipeline/deflection_money.py`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `plans/PR-Resolution-Audit-S8b-Money-Reconciliation.md`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_run_deflection_full_report_qa_live_runner.py`
+- `tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py`
+- `tests/test_smoke_content_ops_deflection_pdf_export_validators.py`
+
+### Review Contract
+
+Acceptance criteria:
+1. A model whose headline money, row money, repeat count, or annualized
+   figure drifted from the billed-repeat predicate fails the scorecard
+   with a named `money.*` assertion, and therefore 502s at the S8a
+   persist gate.
+2. The healthy fixture passes raw and projected, exactly (no
+   tolerance).
+3. The billed-repeat rule exists in exactly ONE function used by both
+   the count computation and the reconciliation guard.
+4. Signed delta money quantizes ROUND_HALF_UP on both signs at compute
+   (`deflection_delta.py`) and display (`_whole_dollar_money`); shape
+   unchanged.
+5. Report-path money computation and display are byte-identical.
+
+Reachability proof: the assertions live in
+`build_deflection_full_report_qa_scorecard`, which S8a's
+`check_deflection_report_artifact_qa` runs at the persist boundary on
+both the stored payload and the paid projection; tests drive the
+drifted artifacts through the gate, not just the scorecard.
+
+Affected surfaces: QA scorecard, persist gate verdicts, delta compute,
+delta delivery email rounding.
+
+Risk areas: false positives on legitimately-shaped models (bounded by
+exact linearity of the money rule and the uncapped stored rows,
+verified empirically; existing scorecard fixtures re-checked); the
+half-even -> half-up boundary shifts some delta displays by one unit at
+exact .5 boundaries (intended, canonical).
+
+Reviewer rules triggered: R1, R2, R3, R8, R10, R14 (extracted package change; test evidence; money-path change; billing figures; gate predicate change; both-direction probes).
+
+## Mechanism
+
+`_is_billed_repeat_item(item)` owns the `>= 2` rule;
+`_repeat_ticket_count` sums `_ticket_count` over items passing it. The
+scorecard's new `money.*` assertions re-apply the predicate to the
+model's own `ranked_questions.data.rows` and verify every money figure
+against `deflection_money` -- pure verification, no computation of new
+values. The delta path swaps float rounding for the shared signed
+Decimal quantizer.
+
+## Intentional
+
+- The guard lives in the SCORECARD (not a second gate): S8a already
+  runs the scorecard at persist on raw + projected payloads, so the
+  money guard rides the existing fail-closed boundary with zero new
+  wiring.
+- Exact equality, not tolerance: 13.50 x integer is exact at 2dp and
+  annualized figures are quantized once at compute -- a tolerance would
+  mask exactly the drift class P5-7 documents.
+- One named predicate: the audit's second-side trap is a guard that
+  re-hardcodes `tc >= 2` and diverges from the billing rule later.
+- Delta rounding fixed at compute AND display: fixing only display
+  leaves half-even sums in persisted deltas.
+
+## Deferred
+
+- Annualized-field EXPOSURE decision (operator, #1993).
+- Ops sweep over already-persisted artifacts (S8a deferred item).
+- Delta-report money reconciliation guard (deltas have no scorecard
+  today; follow-up if delta drift materializes).
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_deflection_report.py -q`
+- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q`
+- `python -m pytest tests/test_extracted_content_deflection_submit.py -q`
+- Full CI mirror: bash `scripts/run_extracted_pipeline_checks.sh`
+- Drifted fixtures reproduced failing through the persist gate before
+  the fix was called done.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/content_ops_deflection_delivery.py` | 14 |
+| `extracted_content_pipeline/deflection_delta.py` | 6 |
+| `extracted_content_pipeline/deflection_money.py` | 12 |
+| `extracted_content_pipeline/faq_deflection_report.py` | 119 |
+| `plans/PR-Resolution-Audit-S8b-Money-Reconciliation.md` | 211 |
+| `tests/test_atlas_content_ops_deflection_delivery.py` | 23 |
+| `tests/test_content_ops_deflection_report.py` | 96 |
+| `tests/test_run_deflection_full_report_qa_live_runner.py` | 15 |
+| `tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py` | 5 |
+| `tests/test_smoke_content_ops_deflection_pdf_export_validators.py` | 15 |
+| **Total** | **516** |

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -1963,3 +1963,26 @@ def test_deflection_report_result_url_defaults_to_live_portfolio_result_route() 
 def test_deflection_report_result_url_requires_configured_destination() -> None:
     with pytest.raises(ValueError, match="result_base_url or result_url_template"):
         deflection_report_result_url(request_id="req-123", config=_config(result_base_url=""))
+
+
+# S8b: signed delta money rounds HALF-UP (the canonical deflection_money
+# rule) at display -- f-string float formatting rounded half-even.
+
+
+def test_signed_email_money_rounds_half_up_on_both_signs() -> None:
+    from atlas_brain.content_ops_deflection_delivery import _signed_email_money
+
+    assert _signed_email_money(2.5) == "+$3"
+    assert _signed_email_money(-2.5) == "-$3"
+    assert _signed_email_money(1.5) == "+$2"
+    assert _signed_email_money(0) == "$0"
+
+
+def test_signed_delta_compute_quantizes_half_up() -> None:
+    from extracted_content_pipeline.deflection_money import (
+        signed_support_cost_delta_usd,
+    )
+
+    assert signed_support_cost_delta_usd(2.005) == 2.01
+    assert signed_support_cost_delta_usd(-2.005) == -2.01
+    assert signed_support_cost_delta_usd(0) == 0.0

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -3613,6 +3613,24 @@ def test_deflection_full_report_qa_scorecard_checks_surface_caps_behaviorally() 
 
     support_tax["generated_question_count"] = 30
     ranked_rows[:] = [dict(ranked_rows[0], rank=index) for index in range(1, 31)]
+    # Keep the inflated fixture money-consistent with the S8b guard: the
+    # headline must equal the billed-repeat predicate over the new rows.
+    from extracted_content_pipeline.deflection_money import (
+        annualized_support_cost_usd,
+        support_cost_usd,
+    )
+
+    inflated_repeat = sum(
+        int(row["ticket_count"])
+        for row in ranked_rows
+        if int(row["ticket_count"]) >= 2
+    )
+    support_tax["repeat_ticket_count"] = inflated_repeat
+    support_tax["estimated_support_cost"] = support_cost_usd(inflated_repeat)
+    support_tax["annualized_support_cost"] = annualized_support_cost_usd(
+        inflated_repeat,
+        support_tax["source_date_window"]["source_window_days"],
+    )
     detail_rows[:] = [dict(detail_rows[0], rank=index) for index in range(1, 13)]
     diagnostic_rows[:] = [dict(diagnostic_rows[0]) for _ in range(30)]
     seo_targets["phrases"] = [f"phrase {index}" for index in range(1, 31)]
@@ -7496,5 +7514,83 @@ def test_qa_gate_refuses_an_export_missing_linkage_keys() -> None:
         check_deflection_report_artifact_qa(drifted)
 
     assert "evidence_export.matches_stored_artifact" in (
+        exc_info.value.failing_assertion_ids
+    )
+
+
+# S8b: money reconciliation guard (P5-7) -- the scorecard verifies every
+# money figure against the ONE billed-repeat predicate, and the S8a gate
+# makes it fail-closed at persist.
+
+
+def _drifted(mutate) -> dict:
+    artifact = build_deflection_report_artifact(_structured_report_fixture_result())
+    payload = json.loads(
+        json.dumps(
+            scrub_deflection_report_payload(artifact.as_dict()), default=str
+        )
+    )
+    mutate(payload)
+    return payload
+
+
+def _section_data(payload: dict, section_id: str) -> dict:
+    for section in payload["report_model"]["sections"]:
+        if section["id"] == section_id:
+            return section["data"]
+    raise AssertionError(f"missing section {section_id}")
+
+
+def test_money_guard_passes_the_healthy_artifact() -> None:
+    payload = _drifted(lambda p: None)
+    assert check_deflection_report_artifact_qa(payload)["ok"] is True
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_id"),
+    [
+        (
+            lambda p: _section_data(p, "support_tax").__setitem__(
+                "repeat_ticket_count", 999
+            ),
+            "money.support_tax.repeat_ticket_count.matches_predicate",
+        ),
+        (
+            lambda p: _section_data(p, "support_tax").__setitem__(
+                "estimated_support_cost", 999.0
+            ),
+            "money.support_tax.estimated_support_cost.matches_rule",
+        ),
+        (
+            lambda p: _section_data(p, "ranked_questions")["rows"][0].__setitem__(
+                "estimated_support_cost", 1.0
+            ),
+            "money.rows.each_priced_by_rule",
+        ),
+        (
+            lambda p: _section_data(p, "support_tax").__setitem__(
+                "annualized_support_cost", 5.0
+            ),
+            "money.support_tax.annualized_support_cost.matches_rule",
+        ),
+    ],
+)
+def test_money_guard_refuses_drifted_money(mutate, expected_id: str) -> None:
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(_drifted(mutate))
+    assert expected_id in exc_info.value.failing_assertion_ids
+
+
+def test_money_guard_refuses_dateless_run_rate_drift() -> None:
+    def mutate(payload: dict) -> None:
+        data = _section_data(payload, "support_tax")
+        # Flip to the dateless x12 basis with a wrong run-rate figure.
+        data["source_date_window"] = None
+        data.pop("annualized_support_cost", None)
+        data["annualized_run_rate_support_cost"] = 1.0
+
+    with pytest.raises(DeflectionReportQAGateError) as exc_info:
+        check_deflection_report_artifact_qa(_drifted(mutate))
+    assert "money.support_tax.annualized_run_rate.matches_rule" in (
         exc_info.value.failing_assertion_ids
     )

--- a/tests/test_run_deflection_full_report_qa_live_runner.py
+++ b/tests/test_run_deflection_full_report_qa_live_runner.py
@@ -66,6 +66,7 @@ def _report_model() -> dict[str, object]:
                     "assisted_contact_cost": 13.5,
                     "estimated_support_cost": 108.0,
                     "source_date_window": {},
+                    "annualized_run_rate_support_cost": 1296.0,
                     "drafted_answer_count": 1,
                     "no_proven_answer_count": 1,
                     "ticket_source_count": 8,
@@ -87,8 +88,18 @@ def _report_model() -> dict[str, object]:
                 "priority": 30,
                 "data": {
                     "rows": [
-                        {"rank": 1, "question": "How do I export attribution reports?"},
-                        {"rank": 2, "question": "How do I invite teammates?"},
+                        {
+                            "rank": 1,
+                            "question": "How do I export attribution reports?",
+                            "ticket_count": 5,
+                            "estimated_support_cost": 67.5,
+                        },
+                        {
+                            "rank": 2,
+                            "question": "How do I invite teammates?",
+                            "ticket_count": 3,
+                            "estimated_support_cost": 40.5,
+                        },
                     ],
                 },
             },

--- a/tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py
+++ b/tests/test_smoke_content_ops_deflection_hosted_qa_scorecard.py
@@ -33,6 +33,7 @@ def _report_model() -> dict[str, object]:
                     "assisted_contact_cost": 13.5,
                     "estimated_support_cost": 108.0,
                     "source_date_window": {},
+                    "annualized_run_rate_support_cost": 1296.0,
                     "drafted_answer_count": 1,
                     "no_proven_answer_count": 1,
                     "ticket_source_count": 8,
@@ -50,7 +51,7 @@ def _report_model() -> dict[str, object]:
             },
             {
                 "id": "ranked_questions",
-                "data": {"rows": [{"rank": 1}, {"rank": 2}]},
+                "data": {"rows": [{"rank": 1, "ticket_count": 5, "estimated_support_cost": 67.5}, {"rank": 2, "ticket_count": 3, "estimated_support_cost": 40.5}]},
             },
             {
                 "id": "priority_fix_queue",
@@ -102,7 +103,7 @@ def _report_model() -> dict[str, object]:
             },
             {
                 "id": "question_details",
-                "data": {"rows": [{"rank": 1}, {"rank": 2}]},
+                "data": {"rows": [{"rank": 1, "ticket_count": 5, "estimated_support_cost": 67.5}, {"rank": 2, "ticket_count": 3, "estimated_support_cost": 40.5}]},
             },
             {
                 "id": "complete_evidence",

--- a/tests/test_smoke_content_ops_deflection_pdf_export_validators.py
+++ b/tests/test_smoke_content_ops_deflection_pdf_export_validators.py
@@ -59,6 +59,7 @@ def _report_model() -> dict[str, object]:
                     "assisted_contact_cost": 13.5,
                     "estimated_support_cost": 108.0,
                     "source_date_window": {},
+                    "annualized_run_rate_support_cost": 1296.0,
                     "drafted_answer_count": 1,
                     "no_proven_answer_count": 1,
                     "ticket_source_count": 8,
@@ -78,8 +79,18 @@ def _report_model() -> dict[str, object]:
                 "id": "ranked_questions",
                 "data": {
                     "rows": [
-                        {"rank": 1, "question": "How do I export attribution reports?"},
-                        {"rank": 2, "question": "How do I invite teammates?"},
+                        {
+                            "rank": 1,
+                            "question": "How do I export attribution reports?",
+                            "ticket_count": 5,
+                            "estimated_support_cost": 67.5,
+                        },
+                        {
+                            "rank": 2,
+                            "question": "How do I invite teammates?",
+                            "ticket_count": 3,
+                            "estimated_support_cost": 40.5,
+                        },
                     ],
                 },
             },


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S8b-Money-Reconciliation.md

Slice phase: Vertical slice

S8b of the #1993 remediation arc (closes #2052, launch blocker #7 second half; P5-7 in the audit). No model-level money reconciliation existed: headline, per-row, and annualized money were computed once at build time and never cross-checked, so sum-of-rendered-rows vs headline could silently drift (x16 annualized amplification). Separately, the S4-deferred delta-money path still rounded with float semantics (half-even) while canonical money is Decimal ROUND_HALF_UP.

## Intentional

- The guard lives in the SCORECARD: S8a already runs it fail-closed at persist on both the stored payload and the paid projection, so the money guard rides the existing boundary with zero new wiring.
- Exact equality, not tolerance: 13.50 x integer is exact at 2dp; a tolerance would mask exactly the P5-7 drift class.
- ONE named predicate (`_is_billed_repeat_item`) owns the >=2 billed-repeat rule, used by both the count computation and the guard — never a re-hardcoded threshold (the audit's second-side trap).
- Delta rounding fixed at compute AND display; fixing only display leaves half-even sums in persisted deltas.

## Deferred

- Annualized-field EXPOSURE decision (operator, #1993).
- Ops sweep over already-persisted artifacts (S8a deferred item).
- Delta-report money reconciliation guard (deltas have no scorecard today).

## Parked hardening

- None new; residual edge semantics tracked on #1993.

## Cold diff reconstruction

- `extracted_content_pipeline/faq_deflection_report.py`: `_is_billed_repeat_item` extracts the existing `_ticket_count(item) >= 2` rule (semantics identical); `_repeat_ticket_count` now uses it; `_add_money_reconciliation_assertions` adds five verify-only `money.*` assertions to the scorecard — headline repeat count equals the predicate over the model's own `ranked_questions.data.rows`; headline cost equals `support_cost_usd(repeat)`; billed rows' money sums exactly to the headline; each row is priced by `support_cost_usd(row.ticket_count)`; the annualized figure matches the dated (`annualized_support_cost_usd`) or dateless run-rate (`support_cost_usd(repeat*12)`) basis.
- `extracted_content_pipeline/deflection_money.py`: `signed_support_cost_delta_usd` — sign-preserving Decimal ROUND_HALF_UP quantizer (the report-path `support_cost_usd` clamps to zero, so deltas needed their own). A signed FORMATTER was drafted and removed at cold-diff review: no consumer exists.
- `extracted_content_pipeline/deflection_delta.py`: both float `round(x, 2)` call sites (per-row delta, summary sum) swapped to the signed quantizer.
- `atlas_brain/content_ops_deflection_delivery.py`: `_whole_dollar_money` quantizes half-up via Decimal instead of f-string float formatting (half-even); display shape unchanged — the distinguishing case is a $2.50 delta now showing +$3, not +$2.
- Tests: healthy fixture passes raw + projected exactly; five drift directions trip named `money.*` assertions through the S8a persist gate; delta boundary pins (.005 cents, .5 whole dollars, both signs). Three smoke/live-runner fixtures were hand-rolled money-INCONSISTENT models (rows without ticket_count/money against a nonzero headline — exactly the drift the guard refuses) and were made consistent; one pre-existing surface-caps test fixture likewise.

Empirical pre-checks (before coding): the invariant holds exactly on the real fixture, raw AND projected (headline repeat=8 / cost=108.0 == billed-row sum == recompute); rows are stored uncapped so summing `data.rows` is sound.

## Verification

- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_extracted_content_deflection_submit.py -q` (`345 passed, 5 skipped`)
- Smoke/live-runner suites (`38 passed`)
- Full CI mirror: bash `scripts/run_extracted_pipeline_checks.sh` (`5935 passed, 21 skipped`)
- Both error directions pinned for every new assertion and both rounding boundaries.

Reviewer rules triggered: R1, R2, R3, R8, R10, R14 (extracted package change; test evidence; money-path change; billing figures; gate predicate change; both-direction probes).

Diff-budget override: the predicate extraction, the five reconciliation assertions, and the both-direction drift tests are one indivisible money-integrity decision; ~40% of the added lines are tests, and the three smoke-fixture consistency updates are forced by the new guard refusing their hand-rolled money-inconsistent models.

## Diff size

~496 added lines (see plan table); dominated by tests + plan doc.
