### PR TITLE
Install the live PR readiness producer

### DIFF
--- a/.github/workflows/codex_wake_bridge_checks.yml
+++ b/.github/workflows/codex_wake_bridge_checks.yml
@@ -11,11 +11,13 @@ on:
       - "scripts/codex_wake_bridge.py"
       - "scripts/codex_issue_queue.py"
       - "scripts/install_codex_wake_bridge.py"
+      - "scripts/pr_watcher.py"
       - "scripts/report_pr_watcher_state.py"
       - "tests/test_audit_pr_watcher_safety.py"
       - "tests/test_codex_wake_bridge.py"
       - "tests/test_codex_issue_queue.py"
       - "tests/test_install_codex_wake_bridge.py"
+      - "tests/test_pr_watcher.py"
       - "tests/test_report_pr_watcher_state.py"
 
 jobs:
@@ -38,6 +40,7 @@ jobs:
             tests/test_codex_wake_bridge.py \
             tests/test_codex_issue_queue.py \
             tests/test_install_codex_wake_bridge.py \
+            tests/test_pr_watcher.py \
             tests/test_report_pr_watcher_state.py \
             tests/test_audit_pr_watcher_safety.py \
             -q

--- a/docs/long_running_session_watcher_handoff.md
+++ b/docs/long_running_session_watcher_handoff.md
@@ -274,10 +274,11 @@ EOF
 ```
 
 Install the repo-owned watcher producer, bridge wrapper, trusted bridge copy,
-and systemd drop-in through the installer. The wrapper invokes the installed
-watcher and bridge copies rather than executing either script from the watched
-PR worktree. One systemd template can safely serve multiple sessions without
-baking one worktree path into every timer.
+AI-reconciliation checker and parser dependency, and systemd drop-in through
+the installer. The watcher and wrapper invoke those installed copies rather
+than executing scripts from the watched PR worktree. One systemd template can
+safely serve multiple sessions without baking one worktree path into every
+timer.
 
 ```bash
 python scripts/install_codex_wake_bridge.py --reload-systemd
@@ -315,9 +316,9 @@ systemctl --user disable --now "atlas-pr-watch@${SESSION_ID}.timer"
 
 | State | Meaning | Builder action |
 |---|---|---|
-| `pending` | At least one check is still pending | Record the next poll; do not ask the operator to babysit CI |
+| `pending` | At least one check is still pending and no new review/comment activity was observed | Record the next poll; do not ask the operator to babysit CI |
 | `attention` | Red/canceled check, failed AI reconciliation, or status details such as `head_mismatch: true` | Inspect the owned PR, fix the root cause in-scope, push, update watcher config head SHA. If `head_mismatch` is true, follow the stop/fetch/inspect branch before any force-push or merge |
-| `review_changed` | New review/comment activity since last poll | Inspect comments before any merge decision |
+| `review_changed` | New review/comment activity since last poll, including while checks are pending | Inspect comments before any merge decision |
 | `ready_for_human_merge` | The snapshot label and version-1 proof agree: same open/non-draft head, required checks complete/green, all thread pages fetched, zero unresolved threads, no changes requested, clean merge state | Run `scripts/report_pr_watcher_state.py`; missing/contradictory proof is reported as attention. Otherwise report readiness or perform the active-builder guarded merge only when explicitly authorized and after fresh live guards |
 
 The installed producer reads branch protection's required-context inventory,
@@ -328,6 +329,8 @@ the observed set. A changed head, empty/malformed required policy, unreported
 required context, incomplete pagination, unresolved thread (including
 outdated), or GitHub read error cannot produce a ready proof. The JSON snapshot
 is replaced atomically so the bridge/reporter cannot consume a partial file.
+Live AI reconciliation runs from the exact checker and parser sources installed
+beside the watcher; it never executes the watched PR worktree's checker.
 
 ## Prompt For Other Builder Sessions
 

--- a/docs/long_running_session_watcher_handoff.md
+++ b/docs/long_running_session_watcher_handoff.md
@@ -28,10 +28,12 @@ Long-running sessions now have two durable responsibilities:
 2. Record the actual wake mode after each PR open or push: Claude Code native
    subscription/polling, a Codex wake bridge, or local watcher state-only.
 
-The local watcher is intentionally local and per session. One Codex/local
-session equals one watcher config. A second Codex/local session should create a
-second config and timer rather than reuse another session's watcher. Claude Code
-native sessions do not need this local watcher path.
+The watcher executable is an installed copy of repo-owned
+`scripts/pr_watcher.py`; its configs and output remain intentionally local and
+per session. One Codex/local session equals one watcher config. A second
+Codex/local session should create a second config and timer rather than reuse
+another session's watcher. Claude Code native sessions do not need this local
+watcher path.
 
 ## Wake Modes
 
@@ -63,7 +65,7 @@ These files are local machine infrastructure, not committed repo files:
 
 | Path | Purpose |
 |---|---|
-| `~/.local/bin/atlas-pr-watch` | One-shot watcher executable |
+| `~/.local/bin/atlas-pr-watch` | Installed repo-owned one-shot producer (`scripts/pr_watcher.py`) |
 | `~/.config/systemd/user/atlas-pr-watch@.service` | User systemd service template |
 | `~/.config/systemd/user/atlas-pr-watch@.timer` | User systemd timer template, every 30 minutes |
 | `~/.config/atlas-pr-watchers/<session-id>.env` | One config per builder session |
@@ -73,9 +75,9 @@ These files are local machine infrastructure, not committed repo files:
 | `~/.local/state/atlas-pr-watchers/<session-id>.log` | Append-only watcher log |
 
 If a Codex/local session is using local watcher state and
-`~/.local/bin/atlas-pr-watch` is missing, stop and ask the operator. Do not
-recreate a merge-capable watcher from scratch. The watcher must stay read-only
-with respect to GitHub merges.
+`~/.local/bin/atlas-pr-watch` is missing or drifted, run the repo-owned
+installer and its `--check` mode. Do not recreate a watcher from ad hoc local
+source. The watcher must stay read-only with respect to GitHub merges.
 
 ## Push/Review-Event Hook
 
@@ -271,12 +273,11 @@ NOTIFY="1"
 EOF
 ```
 
-Install the bridge wrapper, trusted bridge copy, and systemd drop-in through the
-repo-owned installer. The wrapper reads `REPO_DIR` from the session config each
-time it runs, but it invokes the installed bridge copy rather than executing
-`scripts/codex_wake_bridge.py` from the watched PR worktree. One systemd
-template can safely serve multiple sessions without baking one worktree path
-into every timer.
+Install the repo-owned watcher producer, bridge wrapper, trusted bridge copy,
+and systemd drop-in through the installer. The wrapper invokes the installed
+watcher and bridge copies rather than executing either script from the watched
+PR worktree. One systemd template can safely serve multiple sessions without
+baking one worktree path into every timer.
 
 ```bash
 python scripts/install_codex_wake_bridge.py --reload-systemd
@@ -318,6 +319,15 @@ systemctl --user disable --now "atlas-pr-watch@${SESSION_ID}.timer"
 | `attention` | Red/canceled check, failed AI reconciliation, or status details such as `head_mismatch: true` | Inspect the owned PR, fix the root cause in-scope, push, update watcher config head SHA. If `head_mismatch` is true, follow the stop/fetch/inspect branch before any force-push or merge |
 | `review_changed` | New review/comment activity since last poll | Inspect comments before any merge decision |
 | `ready_for_human_merge` | The snapshot label and version-1 proof agree: same open/non-draft head, required checks complete/green, all thread pages fetched, zero unresolved threads, no changes requested, clean merge state | Run `scripts/report_pr_watcher_state.py`; missing/contradictory proof is reported as attention. Otherwise report readiness or perform the active-builder guarded merge only when explicitly authorized and after fresh live guards |
+
+The installed producer reads branch protection's required-context inventory,
+compares it with `gh pr checks --required`, fetches every GraphQL
+`reviewThreads` page, and reads PR metadata again after those calls. This
+prevents a required context that has not reported yet from disappearing from
+the observed set. A changed head, empty/malformed required policy, unreported
+required context, incomplete pagination, unresolved thread (including
+outdated), or GitHub read error cannot produce a ready proof. The JSON snapshot
+is replaced atomically so the bridge/reporter cannot consume a partial file.
 
 ## Prompt For Other Builder Sessions
 

