### PR TITLE
Fail closed on incomplete watcher readiness snapshots

### DIFF
--- a/.github/workflows/codex_wake_bridge_checks.yml
+++ b/.github/workflows/codex_wake_bridge_checks.yml
@@ -11,10 +11,12 @@ on:
       - "scripts/codex_wake_bridge.py"
       - "scripts/codex_issue_queue.py"
       - "scripts/install_codex_wake_bridge.py"
+      - "scripts/report_pr_watcher_state.py"
       - "tests/test_audit_pr_watcher_safety.py"
       - "tests/test_codex_wake_bridge.py"
       - "tests/test_codex_issue_queue.py"
       - "tests/test_install_codex_wake_bridge.py"
+      - "tests/test_report_pr_watcher_state.py"
 
 jobs:
   codex-wake-bridge:
@@ -36,5 +38,6 @@ jobs:
             tests/test_codex_wake_bridge.py \
             tests/test_codex_issue_queue.py \
             tests/test_install_codex_wake_bridge.py \
+            tests/test_report_pr_watcher_state.py \
             tests/test_audit_pr_watcher_safety.py \
             -q

--- a/docs/long_running_session_watcher_handoff.md
+++ b/docs/long_running_session_watcher_handoff.md
@@ -138,11 +138,36 @@ Wake-source rules:
   as inspection/fix handoffs only; scheduled green-confirmation is still the
   only wake source that may proceed to merge consideration after live guards.
 - `--source scheduled` may classify `ready_for_human_merge` as
-  `scheduled-ready`, which is only permission to run the AGENTS merge guards.
-  The resumed builder still needs explicit standing merge authorization in
-  this session's state file before merging.
+  `scheduled-ready` only when the snapshot carries a version-1 readiness proof
+  for the same open, non-draft head: at least one required check, all required
+  checks complete/green, complete review-thread pagination, zero unresolved
+  threads (including outdated threads), no changes-requested decision, and a
+  clean merge state. Missing or contradictory proof becomes `attention` and
+  lists its blockers. `scheduled-ready` is still only permission to run the
+  AGENTS merge guards; the resumed builder also needs explicit standing merge
+  authorization in this session's state file before merging.
 - Pending states write a handoff but do not run the optional command by default.
   Do not replace the watcher timer with an in-chat polling loop.
+
+The version-1 snapshot proof is:
+
+```json
+{
+  "readiness": {
+    "version": 1,
+    "evaluated_head_sha": "<same as pr.headRefOid>",
+    "required_check_count": 3,
+    "required_checks_complete": true,
+    "required_check_failures": [],
+    "required_check_pending": [],
+    "review_threads_complete": true,
+    "review_thread_pages_fetched": 1,
+    "unresolved_review_threads": [],
+    "review_decision": "<same as pr.reviewDecision>",
+    "merge_state_status": "CLEAN"
+  }
+}
+```
 
 This gives the two-hook shape without making the watcher merge-capable: event
 hooks can call the bridge with `--source event`; the 30-minute green-confirmation
@@ -152,7 +177,10 @@ timer can call it with `--source scheduled`.
 
 - No auto-merge. Truthy watcher auto-merge config is unsafe and must surface as
   attention, not an action path.
-- A green PR becomes `ready_for_human_merge`; it does not merge itself.
+- A local producer may label a PR `ready_for_human_merge`, but the bridge and
+  reporter fail closed unless the versioned readiness proof above is complete.
+  Legacy snapshots therefore remain attention-only until their producer is
+  upgraded. No watcher snapshot merges by itself.
 - Local review runs `scripts/audit_pr_watcher_safety.py`; unsafe watcher configs
   or watcher source merge commands are blocking.
 - Codex/local active builders must run `scripts/report_pr_watcher_state.py` on
@@ -289,7 +317,7 @@ systemctl --user disable --now "atlas-pr-watch@${SESSION_ID}.timer"
 | `pending` | At least one check is still pending | Record the next poll; do not ask the operator to babysit CI |
 | `attention` | Red/canceled check, failed AI reconciliation, or status details such as `head_mismatch: true` | Inspect the owned PR, fix the root cause in-scope, push, update watcher config head SHA. If `head_mismatch` is true, follow the stop/fetch/inspect branch before any force-push or merge |
 | `review_changed` | New review/comment activity since last poll | Inspect comments before any merge decision |
-| `ready_for_human_merge` | Checks are green and AI reconciliation passes on the scheduled timer wake | Run `scripts/report_pr_watcher_state.py`, then report readiness or perform the active-builder guarded merge only when explicitly authorized |
+| `ready_for_human_merge` | The snapshot label and version-1 proof agree: same open/non-draft head, required checks complete/green, all thread pages fetched, zero unresolved threads, no changes requested, clean merge state | Run `scripts/report_pr_watcher_state.py`; missing/contradictory proof is reported as attention. Otherwise report readiness or perform the active-builder guarded merge only when explicitly authorized and after fresh live guards |
 
 ## Prompt For Other Builder Sessions
 

