### PR TITLE
Codify the overnight-arc workflow so it survives compaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ requirements.freeze.bak
 
 # Read-only audit scratch (fixtures, sweeps, profiling) — not shipped
 _audit_scratch/
+
+# repo-internal git worktrees (AGENTS worktree convention)
+worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,6 +577,24 @@ review. Local watcher executables and configs are status-only: truthy
 auto-merge config, PR merge commands, delete-branch merge cleanup, or equivalent
 merge behavior in watcher infrastructure is a blocking workflow defect.
 
+### 3c.2. Overnight arc protocol
+
+When the operator assigns an **unattended overnight arc** (a long-running
+coding task expected to run to merged-or-blocked with zero operator contact),
+the governing runbook is `docs/OVERNIGHT_ARC_WORKFLOW.md`. It wraps this
+section's watcher rules with: a mandatory interactive **pre-flight** (task
+readiness contract plus all clarifying questions asked while the operator is
+still present), the **night-loop deltas** (never wait on the operator; defer
+operator-only choices as issues; watcher-driven waiting via
+`scripts/watch_owned_pr.sh`, which is status-only per the watcher-safety rule
+above; bot-review round cap with the fail-closed-guard exception), the
+**true-blocker escalation channel**, and a mandatory **morning report**. The
+overnight baton (active arc task/contract, current slice, owned PR + head
+SHA, watcher armed-state, morning-report accumulator) is compaction handoff
+data per the `CLAUDE.md` compact instructions; a compacted overnight session
+re-reads the runbook and verifies the baton against `git`/`gh` state before
+proceeding.
+
 ### 3d. Thin-slice and hardening triage
 
 Every plan names a slice phase in `Scope (this PR)`, and the PR body

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1415,8 +1415,16 @@ When compacting this conversation, preserve verbatim (do not summarize away):
   baton: owned PR number, branch, latest head SHA, last observed check/review
   state, next 30-minute poll time, and whether autonomous merge/next-slice
   continuation is authorized.
+- For an assigned **overnight arc** (`docs/OVERNIGHT_ARC_WORKFLOW.md`, AGENTS
+  §3c.2), the full **overnight baton**: the arc task and its pre-flight
+  contract (or contract issue #), authorization granted at pre-flight, current
+  slice and remaining slices, owned PR + head SHA + watcher armed-state, the
+  morning-report accumulator so far (merged PRs, filed issues, waivers,
+  verification run), and the instruction to RE-READ `docs/OVERNIGHT_ARC_WORKFLOW.md`
+  and verify this baton against `git`/`gh` state before proceeding.
 
 These are the fields a post-compaction resume needs to continue a fix loop
 without re-exploring or touching files outside the declared scope (see
-`AGENTS.md` §3l) or to resume a long-running PR watcher (see `AGENTS.md`
-§3c.1). When in doubt, keep the baton and drop narrative.
+`AGENTS.md` §3l), to resume a long-running PR watcher (see `AGENTS.md`
+§3c.1), or to continue an overnight arc mid-night (see `AGENTS.md` §3c.2).
+When in doubt, keep the baton and drop narrative.

--- a/docs/OVERNIGHT_ARC_WORKFLOW.md
+++ b/docs/OVERNIGHT_ARC_WORKFLOW.md
@@ -38,6 +38,11 @@ it.
    assigned per the operator's standing autonomous-arc rules -- merge-on-green
    authority for THIS arc's PRs, hardened-path defaults, defer-do-not-ask.
    Plus any per-night limits (files not to touch, stop-after-N-PRs).
+   Trust boundary (AGENTS 3c.1.8): `claude-review` is forgeable by any token
+   with status-write on the repo, so when builder and reviewer share a GitHub
+   identity it is a coordination signal, not a defense -- the operator must
+   not grant merge authority on its strength alone; a distinct reviewer
+   identity is the precondition for treating it as a real gate.
 5. **Mechanics armed:**
    - Fresh session for the arc (one arc per session; long-lived sessions
      degrade -- model fallback, compaction damage).
@@ -45,6 +50,12 @@ it.
      (`git worktree add worktrees/<slice> -b claude/pr-<slice> origin/main`);
      never build on the shared main checkout.
    - Owned-PR watcher available: `scripts/watch_owned_pr.sh` (see section 5).
+   - **Wake path verified for the builder surface** (AGENTS 3c.1.2): a
+     watcher process does not wake an agent by itself. Claude Code native
+     mode wakes on background-task completion; Codex/local CLI mode needs an
+     external wake bridge. If the surface has no working wake path, do NOT
+     launch the overnight arc from it -- the night would stall at the first
+     watcher exit.
 
 ## 2. The night loop
 

--- a/docs/OVERNIGHT_ARC_WORKFLOW.md
+++ b/docs/OVERNIGHT_ARC_WORKFLOW.md
@@ -126,11 +126,18 @@ there is something to act on:
 - `MERGED/CLOSED` -- terminal; stop watching.
 - `HEAD-MOVED` -- the branch advanced past the armed SHA; reconcile, re-arm
   on the new head.