--- a/plans/PR-Watcher-Live-Readiness-Producer.md
+++ b/plans/PR-Watcher-Live-Readiness-Producer.md
@@ -1,0 +1,186 @@
+# PR-Watcher-Live-Readiness-Producer
+
+## Why this slice exists
+
+The operator asked to continue the Atlas overnight-PR safety arc after
+`PR-Watcher-Zero-Thread-Readiness` merged as #2062. That predecessor made the
+wake bridge and reporter reject incomplete readiness snapshots, but it
+intentionally left the only scheduled producer as an untracked
+`~/.local/bin/atlas-pr-watch` file. The live file still summarizes all checks
+without discovering the required subset, counts comments/reviews without
+fetching review threads, reads the PR head only once, and never emits the
+version-1 proof. The consumers are now safely fail-closed, but no scheduled
+watcher can truthfully reach ready.
+
+This workflow/process slice is justified by a release-gate safety risk and the
+real failed reachability left by #2062: a machine-local producer outside CI can
+silently drift from the merge-readiness contract. Diff-budget override: the
+installed-runtime slice exceeds the 400-LOC target because the producer,
+adversarial GitHub transport fixtures, installer reachability, documentation,
+and dedicated CI enrollment are one indivisible trust boundary. Splitting them
+would ship either uninstalled floating code or an installed release gate
+without failure-branch proof.
+
+### Problem-derived contract
+
+- Root cause: the scheduled watcher executable is machine-local rather than
+  repository-owned, so source review and CI cannot enforce how it discovers
+  GitHub state or whether its `ready_for_human_merge` label is backed by the
+  version-1 proof. Its single head read also leaves a check-collection race.
+- Correct fix must touch/change: add one repo-owned one-shot watcher producer;
+  install and verify that exact source through the existing wake-bridge
+  installer; fetch all checks plus the actual required subset, paginate every
+  review-thread page, retain unresolved outdated threads, re-read the head
+  after collection, run reconciliation, and atomically write the existing
+  snapshot with the version-1 proof; make every API, schema, pagination,
+  required-set, head-race, review, and merge-state failure non-ready; enroll
+  the installed entrypoint and negative fixtures in dedicated CI.
+- Must not change: do not add GitHub mutation or merge commands, do not change
+  the version-1 consumer contract or wake classifications from #2062, do not
+  change AI-reconciliation semantics, do not mutate branch protection, do not
+  modify open PR #2063 or its foreground shell watcher, and do not touch any
+  product/runtime lane.
+
+## Scope (this PR)
+
+Ownership lane: workflow/pr-watcher-readiness
+Slice phase: Workflow/process
+
+Max files: 7
+
+1. Replace the untracked scheduled producer with a repository-owned installed
+   copy that preserves the current config/state/session-log interface while
+   emitting the version-1 readiness proof.
+2. Discover required checks separately from the all-check attention summary,
+   fetch every review-thread page, and double-read the PR head so incomplete,
+   malformed, stale, or contradictory observations fail closed.
+3. Prove the real installed CLI writes a consumer-accepted snapshot and enroll
+   every changed watcher/installer test in the dedicated PR-head job.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The existing installer writes and `--check` verifies an executable
+        `atlas-pr-watch` byte-for-byte from repository source; its wrapper calls
+        that installed path rather than assuming `~/.local/bin`.
+  - [ ] A one-shot poll fetches the same open, non-draft head before and after
+        collection, branch protection's required-context inventory, all check
+        runs, the currently reported required runs, every review-thread page,
+        the current review decision/merge state, and live reconciliation before
+        it can label the snapshot ready.
+  - [ ] Only required checks with pass buckets are complete/green; empty,
+        unreported, pending, failed, canceled, skipped, unknown, or malformed
+        required results/policy cannot produce ready.
+  - [ ] Thread pagination is complete and bounded; every unresolved thread,
+        including outdated threads, appears in the proof and blocks ready.
+  - [ ] GitHub command failures, GraphQL `errors`, malformed envelopes, missing
+        cursors, page-cap exhaustion, changed heads, dirty worktrees, drafts,
+        changes requested, and non-clean merge states all fail closed with
+        diagnosable snapshot fields or a non-zero producer error.
+  - [ ] Snapshot replacement is atomic, and untrusted PR text written to the
+        session-state/log receipt cannot inject multiline control text.
+  - [ ] The dedicated workflow path filters and pytest command execute the new
+        producer tests plus every modified installer test.
+- Reachability proof: install into temporary bin/systemd directories, execute
+  the installed `atlas-pr-watch` entrypoint against a fake outermost `gh`
+  transport and real config/state filesystem, then assert the observable JSON
+  is accepted by `scripts/codex_wake_bridge.py::readiness_blockers`.
+- Affected surfaces: developer tooling, GitHub CLI transport, local watcher
+  installation, scheduled watcher state, CI enrollment, operator handoff docs.
+- Risk areas: false-green merge readiness, head/check races, incomplete
+  pagination, untrusted GitHub text, atomic state publication, installer drift,
+  backward compatibility with existing watcher configs.
+- Reviewer rules triggered: R1, R2, R3, R6, R7, R8, R10, R12, R14.
+
+### Files touched
+
+- `.github/workflows/codex_wake_bridge_checks.yml`
+- `docs/long_running_session_watcher_handoff.md`
+- `plans/PR-Watcher-Live-Readiness-Producer.md`
+- `scripts/install_codex_wake_bridge.py`
+- `scripts/pr_watcher.py`
+- `tests/test_install_codex_wake_bridge.py`
+- `tests/test_pr_watcher.py`
+
+## Mechanism
+
+`scripts/pr_watcher.py` is a standalone one-shot producer copied to
+`atlas-pr-watch` by `scripts/install_codex_wake_bridge.py`. It loads the
+existing per-session config, performs argument-vector-only `gh` calls, and
+keeps all GitHub access behind the subprocess transport. It reads PR metadata,
+branch protection's required-context policy, all checks, currently reported
+required checks, flat review activity, and paginated GraphQL review threads;
+runs the existing reconciliation checker; reads PR metadata again; and
+classifies only a stable observation. Comparing policy contexts with reported
+required runs prevents a required job that has not materialized from vanishing
+from the proof. The proof stores the initial evaluated head, required-check
+results, complete pagination receipt, unresolved thread descriptors without
+comment bodies, review decision, and merge state.
+
+Pending check runs remain `pending`; API/schema/head/required/thread/review or
+merge blockers become `attention`; a closed PR becomes `closed`; only a proof
+that the #2062 consumer predicate accepts becomes
+`ready_for_human_merge`. JSON is written through a same-directory temporary
+file plus `os.replace`, so concurrent reporters never see half a snapshot.
+Human-readable receipts collapse GitHub-controlled fields to one line before
+updating the local session state/log.
+
+The existing installer copies the watcher, bridge, and wrapper as one versioned
+installation and verifies exact content plus executability. The
+installed-entrypoint test proves the actual executable path reaches a
+version-1 state file.
+
+## Intentional
+
+- The version-1 proof contract from #2062 is unchanged. `claude-review` is not
+  invented as an "actual required" check while branch protection does not
+  require it; AGENTS live merge guards still require that separate review gate
+  before any active builder merge.
+- Skipped required checks fail closed even if GitHub might otherwise consider
+  a skipped job satisfied. A release gate that did not execute is not evidence
+  of green behavior.
+- The GraphQL proof stores thread identifiers/locations/resolution flags, not
+  comment bodies. Bodies are unnecessary for a zero-thread invariant and are
+  untrusted prompt material.
+- Open PR #2063 owns a foreground overnight status script. This slice does not
+  edit or depend on that branch; the installed systemd JSON producer and the
+  foreground watcher remain separate entrypoints with separate state duties.
+
+## Deferred
+
+- Global branch-protection changes remain operator-owned: enable required
+  conversation resolution after parallel lanes are assessed; reconcile the
+  live required set with repo policy (`diff-budget` is currently absent); and
+  require `claude-review` only after a distinct reviewer identity exists.
+- Central repo-only safety-audit enrollment for `scripts/pr_watcher.py` is a
+  follow-up after open PR #2063 lands. That PR already owns the exact
+  `REPO_WATCHER_SOURCES` and `build_findings` hunks required to establish the
+  shared registry, so this slice must not create a conflicting second owner.
+- A true review-event-to-Codex wake integration remains outside this producer;
+  it records scheduled state and the existing bridge builds the handoff.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_codex_wake_bridge.py tests/test_codex_issue_queue.py tests/test_install_codex_wake_bridge.py tests/test_pr_watcher.py tests/test_report_pr_watcher_state.py tests/test_audit_pr_watcher_safety.py -q` - 148 passed.
+- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - ratchet passed; the new producer scores 4 with no new brittleness above baseline.
+- Temporary `install_codex_wake_bridge.py` install + `--check`, installed watcher/bridge `--help`, and installed-source watcher safety audit - passed.
+- `python scripts/audit_pr_watcher_safety.py --repo-root . --repo-only` - passed for the audit's current registered surfaces.
+- `python scripts/audit_workflow_security_posture.py .github/workflows` - passed with pre-existing warnings only.
+- `python scripts/sync_pr_plan.py plans/PR-Watcher-Live-Readiness-Producer.md --check` - passed.
+- `git diff --check` and focused `py_compile` - passed.
+- Pending before push: the single `push_pr.sh` local-review run.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/codex_wake_bridge_checks.yml` | 3 |
+| `docs/long_running_session_watcher_handoff.md` | 38 |
+| `plans/PR-Watcher-Live-Readiness-Producer.md` | 186 |
+| `scripts/install_codex_wake_bridge.py` | 52 |
+| `scripts/pr_watcher.py` | 736 |
+| `tests/test_install_codex_wake_bridge.py` | 43 |
+| `tests/test_pr_watcher.py` | 711 |
+| **Total** | **1769** |

--- a/plans/PR-Watcher-Live-Readiness-Producer.md
+++ b/plans/PR-Watcher-Live-Readiness-Producer.md
@@ -31,8 +31,9 @@ without failure-branch proof.
   install and verify that exact source through the existing wake-bridge
   installer; fetch all checks plus the actual required subset, paginate every
   review-thread page, retain unresolved outdated threads, re-read the head
-  after collection, run reconciliation, and atomically write the existing
-  snapshot with the version-1 proof; make every API, schema, pagination,
+  after collection, run reconciliation from an installed trusted copy, and
+  atomically write the existing snapshot with the version-1 proof; make every
+  API, schema, pagination,
   required-set, head-race, review, and merge-state failure non-ready; enroll
   the installed entrypoint and negative fixtures in dedicated CI.
 - Must not change: do not add GitHub mutation or merge commands, do not change
@@ -63,6 +64,9 @@ Max files: 7
   - [ ] The existing installer writes and `--check` verifies an executable
         `atlas-pr-watch` byte-for-byte from repository source; its wrapper calls
         that installed path rather than assuming `~/.local/bin`.
+  - [ ] The installer writes and verifies the reconciliation checker plus its
+        parser dependency, and the watcher never executes reconciliation code
+        from the watched PR worktree.
   - [ ] A one-shot poll fetches the same open, non-draft head before and after
         collection, branch protection's required-context inventory, all check
         runs, the currently reported required runs, every review-thread page,
@@ -79,6 +83,8 @@ Max files: 7
         diagnosable snapshot fields or a non-zero producer error.
   - [ ] Snapshot replacement is atomic, and untrusted PR text written to the
         session-state/log receipt cannot inject multiline control text.
+  - [ ] New review/comment activity produces `review_changed` even when checks
+        are pending, so attention events are not silently swallowed.
   - [ ] The dedicated workflow path filters and pytest command execute the new
         producer tests plus every modified installer test.
 - Reachability proof: install into temporary bin/systemd directories, execute
@@ -110,7 +116,7 @@ existing per-session config, performs argument-vector-only `gh` calls, and
 keeps all GitHub access behind the subprocess transport. It reads PR metadata,
 branch protection's required-context policy, all checks, currently reported
 required checks, flat review activity, and paginated GraphQL review threads;
-runs the existing reconciliation checker; reads PR metadata again; and
+runs the installed trusted reconciliation checker; reads PR metadata again; and
 classifies only a stable observation. Comparing policy contexts with reported
 required runs prevents a required job that has not materialized from vanishing
 from the proof. The proof stores the initial evaluated head, required-check
@@ -125,8 +131,9 @@ file plus `os.replace`, so concurrent reporters never see half a snapshot.
 Human-readable receipts collapse GitHub-controlled fields to one line before
 updating the local session state/log.
 
-The existing installer copies the watcher, bridge, and wrapper as one versioned
-installation and verifies exact content plus executability. The
+The existing installer copies the watcher, bridge, reconciliation checker and
+parser dependency, and wrapper as one versioned installation and verifies
+exact content plus executability. The
 installed-entrypoint test proves the actual executable path reaches a
 version-1 state file.
 
@@ -163,9 +170,9 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_codex_wake_bridge.py tests/test_codex_issue_queue.py tests/test_install_codex_wake_bridge.py tests/test_pr_watcher.py tests/test_report_pr_watcher_state.py tests/test_audit_pr_watcher_safety.py -q` - 148 passed.
+- `python -m pytest tests/test_codex_wake_bridge.py tests/test_codex_issue_queue.py tests/test_install_codex_wake_bridge.py tests/test_pr_watcher.py tests/test_report_pr_watcher_state.py tests/test_audit_pr_watcher_safety.py -q` - 152 passed.
 - `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - ratchet passed; the new producer scores 4 with no new brittleness above baseline.
-- Temporary `install_codex_wake_bridge.py` install + `--check`, installed watcher/bridge `--help`, and installed-source watcher safety audit - passed.
+- Temporary `install_codex_wake_bridge.py` install + `--check`, installed watcher/bridge/reconciliation-checker `--help`, and installed-source watcher safety audit - passed.
 - `python scripts/audit_pr_watcher_safety.py --repo-root . --repo-only` - passed for the audit's current registered surfaces.
 - `python scripts/audit_workflow_security_posture.py .github/workflows` - passed with pre-existing warnings only.
 - `python scripts/sync_pr_plan.py plans/PR-Watcher-Live-Readiness-Producer.md --check` - passed.
@@ -177,10 +184,10 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `.github/workflows/codex_wake_bridge_checks.yml` | 3 |
-| `docs/long_running_session_watcher_handoff.md` | 38 |
-| `plans/PR-Watcher-Live-Readiness-Producer.md` | 186 |
-| `scripts/install_codex_wake_bridge.py` | 52 |
-| `scripts/pr_watcher.py` | 736 |
-| `tests/test_install_codex_wake_bridge.py` | 43 |
-| `tests/test_pr_watcher.py` | 711 |
-| **Total** | **1769** |
+| `docs/long_running_session_watcher_handoff.md` | 45 |
+| `plans/PR-Watcher-Live-Readiness-Producer.md` | 193 |
+| `scripts/install_codex_wake_bridge.py` | 77 |
+| `scripts/pr_watcher.py` | 743 |
+| `tests/test_install_codex_wake_bridge.py` | 80 |
+| `tests/test_pr_watcher.py` | 773 |
+| **Total** | **1914** |

--- a/scripts/install_codex_wake_bridge.py
+++ b/scripts/install_codex_wake_bridge.py
@@ -18,9 +18,14 @@ from typing import Sequence
 WRAPPER_NAME = "atlas-pr-watch-and-wake"
 BRIDGE_NAME = "atlas-codex-wake-bridge"
 WATCHER_NAME = "atlas-pr-watch"
+RECONCILIATION_LIB_DIR = "atlas-pr-watch-lib"
+RECONCILIATION_CHECKER_NAME = "check_ai_reconciliation_live.py"
+RECONCILIATION_AUDIT_NAME = "audit_ai_reconciliation.py"
 DROPIN_REL = Path("atlas-pr-watch@.service.d") / "wake-bridge.conf"
 BRIDGE_SOURCE = Path(__file__).with_name("codex_wake_bridge.py")
 WATCHER_SOURCE = Path(__file__).with_name("pr_watcher.py")
+RECONCILIATION_CHECKER_SOURCE = Path(__file__).with_name(RECONCILIATION_CHECKER_NAME)
+RECONCILIATION_AUDIT_SOURCE = Path(__file__).with_name(RECONCILIATION_AUDIT_NAME)
 
 
 def _shell_token(path: Path) -> str:
@@ -66,6 +71,14 @@ def _bridge_text() -> str:
 
 def _watcher_text() -> str:
     return WATCHER_SOURCE.read_text(encoding="utf-8")
+
+
+def _reconciliation_checker_text() -> str:
+    return RECONCILIATION_CHECKER_SOURCE.read_text(encoding="utf-8")
+
+
+def _reconciliation_audit_text() -> str:
+    return RECONCILIATION_AUDIT_SOURCE.read_text(encoding="utf-8")
 
 
 def _systemd_exec_token(path: Path) -> str:
@@ -117,10 +130,15 @@ def check_install(bin_dir: Path, systemd_dir: Path) -> tuple[bool, list[str]]:
     wrapper = bin_dir / WRAPPER_NAME
     bridge = bin_dir / BRIDGE_NAME
     watcher = bin_dir / WATCHER_NAME