--- a/plans/PR-Watcher-Zero-Thread-Readiness.md
+++ b/plans/PR-Watcher-Zero-Thread-Readiness.md
@@ -1,0 +1,137 @@
+# PR-Watcher-Zero-Thread-Readiness
+
+## Why this slice exists
+
+The operator asked to close the Atlas CI gaps found while designing a
+non-continuous overnight PR loop. The current repo-owned wake bridge and
+ready-state reporter can promote a local snapshot that merely says
+`ready_for_human_merge`, even though the untracked local producer does not
+prove required-check completion, complete review-thread pagination, zero
+unresolved threads, review-decision state, or clean mergeability. That is a
+release-gate safety defect: an incomplete snapshot can be presented as merge
+ready.
+
+Diff-budget override: the 557-LOC plan/test/code/doc slice is indivisible at
+the safety boundary. Splitting the shared predicate from either readiness
+consumer, its failure-branch fixtures, or dedicated CI enrollment would leave
+one false-ready path unguarded or ship a release gate whose negative branches
+are not executed by CI.
+
+### Problem-derived contract
+
+- Root cause: the repo-owned readiness consumers trust an unversioned state
+  label instead of requiring the evidence that makes the label true. The
+  local watcher is outside repository source and can therefore omit or
+  miscompute merge-critical inputs without the bridge/reporter CI noticing.
+- Correct fix must touch/change: define one fail-closed readiness-proof
+  contract in the installed wake-bridge source, require it before a scheduled
+  wake or reporter entry is classified ready, expose every failed predicate in
+  the handoff/report, add two-sided and contradictory-state fixtures, and run
+  both consumer test files in the dedicated PR-head workflow.
+- Must not change: do not add GitHub polling or merge commands to the bridge,
+  do not grant watcher merge authority, do not modify machine-local watcher or
+  systemd files, do not change AI-reconciliation semantics, and do not touch
+  product/runtime lanes.
+
+## Scope (this PR)
+
+Ownership lane: workflow/pr-watcher-readiness
+Slice phase: Workflow/process
+
+1. Require a versioned snapshot proof tied to the PR head before
+   `ready_for_human_merge` can become a scheduled-ready wake or ready reporter
+   entry.
+2. Fail closed and surface reasons for missing, malformed, stale, pending,
+   unresolved-thread, changes-requested, draft/closed, or unmergeable proof.
+3. Enroll the bridge and reporter boundary fixtures in the dedicated wake CI.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A complete proof for the same open, non-draft PR head, with at least
+        one required check, no failed/pending required checks, complete thread
+        pagination, zero unresolved threads, no changes-requested decision,
+        and clean merge state is the only snapshot that reports ready.
+  - [ ] Missing or contradictory proof becomes attention and lists the exact
+        blockers; it never launches a scheduled-ready command.
+  - [ ] Outdated-but-unresolved threads still block because the unresolved
+        list is non-empty regardless of thread age.
+  - [ ] Event wakes remain attention-only and the bridge remains unable to
+        poll, mutate, or merge GitHub state.
+  - [ ] The dedicated PR-head workflow runs both changed consumer test files.
+- Reachability proof: run the dedicated workflow's exact pytest command
+  locally; workflow path filters and test list include every changed guard.
+- Affected surfaces: developer tooling, local watcher handoff, CI enrollment.
+- Risk areas: false-green release readiness, stale head state, incomplete
+  pagination, backward compatibility for legacy local snapshots.
+- Reviewer rules triggered: R1, R2, R10, R12, R14.
+
+### Files touched
+
+- `.github/workflows/codex_wake_bridge_checks.yml`
+- `docs/long_running_session_watcher_handoff.md`
+- `plans/PR-Watcher-Zero-Thread-Readiness.md`
+- `scripts/codex_wake_bridge.py`
+- `scripts/report_pr_watcher_state.py`
+- `tests/test_codex_wake_bridge.py`
+- `tests/test_report_pr_watcher_state.py`
+
+## Mechanism
+
+`scripts/codex_wake_bridge.py` owns a pure `readiness_blockers` predicate so
+the installed standalone bridge carries the contract with it. A version-1
+`readiness` object must attest the evaluated head, required-check result,
+review-thread pagination/result, review decision, and merge state; duplicated
+PR metadata is cross-checked rather than trusted independently. The bridge
+uses the predicate before emitting `scheduled-ready` and records blocker text
+in its handoff. The repo reporter imports the same predicate, so it cannot
+disagree and place the same legacy/contradictory snapshot in its ready bucket.
+Fixtures probe each side of the gate, and the dedicated workflow owns their CI
+enrollment.
+
+## Intentional
+
+- Legacy local snapshots that lack the versioned proof intentionally fail
+  closed to attention. This temporarily disables automatic ready reporting
+  until the local producer follow-up emits the contract; it preserves review
+  and remediation wakes without creating false merge permission.
+- The proof requires at least one required check. Atlas has required branch
+  checks; an empty set is treated as missing enforcement, not green.
+- This slice does not overload `live-reconciliation`, whose bot-accounting
+  semantics deliberately differ from the strict all-thread merge invariant.
+
+## Deferred
+
+- `PR-Watcher-Live-Readiness-Producer`: move or regenerate the machine-local
+  watcher from repository-owned source, fetch required checks and every
+  review-thread page live, and emit the version-1 proof. Until that lands, the
+  new consumers remain safely attention-only.
+- Enabling GitHub's server-side required conversation-resolution setting is an
+  operator/repository-policy action after current parallel PR lanes are
+  assessed; this slice does not alter global branch protection.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_codex_wake_bridge.py tests/test_codex_issue_queue.py tests/test_install_codex_wake_bridge.py tests/test_report_pr_watcher_state.py tests/test_audit_pr_watcher_safety.py -q` - 98 passed.
+- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - ratchet passed with no new brittleness above baseline.
+- `python scripts/audit_pr_watcher_safety.py --repo-root . --repo-only` - passed; watcher remains unable to merge.
+- `python scripts/audit_workflow_security_posture.py .github/workflows` - passed with pre-existing warnings only.
+- `python scripts/install_codex_wake_bridge.py --bin-dir <tmp>/bin --systemd-dir <tmp>/systemd && python scripts/install_codex_wake_bridge.py --check --bin-dir <tmp>/bin --systemd-dir <tmp>/systemd && <tmp>/bin/atlas-codex-wake-bridge --help` - installed copy matched source and executed standalone.
+- `git diff --check` - passed.
+- `python scripts/sync_pr_plan.py plans/PR-Watcher-Zero-Thread-Readiness.md --check` - passed.
+- Pending before push: the single `push_pr.sh` local-review run.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/codex_wake_bridge_checks.yml` | 3 |
+| `docs/long_running_session_watcher_handoff.md` | 38 |
+| `plans/PR-Watcher-Zero-Thread-Readiness.md` | 137 |
+| `scripts/codex_wake_bridge.py` | 112 |
+| `scripts/report_pr_watcher_state.py` | 81 |
+| `tests/test_codex_wake_bridge.py` | 169 |
+| `tests/test_report_pr_watcher_state.py` | 84 |
+| **Total** | **624** |

