### PR TITLE
Resolution Audit S6A.1: structured privacy semantics

### DIFF
--- a/docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md
+++ b/docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md
@@ -42,7 +42,7 @@ Minimum true before paid reports ship:
 | 1 | Fragmentation undercount (F1/F3/F6) | S5 #2033 | CONDITIONAL (booster ON+calibrated; default OFF) |
 | 2 | Header/data-loss admission (C1/H4/C2) | S1 #2026 | MOSTLY (dup-header/encoding closed; terse-first-row + missing-ID residual) |
 | 3 | Money reconciliation (P5-2) | S4 #2031 | DISPLAY-only (buyer-visible cents change needs approval; P5-7 model guard -> S8) |
-| 4 | PII private/internal notes | S6A #2046 | MERGED 2026-07-08 -- CLOSED |
+| 4 | PII private/internal notes | S6A #2046 + follow-up #2060 | REOPENED -- structured-marker semantics + generic execute authority |
 | 5 | Junk/auto-reply/OOO gate (F2, incl HTML M6) | S6B #2053 MERGED (line plumbing) + S6E #2049 (detection rules, PR open) | IN PROGRESS |
 | 6 | Date transposition/window (C3/M7) | S7 | OPEN |
 | 7 | Fail-closed runtime guard (P5-7 + scorecard) | S8 | OPEN (scorecard zero runtime callers) |
@@ -63,6 +63,13 @@ precondition for S8).
   cap -- unbounded parse memory (deferred).
 - S5 #2033: fixed overmerge/fabrication/order-dependence; F1 undercount remains
   conditional on the default-OFF embedding booster (above).
+- S6A #2046: five post-merge classifier findings remain live on current main.
+  Nested private assertions, object-wrapped false publication flags, and
+  conjunction phrases can admit private text; neutral structured labels and
+  requester/client/end-user labels can drop public text. Generic `/execute`
+  also restores raw `source_material` over the provider-filtered package.
+  Remediation is serialized under #2060 as S6A.1 classifier semantics then
+  S6A.2 authoritative source admission.
 - Verified safe: S1 `_source_id_fallback` marker stripped by the `_public_ticket_row`
   allowlist (`:448`) -- no buyer-facing leak.
 
@@ -76,8 +83,8 @@ precondition for S8).
 
 ### Sequencing
 