+    reconciliation_dir = bin_dir / RECONCILIATION_LIB_DIR
+    reconciliation_checker = reconciliation_dir / RECONCILIATION_CHECKER_NAME
+    reconciliation_audit = reconciliation_dir / RECONCILIATION_AUDIT_NAME
     checks = [
         _matches(wrapper, _wrapper_text(watcher, bridge), executable=True),
         _matches(bridge, _bridge_text(), executable=True),
         _matches(watcher, _watcher_text(), executable=True),
+        _matches(reconciliation_checker, _reconciliation_checker_text()),
+        _matches(reconciliation_audit, _reconciliation_audit_text()),
         _matches(systemd_dir / DROPIN_REL, _dropin_text(wrapper)),
     ]
     ok = all(passed for passed, _message in checks)
@@ -131,12 +149,19 @@ def install(bin_dir: Path, systemd_dir: Path, *, reload_systemd: bool) -> tuple[
     wrapper = bin_dir / WRAPPER_NAME
     bridge = bin_dir / BRIDGE_NAME
     watcher = bin_dir / WATCHER_NAME
+    reconciliation_dir = bin_dir / RECONCILIATION_LIB_DIR
+    reconciliation_checker = reconciliation_dir / RECONCILIATION_CHECKER_NAME
+    reconciliation_audit = reconciliation_dir / RECONCILIATION_AUDIT_NAME
     dropin = systemd_dir / DROPIN_REL
+    _write(reconciliation_audit, _reconciliation_audit_text())
+    _write(reconciliation_checker, _reconciliation_checker_text())
     _write(bridge, _bridge_text(), executable=True)
     _write(watcher, _watcher_text(), executable=True)
     _write(wrapper, _wrapper_text(watcher, bridge), executable=True)
     _write(dropin, _dropin_text(wrapper))
     messages = [
+        f"wrote: {reconciliation_audit}",
+        f"wrote: {reconciliation_checker}",
         f"wrote: {bridge}",
         f"wrote: {watcher}",
         f"wrote: {wrapper}",

--- a/scripts/install_codex_wake_bridge.py
+++ b/scripts/install_codex_wake_bridge.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Install or verify the local Codex watcher wake wrapper.
+"""Install or verify the repo-owned PR watcher and Codex wake wrapper.
 
-This writes local user files only. The wrapper keeps the watcher read-only:
-it runs the one-shot watcher, then asks the repo bridge to build/run the Codex
-handoff for scheduled wakes.
+This writes local user files only. The installed producer and wrapper keep the
+watcher read-only: they record one snapshot, then ask the bridge to build/run
+the Codex handoff for scheduled wakes.
 """
 from __future__ import annotations
 
@@ -17,8 +17,10 @@ from typing import Sequence
 
 WRAPPER_NAME = "atlas-pr-watch-and-wake"
 BRIDGE_NAME = "atlas-codex-wake-bridge"
+WATCHER_NAME = "atlas-pr-watch"
 DROPIN_REL = Path("atlas-pr-watch@.service.d") / "wake-bridge.conf"
 BRIDGE_SOURCE = Path(__file__).with_name("codex_wake_bridge.py")
+WATCHER_SOURCE = Path(__file__).with_name("pr_watcher.py")
 
 
 def _shell_token(path: Path) -> str:
@@ -26,10 +28,11 @@ def _shell_token(path: Path) -> str:
     return f"'{escaped}'"
 
 
-def _wrapper_text(bridge: Path) -> str:
+def _wrapper_text(watcher: Path, bridge: Path) -> str:
     return f"""#!/usr/bin/env bash
 set -euo pipefail
 session_id="${{1:?watcher session id required}}"
+watcher={_shell_token(watcher)}
 bridge={_shell_token(bridge)}
 
 if [[ ! "$session_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || [[ "$session_id" == *..* ]]; then
@@ -52,13 +55,18 @@ if [ -z "${{REPO_DIR:-}}" ] || [ ! -d "$REPO_DIR" ]; then
   exit 2
 fi
 
-~/.local/bin/atlas-pr-watch "${{session_id}}"
+"$watcher" "${{session_id}}"
 python "$bridge" "${{session_id}}" --source scheduled
 """
 
 
 def _bridge_text() -> str:
     return BRIDGE_SOURCE.read_text(encoding="utf-8")
+
+
+def _watcher_text() -> str:
+    return WATCHER_SOURCE.read_text(encoding="utf-8")
+
 
 def _systemd_exec_token(path: Path) -> str:
     resolved = path.expanduser().resolve(strict=False)
@@ -80,10 +88,15 @@ ExecStart={_systemd_exec_token(wrapper)} %i
 
 def _write(path: Path, text: str, *, executable: bool = False) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
-    if executable:
-        mode = path.stat().st_mode
-        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    staged_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        staged_path.write_text(text, encoding="utf-8")
+        if executable:
+            mode = staged_path.stat().st_mode
+            staged_path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.replace(staged_path, path)
+    finally:
+        staged_path.unlink(missing_ok=True)
 
 
 def _matches(path: Path, expected: str, *, executable: bool = False) -> tuple[bool, str]:
@@ -103,23 +116,32 @@ def _matches(path: Path, expected: str, *, executable: bool = False) -> tuple[bo
 def check_install(bin_dir: Path, systemd_dir: Path) -> tuple[bool, list[str]]:
     wrapper = bin_dir / WRAPPER_NAME
     bridge = bin_dir / BRIDGE_NAME
+    watcher = bin_dir / WATCHER_NAME
     checks = [
-        _matches(wrapper, _wrapper_text(bridge), executable=True),
+        _matches(wrapper, _wrapper_text(watcher, bridge), executable=True),
         _matches(bridge, _bridge_text(), executable=True),
+        _matches(watcher, _watcher_text(), executable=True),
         _matches(systemd_dir / DROPIN_REL, _dropin_text(wrapper)),
     ]
-    ok = all(item[0] for item in checks)
-    return ok, [item[1] for item in checks]
+    ok = all(passed for passed, _message in checks)
+    return ok, [message for _passed, message in checks]
 
 
 def install(bin_dir: Path, systemd_dir: Path, *, reload_systemd: bool) -> tuple[int, list[str]]:
     wrapper = bin_dir / WRAPPER_NAME
     bridge = bin_dir / BRIDGE_NAME
+    watcher = bin_dir / WATCHER_NAME
     dropin = systemd_dir / DROPIN_REL
-    _write(wrapper, _wrapper_text(bridge), executable=True)
     _write(bridge, _bridge_text(), executable=True)
+    _write(watcher, _watcher_text(), executable=True)
+    _write(wrapper, _wrapper_text(watcher, bridge), executable=True)
     _write(dropin, _dropin_text(wrapper))
-    messages = [f"wrote: {wrapper}", f"wrote: {bridge}", f"wrote: {dropin}"]
+    messages = [
+        f"wrote: {bridge}",
+        f"wrote: {watcher}",
+        f"wrote: {wrapper}",
+        f"wrote: {dropin}",
+    ]
     exit_code = 0
     if reload_systemd:
         proc = subprocess.run(

--- a/scripts/pr_watcher.py
+++ b/scripts/pr_watcher.py
@@ -1,0 +1,736 @@
+#!/usr/bin/env python3
+"""Produce one fail-closed Atlas PR watcher snapshot.
+
+The systemd timer invokes an installed copy of this file. The producer reads
+GitHub and local worktree state, writes a versioned readiness proof, and never
+mutates or merges a pull request.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import Any, Sequence
+from urllib.parse import quote
+
+
+HOME = Path.home()
+DEFAULT_CONFIG_DIR = HOME / ".config" / "atlas-pr-watchers"
+DEFAULT_STATE_DIR = HOME / ".local" / "state" / "atlas-pr-watchers"
+MARKER_START = "<!-- atlas-pr-watch:start -->"
+MARKER_END = "<!-- atlas-pr-watch:end -->"
+SAFE_WATCHER_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+VALID_CHECK_EXIT_CODES = {0, 1, 8}
+MAX_THREAD_PAGES = 50
+COMMAND_TIMEOUT_SECONDS = 60
+
+THREADS_QUERY = """
+query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:100, after:$cursor){
+        pageInfo{ hasNextPage endCursor }
+        nodes{ id isResolved isOutdated path line }
+      }
+    }
+  }
+}
+"""
+
+
+def _valid_watcher_id(value: str) -> bool:
+    return bool(SAFE_WATCHER_ID_RE.fullmatch(value)) and ".." not in value and not value.startswith(".")
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"invalid config line in {path}: {raw_line!r}")
+        key, raw_value = line.split("=", 1)
+        parts = shlex.split(raw_value.strip()) if raw_value.strip() else []
+        if len(parts) > 1:
+            raise ValueError(f"config value must be quoted in {path}: {key.strip()}")
+        values[key.strip()] = next(iter(parts), "")
+    return values
+
+
+def _run(command: Sequence[str], *, cwd: Path) -> tuple[int, str, str]:
+    program = next(iter(command), "")
+    if not program:
+        return 127, "", "cannot run an empty command"
+    try:
+        proc = subprocess.run(
+            list(command),
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", f"command timed out after {COMMAND_TIMEOUT_SECONDS}s: {program}"
+    except OSError as exc:
+        return 127, "", f"could not run {program}: {exc}"
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _run_json(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    allowed_codes: set[int],
+    expected_type: type,
+) -> tuple[Any | None, str | None]:
+    program = next(iter(command), "command")
+    code, stdout, stderr = _run(command, cwd=cwd)
+    if code not in allowed_codes:
+        detail = stderr or stdout or f"exit {code}"
+        return None, f"{program} command failed ({code}): {detail}"
+    try:
+        value = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return None, f"{program} returned invalid JSON: {exc}"
+    if not isinstance(value, expected_type):
+        return None, f"{program} JSON must be {expected_type.__name__}"
+    return value, None
+
+
+def _pr_view_command(pr: str, repo: str) -> list[str]:
+    return [
+        "gh",
+        "pr",
+        "view",
+        pr,
+        "--repo",
+        repo,
+        "--json",
+        "number,title,url,baseRefName,headRefName,headRefOid,mergeStateStatus,reviewDecision,isDraft,state",
+    ]
+
+
+def _validate_pr_metadata(value: dict[str, Any], *, label: str) -> str | None:
+    number = value.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+        return f"{label} PR metadata has no positive number"
+    for key in (
+        "title",
+        "url",
+        "baseRefName",
+        "headRefName",
+        "headRefOid",
+        "mergeStateStatus",
+        "state",
+    ):
+        if not isinstance(value.get(key), str) or not value[key]:
+            return f"{label} PR metadata has no {key}"
+    if not isinstance(value.get("isDraft"), bool):
+        return f"{label} PR metadata has no boolean isDraft"
+    review_decision = value.get("reviewDecision")
+    if "reviewDecision" not in value or (
+        review_decision is not None and not isinstance(review_decision, str)
+    ):
+        return f"{label} PR metadata has malformed reviewDecision"
+    return None
+
+
+def _checks_command(pr: str, repo: str, *, required: bool) -> list[str]:
+    command = [
+        "gh",
+        "pr",
+        "checks",
+        pr,
+        "--repo",
+        repo,
+        "--json",
+        "name,state,bucket,link,workflow,startedAt,completedAt,description,event",
+    ]
+    if required:
+        command.append("--required")
+    return command
+
+
+def _required_policy_command(repo: str, base_ref: str) -> list[str]:
+    encoded_ref = quote(base_ref, safe="")
+    return [
+        "gh",
+        "api",
+        f"repos/{repo}/branches/{encoded_ref}/protection/required_status_checks",
+    ]
+
+
+def _required_contexts(payload: dict[str, Any]) -> tuple[set[str], str | None]:
+    raw_contexts = payload.get("contexts")
+    raw_checks = payload.get("checks")
+    if not isinstance(raw_contexts, list) or not isinstance(raw_checks, list):
+        return set(), "required-status policy contexts/checks are malformed"
+    contexts: set[str] = set()
+    for index, item in enumerate(raw_contexts):
+        if not isinstance(item, str) or not item:
+            return set(), f"required-status context {index} is malformed"
+        contexts.add(item)
+    for index, item in enumerate(raw_checks):
+        if not isinstance(item, dict):
+            return set(), f"required-status check {index} is not an object"
+        context = item.get("context")
+        if not isinstance(context, str) or not context:
+            return set(), f"required-status check {index} has no context"
+        contexts.add(context)
+    return contexts, None
+
+
+def _check_summary(checks: list[Any], *, required: bool) -> tuple[list[str], list[str], str | None]:
+    failures: list[str] = []
+    pending: list[str] = []
+    for index, item in enumerate(checks):
+        if not isinstance(item, dict):
+            return [], [], f"check result {index} is not an object"
+        name = item.get("name")
+        bucket = item.get("bucket")
+        if not isinstance(name, str) or not name:
+            return [], [], f"check result {index} has no name"
+        if not isinstance(bucket, str) or not bucket:
+            return [], [], f"check {name!r} has no bucket"
+        normalized = bucket.lower()
+        if normalized == "pass":
+            continue
+        if normalized == "pending":
+            pending.append(name)
+            continue
+        if not required and normalized == "skipping":
+            continue
+        failures.append(f"{name} ({normalized})")
+    return failures, pending, None
+
+
+def _repo_parts(repo: str) -> tuple[str, str]:
+    owner, separator, name = repo.partition("/")
+    if not separator or not owner or not name or "/" in name:
+        raise ValueError("REPO must be an owner/name slug")
+    return owner, name
+
+
+def _fetch_threads(pr: int, repo: str, *, cwd: Path) -> tuple[list[dict[str, Any]], int, bool, str | None]:
+    owner, name = _repo_parts(repo)
+    unresolved: list[dict[str, Any]] = []
+    cursor: str | None = None
+    pages = 0
+    for _ in range(MAX_THREAD_PAGES):
+        command = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={THREADS_QUERY}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"pr={pr}",
+        ]
+        if cursor is not None:
+            command.extend(["-F", f"cursor={cursor}"])
+        payload, error = _run_json(
+            command,
+            cwd=cwd,
+            allowed_codes={0},
+            expected_type=dict,
+        )
+        if error:
+            return unresolved, pages, False, error
+        if not isinstance(payload, dict):
+            return unresolved, pages, False, "GraphQL response must be an object"
+        graphql_errors = payload.get("errors")
+        if graphql_errors:
+            return unresolved, pages, False, "GraphQL response contains errors"
+        data = payload.get("data")
+        repository = data.get("repository") if isinstance(data, dict) else None
+        pull_request = repository.get("pullRequest") if isinstance(repository, dict) else None
+        threads = pull_request.get("reviewThreads") if isinstance(pull_request, dict) else None
+        if threads is None:
+            return unresolved, pages, False, "GraphQL reviewThreads envelope is missing"
+        if not isinstance(threads, dict):
+            return unresolved, pages, False, "GraphQL reviewThreads must be an object"
+        nodes = threads.get("nodes")
+        page_info = threads.get("pageInfo")
+        if not isinstance(nodes, list) or not isinstance(page_info, dict):
+            return unresolved, pages, False, "GraphQL thread nodes/pageInfo are malformed"
+        pages += 1
+        for index, node in enumerate(nodes):
+            if not isinstance(node, dict):
+                return unresolved, pages, False, f"review thread {index} is not an object"
+            is_resolved = node.get("isResolved")
+            is_outdated = node.get("isOutdated")
+            if not isinstance(is_resolved, bool) or not isinstance(is_outdated, bool):
+                return unresolved, pages, False, f"review thread {index} has malformed resolution flags"
+            thread_id = node.get("id")
+            path = node.get("path")
+            line = node.get("line")
+            if not isinstance(thread_id, str) or not thread_id:
+                return unresolved, pages, False, f"review thread {index} has no id"
+            if path is not None and not isinstance(path, str):
+                return unresolved, pages, False, f"review thread {index} has malformed path"
+            if line is not None and (not isinstance(line, int) or isinstance(line, bool)):
+                return unresolved, pages, False, f"review thread {index} has malformed line"
+            if is_resolved:
+                continue
+            unresolved.append(
+                {
+                    "id": thread_id,
+                    "is_outdated": is_outdated,
+                    "path": path,
+                    "line": line,
+                }
+            )
+        has_next = page_info.get("hasNextPage")
+        if not isinstance(has_next, bool):
+            return unresolved, pages, False, "GraphQL hasNextPage must be boolean"
+        if not has_next:
+            return unresolved, pages, True, None
+        next_cursor = page_info.get("endCursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            return unresolved, pages, False, "GraphQL pagination cursor is missing"
+        cursor = next_cursor
+    return unresolved, pages, False, f"review-thread pagination exceeded {MAX_THREAD_PAGES} pages"
+
+
+def _read_previous(path: Path) -> tuple[dict[str, Any], str | None]:
+    if not path.exists():
+        return {}, None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, f"could not read previous watcher state: {exc}"
+    if not isinstance(value, dict):
+        return {}, "previous watcher state must be an object"
+    return value, None
+
+
+def _stored_count(previous: dict[str, Any], key: str) -> tuple[int, str | None]:
+    value = previous.get(key, 0)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value, None
+    return 0, f"previous watcher state has invalid {key}"
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _one_line(value: Any) -> str:
+    text = " ".join(str(value or "").split())
+    return text.replace(MARKER_START, "[watcher-marker]").replace(MARKER_END, "[watcher-marker]")
+
+
+def _write_session_state(path: Path, block: str) -> None:
+    if not path.is_file():
+        return
+    text = path.read_text(encoding="utf-8")
+    marked = f"{MARKER_START}\n{block}\n{MARKER_END}"
+    if MARKER_START in text and MARKER_END in text:
+        before, rest = text.split(MARKER_START, 1)
+        _, after = rest.split(MARKER_END, 1)
+        updated = f"{before}{marked}{after}"
+    else:
+        updated = text.rstrip() + "\n\n" + marked + "\n"
+    _atomic_write(path, updated)
+
+
+def _notify(title: str, body: str, enabled: bool) -> None:
+    if enabled and shutil.which("notify-send") is not None:
+        _run(["notify-send", title, body], cwd=HOME)
+
+
+def _disable_timer(watcher_id: str) -> None:
+    if shutil.which("systemctl") is not None:
+        _run(["systemctl", "--user", "disable", "--now", f"atlas-pr-watch@{watcher_id}.timer"], cwd=HOME)
+
+
+def _classify(
+    *,
+    pr: dict[str, Any],
+    errors: Sequence[str | None],
+    unsafe_auto_merge: bool,
+    head_mismatch: bool,
+    worktree_dirty: bool,
+    failures: list[str],
+    required_failures: list[str],
+    pending: list[str],
+    required_pending: list[str],
+    required_count: int,
+    threads_complete: bool,
+    unresolved_threads: list[dict[str, Any]],
+    reconciliation_code: int,
+    review_changed: bool,
+) -> str:
+    if unsafe_auto_merge:
+        return "attention"
+    if pr.get("state") in {"MERGED", "CLOSED"}:
+        return "closed"
+    if errors or head_mismatch or worktree_dirty:
+        return "attention"
+    if pr.get("state") != "OPEN":
+        return "attention"
+    if failures or required_failures or required_count < 1 or reconciliation_code != 0:
+        return "attention"
+    if not threads_complete or unresolved_threads or pr.get("isDraft") is not False:
+        return "attention"
+    if str(pr.get("reviewDecision") or "").upper() == "CHANGES_REQUESTED":
+        return "attention"
+    if pending or required_pending:
+        return "pending"
+    if pr.get("mergeStateStatus") != "CLEAN":
+        return "attention"
+    if review_changed:
+        return "review_changed"
+    return "ready_for_human_merge"
+
+
+def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int, dict[str, Any], str]:
+    config_path = config_dir / f"{watcher_id}.env"
+    if not config_path.exists():
+        raise ValueError(f"watcher config not found: {config_path}")
+    config = _load_env(config_path)
+    repo_dir = Path(config.get("REPO_DIR", "")).expanduser()
+    if not repo_dir.is_dir():
+        raise ValueError(f"invalid REPO_DIR: {repo_dir}")
+    pr_text = config.get("PR", "")
+    if not pr_text.isdigit() or int(pr_text) < 1:
+        raise ValueError("PR must be a positive integer")
+    repo = config.get("REPO", "")
+    _repo_parts(repo)
+
+    status_path = state_dir / f"{watcher_id}.json"
+    previous, previous_error = _read_previous(status_path)
+    pr_initial, initial_error = _run_json(
+        _pr_view_command(pr_text, repo), cwd=repo_dir, allowed_codes={0}, expected_type=dict
+    )
+    all_checks, all_checks_error = _run_json(
+        _checks_command(pr_text, repo, required=False),
+        cwd=repo_dir,
+        allowed_codes=VALID_CHECK_EXIT_CODES,
+        expected_type=list,
+    )
+    required_checks, required_error = _run_json(
+        _checks_command(pr_text, repo, required=True),
+        cwd=repo_dir,
+        allowed_codes=VALID_CHECK_EXIT_CODES,
+        expected_type=list,
+    )
+    base_ref = pr_initial.get("baseRefName") if isinstance(pr_initial, dict) else None
+    if isinstance(base_ref, str) and base_ref:
+        required_policy, required_policy_error = _run_json(
+            _required_policy_command(repo, base_ref),
+            cwd=repo_dir,
+            allowed_codes={0},
+            expected_type=dict,
+        )
+    else:
+        required_policy = None
+        required_policy_error = "initial PR metadata has no baseRefName for required-check discovery"
+    review_data, reviews_error = _run_json(
+        ["gh", "pr", "view", pr_text, "--repo", repo, "--comments", "--json", "comments,reviews"],
+        cwd=repo_dir,
+        allowed_codes={0},
+        expected_type=dict,
+    )
+    unresolved_threads, thread_pages, threads_complete, threads_error = _fetch_threads(
+        int(pr_text), repo, cwd=repo_dir
+    )
+    reconciliation_command = [
+        sys.executable,
+        "scripts/check_ai_reconciliation_live.py",
+        "--pr",
+        pr_text,
+        "--repo",
+        repo,
+    ]
+    reconciliation_code, reconciliation_out, reconciliation_err = _run(reconciliation_command, cwd=repo_dir)
+    pr_final, final_error = _run_json(
+        _pr_view_command(pr_text, repo), cwd=repo_dir, allowed_codes={0}, expected_type=dict
+    )
+
+    pr_initial = pr_initial if isinstance(pr_initial, dict) else {}
+    pr = pr_final if isinstance(pr_final, dict) else pr_initial
+    initial_shape_error = _validate_pr_metadata(pr_initial, label="initial") if pr_initial else None
+    final_shape_error = _validate_pr_metadata(pr, label="final") if pr else None
+    all_checks = all_checks if isinstance(all_checks, list) else []
+    required_checks = required_checks if isinstance(required_checks, list) else []
+    required_policy = required_policy if isinstance(required_policy, dict) else {}
+    failures, pending, all_shape_error = _check_summary(all_checks, required=False)
+    required_failures, required_pending, required_shape_error = _check_summary(required_checks, required=True)
+    expected_required, required_policy_shape_error = _required_contexts(required_policy)
+    reported_required = {
+        item.get("name")
+        for item in required_checks
+        if isinstance(item, dict) and isinstance(item.get("name"), str) and item.get("name")
+    }
+    missing_required = sorted(expected_required - reported_required)
+    required_pending.extend(f"{name} (not reported)" for name in missing_required)
+    required_contexts = expected_required | reported_required
+    checks_errors = [
+        item
+        for item in (
+            all_checks_error,
+            required_error,
+            required_policy_error,
+            all_shape_error,
+            required_shape_error,
+            required_policy_shape_error,
+        )
+        if item
+    ]
+    checks_error = "; ".join(checks_errors) if checks_errors else None
+
+    comments = review_data.get("comments") if isinstance(review_data, dict) else None
+    reviews = review_data.get("reviews") if isinstance(review_data, dict) else None
+    if not isinstance(comments, list) or not isinstance(reviews, list):
+        comments = []
+        reviews = []
+        reviews_error = reviews_error or "review comments/reviews envelope is malformed"
+    comment_count = len(comments)
+    review_count = len(reviews)
+    previous_comments, previous_comments_error = _stored_count(previous, "comment_count")
+    previous_reviews, previous_reviews_error = _stored_count(previous, "review_count")
+    previous_errors = [
+        item
+        for item in (previous_error, previous_comments_error, previous_reviews_error)
+        if item
+    ]
+    previous_error = "; ".join(previous_errors) if previous_errors else None
+    review_changed = comment_count > previous_comments or review_count > previous_reviews
+
+    dirty_code, dirty_out, dirty_err = _run(["git", "status", "--porcelain"], cwd=repo_dir)
+    worktree_dirty = dirty_code != 0 or bool(dirty_out) or bool(dirty_err)
+    expected_head = config.get("HEAD_SHA", "")
+    initial_head = str(pr_initial.get("headRefOid") or "")
+    final_head = str(pr.get("headRefOid") or "")
+    initial_base = str(pr_initial.get("baseRefName") or "")
+    final_base = str(pr.get("baseRefName") or "")
+    head_mismatch = (
+        not expected_head
+        or not initial_head
+        or initial_head != expected_head
+        or final_head != initial_head
+    )
+    base_mismatch_error = (
+        "base branch changed during watcher observation"
+        if not initial_base or final_base != initial_base
+        else None
+    )
+    unsafe_auto_merge = config.get("AUTO_MERGE", "0").lower() not in {"0", "false", "no", "off", ""}
+    merge_error = "unsafe auto-merge config ignored; watcher cannot merge" if unsafe_auto_merge else ""
+    errors = [
+        item
+        for item in (
+            previous_error,
+            initial_error,
+            final_error,
+            initial_shape_error,
+            final_shape_error,
+            base_mismatch_error,
+            checks_error,
+            reviews_error,
+            threads_error,
+        )
+        if item
+    ]
+    state = _classify(
+        pr=pr,
+        errors=errors,
+        unsafe_auto_merge=unsafe_auto_merge,
+        head_mismatch=head_mismatch,
+        worktree_dirty=worktree_dirty,
+        failures=failures,
+        required_failures=required_failures,
+        pending=pending,
+        required_pending=required_pending,
+        required_count=len(required_contexts),
+        threads_complete=threads_complete,
+        unresolved_threads=unresolved_threads,
+        reconciliation_code=reconciliation_code,
+        review_changed=review_changed,
+    )
+
+    now = dt.datetime.now().astimezone()
+    try:
+        poll_minutes = int(config.get("POLL_MINUTES", "30"))
+    except ValueError as exc:
+        raise ValueError("POLL_MINUTES must be an integer") from exc
+    if not 1 <= poll_minutes <= 1440:
+        raise ValueError("POLL_MINUTES must be between 1 and 1440")
+    next_poll = now + dt.timedelta(minutes=poll_minutes)
+    reconciliation_text = reconciliation_out or reconciliation_err
+    status: dict[str, Any] = {
+        "watcher_id": watcher_id,
+        "label": config.get("LABEL", f"PR #{pr_text}"),
+        "observed_at": now.isoformat(timespec="seconds"),
+        "next_poll_at": next_poll.isoformat(timespec="seconds"),
+        "state": state,
+        "pr": pr,
+        "check_failures": failures,
+        "check_pending": pending,
+        "comment_count": comment_count,
+        "review_count": review_count,
+        "review_changed": review_changed,
+        "head_mismatch": head_mismatch,
+        "worktree_dirty": worktree_dirty,
+        "merge_output": "",
+        "merge_error": merge_error,
+        "reconciliation_exit_code": reconciliation_code,
+        "reconciliation_summary": "\n".join(reconciliation_text.splitlines()[-8:]),
+        "view_error": "; ".join(
+            item
+            for item in (
+                initial_error,
+                final_error,
+                initial_shape_error,
+                final_shape_error,
+                base_mismatch_error,
+            )
+            if item
+        ),
+        "checks_error": checks_error or "",
+        "reviews_error": reviews_error or "",
+        "review_threads_error": threads_error or "",
+        "previous_state_error": previous_error or "",
+        "worktree_status_error": dirty_err if dirty_code else "",
+        "readiness": {
+            "version": 1,
+            "evaluated_head_sha": initial_head,
+            "required_check_count": len(required_contexts),
+            "required_checks_complete": (
+                not required_error
+                and not required_policy_error
+                and not required_shape_error
+                and not required_policy_shape_error
+                and len(required_contexts) > 0
+                and not required_failures
+                and not required_pending
+            ),
+            "required_check_failures": required_failures,
+            "required_check_pending": required_pending,
+            "review_threads_complete": threads_complete,
+            "review_thread_pages_fetched": thread_pages,
+            "unresolved_review_threads": unresolved_threads,
+            "review_decision": pr.get("reviewDecision"),
+            "merge_state_status": pr.get("mergeStateStatus"),
+        },
+    }
+    _atomic_write(status_path, json.dumps(status, indent=2, sort_keys=True) + "\n")
+
+    label = _one_line(status["label"])
+    block = "\n".join(
+        [
+            f"Watcher: {_one_line(watcher_id)}",
+            f"Observed: {now.strftime('%Y-%m-%d %H:%M %Z')}",
+            f"Next poll: {next_poll.strftime('%Y-%m-%d %H:%M %Z')}",
+            f"State: {state}",
+            f"PR: #{_one_line(pr.get('number', pr_text))} {_one_line(pr.get('title', ''))}",
+            f"URL: {_one_line(pr.get('url', ''))}",
+            f"Head: {_one_line(pr.get('headRefName', ''))} @ {_one_line(final_head)}",
+            f"Expected head: {_one_line(expected_head or 'missing')}",
+            f"Merge state: {_one_line(pr.get('mergeStateStatus', ''))}",
+            f"Review decision: {_one_line(pr.get('reviewDecision') or 'none')}",
+            f"Worktree dirty: {'yes' if worktree_dirty else 'no'}",
+            f"Failing checks: {_one_line(', '.join(failures) or 'none')}",
+            f"Pending checks: {_one_line(', '.join(pending) or 'none')}",
+            (
+                f"Required checks: {len(required_contexts)} total, "
+                f"{len(required_failures)} failed, {len(required_pending)} pending"
+            ),
+            f"Unresolved review threads: {len(unresolved_threads)} across {thread_pages} fetched page(s)",
+            f"Reviews/comments: {review_count} reviews, {comment_count} comments",
+            f"Review changed since last poll: {'yes' if review_changed else 'no'}",
+            f"AI reconciliation: {'pass' if reconciliation_code == 0 else 'fail'}",
+            "Watcher merge authority: forbidden",
+        ]
+    )
+    session_state_value = config.get("SESSION_STATE", "")
+    receipt_errors: list[str] = []
+    if session_state_value:
+        try:
+            _write_session_state(Path(session_state_value).expanduser(), block)
+        except OSError as exc:
+            receipt_errors.append(f"session-state receipt failed: {exc}")
+    log_path = state_dir / f"{watcher_id}.log"
+    try:
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(block + "\n\n")
+    except OSError as exc:
+        receipt_errors.append(f"watcher log receipt failed: {exc}")
+    if receipt_errors:
+        block += "\nReceipt errors: " + _one_line("; ".join(receipt_errors))
+
+    notify = config.get("NOTIFY", "1").lower() not in {"0", "false", "no", "off"}
+    if state == "attention":
+        _notify(
+            f"Atlas PR watcher: {label} needs attention",
+            _one_line(
+                ", ".join(errors + failures + required_failures)
+                or "review/readiness blocker"
+            ),
+            notify,
+        )
+    elif state == "ready_for_human_merge":
+        _notify(
+            f"Atlas PR watcher: {label} is green",
+            "Ready for active-agent guards; watcher merge is forbidden.",
+            notify,
+        )
+    elif state == "review_changed":
+        _notify(f"Atlas PR watcher: {label} has new review activity", "Inspect before any merge decision.", notify)
+    elif state == "closed":
+        _disable_timer(watcher_id)
+    return 0, status, block
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("watcher_id")
+    parser.add_argument("--config-dir", type=Path, default=DEFAULT_CONFIG_DIR)
+    parser.add_argument("--state-dir", type=Path, default=DEFAULT_STATE_DIR)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if not _valid_watcher_id(args.watcher_id):
+        print(f"invalid watcher id: {args.watcher_id!r}", file=sys.stderr)
+        return 2
+    try:
+        code, _status, block = produce(
+            args.watcher_id,
+            config_dir=args.config_dir.expanduser(),
+            state_dir=args.state_dir.expanduser(),
+        )
+    except (OSError, ValueError) as exc:
+        print(f"PR watcher: {exc}", file=sys.stderr)
+        return 2
+    print(block)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_watcher.py
+++ b/scripts/pr_watcher.py
@@ -30,6 +30,11 @@ SAFE_WATCHER_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 VALID_CHECK_EXIT_CODES = {0, 1, 8}
 MAX_THREAD_PAGES = 50
 COMMAND_TIMEOUT_SECONDS = 60
+RECONCILIATION_LIB_DIR = "atlas-pr-watch-lib"
+RECONCILIATION_CHECKER_NAME = "check_ai_reconciliation_live.py"
+TRUSTED_RECONCILIATION_CHECKER = (
+    Path(__file__).resolve().parent / RECONCILIATION_LIB_DIR / RECONCILIATION_CHECKER_NAME
+)
 
 THREADS_QUERY = """
 query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
