### PR TITLE
Decouple SignalWire from the frozen signalwire SDK (twilio 9)

### DIFF
--- a/atlas_brain/mcp/twilio_server.py
+++ b/atlas_brain/mcp/twilio_server.py
@@ -113,10 +113,10 @@ def _client():
 
     if _is_signalwire():
         try:
-            from signalwire.rest import Client
+            from twilio.rest import Client
         except ImportError:
             raise RuntimeError(
-                "SignalWire package not installed. Run: pip install signalwire"
+                "Twilio package not installed. Run: pip install twilio"
             )
 
         space = comms_settings.signalwire_space
@@ -136,10 +136,12 @@ def _client():
                 "ATLAS_COMMS_SIGNALWIRE_RECORDING_TOKEN, and "
                 "ATLAS_COMMS_SIGNALWIRE_SPACE."
             )
-        _cached_client = Client(
-            account_sid, token,
-            signalwire_space_url=f"https://{space}.signalwire.com",
-        )
+        # SignalWire's LaML API is twilio-compatible; point the twilio
+        # client at the space's /api/laml root. The signalwire SDK (which
+        # only did this base_url override) was dropped -- it pinned
+        # twilio==6.54.0.
+        _cached_client = Client(account_sid, token)
+        _cached_client.api.base_url = f"https://{space}.signalwire.com/api/laml"
         return _cached_client
     else:
         try:

--- a/atlas_comms/providers/signalwire.py
+++ b/atlas_comms/providers/signalwire.py
@@ -71,9 +71,9 @@ class SignalWireProvider(TelephonyProvider):
         return self._connected
 
     async def connect(self) -> None:
-        """Initialize SignalWire client."""
+        """Initialize the SignalWire client (twilio SDK pointed at the space)."""
         try:
-            from signalwire.rest import Client
+            from twilio.rest import Client
 
             project_id = comms_settings.signalwire_project_id
             api_token = comms_settings.signalwire_api_token
@@ -87,18 +87,21 @@ class SignalWireProvider(TelephonyProvider):
                     "ATLAS_COMMS_SIGNALWIRE_SPACE"
                 )
 
+            # SignalWire exposes a twilio-compatible LaML REST API at
+            # https://<space>.signalwire.com/2010-04-01/... . Point the
+            # twilio client's Api domain at the space instead of
+            # api.twilio.com -- exactly what the (now removed) signalwire
+            # SDK did, minus its pin to twilio==6.54.0.
             self._space_url = f"https://{space}.signalwire.com"
-            self._client = Client(
-                project_id,
-                api_token,
-                signalwire_space_url=self._space_url,
-            )
+            client = Client(project_id, api_token)
+            client.api.base_url = self._space_url
+            self._client = client
             self._connected = True
             logger.info("SignalWire provider connected to %s", self._space_url)
 
         except ImportError:
             raise ImportError(
-                "SignalWire package not installed. Run: pip install signalwire"
+                "Twilio package not installed. Run: pip install twilio"
             )
 
     async def disconnect(self) -> None:

--- a/atlas_comms/providers/signalwire.py
+++ b/atlas_comms/providers/signalwire.py
@@ -87,14 +87,14 @@ class SignalWireProvider(TelephonyProvider):
                     "ATLAS_COMMS_SIGNALWIRE_SPACE"
                 )
 
-            # SignalWire exposes a twilio-compatible LaML REST API at
-            # https://<space>.signalwire.com/2010-04-01/... . Point the
-            # twilio client's Api domain at the space instead of
-            # api.twilio.com -- exactly what the (now removed) signalwire
-            # SDK did, minus its pin to twilio==6.54.0.
+            # SignalWire's twilio-compatible LaML REST API root is
+            # https://<space>.signalwire.com/api/laml/2010-04-01/... . Point
+            # the twilio client's Api domain there instead of api.twilio.com
+            # (the signalwire SDK, now removed, did the same base_url
+            # override but pinned twilio==6.54.0).
             self._space_url = f"https://{space}.signalwire.com"
             client = Client(project_id, api_token)
-            client.api.base_url = self._space_url
+            client.api.base_url = f"{self._space_url}/api/laml"
             self._client = client
             self._connected = True
             logger.info("SignalWire provider connected to %s", self._space_url)

--- a/constraints.root-asr.txt
+++ b/constraints.root-asr.txt
@@ -8,6 +8,7 @@ accelerate==1.14.0
 addict==2.4.0
 aiohappyeyeballs==2.7.1
 aiohttp==3.14.1
+aiohttp-retry==2.9.1
 aiomqtt==2.5.1
 aiosignal==1.4.0
 aistore==1.25.0
@@ -229,7 +230,6 @@ sentry-sdk==2.64.0
 setuptools==81.0.0
 sgmllib3k==1.0.0
 shellingham==1.5.4
-signalwire==2.0.4
 six==1.17.0
 slowapi==0.1.10
 smart-open==8.0.0
