### PR TITLE
Audit required process-gate status checks

### DIFF
--- a/.github/workflows/branch_protection_required_checks.yml
+++ b/.github/workflows/branch_protection_required_checks.yml
@@ -9,8 +9,13 @@ on:
       - main
     paths:
       - ".github/workflows/branch_protection_required_checks.yml"
+      - ".github/workflows/ai_reconciliation_live.yml"
+      - ".github/workflows/diff_budget.yml"
       - ".github/workflows/gitleaks_baseline_growth_guard.yml"
+      - ".github/workflows/plan_admission.yml"
+      - ".github/workflows/review_contract.yml"
       - ".github/workflows/security_guardrails.yml"
+      - ".github/workflows/session_lane.yml"
       - "docs/SECURITY_GUARDRAILS.md"
       - "scripts/check_required_status_checks.py"
       - "tests/test_security_guardrails_workflow.py"
@@ -46,7 +51,7 @@ jobs:
             "repos/${REPOSITORY}/branches/main/protection/required_status_checks" \
             > /tmp/required-status-checks.json
 
-      - name: Verify required security checks
+      - name: Verify required branch-protection checks
         if: env.BRANCH_PROTECTION_READ_TOKEN != ''
         run: |
           python scripts/check_required_status_checks.py \

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -66,46 +66,43 @@ workflow suppresses the follow-up chain entirely (no event model exists
 that delivers trusted code on review events); the fallback is a scheduled
 trusted sweep, parked in plans/PR-Trusted-Base-Gate-Execution.md.
 
-Branch protection for `main` requires `live-reconciliation`, `diff-budget`
-(the AGENTS.md diff-budget gate), `Gitleaks PR secret scan`, and
-`Gitleaks baseline growth guard`. The
-`Branch Protection Required Checks` workflow audits that live repository
-setting on a weekly/manual cadence and on trusted `main` updates touching the
-branch-protection checker, the security workflows, or security guardrail docs
-when `ATLAS_BRANCH_PROTECTION_READ_TOKEN` is configured with GitHub
-Administration read permission. The audit requires those contexts to be pinned
-to the GitHub Actions app source in branch protection, not only present as
-legacy bare context names.
+The target branch-protection set for #2104 non-Claude process-gate enrollment
+is `live-reconciliation`, `diff-budget` (the AGENTS.md diff-budget gate),
+`Gitleaks PR secret scan`, `Gitleaks baseline growth guard`, `plan-admission`,
+`session-lane`, and `review-contract`. The `Branch Protection Required Checks` workflow
+audits the live repository setting on a weekly/manual cadence and on
+trusted `main` updates touching the branch-protection checker, any audited
+producer workflow, or security guardrail docs when
+`ATLAS_BRANCH_PROTECTION_READ_TOKEN` is configured with GitHub Administration
+read permission. The audit requires those contexts to be pinned to the GitHub
+Actions app source in branch protection, not only present as legacy bare
+context names.
 
 The workflow security posture auditor admits
 `.github/workflows/session_lane.yml` / `session-lane` only when it has the same
 event guard and base-SHA checkout shape as the existing PR meta-gates. The
-workflow is an advisory producer for #2104 burn-in: it checks out trusted base
-code, materializes the PR head as git data, writes the trusted event PR body to
-a temporary file, and runs the base-owned session-drift auditor against that
-data worktree. Branch-protection enrollment remains a separate REST PATCH slice
-after the producer proves stable and the existing required contexts can be
-preserved.
+workflow checks out trusted base code, materializes the PR head as git data,
+writes the trusted event PR body to a temporary file, and runs the base-owned
+session-drift auditor against that data worktree. Live branch-protection
+enrollment remains a separate REST PATCH step that must preserve the existing
+required contexts.
 
 The same auditor admits
 `.github/workflows/plan_admission.yml` / `plan-admission` only under that exact