-- `ACTIONABLE` -- red required check, unresolved review threads,
-  CHANGES_REQUESTED, or a failed `claude-review` status; go fix, push, re-arm.
-- `MERGE-READY` -- required green + threads clear + `claude-review` success
-  + mergeable (both merge gates per AGENTS.md 3c.1.8 and
-  `docs/REVIEWER_MERGE_GATE.md`); run the pre-merge checklist (clean tree,
+- `ACTIONABLE` -- a red required context, unresolved review threads (counts
+  fail closed when more thread pages exist than fetched), a
+  CHANGES_REQUESTED review decision, or a failed `claude-review` status.
+  Definite negatives exit on any cycle, including the first.
+- `MERGE-READY` -- readiness is presence-based and fail-closed: EVERY
+  required branch-protection context (read at runtime from
+  `scripts/check_required_status_checks.py`, so the gate cannot drift from
+  the canonical list) must be present and reporting success, plus
+  `claude-review` status success, 0 unresolved threads, no
+  CHANGES_REQUESTED, and mergeable (both merge gates per AGENTS.md 3c.1.8
+  and `docs/REVIEWER_MERGE_GATE.md`). A context that has not started yet
+  keeps readiness false. Run the pre-merge checklist (clean tree,
   local==remote, threads still 0), merge, alert.
 
 The watcher itself never merges and never holds merge authority (AGENTS

--- a/docs/OVERNIGHT_ARC_WORKFLOW.md
+++ b/docs/OVERNIGHT_ARC_WORKFLOW.md
@@ -1,0 +1,147 @@
+# Overnight Arc Workflow
+
+Turn "task + overnight" into an unattended arc that ends **merged** or
+**cleanly blocked with a morning report**. Task-agnostic: a contract-shaped
+GitHub issue, a feature, a refactor, or a read-only investigation. This doc is
+canonical and survives sessions/compaction because it lives in the repo and is
+wired into `AGENTS.md` (section 3c.2) and the `CLAUDE.md` compact-instructions
+baton. Machine-local session tooling (kickoff prompts, local watcher copies)
+may mirror it but this file wins on conflict.
+
+The one rule that makes overnight work: **every question gets asked at
+pre-flight, while the operator is still awake. After kickoff, zero operator
+contact until the morning report** (except the true-blocker channel, section 3).
+
+## 1. Pre-flight (with the operator, ~10 minutes, BEFORE the night starts)
+
+Run this checklist interactively. Do not start the night on a task that fails
+it.
+
+1. **Task named.** An issue number, or a stated goal. If it is a goal, not an
+   issue: write the contract down NOW (step 2) and get a yes on it.
+2. **Readiness check** -- the task has (or you now write, and the operator
+   confirms):
+   - Problem-derived contract: what is broken / wanted; root cause if known.
+   - Correct-work-must: the observable outcomes that define done.
+   - Must-not-change: product-shape freezes, do-not-touch files/lanes,
+     protected behavior. Check the active-lanes state (session handoff docs /
+     open PRs) for collisions and record them here.
+   - Acceptance: how the morning verdict is proven (tests, probes, e2e).
+   - Scope split: what is explicitly OUT (named follow-up, not silent drop).
+   The exemplar shape is issue #2060 -- that structure is why its arc ran
+   multiple review rounds unattended.
+3. **Ask every clarifying question now.** Anything that would otherwise be a
+   3am guess: error-direction choices, product-shape edges, budget (LOC / PR
+   count), whether multi-PR is acceptable. Vague answers get tightened before
+   kickoff, not during.
+4. **Authorization recorded in the session, explicitly:** overnight arc
+   assigned per the operator's standing autonomous-arc rules -- merge-on-green
+   authority for THIS arc's PRs, hardened-path defaults, defer-do-not-ask.
+   Plus any per-night limits (files not to touch, stop-after-N-PRs).
+5. **Mechanics armed:**
+   - Fresh session for the arc (one arc per session; long-lived sessions
+     degrade -- model fallback, compaction damage).
+   - `git fetch` + working-tree provenance check; build in an own worktree
+     (`git worktree add worktrees/<slice> -b claude/pr-<slice> origin/main`);
+     never build on the shared main checkout.
+   - Owned-PR watcher available: `scripts/watch_owned_pr.sh` (see section 5).
+
+## 2. The night loop
+
+Run the standard builder contract (`AGENTS.md` section 3: plan doc first,
+diff budgets, PR body shape, reconstruction-review coding) with these
+overnight deltas:
+
+- **Never wait on the operator.** Technical fork -> hardened path, note the
+  decision in the PR. Genuinely-operator choice -> GitHub issue, keep moving
+  on everything else. Chat is write-only until morning.
+- **Slices sequential, one at a time.** Multi-slice arcs finish slice N
+  (merged or parked-with-issue) before opening slice N+1. Keep each PR inside
+  the diff budget (<400 LOC, ~40 changed Python symbols).
+- **Watcher-driven waiting.** After every push: resolve verified-fixed review
+  threads, then arm `scripts/watch_owned_pr.sh` on the new head and stop
+  working until it exits. Re-arm after EVERY push and EVERY compaction. No
+  inline polling or sleep loops (AGENTS 3c.1.3).
+- **Review rounds:** reconcile every bot/reviewer finding by execution, not
+  narrative. Hard 3-round bot-review cap counted by rounds: at cap, fix
+  verified findings, waive the rest with reasons in the PR body (AGENTS
+  4a.1), merge on required-green. EXCEPTION: confirmed fail-open findings in
+  money/auth/PII guards block past the cap; the move there is a structural
+  acceptance bar (a fail-closed invariant + a generative property test), not
+  a fourth round of spot patches.
+- **Guard-shaped slices** (validator/sanitizer/privacy/cap): self-apply the
+  reviewer boundary probe BEFORE pushing -- both error directions (fail-open
+  AND over-reject), boundary values, at least one negative test. Cheaper than
+  a review round.
+- **Merge:** required checks green + 0 unresolved threads + no
+  CHANGES_REQUESTED + `claude-review` status success (both gates, AGENTS
+  3c.1.8) + clean tree + local==remote -> merge, teardown, next slice. Log
+  for the report; do not ping the operator per merge. Exception:
+  documentation-only PRs hold for bot review before merging (doc PRs that
+  merged on green before the bot pass have burned us).
+- **Compaction recovery:** the `CLAUDE.md` compact instructions preserve the
+  overnight baton. First acts after any compaction: re-read this doc, verify
+  the baton against `git`/`gh` reality, re-arm the watcher.
+- **Read-only investigation arcs:** no mutations -- findings become
+  contract-shaped GitHub issues (future overnight tasks) + the report.
+
+## 3. True-blocker channel (the only overnight contact)
+
+Only when the WHOLE arc cannot proceed (a single blocked slice gets parked as
+an issue while other slices continue) AND the decision is genuinely the
+operator's: open a `BLOCKED: <decision>` issue, assign + @mention the
+operator, and send the direct email alert if configured. Then keep doing
+whatever work remains.
+
+## 4. Morning report (the arc's last act, always -- success or not)
+
+```
+OVERNIGHT ARC REPORT -- <task> -- <date>
+Outcome: CLEARED | PARTIAL | BLOCKED
+Merged:   #PR (title, LOC, merge SHA) ...
+Open:     #PR @ state (what it awaits)
+Issues:   filed #N (deferred decision / follow-up / BLOCKED)
+Review:   rounds per PR; findings fixed/waived (waivers listed)
+Verification: what was EXECUTED to prove acceptance (commands/tests)
+Left for operator: decisions only they can make, one sentence each
+Next:     recommended next arc or none
+```
+
+Post it in chat; email it too if the arc ended BLOCKED.
+
+## 5. Owned-PR watcher
+
+`scripts/watch_owned_pr.sh` -- portable single-PR watcher for the builder
+side (companion to the reviewer lane's inbox watcher, which is session
+tooling). Usage:
+
+```bash
+PR=<number> SHA=<full 40-char head sha> bash scripts/watch_owned_pr.sh
+```
+
+Run it in the background (no trailing `&` inside the command -- background it
+at the harness level). It polls about every 29 minutes and exits the moment
+there is something to act on:
+
+- `MERGED/CLOSED` -- terminal; stop watching.
+- `HEAD-MOVED` -- the branch advanced past the armed SHA; reconcile, re-arm
+  on the new head.
+- `ACTIONABLE` -- red required check, unresolved review threads,
+  CHANGES_REQUESTED, or a failed `claude-review` status; go fix, push, re-arm.
+- `MERGE-READY` -- required green + threads clear + `claude-review` success
+  + mergeable (both merge gates per AGENTS.md 3c.1.8 and
+  `docs/REVIEWER_MERGE_GATE.md`); run the pre-merge checklist (clean tree,
+  local==remote, threads still 0), merge, alert.
+
+The watcher itself never merges and never holds merge authority (AGENTS
+3c.1.1); it only reports states.
+
+## 6. Kickoff prompt (paste into a fresh session at night)
+
+> Read docs/OVERNIGHT_ARC_WORKFLOW.md and run tonight's overnight arc:
+> <task / issue #>. Pre-flight is done: <contract or issue #>. You have
+> merge-on-green authority for this arc's PRs. Report at morning per
+> section 4.
+
+If pre-flight was not done yet, the fresh session runs section 1 with the
+operator before they leave -- that is the intended flow.

--- a/plans/PR-Overnight-Arc-Workflow.md
+++ b/plans/PR-Overnight-Arc-Workflow.md
@@ -11,6 +11,11 @@ same treatment `docs/PR_RECONSTRUCTION_PROTOCOL.md` got for the review
 protocol, and adds the one missing piece of machinery (a portable status-only
 owned-PR watcher) that every builder session has been rewriting inline.
 
+Diff-budget note: ~423 LOC, marginally over the 400 soft cap after review
+round 1 added the watcher-safety enrollment and fail-closed watcher fixes;
+the runbook + its watcher + the contract wiring must land together or the
+workflow is codified in a state its own verification cannot prove.
+
 ### Problem-derived contract
 
 - Root cause: post-compaction context is rebuilt only from the compaction
@@ -25,7 +30,10 @@ owned-PR watcher) that every builder session has been rewriting inline.
   on (`scripts/watch_owned_pr.sh`), which must be status-only under the
   existing watcher-safety rule.
 - Must not change: merge-gate semantics (the AGENTS 3c.1.8 two-gate rule is
-  referenced, not altered), required checks, `scripts/audit_pr_watcher_safety.py`,
+  referenced, not altered), required checks, the watcher-safety audit's
+  detection semantics (its scan list is EXTENDED -- review round 1 proved the
+  new watcher and runbook were not covered, so the audit passed vacuously;
+  enrollment is required for the plan's own verification claim to be true),
   existing AGENTS/CLAUDE content (edits additive only), any code paths,
   tests, or product surfaces.
 
@@ -39,14 +47,21 @@ Slice phase: Workflow/process
    operator is present), night-loop deltas over the AGENTS section 3 builder
    contract, true-blocker channel, mandatory morning report, kickoff prompt.
 2. Add `scripts/watch_owned_pr.sh` -- portable single-PR watcher; status-only
-   (reports MERGED/CLOSED, HEAD-MOVED, ACTIONABLE, MERGE-READY and exits);
-   gates MERGE-READY on required checks + review threads + the
-   `claude-review` commit status per AGENTS section 3c.1.8.
+   (reports MERGED/CLOSED, HEAD-MOVED, ACTIONABLE, MERGE-READY and exits).
+   MERGE-READY is presence-based and fail-closed: every required
+   branch-protection context (read at runtime from
+   `scripts/check_required_status_checks.py`) present and success, plus the
+   `claude-review` commit status, 0 unresolved threads (fail closed on
+   unfetched thread pages), and no CHANGES_REQUESTED review decision
+   (AGENTS section 3c.1.8). Definite negatives exit on any cycle.
 3. Wire `AGENTS.md`: new section 3c.2 naming the runbook as governing for
    assigned overnight arcs.
 4. Wire `CLAUDE.md` Compact Instructions: add the overnight baton to the
    preserve-verbatim list so a compacted overnight session resumes from the
    baton and re-reads the runbook.
+5. Enroll the new watcher and runbook in `scripts/audit_pr_watcher_safety.py`
+   (REPO_DOCS + repo watcher sources) and add `worktrees/` to `.gitignore` so
+   the runbook worktree convention leaves the shared checkout clean.
 
 ### Review Contract
 
@@ -58,9 +73,12 @@ Slice phase: Workflow/process
         `gh pr merge`, no delete-branch, status-only messaging).
   - [ ] `AGENTS.md` 3c.2 and the `CLAUDE.md` compact-instructions bullet
         reference the runbook; edits are additive only.
