### PR TITLE
Batch cross-layer caller hints into one repository scan

### DIFF
--- a/plans/PR-Pre-Push-Caller-Hints-Timeout.md
+++ b/plans/PR-Pre-Push-Caller-Hints-Timeout.md
@@ -1,0 +1,156 @@
+# PR-Pre-Push-Caller-Hints-Timeout
+
+## Why this slice exists
+
+PR #2061's privacy vertical proof is code-green and reconciled, but its
+`pre-push-audit` check is red because GitHub cancels the local-review bundle at
+the job's hard 10-minute limit while `audit_cross_layer_callers.py` is running.
+The exact-head run
+`https://github.com/canfieldjuan/ATLAS/actions/runs/29134149285` passed every
+preceding audit and then emitted only `==> Cross-layer caller hints` before
+cancellation. This workflow/process slice is justified by that failed product
+run and implements the operator's explicit instruction to remove the blocker
+without modifying #2061's privacy code.
+
+The same #2061 tree reproduces the cost locally: 111 changed Python symbols,
+2,893 searchable tracked code files, 813 reported references, and 202.19 seconds
+for the caller-hint audit alone. Raising the workflow timeout would preserve the
+underlying changed-symbol x repository scan and make the next large guard PR fail
+later, so this slice fixes the algorithmic root.
+
+### Problem-derived contract
+
+- Root cause: `build_hints` calls `find_references` once per changed symbol, and
+  each call rereads every non-diff tracked code file and retokenizes every Python
+  file. Runtime therefore scales as O(changed symbols x repository bytes): #2061
+  performs roughly 321,000 file visits before pattern filtering. The GitHub
+  runner cannot finish that advisory scan inside ten minutes. This slice fixes
+  the root; the timeout is a consequence, not the repair target.
+- Correct fix must touch/change: `scripts/audit_cross_layer_callers.py` must
+  index candidate symbol-name lines for all changed symbols in one repository
+  pass, then apply each symbol's existing class/function/method patterns to only
+  those candidates. It must preserve output ordering, reference counts, path
+  safety, changed-symbol detection, Python token filtering, malformed-token
+  fallback, non-Python comment filtering, Unicode-decode skips, and advisory
+  exit behavior. `tests/test_audit_cross_layer_callers.py` must prove multiple
+  symbols share one read/tokenization pass and that references/noise retain the
+  existing semantics. The actual #2061 tree must reproduce 111 symbols and 813
+  references with materially lower runtime.
+- Must not change: `.github/workflows/pre_push_audit.yml` timeout or trusted-base
+  security boundary, `scripts/local_pr_review.sh` check ordering/pass-fail
+  semantics, branch protection, reviewer gates, privacy code/tests/PR #2061,
+  watcher infrastructure, or any product surface.
+
+## Scope (this PR)
+
+Ownership lane: workflow/pre-push-audit-performance
+Slice phase: Workflow/process
+
+1. Replace per-symbol repository rescans with a single batched candidate index
+   in the existing cross-layer caller-hint auditor.
+2. Add fixture coverage for shared file reads, multiple function/method/class
+   symbols, comment/noise rejection, and malformed-Python fallback.
+3. Benchmark the real #2061 head against current `origin/main` and compare its
+   symbol/reference output to the captured baseline.
+
+Max files: 3
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] All searchable tracked files are read at most once per audit invocation,
+        independent of the number of changed symbols.
+  - [ ] Python files are tokenized once and candidate lines are indexed by the
+        requested symbol names; malformed Python retains the existing all-line
+        fallback rather than silently disappearing.
+  - [ ] Non-Python code keeps the existing blank/comment-line exclusions and
+        class/function/method reference patterns remain unchanged.
+  - [ ] Multiple changed symbols with the same name each receive the same
+        matching references without duplicate file reads.
+  - [ ] Unicode-decode failures remain advisory skips and unsafe repository
+        paths still fail closed.
+  - [ ] The CLI output order and summary counts remain stable for equivalent
+        input; the captured #2061 baseline remains 111 changed symbols and 813
+        non-diff references.
+  - [ ] The real #2061 audit completes locally in under 20 seconds, at least a
+        10x improvement over the measured 202.19-second baseline.
+  - [ ] The pre-push workflow timeout and trusted-base execution contract are
+        untouched; no product or privacy behavior changes.
+- Reachability proof: run the actual CLI entrypoint from a detached #2061
+  worktree against `origin/main`, capture its emitted summary/reference hints,
+  compare that output with the pre-change baseline, and record elapsed time.
+- Affected surfaces: advisory cross-layer caller hints inside local and GitHub
+  pre-push review bundles.
+- Risk areas: false-negative caller hints, output-order drift, excessive memory
+  from indexing, malformed-source handling, and trusted-base workflow behavior.
+- Reviewer rules triggered: R1, R2, R10, R12, R13, R14.
+
+### Files touched
+
+- `plans/PR-Pre-Push-Caller-Hints-Timeout.md`
+- `scripts/audit_cross_layer_callers.py`
+- `tests/test_audit_cross_layer_callers.py`
+
+## Mechanism
+
+Collect the changed symbols exactly as today, group them by simple name, and
+scan the sorted searchable file list once. For Python, tokenize each file once
+and retain line numbers only for `NAME` tokens present in the requested-name
+set. For non-Python code, retain only existing non-comment candidate lines and
+extract requested identifier names with one combined escaped-name regex. If
+Python tokenization fails, fall back to name extraction across all lines, which
+preserves today's conservative behavior.
+
+For each candidate name/line, apply the unchanged `reference_patterns` for all
+changed symbols sharing that name and append a `Reference` to that symbol's
+ordered bucket. Finally construct `CallerHint` values in original changed-symbol
+order. This changes scan shape from one full repository traversal per symbol to
+one traversal plus candidate pattern checks; it does not change what qualifies
+as a reference.
+
+## Intentional
+
+- No workflow timeout increase: the measured root is repeated parsing, and a
+  larger timeout would only postpone the same failure class.
+- No external `rg` dependency or shell pipeline: the auditor keeps its portable
+  Python/tokenize semantics and fixture-testable path/error behavior.
+- A small in-memory candidate index is intentional. It stores only matching
+  name/line pairs and rendered reference snippets, not whole repository text.
+- Added/deleted Python files and decorator-only edits retain their documented
+  advisory blind spots; this slice changes performance, not audit scope.
+
+## Deferred
+
+- Making advisory workflow checks required remains tracked in #2035 and is not
+  decided by this performance repair.
+- Any future semantic expansion of caller detection (imports, property reads,
+  deleted symbols, decorators) requires its own accepted slice and precision
+  fixtures.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_audit_cross_layer_callers.py -q` (`15 passed`).
+- The pre-push workflow's complete PR-review tooling test list plus
+  `tests/test_audit_cross_layer_callers.py` (`449 passed`).
+- Exact `phase-c4-scripts` maturity ratchet command from CI (passed; no new
+  brittleness above `baseline_scripts.json`).
+- Real #2061 CLI baseline from detached head `74d432fdb` against `origin/main`:
+  `/usr/bin/time ... audit_cross_layer_callers.py origin/main` (`202.19s`, 111
+  changed symbols, 813 non-diff references).
+- Real #2061 CLI after the batched scan: the same command (`2.24s`, 111 changed
+  symbols, 813 non-diff references; `cmp` confirmed byte-identical output).
+- Plan sync check against `origin/main` (passed).
+- `git diff --check` (passed).
+- Cold reconstruction found no gap, forbidden touch, or untraced change.
+- Pending before push: the managed local review bundle.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Pre-Push-Caller-Hints-Timeout.md` | 156 |
+| `scripts/audit_cross_layer_callers.py` | 104 |
+| `tests/test_audit_cross_layer_callers.py` | 138 |
+| **Total** | **398** |

