### PR TITLE
Content Factory stage runner (Phase 2.2b)

### DIFF
--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -1,0 +1,117 @@
+"""Run one Content Factory stage: call its Open WebUI worker, extract the JSON
+artifact from the reply, and validate + persist it via the artifact store.
+
+Open WebUI is the external boundary here (it fronts the local model); the store
+and the content_factory contracts do the validation, so a worker that returns
+malformed output is caught before anything is persisted. This runs in the
+atlas_brain env (it uses the store + contracts); OWUI worker wrappers are
+addressed by model id.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from atlas_brain.services.content_factory_store import DEFAULT_ROOT, write_artifact
+
+DEFAULT_OWUI_URL = "http://127.0.0.1:8080"
+
+# A leading ```/```json fence and a trailing fence, so a fenced reply still
+# yields its JSON body.
+_FENCE_OPEN = re.compile(r"^```[a-zA-Z0-9]*\s*")
+_FENCE_CLOSE = re.compile(r"\s*```$")
+
+
+class WorkerError(RuntimeError):
+    """Raised when the worker call fails or returns no usable JSON artifact."""
+
+
+def extract_json(text: str) -> dict[str, Any] | None:
+    """Return the single JSON object embedded in a worker reply, tolerating code
+    fences and surrounding prose. Returns None if no JSON object parses."""
+    stripped = _FENCE_CLOSE.sub("", _FENCE_OPEN.sub("", text.strip())).strip()
+    start, end = stripped.find("{"), stripped.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        value = json.loads(stripped[start : end + 1])
+    except (ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def call_worker(
+    model: str,
+    user_content: str,
+    *,
+    api_key: str,
+    base_url: str = DEFAULT_OWUI_URL,
+    timeout: float = 420.0,
+) -> str:
+    """POST one user turn to Open WebUI's chat completions for ``model`` and
+    return the assistant's text.
+
+    Raises WorkerError on a transport/HTTP failure, a non-JSON body, or a
+    response that carries no assistant message.
+    """
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": user_content}],
+            "stream": False,
+        }
+    ).encode()
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/api/chat/completions",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = json.loads(response.read() or b"null")
+    except urllib.error.URLError as exc:  # HTTPError is a subclass
+        raise WorkerError(f"Open WebUI chat call failed for {model!r}: {exc}") from exc
+    except ValueError as exc:
+        raise WorkerError(f"Open WebUI returned non-JSON for {model!r}: {exc}") from exc
+    try:
+        content = body["choices"][0]["message"].get("content")
+    except (KeyError, IndexError, TypeError) as exc:
+        raise WorkerError(
+            f"Open WebUI response for {model!r} has no assistant message"
+        ) from exc
+    return content or ""
+
+
+def run_stage(
+    job_id: str,
+    stage: str,
+    model: str,
+    user_content: str,
+    *,
+    api_key: str,
+    base_url: str = DEFAULT_OWUI_URL,
+    root: Path | str = DEFAULT_ROOT,
+) -> dict[str, Any]:
+    """Run one stage end to end: call the worker, extract its JSON artifact, then
+    validate + persist it via the store. Returns the store's record.
+
+    Raises WorkerError if the worker call fails or returns no JSON object, and
+    ValueError / pydantic ValidationError (from the store) if the artifact fails
+    its contract -- so a malformed stage output is never persisted.
+    """
+    reply = call_worker(model, user_content, api_key=api_key, base_url=base_url)
+    artifact = extract_json(reply)
+    if artifact is None:
+        raise WorkerError(
+            f"stage {stage!r}: worker {model!r} returned no JSON artifact"
+        )
+    return write_artifact(job_id, stage, artifact, root=root)

--- a/plans/PR-Content-Factory-Runner.md
+++ b/plans/PR-Content-Factory-Runner.md
@@ -1,0 +1,113 @@
+# PR-Content-Factory-Runner
+
+## Why this slice exists
+
+The Content Factory has contracts (#2116) and an artifact store (#2121), but no
+code that actually runs a worker and lands its output. The Phase 1.4 end-to-end
+run did this with an ad-hoc scratchpad script that hit Open WebUI's chat API and
+wrote files with no contract validation. This slice makes that a real, tested
+primitive: call a worker via Open WebUI, robustly extract its JSON artifact, and
+validate + persist it via the store. It is the bridge between the OWUI worker
+wrappers and the atlas_brain pipeline, and the unit the future multi-stage
+orchestrator calls once per stage.
+
+### Problem-derived contract
+
+A correct fix must:
+- Call a worker by model id through Open WebUI's chat completions and return the
+  assistant text, failing loudly (not silently) on transport/HTTP errors, a
+  non-JSON body, or a response with no assistant message.
+- Extract a single JSON object from the reply, tolerating code fences and
+  surrounding prose (weak local models wrap output), and return None when none
+  parses -- never a partial or non-dict value.
+- Validate + persist through the store, so a malformed worker output is caught by
+  the contract and never lands on disk.
+- Live in atlas_brain (it uses the store + contracts); Open WebUI is the external
+  boundary and is the only thing mocked in tests.
+- Be model-agnostic: it addresses a worker by id and cares nothing about which
+  model backs it.
+
+## Scope (this PR)
+
+Ownership lane: content-factory
+Slice phase: vertical slice
+
+Arc Phase 2.2b: the single-stage runner. The multi-stage orchestrator (sequence,
+retry cap, manifest assembly, human-approval states) is a later slice.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] call_worker POSTs one user turn to OWUI chat completions and returns the
+        assistant text; a transport/HTTP error, non-JSON body, or missing
+        assistant message raises WorkerError (no silent failure).
+  - [ ] extract_json returns the embedded JSON object for clean, fenced, and
+        prose-wrapped replies, and None for no-JSON, invalid-JSON, and non-dict
+        (array) replies.
+  - [ ] run_stage calls the worker, extracts, then validates + persists via the
+        store; no-JSON raises WorkerError and a contract-invalid artifact raises
+        ValidationError, and in both cases nothing is persisted.
+- Reachability proof: N/A for a production surface -- no runtime caller yet (the
+  orchestrator is a later slice). Proof is the test suite with OWUI mocked and a
+  real store against a temp filesystem.
+- Affected surfaces: one new runner module and its test file; no existing file
+  modified; nothing imports the module yet.
+- Risk areas: OWUI response shape handling (mocked both success and error paths);
+  JSON extraction from noisy replies (boundary-probed); fail-closed persistence
+  is delegated to the already-tested store.
+- Reviewer rules triggered: R2.
+
+### Files touched
+- `atlas_brain/services/content_factory_runner.py`
+- `tests/test_content_factory_runner.py`
+- `plans/PR-Content-Factory-Runner.md`
+
+Max files: 3
+
+## Mechanism
+
+call_worker builds a stream=false chat-completions POST to Open WebUI for a model
+id (bearer api_key) and returns choices[0].message.content, wrapping URLError
+(HTTPError included), a non-JSON body, and a missing message in WorkerError.
+extract_json strips a leading/trailing code fence, takes the first-brace-to-last-
+brace slice, json.loads it, and returns it only if it is a dict. run_stage chains
+them and hands the artifact to the store's write_artifact, which does all contract
+validation and path-guarded, git-tracked persistence. api_key and base_url are
+parameters (no secret in code, no config surface this slice); root defaults to
+the store's default and is overridable for tests.
+
+## Intentional
+
+- Open WebUI is the only mocked boundary; the store and contracts are real, so
+  the extract + validate + persist path is exercised for real (real-adapters rule).
+- No secret and no config.py surface: api_key/base_url/root are parameters.
+- Single-stage only: sequencing, retries, and manifest assembly are the
+  orchestrator's job (later), keeping this unit small and composable.
+
+## Deferred
+
+- The multi-stage orchestrator (stage order, retry cap, needs-human states,
+  manifest assembly) -- a later slice.
+- A typed config field for the OWUI base URL / key (add when a runtime caller
+  needs it).
+- An OWUI-side Action button that triggers a stage from the chat UI (optional UI).
+
+## Verification
+
+```
+python -m pytest tests/test_content_factory_runner.py -q
+```
+16 tests pass with Open WebUI mocked and a real store on a temp filesystem:
+extract_json handles clean/fenced/prose replies and rejects no-JSON, invalid, and
+array replies; call_worker returns content and raises WorkerError on HTTP error
+and a missing message; run_stage persists a valid artifact, extracts from fenced
+prose, and on no-JSON or a contract-invalid artifact raises and persists nothing.
+
+## Estimated diff size
+
+| File | Lines |
+|---|---|
+| atlas_brain/services/content_factory_runner.py | 100 |
+| tests/test_content_factory_runner.py | 142 |
+| plans/PR-Content-Factory-Runner.md | 100 |
+| **Total** | **342** |

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -1,0 +1,125 @@
+"""Tests for the Content Factory stage runner.
+
+Open WebUI (the HTTP chat call) is the external boundary and is mocked; the store
+and contracts are real, so run_stage's extract + validate + persist path is
+exercised for real against a temp filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+import atlas_brain.services.content_factory_runner as runner
+from atlas_brain.services.content_factory_runner import (
+    WorkerError,
+    call_worker,
+    extract_json,
+    run_stage,
+)
+from atlas_brain.services.content_factory_store import job_dir
+
+BRIEF_JSON = '{"schema": "content_brief.v1", "project_id": "resolution-audit", "request_raw": "x"}'
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# --- extract_json ---
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        BRIEF_JSON,
+        "```json\n" + BRIEF_JSON + "\n```",
+        "```\n" + BRIEF_JSON + "\n```",
+        "Here is the brief:\n" + BRIEF_JSON + "\nHope that helps.",
+    ],
+)
+def test_extract_json_variants(text):
+    data = extract_json(text)
+    assert data is not None and data["schema"] == "content_brief.v1"
+
+
+@pytest.mark.parametrize(
+    "text", ["no json here", "", "[1, 2, 3]", "{not valid}", "```json\n[]\n```"]
+)
+def test_extract_json_returns_none(text):
+    assert extract_json(text) is None
+
+
+# --- call_worker (OWUI HTTP boundary mocked) ---
+
+
+def test_call_worker_returns_content(monkeypatch):
+    resp = json.dumps({"choices": [{"message": {"content": "hi"}}]}).encode()
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _FakeResponse(resp))
+    assert call_worker("m", "u", api_key="k") == "hi"
+
+
+def test_call_worker_http_error_raises_worker_error(monkeypatch):
+    def boom(*a, **k):
+        raise urllib.error.HTTPError("url", 500, "err", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    with pytest.raises(WorkerError):
+        call_worker("m", "u", api_key="k")
+
+
+def test_call_worker_missing_message_raises(monkeypatch):
+    resp = json.dumps({"choices": []}).encode()
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _FakeResponse(resp))
+    with pytest.raises(WorkerError):
+        call_worker("m", "u", api_key="k")
+
+
+# --- run_stage (worker mocked, real store) ---
+
+
+def test_run_stage_persists_valid_artifact(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: BRIEF_JSON)
+    rec = runner.run_stage("job1", "brief", "cf-brief-architect", "req", api_key="k", root=tmp_path)
+    assert Path(rec["path"]).exists() and rec["schema"] == "content_brief.v1"
+
+
+def test_run_stage_extracts_from_fenced_prose(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        runner, "call_worker", lambda *a, **k: "Sure:\n```json\n" + BRIEF_JSON + "\n```"
+    )
+    rec = runner.run_stage("job1", "brief", "m", "req", api_key="k", root=tmp_path)
+    assert Path(rec["path"]).exists()
+
+
+def test_run_stage_no_json_raises_and_persists_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: "I cannot help with that.")
+    with pytest.raises(WorkerError):
+        runner.run_stage("job1", "brief", "m", "req", api_key="k", root=tmp_path)
+    assert not job_dir("job1", root=tmp_path).exists()
+
+
+def test_run_stage_invalid_artifact_not_persisted(tmp_path, monkeypatch):
+    bad = (
+        '{"schema": "evidence_packet.v1", "project_id": "p", '
+        '"evidence": [{"id": "e", "quote": "q", "source_id": ""}]}'
+    )
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: bad)
+    with pytest.raises(ValidationError):
+        runner.run_stage("job1", "evidence", "m", "req", api_key="k", root=tmp_path)
+    assert not job_dir("job1", root=tmp_path).exists()


