### PR TITLE
Close #2129: followup-contract machine-progress hardening

### DIFF
--- a/atlas_brain/schemas/followup_workflow.py
+++ b/atlas_brain/schemas/followup_workflow.py
@@ -138,6 +138,15 @@ class FollowUpDraftResult(BaseModel):
                 raise ValueError("a drafted result carries no error_code")
             if self.failed_stage is not None:
                 raise ValueError("a drafted result may not carry a failed_stage")
+            # The approval stage is server-owned and runs AFTER the worker's draft.
+            # A drafted result may not claim the approval stage completed -- that is a
+            # worker-controlled machine claim about the server-owned boundary, even
+            # though it grants nothing (resolve_approval ignores it). Fail closed.
+            if "approval" in self.stages_completed:
+                raise ValueError(
+                    "a drafted result may not claim the approval stage completed; "
+                    "approval is server-owned"
+                )
         else:
             expected = STATUS_ERROR_CODE[self.status]
             if self.error_code != expected:  # exact canonical (already stripped)
@@ -146,14 +155,18 @@ class FollowUpDraftResult(BaseModel):
                 )
             if self.failed_stage is None:
                 raise ValueError(f"status {self.status!r} requires a failed_stage")
-            # Stages at or after the failed stage cannot have completed.
-            fail_index = STAGE_ORDER.index(self.failed_stage)
-            for stage in self.stages_completed:
-                if STAGE_ORDER.index(stage) >= fail_index:
-                    raise ValueError(
-                        f"stages_completed may not include {stage!r} at or after "
-                        f"failed_stage {self.failed_stage!r}"
-                    )
+            # A failure at stage N means exactly stages 0..N-1 completed, in order
+            # (linear workflow). stages_completed must be that exact ordered prefix,
+            # so a missing, reordered, duplicated, or at/after entry all fail closed
+            # -- same fail-closed treatment as the canonical error_code above, rather
+            # than merely rejecting stages at/after the failure.
+            expected_prefix = list(STAGE_ORDER[: STAGE_ORDER.index(self.failed_stage)])
+            if self.stages_completed != expected_prefix:
+                raise ValueError(
+                    f"stages_completed must be the ordered pre-failure prefix "
+                    f"{expected_prefix!r} for failed_stage {self.failed_stage!r}, "
+                    f"got {self.stages_completed!r}"
+                )
 
         # The worker may not emit "approved" (any case/whitespace); approval is
         # server-owned. Any other value must be a known benign state. approval_state