-guard shape. The workflow is an advisory producer for #2104 burn-in: it checks
-out trusted base code, materializes the PR head as git data, and runs the
-base-owned plan-admission auditor against that data worktree. Branch-protection
-enrollment remains a separate REST PATCH slice after the producer proves stable
-and the existing required contexts can be preserved.
+guard shape. The workflow checks out trusted base code, materializes the PR head
+as git data, and runs the base-owned plan-admission auditor against that data
+worktree. Live branch-protection enrollment remains a separate REST PATCH step
+that must preserve the existing required contexts.
 
-The same auditor pre-admits a future
+The same auditor admits the
 `.github/workflows/review_contract.yml` / `review-contract` trusted-base
 producer only when the whole workflow file matches the canonical normalized YAML
 stored in the base-owned posture auditor. This keeps the pre-admission
 fail-closed without maintaining a per-field predicate ladder: permissions,
 checkout depth, step order, run blocks, and no-plan behavior are admitted or
-rejected as one workflow-shaped unit. The workflow itself lands in a later #2104
-slice after this canonical allowlist is on `main`, for the same trusted-base
-bootstrap reason: base-owned `pre-push-audit` must already know the exact
-workflow shape before it can safely evaluate that new `pull_request_target`
-workflow as PR data.
+rejected as one workflow-shaped unit. The workflow itself is now on `main`; live
+branch-protection enrollment remains a separate REST PATCH step that must
+preserve the existing required contexts.
 
 - Full-history secret scan: Gitleaks checks out the complete branch history
   (`fetch-depth: 0`) so leaked keys in old commits are in scope. The workflow