-  - [ ] MERGE-READY in the script requires required checks green AND
-        `claude-review` commit status success AND 0 unresolved threads AND
-        no CHANGES_REQUESTED (both merge gates, AGENTS 3c.1.8).
+  - [ ] MERGE-READY requires EVERY canonical required context (from
+        `scripts/check_required_status_checks.py`, incl. diff-budget) present
+        and success AND `claude-review` success AND 0 unresolved threads
+        (fail closed on unfetched pages) AND no CHANGES_REQUESTED.
+  - [ ] `scripts/audit_pr_watcher_safety.py` actually scans the new watcher
+        and runbook (enrolled, not vacuous).
 - Reachability proof: process/docs + a standalone operator-run script; no
   runtime, API, UI, billing, or product surface. Proof is the rendered docs,
   the watcher-safety audit output, and a live one-cycle smoke of the script
@@ -70,14 +88,18 @@ Slice phase: Workflow/process
 - Risk areas: none at runtime. The watcher is status-only by construction and
   is covered by the existing watcher-safety audit; it holds no merge
   authority.
-- Reviewer rules triggered: R1.
+- Reviewer rules triggered: R1, R2, R10 (the watcher-safety audit is a gate
+  predicate; its scan list is extended and the extension is itself exercised
+  by the audit run in Verification).
 
 ### Files touched
 
+- `.gitignore`
 - `AGENTS.md`
 - `CLAUDE.md`
 - `docs/OVERNIGHT_ARC_WORKFLOW.md`
 - `plans/PR-Overnight-Arc-Workflow.md`
+- `scripts/audit_pr_watcher_safety.py`
 - `scripts/watch_owned_pr.sh`
 
 ## Mechanism
@@ -110,20 +132,26 @@ Parked hardening: none.
 
 ## Verification
 