@@ -187,6 +192,8 @@ def _required_contexts(payload: dict[str, Any]) -> tuple[set[str], str | None]:
         if not isinstance(context, str) or not context:
             return set(), f"required-status check {index} has no context"
         contexts.add(context)
+    if not contexts:
+        return set(), "required-status policy has no contexts/checks"
     return contexts, None
 
 
@@ -398,12 +405,12 @@ def _classify(
         return "attention"
     if str(pr.get("reviewDecision") or "").upper() == "CHANGES_REQUESTED":
         return "attention"
+    if review_changed:
+        return "review_changed"
     if pending or required_pending:
         return "pending"
     if pr.get("mergeStateStatus") != "CLEAN":
         return "attention"
-    if review_changed:
-        return "review_changed"
     return "ready_for_human_merge"
 
 
@@ -460,7 +467,7 @@ def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int,
     )
     reconciliation_command = [
         sys.executable,
-        "scripts/check_ai_reconciliation_live.py",
+        str(TRUSTED_RECONCILIATION_CHECKER),
         "--pr",
         pr_text,
         "--repo",

--- a/tests/test_install_codex_wake_bridge.py
+++ b/tests/test_install_codex_wake_bridge.py
@@ -39,15 +39,18 @@ def test_install_writes_wrapper_and_systemd_dropin(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
     wrapper = bin_dir / "atlas-pr-watch-and-wake"
     bridge = bin_dir / "atlas-codex-wake-bridge"
+    watcher = bin_dir / "atlas-pr-watch"
     dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
     wrapper_text = wrapper.read_text(encoding="utf-8")
-    assert wrapper_text == installer._wrapper_text(bridge)
+    assert wrapper_text == installer._wrapper_text(watcher, bridge)
     assert bridge.read_text(encoding="utf-8") == (ROOT / "scripts" / "codex_wake_bridge.py").read_text(encoding="utf-8")
+    assert watcher.read_text(encoding="utf-8") == (ROOT / "scripts" / "pr_watcher.py").read_text(encoding="utf-8")
     assert dropin.read_text(encoding="utf-8") == installer._dropin_text(wrapper)
     assert os.access(wrapper, os.X_OK)
     assert os.access(bridge, os.X_OK)
+    assert os.access(watcher, os.X_OK)
     assert "invalid watcher id" in wrapper_text
-    assert "atlas-pr-watch" in wrapper_text
+    assert str(watcher) in wrapper_text
     assert str(bridge) in wrapper_text
     assert "scripts/codex_wake_bridge.py" not in wrapper_text
     assert 'cd "$REPO_DIR"' not in wrapper_text
@@ -61,10 +64,13 @@ def test_check_mode_fails_when_dropin_points_at_default_wrapper_with_custom_bin_
     systemd_dir = tmp_path / "systemd"
     wrapper = bin_dir / "atlas-pr-watch-and-wake"
     bridge = bin_dir / "atlas-codex-wake-bridge"
+    watcher = bin_dir / "atlas-pr-watch"
     wrapper.parent.mkdir(parents=True)
-    wrapper.write_text(installer._wrapper_text(bridge), encoding="utf-8")
+    wrapper.write_text(installer._wrapper_text(watcher, bridge), encoding="utf-8")
     bridge.write_text(installer._bridge_text(), encoding="utf-8")
+    watcher.write_text(installer._watcher_text(), encoding="utf-8")
     bridge.chmod(bridge.stat().st_mode | stat.S_IXUSR)
+    watcher.chmod(watcher.stat().st_mode | stat.S_IXUSR)
     wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
     dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
     dropin.parent.mkdir(parents=True)
@@ -95,8 +101,9 @@ def test_dropin_uses_absolute_quoted_wrapper_for_relative_bin_dir(tmp_path: Path
     assert result.returncode == 0, result.stdout + result.stderr
     wrapper = (tmp_path / "relative bin" / "atlas-pr-watch-and-wake").resolve(strict=False)
     bridge = (tmp_path / "relative bin" / "atlas-codex-wake-bridge").resolve(strict=False)
+    watcher = (tmp_path / "relative bin" / "atlas-pr-watch").resolve(strict=False)
     dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
-    assert wrapper.read_text(encoding="utf-8") == installer._wrapper_text(bridge)
+    assert wrapper.read_text(encoding="utf-8") == installer._wrapper_text(watcher, bridge)
     assert dropin.read_text(encoding="utf-8") == installer._dropin_text(wrapper)
     assert f'ExecStart="{wrapper}" %i' in dropin.read_text(encoding="utf-8")
 
@@ -141,15 +148,36 @@ def test_check_mode_passes_after_install(tmp_path: Path) -> None:
     assert "ok:" in result.stdout
 
 
+def test_check_mode_fails_when_installed_watcher_drifts(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    systemd_dir = tmp_path / "systemd"
+    assert _run("--bin-dir", str(bin_dir), "--systemd-dir", str(systemd_dir)).returncode == 0
+    (bin_dir / "atlas-pr-watch").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+    result = _run(
+        "--check",
+        "--bin-dir",
+        str(bin_dir),
+        "--systemd-dir",
+        str(systemd_dir),
+    )
+
+    assert result.returncode == 1
+    assert f"content drift: {bin_dir / 'atlas-pr-watch'}" in result.stdout
+
+
 def test_check_mode_fails_when_systemd_still_calls_bare_watcher(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     systemd_dir = tmp_path / "systemd"
     wrapper = bin_dir / "atlas-pr-watch-and-wake"
     bridge = bin_dir / "atlas-codex-wake-bridge"
+    watcher = bin_dir / "atlas-pr-watch"
     wrapper.parent.mkdir(parents=True)
-    wrapper.write_text(installer._wrapper_text(bridge), encoding="utf-8")
+    wrapper.write_text(installer._wrapper_text(watcher, bridge), encoding="utf-8")
     bridge.write_text(installer._bridge_text(), encoding="utf-8")
+    watcher.write_text(installer._watcher_text(), encoding="utf-8")
     bridge.chmod(bridge.stat().st_mode | stat.S_IXUSR)
+    watcher.chmod(watcher.stat().st_mode | stat.S_IXUSR)
     wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
     dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
     dropin.parent.mkdir(parents=True)
@@ -172,10 +200,13 @@ def test_check_mode_fails_when_wrapper_is_not_executable(tmp_path: Path) -> None
     systemd_dir = tmp_path / "systemd"
     wrapper = bin_dir / "atlas-pr-watch-and-wake"
     bridge = bin_dir / "atlas-codex-wake-bridge"
+    watcher = bin_dir / "atlas-pr-watch"
     wrapper.parent.mkdir(parents=True)
-    wrapper.write_text(installer._wrapper_text(bridge), encoding="utf-8")
+    wrapper.write_text(installer._wrapper_text(watcher, bridge), encoding="utf-8")
     bridge.write_text(installer._bridge_text(), encoding="utf-8")
+    watcher.write_text(installer._watcher_text(), encoding="utf-8")
     bridge.chmod(bridge.stat().st_mode | stat.S_IXUSR)
+    watcher.chmod(watcher.stat().st_mode | stat.S_IXUSR)
     dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
     dropin.parent.mkdir(parents=True)
     dropin.write_text(installer._dropin_text(wrapper), encoding="utf-8")

--- a/tests/test_install_codex_wake_bridge.py
+++ b/tests/test_install_codex_wake_bridge.py
@@ -40,11 +40,20 @@ def test_install_writes_wrapper_and_systemd_dropin(tmp_path: Path) -> None:
     wrapper = bin_dir / "atlas-pr-watch-and-wake"
     bridge = bin_dir / "atlas-codex-wake-bridge"
     watcher = bin_dir / "atlas-pr-watch"
+    reconciliation_dir = bin_dir / installer.RECONCILIATION_LIB_DIR
+    reconciliation_checker = reconciliation_dir / installer.RECONCILIATION_CHECKER_NAME
+    reconciliation_audit = reconciliation_dir / installer.RECONCILIATION_AUDIT_NAME
     dropin = systemd_dir / "atlas-pr-watch@.service.d" / "wake-bridge.conf"
     wrapper_text = wrapper.read_text(encoding="utf-8")
     assert wrapper_text == installer._wrapper_text(watcher, bridge)
     assert bridge.read_text(encoding="utf-8") == (ROOT / "scripts" / "codex_wake_bridge.py").read_text(encoding="utf-8")
     assert watcher.read_text(encoding="utf-8") == (ROOT / "scripts" / "pr_watcher.py").read_text(encoding="utf-8")
+    assert reconciliation_checker.read_text(encoding="utf-8") == (
+        ROOT / "scripts" / installer.RECONCILIATION_CHECKER_NAME
+    ).read_text(encoding="utf-8")
+    assert reconciliation_audit.read_text(encoding="utf-8") == (
+        ROOT / "scripts" / installer.RECONCILIATION_AUDIT_NAME
+    ).read_text(encoding="utf-8")
     assert dropin.read_text(encoding="utf-8") == installer._dropin_text(wrapper)
     assert os.access(wrapper, os.X_OK)
     assert os.access(bridge, os.X_OK)
@@ -164,6 +173,34 @@ def test_check_mode_fails_when_installed_watcher_drifts(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert f"content drift: {bin_dir / 'atlas-pr-watch'}" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        Path(installer.RECONCILIATION_LIB_DIR) / installer.RECONCILIATION_CHECKER_NAME,
+        Path(installer.RECONCILIATION_LIB_DIR) / installer.RECONCILIATION_AUDIT_NAME,
+    ],
+)
+def test_check_mode_fails_when_installed_reconciliation_source_drifts(
+    tmp_path: Path,
+    relative_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    systemd_dir = tmp_path / "systemd"
+    assert _run("--bin-dir", str(bin_dir), "--systemd-dir", str(systemd_dir)).returncode == 0
+    (bin_dir / relative_path).write_text("# drifted\n", encoding="utf-8")
+
+    result = _run(
+        "--check",
+        "--bin-dir",
+        str(bin_dir),
+        "--systemd-dir",
+        str(systemd_dir),
+    )
+
+    assert result.returncode == 1
+    assert f"content drift: {bin_dir / relative_path}" in result.stdout
 
 
 def test_check_mode_fails_when_systemd_still_calls_bare_watcher(tmp_path: Path) -> None:

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -95,9 +95,11 @@ class FakeRun:
         self.thread_pages = list(thread_pages or [_response(_thread_page())])
         self.reconciliation = reconciliation
         self.git_status = git_status
+        self.commands: list[list[str]] = []
 
     def __call__(self, command, *, cwd: Path):
         args = list(command)
+        self.commands.append(args)
         if args[:3] == ["gh", "pr", "view"] and "--comments" not in args:
             return self.pr_responses.pop(0)
         if args[:3] == ["gh", "pr", "checks"]:
@@ -108,7 +110,11 @@ class FakeRun:
             return self.reviews
         if args[:3] == ["gh", "api", "graphql"]:
             return self.thread_pages.pop(0)
-        if len(args) > 1 and args[0] == sys.executable and args[1] == "scripts/check_ai_reconciliation_live.py":
+        if (
+            len(args) > 1
+            and args[0] == sys.executable
+            and Path(args[1]).name == watcher.RECONCILIATION_CHECKER_NAME
+        ):
             return self.reconciliation
         if args[:3] == ["git", "status", "--porcelain"]:
             return self.git_status
@@ -153,7 +159,8 @@ def _produce(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake: FakeRun, *, 
 
 
 def test_valid_snapshot_is_ready_and_accepted_by_consumer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    status = _produce(tmp_path, monkeypatch, FakeRun())
+    fake = FakeRun()
+    status = _produce(tmp_path, monkeypatch, fake)
 
     assert status["state"] == "ready_for_human_merge"
     assert status["readiness"] == {
@@ -170,6 +177,22 @@ def test_valid_snapshot_is_ready_and_accepted_by_consumer(tmp_path: Path, monkey
         "merge_state_status": "CLEAN",
     }
     assert wake_bridge.readiness_blockers(status) == []
+    reconciliation_commands = [
+        command
+        for command in fake.commands
+        if len(command) > 1 and Path(command[1]).name == watcher.RECONCILIATION_CHECKER_NAME
+    ]
+    assert reconciliation_commands == [
+        [
+            sys.executable,
+            str(watcher.TRUSTED_RECONCILIATION_CHECKER),
+            "--pr",
+            "7",
+            "--repo",
+            "owner/repo",
+        ]
+    ]
+    assert watcher.TRUSTED_RECONCILIATION_CHECKER.parent.name == watcher.RECONCILIATION_LIB_DIR
 
 
 def test_invalid_repo_config_raises_before_transport(tmp_path: Path) -> None:
@@ -227,6 +250,45 @@ def test_empty_required_policy_cannot_be_ready(
     assert status["state"] == "attention"
     assert status["readiness"]["required_check_count"] == 0
     assert "required check count must be at least 1" in wake_bridge.readiness_blockers(status)
+
+
+def test_reported_required_row_cannot_mask_empty_policy_inventory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            required_checks=_response([_check("reported-only")]),
+            required_policy=_response({"contexts": [], "checks": []}),
+        ),
+    )
+
+    assert status["state"] == "attention"
+    assert status["readiness"]["required_check_count"] == 1
+    assert status["readiness"]["required_checks_complete"] is False
+    assert "required-status policy has no contexts/checks" in status["checks_error"]
+    assert wake_bridge.readiness_blockers(status)
+
+
+def test_review_change_is_actionable_while_checks_are_pending(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            all_checks=_response([_check("required-a", "pending")]),
+            required_checks=_response([_check("required-a", "pending")]),
+            reviews=_response({"comments": [{"id": "new-review"}], "reviews": []}),
+        ),
+    )
+
+    assert status["review_changed"] is True
+    assert status["check_pending"] == ["required-a"]
+    assert status["state"] == "review_changed"
 
 
 @pytest.mark.parametrize("malformed", [["not-an-object"], [{"name": "x"}], [{"bucket": "pass"}]])

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -1,0 +1,711 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import textwrap
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "pr_watcher.py"
+INSTALLER = ROOT / "scripts" / "install_codex_wake_bridge.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+watcher = _load("pr_watcher", SCRIPT)
+wake_bridge = _load("codex_wake_bridge_for_watcher_tests", ROOT / "scripts" / "codex_wake_bridge.py")
+
+
+def _pr(*, head: str = "head-a", state: str = "OPEN", draft: bool = False, decision: str = "", merge: str = "CLEAN") -> dict[str, Any]:
+    return {
+        "number": 7,
+        "title": "Watcher producer",
+        "url": "https://github.test/owner/repo/pull/7",
+        "baseRefName": "main",
+        "headRefName": "claude/pr-watcher",
+        "headRefOid": head,
+        "mergeStateStatus": merge,
+        "reviewDecision": decision,
+        "isDraft": draft,
+        "state": state,
+    }
+
+
+def _check(name: str, bucket: str = "pass") -> dict[str, Any]:
+    return {"name": name, "bucket": bucket, "state": "SUCCESS"}
+
+
+def _thread_page(nodes: list[dict[str, Any]] | None = None, *, has_next: bool = False, cursor: str | None = None) -> dict[str, Any]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": nodes or [],
+                        "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                    }
+                }
+            }
+        }
+    }
+
+
+def _response(payload: Any, code: int = 0, stderr: str = "") -> tuple[int, str, str]:
+    return code, json.dumps(payload), stderr
+
+
+class FakeRun:
+    def __init__(
+        self,
+        *,
+        pr_responses: list[tuple[int, str, str]] | None = None,
+        all_checks: tuple[int, str, str] | None = None,
+        required_checks: tuple[int, str, str] | None = None,
+        required_policy: tuple[int, str, str] | None = None,
+        reviews: tuple[int, str, str] | None = None,
+        thread_pages: list[tuple[int, str, str]] | None = None,
+        reconciliation: tuple[int, str, str] = (0, "clean", ""),
+        git_status: tuple[int, str, str] = (0, "", ""),
+    ) -> None:
+        self.pr_responses = list(pr_responses or [_response(_pr()), _response(_pr())])
+        self.all_checks = all_checks or _response([_check("required-a"), _check("optional-a")])
+        self.required_checks = required_checks or _response([_check("required-a")])
+        self.required_policy = required_policy or _response(
+            {
+                "contexts": ["required-a"],
+                "checks": [{"context": "required-a", "app_id": 15368}],
+            }
+        )
+        self.reviews = reviews or _response({"comments": [], "reviews": []})
+        self.thread_pages = list(thread_pages or [_response(_thread_page())])
+        self.reconciliation = reconciliation
+        self.git_status = git_status
+
+    def __call__(self, command, *, cwd: Path):
+        args = list(command)
+        if args[:3] == ["gh", "pr", "view"] and "--comments" not in args:
+            return self.pr_responses.pop(0)
+        if args[:3] == ["gh", "pr", "checks"]:
+            return self.required_checks if "--required" in args else self.all_checks
+        if args[:2] == ["gh", "api"] and args[2] != "graphql":
+            return self.required_policy
+        if args[:3] == ["gh", "pr", "view"] and "--comments" in args:
+            return self.reviews
+        if args[:3] == ["gh", "api", "graphql"]:
+            return self.thread_pages.pop(0)
+        if len(args) > 1 and args[0] == sys.executable and args[1] == "scripts/check_ai_reconciliation_live.py":
+            return self.reconciliation
+        if args[:3] == ["git", "status", "--porcelain"]:
+            return self.git_status
+        if args[:3] == ["systemctl", "--user", "disable"]:
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {args}")
+
+
+def _config(tmp_path: Path, *, head: str = "head-a", extra: str = "") -> tuple[Path, Path, Path]:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    state_dir = tmp_path / "state"
+    (config_dir / "session.env").write_text(
+        textwrap.dedent(
+            f"""\
+            LABEL="Watcher producer"
+            REPO_DIR="{repo_dir}"
+            PR="7"
+            REPO="owner/repo"
+            HEAD_SHA="{head}"
+            POLL_MINUTES="30"
+            AUTO_MERGE="0"
+            NOTIFY="0"
+            {extra}
+            """
+        ),
+        encoding="utf-8",
+    )
+    return config_dir, state_dir, repo_dir
+
+
+def _produce(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake: FakeRun, *, head: str = "head-a", extra: str = "") -> dict[str, Any]:
+    config_dir, state_dir, _repo_dir = _config(tmp_path, head=head, extra=extra)
+    monkeypatch.setattr(watcher, "_run", fake)
+    code, status, _block = watcher.produce("session", config_dir=config_dir, state_dir=state_dir)
+    assert code == 0
+    assert json.loads((state_dir / "session.json").read_text(encoding="utf-8")) == status
+    assert not list(state_dir.glob(".*.tmp"))
+    return status
+
+
+def test_valid_snapshot_is_ready_and_accepted_by_consumer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    status = _produce(tmp_path, monkeypatch, FakeRun())
+
+    assert status["state"] == "ready_for_human_merge"
+    assert status["readiness"] == {
+        "version": 1,
+        "evaluated_head_sha": "head-a",
+        "required_check_count": 1,
+        "required_checks_complete": True,
+        "required_check_failures": [],
+        "required_check_pending": [],
+        "review_threads_complete": True,
+        "review_thread_pages_fetched": 1,
+        "unresolved_review_threads": [],
+        "review_decision": "",
+        "merge_state_status": "CLEAN",
+    }
+    assert wake_bridge.readiness_blockers(status) == []
+
+
+def test_invalid_repo_config_raises_before_transport(tmp_path: Path) -> None:
+    config_dir, state_dir, _repo_dir = _config(tmp_path)
+    path = config_dir / "session.env"
+    path.write_text(path.read_text(encoding="utf-8").replace("owner/repo", "not-a-slug"), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="owner/name"):
+        watcher.produce("session", config_dir=config_dir, state_dir=state_dir)
+
+
+@pytest.mark.parametrize(
+    ("required", "expected_state", "expected_fragment"),
+    [
+        ([], "pending", "required-a (not reported)"),
+        ([_check("required-a", "pending")], "pending", "required-a"),
+        ([_check("required-a", "fail")], "attention", "required-a (fail)"),
+        ([_check("required-a", "cancel")], "attention", "required-a (cancel)"),
+        ([_check("required-a", "skipping")], "attention", "required-a (skipping)"),
+        ([_check("required-a", "mystery")], "attention", "required-a (mystery)"),
+    ],
+)
+def test_required_check_boundaries_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    required: list[dict[str, Any]],
+    expected_state: str,
+    expected_fragment: str | None,
+) -> None:
+    all_checks = required or [_check("optional-a")]
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(all_checks=_response(all_checks), required_checks=_response(required)),
+    )
+
+    assert status["state"] == expected_state
+    assert status["readiness"]["required_checks_complete"] is False
+    if expected_fragment:
+        combined = status["readiness"]["required_check_failures"] + status["readiness"]["required_check_pending"]
+        assert expected_fragment in combined
+    assert wake_bridge.readiness_blockers(status)
+
+
+def test_empty_required_policy_cannot_be_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(required_checks=_response([]), required_policy=_response({"contexts": [], "checks": []})),
+    )
+
+    assert status["state"] == "attention"
+    assert status["readiness"]["required_check_count"] == 0
+    assert "required check count must be at least 1" in wake_bridge.readiness_blockers(status)
+
+
+@pytest.mark.parametrize("malformed", [["not-an-object"], [{"name": "x"}], [{"bucket": "pass"}]])
+def test_malformed_required_check_rows_are_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    malformed: list[Any],
+) -> None:
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(required_checks=_response(malformed)),
+    )
+
+    assert status["state"] == "attention"
+    assert status["checks_error"]
+    assert status["readiness"]["required_checks_complete"] is False
+
+
+def test_optional_non_skipped_failure_still_blocks_green_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            all_checks=_response([_check("required-a"), _check("optional-a", "fail")]),
+            required_checks=_response([_check("required-a")]),
+        ),
+    )
+
+    assert status["state"] == "attention"
+    assert status["check_failures"] == ["optional-a (fail)"]
+    assert status["readiness"]["required_checks_complete"] is True
+
+
+def test_optional_skipped_check_does_not_block_green_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            all_checks=_response([_check("required-a"), _check("optional-a", "skipping")]),
+            required_checks=_response([_check("required-a")]),
+        ),
+    )
+
+    assert status["state"] == "ready_for_human_merge"
+    assert status["check_failures"] == []
+
+
+def test_paginates_all_threads_and_outdated_unresolved_still_blocks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unresolved = {
+        "id": "thread-1",
+        "isResolved": False,
+        "isOutdated": True,
+        "path": "scripts/pr_watcher.py",
+        "line": 12,
+    }
+    pages = [
+        _response(_thread_page([unresolved], has_next=True, cursor="cursor-1")),
+        _response(_thread_page()),
+    ]
+
+    status = _produce(tmp_path, monkeypatch, FakeRun(thread_pages=pages))
+
+    assert status["state"] == "attention"
+    assert status["readiness"]["review_threads_complete"] is True
+    assert status["readiness"]["review_thread_pages_fetched"] == 2
+    assert status["readiness"]["unresolved_review_threads"] == [
+        {"id": "thread-1", "is_outdated": True, "path": "scripts/pr_watcher.py", "line": 12}
+    ]
+
+
+def test_head_change_during_collection_is_attention(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = FakeRun(pr_responses=[_response(_pr(head="head-a")), _response(_pr(head="head-b"))])
+
+    status = _produce(tmp_path, monkeypatch, fake)
+
+    assert status["state"] == "attention"
+    assert status["head_mismatch"] is True
+    assert status["pr"]["headRefOid"] == "head-b"
+    assert status["readiness"]["evaluated_head_sha"] == "head-a"
+    assert "evaluated head SHA does not match PR head" in wake_bridge.readiness_blockers(status)
+
+
+def test_base_change_during_collection_invalidates_required_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initial = _pr()
+    final = _pr()
+    final["baseRefName"] = "release"
+
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(pr_responses=[_response(initial), _response(final)]),
+    )
+
+    assert status["state"] == "attention"
+    assert "base branch changed during watcher observation" in status["view_error"]
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("number", 0),
+        ("headRefOid", ""),
+        ("isDraft", "false"),
+        ("reviewDecision", 7),
+        ("mergeStateStatus", None),
+    ],
+)
+def test_malformed_pr_metadata_is_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    replacement: Any,
+) -> None:
+    malformed = _pr()
+    malformed[field] = replacement
+
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(pr_responses=[_response(malformed), _response(malformed)]),
+    )
+
+    assert status["state"] == "attention"
+    assert status["view_error"]
+
+
+@pytest.mark.parametrize(
+    ("fake", "field"),
+    [
+        (FakeRun(all_checks=(2, "", "checks unavailable")), "checks_error"),
+        (FakeRun(required_checks=(2, "", "required unavailable")), "checks_error"),
+        (FakeRun(required_policy=(2, "", "policy unavailable")), "checks_error"),
+        (FakeRun(required_policy=_response({"contexts": "required-a", "checks": []})), "checks_error"),
+        (FakeRun(reviews=(2, "", "reviews unavailable")), "reviews_error"),
+        (FakeRun(thread_pages=[_response({"errors": [{"message": "denied"}]})]), "review_threads_error"),
+        (
+            FakeRun(pr_responses=[_response(_pr()), (2, "", "refresh unavailable")]),
+            "view_error",
+        ),
+    ],
+)
+def test_github_read_failures_are_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake: FakeRun,
+    field: str,
+) -> None:
+    status = _produce(tmp_path, monkeypatch, fake)
+
+    assert status["state"] == "attention"
+    assert status[field]
+
+
+def test_required_policy_transport_failure_reaches_attention_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir, state_dir, _repo_dir = _config(tmp_path)
+
+    def transport(command, **_kwargs):
+        args = list(command)
+        if args[:3] == ["gh", "pr", "view"] and "--comments" not in args:
+            return subprocess.CompletedProcess(args, 0, json.dumps(_pr()), "")
+        if args[:3] == ["gh", "pr", "checks"]:
+            return subprocess.CompletedProcess(args, 0, json.dumps([_check("required-a")]), "")
+        if args[:2] == ["gh", "api"] and args[2] != "graphql":
+            return subprocess.CompletedProcess(args, 1, "", "policy denied")
+        if args[:3] == ["gh", "pr", "view"] and "--comments" in args:
+            return subprocess.CompletedProcess(args, 0, json.dumps({"comments": [], "reviews": []}), "")
+        if args[:3] == ["gh", "api", "graphql"]:
+            return subprocess.CompletedProcess(args, 0, json.dumps(_thread_page()), "")
+        if len(args) > 1 and args[0] == sys.executable:
+            return subprocess.CompletedProcess(args, 0, "clean", "")
+        if args[:3] == ["git", "status", "--porcelain"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        raise AssertionError(f"unexpected transport command: {args}")
+
+    monkeypatch.setattr(watcher.subprocess, "run", transport)
+
+    code, status, _block = watcher.produce("session", config_dir=config_dir, state_dir=state_dir)
+
+    assert code == 0
+    assert status["state"] == "attention"
+    assert "policy denied" in status["checks_error"]
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_code", "expected_text"),
+    [
+        (subprocess.TimeoutExpired(["gh"], watcher.COMMAND_TIMEOUT_SECONDS), 124, "timed out"),
+        (OSError("missing executable"), 127, "could not run"),
+    ],
+)
+def test_command_transport_errors_are_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception: BaseException,
+    expected_code: int,
+    expected_text: str,
+) -> None:
+    def fail(*_args, **_kwargs):
+        raise exception
+
+    monkeypatch.setattr(watcher.subprocess, "run", fail)
+
+    code, stdout, stderr = watcher._run(["gh", "pr", "view"], cwd=tmp_path)
+
+    assert code == expected_code
+    assert stdout == ""
+    assert expected_text in stderr
+
+
+def test_missing_cursor_and_page_cap_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _config(tmp_path)
+    repo_dir = tmp_path / "repo"
+    monkeypatch.setattr(watcher, "_run_json", lambda *args, **kwargs: (_thread_page(has_next=True, cursor=None), None))
+    unresolved, pages, complete, error = watcher._fetch_threads(7, "owner/repo", cwd=repo_dir)
+    assert unresolved == []
+    assert pages == 1
+    assert complete is False
+    assert error == "GraphQL pagination cursor is missing"
+
+    monkeypatch.setattr(watcher, "MAX_THREAD_PAGES", 2)
+    monkeypatch.setattr(watcher, "_run_json", lambda *args, **kwargs: (_thread_page(has_next=True, cursor="again"), None))
+    _unresolved, pages, complete, error = watcher._fetch_threads(7, "owner/repo", cwd=repo_dir)
+    assert pages == 2
+    assert complete is False
+    assert error == "review-thread pagination exceeded 2 pages"
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        {"id": "", "isResolved": False, "isOutdated": False, "path": "x.py", "line": 1},
+        {"id": "t", "isResolved": "no", "isOutdated": False, "path": "x.py", "line": 1},
+        {"id": "t", "isResolved": False, "isOutdated": False, "path": 7, "line": 1},
+        {"id": "t", "isResolved": False, "isOutdated": False, "path": "x.py", "line": True},
+    ],
+)
+def test_malformed_review_thread_nodes_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    node: dict[str, Any],
+) -> None:
+    _config(tmp_path)
+    repo_dir = tmp_path / "repo"
+    monkeypatch.setattr(
+        watcher,
+        "_run_json",
+        lambda *args, **kwargs: (_thread_page([node]), None),
+    )
+
+    unresolved, pages, complete, error = watcher._fetch_threads(7, "owner/repo", cwd=repo_dir)
+
+    assert unresolved == []
+    assert pages == 1
+    assert complete is False
+    assert error
+
+
+@pytest.mark.parametrize(
+    ("pr_value", "all_checks", "reconciliation", "git_status", "expected"),
+    [
+        (_pr(draft=True), None, (0, "clean", ""), (0, "", ""), "attention"),
+        (_pr(decision="CHANGES_REQUESTED"), None, (0, "clean", ""), (0, "", ""), "attention"),
+        (_pr(merge="DIRTY"), None, (0, "clean", ""), (0, "", ""), "attention"),
+        (_pr(merge="UNSTABLE"), [_check("required-a", "pending")], (0, "clean", ""), (0, "", ""), "pending"),
+        (_pr(state="MERGED"), None, (0, "clean", ""), (0, "", ""), "closed"),
+        (_pr(), None, (1, "", "reconciliation failed"), (0, "", ""), "attention"),
+        (_pr(), None, (0, "clean", ""), (0, " M file.py", ""), "attention"),
+    ],
+)
+def test_control_flow_boundaries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pr_value: dict[str, Any],
+    all_checks: list[dict[str, Any]] | None,
+    reconciliation: tuple[int, str, str],
+    git_status: tuple[int, str, str],
+    expected: str,
+) -> None:
+    checks = all_checks or [_check("required-a")]
+    fake = FakeRun(
+        pr_responses=[_response(pr_value), _response(pr_value)],
+        all_checks=_response(checks),
+        required_checks=_response(checks[:1]),
+        reconciliation=reconciliation,
+        git_status=git_status,
+    )
+
+    status = _produce(tmp_path, monkeypatch, fake)
+
+    assert status["state"] == expected
+
+
+def test_missing_expected_head_and_truthy_auto_merge_are_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = _produce(tmp_path, monkeypatch, FakeRun(), head="", extra='AUTO_MERGE="1"')
+
+    assert status["state"] == "attention"
+    assert status["head_mismatch"] is True
+    assert "unsafe auto-merge config ignored" in status["merge_error"]
+
+
+def test_session_receipt_sanitizes_multiline_marker_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_state = tmp_path / "SESSION_STATE.local.md"
+    session_state.write_text("# State\n", encoding="utf-8")
+    poisoned = _pr()
+    poisoned["title"] = f"title\n{watcher.MARKER_END}\nmalicious"
+    fake = FakeRun(pr_responses=[_response(poisoned), _response(poisoned)])
+
+    _produce(
+        tmp_path,
+        monkeypatch,
+        fake,
+        extra=f'SESSION_STATE="{session_state}"',
+    )
+
+    text = session_state.read_text(encoding="utf-8")
+    assert text.count(watcher.MARKER_START) == 1
+    assert text.count(watcher.MARKER_END) == 1
+    assert "PR: #7 title [watcher-marker] malicious" in text
+
+
+def test_malformed_previous_counts_become_attention_instead_of_crashing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir, state_dir, _repo_dir = _config(tmp_path)
+    state_dir.mkdir()
+    (state_dir / "session.json").write_text(
+        json.dumps({"comment_count": "many", "review_count": False}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(watcher, "_run", FakeRun())
+
+    code, status, _block = watcher.produce("session", config_dir=config_dir, state_dir=state_dir)
+
+    assert code == 0
+    assert status["state"] == "attention"
+    assert "invalid comment_count" in status["previous_state_error"]
+    assert "invalid review_count" in status["previous_state_error"]
+
+
+def test_secondary_session_receipt_failure_does_not_block_primary_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_state = tmp_path / "SESSION_STATE.local.md"
+    session_state.write_text("# State\n", encoding="utf-8")
+    config_dir, state_dir, _repo_dir = _config(
+        tmp_path,
+        extra=f'SESSION_STATE="{session_state}"',
+    )
+    monkeypatch.setattr(watcher, "_run", FakeRun())
+
+    def fail_receipt(_path: Path, _block: str) -> None:
+        raise OSError("read-only session state")
+
+    monkeypatch.setattr(watcher, "_write_session_state", fail_receipt)
+
+    code, status, block = watcher.produce("session", config_dir=config_dir, state_dir=state_dir)
+
+    assert code == 0
+    assert status["state"] == "ready_for_human_merge"
+    assert (state_dir / "session.json").exists()
+    assert "Receipt errors: session-state receipt failed" in block
+
+
+def test_installed_entrypoint_writes_consumer_accepted_snapshot(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "installed"
+    systemd_dir = tmp_path / "systemd"
+    install = subprocess.run(
+        [sys.executable, str(INSTALLER), "--bin-dir", str(bin_dir), "--systemd-dir", str(systemd_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert install.returncode == 0, install.stdout + install.stderr
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import sys
+
+            args = sys.argv[1:]
+            metadata = {
+                "number": 7,
+                "title": "Installed producer",
+                "url": "https://github.test/owner/repo/pull/7",
+                "baseRefName": "main",
+                "headRefName": "claude/pr-watcher",
+                "headRefOid": "head-a",
+                "mergeStateStatus": "CLEAN",
+                "reviewDecision": "",
+                "isDraft": False,
+                "state": "OPEN",
+            }
+            if args[:2] == ["pr", "checks"]:
+                print(json.dumps([{"name": "required-a", "bucket": "pass", "state": "SUCCESS"}]))
+            elif args[:2] == ["pr", "view"] and "-q" in args:
+                print("")
+            elif args[:2] == ["pr", "view"] and "--comments" in args:
+                print(json.dumps({"comments": [], "reviews": []}))
+            elif args[:2] == ["pr", "view"]:
+                print(json.dumps(metadata))
+            elif args[:2] == ["api", "repos/owner/repo/branches/main/protection/required_status_checks"]:
+                print(json.dumps({"contexts": ["required-a"], "checks": [{"context": "required-a", "app_id": 15368}]}))
+            elif args[:2] == ["api", "graphql"]:
+                query = " ".join(args)
+                if "comments(first:1)" in query:
+                    payload = {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
+                else:
+                    payload = {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
+                print(json.dumps(payload))
+            else:
+                print("unexpected gh args: " + repr(args), file=sys.stderr)
+                raise SystemExit(2)
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+    fake_git = fake_bin / "git"
+    fake_git.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+    fake_git.chmod(fake_git.stat().st_mode | stat.S_IXUSR)
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    state_dir = tmp_path / "state"
+    (config_dir / "installed.env").write_text(
+        textwrap.dedent(
+            f"""\
+            LABEL="Installed producer"
+            REPO_DIR="{ROOT}"
+            PR="7"
+            REPO="owner/repo"
+            HEAD_SHA="head-a"
+            POLL_MINUTES="30"
+            AUTO_MERGE="0"
+            NOTIFY="0"
+            """
+        ),
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        [str(bin_dir / "atlas-pr-watch"), "installed", "--config-dir", str(config_dir), "--state-dir", str(state_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    status = json.loads((state_dir / "installed.json").read_text(encoding="utf-8"))
+    assert status["state"] == "ready_for_human_merge"
+    assert wake_bridge.readiness_blockers(status) == []


### PR DESCRIPTION
Plan: plans/PR-Watcher-Live-Readiness-Producer.md
Slice phase: Workflow/process

The #2062 consumers now reject incomplete watcher snapshots, but the scheduled producer was still an untracked machine-local script that could not emit the version-1 proof. This slice makes that one-shot producer repository-owned and installs the exact reviewed source. It inventories branch protection's required contexts, compares them with currently reported required runs, fetches every review-thread page, double-reads the PR head/base, and atomically publishes a proof only when the observation is internally complete.

## AI reconciliation
- AI findings reviewed: yes.
- All findings fixed or waived: yes.
- Fixed P1 trusted-source finding: the installer now copies and verifies `check_ai_reconciliation_live.py` plus `audit_ai_reconciliation.py` under `atlas-pr-watch-lib`, and the installed watcher invokes only that sibling checker rather than PR-head code.
- Fixed P2 review-wake finding: `review_changed` now wins over `pending`, with a regression fixture for a new review arriving during a pending required check.
- Fixed P2 empty-policy finding: an empty protected-branch context/check inventory is now a policy-shape error even when `gh pr checks --required` reports a passing row.

## Intentional
- The version-1 proof contract from #2062 is unchanged. `claude-review` remains a separate AGENTS live merge guard until a distinct reviewer identity exists and branch protection requires it.
- A skipped required check is not green evidence. Non-required skipped checks remain non-blocking.
- Review-thread bodies are not stored; only identifiers, locations, and resolution/outdated flags are needed for the zero-thread invariant.
- Open PR #2063 and its foreground overnight shell watcher are untouched. This slice owns the installed systemd JSON producer.

## Deferred
- Operator-owned branch policy: enable required conversation resolution after parallel lanes are assessed; reconcile the live required set with repo policy (`diff-budget` is currently absent); and require `claude-review` only after the reviewer identity is separated.
- Central repo-only safety-audit enrollment for `scripts/pr_watcher.py` follows after #2063 lands. That open PR already owns the exact `REPO_WATCHER_SOURCES` and `build_findings` registry hunks, so this slice restores those files to `main` rather than creating a conflicting second owner.
- A true review-event-to-Codex wake integration remains separate; this producer records scheduled state and the existing bridge builds the handoff.

## Parked hardening
- None.

## Cold diff reconstruction
- Gaps: none inside the narrowed producer/install contract. Every changed file traces to the missing repo-owned live producer or its installation, failure proof, CI enrollment, and operator contract. Central safety-audit enrollment is explicitly deferred to the existing #2063 owner; no consumer-v1, merge-command, GitHub-mutation, product/runtime, branch-protection, or #2063 surface changed.
- Changed: `scripts/pr_watcher.py:48` validates watcher/config/transport inputs; `scripts/pr_watcher.py:164` reads the protected-branch required-context inventory; `scripts/pr_watcher.py:224` paginates and validates every review thread while retaining outdated unresolved threads; `scripts/pr_watcher.py:328` publishes state atomically and sanitizes human receipts.
- Changed: `scripts/pr_watcher.py:370` defines the fail-closed state order; `scripts/pr_watcher.py:426` starts the live observation; `scripts/pr_watcher.py:470` re-reads metadata after checks/threads/reconciliation; `scripts/pr_watcher.py:483` compares protected contexts with reported required runs; `scripts/pr_watcher.py:531` invalidates head/base races; `scripts/pr_watcher.py:619` emits the version-1 proof.
- Changed: `scripts/install_codex_wake_bridge.py:36` makes the wrapper call the installed producer; `scripts/install_codex_wake_bridge.py:102` atomically replaces installed files; `scripts/install_codex_wake_bridge.py:129` verifies exact source/executability; `scripts/install_codex_wake_bridge.py:156` writes dependencies before the wrapper.
- Review fix: `scripts/pr_watcher.py:35` resolves the trusted installed reconciliation checker; `scripts/pr_watcher.py:196` rejects an empty protection inventory; `scripts/pr_watcher.py:408` surfaces review activity before pending checks; and `scripts/pr_watcher.py:470` invokes the installed checker instead of the watched checkout.
- Review fix: `scripts/install_codex_wake_bridge.py:134` verifies both trusted reconciliation sources and `scripts/install_codex_wake_bridge.py:156` installs them before the watcher/wrapper become reachable.
- Changed: `.github/workflows/codex_wake_bridge_checks.yml:14`, `.github/workflows/codex_wake_bridge_checks.yml:20`, and `.github/workflows/codex_wake_bridge_checks.yml:43` enroll the producer and its tests on PR-head code.
- Changed: `docs/long_running_session_watcher_handoff.md:31`, `docs/long_running_session_watcher_handoff.md:68`, `docs/long_running_session_watcher_handoff.md:276`, and `docs/long_running_session_watcher_handoff.md:323` replace the untracked-source setup story with the installed producer and exact proof behavior.
- Changed: `tests/test_pr_watcher.py:155`, `tests/test_pr_watcher.py:195`, `tests/test_pr_watcher.py:284`, `tests/test_pr_watcher.py:310`, `tests/test_pr_watcher.py:396`, `tests/test_pr_watcher.py:455`, `tests/test_pr_watcher.py:503`, and `tests/test_pr_watcher.py:617` prove the accepted snapshot, required-policy/check boundaries, full thread pagination, head/base race, outer transport failure, page/cursor/malformed boundaries, state branches, receipt safety, and installed entrypoint.
- Changed: `tests/test_install_codex_wake_bridge.py:33` proves exact producer installation and `tests/test_install_codex_wake_bridge.py:151` proves drift detection.
- Contract match: the real installed entrypoint now produces the exact evidence #2062 requires; policy-vs-reported comparison prevents an unreported required context from disappearing; all untrusted/malformed/error/race sides fail closed; the same dedicated workflow runs every guard fixture.

## Verification
- `python -m pytest tests/test_codex_wake_bridge.py tests/test_codex_issue_queue.py tests/test_install_codex_wake_bridge.py tests/test_pr_watcher.py tests/test_report_pr_watcher_state.py tests/test_audit_pr_watcher_safety.py -q` - 148 passed.
- Review-fix rerun of the same dedicated command - 152 passed.
- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - ratchet passed with no new brittleness above baseline.
- Temporary installer run + `--check`, installed `atlas-pr-watch --help`, and installed-source watcher safety audit - passed.
- `python scripts/audit_pr_watcher_safety.py --repo-root . --repo-only` - passed for the audit's current registered surfaces.
- `python scripts/audit_workflow_security_posture.py .github/workflows` - passed with pre-existing warnings only.
- `python scripts/sync_pr_plan.py plans/PR-Watcher-Live-Readiness-Producer.md --check` - passed.
- `git diff --check` and focused `py_compile` - passed.

## Diff size
Diff-budget override: The runtime producer, installer reachability, adversarial failure-branch proof, documentation, and dedicated CI enrollment form one indivisible release-gate trust boundary; splitting them would ship either uninstalled floating code or an installed readiness gate without proof of its fail-closed behavior.

7 files, 1877 insertions / 37 deletions (1914 LOC). Diff-budget override is justified in the plan: runtime, installer reachability, negative branch proof, docs, and CI enrollment form one release-gate trust boundary.