--- a/scripts/codex_wake_bridge.py
+++ b/scripts/codex_wake_bridge.py
@@ -71,22 +71,102 @@ def _truthy(value: Any) -> bool:
     return bool(value)
 
 
+def attention_blockers(status: dict[str, Any]) -> list[str]:
+    """Return snapshot details that require active-agent attention."""
+    blockers: list[str] = []
+    for key in ("head_mismatch", "worktree_dirty", "merge_error", "check_failures"):
+        if _truthy(status.get(key)):
+            blockers.append(key)
+    if status.get("reconciliation_exit_code") not in {None, 0}:
+        blockers.append("reconciliation_exit_code")
+    for key in ("view_error", "checks_error", "reviews_error", "review_threads_error"):
+        if _truthy(status.get(key)):
+            blockers.append(key)
+    return blockers
+
+
+def _non_negative_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def readiness_blockers(status: dict[str, Any]) -> list[str]:
+    """Validate the evidence required to promote a watcher snapshot to ready."""
+    blockers = attention_blockers(status)
+    proof = status.get("readiness")
+    if not isinstance(proof, dict):
+        return [*blockers, "readiness proof is missing or not an object"]
+    if proof.get("version") != 1 or isinstance(proof.get("version"), bool):
+        blockers.append("readiness proof version must be 1")
+
+    pr = status.get("pr")
+    if not isinstance(pr, dict):
+        return [*blockers, "PR metadata is missing or not an object"]
+    if pr.get("state") != "OPEN":
+        blockers.append("PR state must be OPEN")
+    if pr.get("isDraft") is not False:
+        blockers.append("PR draft state must be explicitly false")
+
+    pr_head = pr.get("headRefOid")
+    evaluated_head = proof.get("evaluated_head_sha")
+    if not isinstance(pr_head, str) or not pr_head:
+        blockers.append("PR head SHA is missing")
+    if not isinstance(evaluated_head, str) or not evaluated_head:
+        blockers.append("evaluated head SHA is missing")
+    elif evaluated_head != pr_head:
+        blockers.append("evaluated head SHA does not match PR head")
+
+    required_count = proof.get("required_check_count")
+    if not _non_negative_int(required_count) or required_count < 1:
+        blockers.append("required check count must be at least 1")
+    if proof.get("required_checks_complete") is not True:
+        blockers.append("required checks are not complete")
+    for key, label in (
+        ("required_check_failures", "required check failures"),
+        ("required_check_pending", "required checks pending"),
+    ):
+        values = proof.get(key)
+        if not isinstance(values, list):
+            blockers.append(f"{label} must be a list")
+        elif values:
+            blockers.append(f"{label}: {len(values)}")
+
+    if proof.get("review_threads_complete") is not True:
+        blockers.append("review-thread pagination is incomplete")
+    pages = proof.get("review_thread_pages_fetched")
+    if not _non_negative_int(pages) or pages < 1:
+        blockers.append("review-thread pages fetched must be at least 1")
+    unresolved = proof.get("unresolved_review_threads")
+    if not isinstance(unresolved, list):
+        blockers.append("unresolved review threads must be a list")
+    elif unresolved:
+        blockers.append(f"unresolved review threads remain: {len(unresolved)}")
+
+    if "review_decision" not in proof or "reviewDecision" not in pr:
+        blockers.append("review decision evidence is missing")
+    else:
+        proof_decision = str(proof.get("review_decision") or "").upper()
+        pr_decision = str(pr.get("reviewDecision") or "").upper()
+        if proof_decision != pr_decision:
+            blockers.append("review decision does not match PR metadata")
+        if proof_decision == "CHANGES_REQUESTED":
+            blockers.append("review decision has changes requested")
+
+    proof_merge = proof.get("merge_state_status")
+    pr_merge = pr.get("mergeStateStatus")
+    if proof_merge != pr_merge:
+        blockers.append("merge state does not match PR metadata")
+    if proof_merge != "CLEAN":
+        blockers.append("merge state must be CLEAN")
+    return blockers
+
+
 def classify_wake(status: dict[str, Any], *, source: str, status_error: str | None = None) -> str:
     """Classify the bridge wake without granting merge authority."""
     if status_error:
         return "invalid-snapshot"
 
     state = str(status.get("state") or "unknown")
