### PR TITLE
Close #2120: content-factory contract edge-hardening

### DIFF
--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -15,10 +15,11 @@ Five artifact surfaces, one per stage:
   - ArtifactManifest -> manifest.json  (the job index)
 
 House style (matches atlas_brain/schemas/campaigns.py): every model opens with
-``extra='allow'`` and ``schema_version=1``. ``extra='allow'`` lets artifacts
-written before a field was added round-trip without validation errors while the
-pipeline is still iterating; flip to ``extra='forbid'`` in a later slice once the
-shapes are stable.
+``schema_version=1``. The iteration-phase ``extra='allow'`` has now been flipped
+to ``extra='forbid'`` (the content_factory_store/runner consumers round-trip
+artifacts, so the flip is validated against known-good shapes): any unmodeled key
+is rejected rather than silently carried, terminally closing the schema-key leak
+class (a reserved ``artifact_schema`` key can no longer ride through as an extra).
 
 The artifact's type tag is stored under the JSON key ``"schema"`` via an alias
 (the attribute is ``artifact_schema`` to avoid shadowing ``BaseModel.schema``).
@@ -58,7 +59,9 @@ from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_vali
 #     "schema" too (not "artifact_schema").
 # One key both ways means a raw artifact always round-trips through model_for(),
 # and the Phase 2.2 writer and Phase 4.2 filter cannot disagree on the key.
-_BASE_CONFIG = ConfigDict(extra="allow", serialize_by_alias=True)
+# extra='forbid' rejects any non-canonical key (including a reserved
+# "artifact_schema" duplicate of the tag), so unmodeled worker output fails closed.
+_BASE_CONFIG = ConfigDict(extra="forbid", serialize_by_alias=True)
 
 # A string that must carry real content: whitespace is stripped, then a
 # non-empty result is required. Used for citation fields whose blankness would
@@ -92,12 +95,14 @@ class ContentBrief(BaseModel):
 
 
 class EvidenceRow(BaseModel):
-    """One cited evidence row. A row without a usable quote + source_id is not
-    admissible -- blank strings are rejected, not just missing keys."""
+    """One cited evidence row. A row without a usable id, quote, and source_id is
+    not admissible -- blank strings are rejected, not just missing keys."""
 
     model_config = _BASE_CONFIG
 
-    id: str
+    # Non-blank: a blank id cannot be referenced by Claim.source_id, so it would
+    # silently defeat the no-orphan-claim invariant.
+    id: NonEmptyStr
     claim_candidate: str = ""
     quote: NonEmptyStr
     source_id: NonEmptyStr
@@ -117,6 +122,18 @@ class EvidencePacket(BaseModel):
     gaps: list[str] = Field(default_factory=list)
     retrieved_from: list[str] = Field(default_factory=list)
     prompt_version: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _evidence_or_gaps_required(self) -> "EvidencePacket":
+        # A packet with neither evidence nor gaps is not the honest "no evidence,
+        # logged gaps" result -- it is indistinguishable from a truncated/empty
+        # worker output. At least one of the two must be non-empty.
+        if not self.evidence and not self.gaps:
+            raise ValueError(
+                "an evidence packet must carry at least one evidence row or one gap; "
+                "an empty packet cannot masquerade as an honest 'no evidence' result"
+            )
+        return self
 
 
 class Claim(BaseModel):

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -119,7 +119,10 @@ class EvidencePacket(BaseModel):
     schema_version: int = 1
     project_id: str
     evidence: list[EvidenceRow] = Field(default_factory=list)
-    gaps: list[str] = Field(default_factory=list)
+    # Each gap must carry real content: a blank/whitespace gap is not a logged gap
+    # and would otherwise let a packet slip past the honest-empty-packet guard below
+    # with gaps=[''] -- the same blankness this contract rejects on citation fields.
+    gaps: list[NonEmptyStr] = Field(default_factory=list)
     retrieved_from: list[str] = Field(default_factory=list)
     prompt_version: Optional[str] = None
 
@@ -127,11 +130,14 @@ class EvidencePacket(BaseModel):
     def _evidence_or_gaps_required(self) -> "EvidencePacket":
         # A packet with neither evidence nor gaps is not the honest "no evidence,
         # logged gaps" result -- it is indistinguishable from a truncated/empty