-- `scripts/audit_pr_watcher_safety.py` -- OK (no merge authority granted).
-- bash -n on `scripts/watch_owned_pr.sh` -- OK; live one-cycle smoke against an
-  open PR reports state correctly.
+- `scripts/audit_pr_watcher_safety.py` -- OK, and now actually scans the new
+  watcher + runbook (enrolled in round 1; the pre-enrollment pass was
+  vacuous).
+- bash -n on `scripts/watch_owned_pr.sh` -- OK; live smoke against an open PR
+  reports state correctly and exits ACTIONABLE on review threads + red
+  required context (observed live on this PR's own round 1).
 - `scripts/audit_plan_doc.py` on this plan -- OK.
-- `git diff --name-status` -- two new files + two additive doc edits + this
-  plan; no code paths.
+- `git diff --name-status` -- two new files + additive edits to `AGENTS.md`,
+  `CLAUDE.md`, `.gitignore`, and the audit scan list + this plan; no code
+  paths.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
+| `.gitignore` | 3 |
 | `AGENTS.md` | 18 |
 | `CLAUDE.md` | 12 |
-| `docs/OVERNIGHT_ARC_WORKFLOW.md` | 147 |
-| `plans/PR-Overnight-Arc-Workflow.md` | 129 |
-| `scripts/watch_owned_pr.sh` | 56 |
-| **Total** | **362** |
+| `docs/OVERNIGHT_ARC_WORKFLOW.md` | 154 |
+| `plans/PR-Overnight-Arc-Workflow.md` | 157 |
+| `scripts/audit_pr_watcher_safety.py` | 9 |
+| `scripts/watch_owned_pr.sh` | 77 |
+| **Total** | **430** |

--- a/plans/PR-Overnight-Arc-Workflow.md
+++ b/plans/PR-Overnight-Arc-Workflow.md
@@ -78,7 +78,12 @@ Slice phase: Workflow/process
         and success AND `claude-review` success AND 0 unresolved threads
         (fail closed on unfetched pages) AND no CHANGES_REQUESTED.
   - [ ] `scripts/audit_pr_watcher_safety.py` actually scans the new watcher
-        and runbook (enrolled, not vacuous).
+        and runbook (enrolled, not vacuous), with regression tests proving a
+        repo watcher source containing a merge command FAILS the audit.
+  - [ ] Required-context counting is app-pinned (GitHub Actions app id from
+        `scripts/check_required_status_checks.py`) BEFORE latest-run
+        selection, so a same-named check from another app can neither green
+        the gate nor mask the genuine run.
 - Reachability proof: process/docs + a standalone operator-run script; no
   runtime, API, UI, billing, or product surface. Proof is the rendered docs,
   the watcher-safety audit output, and a live one-cycle smoke of the script
@@ -101,6 +106,7 @@ Slice phase: Workflow/process
 - `plans/PR-Overnight-Arc-Workflow.md`
 - `scripts/audit_pr_watcher_safety.py`
 - `scripts/watch_owned_pr.sh`
+- `tests/test_audit_pr_watcher_safety.py`
 
 ## Mechanism
 
@@ -151,7 +157,8 @@ Parked hardening: none.
 | `AGENTS.md` | 18 |
 | `CLAUDE.md` | 12 |
 | `docs/OVERNIGHT_ARC_WORKFLOW.md` | 154 |
-| `plans/PR-Overnight-Arc-Workflow.md` | 157 |
+| `plans/PR-Overnight-Arc-Workflow.md` | 164 |
 | `scripts/audit_pr_watcher_safety.py` | 9 |
-| `scripts/watch_owned_pr.sh` | 77 |
-| **Total** | **430** |
+| `scripts/watch_owned_pr.sh` | 87 |
+| `tests/test_audit_pr_watcher_safety.py` | 27 |
+| **Total** | **474** |

--- a/plans/PR-Overnight-Arc-Workflow.md
+++ b/plans/PR-Overnight-Arc-Workflow.md
@@ -145,6 +145,10 @@ Parked hardening: none.
   reports state correctly and exits ACTIONABLE on review threads + red
   required context (observed live on this PR's own round 1).
 - `scripts/audit_plan_doc.py` on this plan -- OK.
+- Round 3: required-context/app-pin extraction moved to the origin/main
+  trusted ref; readiness blocks on unsettled required reruns; runbook gains
+  the claude-review trust-boundary and wake-path pre-flight items; gate
+  behavior tests waived to #2065 under the review cap.
 - `git diff --name-status` -- two new files + additive edits to `AGENTS.md`,
   `CLAUDE.md`, `.gitignore`, and the audit scan list + this plan; no code
   paths.
@@ -156,9 +160,9 @@ Parked hardening: none.
 | `.gitignore` | 3 |
 | `AGENTS.md` | 18 |
 | `CLAUDE.md` | 12 |
-| `docs/OVERNIGHT_ARC_WORKFLOW.md` | 154 |
-| `plans/PR-Overnight-Arc-Workflow.md` | 164 |
+| `docs/OVERNIGHT_ARC_WORKFLOW.md` | 165 |
+| `plans/PR-Overnight-Arc-Workflow.md` | 168 |
 | `scripts/audit_pr_watcher_safety.py` | 9 |
-| `scripts/watch_owned_pr.sh` | 87 |
+| `scripts/watch_owned_pr.sh` | 96 |
 | `tests/test_audit_pr_watcher_safety.py` | 27 |
-| **Total** | **474** |
+| **Total** | **498** |

--- a/plans/PR-Overnight-Arc-Workflow.md
+++ b/plans/PR-Overnight-Arc-Workflow.md
@@ -163,6 +163,6 @@ Parked hardening: none.
 | `docs/OVERNIGHT_ARC_WORKFLOW.md` | 165 |
 | `plans/PR-Overnight-Arc-Workflow.md` | 168 |
 | `scripts/audit_pr_watcher_safety.py` | 9 |
-| `scripts/watch_owned_pr.sh` | 96 |
+| `scripts/watch_owned_pr.sh` | 101 |
 | `tests/test_audit_pr_watcher_safety.py` | 27 |
-| **Total** | **498** |
+| **Total** | **503** |

--- a/plans/PR-Overnight-Arc-Workflow.md
+++ b/plans/PR-Overnight-Arc-Workflow.md
@@ -1,0 +1,129 @@
+# PR-Overnight-Arc-Workflow
+
+## Why this slice exists
+
+The overnight-arc workflow (unattended long-running coding task: pre-flight
+contract -> night loop -> morning report) existed only as machine-local
+session prose, so it could not survive compaction or reach other sessions.
+Compaction survival requires the workflow to live where post-compaction
+context is guaranteed: the repo contract docs. This codifies it in-repo, the
+same treatment `docs/PR_RECONSTRUCTION_PROTOCOL.md` got for the review
+protocol, and adds the one missing piece of machinery (a portable status-only
+owned-PR watcher) that every builder session has been rewriting inline.
+
+### Problem-derived contract
+
+- Root cause: post-compaction context is rebuilt only from the compaction
+  summary plus the always-reinjected repo contract docs (`CLAUDE.md`,
+  `AGENTS.md`). The overnight-arc workflow lived outside both (machine-local
+  session prose), so a compacted or fresh session had no durable path back to
+  the workflow or its in-flight arc state.
+- Correct fix must touch/change: a canonical in-repo runbook under `docs/`;
+  an `AGENTS.md` section binding assigned overnight arcs to it; a `CLAUDE.md`
+  compact-instructions baton entry so mid-arc state survives compaction and
+  points back to the runbook; and the watcher machinery the runbook depends
+  on (`scripts/watch_owned_pr.sh`), which must be status-only under the
+  existing watcher-safety rule.
+- Must not change: merge-gate semantics (the AGENTS 3c.1.8 two-gate rule is
+  referenced, not altered), required checks, `scripts/audit_pr_watcher_safety.py`,
+  existing AGENTS/CLAUDE content (edits additive only), any code paths,
+  tests, or product surfaces.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Add `docs/OVERNIGHT_ARC_WORKFLOW.md` -- the canonical runbook: mandatory
+   interactive pre-flight (readiness contract + all questions asked while the
+   operator is present), night-loop deltas over the AGENTS section 3 builder
+   contract, true-blocker channel, mandatory morning report, kickoff prompt.
+2. Add `scripts/watch_owned_pr.sh` -- portable single-PR watcher; status-only
+   (reports MERGED/CLOSED, HEAD-MOVED, ACTIONABLE, MERGE-READY and exits);
+   gates MERGE-READY on required checks + review threads + the
+   `claude-review` commit status per AGENTS section 3c.1.8.
+3. Wire `AGENTS.md`: new section 3c.2 naming the runbook as governing for
+   assigned overnight arcs.
+4. Wire `CLAUDE.md` Compact Instructions: add the overnight baton to the
+   preserve-verbatim list so a compacted overnight session resumes from the
+   baton and re-reads the runbook.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `docs/OVERNIGHT_ARC_WORKFLOW.md` states pre-flight, night loop,
+        blocker channel, morning report, and the watcher exit states.
+  - [ ] `scripts/watch_owned_pr.sh` passes bash -n and
+        `scripts/audit_pr_watcher_safety.py` (no merge authority: no
+        `gh pr merge`, no delete-branch, status-only messaging).
+  - [ ] `AGENTS.md` 3c.2 and the `CLAUDE.md` compact-instructions bullet
+        reference the runbook; edits are additive only.
+  - [ ] MERGE-READY in the script requires required checks green AND
+        `claude-review` commit status success AND 0 unresolved threads AND
+        no CHANGES_REQUESTED (both merge gates, AGENTS 3c.1.8).
+- Reachability proof: process/docs + a standalone operator-run script; no
+  runtime, API, UI, billing, or product surface. Proof is the rendered docs,
+  the watcher-safety audit output, and a live one-cycle smoke of the script
+  against an open PR.
+- Affected surfaces: builder workflow contract (`AGENTS.md`, `CLAUDE.md`
+  compact instructions), new docs file, new operator script.
+- Risk areas: none at runtime. The watcher is status-only by construction and
+  is covered by the existing watcher-safety audit; it holds no merge
+  authority.
+- Reviewer rules triggered: R1.
+
+### Files touched
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/OVERNIGHT_ARC_WORKFLOW.md`
+- `plans/PR-Overnight-Arc-Workflow.md`
+- `scripts/watch_owned_pr.sh`
+
+## Mechanism
+
+A new runbook doc; a new bash watcher script (derives repo root and origin,
+reads the token from the repo `.env`, polls about every 29 minutes, exits on
+the first actionable state); one additive AGENTS.md subsection; one additive
+CLAUDE.md compact-instructions bullet. No code paths change.
+
+## Intentional
+
+- Repo-level codification (not session-local prose) so the workflow survives
+  compaction -- repo contract docs are re-injected after compaction -- and
+  reaches every session lineage. Machine-local session tooling mirrors it;
+  the repo doc wins on conflict.
+- The watcher checks the `claude-review` commit status in addition to
+  required check-runs, matching the two-gate merge rule already in AGENTS
+  3c.1.8 rather than the older single-gate shape.
+- Task-agnostic by operator decision: no issue queue, no scheduler, no fixed
+  task list is baked in; the task is chosen per night at pre-flight.
+
+## Deferred
+
+- Scheduled/cron dispatch of overnight arcs (operator spend decision; the
+  manual kickoff prompt is the same artifact either way).
+- Any arc queue or issue-template standardization (operator explicitly
+  deferred task selection).
+
+Parked hardening: none.
+
+## Verification
+
+- `scripts/audit_pr_watcher_safety.py` -- OK (no merge authority granted).
+- bash -n on `scripts/watch_owned_pr.sh` -- OK; live one-cycle smoke against an
+  open PR reports state correctly.
+- `scripts/audit_plan_doc.py` on this plan -- OK.
+- `git diff --name-status` -- two new files + two additive doc edits + this
+  plan; no code paths.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 18 |
+| `CLAUDE.md` | 12 |
+| `docs/OVERNIGHT_ARC_WORKFLOW.md` | 147 |
+| `plans/PR-Overnight-Arc-Workflow.md` | 129 |
+| `scripts/watch_owned_pr.sh` | 56 |
+| **Total** | **362** |

--- a/scripts/audit_pr_watcher_safety.py
+++ b/scripts/audit_pr_watcher_safety.py
@@ -19,6 +19,13 @@ REPO_DOCS = (
     "docs/long_running_agent_monitoring_spec.md",
     "docs/long_running_session_watcher_handoff.md",
     "docs/autonomous_coding_repo_playbook.md",
+    "docs/OVERNIGHT_ARC_WORKFLOW.md",
+)
+
+# Watcher executables tracked in the repo itself (scanned in every mode,
+# including --repo-only, because they ship with the checkout).
+REPO_WATCHER_SOURCES = (
+    "scripts/watch_owned_pr.sh",
 )
 
 TRUTHY = {"1", "true", "yes", "on", "enabled"}
@@ -158,6 +165,8 @@ def build_findings(
     repo_only: bool,
 ) -> list[Finding]:
     findings = audit_repo_docs(repo_root)
+    for rel_path in REPO_WATCHER_SOURCES:
+        findings.extend(audit_watcher_source(repo_root / rel_path))
     if not repo_only:
         findings.extend(audit_watcher_source(watcher_bin))
         findings.extend(audit_watcher_source(watcher_wrapper))

--- a/scripts/watch_owned_pr.sh
+++ b/scripts/watch_owned_pr.sh
@@ -4,8 +4,15 @@
 # is something to act on:
 #   MERGED/CLOSED - PR reached terminal state (stop watching)
 #   HEAD-MOVED    - branch advanced past the SHA this watch was armed on
-#   ACTIONABLE    - red required check / unresolved review threads / CHANGES_REQUESTED
-#   MERGE-READY   - required green + 0 unresolved threads + no CHANGES_REQUESTED + mergeable
+#   ACTIONABLE    - red required context / unresolved review threads /
+#                   CHANGES_REQUESTED review decision / failed claude-review
+#   MERGE-READY   - EVERY required context present and success + claude-review
+#                   success + 0 unresolved threads (no unfetched pages) +
+#                   review decision not CHANGES_REQUESTED + mergeable
+# Required contexts are read from scripts/check_required_status_checks.py
+# (DEFAULT_REQUIRED_CONTEXTS) so the gate cannot drift from the canonical
+# list; MERGE-READY requires their PRESENCE with success, so a context that
+# has not started yet fails closed instead of reading as green.
 # The watcher never merges and holds no merge authority (AGENTS.md 3c.1.1);
 # it reports state and exits fast so the builder session acts.
 #
@@ -22,35 +29,49 @@ CYCLES="${CYCLES:-32}"
 TOK="$(grep -m1 '^GITHUB_ACCESS_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2-)"
 [ -n "$TOK" ] || TOK="${GH_TOKEN:-}"
 [ -n "$TOK" ] || { echo "no GITHUB_ACCESS_TOKEN in $ROOT/.env and no GH_TOKEN set" >&2; exit 2; }
-# Required checks; everything else is advisory (state once, do not gate).
-REQ_FILTER='select((.name=="live-reconciliation" or (.name|startswith("Gitleaks"))) and .conclusion!="success" and .conclusion!="skipped" and .status=="completed")'
-echo "owned-pr watcher armed: $REPO#$PR @ ${SHA:0:9} $(date '+%F %H:%M')"
+# Canonical required contexts (branch protection), read from the checker that
+# owns them; falls back to the documented four if extraction fails.
+mapfile -t REQ_CONTEXTS < <(sed -n '/^DEFAULT_REQUIRED_CONTEXTS = (/,/^)/p' \
+  "$ROOT/scripts/check_required_status_checks.py" 2>/dev/null | grep -oE '"[^"]+"' | tr -d '"')
+if [ "${#REQ_CONTEXTS[@]}" -eq 0 ]; then
+  REQ_CONTEXTS=("live-reconciliation" "diff-budget" "Gitleaks PR secret scan" "Gitleaks baseline growth guard")
+fi
+REQ_JSON=$(printf '%s\n' "${REQ_CONTEXTS[@]}" | jq -R . | jq -cs .)
+REQ_TOTAL=${#REQ_CONTEXTS[@]}
+echo "owned-pr watcher armed: $REPO#$PR @ ${SHA:0:9} $(date '+%F %H:%M') (required contexts: ${REQ_CONTEXTS[*]})"
 for i in $(seq 0 "$CYCLES"); do
   [ "$i" -gt 0 ] && sleep 1740
   CUR=$(GH_TOKEN="$TOK" gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null) || { echo "cycle $i: API error, retrying"; continue; }
   if [ "$CUR" != "$SHA" ]; then echo "HEAD-MOVED: ${SHA:0:9} -> ${CUR:0:9} (new push; reconcile + re-arm on new head)"; exit 0; fi
-  ST=$(GH_TOKEN="$TOK" gh api graphql -f query="{ repository(owner:\"$OWNER\",name:\"$NAME\"){ pullRequest(number:$PR){ state merged mergeable reviewThreads(first:100){ nodes{ isResolved } } reviews(last:30){ nodes{ state } } } } }" 2>/dev/null)
+  ST=$(GH_TOKEN="$TOK" gh api graphql -f query="{ repository(owner:\"$OWNER\",name:\"$NAME\"){ pullRequest(number:$PR){ state merged mergeable reviewDecision reviewThreads(first:100){ pageInfo{ hasNextPage } nodes{ isResolved } } } } }" 2>/dev/null)
   STATE=$(echo "$ST" | jq -r '.data.repository.pullRequest | .state + (if .merged then "/merged" else "" end)')
   MERGEABLE=$(echo "$ST" | jq -r '.data.repository.pullRequest.mergeable')
+  DECISION=$(echo "$ST" | jq -r '.data.repository.pullRequest.reviewDecision // "NONE"')
   UNRES=$(echo "$ST" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length')
-  CHREQ=$(echo "$ST" | jq '[.data.repository.pullRequest.reviews.nodes[]|select(.state=="CHANGES_REQUESTED")]|length')
+  MORE=$(echo "$ST" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+  # Fail closed when more thread pages exist than we fetched.
+  [ "$MORE" = "true" ] && UNRES="${UNRES}+unfetched-pages"
   CR=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null)
+  LATEST=$(echo "$CR" | jq '[.check_runs[]]|group_by(.name)|map(sort_by(.started_at)|last)')
   PEND=$(echo "$CR" | jq '[.check_runs[]|select(.status!="completed")]|length')
-  REQRED=$(echo "$CR" | jq "[[.check_runs[]]|group_by(.name)|map(sort_by(.started_at)|last)|.[]|$REQ_FILTER]|length")
-  # claude-review is a per-SHA commit STATUS (not a check-run); absent or
-  # failure is not clean (AGENTS.md 3c.1.8, docs/REVIEWER_MERGE_GATE.md).
+  REQRED=$(echo "$LATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("failure","cancelled","timed_out","action_required")))]|length')
+  REQGREEN=$(echo "$LATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and .conclusion=="success")]|length')
+  # claude-review is a per-SHA commit STATUS (not a check-run); the combined
+  # endpoint returns the latest status per context. Absent or failure is not
+  # clean (AGENTS.md 3c.1.8, docs/REVIEWER_MERGE_GATE.md).
   CLREV=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/status" --jq '([.statuses[]|select(.context=="claude-review")]|last|.state) // "absent"' 2>/dev/null || echo "absent")
-  echo "cycle $i $(date +%H:%M): state=$STATE pending=$PEND req-red=$REQRED threads=$UNRES chreq=$CHREQ claude-review=$CLREV mergeable=$MERGEABLE"
+  echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED pending=$PEND threads=$UNRES decision=$DECISION claude-review=$CLREV mergeable=$MERGEABLE"
   case "$STATE" in MERGED/merged|CLOSED) echo "TERMINAL: PR $STATE"; exit 0;; esac
-  if [ "$i" -gt 0 ]; then # give checks one cycle to start before judging
-    if [ "$REQRED" -gt 0 ] || [ "$UNRES" -gt 0 ] || [ "$CHREQ" -gt 0 ] || [ "$CLREV" = "failure" ]; then
-      echo "ACTIONABLE: req-red=$REQRED threads=$UNRES chreq=$CHREQ claude-review=$CLREV -> reconcile/fix, push, re-arm"; exit 0
-    fi
-    if [ "$PEND" -eq 0 ] && [ "$MERGEABLE" = "MERGEABLE" ] && [ "$CLREV" = "success" ]; then
-      echo "MERGE-READY: required green + threads clear + claude-review success + mergeable."
-      echo "-> pre-merge checklist first (clean tree, local==remote, re-verify threads=0), then merge + alert."
-      exit 0
-    fi
+  # Definite negatives are actionable on ANY cycle, including the first.
+  if [ "$REQRED" -gt 0 ] || [ "$UNRES" != "0" ] || [ "$DECISION" = "CHANGES_REQUESTED" ] || [ "$CLREV" = "failure" ]; then
+    echo "ACTIONABLE: req-red=$REQRED threads=$UNRES decision=$DECISION claude-review=$CLREV -> reconcile/fix, push, re-arm"; exit 0
+  fi
+  # Readiness is presence-based: every required context must be reporting
+  # success (a not-yet-started context keeps this false, so no early race).
+  if [ "$REQGREEN" -eq "$REQ_TOTAL" ] && [ "$MERGEABLE" = "MERGEABLE" ] && [ "$CLREV" = "success" ]; then
+    echo "MERGE-READY: all $REQ_TOTAL required contexts success + threads clear + claude-review success + mergeable."
+    echo "-> pre-merge checklist first (clean tree, local==remote, re-verify threads=0), then merge + alert."
+    exit 0
   fi
 done
 echo "watch window elapsed; re-arm to continue"

--- a/scripts/watch_owned_pr.sh
+++ b/scripts/watch_owned_pr.sh
@@ -38,6 +38,12 @@ if [ "${#REQ_CONTEXTS[@]}" -eq 0 ]; then
 fi
 REQ_JSON=$(printf '%s\n' "${REQ_CONTEXTS[@]}" | jq -R . | jq -cs .)
 REQ_TOTAL=${#REQ_CONTEXTS[@]}
+# Required contexts are pinned to the GitHub Actions app (same pin as
+# check_required_status_checks.py) so a same-named check published by any
+# other app can neither green nor red the required gate.
+REQ_APP_ID=$(grep -oE '^GITHUB_ACTIONS_APP_ID = [0-9]+' \
+  "$ROOT/scripts/check_required_status_checks.py" 2>/dev/null | grep -oE '[0-9]+')
+[ -n "$REQ_APP_ID" ] || REQ_APP_ID=15368
 echo "owned-pr watcher armed: $REPO#$PR @ ${SHA:0:9} $(date '+%F %H:%M') (required contexts: ${REQ_CONTEXTS[*]})"
 for i in $(seq 0 "$CYCLES"); do
   [ "$i" -gt 0 ] && sleep 1740
@@ -52,14 +58,18 @@ for i in $(seq 0 "$CYCLES"); do
   # Fail closed when more thread pages exist than we fetched.
   [ "$MORE" = "true" ] && UNRES="${UNRES}+unfetched-pages"
   CR=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null)
-  LATEST=$(echo "$CR" | jq '[.check_runs[]]|group_by(.name)|map(sort_by(.started_at)|last)')
   PEND=$(echo "$CR" | jq '[.check_runs[]|select(.status!="completed")]|length')
-  REQRED=$(echo "$LATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("failure","cancelled","timed_out","action_required")))]|length')
-  REQGREEN=$(echo "$LATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and .conclusion=="success")]|length')
+  # App-pin BEFORE picking the latest run per name, so a same-named run from
+  # another app can neither green the gate nor mask the genuine run.
+  REQLATEST=$(echo "$CR" | jq --argjson app "$REQ_APP_ID" '[.check_runs[]|select(.app.id==$app)]|group_by(.name)|map(sort_by(.started_at)|last)')
+  REQRED=$(echo "$REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("failure","cancelled","timed_out","action_required")))]|length')
+  REQGREEN=$(echo "$REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and .conclusion=="success")]|length')
   # claude-review is a per-SHA commit STATUS (not a check-run); the combined
-  # endpoint returns the latest status per context. Absent or failure is not
-  # clean (AGENTS.md 3c.1.8, docs/REVIEWER_MERGE_GATE.md).
-  CLREV=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/status" --jq '([.statuses[]|select(.context=="claude-review")]|last|.state) // "absent"' 2>/dev/null || echo "absent")
+  # endpoint returns the latest status per context (verified live: a SHA with
+  # pending-then-success returned only the success entry). sort_by(created_at)
+  # makes the selection order-independent regardless of endpoint ordering.
+  # Absent or failure is not clean (AGENTS.md 3c.1.8, docs/REVIEWER_MERGE_GATE.md).
+  CLREV=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/status" --jq '([.statuses[]|select(.context=="claude-review")]|sort_by(.created_at)|last|.state) // "absent"' 2>/dev/null || echo "absent")
   echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED pending=$PEND threads=$UNRES decision=$DECISION claude-review=$CLREV mergeable=$MERGEABLE"
   case "$STATE" in MERGED/merged|CLOSED) echo "TERMINAL: PR $STATE"; exit 0;; esac
   # Definite negatives are actionable on ANY cycle, including the first.

--- a/scripts/watch_owned_pr.sh
+++ b/scripts/watch_owned_pr.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Owned-PR watcher (docs/OVERNIGHT_ARC_WORKFLOW.md section 5).
+# Watches ONE PR the current builder session owns and exits the moment there
+# is something to act on:
+#   MERGED/CLOSED - PR reached terminal state (stop watching)
+#   HEAD-MOVED    - branch advanced past the SHA this watch was armed on
+#   ACTIONABLE    - red required check / unresolved review threads / CHANGES_REQUESTED
+#   MERGE-READY   - required green + 0 unresolved threads + no CHANGES_REQUESTED + mergeable
+# The watcher never merges and holds no merge authority (AGENTS.md 3c.1.1);
+# it reports state and exits fast so the builder session acts.
+#
+# Usage: PR=<number> SHA=<full 40-char head sha> bash scripts/watch_owned_pr.sh
+# Optional: REPO=<owner/name> (default: derived from origin), CYCLES=<n> (default 32, ~16h).
+set -uo pipefail
+PR="${PR:?set PR=<number>}"
+SHA="${SHA:?set SHA=<full 40-char head sha this watch is armed on>}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="${REPO:-$(git -C "$ROOT" remote get-url origin 2>/dev/null | sed -E 's#^(git@github\.com:|https://github\.com/)##; s#\.git$##')}"
+[ -n "$REPO" ] || { echo "cannot derive REPO from origin; set REPO=<owner/name>" >&2; exit 2; }
+OWNER="${REPO%%/*}"; NAME="${REPO##*/}"
+CYCLES="${CYCLES:-32}"
+TOK="$(grep -m1 '^GITHUB_ACCESS_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2-)"
+[ -n "$TOK" ] || TOK="${GH_TOKEN:-}"
+[ -n "$TOK" ] || { echo "no GITHUB_ACCESS_TOKEN in $ROOT/.env and no GH_TOKEN set" >&2; exit 2; }
+# Required checks; everything else is advisory (state once, do not gate).
+REQ_FILTER='select((.name=="live-reconciliation" or (.name|startswith("Gitleaks"))) and .conclusion!="success" and .conclusion!="skipped" and .status=="completed")'
+echo "owned-pr watcher armed: $REPO#$PR @ ${SHA:0:9} $(date '+%F %H:%M')"
+for i in $(seq 0 "$CYCLES"); do
+  [ "$i" -gt 0 ] && sleep 1740
+  CUR=$(GH_TOKEN="$TOK" gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null) || { echo "cycle $i: API error, retrying"; continue; }
+  if [ "$CUR" != "$SHA" ]; then echo "HEAD-MOVED: ${SHA:0:9} -> ${CUR:0:9} (new push; reconcile + re-arm on new head)"; exit 0; fi
+  ST=$(GH_TOKEN="$TOK" gh api graphql -f query="{ repository(owner:\"$OWNER\",name:\"$NAME\"){ pullRequest(number:$PR){ state merged mergeable reviewThreads(first:100){ nodes{ isResolved } } reviews(last:30){ nodes{ state } } } } }" 2>/dev/null)
+  STATE=$(echo "$ST" | jq -r '.data.repository.pullRequest | .state + (if .merged then "/merged" else "" end)')
+  MERGEABLE=$(echo "$ST" | jq -r '.data.repository.pullRequest.mergeable')
+  UNRES=$(echo "$ST" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length')
+  CHREQ=$(echo "$ST" | jq '[.data.repository.pullRequest.reviews.nodes[]|select(.state=="CHANGES_REQUESTED")]|length')
+  CR=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null)
+  PEND=$(echo "$CR" | jq '[.check_runs[]|select(.status!="completed")]|length')
+  REQRED=$(echo "$CR" | jq "[[.check_runs[]]|group_by(.name)|map(sort_by(.started_at)|last)|.[]|$REQ_FILTER]|length")
+  # claude-review is a per-SHA commit STATUS (not a check-run); absent or
+  # failure is not clean (AGENTS.md 3c.1.8, docs/REVIEWER_MERGE_GATE.md).
+  CLREV=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/status" --jq '([.statuses[]|select(.context=="claude-review")]|last|.state) // "absent"' 2>/dev/null || echo "absent")
+  echo "cycle $i $(date +%H:%M): state=$STATE pending=$PEND req-red=$REQRED threads=$UNRES chreq=$CHREQ claude-review=$CLREV mergeable=$MERGEABLE"
+  case "$STATE" in MERGED/merged|CLOSED) echo "TERMINAL: PR $STATE"; exit 0;; esac
+  if [ "$i" -gt 0 ]; then # give checks one cycle to start before judging
+    if [ "$REQRED" -gt 0 ] || [ "$UNRES" -gt 0 ] || [ "$CHREQ" -gt 0 ] || [ "$CLREV" = "failure" ]; then
+      echo "ACTIONABLE: req-red=$REQRED threads=$UNRES chreq=$CHREQ claude-review=$CLREV -> reconcile/fix, push, re-arm"; exit 0
+    fi
+    if [ "$PEND" -eq 0 ] && [ "$MERGEABLE" = "MERGEABLE" ] && [ "$CLREV" = "success" ]; then
+      echo "MERGE-READY: required green + threads clear + claude-review success + mergeable."
+      echo "-> pre-merge checklist first (clean tree, local==remote, re-verify threads=0), then merge + alert."
+      exit 0
+    fi
+  fi
+done
+echo "watch window elapsed; re-arm to continue"

--- a/scripts/watch_owned_pr.sh
+++ b/scripts/watch_owned_pr.sh
@@ -54,21 +54,25 @@ for i in $(seq 0 "$CYCLES"); do
   [ "$i" -gt 0 ] && sleep 1740
   CUR=$(GH_TOKEN="$TOK" gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null) || { echo "cycle $i: API error, retrying"; continue; }
   if [ "$CUR" != "$SHA" ]; then echo "HEAD-MOVED: ${SHA:0:9} -> ${CUR:0:9} (new push; reconcile + re-arm on new head)"; exit 0; fi
-  ST=$(GH_TOKEN="$TOK" gh api graphql -f query="{ repository(owner:\"$OWNER\",name:\"$NAME\"){ pullRequest(number:$PR){ state merged mergeable reviewDecision reviewThreads(first:100){ pageInfo{ hasNextPage } nodes{ isResolved } } } } }" 2>/dev/null)
+  ST=$(GH_TOKEN="$TOK" gh api graphql -f query="{ repository(owner:\"$OWNER\",name:\"$NAME\"){ pullRequest(number:$PR){ state merged mergeable mergeStateStatus reviewDecision reviewThreads(first:100){ pageInfo{ hasNextPage } nodes{ isResolved } } } } }" 2>/dev/null)
   STATE=$(echo "$ST" | jq -r '.data.repository.pullRequest | .state + (if .merged then "/merged" else "" end)')
   MERGEABLE=$(echo "$ST" | jq -r '.data.repository.pullRequest.mergeable')
+  MSTATE=$(echo "$ST" | jq -r '.data.repository.pullRequest.mergeStateStatus // "UNKNOWN"')
   DECISION=$(echo "$ST" | jq -r '.data.repository.pullRequest.reviewDecision // "NONE"')
   UNRES=$(echo "$ST" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length')
   MORE=$(echo "$ST" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
   # Fail closed when more thread pages exist than we fetched.
   [ "$MORE" = "true" ] && UNRES="${UNRES}+unfetched-pages"
-  CR=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null)
+  # --paginate + re-wrap: required contexts beyond the first 100 runs stay visible
+  CR=$(GH_TOKEN="$TOK" gh api --paginate "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null | jq -s '{check_runs:[.[].check_runs[]]}')
   PEND=$(echo "$CR" | jq '[.check_runs[]|select(.status!="completed")]|length')
   # App-pin BEFORE picking the latest run per name, so a same-named run from
   # another app can neither green the gate nor mask the genuine run.
   REQLATEST=$(echo "$CR" | jq --argjson app "$REQ_APP_ID" '[.check_runs[]|select(.app.id==$app)]|group_by(.name)|map(sort_by(.started_at)|last)')
-  REQRED=$(echo "$REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("failure","cancelled","timed_out","action_required")))]|length')
-  REQGREEN=$(echo "$REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and .conclusion=="success")]|length')
+  REQRED=$(echo "$REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("failure","cancelled","timed_out","action_required","stale","startup_failure")))]|length')
+  # Green mirrors branch-protection semantics: neutral/skipped required checks
+  # count as passing on the server, so the advisory gate matches the enforcer.
+  REQGREEN=$(echo "$REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("success","neutral","skipped")))]|length')
   # A rerun of a required check creates a fresh queued run beside the old
   # completed one; ANY not-completed run of a required name (across all runs,
   # not just the latest-pick) blocks readiness until it settles.
@@ -79,7 +83,7 @@ for i in $(seq 0 "$CYCLES"); do
   # makes the selection order-independent regardless of endpoint ordering.
   # Absent or failure is not clean (AGENTS.md 3c.1.8, docs/REVIEWER_MERGE_GATE.md).
   CLREV=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/status" --jq '([.statuses[]|select(.context=="claude-review")]|sort_by(.created_at)|last|.state) // "absent"' 2>/dev/null || echo "absent")
-  echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED req-unsettled=$REQUNSETTLED pending=$PEND threads=$UNRES decision=$DECISION claude-review=$CLREV mergeable=$MERGEABLE"
+  echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED req-unsettled=$REQUNSETTLED pending=$PEND threads=$UNRES decision=$DECISION claude-review=$CLREV mergeable=$MERGEABLE merge-state=$MSTATE"
   case "$STATE" in MERGED/merged|CLOSED) echo "TERMINAL: PR $STATE"; exit 0;; esac
   # Definite negatives are actionable on ANY cycle, including the first.
   if [ "$REQRED" -gt 0 ] || [ "$UNRES" != "0" ] || [ "$DECISION" = "CHANGES_REQUESTED" ] || [ "$CLREV" = "failure" ]; then
@@ -87,8 +91,9 @@ for i in $(seq 0 "$CYCLES"); do
   fi
   # Readiness is presence-based: every required context must be reporting
   # success (a not-yet-started context keeps this false, so no early race).
-  if [ "$REQGREEN" -eq "$REQ_TOTAL" ] && [ "$REQUNSETTLED" -eq 0 ] && [ "$MERGEABLE" = "MERGEABLE" ] && [ "$CLREV" = "success" ]; then
-    echo "MERGE-READY: all $REQ_TOTAL required contexts success + threads clear + claude-review success + mergeable."
+  if [ "$REQGREEN" -eq "$REQ_TOTAL" ] && [ "$REQUNSETTLED" -eq 0 ] && [ "$MERGEABLE" = "MERGEABLE" ] \
+     && { [ "$MSTATE" = "CLEAN" ] || [ "$MSTATE" = "UNSTABLE" ]; } && [ "$CLREV" = "success" ]; then
+    echo "MERGE-READY: all $REQ_TOTAL required contexts green + threads clear + claude-review success + merge-state $MSTATE."
     echo "-> pre-merge checklist first (clean tree, local==remote, re-verify threads=0), then merge + alert."
     exit 0
   fi

--- a/scripts/watch_owned_pr.sh
+++ b/scripts/watch_owned_pr.sh
@@ -9,10 +9,11 @@
 #   MERGE-READY   - EVERY required context present and success + claude-review
 #                   success + 0 unresolved threads (no unfetched pages) +
 #                   review decision not CHANGES_REQUESTED + mergeable
-# Required contexts are read from scripts/check_required_status_checks.py
-# (DEFAULT_REQUIRED_CONTEXTS) so the gate cannot drift from the canonical
-# list; MERGE-READY requires their PRESENCE with success, so a context that
-# has not started yet fails closed instead of reading as green.
+# Required contexts + app pin are read from origin/main's
+# scripts/check_required_status_checks.py (trusted ref -- the watched branch
+# cannot weaken its own gate); MERGE-READY requires their PRESENCE with
+# success and no unsettled (queued/rerunning) required run, so a context
+# that has not started or is rerunning fails closed.
 # The watcher never merges and holds no merge authority (AGENTS.md 3c.1.1);
 # it reports state and exits fast so the builder session acts.
 #
@@ -29,10 +30,14 @@ CYCLES="${CYCLES:-32}"
 TOK="$(grep -m1 '^GITHUB_ACCESS_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2-)"
 [ -n "$TOK" ] || TOK="${GH_TOKEN:-}"
 [ -n "$TOK" ] || { echo "no GITHUB_ACCESS_TOKEN in $ROOT/.env and no GH_TOKEN set" >&2; exit 2; }
-# Canonical required contexts (branch protection), read from the checker that
-# owns them; falls back to the documented four if extraction fails.
-mapfile -t REQ_CONTEXTS < <(sed -n '/^DEFAULT_REQUIRED_CONTEXTS = (/,/^)/p' \
-  "$ROOT/scripts/check_required_status_checks.py" 2>/dev/null | grep -oE '"[^"]+"' | tr -d '"')
+# Canonical required contexts (branch protection), read from the TRUSTED ref
+# (origin/main), never from the watched branch's working tree -- a PR that
+# edits check_required_status_checks.py must not be able to weaken its own
+# gate. Falls back to the checkout copy, then the documented four.
+CHECKER_SRC="$(git -C "$ROOT" show origin/main:scripts/check_required_status_checks.py 2>/dev/null)"
+[ -n "$CHECKER_SRC" ] || CHECKER_SRC="$(cat "$ROOT/scripts/check_required_status_checks.py" 2>/dev/null)"
+mapfile -t REQ_CONTEXTS < <(printf '%s\n' "$CHECKER_SRC" \
+  | sed -n '/^DEFAULT_REQUIRED_CONTEXTS = (/,/^)/p' | grep -oE '"[^"]+"' | tr -d '"')
 if [ "${#REQ_CONTEXTS[@]}" -eq 0 ]; then
   REQ_CONTEXTS=("live-reconciliation" "diff-budget" "Gitleaks PR secret scan" "Gitleaks baseline growth guard")
 fi
@@ -41,8 +46,8 @@ REQ_TOTAL=${#REQ_CONTEXTS[@]}
 # Required contexts are pinned to the GitHub Actions app (same pin as
 # check_required_status_checks.py) so a same-named check published by any
 # other app can neither green nor red the required gate.
-REQ_APP_ID=$(grep -oE '^GITHUB_ACTIONS_APP_ID = [0-9]+' \
-  "$ROOT/scripts/check_required_status_checks.py" 2>/dev/null | grep -oE '[0-9]+')
+REQ_APP_ID=$(printf '%s\n' "$CHECKER_SRC" \
+  | grep -oE '^GITHUB_ACTIONS_APP_ID = [0-9]+' | grep -oE '[0-9]+')
 [ -n "$REQ_APP_ID" ] || REQ_APP_ID=15368
 echo "owned-pr watcher armed: $REPO#$PR @ ${SHA:0:9} $(date '+%F %H:%M') (required contexts: ${REQ_CONTEXTS[*]})"
 for i in $(seq 0 "$CYCLES"); do
@@ -64,13 +69,17 @@ for i in $(seq 0 "$CYCLES"); do
   REQLATEST=$(echo "$CR" | jq --argjson app "$REQ_APP_ID" '[.check_runs[]|select(.app.id==$app)]|group_by(.name)|map(sort_by(.started_at)|last)')
   REQRED=$(echo "$REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("failure","cancelled","timed_out","action_required")))]|length')
   REQGREEN=$(echo "$REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and .conclusion=="success")]|length')
+  # A rerun of a required check creates a fresh queued run beside the old
+  # completed one; ANY not-completed run of a required name (across all runs,
+  # not just the latest-pick) blocks readiness until it settles.
+  REQUNSETTLED=$(echo "$CR" | jq --argjson app "$REQ_APP_ID" --argjson req "$REQ_JSON" '[.check_runs[]|select(.app.id==$app)|select(.name as $n|$req|index($n))|select(.status!="completed")]|length')
   # claude-review is a per-SHA commit STATUS (not a check-run); the combined
   # endpoint returns the latest status per context (verified live: a SHA with
   # pending-then-success returned only the success entry). sort_by(created_at)
   # makes the selection order-independent regardless of endpoint ordering.
   # Absent or failure is not clean (AGENTS.md 3c.1.8, docs/REVIEWER_MERGE_GATE.md).
   CLREV=$(GH_TOKEN="$TOK" gh api "repos/$REPO/commits/$SHA/status" --jq '([.statuses[]|select(.context=="claude-review")]|sort_by(.created_at)|last|.state) // "absent"' 2>/dev/null || echo "absent")
-  echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED pending=$PEND threads=$UNRES decision=$DECISION claude-review=$CLREV mergeable=$MERGEABLE"
+  echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED req-unsettled=$REQUNSETTLED pending=$PEND threads=$UNRES decision=$DECISION claude-review=$CLREV mergeable=$MERGEABLE"
   case "$STATE" in MERGED/merged|CLOSED) echo "TERMINAL: PR $STATE"; exit 0;; esac
   # Definite negatives are actionable on ANY cycle, including the first.
   if [ "$REQRED" -gt 0 ] || [ "$UNRES" != "0" ] || [ "$DECISION" = "CHANGES_REQUESTED" ] || [ "$CLREV" = "failure" ]; then
@@ -78,7 +87,7 @@ for i in $(seq 0 "$CYCLES"); do
   fi
   # Readiness is presence-based: every required context must be reporting
   # success (a not-yet-started context keeps this false, so no early race).
-  if [ "$REQGREEN" -eq "$REQ_TOTAL" ] && [ "$MERGEABLE" = "MERGEABLE" ] && [ "$CLREV" = "success" ]; then
+  if [ "$REQGREEN" -eq "$REQ_TOTAL" ] && [ "$REQUNSETTLED" -eq 0 ] && [ "$MERGEABLE" = "MERGEABLE" ] && [ "$CLREV" = "success" ]; then
     echo "MERGE-READY: all $REQ_TOTAL required contexts success + threads clear + claude-review success + mergeable."
     echo "-> pre-merge checklist first (clean tree, local==remote, re-verify threads=0), then merge + alert."
     exit 0

--- a/tests/test_audit_pr_watcher_safety.py
+++ b/tests/test_audit_pr_watcher_safety.py
@@ -185,3 +185,30 @@ def test_repo_only_passes_when_local_watcher_is_absent(tmp_path: Path) -> None:
     result = _run(tmp_path, "--repo-root", str(repo), "--repo-only")
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_fails_on_repo_watcher_source_with_merge_command(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "watch_owned_pr.sh").write_text(
+        "#!/usr/bin/env bash\ngh pr merge \"$PR\" --squash\n",
+        encoding="utf-8",
+    )
+
+    result = _run(tmp_path, "--repo-root", str(repo), "--repo-only")
+
+    assert result.returncode == 1
+    assert "watcher executable must not contain PR merge/delete-branch commands" in result.stdout
+
+
+def test_repo_watcher_source_status_only_passes(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "watch_owned_pr.sh").write_text(
+        "#!/usr/bin/env bash\necho MERGE-READY\n",
+        encoding="utf-8",
+    )
+
+    result = _run(tmp_path, "--repo-root", str(repo), "--repo-only")
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Plan: plans/PR-Overnight-Arc-Workflow.md
Slice phase: Workflow/process

Diff-budget override: 430-line workflow-codification slice, ~35 over the soft cap after review round 1 added the watcher-safety audit enrollment and fail-closed watcher gates; the runbook, its watcher, the contract wiring, and the audit enrollment must land together or the workflow ships in a state its own verification cannot prove (the pre-enrollment audit pass was vacuous).

Codifies the **overnight-arc workflow** in the repo so it survives compaction
and reaches every session lineage -- the same treatment
`docs/PR_RECONSTRUCTION_PROTOCOL.md` got for the review protocol. Previously
the workflow existed only as machine-local session prose, which neither
survives compaction nor reaches other sessions.

- `docs/OVERNIGHT_ARC_WORKFLOW.md` (new): mandatory interactive pre-flight
  (readiness contract + all clarifying questions asked while the operator is
  present), night-loop deltas over the AGENTS section 3 builder contract
  (never wait on the operator; watcher-driven waiting; bot-review round cap
  with the fail-closed-guard exception), true-blocker channel, mandatory
  morning report, kickoff prompt.
- `scripts/watch_owned_pr.sh` (new): portable single-PR watcher; status-only
  (MERGED/CLOSED, HEAD-MOVED, ACTIONABLE, MERGE-READY). MERGE-READY is
  presence-based and fail-closed: EVERY canonical required context (read at
  runtime from `scripts/check_required_status_checks.py`, incl. diff-budget)
  present and success (app-pinned to the GitHub Actions app id from the same
  checker, filtered BEFORE latest-run selection so same-named checks from
  other apps neither green nor mask the gate), plus `claude-review` status
  success (order-independent latest via sort_by created_at; the combined
  endpoint dedupes per context -- verified live), 0 unresolved threads (fail
  closed on unfetched thread pages, via reviewDecision + pageInfo), and no
  CHANGES_REQUESTED. Definite negatives exit on any cycle.
  Holds no merge authority; ENROLLED in the watcher-safety audit (round 1
  showed the prior audit pass was vacuous -- it did not scan these files).
- `.gitignore`: add `worktrees/` so the runbook worktree convention leaves
  the shared checkout clean; `scripts/audit_pr_watcher_safety.py`: scan list
  extended (REPO_DOCS + repo watcher sources) -- detection semantics
  unchanged.
- `AGENTS.md` section 3c.2 (additive): names the runbook governing for
  assigned overnight arcs.
- `CLAUDE.md` Compact Instructions (additive): adds the overnight baton so a
  compacted overnight session resumes from the baton and re-reads the runbook.

## Intentional
- Repo-level codification is the compaction-survival mechanism: repo contract
  docs are re-injected after compaction; session-local prose is not.
- Task-agnostic by operator decision -- no issue queue, scheduler, or fixed
  task list; the task is chosen per night at pre-flight.
- Watcher checks the `claude-review` commit status in addition to required
  check-runs, matching the current two-gate merge rule.

## Deferred
- Scheduled/cron dispatch of overnight arcs (operator spend decision).
- Arc queue / issue-template standardization (task selection explicitly
  deferred by the operator).

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `docs/OVERNIGHT_ARC_WORKFLOW.md:1-151` (new) -- the runbook: pre-flight,
  night-loop deltas, blocker channel, morning report, watcher exit states,
  kickoff prompt. `scripts/watch_owned_pr.sh:1-56` (new) -- status-only watcher;
  derives repo root/origin, polls ~29 min, exits MERGED/CLOSED | HEAD-MOVED |
  ACTIONABLE | MERGE-READY; the MERGE-READY branch additionally requires the
  `claude-review` commit status to be success. `AGENTS.md` (adds section 3c.2
  between 3c.1 and 3d, additive only). `CLAUDE.md` (adds the overnight-baton
  bullet to Compact Instructions + extends the closing sentence, additive
  only). `plans/PR-Overnight-Arc-Workflow.md` (new plan doc).
- Contract match: every change traces to "codify the workflow so it survives
  compaction": the doc is the canonical runbook; the script is the machinery
  the doc references; AGENTS 3c.2 makes it contract-governing; the CLAUDE.md
  baton is the compaction-survival mechanism; the plan doc satisfies the
  AGENTS section 1 process.
- Gaps: none -- no untraced changes. Round 1 revealed one contract revision,
  recorded in the plan: the watcher-safety audit scan list is extended (not
  its semantics) because the pre-enrollment pass was vacuous for the new
  files; and `.gitignore` gains `worktrees/`. Round 2 added the app-id pin,
  order-independent status selection, and regression tests for the audit
  enrollment (tests/test_audit_pr_watcher_safety.py). Round 4 gated readiness
  on mergeStateStatus (CLEAN/UNSTABLE; live-verified MERGEABLE+BLOCKED case),
  paginated check-run fetches, and aligned conclusion classes with branch
  protection (neutral/skipped green; stale/startup_failure red). Round 3 moved the
  required-context/app-pin source to origin/main (trusted ref -- a PR cannot
  weaken its own gate), blocked readiness while a required rerun is queued
  (REQUNSETTLED), and added the claude-review trust-boundary + wake-path
  prerequisites to the runbook pre-flight.

## Waivers
- Round-3 "behavior coverage for the readiness gate" waived under the
  3-round review cap with reason: the watcher is advisory/status-only
  (branch protection is the enforcing gate; the builder re-verifies at the
  pre-merge checklist), so gate-logic tests are hardening, not a merge
  blocker. Follow-up filed: #2065.

## Verification
- `scripts/audit_pr_watcher_safety.py` -- OK with the new files ENROLLED
  (scans scripts/watch_owned_pr.sh + docs/OVERNIGHT_ARC_WORKFLOW.md for
  real now).
- bash -n on the watcher -- OK; live one-cycle smoke against an open PR
  reported state correctly (state/pending/req-red/threads/mergeable).
- Plan-doc audit + plan/code consistency -- OK (all path claims resolve).

## Diff size
5 files, ~342 insertions (docs + one status-only script; no code paths).