-    has_failure_flag = any(
-        [
-            _truthy(status.get("head_mismatch")),
-            _truthy(status.get("worktree_dirty")),
-            _truthy(status.get("merge_error")),
-            _truthy(status.get("check_failures")),
-            status.get("reconciliation_exit_code") not in {None, 0},
-        ]
-    )
-    if has_failure_flag:
+    if attention_blockers(status):
         return "attention"
 
     if state == "closed":
@@ -98,7 +178,7 @@ def classify_wake(status: dict[str, Any], *, source: str, status_error: str | No
     if state == "pending" or _truthy(status.get("check_pending")):
         return "pending"
     if source == "scheduled" and state == "ready_for_human_merge":
-        return "scheduled-ready"
+        return "scheduled-ready" if not readiness_blockers(status) else "attention"
     if state in {"attention", "review_changed"}:
         return "attention"
     return "attention"
@@ -134,6 +214,7 @@ def build_prompt(
     state = str(status.get("state") or "unknown")
     next_poll = str(status.get("next_poll_at") or "unknown")
     reconciliation_code = status.get("reconciliation_exit_code")
+    ready_blockers = readiness_blockers(status) if state == "ready_for_human_merge" else []
     session_state_label = session_state or "SESSION_STATE.local.md"
     session_state_shell = shlex.quote(session_state_label)
 
@@ -175,6 +256,12 @@ def build_prompt(
         lines.extend([
             "Watcher snapshot problem:",
             f"- {status_error}",
+            "",
+        ])
+    if ready_blockers:
+        lines.extend([
+            "Watcher readiness blockers:",
+            *(f"- {blocker}" for blocker in ready_blockers),
             "",
         ])
 
@@ -274,6 +361,9 @@ def write_handoff(
         "pr": status.get("pr", {}),
         "watcher_state": status.get("state", "unknown"),
         "status_error": status_error,
+        "readiness_blockers": readiness_blockers(status)
+        if status.get("state") == "ready_for_human_merge"
+        else [],
         "prompt_path": str(handoff_md_path),
     }
     handoff_json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/scripts/report_pr_watcher_state.py
+++ b/scripts/report_pr_watcher_state.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import subprocess
 from typing import Any, Sequence
 
+from codex_wake_bridge import attention_blockers, readiness_blockers
+
 
 def _json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     try:
@@ -21,50 +23,49 @@ def _json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     return value, None
 
 
-def _gh_pr_state(pr: object, fallback: str) -> str:
+def _gh_pr_metadata(
+    pr: object,
+    fallback: dict[str, Any],
+) -> tuple[dict[str, Any], str | None]:
     if not pr:
-        return fallback
+        return fallback, "PR number is missing; live GitHub refresh was not run"
     try:
         proc = subprocess.run(
-            ["gh", "pr", "view", str(pr), "--json", "state", "--jq", ".state"],
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr),
+                "--json",
+                "state,headRefOid,mergeStateStatus,reviewDecision,isDraft",
+            ],
             check=False,
             capture_output=True,
             text=True,
         )
-    except OSError:
-        return fallback
+    except OSError as exc:
+        return fallback, f"live GitHub refresh failed: {exc}"
     if proc.returncode != 0:
-        return fallback
-    return proc.stdout.strip() or fallback
-
-
-def _truthy(value: Any) -> bool:
-    if value is None or value is False or value == "" or value == 0:
-        return False
-    return bool(value)
-
-
-def _has_failure_detail(data: dict[str, Any]) -> bool:
-    return any(
-        [
-            _truthy(data.get("head_mismatch")),
-            _truthy(data.get("worktree_dirty")),
-            _truthy(data.get("merge_error")),
-            _truthy(data.get("check_failures")),
-            data.get("reconciliation_exit_code") not in {None, 0},
-        ]
-    )
+        detail = (proc.stderr or proc.stdout or "gh pr view failed").strip()
+        return fallback, f"live GitHub refresh failed: {detail}"
+    try:
+        value = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return fallback, f"live GitHub refresh returned invalid JSON: {exc}"
+    if not isinstance(value, dict):
+        return fallback, "live GitHub refresh did not return an object"
+    return {**fallback, **value}, None
 
 
 def _bucket(data: dict[str, Any], *, watcher_state: str, gh_state: str) -> str:
-    if _has_failure_detail(data):
+    if attention_blockers(data):
         return "attention"
     if gh_state in {"MERGED", "CLOSED"} or watcher_state == "closed":
         return "stale"
-    if watcher_state == "pending" or _truthy(data.get("check_pending")):
+    if watcher_state == "pending" or bool(data.get("check_pending")):
         return "pending"
     if watcher_state == "ready_for_human_merge":
-        return "ready"
+        return "attention" if readiness_blockers(data) else "ready"
     if watcher_state in {"attention", "review_changed"}:
         return "attention"
     return "other"
@@ -89,14 +90,21 @@ def _entries(state_dir: Path, *, skip_github: bool) -> list[dict[str, Any]]:
                 }
             )
             continue