-verify F1 booster || merge S6A (#2046) -> S6B (+junk rules / S6E) || S7 date-parse
--> S6C || S6D -> S8 (last; the fail-closed gate). ~9-13 dev-days, parallelizable.
+verify F1 booster || close S6A follow-up #2060 (S6A.1 -> S6A.2). Historical
+sequencing for S6B-S8 remains below; live GitHub issue state is authoritative.
 
 ## Gaps In The Existing Issue Body
 
@@ -307,9 +314,10 @@ Confirmed components:
 - Subject/body/comments are concatenated.
 - HTML is compacted to text, but signatures, quoted chains, junk auto-replies,
   and low-ratio embedded NULs are not governed by one explicit chokepoint.
-- `_comment_text` only skips comments where `public is False`; private/internal
-  markers such as `is_private`, `is_internal`, or string `"false"` can still
-  flow into ticket text.
+- Package rows and Zendesk comments share `support_ticket_privacy.py`, but its
+  structured decision representation still loses nested polarity and diverges
+  between scalar and object labels; generic `/execute` can also restore raw
+  source material after provider filtering (#2060).
 - Status values outside the small resolved/open/reopened/cancelled sets
   normalize to `other`, so resolved outcome evidence can be undercounted.
 - The final report scrubber exists for scrubbed paths, but CLI/customer-facing
@@ -320,7 +328,9 @@ Expected fix:
 - Add one ticket-text hygiene chokepoint before clustering.
 - Test junk auto-reply, signature, quoted thread, NUL, and near-miss legitimate
   customer wording.
-- Add private/internal comment fixtures and status synonym fixtures.
+- Close #2060 with class-level private/public marker fixtures plus real submit
+  and generic execute persisted-artifact proofs; keep status synonyms in their
+  existing independent slice.
 - Keep final-output scrub tests intact.
 
 ### S7 - Date Parsing And Date Window Policy
@@ -404,7 +414,10 @@ These are not coding-start items until the operator approves the product shape:
 - [x] S5 clustering first implementation PR linked here: #2033. F1 undercount
   CONDITIONAL -- closes only with the default-OFF embedding booster ON+calibrated.
 - [ ] S5 clustering calibration (real-corpus + booster on/off decision) PR linked here.
-- [x] S6A private/internal admission boundary PR linked here: #2046 (merged 2026-07-08; issue #2042 closed; closed token-stem predicate + ~335-case grammar sweep, 46 reviewer findings resolved across 9 rounds).
+- [x] Historical S6A private/internal admission boundary linked here: #2046
+  (merged 2026-07-08; issue #2042 closed).
+- [ ] S6A post-merge remediation #2060: S6A.1 structured privacy semantics and
+  S6A.2 authoritative source admission both merged.
 - [x] S6B HTML line-preserving hygiene PR linked here: #2053 (merged 2026-07-09; issue #2043 closed; line seam + blockquote exclusion + no-data-loss; 12 review rounds, 45 findings -- see PR for the review-loop lesson).
 - [ ] S6E junk/auto-reply/OOO detection gate PR linked here (issue #2049; after S6B).
 - [ ] S6D-M9 status-synonym micro-slice PR linked here (issue #2050; independent).

--- a/extracted_content_pipeline/support_ticket_privacy.py
+++ b/extracted_content_pipeline/support_ticket_privacy.py
@@ -29,14 +29,29 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass, replace
 from decimal import Decimal
+from enum import Enum
 from functools import lru_cache
 from typing import Any
+
+from .support_ticket_clustering import support_ticket_plain_text
 
 _COMPACT_RE = re.compile(r"[^a-z0-9]+")
 _CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _NUMERIC_MARKER_RE = re.compile(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?\Z")
+_NONFINITE_NUMERIC_RE = re.compile(r"[+-]?(?:inf(?:inity)?|[sq]?nan\d*)\Z")
+_ISO_DATE_DATA_RE = re.compile(
+    r"(?P<year>\d{4})-"
+    r"(?P<month>0[1-9]|1[0-2])-"
+    r"(?P<day>0[1-9]|[12]\d|3[01])"
+    r"(?:(?:[t ](?:[01]\d|2[0-3]):[0-5]\d"
+    r"(?::[0-5]\d(?:\.\d+)?)?"
+    r"(?:z|[+-](?:[01]\d|2[0-3]):?[0-5]\d)?)?"
+    r"|(?:z|[+-](?:[01]\d|2[0-3]):?[0-5]\d))?\Z"
+)
+_ISO_DATE_CANDIDATE_RE = re.compile(r"\d{4}-\d")
 
 # Key stems: the CLOSED set of privacy meanings a key can carry. A key
 # classifies iff its semantic remainder equals one of these exactly.
@@ -53,8 +68,8 @@ _PRIVATE_KEY_STEMS = frozenset({
     "staffonly",
 })
 _PUBLIC_KEY_STEMS = frozenset({"public", "visible", "external"})
-# Publication/facing flags assert privacy ONLY through boolean values:
-# ``published: false`` is private, but ``published: <date>`` is a data column.
+# Publication/facing flags admit recognized public values plus explicit
+# date/finite-number data shapes; every other present value fails closed.
 _PUBLIC_FLAG_KEY_STEMS = frozenset({
     "published", "customerfacing", "clientfacing", "userfacing", "publicfacing",
 })
@@ -69,12 +84,16 @@ _PUBLIC_AUDIENCE_TOKENS = frozenset({
 # "private_response", "for internal use only").
 _VALUE_STRUCTURAL_TOKENS = frozenset({
     "is", "to", "for", "of", "the", "from", "only", "use", "uses",
+    "and", "or", "end",
     "access", "team", "teams", "note", "notes", "comment", "comments",
     "reply", "replies", "message", "messages", "msg",
     "response", "responses", "answer", "answers", "facing",
 })
 _VALUE_LABEL_KEY_STEMS = frozenset({"access", "audience"})
 _KIND_KEY_STEMS = frozenset({"type", "kind"})
+# Exact producer data columns that otherwise resemble a prefix-stripped marker.
+# Normalizing first keeps snake/camel/space/hyphen spellings equivalent.
+_NON_MARKER_KEY_COMPACTS = frozenset({"hasaccess"})
 
 # Structural tokens that carry no privacy meaning; removing them exposes the
 # semantic remainder (``visible_to_customer`` -> ``visible``).
@@ -130,6 +149,7 @@ _PUBLIC_LABELS = frozenset({
     "anyone",
     "all",
 })
+_STRICT_PUBLIC_LABELS = _PUBLIC_LABELS | _PUBLIC_AUDIENCE_TOKENS
 _PRIVATE_LABELS = frozenset({
     "private",
     "privatecomment",
@@ -163,14 +183,137 @@ _OBJECT_MARKER_KEYS = frozenset({
     "internal",
     "hidden",
 })
+_COMMENT_CONTENT_KEY_TOKENS = frozenset({
+    "body", "message", "text", "content", "description",
+    "plainbody", "htmlbody",
+})
 _AMBIGUOUS_MARKER = "__ambiguous__"
+_PUBLIC_PHRASE_MARKER = "__public_phrase__"
 
-_KIND_PRIVATE = "private"
-_KIND_PUBLIC = "public"
-_KIND_PUBLIC_FLAG = "public_flag"
-_KIND_STRICT_LABEL = "strict_label"
-_KIND_VALUE_LABEL = "value_label"
-_KIND_KIND = "kind"
+class _MarkerFamily(Enum):
+    PRIVATE = "private"
+    PUBLIC = "public"
+    PUBLIC_FLAG = "public_flag"
+    STRICT_LABEL = "strict_label"
+    VALUE_LABEL = "value_label"
+    KIND = "kind"
+
+
+_KIND_PRIVATE = _MarkerFamily.PRIVATE
+_KIND_PUBLIC = _MarkerFamily.PUBLIC
+_KIND_PUBLIC_FLAG = _MarkerFamily.PUBLIC_FLAG
+_KIND_STRICT_LABEL = _MarkerFamily.STRICT_LABEL
+_KIND_VALUE_LABEL = _MarkerFamily.VALUE_LABEL
+_KIND_KIND = _MarkerFamily.KIND
+
+
+class _PrivacyVerdict(Enum):
+    ABSENT = "absent"
+    PUBLIC = "public"
+    PRIVATE = "private"
+    NEUTRAL_UNKNOWN = "neutral_unknown"
+    AMBIGUOUS = "ambiguous"
+
+
+class _PublicationDataKind(Enum):
+    NOT_DATA = "not_data"
+    VALID = "valid"
+    INVALID_DATE = "invalid_date"
+
+
+@dataclass(frozen=True)
+class _MarkerDecision:
+    verdict: _PrivacyVerdict
+    token: str = ""
+    boolish: bool | None = None
+    boolean_assertion: bool = False
+    malformed_numeric: bool = False
+    malformed_boolean_numeric: bool = False
+    nonfinite_numeric: bool = False
+    recognized_failing: bool = False
+    publication_data: bool = False
+    privacy_structure: bool = False
+    strict_public_label: bool = False
+    public_phrase: bool = False
+    content_container: bool = False
+
+
+@dataclass(frozen=True)
+class _KeyDecision:
+    family: _MarkerFamily
+    note_alias: bool = False
+    flag_shaped: bool = False
+
+
+@dataclass(frozen=True)
+class _FamilyPolicy:
+    boolean_admits: frozenset[bool]
+    verdicts_admit: frozenset[_PrivacyVerdict]
+    admit_strict_public_label: bool = False
+    admit_public_phrase: bool = False
+    admit_publication_data: bool = False
+    admit_neutral: bool = False
+    admit_content: bool = False
+    malformed_fails: bool = False
+    malformed_boolean_fails: bool = False
+    nonfinite_fails: bool = False
+    recognized_failing_fails: bool = False
+
+
+_FAMILY_POLICIES = {
+    _KIND_PRIVATE: _FamilyPolicy(
+        boolean_admits=frozenset({False}),
+        verdicts_admit=frozenset({_PrivacyVerdict.PUBLIC}),
+        admit_content=True,
+        malformed_fails=True,
+        malformed_boolean_fails=True,
+        recognized_failing_fails=True,
+    ),
+    _KIND_PUBLIC: _FamilyPolicy(
+        boolean_admits=frozenset({True}),
+        verdicts_admit=frozenset({_PrivacyVerdict.PUBLIC}),
+        admit_public_phrase=True,
+        admit_content=True,
+        malformed_fails=True,
+        recognized_failing_fails=True,
+    ),
+    _KIND_PUBLIC_FLAG: _FamilyPolicy(
+        boolean_admits=frozenset({True}),
+        verdicts_admit=frozenset({_PrivacyVerdict.PUBLIC}),
+        admit_strict_public_label=True,
+        admit_public_phrase=True,
+        admit_publication_data=True,
+        nonfinite_fails=True,
+        recognized_failing_fails=True,
+    ),
+    _KIND_STRICT_LABEL: _FamilyPolicy(
+        boolean_admits=frozenset(),
+        verdicts_admit=frozenset({_PrivacyVerdict.PUBLIC}),
+        admit_strict_public_label=True,
+        admit_public_phrase=True,
+        malformed_fails=True,
+        malformed_boolean_fails=True,
+        recognized_failing_fails=True,
+    ),
+    _KIND_VALUE_LABEL: _FamilyPolicy(
+        boolean_admits=frozenset({False, True}),
+        verdicts_admit=frozenset({
+            _PrivacyVerdict.PUBLIC,
+            _PrivacyVerdict.NEUTRAL_UNKNOWN,
+        }),
+        admit_neutral=True,
+        malformed_fails=True,
+        malformed_boolean_fails=True,
+    ),
+    _KIND_KIND: _FamilyPolicy(
+        boolean_admits=frozenset({False, True}),
+        verdicts_admit=frozenset({
+            _PrivacyVerdict.PUBLIC,
+            _PrivacyVerdict.NEUTRAL_UNKNOWN,
+        }),
+        admit_neutral=True,
+    ),
+}
 
 
 def support_ticket_comment_is_private(comment: Mapping[str, Any]) -> bool:
@@ -202,73 +345,122 @@ def _mapping_is_private(value: Mapping[str, Any], *, row_mode: bool) -> bool:
         classified = _classify_key(str(key))
         if classified is None:
             continue
-        kind, note_alias, flag_shaped = classified
-        marker = _marker(raw_value, negative_polarity=kind == _KIND_PRIVATE)
-        if marker is None:
+        kind = classified.family
+        content_column = classified.note_alias and not classified.flag_shaped
+        allow_content = content_column and (
+            row_mode or kind == _KIND_PUBLIC
+        )
+        marker = _marker(
+            raw_value,
+            negative_polarity=kind == _KIND_PRIVATE,
+            outer_kind=kind,
+            allow_content_sequence=allow_content,
+        )
+        if marker.verdict is _PrivacyVerdict.ABSENT:
             continue
-        content_column = note_alias and not flag_shaped
-        if _marker_is_private(
+        if _decision_is_private(
             kind, marker, content_column=content_column, row_mode=row_mode
         ):
             return True
     return False
 
 
-def _marker_is_private(
-    kind: str,
-    marker: str,
+def _decision_is_private(
+    kind: _MarkerFamily,
+    marker: _MarkerDecision,
     *,
     content_column: bool,
     row_mode: bool,
 ) -> bool:
-    if kind == _KIND_PRIVATE:
-        boolish = _boolish(marker)
-        if boolish is False or marker in _PUBLIC_LABELS:
-            return False
-        if boolish is True:
-            return True
-        if marker != _AMBIGUOUS_MARKER and _label_is_private(marker):
-            return True
-        # Remaining markers are unresolved text or container shapes. Under a
-        # non-flag note/comment-suffixed key in row mode these are content
-        # columns, not privacy flags -- but digit-only values are flag
-        # values, not content; everywhere else they fail closed.
-        if row_mode and content_column and not marker.isdigit():
-            return False
+    policy = _FAMILY_POLICIES[kind]
+    if marker.nonfinite_numeric and policy.nonfinite_fails:
         return True
-    if kind == _KIND_PUBLIC:
-        boolish = _boolish(marker)
-        if boolish is True or marker in _PUBLIC_LABELS:
-            return False
-        if boolish is False:
-            return True
-        if marker != _AMBIGUOUS_MARKER and _label_is_private(marker):
-            return True
-        # Remaining markers are unresolved text or container shapes. Under a
-        # non-flag note/comment-suffixed public key these are content columns
-        # (public_comment / public_comments hold customer text or comment
-        # lists in _PUBLIC_COMMENT_KEYS ingestion), not privacy flags --
-        # but digit-only values are flag values, not content; everywhere
-        # else (incl. is_/has_ flag aliases) they fail closed.
-        return not (content_column and not marker.isdigit())
-    if kind == _KIND_PUBLIC_FLAG:
-        # Publication/facing flags assert privacy only via booleans:
-        # published: false is private; published: <date> is a data column.
-        return _boolish(marker) is False
-    if kind == _KIND_STRICT_LABEL:
-        return marker not in _PUBLIC_LABELS
-    if kind == _KIND_VALUE_LABEL:
-        return marker == _AMBIGUOUS_MARKER or _label_is_private(marker)
-    # _KIND_KIND: categorical, fail-open on unknown kinds by design.
-    return marker == _AMBIGUOUS_MARKER or _label_is_private(marker)
+    if (
+        marker.malformed_numeric
+        and policy.malformed_fails
+        and (
+            not marker.malformed_boolean_numeric
+            or policy.malformed_boolean_fails
+        )
+    ):
+        return True
+    if (
+        marker.recognized_failing
+        and marker.privacy_structure
+        and policy.recognized_failing_fails
+    ):
+        return True
+    if (
+        policy.admit_content
+        and content_column
+        and marker.content_container
+        and marker.boolish is None
+        and (
+            marker.verdict is _PrivacyVerdict.NEUTRAL_UNKNOWN
+            or (
+                marker.verdict is _PrivacyVerdict.AMBIGUOUS
+                and not marker.privacy_structure
+            )
+        )
+        and (row_mode or kind is _KIND_PUBLIC)
+    ):
+        return False
+    if marker.recognized_failing and policy.recognized_failing_fails:
+        return True
+    if marker.boolish is not None:
+        return marker.boolish not in policy.boolean_admits
+    if marker.verdict in policy.verdicts_admit:
+        return False
+    if (
+        policy.admit_strict_public_label
+        and marker.verdict is _PrivacyVerdict.NEUTRAL_UNKNOWN
+        and marker.strict_public_label
+    ):
+        return False
+    if (
+        policy.admit_public_phrase
+        and marker.verdict is _PrivacyVerdict.NEUTRAL_UNKNOWN
+        and marker.public_phrase
+    ):
+        return False
+    if policy.admit_publication_data and marker.publication_data:
+        return False
+    if policy.admit_neutral and marker.verdict is _PrivacyVerdict.NEUTRAL_UNKNOWN:
+        return False
+    return True
+
+
+def _boolean_verdict(
+    family: _MarkerFamily | None,
+    value: bool,
+    *,
+    neutral_wrapper: bool,
+) -> _PrivacyVerdict:
+    if family is None:
+        return _PrivacyVerdict.AMBIGUOUS
+    if family in (_KIND_VALUE_LABEL, _KIND_KIND):
+        return _PrivacyVerdict.NEUTRAL_UNKNOWN
+    if family is _KIND_STRICT_LABEL:
+        return (
+            _PrivacyVerdict.NEUTRAL_UNKNOWN
+            if neutral_wrapper
+            else _PrivacyVerdict.AMBIGUOUS
+        )
+    return (
+        _PrivacyVerdict.PUBLIC
+        if value in _FAMILY_POLICIES[family].boolean_admits
+        else _PrivacyVerdict.PRIVATE
+    )
 
 
 @lru_cache(maxsize=4096)
-def _classify_key(key: str) -> tuple[str, bool, bool] | None:
+def _classify_key(key: str) -> _KeyDecision | None:
     tokens = _key_tokens(key)
     if not tokens:
         return None
     compact_all = "".join(tokens)
+    if compact_all in _NON_MARKER_KEY_COMPACTS:
+        return None
     note_alias = any(hint in compact_all for hint in _NOTE_HINTS)
     # Flag-shaped aliases (is_/has_/was_ prefixed or *_flag) are assertions,
     # never content columns, so the content carveouts must not apply to them.
@@ -288,12 +480,25 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
     if tokens[0] in ("not", "non") and len(tokens) > 1:
         rest = _classify_key(" ".join(tokens[1:]))
         if rest is not None:
-            rest_kind, rest_note, rest_flag = rest
-            if rest_kind in (_KIND_PUBLIC, _KIND_PUBLIC_FLAG):
-                return (_KIND_PRIVATE, note_alias or rest_note, flag_shaped or rest_flag)
-            if rest_kind == _KIND_PRIVATE:
-                return (_KIND_PUBLIC, note_alias or rest_note, flag_shaped or rest_flag)
+            if rest.family in (_KIND_PUBLIC, _KIND_PUBLIC_FLAG):
+                return _KeyDecision(
+                    _KIND_PRIVATE,
+                    note_alias or rest.note_alias,
+                    flag_shaped or rest.flag_shaped,
+                )
+            if rest.family == _KIND_PRIVATE:
+                return _KeyDecision(
+                    _KIND_PUBLIC,
+                    note_alias or rest.note_alias,
+                    flag_shaped or rest.flag_shaped,
+                )
         # Unresolvable negations stay unclassified rather than guessing.
+    # Compact ``un<public-stem>`` assertions (unpublished / unpublic) carry the
+    # private polarity. Restrict this to an exact public/public-flag remainder;
+    # arbitrary ``un...`` producer columns remain unclassified.
+    for candidate in candidates:
+        if _is_compact_negated_public_stem(candidate):
+            return _KeyDecision(_KIND_PRIVATE, note_alias, True)
     # Audience-only compounds (admin_only / team_only / support_team_only):
     # every token before "only" is a private audience.
     if (
@@ -301,7 +506,7 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
         and tokens[-1] == "only"
         and all(token in _PRIVATE_AUDIENCE_TOKENS for token in tokens[:-1])
     ):
-        return (_KIND_PRIVATE, note_alias, flag_shaped)
+        return _KeyDecision(_KIND_PRIVATE, note_alias, flag_shaped)
     # Audience-note keys (staff_note / agent_reply / support_note): every
     # token is a private audience or note structure, with both present.
     note_structure = frozenset({
@@ -317,7 +522,7 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
             for token in tokens
         )
     ):
-        return (_KIND_PRIVATE, True, flag_shaped)
+        return _KeyDecision(_KIND_PRIVATE, True, flag_shaped)
     # All-public-family compounds (publicly_visible / public_visibility):
     # every meaningful token asserts the public side.
     meaningful = [token for token in tokens if token not in _KEY_STOP_TOKENS]
@@ -326,19 +531,19 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
         and len(meaningful) >= 2
         and all(token in _PUBLIC_FAMILY_TOKENS for token in meaningful)
     ):
-        return (_KIND_PUBLIC, note_alias, flag_shaped)
+        return _KeyDecision(_KIND_PUBLIC, note_alias, flag_shaped)
     for candidate in candidates:
         # Bare audience-only compounds (admin_only / team_only /
         # support_only) are the staff-only side, same as agent_only.
         if candidate.endswith("only") and candidate[:-4] in _PRIVATE_AUDIENCE_TOKENS:
-            return (_KIND_PRIVATE, note_alias, flag_shaped)
+            return _KeyDecision(_KIND_PRIVATE, note_alias, flag_shaped)
         for stem in _stem_forms(candidate):
             kind = _stem_kind(stem)
             if kind is not None:
                 if kind == _KIND_PUBLIC and private_audience:
                     # visible_to_agents / public_to_staff assert privacy.
                     kind = _KIND_PRIVATE
-                return (kind, note_alias, flag_shaped)
+                return _KeyDecision(kind, note_alias, flag_shaped)
     # Audience-flip pass: private-audience tokens are droppable structure on
     # a public-visibility stem (visible_to_internal / public_to_internal).
     if private_audience:
@@ -351,16 +556,41 @@ def _classify_key(key: str) -> tuple[str, bool, bool] | None:
         if depersoned and len(depersoned) < len(tokens):
             for stem in _stem_forms("".join(depersoned)):
                 if _stem_kind(stem) in (_KIND_PUBLIC, _KIND_PUBLIC_FLAG):
-                    return (_KIND_PRIVATE, note_alias, flag_shaped)
+                    return _KeyDecision(_KIND_PRIVATE, note_alias, flag_shaped)
     # Label-style suffixes are structural only on label-class stems
     # (visibility_status / privacy_label / access_label), never on
     # private stems (internal_status stays a data column).
     delabeled = [token for token in filtered or tokens if token not in _LABELISH_TOKENS]
     if delabeled and len(delabeled) < len(filtered or tokens):
         for stem in _stem_forms("".join(delabeled)):
+            if _is_compact_negated_public_stem(stem):
+                return _KeyDecision(_KIND_PRIVATE, note_alias, True)
             kind = _stem_kind(stem)
-            if kind in (_KIND_STRICT_LABEL, _KIND_VALUE_LABEL):
-                return (kind, note_alias, flag_shaped)
+            if kind in (
+                _KIND_PUBLIC_FLAG, _KIND_STRICT_LABEL, _KIND_VALUE_LABEL,
+            ):
+                return _KeyDecision(kind, note_alias, flag_shaped)
+    # Pre-compacted producer keys (customerFacingStatus ->
+    # customerfacingstatus) cannot use the token-level delabel pass because the
+    # public-facing words are also structural stop tokens. Strip the label/status
+    # suffix only when the exact remainder is a public-flag stem.
+    for candidate in candidates:
+        for suffix in _LABELISH_TOKENS:
+            if candidate.endswith(suffix) and len(candidate) > len(suffix):
+                remainder = candidate[: -len(suffix)]
+                if _is_compact_negated_public_stem(remainder):
+                    return _KeyDecision(_KIND_PRIVATE, note_alias, True)
+                kind = _stem_kind(remainder)
+                if kind in (
+                    _KIND_PUBLIC_FLAG,
+                    _KIND_STRICT_LABEL,
+                    _KIND_VALUE_LABEL,
+                ):
+                    return _KeyDecision(
+                        kind,
+                        note_alias,
+                        flag_shaped,
+                    )
     return None
 
 
@@ -379,6 +609,59 @@ def _key_tokens(key: str) -> tuple[str, ...]:
         _ADVERB_TOKEN_MAP.get(token, token)
         for token in _TOKEN_RE.findall(spaced.lower())
     )
+
+
+_VALUE_SEGMENT_TOKENS = frozenset({
+    *_PRIVATE_KEY_STEMS,
+    *_PRIVATE_AUDIENCE_TOKENS,
+    *_PUBLIC_FAMILY_TOKENS,
+    *_PUBLIC_AUDIENCE_TOKENS,
+    *_PUBLIC_LABELS,
+    *_VALUE_STRUCTURAL_TOKENS,
+    *_TRUTHY_TEXT,
+    *_FALSEY_TEXT,
+    *_ADVERB_TOKEN_MAP,
+    "kept",
+    "longer",
+    "made",
+    "never",
+    "no",
+    "non",
+    "not",
+    "open",
+    "shared",
+    "un",
+    "withheld",
+    "without",
+})
+_VALUE_SEGMENT_TOKENS_LONGEST = tuple(
+    sorted(_VALUE_SEGMENT_TOKENS, key=lambda token: (-len(token), token))
+)
+
+
+@lru_cache(maxsize=4096)
+def _value_tokens(value: str) -> tuple[str, ...]:
+    tokens = _key_tokens(value)
+    if len(tokens) != 1:
+        return tokens
+    compact = tokens[0]
+
+    @lru_cache(maxsize=None)
+    def split(remainder: str) -> tuple[str, ...] | None:
+        if not remainder:
+            return ()
+        for token in _VALUE_SEGMENT_TOKENS_LONGEST:
+            if not remainder.startswith(token):
+                continue
+            tail = split(remainder[len(token):])
+            if tail is not None:
+                return (token, *tail)
+        return None
+
+    segmented = split(compact)
+    if segmented is None or len(segmented) < 2:
+        return tokens
+    return tuple(_ADVERB_TOKEN_MAP.get(token, token) for token in segmented)
 
 
 def _stem_forms(compact: str) -> tuple[str, ...]:
@@ -400,7 +683,7 @@ def _stem_forms(compact: str) -> tuple[str, ...]:
     return tuple(seen)
 
 
-def _stem_kind(stem: str) -> str | None:
+def _stem_kind(stem: str) -> _MarkerFamily | None:
     if stem in _PRIVATE_KEY_STEMS:
         return _KIND_PRIVATE
     if stem in _PUBLIC_KEY_STEMS:
@@ -416,35 +699,322 @@ def _stem_kind(stem: str) -> str | None:
     return None
 
 
-def _marker(value: Any, *, negative_polarity: bool = False) -> str | None:
+def _is_compact_negated_public_stem(compact: str) -> bool:
+    for prefix in ("un", "not", "non"):
+        if compact.startswith(prefix) and len(compact) > len(prefix):
+            if _stem_kind(compact[len(prefix):]) in (
+                _KIND_PUBLIC,
+                _KIND_PUBLIC_FLAG,
+            ):
+                return True
+    return False
+
+
+def _marker(
+    value: Any,
+    *,
+    negative_polarity: bool = False,
+    outer_kind: _MarkerFamily | None = None,
+    allow_content_sequence: bool = False,
+    neutral_boolean_wrapper: bool = False,
+) -> _MarkerDecision:
     if value is None:
-        return None
+        return _MarkerDecision(_PrivacyVerdict.ABSENT)
     if isinstance(value, bool):
-        return "true" if value else "false"
+        return _scalar_marker_decision("true" if value else "false")
     if isinstance(value, Mapping):
         # A present-but-empty structured marker is unresolvable, not absent:
         # {"privacy": {}} fails closed like any other unreadable marker.
         if not value:
-            return _AMBIGUOUS_MARKER
-        return _object_marker(value, negative_polarity=negative_polarity)
+            return _MarkerDecision(
+                _PrivacyVerdict.AMBIGUOUS,
+                token=_AMBIGUOUS_MARKER,
+                privacy_structure=True,
+            )
+        return _object_marker(
+            value,
+            negative_polarity=negative_polarity,
+            outer_kind=outer_kind,
+            allow_content=allow_content_sequence,
+        )
     if isinstance(value, (int, float)):
-        return _numeric_marker(str(value).strip().lower()) or _key(value)
+        text = str(value).strip().lower()
+        marker = _numeric_marker(text)
+        if marker is not None:
+            return _scalar_marker_decision(marker)
+        publication_kind = _publication_data_kind(text)
+        return _scalar_marker_decision(
+            _key(value),
+            # Type provenance is authoritative here: JSON exponent overflow is
+            # decoded as a non-finite float whose rendered token is ``inf``.
+            malformed_numeric=True,
+            nonfinite_numeric=_text_is_nonfinite_numeric(text),
+            recognized_failing=_text_is_nonfinite_numeric(text),
+            publication_data=publication_kind is _PublicationDataKind.VALID,
+        )
     if isinstance(value, str):
-        text = value.strip().lower()
+        raw_text = value.strip()
+        text = raw_text.lower()
         if not text:
-            return None
+            return _MarkerDecision(_PrivacyVerdict.ABSENT)
         numeric = _numeric_marker(text)
         if numeric is not None:
-            return numeric
-        return _value_marker(text)
-    if isinstance(value, (list, tuple, set, frozenset)) and not value:
-        # Present-but-empty sequence markers fail closed like empty objects.
-        return _AMBIGUOUS_MARKER
+            return _scalar_marker_decision(
+                numeric,
+                malformed_numeric="e" in text,
+                malformed_boolean_numeric="e" in text,
+            )
+        resolved_marker = _value_marker(raw_text)
+        nonfinite_numeric = _text_is_nonfinite_numeric(text)
+        publication_kind = _publication_data_kind(text)
+        decision = _scalar_marker_decision(
+            resolved_marker,
+            malformed_numeric=(
+                _NUMERIC_MARKER_RE.fullmatch(text) is not None
+                or nonfinite_numeric
+            ),
+            nonfinite_numeric=nonfinite_numeric,
+            recognized_failing=(
+                resolved_marker == _AMBIGUOUS_MARKER
+                or _label_is_private(resolved_marker)
+                or nonfinite_numeric
+                or publication_kind is _PublicationDataKind.INVALID_DATE
+                or _is_compact_negated_public_stem(_key(text))
+                or (
+                    resolved_marker not in _STRICT_PUBLIC_LABELS
+                    and resolved_marker != _PUBLIC_PHRASE_MARKER
+                    and _text_has_privacy_vocabulary(raw_text)
+                )
+            ),
+            publication_data=publication_kind is _PublicationDataKind.VALID,
+        )
+        if allow_content_sequence:
+            return replace(decision, content_container=True)
+        return decision
+    if isinstance(value, (list, tuple, set, frozenset)):
+        if not value:
+            # Empty sequences remain unresolved; row content-column policy may
+            # still recognize them as an empty comments container.
+            return _MarkerDecision(
+                _PrivacyVerdict.AMBIGUOUS,
+                token=_AMBIGUOUS_MARKER,
+                content_container=allow_content_sequence,
+            )
+        return _sequence_marker(
+            value,
+            negative_polarity=negative_polarity,
+            outer_kind=outer_kind,
+            allow_content=allow_content_sequence,
+            neutral_boolean_wrapper=neutral_boolean_wrapper,
+        )
     # Present but shaped in a way this boundary cannot resolve: fail closed.
-    return _AMBIGUOUS_MARKER
+    return _MarkerDecision(
+        _PrivacyVerdict.AMBIGUOUS,
+        token=_AMBIGUOUS_MARKER,
+    )
 
 
-def _object_marker(value: Mapping[str, Any], *, negative_polarity: bool) -> str:
+def _rendered_comment_text_has_content(value: str) -> bool:
+    return any(character.isalnum() for character in support_ticket_plain_text(value))
+
+
+def _is_absent_placeholder(
+    value: Any,
+    *,
+    rendered_content: bool = False,
+) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        if rendered_content:
+            return not _rendered_comment_text_has_content(value)
+        return not value.strip()
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return all(
+            _is_absent_placeholder(item, rendered_content=rendered_content)
+            for item in value
+        )
+    if isinstance(value, Mapping):
+        allowed_keys = _OBJECT_MARKER_KEYS
+        if rendered_content:
+            allowed_keys = allowed_keys | _COMMENT_CONTENT_KEY_TOKENS
+        return bool(value) and all(
+            _key(key) in allowed_keys
+            and _is_absent_placeholder(
+                item,
+                rendered_content=rendered_content,
+            )
+            for key, item in value.items()
+        )
+    return False
+
+
+def _sequence_marker(
+    value: list[Any] | tuple[Any, ...] | set[Any] | frozenset[Any],
+    *,
+    negative_polarity: bool,
+    outer_kind: _MarkerFamily | None,
+    allow_content: bool,
+    neutral_boolean_wrapper: bool,
+) -> _MarkerDecision:
+    """Combine marker-shaped sequence elements without consuming content lists."""
+
+    substantive_items = tuple(
+        item
+        for item in value
+        if not _is_absent_placeholder(item, rendered_content=allow_content)
+    )
+    if not substantive_items:
+        return _MarkerDecision(_PrivacyVerdict.ABSENT)
+    if len(substantive_items) == 1:
+        return _marker(
+            next(iter(substantive_items)),
+            negative_polarity=negative_polarity,
+            outer_kind=outer_kind,
+            allow_content_sequence=allow_content,
+            neutral_boolean_wrapper=neutral_boolean_wrapper,
+        )
+
+    decisions: list[_MarkerDecision] = []
+    unresolved_element = False
+    content_element = False
+    for item in substantive_items:
+        if allow_content and isinstance(item, str):
+            content_marker = _marker(
+                item,
+                negative_polarity=negative_polarity,
+                outer_kind=outer_kind,
+                allow_content_sequence=True,
+                neutral_boolean_wrapper=neutral_boolean_wrapper,
+            )
+            if content_marker.verdict is _PrivacyVerdict.ABSENT:
+                continue
+            if outer_kind is None or _decision_is_private(
+                outer_kind,
+                content_marker,
+                content_column=True,
+                row_mode=True,
+            ):
+                decisions.append(_MarkerDecision(
+                    _PrivacyVerdict.PRIVATE,
+                    boolean_assertion=content_marker.boolean_assertion,
+                    malformed_numeric=content_marker.malformed_numeric,
+                    malformed_boolean_numeric=(
+                        content_marker.malformed_boolean_numeric
+                    ),
+                    nonfinite_numeric=content_marker.nonfinite_numeric,
+                    recognized_failing=content_marker.recognized_failing,
+                    privacy_structure=True,
+                    strict_public_label=content_marker.strict_public_label,
+                    public_phrase=content_marker.public_phrase,
+                ))
+            else:
+                content_element = True
+            continue
+        if (
+            allow_content
+            and isinstance(item, Mapping)
+            and _mapping_has_comment_content(item)
+        ):
+            content_marker = _object_marker(
+                item,
+                negative_polarity=negative_polarity,
+                outer_kind=outer_kind,
+                allow_content=True,
+            )
+            if outer_kind is None or _decision_is_private(
+                outer_kind,
+                content_marker,
+                content_column=True,
+                row_mode=True,
+            ):
+                decisions.append(_MarkerDecision(
+                    _PrivacyVerdict.PRIVATE,
+                    privacy_structure=True,
+                ))
+            else:
+                content_element = True
+            continue
+        marker = _marker(
+            item,
+            negative_polarity=negative_polarity,
+            outer_kind=outer_kind,
+            neutral_boolean_wrapper=neutral_boolean_wrapper,
+        )
+        if marker.verdict is _PrivacyVerdict.ABSENT:
+            continue
+        if (
+            allow_content
+            and marker.boolish is not None
+            and not marker.privacy_structure
+        ):
+            unresolved_element = True
+            continue
+        marker_shaped = (
+            marker.privacy_structure
+            or marker.malformed_numeric
+            or marker.recognized_failing
+            or marker.publication_data
+            or marker.boolish is not None
+            or marker.verdict in (_PrivacyVerdict.PUBLIC, _PrivacyVerdict.PRIVATE)
+            or marker.strict_public_label
+        )
+        if not marker_shaped:
+            # Preserve unresolved provenance. The caller's row-mode content
+            # carveout, not this recursive parser, decides whether an entirely
+            # content-shaped sequence is admissible.
+            unresolved_element = True
+            continue
+        verdict = marker.verdict
+        if marker.boolish is not None:
+            verdict = _boolean_verdict(
+                outer_kind,
+                marker.boolish,
+                neutral_wrapper=neutral_boolean_wrapper,
+            )
+        decisions.append(_MarkerDecision(
+            verdict,
+            token=marker.token,
+            boolean_assertion=marker.boolean_assertion,
+            malformed_numeric=marker.malformed_numeric,
+            malformed_boolean_numeric=marker.malformed_boolean_numeric,
+            nonfinite_numeric=marker.nonfinite_numeric,
+            recognized_failing=marker.recognized_failing,
+            publication_data=marker.publication_data,
+            privacy_structure=True,
+            strict_public_label=marker.strict_public_label,
+            public_phrase=marker.public_phrase,
+        ))
+    if unresolved_element and (decisions or content_element):
+        decisions.append(_MarkerDecision(
+            _PrivacyVerdict.AMBIGUOUS,
+            token=_AMBIGUOUS_MARKER,
+            privacy_structure=True,
+        ))
+    if not decisions and not unresolved_element and not content_element:
+        return _MarkerDecision(_PrivacyVerdict.ABSENT)
+    combined = _combine_marker_decisions(decisions)
+    if (
+        len(decisions) > 1
+        and not any(
+            decision.verdict is _PrivacyVerdict.PUBLIC
+            for decision in decisions
+        )
+        and all(decision.publication_data for decision in decisions)
+    ):
+        combined = replace(combined, publication_data=False)
+    if content_element and not decisions:
+        return replace(combined, content_container=True)
+    return combined
+
+
+def _object_marker(
+    value: Mapping[str, Any],
+    *,
+    negative_polarity: bool,
+    outer_kind: _MarkerFamily | None,
+    allow_content: bool,
+) -> _MarkerDecision:
     """Resolve a structured marker to a verdict in the OUTER key's frame.
 
     Neutral boolean subfields ({"value": true}) take the enclosing key's
@@ -453,52 +1023,293 @@ def _object_marker(value: Mapping[str, Any], *, negative_polarity: bool) -> str:
     conflict between verdicts fails closed.
     """
 
-    verdicts: set[str] = set()
+    decisions: list[_MarkerDecision] = []
     for key, marker_value in value.items():
         compact_key = _key(key)
         classified = _classify_key(str(key))
-        subfield_kind = classified[0] if classified is not None else None
+        subfield_kind = classified.family if classified is not None else None
         polarity_subfield = subfield_kind in (
             _KIND_PRIVATE, _KIND_PUBLIC, _KIND_PUBLIC_FLAG,
         )
         if not polarity_subfield and compact_key not in _OBJECT_MARKER_KEYS:
             if subfield_kind is None:
                 continue
-        marker = _marker(marker_value)
-        if marker is None:
+        if subfield_kind == _KIND_PRIVATE:
+            nested_negative_polarity = True
+        elif subfield_kind in (_KIND_PUBLIC, _KIND_PUBLIC_FLAG):
+            nested_negative_polarity = False
+        else:
+            nested_negative_polarity = negative_polarity
+        marker = _marker(
+            marker_value,
+            negative_polarity=nested_negative_polarity,
+            outer_kind=subfield_kind or outer_kind,
+            neutral_boolean_wrapper=(
+                subfield_kind is None and compact_key in _OBJECT_MARKER_KEYS
+            ),
+        )
+        if marker.verdict is _PrivacyVerdict.ABSENT:
             continue
-        boolish = _boolish(marker)
-        if boolish is not None:
+        if marker.boolish is not None:
             # Assertion subfields carry their OWN polarity ({"private": true},
             # {"publicly_visible": false}); neutral subfields ({"value": true})
             # take the enclosing key's polarity.
-            if subfield_kind == _KIND_PRIVATE:
-                verdicts.add("private" if boolish else "public")
-            elif subfield_kind in (_KIND_PUBLIC, _KIND_PUBLIC_FLAG):
-                verdicts.add("public" if boolish else "private")
+            if subfield_kind is not None:
+                verdict = _boolean_verdict(
+                    subfield_kind,
+                    marker.boolish,
+                    neutral_wrapper=False,
+                )
             elif compact_key in _OBJECT_MARKER_KEYS:
-                if negative_polarity:
-                    verdicts.add("private" if boolish else "public")
-                else:
-                    verdicts.add("public" if boolish else "private")
+                verdict = _boolean_verdict(
+                    outer_kind,
+                    marker.boolish,
+                    neutral_wrapper=True,
+                )
             else:
                 # Label-class alias subfield with a bare boolean: unresolvable.
-                verdicts.add("unknown")
+                verdict = _PrivacyVerdict.AMBIGUOUS
+            decisions.append(_MarkerDecision(
+                verdict,
+                token=marker.token,
+                boolean_assertion=True,
+                malformed_numeric=marker.malformed_numeric,
+                malformed_boolean_numeric=marker.malformed_boolean_numeric,
+                nonfinite_numeric=marker.nonfinite_numeric,
+                recognized_failing=marker.recognized_failing,
+                publication_data=marker.publication_data,
+                privacy_structure=True,
+                strict_public_label=marker.strict_public_label,
+                public_phrase=marker.public_phrase,
+            ))
             continue
-        verdicts.add(_marker_verdict(marker))
-    if not verdicts or "unknown" in verdicts or len(verdicts) > 1:
-        return _AMBIGUOUS_MARKER
-    return next(iter(verdicts))
+        if subfield_kind is not None:
+            policy = _FAMILY_POLICIES[subfield_kind]
+            locally_affirmative = (
+                marker.verdict is _PrivacyVerdict.PUBLIC
+                or (
+                    marker.verdict is _PrivacyVerdict.NEUTRAL_UNKNOWN
+                    and (
+                        (
+                            policy.admit_strict_public_label
+                            and marker.strict_public_label
+                        )
+                        or (
+                            policy.admit_public_phrase
+                            and marker.public_phrase
+                        )
+                    )
+                )
+            )
+            if marker.verdict is _PrivacyVerdict.AMBIGUOUS:
+                verdict = _PrivacyVerdict.AMBIGUOUS
+            elif _decision_is_private(
+                subfield_kind,
+                marker,
+                content_column=False,
+                row_mode=False,
+            ):
+                verdict = _PrivacyVerdict.PRIVATE
+            elif locally_affirmative:
+                verdict = _PrivacyVerdict.PUBLIC
+            elif marker.verdict is _PrivacyVerdict.NEUTRAL_UNKNOWN:
+                verdict = _PrivacyVerdict.NEUTRAL_UNKNOWN
+            else:
+                verdict = _PrivacyVerdict.PUBLIC
+            preserve_rejected_provenance = verdict in (
+                _PrivacyVerdict.PRIVATE,
+                _PrivacyVerdict.AMBIGUOUS,
+            )
+            preserve_affirmative_provenance = verdict is _PrivacyVerdict.PUBLIC
+            decisions.append(_MarkerDecision(
+                verdict,
+                token=marker.token,
+                boolean_assertion=marker.boolean_assertion,
+                malformed_numeric=(
+                    marker.malformed_numeric
+                    if preserve_rejected_provenance
+                    else False
+                ),
+                malformed_boolean_numeric=(
+                    marker.malformed_boolean_numeric
+                    if preserve_rejected_provenance
+                    else False
+                ),
+                nonfinite_numeric=(
+                    marker.nonfinite_numeric
+                    if preserve_rejected_provenance
+                    else False
+                ),
+                recognized_failing=(
+                    marker.recognized_failing
+                    if preserve_rejected_provenance
+                    else False
+                ),
+                publication_data=(
+                    marker.publication_data
+                    if preserve_affirmative_provenance
+                    else False
+                ),
+                privacy_structure=True,
+                strict_public_label=(
+                    marker.strict_public_label
+                    if preserve_affirmative_provenance
+                    else False
+                ),
+                public_phrase=(
+                    marker.public_phrase
+                    if preserve_affirmative_provenance
+                    else False
+                ),
+            ))
+            continue
+        decisions.append(_MarkerDecision(
+            marker.verdict,
+            token=marker.token,
+            boolish=marker.boolish,
+            boolean_assertion=marker.boolean_assertion,
+            malformed_numeric=marker.malformed_numeric,
+            malformed_boolean_numeric=marker.malformed_boolean_numeric,
+            nonfinite_numeric=marker.nonfinite_numeric,
+            recognized_failing=marker.recognized_failing,
+            publication_data=marker.publication_data,
+            privacy_structure=True,
+            strict_public_label=marker.strict_public_label,
+            public_phrase=marker.public_phrase,
+        ))
+    content_container = allow_content and _mapping_has_comment_content(value)
+    if not decisions:
+        if content_container:
+            return _MarkerDecision(
+                _PrivacyVerdict.NEUTRAL_UNKNOWN,
+                content_container=True,
+            )
+        return _MarkerDecision(
+            _PrivacyVerdict.AMBIGUOUS,
+            token=_AMBIGUOUS_MARKER,
+            privacy_structure=True,
+        )
+    return replace(
+        _combine_marker_decisions(decisions),
+        content_container=content_container,
+    )
 
 
-def _marker_verdict(marker: str) -> str:
-    if _boolish(marker) is True or marker in _PUBLIC_LABELS:
-        return "public"
-    if _boolish(marker) is False or (
-        marker != _AMBIGUOUS_MARKER and _label_is_private(marker)
+def _combine_marker_decisions(
+    decisions: list[_MarkerDecision],
+) -> _MarkerDecision:
+    verdicts = {decision.verdict for decision in decisions}
+    assertive_verdicts = verdicts - {_PrivacyVerdict.NEUTRAL_UNKNOWN}
+    recognized_failing = any(
+        decision.recognized_failing for decision in decisions
+    )
+    if (
+        not verdicts
+        or _PrivacyVerdict.AMBIGUOUS in verdicts
+        or len(assertive_verdicts) > 1
     ):
-        return "private"
-    return "unknown"
+        return _MarkerDecision(
+            _PrivacyVerdict.AMBIGUOUS,
+            token=_AMBIGUOUS_MARKER,
+            boolean_assertion=any(
+                decision.boolean_assertion for decision in decisions
+            ),
+            malformed_numeric=any(
+                decision.malformed_numeric for decision in decisions
+            ),
+            malformed_boolean_numeric=any(
+                decision.malformed_boolean_numeric for decision in decisions
+            ),
+            nonfinite_numeric=any(
+                decision.nonfinite_numeric for decision in decisions
+            ),
+            recognized_failing=recognized_failing,
+            publication_data=False,
+            privacy_structure=bool(decisions),
+            strict_public_label=any(
+                decision.strict_public_label for decision in decisions
+            ),
+            public_phrase=any(decision.public_phrase for decision in decisions),
+        )
+    return _MarkerDecision(
+        next(iter(assertive_verdicts), _PrivacyVerdict.NEUTRAL_UNKNOWN),
+        token=next(
+            (
+                decision.token
+                for decision in decisions
+                if decision.malformed_numeric
+            ),
+            "",
+        ),
+        boolean_assertion=any(decision.boolean_assertion for decision in decisions),
+        malformed_numeric=any(
+            decision.malformed_numeric for decision in decisions
+        ),
+        malformed_boolean_numeric=any(
+            decision.malformed_boolean_numeric for decision in decisions
+        ),
+        nonfinite_numeric=any(
+            decision.nonfinite_numeric for decision in decisions
+        ),
+        recognized_failing=recognized_failing,
+        publication_data=(
+            not assertive_verdicts
+            and bool(decisions)
+            and all(decision.publication_data for decision in decisions)
+        ),
+        privacy_structure=True,
+        strict_public_label=any(
+            decision.strict_public_label for decision in decisions
+        ),
+        public_phrase=any(decision.public_phrase for decision in decisions),
+    )
+
+
+def _scalar_marker_decision(
+    marker: str,
+    *,
+    malformed_numeric: bool = False,
+    malformed_boolean_numeric: bool = False,
+    nonfinite_numeric: bool = False,
+    recognized_failing: bool = False,
+    publication_data: bool = False,
+) -> _MarkerDecision:
+    boolish = _boolish(marker)
+    if boolish is not None:
+        # Scalar booleans keep their raw polarity for the outer key family.
+        return _MarkerDecision(
+            _PrivacyVerdict.NEUTRAL_UNKNOWN,
+            token=marker,
+            boolish=boolish,
+            boolean_assertion=True,
+            malformed_numeric=malformed_numeric,
+            malformed_boolean_numeric=malformed_boolean_numeric,
+            nonfinite_numeric=nonfinite_numeric,
+            recognized_failing=recognized_failing,
+            publication_data=publication_data,
+        )
+    if marker in _PUBLIC_LABELS:
+        verdict = _PrivacyVerdict.PUBLIC
+    elif marker == _AMBIGUOUS_MARKER:
+        verdict = _PrivacyVerdict.AMBIGUOUS
+    elif _label_is_private(marker):
+        verdict = _PrivacyVerdict.PRIVATE
+    else:
+        verdict = _PrivacyVerdict.NEUTRAL_UNKNOWN
+    return _MarkerDecision(
+        verdict,
+        token=marker,
+        malformed_numeric=malformed_numeric,
+        malformed_boolean_numeric=malformed_boolean_numeric,
+        nonfinite_numeric=nonfinite_numeric,
+        recognized_failing=recognized_failing,
+        publication_data=publication_data,
+        strict_public_label=(
+            marker in _STRICT_PUBLIC_LABELS
+            or marker == _PUBLIC_PHRASE_MARKER
+        ),
+        public_phrase=marker == _PUBLIC_PHRASE_MARKER,
+    )
 
 
 def _value_marker(text: str) -> str:
@@ -508,7 +1319,10 @@ def _value_marker(text: str) -> str:
     "restricted to agents", "support staff only", "private_response", and
     "visible to customer" resolve by their semantic tokens instead of
     per-spelling compact enumeration. Single tokens and already-known
-    compacts keep the pinned membership behavior.
+    compacts keep the pinned membership behavior. Positive public-audience
+    phrases become strict-public evidence rather than an affirmative public
+    verdict, so the family policy decides whether that evidence admits.
+    Unrecognized prose remains neutral.
     """
 
     compact = _key(text)
@@ -519,7 +1333,7 @@ def _value_marker(text: str) -> str:
         or compact in _FALSEY_TEXT
     ):
         return compact
-    tokens = _key_tokens(text)
+    tokens = _value_tokens(text)
     if len(tokens) >= 2:
         private_side = _PRIVATE_KEY_STEMS | _PRIVATE_AUDIENCE_TOKENS
         public_side = (
@@ -540,7 +1354,7 @@ def _value_marker(text: str) -> str:
             and not has_private
             and all(token in public_side or token in structural for token in tokens)
         ):
-            return "public"
+            return _PUBLIC_PHRASE_MARKER
     return compact
 
 
@@ -557,6 +1371,90 @@ def _numeric_marker(value: str) -> str | None:
     if number == 1:
         return "true"
     return None
+
+
+def _text_is_nonfinite_numeric(value: str) -> bool:
+    return _NONFINITE_NUMERIC_RE.fullmatch(value) is not None
+
+
+def _publication_data_kind(value: str) -> _PublicationDataKind:
+    if _NUMERIC_MARKER_RE.fullmatch(value) is not None:
+        return _PublicationDataKind.VALID
+    if _ISO_DATE_CANDIDATE_RE.match(value) is None:
+        return _PublicationDataKind.NOT_DATA
+    match = _ISO_DATE_DATA_RE.fullmatch(value)
+    if match is None:
+        return _PublicationDataKind.INVALID_DATE
+    year = int(match.group("year"))
+    month = int(match.group("month"))
+    day = int(match.group("day"))
+    if month == 2:
+        leap_year = year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+        max_day = 29 if leap_year else 28
+    elif month in {4, 6, 9, 11}:
+        max_day = 30
+    else:
+        max_day = 31
+    return (
+        _PublicationDataKind.VALID
+        if day <= max_day
+        else _PublicationDataKind.INVALID_DATE
+    )
+
+
+def _text_has_privacy_vocabulary(value: str) -> bool:
+    private_side = _PRIVATE_KEY_STEMS | _PRIVATE_AUDIENCE_TOKENS
+    public_side = (
+        _PUBLIC_FAMILY_TOKENS
+        | _PUBLIC_AUDIENCE_TOKENS
+        | _PUBLIC_LABELS
+        | _PUBLIC_FLAG_KEY_STEMS
+    )
+    return any(
+        token in private_side or token in public_side
+        for token in _value_tokens(value)
+    )
+
+
+def _content_value_has_private_marker(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        if _mapping_is_private(value, row_mode=False):
+            return True
+        marker = _marker(value, outer_kind=_KIND_PUBLIC)
+        if marker.privacy_structure and marker.recognized_failing:
+            return True
+        return any(
+            _key(key) in _COMMENT_CONTENT_KEY_TOKENS
+            and _content_value_has_private_marker(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return any(_content_value_has_private_marker(item) for item in value)
+    return False
+
+
+def _contains_nonblank_comment_text(value: Any) -> bool:
+    if isinstance(value, str):
+        return _rendered_comment_text_has_content(value)
+    if isinstance(value, Mapping):
+        return any(
+            _key(key) in _COMMENT_CONTENT_KEY_TOKENS
+            and _contains_nonblank_comment_text(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return any(_contains_nonblank_comment_text(item) for item in value)
+    return False
+
+
+def _mapping_has_comment_content(value: Mapping[str, Any]) -> bool:
+    if _content_value_has_private_marker(value):
+        return False
+    return any(
+        _key(key) in _COMMENT_CONTENT_KEY_TOKENS
+        and _contains_nonblank_comment_text(item)
+        for key, item in value.items()
+    )
 
 
 def _label_is_private(marker: str) -> bool:

--- a/plans/PR-Resolution-Audit-S6A-Structured-Privacy-Semantics.md
+++ b/plans/PR-Resolution-Audit-S6A-Structured-Privacy-Semantics.md
@@ -1,0 +1,717 @@
+# PR-Resolution-Audit-S6A-Structured-Privacy-Semantics
+
+## Why this slice exists
+
+Issue #2060 reopens Resolution Audit launch-blocker 4 after a cold reconstruction
+of current main proved that the S6A admission boundary merged in #2046 still
+admits structured private markers and drops equivalent public metadata. A mixed
+Zendesk-submit probe carried nested private prose into the stored paid artifact,
+so this is a live privacy boundary defect, not speculative grammar hardening.
+
+This slice fixes the canonical classifier and proves the public submit path. It
+does not claim to close #2060: generic `/execute` can still restore raw caller
+`source_material` over the provider-filtered package, and the serialized S6A.2
+slice owns that separate upstream authority defect.
+
+The diff exceeds the 400-line soft target because this privacy classifier is not
+safe to land without both error-direction class coverage and the real
+submit-to-persist proof. The production change remains one module; the rest is
+the required plan, living-tracker correction, vocabulary-derived adversarial
+matrix, and one route test. Splitting any of those would leave either an
+unreviewable guard or a green helper with no proof that the paid artifact
+boundary uses it.
+
+### Problem-derived contract
+
+- Root cause: marker parsing collapses raw scalar tokens and semantic object
+  decisions into the same strings (`public`, `private`, `__ambiguous__`). Outer
+  key-family policy then reinterprets those strings, losing recursive subfield
+  polarity, losing whether a public-facing decision came from a boolean
+  assertion, and treating a valid unknown object label differently from its
+  scalar equivalent. Sequence content mode also bypasses scalar classification
+  for strings, and malformed provenance is enforced inside individual family
+  branches after other families have already accepted. The value grammar also
+  recognizes positive family stems without recognizing bounded negation of
+  those same stems, while sequence branches treat `ABSENT` as private or
+  unresolved instead of the same identity value objects and scalars use.
+  Public-audience vocabulary is also split between two sets, and conjunction
+  tokens prevent otherwise explicit private phrases from resolving. Positive
+  public-audience phrase promotion is applied without the outer key family's
+  polarity, so `end user` can invert a `private`/`hidden` subfield. Sequence
+  cardinality is also checked before scalar-`ABSENT` placeholders are removed,
+  so one neutral scalar plus a blank takes the stricter multi-item path.
+  Finally, public-flag policy admits every neutral string as if it were
+  publication data, then tries to recover privacy by enumerating negation
+  phrases; every unrecognized private phrasing therefore reopens the same
+  fail-open. These are representation and invariant-placement defects plus a
+  family-default defect, not independent spelling bugs.
+  Round-10 exact-head probes exposed three residual invariant-placement defects:
+  content-container provenance is granted from a body/text key's presence rather
+  than from non-blank textual content; the recursive placeholder predicate skips
+  empty sequences and therefore counts them as substantive; and the existing
+  `malformed_numeric` bit intentionally covers both invalid non-finite numerics
+  and valid finite numerics that are data only for publication flags. Adding the
+  public-flag family to the shared malformed set would therefore close the leak
+  by breaking the required finite-number data path. The missing root signal is
+  distinct non-finite-numeric provenance that survives combination and dominates
+  an otherwise-public sibling.
+  Round-11 exact-head probes showed that the same masking defect still exists one
+  class wider: an affirmative-public sibling can erase privacy-vocabulary text or
+  an invalid date that fails as a scalar, and content-container provenance can
+  erase a recognized private marker nested inside a body/text wrapper. The
+  combiner records public/content evidence but has no uniform recognized-failing
+  evidence that dominates either admission shortcut. Key admission also has two
+  grammar holes before the combiner: compact `un<public-flag-stem>` keys and
+  public-flag stems with `status`/`label` suffixes remain unclassified, so their
+  values bypass the closed family entirely.
+  Round-12 held-out probes show five residual provenance-order defects in that
+  same bounded grammar: compact negated values are recognized only after their
+  spelling has lost token boundaries; `un` key polarity is checked before, but
+  not after, label/status suffix removal; numeric `0`/`1` returns before exponent
+  provenance is attached; invalid-date detection excludes date-only timezone
+  suffixes; and multi-item sequence admission omits otherwise-valid
+  `publication_data` from its marker-shaped path. Each scalar policy is already
+  correct; wrapper/alias ordering is discarding its evidence before combination.
+  Round-13 review proves the deeper architecture is still not closed: family
+  policy is distributed across scalar, object, sequence, and final-admission
+  functions, while normalization repeats before and after lowercasing and
+  compaction. There is no single canonical key meaning, semantic decision, or
+  policy table against which wrapper equivalence can be proved. Consequently
+  public-family failure dominance, qNaN, compact datetime offsets,
+  strict-wrapper exponent provenance, and camelCase phrase boundaries each fall
+  through a different ordering seam. These are not five new strings; they are
+  evidence that production lacks a reference model and class-closure oracle.
+  Round-14 re-review confirms that architecture closed every generated family
+  except invalid publication dates: scalar invalid dates fail closed, but the
+  semantic decision marks them `recognized_failing` only when a narrow
+  date-shaped regex matches. Trailing junk and non-zero-padded calendar forms
+  therefore become neutral evidence inside a wrapper and can be laundered by a
+  public sibling. The root cause is a split publication-data decision -- valid
+  data and invalid date candidates are not produced by one canonical scalar
+  classifier -- plus an oracle domain that omitted those invalid-date shapes.
+  Round-15 review exposes four remaining decision-boundary gaps rather than new
+  vocabulary: placeholder identity recurses through sequences but not generic
+  wrapper mappings; structured recognized-failing evidence is evaluated after
+  the content exit; content presence uses raw non-whitespace rather than the
+  package's rendered-text semantics; and a classified access/type subfield that
+  its own family admits as neutral still exports raw failing provenance to a
+  stricter outer family. These are normalization/precedence defects in the
+  shared semantic model, not four marker strings.
+  Round-16 review shows those predicates were repaired only at one structural
+  level. Recognized-failing marker evidence is not derived recursively through
+  nested content wrappers; absence identity does not use rendered-content
+  semantics for body-bearing mappings inside sequences; admitted content is
+  still also labeled unresolved and can conflict with an explicit public
+  sibling; and a locally neutral classified subfield still exports affirmative
+  strict/publication provenance. The root is four incomplete semantic folds at
+  the shared choke point, not another value-vocabulary gap.
+- Correct fix must touch/change: the package-owned
+  `support_ticket_privacy.py` classifier must preserve distinct public, private,
+  neutral-unknown, ambiguous, and absent decisions plus boolean-assertion origin
+  through recursive object resolution, including neutral wrapper depth. Empty
+  mapping markers must retain structured provenance; classified nested subfields
+  must retain neutral rather than being promoted to public; and strict-public
+  evidence across neutral subfields must aggregate without mapping-order loss.
+  Neutral boolean wrappers must also retain their outer key family so categorical
+  strict labels cannot inherit public polarity, and neutral metadata must remain
+  non-conflicting beside an explicit public/private verdict. Multi-token public
+  audience phrases must preserve `end user` as one semantic audience. Public-
+  facing flags must honor explicit private text independently of boolean origin,
+  while access/audience value labels must reject the complete recognized
+  malformed-numeric class, including exponent notation and non-finite numeric
+  values produced by JSON exponent overflow or represented as CSV strings,
+  without rejecting valid producer-defined neutral text. Numeric provenance must
+  survive recursive object resolution rather than being inferred later from a
+  compacted token. Recursive marker resolution must also traverse non-empty
+  sequence wrappers while accepting genuine row-level note/comment content only
+  when the caller establishes that context and each body-bearing comment is
+  independently public. Strict-label policy must consume malformed-numeric and
+  strict-public-audience provenance in object and sequence forms. A classified
+  strict-label boolean subfield must remain fail-closed instead of being demoted
+  to neutral metadata beside public evidence, while generic categorical wrapper
+  booleans must retain scalar/object/direct-sequence/nested-sequence parity for
+  access/audience and type/kind. Strict sequences must preserve whether a boolean
+  is raw assertion material or arrived through a generic wrapper: raw booleans
+  remain ambiguous, while generic wrapper booleans remain neutral metadata.
+  Key-family policy must consume that decision directly before any content
+  carveout. Non-empty note/comment mappings without an actual body-bearing
+  content field must retain structured provenance and fail closed, while real
+  body-bearing mappings and free-text sequences retain the named content exit.
+  Every singleton list/tuple/set/frozenset wrapper must reuse the scalar decision path;
+  multi-item content sequences must classify each string first and treat only
+  scalar-admissible neutral/public text as content. Malformed-numeric provenance
+  must fail closed before any private/public/strict/value-label family can
+  accept, while publication/facing and type/kind retain their documented data-
+  column semantics. CI-facing tests must generate scalar/singleton list/tuple/
+  generic-value-wrapper parity for marker families whose wrappers inherit the
+  outer polarity. Note/comment content mappings remain structured markers and
+  retain their separate fail-closed policy.
+  Public-flag and strict-label families must admit only affirmative recognized
+  public evidence; publication/facing flags additionally admit an explicit ISO
+  date/time or finite-number data shape. Every other non-empty unrecognized text
+  must fail closed without a negation-phrase enumeration. Access/audience and
+  type/kind must retain #2060's separate neutral producer-data policy. `ABSENT`
+  sequence elements (blank strings and `None`, including nested placeholder-only
+  wrappers) must be removed before sequence cardinality is selected, so one
+  remaining element reuses the scalar path in both content and marker modes,
+  while recognized private, malformed, conflicting, and multiple unresolved
+  non-absent siblings retain their existing fail-closed effect. Positive
+  multi-token public-audience phrases must be recognized only where the outer
+  public/strict family permits that polarity; private-family subfields must not
+  be inverted, while exact explicit `public` labels retain their established
+  meaning. CI-facing tests must derive public/private token combinations,
+  unrecognized contexts, container shapes, and blank placement from the family
+  vocabulary across every family in both error directions.
+  Content-container provenance must require non-blank text under a recognized
+  body/text field, including nested content wrappers; empty, whitespace, `None`,
+  and placeholder-only content shapes must remain structured and fail closed.
+  Empty nested sequences must be `ABSENT` identity before outer sequence
+  cardinality without changing the established top-level empty-comment-list
+  content behavior. Marker decisions must separately carry non-finite-numeric
+  provenance through object and sequence combination; every publication/facing
+  family must reject that provenance before affirmative public evidence, while
+  calendar-valid dates and finite numbers continue to admit in scalar and
+  public-labeled structured controls.
+  Closed-family scalar decisions must additionally carry one
+  `recognized_failing` invariant derived from privacy vocabulary, invalid
+  date/non-finite data shapes, and explicit private/ambiguous decisions. Object
+  and sequence combination must propagate it and fail closed before a public
+  label can admit; genuinely neutral metadata without privacy vocabulary remains
+  compatible beside explicit public evidence. Content admission must recursively
+  apply the existing key-family classifier inside recognized body/text wrappers
+  and deny the carveout when any nested marker resolves private, while explicit
+  public controls and genuine text remain admitted. Key classification must
+  recognize compact `un` plus an exact public/public-flag stem as the private
+  side, and remove `status`/`label` only when the remaining exact stem is a
+  public-flag family, preserving unrelated data-column keys.
+  Compact negated closed-family values must resolve through the same bounded
+  public/public-flag stem grammar before public siblings combine. Label/status
+  stripping must then reapply that exact negated-stem grammar. Numeric parsing
+  must retain exponent-shaped malformed provenance even when its numeric value
+  is boolean-like `0` or `1`. Date-like detection must classify malformed
+  calendar values with date-only `Z`/offset suffixes as failing evidence without
+  widening arbitrary prose. Valid publication dates/numbers must remain
+  marker-shaped in multi-item public-label sequences so wrapper policy matches
+  scalar/object policy.
+  The correct architectural fix must canonicalize keys into one typed family
+  decision, canonicalize scalars/objects/sequences into one semantic decision,
+  and apply exactly one immutable family-policy table. No family admission rule
+  may remain in recursive parsing. The table must own boolean polarity,
+  admitted verdicts, strict-public labels, neutral-data admission, publication
+  data, content carveouts, and malformed/non-finite/failing precedence. A small
+  independent test oracle must express the same product contract without
+  importing runtime internals, generate family x semantic atom x key/value
+  spelling x container x sibling-evidence compositions, and compare every case
+  to the public predicates. New examples may extend a semantic atom generator,
+  but must not add production admission branches.
+  Publication data must likewise be one semantic classification with valid,
+  invalid-date-candidate, and not-data outcomes. A date candidate that does not
+  produce valid publication data must set the existing `recognized_failing`
+  evidence before wrapper combination; arbitrary neutral prose must remain
+  not-data. The generated oracle must include trailing-junk, non-zero-padded,
+  and out-of-range date candidates across every family and supported wrapper/
+  sibling composition so scalar and masked outcomes cannot diverge again.
+  Placeholder normalization must recurse through non-empty recognized wrapper
+  mappings whose values are all absent, without treating an empty structured
+  marker as absent. Structured recognized-failing evidence must dominate the
+  content carveout, while direct free-text content retains its established
+  path. Content existence must use the same rendered plain-text semantics as
+  package normalization so markup/entity-only placeholders cannot authorize
+  content admission. A classified subfield must export the result of its own
+  family policy to the outer combiner: provenance that the subfield family
+  admits as neutral cannot be reinterpreted as failing by the outer family,
+  while locally rejected provenance remains private.
+  Recognized-failing dominance must recurse through every recognized content
+  wrapper depth before any content carveout. In content-sequence context,
+  absence must recurse through body/text wrapper mappings and use fully rendered
+  text, with content requiring at least one alphanumeric Unicode character;
+  admitted content is compatible evidence rather than an unresolved sibling.
+  A classified subfield may export affirmative strict/publication provenance
+  only when its own family decision is public; a locally neutral result exports
+  no positive provenance to the outer family.
+  The documented `has_access` data column must remain unclassified for every
+  normalized spelling and value shape instead of inheriting access-marker
+  policy from generic `has` prefix stripping. Public strict labels must share
+  the public-audience vocabulary; conjunctions must be value structure.
+  CI-facing classifier tests
+  must cover both error directions and held-out same-class cases, and the real
+  `/deflection-reports/submit` route must prove mixed public/private input keeps
+  public evidence while no private sentinel reaches the snapshot or stored
+  artifact. Package-level tests must prove recognized private/malformed
+  structures cannot use row content-column carveouts. The living remediation
+  tracker must reopen S6A and link #2060.
+- Must not change: support-ticket package/Zendesk caller signatures, input-package
+  precedence, the generic `/execute` merge, downstream campaign-source guard,
+  report/snapshot/email/PDF/landing/pricing/checkout shape, scrubber grammar,
+  clustering, junk, date, money, billing, delivery, database schemas, or any
+  other lane.
+
+## Scope (this PR)
+
+Ownership lane: resolution-audit/privacy-admission
+Slice phase: Vertical slice
+
+1. Replace string-overloaded structured marker decisions with an internal typed
+   decision consumed consistently by each existing key family.
+2. Close the original post-merge finding classes and reviewed same-root
+   regressions in both directions without changing the established content-
+   column carveouts.
+3. Prove the fix through the real mixed Zendesk full-thread submit route and
+   persisted report artifact.
+4. Prove package normalization rejects recognized private/malformed note and
+   comment structures, including empty mapping markers and nested neutral metadata,
+   while preserving genuine content containers.
+5. Correct the local Resolution Audit tracker to show S6A reopened under #2060.
+
+Max files: 6
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Nested private/hidden assertions, object-wrapped false publication
+        flags, and explicit private conjunction phrases classify private.
+  - [ ] Neutral object labels and requester/client/end-user strict labels
+        classify public/neutral consistently with scalar/key-form equivalents.
+  - [ ] Empty, malformed, and contradictory structured markers still fail
+        closed; free-text comment/note content columns still admit.
+  - [ ] A note/comment body, text, message, content, or description key grants
+        the content carveout only when its value contains non-blank text; empty,
+        whitespace, `None`, empty-container, and placeholder-only wrappers reject
+        at classifier and package boundaries.
+  - [ ] Recognized privacy keys nested inside body/text/content wrappers are
+        classified before content provenance is granted; private/failing markers
+        reject through mapping/sequence nesting while explicit-public plus genuine
+        text controls retain the content path.
+  - [ ] Nested classified neutral metadata never becomes affirmative public
+        evidence, and strict-public evidence is independent of mapping order.
+  - [ ] Bare boolean wrappers under strict categorical labels fail closed;
+        explicit public labels remain public beside neutral metadata.
+  - [ ] End-user visibility phrases classify like equivalent end-user key forms.
+  - [ ] Public-facing flags reject explicit private text but retain neutral date
+        columns; access/audience reject malformed numerics, including scalar and
+        object-wrapped exponent notation, JSON exponent overflow, and string
+        non-finite forms, while valid neutral producer labels remain admitted per
+        #2060.
+  - [ ] Non-empty sequence wrappers preserve recognized marker decisions and
+        reject structured private assertions. Genuine row-level string/body
+        note and comment containers retain the carveout only when body-bearing
+        mappings independently classify public; non-content keys remain closed.
+  - [ ] Non-empty unknown and neutral-wrapper note/comment mappings fail closed
+        across scalar mapping and sequence containers, while genuine body/text
+        containers and the pinned public-comment compatibility path still admit.
+  - [ ] Singleton list, tuple, set, and frozenset containers match scalar
+        outcomes across every key family for private, public, neutral, boolean,
+        and malformed-numeric values; content lists classify recognized scalar
+        markers before using the free-text carveout.
+  - [ ] Malformed-numeric provenance fails closed before public/private/strict/
+        value-label acceptance in scalar, object, list, tuple, and generic-value
+        wrappers; publication/facing and type/kind data semantics remain stable.
+  - [ ] Publication/facing and strict families reject every non-empty
+        unrecognized text by default, including but not limited to negated,
+        withheld, and private-context phrases; recognized public evidence still
+        admits, and publication/facing ISO dates and finite numbers retain their
+        data-column outcome.
+  - [ ] Every publication/facing key rejects non-finite numeric provenance beside
+        a public label and through object/sequence wrappers; public-labeled valid
+        dates and finite numbers remain admitted, so the repair does not widen the
+        shared malformed-family set.
+  - [ ] A public label cannot mask any recognized-failing closed-family value:
+        privacy-vocabulary text, invalid date-like data, non-finite numerics, and
+        explicit private/ambiguous decisions reject across public-flag/strict
+        families and object/sequence/nested wrappers; genuinely neutral metadata
+        plus explicit public evidence and valid publication data still admit.
+  - [ ] Compact `un<public/public-flag-stem>` keys fail closed like existing
+        `not_`/`non_` key forms, and public-flag `*_status`/`*_label` aliases reach
+        the same family policy without classifying unrelated status columns.
+  - [ ] Compact `un`/`not`/`non` public-flag values remain recognized failing
+        beside public evidence, and suffixed negated keys such as
+        `unpublished_status` reuse the same private polarity after suffix removal.
+  - [ ] Exponent-shaped numeric `0`/`1` retains malformed provenance for
+        access/audience and note/comment sequences; plain booleans and ordinary
+        `0`/`1` controls retain their established outcomes.
+  - [ ] Invalid calendar values with date-only `Z` or numeric-offset suffixes
+        cannot be masked by public evidence, while calendar-valid date/time
+        values remain publication data.
+  - [ ] Multi-item public-label sequences preserve valid publication-data
+        evidence and admit `public` plus a valid date/finite number without
+        weakening failing siblings.
+  - [ ] Key classification returns one typed canonical family decision; runtime
+        code does not pass raw family strings or reclassify a key after value
+        recursion begins.
+  - [ ] One immutable family-policy table is the only place that decides boolean
+        polarity, verdict admission, neutral-data behavior, publication data,
+        content carveouts, and malformed/non-finite/recognized-failing precedence.
+  - [ ] Recursive scalar/object/sequence parsing only produces and combines
+        semantic decisions; it contains no family-specific row-admission exits.
+  - [ ] An independent generated oracle covers every supported family across
+        public/private/unknown/boolean/malformed/non-finite/publication atoms,
+        separator/camel/compact spellings, scalar/object/sequence wrappers, and
+        public/failing siblings, and matches both public predicates.
+  - [ ] Public-family objects cannot launder failing public vocabulary; qNaN is
+        non-finite; compact-offset datetimes remain publication data; strict
+        wrappers retain exponent provenance; and camelCase private conjunctions
+        retain token boundaries as consequences of canonicalization, not bespoke
+        admission clauses.
+  - [ ] Publication text produces one semantic valid/invalid/not-data decision;
+        invalid date candidates, including trailing-junk, non-zero-padded, and
+        out-of-range forms, reject identically as scalars and beside public
+        siblings across every supported family and wrapper, while neutral prose
+        and valid dates keep their established outcomes.
+  - [ ] Non-empty generic marker wrappers containing only blank, `None`, empty
+        sequence, or recursively placeholder-only values act as `ABSENT` identity
+        before sequence cardinality; empty structured mappings remain fail-closed.
+  - [ ] Recognized-failing marker subfields inside body-bearing note/comment
+        mappings reject before the content carveout, while direct and nested
+        genuine free text keeps the documented content path.
+  - [ ] Markup/entity-only bodies that render to no ticket text do not grant the
+        content carveout; rendered text uses the package normalization semantics.
+  - [ ] Access/audience and type/kind subfields admitted as neutral by their own
+        family policy do not leak raw failing provenance into an outer public/
+        strict family; locally private subfields still dominate outer evidence.
+  - [ ] Recognized-failing status/value/label/name markers reject through every
+        supported body/text/content wrapper depth before content admission.
+  - [ ] Content-sequence absence recursively removes rendered-empty body
+        mappings, including decoded entity/punctuation-only values, while
+        alphanumeric rendered content remains substantive.
+  - [ ] Admitted comment content can compose with a standalone explicit-public
+        marker without becoming ambiguous; private/failing siblings still win.
+  - [ ] Locally neutral access/audience/type/kind subfields export neither
+        strict-public nor publication-data provenance; an explicit outer public
+        sibling is required for admission.
+  - [ ] Blank-string and `None` sequence elements act as `ABSENT` identity in
+        both content and marker paths: after removal, a single neutral/public
+        survivor matches its scalar result, while multiple unresolved survivors
+        and recognized private/malformed siblings retain fail-closed behavior.
+  - [ ] Empty list/tuple/set/frozenset elements are likewise `ABSENT` when nested
+        inside a marker sequence, while a top-level empty comments container keeps
+        its established content-column behavior.
+  - [ ] Multi-token public-audience phrases under `private`, `hidden`, and
+        equivalent private-polarity subfields cannot become public evidence;
+        public/strict visibility contexts still recognize those phrases and an
+        exact explicit `public` value under a private key retains its control
+        behavior.
+  - [ ] A vocabulary-derived property matrix spans public/private tokens,
+        unrecognized contexts, scalar/object/sequence containers, blank/`None`
+        placement, and private/public/public-flag/strict/value-label/kind/content
+        families; publication/strict default closed while access/audience and
+        type/kind retain neutral producer text.
+  - [ ] `has_access` remains a data column across normalized snake, camel,
+        hyphen, space, and case spellings and cannot inherit malformed-numeric
+        access-marker rejection from prefix stripping.
+  - [ ] Classified strict-label boolean subfields remain fail-closed beside an
+        explicit public sibling; generic neutral wrapper metadata remains neutral.
+  - [ ] Strict labels reject malformed-numeric provenance even beside public
+        evidence, and requester/client/end-user sequence wrappers retain the same
+        public result as scalar and object forms.
+  - [ ] Generic booleans under access/audience and type/kind retain their scalar
+        family semantics through object, list/tuple, and nested sequence wrappers;
+        classified strict boolean subfields do not become affirmative public.
+  - [ ] Raw booleans in strict sequences remain ambiguous beside public audience
+        evidence, while generic `value`-wrapped sequence booleans remain neutral.
+  - [ ] Neutral wrapper recursion preserves inherited polarity at depths 1-3,
+        and classified non-boolean subfields obey their own key-family policy.
+  - [ ] Unknown-key subtrees remain opaque consistently at row, comment,
+        marker-object, and body-bearing content levels; recognized privacy keys
+        at those same levels still fail closed.
+  - [ ] Package normalization rejects recognized private/malformed structures
+        before they enter `source_material`.
+  - [ ] At least 5-10 held-out same-class probes exercise recursive polarity,
+        object/scalar parity, public audiences, and conjunctions.
+  - [ ] A mixed real submit retains public evidence and excludes a private
+        sentinel from response, snapshot, and stored artifact.
+  - [ ] No product shape or non-privacy lane changes.
+- Reachability proof: POST `/ops/deflection-reports/submit` through the real
+  router, Zendesk full-thread importer, input package, report service, scrub/QA
+  gate, and `InMemoryDeflectionReportArtifactStore`; inspect response, snapshot,
+  and stored artifact state.
+- Affected surfaces: support-ticket privacy classifier, public Resolution Audit
+  submit admission, generated report persistence, remediation tracker.
+- Risk areas: privacy leakage, public-ticket data loss, backward compatibility
+  of producer marker shapes.
+- Reviewer rules triggered: R1, R2, R3, R10, R12, R13, R14; guard-shaped
+  boundary probe required.
+
+### Files touched
+
+- `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md`
+- `extracted_content_pipeline/support_ticket_privacy.py`
+- `plans/PR-Resolution-Audit-S6A-Structured-Privacy-Semantics.md`
+- `tests/test_extracted_content_deflection_submit.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_support_ticket_privacy_sweep.py`
+
+## Mechanism
+
+Introduce a private marker-decision value carrying one of `PUBLIC`, `PRIVATE`,
+`NEUTRAL_UNKNOWN`, `AMBIGUOUS`, or `ABSENT`, plus whether the decision came from
+a boolean assertion. Scalars and recursive objects resolve into this value;
+objects combine all recognized subfield decisions, preserve inherited polarity
+through neutral wrappers, apply classified subfields through their own family
+policy without promoting neutral results, aggregate strict-public evidence
+across all neutral subfields, retain the outer key family through neutral boolean
+wrappers, ignore neutral metadata when combining an explicit public/private
+verdict, and return ambiguous only on assertive contradiction or malformed
+containers. Decisions retain malformed-numeric provenance across scalar and
+object forms so value-label policy does not depend on the compacted spelling of
+the numeric token, including non-finite numeric strings from CSV-shaped inputs.
+The decision also retains explicit publication-data provenance for ISO
+date/time and finite-number shapes, allowing public flags to distinguish real
+data from arbitrary neutral text without interpreting open-ended prose.
+It separately carries non-finite-numeric provenance, propagated with `any`
+through object and sequence combination, so publication/facing policy can reject
+invalid numeric evidence before an explicit public sibling without treating a
+valid finite number as malformed publication data.
+The same decision carries a single `recognized_failing` bit for every
+closed-family scalar that contains privacy vocabulary, invalid date/non-finite
+data, or an explicit private/ambiguous verdict. The shared combiner makes that
+bit dominant before public-label admission, so adding another failing vocabulary
+member or container cannot create a new laundering branch.
+Publication-shaped text is classified once into valid data, an invalid date
+candidate, or unrelated text. The classifier recognizes the stable ISO date
+namespace rather than enumerating invalid suffix/month/day spellings, validates
+the existing calendar/time grammar for the valid outcome, and derives both
+`publication_data` and `recognized_failing` from that one result. Recursive
+objects and sequences therefore cannot reinterpret a scalar-invalid date as
+neutral merely because a public sibling is present.
+Non-empty sequences recursively combine recognized marker decisions using the
+same verdict combiner as objects. A singleton sequence delegates to `_marker`
+exactly once so it cannot diverge from its scalar form. Scalar-`ABSENT`
+placeholders and nested placeholder-only wrappers are removed before that
+cardinality decision, so a sequence with one substantive survivor also
+delegates to `_marker`; true multi-item content
+sequences classify every string through that same path and use the content exit
+only when the scalar family policy admits it. Deeper recursive `ABSENT`
+decisions remain identity values during aggregation, matching object subfield
+and scalar semantics without weakening any non-absent unresolved/private
+decision. The caller explicitly marks genuine
+note/comment columns; row inputs and the pinned public-comment compatibility
+path treat strings and body-bearing mappings as content, and each mapping is
+independently checked for privacy before the carveout applies. Strict-public
+audience provenance participates in sequence
+decisions, and strict-label policy rejects malformed-numeric provenance before
+accepting public evidence. Classified strict-label boolean subfields remain
+ambiguous/fail-closed; generic boolean wrapper keys retain the neutral categorical
+semantics of scalar access/audience/type/kind values through direct and nested
+sequence wrappers. Generic-wrapper origin is carried into nested sequences so
+strict raw booleans remain ambiguous while `value`-wrapped booleans remain
+neutral metadata. The decision also records whether an object actually
+contained privacy structure, including an empty mapping marker, so only genuine
+free-text/comment containers can use the row content carveout.
+
+Placeholder identity also descends through non-empty generic marker mappings
+whose recognized wrapper values are all recursively absent; a bare empty mapping
+keeps structured ambiguous provenance. Classified subfields are reduced through
+their own family policy before entering the outer combiner: locally admitted
+neutral values export neutral evidence without raw failing flags, while locally
+rejected values export `PRIVATE`. This keeps outer policy from overriding the
+documented access/audience/type/kind carve-out.
+
+For content sequences, the same absence fold recognizes content wrapper keys
+and evaluates strings after package rendering; only rendered alphanumeric text
+is substantive. Content admitted by family policy is recorded solely as content
+evidence, not simultaneously as unresolved evidence. Before content admission,
+recognized-failing semantics are derived recursively through recognized content
+wrappers. Classified subfield reduction exports positive strict/publication
+provenance only from a locally public decision, so neutral family carve-outs
+cannot authorize a stricter outer family.
+
+The decision separately records named content-container provenance. Raw text,
+empty top-level comment lists, and body-bearing mappings receive that provenance only in
+the established row/public-comment content context; unknown or neutral wrapper
+mappings without a body-bearing field retain structured provenance and fail
+closed. A body-bearing mapping qualifies only when a recognized content field
+contains rendered plain text under the same HTML/entity normalization used by
+the package; blank, markup-only, entity-only, `None`, and placeholder-only fields
+cannot turn key presence into an admission signal. Structured recognized-failing
+evidence is evaluated before the content exit, while direct free text retains
+content provenance. Empty sequences nested inside a larger marker
+sequence are removed as `ABSENT` before cardinality, without changing the
+top-level empty-comments compatibility path. Exact normalized `has_access`
+spellings exit key classification before generic prefix stripping, leaving
+actual `access`, `access_label`, and flag-shaped access markers unchanged.
+Before granting nested content provenance, the same key-family classifier walks
+only recognized body/text/content wrappers and rejects any nested marker that
+resolves private; unknown non-content subtrees remain opaque. Compact `un` key
+forms are flipped only when their exact remainder is public/public-flag, and
+label/status suffix removal is extended only to exact public-flag stems.
+The same bounded negated-stem resolver is reused for compact closed-family
+values and after label/status key suffix removal. Scalar numeric parsing records
+exponent-shaped malformed provenance before returning boolean-like `0`/`1`, and
+invalid-date detection accepts only ISO-shaped date/time or timezone suffixes.
+Sequence marker-shape detection includes `publication_data`, preserving the
+scalar/object admission decision for valid dates and finite numbers beside
+public evidence.
+
+Round-13 replaces distributed admission with three explicit layers.
+`_classify_key` returns a typed canonical key decision. Recursive value parsing
+returns only semantic evidence and never admits a row. `_decision_is_private`
+then consults one `_FAMILY_POLICIES` table for every family behavior, including
+content eligibility supplied by the caller. Scalar normalization preserves
+original camel boundaries before case folding, assigns numeric/date/non-finite
+evidence once, and passes the same decision through every container. The
+test-side reference oracle independently defines semantic atoms and family
+policies, generates supported normalization/container compositions, and asserts
+the two public entrypoints match the oracle without importing any private
+runtime helper or constant.
+
+Existing key-family policy then consumes the decision instead of reinterpreting
+the strings `public` and `private`:
+
+- malformed provenance is rejected once, before private/public/strict/value-
+  label family acceptance;
+- private/public assertions retain fail-closed unknown behavior and row-mode
+  content-column carveouts;
+- publication/facing flags admit recognized public decisions and explicit ISO
+  date/time or finite-number data shapes only, failing closed on every other
+  non-empty neutral string;
+- strict labels admit recognized public decisions only and likewise fail closed
+  on unrecognized text;
+- audience/access and type/kind reject private or ambiguous decisions but admit
+  valid neutral unknown labels.
+
+Public strict-label membership is derived from the existing public audience
+tokens. Unrecognized public/private phrase contexts need no semantic scan: the
+public-flag and strict family policies reject neutral text by default, while
+the access/audience and type/kind policies retain their documented neutral-data
+carve-out. `and`/`or` plus the separator in `end user` become structural only
+inside recognized value phrases. Positive
+public-audience phrase promotion is enabled only for public/public-flag/strict
+outer families; the exact-label fast path remains unchanged, so explicit
+`private: public` retains its established public override while
+`private: end user` cannot invert private polarity. No caller or artifact
+contract changes.
+
+## Intentional
+
+- This fixes the semantic representation root rather than adding the thirteen
+  reproduced strings to denylists/allowlists.
+- `InMemoryDeflectionReportArtifactStore` is the real local implementation of
+  the report-store protocol and is appropriate for route-level observable-state
+  proof; no pool or query-string fake is introduced.
+- Top-level publication/facing date-valued columns remain admitted. When nested
+  under a strict marker family, a neutral date is not promoted into affirmative
+  public evidence. Finite numeric publication data likewise remains admitted,
+  while boolean false asserts privacy. Arbitrary neutral text is not guessed at
+  or scanned as natural language; it fails closed for publication/strict policy.
+- Access/audience deliberately retain #2060's value-label semantics: known
+  private labels and malformed numeric markers reject, while producer-defined
+  neutral text remains admissible. Treating every unknown text label as private
+  would reverse the issue's required public/neutral error direction.
+- A blank or `None` beside one neutral access/audience label is representation
+  noise and therefore reuses the scalar decision, including through a nested
+  placeholder-only wrapper. Two substantive neutral labels remain a genuinely
+  multi-valued unresolved marker and stay fail-closed.
+- Review thread `PRRT_kwDOQ5Uhrs6P-Uf_` is not implemented as an admission
+  widening: a valid date/number does not erase an unrecognized textual sibling
+  under publication/strict policy. Admitting that object would contradict the
+  operator's explicit fail-closed-on-any-unknown-text contract and would let the
+  same class reopen beside data-shaped evidence. Recognized-public plus valid
+  date/finite-number controls remain admitted.
+- Multi-token public-audience phrases are contextual vocabulary, not universal
+  overrides. Private-family fields preserve their negative polarity, while the
+  exact scalar label `public` remains the existing explicit polarity override.
+- `has_access` is a documented producer data column, so its normalized exact
+  spellings are exempted before prefix stripping. The exemption does not apply
+  to `access`, `access_label`, `has_access_flag`, or other marker-shaped keys.
+- Unknown-key subtrees remain opaque at every level. Recursing into arbitrary
+  producer metadata would replace the classifier's closed vocabulary with an
+  unbounded structural scan and create inconsistent over-scrub risk; recognized
+  nested privacy keys remain fail-closed. Review threads
+  `PRRT_kwDOQ5Uhrs6P0VhX` and `PRRT_kwDOQ5Uhrs6P0Vha` are waived on this basis.
+- The downstream campaign-source scalar guard remains defense-in-depth in this
+  slice; broadening it across non-ticket campaign inputs would widen blast
+  radius without fixing the generic provider-authority root.
+- The maturity baseline is not widened. The attributable score increase was an
+  unguarded first-token index, not the intentional fail-closed exception handler;
+  aggregating semantic evidence removes that index. The unrelated seller-campaign
+  INTERNAL_MOCK count remains unchanged at its pre-existing baseline.
+
+## Deferred
+
+- #2060 S6A.2: make normalized support-ticket `source_material` authoritative in
+  `ContentOpsInputPackage` merge and prove generic `/execute` cannot restore raw
+  rejected rows. This is required before #2060 closes.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_support_ticket_privacy_sweep.py
+  tests/test_extracted_support_ticket_input_package.py -k
+  'public_marker_composes_with_admitted_content or
+  rendered_empty_content_wrappers_are_sequence_identity or
+  rendered_alphanumeric_content_remains_substantive or
+  recognized_failing_markers_dominate_at_every_content_depth or
+  locally_neutral_subfields_export_no_positive_provenance or
+  rejects_structured_private_content_columns or
+  ignores_blank_marker_placeholders' -q` (`139 passed, 5101 deselected`).
+- `python -m pytest tests/test_support_ticket_privacy.py
+  tests/test_support_ticket_privacy_sweep.py
+  tests/test_extracted_support_ticket_input_package.py
+  tests/test_extracted_content_deflection_submit.py -q` (`5535 passed`).
+- `python -m pytest tests/test_support_ticket_privacy_sweep.py -k
+  'placeholder_only_marker_wrappers or
+  content_carveout_requires_rendered_text or
+  structured_failing_markers_dominate_content_carveout or
+  neutral_subfield_policy_precedes_outer_family_policy' -q` (`79 passed,
+  4865 deselected`).
+- `python -m pytest tests/test_support_ticket_privacy_sweep.py -k
+  generated_reference_model_matches_supported_cross_product -q` (`1 passed,
+  4864 deselected`; failed before the runtime fix on masked
+  `2026-02-30x`, then passed after the canonical publication-data decision).
+- `python -m pytest tests/test_support_ticket_privacy_sweep.py
+  tests/test_extracted_support_ticket_input_package.py -k
+  'generated_reference_model or
+  closed_families_reject_unrecognized_text_by_construction or
+  data_families_retain_neutral_text_by_construction or
+  closed_families_retain_recognized_public_values or
+  public_flags_admit_explicit_date_and_number_data_shapes or
+  public_flags_reject_invalid_data_shapes or
+  public_flags_reject_nonfinite_data_beside_public_evidence or
+  public_flags_keep_valid_data_beside_public_evidence or
+  blank_is_identity_across_every_family_and_container or
+  empty_nested_sequences_are_identity_across_every_family or
+  content_carveout_requires_nonblank_text or
+  content_carveout_keeps_nested_nonblank_text or
+  public_audience_phrases_do_not_invert_private_polarity or
+  ignores_blank_marker_placeholders or
+  rejects_structured_private_content_columns or
+  keeps_neutral_data_family_text or
+  unprefixed_public_flag_keys or
+  public_flag_label_status_aliases or
+  public_evidence_cannot_mask_recognized_failing_values or
+  public_evidence_keeps_genuinely_neutral_metadata or
+  nested_content_privacy_markers_dominate_carveout or
+  nested_content_public_markers_keep_genuine_text or
+  boolish_exponent_numerics' -q`
+  (`4181 passed, 923 deselected`).
+- The generated reference-model test independently evaluates `12884`
+  family/key/value/wrapper/sibling/content comparisons without importing
+  runtime-private helpers or constants.
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_zendesk_export.py -k 'private or public or visibility or internal or placeholder or neutral_data_family' -q`
+  (`176 passed, 123 deselected`).
+- Bash `scripts/validate_extracted_content_pipeline.sh` (passed).
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  (clean).
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` (0 findings).
+- Bash `scripts/check_ascii_python.sh` (passed).
+- Bash `scripts/run_extracted_pipeline_checks.sh`
+  (passed; one third-party `pynvml` deprecation warning).
+- Python `scripts/maturity_sweep.py` with the workflow's exact
+  extracted-content-pipeline baseline, threshold, and sensitive globs (passed;
+  no baseline diff).
+- `python scripts/sync_pr_plan.py
+  plans/PR-Resolution-Audit-S6A-Structured-Privacy-Semantics.md origin/main --check`
+  (passed).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md` | 29 |
+| `extracted_content_pipeline/support_ticket_privacy.py` | 1126 |
+| `plans/PR-Resolution-Audit-S6A-Structured-Privacy-Semantics.md` | 717 |
+| `tests/test_extracted_content_deflection_submit.py` | 61 |
+| `tests/test_extracted_support_ticket_input_package.py` | 276 |
+| `tests/test_support_ticket_privacy_sweep.py` | 1665 |
+| **Total** | **3874** |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -2233,6 +2233,67 @@ async def test_deflection_submit_accepts_full_thread_multipart_json_upload() -> 
 
 
 @pytest.mark.asyncio
+async def test_deflection_submit_excludes_nested_private_comments_from_stored_artifact() -> None:
+    private_sentinel = "PRIVATE NESTED WORKAROUND MUST NOT REACH THE REPORT"
+    public_question = "How do I export an attribution report?"
+    public_comment_sentinel = "Where can I download the attribution CSV export?"
+    tickets = []
+    for ticket_id in (101, 102):
+        requester_id = ticket_id * 10
+        tickets.append({
+            "ticket": {
+                "id": ticket_id,
+                "requester_id": requester_id,
+                "subject": "Attribution export help",
+                "description": public_question,
+                "status": "open",
+            },
+            "comments": [
+                {
+                    "author_id": requester_id,
+                    "visibility": "requester",
+                    "plain_body": public_comment_sentinel,
+                },
+                {
+                    "author_id": 999,
+                    "visibility": {"private": {"value": True}},
+                    "plain_body": private_sentinel,
+                },
+            ],
+        })
+    artifact_data = json.dumps({"tickets": tickets}).encode("utf-8")
+    store = InMemoryDeflectionReportArtifactStore()
+    submit = _route(_router(store), "/ops/deflection-reports/submit", "POST")
+    request = _FormRequest({
+        "json_file": _Upload(artifact_data, filename="zendesk-thread.json"),
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+        "importer_mode": "full_thread",
+    })
+
+    payload = await submit.endpoint(request)
+    request_id = payload["request_id"]
+    snapshot = await store.get_snapshot(
+        account_id="acct-portfolio-submit",
+        request_id=request_id,
+    )
+    record = await store.get_artifact_record(
+        account_id="acct-portfolio-submit",
+        request_id=request_id,
+    )
+
+    assert payload["status"] == "completed"
+    assert payload["input_provider"]["metadata"]["included_row_count"] == 2
+    assert snapshot is not None
+    assert record is not None
+    assert public_comment_sentinel in json.dumps(record.artifact)
+    assert private_sentinel not in json.dumps(payload)
+    assert private_sentinel not in json.dumps(snapshot)
+    assert private_sentinel not in json.dumps(record.artifact)
+
+
+@pytest.mark.asyncio
 async def test_deflection_submit_full_thread_upload_limit_caps_parse_and_diagnostics() -> None:
     router = _router(InMemoryDeflectionReportArtifactStore())
     submit = _route(router, "/ops/deflection-reports/submit", "POST")

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -568,6 +568,24 @@ def test_support_ticket_bundle_inherits_parent_fields_and_comment_text() -> None
     assert package.inputs["has_dated_window"] is False
 
 
+def test_support_ticket_public_comment_markers_preserve_mixed_content_list() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "public-comment-list",
+            "subject": "How do I export invoices?",
+            "public_comments": [
+                {"visibility": "requester", "body": "Open Billing."},
+                {"body": "Choose Export CSV."},
+            ],
+        }
+    ])
+
+    assert package.metadata["included_row_count"] == 1
+    assert package.inputs["source_material"][0]["text"] == (
+        "How do I export invoices? Open Billing. Choose Export CSV."
+    )
+
+
 def test_support_ticket_input_package_surfaces_explicit_resolution_evidence() -> None:
     package = build_support_ticket_input_package([
         {
@@ -1940,6 +1958,26 @@ def test_zendesk_full_thread_rows_load_from_json_file() -> None:
     assert result.warnings == ()
 
 
+def test_zendesk_json_exponent_overflow_access_marker_fails_closed() -> None:
+    private_sentinel = "PRIVATE EXPONENT OVERFLOW MUST NOT BE ADMITTED"
+    result = load_zendesk_full_thread_rows_from_json_bytes(
+        (
+            '{"tickets":['
+            '{"ticket":{"id":"overflow-private","subject":"Internal",'
+            '"description":"'
+            + private_sentinel
+            + '","access":1e309}},'
+            '{"ticket":{"id":"public-control","subject":"Export invoices",'
+            '"description":"Where do invoice exports live?"}}]}'
+        ).encode("utf-8")
+    )
+
+    assert result.warnings == ()
+    assert result.source_row_count == 2
+    assert [row["ticket_id"] for row in result.rows] == ["public-control"]
+    assert private_sentinel not in json.dumps(result.rows)
+
+
 def test_zendesk_full_thread_rows_cap_admitted_rows_and_preserve_source_count() -> None:
     result = load_zendesk_full_thread_rows_from_json_bytes(
         ZENDESK_THREAD_SAMPLE.read_bytes(),
@@ -2079,6 +2117,221 @@ def test_zendesk_full_thread_rows_skip_private_comment_marker_variants(
     assert "Internal billing flag" not in json.dumps(result.rows)
 
 
+@pytest.mark.parametrize("private_marker", [
+    {"private_note": {"value": True}},
+    {"private_note": {}},
+    {"private_note": {"body": ""}},
+    {"private_note": {"text": ["", None]}},
+    {"internal_notes": {"message": {"text": ""}}},
+    {"private_note": {"foo": "bar"}},
+    {"private_note": {"value": "billing role"}},
+    {"internal_notes": [{"metadata": "billing role"}]},
+    {"private_note": ["private"]},
+    {"private_note": ("true",)},
+    {"public_comment": ["false"]},
+    {"internal_notes": ["2e3"]},
+    {"public": {"name": "public", "value": "2e3"}},
+    {"visible": {"label": "public", "status": "Infinity"}},
+    {"external": {"public": True, "value": 5}},
+    {"published": "not published"},
+    {"published": "never published"},
+    {"published": "unpublished"},
+    {"unpublished": True},
+    {"unpublic": True},
+    {"published_status": "not published"},
+    {"customer_facing_label": False},
+    {"customer_facing": "not customer facing"},
+    {"privacy": {"value": True}},
+    {"published": "private"},
+    {"customer_facing": "confidential"},
+    {"published": {"value": "private"}},
+    {"published": {"label": "public", "value": "Infinity"}},
+    {"customer_facing": ["public", "NaN"]},
+    {"published": {"label": "public", "value": "not published"}},
+    {"published": {"label": "public", "value": "kept private"}},
+    {"published": {"label": "public", "value": "2026-02-30"}},
+    {"published": {"label": "public", "value": "unpublished"}},
+    {"published": {"label": "public", "value": "notpublished"}},
+    {"published": {"label": "public", "value": "nonpublished"}},
+    {"unpublished_status": True},
+    {"unpublishedStatus": True},
+    {"unpublished_label": True},
+    {"published": {"label": "public", "value": "2026-13-01Z"}},
+    {"public": {"label": "public", "value": "not publicly visible"}},
+    {"access": 5},
+    {"access": "2e3"},
+    {"access": "1e0"},
+    {"audience": {"value": "-1e2"}},
+    {"access": "Infinity"},
+    {"access": "qNaN"},
+    {"published": {"label": "public", "value": "qNaN"}},
+    {"visibility": {"label": "public", "value": "1e0"}},
+    {"access": "internalAndPrivate"},
+    {"private_note": [{"value": True}]},
+    {"private_note": ["0e0"]},
+    {"visibility": {"label": "public", "privacy": True}},
+    {"visibility": {"name": "public", "value": "2e3"}},
+    {"public_comment": {"value": False, "body": "private content"}},
+    {
+        "public_comment": {
+            "public": True,
+            "value": False,
+            "body": "private content",
+        },
+    },
+    {"public_comment": {"value": [], "body": "private content"}},
+    {
+        "public_comments": [{
+            "body": {"private": True, "text": "private nested content"},
+        }],
+    },
+    {
+        "public_comment": {
+            "body": {
+                "text": "private nested content",
+                "status": "kept private",
+            },
+        },
+    },
+    {"visibility": {"published": "2026-07-09"}},
+    {"private": "end user"},
+    {"hidden": "visible to end user"},
+    {"visibility": {"private": "end user"}},
+    {"visibility": {"hidden": "visible to end user"}},
+    {"published": "kept private"},
+    {"published": "no longer public"},
+    {"published": "withheld from public"},
+    {"customer_facing": "not made public"},
+    {"published": "not exposed"},
+    {"visibility": "not private"},
+    {"visibility": "made public"},
+    {"visibility": "open to public"},
+    {"visibility": "shared with customer"},
+])
+def test_support_ticket_input_package_rejects_structured_private_content_columns(
+    private_marker: dict[str, object],
+) -> None:
+    private_sentinel = "PRIVATE STRUCTURED CONTENT MUST NOT BE ADMITTED"
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "private-structured",
+            "subject": "Internal workaround",
+            "description": private_sentinel,
+            **private_marker,
+        },
+        {
+            "ticket_id": "public-control",
+            "subject": "How do I export invoices?",
+            "description": "Where do invoice exports live?",
+        },
+    ])
+
+    assert package.metadata["included_row_count"] == 1
+    assert package.inputs["source_material"][0]["source_id"] == "public-control"
+    assert private_sentinel not in json.dumps(package.as_dict())
+
+
+@pytest.mark.parametrize(
+    "public_marker",
+    [
+        {"public_comments": ["customer question", ""]},
+        {"public_comments": [{"body": "customer question"}, {"body": ""}]},
+        {
+            "public_comments": [
+                {"body": "customer question"},
+                {"body": "&copy;"},
+            ],
+        },
+        {
+            "public_comments": [
+                {"body": "customer question"},
+                {"public": True},
+            ],
+        },
+        {"visibility": ["requester", ""]},
+        {"visibility": [None, "requester"]},
+        {"published": ["2026-07-09", ""]},
+        {"published": [None, "2026-07-09"]},
+        {"published": ["2026-07-09", []]},
+        {"access": ["billing role", ""]},
+        {"access": ["billing role", ()]},
+        {"audience": [None, "partner workspace"]},
+        {"visibility": ["requester", [[], ()]]},
+        {"type": ["billing role", frozenset()]},
+    ],
+)
+def test_support_ticket_input_package_ignores_blank_marker_placeholders(
+    public_marker: dict[str, object],
+) -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": "public-with-placeholder",
+        "subject": "How do I export invoices?",
+        "description": "Where do invoice exports live?",
+        **public_marker,
+    }])
+
+    assert package.metadata["included_row_count"] == 1
+    assert package.inputs["source_material"][0]["source_id"] == (
+        "public-with-placeholder"
+    )
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("has_access", 2),
+        ("has_access", "2e3"),
+        ("hasAccess", -7),
+        ("has-access", {"value": 3}),
+        ("has access", ["internal", 2]),
+        ("HAS_ACCESS", {"nested": {"value": False}}),
+    ],
+)
+def test_support_ticket_input_package_keeps_has_access_data_columns(
+    column: str,
+    value: object,
+) -> None:
+    public_body = "HAS ACCESS DATA COLUMN MUST NOT DROP THIS ROW"
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "has-access-data",
+            "subject": "How do I export invoices?",
+            "description": public_body,
+            column: value,
+        }
+    ])
+
+    assert package.metadata["included_row_count"] == 1
+    assert package.inputs["source_material"][0]["source_id"] == "has-access-data"
+    assert public_body in json.dumps(package.as_dict())
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("access", "kept private"),
+        ("audience", "no longer public"),
+        ("type", "withheld from public"),
+        ("kind", "shared with customer"),
+    ],
+)
+def test_support_ticket_input_package_keeps_neutral_data_family_text(
+    key: str,
+    value: str,
+) -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": "neutral-data-family",
+        "subject": "How do I export invoices?",
+        "description": "Where do invoice exports live?",
+        key: {"value": [value]},
+    }])
+
+    assert package.metadata["included_row_count"] == 1
+    assert package.inputs["source_material"][0]["source_id"] == (
+        "neutral-data-family"
+    )
+
+
 @pytest.mark.parametrize("public_marker", [
     {},
     {"public": True},
@@ -2087,7 +2340,30 @@ def test_zendesk_full_thread_rows_skip_private_comment_marker_variants(
     {"is_public": "yes"},
     {"visibility": "public"},
     {"visibility": {"name": "public"}},
+    {"visibility": {"name": "public", "value": "billing role"}},
+    {"visibility": "visible to end user"},
+    {"published": "2026-07-09"},
+    {"published": "2026-07-09Z"},
+    {"published": "2026-07-09T12:34+0000"},
+    {"published": 5},
+    {"published": "2e3"},
+    {"published": ["public", "2026-07-09"]},
+    {"published": ["2026-07-09+00:00", "public"]},
+    {"unpublished": False},
+    {"published_status": "2026-07-09"},
+    {"customer_facing_label": 5},
+    {"published": {"label": "public", "value": "billing role"}},
+    {"public_comments": [{
+        "body": {"public": True, "text": "customer text"},
+    }]},
+    {"access": "partner workspace"},
+    {"access": {"value": True}},
+    {"access": [True]},
+    {"type": {"value": [False]}},
+    {"visibility": ["requester"]},
     {"privacy": {"label": "customer"}},
+    {"private": "public"},
+    {"visibility": {"public": "end user"}},
 ])
 def test_zendesk_full_thread_rows_keep_public_comment_marker_variants(
     public_marker: dict[str, object],

--- a/tests/test_support_ticket_privacy_sweep.py
+++ b/tests/test_support_ticket_privacy_sweep.py
@@ -170,6 +170,13 @@ def test_sweep_object_public_forms_pass() -> None:
         ("hidden_count", 3),
         ("internal_status", "open"),
         ("has_access", True),
+        ("has_access", 2),
+        ("has_access", "2e3"),
+        ("has_access", float("inf")),
+        ("hasAccess", -7),
+        ("has-access", {"value": 3}),
+        ("has access", ["internal", 2]),
+        ("HAS_ACCESS", {"nested": {"value": False}}),
         ("support_ticket_id", "T-1"),
         ("end_date", "2026-01-01"),
         ("from_email", "a@b.example"),
@@ -194,3 +201,1661 @@ def test_sweep_content_columns_do_not_reject_rows(column: str) -> None:
     assert support_ticket_row_is_private(
         {"body": "x", column: "free text content here"}
     ) is False
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("private_note", {}),
+        ("public_comment", {}),
+    ],
+)
+def test_sweep_empty_structured_content_columns_fail_closed(
+    column: str,
+    value: object,
+) -> None:
+    assert support_ticket_row_is_private({"body": "x", column: value}) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"private_note": {"foo": "bar"}},
+        {"internal_notes": {"metadata": "billing role"}},
+        {"agent_note": {"label": "billing role"}},
+        {"staff_reply": {"value": "billing role"}},
+        {"public_comment": {"custom": "customer role"}},
+        {"public_comments": {"wrapper": {"foo": "bar"}}},
+        {"private_notes": [{"foo": "bar"}]},
+        {"internal_comments": [{"value": "billing role"}]},
+        {"agent_messages": ({"label": "billing role"},)},
+        {"public_comments": [{"metadata": {"foo": "bar"}}]},
+    ],
+)
+def test_sweep_non_content_structured_note_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"private_note": {"body": "agent note text"}},
+        {"internal_notes": {"text": "agent note text", "foo": "bar"}},
+        {"agent_note": {"content": "agent note text", "metadata": "v2"}},
+        {
+            "public_comment": {
+                "plain_body": "customer comment text",
+                "value": "billing role",
+            }
+        },
+        {"staff_reply": {"message": "agent reply text"}},
+        {"public_comments": {"description": "customer comment text"}},
+    ],
+)
+def test_sweep_body_bearing_note_containers_retain_row_carveout(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({**marker, "body": "x"}) is False
+
+
+_PARITY_VALUES = (
+    "private",
+    "internal",
+    "true",
+    "false",
+    "public",
+    "requester",
+    "billing role",
+    "2e3",
+    "Infinity",
+    True,
+    False,
+    2,
+)
+
+_PUBLIC_FAMILY_VALUE_STEMS = (
+    ("public", "public"),
+    ("visible", "visible"),
+    ("external", "external"),
+    ("published", "published"),
+    ("customer_facing", "customer facing"),
+    ("client_facing", "client facing"),
+    ("user_facing", "user facing"),
+    ("public_facing", "public facing"),
+    ("visibility", "visible"),
+    ("privacy", "public"),
+    ("confidentiality", "public"),
+)
+
+_NEGATED_PUBLIC_FAMILY_VALUES = tuple(
+    (key, value)
+    for key, stem in _PUBLIC_FAMILY_VALUE_STEMS
+    for value in (
+        f"not {stem}",
+        f"NOT {stem.upper()}",
+        f"never {stem}",
+        f"NEVER {stem.upper()}",
+        f"un{stem.replace(' ', '')}",
+        f"UN{stem.replace(' ', '').upper()}",
+    )
+)
+
+_PUBLIC_FLAG_KEYS = (
+    "published",
+    "customer_facing",
+    "client_facing",
+    "user_facing",
+    "public_facing",
+)
+_STRICT_LABEL_KEYS = ("visibility", "privacy", "confidentiality")
+_DEFAULT_CLOSED_TEXT_KEYS = (
+    "private",
+    "public",
+    *_PUBLIC_FLAG_KEYS,
+    *_STRICT_LABEL_KEYS,
+)
+_NEUTRAL_DATA_KEYS = ("access", "audience", "type", "kind")
+_SEMANTIC_PUBLIC_TOKENS = tuple(dict.fromkeys(
+    [value for _, value in _PUBLIC_FAMILY_VALUE_STEMS]
+    + [*_PUBLIC_AUDIENCES, "end user"]
+))
+_SEMANTIC_PRIVATE_TOKENS = tuple(dict.fromkeys(
+    [*_PRIVATE_STEMS, *_PRIVATE_AUDIENCES]
+))
+_UNRECOGNIZED_CONTEXT_TEMPLATES = (
+    "kept {}",
+    "no longer {}",
+    "withheld from {}",
+    "not made {}",
+    "open to {}",
+    "shared with {}",
+)
+_UNRECOGNIZED_CONTEXT_VALUES = tuple(dict.fromkeys(
+    template.format(token)
+    for template, token in itertools.product(
+        _UNRECOGNIZED_CONTEXT_TEMPLATES,
+        _SEMANTIC_PUBLIC_TOKENS + _SEMANTIC_PRIVATE_TOKENS,
+    )
+))
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS)
+def test_sweep_unprefixed_public_flag_keys_fail_closed(key: str) -> None:
+    compact_key = key.replace("_", "")
+    assert support_ticket_comment_is_private({
+        f"un{compact_key}": True,
+        "body": "x",
+    }) is True
+    assert support_ticket_comment_is_private({
+        f"un{compact_key}": False,
+        "body": "x",
+    }) is False
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS)
+@pytest.mark.parametrize("suffix", ["status", "label"])
+def test_sweep_public_flag_label_status_aliases_reuse_family_policy(
+    key: str,
+    suffix: str,
+) -> None:
+    aliases = (
+        f"{key}_{suffix}",
+        f"{key.replace('_', '')}{suffix}",
+    )
+    for alias in aliases:
+        assert support_ticket_comment_is_private({
+            alias: "not published",
+            "body": "x",
+        }) is True
+        assert support_ticket_comment_is_private({
+            alias: "2026-07-09",
+            "body": "x",
+        }) is False
+        for prefix in ("un", "not", "non"):
+            assert support_ticket_comment_is_private({
+                f"{prefix}{key.replace('_', '')}_{suffix}": True,
+                "body": "x",
+            }) is True
+            assert support_ticket_comment_is_private({
+                f"{prefix}{key.replace('_', '')}{suffix}": True,
+                "body": "x",
+            }) is True
+
+
+_RECOGNIZED_FAILING_CLOSED_VALUES = (
+    *_UNRECOGNIZED_CONTEXT_VALUES,
+    "2026-02-30",
+    "2026-13-01",
+    "2026-02-30Z",
+    "2026-13-01+0000",
+    "2026-13-01+00:00",
+    "Infinity",
+    "NaN",
+    "unpublished",
+    "notpublished",
+    "nonpublished",
+)
+
+
+def _semantic_container_shapes(value: str) -> tuple[object, ...]:
+    return (
+        value,
+        {"value": value},
+        [value],
+        (value,),
+        {value},
+        frozenset({value}),
+        [[value]],
+        {"value": [value]},
+    )
+
+
+def _reference_spellings(words: tuple[str, ...]) -> tuple[str, ...]:
+    if len(words) == 1:
+        return words
+    camel = words[0] + "".join(word.title() for word in words[1:])
+    return tuple(dict.fromkeys((
+        " ".join(words),
+        "_".join(words),
+        "-".join(words),
+        camel,
+        "".join(words),
+    )))
+
+
+_REFERENCE_KEYS = {
+    "private": tuple(dict.fromkeys(
+        spelling
+        for words in (("private",), ("internal", "flag"), ("not", "public"))
+        for spelling in _reference_spellings(words)
+    )),
+    "public": tuple(dict.fromkeys(
+        spelling
+        for words in (("public",), ("is", "public"), ("external",))
+        for spelling in _reference_spellings(words)
+    )),
+    "public_flag": tuple(dict.fromkeys(
+        spelling
+        for words in (
+            ("published",),
+            ("customer", "facing"),
+            ("public", "facing", "status"),
+        )
+        for spelling in _reference_spellings(words)
+    )),
+    "strict": tuple(dict.fromkeys(
+        spelling
+        for words in (
+            ("visibility",),
+            ("privacy", "label"),
+            ("confidentiality",),
+        )
+        for spelling in _reference_spellings(words)
+    )),
+    "value": tuple(dict.fromkeys(
+        spelling
+        for words in (("access",), ("audience", "label"))
+        for spelling in _reference_spellings(words)
+    )),
+    "kind": ("type", "kind"),
+}
+
+_REFERENCE_ATOMS = {
+    "public": ("public",),
+    "public_phrase": _reference_spellings(("visible", "to", "customer")),
+    "strict_public": ("requester", "client"),
+    "private": (
+        "private",
+        *_reference_spellings(("internal", "and", "private")),
+        *_reference_spellings(("agents", "and", "staff", "only")),
+    ),
+    "recognized_context": _reference_spellings(("not", "publicly", "visible")),
+    "unknown": _reference_spellings(("billing", "role")),
+    "true": (True, "true", "1"),
+    "false": (False, "false", "0"),
+    "exponent_true": ("1e0", "+1e+0"),
+    "malformed_numeric": ("2e3", "-7"),
+    "nonfinite": ("NaN", "sNaN42", "qNaN", "-qNaN7", "Infinity"),
+    "publication_date": (
+        "2026-07-09",
+        "2026-07-09Z",
+        "2026-07-09T12:34+0000",
+        "2026-07-09T12:34+00:00",
+    ),
+    "finite_number": (5,),
+    "invalid_date": (
+        "2026-02-30",
+        "2026-13-01Z",
+        "2026-02-30x",
+        "2026-2-3",
+        "2026-13-1",
+        "2026-02-30 junk",
+    ),
+}
+
+
+def _reference_expected_private(family: str, atom: str) -> bool:
+    if atom == "public":
+        return False
+    if atom == "public_phrase":
+        return family == "private"
+    if atom == "strict_public":
+        return family in {"private", "public"}
+    if atom in {"private", "recognized_context"}:
+        return family not in {"value", "kind"} or atom == "private"
+    if atom == "unknown":
+        return family in {"private", "public", "public_flag", "strict"}
+    if atom == "true":
+        return family in {"private", "strict"}
+    if atom == "false":
+        return family in {"public", "public_flag", "strict"}
+    if atom == "exponent_true":
+        return family in {"private", "strict", "value"}
+    if atom == "malformed_numeric":
+        return family in {"private", "public", "strict", "value"}
+    if atom == "nonfinite":
+        return family != "kind"
+    if atom == "publication_date":
+        return family in {"private", "public", "strict"}
+    if atom == "finite_number":
+        return family in {"private", "public", "strict", "value"}
+    if atom == "invalid_date":
+        return family in {"private", "public", "public_flag", "strict"}
+    raise AssertionError(f"unmodeled reference atom: {atom}")
+
+
+def test_sweep_generated_reference_model_matches_supported_cross_product() -> None:
+    wrappers = (
+        lambda value: value,
+        lambda value: {"value": value},
+        lambda value: [value],
+        lambda value: {"value": [value]},
+    )
+    for family, keys in _REFERENCE_KEYS.items():
+        for atom, raw_values in _REFERENCE_ATOMS.items():
+            expected = _reference_expected_private(family, atom)
+            for key, raw_value, wrap in itertools.product(
+                keys,
+                raw_values,
+                wrappers,
+            ):
+                marker = {"body": "x", key: wrap(raw_value)}
+                assert support_ticket_comment_is_private(marker) is expected, (
+                    family,
+                    atom,
+                    key,
+                    raw_value,
+                    marker,
+                )
+
+    closed_keys = tuple(
+        (family, key)
+        for family in ("public", "public_flag", "strict")
+        for key in _REFERENCE_KEYS[family]
+    )
+    for family, key in closed_keys:
+        for atom in ("private", "recognized_context", "nonfinite", "invalid_date"):
+            for raw_value in _REFERENCE_ATOMS[atom]:
+                for shaped in (
+                    {"label": "public", "value": raw_value},
+                    {"public": True, "value": raw_value},
+                    ["public", raw_value],
+                    {"value": ["public", raw_value]},
+                ):
+                    assert support_ticket_comment_is_private({
+                        "body": "x",
+                        key: shaped,
+                    }) is True, (family, atom, key, raw_value, shaped)
+
+        for raw_value in _REFERENCE_ATOMS["publication_date"]:
+            for shaped in (
+                {"label": "public", "value": raw_value},
+                {"public": True, "value": raw_value},
+                ["public", raw_value],
+                {"value": ["public", raw_value]},
+            ):
+                assert support_ticket_comment_is_private({
+                    "body": "x",
+                    key: shaped,
+                }) is False, (family, "publication_date", key, raw_value, shaped)
+
+        for raw_value in _REFERENCE_ATOMS["finite_number"]:
+            expected = family != "public_flag"
+            for shaped in (
+                {"label": "public", "value": raw_value},
+                {"public": True, "value": raw_value},
+                ["public", raw_value],
+                {"value": ["public", raw_value]},
+            ):
+                assert support_ticket_comment_is_private({
+                    "body": "x",
+                    key: shaped,
+                }) is expected, (family, "finite_number", key, raw_value, shaped)
+
+    for key in ("privateNote", "publicComments"):
+        assert support_ticket_row_is_private({
+            "body": "x",
+            key: ["customer question", "follow-up"],
+        }) is False
+        assert support_ticket_row_is_private({
+            "body": "x",
+            key: ["private"],
+        }) is True
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS + _STRICT_LABEL_KEYS)
+@pytest.mark.parametrize("value", _RECOGNIZED_FAILING_CLOSED_VALUES)
+def test_sweep_public_evidence_cannot_mask_recognized_failing_values(
+    key: str,
+    value: str,
+) -> None:
+    for shaped_value in (
+        {"label": "public", "value": value},
+        {"value": value, "label": "public"},
+        ["public", value],
+        {"value": ["public", value]},
+        {"value": {"label": "public", "value": value}},
+    ):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is True
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS + _STRICT_LABEL_KEYS)
+@pytest.mark.parametrize("value", ["billing role", "release cohort"])
+def test_sweep_public_evidence_keeps_genuinely_neutral_metadata(
+    key: str,
+    value: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        key: {"label": "public", "value": value},
+    }) is False
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["private_note", "internal_notes", "public_comment", "public_comments"],
+)
+@pytest.mark.parametrize("value", _PARITY_VALUES)
+def test_sweep_content_singletons_match_scalar_policy(
+    key: str,
+    value: object,
+) -> None:
+    expected = support_ticket_row_is_private({"body": "x", key: value})
+
+    for wrapped in ([value], (value,), {value}, frozenset({value})):
+        assert support_ticket_row_is_private({
+            "body": "x",
+            key: wrapped,
+        }) is expected
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"private_note": ["private", "customer question"]},
+        {"internal_notes": ["true", "customer question"]},
+        {"public_comment": ["false", "customer question"]},
+        {"public_comments": ["2e3", "customer question"]},
+    ],
+)
+def test_sweep_content_sequences_classify_each_string_before_carveout(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize("key", ["private_note", "public_comments"])
+def test_sweep_content_sequences_retain_free_text_carveout(key: str) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        key: ["customer question", "follow-up"],
+    }) is False
+
+
+@pytest.mark.parametrize("key", ["access", "audience"])
+@pytest.mark.parametrize("value", ["0e0", "1e0", "+1e+0", "-0e-2"])
+def test_sweep_boolish_exponent_numerics_retain_malformed_provenance(
+    key: str,
+    value: str,
+) -> None:
+    for shaped_value in (value, {"value": value}, [value], [[value]]):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is True
+
+
+@pytest.mark.parametrize("key", ["private_note", "internal_notes"])
+@pytest.mark.parametrize("value", ["0e0", "1e0"])
+def test_sweep_content_sequences_reject_boolish_exponent_numerics(
+    key: str,
+    value: str,
+) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        key: [value],
+    }) is True
+
+
+@pytest.mark.parametrize(("key", "value"), _NEGATED_PUBLIC_FAMILY_VALUES)
+def test_sweep_negated_public_family_vocabulary_fails_closed(
+    key: str,
+    value: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        key: value,
+    }) is True
+
+
+@pytest.mark.parametrize(("key", "value"), _PUBLIC_FAMILY_VALUE_STEMS)
+def test_sweep_positive_public_family_vocabulary_still_admits(
+    key: str,
+    value: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        key: value,
+    }) is False
+
+
+@pytest.mark.parametrize("key", _DEFAULT_CLOSED_TEXT_KEYS)
+@pytest.mark.parametrize("value", _UNRECOGNIZED_CONTEXT_VALUES)
+def test_sweep_closed_families_reject_unrecognized_text_by_construction(
+    key: str,
+    value: str,
+) -> None:
+    for shaped_value in _semantic_container_shapes(value):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is True
+
+
+@pytest.mark.parametrize("key", _NEUTRAL_DATA_KEYS)
+@pytest.mark.parametrize("value", _UNRECOGNIZED_CONTEXT_VALUES)
+def test_sweep_data_families_retain_neutral_text_by_construction(
+    key: str,
+    value: str,
+) -> None:
+    for shaped_value in _semantic_container_shapes(value):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is False
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS + _STRICT_LABEL_KEYS)
+@pytest.mark.parametrize(
+    "value",
+    ["public", "customer", "requester", "visible to customer", "end user"],
+)
+def test_sweep_closed_families_retain_recognized_public_values(
+    key: str,
+    value: str,
+) -> None:
+    for shaped_value in _semantic_container_shapes(value):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is False
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS)
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-07-09",
+        "2026-07-09Z",
+        "2026-07-09+0000",
+        "2026-07-09+00:00",
+        "2026-07-09T12:34:56Z",
+        5,
+        "2e3",
+    ],
+)
+def test_sweep_public_flags_admit_explicit_date_and_number_data_shapes(
+    key: str,
+    value: object,
+) -> None:
+    for shaped_value in (value, {"value": value}, [value], (value,)):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is False
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS)
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Infinity",
+        "NaN",
+        "2026-99-99",
+        "2026-02-30",
+        "2026-99-99Z",
+        "2026-02-30+0000",
+        "2026-02-30+00:00",
+    ],
+)
+def test_sweep_public_flags_reject_invalid_data_shapes(
+    key: str,
+    value: str,
+) -> None:
+    for shaped_value in (value, {"value": value}, [value], (value,)):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is True
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS)
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Infinity", "-Infinity", "NaN", "+sNaN42",
+        float("inf"), float("-inf"), float("nan"),
+    ],
+)
+def test_sweep_public_flags_reject_nonfinite_data_beside_public_evidence(
+    key: str,
+    value: object,
+) -> None:
+    for shaped_value in (
+        {"label": "public", "value": value},
+        {"name": "requester", "status": value},
+        ["public", value],
+        {"value": ["public", value]},
+    ):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is True
+
+
+@pytest.mark.parametrize("key", _PUBLIC_FLAG_KEYS)
+@pytest.mark.parametrize(
+    "value",
+    ["2026-07-09", "2026-07-09Z", "2026-07-09+00:00", 5, "2e3"],
+)
+def test_sweep_public_flags_keep_valid_data_beside_public_evidence(
+    key: str,
+    value: object,
+) -> None:
+    for shaped_value in (
+        {"label": "public", "value": value},
+        ["public", value],
+        [value, "public"],
+        {"value": ["public", value]},
+    ):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: shaped_value,
+        }) is False
+
+
+@pytest.mark.parametrize(
+    "key",
+    _PUBLIC_FLAG_KEYS,
+)
+def test_sweep_public_flag_date_values_still_admit(key: str) -> None:
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        key: "2026-07-09",
+    }) is False
+
+
+@pytest.mark.parametrize("key", ["access", "audience", "type", "kind"])
+@pytest.mark.parametrize(
+    "value",
+    ["not published", "never published", "unpublished"],
+)
+def test_sweep_negated_public_vocabulary_does_not_widen_to_data_families(
+    key: str,
+    value: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        key: value,
+    }) is False
+
+
+@pytest.mark.parametrize("placeholder", ["", "   ", None])
+@pytest.mark.parametrize(
+    ("key", "public_value"),
+    [
+        ("public_comments", "customer question"),
+        ("private_note", "customer question"),
+        ("visibility", "requester"),
+        ("public", "public"),
+    ],
+)
+def test_sweep_absent_sequence_elements_do_not_override_public_evidence(
+    key: str,
+    public_value: str,
+    placeholder: object,
+) -> None:
+    for value in (
+        [public_value, placeholder],
+        [placeholder, public_value],
+        (public_value, placeholder),
+    ):
+        assert support_ticket_row_is_private({"body": "x", key: value}) is False
+
+
+@pytest.mark.parametrize("placeholder", ["", "   ", None])
+@pytest.mark.parametrize(
+    ("key", "neutral_value"),
+    [
+        ("published", "2026-07-09"),
+        ("access", "billing role"),
+        ("audience", "partner workspace"),
+    ],
+)
+def test_sweep_absent_sequence_elements_preserve_scalar_neutral_outcome(
+    key: str,
+    neutral_value: str,
+    placeholder: object,
+) -> None:
+    expected = support_ticket_row_is_private({
+        "body": "x",
+        key: neutral_value,
+    })
+    assert expected is False
+
+    for value in (
+        [neutral_value, placeholder],
+        [placeholder, neutral_value],
+        (neutral_value, placeholder),
+        {neutral_value, placeholder},
+        frozenset({neutral_value, placeholder}),
+    ):
+        assert support_ticket_row_is_private({"body": "x", key: value}) is expected
+
+
+@pytest.mark.parametrize("placeholder", ["", "   ", None])
+@pytest.mark.parametrize(
+    ("key", "scalar_value", "expected"),
+    [
+        ("private", "public", False),
+        ("private", "private", True),
+        ("public", "public", False),
+        ("public", "private", True),
+        ("published", "2026-07-09", False),
+        ("published", "kept private", True),
+        ("visibility", "requester", False),
+        ("visibility", "opaque producer status", True),
+        ("access", "billing role", False),
+        ("access", "private", True),
+        ("type", "billing role", False),
+        ("type", "private", True),
+        ("private_note", "customer question", False),
+        ("private_note", "true", True),
+    ],
+)
+def test_sweep_blank_is_identity_across_every_family_and_container(
+    key: str,
+    scalar_value: str,
+    expected: bool,
+    placeholder: object,
+) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        key: scalar_value,
+    }) is expected
+
+    wrapped_values: list[object] = [
+        [scalar_value, placeholder],
+        [placeholder, scalar_value],
+        (scalar_value, placeholder),
+        {scalar_value, placeholder},
+        frozenset({scalar_value, placeholder}),
+        [[scalar_value], [placeholder]],
+        [[placeholder], [scalar_value]],
+    ]
+    if key != "private_note":
+        wrapped_values.extend([
+            {"value": [scalar_value, placeholder]},
+            {"value": [[scalar_value], [placeholder]]},
+        ])
+    for value in wrapped_values:
+        assert support_ticket_row_is_private({"body": "x", key: value}) is expected
+
+
+@pytest.mark.parametrize("placeholder", [[], (), set(), frozenset(), [[], ()]])
+@pytest.mark.parametrize(
+    ("key", "scalar_value", "expected"),
+    [
+        ("private", "public", False),
+        ("public", "public", False),
+        ("published", "2026-07-09", False),
+        ("visibility", "requester", False),
+        ("access", "billing role", False),
+        ("type", "billing role", False),
+        ("private_note", "customer question", False),
+    ],
+)
+def test_sweep_empty_nested_sequences_are_identity_across_every_family(
+    key: str,
+    scalar_value: str,
+    expected: bool,
+    placeholder: object,
+) -> None:
+    for value in ([scalar_value, placeholder], [placeholder, scalar_value]):
+        assert support_ticket_row_is_private({"body": "x", key: value}) is expected
+
+    if key != "private_note":
+        assert support_ticket_row_is_private({
+            "body": "x",
+            key: {"value": [scalar_value, placeholder]},
+        }) is expected
+
+
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        {"value": ""},
+        {"value": []},
+        {"value": {"value": None}},
+        {"label": ["", None]},
+    ],
+)
+@pytest.mark.parametrize(
+    ("key", "scalar_value"),
+    [
+        ("visibility", "requester"),
+        ("published", "2026-07-09"),
+        ("access", "billing role"),
+        ("type", "billing role"),
+    ],
+)
+def test_sweep_placeholder_only_marker_wrappers_are_sequence_identity(
+    key: str,
+    scalar_value: str,
+    placeholder: dict[str, object],
+) -> None:
+    for value in ([scalar_value, placeholder], [placeholder, scalar_value]):
+        assert support_ticket_row_is_private({"body": "x", key: value}) is False
+
+    assert support_ticket_row_is_private({
+        "body": "x",
+        key: [scalar_value, {}],
+    }) is True
+
+
+@pytest.mark.parametrize(
+    ("key", "values"),
+    [
+        ("published", ["2026-07-09", "2026-07-10"]),
+        ("access", ["billing role", "partner workspace"]),
+        ("audience", ["billing role", "partner workspace"]),
+    ],
+)
+def test_sweep_multiple_substantive_neutral_values_remain_fail_closed(
+    key: str,
+    values: list[str],
+) -> None:
+    assert support_ticket_row_is_private({"body": "x", key: values}) is True
+
+
+@pytest.mark.parametrize("placeholder", ["", "   ", None])
+@pytest.mark.parametrize(
+    ("key", "private_value"),
+    [
+        ("private_note", "private"),
+        ("public_comments", "false"),
+        ("visibility", "internal"),
+        ("visibility", "2e3"),
+        ("published", "private"),
+    ],
+)
+def test_sweep_absent_sequence_elements_do_not_mask_private_evidence(
+    key: str,
+    private_value: str,
+    placeholder: object,
+) -> None:
+    for value in (
+        [private_value, placeholder],
+        [placeholder, private_value],
+        (private_value, placeholder),
+    ):
+        assert support_ticket_row_is_private({"body": "x", key: value}) is True
+
+
+@pytest.mark.parametrize("key", ["visibility", "public_comments"])
+def test_sweep_all_absent_sequence_elements_match_absent_scalar(key: str) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        key: ["", None, "   "],
+    }) is False
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["private", "public", "visibility", "access", "type", "published"],
+)
+@pytest.mark.parametrize("value", _PARITY_VALUES)
+def test_sweep_marker_singletons_match_scalar_and_value_wrapper_policy(
+    key: str,
+    value: object,
+) -> None:
+    expected = support_ticket_comment_is_private({"body": "x", key: value})
+
+    for wrapped in (
+        [value],
+        (value,),
+        {value},
+        frozenset({value}),
+        {"value": value},
+    ):
+        assert support_ticket_comment_is_private({
+            "body": "x",
+            key: wrapped,
+        }) is expected
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"public": {"name": "public", "value": "2e3"}},
+        {"public": {"label": "public", "status": "Infinity"}},
+        {"public": {"public": True, "value": 5}},
+        {"visible": {"name": "public", "value": "-1e2"}},
+        {"visible": {"label": "requester", "status": "NaN"}},
+        {"visible": {"public": True, "value": float("inf")}},
+        {"external": {"name": "public", "value": "+4E-2"}},
+        {"external": {"label": "client", "status": "-Infinity"}},
+        {"external": {"public": True, "value": -7}},
+    ],
+)
+def test_sweep_public_families_reject_malformed_numeric_provenance(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({**marker, "body": "x"}) is True
+
+
+def test_sweep_malformed_data_column_families_retain_scalar_policy() -> None:
+    for key in ("published", "customer_facing", "type", "kind"):
+        scalar = support_ticket_comment_is_private({"body": "x", key: "2e3"})
+        wrapped = support_ticket_comment_is_private({
+            "body": "x",
+            key: {"value": "2e3"},
+        })
+        assert wrapped is scalar
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"metadata": {"private": True}},
+        {"visibility": {"name": "public", "metadata": {"private": True}}},
+        {
+            "public_comments": [
+                {"body": "customer text", "metadata": {"private": True}}
+            ]
+        },
+    ],
+)
+def test_sweep_unknown_key_subtrees_remain_opaque(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({**marker, "body": "x"}) is False
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"visibility": {"name": "public", "privacy": True}},
+        {"public_comments": [{"body": "private text", "privacy": True}]},
+    ],
+)
+def test_sweep_recognized_nested_privacy_still_fails_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"private_note": [{"value": True}]},
+        {"internal_notes": ({"private": True},)},
+        {"public_comment": [{"value": False}]},
+        {"public_comments": [{"hidden": True}, {"body": "customer text"}]},
+        {"public_comments": [True, "customer text"]},
+        {
+            "public_comments": [
+                {"visibility": "requester", "body": "public text"},
+                {"hidden": True, "body": "private text"},
+            ]
+        },
+    ],
+)
+def test_sweep_sequence_wrapped_structured_markers_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"private_notes": ["agent note text"]},
+        {"private_notes": [{"body": "agent note text"}]},
+        {"private_notes": ["agent note text", {"body": "more context"}]},
+        {"public_comments": ["customer comment text"]},
+        {"public_comments": [{"body": "customer comment text"}]},
+        {"public_comments": ["customer comment text", {"body": "more context"}]},
+    ],
+)
+def test_sweep_sequence_content_containers_retain_row_carveout(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({**marker, "body": "x"}) is False
+
+
+@pytest.mark.parametrize("public_marker", [{"public": True}, {"private": False}])
+@pytest.mark.parametrize(
+    "content",
+    ["customer question", {"body": "customer question"}],
+)
+def test_sweep_public_marker_composes_with_admitted_content(
+    public_marker: dict[str, object],
+    content: object,
+) -> None:
+    assert support_ticket_row_is_private({
+        "public_comments": [content, public_marker],
+    }) is False
+
+
+@pytest.mark.parametrize("alias", ["private_note", "internal_notes"])
+@pytest.mark.parametrize(
+    "content_key",
+    [
+        "body", "message", "text", "content", "description",
+        "plain_body", "html_body",
+    ],
+)
+@pytest.mark.parametrize(
+    "empty_content",
+    ["", "   ", None, [], ["", None], {}, {"text": ""}],
+)
+def test_sweep_content_carveout_requires_nonblank_text(
+    alias: str,
+    content_key: str,
+    empty_content: object,
+) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        alias: {content_key: empty_content},
+    }) is True
+
+
+@pytest.mark.parametrize(
+    "alias",
+    ["private_note", "internal_notes", "public_comment"],
+)
+@pytest.mark.parametrize("content_key", ["body", "html_body", "content"])
+@pytest.mark.parametrize("empty_content", ["<br>", "<p></p>", "&nbsp;"])
+def test_sweep_content_carveout_requires_rendered_text(
+    alias: str,
+    content_key: str,
+    empty_content: str,
+) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        alias: {content_key: empty_content},
+    }) is True
+
+    assert support_ticket_row_is_private({
+        "body": "x",
+        alias: {content_key: "<p>customer text</p>"},
+    }) is False
+
+
+@pytest.mark.parametrize(
+    "rendered_empty",
+    ["&amp;", "&lt;", "&copy;", "&amp;&amp;", "...", "<b>&copy;</b>"],
+)
+@pytest.mark.parametrize("depth", [1, 2, 3])
+def test_sweep_rendered_empty_content_wrappers_are_sequence_identity(
+    rendered_empty: str,
+    depth: int,
+) -> None:
+    placeholder: object = rendered_empty
+    for index in range(depth):
+        key = "body" if index % 2 == 0 else "text"
+        placeholder = {key: placeholder}
+
+    assert support_ticket_row_is_private({
+        "public_comments": [
+            {"body": "customer question"},
+            placeholder,
+        ],
+    }) is False
+
+
+@pytest.mark.parametrize("rendered_content", ["A", "&#65;", "customer?"])
+def test_sweep_rendered_alphanumeric_content_remains_substantive(
+    rendered_content: str,
+) -> None:
+    assert support_ticket_row_is_private({
+        "public_comments": [
+            {"body": "customer question"},
+            {"body": rendered_content},
+        ],
+    }) is False
+
+
+@pytest.mark.parametrize("alias", ["private_note", "internal_notes"])
+@pytest.mark.parametrize(
+    "content",
+    [
+        {"body": "agent note text"},
+        {"body": ["", {"text": "agent note text"}]},
+    ],
+)
+def test_sweep_content_carveout_keeps_nested_nonblank_text(
+    alias: str,
+    content: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        alias: content,
+    }) is False
+
+
+@pytest.mark.parametrize(
+    "alias",
+    ["private_note", "internal_notes", "public_comments"],
+)
+@pytest.mark.parametrize("content_key", ["body", "text", "content", "message"])
+@pytest.mark.parametrize(
+    "privacy_marker",
+    [
+        {"private": True},
+        {"hidden": True},
+        {"privacy": True},
+        {"public": False},
+    ],
+)
+def test_sweep_nested_content_privacy_markers_dominate_carveout(
+    alias: str,
+    content_key: str,
+    privacy_marker: dict[str, object],
+) -> None:
+    nested = {**privacy_marker, "text": "private nested content"}
+    for content_value in (nested, [nested], {"content": [nested]}):
+        assert support_ticket_row_is_private({
+            "body": "x",
+            alias: {content_key: content_value},
+        }) is True
+
+
+@pytest.mark.parametrize("alias", ["private_note", "public_comments"])
+@pytest.mark.parametrize("public_marker", [{"public": True}, {"private": False}])
+def test_sweep_nested_content_public_markers_keep_genuine_text(
+    alias: str,
+    public_marker: dict[str, object],
+) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        alias: {"body": {**public_marker, "text": "customer content"}},
+    }) is False
+
+
+@pytest.mark.parametrize(
+    "alias",
+    ["private_note", "public_comment", "public_comments"],
+)
+@pytest.mark.parametrize("marker_key", ["status", "value", "label", "name"])
+def test_sweep_structured_failing_markers_dominate_content_carveout(
+    alias: str,
+    marker_key: str,
+) -> None:
+    assert support_ticket_row_is_private({
+        "body": "x",
+        alias: {"body": "customer text", marker_key: "kept private"},
+    }) is True
+
+    assert support_ticket_row_is_private({
+        "body": "x",
+        alias: "customer says kept private for later",
+    }) is False
+
+
+@pytest.mark.parametrize("alias", ["private_note", "public_comment"])
+@pytest.mark.parametrize("marker_key", ["status", "value", "label", "name"])
+@pytest.mark.parametrize("depth", [1, 2, 3])
+def test_sweep_recognized_failing_markers_dominate_at_every_content_depth(
+    alias: str,
+    marker_key: str,
+    depth: int,
+) -> None:
+    nested: object = {
+        "text": "PRIVATE SENTINEL",
+        marker_key: "kept private",
+    }
+    for index in range(depth):
+        key = "body" if index % 2 == 0 else "content"
+        nested = {key: nested}
+
+    assert support_ticket_row_is_private({alias: nested}) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"visibility": ["public", "billing role"]},
+        {"public": [True, "billing role"]},
+        {"private": [False, "billing role"]},
+    ],
+)
+def test_sweep_mixed_sequence_markers_preserve_unresolved_provenance(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize("audience", ["requester", "client", "end user"])
+def test_sweep_strict_public_audiences_survive_sequence_wrappers(
+    audience: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "visibility": [audience],
+        "body": "x",
+    }) is False
+
+
+@pytest.mark.parametrize("audience", ["requester", "client", "end user"])
+@pytest.mark.parametrize("value", [True, False])
+@pytest.mark.parametrize("reverse", [True, False])
+def test_sweep_raw_strict_sequence_booleans_stay_ambiguous(
+    audience: str,
+    value: bool,
+    reverse: bool,
+) -> None:
+    sequence = [value, audience] if reverse else [audience, value]
+
+    assert support_ticket_comment_is_private({
+        "visibility": sequence,
+        "body": "x",
+    }) is True
+
+
+@pytest.mark.parametrize("audience", ["requester", "client", "end user"])
+@pytest.mark.parametrize("value", [True, False])
+def test_sweep_generic_strict_sequence_booleans_remain_neutral(
+    audience: str,
+    value: bool,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "visibility": {"label": audience, "value": [[value]]},
+        "body": "x",
+    }) is False
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"visibility": {"private": {"value": True}}},
+        {"privacy": {"hidden": {"value": True}}},
+        {"visibility": {"confidential": {"value": True}}},
+        {"privacy": {"restricted": {"value": True}}},
+        {"visibility": {"public": {"value": False}}},
+        {"privacy": {"publicly_visible": {"value": False}}},
+        {"visibility": {"hidden_from_customer": {"value": True}}},
+    ],
+)
+def test_sweep_nested_assertion_objects_preserve_private_polarity(
+    marker: dict[str, object],
+) -> None:
+    row = {**marker, "body": "private text"}
+
+    assert support_ticket_comment_is_private(row) is True
+    assert support_ticket_row_is_private(row) is True
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3])
+@pytest.mark.parametrize(("value", "expected_private"), [(True, True), (False, False)])
+def test_sweep_neutral_object_wrappers_inherit_private_polarity(
+    depth: int,
+    value: bool,
+    expected_private: bool,
+) -> None:
+    nested: object = value
+    for _ in range(depth):
+        nested = {"value": nested}
+
+    assert support_ticket_comment_is_private(
+        {"private": nested, "body": "x"}
+    ) is expected_private
+
+
+@pytest.mark.parametrize(
+    ("marker", "expected_private"),
+    [
+        ({"visibility": {"private": "client"}}, True),
+        ({"visibility": {"public": "client"}}, True),
+        ({"visibility": {"visibility": "client"}}, False),
+    ],
+)
+def test_sweep_nested_classified_labels_use_their_own_family_policy(
+    marker: dict[str, object],
+    expected_private: bool,
+) -> None:
+    assert support_ticket_comment_is_private(
+        {**marker, "body": "x"}
+    ) is expected_private
+
+
+def test_sweep_nested_classified_neutral_is_not_promoted_to_public() -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": {"published": "2026-07-09"}, "body": "x"}
+    ) is True
+
+
+@pytest.mark.parametrize(
+    ("outer_key", "subfield", "neutral_value"),
+    [
+        ("visibility", "access", "end user"),
+        ("visibility", "audience", "client"),
+        ("published", "type", "2026-07-09"),
+        ("customer_facing", "kind", "2e3"),
+    ],
+)
+def test_sweep_locally_neutral_subfields_export_no_positive_provenance(
+    outer_key: str,
+    subfield: str,
+    neutral_value: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        outer_key: {subfield: neutral_value},
+    }) is True
+
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        outer_key: {"label": "public", subfield: neutral_value},
+    }) is False
+
+
+def test_sweep_private_and_neutral_nested_subfields_fail_closed() -> None:
+    assert support_ticket_comment_is_private({
+        "visibility": {"private": True, "type": "billing role"},
+        "body": "x",
+    }) is True
+
+
+@pytest.mark.parametrize(
+    ("outer_key", "public_label"),
+    [("visibility", "requester"), ("published", "public")],
+)
+@pytest.mark.parametrize("subfield", ["access", "audience", "type", "kind"])
+@pytest.mark.parametrize(
+    "neutral_value",
+    ["kept private", "withheld from public", "billing role"],
+)
+def test_sweep_neutral_subfield_policy_precedes_outer_family_policy(
+    outer_key: str,
+    public_label: str,
+    subfield: str,
+    neutral_value: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        outer_key: {"label": public_label, subfield: neutral_value},
+    }) is False
+
+    assert support_ticket_comment_is_private({
+        "body": "x",
+        outer_key: {"label": public_label, subfield: "private"},
+    }) is True
+
+
+@pytest.mark.parametrize("key", ["privacy", "confidentiality"])
+@pytest.mark.parametrize("value", [True, False])
+def test_sweep_boolean_strict_label_wrappers_fail_closed(
+    key: str,
+    value: bool,
+) -> None:
+    assert support_ticket_comment_is_private(
+        {key: {"value": value}, "body": "x"}
+    ) is True
+
+
+@pytest.mark.parametrize("key", ["access", "audience", "type", "kind"])
+@pytest.mark.parametrize("value", [True, False])
+def test_sweep_categorical_boolean_wrappers_match_scalar_policy(
+    key: str,
+    value: bool,
+) -> None:
+    expected = support_ticket_comment_is_private({key: value, "body": "x"})
+
+    for wrapped in (
+        {"value": value},
+        [value],
+        (value,),
+        {"value": [value]},
+        {"value": (value,)},
+    ):
+        assert support_ticket_comment_is_private({
+            key: wrapped,
+            "body": "x",
+        }) is expected
+
+
+@pytest.mark.parametrize("strict_key", ["privacy", "confidentiality"])
+@pytest.mark.parametrize("value", [True, False])
+def test_sweep_classified_strict_booleans_conflict_with_public_evidence(
+    strict_key: str,
+    value: bool,
+) -> None:
+    assert support_ticket_comment_is_private({
+        "visibility": {"label": "public", strict_key: value},
+        "body": "x",
+    }) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"published": {"value": False}},
+        {"customer_facing": {"value": False}},
+        {"client_facing": {"status": False}},
+        {"user_facing": {"public": False}},
+        {"public_facing": {"is_public": False}},
+        {"published": {}},
+        {"customer_facing": {"label": "public", "value": False}},
+    ],
+)
+def test_sweep_object_wrapped_false_public_flags_fail_closed(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"published": {"value": "2026-07-09"}},
+        {"customer_facing": {"value": True}},
+    ],
+)
+def test_sweep_object_wrapped_public_flags_keep_public_values(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({**marker, "body": "x"}) is False
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"published": "private"},
+        {"customer_facing": "confidential"},
+        {"user_facing": "internal only"},
+        {"published": {"value": "private"}},
+    ],
+)
+def test_sweep_public_flags_honor_explicit_private_text(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    ("key", "label"),
+    [
+        ("access", "internal and private"),
+        ("audience", "agents and staff only"),
+        ("type", "staff and agent reply"),
+        ("access", "restricted or internal"),
+        ("audience", "support and admins only"),
+        ("kind", "private or confidential response"),
+    ],
+)
+def test_sweep_private_value_conjunctions_fail_closed(key: str, label: str) -> None:
+    assert support_ticket_comment_is_private({key: label, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    ("key", "wrapped_label"),
+    [
+        ("access", {"label": "billing role"}),
+        ("audience", {"label": "enterprise admins"}),
+        ("type", {"name": "question"}),
+        ("access", {"name": "workspace owners"}),
+        ("audience", {"status": "trial accounts"}),
+        ("kind", {"label": "incident"}),
+    ],
+)
+def test_sweep_neutral_object_labels_match_scalar_fail_open_policy(
+    key: str,
+    wrapped_label: dict[str, str],
+) -> None:
+    scalar_label = next(iter(wrapped_label.values()))
+
+    assert support_ticket_comment_is_private(
+        {key: wrapped_label, "body": "x"}
+    ) is False
+    assert support_ticket_comment_is_private(
+        {key: scalar_label, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"access": 5},
+        {"audience": -7},
+        {"access": {"value": 5}},
+        {"access": "2e3"},
+        {"audience": "-1e2"},
+        {"access": {"value": "2e3"}},
+        {"audience": {"label": "+4E-2"}},
+        {"access": float("inf")},
+        {"audience": float("-inf")},
+        {"access": {"value": float("nan")}},
+        {"access": "Infinity"},
+        {"audience": "-Infinity"},
+        {"access": {"value": "NaN"}},
+        {"audience": {"label": "+sNaN42"}},
+    ],
+)
+def test_sweep_value_labels_reject_malformed_numeric_markers(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"access": "gizmo"},
+        {"audience": "xyz123"},
+    ],
+)
+def test_sweep_value_labels_retain_producer_defined_neutral_text(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({**marker, "body": "x"}) is False
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"visibility": {"name": "public", "value": "2e3"}},
+        {"privacy": {"label": "customer", "value": "Infinity"}},
+        {"confidentiality": {"name": "requester", "value": 5}},
+    ],
+)
+def test_sweep_strict_labels_reject_malformed_numeric_provenance(
+    marker: dict[str, object],
+) -> None:
+    assert support_ticket_comment_is_private({**marker, "body": "x"}) is True
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "requester",
+        "client",
+        "end user",
+        "requesters",
+        "clients",
+        "endusers",
+        "viewers",
+    ],
+)
+def test_sweep_strict_labels_admit_public_audiences(label: str) -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": label, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"name": "requester", "value": "billing role"},
+        {"value": "billing role", "name": "requester"},
+    ],
+)
+def test_sweep_strict_label_object_is_mapping_order_independent(
+    marker: dict[str, str],
+) -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": marker, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"name": "public", "value": "billing role"},
+        {"value": "billing role", "name": "public"},
+    ],
+)
+def test_sweep_explicit_public_label_ignores_neutral_metadata(
+    marker: dict[str, str],
+) -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": marker, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["visible to end user", "visible to end users", "public for end users"],
+)
+def test_sweep_end_user_visibility_phrases_are_public(label: str) -> None:
+    assert support_ticket_comment_is_private(
+        {"visibility": label, "body": "x"}
+    ) is False
+
+
+@pytest.mark.parametrize("private_key", ["private", "hidden", "internal"])
+@pytest.mark.parametrize("label", ["end user", "visible to end user"])
+def test_sweep_public_audience_phrases_do_not_invert_private_polarity(
+    private_key: str,
+    label: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        private_key: label,
+        "body": "x",
+    }) is True
+    assert support_ticket_comment_is_private({
+        "visibility": {private_key: label},
+        "body": "x",
+    }) is True
+
+
+@pytest.mark.parametrize("key", ["access", "audience", "type", "kind"])
+def test_sweep_public_audience_phrases_retain_data_family_semantics(
+    key: str,
+) -> None:
+    assert support_ticket_comment_is_private({
+        key: "end user",
+        "body": "x",
+    }) is False
+
+
+def test_sweep_explicit_public_labels_retain_private_field_override() -> None:
+    assert support_ticket_comment_is_private({
+        "private": "public",
+        "body": "x",
+    }) is False
+    assert support_ticket_comment_is_private({
+        "visibility": {"public": "end user"},
+        "body": "x",
+    }) is False
+
+
+def test_sweep_public_audience_label_does_not_invert_private_assertion() -> None:
+    assert support_ticket_comment_is_private(
+        {"private": "client", "body": "x"}
+    ) is True


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S6A-Structured-Privacy-Semantics.md
Slice phase: Vertical slice

Refs #2060.

Diff-budget override: This 3874-line privacy-boundary representation rewrite is indivisible because the typed classifier, independent generated oracle, package admission proof, and real submit-to-persist proof must land together; splitting them would permit an unproven PII guard to merge.

Current main overloads scalar marker tokens and structured semantic decisions, so nested polarity and container provenance can be lost. Rounds 10-12 exposed repeated ordering leaks across keys, scalars, objects, sequences, and sibling evidence. Round-13 confirmed the architectural cause: family admission remained distributed across recursive parsing and final policy, while normalization repeatedly discarded spelling and provenance. Round-14 unified publication validity. Round-15 then found four shared-boundary gaps: generic wrapper placeholders were not identity, structured failure was evaluated after content admission, markup-only bodies counted as text, and locally admitted neutral subfields exported raw failure flags to stricter outer families. Round-16 showed those folds stopped one level early: failing metadata did not recurse through content wrappers, rendered-empty body mappings were not identity inside content sequences, admitted content was also marked unresolved beside public evidence, and locally neutral subfields still exported affirmative provenance. This slice now closes those predicates recursively at the shared choke point. It canonicalizes keys into typed families, canonicalizes every value/container into one semantic decision, classifies publication text once as valid/invalid-date/not-data, reduces classified subfields through their own policy, and applies one immutable outer family-policy table. An independently written generated oracle compares 12,884 supported compositions and the held-out matrices cover the recursive Round-16 interactions. The model preserves #2060's neutral access/audience/type/kind policy and proves the boundary through the real Zendesk submit-to-persist path. It does not claim to close #2060; generic `/execute` source authority remains S6A.2.

## Intentional
- Fix the family admission invariant instead of adding the latest private phrases to a denylist: publication/facing and strict families reject unrecognized text by default.
- Admit only affirmative recognized-public evidence under closed families; publication/facing flags additionally admit calendar-valid ISO date/time and finite-number data shapes.
- Keep access/audience and type/kind producer-defined neutral text admitted per #2060, while known private and malformed-numeric values remain closed.
- Remove blank/`None` and nested placeholder-only wrappers before sequence cardinality, so one substantive survivor always reuses scalar policy in every family.
- Scope multi-token public-audience promotion to public/public-flag/strict contexts; private/hidden subfields cannot be inverted, while exact `public` overrides retain established behavior.
- Keep unknown-key subtrees opaque under the closed vocabulary; recognized nested privacy keys remain fail-closed.
- Preserve genuine note/comment content containers and documented `has_access` data columns.
- Require non-blank text under a recognized content field before a structured note/comment value can use the content carveout.
- Carry non-finite numeric provenance separately from finite publication-number data, so invalid evidence dominates a public sibling without rejecting `5`/`2e3` controls.
- Carry a uniform recognized-failing decision through every object/sequence combiner so public evidence cannot mask private/ambiguous vocabulary, invalid dates, or non-finite values.
- Recognize exact compact `un<public-flag-stem>` assertions and public-flag `status`/`label` aliases without widening arbitrary producer columns.
- Recursively inspect recognized body/text/content wrappers for classified privacy markers before granting the content carveout; genuine text with explicit public controls remains admitted.
- Reuse exact compact-negation grammar after label/status suffix stripping and for closed-family values, while keeping access/audience/type/kind neutral text unchanged.
- Preserve exponent-malformed provenance for access/audience and private-note polarity even when the numeric value is boolean-like; keep affirmative `public: "1e0"` compatibility.
- Treat ISO-shaped date-only timezone suffixes as publication data when calendar-valid and recognized failing when invalid; keep valid dates/numbers marker-shaped beside public sequence evidence.
- Replace raw family strings with typed key decisions and centralize every admission dimension in `_FAMILY_POLICIES`; recursive parsing only emits or combines evidence.
- Preserve distinct public-phrase, strict-label, malformed-boolean-numeric, non-finite, publication, content, and recognized-failing evidence instead of inferring one from another after combination.
- Use vocabulary segmentation only when a compact value can be fully decomposed into known semantic tokens; arbitrary producer metadata remains neutral.
- Keep the independent reference oracle test-side: it imports only the public predicates and defines its own families, atoms, policy expectations, spellings, wrappers, and sibling compositions.
- Derive valid publication data and invalid-date failure evidence from one semantic classifier over the ISO date namespace; trailing junk, non-zero-padded, and out-of-range dates are oracle atoms, not production string clauses.
- Recurse `ABSENT` identity through non-empty recognized generic wrapper mappings while keeping bare empty structured markers fail-closed.
- Let structured recognized-failing evidence dominate the content exit, but preserve direct free-text content compatibility.
- Reuse package plain-text rendering to distinguish real comment text from markup/entity-only placeholders.
- Export the result of a classified subfield's own family policy to the outer combiner; locally admitted neutral metadata cannot regain discarded failure provenance.
- Recurse recognized-failing and rendered-absence predicates through supported content wrappers; require rendered alphanumeric text, treat admitted content as compatible evidence, and export positive subfield provenance only from a locally affirmative decision.
- Treat empty nested sequences as placeholder identity while retaining the established top-level empty-comments container behavior.
- Keep publication/strict unknown text fail-closed even beside a valid date/number; thread `PRRT_kwDOQ5Uhrs6P-Uf_` is reconciled as a contract-conflicting admission widening, not implemented.
- Keep the maturity baseline unchanged; the final implementation adds no new brittleness signal.
- Use the real in-memory report-store adapter and assert persisted state, not fake pool calls.

## Deferred
- #2060 S6A.2: make normalized support-ticket `source_material` authoritative in `ContentOpsInputPackage` merge and prove generic `/execute` cannot restore rejected rows.

## Parked hardening
- None.

## Cold diff reconstruction
- Gaps first: none for the S6A.1 contract. #2060 remains deliberately open for S6A.2; this PR does not claim generic `/execute` is fixed.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:211` carries typed absent/public/private/neutral/ambiguous decisions plus boolean, malformed, non-finite-numeric, publication-data, structured, audience, and content provenance; `:273` consumes those decisions through the existing key-family policies.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:329` makes publication/facing admission recognized-public-or-explicit-data only; `:538` records scalar numeric provenance; `:916` combines it without allowing non-finite evidence to disappear beside public evidence.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:391` classifies exact compact negated public assertions and `:457` reuses public-flag policy for exact label/status aliases; arbitrary `un...` and unrelated label columns remain outside the privacy grammar.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:600` tags private/ambiguous vocabulary, invalid dates, and non-finite values as recognized failing evidence; `:963` makes that evidence dominate public siblings uniformly across object/sequence order and wrapper depth.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:600` defines recursive placeholder identity, including empty nested sequences, before cardinality; `:1096` requires actual non-blank body/text content before mapping-shaped note/comment values receive the content carveout.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:1172` recursively applies the same classifier inside recognized body/text/content wrappers before `:1200` grants the content carveout.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:43` recognizes bounded date-only timezone suffixes; `:399` reuses exact compact negation after suffix removal; `:602` preserves closed-family compact values and exponent provenance; `:750` retains publication-data evidence in public-label sequences without admitting multiple bare dates.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:194` defines typed marker families and canonical key/semantic decisions; `:256` is the single immutable family-policy table; `:361` is the only row-admission evaluator.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:593` preserves camel/separator boundaries and fully segments only closed-vocabulary compact values; `:700` assigns scalar provenance once; object/sequence combination carries that evidence without changing policy.
- Changed: `tests/test_support_ticket_privacy_sweep.py:415` defines the independent reference spellings, families, semantic atoms, and expected policy; `:522` checks 12,884 generated cross-product compositions through public entrypoints only, including invalid-date trailing-junk, non-zero-padded, and out-of-range forms.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:1287` produces one valid/invalid-date/not-data publication decision; scalar evidence derives both publication admission and recognized failure from it, so wrappers cannot launder a scalar-invalid date.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:384` gives structured failing evidence precedence over content admission; `:821` recursively removes placeholder-only generic wrapper mappings before sequence cardinality; `:1073` exports locally admitted neutral subfields without raw rejected provenance; `:1376` uses package plain-text rendering for content existence.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:817` derives rendered-content identity from alphanumeric package text; `:862` applies it recursively before content-sequence cardinality; `:1088` distinguishes locally affirmative subfield evidence from neutral family admission; and `:1419` derives recognized-failing evidence at every supported content-wrapper depth.
- Changed: `tests/test_support_ticket_privacy_sweep.py:1019`, `:1245`, `:1324`, and `:1463` cover placeholder wrappers, rendered-empty content, structured failing content metadata, and neutral-subfield/outer-family precedence with positive and negative controls.
- Changed: `extracted_content_pipeline/support_ticket_privacy.py:1007` leaves unrecognized prose neutral for outer-family policy and scopes positive public phrases to permitted contexts; `:1077` recognizes finite numerics and calendar-valid ISO date/time shapes without an exception/baseline waiver.
- Changed: `tests/test_support_ticket_privacy_sweep.py:305` derives family/token/context/container matrices; `:422` proves closed-family unknown text rejects; `:502`, `:671`, and `:870` prove non-finite dominance, empty-sequence identity, and real-text content admission; `:1260` proves public phrases cannot invert private polarity.
- Changed: `tests/test_support_ticket_privacy_sweep.py:344` derives compact-negation and public-flag alias coverage; `:378` proves every closed family/container rejects recognized failing siblings despite public evidence; `:987` proves nested privacy dominates the content carveout with explicit-public controls beside it.
- Changed: `tests/test_extracted_support_ticket_input_package.py:2177` proves the Round-10 PII probes cannot enter `source_material`; `:2216` proves blank/empty placeholders retain public rows; `:2271` proves the #2060 neutral-data carve-out still reaches the package boundary.
- Changed: `tests/test_extracted_content_deflection_submit.py:2236` drives the real mixed Zendesk full-thread submit and verifies public evidence remains while the private sentinel is absent from response, snapshot, and stored artifact.
- Changed: `docs/audits/resolution-audit-csv/CURRENT_CODE_REMEDIATION_ARC.md:45` reopens blocker 4 and `:417` preserves #2046 as history while tracking both #2060 slices as incomplete.
- Contract match: every runtime delta implements typed provenance, closed-family admission, real-text content provenance, or uniform `ABSENT` identity; every new assertion is derived class coverage, package-boundary evidence, or real-entrypoint proof.
- Forbidden-touch check: input-package precedence, generic `/execute`, campaign-source guard, report/snapshot/email/PDF/landing/pricing/checkout shape, scrubber, clustering, junk, dates, money, billing, delivery, and schemas are untouched.
- Untraced changes: none.

## Reviewer findings reconciliation
- AI findings reviewed: yes.
- Round 9 was reproduced before the fix: unrecognized private/public contexts leaked through publication flags, equivalent text disagreed between publication and strict families, and blank placeholders dropped otherwise-admitted publication/access values.
- Fixed: `PRRT_kwDOQ5Uhrs6P9OzB` at the root by removing blank/`None` and nested placeholder-only wrappers before sequence cardinality across content, private/public, public-flag, strict, value-label, and kind families.
- Fixed: the current-head Codex P1 by enabling positive public-audience phrase promotion only for public/public-flag/strict outer contexts; private/hidden/internal scalar and nested subfields remain closed.
- Fixed: the Round-9 Claude BLOCKER by replacing phrase-negator enumeration with a public-flag closed default and explicit publication-data provenance. The vocabulary-derived property matrix spans public/private tokens, six unrecognized contexts, eight scalar/object/sequence shapes, every family, and both error directions.
- Fixed: `PRRT_kwDOQ5Uhrs6P-Ufp` at the content-provenance root. Body/text key presence no longer grants the carveout; seven content-key families x seven empty/placeholder shapes now require non-blank text, with positive nested-content controls.
- Fixed: `PRRT_kwDOQ5Uhrs6P-Uft` by making empty nested list/tuple/set/frozenset values recursive `ABSENT` identity before sequence cardinality across every marker family; top-level empty comment containers retain their pinned behavior.
- Fixed: `PRRT_kwDOQ5Uhrs6P-Uf3` without adding `_KIND_PUBLIC_FLAG` to the shared malformed set. A distinct non-finite signal propagates through objects/sequences and rejects before public-flag evidence; every public-flag family x non-finite/object/sequence matrix rejects while public-labeled dates and finite `5`/`2e3` controls admit.
- Fixed: `PRRT_kwDOQ5Uhrs6QAFRI` by classifying exact compact `un<public/public-flag stem>` assertions (`unpublished`, `unpublic`) with private polarity; false controls remain public.
- Fixed: `PRRT_kwDOQ5Uhrs6QAFRM` at the combiner choke point. Recognized failing evidence now propagates independently of verdict and dominates a public sibling for private/ambiguous phrases, invalid dates, and non-finite values across order, sequence, and nested wrappers; neutral metadata and valid date/number controls remain admitted.
- Fixed: `PRRT_kwDOQ5Uhrs6QAFRN` by recursively checking recognized body/text/content wrappers for classified privacy evidence before content admission; nested `private`, `hidden`, `privacy`, and `public: false` markers reject while genuine text with `public: true` admits.
- Fixed: the Round-11 Codex alias gap by routing exact public-flag `status`/`label` aliases such as `published_status`, `customer_facing_status`, and `public_facing_label` through the same closed family policy.
- Fixed: `PRRT_kwDOQ5Uhrs6QA9NP` by resolving exact compact `un`/`not`/`non` plus public/public-flag stems only inside publication/strict families; public siblings can no longer mask them, while #2060 neutral-data families retain producer text.
- Fixed: `PRRT_kwDOQ5Uhrs6QA9NQ` by reapplying that same bounded negated-stem grammar after label/status suffix removal, covering snake/camel/pre-compacted aliases without widening unrelated status columns.
- Fixed: `PRRT_kwDOQ5Uhrs6QA9NR` by retaining exponent-shaped malformed provenance through boolean-like numeric decisions for access/audience and private-note polarity; plain `0`/`1` and affirmative public `1e0` controls retain their established behavior.
- Fixed: `PRRT_kwDOQ5Uhrs6QA9NT` by recognizing date-only `Z` and numeric-offset ISO shapes before calendar validation; invalid dates dominate public evidence while valid suffixed dates admit.
- Fixed: `PRRT_kwDOQ5Uhrs6QA9NV` by treating publication data as marker-shaped in sequences and requiring affirmative public evidence when multiple publication-data siblings are present; `public` plus valid date/number admits, two bare dates remain fail-closed.
- Fixed by model: `PRRT_kwDOQ5Uhrs6QBRb-` because recognized-failing evidence is now semantic and `_KIND_PUBLIC` consumes it through the same policy table as publication/strict families.
- Fixed by model: `PRRT_kwDOQ5Uhrs6QBRcC` because the non-finite atom accepts quiet and signaling NaN forms, and every family policy decides that atom uniformly.
- Fixed by model: `PRRT_kwDOQ5Uhrs6QBRcE` because ISO datetime normalization accepts colonized and compact numeric offsets before calendar validation.
- Fixed by model: `PRRT_kwDOQ5Uhrs6QBRcF` because malformed boolean-numeric provenance survives scalar/object/sequence combination independently of unrelated boolean siblings, and strict policy rejects it.
- Fixed by model: `PRRT_kwDOQ5Uhrs6QBRcG` because value tokenization preserves camel boundaries and fully segments closed-vocabulary compact conjunctions before phrase classification.
- Fixed by model: the Round-14 invalid-date parity blocker because publication text now produces one semantic valid/invalid-date/not-data decision and the independent oracle spans the previously omitted trailing-junk, non-zero-padded, and out-of-range date family across scalar and masked wrappers.
- Fixed: `PRRT_kwDOQ5Uhrs6QC3iD` by recursively treating non-empty recognized wrapper mappings whose contents are all absent as sequence identity while retaining bare `{}` as structured/ambiguous.
- Fixed: `PRRT_kwDOQ5Uhrs6QC3iE` by making structured recognized-failing evidence dominate the content exit; direct free-text content remains admitted.
- Fixed: `PRRT_kwDOQ5Uhrs6QC3iF` by using the package's rendered plain-text normalization before content provenance is granted; markup/entity-only bodies are empty and real rendered text remains content.
- Fixed: `PRRT_kwDOQ5Uhrs6QC3iH` by reducing classified non-boolean subfields through their own family policy and clearing locally admitted failure flags before outer combination; locally rejected private values still dominate.
- Fixed: `PRRT_kwDOQ5Uhrs6QDHrY` by deriving recognized-failing marker semantics at every recognized body/text/content wrapper depth before the content carveout.
- Fixed: `PRRT_kwDOQ5Uhrs6QDHra` by applying recursive rendered-content absence to body-bearing mappings before content-sequence cardinality.
- Fixed: `PRRT_kwDOQ5Uhrs6QDHrd` by recording admitted text/body mappings as compatible content evidence instead of simultaneously marking them unresolved; raw boolean and unknown siblings remain ambiguous.
- Fixed: `PRRT_kwDOQ5Uhrs6QDHrf` by exporting strict/publication provenance only from a locally affirmative classified-subfield decision; access/audience/type/kind neutral admission alone cannot authorize an outer public/strict family.
- Waiver: `PRRT_kwDOQ5Uhrs6P-Uf_` asks a valid date/number to override an unrecognized textual sibling. That contradicts the operator-approved publication/strict invariant that every unknown text fails closed and would reopen the class beside data-shaped evidence. Recognized-public plus valid date/finite-number controls remain admitted; unknown labels remain closed.
- Fixed controls: recognized-public values and valid publication date/number shapes still admit; invalid dates/non-finite numbers reject; access/audience/type/kind neutral producer text still admits through nested wrappers; explicit private/malformed/conflicting evidence still rejects.
- Prior nested-resolution, structured/content precedence, malformed provenance, categorical wrapper, `has_access`, singleton parity, and route-proof findings remain fixed by the typed decision/combiner architecture and the full regression corpus.
- Waiver: threads `PRRT_kwDOQ5Uhrs6P0VhX` and `PRRT_kwDOQ5Uhrs6P0Vha` request recursion into unknown-key subtrees. The classifier intentionally ignores those subtrees uniformly under its closed key vocabulary; recognized nested privacy keys remain fail-closed and are pinned beside the waiver cases.
- Waiver: rejecting every unknown textual access/audience label would contradict #2060. Known private labels and malformed numerics reject; producer-defined neutral text remains admissible and is now pinned at classifier and package boundaries.
- All fixed or waived: yes for S6A.1 through Round-16. S6A.2 generic `/execute` authority is an explicit deferred issue slice, not a waived finding.

## Verification
- Round-16 focused recursive boundary matrix: `139 passed, 5101 deselected`.
- Privacy/package/submit suite: `5535 passed`.
- Round-15 focused boundary matrix: `79 passed, 4865 deselected`.
- Vocabulary/model focused matrix: `4181 passed, 923 deselected`.
- Invalid-date oracle regression: failed before the runtime fix on masked `2026-02-30x`, then `1 passed, 4864 deselected` after the canonical publication-data decision.
- Independent generated oracle: `12884` family/key/value/wrapper/sibling/content comparisons.
- Caller-layer package/Zendesk sweep: `176 passed, 123 deselected`.
- `bash scripts/validate_extracted_content_pipeline.sh` passed; extracted reasoning-import audit clean; standalone debt audit 0; ASCII and whitespace checks passed.
- `bash scripts/run_extracted_pipeline_checks.sh` passed (one third-party `pynvml` deprecation warning).
- Exact extracted-content-pipeline maturity ratchet passed with no baseline diff.
- Plan sync check passed.

## Diff size
6 files, +3752 / -122 (3874 changed lines). The plan documents why the typed guard, independent oracle, package-boundary proof, real route proof, and tracker correction are indivisible despite the 400-line soft target.