--- a/plans/PR-Process-Gate-Required-Status-Audit.md
+++ b/plans/PR-Process-Gate-Required-Status-Audit.md
@@ -1,0 +1,142 @@
+# PR-Process-Gate-Required-Status-Audit
+
+## Why this slice exists
+
+#2104 is the follow-up to move the process gates from advisory producer status
+to required branch-protection contexts after the trusted-base producers exist.
+The three non-reviewer producers now exist on `main`: `session-lane`,
+`plan-admission`, and `review-contract`. The remaining repo-side gap is that
+the live branch-protection auditor still only knows the old baseline from
+`scripts/check_required_status_checks.py:13-18`, while the live payload still
+contains only `live-reconciliation`, `Gitleaks PR secret scan`, and `Gitleaks
+baseline growth guard`. That means the repo has no watchdog for the newly
+enrolled process gates or the already-documented `diff-budget` requirement.
+
+This is a workflow/process slice justified by #2104/#2035: process-gate
+enrollment is the safety gap that kept advisory gates bypassable during the
+recent non-converging builder arcs.
+
+### Problem-derived contract
+
+- Root cause: the required-status audit's source of truth stops at the legacy
+  four-context baseline (`scripts/check_required_status_checks.py:13-18`), so
+  it cannot fail when `plan-admission`, `session-lane`, or `review-contract`
+  are absent from branch protection. The security docs also still describe the
+  new producers as advisory/deferred (`docs/SECURITY_GUARDRAILS.md:80-108`)
+  even though they are now on `main` and ready for the non-Claude enrollment
+  step.
+- Correct fix must touch/change: update
+  `scripts/check_required_status_checks.py` to include the non-Claude process
+  gate contexts in the default required GitHub Actions check set; update the
+  focused tests in `tests/test_security_guardrails_workflow.py` so the default
+  pass/fail cases cover those contexts and wrong-source failures; update
+  `.github/workflows/branch_protection_required_checks.yml` so the live audit
+  is triggered when any producer workflow changes; update
+  `docs/SECURITY_GUARDRAILS.md` to describe the required non-Claude context set
+  and the separate live REST enrollment step.
+- Must not change: do not mutate live branch protection in this PR; do not add
+  `claude-review` as a required context; do not change the producer workflow
+  semantics for `plan-admission`, `session-lane`, `review-contract`,
+  `diff-budget`, Gitleaks, or reconciliation; do not touch product behavior,
+  schemas, migrations, extracted packages, customer-facing surfaces, open
+  content-factory PR #2126, local-model PR #2117, Dependabot, or protected
+  Resolution Audit S6 work.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/process-gate-enrollment
+Slice phase: Workflow/process
+
+1. Make the branch-protection required-status auditor's default check set match
+   the intended non-Claude required contexts.
+2. Update the branch-protection audit workflow triggers and security docs so
+   producer changes and the live REST enrollment step are visible.
+3. Add/update focused tests proving default pass, missing-context fail, legacy
+   unpinned fail, and wrong-app fail behavior for the full context set.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The default required check set contains `live-reconciliation`,
+        `diff-budget`, `Gitleaks PR secret scan`, `Gitleaks baseline growth
+        guard`, `plan-admission`, `session-lane`, and `review-contract`.
+  - [ ] Each default context must be pinned to GitHub Actions app id `15368`;
+        legacy bare contexts and wrong app IDs still fail.
+  - [ ] `claude-review` is intentionally absent from this PR's default set.
+  - [ ] The branch-protection audit workflow reruns on edits to all producer
+        workflows whose contexts it audits.
+  - [ ] Docs no longer describe the now-merged process producers as merely
+        future/advisory, and they keep live REST enrollment separate.
+- Reachability proof: `scripts/check_required_status_checks.py` run against a
+  synthetic full payload exits 0, and against a live-shaped missing payload
+  exits 1 in tests/manual verification.
+- Affected surfaces: `scripts/check_required_status_checks.py`,
+  `.github/workflows/branch_protection_required_checks.yml`,
+  `docs/SECURITY_GUARDRAILS.md`, `tests/test_security_guardrails_workflow.py`,
+  this plan.
+- Risk areas: branch-protection check-name drift, accidentally requiring a
+  forgeable/non-GitHub-Actions context, stale docs that claim live protection
+  has changed before the REST PATCH, workflow trigger omissions.
+- Reviewer rules triggered: R1, R2, R3, R8, R10, R14.
+
+### Files touched
+
+- `.github/workflows/branch_protection_required_checks.yml`
+- `docs/SECURITY_GUARDRAILS.md`
+- `plans/PR-Process-Gate-Required-Status-Audit.md`
+- `scripts/check_required_status_checks.py`
+- `tests/test_security_guardrails_workflow.py`
+
+## Mechanism
+
+The auditor already normalizes GitHub's `contexts` and `checks` shapes and
+requires each default context to appear in `checks[]` with the GitHub Actions app
+id. This PR keeps that mechanism and only expands its default contract to the
+non-Claude process-gate contexts that now have merged trusted-base producers.
+The branch-protection workflow trigger list is extended so edits to those
+producer workflows rerun the live audit. Documentation is updated to separate
+"the repo now audits for these contexts" from "the operator/live REST PATCH has
+enrolled them."
+
+## Intentional
+
+- `claude-review` is not enrolled here. This follows the current operator policy
+  for this arc: Codex/live-reconciliation is the required review signal; Claude's
+  commit status remains out of the branch-protection set unless a separate
+  reviewer identity decision is made later.
+- This PR does not mutate live branch protection. The actual REST PATCH is an
+  external settings change after the code/documentation PR is reviewed and
+  merged.
+
+## Deferred
+
+- Apply the minimal REST branch-protection PATCH after this PR is reviewed and
+  merged: preserve existing checks, add `diff-budget`, `plan-admission`,
+  `session-lane`, and `review-contract`, then re-fetch and run the live auditor.
+- If the operator later provisions a non-forgeable reviewer identity and wants a
+  separate required reviewer status, handle that in a separate policy slice.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: `python -m pytest tests/test_security_guardrails_workflow.py -q` --
+  15 passed.
+- Passed: synthetic full-payload CLI probe through
+  `scripts/check_required_status_checks.py` -- expected PASS with all seven
+  required contexts pinned to GitHub Actions app id `15368`.
+- Passed: synthetic current-live-shaped CLI probe through
+  `scripts/check_required_status_checks.py` -- expected FAIL on `diff-budget`,
+  `plan-admission`, `session-lane`, and `review-contract`.
+- Passed: `scripts/push_pr.sh` local-review wrapper -- all local review checks passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/branch_protection_required_checks.yml` | 7 |
+| `docs/SECURITY_GUARDRAILS.md` | 51 |
+| `plans/PR-Process-Gate-Required-Status-Audit.md` | 142 |
+| `scripts/check_required_status_checks.py` | 3 |
+| `tests/test_security_guardrails_workflow.py` | 69 |
+| **Total** | **272** |

--- a/scripts/check_required_status_checks.py
+++ b/scripts/check_required_status_checks.py
@@ -15,6 +15,9 @@ DEFAULT_REQUIRED_CONTEXTS = (
     "diff-budget",
     "Gitleaks PR secret scan",
     "Gitleaks baseline growth guard",
+    "plan-admission",
+    "session-lane",
+    "review-contract",
 )
 
 

--- a/tests/test_security_guardrails_workflow.py
+++ b/tests/test_security_guardrails_workflow.py
@@ -15,6 +15,15 @@ BRANCH_PROTECTION_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "
 PRE_COMMIT_CONFIG = Path(__file__).resolve().parents[1] / ".pre-commit-config.yaml"
 SECURITY_GUARDRAILS_DOC = Path(__file__).resolve().parents[1] / "docs" / "SECURITY_GUARDRAILS.md"
 REQUIRED_STATUS_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_required_status_checks.py"
+EXPECTED_REQUIRED_CONTEXTS = [
+    "live-reconciliation",
+    "diff-budget",
+    "Gitleaks PR secret scan",
+    "Gitleaks baseline growth guard",
+    "plan-admission",
+    "session-lane",
+    "review-contract",
+]
 
 
 def _workflow_text() -> str:
@@ -95,9 +104,8 @@ def test_security_guardrails_docs_explain_gitleaks_pre_commit_install() -> None:
 def test_security_guardrails_docs_name_required_gitleaks_checks() -> None:
     text = SECURITY_GUARDRAILS_DOC.read_text(encoding="utf-8")
 
-    assert "`Gitleaks PR secret scan`" in text
-    assert "`Gitleaks baseline growth guard`" in text
-    assert "`diff-budget`" in text
+    for context in EXPECTED_REQUIRED_CONTEXTS:
+        assert f"`{context}`" in text
     assert "`Branch Protection Required Checks` workflow" in text
 
 
@@ -107,8 +115,13 @@ def test_branch_protection_workflow_audits_live_required_checks() -> None:
     assert "branches/main/protection/required_status_checks" in text
     assert "ATLAS_BRANCH_PROTECTION_READ_TOKEN" in text
     assert "BRANCH_PROTECTION_READ_TOKEN != ''" in text
+    assert ".github/workflows/ai_reconciliation_live.yml" in text
+    assert ".github/workflows/diff_budget.yml" in text
     assert ".github/workflows/gitleaks_baseline_growth_guard.yml" in text
+    assert ".github/workflows/plan_admission.yml" in text
+    assert ".github/workflows/review_contract.yml" in text
     assert ".github/workflows/security_guardrails.yml" in text
+    assert ".github/workflows/session_lane.yml" in text
     assert (
         "if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'"
         in text
@@ -134,10 +147,12 @@ def test_branch_protection_workflow_ref_guard_precedes_admin_read_token() -> Non
 def test_required_status_check_audit_accepts_contexts_and_checks_shapes() -> None:
     checker = _load_required_status_script()
     payload = {
-        "contexts": ["live-reconciliation", "diff-budget"],
+        "contexts": ["live-reconciliation", "diff-budget", "plan-admission"],
         "checks": [
             {"context": "Gitleaks PR secret scan"},
             {"context": "Gitleaks baseline growth guard"},
+            {"context": "session-lane"},
+            {"context": "review-contract"},
         ],
     }
 
@@ -147,42 +162,25 @@ def test_required_status_check_audit_accepts_contexts_and_checks_shapes() -> Non
 def test_required_status_check_audit_accepts_github_actions_source() -> None:
     checker = _load_required_status_script()
     payload = {
-        "contexts": [
-            "live-reconciliation",
-            "diff-budget",
-            "Gitleaks PR secret scan",
-            "Gitleaks baseline growth guard",
-        ],
         "checks": [
-            {"context": "live-reconciliation", "app_id": checker.GITHUB_ACTIONS_APP_ID},
-            {"context": "diff-budget", "app_id": checker.GITHUB_ACTIONS_APP_ID},
-            {"context": "Gitleaks PR secret scan", "app_id": checker.GITHUB_ACTIONS_APP_ID},
-            {"context": "Gitleaks baseline growth guard", "app_id": checker.GITHUB_ACTIONS_APP_ID},
+            {"context": context, "app_id": checker.GITHUB_ACTIONS_APP_ID}
+            for context in EXPECTED_REQUIRED_CONTEXTS
         ],
     }
 
+    assert checker.DEFAULT_REQUIRED_CONTEXTS == tuple(EXPECTED_REQUIRED_CONTEXTS)
     assert checker.required_status_check_failures(payload) == []
 
 
 def test_required_status_check_audit_rejects_legacy_only_contexts() -> None:
     checker = _load_required_status_script()
     payload = {
-        "contexts": [
-            "live-reconciliation",
-            "diff-budget",
-            "Gitleaks PR secret scan",
-            "Gitleaks baseline growth guard",
-        ],
+        "contexts": EXPECTED_REQUIRED_CONTEXTS,
     }
 
     failures = checker.required_status_check_failures(payload)
 
-    assert [failure.context for failure in failures] == [
-        "live-reconciliation",
-        "diff-budget",
-        "Gitleaks PR secret scan",
-        "Gitleaks baseline growth guard",
-    ]
+    assert [failure.context for failure in failures] == EXPECTED_REQUIRED_CONTEXTS
     assert all("expected app_id" in failure.reason for failure in failures)
 
 
@@ -192,22 +190,28 @@ def test_required_status_check_audit_rejects_wrong_check_source() -> None:
         "checks": [
             {"context": "live-reconciliation", "app_id": checker.GITHUB_ACTIONS_APP_ID},
             {"context": "diff-budget", "app_id": checker.GITHUB_ACTIONS_APP_ID},
-            {"context": "Gitleaks PR secret scan", "app_id": -1},
-            {"context": "Gitleaks baseline growth guard", "app_id": None},
+            {"context": "Gitleaks PR secret scan", "app_id": checker.GITHUB_ACTIONS_APP_ID},
+            {
+                "context": "Gitleaks baseline growth guard",
+                "app_id": checker.GITHUB_ACTIONS_APP_ID,
+            },
+            {"context": "plan-admission", "app_id": -1},
+            {"context": "session-lane", "app_id": None},
+            {"context": "review-contract", "app_id": checker.GITHUB_ACTIONS_APP_ID},
         ],
     }
 
     failures = checker.required_status_check_failures(payload)
 
     assert [failure.context for failure in failures] == [
-        "Gitleaks PR secret scan",
-        "Gitleaks baseline growth guard",
+        "plan-admission",
+        "session-lane",
     ]
     assert "found app_id -1" in failures[0].reason
     assert "found legacy/unpinned" in failures[1].reason
 
 
-def test_required_status_check_audit_fails_when_gitleaks_context_missing() -> None:
+def test_required_status_check_audit_fails_when_required_contexts_missing() -> None:
     checker = _load_required_status_script()
     payload = {
         "required_status_checks": {
@@ -219,4 +223,7 @@ def test_required_status_check_audit_fails_when_gitleaks_context_missing() -> No
         "diff-budget",
         "Gitleaks PR secret scan",
         "Gitleaks baseline growth guard",
+        "plan-admission",
+        "session-lane",
+        "review-contract",
     ]


### PR DESCRIPTION
Plan: plans/PR-Process-Gate-Required-Status-Audit.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/process-gate-enrollment

#2104 has the trusted-base producers for `plan-admission`, `session-lane`, and `review-contract` on `main`, but the branch-protection required-status auditor still only knew the old baseline. This PR expands the non-Claude required-context contract, updates the live audit workflow triggers, and documents that the live REST branch-protection PATCH remains the next external settings step.

## Intentional

- `claude-review` is intentionally not added to the required set in this slice; this arc uses Codex/live-reconciliation as the required reviewer signal.
- This PR does not mutate live branch protection. The REST PATCH is deferred until after this code/doc audit slice is reviewed and merged.

## Deferred

- Apply the minimal REST branch-protection PATCH after merge: preserve existing checks, add `diff-budget`, `plan-admission`, `session-lane`, and `review-contract`, then re-fetch and run the live auditor.
- Any future non-forgeable reviewer status belongs in a separate policy slice.

## Parked hardening

- None.

## AI reconciliation

- [chatgpt-codex-connector] Include live-reconciliation producer in audit triggers: fixed by adding `.github/workflows/ai_reconciliation_live.yml` to the branch-protection audit workflow push paths and covering it in `tests/test_security_guardrails_workflow.py`.

All findings fixed or waived: yes.

## Cold diff reconstruction

- Changed: `scripts/check_required_status_checks.py:13-20` expands `DEFAULT_REQUIRED_CONTEXTS` from the old baseline to include `plan-admission`, `session-lane`, and `review-contract`.
- Contract match: satisfies the required audit-source-of-truth update; keeps GitHub Actions app-id pinning unchanged.
- Changed: `.github/workflows/branch_protection_required_checks.yml:10-21` adds producer workflow paths for `ai_reconciliation_live`, `diff_budget`, `plan_admission`, `review_contract`, and `session_lane`; `.github/workflows/branch_protection_required_checks.yml:54` renames the step to branch-protection checks.
- Contract match: satisfies the workflow-trigger coverage requirement without changing fetch/auth/audit behavior.
- Changed: `docs/SECURITY_GUARDRAILS.md:69-105` documents the target non-Claude required set and changes the now-merged producers from future/advisory wording to live producer wording while keeping REST enrollment separate.
- Contract match: satisfies the docs update and avoids claiming live protection has already changed.
- Changed: `tests/test_security_guardrails_workflow.py:18-26` defines the expected context list; `tests/test_security_guardrails_workflow.py:104-124` verifies docs/workflow trigger coverage; `tests/test_security_guardrails_workflow.py:147-229` verifies missing-context, default-pass, legacy-only, and wrong-app failure behavior for the full context set.
- Contract match: satisfies the focused regression coverage requirement.
- Changed: `plans/PR-Process-Gate-Required-Status-Audit.md:1-142` records the problem-derived contract, scope, verification, and diff budget.
- Contract match: required AGENTS.md plan-first artifact.
- Gaps: none. No product behavior, schemas, extracted packages, branch-protection live settings, `claude-review`, #2126, #2117, Dependabot, or protected Resolution Audit S6 work changed.

## Verification

- `python -m pytest tests/test_security_guardrails_workflow.py -q` -- 15 passed.
- Synthetic full-payload CLI probe: `python scripts/check_required_status_checks.py` returned PASS with all seven required contexts pinned to GitHub Actions app id `15368`.
- Synthetic current-live-shaped CLI probe: `python scripts/check_required_status_checks.py` returned FAIL on `diff-budget`, `plan-admission`, `session-lane`, and `review-contract`.
- `git diff --check` -- passed.
- `scripts/push_pr.sh` local-review wrapper -- passed.

## Diff size

5 files, +213 / -59