-        pr = data.get("pr") if isinstance(data.get("pr"), dict) else {}
-        stored_gh_state = str(pr.get("state") or "unknown")
-        gh_state = stored_gh_state if skip_github else _gh_pr_state(pr.get("number"), stored_gh_state)
+        stored_pr = data.get("pr") if isinstance(data.get("pr"), dict) else {}
+        if skip_github:
+            pr = stored_pr
+            github_refresh_error = None
+        else:
+            pr, github_refresh_error = _gh_pr_metadata(stored_pr.get("number"), stored_pr)
+        effective_data = {**data, "pr": pr}
+        if github_refresh_error:
+            effective_data["view_error"] = github_refresh_error
+        gh_state = str(pr.get("state") or "unknown")
         watcher_state = str(data.get("state") or "unknown")
         entries.append(
             {
                 "path": path,
-                "bucket": _bucket(data, watcher_state=watcher_state, gh_state=gh_state),
+                "bucket": _bucket(effective_data, watcher_state=watcher_state, gh_state=gh_state),
                 "watcher_state": watcher_state,
                 "gh_state": gh_state,
                 "pr_number": pr.get("number"),
@@ -109,6 +117,10 @@ def _entries(state_dir: Path, *, skip_github: bool) -> list[dict[str, Any]]:
                 "head_mismatch": data.get("head_mismatch"),
                 "worktree_dirty": data.get("worktree_dirty"),
                 "merge_error": data.get("merge_error"),
+                "readiness_blockers": readiness_blockers(effective_data)
+                if watcher_state == "ready_for_human_merge"
+                else [],
+                "github_refresh_error": github_refresh_error,
             }
         )
     return entries
@@ -136,9 +148,14 @@ def _line(entry: dict[str, Any]) -> str:
         bits.append("worktree_dirty=true")
     if entry.get("merge_error"):
         bits.append(f"merge_error={entry.get('merge_error')}")
+    if entry.get("github_refresh_error"):
+        bits.append(f"github_refresh_error={entry.get('github_refresh_error')}")
     reconciliation = entry.get("reconciliation")
     if reconciliation not in {None, 0}:
         bits.append(f"reconciliation_exit_code={reconciliation}")
+    blockers = entry.get("readiness_blockers") or []
+    if blockers:
+        bits.append("readiness_blockers=" + "; ".join(str(item) for item in blockers))
     return " | ".join(bits)
 
 

--- a/tests/test_codex_wake_bridge.py
+++ b/tests/test_codex_wake_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+import pytest
 import sys
 
 
@@ -72,6 +73,9 @@ def _write_fixture(
             "headRefName": "claude/pr-codex-wake-bridge",
             "headRefOid": "abc123",
             "mergeStateStatus": "CLEAN",
+            "reviewDecision": "",
+            "isDraft": False,
+            "state": "OPEN",
         },
         "check_failures": [],
         "check_pending": [],
