### PR TITLE
Resolution Audit S6C: scalar history cleanup

### DIFF
--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -97,6 +97,42 @@ _QUESTION_STARTS = (
     "where ",
     "why ",
 )
+_HISTORY_BLANK_LINE_RE = re.compile(r"\n[ \t]*\n+")
+_HISTORY_SIGNATURE_BOUNDARY_RE = re.compile(r"^\s*(?:--+|__+)\s*$")
+_HISTORY_MOBILE_SIGNATURE_RE = re.compile(
+    r"^\s*sent from my (?:iphone|ipad|android(?: phone| device)?|mobile device)"
+    r"\.?\s*$",
+    re.IGNORECASE,
+)
+_HISTORY_QUOTED_REPLY_HEADER_RE = re.compile(
+    r"^\s*on\s+"
+    r"(?:(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b|"
+    r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b|"
+    r"\d{1,4}[-/]\d{1,2}(?:[-/]\d{1,4})?\b|"
+    r"\d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)"
+    r"[a-z]*\b|"
+    r".{0,120}\b\d{1,2}:\d{2}\b|"
+    r".{0,120}<[^>]+@[^>]+>|"
+    r".{0,120}\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b)"
+    r".{0,160}\s+wrote:\s*$",
+    re.IGNORECASE,
+)
+_HISTORY_CUSTOMER_MESSAGE_BOUNDARY_RE = re.compile(
+    r"^(?:"
+    r"(?:customer|requester|user)\s*[:\-]|"
+    r"(?:can|could|do|does|how|is|should|what|when|where|why)\s+"
+    r"(?:i|we|my|our)\b|"
+    r"(?:i|we|my|our)\b.*\b(?:cannot|can't|couldn't|didn't|"
+    r"doesn't|error|fail(?:ed|s|ing)?|issue|need|problem|still|unable)\b|"
+    r"still\b"
+    r")",
+    re.IGNORECASE,
+)
+_HISTORY_FOOTER_RE = re.compile(
+    r"\b(?:confidential(?:ity)?|disclos(?:e|ed|ure)|intended recipient|"
+    r"privileged|unauthorized|do not (?:copy|distribute))\b",
+    re.IGNORECASE,
+)
 
 _SOURCE_ID_KEYS = ("source_id", "ticket_id", "id", "case_id", "conversation_id")
 _SOURCE_TITLE_KEYS = (
@@ -145,6 +181,11 @@ _PUBLIC_COMMENT_KEYS = (
     "history",
     "conversation_history",
 )
+_SCALAR_HISTORY_KEYS = frozenset({
+    "ticket_history",
+    "history",
+    "conversation_history",
+})
 _RESOLUTION_TEXT_KEYS = (
     "resolution",
     "resolution_text",
@@ -812,6 +853,11 @@ def _raw_comment_texts(row: Mapping[str, Any]) -> list[str]:
         if isinstance(comments, Mapping):
             comments = (comments,)
         elif isinstance(comments, str):
+            if key in _SCALAR_HISTORY_KEYS:
+                text = _scalar_history_text(comments)
+                if text:
+                    texts.append(text)
+                continue
             comments = (comments,)
         elif not isinstance(comments, Sequence) or isinstance(
             comments,
@@ -832,6 +878,11 @@ def _comments_text(row: Mapping[str, Any]) -> str:
         if isinstance(comments, Mapping):
             comments = (comments,)
         elif isinstance(comments, str):
+            if key in _SCALAR_HISTORY_KEYS:
+                text = _scalar_history_text(comments)
+                if text:
+                    parts.append(text)
+                continue
             comments = (comments,)
         elif not isinstance(comments, Sequence) or isinstance(
             comments,
@@ -843,6 +894,78 @@ def _comments_text(row: Mapping[str, Any]) -> str:
             if text:
                 parts.append(support_ticket_plain_text(text))
     return support_ticket_plain_text("\n".join(parts))
+
+
+def _scalar_history_text(value: Any) -> str:
+    """Admit new messages while excluding scalar transcript quote/footer runs."""
+
+    raw = str(value or "").replace("\r\n", "\n").replace("\r", "\n")
+    if not raw.strip():
+        return ""
+    blank_marker = "ATLAS_HISTORY_BLANK_BOUNDARY"
+    while blank_marker in raw:
+        blank_marker += "_"
+    marked = _HISTORY_BLANK_LINE_RE.sub(f"\n{blank_marker}\n", raw)
+    lines = support_ticket_plain_text_lines(marked).splitlines()
+
+    admitted: list[str] = []
+    skip_mode = ""
+    signature_blank_seen = False
+    for raw_line in lines:
+        line = raw_line.strip()
+        if line == blank_marker:
+            if skip_mode == "signature":
+                signature_blank_seen = True
+            continue
+        if not line:
+            continue
+        if skip_mode:
+            if line.startswith(">"):
+                continue
+            if skip_mode == "signature" and _HISTORY_FOOTER_RE.search(line):
+                signature_blank_seen = False
+                continue
+            if not _history_line_starts_message(
+                line,
+                skip_mode=skip_mode,
+                signature_blank_seen=signature_blank_seen,
+            ):
+                continue
+            skip_mode = ""
+            signature_blank_seen = False
+        if (
+            _HISTORY_SIGNATURE_BOUNDARY_RE.fullmatch(line)
+            or _HISTORY_MOBILE_SIGNATURE_RE.fullmatch(line)
+        ):
+            skip_mode = "signature"
+            signature_blank_seen = False
+            continue
+        if _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line):
+            skip_mode = "quote"
+            signature_blank_seen = False
+            continue
+        if line.startswith(">"):
+            continue
+        admitted.append(line)
+    return support_ticket_plain_text("\n".join(admitted))
+
+
+def _history_line_starts_message(
+    line: str,
+    *,
+    skip_mode: str,
+    signature_blank_seen: bool,
+) -> bool:
+    if _HISTORY_CUSTOMER_MESSAGE_BOUNDARY_RE.match(line):
+        return True
+    if skip_mode != "signature":
+        return False
+    words = re.findall(r"[A-Za-z0-9]+", line)
+    return bool(
+        signature_blank_seen
+        or ("?" in line and len(words) >= 2)
+        or re.match(r"^please\b", line, re.IGNORECASE)
+    )
 
 
 def _comment_text(item: Any) -> str:

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -117,6 +117,7 @@ _HISTORY_ORIGINAL_MESSAGE_RE = re.compile(r"^\s*-{2,}\s*original message\s*-{2,}
 _HISTORY_QUOTED_REPLY_HEADER_RE = re.compile(
     r"^\s*on\s+(?P<history_reply_prefix>[^\n]{1,280})\s+wrote:\s*$", re.I)
 _HISTORY_QUOTE_PREFIX_RE = re.compile(r"^\s*(?:>\s*)+(?P<history_quoted_line>.*)$")
+_HISTORY_ANGLE_EMAIL_RE = re.compile(r"<[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}>")
 _HISTORY_REPLY_DATE_RE = re.compile(
     r"(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b|"
     r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b|"
@@ -125,6 +126,8 @@ _HISTORY_REPLY_DATE_RE = re.compile(
     re.IGNORECASE,
 )
 _HISTORY_REPLY_EMAIL_RE = re.compile(r"<[^>]+@[^>]+>|\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b", re.I)
+_HISTORY_MAIL_HEADER_RE = re.compile(r"^(?P<history_header_name>[A-Za-z][A-Za-z-]{0,40}):")
+_HISTORY_MAIL_HEADER_LOOKAHEAD = 12
 _HISTORY_PERSON_TOKEN = r"[^\W\d_][^\W\d_.'\u2019-]*"
 _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(r"^(?:customer|requester|user)\s*:", re.I)
 _HISTORY_SIGNATURE_PERSON_RE = re.compile(
@@ -922,6 +925,9 @@ def _scalar_history_text(value: Any) -> str:
         blank_marker += "_"
     marked = _HISTORY_HTML_BLANK_RE.sub(f"\n{blank_marker}\n", raw)
     marked = _HISTORY_BLANK_LINE_RE.sub(f"\n{blank_marker}\n", marked)
+    marked = _HISTORY_ANGLE_EMAIL_RE.sub(
+        lambda match: match.group(0).replace("<", "&lt;").replace(">", "&gt;"), marked
+    )
     lines = support_ticket_plain_text_lines(marked).splitlines()
 
     admitted: list[str] = []
@@ -974,15 +980,20 @@ def _history_line_is_reply_header(
 ) -> bool:
     probe, header_is_quoted = _history_line_probe(line)
     if _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(probe):
-        tail: list[str] = []
-        for item in lines[line_index + 1 : line_index + 5]:
+        from_seen = timestamp_seen = False
+        for item in lines[
+            line_index + 1 : line_index + 1 + _HISTORY_MAIL_HEADER_LOOKAHEAD
+        ]:
             if item.strip() == blank_marker:
-                continue
+                break
             tail_probe, _ = _history_line_probe(item.strip())
-            tail.append(tail_probe.lower())
-        return any(item.startswith("from:") for item in tail) and any(
-            item.startswith(("sent:", "date:")) for item in tail
-        )
+            header_match = _HISTORY_MAIL_HEADER_RE.match(tail_probe)
+            if not header_match:
+                break
+            header_name = header_match.group("history_header_name").lower()
+            from_seen = from_seen or header_name == "from"
+            timestamp_seen = timestamp_seen or header_name in {"sent", "date"}
+        return from_seen and timestamp_seen
     match = _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(probe)
     if not match:
         return False

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -129,6 +129,7 @@ _HISTORY_REPLY_TIME_SENDER_RE = re.compile(
     r"[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){0,3}\s*$")
 _HISTORY_REPLY_NAME_SENDER_RE = re.compile(
     r",\s*[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}\s*$")
+_HISTORY_REPLY_PRONOUN_SENDER_RE = re.compile(r"(?:^|[\s,])(?:I|We)\s*$", re.I)
 _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(r"^(?:customer|requester|user)\s*:", re.I)
 _HISTORY_CUSTOMER_VOICE_RE = re.compile(
     r"^(?:"
@@ -149,6 +150,7 @@ _HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
     re.IGNORECASE,
 )
 _HISTORY_SIGNATURE_NAME_RE = re.compile(r"^[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}$")
+_HISTORY_SIGNATURE_IDENTITY_RE = re.compile(r"^[A-Z][A-Za-z&.'-]{1,79}$")
 _HISTORY_SIGNATURE_COMPANY_RE = re.compile(
     r"^(?:[A-Z][A-Za-z&.'-]*[A-Z][A-Za-z&.'-]*|[A-Z][A-Za-z&.'-]*"
     r"(?:\s+[A-Z][A-Za-z&.'-]*){0,3}\s+(?:Inc|LLC|Ltd|Corp|Company))\.?$")
@@ -734,7 +736,9 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
         gate_body,
         had_source_text=bool(raw_body.strip() or any(raw_comments) or raw_scalar_history),
     )
-    if junk_reason is None and raw_scalar_history and not gate_body:
+    explicit_evidence = _first_text(row, _RESOLUTION_TEXT_KEYS) or _evidence_text(
+        _first_value(row, _MEASURED_OUTCOME_KEYS))
+    if junk_reason is None and raw_scalar_history and not gate_body and not explicit_evidence:
         junk_reason = support_ticket_row_is_junk("", "", had_source_text=True)
     if junk_reason:
         # Junk rows (auto-replies, bounces, no-new-content) must not count
@@ -981,7 +985,7 @@ def _history_line_is_reply_header(
     if not match:
         return False
     prefix = match.group("history_reply_prefix")
-    sender_match = (
+    sender_match = not _HISTORY_REPLY_PRONOUN_SENDER_RE.search(prefix) and (
         _HISTORY_REPLY_EMAIL_RE.search(prefix)
         or _HISTORY_REPLY_TIME_SENDER_RE.search(prefix)
         or _HISTORY_REPLY_NAME_SENDER_RE.search(prefix)
@@ -1024,7 +1028,9 @@ def _history_line_starts_signature(
             candidate, skip_mode="signature", signature_blank_seen=blank_before
         ):
             return True
-        if role_lines < _HISTORY_SIGNATURE_MAX_ROLES and _HISTORY_SIGNATURE_NAME_RE.fullmatch(candidate):
+        if role_lines < _HISTORY_SIGNATURE_MAX_ROLES and (
+            _HISTORY_SIGNATURE_NAME_RE.fullmatch(candidate) or
+            _HISTORY_SIGNATURE_IDENTITY_RE.fullmatch(candidate)):
             role_lines += 1
             continue
         return False

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -98,10 +98,21 @@ _QUESTION_STARTS = (
     "why ",
 )
 _HISTORY_BLANK_LINE_RE = re.compile(r"\n[ \t]*\n+")
+_HISTORY_HTML_BLANK_RE = re.compile(
+    r"(?:<br\s*/?>\s*){2,}|"
+    r"<p\b[^>]*>\s*(?:(?:&nbsp;|&#160;)|<br\s*/?>)?\s*</p>",
+    re.IGNORECASE,
+)
 _HISTORY_SIGNATURE_BOUNDARY_RE = re.compile(r"^\s*(?:--+|__+)\s*$")
 _HISTORY_MOBILE_SIGNATURE_RE = re.compile(
     r"^\s*sent from my (?:iphone|ipad|android(?: phone| device)?|mobile device)"
+    r"(?:\s*[,;-]\s*(?:please\s+)?(?:excuse|pardon)"
+    r"(?:\s+(?:any|the))?\s+(?:typos?|errors?))?"
     r"\.?\s*$",
+    re.IGNORECASE,
+)
+_HISTORY_ORIGINAL_MESSAGE_RE = re.compile(
+    r"^\s*-{2,}\s*original message\s*-{2,}\s*$",
     re.IGNORECASE,
 )
 _HISTORY_QUOTED_REPLY_HEADER_RE = re.compile(
@@ -123,9 +134,14 @@ _HISTORY_CUSTOMER_MESSAGE_BOUNDARY_RE = re.compile(
     r"(?:can|could|do|does|how|is|should|what|when|where|why)\s+"
     r"(?:i|we|my|our)\b|"
     r"(?:i|we|my|our)\b.*\b(?:cannot|can't|couldn't|didn't|"
-    r"doesn't|error|fail(?:ed|s|ing)?|issue|need|problem|still|unable)\b|"
-    r"still\b"
+    r"doesn't|error|fail(?:ed|s|ing)?|issue|need|problem|still|unable)\b"
     r")",
+    re.IGNORECASE,
+)
+_HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
+    r"\b(?:still|remains?|keeps?)\b.{0,80}\b"
+    r"(?:broken|fail(?:ed|s|ing)?|stuck|unavailable|unable|error)\b|"
+    r"^\s*(?:cannot|can't|unable to)\b",
     re.IGNORECASE,
 )
 _HISTORY_FOOTER_RE = re.compile(
@@ -905,7 +921,8 @@ def _scalar_history_text(value: Any) -> str:
     blank_marker = "ATLAS_HISTORY_BLANK_BOUNDARY"
     while blank_marker in raw:
         blank_marker += "_"
-    marked = _HISTORY_BLANK_LINE_RE.sub(f"\n{blank_marker}\n", raw)
+    marked = _HISTORY_HTML_BLANK_RE.sub(f"\n{blank_marker}\n", raw)
+    marked = _HISTORY_BLANK_LINE_RE.sub(f"\n{blank_marker}\n", marked)
     lines = support_ticket_plain_text_lines(marked).splitlines()
 
     admitted: list[str] = []
@@ -940,14 +957,17 @@ def _scalar_history_text(value: Any) -> str:
             skip_mode = "signature"
             signature_blank_seen = False
             continue
-        if _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line):
+        if (
+            _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line)
+            or _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(line)
+        ):
             skip_mode = "quote"
             signature_blank_seen = False
             continue
         if line.startswith(">"):
             continue
         admitted.append(line)
-    return support_ticket_plain_text("\n".join(admitted))
+    return "\n".join(admitted)
 
 
 def _history_line_starts_message(
@@ -958,13 +978,10 @@ def _history_line_starts_message(
 ) -> bool:
     if _HISTORY_CUSTOMER_MESSAGE_BOUNDARY_RE.match(line):
         return True
-    if skip_mode != "signature":
-        return False
-    words = re.findall(r"[A-Za-z0-9]+", line)
     return bool(
-        signature_blank_seen
-        or ("?" in line and len(words) >= 2)
-        or re.match(r"^please\b", line, re.IGNORECASE)
+        skip_mode == "signature"
+        and signature_blank_seen
+        and _HISTORY_POST_SIGNATURE_FAILURE_RE.search(line)
     )
 
 

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -100,7 +100,8 @@ _QUESTION_STARTS = (
 _HISTORY_BLANK_LINE_RE = re.compile(r"\n[ \t]*\n+")
 _HISTORY_HTML_BLANK_RE = re.compile(
     r"(?:<br\s*/?>\s*){2,}|"
-    r"<p\b[^>]*>\s*(?:(?:&nbsp;|&#160;)|<br\s*/?>)?\s*</p>",
+    r"<(?P<history_blank_tag>p|div)\b[^>]*>\s*"
+    r"(?:(?:&nbsp;|&#160;)|<br\s*/?>)?\s*</(?P=history_blank_tag)>",
     re.IGNORECASE,
 )
 _HISTORY_SIGNATURE_BOUNDARY_RE = re.compile(r"^\s*(?:--+|__+)\s*$")
@@ -128,14 +129,21 @@ _HISTORY_QUOTED_REPLY_HEADER_RE = re.compile(
     r".{0,160}\s+wrote:\s*$",
     re.IGNORECASE,
 )
-_HISTORY_CUSTOMER_MESSAGE_BOUNDARY_RE = re.compile(
+_HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(
+    r"^(?:customer|requester|user)\s*[:\-]",
+    re.IGNORECASE,
+)
+_HISTORY_CUSTOMER_VOICE_RE = re.compile(
     r"^(?:"
-    r"(?:customer|requester|user)\s*[:\-]|"
     r"(?:can|could|do|does|how|is|should|what|when|where|why)\s+"
     r"(?:i|we|my|our)\b|"
     r"(?:i|we|my|our)\b.*\b(?:cannot|can't|couldn't|didn't|"
     r"doesn't|error|fail(?:ed|s|ing)?|issue|need|problem|still|unable)\b"
     r")",
+    re.IGNORECASE,
+)
+_HISTORY_POST_SIGNATURE_REQUEST_RE = re.compile(
+    r"^(?:can|could|will|would)\s+you\b.{0,160}\?\s*$",
     re.IGNORECASE,
 )
 _HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
@@ -928,6 +936,7 @@ def _scalar_history_text(value: Any) -> str:
     admitted: list[str] = []
     skip_mode = ""
     signature_blank_seen = False
+    quote_allows_labeled_resume = True
     for raw_line in lines:
         line = raw_line.strip()
         if line == blank_marker:
@@ -936,17 +945,28 @@ def _scalar_history_text(value: Any) -> str:
             continue
         if not line:
             continue
+        if (
+            _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line)
+            or _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(line)
+        ):
+            if skip_mode == "signature":
+                quote_allows_labeled_resume = False
+            elif skip_mode != "quote":
+                quote_allows_labeled_resume = True
+            skip_mode = "quote"
+            signature_blank_seen = False
+            continue
         if skip_mode:
             if line.startswith(">"):
-                continue
-            if skip_mode == "signature" and _HISTORY_FOOTER_RE.search(line):
-                signature_blank_seen = False
                 continue
             if not _history_line_starts_message(
                 line,
                 skip_mode=skip_mode,
                 signature_blank_seen=signature_blank_seen,
+                quote_allows_labeled_resume=quote_allows_labeled_resume,
             ):
+                if skip_mode == "signature" and _HISTORY_FOOTER_RE.search(line):
+                    signature_blank_seen = False
                 continue
             skip_mode = ""
             signature_blank_seen = False
@@ -955,13 +975,6 @@ def _scalar_history_text(value: Any) -> str:
             or _HISTORY_MOBILE_SIGNATURE_RE.fullmatch(line)
         ):
             skip_mode = "signature"
-            signature_blank_seen = False
-            continue
-        if (
-            _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line)
-            or _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(line)
-        ):
-            skip_mode = "quote"
             signature_blank_seen = False
             continue
         if line.startswith(">"):
@@ -975,13 +988,25 @@ def _history_line_starts_message(
     *,
     skip_mode: str,
     signature_blank_seen: bool,
+    quote_allows_labeled_resume: bool,
 ) -> bool:
-    if _HISTORY_CUSTOMER_MESSAGE_BOUNDARY_RE.match(line):
+    if skip_mode == "quote":
+        return bool(
+            quote_allows_labeled_resume
+            and _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE.match(line)
+        )
+    if (
+        _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE.match(line)
+        or _HISTORY_CUSTOMER_VOICE_RE.match(line)
+    ):
         return True
     return bool(
         skip_mode == "signature"
         and signature_blank_seen
-        and _HISTORY_POST_SIGNATURE_FAILURE_RE.search(line)
+        and (
+            _HISTORY_POST_SIGNATURE_FAILURE_RE.search(line)
+            or _HISTORY_POST_SIGNATURE_REQUEST_RE.match(line)
+        )
     )
 
 

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -116,6 +116,7 @@ _HISTORY_MOBILE_SIGNATURE_RE = re.compile(
 _HISTORY_ORIGINAL_MESSAGE_RE = re.compile(r"^\s*-{2,}\s*original message\s*-{2,}\s*$", re.I)
 _HISTORY_QUOTED_REPLY_HEADER_RE = re.compile(
     r"^\s*on\s+(?P<history_reply_prefix>[^\n]{1,280})\s+wrote:\s*$", re.I)
+_HISTORY_QUOTE_PREFIX_RE = re.compile(r"^\s*(?:>\s*)+(?P<history_quoted_line>.*)$")
 _HISTORY_REPLY_DATE_RE = re.compile(
     r"(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b|"
     r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b|"
@@ -125,43 +126,25 @@ _HISTORY_REPLY_DATE_RE = re.compile(
 )
 _HISTORY_REPLY_EMAIL_RE = re.compile(r"<[^>]+@[^>]+>|\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b", re.I)
 _HISTORY_PERSON_TOKEN = r"[^\W\d_][^\W\d_.'\u2019-]*"
-_HISTORY_REPLY_TIME_SENDER_RE = re.compile(
-    r"\b\d{1,2}:\d{2}\b(?:\s*[AaPp][Mm])?[\s,]+"
-    r"[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}\s*$")
-_HISTORY_REPLY_NAME_SENDER_RE = re.compile(
-    r",\s*[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}\s*$")
-_HISTORY_REPLY_NON_PERSON_SENDER_RE = re.compile(r"(?:^|[\s,])(?:i|we|you|he|she|it|they|this|that|these|those|a|an|the|my|our|your|his|her|its|their)(?:\s+\S+)*\s*$", re.I)
 _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(r"^(?:customer|requester|user)\s*:", re.I)
-_HISTORY_CUSTOMER_VOICE_RE = re.compile(
-    r"^(?:"
-    r"(?:can|could|do|does|how|is|should|what|when|where|why)\s+"
-    r"(?:i|we)\b|"
-    r"(?:i|we)\b.{0,200}\b(?:error|fail(?:ed|s|ing)?|issue|problem|unable|cannot|can['\u2019]?t|couldn['\u2019]?t)\b"
-    r")",
-    re.IGNORECASE,
+_HISTORY_SIGNATURE_PERSON_RE = re.compile(
+    rf"^{_HISTORY_PERSON_TOKEN}(?:\s+{_HISTORY_PERSON_TOKEN}){{0,3}}$"
 )
-_HISTORY_POST_SIGNATURE_REQUEST_RE = re.compile(r"^(?:can|could|will|would)\s+you\b.{0,160}\?\s*$", re.I)
-_HISTORY_POST_SIGNATURE_NEED_RE = re.compile(
-    r"^(?:i|we)\s+need\s+(?:(?!to\b)(?:the|a|an|my|our)\b|(?:help|assistance)\s+with\b).{1,160}$",
-    re.IGNORECASE,
+_HISTORY_VALEDICTION_RE = re.compile(
+    r"^(?:thanks|thank you|best|regards|sincerely|cheers)[,!]?$", re.I
 )
-_HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
-    r"\b(?:still|remains?|keeps?)\b.{0,80}\b"
-    r"(?:broken|fail(?:ed|s|ing)?|stuck|unavailable|unable|error)\b",
-    re.IGNORECASE,
-)
-_HISTORY_SIGNATURE_PERSON_RE = re.compile(rf"^{_HISTORY_PERSON_TOKEN}(?:\s+{_HISTORY_PERSON_TOKEN}){{0,3}}$")
-_HISTORY_SIGNATURE_COMPANY_RE = re.compile(
-    r"^(?:[A-Z][A-Za-z&.'-]*[A-Z][A-Za-z&.'-]*|[A-Z][A-Za-z&.'-]*"
-    r"(?:\s+[A-Z][A-Za-z&.'-]*){0,3}\s+(?:Inc|LLC|Ltd|Corp|Company))\.?$")
-_HISTORY_VALEDICTION_RE = re.compile(r"^(?:thanks|thank you|best|regards|sincerely|cheers)[,!]?$", re.I)
 _HISTORY_SIGNATURE_LOOKAHEAD = 10
-_HISTORY_SIGNATURE_MAX_ROLES = 2
 _HISTORY_SIGNATURE_CONTACT_RE = re.compile(
     r"[\w.+-]+@"
     r"[\w.-]+\.[a-z]{2,}|https?://|www\.|(?:^|\s)\+?\d[\d .()/-]{6,}\d(?:\s|$)",
     re.IGNORECASE,
 )
+_HISTORY_EVENT_POLICY = {
+    "blank": ("", False),
+    "quote": ("quote", False),
+    "signature": ("signature", False),
+    "customer": ("", True),
+}
 
 _SOURCE_ID_KEYS = ("source_id", "ticket_id", "id", "case_id", "conversation_id")
 _SOURCE_TITLE_KEYS = (
@@ -943,119 +926,110 @@ def _scalar_history_text(value: Any) -> str:
 
     admitted: list[str] = []
     skip_mode = ""
-    signature_blank_seen = False
     for line_index, raw_line in enumerate(lines):
         line = raw_line.strip()
-        if line == blank_marker:
-            if skip_mode == "signature":
-                signature_blank_seen = True
-            continue
-        if not line:
-            continue
-        if _history_line_is_reply_header(lines, line_index=line_index, line=line):
-            skip_mode = "quote"
-            signature_blank_seen = False
-            continue
-        if skip_mode:
-            if not _history_line_starts_message(
-                line,
-                skip_mode=skip_mode,
-                signature_blank_seen=signature_blank_seen,
-            ):
-                continue
-            skip_mode = ""
-            signature_blank_seen = False
-        if _history_line_starts_signature(
+        event = _history_line_event(
             lines, line_index=line_index, line=line, blank_marker=blank_marker
-        ):
-            skip_mode = "signature"
-            signature_blank_seen = False
-            continue
-        admitted.append(line)
+        )
+        policy = _HISTORY_EVENT_POLICY.get(event)
+        if policy:
+            skip_mode, emit = policy
+        else:
+            emit = not skip_mode
+        if emit:
+            admitted.append(line)
     return "\n".join(admitted)
 
 
+def _history_line_event(
+    lines: Sequence[str], *, line_index: int, line: str, blank_marker: str
+) -> str:
+    if not line or line == blank_marker:
+        return "blank"
+    probe, _ = _history_line_probe(line)
+    if _history_line_is_reply_header(
+        lines, line_index=line_index, line=line, blank_marker=blank_marker
+    ):
+        return "quote"
+    if _history_line_starts_signature(
+        lines, line_index=line_index, line=line, blank_marker=blank_marker
+    ):
+        return "signature"
+    if _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE.match(probe):
+        return "customer"
+    return "text"
+
+
+def _history_line_probe(line: str) -> tuple[str, bool]:
+    """Return detection text without mutating customer-visible quote markers."""
+
+    match = _HISTORY_QUOTE_PREFIX_RE.fullmatch(line)
+    if not match:
+        return line.strip(), False
+    return match.group("history_quoted_line").strip(), True
+
+
 def _history_line_is_reply_header(
-    lines: Sequence[str], *, line_index: int, line: str
+    lines: Sequence[str], *, line_index: int, line: str, blank_marker: str
 ) -> bool:
-    if _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(line):
-        tail = [item.strip().lower() for item in lines[line_index + 1 : line_index + 5]]
-        return any(item.startswith("from:") for item in tail) and any(item.startswith(("sent:", "date:")) for item in tail)
-    match = _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line)
+    probe, header_is_quoted = _history_line_probe(line)
+    if _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(probe):
+        tail: list[str] = []
+        for item in lines[line_index + 1 : line_index + 5]:
+            if item.strip() == blank_marker:
+                continue
+            tail_probe, _ = _history_line_probe(item.strip())
+            tail.append(tail_probe.lower())
+        return any(item.startswith("from:") for item in tail) and any(
+            item.startswith(("sent:", "date:")) for item in tail
+        )
+    match = _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(probe)
     if not match:
         return False
     prefix = match.group("history_reply_prefix")
-    sender_match = not _HISTORY_REPLY_NON_PERSON_SENDER_RE.search(prefix) and (
-        _HISTORY_REPLY_EMAIL_RE.search(prefix)
-        or _HISTORY_REPLY_TIME_SENDER_RE.search(prefix)
-        or _HISTORY_REPLY_NAME_SENDER_RE.search(prefix)
-    )
-    return bool(_HISTORY_REPLY_DATE_RE.search(prefix) and sender_match)
+    if not _HISTORY_REPLY_DATE_RE.search(prefix):
+        return False
+    if header_is_quoted or _HISTORY_REPLY_EMAIL_RE.search(prefix):
+        return True
+    for item in lines[line_index + 1 : line_index + 4]:
+        candidate = item.strip()
+        if not candidate or candidate == blank_marker:
+            continue
+        _, candidate_is_quoted = _history_line_probe(candidate)
+        return candidate_is_quoted
+    return False
 
 
 def _history_line_starts_signature(
     lines: Sequence[str], *, line_index: int, line: str, blank_marker: str
 ) -> bool:
-    if _HISTORY_MOBILE_SIGNATURE_RE.fullmatch(line):
+    probe, _ = _history_line_probe(line)
+    if _HISTORY_MOBILE_SIGNATURE_RE.fullmatch(probe):
         return True
-    if not _HISTORY_SIGNATURE_BOUNDARY_RE.fullmatch(line):
+    if not _HISTORY_SIGNATURE_BOUNDARY_RE.fullmatch(probe):
         return False
     tail = lines[line_index + 1 : line_index + 1 + _HISTORY_SIGNATURE_LOOKAHEAD]
-    semantic: list[tuple[int, str, bool]] = []
-    blank_before = False
-    for relative_index, item in enumerate(tail):
+    signature_head_seen = False
+    for item in tail:
         candidate = item.strip()
         if candidate == blank_marker:
-            blank_before = True
-        elif candidate:
-            semantic.append((relative_index, candidate, blank_before))
-            blank_before = False
-
-    tokens = iter(semantic)
-    relative_index, first, blank_before = next(tokens, (-1, "", False))
-    if _HISTORY_VALEDICTION_RE.fullmatch(first):
-        relative_index, first, blank_before = next(tokens, (-1, "", False))
-    if not (_HISTORY_SIGNATURE_PERSON_RE.fullmatch(first) and
-            all(token[:1].isupper() for token in first.split())):
-        return False
-    role_lines = 0
-    for relative_index, candidate, blank_before in tokens:
-        offset = line_index + 1 + relative_index
-        if _HISTORY_SIGNATURE_CONTACT_RE.search(candidate) or _HISTORY_SIGNATURE_COMPANY_RE.fullmatch(candidate):
-            return True
-        if _history_line_is_reply_header(lines, line_index=offset, line=candidate):
-            return True
-        if _history_line_starts_message(
-            candidate, skip_mode="signature", signature_blank_seen=blank_before
-        ):
-            return True
-        if role_lines < _HISTORY_SIGNATURE_MAX_ROLES and _HISTORY_SIGNATURE_PERSON_RE.fullmatch(candidate) and \
-                all(token[:1].isupper() for token in candidate.split()):
-            role_lines += 1
+            return False
+        candidate_probe, _ = _history_line_probe(candidate)
+        if _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE.match(candidate_probe):
+            return False
+        if not signature_head_seen and _HISTORY_VALEDICTION_RE.fullmatch(candidate_probe):
             continue
-        return False
+        if not signature_head_seen:
+            signature_head_seen = bool(
+                _HISTORY_SIGNATURE_PERSON_RE.fullmatch(candidate_probe)
+                and all(token[:1].isupper() for token in candidate_probe.split())
+            )
+            if not signature_head_seen:
+                return False
+            continue
+        if _HISTORY_SIGNATURE_CONTACT_RE.search(candidate_probe):
+            return True
     return False
-
-
-def _history_line_starts_message(
-    line: str, *, skip_mode: str, signature_blank_seen: bool
-) -> bool:
-    if skip_mode == "quote":
-        return False
-    if (
-        _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE.match(line)
-        or _HISTORY_CUSTOMER_VOICE_RE.match(line)
-    ):
-        return True
-    return bool(
-        skip_mode == "signature"
-        and signature_blank_seen
-        and (
-            _HISTORY_POST_SIGNATURE_FAILURE_RE.search(line)
-            or _HISTORY_POST_SIGNATURE_REQUEST_RE.match(line)
-            or _HISTORY_POST_SIGNATURE_NEED_RE.match(line)
-        )
-    )
 
 
 def _comment_text(item: Any) -> str:

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -124,12 +124,13 @@ _HISTORY_REPLY_DATE_RE = re.compile(
     re.IGNORECASE,
 )
 _HISTORY_REPLY_EMAIL_RE = re.compile(r"<[^>]+@[^>]+>|\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b", re.I)
+_HISTORY_PERSON_TOKEN = r"[^\W\d_][^\W\d_.'\u2019-]*"
 _HISTORY_REPLY_TIME_SENDER_RE = re.compile(
     r"\b\d{1,2}:\d{2}\b(?:\s*[AaPp][Mm])?[\s,]+"
-    r"[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){0,3}\s*$")
+    r"[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}\s*$")
 _HISTORY_REPLY_NAME_SENDER_RE = re.compile(
     r",\s*[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}\s*$")
-_HISTORY_REPLY_PRONOUN_SENDER_RE = re.compile(r"(?:^|[\s,])(?:I|We)\s*$", re.I)
+_HISTORY_REPLY_NON_PERSON_SENDER_RE = re.compile(r"(?:^|[\s,])(?:i|we|you|he|she|it|they|this|that|these|those|a|an|the|my|our|your|his|her|its|their)(?:\s+\S+)*\s*$", re.I)
 _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(r"^(?:customer|requester|user)\s*:", re.I)
 _HISTORY_CUSTOMER_VOICE_RE = re.compile(
     r"^(?:"
@@ -149,8 +150,7 @@ _HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
     r"(?:broken|fail(?:ed|s|ing)?|stuck|unavailable|unable|error)\b",
     re.IGNORECASE,
 )
-_HISTORY_SIGNATURE_NAME_RE = re.compile(r"^[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}$")
-_HISTORY_SIGNATURE_IDENTITY_RE = re.compile(r"^[A-Z][A-Za-z&.'-]{1,79}$")
+_HISTORY_SIGNATURE_PERSON_RE = re.compile(rf"^{_HISTORY_PERSON_TOKEN}(?:\s+{_HISTORY_PERSON_TOKEN}){{0,3}}$")
 _HISTORY_SIGNATURE_COMPANY_RE = re.compile(
     r"^(?:[A-Z][A-Za-z&.'-]*[A-Z][A-Za-z&.'-]*|[A-Z][A-Za-z&.'-]*"
     r"(?:\s+[A-Z][A-Za-z&.'-]*){0,3}\s+(?:Inc|LLC|Ltd|Corp|Company))\.?$")
@@ -980,12 +980,12 @@ def _history_line_is_reply_header(
 ) -> bool:
     if _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(line):
         tail = [item.strip().lower() for item in lines[line_index + 1 : line_index + 5]]
-        return any(item.startswith("from:") for item in tail) and any(item.startswith("sent:") for item in tail)
+        return any(item.startswith("from:") for item in tail) and any(item.startswith(("sent:", "date:")) for item in tail)
     match = _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line)
     if not match:
         return False
     prefix = match.group("history_reply_prefix")
-    sender_match = not _HISTORY_REPLY_PRONOUN_SENDER_RE.search(prefix) and (
+    sender_match = not _HISTORY_REPLY_NON_PERSON_SENDER_RE.search(prefix) and (
         _HISTORY_REPLY_EMAIL_RE.search(prefix)
         or _HISTORY_REPLY_TIME_SENDER_RE.search(prefix)
         or _HISTORY_REPLY_NAME_SENDER_RE.search(prefix)
@@ -1015,7 +1015,8 @@ def _history_line_starts_signature(
     relative_index, first, blank_before = next(tokens, (-1, "", False))
     if _HISTORY_VALEDICTION_RE.fullmatch(first):
         relative_index, first, blank_before = next(tokens, (-1, "", False))
-    if not _HISTORY_SIGNATURE_NAME_RE.fullmatch(first):
+    if not (_HISTORY_SIGNATURE_PERSON_RE.fullmatch(first) and
+            all(token[:1].isupper() for token in first.split())):
         return False
     role_lines = 0
     for relative_index, candidate, blank_before in tokens:
@@ -1028,9 +1029,8 @@ def _history_line_starts_signature(
             candidate, skip_mode="signature", signature_blank_seen=blank_before
         ):
             return True
-        if role_lines < _HISTORY_SIGNATURE_MAX_ROLES and (
-            _HISTORY_SIGNATURE_NAME_RE.fullmatch(candidate) or
-            _HISTORY_SIGNATURE_IDENTITY_RE.fullmatch(candidate)):
+        if role_lines < _HISTORY_SIGNATURE_MAX_ROLES and _HISTORY_SIGNATURE_PERSON_RE.fullmatch(candidate) and \
+                all(token[:1].isupper() for token in candidate.split()):
             role_lines += 1
             continue
         return False

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -127,18 +127,20 @@ _HISTORY_REPLY_EMAIL_RE = re.compile(r"<[^>]+@[^>]+>|\b[\w.+-]+@[\w.-]+\.[a-z]{2
 _HISTORY_REPLY_TIME_SENDER_RE = re.compile(
     r"\b\d{1,2}:\d{2}\b(?:\s*[AaPp][Mm])?[\s,]+"
     r"[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){0,3}\s*$")
+_HISTORY_REPLY_NAME_SENDER_RE = re.compile(
+    r",\s*[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}\s*$")
 _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(r"^(?:customer|requester|user)\s*:", re.I)
 _HISTORY_CUSTOMER_VOICE_RE = re.compile(
     r"^(?:"
     r"(?:can|could|do|does|how|is|should|what|when|where|why)\s+"
     r"(?:i|we)\b|"
-    r"(?:i|we)\b.{0,200}\b(?:error|fail(?:ed|s|ing)?|issue|problem|still|unable)\b"
+    r"(?:i|we)\b.{0,200}\b(?:error|fail(?:ed|s|ing)?|issue|problem|unable|cannot|can['\u2019]?t|couldn['\u2019]?t)\b"
     r")",
     re.IGNORECASE,
 )
 _HISTORY_POST_SIGNATURE_REQUEST_RE = re.compile(r"^(?:can|could|will|would)\s+you\b.{0,160}\?\s*$", re.I)
 _HISTORY_POST_SIGNATURE_NEED_RE = re.compile(
-    r"^(?:i|we)\s+need\s+(?!to\b)(?:the|a|an|my|our)\b.{1,160}$",
+    r"^(?:i|we)\s+need\s+(?:(?!to\b)(?:the|a|an|my|our)\b|(?:help|assistance)\s+with\b).{1,160}$",
     re.IGNORECASE,
 )
 _HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
@@ -147,6 +149,12 @@ _HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
     re.IGNORECASE,
 )
 _HISTORY_SIGNATURE_NAME_RE = re.compile(r"^[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}$")
+_HISTORY_SIGNATURE_COMPANY_RE = re.compile(
+    r"^(?:[A-Z][A-Za-z&.'-]*[A-Z][A-Za-z&.'-]*|[A-Z][A-Za-z&.'-]*"
+    r"(?:\s+[A-Z][A-Za-z&.'-]*){0,3}\s+(?:Inc|LLC|Ltd|Corp|Company))\.?$")
+_HISTORY_VALEDICTION_RE = re.compile(r"^(?:thanks|thank you|best|regards|sincerely|cheers)[,!]?$", re.I)
+_HISTORY_SIGNATURE_LOOKAHEAD = 10
+_HISTORY_SIGNATURE_MAX_ROLES = 2
 _HISTORY_SIGNATURE_CONTACT_RE = re.compile(
     r"[\w.+-]+@"
     r"[\w.-]+\.[a-z]{2,}|https?://|www\.|(?:^|\s)\+?\d[\d .()/-]{6,}\d(?:\s|$)",
@@ -200,11 +208,9 @@ _PUBLIC_COMMENT_KEYS = (
     "history",
     "conversation_history",
 )
-_SCALAR_HISTORY_KEYS = frozenset({
-    "ticket_history",
-    "history",
-    "conversation_history",
-})
+_SCALAR_HISTORY_KEYS = frozenset((
+    "ticket_history", "history", "conversation_history",
+))
 _RESOLUTION_TEXT_KEYS = (
     "resolution",
     "resolution_text",
@@ -709,10 +715,9 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
         return {}
     source_title = support_ticket_plain_text(_first_text(row, _SOURCE_TITLE_KEYS))
     text = _ticket_text(row, source_title=source_title)
-    if not text:
-        return {}
     raw_body = _first_text(row, _TEXT_KEYS)
     raw_comments = _raw_comment_texts(row)
+    raw_scalar_history = any(isinstance(value := _first_value(row, (key,)), str) and value.strip() for key in _SCALAR_HISTORY_KEYS)
     body_part = support_ticket_plain_text_lines(raw_body)
     if body_part:
         # A row with real customer body text is judged on that body; a
@@ -727,12 +732,16 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     junk_reason = support_ticket_row_is_junk(
         source_title,
         gate_body,
-        had_source_text=bool(raw_body.strip() or any(raw_comments)),
+        had_source_text=bool(raw_body.strip() or any(raw_comments) or raw_scalar_history),
     )
+    if junk_reason is None and raw_scalar_history and not gate_body:
+        junk_reason = support_ticket_row_is_junk("", "", had_source_text=True)
     if junk_reason:
         # Junk rows (auto-replies, bounces, no-new-content) must not count
         # toward billed clusters (F2); the caller counts the bounded reason.
         return {"_junk_reason": junk_reason}
+    if not text:
+        return {}
     source_id = _first_text(row, _SOURCE_ID_KEYS)
     source_id_fallback = not source_id
     if source_id_fallback:
@@ -939,7 +948,7 @@ def _scalar_history_text(value: Any) -> str:
             continue
         if not line:
             continue
-        if _history_line_is_reply_header(line):
+        if _history_line_is_reply_header(lines, line_index=line_index, line=line):
             skip_mode = "quote"
             signature_blank_seen = False
             continue
@@ -952,7 +961,9 @@ def _scalar_history_text(value: Any) -> str:
                 continue
             skip_mode = ""
             signature_blank_seen = False
-        if _history_line_starts_signature(lines, line_index=line_index, line=line):
+        if _history_line_starts_signature(
+            lines, line_index=line_index, line=line, blank_marker=blank_marker
+        ):
             skip_mode = "signature"
             signature_blank_seen = False
             continue
@@ -960,31 +971,63 @@ def _scalar_history_text(value: Any) -> str:
     return "\n".join(admitted)
 
 
-def _history_line_is_reply_header(line: str) -> bool:
+def _history_line_is_reply_header(
+    lines: Sequence[str], *, line_index: int, line: str
+) -> bool:
     if _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(line):
-        return True
+        tail = [item.strip().lower() for item in lines[line_index + 1 : line_index + 5]]
+        return any(item.startswith("from:") for item in tail) and any(item.startswith("sent:") for item in tail)
     match = _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line)
     if not match:
         return False
     prefix = match.group("history_reply_prefix")
-    return bool(_HISTORY_REPLY_DATE_RE.search(prefix) and (
-        _HISTORY_REPLY_EMAIL_RE.search(prefix) or _HISTORY_REPLY_TIME_SENDER_RE.search(prefix)
-    ))
+    sender_match = (
+        _HISTORY_REPLY_EMAIL_RE.search(prefix)
+        or _HISTORY_REPLY_TIME_SENDER_RE.search(prefix)
+        or _HISTORY_REPLY_NAME_SENDER_RE.search(prefix)
+    )
+    return bool(_HISTORY_REPLY_DATE_RE.search(prefix) and sender_match)
 
 
-def _history_line_starts_signature(lines: Sequence[str], *, line_index: int, line: str) -> bool:
+def _history_line_starts_signature(
+    lines: Sequence[str], *, line_index: int, line: str, blank_marker: str
+) -> bool:
     if _HISTORY_MOBILE_SIGNATURE_RE.fullmatch(line):
         return True
     if not _HISTORY_SIGNATURE_BOUNDARY_RE.fullmatch(line):
         return False
-    for candidate in lines[line_index + 1 : line_index + 5]:
-        candidate = candidate.strip()
-        if not candidate or candidate.startswith("ATLAS_HISTORY_BLANK_BOUNDARY"):
-            break
-        return bool(
-            _HISTORY_SIGNATURE_NAME_RE.fullmatch(candidate)
-            or _HISTORY_SIGNATURE_CONTACT_RE.search(candidate)
-        )
+    tail = lines[line_index + 1 : line_index + 1 + _HISTORY_SIGNATURE_LOOKAHEAD]
+    semantic: list[tuple[int, str, bool]] = []
+    blank_before = False
+    for relative_index, item in enumerate(tail):
+        candidate = item.strip()
+        if candidate == blank_marker:
+            blank_before = True
+        elif candidate:
+            semantic.append((relative_index, candidate, blank_before))
+            blank_before = False
+
+    tokens = iter(semantic)
+    relative_index, first, blank_before = next(tokens, (-1, "", False))
+    if _HISTORY_VALEDICTION_RE.fullmatch(first):
+        relative_index, first, blank_before = next(tokens, (-1, "", False))
+    if not _HISTORY_SIGNATURE_NAME_RE.fullmatch(first):
+        return False
+    role_lines = 0
+    for relative_index, candidate, blank_before in tokens:
+        offset = line_index + 1 + relative_index
+        if _HISTORY_SIGNATURE_CONTACT_RE.search(candidate) or _HISTORY_SIGNATURE_COMPANY_RE.fullmatch(candidate):
+            return True
+        if _history_line_is_reply_header(lines, line_index=offset, line=candidate):
+            return True
+        if _history_line_starts_message(
+            candidate, skip_mode="signature", signature_blank_seen=blank_before
+        ):
+            return True
+        if role_lines < _HISTORY_SIGNATURE_MAX_ROLES and _HISTORY_SIGNATURE_NAME_RE.fullmatch(candidate):
+            role_lines += 1
+            continue
+        return False
     return False
 
 

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -101,7 +101,8 @@ _HISTORY_BLANK_LINE_RE = re.compile(r"\n[ \t]*\n+")
 _HISTORY_HTML_BLANK_RE = re.compile(
     r"(?:<br\s*/?>\s*){2,}|"
     r"<(?P<history_blank_tag>p|div)\b[^>]*>\s*"
-    r"(?:(?:&nbsp;|&#160;)|<br\s*/?>)?\s*</(?P=history_blank_tag)>",
+    r"(?:(?:&nbsp;|&#(?:160|x0*a0);|<br\s*/?>)\s*)*"
+    r"</(?P=history_blank_tag)>",
     re.IGNORECASE,
 )
 _HISTORY_SIGNATURE_BOUNDARY_RE = re.compile(r"^\s*(?:--+|__+)\s*$")
@@ -113,48 +114,38 @@ _HISTORY_MOBILE_SIGNATURE_RE = re.compile(
     re.IGNORECASE,
 )
 _HISTORY_ORIGINAL_MESSAGE_RE = re.compile(
-    r"^\s*-{2,}\s*original message\s*-{2,}\s*$",
-    re.IGNORECASE,
-)
+    r"^\s*-{2,}\s*original message\s*-{2,}\s*$", re.IGNORECASE)
 _HISTORY_QUOTED_REPLY_HEADER_RE = re.compile(
     r"^\s*on\s+"
-    r"(?:(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b|"
+    r"(?=[^\n]{0,240}(?:(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b|"
     r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b|"
-    r"\d{1,4}[-/]\d{1,2}(?:[-/]\d{1,4})?\b|"
-    r"\d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)"
-    r"[a-z]*\b|"
-    r".{0,120}\b\d{1,2}:\d{2}\b|"
-    r".{0,120}<[^>]+@[^>]+>|"
-    r".{0,120}\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b)"
-    r".{0,160}\s+wrote:\s*$",
+    r"\d{1,4}[-/]\d{1,2}(?:[-/]\d{1,4})?\b|\d{1,2}\s+"
+    r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b))"
+    r"(?=[^\n]{0,260}(?:\b\d{1,2}:\d{2}\b|<[^>]+@[^>]+>|"
+    r"\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b))[^\n]{1,280}\s+wrote:\s*$",
     re.IGNORECASE,
 )
 _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(
-    r"^(?:customer|requester|user)\s*[:\-]",
-    re.IGNORECASE,
-)
+    r"^(?:customer|requester|user)\s*:", re.IGNORECASE)
 _HISTORY_CUSTOMER_VOICE_RE = re.compile(
     r"^(?:"
     r"(?:can|could|do|does|how|is|should|what|when|where|why)\s+"
-    r"(?:i|we|my|our)\b|"
-    r"(?:i|we|my|our)\b.*\b(?:cannot|can't|couldn't|didn't|"
-    r"doesn't|error|fail(?:ed|s|ing)?|issue|need|problem|still|unable)\b"
+    r"(?:i|we)\b|"
+    r"(?:i|we)\b.{0,200}\b(?:error|fail(?:ed|s|ing)?|issue|problem|still|unable)\b"
     r")",
     re.IGNORECASE,
 )
 _HISTORY_POST_SIGNATURE_REQUEST_RE = re.compile(
-    r"^(?:can|could|will|would)\s+you\b.{0,160}\?\s*$",
-    re.IGNORECASE,
-)
+    r"^(?:can|could|will|would)\s+you\b.{0,160}\?\s*$", re.IGNORECASE)
 _HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
     r"\b(?:still|remains?|keeps?)\b.{0,80}\b"
     r"(?:broken|fail(?:ed|s|ing)?|stuck|unavailable|unable|error)\b|"
     r"^\s*(?:cannot|can't|unable to)\b",
     re.IGNORECASE,
 )
-_HISTORY_FOOTER_RE = re.compile(
-    r"\b(?:confidential(?:ity)?|disclos(?:e|ed|ure)|intended recipient|"
-    r"privileged|unauthorized|do not (?:copy|distribute))\b",
+_HISTORY_SIGNATURE_EVIDENCE_RE = re.compile(
+    r"\b(?:agent|support|team|telephone|phone|mobile)\b|[\w.+-]+@"
+    r"[\w.-]+\.[a-z]{2,}|https?://|www\.|(?:^|\s)\+?\d[\d .()/-]{6,}\d(?:\s|$)",
     re.IGNORECASE,
 )
 
@@ -937,7 +928,7 @@ def _scalar_history_text(value: Any) -> str:
     skip_mode = ""
     signature_blank_seen = False
     quote_allows_labeled_resume = True
-    for raw_line in lines:
+    for line_index, raw_line in enumerate(lines):
         line = raw_line.strip()
         if line == blank_marker:
             if skip_mode == "signature":
@@ -965,15 +956,10 @@ def _scalar_history_text(value: Any) -> str:
                 signature_blank_seen=signature_blank_seen,
                 quote_allows_labeled_resume=quote_allows_labeled_resume,
             ):
-                if skip_mode == "signature" and _HISTORY_FOOTER_RE.search(line):
-                    signature_blank_seen = False
                 continue
             skip_mode = ""
             signature_blank_seen = False
-        if (
-            _HISTORY_SIGNATURE_BOUNDARY_RE.fullmatch(line)
-            or _HISTORY_MOBILE_SIGNATURE_RE.fullmatch(line)
-        ):
+        if _history_line_starts_signature(lines, line_index=line_index, line=line):
             skip_mode = "signature"
             signature_blank_seen = False
             continue
@@ -981,6 +967,22 @@ def _scalar_history_text(value: Any) -> str:
             continue
         admitted.append(line)
     return "\n".join(admitted)
+
+
+def _history_line_starts_signature(
+    lines: Sequence[str], *, line_index: int, line: str
+) -> bool:
+    if _HISTORY_MOBILE_SIGNATURE_RE.fullmatch(line):
+        return True
+    if not _HISTORY_SIGNATURE_BOUNDARY_RE.fullmatch(line):
+        return False
+    for candidate in lines[line_index + 1 : line_index + 5]:
+        candidate = candidate.strip()
+        if not candidate or candidate.startswith("ATLAS_HISTORY_BLANK_BOUNDARY"):
+            break
+        if _HISTORY_SIGNATURE_EVIDENCE_RE.search(candidate):
+            return True
+    return False
 
 
 def _history_line_starts_message(

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -97,7 +97,7 @@ _QUESTION_STARTS = (
     "where ",
     "why ",
 )
-_HISTORY_BLANK_LINE_RE = re.compile(r"\n[ \t]*\n+")
+_HISTORY_BLANK_LINE_RE = re.compile(r"\n[^\S\r\n]*\n+")
 _HISTORY_HTML_BLANK_RE = re.compile(
     r"(?:<br\s*/?>\s*){2,}|"
     r"<(?P<history_blank_tag>p|div)\b[^>]*>\s*"
@@ -113,20 +113,21 @@ _HISTORY_MOBILE_SIGNATURE_RE = re.compile(
     r"\.?\s*$",
     re.IGNORECASE,
 )
-_HISTORY_ORIGINAL_MESSAGE_RE = re.compile(
-    r"^\s*-{2,}\s*original message\s*-{2,}\s*$", re.IGNORECASE)
+_HISTORY_ORIGINAL_MESSAGE_RE = re.compile(r"^\s*-{2,}\s*original message\s*-{2,}\s*$", re.I)
 _HISTORY_QUOTED_REPLY_HEADER_RE = re.compile(
-    r"^\s*on\s+"
-    r"(?=[^\n]{0,240}(?:(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b|"
+    r"^\s*on\s+(?P<history_reply_prefix>[^\n]{1,280})\s+wrote:\s*$", re.I)
+_HISTORY_REPLY_DATE_RE = re.compile(
+    r"(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b|"
     r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b|"
     r"\d{1,4}[-/]\d{1,2}(?:[-/]\d{1,4})?\b|\d{1,2}\s+"
-    r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b))"
-    r"(?=[^\n]{0,260}(?:\b\d{1,2}:\d{2}\b|<[^>]+@[^>]+>|"
-    r"\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b))[^\n]{1,280}\s+wrote:\s*$",
+    r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b",
     re.IGNORECASE,
 )
-_HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(
-    r"^(?:customer|requester|user)\s*:", re.IGNORECASE)
+_HISTORY_REPLY_EMAIL_RE = re.compile(r"<[^>]+@[^>]+>|\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b", re.I)
+_HISTORY_REPLY_TIME_SENDER_RE = re.compile(
+    r"\b\d{1,2}:\d{2}\b(?:\s*[AaPp][Mm])?[\s,]+"
+    r"[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){0,3}\s*$")
+_HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE = re.compile(r"^(?:customer|requester|user)\s*:", re.I)
 _HISTORY_CUSTOMER_VOICE_RE = re.compile(
     r"^(?:"
     r"(?:can|could|do|does|how|is|should|what|when|where|why)\s+"
@@ -135,16 +136,19 @@ _HISTORY_CUSTOMER_VOICE_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
-_HISTORY_POST_SIGNATURE_REQUEST_RE = re.compile(
-    r"^(?:can|could|will|would)\s+you\b.{0,160}\?\s*$", re.IGNORECASE)
-_HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
-    r"\b(?:still|remains?|keeps?)\b.{0,80}\b"
-    r"(?:broken|fail(?:ed|s|ing)?|stuck|unavailable|unable|error)\b|"
-    r"^\s*(?:cannot|can't|unable to)\b",
+_HISTORY_POST_SIGNATURE_REQUEST_RE = re.compile(r"^(?:can|could|will|would)\s+you\b.{0,160}\?\s*$", re.I)
+_HISTORY_POST_SIGNATURE_NEED_RE = re.compile(
+    r"^(?:i|we)\s+need\s+(?!to\b)(?:the|a|an|my|our)\b.{1,160}$",
     re.IGNORECASE,
 )
-_HISTORY_SIGNATURE_EVIDENCE_RE = re.compile(
-    r"\b(?:agent|support|team|telephone|phone|mobile)\b|[\w.+-]+@"
+_HISTORY_POST_SIGNATURE_FAILURE_RE = re.compile(
+    r"\b(?:still|remains?|keeps?)\b.{0,80}\b"
+    r"(?:broken|fail(?:ed|s|ing)?|stuck|unavailable|unable|error)\b",
+    re.IGNORECASE,
+)
+_HISTORY_SIGNATURE_NAME_RE = re.compile(r"^[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){1,3}$")
+_HISTORY_SIGNATURE_CONTACT_RE = re.compile(
+    r"[\w.+-]+@"
     r"[\w.-]+\.[a-z]{2,}|https?://|www\.|(?:^|\s)\+?\d[\d .()/-]{6,}\d(?:\s|$)",
     re.IGNORECASE,
 )
@@ -927,7 +931,6 @@ def _scalar_history_text(value: Any) -> str:
     admitted: list[str] = []
     skip_mode = ""
     signature_blank_seen = False
-    quote_allows_labeled_resume = True
     for line_index, raw_line in enumerate(lines):
         line = raw_line.strip()
         if line == blank_marker:
@@ -936,25 +939,15 @@ def _scalar_history_text(value: Any) -> str:
             continue
         if not line:
             continue
-        if (
-            _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line)
-            or _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(line)
-        ):
-            if skip_mode == "signature":
-                quote_allows_labeled_resume = False
-            elif skip_mode != "quote":
-                quote_allows_labeled_resume = True
+        if _history_line_is_reply_header(line):
             skip_mode = "quote"
             signature_blank_seen = False
             continue
         if skip_mode:
-            if line.startswith(">"):
-                continue
             if not _history_line_starts_message(
                 line,
                 skip_mode=skip_mode,
                 signature_blank_seen=signature_blank_seen,
-                quote_allows_labeled_resume=quote_allows_labeled_resume,
             ):
                 continue
             skip_mode = ""
@@ -963,15 +956,23 @@ def _scalar_history_text(value: Any) -> str:
             skip_mode = "signature"
             signature_blank_seen = False
             continue
-        if line.startswith(">"):
-            continue
         admitted.append(line)
     return "\n".join(admitted)
 
 
-def _history_line_starts_signature(
-    lines: Sequence[str], *, line_index: int, line: str
-) -> bool:
+def _history_line_is_reply_header(line: str) -> bool:
+    if _HISTORY_ORIGINAL_MESSAGE_RE.fullmatch(line):
+        return True
+    match = _HISTORY_QUOTED_REPLY_HEADER_RE.fullmatch(line)
+    if not match:
+        return False
+    prefix = match.group("history_reply_prefix")
+    return bool(_HISTORY_REPLY_DATE_RE.search(prefix) and (
+        _HISTORY_REPLY_EMAIL_RE.search(prefix) or _HISTORY_REPLY_TIME_SENDER_RE.search(prefix)
+    ))
+
+
+def _history_line_starts_signature(lines: Sequence[str], *, line_index: int, line: str) -> bool:
     if _HISTORY_MOBILE_SIGNATURE_RE.fullmatch(line):
         return True
     if not _HISTORY_SIGNATURE_BOUNDARY_RE.fullmatch(line):
@@ -980,23 +981,18 @@ def _history_line_starts_signature(
         candidate = candidate.strip()
         if not candidate or candidate.startswith("ATLAS_HISTORY_BLANK_BOUNDARY"):
             break
-        if _HISTORY_SIGNATURE_EVIDENCE_RE.search(candidate):
-            return True
+        return bool(
+            _HISTORY_SIGNATURE_NAME_RE.fullmatch(candidate)
+            or _HISTORY_SIGNATURE_CONTACT_RE.search(candidate)
+        )
     return False
 
 
 def _history_line_starts_message(
-    line: str,
-    *,
-    skip_mode: str,
-    signature_blank_seen: bool,
-    quote_allows_labeled_resume: bool,
+    line: str, *, skip_mode: str, signature_blank_seen: bool
 ) -> bool:
     if skip_mode == "quote":
-        return bool(
-            quote_allows_labeled_resume
-            and _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE.match(line)
-        )
+        return False
     if (
         _HISTORY_EXPLICIT_CUSTOMER_BOUNDARY_RE.match(line)
         or _HISTORY_CUSTOMER_VOICE_RE.match(line)
@@ -1008,6 +1004,7 @@ def _history_line_starts_message(
         and (
             _HISTORY_POST_SIGNATURE_FAILURE_RE.search(line)
             or _HISTORY_POST_SIGNATURE_REQUEST_RE.match(line)
+            or _HISTORY_POST_SIGNATURE_NEED_RE.match(line)
         )
     )
 

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -2,43 +2,14 @@
 
 ## Why this slice exists
 
-Issue #2044 splits scalar transcript cleanup out of paused evidence branch
-#2037 after the Resolution Audit CSV run exposed a correctness boundary that
-ordinary one-message cleanup cannot represent. Current
-`_comments_text()` treats a scalar `ticket_history`, `history`, or
-`conversation_history` value as one comment and immediately compacts it.
-That erases message boundaries and admits signature footers and old quoted
-replies as customer evidence. Stopping at the first signature or quote would
-instead discard later public customer follow-ups, so that downstream symptom
-fix is also incorrect.
-
-This change fixes the root in the scalar-history admission path: it gives that
-path an explicit transcript state machine before compact customer text is
-assembled. The recent S6B line-preserving extraction is reused as the upstream
-text component; no second HTML parser or downstream report scrubber is added.
+Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_comments_text()` compacts all three scalar-history aliases as single comments, erasing the boundaries needed to exclude signatures and old replies without losing later follow-ups. This hardening slice fixes that root at the input-admission seam.
 
 ### Problem-derived contract
 
-- Root cause: scalar transcript fields contain several messages in one string,
-  but the current adapter applies the same one-message compaction used for
-  ordinary bodies and comment objects. Once compacted, the adapter cannot tell
-  customer follow-ups from signatures or quoted reply history.
-- Correct fix must touch/change: only scalar `ticket_history`, `history`, and
-  `conversation_history` string handling in
-  `extracted_content_pipeline/support_ticket_input_package.py`; preserve
-  later customer messages after a blank or recognizable new-message boundary;
-  suppress signature/footer runs and quoted-reply bodies with or without `>`;
-  require date, time, or email evidence before treating an `On ... wrote:` line
-  as a reply header; feed the same cleaned scalar transcript to the junk gate
-  and emitted customer text; and prove the behavior through the real
-  `build_support_ticket_input_package` entrypoint with the cited cases plus
-  held-out transcript compositions.
-- Must not change: ordinary body fields; scalar one-message comment aliases;
-  list/object comment handling; package or Zendesk private/internal admission;
-  S6B HTML tag recognition and line extraction; S6E junk admission;
-  S6D customer evidence-tier or status/outcome semantics; resolution evidence;
-  final-output scrubber grammar; or report, snapshot, email, PDF, landing,
-  checkout, and other product shape.
+- Root cause: one-message compaction runs before a multi-message scalar history can distinguish customer text from signatures, footers, and quoted history.
+- Correct fix: sanitize only the three scalar-history aliases; preserve plain/HTML blanks; recognize bounded signature, mobile, `On ... wrote:`, and Outlook separators; use mode-specific resume evidence; feed one line-preserved result to the junk gate and compact only emitted output.
+- Proof: exercise `build_support_ticket_input_package` with positive, negative, composed, and held-out transcript shapes.
+- Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
 ## Scope (this PR)
 
@@ -46,34 +17,17 @@ Ownership lane: resolution-audit-csv
 Slice phase: Production hardening
 Max files: 3
 
-1. Add a bounded scalar-history transcript sanitizer at the support-ticket
-   input-package chokepoint and route only scalar history aliases through it.
-2. Add real-entrypoint regression coverage for signature and quoted-reply
-   state transitions, including held-out variants that prove the class rather
-   than the paused branch's exact examples.
-3. Leave the paused #2037 branch as read-only evidence and implement from
-   current `origin/main` after S6B/S6E.
+1. Add the bounded scalar-history state machine at the input-package choke point.
+2. Add real-entrypoint boundary-composition and junk-admission regressions.
+3. Treat paused #2037 as read-only evidence and build from current main.
 
 ### Review Contract
 
-- Acceptance criteria:
-  - later customer messages survive after signatures and reply quotes;
-  - signature/footer lines remain excluded until a blank or recognizable
-    customer-message boundary;
-  - prefixed and unprefixed old quoted bodies remain excluded;
-  - an ordinary customer sentence containing `wrote:` without date/time/email
-    reply metadata is preserved;
-  - ordinary body and non-history comment paths retain their current behavior.
-- Affected surfaces: extracted support-ticket scalar history normalization and
-  its package-level tests only.
-- Risk areas: a false resume can publish footer/old-reply text as customer
-  evidence; an over-broad boundary can discard a real later customer message.
-- Reviewer rules triggered: R1 requirements match, R2 two-sided detector
-  evidence, R10 maintainability, R13 held-out class proof, and R14 codebase
-  verification with a boundary probe.
-- Reachability proof: tests call the real `build_support_ticket_input_package`
-  entrypoint and assert its emitted `source_material` text; this is an existing
-  adapter behavior, not a new runtime or buyer-visible surface.
+- Acceptance: later customer messages survive; signature/footer and old-reply runs do not; false `wrote:` near-matches remain; ordinary bodies and non-history comments retain behavior.
+- Affected surfaces: scalar-history normalization and its package tests only.
+- Risks: false resume publishes old/footer text; false skip loses customer text.
+- Reviewer rules triggered: R1, R2, R10, R13, R14, including a boundary probe.
+- Reachability: package-entrypoint tests assert emitted `source_material` text or the junk-gate result.
 
 ### Files touched
 
@@ -83,66 +37,38 @@ Max files: 3
 
 ## Mechanism
 
-The input adapter will recognize only scalar values under the three explicit
-history aliases. It will pass those strings through the existing S6B
-line-preserving text seam, retaining explicit plain-text blank separators for
-transcript state. A small state machine emits admitted lines while in normal
-mode and switches to signature-skip or quote-skip mode at anchored boundaries.
-
-Signature mode may resume after a blank or strong customer-message boundary
-while bounded legal-footer shapes remain excluded. Quote mode stays closed
-across blanks and agent-like sentences; only an explicit customer label or
-first-person question/failure follow-up resumes it. Quote-prefixed lines stay
-excluded. Reply headers require `On ... wrote:` plus a date, time, or email cue,
-so ordinary product prose remains admitted. The same sanitized transcript
-feeds junk admission and emitted customer text before final compaction.
+Before S6B extraction, the sanitizer marks text/HTML blanks. A two-mode scanner skips signatures or quoted history: quote mode resumes only on explicit/first-person customer evidence; signature mode also admits a bounded failure cue after a blank. It returns lines for S6E, then final assembly compacts once.
 
 ## Intentional
 
-- The sanitizer is private to the input package rather than a new shared
-  hygiene framework. S6A privacy, S6B HTML extraction, and S6E junk admission
-  already own their boundaries; widening those modules would reassemble the
-  broad #2037 PR this queue deliberately split.
-- Structured comment lists keep their current per-comment privacy and text
-  handling because their container already preserves message boundaries.
-- The recognizable-message predicate is conservative and two-sided. It admits
-  question-shaped or explicit customer follow-ups, not arbitrary post-footer
-  prose; explicit blank separation remains the generic escape hatch.
-- Quote and signature modes deliberately differ: a blank may end a signature,
-  but cannot prove an unprefixed quoted reply has ended.
-- No customer-facing copy or output shape changes are authorized or required.
+- Structured comment containers keep their existing privacy/text path.
+- `On ... wrote:` needs date/time/email evidence; Outlook uses its anchored separator; arbitrary `wrote:` prose is not a boundary.
+- Quote blanks prove nothing; signature blanks are only one part of the stronger resume rule.
+- No shared hygiene framework or customer-facing output-shape change is added.
 
 ## Deferred
 
-- #2050 owns status/outcome synonyms; #2045 owns evidence-tier semantics after S6C.
-- #2037 remains paused evidence and must not be revived or merged.
+- #2050 owns status/outcome synonyms; #2045 owns evidence-tier semantics.
+- #2037 stays paused and must not be revived or merged.
 
 Parked hardening: none.
 
 ## Verification
 
-- Command: python -m pytest tests/test_extracted_support_ticket_input_package.py -k 's6c_' -q
-  - Passed: 12 passed, 243 deselected after exact-head review probes.
-- Command: python -m pytest tests/test_extracted_support_ticket_input_package.py -q
-  - Passed: 255 passed.
-- Command: bash scripts/validate_extracted_content_pipeline.sh
-  - Passed: mapped files and hard-import checks clean.
-- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
-  - Passed: clean.
-- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
-  - Passed: zero Atlas runtime import findings.
-- Command: bash scripts/check_ascii_python.sh
-  - Passed.
-- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py
-  - Passed: 201 matching tests enrolled.
-- Command: bash scripts/run_extracted_pipeline_checks.sh
-  - Passed: 10,741 passed, 21 skipped, 1 pre-existing `pynvml` warning.
+- Command: pytest -q tests/test_extracted_support_ticket_input_package.py -k 's6c_scalar_history' — 15 passed, 244 deselected.
+- Command: pytest -q tests/test_extracted_support_ticket_input_package.py — 259 passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh — passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — clean.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt — zero findings.
+- Command: bash scripts/check_ascii_python.sh — passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py — 201 tests enrolled.
+- Command: bash scripts/run_extracted_pipeline_checks.sh — 10,745 passed, 21 skipped; one pre-existing pynvml warning.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_input_package.py` | 123 |
-| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 148 |
-| `tests/test_extracted_support_ticket_input_package.py` | 128 |
-| **Total** | **399** |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 140 |
+| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 74 |
+| `tests/test_extracted_support_ticket_input_package.py` | 178 |
+| **Total** | **392** |

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -7,7 +7,7 @@ Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_co
 ### Problem-derived contract
 
 - Root cause: one-message compaction erased transcript structure; within the replacement scanner, token-level regex matches still act as semantic line roles without sufficient delimiter, sender, container, or neighboring-line evidence.
-- Correct fix: classify bounded blanks, reply headers, role labels, signatures, customer cues, and footers before applying mode policy; require delimiter-safe roles, date-plus-sender quotes, contextual dash signatures, and operational customer voice; feed one line-preserved result to the junk gate and compact only emitted output.
+- Correct fix: classify Unicode blanks, sender-bearing reply headers, signature-tail shapes, and operational customer cues before mode policy; make quoted tails terminal, preserve ordinary `>`/dash details, and feed one line-preserved result to the junk gate before compacting output.
 - Proof: exercise `build_support_ticket_input_package` with positive, negative, composed, and held-out transcript shapes.
 - Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
@@ -21,7 +21,7 @@ Max files: 3
 
 ### Review Contract
 
-- Acceptance: real customer details and post-footer requests survive; header/footer near-matches and old-reply tails do not; repeated HTML blanks normalize; ordinary bodies/comments retain behavior.
+- Acceptance: customer thresholds/details and bounded post-footer requests survive; senderless/header/footer near-matches and every old-reply tail do not; Unicode/HTML blanks normalize; ordinary bodies/comments retain behavior.
 - Affected surfaces: scalar-history normalization and its package tests only.
 - Risks: false resume publishes old/footer text; false skip loses customer text.
 - Reviewer rules triggered: R1, R2, R10, R13, R14, including a boundary probe.
@@ -35,12 +35,12 @@ Max files: 3
 
 ## Mechanism
 
-Before S6B extraction, the sanitizer marks bounded text/HTML blanks. Canonical line classifiers use delimiter-safe roles, date-plus-sender reply evidence, and bounded lookahead for ambiguous dash signatures. Mode policy then applies terminal quote and customer-before-footer transitions without clearing a witnessed blank. It returns lines for S6E, then final assembly compacts once.
+Before S6B extraction, the sanitizer marks Unicode/HTML blanks. Reply headers require date plus email or time-followed-by-name evidence and enter terminal quote mode. Ambiguous dashes inspect only the immediate tail for name/contact shape, never vocabulary. Signature mode admits bounded requests/failures without accepting legal disclaimers; normal mode preserves `>` lines.
 
 ## Intentional
 
 - Structured comment containers retain their privacy/text path; no shared hygiene framework or customer-facing shape change is added.
-- `On ... wrote:` needs date plus time/email evidence; arbitrary `wrote:` prose, quote blanks, and bare questions prove no boundary, while signature blanks remain only one part of a customer-shaped resume rule.
+- `On ... wrote:` needs date plus real sender evidence and is terminal; arbitrary `wrote:` prose, quote labels/blanks/questions prove no new boundary, while signature blanks remain only one part of a customer-shaped resume rule.
 
 ## Deferred
 
@@ -63,7 +63,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_input_package.py` | 167 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 164 |
 | `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 69 |
-| `tests/test_extracted_support_ticket_input_package.py` | 163 |
-| **Total** | **399** |
+| `tests/test_extracted_support_ticket_input_package.py` | 165 |
+| **Total** | **398** |

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -6,8 +6,8 @@ Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_co
 
 ### Problem-derived contract
 
-- Root cause: one-message compaction erased transcript structure; within the replacement scanner, shared resume predicates and late separator checks still let quote/signature modes cross semantic boundaries.
-- Correct fix: sanitize only the three scalar-history aliases; normalize text/HTML block blanks; recognize separators before resumes; make quote resumes explicit and signature resumes customer-shaped; make a quote tail entered from a signature terminal; feed one line-preserved result to the junk gate and compact only emitted output.
+- Root cause: one-message compaction erased transcript structure; within the replacement scanner, token-level regex matches still act as semantic line roles without sufficient delimiter, sender, container, or neighboring-line evidence.
+- Correct fix: classify bounded blanks, reply headers, role labels, signatures, customer cues, and footers before applying mode policy; require delimiter-safe roles, date-plus-sender quotes, contextual dash signatures, and operational customer voice; feed one line-preserved result to the junk gate and compact only emitted output.
 - Proof: exercise `build_support_ticket_input_package` with positive, negative, composed, and held-out transcript shapes.
 - Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
@@ -17,13 +17,11 @@ Ownership lane: resolution-audit-csv
 Slice phase: Production hardening
 Max files: 3
 
-1. Add the bounded scalar-history state machine at the input-package choke point.
-2. Add real-entrypoint boundary-composition and junk-admission regressions.
-3. Treat paused #2037 as read-only evidence and build from current main.
+1. Add the bounded scalar-history state machine and real-entrypoint composition/junk regressions at the input-package choke point, treating paused #2037 as read-only evidence.
 
 ### Review Contract
 
-- Acceptance: real post-signature customer requests survive; signature/footer and composed old-reply tails do not; quote questions cannot self-resume; ordinary bodies/comments retain behavior.
+- Acceptance: real customer details and post-footer requests survive; header/footer near-matches and old-reply tails do not; repeated HTML blanks normalize; ordinary bodies/comments retain behavior.
 - Affected surfaces: scalar-history normalization and its package tests only.
 - Risks: false resume publishes old/footer text; false skip loses customer text.
 - Reviewer rules triggered: R1, R2, R10, R13, R14, including a boundary probe.
@@ -37,19 +35,16 @@ Max files: 3
 
 ## Mechanism
 
-Before S6B extraction, the sanitizer marks text/HTML block blanks. Separators transition before resume checks. Quote mode resumes only on explicit transcript roles, and becomes terminal when entered from a signature; signature mode checks explicit/customer-shaped post-blank cues before footer suppression. It returns lines for S6E, then final assembly compacts once.
+Before S6B extraction, the sanitizer marks bounded text/HTML blanks. Canonical line classifiers use delimiter-safe roles, date-plus-sender reply evidence, and bounded lookahead for ambiguous dash signatures. Mode policy then applies terminal quote and customer-before-footer transitions without clearing a witnessed blank. It returns lines for S6E, then final assembly compacts once.
 
 ## Intentional
 
-- Structured comment containers keep their existing privacy/text path.
-- `On ... wrote:` needs date/time/email evidence; Outlook uses its anchored separator; arbitrary `wrote:` prose is not a boundary.
-- Quote blanks and bare questions prove nothing; signature blanks are only one part of a customer-shaped resume rule.
-- No shared hygiene framework or customer-facing output-shape change is added.
+- Structured comment containers retain their privacy/text path; no shared hygiene framework or customer-facing shape change is added.
+- `On ... wrote:` needs date plus time/email evidence; arbitrary `wrote:` prose, quote blanks, and bare questions prove no boundary, while signature blanks remain only one part of a customer-shaped resume rule.
 
 ## Deferred
 
-- #2050 owns status/outcome synonyms; #2045 owns evidence-tier semantics.
-- #2037 stays paused and must not be revived or merged.
+- #2050 owns status/outcome synonyms; #2045 owns evidence tiers; #2037 stays paused and must not be revived or merged.
 
 Parked hardening: none.
 
@@ -68,7 +63,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_input_package.py` | 165 |
-| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 74 |
-| `tests/test_extracted_support_ticket_input_package.py` | 159 |
-| **Total** | **398** |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 167 |
+| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 69 |
+| `tests/test_extracted_support_ticket_input_package.py` | 163 |
+| **Total** | **399** |

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -7,9 +7,9 @@ Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_co
 ### Problem-derived contract
 
 - Root cause: one-message compaction erased transcript boundaries, while the first state machine substituted open-ended sender-name inference and terminal quote skipping for those missing boundaries. That creates two failure classes: arbitrary title-cased prose can be discarded as a reply, and later customer messages can never resume after a recognized quote.
-- Correct fix: canonicalize each scalar-history line once for detection while retaining its original content form; derive one structural event (blank, corroborated reply header, corroborated signature, likely customer-message boundary, or ordinary text); and apply the same explicit state transition table to every scalar-history alias. Reply admission requires affirmative email/original-message/quote-marker evidence, not guessed person identity. Quote and signature states both end at a blank or likely customer-message boundary.
+- Correct fix: canonicalize each scalar-history line once for detection while retaining its original content form and raw angle-bracket email evidence; derive one structural event (blank, corroborated reply header, corroborated signature, likely customer-message boundary, or ordinary text); and apply the same explicit state transition table to every scalar-history alias. Reply admission requires affirmative email/original-message/quote-marker evidence, not guessed person identity. Original-message evidence scans a bounded complete header-field run rather than a fixed four-line prefix. Quote and signature states both end at a blank or likely customer-message boundary.
 - Safety bias: ambiguous free text is customer content by default. More old-text leakage is acceptable where reply evidence is absent; customer-content loss is not. A Unicode name alone therefore does not prove a reply, while a quote-prefixed Unicode reply header does.
-- Proof: exercise `build_support_ticket_input_package` with a grammar-derived event/state cross-product, including quote-marker depth, Unicode sender text, blank and no-blank resumptions, and titled/untitled all-quote admission outcomes.
+- Proof: exercise `build_support_ticket_input_package` with a grammar-derived event/state cross-product, including quote-marker depth, Unicode sender text, plain/HTML separators with angle-bracket emails, bounded original-message header permutations, blank and no-blank resumptions, and titled/untitled all-quote admission outcomes.
 - Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
 ## Scope (this PR)
@@ -22,7 +22,7 @@ Max files: 3
 
 ### Review Contract
 
-- Acceptance: quoted and signature runs resume after blank or structural customer boundaries; reply headers need affirmative structural evidence; `>` markers are detection-only and standalone customer `>` lines remain content; original-message blocks accept `Sent:` or `Date:`; ordinary comments retain behavior.
+- Acceptance: quoted and signature runs resume after blank or structural customer boundaries; reply headers need affirmative structural evidence even when HTML parsing would otherwise consume an angle-bracket email; `>` markers are detection-only and standalone customer `>` lines remain content; complete bounded original-message header runs accept `Sent:` or `Date:` after optional `To:`/`Cc:`/`Bcc:` fields; ordinary comments retain behavior.
 - Affected surfaces/risks: scalar-history normalization/tests only; false resume publishes old/footer text and false skip loses customer text.
 - Reviewer rules triggered: R1, R2, R10, R13, R14 with a boundary probe; reachability uses package-entrypoint emitted text or junk-gate results.
 
@@ -34,13 +34,14 @@ Max files: 3
 
 ## Mechanism
 
-Before S6B extraction, the sanitizer preserves blank events and computes a detection probe with leading quote markers removed. A single event classifier recognizes corroborated reply headers, corroborated signature starts, and structural customer-message boundaries. One state table then emits ordinary content, skips quote/signature runs, and resumes either run on blank or customer-message events. Original-message headers accept `Sent:`/`Date:` parity; `On ... wrote:` requires a date plus email or quote-marker evidence.
+Before S6B extraction, the sanitizer protects raw angle-bracket emails, preserves blank events, and computes a detection probe with leading quote markers removed. A single event classifier recognizes corroborated reply headers, corroborated signature starts, and structural customer-message boundaries. One state table then emits ordinary content, skips quote/signature runs, and resumes either run on blank or customer-message events. Original-message recognition consumes a bounded run of known mail-header fields and accepts `Sent:`/`Date:` parity; `On ... wrote:` requires a date plus email or quote-marker evidence.
 
 ## Intentional
 
 - Structured comment containers retain their privacy/text path; no shared hygiene framework or customer-facing shape change is added.
 - Customer-content preservation wins ties: uncorroborated Unicode or ASCII name-shaped `On ... wrote:` text remains content instead of invoking open-ended person inference. Quote markers are stripped only for header detection, never from emitted customer text.
 - Signature delimiters require bounded contact evidence; first-name, role, and company lines do not prove a signature alone. Mobile signatures remain exact structural markers, but both signature forms resume on the same blank/customer-boundary policy as quotes.
+- Bare blank resumption is retained intentionally because accepted issue #2044 names blank as a valid end to quote/signature exclusion. The contrary review request is waived rather than silently changing the accepted product contract.
 
 ## Deferred
 
@@ -50,7 +51,7 @@ Parked hardening: none.
 
 ## Verification
 
-- Commands: focused scalar-history pytest — 3 passed/243 deselected with 128 generated event/state cases; owning file — 246 passed; exact extracted-content maturity ratchet — passed at the pre-PR file score of 9.
+- Commands: focused scalar-history pytest — 3 passed/243 deselected with 577 generated event/state cases; owning file — 246 passed; exact extracted-content maturity ratchet — passed at the pre-PR file score of 9.
 - Commands: validate_extracted_content_pipeline.sh — passed; forbid/audit-standalone/ASCII audits — clean; CI-enrollment audit passed inside the package gauntlet.
 - Command: bash scripts/run_extracted_pipeline_checks.sh — 10,732 passed, 21 skipped; one pre-existing pynvml warning.
 
@@ -58,7 +59,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_input_package.py` | 193 |
-| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 64 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 204 |
+| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 65 |
 | `tests/test_extracted_support_ticket_input_package.py` | 130 |
-| **Total** | **387** |
+| **Total** | **399** |

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -6,8 +6,8 @@ Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_co
 
 ### Problem-derived contract
 
-- Root cause: one-message compaction erased transcript structure; the generated oracle still tested sender and admission rules on only one matching production, allowing parallel timestamped-pronoun and explicit-evidence paths to receive the wrong semantic verdict.
-- Correct fix: keep bounded reply/signature grammars and one skip policy, while applying pronoun, explicit-evidence, and bounded identity-line rules across every history alias and matching production; narrow grammar decisions to those semantic roles.
+- Root cause: one-message compaction erased transcript structure; the generated oracle still modeled person evidence as ASCII multi-token shape and original-message evidence as `Sent:` only, leaving parallel non-person, Unicode/first-name, and `Date:` productions outside the semantic classes.
+- Correct fix: keep bounded reply/signature grammars and one skip policy, while applying non-person sender rejection, Unicode/first-name heads with adjacent confirmation, and `Sent:`/`Date:` parity across every history alias and matching production.
 - Proof: exercise `build_support_ticket_input_package` with the full generated parity/semantic cross-product plus titled/untitled all-quote admission outcomes.
 - Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
@@ -21,7 +21,7 @@ Max files: 3
 
 ### Review Contract
 
-- Acceptance: headings/contact-first details survive; every reply-sender production requires real person evidence; explicit evidence keeps quote-empty rows; bounded company lines compose only with signature evidence; ordinary comments retain behavior.
+- Acceptance: every reply-sender production rejects grammatical non-person phrases; first-name and Unicode signature heads require adjacent evidence; original-message blocks accept `Sent:` or `Date:`; ordinary comments retain behavior.
 - Affected surfaces/risks: scalar-history normalization/tests only; false resume publishes old/footer text and false skip loses customer text.
 - Reviewer rules triggered: R1, R2, R10, R13, R14 with a boundary probe; reachability uses package-entrypoint emitted text or junk-gate results.
 
@@ -33,12 +33,12 @@ Max files: 3
 
 ## Mechanism
 
-Before S6B extraction, the sanitizer marks Unicode/HTML blanks. A reply grammar requires date plus email or non-pronoun time/name and delimiter/multi-token-person evidence. A signature grammar scans bounded identity lines for contact/company evidence and feeds one skip policy. Hygiene-empty scalar history clears title only when no explicit evidence keeps the row.
+Before S6B extraction, the sanitizer marks Unicode/HTML blanks. A reply grammar requires date plus email or a multi-token person shape that excludes grammatical non-person phrases. A signature grammar admits Unicode/first-name heads only with bounded adjacent evidence. Original-message headers accept `Sent:`/`Date:` parity.
 
 ## Intentional
 
 - Structured comment containers retain their privacy/text path; no shared hygiene framework or customer-facing shape change is added.
-- `On ... wrote:` needs date plus grammar-recognized non-pronoun sender evidence and is terminal. Contact-first details and role/company lines never prove a signature alone; bounded person plus terminal evidence must confirm it.
+- `On ... wrote:` needs date plus grammar-recognized person evidence and is terminal; pronoun/determiner phrases remain content. First-name, role, and company lines never prove a signature alone; bounded terminal evidence must confirm them.
 
 ## Deferred
 
@@ -48,7 +48,7 @@ Parked hardening: none.
 
 ## Verification
 
-- Commands: focused scalar-history pytest — 2 passed/244 deselected with 4,727 generated parity/semantic/admission cases; owning file — 246 passed; exact maturity ratchet — passed.
+- Commands: focused scalar-history pytest — 2 passed/244 deselected with 13,950 generated semantic/admission cases; owning file — 246 passed; exact maturity ratchet — passed.
 - Commands: validate_extracted_content_pipeline.sh — passed; forbid/audit-standalone/ASCII audits — clean; CI enrollment — 201 tests enrolled.
 - Command: bash scripts/run_extracted_pipeline_checks.sh — 10,732 passed, 21 skipped; one pre-existing pynvml warning.
 

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -6,8 +6,8 @@ Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_co
 
 ### Problem-derived contract
 
-- Root cause: one-message compaction erased transcript structure; the first generated oracle closed under-exclusion but under-modeled over-exclusion roles, allowing pronoun senders, contact-first details, legal footers, help requests, and titled hygiene-empty rows to receive the wrong semantic verdict.
-- Correct fix: keep bounded reply/signature grammars and one skip policy, while extending the independent oracle across sender arity, contact-first detail, operational continuation versus footer, and hygiene-empty title variants; narrow grammar decisions to those semantic roles.
+- Root cause: one-message compaction erased transcript structure; the generated oracle still tested sender and admission rules on only one matching production, allowing parallel timestamped-pronoun and explicit-evidence paths to receive the wrong semantic verdict.
+- Correct fix: keep bounded reply/signature grammars and one skip policy, while applying pronoun, explicit-evidence, and bounded identity-line rules across every history alias and matching production; narrow grammar decisions to those semantic roles.
 - Proof: exercise `build_support_ticket_input_package` with the full generated parity/semantic cross-product plus titled/untitled all-quote admission outcomes.
 - Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
@@ -21,7 +21,7 @@ Max files: 3
 
 ### Review Contract
 
-- Acceptance: headings/contact-first details survive; reply senders require real person evidence; operational help/failure resumes while legal footer prose stays skipped; signature sequences compose across blanks/roles; titled and untitled all-quote rows count as no-new-content; ordinary comments retain behavior.
+- Acceptance: headings/contact-first details survive; every reply-sender production requires real person evidence; explicit evidence keeps quote-empty rows; bounded company lines compose only with signature evidence; ordinary comments retain behavior.
 - Affected surfaces/risks: scalar-history normalization/tests only; false resume publishes old/footer text and false skip loses customer text.
 - Reviewer rules triggered: R1, R2, R10, R13, R14 with a boundary probe; reachability uses package-entrypoint emitted text or junk-gate results.
 
@@ -33,12 +33,12 @@ Max files: 3
 
 ## Mechanism
 
-Before S6B extraction, the sanitizer marks Unicode/HTML blanks. A reply grammar requires date plus email, time/name, or delimiter/multi-token-person evidence. A signature grammar requires person context before contact/company evidence, ignores identity blanks, and feeds one skip policy whose continuation roles separate operational requests/failures from footer prose. Hygiene-empty scalar history clears title only for junk admission.
+Before S6B extraction, the sanitizer marks Unicode/HTML blanks. A reply grammar requires date plus email or non-pronoun time/name and delimiter/multi-token-person evidence. A signature grammar scans bounded identity lines for contact/company evidence and feeds one skip policy. Hygiene-empty scalar history clears title only when no explicit evidence keeps the row.
 
 ## Intentional
 
 - Structured comment containers retain their privacy/text path; no shared hygiene framework or customer-facing shape change is added.
-- `On ... wrote:` needs date plus grammar-recognized sender evidence and is terminal; pronoun/single-token prose remains content. Contact-first details and role lines never prove a signature alone; bounded person plus terminal evidence must confirm it.
+- `On ... wrote:` needs date plus grammar-recognized non-pronoun sender evidence and is terminal. Contact-first details and role/company lines never prove a signature alone; bounded person plus terminal evidence must confirm it.
 
 ## Deferred
 
@@ -48,7 +48,7 @@ Parked hardening: none.
 
 ## Verification
 
-- Commands: focused scalar-history pytest — 2 passed/244 deselected with 3,521 generated parity/semantic/admission cases; owning file — 246 passed; exact maturity ratchet — passed.
+- Commands: focused scalar-history pytest — 2 passed/244 deselected with 4,727 generated parity/semantic/admission cases; owning file — 246 passed; exact maturity ratchet — passed.
 - Commands: validate_extracted_content_pipeline.sh — passed; forbid/audit-standalone/ASCII audits — clean; CI enrollment — 201 tests enrolled.
 - Command: bash scripts/run_extracted_pipeline_checks.sh — 10,732 passed, 21 skipped; one pre-existing pynvml warning.
 
@@ -56,7 +56,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_input_package.py` | 213 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 219 |
 | `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 62 |
-| `tests/test_extracted_support_ticket_input_package.py` | 122 |
-| **Total** | **397** |
+| `tests/test_extracted_support_ticket_input_package.py` | 118 |
+| **Total** | **399** |

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -2,13 +2,14 @@
 
 ## Why this slice exists
 
-Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_comments_text()` compacts all three scalar-history aliases as single comments, erasing the boundaries needed to exclude signatures and old replies without losing later follow-ups. This hardening slice fixes that root at the input-admission seam.
+Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_comments_text()` compacts all three scalar-history aliases as single comments, erasing the boundaries needed to exclude signatures and old replies without losing later follow-ups. The investigation also proved the current PR implementation made quote mode terminal and tried to infer people from an open-ended sender vocabulary. Both contradict the accepted issue: quote/signature runs must end at blank or likely new-message boundaries, and ambiguous customer prose must remain content. This hardening slice fixes that root at the input-admission seam.
 
 ### Problem-derived contract
 
-- Root cause: one-message compaction erased transcript structure; the generated oracle still modeled person evidence as ASCII multi-token shape and original-message evidence as `Sent:` only, leaving parallel non-person, Unicode/first-name, and `Date:` productions outside the semantic classes.
-- Correct fix: keep bounded reply/signature grammars and one skip policy, while applying non-person sender rejection, Unicode/first-name heads with adjacent confirmation, and `Sent:`/`Date:` parity across every history alias and matching production.
-- Proof: exercise `build_support_ticket_input_package` with the full generated parity/semantic cross-product plus titled/untitled all-quote admission outcomes.
+- Root cause: one-message compaction erased transcript boundaries, while the first state machine substituted open-ended sender-name inference and terminal quote skipping for those missing boundaries. That creates two failure classes: arbitrary title-cased prose can be discarded as a reply, and later customer messages can never resume after a recognized quote.
+- Correct fix: canonicalize each scalar-history line once for detection while retaining its original content form; derive one structural event (blank, corroborated reply header, corroborated signature, likely customer-message boundary, or ordinary text); and apply the same explicit state transition table to every scalar-history alias. Reply admission requires affirmative email/original-message/quote-marker evidence, not guessed person identity. Quote and signature states both end at a blank or likely customer-message boundary.
+- Safety bias: ambiguous free text is customer content by default. More old-text leakage is acceptable where reply evidence is absent; customer-content loss is not. A Unicode name alone therefore does not prove a reply, while a quote-prefixed Unicode reply header does.
+- Proof: exercise `build_support_ticket_input_package` with a grammar-derived event/state cross-product, including quote-marker depth, Unicode sender text, blank and no-blank resumptions, and titled/untitled all-quote admission outcomes.
 - Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
 ## Scope (this PR)
@@ -17,11 +18,11 @@ Ownership lane: resolution-audit-csv
 Slice phase: Production hardening
 Max files: 3
 
-1. Add the bounded scalar-history state machine and real-entrypoint composition/junk regressions at the input-package choke point, treating paused #2037 as read-only evidence.
+1. Replace sender-vocabulary inference with one bounded structural event/state model at the scalar-history input-package choke point, treating paused #2037 as read-only evidence.
 
 ### Review Contract
 
-- Acceptance: every reply-sender production rejects grammatical non-person phrases; first-name and Unicode signature heads require adjacent evidence; original-message blocks accept `Sent:` or `Date:`; ordinary comments retain behavior.
+- Acceptance: quoted and signature runs resume after blank or structural customer boundaries; reply headers need affirmative structural evidence; `>` markers are detection-only and standalone customer `>` lines remain content; original-message blocks accept `Sent:` or `Date:`; ordinary comments retain behavior.
 - Affected surfaces/risks: scalar-history normalization/tests only; false resume publishes old/footer text and false skip loses customer text.
 - Reviewer rules triggered: R1, R2, R10, R13, R14 with a boundary probe; reachability uses package-entrypoint emitted text or junk-gate results.
 
@@ -33,12 +34,13 @@ Max files: 3
 
 ## Mechanism
 
-Before S6B extraction, the sanitizer marks Unicode/HTML blanks. A reply grammar requires date plus email or a multi-token person shape that excludes grammatical non-person phrases. A signature grammar admits Unicode/first-name heads only with bounded adjacent evidence. Original-message headers accept `Sent:`/`Date:` parity.
+Before S6B extraction, the sanitizer preserves blank events and computes a detection probe with leading quote markers removed. A single event classifier recognizes corroborated reply headers, corroborated signature starts, and structural customer-message boundaries. One state table then emits ordinary content, skips quote/signature runs, and resumes either run on blank or customer-message events. Original-message headers accept `Sent:`/`Date:` parity; `On ... wrote:` requires a date plus email or quote-marker evidence.
 
 ## Intentional
 
 - Structured comment containers retain their privacy/text path; no shared hygiene framework or customer-facing shape change is added.
-- `On ... wrote:` needs date plus grammar-recognized person evidence and is terminal; pronoun/determiner phrases remain content. First-name, role, and company lines never prove a signature alone; bounded terminal evidence must confirm them.
+- Customer-content preservation wins ties: uncorroborated Unicode or ASCII name-shaped `On ... wrote:` text remains content instead of invoking open-ended person inference. Quote markers are stripped only for header detection, never from emitted customer text.
+- Signature delimiters require bounded contact evidence; first-name, role, and company lines do not prove a signature alone. Mobile signatures remain exact structural markers, but both signature forms resume on the same blank/customer-boundary policy as quotes.
 
 ## Deferred
 
@@ -48,15 +50,15 @@ Parked hardening: none.
 
 ## Verification
 
-- Commands: focused scalar-history pytest — 2 passed/244 deselected with 13,950 generated semantic/admission cases; owning file — 246 passed; exact maturity ratchet — passed.
-- Commands: validate_extracted_content_pipeline.sh — passed; forbid/audit-standalone/ASCII audits — clean; CI enrollment — 201 tests enrolled.
+- Commands: focused scalar-history pytest — 3 passed/243 deselected with 128 generated event/state cases; owning file — 246 passed; exact extracted-content maturity ratchet — passed at the pre-PR file score of 9.
+- Commands: validate_extracted_content_pipeline.sh — passed; forbid/audit-standalone/ASCII audits — clean; CI-enrollment audit passed inside the package gauntlet.
 - Command: bash scripts/run_extracted_pipeline_checks.sh — 10,732 passed, 21 skipped; one pre-existing pynvml warning.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_input_package.py` | 219 |
-| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 62 |
-| `tests/test_extracted_support_ticket_input_package.py` | 118 |
-| **Total** | **399** |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 193 |
+| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 64 |
+| `tests/test_extracted_support_ticket_input_package.py` | 130 |
+| **Total** | **387** |

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -6,9 +6,9 @@ Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_co
 
 ### Problem-derived contract
 
-- Root cause: one-message compaction erased transcript structure; within the replacement scanner, token-level regex matches still act as semantic line roles without sufficient delimiter, sender, container, or neighboring-line evidence.
-- Correct fix: classify Unicode blanks, sender-bearing reply headers, signature-tail shapes, and operational customer cues before mode policy; make quoted tails terminal, preserve ordinary `>`/dash details, and feed one line-preserved result to the junk gate before compacting output.
-- Proof: exercise `build_support_ticket_input_package` with positive, negative, composed, and held-out transcript shapes.
+- Root cause: one-message compaction erased transcript structure; the first generated oracle closed under-exclusion but under-modeled over-exclusion roles, allowing pronoun senders, contact-first details, legal footers, help requests, and titled hygiene-empty rows to receive the wrong semantic verdict.
+- Correct fix: keep bounded reply/signature grammars and one skip policy, while extending the independent oracle across sender arity, contact-first detail, operational continuation versus footer, and hygiene-empty title variants; narrow grammar decisions to those semantic roles.
+- Proof: exercise `build_support_ticket_input_package` with the full generated parity/semantic cross-product plus titled/untitled all-quote admission outcomes.
 - Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
 ## Scope (this PR)
@@ -21,11 +21,9 @@ Max files: 3
 
 ### Review Contract
 
-- Acceptance: customer thresholds/details and bounded post-footer requests survive; senderless/header/footer near-matches and every old-reply tail do not; Unicode/HTML blanks normalize; ordinary bodies/comments retain behavior.
-- Affected surfaces: scalar-history normalization and its package tests only.
-- Risks: false resume publishes old/footer text; false skip loses customer text.
-- Reviewer rules triggered: R1, R2, R10, R13, R14, including a boundary probe.
-- Reachability: package-entrypoint tests assert emitted `source_material` text or the junk-gate result.
+- Acceptance: headings/contact-first details survive; reply senders require real person evidence; operational help/failure resumes while legal footer prose stays skipped; signature sequences compose across blanks/roles; titled and untitled all-quote rows count as no-new-content; ordinary comments retain behavior.
+- Affected surfaces/risks: scalar-history normalization/tests only; false resume publishes old/footer text and false skip loses customer text.
+- Reviewer rules triggered: R1, R2, R10, R13, R14 with a boundary probe; reachability uses package-entrypoint emitted text or junk-gate results.
 
 ### Files touched
 
@@ -35,12 +33,12 @@ Max files: 3
 
 ## Mechanism
 
-Before S6B extraction, the sanitizer marks Unicode/HTML blanks. Reply headers require date plus email or time-followed-by-name evidence and enter terminal quote mode. Ambiguous dashes inspect only the immediate tail for name/contact shape, never vocabulary. Signature mode admits bounded requests/failures without accepting legal disclaimers; normal mode preserves `>` lines.
+Before S6B extraction, the sanitizer marks Unicode/HTML blanks. A reply grammar requires date plus email, time/name, or delimiter/multi-token-person evidence. A signature grammar requires person context before contact/company evidence, ignores identity blanks, and feeds one skip policy whose continuation roles separate operational requests/failures from footer prose. Hygiene-empty scalar history clears title only for junk admission.
 
 ## Intentional
 
 - Structured comment containers retain their privacy/text path; no shared hygiene framework or customer-facing shape change is added.
-- `On ... wrote:` needs date plus real sender evidence and is terminal; arbitrary `wrote:` prose, quote labels/blanks/questions prove no new boundary, while signature blanks remain only one part of a customer-shaped resume rule.
+- `On ... wrote:` needs date plus grammar-recognized sender evidence and is terminal; pronoun/single-token prose remains content. Contact-first details and role lines never prove a signature alone; bounded person plus terminal evidence must confirm it.
 
 ## Deferred
 
@@ -50,20 +48,15 @@ Parked hardening: none.
 
 ## Verification
 
-- Command: pytest -q tests/test_extracted_support_ticket_input_package.py -k 's6c_scalar_history' — 16 passed, 244 deselected.
-- Command: pytest -q tests/test_extracted_support_ticket_input_package.py — 260 passed.
-- Command: bash scripts/validate_extracted_content_pipeline.sh — passed.
-- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — clean.
-- Command: python scripts/audit_extracted_standalone.py --fail-on-debt — zero findings.
-- Command: bash scripts/check_ascii_python.sh — passed.
-- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py — 201 tests enrolled.
-- Command: bash scripts/run_extracted_pipeline_checks.sh — 10,746 passed, 21 skipped; one pre-existing pynvml warning.
+- Commands: focused scalar-history pytest — 2 passed/244 deselected with 3,521 generated parity/semantic/admission cases; owning file — 246 passed; exact maturity ratchet — passed.
+- Commands: validate_extracted_content_pipeline.sh — passed; forbid/audit-standalone/ASCII audits — clean; CI enrollment — 201 tests enrolled.
+- Command: bash scripts/run_extracted_pipeline_checks.sh — 10,732 passed, 21 skipped; one pre-existing pynvml warning.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_input_package.py` | 164 |
-| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 69 |
-| `tests/test_extracted_support_ticket_input_package.py` | 165 |
-| **Total** | **398** |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 213 |
+| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 62 |
+| `tests/test_extracted_support_ticket_input_package.py` | 122 |
+| **Total** | **397** |

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -1,0 +1,148 @@
+# PR-Resolution-Audit-S6C-Scalar-History
+
+## Why this slice exists
+
+Issue #2044 splits scalar transcript cleanup out of paused evidence branch
+#2037 after the Resolution Audit CSV run exposed a correctness boundary that
+ordinary one-message cleanup cannot represent. Current
+`_comments_text()` treats a scalar `ticket_history`, `history`, or
+`conversation_history` value as one comment and immediately compacts it.
+That erases message boundaries and admits signature footers and old quoted
+replies as customer evidence. Stopping at the first signature or quote would
+instead discard later public customer follow-ups, so that downstream symptom
+fix is also incorrect.
+
+This change fixes the root in the scalar-history admission path: it gives that
+path an explicit transcript state machine before compact customer text is
+assembled. The recent S6B line-preserving extraction is reused as the upstream
+text component; no second HTML parser or downstream report scrubber is added.
+
+### Problem-derived contract
+
+- Root cause: scalar transcript fields contain several messages in one string,
+  but the current adapter applies the same one-message compaction used for
+  ordinary bodies and comment objects. Once compacted, the adapter cannot tell
+  customer follow-ups from signatures or quoted reply history.
+- Correct fix must touch/change: only scalar `ticket_history`, `history`, and
+  `conversation_history` string handling in
+  `extracted_content_pipeline/support_ticket_input_package.py`; preserve
+  later customer messages after a blank or recognizable new-message boundary;
+  suppress signature/footer runs and quoted-reply bodies with or without `>`;
+  require date, time, or email evidence before treating an `On ... wrote:` line
+  as a reply header; feed the same cleaned scalar transcript to the junk gate
+  and emitted customer text; and prove the behavior through the real
+  `build_support_ticket_input_package` entrypoint with the cited cases plus
+  held-out transcript compositions.
+- Must not change: ordinary body fields; scalar one-message comment aliases;
+  list/object comment handling; package or Zendesk private/internal admission;
+  S6B HTML tag recognition and line extraction; S6E junk admission;
+  S6D customer evidence-tier or status/outcome semantics; resolution evidence;
+  final-output scrubber grammar; or report, snapshot, email, PDF, landing,
+  checkout, and other product shape.
+
+## Scope (this PR)
+
+Ownership lane: resolution-audit-csv
+Slice phase: Production hardening
+Max files: 3
+
+1. Add a bounded scalar-history transcript sanitizer at the support-ticket
+   input-package chokepoint and route only scalar history aliases through it.
+2. Add real-entrypoint regression coverage for signature and quoted-reply
+   state transitions, including held-out variants that prove the class rather
+   than the paused branch's exact examples.
+3. Leave the paused #2037 branch as read-only evidence and implement from
+   current `origin/main` after S6B/S6E.
+
+### Review Contract
+
+- Acceptance criteria:
+  - later customer messages survive after signatures and reply quotes;
+  - signature/footer lines remain excluded until a blank or recognizable
+    customer-message boundary;
+  - prefixed and unprefixed old quoted bodies remain excluded;
+  - an ordinary customer sentence containing `wrote:` without date/time/email
+    reply metadata is preserved;
+  - ordinary body and non-history comment paths retain their current behavior.
+- Affected surfaces: extracted support-ticket scalar history normalization and
+  its package-level tests only.
+- Risk areas: a false resume can publish footer/old-reply text as customer
+  evidence; an over-broad boundary can discard a real later customer message.
+- Reviewer rules triggered: R1 requirements match, R2 two-sided detector
+  evidence, R10 maintainability, R13 held-out class proof, and R14 codebase
+  verification with a boundary probe.
+- Reachability proof: tests call the real `build_support_ticket_input_package`
+  entrypoint and assert its emitted `source_material` text; this is an existing
+  adapter behavior, not a new runtime or buyer-visible surface.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `plans/PR-Resolution-Audit-S6C-Scalar-History.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+
+## Mechanism
+
+The input adapter will recognize only scalar values under the three explicit
+history aliases. It will pass those strings through the existing S6B
+line-preserving text seam, retaining explicit plain-text blank separators for
+transcript state. A small state machine emits admitted lines while in normal
+mode and switches to signature-skip or quote-skip mode at anchored boundaries.
+
+Signature mode may resume after a blank or strong customer-message boundary
+while bounded legal-footer shapes remain excluded. Quote mode stays closed
+across blanks and agent-like sentences; only an explicit customer label or
+first-person question/failure follow-up resumes it. Quote-prefixed lines stay
+excluded. Reply headers require `On ... wrote:` plus a date, time, or email cue,
+so ordinary product prose remains admitted. The same sanitized transcript
+feeds junk admission and emitted customer text before final compaction.
+
+## Intentional
+
+- The sanitizer is private to the input package rather than a new shared
+  hygiene framework. S6A privacy, S6B HTML extraction, and S6E junk admission
+  already own their boundaries; widening those modules would reassemble the
+  broad #2037 PR this queue deliberately split.
+- Structured comment lists keep their current per-comment privacy and text
+  handling because their container already preserves message boundaries.
+- The recognizable-message predicate is conservative and two-sided. It admits
+  question-shaped or explicit customer follow-ups, not arbitrary post-footer
+  prose; explicit blank separation remains the generic escape hatch.
+- Quote and signature modes deliberately differ: a blank may end a signature,
+  but cannot prove an unprefixed quoted reply has ended.
+- No customer-facing copy or output shape changes are authorized or required.
+
+## Deferred
+
+- #2050 owns status/outcome synonyms; #2045 owns evidence-tier semantics after S6C.
+- #2037 remains paused evidence and must not be revived or merged.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_extracted_support_ticket_input_package.py -k 's6c_' -q
+  - Passed: 12 passed, 243 deselected after exact-head review probes.
+- Command: python -m pytest tests/test_extracted_support_ticket_input_package.py -q
+  - Passed: 255 passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed: mapped files and hard-import checks clean.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed: clean.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed: zero Atlas runtime import findings.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - Passed: 201 matching tests enrolled.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Passed: 10,741 passed, 21 skipped, 1 pre-existing `pynvml` warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/support_ticket_input_package.py` | 123 |
+| `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 148 |
+| `tests/test_extracted_support_ticket_input_package.py` | 128 |
+| **Total** | **399** |

--- a/plans/PR-Resolution-Audit-S6C-Scalar-History.md
+++ b/plans/PR-Resolution-Audit-S6C-Scalar-History.md
@@ -6,8 +6,8 @@ Issue #2044 splits scalar-transcript cleanup from paused evidence PR #2037. `_co
 
 ### Problem-derived contract
 
-- Root cause: one-message compaction runs before a multi-message scalar history can distinguish customer text from signatures, footers, and quoted history.
-- Correct fix: sanitize only the three scalar-history aliases; preserve plain/HTML blanks; recognize bounded signature, mobile, `On ... wrote:`, and Outlook separators; use mode-specific resume evidence; feed one line-preserved result to the junk gate and compact only emitted output.
+- Root cause: one-message compaction erased transcript structure; within the replacement scanner, shared resume predicates and late separator checks still let quote/signature modes cross semantic boundaries.
+- Correct fix: sanitize only the three scalar-history aliases; normalize text/HTML block blanks; recognize separators before resumes; make quote resumes explicit and signature resumes customer-shaped; make a quote tail entered from a signature terminal; feed one line-preserved result to the junk gate and compact only emitted output.
 - Proof: exercise `build_support_ticket_input_package` with positive, negative, composed, and held-out transcript shapes.
 - Must not change: ordinary bodies/comments, structured-comment privacy, S6B/S6E/S6D semantics, resolution evidence, or customer-facing product shape.
 
@@ -23,7 +23,7 @@ Max files: 3
 
 ### Review Contract
 
-- Acceptance: later customer messages survive; signature/footer and old-reply runs do not; false `wrote:` near-matches remain; ordinary bodies and non-history comments retain behavior.
+- Acceptance: real post-signature customer requests survive; signature/footer and composed old-reply tails do not; quote questions cannot self-resume; ordinary bodies/comments retain behavior.
 - Affected surfaces: scalar-history normalization and its package tests only.
 - Risks: false resume publishes old/footer text; false skip loses customer text.
 - Reviewer rules triggered: R1, R2, R10, R13, R14, including a boundary probe.
@@ -37,13 +37,13 @@ Max files: 3
 
 ## Mechanism
 
-Before S6B extraction, the sanitizer marks text/HTML blanks. A two-mode scanner skips signatures or quoted history: quote mode resumes only on explicit/first-person customer evidence; signature mode also admits a bounded failure cue after a blank. It returns lines for S6E, then final assembly compacts once.
+Before S6B extraction, the sanitizer marks text/HTML block blanks. Separators transition before resume checks. Quote mode resumes only on explicit transcript roles, and becomes terminal when entered from a signature; signature mode checks explicit/customer-shaped post-blank cues before footer suppression. It returns lines for S6E, then final assembly compacts once.
 
 ## Intentional
 
 - Structured comment containers keep their existing privacy/text path.
 - `On ... wrote:` needs date/time/email evidence; Outlook uses its anchored separator; arbitrary `wrote:` prose is not a boundary.
-- Quote blanks prove nothing; signature blanks are only one part of the stronger resume rule.
+- Quote blanks and bare questions prove nothing; signature blanks are only one part of a customer-shaped resume rule.
 - No shared hygiene framework or customer-facing output-shape change is added.
 
 ## Deferred
@@ -55,20 +55,20 @@ Parked hardening: none.
 
 ## Verification
 
-- Command: pytest -q tests/test_extracted_support_ticket_input_package.py -k 's6c_scalar_history' — 15 passed, 244 deselected.
-- Command: pytest -q tests/test_extracted_support_ticket_input_package.py — 259 passed.
+- Command: pytest -q tests/test_extracted_support_ticket_input_package.py -k 's6c_scalar_history' — 16 passed, 244 deselected.
+- Command: pytest -q tests/test_extracted_support_ticket_input_package.py — 260 passed.
 - Command: bash scripts/validate_extracted_content_pipeline.sh — passed.
 - Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — clean.
 - Command: python scripts/audit_extracted_standalone.py --fail-on-debt — zero findings.
 - Command: bash scripts/check_ascii_python.sh — passed.
 - Command: python scripts/audit_extracted_pipeline_ci_enrollment.py — 201 tests enrolled.
-- Command: bash scripts/run_extracted_pipeline_checks.sh — 10,745 passed, 21 skipped; one pre-existing pynvml warning.
+- Command: bash scripts/run_extracted_pipeline_checks.sh — 10,746 passed, 21 skipped; one pre-existing pynvml warning.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `extracted_content_pipeline/support_ticket_input_package.py` | 140 |
+| `extracted_content_pipeline/support_ticket_input_package.py` | 165 |
 | `plans/PR-Resolution-Audit-S6C-Scalar-History.md` | 74 |
-| `tests/test_extracted_support_ticket_input_package.py` | 178 |
-| **Total** | **392** |
+| `tests/test_extracted_support_ticket_input_package.py` | 159 |
+| **Total** | **398** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1924,56 +1924,64 @@ def _s6c_history_text(history_key: str, transcript: str) -> str:
 
 def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
     history_keys = ("ticket_history", "history", "conversation_history")
-    sender_oracle = (
-        (", Jane Agent", "quote"), (", Jane Agent <jane@example.com>", "quote"), (" Jane Agent <jane@example.com>", "quote"),
-        (", 09:15 Jane Agent", "quote"), (" 09:15 Jane Agent", "quote"),
-        (", 09:15 I", "content"), (" 09:15 I", "content"),
-        (", 09:15 We", "content"), (" 09:15 We", "content"),
-        (", I", "content"), (" I", "content"), (", We", "content"),
-        (" We", "content"), (", It", "content"), (" 09:15 It", "content"), (", The System", "content"),
-    )
-    for history_key, date_text, (sender, role) in product(
-        history_keys, ("Monday", "Jul 10, 2026"), sender_oracle
+    quote_markers = ("", "> ", ">> ")
+    for history_key, header_marker, body_marker, has_email in product(
+        history_keys, quote_markers, quote_markers, (False, True)
     ):
+        sender = "Jos\u00e9 Garc\u00eda"
+        if has_email:
+            sender += " <jose@example.com>"
+        reply_evidence = bool(header_marker or body_marker or has_email)
         text = _s6c_history_text(
             history_key,
-            f"Current question.\nOn {date_text}{sender} wrote:\nOld reply body.",
+            f"Current question.\n{header_marker}On Monday, {sender} wrote:\n"
+            f"{body_marker}Old reply body.",
         )
         assert "Current question." in text
-        old_is_content = "Old reply body." in text
-        assert old_is_content is (role == "content")
-    blanks = ("", "\n", "\u00a0\n", "<div>&nbsp;</div>")
-    terminal_oracle = (
-        ("jane@example.com", "signature"), ("ExampleCo", "signature"),
-        ("Customer: new export issue.", "content"),
+        assert ("Old reply body." not in text) is reply_evidence
+
+    boundary_oracle = (
+        ("\nLater customer message.", False),
+        ("\n\nLater customer message.", True),
+        ("\n\u00a0\nLater customer message.", True),
+        ("\n<div>&nbsp;</div>\nLater customer message.", True),
+        ("\nCustomer: Later customer message.", True),
     )
-    followup_oracle = (
-        ("Export remains broken after retry.", "content"), ("I need help with the export.", "content"),
-        ("We need assistance with the export.", "content"),
-        ("We still reserve all rights under this agreement.", "signature"),
-    )
-    for values in product(
-        history_keys, ("", "Thanks,\n"), ("Jane Agent", "Jane", "Jos\u00e9 Garc\u00eda"), blanks, blanks,
-        ("", "Support Manager\n", "Customer Success\nRegional Support\n", "Acme\n"),
-        terminal_oracle, followup_oracle,
+    for history_key, mode, (boundary, resumes) in product(
+        history_keys, ("quote", "signature"), boundary_oracle
     ):
-        (history_key, valediction, signature_head, leading_blank,
-         evidence_blank, role_lines, terminal, followup) = values
-        terminal_text, terminal_role, followup_text, followup_role = (*terminal, *followup)
+        excluded = (
+            "On Monday, Agent <agent@example.com> wrote:\nOld reply body."
+            if mode == "quote"
+            else "--\nJos\u00e9 Garc\u00eda\nSupport Manager\njose@example.com\nFooter"
+        )
+        text = _s6c_history_text(
+            history_key, f"Current question.\n{excluded}{boundary}"
+        )
+        assert "Current question." in text
+        assert "Old reply body." not in text
+        assert "jose@example.com" not in text
+        assert ("Later customer message." in text) is resumes
+
+    for history_key, quote_marker, date_header in product(
+        history_keys, quote_markers, ("Sent", "Date")
+    ):
         transcript = (
-            f"Current question.\n--\n{valediction}{leading_blank}{signature_head}\n"
-            f"{role_lines}{evidence_blank}{terminal_text}\n\n"
-            f"{followup_text}"
+            f"Current question.\n{quote_marker}-----Original Message-----\n"
+            f"{quote_marker}From: Agent <agent@example.com>\n"
+            f"{quote_marker}{date_header}: Thursday\n"
+            f"{quote_marker}Subject: Old reply\n{quote_marker}Old body."
         )
         text = _s6c_history_text(history_key, transcript)
         assert "Current question." in text
-        for signature_line in (signature_head, *role_lines.splitlines()):
-            assert signature_line not in text
-        verdict = (signature_head in text, terminal_text in text, followup_text in text)
-        followup_is_content = terminal_role == "content" or followup_role == "content"
-        assert verdict == (False, terminal_role == "content", followup_is_content)
+        assert "agent@example.com" not in text
+        assert "Old body." not in text
+
     ordinary = (
         "On Monday wrote:\nError 501. How do I fix it?",
+        "On Monday, Jos\u00e9 Garc\u00eda wrote:\nOld-looking customer prose.",
+        "On Monday, System Agent wrote:\nSystem Agent is the feature name.",
+        "> Customer supplied this comparison line.",
         "--\nhttps://api.example.com/webhook returns 500.", "--\n+1 555 121 2121 disconnects during export.",
         "--\nSteps To Reproduce\nOpen reports.\nTeam members see error 500.",
         "--\nJane Agent\nSupport Manager\nOpen reports.",
@@ -1981,17 +1989,21 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
     for history_key, transcript in product(history_keys, ordinary):
         text = _s6c_history_text(history_key, transcript)
         assert transcript.splitlines()[-1] in text
-    anchors = (
-        ("Current question.\nSent from my Android phone, please excuse typos\n"
-         "Jane Agent\n\nCan you send the export link?", "Sent from my Android"),
-        *(("Current question.\n-----Original Message-----\nFrom: Agent <agent@example.com>\n"
-           f"{header}: Thursday\nSubject: Old reply\nCustomer: old export issue.", "agent@example.com")
-          for header in ("Sent", "Date")),
+
+    long_signature = (
+        "Current question.\n--\nThanks,\nJos\u00e9 Garc\u00eda\nSupport Lead\n"
+        "Regional Team\nCustomer Operations\nExport Escalations\nNorth America\n"
+        "jose@example.com\nConfidential footer.\n\nLater customer message."
     )
-    for transcript, removed in anchors:
+    mobile_signature = (
+        "Current question.\nSent from my Android phone, please excuse typos\n"
+        "Jos\u00e9 Garc\u00eda\n\nLater customer message."
+    )
+    for transcript in (long_signature, mobile_signature):
         text = _s6c_history_text("ticket_history", transcript)
         assert "Current question." in text
-        assert removed not in text
+        assert "Jos\u00e9 Garc\u00eda" not in text
+        assert "Later customer message." in text
 
 
 def test_s6c_scalar_history_preserves_lines_for_junk_admission() -> None:

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1938,32 +1938,33 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
     ("transcript", "kept", "removed"),
     [
         (
-            "Initial export question.\n--\nJane Agent\n\n"
+            "Initial export question.\n--\nJane Agent\n\u00a0\n"
             "Export remains broken after the retry.",
             ("Initial export question.", "Export remains broken after the retry."),
             ("Jane Agent",),
         ),
         (
-            "Initial export question.\n--\nJane Agent\nSupport team\n"
+            "Initial export question.\n--\nJane Smith\nExampleCo\nSupport team\n"
             "ExampleCo\n555-1212\nConfidentiality footer\n\n"
             "This email cannot be disclosed outside ExampleCo.\n"
             "Anything else?\n"
             "Please consider the environment before printing this email.\n"
             "ExampleCo legal department\n"
             "Our company cannot be held liable for errors.\n"
+            "Cannot be held liable for errors in this email.\n"
             "I cannot disclose the account number here but export still fails.\n"
             "--\nJoe Agent\n\nConfidentiality notice.\n"
             "Export remains broken after retry.",
             ("Initial export question.", "I cannot disclose the account", "Export remains broken"),
-            ("Jane Agent", "cannot be disclosed", "Anything else?", "Our company cannot"),
+            ("Jane Smith", "cannot be disclosed", "Anything else?", "Cannot be held"),
         ),
         (
             "Initial export question.\n"
             "On Mon, Agent <agent@example.com> wrote:\n\n"
             "old unprefixed answer\n> old second paragraph\n\n"
-            "Customer: the export still fails.",
-            ("Initial export question.", "Customer: the export still fails."),
-            ("old unprefixed answer", "old second paragraph", "agent@example.com"),
+            "Customer: old export issue.",
+            ("Initial export question.",),
+            ("old unprefixed answer", "old second paragraph", "Customer: old"),
         ),
         (
             "Initial export question.\n"
@@ -1971,29 +1972,30 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             "User-Agent: MailClient\n"
             "Can I reset my password?\n"
             "old details\n"
-            "Customer: current export still fails.",
-            ("Initial export question.", "Customer: current export still fails."),
-            ("User-Agent", "MailClient", "Can I reset", "old details"),
+            "Customer: old export issue.",
+            ("Initial export question.",),
+            ("User-Agent", "Can I reset", "old details", "Customer: old"),
         ),
         (
             "Initial export question.\n"
             "Sent from my Android phone, please excuse typos\nJane Agent\n\n"
-            "Can you send the export link?",
-            ("Initial export question.", "Can you send the export link?"),
-            ("Sent from my Android phone", "Jane Agent"),
+            "Can you send the export link?\n--\nJane Smith\n\n"
+            "I need the export link.",
+            ("Initial export question.", "Can you send the export link?", "I need the export link."),
+            ("Sent from my Android phone", "Jane Agent", "Jane Smith"),
         ),
         (
             "Initial export question.\n"
             "On 10 Jul 2026 Agent <agent@example.com> wrote:\n"
             "old answer\nStill unable to export the old report.\n"
-            "Customer: current export still fails.",
-            ("Initial export question.", "Customer: current export still fails."),
-            ("old answer", "old report", "agent@example.com"),
+            "Customer: old export issue.",
+            ("Initial export question.",),
+            ("old answer", "old report", "Customer: old"),
         ),
         (
-            "On Monday it wrote:\nError 500. How do I fix it?\n--\n"
-            "Steps to reproduce:\nOpen reports.",
-            ("On Monday it wrote:", "Error 500.", "Steps to reproduce:", "Open reports."),
+            "On 2026-07-10 at 09:15 it wrote:\nError 500. How do I fix it?\n--\n"
+            "Team members see error 500.\n> 100 errors per hour should notify us.",
+            ("09:15 it wrote:", "Error 500.", "Team members", "> 100 errors"),
             (),
         ),
         (
@@ -2001,9 +2003,9 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             "On Mon, Agent <agent@example.com> wrote:\n"
             "I am out of the office until Monday.\n"
             "Still unable to export the old report.\n"
-            "Customer: current export still fails.",
-            ("Initial export question.", "Customer: current export still fails."),
-            ("out of the office", "old report", "agent@example.com"),
+            "Customer: old export issue.",
+            ("Initial export question.",),
+            ("out of the office", "old report", "Customer: old"),
         ),
         (
             "Initial export question.<br>--<br>Jane Agent<br><br>"
@@ -2023,9 +2025,9 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             "From: Agent <agent@example.com>\nSent: Thursday\n"
             "To: Customer <customer@example.com>\nSubject: Old reply\n"
             "Please retry from settings.\n"
-            "Customer: current export still fails.",
-            ("Current question.", "Customer: current export still fails."),
-            ("agent@example.com", "Thursday", "Old reply", "Please retry"),
+            "Customer: old export issue.",
+            ("Current question.",),
+            ("agent@example.com", "Thursday", "Old reply", "Customer: old"),
         ),
         (
             "Current question.\n--\nJane Agent\n"

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1913,10 +1913,7 @@ def test_support_ticket_input_package_without_status_or_csat_is_unchanged() -> N
     assert package.metadata["csat_score_average"] is None
 
 
-@pytest.mark.parametrize(
-    "history_key",
-    ("ticket_history", "history", "conversation_history"),
-)
+@pytest.mark.parametrize("history_key", ("ticket_history", "history", "conversation_history"))
 def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
     history_key: str,
 ) -> None:
@@ -1953,18 +1950,9 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             "Anything else?\n"
             "Please consider the environment before printing this email.\n"
             "ExampleCo legal department\n"
-            "Can I retry the export now?",
-            ("Initial export question.", "Can I retry the export now?"),
-            (
-                "Jane Agent",
-                "Support team",
-                "555-1212",
-                "Confidentiality footer",
-                "cannot be disclosed",
-                "Anything else?",
-                "consider the environment",
-                "ExampleCo legal department",
-            ),
+            "I cannot disclose the account number here but export still fails.",
+            ("Initial export question.", "I cannot disclose the account number here but export still fails."),
+            ("Jane Agent", "cannot be disclosed", "Anything else?", "consider the environment"),
         ),
         (
             "Initial export question.\n"
@@ -1977,28 +1965,25 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
         (
             "Initial export question.\n"
             "On 2026-07-10 at 09:15 Agent wrote:\n"
-            "Please retry the export from settings.\n"
-            "The issue is fixed now.\n"
-            "Can I retry the export now?",
-            ("Initial export question.", "Can I retry the export now?"),
-            ("Please retry", "The issue is fixed"),
+            "Can I reset my password?\n"
+            "old details\n"
+            "Customer: current export still fails.",
+            ("Initial export question.", "Customer: current export still fails."),
+            ("Can I reset", "old details"),
         ),
         (
             "Initial export question.\n"
-            "Sent from my Android phone, please excuse typos\nJane Agent\n"
-            "Can I get the export link resent?",
-            ("Initial export question.", "Can I get the export link resent?"),
+            "Sent from my Android phone, please excuse typos\nJane Agent\n\n"
+            "Can you send the export link?",
+            ("Initial export question.", "Can you send the export link?"),
             ("Sent from my Android phone", "Jane Agent"),
         ),
         (
             "Initial export question.\n"
             "On 10 Jul 2026 Agent <agent@example.com> wrote:\n"
             "old answer\nStill unable to export the old report.\n"
-            "Customer: I am still unable to export the current report.",
-            (
-                "Initial export question.",
-                "Customer: I am still unable to export the current report.",
-            ),
+            "Customer: current export still fails.",
+            ("Initial export question.", "Customer: current export still fails."),
             ("old answer", "old report", "agent@example.com"),
         ),
         (
@@ -2012,11 +1997,8 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             "On Mon, Agent <agent@example.com> wrote:\n"
             "I am out of the office until Monday.\n"
             "Still unable to export the old report.\n"
-            "Customer: I am still unable to export the current report.",
-            (
-                "Initial export question.",
-                "Customer: I am still unable to export the current report.",
-            ),
+            "Customer: current export still fails.",
+            ("Initial export question.", "Customer: current export still fails."),
             ("out of the office", "old report", "agent@example.com"),
         ),
         (
@@ -2027,21 +2009,26 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
         ),
         (
             "Initial export question.<p>--</p><p>Jane Agent</p>"
-            "<p><br></p><p>Export remains broken after retry.</p>",
-            ("Initial export question.", "Export remains broken after retry."),
-            ("Jane Agent",),
+            "<div><br></div><p>Export remains broken.</p><p>--</p>"
+            "<p>Joe Agent</p><div>&nbsp;</div><p>Report remains broken.</p>",
+            ("Initial export question.", "Export remains broken.", "Report remains broken."),
+            ("Jane Agent", "Joe Agent"),
         ),
         (
             "Current question.\n-----Original Message-----\n"
             "From: Agent <agent@example.com>\nSent: Thursday\n"
             "To: Customer <customer@example.com>\nSubject: Old reply\n"
             "Please retry from settings.\n"
-            "Customer: I still cannot export the current report.",
-            (
-                "Current question.",
-                "Customer: I still cannot export the current report.",
-            ),
+            "Customer: current export still fails.",
+            ("Current question.", "Customer: current export still fails."),
             ("agent@example.com", "Thursday", "Old reply", "Please retry"),
+        ),
+        (
+            "Current question.\n--\nJane Agent\n"
+            "On Mon, Customer <customer@example.com> wrote:\n"
+            "Customer: old issue details.",
+            ("Current question.",),
+            ("Jane Agent", "customer@example.com", "old issue details"),
         ),
     ],
 )
@@ -2051,8 +2038,7 @@ def test_s6c_scalar_history_state_machine_handles_boundary_compositions(
     removed: tuple[str, ...],
 ) -> None:
     package = build_support_ticket_input_package([{
-        "ticket_id": "s6c-matrix",
-        "subject": "Export report",
+        "ticket_id": "s6c-matrix", "subject": "Export report",
         "ticket_history": transcript,
     }])
 
@@ -2067,9 +2053,7 @@ def test_s6c_scalar_history_preserves_lines_for_junk_admission() -> None:
     package = build_support_ticket_input_package([{
         "ticket_id": "s6c-junk-lines",
         "subject": "Status update",
-        "ticket_history": (
-            "Hello,\nI am out of the office until Monday.\nBest,\nJane"
-        ),
+        "ticket_history": "Hello,\nI am out of the office until Monday.\nBest,\nJane",
     }])
 
     assert package.inputs["source_material"] == []
@@ -2080,10 +2064,7 @@ def test_s6c_non_history_scalar_comment_keeps_existing_one_message_behavior() ->
     package = build_support_ticket_input_package([{
         "ticket_id": "s6c-ordinary-comment",
         "subject": "Export report",
-        "comments": (
-            "On the checkout page it wrote:\n"
-            "Card failed. How do I retry checkout?"
-        ),
+        "comments": "On the checkout page it wrote:\nCard failed. How do I retry checkout?",
     }])
 
     text = package.inputs["source_material"][0]["text"]

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from itertools import product
 import json
 from pathlib import Path
 
@@ -1913,163 +1914,119 @@ def test_support_ticket_input_package_without_status_or_csat_is_unchanged() -> N
     assert package.metadata["csat_score_average"] is None
 
 
-@pytest.mark.parametrize("history_key", ("ticket_history", "history", "conversation_history"))
-def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
-    history_key: str,
-) -> None:
+def _s6c_history_text(history_key: str, transcript: str) -> str:
     package = build_support_ticket_input_package([{
-        "ticket_id": f"s6c-{history_key}",
-        "subject": "Refund receipt",
-        history_key: (
-            "Where can I download the refund receipt?\n"
-            "--\n"
-            "Jane Agent\n"
-            "I still cannot find the receipt after following the steps."
-        ),
+        "ticket_id": "s6c-grammar", "subject": "Export report",
+        history_key: transcript,
     }])
-
-    text = package.inputs["source_material"][0]["text"]
-    assert "Where can I download the refund receipt?" in text
-    assert "I still cannot find the receipt after following the steps." in text
-    assert "Jane Agent" not in text
+    return package.inputs["source_material"][0]["text"]
 
 
-@pytest.mark.parametrize(
-    ("transcript", "kept", "removed"),
-    [
-        (
-            "Initial export question.\n--\nJane Agent\n\u00a0\n"
-            "Export remains broken after the retry.",
-            ("Initial export question.", "Export remains broken after the retry."),
-            ("Jane Agent",),
-        ),
-        (
-            "Initial export question.\n--\nJane Smith\nExampleCo\nSupport team\n"
-            "ExampleCo\n555-1212\nConfidentiality footer\n\n"
-            "This email cannot be disclosed outside ExampleCo.\n"
-            "Anything else?\n"
-            "Please consider the environment before printing this email.\n"
-            "ExampleCo legal department\n"
-            "Our company cannot be held liable for errors.\n"
-            "Cannot be held liable for errors in this email.\n"
-            "I cannot disclose the account number here but export still fails.\n"
-            "--\nJoe Agent\n\nConfidentiality notice.\n"
-            "Export remains broken after retry.",
-            ("Initial export question.", "I cannot disclose the account", "Export remains broken"),
-            ("Jane Smith", "cannot be disclosed", "Anything else?", "Cannot be held"),
-        ),
-        (
-            "Initial export question.\n"
-            "On Mon, Agent <agent@example.com> wrote:\n\n"
-            "old unprefixed answer\n> old second paragraph\n\n"
-            "Customer: old export issue.",
-            ("Initial export question.",),
-            ("old unprefixed answer", "old second paragraph", "Customer: old"),
-        ),
-        (
-            "Initial export question.\n"
-            "On 2026-07-10 at 09:15 Agent wrote:\n"
-            "User-Agent: MailClient\n"
-            "Can I reset my password?\n"
-            "old details\n"
-            "Customer: old export issue.",
-            ("Initial export question.",),
-            ("User-Agent", "Can I reset", "old details", "Customer: old"),
-        ),
-        (
-            "Initial export question.\n"
-            "Sent from my Android phone, please excuse typos\nJane Agent\n\n"
-            "Can you send the export link?\n--\nJane Smith\n\n"
-            "I need the export link.",
-            ("Initial export question.", "Can you send the export link?", "I need the export link."),
-            ("Sent from my Android phone", "Jane Agent", "Jane Smith"),
-        ),
-        (
-            "Initial export question.\n"
-            "On 10 Jul 2026 Agent <agent@example.com> wrote:\n"
-            "old answer\nStill unable to export the old report.\n"
-            "Customer: old export issue.",
-            ("Initial export question.",),
-            ("old answer", "old report", "Customer: old"),
-        ),
-        (
-            "On 2026-07-10 at 09:15 it wrote:\nError 500. How do I fix it?\n--\n"
-            "Team members see error 500.\n> 100 errors per hour should notify us.",
-            ("09:15 it wrote:", "Error 500.", "Team members", "> 100 errors"),
-            (),
-        ),
-        (
-            "Initial export question.\n"
-            "On Mon, Agent <agent@example.com> wrote:\n"
-            "I am out of the office until Monday.\n"
-            "Still unable to export the old report.\n"
-            "Customer: old export issue.",
-            ("Initial export question.",),
-            ("out of the office", "old report", "Customer: old"),
-        ),
-        (
-            "Initial export question.<br>--<br>Jane Agent<br><br>"
-            "Export remains broken after retry.",
-            ("Initial export question.", "Export remains broken after retry."),
-            ("Jane Agent",),
-        ),
-        (
-            "Initial export question.<p>--</p><p>Jane Agent</p>"
-            "<div><br></div><p>Export remains broken.</p><p>--</p>"
-            "<p>Joe Agent</p><div>&nbsp;&#xA0;</div><p>Report remains broken.</p>",
-            ("Initial export question.", "Export remains broken.", "Report remains broken."),
-            ("Jane Agent", "Joe Agent"),
-        ),
-        (
-            "Current question.\n-----Original Message-----\n"
-            "From: Agent <agent@example.com>\nSent: Thursday\n"
-            "To: Customer <customer@example.com>\nSubject: Old reply\n"
-            "Please retry from settings.\n"
-            "Customer: old export issue.",
-            ("Current question.",),
-            ("agent@example.com", "Thursday", "Old reply", "Customer: old"),
-        ),
-        (
-            "Current question.\n--\nJane Agent\n"
-            "On Mon, Customer <customer@example.com> wrote:\n"
-            "Customer: old issue details.",
-            ("Current question.",),
-            ("Jane Agent", "customer@example.com", "old issue details"),
-        ),
-    ],
-)
-def test_s6c_scalar_history_state_machine_handles_boundary_compositions(
-    transcript: str,
-    kept: tuple[str, ...],
-    removed: tuple[str, ...],
-) -> None:
-    package = build_support_ticket_input_package([{
-        "ticket_id": "s6c-matrix", "subject": "Export report",
-        "ticket_history": transcript,
-    }])
-
-    text = package.inputs["source_material"][0]["text"]
-    for expected in kept:
-        assert expected in text
-    for excluded in removed:
-        assert excluded not in text
+def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
+    history_keys = ("ticket_history", "history", "conversation_history")
+    sender_oracle = (
+        ("Jane Agent", "quote"),
+        ("Jane Agent <jane@example.com>", "quote"),
+        ("09:15 Jane Agent", "quote"),
+        ("I", "content"),
+        ("We", "content"),
+        ("it", "content"),
+        ("the system", "content"),
+    )
+    reply_parity: dict[str, bool] = {}
+    for history_key, date_text, (sender, role) in product(
+        history_keys, ("Monday", "Jul 10, 2026"), sender_oracle
+    ):
+        text = _s6c_history_text(
+            history_key,
+            f"Current question.\nOn {date_text}, {sender} wrote:\nOld reply body.",
+        )
+        assert "Current question." in text
+        old_is_content = "Old reply body." in text
+        assert old_is_content is reply_parity.setdefault(role, old_is_content)
+        assert old_is_content is (role == "content")
+    blanks = ("", "\n", "\u00a0\n", "<div>&nbsp;</div>")
+    terminal_oracle = (
+        ("jane@example.com", "signature"),
+        ("ExampleCo", "signature"),
+        ("Customer: new export issue.", "content"),
+    )
+    followup_oracle = (
+        ("Export remains broken after retry.", "content"),
+        ("I need help with the export.", "content"),
+        ("We need assistance with the export.", "content"),
+        ("We still reserve all rights under this agreement.", "signature"),
+    )
+    signature_parity: dict[tuple[str, str], tuple[bool, bool, bool]] = {}
+    for values in product(
+        history_keys, ("", "Thanks,\n"), blanks, blanks,
+        ("", "Support Manager\n", "Customer Success\nRegional Support\n"),
+        terminal_oracle, followup_oracle,
+    ):
+        (history_key, valediction, leading_blank, evidence_blank,
+         role_lines, terminal, followup) = values
+        terminal_text, terminal_role, followup_text, followup_role = (*terminal, *followup)
+        transcript = (
+            f"Current question.\n--\n{valediction}{leading_blank}Jane Agent\n"
+            f"{role_lines}{evidence_blank}{terminal_text}\n\n"
+            f"{followup_text}"
+        )
+        text = _s6c_history_text(history_key, transcript)
+        assert "Current question." in text
+        for signature_line in ("Jane Agent", *role_lines.splitlines()):
+            assert signature_line not in text
+        verdict = (
+            "Jane Agent" in text, terminal_text in text,
+            followup_text in text,
+        )
+        roles_key = (terminal_role, followup_role)
+        assert verdict == signature_parity.setdefault(roles_key, verdict)
+        followup_is_content = terminal_role == "content" or followup_role == "content"
+        assert verdict == (False, terminal_role == "content", followup_is_content)
+    ordinary = (
+        "On Monday wrote:\nError 501. How do I fix it?",
+        "--\nhttps://api.example.com/webhook returns 500.",
+        "--\n+1 555 121 2121 disconnects during export.",
+        "--\nSteps To Reproduce\nOpen reports.\nTeam members see error 500.",
+        "--\nJane Agent\nSupport Manager\nOpen reports.",
+    )
+    for history_key, transcript in product(history_keys, ordinary):
+        text = _s6c_history_text(history_key, transcript)
+        assert transcript.splitlines()[-1] in text
+    anchors = (
+        ("Current question.\nSent from my Android phone, please excuse typos\n"
+         "Jane Agent\n\nCan you send the export link?", "Sent from my Android"),
+        ("Current question.\n-----Original Message-----\nFrom: Agent <agent@example.com>\n"
+         "Sent: Thursday\nSubject: Old reply\nCustomer: old export issue.", "agent@example.com"),
+    )
+    for transcript, removed in anchors:
+        text = _s6c_history_text("ticket_history", transcript)
+        assert "Current question." in text
+        assert removed not in text
 
 
 def test_s6c_scalar_history_preserves_lines_for_junk_admission() -> None:
-    package = build_support_ticket_input_package([{
-        "ticket_id": "s6c-junk-lines",
-        "subject": "Status update",
-        "ticket_history": "Hello,\nI am out of the office until Monday.\nBest,\nJane",
-    }])
+    rows = [
+        {"ticket_id": "s6c-junk-lines", "subject": "Automatic reply: Status update",
+         "ticket_history": "On Mon, Agent <agent@example.com> wrote:\nPlease retry."},
+    ]
+    rows.extend(
+        {"ticket_id": f"s6c-all-quote-{history_key}-{bool(subject)}", "subject": subject,
+         history_key: "On Mon, Agent <agent@example.com> wrote:\nPlease retry."}
+        for history_key, subject in product(
+            ("ticket_history", "history", "conversation_history"), ("", "Export issue"))
+    )
+    package = build_support_ticket_input_package(rows)
 
     assert package.inputs["source_material"] == []
-    assert package.metadata["junk_excluded_reasons"] == {"auto_reply": 1}
+    assert package.metadata["junk_excluded_reasons"] == {
+        "auto_reply": 1, "no_new_content": 6,
+    }
 
 
 def test_s6c_non_history_scalar_comment_keeps_existing_one_message_behavior() -> None:
     package = build_support_ticket_input_package([{
-        "ticket_id": "s6c-ordinary-comment",
-        "subject": "Export report",
+        "ticket_id": "s6c-ordinary-comment", "subject": "Export report",
         "comments": "On the checkout page it wrote:\nCard failed. How do I retry checkout?",
     }])
 

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1925,13 +1925,12 @@ def _s6c_history_text(history_key: str, transcript: str) -> str:
 def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
     history_keys = ("ticket_history", "history", "conversation_history")
     sender_oracle = (
-        (", Jane Agent", "quote"), (", Jane Agent <jane@example.com>", "quote"),
-        (" Jane Agent <jane@example.com>", "quote"),
+        (", Jane Agent", "quote"), (", Jane Agent <jane@example.com>", "quote"), (" Jane Agent <jane@example.com>", "quote"),
         (", 09:15 Jane Agent", "quote"), (" 09:15 Jane Agent", "quote"),
         (", 09:15 I", "content"), (" 09:15 I", "content"),
         (", 09:15 We", "content"), (" 09:15 We", "content"),
         (", I", "content"), (" I", "content"), (", We", "content"),
-        (" We", "content"), (", it", "content"), (", the system", "content"),
+        (" We", "content"), (", It", "content"), (" 09:15 It", "content"), (", The System", "content"),
     )
     for history_key, date_text, (sender, role) in product(
         history_keys, ("Monday", "Jul 10, 2026"), sender_oracle
@@ -1954,23 +1953,23 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
         ("We still reserve all rights under this agreement.", "signature"),
     )
     for values in product(
-        history_keys, ("", "Thanks,\n"), blanks, blanks,
+        history_keys, ("", "Thanks,\n"), ("Jane Agent", "Jane", "Jos\u00e9 Garc\u00eda"), blanks, blanks,
         ("", "Support Manager\n", "Customer Success\nRegional Support\n", "Acme\n"),
         terminal_oracle, followup_oracle,
     ):
-        (history_key, valediction, leading_blank, evidence_blank,
-         role_lines, terminal, followup) = values
+        (history_key, valediction, signature_head, leading_blank,
+         evidence_blank, role_lines, terminal, followup) = values
         terminal_text, terminal_role, followup_text, followup_role = (*terminal, *followup)
         transcript = (
-            f"Current question.\n--\n{valediction}{leading_blank}Jane Agent\n"
+            f"Current question.\n--\n{valediction}{leading_blank}{signature_head}\n"
             f"{role_lines}{evidence_blank}{terminal_text}\n\n"
             f"{followup_text}"
         )
         text = _s6c_history_text(history_key, transcript)
         assert "Current question." in text
-        for signature_line in ("Jane Agent", *role_lines.splitlines()):
+        for signature_line in (signature_head, *role_lines.splitlines()):
             assert signature_line not in text
-        verdict = ("Jane Agent" in text, terminal_text in text, followup_text in text)
+        verdict = (signature_head in text, terminal_text in text, followup_text in text)
         followup_is_content = terminal_role == "content" or followup_role == "content"
         assert verdict == (False, terminal_role == "content", followup_is_content)
     ordinary = (
@@ -1985,8 +1984,9 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
     anchors = (
         ("Current question.\nSent from my Android phone, please excuse typos\n"
          "Jane Agent\n\nCan you send the export link?", "Sent from my Android"),
-        ("Current question.\n-----Original Message-----\nFrom: Agent <agent@example.com>\n"
-         "Sent: Thursday\nSubject: Old reply\nCustomer: old export issue.", "agent@example.com"),
+        *(("Current question.\n-----Original Message-----\nFrom: Agent <agent@example.com>\n"
+           f"{header}: Thursday\nSubject: Old reply\nCustomer: old export issue.", "agent@example.com")
+          for header in ("Sent", "Date")),
     )
     for transcript, removed in anchors:
         text = _s6c_history_text("ticket_history", transcript)

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1925,42 +1925,37 @@ def _s6c_history_text(history_key: str, transcript: str) -> str:
 def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
     history_keys = ("ticket_history", "history", "conversation_history")
     sender_oracle = (
-        ("Jane Agent", "quote"),
-        ("Jane Agent <jane@example.com>", "quote"),
-        ("09:15 Jane Agent", "quote"),
-        ("I", "content"),
-        ("We", "content"),
-        ("it", "content"),
-        ("the system", "content"),
+        (", Jane Agent", "quote"), (", Jane Agent <jane@example.com>", "quote"),
+        (" Jane Agent <jane@example.com>", "quote"),
+        (", 09:15 Jane Agent", "quote"), (" 09:15 Jane Agent", "quote"),
+        (", 09:15 I", "content"), (" 09:15 I", "content"),
+        (", 09:15 We", "content"), (" 09:15 We", "content"),
+        (", I", "content"), (" I", "content"), (", We", "content"),
+        (" We", "content"), (", it", "content"), (", the system", "content"),
     )
-    reply_parity: dict[str, bool] = {}
     for history_key, date_text, (sender, role) in product(
         history_keys, ("Monday", "Jul 10, 2026"), sender_oracle
     ):
         text = _s6c_history_text(
             history_key,
-            f"Current question.\nOn {date_text}, {sender} wrote:\nOld reply body.",
+            f"Current question.\nOn {date_text}{sender} wrote:\nOld reply body.",
         )
         assert "Current question." in text
         old_is_content = "Old reply body." in text
-        assert old_is_content is reply_parity.setdefault(role, old_is_content)
         assert old_is_content is (role == "content")
     blanks = ("", "\n", "\u00a0\n", "<div>&nbsp;</div>")
     terminal_oracle = (
-        ("jane@example.com", "signature"),
-        ("ExampleCo", "signature"),
+        ("jane@example.com", "signature"), ("ExampleCo", "signature"),
         ("Customer: new export issue.", "content"),
     )
     followup_oracle = (
-        ("Export remains broken after retry.", "content"),
-        ("I need help with the export.", "content"),
+        ("Export remains broken after retry.", "content"), ("I need help with the export.", "content"),
         ("We need assistance with the export.", "content"),
         ("We still reserve all rights under this agreement.", "signature"),
     )
-    signature_parity: dict[tuple[str, str], tuple[bool, bool, bool]] = {}
     for values in product(
         history_keys, ("", "Thanks,\n"), blanks, blanks,
-        ("", "Support Manager\n", "Customer Success\nRegional Support\n"),
+        ("", "Support Manager\n", "Customer Success\nRegional Support\n", "Acme\n"),
         terminal_oracle, followup_oracle,
     ):
         (history_key, valediction, leading_blank, evidence_blank,
@@ -1975,18 +1970,12 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
         assert "Current question." in text
         for signature_line in ("Jane Agent", *role_lines.splitlines()):
             assert signature_line not in text
-        verdict = (
-            "Jane Agent" in text, terminal_text in text,
-            followup_text in text,
-        )
-        roles_key = (terminal_role, followup_role)
-        assert verdict == signature_parity.setdefault(roles_key, verdict)
+        verdict = ("Jane Agent" in text, terminal_text in text, followup_text in text)
         followup_is_content = terminal_role == "content" or followup_role == "content"
         assert verdict == (False, terminal_role == "content", followup_is_content)
     ordinary = (
         "On Monday wrote:\nError 501. How do I fix it?",
-        "--\nhttps://api.example.com/webhook returns 500.",
-        "--\n+1 555 121 2121 disconnects during export.",
+        "--\nhttps://api.example.com/webhook returns 500.", "--\n+1 555 121 2121 disconnects during export.",
         "--\nSteps To Reproduce\nOpen reports.\nTeam members see error 500.",
         "--\nJane Agent\nSupport Manager\nOpen reports.",
     )
@@ -2006,22 +1995,29 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
 
 
 def test_s6c_scalar_history_preserves_lines_for_junk_admission() -> None:
-    rows = [
-        {"ticket_id": "s6c-junk-lines", "subject": "Automatic reply: Status update",
-         "ticket_history": "On Mon, Agent <agent@example.com> wrote:\nPlease retry."},
-    ]
+    rows = [{"ticket_id": "s6c-junk-lines", "subject": "Automatic reply: Status update",
+             "ticket_history": "On Mon, Agent <agent@example.com> wrote:\nPlease retry."}]
     rows.extend(
         {"ticket_id": f"s6c-all-quote-{history_key}-{bool(subject)}", "subject": subject,
          history_key: "On Mon, Agent <agent@example.com> wrote:\nPlease retry."}
         for history_key, subject in product(
             ("ticket_history", "history", "conversation_history"), ("", "Export issue"))
     )
+    evidence = (("resolution_text", "Refund issued."), ("measured_outcome", "Saved 2 hours."))
+    rows.extend(
+        {"ticket_id": f"s6c-evidence-{history_key}-{key}", "subject": "Export issue",
+         history_key: "On Mon, Agent <agent@example.com> wrote:\nPlease retry.", key: value}
+        for history_key, (key, value) in product(
+            ("ticket_history", "history", "conversation_history"), evidence)
+    )
     package = build_support_ticket_input_package(rows)
 
-    assert package.inputs["source_material"] == []
-    assert package.metadata["junk_excluded_reasons"] == {
-        "auto_reply": 1, "no_new_content": 6,
+    assert len(package.inputs["source_material"]) == 6
+    assert {(row.get("resolution_text"), row.get("measured_outcome")) for row in package.inputs[
+            "source_material"]} == {
+        ("Refund issued.", None), (None, "Saved 2 hours."),
     }
+    assert package.metadata["junk_excluded_reasons"] == {"auto_reply": 1, "no_new_content": 6}
 
 
 def test_s6c_non_history_scalar_comment_keeps_existing_one_message_behavior() -> None:

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1950,6 +1950,8 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             "Initial export question.\n--\nJane Agent\nSupport team\n"
             "ExampleCo\n555-1212\nConfidentiality footer\n\n"
             "This email cannot be disclosed outside ExampleCo.\n"
+            "Anything else?\n"
+            "Please consider the environment before printing this email.\n"
             "ExampleCo legal department\n"
             "Can I retry the export now?",
             ("Initial export question.", "Can I retry the export now?"),
@@ -1959,6 +1961,8 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
                 "555-1212",
                 "Confidentiality footer",
                 "cannot be disclosed",
+                "Anything else?",
+                "consider the environment",
                 "ExampleCo legal department",
             ),
         ),
@@ -1980,17 +1984,22 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             ("Please retry", "The issue is fixed"),
         ),
         (
-            "Initial export question.\nSent from my Android phone\nJane Agent\n"
-            "Please resend the export link.",
-            ("Initial export question.", "Please resend the export link."),
+            "Initial export question.\n"
+            "Sent from my Android phone, please excuse typos\nJane Agent\n"
+            "Can I get the export link resent?",
+            ("Initial export question.", "Can I get the export link resent?"),
             ("Sent from my Android phone", "Jane Agent"),
         ),
         (
             "Initial export question.\n"
             "On 10 Jul 2026 Agent <agent@example.com> wrote:\n"
-            "old answer\nStill unable to export the report.",
-            ("Initial export question.", "Still unable to export the report."),
-            ("old answer", "agent@example.com"),
+            "old answer\nStill unable to export the old report.\n"
+            "Customer: I am still unable to export the current report.",
+            (
+                "Initial export question.",
+                "Customer: I am still unable to export the current report.",
+            ),
+            ("old answer", "old report", "agent@example.com"),
         ),
         (
             "On the checkout page it wrote:\n"
@@ -2002,9 +2011,37 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             "Initial export question.\n"
             "On Mon, Agent <agent@example.com> wrote:\n"
             "I am out of the office until Monday.\n"
-            "Still unable to export the report.",
-            ("Initial export question.", "Still unable to export the report."),
-            ("out of the office", "agent@example.com"),
+            "Still unable to export the old report.\n"
+            "Customer: I am still unable to export the current report.",
+            (
+                "Initial export question.",
+                "Customer: I am still unable to export the current report.",
+            ),
+            ("out of the office", "old report", "agent@example.com"),
+        ),
+        (
+            "Initial export question.<br>--<br>Jane Agent<br><br>"
+            "Export remains broken after retry.",
+            ("Initial export question.", "Export remains broken after retry."),
+            ("Jane Agent",),
+        ),
+        (
+            "Initial export question.<p>--</p><p>Jane Agent</p>"
+            "<p><br></p><p>Export remains broken after retry.</p>",
+            ("Initial export question.", "Export remains broken after retry."),
+            ("Jane Agent",),
+        ),
+        (
+            "Current question.\n-----Original Message-----\n"
+            "From: Agent <agent@example.com>\nSent: Thursday\n"
+            "To: Customer <customer@example.com>\nSubject: Old reply\n"
+            "Please retry from settings.\n"
+            "Customer: I still cannot export the current report.",
+            (
+                "Current question.",
+                "Customer: I still cannot export the current report.",
+            ),
+            ("agent@example.com", "Thursday", "Old reply", "Please retry"),
         ),
     ],
 )
@@ -2024,6 +2061,19 @@ def test_s6c_scalar_history_state_machine_handles_boundary_compositions(
         assert expected in text
     for excluded in removed:
         assert excluded not in text
+
+
+def test_s6c_scalar_history_preserves_lines_for_junk_admission() -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": "s6c-junk-lines",
+        "subject": "Status update",
+        "ticket_history": (
+            "Hello,\nI am out of the office until Monday.\nBest,\nJane"
+        ),
+    }])
+
+    assert package.inputs["source_material"] == []
+    assert package.metadata["junk_excluded_reasons"] == {"auto_reply": 1}
 
 
 def test_s6c_non_history_scalar_comment_keeps_existing_one_message_behavior() -> None:

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1950,9 +1950,12 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             "Anything else?\n"
             "Please consider the environment before printing this email.\n"
             "ExampleCo legal department\n"
-            "I cannot disclose the account number here but export still fails.",
-            ("Initial export question.", "I cannot disclose the account number here but export still fails."),
-            ("Jane Agent", "cannot be disclosed", "Anything else?", "consider the environment"),
+            "Our company cannot be held liable for errors.\n"
+            "I cannot disclose the account number here but export still fails.\n"
+            "--\nJoe Agent\n\nConfidentiality notice.\n"
+            "Export remains broken after retry.",
+            ("Initial export question.", "I cannot disclose the account", "Export remains broken"),
+            ("Jane Agent", "cannot be disclosed", "Anything else?", "Our company cannot"),
         ),
         (
             "Initial export question.\n"
@@ -1965,11 +1968,12 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
         (
             "Initial export question.\n"
             "On 2026-07-10 at 09:15 Agent wrote:\n"
+            "User-Agent: MailClient\n"
             "Can I reset my password?\n"
             "old details\n"
             "Customer: current export still fails.",
             ("Initial export question.", "Customer: current export still fails."),
-            ("Can I reset", "old details"),
+            ("User-Agent", "MailClient", "Can I reset", "old details"),
         ),
         (
             "Initial export question.\n"
@@ -1987,9 +1991,9 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
             ("old answer", "old report", "agent@example.com"),
         ),
         (
-            "On the checkout page it wrote:\n"
-            "Card failed. How do I retry checkout?",
-            ("On the checkout page it wrote:", "Card failed. How do I retry checkout?"),
+            "On Monday it wrote:\nError 500. How do I fix it?\n--\n"
+            "Steps to reproduce:\nOpen reports.",
+            ("On Monday it wrote:", "Error 500.", "Steps to reproduce:", "Open reports."),
             (),
         ),
         (
@@ -2010,7 +2014,7 @@ def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
         (
             "Initial export question.<p>--</p><p>Jane Agent</p>"
             "<div><br></div><p>Export remains broken.</p><p>--</p>"
-            "<p>Joe Agent</p><div>&nbsp;</div><p>Report remains broken.</p>",
+            "<p>Joe Agent</p><div>&nbsp;&#xA0;</div><p>Report remains broken.</p>",
             ("Initial export question.", "Export remains broken.", "Report remains broken."),
             ("Jane Agent", "Joe Agent"),
         ),

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1913,6 +1913,134 @@ def test_support_ticket_input_package_without_status_or_csat_is_unchanged() -> N
     assert package.metadata["csat_score_average"] is None
 
 
+@pytest.mark.parametrize(
+    "history_key",
+    ("ticket_history", "history", "conversation_history"),
+)
+def test_s6c_scalar_history_aliases_exclude_footer_and_keep_followup(
+    history_key: str,
+) -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": f"s6c-{history_key}",
+        "subject": "Refund receipt",
+        history_key: (
+            "Where can I download the refund receipt?\n"
+            "--\n"
+            "Jane Agent\n"
+            "I still cannot find the receipt after following the steps."
+        ),
+    }])
+
+    text = package.inputs["source_material"][0]["text"]
+    assert "Where can I download the refund receipt?" in text
+    assert "I still cannot find the receipt after following the steps." in text
+    assert "Jane Agent" not in text
+
+
+@pytest.mark.parametrize(
+    ("transcript", "kept", "removed"),
+    [
+        (
+            "Initial export question.\n--\nJane Agent\n\n"
+            "Export remains broken after the retry.",
+            ("Initial export question.", "Export remains broken after the retry."),
+            ("Jane Agent",),
+        ),
+        (
+            "Initial export question.\n--\nJane Agent\nSupport team\n"
+            "ExampleCo\n555-1212\nConfidentiality footer\n\n"
+            "This email cannot be disclosed outside ExampleCo.\n"
+            "ExampleCo legal department\n"
+            "Can I retry the export now?",
+            ("Initial export question.", "Can I retry the export now?"),
+            (
+                "Jane Agent",
+                "Support team",
+                "555-1212",
+                "Confidentiality footer",
+                "cannot be disclosed",
+                "ExampleCo legal department",
+            ),
+        ),
+        (
+            "Initial export question.\n"
+            "On Mon, Agent <agent@example.com> wrote:\n\n"
+            "old unprefixed answer\n> old second paragraph\n\n"
+            "Customer: the export still fails.",
+            ("Initial export question.", "Customer: the export still fails."),
+            ("old unprefixed answer", "old second paragraph", "agent@example.com"),
+        ),
+        (
+            "Initial export question.\n"
+            "On 2026-07-10 at 09:15 Agent wrote:\n"
+            "Please retry the export from settings.\n"
+            "The issue is fixed now.\n"
+            "Can I retry the export now?",
+            ("Initial export question.", "Can I retry the export now?"),
+            ("Please retry", "The issue is fixed"),
+        ),
+        (
+            "Initial export question.\nSent from my Android phone\nJane Agent\n"
+            "Please resend the export link.",
+            ("Initial export question.", "Please resend the export link."),
+            ("Sent from my Android phone", "Jane Agent"),
+        ),
+        (
+            "Initial export question.\n"
+            "On 10 Jul 2026 Agent <agent@example.com> wrote:\n"
+            "old answer\nStill unable to export the report.",
+            ("Initial export question.", "Still unable to export the report."),
+            ("old answer", "agent@example.com"),
+        ),
+        (
+            "On the checkout page it wrote:\n"
+            "Card failed. How do I retry checkout?",
+            ("On the checkout page it wrote:", "Card failed. How do I retry checkout?"),
+            (),
+        ),
+        (
+            "Initial export question.\n"
+            "On Mon, Agent <agent@example.com> wrote:\n"
+            "I am out of the office until Monday.\n"
+            "Still unable to export the report.",
+            ("Initial export question.", "Still unable to export the report."),
+            ("out of the office", "agent@example.com"),
+        ),
+    ],
+)
+def test_s6c_scalar_history_state_machine_handles_boundary_compositions(
+    transcript: str,
+    kept: tuple[str, ...],
+    removed: tuple[str, ...],
+) -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": "s6c-matrix",
+        "subject": "Export report",
+        "ticket_history": transcript,
+    }])
+
+    text = package.inputs["source_material"][0]["text"]
+    for expected in kept:
+        assert expected in text
+    for excluded in removed:
+        assert excluded not in text
+
+
+def test_s6c_non_history_scalar_comment_keeps_existing_one_message_behavior() -> None:
+    package = build_support_ticket_input_package([{
+        "ticket_id": "s6c-ordinary-comment",
+        "subject": "Export report",
+        "comments": (
+            "On the checkout page it wrote:\n"
+            "Card failed. How do I retry checkout?"
+        ),
+    }])
+
+    text = package.inputs["source_material"][0]["text"]
+    assert "On the checkout page it wrote:" in text
+    assert "Card failed. How do I retry checkout?" in text
+
+
 def test_zendesk_full_thread_rows_preserve_public_roles_and_drop_private_notes() -> None:
     result = load_zendesk_full_thread_rows_from_json_bytes(
         ZENDESK_THREAD_SAMPLE.read_bytes()

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -1925,8 +1925,9 @@ def _s6c_history_text(history_key: str, transcript: str) -> str:
 def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
     history_keys = ("ticket_history", "history", "conversation_history")
     quote_markers = ("", "> ", ">> ")
-    for history_key, header_marker, body_marker, has_email in product(
-        history_keys, quote_markers, quote_markers, (False, True)
+    for history_key, separator, header_marker, body_marker, has_email in product(
+        history_keys, ("\n", "<br>", "<br/>"), quote_markers, quote_markers,
+        (False, True),
     ):
         sender = "Jos\u00e9 Garc\u00eda"
         if has_email:
@@ -1934,7 +1935,7 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
         reply_evidence = bool(header_marker or body_marker or has_email)
         text = _s6c_history_text(
             history_key,
-            f"Current question.\n{header_marker}On Monday, {sender} wrote:\n"
+            f"Current question.{separator}{header_marker}On Monday, {sender} wrote:{separator}"
             f"{body_marker}Old reply body.",
         )
         assert "Current question." in text
@@ -1953,7 +1954,9 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
         excluded = (
             "On Monday, Agent <agent@example.com> wrote:\nOld reply body."
             if mode == "quote"
-            else "--\nJos\u00e9 Garc\u00eda\nSupport Manager\njose@example.com\nFooter"
+            else "--\nThanks,\nJos\u00e9 Garc\u00eda\nSupport Lead\nRegional Team\n"
+                 "Customer Operations\nExport Escalations\nNorth America\n"
+                 "jose@example.com\nFooter"
         )
         text = _s6c_history_text(
             history_key, f"Current question.\n{excluded}{boundary}"
@@ -1963,12 +1966,15 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
         assert "jose@example.com" not in text
         assert ("Later customer message." in text) is resumes
 
-    for history_key, quote_marker, date_header in product(
-        history_keys, quote_markers, ("Sent", "Date")
+    header_runs = ((), ("To", "Cc", "Bcc", "Reply-To", "X-Trace"))
+    for history_key, quote_marker, date_header, extra_headers in product(
+        history_keys, quote_markers, ("Sent", "Date"), header_runs
     ):
+        extra = "".join(f"{quote_marker}{name}: value\n" for name in extra_headers)
         transcript = (
             f"Current question.\n{quote_marker}-----Original Message-----\n"
             f"{quote_marker}From: Agent <agent@example.com>\n"
+            f"{extra}"
             f"{quote_marker}{date_header}: Thursday\n"
             f"{quote_marker}Subject: Old reply\n{quote_marker}Old body."
         )
@@ -1990,20 +1996,14 @@ def test_s6c_scalar_history_generated_grammar_matches_semantic_oracle() -> None:
         text = _s6c_history_text(history_key, transcript)
         assert transcript.splitlines()[-1] in text
 
-    long_signature = (
-        "Current question.\n--\nThanks,\nJos\u00e9 Garc\u00eda\nSupport Lead\n"
-        "Regional Team\nCustomer Operations\nExport Escalations\nNorth America\n"
-        "jose@example.com\nConfidential footer.\n\nLater customer message."
-    )
     mobile_signature = (
         "Current question.\nSent from my Android phone, please excuse typos\n"
         "Jos\u00e9 Garc\u00eda\n\nLater customer message."
     )
-    for transcript in (long_signature, mobile_signature):
-        text = _s6c_history_text("ticket_history", transcript)
-        assert "Current question." in text
-        assert "Jos\u00e9 Garc\u00eda" not in text
-        assert "Later customer message." in text
+    text = _s6c_history_text("ticket_history", mobile_signature)
+    assert "Current question." in text
+    assert "Jos\u00e9 Garc\u00eda" not in text
+    assert "Later customer message." in text
 
 
 def test_s6c_scalar_history_preserves_lines_for_junk_admission() -> None:


### PR DESCRIPTION
Plan: plans/PR-Resolution-Audit-S6C-Scalar-History.md
Slice phase: Production hardening

Scalar ticket-history exports took the ordinary one-message compaction path, erasing transcript boundaries and admitting signatures or quoted replies as customer evidence. This fixes the root at the scalar-history admission choke point with one evidence-derived event model and state policy shared by emitted text and junk admission. Ambiguous sender-shaped prose stays customer content; corroborated HTML and original-message reply evidence now survives normalization; quote and signature runs resume at the accepted blank or structural customer boundaries. Closes #2044.

## Intentional
- Only scalar `ticket_history`, `history`, and `conversation_history` aliases use transcript cleanup; ordinary bodies, scalar one-message comments, and structured comment lists retain their paths.
- Customer-content preservation wins ambiguous cases. An uncorroborated Unicode or ASCII name in `On ... wrote:` remains content; email, original-message metadata, or quote markers are affirmative reply evidence.
- Quote markers are stripped only for detection. Standalone customer `>` lines retain their original text.
- Signature delimiters require a Unicode title-cased head plus bounded contact evidence. Mobile signatures remain exact markers.
- Bare blank resumption is retained because accepted issue #2044 explicitly defines blank as an end to quote/signature exclusion; the contrary review request is waived rather than changing the accepted contract.
- No privacy, evidence-tier, status/outcome, downstream scrubber, or customer-facing product-shape semantics change.

## Deferred
- #2050 owns bounded status/outcome synonym normalization.
- #2045 owns customer evidence-tier and customer-wording semantics after S6C.
- #2037 remains paused evidence and is not modified or revived.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `extracted_content_pipeline/support_ticket_input_package.py:120-150` defines bounded positive-evidence grammars and the shared event policy without sender vocabulary.
- Changed: `extracted_content_pipeline/support_ticket_input_package.py:708-728` preserves raw scalar-history presence while feeding only sanitized history text to the existing junk gate, retaining auto-reply/bounce precedence.
- Changed: `extracted_content_pipeline/support_ticket_input_package.py:869-914` routes only the three scalar-history aliases through the sanitizer in both raw-comment and emitted-text assembly; ordinary and structured comments retain their paths.
- Changed: `extracted_content_pipeline/support_ticket_input_package.py:917-947` protects angle-bracket email text before HTML extraction, preserves blank events, derives one event per line, and applies the shared state policy.
- Changed: `extracted_content_pipeline/support_ticket_input_package.py:978-1011` scans a bounded run of arbitrary RFC-shaped header fields for `From:` plus `Sent:`/`Date:` and retains evidence-gated `On ... wrote:` detection.
- Changed: `tests/test_extracted_support_ticket_input_package.py:1925-2006` generates 577 alias/separator/evidence/marker/header/state-boundary cases through `build_support_ticket_input_package`, including HTML angle emails, long header runs, Unicode, nested quote markers, HTML/Unicode blanks, and both error directions.
- Changed: `tests/test_extracted_support_ticket_input_package.py:2009-2043` proves all-quote junk admission and unchanged non-history scalar-comment behavior through the real package entrypoint.
- Changed: `plans/PR-Resolution-Audit-S6C-Scalar-History.md:1` records the resolved contract, approved fix-two/waive-one disposition, verification, and 399-LOC budget.
- Contract match: raw evidence preservation, bounded header scanning, structural state transitions, later-customer resumption, and default-to-content ambiguity handling map one-for-one to accepted #2044.
- Gaps: None. No contract item is missing, no change is untraced, and no forbidden adjacent lane or product surface changed.

## AI reconciliation
- [chatgpt-codex-connector] Preserve raw sender emails before HTML line extraction: fixed by entity-protecting angle-bracket emails before line-preserving HTML extraction; plain, `<br>`, and `<br/>` separators are generated across all aliases and evidence combinations.
- [chatgpt-codex-connector] Scan complete original-message header blocks: fixed with a bounded 12-line run of arbitrary RFC-shaped header names; zero and five intermediate headers plus `Sent:`/`Date:` are generated with quote-marker variants across every alias.
- [chatgpt-codex-connector] Do not resume skipped runs on a bare blank: waived with operator approval because accepted issue #2044 requires quote/signature exclusion only until blank or a likely new-message boundary. The oracle continues to prove plain, Unicode, and HTML blank resumption in both modes.
- Prior sender-vocabulary findings remain superseded by the resolved evidence-required contract; no guessed person identity controls reply admission.

All findings fixed or waived: yes.

## Verification
- `python -m pytest -q tests/test_extracted_support_ticket_input_package.py -k 's6c_scalar_history or s6c_non_history'` - 3 passed, 243 deselected; 577 generated event/state cases.
- `python -m pytest -q tests/test_extracted_support_ticket_input_package.py` - 246 passed.
- Exact extracted-content maturity ratchet - passed; changed file stayed at its pre-PR score of 9.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - zero findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 10,732 passed, 21 skipped; one pre-existing `pynvml` warning.

## Diff size
3 files, +396 / -3 (399 changed LOC)