--- a/scripts/audit_cross_layer_callers.py
+++ b/scripts/audit_cross_layer_callers.py
@@ -101,8 +101,9 @@ def build_hints(base_ref: str) -> tuple[CallerHint, ...]:
         for path in tracked_files()
         if path not in changed and is_code_path(path)
     )
+    references = find_references_by_symbol(symbols, searchable)
     return tuple(
-        CallerHint(symbol=symbol, references=find_references(symbol, searchable))
+        CallerHint(symbol=symbol, references=references[symbol])
         for symbol in symbols
     )
 
@@ -215,21 +216,50 @@ def _symbol_kind(node: ast.AST) -> str:
     return "function"
 
 
-def find_references(symbol: ChangedSymbol, paths: Sequence[str]) -> tuple[Reference, ...]:
-    references: list[Reference] = []
-    patterns = reference_patterns(symbol)
+def find_references_by_symbol(
+    symbols: Sequence[ChangedSymbol],
+    paths: Sequence[str],
+) -> dict[ChangedSymbol, tuple[Reference, ...]]:
+    if not symbols:
+        return {}
+    symbols_by_name: dict[str, list[ChangedSymbol]] = {}
+    for symbol in symbols:
+        symbols_by_name.setdefault(symbol.name, []).append(symbol)
+    references: dict[ChangedSymbol, list[Reference]] = {
+        symbol: [] for symbol in symbols
+    }
+    patterns = {
+        symbol: reference_patterns(symbol)
+        for symbol in symbols
+    }
+    requested_names = frozenset(symbols_by_name)
+    name_pattern = re.compile(
+        rf"\b(?:{'|'.join(re.escape(name) for name in sorted(requested_names))})\b"
+    )
+
     for path in paths:
         try:
             text = Path(path).read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        candidate_lines = code_reference_lines(path, text, symbol)