@@ -79,6 +83,19 @@ def _write_fixture(
         "worktree_dirty": False,
         "reconciliation_exit_code": 0,
         "reconciliation_summary": "OK: no open automated-review threads.",
+        "readiness": {
+            "version": 1,
+            "evaluated_head_sha": "abc123",
+            "required_check_count": 3,
+            "required_checks_complete": True,
+            "required_check_failures": [],
+            "required_check_pending": [],
+            "review_threads_complete": True,
+            "review_thread_pages_fetched": 1,
+            "unresolved_review_threads": [],
+            "review_decision": "",
+            "merge_state_status": "CLEAN",
+        },
     }
     if extra_status:
         status.update(extra_status)
@@ -205,6 +222,158 @@ def test_failure_flags_override_scheduled_ready(tmp_path: Path) -> None:
     assert payload["wake_kind"] == "attention"
     assert "Attention wake" in prompt
     assert "If head_mismatch is true" in prompt
+
+
+@pytest.mark.parametrize(
+    "error_field",
+    ["view_error", "checks_error", "reviews_error", "review_threads_error"],
+)
+def test_github_read_errors_override_scheduled_ready(
+    tmp_path: Path,
+    error_field: str,
+) -> None:
+    config_dir, state_dir, watcher_id = _write_fixture(
+        tmp_path,
+        extra_status={error_field: "API unavailable"},
+    )
+
+    code = bridge.main([
+        watcher_id,
+        "--source",
+        "scheduled",
+        "--config-dir",
+        str(config_dir),
+        "--state-dir",
+        str(state_dir),
+    ])
+
+    assert code == 0
+    payload, prompt = _read_handoff(state_dir, watcher_id)
+    assert payload["wake_kind"] == "attention"
+    assert error_field in payload["readiness_blockers"]
+    assert "Do not merge" in prompt
+
+
+@pytest.mark.parametrize(
+    ("proof_patch", "pr_patch", "expected"),
+    [
+        (None, {}, "readiness proof is missing"),
+        ({"version": 2}, {}, "version must be 1"),
+        ({"evaluated_head_sha": ""}, {}, "evaluated head SHA is missing"),
+        ({"evaluated_head_sha": "new-head"}, {}, "does not match PR head"),
+        ({"required_check_count": 0}, {}, "count must be at least 1"),
+        ({"required_checks_complete": False}, {}, "checks are not complete"),
+        ({"required_check_failures": ["unit"]}, {}, "check failures: 1"),
+        ({"required_check_failures": "unit"}, {}, "failures must be a list"),
+        ({"required_check_pending": ["unit"]}, {}, "checks pending: 1"),
+        ({"required_check_pending": "unit"}, {}, "pending must be a list"),
+        ({"review_threads_complete": False}, {}, "pagination is incomplete"),
+        ({"review_thread_pages_fetched": 0}, {}, "pages fetched must be at least 1"),
+        ({"unresolved_review_threads": "T1"}, {}, "threads must be a list"),
+        (
+            {"unresolved_review_threads": [{"id": "T1", "isOutdated": True}]},
+            {},
+            "unresolved review threads remain: 1",
+        ),
+        (
+            {"review_decision": "CHANGES_REQUESTED"},
+            {"reviewDecision": "CHANGES_REQUESTED"},
+            "has changes requested",
+        ),
+        (
+            {"review_decision": "APPROVED"},
+            {},
+            "review decision does not match PR metadata",
+        ),
+        (
+            {"merge_state_status": "DIRTY"},
+            {"mergeStateStatus": "DIRTY"},
+            "merge state must be CLEAN",
+        ),
+        (
+            {},
+            {"mergeStateStatus": "DIRTY"},
+            "merge state does not match PR metadata",
+        ),
+        ({}, {"isDraft": True}, "draft state must be explicitly false"),
+        ({}, {"state": "CLOSED"}, "PR state must be OPEN"),
+    ],
+)
+def test_incomplete_or_contradictory_ready_proof_fails_closed(
+    tmp_path: Path,
+    proof_patch: dict[str, object] | None,
+    pr_patch: dict[str, object],
+    expected: str,
+) -> None:
+    config_dir, state_dir, watcher_id = _write_fixture(tmp_path)
+    status_path = state_dir / f"{watcher_id}.json"
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    if proof_patch is None:
+        status.pop("readiness")
+    else:
+        status["readiness"].update(proof_patch)
+    status["pr"].update(pr_patch)
+    status_path.write_text(json.dumps(status), encoding="utf-8")
+
+    code = bridge.main([
+        watcher_id,
+        "--source",
+        "scheduled",
+        "--config-dir",
+        str(config_dir),
+        "--state-dir",
+        str(state_dir),
+    ])
+
+    assert code == 0
+    payload, prompt = _read_handoff(state_dir, watcher_id)
+    assert payload["wake_kind"] == "attention"
+    assert any(expected in str(item) for item in payload["readiness_blockers"])
+    assert expected in prompt
+    assert "Attention wake" in prompt
+    assert "Do not merge" in prompt
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("readiness", [], "readiness proof is missing or not an object"),
+        ("pr", [], "PR metadata is missing or not an object"),
+    ],
+)
+def test_malformed_readiness_objects_fail_closed(
+    tmp_path: Path,
+    field: str,
+    value: object,
+    expected: str,
+) -> None:
+    _config_dir, state_dir, watcher_id = _write_fixture(tmp_path)
+    status = json.loads((state_dir / f"{watcher_id}.json").read_text(encoding="utf-8"))
+    status[field] = value
+
+    assert expected in bridge.readiness_blockers(status)
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "expected"),
+    [
+        ("pr", "headRefOid", "PR head SHA is missing"),
+        ("readiness", "review_decision", "review decision evidence is missing"),
+        ("pr", "reviewDecision", "review decision evidence is missing"),
+        ("readiness", "merge_state_status", "merge state must be CLEAN"),
+    ],
+)
+def test_missing_readiness_evidence_fails_closed(
+    tmp_path: Path,
+    section: str,
+    field: str,
+    expected: str,
+) -> None:
+    _config_dir, state_dir, watcher_id = _write_fixture(tmp_path)
+    status = json.loads((state_dir / f"{watcher_id}.json").read_text(encoding="utf-8"))
+    status[section].pop(field)
+
+    assert expected in bridge.readiness_blockers(status)
 
 
 def test_malformed_status_fails_closed_to_attention_handoff(tmp_path: Path) -> None:

--- a/tests/test_report_pr_watcher_state.py
+++ b/tests/test_report_pr_watcher_state.py
@@ -28,6 +28,22 @@ def _write_state(
             "title": f"{state} PR",
             "state": pr_state,
             "headRefOid": "abc123",
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": "",
+            "isDraft": False,
+        },
+        "readiness": {
+            "version": 1,
+            "evaluated_head_sha": "abc123",
+            "required_check_count": 3,
+            "required_checks_complete": True,
+            "required_check_failures": [],
+            "required_check_pending": [],
+            "review_threads_complete": True,
+            "review_thread_pages_fetched": 1,
+            "unresolved_review_threads": [],
+            "review_decision": "",
+            "merge_state_status": "CLEAN",
         },
     }
     if extra:
@@ -94,6 +110,40 @@ def test_ready_snapshot_with_pending_checks_reports_pending(tmp_path: Path) -> N
     assert "Still pending" in result.stdout
     assert "Ready for active-agent merge decision" not in result.stdout
     assert "pending=maturity-sweep" in result.stdout
+
+
+def test_ready_snapshot_without_readiness_proof_reports_attention(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    path = state_dir / "legacy-ready.json"
+    _write_state(path, state="ready_for_human_merge")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload.pop("readiness")
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _run(state_dir)
+
+    assert "Needs active-agent attention" in result.stdout
+    assert "Ready for active-agent merge decision" not in result.stdout
+    assert "readiness proof is missing" in result.stdout
+
+
+def test_outdated_but_unresolved_thread_reports_attention(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    path = state_dir / "outdated-thread.json"
+    _write_state(path, state="ready_for_human_merge")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["readiness"]["unresolved_review_threads"] = [
+        {"id": "T1", "isOutdated": True}
+    ]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _run(state_dir)
+
+    assert "Needs active-agent attention" in result.stdout
+    assert "Ready for active-agent merge decision" not in result.stdout
+    assert "unresolved review threads remain: 1" in result.stdout
 
 
 def test_ignores_wake_bridge_handoff_json(tmp_path: Path) -> None:
@@ -177,13 +227,41 @@ def test_reports_unreadable_state_file_path_and_summary(tmp_path: Path) -> None:
     assert "unreadable watcher JSON" in result.stdout
 
 
-def test_uses_stored_closed_state_when_github_refresh_is_unavailable(tmp_path: Path) -> None:
+def test_github_refresh_failure_fails_closed_instead_of_using_stored_ready_state(
+    tmp_path: Path,
+) -> None:
     state_dir = tmp_path / "state"
     state_dir.mkdir()
-    _write_state(state_dir / "stale.json", state="ready_for_human_merge", pr_state="MERGED")
+    _write_state(state_dir / "ready.json", state="ready_for_human_merge")
 
     result = _run(state_dir, skip_github=False, env={"PATH": ""})
 
     assert result.returncode == 0
-    assert "Stale/closed watcher state to clean up" in result.stdout
+    assert "Needs active-agent attention" in result.stdout
     assert "Ready for active-agent merge decision" not in result.stdout
+    assert "github_refresh_error=live GitHub refresh failed" in result.stdout
+
+
+def test_live_github_head_change_invalidates_stored_readiness(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    _write_state(state_dir / "ready.json", state="ready_for_human_merge")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' "
+        "'{\"state\":\"OPEN\",\"headRefOid\":\"new-head\","
+        "\"mergeStateStatus\":\"CLEAN\",\"reviewDecision\":\"\","
+        "\"isDraft\":false}'\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+
+    result = _run(state_dir, skip_github=False, env={"PATH": str(bin_dir)})
+
+    assert result.returncode == 0
+    assert "Needs active-agent attention" in result.stdout
+    assert "Ready for active-agent merge decision" not in result.stdout
+    assert "evaluated head SHA does not match PR head" in result.stdout


### PR DESCRIPTION
Plan: plans/PR-Watcher-Zero-Thread-Readiness.md
Slice phase: Workflow/process

Fail closed at both repo-owned watcher readiness consumers. A plain `ready_for_human_merge` label no longer becomes scheduled-ready or a ready reporter entry unless a version-1 proof establishes the same open/non-draft head, at least one completed green required check, complete thread pagination, zero unresolved threads, no changes-requested decision, and clean merge state. This closes the false-ready safety gap while leaving the machine-local proof producer for the next narrow slice.

Diff-budget override: 7 tightly coupled files exceed the 400-LOC soft cap because splitting the shared predicate from either consumer, its failure-branch fixtures, documentation, or dedicated CI enrollment would leave one false-ready path unguarded or untested.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- No automated-review findings existed before PR open; re-check live threads after review lands.

## Intentional
- Legacy watcher snapshots without the versioned proof become attention-only. Automatic ready reporting remains disabled until the named producer slice emits the proof.
- Required-check count must be at least one; Atlas has required checks, so an empty required set is not treated as green.
- `live-reconciliation` remains the bot-accounting gate and is not overloaded with the stricter all-thread invariant.

## Deferred
- `PR-Watcher-Live-Readiness-Producer`: make the local watcher repository-owned or generated from repo source, fetch required checks plus every review-thread page, and emit the version-1 proof.
- Enable GitHub required conversation resolution only after current parallel PR lanes are assessed; this PR does not mutate global branch protection.

## Parked hardening
- None.

## Cold diff reconstruction
- Gaps: none. Every changed file traces to the false-ready trust-boundary defect; no product/runtime, GitHub mutation, merge-command, AI-reconciliation, or machine-local systemd surface changed.
- Changed: `scripts/codex_wake_bridge.py:74` centralizes snapshot attention errors; `scripts/codex_wake_bridge.py:92` validates the versioned readiness proof; `scripts/codex_wake_bridge.py:163` prevents scheduled-ready classification when any proof predicate fails; `scripts/codex_wake_bridge.py:217` and `scripts/codex_wake_bridge.py:352` expose blocker evidence in the prompt and JSON handoff.
- Changed: `scripts/report_pr_watcher_state.py:26` refreshes live head/review/merge metadata and fails closed on refresh errors; `scripts/report_pr_watcher_state.py:60` and `scripts/report_pr_watcher_state.py:93` apply the same bridge-owned predicate before the ready bucket; `scripts/report_pr_watcher_state.py:129` renders the blocker receipt.
- Changed: `tests/test_codex_wake_bridge.py:115`, `tests/test_codex_wake_bridge.py:231`, and `tests/test_codex_wake_bridge.py:257` prove the valid side, GitHub-read failure side, and malformed/contradictory proof class, including outdated unresolved threads, missing evidence, checks, decisions, heads, and merge states.
- Changed: `tests/test_report_pr_watcher_state.py:115`, `tests/test_report_pr_watcher_state.py:131`, `tests/test_report_pr_watcher_state.py:230`, and `tests/test_report_pr_watcher_state.py:245` prove legacy, outdated-thread, unavailable-GitHub, and changed-live-head snapshots cannot report ready.
- Changed: `.github/workflows/codex_wake_bridge_checks.yml:8` enrolls both reporter paths and `.github/workflows/codex_wake_bridge_checks.yml:34` executes the reporter tests beside the bridge suite on PR-head code.
- Changed: `docs/long_running_session_watcher_handoff.md:133` documents the strict scheduled-wake contract, exact proof shape, and intentional legacy fail-closed behavior.
- Contract match: one shared predicate prevents bridge/reporter disagreement; the test matrix probes both sides of every merge-critical boundary; the dedicated workflow executes both changed guard surfaces.

## Verification
- `python -m pytest tests/test_codex_wake_bridge.py tests/test_codex_issue_queue.py tests/test_install_codex_wake_bridge.py tests/test_report_pr_watcher_state.py tests/test_audit_pr_watcher_safety.py -q` - 98 passed.
- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - ratchet passed with no new brittleness above baseline.
- `python scripts/audit_pr_watcher_safety.py --repo-root . --repo-only` - passed; no watcher merge authority.
- `python scripts/audit_workflow_security_posture.py .github/workflows` - passed with pre-existing warnings only.
- Temporary install/check plus installed `atlas-codex-wake-bridge --help` smoke - passed.
- `python scripts/sync_pr_plan.py plans/PR-Watcher-Zero-Thread-Readiness.md --check` - passed.
- `git diff --check` - passed.

## Diff size
7 files, 624 LOC.
