### PR TITLE
Deflection report accounting regression for S6A.2 authoritative admission

### DIFF
--- a/plans/PR-Deflection-Report-Accounting-Regression.md
+++ b/plans/PR-Deflection-Report-Accounting-Regression.md
@@ -1,0 +1,109 @@
+# PR-Deflection-Report-Accounting-Regression
+
+## Why this slice exists
+
+The authoritative source-admission fix (#2071) corrected a report-accounting
+defect: a caller-supplied private support-ticket row could re-inject over the
+provider's filtered source_material, so the FAQ deflection report counted the
+rejected private row as an extra source ("Ticket sources represented: 3" instead
+of 2) and emitted a false "appeared only once" singleton warning. That fix is
+guarded at the input-provider merge layer
+(tests/test_extracted_content_ops_input_provider.py) but has no committed test
+at the report-accounting layer -- the mixed public/private execute-path scenario
+lived only in an ad hoc validation harness. This slice commits that scenario as
+a regression so a future change that reopens the re-injection cannot pass CI.
+
+### Problem-derived contract
+
+- Root cause: the #2071 authoritative-merge behavior is only guarded at the
+  package/merge unit layer; the observable report accounting (source count and
+  singleton warning on the real execute path) has no regression test, so a
+  merge regression would surface only in a live report, not in CI.
+- Correct fix must touch/change: add one behavioral regression test on the real
+  execute route with the Atlas support-ticket input provider and real FAQ
+  deflection report service, asserting the rejected private row is not counted
+  as a source and does not trigger the singleton warning.
+- Must not change: any runtime or product code, the report shape, the privacy
+  classifier, the merge contract, or any adjacent lane. Test-only.
+
+## Scope (this PR)
+
+Ownership lane: resolution-audit/privacy-admission
+Slice phase: Robust testing
+
+Max files: 2
+
+1. Add a report-accounting regression test on POST /content-ops/execute that
+   submits two public rows plus one caller re-injected private row and asserts
+   the report counts only the two admitted sources, omits the singleton warning,
+   and never emits the private sentinel.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The test drives the real execute route with the Atlas support-ticket
+        input provider, real FAQ deflection report service, and in-memory report
+        store -- no mock of the code under test.
+  - [ ] It asserts ticket_source_count is 2 and "Ticket sources represented: 2"
+        appears in the report markdown, not 3.
+  - [ ] It asserts the false "appeared only once" singleton warning is absent.
+  - [ ] It asserts the private sentinel is absent from the persisted artifact.
+  - [ ] The test fails on pre-#2071 code and passes on current code, so it
+        guards the fix rather than asserting vacuously.
+  - [ ] No runtime, product, or extracted-package code changes.
+- Reachability proof: the test calls the real route end to end and reads the
+  persisted artifact back from the store.
+- Affected surfaces: test suite only.
+- Risk areas: none beyond test determinism; inputs and assertions are fixed.
+- Reviewer rules triggered: R14 (reconstruct behavior). No guard is added, so no
+  boundary probe is required.
+
+### Files touched
+
+- `plans/PR-Deflection-Report-Accounting-Regression.md`
+- `tests/test_extracted_content_ops_live_execute_harness.py`
+
+## Mechanism
+
+The test mirrors the S6A.2 validation scenario as a committed pytest in
+tests/test_extracted_content_ops_live_execute_harness.py. It builds
+source_material with two public support-ticket rows sharing one question and one
+private row whose nested public_comment body is marked "kept private" and
+carries a sentinel. It constructs the control-surface router with
+build_content_ops_input_provider(), which filters the private row and declares
+source_material authoritative, then posts the raw three-row source_material as
+caller input -- the re-injection vector. It reads the persisted artifact from
+the in-memory store and asserts the source count is 2, the singleton warning is
+absent, and the sentinel never reaches the artifact.
+
+## Intentional
+
+- The test asserts on the report markdown and summary ticket_source_count rather
+  than provider metadata, because provider included_row_count was already 2
+  before #2071; the defect was purely downstream accounting, so the guard must
+  live at the report layer.
+- The sentinel-absent assertion is defense in depth. Content scrubbing is
+  #2061's job and is already covered, but co-asserting it keeps the scenario
+  self-documenting.
+- Placed in the existing live-execute-harness suite to reuse its real-adapter
+  router idiom rather than add a new fixture file.
+
+## Deferred
+
+- The builder's "4 CI proofs" label is not reconciled to named tests; not
+  required for correctness, since the superset report and submit suites pass.
+  None otherwise.
+
+Parked hardening: none.
+
+## Verification
+
+- run sync_pr_plan.py and the local run before push.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Deflection-Report-Accounting-Regression.md` | 109 |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | 78 |
+| **Total** | **187** |

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -856,6 +856,84 @@ async def test_live_execute_route_returns_faq_deflection_report_artifact() -> No
     assert artifact["faq_result"]["markdown"].startswith("# Hosted FAQ Source")
 
 
+async def test_live_execute_route_excludes_reinjected_private_row_from_source_accounting() -> None:
+    # Regression for the authoritative source-admission fix (#2071) at the
+    # report-accounting layer. The support-ticket input provider filters the
+    # private row and marks source_material authoritative; the caller re-submits
+    # the raw rows (including the private one) as inputs.source_material. Before
+    # #2071 the raw value overrode the provider's filtered value, so the rejected
+    # private row was counted as a third source and produced a false
+    # "appeared only once" singleton warning. The private text itself is scrubbed
+    # by the #2061 classifier regardless; this test guards the source COUNT and
+    # the singleton warning, which is the accounting #2071 fixed (3 -> 2). The
+    # existing submit-path test only asserts included_row_count and content
+    # exclusion, not the report-accounting count on the execute path.
+    private_sentinel = "PRIVATE RAW WORKAROUND MUST NOT REACH THE REPORT"
+    public_question = "How do I export an attribution report?"
+    public_resolution = "Open Analytics, choose Attribution, then download the CSV."
+    source_material: list[dict[str, Any]] = [
+        {
+            "ticket_id": f"public-{index}",
+            "source_type": "support_ticket",
+            "subject": public_question,
+            "message": public_question,
+            "resolution_text": public_resolution,
+        }
+        for index in (1, 2)
+    ]
+    source_material.append({
+        "ticket_id": "private-1",
+        "source_type": "support_ticket",
+        "subject": "Internal attribution workaround",
+        "description": private_sentinel,
+        "public_comment": {"body": {"text": private_sentinel, "status": "kept private"}},
+    })
+
+    store = InMemoryDeflectionReportArtifactStore()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(),
+        input_provider=build_content_ops_input_provider(),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        scope_provider=lambda: TenantScope(
+            account_id="acct-faq-privacy",
+            user_id="user-faq",
+        ),
+        deflection_report_store_provider=lambda: store,
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint({
+        "outputs": ["faq_deflection_report"],
+        "limit": 3,
+        "require_quality_gates": False,
+        "inputs": {"source_material": source_material},
+    })
+
+    assert payload["status"] == "completed"
+    # The provider admitted only the two public rows; the private row was filtered
+    # before merge and the caller's re-injection did not restore it.
+    assert payload["input_provider"]["metadata"]["included_row_count"] == 2
+
+    record = await store.get_artifact_record(
+        account_id="acct-faq-privacy",
+        request_id=payload["request_id"],
+    )
+    assert record is not None
+    assert record.artifact is not None
+    artifact = record.artifact
+
+    # Core #2071 regression: the rejected private row is not counted as a source.
+    assert artifact["summary"]["ticket_source_count"] == 2
+    markdown = artifact["markdown"]
+    assert "Ticket sources represented: 2" in markdown
+    # ...and it does not trigger the false singleton warning.
+    assert "appeared only once" not in markdown
+    # Defense in depth: the private text never reaches the persisted artifact.
+    assert private_sentinel not in json.dumps(artifact, default=str)
+
+
 async def test_live_execute_route_handles_bulk_faq_deflection_report() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     router = create_content_ops_control_surface_router(


### PR DESCRIPTION
Plan: plans/PR-Deflection-Report-Accounting-Regression.md
Slice phase: Robust testing

Follow-up to #2071. The authoritative source-admission fix is guarded at the input-provider merge layer (`tests/test_extracted_content_ops_input_provider.py`) but had no committed test at the report-accounting layer; the mixed public/private execute-path scenario lived only in an ad hoc validation harness. This slice commits that scenario as a regression so a change that reopens the caller re-injection cannot pass CI. Test-only: no runtime, product, or extracted-package code changes.

## Intentional
- Asserts on the report markdown and summary `ticket_source_count` rather than provider metadata, because provider `included_row_count` was already 2 before #2071; the defect was purely downstream accounting, so the guard lives at the report layer.
- Co-asserts the private sentinel is absent from the persisted artifact as defense in depth; content scrubbing is #2061's job and is already covered.
- Placed in the existing live-execute-harness suite to reuse its real-adapter router idiom rather than add a new fixture file.

## Deferred
- The builder's "4 CI proofs" label is not reconciled to named tests; not required for correctness, since the superset report and submit suites pass. None otherwise.

## Parked hardening
- None.

## Cold diff reconstruction
- Gaps first: none. The diff adds one regression test plus its plan doc; no runtime file is touched.
- Changed: `tests/test_extracted_content_ops_live_execute_harness.py:859` adds `test_live_execute_route_excludes_reinjected_private_row_from_source_accounting`, which drives the real `/content-ops/execute` route with `build_content_ops_input_provider()` and a real `FAQDeflectionReportService()`, posts two public rows plus one caller re-injected private row, and asserts `included_row_count` is 2, summary `ticket_source_count` is 2, "Ticket sources represented: 2" is in the markdown, the "appeared only once" singleton warning is absent, and the private sentinel is absent from the persisted artifact.
- Changed: `plans/PR-Deflection-Report-Accounting-Regression.md` is the plan doc for this slice.
- Contract match: the single test proves the report-accounting acceptance direction the #2071 arc left untested; it fails on pre-#2071 code (`ticket_source_count` 3) and passes on current code.
- Forbidden-touch check: no runtime, product, extracted-package, classifier, merge, or route code is changed; report and product shape are untouched.
- Untraced changes: none.

## Verification
- New regression at current head (post-#2071): `1 passed, 13 deselected`.
- Same test on pre-#2071 code (`1343e9fdd`): `1 failed` at `assert 3 == 2` on `ticket_source_count`, proving it guards the fix rather than asserting vacuously.
- Report and submit suites at origin/main: `304 passed, 4 skipped`.

## Diff size
2 files, +187 / -0.