-        for index, line in enumerate(text.splitlines(), start=1):
-            if index in candidate_lines and any(pattern.search(line) for pattern in patterns):
-                references.append(
-                    Reference(path=path, line=index, text=line.strip()[:160])
-                )
-    return tuple(references)
+        lines = text.splitlines()
+        candidates = candidate_names_by_line(
+            path,
+            text,
+            requested_names,
+            name_pattern,
+        )
+        for index in sorted(candidates):
+            line = lines[index - 1]
+            reference = Reference(path=path, line=index, text=line.strip()[:160])
+            for name in candidates[index]:
+                for symbol in symbols_by_name[name]:
+                    if any(pattern.search(line) for pattern in patterns[symbol]):
+                        references[symbol].append(reference)
+    return {
+        symbol: tuple(symbol_references)
+        for symbol, symbol_references in references.items()
+    }
 
 
 def reference_patterns(symbol: ChangedSymbol) -> tuple[re.Pattern[str], ...]:
@@ -245,31 +275,57 @@ def reference_patterns(symbol: ChangedSymbol) -> tuple[re.Pattern[str], ...]:
     return (re.compile(rf"\b{escaped}\s*\("),)
 
 
-def code_reference_lines(path: str, text: str, symbol: ChangedSymbol) -> set[int]:
+def candidate_names_by_line(
+    path: str,
+    text: str,
+    requested_names: frozenset[str],
+    name_pattern: re.Pattern[str],
+) -> dict[int, set[str]]:
     if PurePosixPath(path).suffix in {".py", ".pyi"}:
-        return python_name_lines(text, symbol.name)
-    return non_python_candidate_lines(text)
+        return python_names_by_line(text, requested_names, name_pattern)
+    return non_python_names_by_line(text, name_pattern)
 
 
-def python_name_lines(text: str, name: str) -> set[int]:
-    lines: set[int] = set()
+def python_names_by_line(
+    text: str,
+    requested_names: frozenset[str],
+    name_pattern: re.Pattern[str],
+) -> dict[int, set[str]]:
+    lines: dict[int, set[str]] = {}
     try:
         tokens = tokenize.generate_tokens(StringIO(text).readline)
         for token in tokens:
-            if token.type == tokenize.NAME and token.string == name:
-                lines.add(token.start[0])
+            if token.type == tokenize.NAME and token.string in requested_names:
+                lines.setdefault(token.start[0], set()).add(token.string)
     except tokenize.TokenError:
-        return set(range(1, len(text.splitlines()) + 1))
+        return names_by_line(text, name_pattern, skip_comment_lines=False)
     return lines
 
 