### PR DESCRIPTION
Plan: plans/PR-Content-Factory-Runner.md
Slice phase: vertical slice
Ownership lane: content-factory

Adds the Content Factory stage runner: call an Open WebUI worker via chat
completions, robustly extract its JSON artifact (tolerating code fences + prose),
and validate + persist via the store (#2121). Model-independent; Open WebUI HTTP
is the only mocked boundary. No runtime wiring yet.

## Intentional
- Open WebUI is the only mocked boundary; the store + contracts are real, so the extract + validate + persist path is exercised for real. No secret and no config.py surface (api_key/base_url/root are parameters). Single-stage only; sequencing/retries/manifest are the later orchestrator's job.

## Deferred
- The multi-stage orchestrator (stage order, retry cap, needs-human states, manifest assembly); a typed config field for the OWUI base URL/key; an optional OWUI-side Action button.

## Parked hardening
- None.

## Cold diff reconstruction
- New runner atlas_brain/services/content_factory_runner.py; new tests/test_content_factory_runner.py; new plan doc. No existing file modified; no import added to any router; nothing consumes the module yet.

## Verification
- python -m pytest tests/test_content_factory_runner.py -q  ->  16 passed. Open WebUI mocked, real store on a temp filesystem: extract_json handles clean/fenced/prose and rejects no-JSON/invalid/array; call_worker raises WorkerError on HTTP error and missing message; run_stage persists a valid artifact and raises (persisting nothing) on no-JSON or a contract-invalid artifact.

## Diff size
- 342 added lines (100 runner + 142 tests + 100 plan doc), under the 400 soft cap.
