### PR TITLE
Resolution Audit CSV S9: anchor the FAQ date window to the data's own recency

### DIFF
--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -539,6 +539,12 @@ def build_support_ticket_input_package(
     }
     if has_valid_date_window:
         inputs["faq_window_days"] = window_days
+        latest_source_date = date_diagnostics.get("latest_source_date")
+        if latest_source_date is not None:
+            # Anchor the window to the DATA's own recency. The downstream
+            # builder falls back to date.today() without an anchor, which
+            # empties a stale-but-valid upload's report (#2056).
+            inputs["faq_as_of_date"] = latest_source_date.isoformat()
 
     metadata: dict[str, Any] = {
         "source": "support_ticket_input_package",
@@ -1106,14 +1112,18 @@ def _source_date_diagnostics(
     # (the warning trigger), not for the missing_count window gate.
     dated_count = 0
     fallback_signal_count = 0
+    latest_source_date = None
     missing_source_ids: list[str] = []
     for index, row in enumerate(rows, start=1):
         if source_date_signal_count is None and _clean(row.get("created_at")) != "":
             fallback_signal_count += 1
-        if parse_support_ticket_source_date(
+        parsed = parse_support_ticket_source_date(
             row.get("created_at"), convention=convention
-        ) is not None:
+        )
+        if parsed is not None:
             dated_count += 1
+            if latest_source_date is None or parsed > latest_source_date:
+                latest_source_date = parsed
             continue
         source_id = _clean(row.get("source_id")) or f"row-{index}"
         missing_source_ids.append(source_id)
@@ -1121,6 +1131,7 @@ def _source_date_diagnostics(
         "included_count": len(rows),
         "dated_count": dated_count,
         "missing_count": len(rows) - dated_count,
+        "latest_source_date": latest_source_date,
         "source_date_signal_count": (
             source_date_signal_count
             if source_date_signal_count is not None

--- a/plans/PR-Resolution-Audit-S9-Window-Anchoring.md
+++ b/plans/PR-Resolution-Audit-S9-Window-Anchoring.md
@@ -1,0 +1,138 @@
+# PR-Resolution-Audit-S9-Window-Anchoring
+
+Ownership lane: resolution-audit-csv
+
+## Why this slice exists
+
+S9 of the #1993 remediation arc (closes #2056, filed from the S7 review).
+A stale-but-valid upload generates a zero-ticket-source FAQ: the package
+enables the downstream date window (`inputs["faq_window_days"]`) without
+anchoring it, and the FAQ builder's `_date_window` falls back to
+`date.today()` when no as-of date is provided, so every normalized source
+row of e.g. a January export processed in July falls outside the window
+and the generated paid FAQ has zero ticket sources. Reproduced before
+coding: 5 rows dated 180 days ago, `window_days=30` -> window enabled,
+`faq_as_of_date` absent -> builder returns 0 sources / 0 items;
+data-anchored, the same rows return 5 sources / 1 item. Pre-existing
+before S7 for any complete US-parseable stale upload; S7's tolerant
+window widened the population.
+
+### Problem-derived contract
+
+- Root cause: the window's ANCHOR was never decided at the boundary that
+  decides the window's VALIDITY. The receiving plumbing already exists
+  end-to-end -- `generation_plan.py` reads and validates `faq_as_of_date`
+  (YYYY-MM-DD, requires `faq_window_days`), threads it to
+  `TicketFAQMarkdownService.generate` -> `build_ticket_faq_markdown` ->
+  `_date_window` -- the package just never emits it.
+- Correct fix must touch/change:
+  1. `extracted_content_pipeline/support_ticket_input_package.py`
+     (owned): `_source_date_diagnostics` captures `latest_source_date`
+     (max parsed `created_at`) in its existing per-row loop; when
+     `has_valid_date_window`, the package emits
+     `inputs["faq_as_of_date"] = latest_source_date.isoformat()`
+     alongside `faq_window_days`. The window then means "the last N days
+     OF THE DATA" -- which is what `source_period` ("Last N days of
+     support tickets") already claims about data it derives from.
+  2. Tests: the pre-coding repro pinned both directions (stale upload's
+     own emitted inputs keep its sources; fresh upload unchanged);
+     `faq_as_of_date` present iff the window is valid; emitted format
+     passes the existing `generation_plan` YYYY-MM-DD validation.
+- Must not change:
+  - `window_days` semantics (caller-declared length) and the 0.9
+    coverage rule (S7).
+  - `_date_window`'s `date.today()` fallback for callers that pass
+    `window_days` without an anchor (other, non-package callers keep
+    their behavior).
+  - Caller precedence: the live deflection-submit route overlays only
+    title/company/contact/platform on `package.inputs`
+    (`control_surfaces.py` `execute_inputs`), so the package emission
+    cannot clobber an operator-supplied value on any existing path.
+  - Report content/shape, money, scrub, gate mechanics.
+
+Review-loop guard: HARD cap of 3 Codex rounds counted by ROUNDS; at cap,
+fix what is written, resolve/waive remaining threads, merge on
+required-green.
+
+## Scope (this PR)
+
+Slice phase: Vertical slice
+
+Max files: 3
+
+1. `extracted_content_pipeline/support_ticket_input_package.py` --
+   latest-date capture + `faq_as_of_date` emission.
+2. `tests/test_support_ticket_dates_window.py` -- both-direction pins.
+3. This plan doc.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `plans/PR-Resolution-Audit-S9-Window-Anchoring.md`
+- `tests/test_support_ticket_dates_window.py`
+
+### Review Contract
+
+Acceptance criteria:
+1. A stale-but-valid upload's emitted inputs (`faq_window_days` +
+   `faq_as_of_date`) drive the FAQ builder to keep its own sources; the
+   zero-source path is closed.
+2. `faq_as_of_date` is emitted iff the dated window is valid, equals the
+   newest parsed source date, and passes the existing generation-plan
+   YYYY-MM-DD validation.
+3. Dateless/invalid-window uploads emit neither key (unchanged).
+4. No downstream behavior change for callers that never receive a
+   package-emitted anchor.
+
+Reachability proof: the emission rides the same `package.inputs` dict the
+live deflection-submit route feeds to `execute_generation`; the e2e test
+drives the builder with the package's own emitted values.
+
+Affected surfaces: package inputs, FAQ date-window basis for
+package-driven runs.
+
+Risk areas: anchor semantics ("Last N days" of data vs of wall clock) --
+the data anchor matches what `source_period` already claims, and the
+wall-clock anchor produced an empty paid report, which no reading of the
+product intends.
+
+Reviewer rules triggered: R1, R2, R10, R14 (extracted package change; test evidence; window-basis gate input change; both-direction probes).
+
+## Mechanism
+
+`_source_date_diagnostics` already parses every row's `created_at`; it now
+also tracks the max parsed date and returns it as `latest_source_date`.
+The package builder emits `faq_as_of_date` next to the existing
+`faq_window_days` emission when the window is valid. Everything
+downstream is existing, already-validated plumbing.
+
+## Intentional
+
+- Anchor decided at admission, once -- the same principle as S7's ISO
+  canonicalization: the component that decides window VALIDITY decides
+  the window ANCHOR, instead of every downstream consumer guessing.
+- Data-max anchor (not upload timestamp): the report's claims are about
+  the data's own recency; wall-clock anchoring is what produced the
+  empty-report defect.
+
+## Deferred
+
+- Surfacing the anchored window dates in report copy (product wording;
+  operator, #1993).
+- Delta-path window semantics (separate lane).
+
+## Verification
+
+- `python -m pytest tests/test_support_ticket_dates_window.py -q`
+- Adjacent: input-package + generation-plan + smoke suites.
+- Full CI mirror: bash `scripts/run_extracted_pipeline_checks.sh`
+- Pre-coding repro pinned as the e2e test (0 sources -> 5 sources).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_input_package.py` | 15 |
+| `plans/PR-Resolution-Audit-S9-Window-Anchoring.md` | 138 |
+| `tests/test_support_ticket_dates_window.py` | 61 |
+| **Total** | **214** |

--- a/tests/test_support_ticket_dates_window.py
+++ b/tests/test_support_ticket_dates_window.py
@@ -240,3 +240,64 @@ def test_excluded_rows_still_prove_the_convention() -> None:
     )
     assert "2026-01-02" in payload  # Jan 2, not Feb 1
     assert "2026-02-01" not in payload
+
+
+# S9 (#2056): the window is anchored to the data's own recency, closing
+# the stale-upload zero-source path.
+
+
+def test_stale_upload_keeps_its_sources_via_the_emitted_anchor() -> None:
+    from datetime import date, timedelta
+
+    from extracted_content_pipeline.ticket_faq_markdown import (
+        build_ticket_faq_markdown,
+    )
+
+    stale = (date.today() - timedelta(days=180)).isoformat()
+    package = build_support_ticket_input_package(
+        _rows([stale] * 5), window_days=30
+    )
+    assert package.inputs["faq_window_days"] == 30
+    assert package.inputs["faq_as_of_date"] == stale
+    source_rows = [
+        {
+            "source_id": f"r{i}",
+            "source_type": "support_ticket",
+            "source_title": "Cannot reset my password",
+            "text": "I cannot reset my password from the login page.",
+            "created_at": stale,
+        }
+        for i in range(5)
+    ]
+    # The defect: without the anchor the builder falls back to
+    # date.today() and drops every source of a stale-but-valid upload.
+    empty = build_ticket_faq_markdown(source_rows, window_days=30)
+    assert empty.ticket_source_count == 0
+    anchored = build_ticket_faq_markdown(
+        source_rows,
+        window_days=package.inputs["faq_window_days"],
+        as_of_date=package.inputs["faq_as_of_date"],
+    )
+    assert anchored.ticket_source_count == 5
+    assert len(anchored.items) == 1
+
+
+def test_anchor_is_the_newest_parsed_date() -> None:
+    package = build_support_ticket_input_package(
+        _rows(["2026-01-05", "2026-01-20", "2026-01-11"])
+    )
+    assert package.inputs["faq_as_of_date"] == "2026-01-20"
+    # And it passes the generation-plan YYYY-MM-DD validation rule.
+    from datetime import date
+
+    assert date.fromisoformat(package.inputs["faq_as_of_date"])
+
+
+def test_no_anchor_without_a_valid_window() -> None:
+    dateless = build_support_ticket_input_package(_rows(["", "", ""]))
+    assert "faq_window_days" not in dateless.inputs
+    assert "faq_as_of_date" not in dateless.inputs
+    sparse = build_support_ticket_input_package(
+        _rows(["2026-01-05"] * 8 + ["", ""])
+    )
+    assert "faq_as_of_date" not in sparse.inputs


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S9-Window-Anchoring.md

Slice phase: Vertical slice

S9 of the #1993 remediation arc (closes #2056, filed from the S7 review). A stale-but-valid upload generated a zero-ticket-source FAQ: the package enables the downstream date window (`faq_window_days`) without anchoring it, and the FAQ builder's `_date_window` falls back to `date.today()`, so every source row of a January export processed in July fell outside the window. Reproduced before coding: 5 rows dated 180 days ago, `window_days=30` -> 0 sources / 0 items today-anchored; 5 sources / 1 item data-anchored. Pre-existing before S7; S7's tolerant window widened the population.

## Intentional

- The anchor is decided at admission, once — the component that decides window VALIDITY decides the window ANCHOR (the same principle as S7's ISO canonicalization).
- Data-max anchor, not wall clock: the report's "Last N days of support tickets" claim is about the data's own recency; wall-clock anchoring is what produced the empty paid report.
- Zero new downstream plumbing: `generation_plan.py` already reads and validates `faq_as_of_date` (YYYY-MM-DD, requires `faq_window_days`) and threads it to `build_ticket_faq_markdown` -> `_date_window`. The package just never emitted it.

## Deferred

- Surfacing the anchored window dates in report copy (product wording; operator, #1993).
- Delta-path window semantics (separate lane).

## Parked hardening

- None new; residual edge semantics tracked on #1993.

## Cold diff reconstruction

- `extracted_content_pipeline/support_ticket_input_package.py`: `_source_date_diagnostics` tracks the max parsed `created_at` in its existing per-row loop and returns it as `latest_source_date`; when `has_valid_date_window`, the package emits `inputs["faq_as_of_date"] = latest_source_date.isoformat()` alongside the existing `faq_window_days` emission. Nothing else changes.
- Caller precedence verified: the live deflection-submit route overlays only title/company/contact/platform on `package.inputs` (`control_surfaces.py` `execute_inputs`), so the emission cannot clobber an operator-supplied value on any existing path; `_date_window`'s `date.today()` fallback is untouched for non-package callers.
- Tests: the pre-coding repro pinned e2e both directions (unanchored builder drops all 5 stale sources; the package's own emitted values keep them); the anchor equals the newest parsed date and passes the generation-plan YYYY-MM-DD rule; dateless and sparse (below 0.9 coverage) uploads emit neither key.

## Verification

- `python -m pytest tests/test_support_ticket_dates_window.py -q` (`24 passed`)
- Full CI mirror: bash `scripts/run_extracted_pipeline_checks.sh` (`5930 passed, 21 skipped`)
- Both error directions pinned: stale-with-anchor keeps sources; no-window uploads emit no anchor.

Reviewer rules triggered: R1, R2, R10, R14 (extracted package change; test evidence; window-basis gate input change; both-direction probes).

## Diff size

~212 added lines (see plan table); under the 400 LOC budget.