-def non_python_candidate_lines(text: str) -> set[int]:
-    lines: set[int] = set()
+def non_python_names_by_line(
+    text: str,
+    name_pattern: re.Pattern[str],
+) -> dict[int, set[str]]:
+    return names_by_line(text, name_pattern, skip_comment_lines=True)
+
+
+def names_by_line(
+    text: str,
+    name_pattern: re.Pattern[str],
+    *,
+    skip_comment_lines: bool,
+) -> dict[int, set[str]]:
+    matches: dict[int, set[str]] = {}
     for index, line in enumerate(text.splitlines(), start=1):
         stripped = line.strip()
-        if stripped and not stripped.startswith(("//", "#", "/*", "*")):
-            lines.add(index)
-    return lines
+        if not stripped:
+            continue
+        if skip_comment_lines and stripped.startswith(("//", "#", "/*", "*")):
+            continue
+        names = {match.group(0) for match in name_pattern.finditer(line)}
+        if names:
+            matches[index] = names
+    return matches
 
 
 def is_code_path(path: str) -> bool:

--- a/tests/test_audit_cross_layer_callers.py
+++ b/tests/test_audit_cross_layer_callers.py
@@ -185,6 +185,144 @@ def test_validate_repo_path_rejects_absolute_path(auditor) -> None:
         auditor.validate_repo_path("/tmp/outside.py")
 
 