--- a/plans/PR-Followup-Contract-Hardening.md
+++ b/plans/PR-Followup-Contract-Hardening.md
@@ -1,0 +1,106 @@
+# PR-Followup-Contract-Hardening
+
+## Why this slice exists
+
+The draft-only customer-follow-up contract (`atlas_brain/schemas/followup_workflow.py`,
+merged in #2126) left three machine-progress refinements deferred to #2129 under the
+3-round Codex cap. They are latent on an unwired contract, but they close the last
+gaps between what the worker can CLAIM in the machine-progress fields and what those
+fields canonically mean, so downstream consumers of the contract never receive a
+non-canonical or approval-adjacent claim. This slice clears #2129: it makes
+`stages_completed` on a failure the exact ordered pre-failure prefix (fail-closed,
+like `error_code`), and forbids a drafted result from claiming the server-owned
+approval stage completed. The third item is a plan-doc reviewer-rules declaration
+(R3), addressed by this slice's Review Contract below.
+
+### Problem-derived contract
+
+From the #2129 findings, a correct fix must:
+- Reject a drafted (successful) result whose `stages_completed` includes `approval`:
+  the approval stage is server-owned and runs after the worker's draft, so the worker
+  may not claim it completed (even though `resolve_approval` already ignores the
+  claim, so nothing is granted).
+- Require `stages_completed` on a failure to be the exact ordered prefix of the stages
+  before `failed_stage` -- a missing, reordered, duplicated, or at/after entry must all
+  fail closed, not merely entries at or after the failed stage.
+- Declare R3 on the Review Contract: the server-owned approval boundary is an
+  authorization surface.
+
+## Scope (this PR)
+
+Ownership lane: followup-workflow
+Slice phase: production hardening
+
+Two guard closures in the existing validator plus their proving tests. No new module,
+no runtime caller, no send path. The contract is still unwired; this only tightens
+its fail-closed machine-progress rules.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A drafted result whose `stages_completed` includes `approval` is rejected; a
+        drafted result reporting only pre-approval stages still validates.
+  - [ ] A failure validates only when `stages_completed` equals the exact ordered
+        prefix before `failed_stage`; missing / reordered / duplicated / at-or-after
+        entries are all rejected.
+  - [ ] All prior #2126 invariants still hold (no regression in the 56 existing tests).
+- Reachability proof: N/A -- contract + validator only, no runtime caller and no send
+  path. Proof is the test suite.
+- Affected surfaces: one existing schema module and its test file; no new file; nothing
+  imports the module yet.
+- Risk areas: the server-owned approval boundary (a drafted result may not claim the
+  approval stage; approval remains derived only via `resolve_approval`); machine-progress
+  canonicality of `stages_completed` on failures.
+- Reviewer rules triggered: R2, R3, R14. R3 is declared because the change tightens the
+  server-owned approval authorization boundary.
+
+### Files touched
+
+- `atlas_brain/schemas/followup_workflow.py`
+- `plans/PR-Followup-Contract-Hardening.md`
+- `tests/test_followup_workflow.py`
+
+## Mechanism
+
+Both closures live in the existing `_fail_closed` model-validator. In the drafted
+branch, `"approval" in stages_completed` now raises (the stage is server-owned). In the
+failure branch, the previous "reject stages at/after `failed_stage`" loop is replaced
+with an exact-equality check against `list(STAGE_ORDER[:index(failed_stage)])`, so
+`stages_completed` must be precisely the ordered pre-failure prefix. Both are consistent
+with the contract's existing fail-closed treatment of the canonical `error_code`.
+
+## Intentional
+
+- Failure `stages_completed` is enforced (fail closed) rather than normalized/derived:
+  a worker that cannot report the canonical pre-failure prefix is malfunctioning, so the
+  whole result is rejected -- the same posture as the exact canonical `error_code` check,
+  not a silent overwrite of a contradictory claim.
+- Drafted `stages_completed` is only blocked from claiming `approval`; a drafted result
+  may still report a subset of the pre-approval stages (`lookup`/`select`/`compose`).
+  The finding was specifically the approval-stage claim; drafted pre-approval stages are
+  informational and not an authorization surface.
+
+## Deferred
+
+- None. This slice closes all three #2129 items (the R3 item is a Review Contract
+  declaration, above).
+
+## Verification
+
+```
+python -m pytest tests/test_followup_workflow.py -q
+```
+60 tests pass (56 existing + 4 new): a drafted result claiming the approval stage is
+rejected while a drafted result reporting pre-approval stages validates; a failure's
+`stages_completed` must equal the exact ordered pre-failure prefix (missing / reordered /
+duplicated / at-or-after all rejected; empty prefix required for a first-stage failure);
+all prior invariants unchanged.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/schemas/followup_workflow.py` | 29 |
+| `plans/PR-Followup-Contract-Hardening.md` | 112 |
+| `tests/test_followup_workflow.py` | 47 |
+| **Total** | **188** |

--- a/tests/test_followup_workflow.py
+++ b/tests/test_followup_workflow.py
@@ -172,7 +172,9 @@ def test_resolve_approval_is_server_owned():
 
 
 def test_resolve_approval_never_approves_non_drafted():
-    r = validate_followup_draft(_failure("partial", failed_stage="compose"))
+    r = validate_followup_draft(
+        _failure("partial", failed_stage="compose", stages_completed=["lookup", "select"])
+    )
     assert resolve_approval(r, server_approved=True) is False
 
 
@@ -258,3 +260,46 @@ def test_stages_completed_before_failed_stage_allowed():
         _failure("partial", failed_stage="compose", stages_completed=["lookup", "select"])
     )
     assert r.stages_completed == ["lookup", "select"]
+
+
+# --- exact pre-failure prefix + drafted approval-stage claim (#2129) ---
+
+
+def test_failure_stages_must_be_exact_ordered_prefix():
+    # missing an earlier stage (compose failure with only "select")
+    with pytest.raises(ValidationError):
+        validate_followup_draft(
+            _failure("partial", failed_stage="compose", stages_completed=["select"])
+        )
+    # reordered
+    with pytest.raises(ValidationError):
+        validate_followup_draft(
+            _failure("partial", failed_stage="compose", stages_completed=["select", "lookup"])
+        )
+    # duplicated
+    with pytest.raises(ValidationError):
+        validate_followup_draft(
+            _failure("partial", failed_stage="compose", stages_completed=["lookup", "lookup"])
+        )
+
+
+def test_failure_at_first_stage_requires_empty_prefix():
+    validate_followup_draft(_failure("no_results", failed_stage="lookup", stages_completed=[]))
+    with pytest.raises(ValidationError):  # nothing can precede the first stage
+        validate_followup_draft(
+            _failure("no_results", failed_stage="lookup", stages_completed=["lookup"])
+        )
+
+
+def test_drafted_may_not_claim_approval_stage():
+    with pytest.raises(ValidationError):
+        validate_followup_draft(
+            {**DRAFTED, "stages_completed": ["lookup", "select", "compose", "approval"]}
+        )
+
+
+def test_drafted_may_report_preapproval_stages():
+    r = validate_followup_draft(
+        {**DRAFTED, "stages_completed": ["lookup", "select", "compose"]}
+    )
+    assert r.stages_completed == ["lookup", "select", "compose"]


### PR DESCRIPTION
Plan: plans/PR-Followup-Contract-Hardening.md
Slice phase: production hardening
Ownership lane: followup-workflow

Clears the three #2129 machine-progress refinements deferred from the draft-only
follow-up contract (#2126) under the 3-round Codex cap. Two guard closures in the
existing validator plus tests: a failure's stages_completed must be the exact ordered
pre-failure prefix (fail closed, like error_code), and a drafted result may not claim
the server-owned approval stage completed. The contract is still unwired; no runtime
caller and no send path.

## Intentional
- Failure stages_completed is enforced fail-closed (must equal the exact ordered prefix before failed_stage) rather than normalized, matching the exact-canonical error_code posture -- a worker that cannot report the canonical prefix is rejected, not silently corrected. Drafted results are only blocked from claiming the approval stage (server-owned); reporting pre-approval stages stays allowed as informational.

## Deferred
- None. All three #2129 items are closed here (the R3 item is a Review Contract declaration in the plan doc).

## Parked hardening
- None.

## Cold diff reconstruction
- Two edits inside the existing _fail_closed model-validator in atlas_brain/schemas/followup_workflow.py: (1) drafted branch rejects "approval" in stages_completed; (2) failure branch replaces the at/after loop with exact-equality against list(STAGE_ORDER[:index(failed_stage)]). tests/test_followup_workflow.py updates one existing test to supply the canonical prefix and adds four tests (exact-prefix missing/reordered/duplicated, first-stage empty prefix, drafted approval-stage rejected, drafted pre-approval stages allowed). No existing file beyond these; nothing imports the module yet.

## Verification
- python -m pytest tests/test_followup_workflow.py -q  ->  60 passed (56 existing + 4 new). A drafted result claiming the approval stage is rejected; a drafted result reporting pre-approval stages validates; a failure's stages_completed must equal the exact ordered pre-failure prefix (missing / reordered / duplicated / at-or-after all rejected); all prior invariants unchanged. scripts/check_ascii_python.sh passes.

## Diff size
- 188 lines (29 schema + 47 tests + 112 plan doc), under the 400 soft cap.

## AI reconciliation

Initial push; no automated-review findings yet. Codex threads are reconciled and this record updated before merge.

All fixed or waived: Yes