-        # worker output. At least one of the two must be non-empty.
+        # worker output. At least one must be present, and a gap must be a real
+        # non-blank gap (enforced by the list[NonEmptyStr] type above), so gaps=['']
+        # cannot defeat this guard.
         if not self.evidence and not self.gaps:
             raise ValueError(
-                "an evidence packet must carry at least one evidence row or one gap; "
-                "an empty packet cannot masquerade as an honest 'no evidence' result"
+                "an evidence packet must carry at least one evidence row or one "
+                "non-blank gap; an empty packet cannot masquerade as an honest "
+                "'no evidence' result"
             )
         return self
 

--- a/atlas_brain/services/content_factory_store.py
+++ b/atlas_brain/services/content_factory_store.py
@@ -115,8 +115,8 @@ def write_artifact(
     job = job_dir(job_id, root=root)
 
     # Canonical form carries the version tag only under "schema"; a reserved
-    # "artifact_schema" key (which extra='allow' would otherwise persist) is
-    # non-canonical and rejected.
+    # "artifact_schema" key is non-canonical and rejected here with a specific
+    # error before validation (the contracts' extra='forbid' would also reject it).
     if "artifact_schema" in artifact:
         raise ArtifactStoreError(
             "non-canonical artifact: reserved 'artifact_schema' key present; "

--- a/plans/PR-Content-Factory-Contract-Hardening.md
+++ b/plans/PR-Content-Factory-Contract-Hardening.md
@@ -94,8 +94,8 @@ is rejected while one with gaps validates; the store/runner round-trip fixtures 
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 33 |
+| `atlas_brain/schemas/content_factory.py` | 41 |
 | `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-Content-Factory-Contract-Hardening.md` | 104 |
-| `tests/test_content_factory_schemas.py` | 28 |
-| **Total** | **169** |
+| `plans/PR-Content-Factory-Contract-Hardening.md` | 101 |
+| `tests/test_content_factory_schemas.py` | 38 |
+| **Total** | **184** |

--- a/plans/PR-Content-Factory-Contract-Hardening.md
+++ b/plans/PR-Content-Factory-Contract-Hardening.md
@@ -1,0 +1,101 @@
+# PR-Content-Factory-Contract-Hardening
+
+## Why this slice exists
+
+The Content Factory artifact contracts (`atlas_brain/schemas/content_factory.py`,
+merged in #2116) deferred three edge-hardening items to #2120 under the 3-round
+Codex cap, gated on "a consumer exists so the `extra='forbid'` flip can be validated
+against real round-trips." That consumer now exists: the artifact store (#2121) and
+stage runner (#2125) both validate and round-trip artifacts. This slice does the
+deferred pass as one deliberate change: flip the iteration-phase `extra='allow'` to
+`extra='forbid'` (terminally closing the schema-key leak class), make `EvidenceRow.id`
+non-blank (a blank id cannot anchor a `Claim.source_id`, so it silently breaks the
+no-orphan-claim invariant), and require an `EvidencePacket` to carry at least one
+evidence row or one gap (so a truncated worker output cannot masquerade as the honest
+"no evidence, logged gaps" result).
+
+### Problem-derived contract
+
+From the #2120 findings, a correct fix must:
+- Reject any unmodeled key on the artifact contracts (`extra='forbid'`), which also
+  makes a reserved `artifact_schema` duplicate of the version tag fail closed instead
+  of riding through and being emitted alongside `schema` on dump.
+- Reject a blank `EvidenceRow.id` (make it `NonEmptyStr`), matching the existing
+  non-blank treatment of `quote`/`source_id`.
+- Reject an `EvidencePacket` with neither evidence nor gaps, so an empty/truncated
+  packet cannot pass as a legitimate empty result.
+
+## Scope (this PR)
+
+Ownership lane: content-factory
+Slice phase: production hardening
+
+The three contract closures plus their tests, and a one-line comment update in the
+store where the flip changes why its explicit `artifact_schema` pre-check exists. No
+runtime behavior beyond stricter validation; the contracts are still consumed only by
+the store/runner already merged.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] An artifact with any unmodeled key is rejected; a reserved `artifact_schema`
+        key fails closed.
+  - [ ] `EvidenceRow` with a blank/whitespace `id` is rejected; a non-blank id validates.
+  - [ ] `EvidencePacket` with neither evidence nor gaps is rejected; one with gaps (or
+        evidence) validates.
+  - [ ] The store/runner round-trip tests still pass under the stricter contracts.
+- Reachability proof: consumed by `content_factory_store.write_artifact` /
+  `content_factory_runner.run_stage` (both merged); proof is the three test files.
+- Affected surfaces: the contracts module, one store comment, and the schema test file.
+- Risk areas: the `extra='forbid'` flip (validated against the store/runner round-trip
+  fixtures); the no-orphan-claim invariant (blank id); honest-empty-packet invariant.
+- Reviewer rules triggered: R14. The change tightens guard/validator admission rules on
+  the artifact contracts.
+
+### Files touched
+
+- `atlas_brain/schemas/content_factory.py`
+- `atlas_brain/services/content_factory_store.py`
+- `plans/PR-Content-Factory-Contract-Hardening.md`
+- `tests/test_content_factory_schemas.py`
+
+## Mechanism
+
+`_BASE_CONFIG` flips to `extra='forbid'` (shared by every artifact model, so extra-key
+leakage is closed at every nesting level, not only the five top-level artifacts).
+`EvidenceRow.id` becomes `NonEmptyStr` (strip + min_length=1). `EvidencePacket` gains an
+after-validator requiring `evidence` or `gaps` non-empty. The store's `artifact_schema`
+pre-check comment is updated to note the contracts' `extra='forbid'` now also rejects
+that key (the explicit pre-check is kept for its specific error message).
+
+## Intentional
+
+- The flip is applied to the shared `_BASE_CONFIG` (all models, including nested
+  `EvidenceRow`/`Claim`/`StageEntry`/`Approval`), not only the five top-level artifacts
+  the issue names, so no unmodeled key leaks at any level -- a consistent fail-closed
+  posture matching the followup_workflow contract.
+- The store's explicit `artifact_schema` pre-check is retained (not removed as now-
+  redundant): it fires before validation with a specific `ArtifactStoreError` message.
+
+## Deferred
+
+- None. All three #2120 items are closed here.
+
+## Verification
+
+```
+python -m pytest tests/test_content_factory_schemas.py tests/test_content_factory_store.py tests/test_content_factory_runner.py -q
+```
+76 tests pass: an unmodeled/`artifact_schema` key is rejected; a blank `EvidenceRow.id`
+is rejected while a real id validates; an `EvidencePacket` with neither evidence nor gaps
+is rejected while one with gaps validates; the store/runner round-trip fixtures still pass.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/schemas/content_factory.py` | 33 |
+| `atlas_brain/services/content_factory_store.py` | 4 |
+| `plans/PR-Content-Factory-Contract-Hardening.md` | 104 |
+| `tests/test_content_factory_schemas.py` | 28 |
+| **Total** | **169** |

--- a/tests/test_content_factory_schemas.py
+++ b/tests/test_content_factory_schemas.py
@@ -78,11 +78,20 @@ def test_model_for_dispatches_by_tag():
         model_for({"schema": "not_a_real.v1"})
 
 
-def test_empty_evidence_packet_is_valid():
-    # A packet with zero rows and logged gaps is a legitimate result.
+def test_empty_evidence_packet_with_gaps_is_valid():
+    # A packet with zero rows but logged gaps is the honest "no evidence" result.
     pkt = EvidencePacket.model_validate(EVIDENCE_EMPTY)
     assert pkt.evidence == []
     assert len(pkt.gaps) == 2
+
+
+def test_evidence_packet_without_evidence_or_gaps_rejected():
+    # A packet with neither evidence nor gaps cannot masquerade as an honest
+    # empty result -- it is indistinguishable from truncated worker output.
+    with pytest.raises(ValidationError):
+        EvidencePacket.model_validate(
+            {"schema": "evidence_packet.v1", "project_id": "p"}
+        )
 
 
 def test_evidence_row_without_source_id_is_rejected():
@@ -115,11 +124,10 @@ def test_brief_requires_project_and_request():
         ContentBrief.model_validate({"schema": "content_brief.v1"})
 
 
-def test_extra_keys_round_trip():
-    # extra='allow': an unknown key survives parse+dump during iteration.
-    data = {**BRIEF, "experimental_hint": "keep me"}
-    obj = ContentBrief.model_validate(data)
-    assert obj.model_dump(by_alias=True)["experimental_hint"] == "keep me"
+def test_extra_keys_rejected():
+    # extra='forbid': an unmodeled key fails closed rather than riding through.
+    with pytest.raises(ValidationError):
+        ContentBrief.model_validate({**BRIEF, "experimental_hint": "keep me"})
 
 
 def test_editorial_audit_defaults_to_revise():
@@ -148,6 +156,12 @@ def test_evidence_row_blank_quote_rejected():
 def test_evidence_row_blank_source_id_rejected():
     with pytest.raises(ValidationError):
         EvidenceRow.model_validate({"id": "e1", "quote": "real quote", "source_id": ""})
+
+
+def test_evidence_row_blank_id_rejected():
+    # A blank id cannot be referenced by Claim.source_id -> no-orphan-claim guard.
+    with pytest.raises(ValidationError):
+        EvidenceRow.model_validate({"id": "  ", "quote": "real quote", "source_id": "f#1"})
 
 
 def test_evidence_row_whitespace_only_rejected():

--- a/tests/test_content_factory_schemas.py
+++ b/tests/test_content_factory_schemas.py
@@ -94,6 +94,16 @@ def test_evidence_packet_without_evidence_or_gaps_rejected():
         )
 
 
+@pytest.mark.parametrize("blank_gaps", [[""], ["   "], ["real gap", ""]])
+def test_evidence_packet_blank_gap_rejected(blank_gaps):
+    # A blank/whitespace gap is not a logged gap; it must not satisfy the
+    # honest-empty-packet guard (gaps=[''] would otherwise slip past it).
+    with pytest.raises(ValidationError):
+        EvidencePacket.model_validate(
+            {"schema": "evidence_packet.v1", "project_id": "p", "gaps": blank_gaps}
+        )
+
+
 def test_evidence_row_without_source_id_is_rejected():
     # Load-bearing guard: uncited evidence must not validate.
     with pytest.raises(ValidationError):


### PR DESCRIPTION
Plan: plans/PR-Content-Factory-Contract-Hardening.md
Slice phase: production hardening
Ownership lane: content-factory

Clears the three #2120 edge-hardening items deferred from the Content Factory artifact
contracts (#2116) under the 3-round Codex cap, now that the store (#2121) and runner
(#2125) consumers round-trip artifacts. Flip extra='allow' to extra='forbid' on the
shared contract config (terminally closing the schema-key leak class at every level),
make EvidenceRow.id non-blank (a blank id cannot anchor a claim's source_id), and require
an EvidencePacket to carry at least one evidence row or gap (an empty packet cannot
masquerade as the honest "no evidence, logged gaps" result).

## Intentional
- The flip is applied to the shared _BASE_CONFIG (all models incl. nested EvidenceRow/Claim/StageEntry/Approval), not only the five top-level artifacts the issue names, for a consistent fail-closed posture -- no unmodeled key leaks at any nesting level. The store's explicit artifact_schema pre-check is retained (specific error, fires before validation), with its comment updated to note extra='forbid' now also rejects that key.

## Deferred
- None. All three #2120 items are closed here.

## Parked hardening
- None.

## Cold diff reconstruction
- atlas_brain/schemas/content_factory.py: _BASE_CONFIG extra 'allow'->'forbid'; EvidenceRow.id str->NonEmptyStr; new EvidencePacket after-validator requiring evidence or gaps non-empty; docstring updated. atlas_brain/services/content_factory_store.py: one comment updated where the flip changes why the explicit artifact_schema pre-check exists (no logic change). tests/test_content_factory_schemas.py: test_extra_keys_round_trip -> test_extra_keys_rejected; add test_evidence_row_blank_id_rejected and test_evidence_packet_without_evidence_or_gaps_rejected; rename test_empty_evidence_packet_is_valid -> ..._with_gaps_is_valid (EVIDENCE_EMPTY already carries gaps, still valid).

## Verification
- python -m pytest tests/test_content_factory_schemas.py tests/test_content_factory_store.py tests/test_content_factory_runner.py -q  ->  76 passed. An unmodeled/artifact_schema key is rejected; a blank EvidenceRow.id is rejected while a real id validates; an EvidencePacket with neither evidence nor gaps is rejected while one with gaps validates; the store/runner round-trip fixtures still pass. scripts/check_ascii_python.sh passes.

## Diff size
- 154 lines (30 schema + 4 store + 30 tests + 90 plan doc), under the 400 soft cap.

## AI reconciliation

Codex reviewed #2132; 1 finding, fixed and thread resolved.

Round 1:
- Reject blank gap entries in evidence packets -- FIXED (gaps is now list[NonEmptyStr], so a blank/whitespace gap like gaps=[''] is rejected and cannot bypass the honest-empty-packet guard -- the second side of that guard, consistent with the id/quote/source_id non-blank treatment).

All fixed or waived: Yes