@@ -269,7 +269,7 @@ tqdm==4.68.4
 trafilatura==2.1.0
 transformers==4.57.6
 triton==3.7.1
-twilio==6.43.0
+twilio==9.10.9
 typer==0.26.8
 typing-extensions==4.16.0
 typing-inspection==0.4.2

--- a/plans/PR-Twilio-SignalWire-Decouple.md
+++ b/plans/PR-Twilio-SignalWire-Decouple.md
@@ -1,0 +1,163 @@
+# PR-Twilio-SignalWire-Decouple
+
+Ownership lane: comms-provider
+
+## Why this slice exists
+
+The `signalwire` Python SDK (`signalwire==2.0.4` in `requirements.txt`,
+latest 2.1.1 on PyPI) hard-pins `twilio==6.54.0`, which transitively pins
+`pyjwt==1.7.1` (and old boto3, etc.). This freezes the ASR/comms
+dependency stack: Dependabot cannot bump twilio to 9 (#2092) and the
+python-security-and-patches group (#2098) cannot install pyjwt 2.x -- the
+`root-asr-constraints` resolution is unsatisfiable ("Because twilio==6.54.0
+depends on pyjwt==1.7.1 ... your requirements are unsatisfiable"). No
+signalwire release relaxes the pin (2.1.1, the latest, still requires
+`twilio==6.54.0`), so the SDK is effectively abandoned.
+
+The `signalwire` SDK is only a thin monkey-patch wrapper over `twilio.rest`
+that overrides the Api-domain `base_url` to the SignalWire space;
+SignalWire serves the twilio-compatible LaML REST API at
+`https://<space>.signalwire.com/2010-04-01/...`. So the wrapper is
+removable: the plain `twilio` SDK reaches SignalWire by pointing its
+client at the space. Decoupling permanently removes the pin blocking
+twilio 9 and the python security group.
+
+### Problem-derived contract
+
+- Root cause: `signalwire==2.0.4` hard-pins `twilio==6.54.0` (which pins
+  `pyjwt==1.7.1`). The signalwire SDK is a wrapper that only rewrites the
+  twilio client's `base_url` to the space; nothing in atlas_comms needs
+  the wrapper itself.
+- Correct fix must touch/change:
+  1. `requirements.txt`: remove `signalwire==2.0.4`; promote `twilio`
+     (currently a commented-out alternative) to a direct dependency at
+     `>=9.10.9,<10`. twilio was only present transitively via signalwire,
+     so removing signalwire without this drops twilio entirely.
+  2. `atlas_comms/providers/signalwire.py` `connect()`: build a plain
+     `twilio.rest.Client(project_id, api_token)` and set
+     `client.api.base_url = f"https://{space}.signalwire.com"` instead of
+     `signalwire.rest.Client(..., signalwire_space_url=...)`. The rest of
+     the provider (`.messages.create`, `.calls.create`,
+     `.calls(sid).update`, `.recordings.create`) is unchanged -- the API
+     surface is identical.
+  3. Tests: a regression test asserting the provider's client points at
+     the space (`client.api.base_url` == space URL) and that
+     messages/calls resolve to the space's `/2010-04-01/` LaML endpoint,
+     plus the missing-credentials guard.
+- Must not change:
+  - `atlas_comms/providers/twilio.py` -- already uses `twilio.rest.Client`;
+    it inherits twilio 9 with no code change (stable API surface).
+  - Every other method in `signalwire.py` (make_call, send_sms, hangup,
+    reject, transfer, start_recording, incoming-call/status/SMS webhook
+    handlers, generate_stream_laml) -- identical twilio API, untouched.
+  - pyjwt/boto3/other requirement pins -- those belong to the python
+    security group (#2098), which this unblocks; not bumped here.
+  - Config, atlas_brain comms code, the twilio MCP server, formatting.
+
+Empirical pre-checks (run before coding): twilio 9.10.9 installed in a
+scratch venv; `Client(project, token)` then `client.api.base_url = space`
+resolves `client.messages` and `client.calls` to
+`https://<space>.signalwire.com/2010-04-01/Accounts/<project>/{Messages,Calls}.json`
+-- byte-for-byte what `signalwire.rest.Client` produced (its source sets
+`self._api.base_url = space_url`). PyPI: signalwire 2.1.1 requires
+`twilio==6.54.0`; twilio 9.10.9 requires `PyJWT>=2.0.0,<3.0.0`.
+
+## Scope (this PR)
+
+Slice phase: Vertical slice
+
+Max files: 4
+
+1. `requirements.txt` -- drop signalwire, add twilio 9.x as a direct dep.
+2. `atlas_comms/providers/signalwire.py` -- twilio-client-pointed-at-space
+   in `connect()`.
+3. `tests/test_signalwire_provider_twilio_base_url.py` -- regression test
+   for the base_url/URL wiring and the credentials guard.
+4. This plan doc.
+
+### Files touched
+
+- `atlas_comms/providers/signalwire.py`
+- `plans/PR-Twilio-SignalWire-Decouple.md`
+- `requirements.txt`
+- `tests/test_signalwire_provider_twilio_base_url.py`
+
+### Review Contract
+
+Acceptance criteria:
+1. `requirements.txt` no longer contains `signalwire`; `twilio` is a direct
+   dependency at `>=9.10.9,<10`.
+2. `atlas_comms/providers/signalwire.py` imports `twilio.rest`, not
+   `signalwire.rest`; `connect()` sets `client.api.base_url` to
+   `https://<space>.signalwire.com`.
+3. The provider's client resolves messages/calls to the space's
+   `/2010-04-01/Accounts/<project>/...` LaML endpoint (proven by test).
+4. No other provider method changed; `atlas_comms/providers/twilio.py` untouched.
+5. The `twilio==6.54.0 -> pyjwt==1.7.1` constraint conflict is gone (CI
+   `root-asr-constraints` no longer trips on it).
+
+Affected surfaces: SignalWire provider client construction (SMS + voice);
+requirements / ASR-constraints resolution.
+
+Risk areas: SignalWire compat-API auth/paths could differ from the
+wrapper's -- mitigated: the wrapper only set `base_url`, which we replicate
+exactly, and the resulting URL construction was verified identical on
+twilio 9. No live-credential send test in CI; the boundary is the URL
+wiring, which is unit-tested.
+
+Reviewer rules triggered: R1 (dependency/requirements change), R2 (test
+evidence for changed behavior), R6 (outward-facing comms provider: SMS/
+voice), R7 (third-party SDK boundary).
+
+## Mechanism
+
+`connect()` constructs `twilio.rest.Client(project_id, api_token)` (the
+project id is the twilio "account_sid"/username; SignalWire uses the same
+HTTP Basic auth) and overrides `client.api.base_url` to the space URL. The
+twilio Api domain then builds `2010-04-01/Accounts/<project>/...` requests
+against `https://<space>.signalwire.com`, which is SignalWire's
+twilio-compatible LaML API. `signalwire.rest.Client` did exactly this
+(`self._api.base_url = space_url`) plus cosmetic ANSI error-formatting
+patches and a Fax domain that atlas_comms never uses.
+
+## Intentional
+
+- Decouple rather than bump signalwire: no signalwire release supports a
+  modern twilio (2.1.1 still pins `twilio==6.54.0`), so bumping is
+  impossible; the wrapper is removable because atlas_comms uses only the
+  twilio-compatible surface (calls/messages/recordings).
+- twilio promoted to a direct dep (was transitive via signalwire): without
+  this, removing signalwire drops twilio and breaks BOTH providers.
+- `>=9.10.9,<10` (not `==`): lets Dependabot keep twilio current within v9
+  while `<10` guards a future major.
+- Keep the `try/except ImportError` shape (message swapped to twilio) to
+  match the sibling `atlas_comms/providers/twilio.py` provider; twilio is now a hard dep so the
+  branch is defensive, not expected.
+
+## Deferred
+
+- The python-security-and-patches group (#2098) recreate + merge (pyjwt/
+  boto3) is unblocked by this but lands separately -- its `boto3==1.43.47`
+  is an independent Dependabot version glitch, not this PR's scope.
+- Dependabot twilio PR #2092 is superseded once twilio is a direct dep at
+  9.x (close/let Dependabot reconcile after merge).
+- Twilio v9 native `region`/`edge` targeting is unused; the `base_url`
+  override is the SignalWire-documented compat path. Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_signalwire_provider_twilio_base_url.py -q`
+- `python -c "import atlas_comms.providers.signalwire"` (no signalwire pkg)
+- Scratch-venv proof (before coding): twilio 9.10.9 `base_url` override
+  resolves messages/calls to the SignalWire `/2010-04-01/...` URL.
+- CI `root-asr-constraints` resolves without the twilio/pyjwt conflict.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| requirements.txt | 3 |
+| atlas_comms/providers/signalwire.py | 19 |
+| tests/test_signalwire_provider_twilio_base_url.py | 49 |
+| plans/PR-Twilio-SignalWire-Decouple.md | ~163 |
+| **Total** | ~240 |

--- a/plans/PR-Twilio-SignalWire-Decouple.md
+++ b/plans/PR-Twilio-SignalWire-Decouple.md
@@ -4,80 +4,100 @@ Ownership lane: comms-provider
 
 ## Why this slice exists
 
-The `signalwire` Python SDK (`signalwire==2.0.4` in `requirements.txt`,
-latest 2.1.1 on PyPI) hard-pins `twilio==6.54.0`, which transitively pins
-`pyjwt==1.7.1` (and old boto3, etc.). This freezes the ASR/comms
-dependency stack: Dependabot cannot bump twilio to 9 (#2092) and the
-python-security-and-patches group (#2098) cannot install pyjwt 2.x -- the
-`root-asr-constraints` resolution is unsatisfiable ("Because twilio==6.54.0
-depends on pyjwt==1.7.1 ... your requirements are unsatisfiable"). No
+The `signalwire` Python SDK (`signalwire==2.0.4`, latest 2.1.1 on PyPI)
+hard-pins `twilio==6.54.0`, which pins `pyjwt==1.7.1` (and old boto3, etc.).
+This freezes the ASR/comms dependency stack: Dependabot cannot bump twilio
+to 9 (#2092) and the python-security-and-patches group (#2098) cannot
+install pyjwt 2.x -- the `root-asr-constraints` resolution is unsatisfiable
+("Because twilio==6.54.0 depends on pyjwt==1.7.1 ... unsatisfiable"). No
 signalwire release relaxes the pin (2.1.1, the latest, still requires
 `twilio==6.54.0`), so the SDK is effectively abandoned.
 
 The `signalwire` SDK is only a thin monkey-patch wrapper over `twilio.rest`
-that overrides the Api-domain `base_url` to the SignalWire space;
-SignalWire serves the twilio-compatible LaML REST API at
-`https://<space>.signalwire.com/2010-04-01/...`. So the wrapper is
-removable: the plain `twilio` SDK reaches SignalWire by pointing its
-client at the space. Decoupling permanently removes the pin blocking
-twilio 9 and the python security group.
+that overrides the Api-domain `base_url` to the SignalWire space; SignalWire
+serves the twilio-compatible LaML REST API at
+`https://<space>.signalwire.com/api/laml/2010-04-01/...`. So the wrapper is
+removable: the plain `twilio` SDK reaches SignalWire by pointing its client
+at the space's `/api/laml` root. Decoupling permanently removes the pin
+blocking twilio 9 and the python security group.
 
 ### Problem-derived contract
 
 - Root cause: `signalwire==2.0.4` hard-pins `twilio==6.54.0` (which pins
   `pyjwt==1.7.1`). The signalwire SDK is a wrapper that only rewrites the
-  twilio client's `base_url` to the space; nothing in atlas_comms needs
-  the wrapper itself.
+  twilio client's `base_url` to the space; nothing in atlas_comms needs the
+  wrapper itself.
 - Correct fix must touch/change:
   1. `requirements.txt`: remove `signalwire==2.0.4`; promote `twilio`
      (currently a commented-out alternative) to a direct dependency at
-     `>=9.10.9,<10`. twilio was only present transitively via signalwire,
-     so removing signalwire without this drops twilio entirely.
+     `>=9.10.9,<10`. twilio was only present transitively via signalwire.
   2. `atlas_comms/providers/signalwire.py` `connect()`: build a plain
      `twilio.rest.Client(project_id, api_token)` and set
-     `client.api.base_url = f"https://{space}.signalwire.com"` instead of
-     `signalwire.rest.Client(..., signalwire_space_url=...)`. The rest of
-     the provider (`.messages.create`, `.calls.create`,
-     `.calls(sid).update`, `.recordings.create`) is unchanged -- the API
-     surface is identical.
-  3. Tests: a regression test asserting the provider's client points at
-     the space (`client.api.base_url` == space URL) and that
-     messages/calls resolve to the space's `/2010-04-01/` LaML endpoint,
-     plus the missing-credentials guard.
+     `client.api.base_url = f"https://{space}.signalwire.com/api/laml"`
+     (SignalWire's LaML compat root) instead of `signalwire.rest.Client`.
+     The rest of the provider is unchanged -- the API surface is identical.
+  3. `atlas_brain/mcp/twilio_server.py` `_get_client()`: the SAME
+     `signalwire.rest.Client(signalwire_space_url=...)` branch must switch
+     to `twilio.rest.Client` + `client.api.base_url = ".../api/laml"`, or
+     the MCP SignalWire call/SMS/recording tools break once the package is
+     removed.
+  4. `constraints.root-asr.txt`: regenerate via
+     `scripts/compile_root_asr_constraints.py` (pinned uv) so the compiled
+     lock no longer pins `twilio==6.43.0`; otherwise `requirements.txt`'s
+     `-c constraints.root-asr.txt` keeps the resolution unsatisfiable. The
+     regen also refreshes the `constraints-root-asr-sha256` digest in
+     `requirements.txt`.
+  5. Tests: a regression test asserting the provider's client points at the
+     space's `/api/laml` root and that messages/calls resolve to
+     `/api/laml/2010-04-01/...`, plus the missing-credentials guard.
 - Must not change:
-  - `atlas_comms/providers/twilio.py` -- already uses `twilio.rest.Client`;
-    it inherits twilio 9 with no code change (stable API surface).
-  - Every other method in `signalwire.py` (make_call, send_sms, hangup,
-    reject, transfer, start_recording, incoming-call/status/SMS webhook
-    handlers, generate_stream_laml) -- identical twilio API, untouched.
-  - pyjwt/boto3/other requirement pins -- those belong to the python
-    security group (#2098), which this unblocks; not bumped here.
-  - Config, atlas_brain comms code, the twilio MCP server, formatting.
+  - Every other method in `atlas_comms/providers/signalwire.py` and the
+    twilio branch of `atlas_brain/mcp/twilio_server.py` -- identical twilio
+    API, untouched.
+  - `atlas_comms/providers/twilio.py` -- inherits twilio 9, no code change.
+  - pyjwt/boto3/other requirement pins beyond what the lock regen resolves
+    -- the python security group (#2098) owns those.
+  - Config, atlas_brain comms code, formatting.
 
-Empirical pre-checks (run before coding): twilio 9.10.9 installed in a
-scratch venv; `Client(project, token)` then `client.api.base_url = space`
-resolves `client.messages` and `client.calls` to
-`https://<space>.signalwire.com/2010-04-01/Accounts/<project>/{Messages,Calls}.json`
--- byte-for-byte what `signalwire.rest.Client` produced (its source sets
-`self._api.base_url = space_url`). PyPI: signalwire 2.1.1 requires
-`twilio==6.54.0`; twilio 9.10.9 requires `PyJWT>=2.0.0,<3.0.0`.
+Contract revision (post-Codex round 1): the original contract missed three
+surfaces, all confirmed by Codex and fixed here -- (a) the compat root is
+`/api/laml/2010-04-01`, not `/2010-04-01`; (b) `atlas_brain/mcp/twilio_server.py` has a
+second `signalwire.rest.Client` site; (c) `constraints.root-asr.txt` itself
+pins `twilio==6.43.0`, so requirements.txt alone left the resolution
+unsatisfiable. Change surface expanded from 3 files to 5 (+ the regenerated
+lock/digest).
+
+Empirical pre-checks: twilio 9.10.9 `client.api.base_url =
+"https://<space>.signalwire.com/api/laml"` resolves messages/calls to
+`https://<space>.signalwire.com/api/laml/2010-04-01/Accounts/<project>/...`
+(matches the in-tree recording helper at `atlas_brain/mcp/twilio_server.py`). PyPI:
+signalwire 2.1.1 requires `twilio==6.54.0`; twilio 9.10.9 requires
+`PyJWT>=2.0.0,<3.0.0`. The pinned-uv lock regen succeeded (proof the tree
+is now satisfiable): `twilio==9.10.9`, `pyjwt==2.13.0`, `+aiohttp`,
+signalwire removed.
 
 ## Scope (this PR)
 
 Slice phase: Vertical slice
 
-Max files: 4
+Max files: 6
 
-1. `requirements.txt` -- drop signalwire, add twilio 9.x as a direct dep.
-2. `atlas_comms/providers/signalwire.py` -- twilio-client-pointed-at-space
-   in `connect()`.
-3. `tests/test_signalwire_provider_twilio_base_url.py` -- regression test
-   for the base_url/URL wiring and the credentials guard.
-4. This plan doc.
+1. `requirements.txt` -- drop signalwire, add twilio 9.x direct; refreshed
+   constraints digest.
+2. `atlas_comms/providers/signalwire.py` -- twilio client at the `/api/laml`
+   space root in `connect()`.
+3. `atlas_brain/mcp/twilio_server.py` -- same substitution in the MCP
+   client factory's signalwire branch.
+4. `constraints.root-asr.txt` -- regenerated lock (twilio 6.43.0 -> 9.10.9,
+   +aiohttp, -signalwire).
+5. `tests/test_signalwire_provider_twilio_base_url.py` -- regression test.
+6. This plan doc.
 
 ### Files touched
 
+- `atlas_brain/mcp/twilio_server.py`
 - `atlas_comms/providers/signalwire.py`
+- `constraints.root-asr.txt`
 - `plans/PR-Twilio-SignalWire-Decouple.md`
 - `requirements.txt`
 - `tests/test_signalwire_provider_twilio_base_url.py`
@@ -86,78 +106,71 @@ Max files: 4
 
 Acceptance criteria:
 1. `requirements.txt` no longer contains `signalwire`; `twilio` is a direct
-   dependency at `>=9.10.9,<10`.
-2. `atlas_comms/providers/signalwire.py` imports `twilio.rest`, not
-   `signalwire.rest`; `connect()` sets `client.api.base_url` to
-   `https://<space>.signalwire.com`.
-3. The provider's client resolves messages/calls to the space's
-   `/2010-04-01/Accounts/<project>/...` LaML endpoint (proven by test).
-4. No other provider method changed; `atlas_comms/providers/twilio.py` untouched.
-5. The `twilio==6.54.0 -> pyjwt==1.7.1` constraint conflict is gone (CI
-   `root-asr-constraints` no longer trips on it).
+   dep at `>=9.10.9,<10`; the `constraints-root-asr-sha256` digest matches
+   the regenerated lock.
+2. `atlas_comms/providers/signalwire.py` and `atlas_brain/mcp/twilio_server.py`
+   import `twilio.rest`, not `signalwire.rest`, and set `client.api.base_url`
+   to `https://<space>.signalwire.com/api/laml`.
+3. The provider's client resolves messages/calls to
+   `/api/laml/2010-04-01/Accounts/<project>/...` (proven by test).
+4. `constraints.root-asr.txt` pins `twilio==9.10.9` (not 6.43.0); the pinned
+   uv regen is reproducible so CI `root-asr-constraints` (--check) passes.
+5. No other provider method changed; `atlas_comms/providers/twilio.py` and
+   the twilio branch of `atlas_brain/mcp/twilio_server.py` untouched.
 
-Affected surfaces: SignalWire provider client construction (SMS + voice);
-requirements / ASR-constraints resolution.
+Affected surfaces: SignalWire provider + MCP client construction (SMS +
+voice + recording); requirements / ASR-constraints resolution.
 
-Risk areas: SignalWire compat-API auth/paths could differ from the
-wrapper's -- mitigated: the wrapper only set `base_url`, which we replicate
-exactly, and the resulting URL construction was verified identical on
-twilio 9. No live-credential send test in CI; the boundary is the URL
-wiring, which is unit-tested.
+Risk areas: SignalWire compat-API path (`/api/laml`) verified against the
+in-tree recording helper + docs; no live-credential send test in CI (the
+boundary is URL wiring, unit-tested).
 
-Reviewer rules triggered: R1 (dependency/requirements change), R2 (test
-evidence for changed behavior), R6 (outward-facing comms provider: SMS/
-voice), R7 (third-party SDK boundary).
+Reviewer rules triggered: R1, R2, R5, R6, R11, R12 (dependency/requirements change; test evidence; outward-facing comms provider + MCP runtime; constraints/lock regen).
 
 ## Mechanism
 
-`connect()` constructs `twilio.rest.Client(project_id, api_token)` (the
-project id is the twilio "account_sid"/username; SignalWire uses the same
-HTTP Basic auth) and overrides `client.api.base_url` to the space URL. The
-twilio Api domain then builds `2010-04-01/Accounts/<project>/...` requests
-against `https://<space>.signalwire.com`, which is SignalWire's
-twilio-compatible LaML API. `signalwire.rest.Client` did exactly this
-(`self._api.base_url = space_url`) plus cosmetic ANSI error-formatting
-patches and a Fax domain that atlas_comms never uses.
+`connect()` / `_get_client()` construct `twilio.rest.Client(id, token)` and
+override `client.api.base_url` to `https://<space>.signalwire.com/api/laml`;
+the twilio Api domain then builds `/api/laml/2010-04-01/Accounts/<project>/`
+requests against SignalWire's twilio-compatible LaML API. The lock is
+regenerated with the pinned uv so `constraints.root-asr.txt` resolves twilio
+9 (+ its aiohttp/pyjwt deps) instead of the old `twilio==6.43.0` pin.
 
 ## Intentional
 
 - Decouple rather than bump signalwire: no signalwire release supports a
-  modern twilio (2.1.1 still pins `twilio==6.54.0`), so bumping is
-  impossible; the wrapper is removable because atlas_comms uses only the
-  twilio-compatible surface (calls/messages/recordings).
-- twilio promoted to a direct dep (was transitive via signalwire): without
-  this, removing signalwire drops twilio and breaks BOTH providers.
-- `>=9.10.9,<10` (not `==`): lets Dependabot keep twilio current within v9
-  while `<10` guards a future major.
-- Keep the `try/except ImportError` shape (message swapped to twilio) to
-  match the sibling `atlas_comms/providers/twilio.py` provider; twilio is now a hard dep so the
-  branch is defensive, not expected.
+  modern twilio (2.1.1 still pins `twilio==6.54.0`).
+- twilio promoted to a direct dep (was transitive via signalwire).
+- `/api/laml` root (not bare `/2010-04-01`): matches SignalWire's documented
+  compat root and the existing in-tree recording helper.
+- `>=9.10.9,<10` keeps Dependabot current within v9 while guarding v10.
+- Lock regenerated (not hand-edited) so the CI `--check` digest matches.
 
 ## Deferred
 
 - The python-security-and-patches group (#2098) recreate + merge (pyjwt/
   boto3) is unblocked by this but lands separately -- its `boto3==1.43.47`
-  is an independent Dependabot version glitch, not this PR's scope.
-- Dependabot twilio PR #2092 is superseded once twilio is a direct dep at
-  9.x (close/let Dependabot reconcile after merge).
-- Twilio v9 native `region`/`edge` targeting is unused; the `base_url`
-  override is the SignalWire-documented compat path. Parked hardening: none.
+  is an independent Dependabot glitch.
+- Dependabot twilio #2092 is superseded once twilio is a direct dep at 9.x.
+- Parked hardening: none.
 
 ## Verification
 
 - `python -m pytest tests/test_signalwire_provider_twilio_base_url.py -q`
 - `python -c "import atlas_comms.providers.signalwire"` (no signalwire pkg)
-- Scratch-venv proof (before coding): twilio 9.10.9 `base_url` override
-  resolves messages/calls to the SignalWire `/2010-04-01/...` URL.
-- CI `root-asr-constraints` resolves without the twilio/pyjwt conflict.
+- `python scripts/compile_root_asr_constraints.py --uv <uv 0.10.10>` wrote
+  the lock (twilio 9 resolves) -- CI `root-asr-constraints --check` matches.
+- Scratch-venv proof: twilio 9.10.9 `/api/laml` base_url resolves to the
+  SignalWire `/api/laml/2010-04-01/...` URL.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| requirements.txt | 3 |
+| requirements.txt | 5 |
 | atlas_comms/providers/signalwire.py | 19 |
+| atlas_brain/mcp/twilio_server.py | 14 |
+| constraints.root-asr.txt | 4 |
 | tests/test_signalwire_provider_twilio_base_url.py | 49 |
-| plans/PR-Twilio-SignalWire-Decouple.md | ~163 |
-| **Total** | ~240 |
+| plans/PR-Twilio-SignalWire-Decouple.md | ~170 |
+| **Total** | ~261 |

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,7 @@ httpx==0.28.1
 websockets==15.0.1
 
 # Telephony (external communications)
-signalwire==2.0.4
-# twilio  # Alternative provider
+twilio>=9.10.9,<10  # SignalWire (twilio-compatible LaML API) + Twilio via the twilio SDK; signalwire SDK dropped (it froze twilio at 6.54.0)
 
 # Discovery
 zeroconf==0.150.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# constraints-root-asr-sha256: ac6cba91aa64f463b352688054aabac327c64c3640793bcec77ca7804751369b
+# constraints-root-asr-sha256: 877f64cfcd9c97777d5f989043b3899f8b93b2dce08ae3e0b9de2b5aa10ed569
 -c constraints.root-asr.txt
 
 fastapi==0.136.3

--- a/tests/test_signalwire_provider_twilio_base_url.py
+++ b/tests/test_signalwire_provider_twilio_base_url.py
@@ -22,7 +22,7 @@ async def test_connect_points_twilio_client_at_signalwire_space(monkeypatch):
     assert provider.is_connected
     # The twilio client's Api domain is pointed at the SignalWire space,
     # not api.twilio.com -- this is what the removed signalwire SDK did.
-    assert provider._client.api.base_url == "https://myspace.signalwire.com"
+    assert provider._client.api.base_url == "https://myspace.signalwire.com/api/laml"
 
     # messages/calls resolve to SignalWire's twilio-compatible LaML endpoint.
     msgs_url = provider._client.messages._version.absolute_url(
@@ -32,10 +32,10 @@ async def test_connect_points_twilio_client_at_signalwire_space(monkeypatch):
         "Accounts/PROJECTID/Calls.json"
     )
     assert msgs_url == (
-        "https://myspace.signalwire.com/2010-04-01/Accounts/PROJECTID/Messages.json"
+        "https://myspace.signalwire.com/api/laml/2010-04-01/Accounts/PROJECTID/Messages.json"
     )
     assert calls_url == (
-        "https://myspace.signalwire.com/2010-04-01/Accounts/PROJECTID/Calls.json"
+        "https://myspace.signalwire.com/api/laml/2010-04-01/Accounts/PROJECTID/Calls.json"
     )
 
 

--- a/tests/test_signalwire_provider_twilio_base_url.py
+++ b/tests/test_signalwire_provider_twilio_base_url.py
@@ -1,0 +1,49 @@
+"""Regression test for the twilio/signalwire decouple.
+
+The `signalwire` SDK was dropped (it froze twilio at 6.54.0); the SignalWire
+provider now uses the plain `twilio` SDK pointed at the space's
+twilio-compatible LaML endpoint. See
+plans/PR-Twilio-SignalWire-Decouple.md.
+"""
+import pytest
+
+from atlas_comms.core.config import comms_settings
+from atlas_comms.providers.signalwire import SignalWireProvider
+
+
+async def test_connect_points_twilio_client_at_signalwire_space(monkeypatch):
+    monkeypatch.setattr(comms_settings, "signalwire_project_id", "PROJECTID", raising=False)
+    monkeypatch.setattr(comms_settings, "signalwire_api_token", "TOKEN", raising=False)
+    monkeypatch.setattr(comms_settings, "signalwire_space", "myspace", raising=False)
+
+    provider = SignalWireProvider()
+    await provider.connect()
+
+    assert provider.is_connected
+    # The twilio client's Api domain is pointed at the SignalWire space,
+    # not api.twilio.com -- this is what the removed signalwire SDK did.
+    assert provider._client.api.base_url == "https://myspace.signalwire.com"
+
+    # messages/calls resolve to SignalWire's twilio-compatible LaML endpoint.
+    msgs_url = provider._client.messages._version.absolute_url(
+        "Accounts/PROJECTID/Messages.json"
+    )
+    calls_url = provider._client.calls._version.absolute_url(
+        "Accounts/PROJECTID/Calls.json"
+    )
+    assert msgs_url == (
+        "https://myspace.signalwire.com/2010-04-01/Accounts/PROJECTID/Messages.json"
+    )
+    assert calls_url == (
+        "https://myspace.signalwire.com/2010-04-01/Accounts/PROJECTID/Calls.json"
+    )
+
+
+async def test_connect_requires_credentials(monkeypatch):
+    monkeypatch.setattr(comms_settings, "signalwire_project_id", "", raising=False)
+    monkeypatch.setattr(comms_settings, "signalwire_api_token", "", raising=False)
+    monkeypatch.setattr(comms_settings, "signalwire_space", "", raising=False)
+
+    provider = SignalWireProvider()
+    with pytest.raises(ValueError):
+        await provider.connect()


### PR DESCRIPTION
Plan: plans/PR-Twilio-SignalWire-Decouple.md

Slice phase: Vertical slice

The `signalwire` SDK (`signalwire==2.0.4`, latest 2.1.1) hard-pins
`twilio==6.54.0`, which pins `pyjwt==1.7.1` and blocks twilio 9 (#2092) and
the python-security-and-patches group (#2098) -- `root-asr-constraints` is
unsatisfiable. No signalwire release relaxes the pin, so the SDK is
abandoned. It is only a wrapper that overrides the twilio client's Api
`base_url` to the SignalWire space, so it is removable: point the plain
twilio SDK at SignalWire's twilio-compatible LaML root
(`https://<space>.signalwire.com/api/laml`). Both SignalWire client sites
(`atlas_comms/providers/signalwire.py` and the MCP factory in
`atlas_brain/mcp/twilio_server.py`) switch to `twilio.rest.Client` + that
`base_url`, and `constraints.root-asr.txt` is regenerated (pinned uv) so the
lock resolves `twilio==9.10.9` instead of the stale `twilio==6.43.0` pin.
`atlas_comms/providers/twilio.py` and every other method are unchanged.

## Intentional

- Decouple, not bump: no signalwire release supports a modern twilio (2.1.1
  still pins 6.54.0).
- twilio promoted to a direct dependency (was transitive via signalwire).
- `/api/laml` root (not bare `/2010-04-01`) matches SignalWire's documented
  compat root and the existing in-tree recording helper.
- Lock regenerated (not hand-edited) so CI `root-asr-constraints --check`
  digest matches.

## Deferred

- The python-security-and-patches group (#2098) is unblocked by this but
  lands separately (its `boto3==1.43.47` is an independent Dependabot
  glitch).
- Dependabot twilio #2092 is superseded once twilio is a direct dep at 9.x.

## Parked hardening

None.

## Cold diff reconstruction

- `requirements.txt`: `signalwire==2.0.4` removed; `# twilio` ->
  `twilio>=9.10.9,<10`; `constraints-root-asr-sha256` digest refreshed by
  the regen. Contract item 1.
- `atlas_comms/providers/signalwire.py` `connect()`: import `twilio.rest`;
  `Client(project, token)` + `client.api.base_url = f"{space}/api/laml"`;
  ImportError message -> twilio. Only `connect()` changed. Contract item 2.
  Verified by the test.
- `atlas_brain/mcp/twilio_server.py` `_get_client()` signalwire branch: same
  substitution (twilio client + `/api/laml` base_url), credential logic
  unchanged; twilio branch untouched. Contract item 3.
- `constraints.root-asr.txt`: regenerated via
  `scripts/compile_root_asr_constraints.py` with the pinned uv --
  `twilio 6.43.0 -> 9.10.9`, `+aiohttp/aiohttp-retry`, `-signalwire`.
  Contract item 4.
- `tests/test_signalwire_provider_twilio_base_url.py` (new): asserts the
  `/api/laml` base_url + `/api/laml/2010-04-01/...` URL resolution + the
  missing-credentials guard. Contract item 5.
- `plans/PR-Twilio-SignalWire-Decouple.md`: the plan (contract revised for
  the three Codex findings).
- Nothing outside these six files changed; `atlas_comms/providers/twilio.py`
  untouched.

## Verification

- `pytest tests/test_signalwire_provider_twilio_base_url.py -q` -> 2 passed
- `python -c "import atlas_comms.providers.signalwire"` OK; `twilio_server.py`
  parses with no `signalwire.rest` reference.
- `scripts/compile_root_asr_constraints.py --uv <uv 0.10.10>` wrote the lock
  (twilio 9 resolves) -- CI `root-asr-constraints --check` matches.
- Scratch-venv proof: twilio 9.10.9 `/api/laml` base_url resolves to
  `https://<space>.signalwire.com/api/laml/2010-04-01/Accounts/<project>/...`.

## Diff size

~254 LOC across `requirements.txt`, `atlas_comms/providers/signalwire.py`,
`atlas_brain/mcp/twilio_server.py`, `constraints.root-asr.txt`, the new test,
and the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Round 1: all 3 Codex threads resolved; re-running live-reconciliation._