+def test_batched_reference_scan_reads_each_file_once(
+    auditor,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    symbol_count = 60
+    file_count = 20
+    symbols = tuple(
+        auditor.ChangedSymbol(
+            path="pkg/lib.py",
+            name=f"helper_{index}",
+            qualname=f"helper_{index}",
+            kind="function",
+            line=index + 1,
+        )
+        for index in range(symbol_count)
+    )
+    paths = tuple(f"callers/caller_{index}.py" for index in range(file_count))
+    calls = "\n".join(f"helper_{index}(value)" for index in range(symbol_count))
+    for path in paths:
+        _write(tmp_path, path, calls + "\n")
+
+    reads: dict[str, int] = {}
+    original_read_text = auditor.Path.read_text
+
+    def counted_read_text(path: Path, *args, **kwargs) -> str:
+        key = path.as_posix()
+        reads[key] = reads.get(key, 0) + 1
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(auditor.Path, "read_text", counted_read_text)
+
+    references = auditor.find_references_by_symbol(symbols, paths)
+
+    assert reads == {path: 1 for path in paths}
+    assert all(len(references[symbol]) == file_count for symbol in symbols)
+
+
+def test_batched_reference_scan_preserves_same_name_symbol_patterns(
+    auditor,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    function = auditor.ChangedSymbol(
+        path="pkg/lib.py",
+        name="normalize",
+        qualname="normalize",
+        kind="function",
+        line=1,
+    )
+    method = auditor.ChangedSymbol(
+        path="pkg/service.py",
+        name="normalize",
+        qualname="Normalizer.normalize",
+        kind="function",
+        line=2,
+    )
+    _write(
+        tmp_path,
+        "caller.py",
+        "normalize(value)\nservice.normalize(value)\nnormalized = value\n",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    references = auditor.find_references_by_symbol(
+        (function, method),
+        ("caller.py",),
+    )
+
+    assert [reference.line for reference in references[function]] == [1, 2]
+    assert [reference.line for reference in references[method]] == [2]
+
+
+def test_batched_reference_scan_keeps_malformed_python_fallback(
+    auditor,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    symbol = auditor.ChangedSymbol(
+        path="pkg/lib.py",
+        name="normalize",
+        qualname="normalize",
+        kind="function",
+        line=1,
+    )
+    _write(tmp_path, "broken.py", 'text = """\nnormalize(value)\n')
+    monkeypatch.chdir(tmp_path)
+
+    references = auditor.find_references_by_symbol((symbol,), ("broken.py",))
+
+    assert [reference.line for reference in references[symbol]] == [2]
+
+
+def test_batched_reference_scan_keeps_non_python_comment_filter(
+    auditor,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    symbol = auditor.ChangedSymbol(
+        path="pkg/lib.py",
+        name="normalize",
+        qualname="normalize",
+        kind="function",
+        line=1,
+    )
+    _write(
+        tmp_path,
+        "caller.ts",
+        "// normalize(value)\nconst value = normalize(input)\n# normalize(value)\n",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    references = auditor.find_references_by_symbol((symbol,), ("caller.ts",))
+
+    assert [reference.line for reference in references[symbol]] == [2]
+
+
+def test_batched_reference_scan_skips_non_utf8_files(
+    auditor,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    symbol = auditor.ChangedSymbol(
+        path="pkg/lib.py",
+        name="normalize",
+        qualname="normalize",
+        kind="function",
+        line=1,
+    )
+    (tmp_path / "caller.py").write_bytes(b"normalize(value)\n\xff")
+    monkeypatch.chdir(tmp_path)
+
+    references = auditor.find_references_by_symbol((symbol,), ("caller.py",))
+
+    assert references[symbol] == ()
+
+
 def _write_fixture_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
Plan: plans/PR-Pre-Push-Caller-Hints-Timeout.md
Slice phase: Workflow/process

Refs #2035. PR #2061's code, reconciliation, unit, and extracted checks are green, but `pre-push-audit` is cancelled at the hard 10-minute job limit inside cross-layer caller hints. The caller auditor currently rereads and retokenizes every tracked code file once per changed symbol, producing roughly 321,000 file visits for #2061. This slice batches all requested symbol names into one repository scan, preserving the advisory output while removing the algorithmic CI blocker.

## Intentional
- Fix the O(changed symbols x repository bytes) scan instead of raising the workflow timeout.
- Keep the existing Python-token, non-Python comment, malformed-token fallback, Unicode skip, path-safety, and advisory exit semantics.
- Use an in-memory index containing only requested name/line candidates and final reference snippets, not repository file bodies.
- Preserve documented blind spots for added/deleted symbols and decorator-only edits; audit-scope expansion is outside this performance repair.

## Deferred
- Making advisory checks required and other CI enforcement decisions remain tracked in #2035.
- Semantic expansion for imports, property reads, deleted symbols, or decorators requires a separate precision-tested slice.

## Parked hardening
- None.

## Cold diff reconstruction
- Gaps first: none.
- Changed: `scripts/audit_cross_layer_callers.py:99` builds one searchable-file list and requests one batched reference index; `:219` groups changed symbols by name, compiles existing per-symbol patterns once, reads each file once, and preserves original symbol/file/line ordering.
- Changed: `scripts/audit_cross_layer_callers.py:278` tokenizes each Python file once, indexes only requested names, conservatively falls back across all lines on malformed Python, and retains the existing non-Python comment exclusions.
- Changed: `tests/test_audit_cross_layer_callers.py:188` proves 60 symbols across 20 files cause exactly 20 reads rather than 1,200; `:227`, `:262`, `:282`, and `:306` preserve same-name function/method patterns, malformed-Python fallback, non-Python filtering, and Unicode skips.
- Changed: `plans/PR-Pre-Push-Caller-Hints-Timeout.md:1` records the failed product run, problem-derived algorithm contract, three-file budget, security boundaries, and real-head benchmark.
- Contract match: the runtime diff changes only repository traversal shape; every detection and rendering rule is reused.
- Forbidden-touch check: the pre-push workflow timeout/trusted-base boundary, local-review ordering, privacy code/PR #2061, branch protection, watchers, and product behavior are untouched.
- Untraced changes: none.

## Verification
- `python -m pytest tests/test_audit_cross_layer_callers.py -q`: 15 passed.
- Complete pre-push PR-review tooling list plus the caller-auditor tests: 449 passed.
- Phase-C4 scripts maturity ratchet: passed with no new baseline debt.
- Real #2061 baseline: 202.19 seconds, 111 symbols, 813 references.
- Real #2061 optimized: 2.24 seconds, 111 symbols, 813 references; output byte-identical via `cmp`.
- Plan sync and `git diff --check`: passed.

## Diff size
3 files, +374 / -24 (398 changed lines).
